### PR TITLE
Fix padding for labeled input with type number

### DIFF
--- a/assets/styles/global/_form.scss
+++ b/assets/styles/global/_form.scss
@@ -28,6 +28,15 @@ TEXTAREA,
     &:hover {
       background: var(--input-hover-bg);
     }
+
+    input[type='number'] {
+      padding: 5px 5px 0 0;
+      line-height: 1.15rem;
+      &:hover {
+        padding: 5px 5px 0 0;
+        line-height: 1.15rem;
+      }
+    }
   }
 
   &.view {
@@ -156,7 +165,7 @@ INPUT.inline-input {
 
 // Styling Checkbox Starts
 /*
-.checkbox, 
+.checkbox,
 .radio {
     position: relative;
     margin: auto;
@@ -165,7 +174,7 @@ INPUT.inline-input {
     clear: both;
     display: inline-block;
     width: 100%;
-  
+
   > * {
     float: left;
   }
@@ -234,7 +243,7 @@ INPUT.inline-input {
 }
 
 
-// Style for Radio 
+// Style for Radio
 .radio .checkbox-custom.circular {
     border-radius: 50%;
     border: 1.5px solid #FFFFFF;

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -80,7 +80,7 @@ export default {
       {{ label }}
       <span v-if="required && !value" class="required">*</span>
     </label>
-    <label class="corner">
+    <label v-if="!!(this.$slots.corner || [])[0]" class="corner">
       <slot name="corner" />
     </label>
     <slot name="prefix" />
@@ -94,7 +94,7 @@ export default {
         <span v-if="required && !value" class="required">*</span>
       </label>
     </slot>
-    <label class="corner">
+    <label v-if="!!(this.$slots.corner || [])[0]" class="corner">
       <slot name="corner" />
     </label>
     <slot name="prefix" />


### PR DESCRIPTION
Fixes the issue where the number inputs are larger on workload pages.


rancher/dashboard#321