### PR TITLE
Ensure a lack of annotations doesn't prevent constraints from rendering

### DIFF
--- a/pages/c/_cluster/gatekeeper/constraints/index.vue
+++ b/pages/c/_cluster/gatekeeper/constraints/index.vue
@@ -42,7 +42,7 @@ export default {
     this.constraints = rawConstraints
       .flat()
       .map((constraint) => {
-        constraint.description = constraint.metadata.annotations[DESCRIPTION];
+        constraint.description = (constraint?.metadata?.annotations || {})[DESCRIPTION];
 
         return constraint;
       });


### PR DESCRIPTION
This ensures we don't attempt to access the description annotation
from the constraints page unless the annotations are present.

rancher/dashboard#383