### PR TITLE
Enabling the ability to mark types and both immutable and unCreatable

### DIFF
--- a/config/type-config.js
+++ b/config/type-config.js
@@ -33,6 +33,8 @@ export default function(store) {
     headers,
     virtualType,
     mapTypeToComponentName,
+    markTypeAsUncreatable,
+    markTypeAsImmutable
   } = DSL(store);
 
   basicType([
@@ -61,6 +63,9 @@ export default function(store) {
 
   weightGroup('Cluster', 99);
   weightGroup('Core', 98);
+
+  markTypeAsUncreatable(NODE);
+  markTypeAsImmutable(NODE);
 
   mapGroup(/^(core)?$/, 'Core', 99);
   mapGroup('apps', 'Apps', 98);

--- a/pages/c/_cluster/_resource/index.vue
+++ b/pages/c/_cluster/_resource/index.vue
@@ -57,6 +57,10 @@ export default {
 
       return this.$store.getters['type-map/pluralLabelFor'](this.schema);
     },
+
+    isCreatable() {
+      return this.$store.getters['type-map/isCreatable'](this.$route.params.resource);
+    }
   },
 
   async asyncData(ctx) {
@@ -112,7 +116,7 @@ export default {
       </h1>
       <div class="actions">
         <nuxt-link
-          v-if="schema"
+          v-if="schema && isCreatable"
           :to="{path: yamlRoute}"
           tag="button"
           type="button"
@@ -121,7 +125,7 @@ export default {
           Create from YAML
         </nuxt-link>
         <nuxt-link
-          v-if="hasEditComponent"
+          v-if="hasEditComponent && isCreatable"
           :to="{path: formRoute}"
           tag="button"
           type="button"

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -401,9 +401,10 @@ export default {
   _standardActions() {
     const links = this.links || {};
     const customEdit = this.$rootGetters['type-map/hasCustomEdit'](this.type);
-    const canCreate = (this.schema?.attributes?.verbs || []).includes('create');
-    const canUpdate = !!links.update;
+    const canCreate = (this.schema?.attributes?.verbs || []).includes('create') && this.$rootGetters['type-map/isCreatable'](this.type);
+    const canUpdate = !!links.update && this.$rootGetters['type-map/isEditable'](this.type);
     const canViewInApi = this.$rootGetters['prefs/get'](DEV);
+    const canDelete = !!links.remove && this.$rootGetters['type-map/isEditable'](this.type);
 
     const all = [
       {
@@ -451,7 +452,7 @@ export default {
         label:      'Delete',
         icon:       'icon icon-fw icon-trash',
         bulkable:   true,
-        enabled:    !!links.remove,
+        enabled:    canDelete,
         bulkAction: 'promptRemove',
       },
       { divider: true },


### PR DESCRIPTION
This is to support special types like Node where the user shouldn't be able
to create the resource through normal means.

rancher/dashboard#507