### PR TITLE
move enabled/disabled badge state func to users model

### DIFF
--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -82,7 +82,7 @@ export default {
     cursor: pointer;
     font-size: 18px;
     line-height: 24px;
-    height: 14px;
+    height: 0.8em;
     width: 18px;
     clear: both;
 }

--- a/models/user.js
+++ b/models/user.js
@@ -41,6 +41,10 @@ export default {
         this.deactivate(item);
       });
     };
+  },
+
+  stateRelevant() {
+    return this.enabled ? 'active' : 'inactive';
   }
 }
 ;

--- a/plugins/norman/resource-instance.js
+++ b/plugins/norman/resource-instance.js
@@ -151,12 +151,10 @@ export default {
   _stateRelevant() {
     if ( this.computed && this.computed.state && this.computed.state.name ) {
       return this.computed.state.name;
-    } else {
-      return this.enabled ? 'active' : 'inactive';
     }
 
     // @TODO unknown
-    // return 'active';
+    return 'active';
   },
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
#293 
- revert prior change: state column in list view defaults to 'active' if resource has no computed state prop
- users state column is based off 'enabled' prop


- minor change to checkbox styling so table header underline is even