### PR TITLE
Removing namespaces from match when empty

### DIFF
--- a/shared/gatekeeper-constraint.vue
+++ b/shared/gatekeeper-constraint.vue
@@ -1,4 +1,5 @@
 <script>
+import Vue from 'vue';
 import { _VIEW } from '../config/query-params';
 import { SCHEMA } from '@/config/types';
 import MatchKinds from '@/components/form/MatchKinds';
@@ -74,6 +75,8 @@ export default {
       ? [{ apiGroups: [''] }]
       : localValue.spec.match.kinds;
 
+    this.purgeNamespacesField(localValue);
+
     const extraDetailColumns = [
       {
         title:   'Template',
@@ -99,6 +102,7 @@ export default {
       handler(value) {
         // We have to set the type for the CreateEditView mixin to know what the type is when creating
         this.type = value.type;
+        this.purgeNamespacesField(this.localValue);
       },
       deep: true
     }
@@ -115,7 +119,6 @@ export default {
       value.spec.parameters = value.spec.parameters || {};
       value.spec.match = value.spec.match || {};
       value.spec.match.kinds = value.spec.match.kinds || [];
-      value.spec.match.namespaces = value.spec.match.namespaces || [];
       value.spec.match.excludedNamespaces = value.spec.match.excludedNamespaces || [];
       value.spec.match.labelSelector = value.spec.match.labelSelector || {};
       value.spec.match.labelSelector.matchExpressions = value.spec.match.labelSelector.matchExpressions || [];
@@ -132,7 +135,17 @@ export default {
         name:   'c-cluster-gatekeeper-constraints',
         params: this.$route.params
       });
-    }
+    },
+    /**
+     * There's an upstream issue which prevents gatekeeper from processing namespaces with empty lists incorrectly.
+     * We need to remove the namespaces field if it's empty.
+     * https://github.com/open-policy-agent/gatekeeper/issues/508
+     */
+    purgeNamespacesField(value) {
+      if (value?.spec?.match?.namespaces && (value.spec.match.namespaces.length === 0)) {
+        Vue.delete(value.spec.match, 'namespaces');
+      }
+    },
   }
 };
 </script>

--- a/shared/gatekeeper-constraint.vue
+++ b/shared/gatekeeper-constraint.vue
@@ -55,13 +55,13 @@ export default {
     });
 
     const localValue = Object.keys(this.value).length > 0
-      ? this.value
+      ? { ...this.value }
       : {
         type:  templateOptions[0].value,
         spec: {
           parameters: {},
           match:      {
-            kinds:              [],
+            kinds:              [{ apiGroups: [''] }],
             namespaces:         [],
             excludedNamespaces: [],
             labelSelector:      { matchExpressions: [] },
@@ -69,6 +69,10 @@ export default {
           }
         }
       };
+
+    localValue.spec.match.kinds = (localValue?.spec?.match?.kinds || []).length === 0
+      ? [{ apiGroups: [''] }]
+      : localValue.spec.match.kinds;
 
     const extraDetailColumns = [
       {


### PR DESCRIPTION
**This should be merged after https://github.com/rancher/dashboard/pull/430**

There's an upstream issue which prevents gatekeeper from processing
namespaces with empty lists incorrectly. We need to remove the
namespaces field if it's empty.
open-policy-agent/gatekeeper#508