### PR TITLE
POST secret type correctly

### DIFF
--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -131,10 +131,11 @@ export const AGE = {
 export const CREATED = {
   name:       'created',
   label:      'Created',
-  value:      'created',
+  value:      'metadata.creationTimestamp',
   sort:       ['created', 'name'],
   search:     false,
   formatter:  'LiveDate',
+  align:     'right'
 };
 
 export const IMAGE = {

--- a/detail/core.v1.secret.vue
+++ b/detail/core.v1.secret.vue
@@ -29,13 +29,17 @@ export default {
 
     dockerRows() {
       const auths = JSON.parse(this.dataRows[0].value).auths;
+      const rows = [];
 
-      const address = Object.keys(auths)[0];
-      const { username, url } = auths[address];
+      for (const address in auths) {
+        rows.push({
+          address,
+          username: auths[address].username,
+          password: auths[address].password
+        });
+      }
 
-      return [{
-        address, username, url
-      }];
+      return rows;
     },
 
     dockerHeaders() {
@@ -52,14 +56,6 @@ export default {
           value: 'username',
         }
       ];
-
-      if (this.dockerRows[0].url) {
-        headers.push({
-          name:  'url',
-          label: 'url(for artifactory/custom)',
-          value: 'url'
-        });
-      }
 
       return headers;
     },

--- a/edit/core.v1.secret.vue
+++ b/edit/core.v1.secret.vue
@@ -1,6 +1,6 @@
 <script>
 import { DOCKER_JSON, OPAQUE, TLS } from '@/models/core.v1.secret';
-import { base64Encode } from '@/utils/crypto';
+import { base64Encode, base64Decode } from '@/utils/crypto';
 import { get } from '@/utils/object';
 import { ANNOTATION, NAMESPACE } from '@/config/types';
 import CreateEditView from '@/mixins/create-edit-view';
@@ -34,15 +34,30 @@ export default {
     ];
     const isNamespaced = !!this.value.metadata.namespace;
 
+    let username;
+    let password;
+    let registryFQDN;
+
+    if (this.value._type === DOCKER_JSON) {
+      const json = base64Decode(this.value.data['.dockerconfigjson']);
+
+      const { auths } = JSON.parse(json);
+
+      registryFQDN = Object.keys(auths)[0];
+
+      username = auths[registryFQDN].username;
+      password = auths[registryFQDN].password;
+    }
+
     return {
       types,
       isNamespaced,
       registryAddresses,
       newNS:            false,
       registryProvider: registryAddresses[0],
-      username:         '',
-      password:         '',
-      registryFQDN:     null,
+      username,
+      password,
+      registryFQDN,
       toUpload:         null,
       key:              null,
       cert:             null

--- a/plugins/norman/resource-instance.js
+++ b/plugins/norman/resource-instance.js
@@ -458,6 +458,7 @@ export default {
         opt.headers['accept'] = 'application/json';
       }
 
+      this.type = this._type;
       opt.data = this;
 
       const res = await this.$dispatch('request', opt);

--- a/plugins/norman/resource-instance.js
+++ b/plugins/norman/resource-instance.js
@@ -458,9 +458,11 @@ export default {
         opt.headers['accept'] = 'application/json';
       }
 
+      // @TODO remove this once the API maps steve _type <-> k8s type in both directions
       if (this._type) {
         this.type = this._type;
       }
+      
       opt.data = this;
 
       const res = await this.$dispatch('request', opt);

--- a/plugins/norman/resource-instance.js
+++ b/plugins/norman/resource-instance.js
@@ -458,7 +458,9 @@ export default {
         opt.headers['accept'] = 'application/json';
       }
 
-      this.type = this._type;
+      if (this._type) {
+        this.type = this._type;
+      }
       opt.data = this;
 
       const res = await this.$dispatch('request', opt);


### PR DESCRIPTION
Create kubernetes resources with 'type' field populated correctly (from _type)
If a reg secret has multiple auths, list them (but don't show for editing)