### PR TITLE
OPA Bugs

### DIFF
--- a/components/GatekeeperConfig.vue
+++ b/components/GatekeeperConfig.vue
@@ -165,8 +165,7 @@ export default {
       try {
         await this.ensureNamespace();
         await this.config.save();
-        // TODO something here causes my entire cluster to die
-        // await this.config.waitForCondition('Installed');
+        await this.config.waitForCondition('Installed');
         this.gatekeeperEnabled = true;
         this.showYamlEditor = false;
         buttonCb(true);

--- a/components/GatekeeperConfig.vue
+++ b/components/GatekeeperConfig.vue
@@ -185,14 +185,17 @@ export default {
      */
     async enable(buttonCb) {
       try {
+        this.saving = true;
         await this.ensureNamespace();
         await this.config.save();
         await this.config.waitForCondition('Deployed');
         this.gatekeeperEnabled = true;
         this.showYamlEditor = false;
+        this.saving = false;
         buttonCb(true);
       } catch (err) {
         this.gatekeeperEnabled = false;
+        this.saving = false;
         if (err?.message) {
           this.errors = [err.message];
         } else {
@@ -403,6 +406,7 @@ export default {
           <button
             type="button"
             class="btn bg-primary"
+            :class="{ disabled: saving }"
             :disable="saving"
             @click="openYamlEditor"
           >

--- a/pages/c/_cluster/gatekeeper/index.vue
+++ b/pages/c/_cluster/gatekeeper/index.vue
@@ -159,7 +159,7 @@ export default {
         :namespaces="namespaces"
         :projects="projects"
       />
-      <InfoBox>
+      <InfoBox v-if="!gateKeeperUnavailable && gatekeeper.id">
         <div class="mb-15">
           <h2>OPA Gatekeeper Violations</h2>
         </div>

--- a/pages/c/_cluster/gatekeeper/index.vue
+++ b/pages/c/_cluster/gatekeeper/index.vue
@@ -55,6 +55,7 @@ export default {
       if (!template?.id ) {
         return {
           gateKeeperUnavailable: true,
+          gatekeeperEnabled:     false,
           mode,
         };
       }
@@ -72,6 +73,7 @@ export default {
       if ( !targetSystemProject ) {
         return {
           gateKeeperUnAvailable: true,
+          gatekeeperEnabled:     false,
           mode,
         };
       }
@@ -109,6 +111,7 @@ export default {
       await store.dispatch('type-map/addRecent', 'workload');
 
       return {
+        gatekeeperEnabled: !!gatekeeper?.id,
         gatekeeper,
         mode,
         namespaces,
@@ -119,6 +122,7 @@ export default {
 
       return {
         gateKeeperUnavailable: true,
+        gatekeeperEnabled:     false,
         mode,
       };
     }
@@ -158,8 +162,9 @@ export default {
         :mode="mode"
         :namespaces="namespaces"
         :projects="projects"
+        @gatekeeperEnabled="status => gatekeeperEnabled = status"
       />
-      <InfoBox v-if="!gateKeeperUnavailable && gatekeeper.id">
+      <InfoBox v-if="gatekeeperEnabled">
         <div class="mb-15">
           <h2>OPA Gatekeeper Violations</h2>
         </div>

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -213,7 +213,7 @@ export default {
 
   waitForTestFn() {
     return (fn, msg, timeoutMs, intervalMs) => {
-      console.log('Wait for', msg);
+      console.log(msg);
 
       if ( !timeoutMs ) {
         timeoutMs = DEFAULT_WAIT_TMIMEOUT;
@@ -296,10 +296,10 @@ export default {
   },
 
   waitForCondition() {
-    return (name, withStatus = 'True') => {
+    return (name, withStatus = 'True', timeoutMs = DEFAULT_WAIT_TMIMEOUT, intervalMs = DEFAULT_WAIT_INTERVAL) => {
       return this.waitForTestFn(() => {
-        return this.hasCondition(name, status);
-      }, `Wait for condition ${ name }=${ status }`);
+        return this.hasCondition(name, withStatus);
+      }, `Wait for condition ${ name }=${ withStatus }`, timeoutMs, intervalMs);
     };
   },
 


### PR DESCRIPTION
Only show Gatekeeper Violations component if Gatekeeper is enabled.
Fix minor console issue in wiatForCondition
Add waitForCondition('Deployed') to gatekeeper app to ensure we don't show the non-config parts of the app before it is deployed
Allow gatekeeper config component to send the enabled flag back up to the route so watchers are only in the config. 


rancher/dashboard#366
rancher/dashboard#376