### PR TITLE
Adding a messaging to constraint template deletion

### DIFF
--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -45,6 +45,20 @@ export default {
       return (type === NAMESPACE || type === RIO.STACK) && this.toRemove.length === 1;
     },
 
+    preventDeletionMessage() {
+      const toRemoveWithWarning = this.toRemove.filter(tr => tr?.preventDeletionMessage);
+
+      if (toRemoveWithWarning.length === 0) {
+        return null;
+      }
+
+      return toRemoveWithWarning[0].preventDeletionMessage;
+    },
+
+    isDeleteDisabled() {
+      return !!this.preventDeletionMessage;
+    },
+
     ...mapState('action-menu', ['showPromptRemove', 'toRemove'])
   },
 
@@ -93,13 +107,14 @@ export default {
           </template>. <span v-if="needsConfirm">Re-enter its name below to confirm:</span>
         </div>
         <input v-if="needsConfirm" id="confirm" v-model="confirmName" type="text" />
-        <span class="text-error"> {{ error }}</span>
+        <span class="text-warning">{{ preventDeletionMessage }}</span>
+        <span class="text-error">{{ error }}</span>
       </div>
       <template slot="actions">
         <button class="btn role-secondary" @click="close">
           Cancel
         </button>
-        <button class="btn bg-error" @click="remove">
+        <button class="btn bg-error" :disabled="isDeleteDisabled" @click="remove">
           Delete
         </button>
       </template>

--- a/models/templates.gatekeeper.sh.constrainttemplate.js
+++ b/models/templates.gatekeeper.sh.constrainttemplate.js
@@ -1,0 +1,19 @@
+export default {
+  constraints() {
+    const type = `constraints.gatekeeper.sh.${ this.id }`;
+
+    if (!this.$rootGetters['cluster/haveAll'](type)) {
+      throw new Error('The constraints have not been loaded');
+    }
+
+    return this.$rootGetters['cluster/all'](type);
+  },
+
+  preventDeletionMessage() {
+    const constraints = this.constraints;
+
+    return constraints.length > 0
+      ? `There are still constaints using this template. You cannot delete this template while it's in use.`
+      : null;
+  }
+};

--- a/pages/c/_cluster/gatekeeper/templates/index.vue
+++ b/pages/c/_cluster/gatekeeper/templates/index.vue
@@ -32,9 +32,19 @@ export default {
     };
   },
 
-  async created() {
-    this.templates = await this.$store.dispatch('cluster/findAll', { type: GATEKEEPER_CONSTRAINT_TEMPLATE });
-  }
+  async asyncData({ store }) {
+    const templates = await store.dispatch('cluster/findAll', { type: GATEKEEPER_CONSTRAINT_TEMPLATE });
+    const constraints = (await Promise.all(templates.map((template) => {
+      const type = `constraints.gatekeeper.sh.${ template.id }`;
+
+      return store.dispatch('cluster/findAll', { type });
+    }))).flat();
+
+    return {
+      templates,
+      constraints,
+    };
+  },
 
 };
 </script>


### PR DESCRIPTION
We don't want the user to delete constraint templates if the templates
are being used by existing constraints. This provides a message and
disables the delete button if the user attempts to delete a template
that's currently in use.

rancher/dashboard#375