### PR TITLE
Increasing the size of the name column of the constraint violations table

### DIFF
--- a/components/GatekeeperViolationsTable.vue
+++ b/components/GatekeeperViolationsTable.vue
@@ -29,7 +29,7 @@ export default {
           label: 'Name',
           value: 'nameDisplay',
           sort:  `nameDisplay`,
-          width: 200
+          width: 270
         },
         this.includeConstraint ? {
           name:  'Constraint',


### PR DESCRIPTION
We want to prevent wrapping on commonly sized names.

rancher/dashboard#386

<img width="1429" alt="Screen Shot 2020-03-27 at 10 48 11 AM" src="https://user-images.githubusercontent.com/55104481/77785224-1d857400-7019-11ea-9cec-aba67bd1ad13.png">
