### PR TITLE
Ensure typeconfigs are applied before type-map getters are used

### DIFF
--- a/config/type-config.js
+++ b/config/type-config.js
@@ -17,7 +17,13 @@ import {
 
 import { DSL } from '@/store/type-map';
 
+let called = false;
+
 export default function(store) {
+  if (called) {
+    return;
+  }
+  called = true;
   const {
     basicType,
     ignoreType,
@@ -38,7 +44,7 @@ export default function(store) {
     WORKLOAD,
   ]);
 
-  mapTypeToComponentName('constraints.gatekeeper.sh.k8sallowedrepos', 'gatekeeper-constraint');
+  mapTypeToComponentName(/^constraints.gatekeeper.sh.*$/, 'gatekeeper-constraint');
 
   ignoreType('events.k8s.io.event'); // Events type moved into core
   ignoreType('extensions.ingress'); // Moved into networking

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,7 +4,6 @@ import { mapState } from 'vuex';
 import {
   mapPref, DEV, THEME, EXPANDED_GROUPS, RECENT_TYPES, FAVORITE_TYPES
 } from '@/store/prefs';
-import applyTypeConfigs from '@/config/type-config';
 import ActionMenu from '@/components/ActionMenu';
 import Jump from '@/components/nav/Jump';
 import NamespaceFilter from '@/components/nav/NamespaceFilter';
@@ -128,7 +127,6 @@ export default {
 
   created() {
     this.queueUpdate = debounce(this.getGroups, 500);
-    applyTypeConfigs(this.$store);
     this.getGroups();
   },
 

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -3,6 +3,7 @@ import { findBy } from '@/utils/array';
 import { SETUP } from '@/config/query-params';
 import { get } from '@/utils/object';
 import { ClusterNotFoundError } from '@/utils/error';
+import applyTypeConfigs from '@/config/type-config';
 
 export default async function({
   route, app, store, redirect, req, isDev
@@ -55,6 +56,8 @@ export default async function({
 
   // Load stuff
   const clusterId = get(route, 'params.cluster');
+
+  applyTypeConfigs(store);
 
   try {
     await Promise.all([

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -769,6 +769,8 @@ export const mutations = {
   },
 
   mapTypeToComponentName(state, { match, replace }) {
+    match = ensureRegex(match);
+    match = regexToString(match);
     state.typeToComponentMappings.push({ match, replace });
   },
 


### PR DESCRIPTION
This ensures that the type configuration is available before resourceDetail looks up custom edits or details.