### PR TITLE
Ensure a namespace is available when cloning a resource

### DIFF
--- a/mixins/create-edit-view.js
+++ b/mixins/create-edit-view.js
@@ -90,7 +90,7 @@ export default {
         if ( this.isCreate ) {
           url = url || this.schema.linkFor('collection');
 
-          if ( this.namespaceSuffixOnCreate ) {
+          if ( this.namespaceSuffixOnCreate && this.value.metadata.namespace ) {
             url += `/${ this.value.metadata.namespace }`;
           }
 


### PR DESCRIPTION
When saving a cloned resource the request was failing because we
were appending 'undefined' to the end of the url. Specifically we
were attempting to append a namespace that didn't exist to the end
of the url. This change will ensure a namespace exists before
appending.

rancher/dashboard#398