### PR TITLE
Fixing warnings

### DIFF
--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -10,8 +10,6 @@ import {
   _UNFLAG,
 } from '@/config/query-params';
 
-import { mapPref, DIFF } from '@/store/prefs';
-
 export default {
   components: {
     Footer,

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -27,6 +27,10 @@ export default {
       type:    Boolean,
       default: false
     },
+    optionKey: {
+      type:    String,
+      default: null
+    },
     optionLabel: {
       type:    String,
       default: 'label'

--- a/components/form/NameNsDescription.vue
+++ b/components/form/NameNsDescription.vue
@@ -182,7 +182,7 @@ export default {
             v-model="name"
             label="Name"
             :disabled="nameDisabled"
-            :mode="nameMode"
+            :mode="mode"
             :min-height="30"
           />
         </slot>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/eslint --ext .js,.vue .",
+    "lint": "./node_modules/.bin/eslint --max-warnings 0 --ext .js,.vue .",
     "test": "./node_modules/.bin/nyc ava --serial --verbose",
     "nuxt": "./node_modules/.bin/nuxt",
     "dev": "./node_modules/.bin/nuxt dev",


### PR DESCRIPTION
This fixes runtime and lint warnings. It also makes the linter
treat warnings as errors now so we'll stop checking in code that has
warnings.

If you want to avoid prs with warnings consider adding a
'yarn lint' or 'yarn build' to .git/hooks/pre-push.