### PR TITLE
fix name for kubectl pod

### DIFF
--- a/components/ContainerExec/LaunchKubeCtl.vue
+++ b/components/ContainerExec/LaunchKubeCtl.vue
@@ -26,7 +26,8 @@ export default {
       return config;
     },
     expectedPodName() {
-      const userName = this.principal.name.toLowerCase();
+      const regex = new RegExp(/[^a-zA-Z0-9\.-]/g);
+      const userName = this.principal.name.toLowerCase().replace(regex, '-' );
       // TODO make pod different clusters
       const cluster = 'local';
 


### PR DESCRIPTION
improved pod naming validation to match kubernetes rules: 
>digits (0-9), lower case letters (a-z), -, and .