### PR TITLE
Add paging to the constraints violation table

### DIFF
--- a/components/GatekeeperViolationsTable.vue
+++ b/components/GatekeeperViolationsTable.vue
@@ -75,6 +75,8 @@ export default {
       :search="false"
       :table-actions="false"
       :row-actions="false"
+      :paging="true"
+      :per-page-override="10"
       key-field="id"
     />
   </div>

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -159,6 +159,16 @@ export default {
     },
 
     /**
+     * Allows you to override the default preference of the number of
+     * items to display per page. This is used by ./paging.js if you're
+     * looking for a reference.
+     */
+    perPageOverride: {
+      type:    Number,
+      default: null,
+    },
+
+    /**
      * What translation key to use for displaying the '1 - 10 of 100 Things' pagination info
      */
     pagingLabel: {

--- a/components/SortableTable/paging.js
+++ b/components/SortableTable/paging.js
@@ -3,7 +3,11 @@ import { PAGE } from '@/config/query-params';
 
 export default {
   computed: {
-    perPage: mapPref(ROWS_PER_PAGE),
+    perPagePref: mapPref(ROWS_PER_PAGE),
+
+    perPage() {
+      return typeof this.perPageOverride === 'number' ? this.perPageOverride : this.perPagePref;
+    },
 
     indexFrom() {
       return Math.max(0, 1 + this.perPage * (this.page - 1));


### PR DESCRIPTION
We don't want the number of violations to flood the entire page.

rancher/dashboard#386