### PR TITLE
Implement the view, create and edit pages for constraints

### DIFF
--- a/assets/styles/global/_form.scss
+++ b/assets/styles/global/_form.scss
@@ -30,6 +30,11 @@ TEXTAREA,
     }
   }
 
+  &.view {
+    border: none;
+    background-color: transparent;
+  }
+
   &::placeholder {
     color: var(--input-placeholder);
   }

--- a/components/ResourceDetail.vue
+++ b/components/ResourceDetail.vue
@@ -133,6 +133,10 @@ export default {
     }
   },
 
+  data() {
+    return { currentValue: this.value };
+  },
+
   computed: {
     isView() {
       return this.mode === _VIEW;
@@ -140,6 +144,10 @@ export default {
 
     isEdit() {
       return this.mode === _EDIT;
+    },
+
+    showEditAsYaml() {
+      return this.isEdit;
     },
 
     doneRoute() {
@@ -189,7 +197,11 @@ export default {
 
     goBack() {
       window.history.length > 1 ? this.$router.go(-1) : this.$router.push('/');
-    }
+    },
+
+    navigateToEditAsYaml() {
+      this.$router.push({ query: { ...this.$route.query, [EDIT_YAML]: _FLAGGED } });
+    },
   }
 };
 </script>
@@ -203,6 +215,7 @@ export default {
         :done-route="doneRoute"
         :parent-route="doneRoute"
         :parent-params="doneParams"
+        :has-edit-as-form="hasCustomEdit"
       />
     </template>
     <template v-else>
@@ -222,6 +235,11 @@ export default {
         <div v-if="isView" class="actions">
           <button ref="actions" type="button" class="btn btn-sm role-multi-action actions" @click="showActions">
             <i class="icon icon-actions" />
+          </button>
+        </div>
+        <div v-if="showEditAsYaml" class="actions">
+          <button class="btn bg-primary" @click="navigateToEditAsYaml">
+            Edit as YAML
           </button>
         </div>
       </header>

--- a/components/form/InputWithSelect.vue
+++ b/components/form/InputWithSelect.vue
@@ -62,6 +62,8 @@ export default {
       :searchable="false"
       :disbaled="isView"
       :clearable="false"
+      :mode="mode"
+      @input="e=>selected=e.value"
     />
     <LabeledInput
       v-if="textLabel"
@@ -72,6 +74,7 @@ export default {
       :placeholder="placeholder"
       :disabled="isView"
       :required="textRequired"
+      :mode="mode"
     />
     <input
       v-else

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -173,7 +173,7 @@ export default {
         value = base64Decode(value);
       }
 
-      const binary = !asciiLike(value);
+      const binary = typeof value === 'string' && !asciiLike(value);
 
       rows.push({
         key,
@@ -512,7 +512,7 @@ export default {
   }
 
   .footer {
-    
+
     .protip {
       float: right;
       padding: 5px 0;

--- a/components/form/LabelSelector.vue
+++ b/components/form/LabelSelector.vue
@@ -1,0 +1,65 @@
+<script>
+import RuleSelector from '@/components/form/RuleSelector';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  components: { RuleSelector },
+
+  props: {
+    value: {
+      type:    Array,
+      default: null
+    },
+    mode: {
+      type:    String,
+      default: _VIEW
+    }
+  },
+
+  data() {
+    return {
+      operatorOptions: [
+        {
+          label: 'is set',
+          value: 'Exists',
+        },
+        {
+          label: 'is not set',
+          value: 'DoesNotExist',
+        },
+        {
+          label: 'in list',
+          value: 'In',
+        },
+        {
+          label: 'not in list',
+          value: 'NotIn',
+        }
+      ]
+    };
+  },
+
+  computed: {
+    localValue: {
+      get() {
+        return this.value;
+      },
+      set(localValue) {
+        this.$emit('input', localValue);
+      }
+    }
+  },
+};
+</script>
+
+<template>
+  <RuleSelector
+    v-model="localValue"
+    :operator-options="operatorOptions"
+    key-header="Label key"
+    operator-header="Label operator"
+    value-header="Label value"
+    add-label="Add Label"
+    :mode="mode"
+  />
+</template>

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -1,6 +1,7 @@
 <script>
 import LabeledFormElement from '@/mixins/labeled-form-element';
 import TextAreaAutoGrow from '@/components/form/TextAreaAutoGrow';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   components: { TextAreaAutoGrow },
@@ -16,6 +17,10 @@ export default {
     hidePlaceholder: {
       type:    Boolean,
       default: true
+    },
+    mode: {
+      type:    String,
+      default: _EDIT
     }
   },
 
@@ -23,6 +28,12 @@ export default {
     const actualPlaceholder = this.hidePlaceholder ? '' : this.placeholder;
 
     return { actualPlaceholder };
+  },
+
+  computed: {
+    isViewing() {
+      return this.mode === _VIEW;
+    }
   },
 
   methods: {
@@ -64,7 +75,18 @@ export default {
 </script>
 
 <template>
-  <div :class="{'labeled-input': true, raised, focused, [mode]: true}">
+  <div v-if="isViewing" :class="{'labeled-input': true, [mode]: true}">
+    <label>
+      {{ label }}
+      <span v-if="required && !value" class="required">*</span>
+    </label>
+    <label class="corner">
+      <slot name="corner" />
+    </label>
+    <slot name="prefix" />
+    <div>{{ value || '&lt;empty&gt;' }}</div>
+  </div>
+  <div v-else :class="{'labeled-input': true, raised, focused, [mode]: true}">
     <slot name="label">
       <label v-if="i18nLabel" k-t="i18nLabel" />
       <label v-else>

--- a/components/form/MatchKinds.vue
+++ b/components/form/MatchKinds.vue
@@ -1,0 +1,97 @@
+<script>
+import ArrayList from '@/components/form/ArrayList';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  components: { ArrayList },
+
+  props: {
+    value: {
+      type:    Array,
+      default: null
+    },
+    mode: {
+      type:    String,
+      default: _VIEW
+    }
+  },
+
+  computed: {
+    localValue: {
+      get() {
+        return this.value;
+      },
+      set(localValue) {
+        this.$emit('input', localValue);
+      }
+    },
+    defaultAddValue() {
+      return {
+        apiGroups:      [],
+        kinds:     []
+      };
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="match-kinds">
+    <ArrayList
+      v-model="localValue"
+      class="match-kinds-list"
+      :protip="false"
+      add-label="Add Kind"
+      :mode="mode"
+      :default-add-value="defaultAddValue"
+    >
+      <template slot="tbody-columns" scope="scope">
+        <td class="api-groups">
+          <ArrayList
+            v-model="scope.row.value.apiGroups"
+            class="api-groups-list"
+            :protip="false"
+            :show-header="true"
+            value-label="ApiGroups"
+            add-label="Add ApiGroup"
+            value-placeholder=""
+            :mode="mode"
+          />
+        </td>
+        <td class="kinds">
+          <ArrayList
+            v-model="scope.row.value.kinds"
+            class="kinds-list"
+            :protip="false"
+            :show-header="true"
+            value-label="Kinds"
+            add-label="Add Kind"
+            value-placeholder=""
+            :mode="mode"
+          />
+        </td>
+      </template>
+    </ArrayList>
+  </div>
+</template>
+
+<style lang="scss">
+.match-kinds {
+  .api-groups,
+  .kinds {
+    vertical-align: top;
+  }
+
+  .match-kinds-list > table {
+    border-collapse: separate;
+    border-spacing: 0px 15px;
+
+    & > tbody > tr:not(:last-of-type) > td {
+      vertical-align: top;
+      padding-bottom: 10px;
+      border-radius: var(--border-radius);
+      border-bottom: 1px solid var(--border);
+    }
+  }
+}
+</style>

--- a/components/form/NamespaceList.vue
+++ b/components/form/NamespaceList.vue
@@ -1,0 +1,74 @@
+<script>
+import ArrayList from '@/components/form/ArrayList';
+import { sortBy } from '@/utils/sort';
+import { _EDIT } from '@/config/query-params';
+import { NAMESPACE } from '@/config/types';
+import LabeledSelect from '@/components/form/LabeledSelect';
+
+export default {
+  components: {
+    ArrayList,
+    LabeledSelect
+  },
+
+  props: {
+    value: {
+      type:    Array,
+      default: null
+    },
+    mode: {
+      type:    String,
+      default: _EDIT
+    }
+  },
+
+  computed: {
+    localValue: {
+      get() {
+        return this.value;
+      },
+      set(localValue) {
+        this.$emit('input', localValue);
+      }
+    },
+    namespaceOptions() {
+      const choices = this.$store.getters['cluster/all'](NAMESPACE);
+
+      return sortBy(
+        choices.map((obj) => {
+          return {
+            label: obj.nameDisplay,
+            value: obj.id
+          };
+        }),
+        'label'
+      );
+    }
+  }
+};
+</script>
+
+<template>
+  <ArrayList v-model="localValue" class="namespace-list" :mode="mode" default-add-value="default">
+    <template slot="tbody-columns" scope="scope">
+      <td>
+        <div class="input-container">
+          <LabeledSelect
+            :mode="mode"
+            :value="scope.row.value"
+            :options="namespaceOptions"
+            label="Namespace"
+            add-label="Add Namespace"
+            @input="scope.row.value = $event; scope.queueUpdate()"
+          />
+        </div>
+      </td>
+    </template>
+  </ArrayList>
+</template>
+
+<style lang="scss">
+.namespace-list .fixed input {
+    height: initial;
+}
+</style>

--- a/components/form/NamespaceSelector.vue
+++ b/components/form/NamespaceSelector.vue
@@ -1,0 +1,66 @@
+<script>
+import RuleSelector from '@/components/form/RuleSelector';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  components: { RuleSelector },
+
+  props: {
+    value: {
+      type:    Array,
+      default: null
+    },
+    mode: {
+      type:    String,
+      default: _VIEW
+    }
+  },
+
+  data() {
+    return {
+      operatorOptions: [
+
+        {
+          label: 'is set',
+          value: 'Exists',
+        },
+        {
+          label: 'is not set',
+          value: 'DoesNotExist',
+        },
+        {
+          label: 'in list',
+          value: 'In',
+        },
+        {
+          label: 'not in list',
+          value: 'NotIn',
+        },
+      ]
+    };
+  },
+
+  computed: {
+    localValue: {
+      get() {
+        return this.value;
+      },
+      set(localValue) {
+        this.$emit('input', localValue);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <RuleSelector
+    v-model="localValue"
+    :operator-options="operatorOptions"
+    key-header="Namespace key"
+    operator-header="Namespace operator"
+    value-header="Namespace value"
+    add-label="Add Namespace"
+    :mode="mode"
+  />
+</template>

--- a/components/form/RuleSelector.vue
+++ b/components/form/RuleSelector.vue
@@ -1,0 +1,123 @@
+<script>
+import { _VIEW } from '@/config/query-params';
+import ArrayList from '@/components/form/ArrayList';
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+
+export default {
+  components: {
+    ArrayList,
+    LabeledInput,
+    LabeledSelect
+  },
+
+  props: {
+    value: {
+      type:    Array,
+      default: null
+    },
+    mode: {
+      type:    String,
+      default: _VIEW
+    },
+    operatorOptions: {
+      type:    Array,
+      default: null
+    },
+    keyHeader: {
+      type:     String,
+      required: true
+    },
+    operatorHeader: {
+      type:     String,
+      required: true
+    },
+    valueHeader: {
+      type:     String,
+      required: true
+    },
+    addLabel: {
+      type:     String,
+      required: true
+    }
+  },
+
+  computed: {
+    localValue: {
+      get() {
+        return this.value;
+      },
+      set(localValue) {
+        this.$emit('input', localValue);
+      }
+    },
+    defaultAddValue() {
+      return {
+        key:      '',
+        operator: this.operatorOptions[0].value,
+        values:    []
+      };
+    }
+  },
+
+  methods: {}
+};
+</script>
+
+<template>
+  <div class="rule-selector">
+    <ArrayList
+      v-model="localValue"
+      :protip="false"
+      :show-header="true"
+      :add-label="addLabel"
+      :default-add-value="defaultAddValue"
+      :mode="mode"
+    >
+      <template slot="thead-columns">
+        <th>{{ keyHeader }}</th>
+        <th>{{ operatorHeader }}</th>
+        <th>{{ valueHeader }}</th>
+      </template>
+      <template slot="tbody-columns" scope="scope">
+        <td>
+          <LabeledInput v-model="scope.row.value.key" :mode="mode" @input="scope.queueUpdate" />
+        </td>
+        <td>
+          <LabeledSelect
+            style="height: 100%;"
+            :mode="mode"
+            :value="scope.row.value.operator"
+            :options="operatorOptions"
+            @input="scope.row.value.operator = $event; scope.queueUpdate()"
+          />
+        </td>
+        <td>
+          <LabeledInput :value="scope.row.value.values.join(',')" :mode="mode" @input="scope.row.value.values = $event.split(','); scope.queueUpdate()" />
+        </td>
+      </template>
+    </ArrayList>
+  </div>
+</template>
+
+<style lang="scss">
+.rule-selector .fixed {
+  input {
+    height: initial;
+  }
+
+  .vs--open {
+    .vs__dropdown-toggle {
+      padding: 18px 0;
+    }
+
+    .labeled-input {
+      display: none;
+    }
+  }
+
+  .vs__dropdown-toggle {
+    padding: 3px 0;
+  }
+}
+</style>

--- a/components/formatter/LinkDetail.vue
+++ b/components/formatter/LinkDetail.vue
@@ -4,7 +4,7 @@ export default {
   props: {
     value: {
       type:     String,
-      required: true
+      default: ''
     },
     row: {
       type:     Object,

--- a/components/formatter/LinkNode.vue
+++ b/components/formatter/LinkNode.vue
@@ -1,5 +1,5 @@
 <script>
-import { NODE } from '../../config/types';
+import { NODE } from '@/config/types';
 
 export default {
   props: {

--- a/config/type-config.js
+++ b/config/type-config.js
@@ -4,6 +4,7 @@ import {
   weightGroup,
   mapGroup,
   mapType,
+  mapTypeToComponentName,
   headers,
   virtualType,
 } from '@/utils/customized';
@@ -78,6 +79,9 @@ export default function() {
   mapGroup(/^(.*\.)?cattle.io$/, 'Rancher');
   mapGroup(/^(.*\.)?istio.io$/, 'Istio');
   mapGroup(/^(.*\.)?knative.io$/, 'Knative');
+  mapGroup(/^(.*\.)?constraints.gatekeeper.sh.*$/, 'Gatekeeper Constraints');
+  mapGroup(/^(.*\.)?templates.gatekeeper.sh.*$/, 'Gatekeeper Constraint Templates');
+  mapTypeToComponentName(/^constraints.gatekeeper.sh.*$/, 'gatekeeper-constraint');
 
   mapGroup(/^(.*)\.k8s.io$/, (group, match) => {
     return match[1].split(/\./).map(x => ucFirst(x)).join('.');

--- a/detail/gatekeeper-constraint.vue
+++ b/detail/gatekeeper-constraint.vue
@@ -1,0 +1,3 @@
+<script>
+export { default } from '@/shared/gatekeeper-constraint';
+</script>

--- a/edit/gatekeeper-constraint.vue
+++ b/edit/gatekeeper-constraint.vue
@@ -1,0 +1,3 @@
+<script>
+export { default } from '@/shared/gatekeeper-constraint';
+</script>

--- a/edit/workload/Job.vue
+++ b/edit/workload/Job.vue
@@ -1,5 +1,5 @@
 <script>
-import { WORKLOAD } from '../../config/types';
+import { WORKLOAD } from '@/config/types';
 import UnitInput from '@/components/form/UnitInput';
 import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';

--- a/edit/workload/ValueFromResource.vue
+++ b/edit/workload/ValueFromResource.vue
@@ -1,6 +1,6 @@
 <script>
-import { CONFIG_MAP, SECRET } from '../../config/types';
-import { get } from '../../utils/object';
+import { CONFIG_MAP, SECRET } from '@/config/types';
+import { get } from '@/utils/object';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import LabeledInput from '@/components/form/LabeledInput';
 

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -1,5 +1,5 @@
 <script>
-import { get, clone } from '../../utils/object';
+import { clone } from '@/utils/object';
 import { CONFIG_MAP, SECRET, WORKLOAD, NODE } from '@/config/types';
 import LoadDeps from '@/mixins/load-deps';
 import Tab from '@/components/Tabbed/Tab';
@@ -298,7 +298,7 @@ export default {
       <Tab label="Labels" name="labelsAndAnnotations">
         <Labels :spec="{metadata}" :mode="mode" />
       </Tab>
-</Tabbed>
+    </Tabbed>
     <Footer :errors="errors" :mode="mode" @save="saveWorkload" @done="done" />
   </form>
 </template>

--- a/shared/gatekeeper-constraint.vue
+++ b/shared/gatekeeper-constraint.vue
@@ -1,0 +1,112 @@
+<script>
+import LabelSelector from '@/components/form/LabelSelector';
+import MatchKinds from '@/components/form/MatchKinds';
+import NamespaceSelector from '@/components/form/NamespaceSelector';
+import NameNsDescription from '@/components/form/NameNsDescription';
+import CreateEditView from '@/mixins/create-edit-view';
+import KeyValue from '@/components/form/KeyValue';
+import NamespaceList from '@/components/form/NamespaceList';
+import Tab from '@/components/Tabbed/Tab';
+import Tabbed from '@/components/Tabbed';
+import Footer from '@/components/form/Footer';
+
+export default {
+  components: {
+    Footer,
+    KeyValue,
+    LabelSelector,
+    MatchKinds,
+    NameNsDescription,
+    NamespaceList,
+    NamespaceSelector,
+    Tab,
+    Tabbed
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    value: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  data() {
+    return { localValue: this.value };
+  },
+
+  created() {
+    const value = this.value;
+
+    value.spec = value.spec || {};
+    value.spec.parameters = value.spec.parameters || {};
+    value.spec.match = value.spec.match || {};
+    value.spec.match.kinds = value.spec.match.kinds || [];
+    value.spec.match.namespaces = value.spec.match.namespaces || [];
+    value.spec.match.excludedNamespaces = value.spec.match.excludedNamespaces || [];
+    value.spec.match.labelSelector = value.spec.match.labelSelector || {};
+    value.spec.match.labelSelector.matchExpressions = value.spec.match.labelSelector.matchExpressions || [];
+    value.spec.match.namespaceSelector = value.spec.match.namespaceSelector || {};
+    value.spec.match.namespaceSelector.matchExpressions = value.spec.match.namespaceSelector.matchExpressions || [];
+
+    this.$emit('input', value);
+  }
+};
+</script>
+<template>
+  <div>
+    <div>
+      <NameNsDescription :value="value" :mode="mode" :namespaced="false" />
+    </div>
+    <br />
+    <div>
+      <h2>Parameters</h2>
+      <KeyValue
+        v-model="localValue.spec.parameters"
+        :value-multiline="false"
+        :mode="mode"
+        :pad-left="false"
+        :read-allowed="false"
+        :as-map="true"
+        add-label="Add Parameter"
+        :protip="false"
+      />
+    </div>
+    <br />
+    <br />
+    <div class="match">
+      <h2>Match</h2>
+      <Tabbed default-tab="labels">
+        <Tab name="namespaces" label="Namespaces">
+          <div class="row">
+            <div class="col span-6">
+              <h4>Namespaces</h4>
+              <NamespaceList v-model="localValue.spec.match.namespaces" :mode="mode" />
+            </div>
+            <div class="col span-6">
+              <h4>Excluded Namespaces</h4>
+              <NamespaceList v-model="localValue.spec.match.excludedNamespaces" :mode="mode" />
+            </div>
+          </div>
+        </Tab>
+        <Tab name="selectors" label="Selectors">
+          <div class="row">
+            <div class="col span-6">
+              <h4>Label Selector</h4>
+              <LabelSelector v-model="localValue.spec.match.labelSelector.matchExpressions" :mode="mode" />
+            </div>
+            <div class="col span-6">
+              <h4>Namespace Selector</h4>
+              <NamespaceSelector v-model="localValue.spec.match.namespaceSelector.matchExpressions" :mode="mode" />
+            </div>
+          </div>
+        </Tab>
+        <Tab name="kinds" label="Kinds">
+          <MatchKinds v-model="localValue.spec.match.kinds" :mode="mode" />
+        </Tab>
+      </Tabbed>
+    </div>
+    <Footer :mode="mode" :errors="errors" @save="save" @done="done" />
+  </div>
+</template>


### PR DESCRIPTION
This implementst the view, create and edit pages for the
gatekeeper constraints. The constraint templates weren't
touched since we intend to only use the yaml editor.

rancher/dashboard#307
![Screen Shot 2020-03-02 at 12 17 23 PM](https://user-images.githubusercontent.com/55104481/75711550-d5766a00-5c83-11ea-9541-83a6f4e82fac.png)
![Screen Shot 2020-03-02 at 12 17 37 PM](https://user-images.githubusercontent.com/55104481/75711546-d4ddd380-5c83-11ea-899a-01b7e052eb07.png)
![Screen Shot 2020-03-02 at 12 17 31 PM](https://user-images.githubusercontent.com/55104481/75711548-d4ddd380-5c83-11ea-9910-2137d4ec2bf0.png)
![Screen Shot 2020-03-02 at 12 45 57 PM](https://user-images.githubusercontent.com/55104481/75711544-d3aca680-5c83-11ea-8bdb-a90ce6838241.png)
![Screen Shot 2020-03-02 at 12 46 07 PM](https://user-images.githubusercontent.com/55104481/75711541-d3141000-5c83-11ea-9386-7081d2214cd1.png)
![Screen Shot 2020-03-02 at 12 46 03 PM](https://user-images.githubusercontent.com/55104481/75711542-d3aca680-5c83-11ea-8ef0-1e9e5942798b.png)


