### PR TITLE
Improving the functionality of YAML clone

### DIFF
--- a/components/ResourceDetail.vue
+++ b/components/ResourceDetail.vue
@@ -227,7 +227,6 @@ export default {
         :parent-route="doneRoute"
         :parent-params="doneParams"
         :has-edit-as-form="hasCustomEdit"
-        :done-override="doneOverride"
       />
     </template>
     <template v-else>

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -9,7 +9,8 @@ import {
   _VIEW,
   _EDIT,
   _PREVIEW,
-  EDIT_YAML
+  EDIT_YAML,
+  _CLONE
 } from '@/config/query-params';
 
 import { mapPref, DIFF } from '@/store/prefs';
@@ -118,6 +119,9 @@ export default {
     isEdit() {
       return this.mode === _EDIT;
     },
+    isClone() {
+      return this.mode === _CLONE;
+    },
     isPreview() {
       return this.mode === _PREVIEW;
     },
@@ -225,7 +229,7 @@ export default {
     },
 
     cancel() {
-      if (this.mode === _CREATE) {
+      if (this.isCreate || this.isClone) {
         return this.done();
       }
       this.mode = _VIEW;
@@ -239,7 +243,7 @@ export default {
 
     async save(buttonDone) {
       try {
-        if ( this.isCreate ) {
+        if ( this.isCreate || this.isClone ) {
           await this.schema.followLink('collection', {
             method:  'POST',
             headers: {
@@ -374,10 +378,10 @@ export default {
         <button v-if="!isView" type="button" class="btn bg-transparent" @click="cancel">
           Cancel
         </button>
-        <button v-if="isEdit" type="button" class="btn bg-transparent" @click="preview">
+        <button v-if="isEdit || isClone" type="button" class="btn bg-transparent" @click="preview">
           Preview
         </button>
-        <AsyncButton v-if="isEdit || isPreview" key="apply" mode="apply" @click="save" />
+        <AsyncButton v-if="isEdit || isClone || isPreview" key="apply" mode="apply" @click="save" />
         <AsyncButton v-if="isCreate" key="create" mode="create" @click="save" />
       </div>
     </footer>


### PR DESCRIPTION
Cloning didn't provide the create or preview buttons and when displayed attempted to update a resource instead of create a
new one.

This will add the buttons and will allow the new resource to be created.

rancher/dashboard#374