### PR TITLE
storybook webpack config for aliased paths

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets": [
+      "@babel/preset-env",
+      "babel-preset-vue"
+    ]
+  }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,22 @@
+
+const path = require('path')
+module.exports = {
+    module: {
+        rules: [
+          {
+            test: /\.s?css$/,
+            loaders: ['style-loader', 'css-loader', 'sass-loader'],
+            include: path.resolve(__dirname, '../')
+          },
+          {
+            test: /\.(svg|woff|woff2|ttf)$/,
+            loader: "file-loader",
+        }
+        ]
+      },
+  resolve: {
+    alias: {
+      '@': path.dirname(path.resolve(__dirname)),
+    }
+  }
+}

--- a/components/form/LabeledInput.stories.js
+++ b/components/form/LabeledInput.stories.js
@@ -1,0 +1,13 @@
+import centered from '@storybook/addon-centered/vue';
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  title:      'Components/Form/Labeled Input',
+  component:  LabeledInput,
+  decorators: [() => '<form><story/></form>'],
+};
+
+export const labeledInput = () => ({
+  components: { LabeledInput },
+  template:   `<LabeledInput type='text' label='Sample Label' placeholder='Sample Placeholder'/>`,
+});


### PR DESCRIPTION
* added webpack config for storybook so all the nuxt-aliased paths involving '@' work