### PR TITLE
App model specialization and OPA Gatekeeper menu items

### DIFF
--- a/models/app.js
+++ b/models/app.js
@@ -1,46 +1,9 @@
 import { addParams } from '@/utils/url';
 import { MODE, _EDIT } from '@/config/query-params';
 
-const GATEKEEPER_DEFAULT_ID = 'rancher-gatekeeper-operator';
-
 export default {
-  isGateKeeper() {
-    return this.id.includes(GATEKEEPER_DEFAULT_ID);
-  },
-  availableActions() {
-    const { isGateKeeper } = this;
-    let out = this._availableActions;
-
-    if (isGateKeeper) {
-      const toFilter = ['cloneYaml'];
-
-      out = out.filter((action) => {
-        if (!toFilter.includes(action.action)) {
-          return action;
-        }
-      });
-
-      const removeMatch = out.find(a => a.action === 'promptRemove');
-
-      if (removeMatch) {
-        removeMatch.label = 'Disable';
-      }
-    }
-
-    return out;
-  },
-
   appEditUrl() {
-    const { isGateKeeper } = this;
-    const router = this.currentRouter();
-
-    if (isGateKeeper) {
-      const url = router.resolve({ name: router.currentRoute.name }).href;
-
-      return url;
-    } else {
-      return this.detailUrl();
-    }
+    return this.detailUrl();
   },
 
   goToEdit() {

--- a/models/apps/rancher-gatekeeper-operator.js
+++ b/models/apps/rancher-gatekeeper-operator.js
@@ -1,0 +1,65 @@
+import { MODE, _CREATE } from '@/config/query-params';
+import { addParams } from '@/utils/url';
+import { GATEKEEPER_CONSTRAINT_TEMPLATE } from '@/config/types';
+
+export default {
+  availableActions() {
+    let out = this._availableActions;
+
+    const toFilter = ['cloneYaml'];
+
+    out = out.filter((action) => {
+      if (!toFilter.includes(action.action)) {
+        return action;
+      }
+    });
+
+    const removeMatch = out.find(a => a.action === 'promptRemove');
+
+    if (removeMatch) {
+      removeMatch.label = 'Disable';
+    }
+
+    return [
+      {
+        action:  'goToAddConstraint',
+        label:   'Add Constraint',
+      },
+      {
+        action:  'goToAddTemplate',
+        label:   'Add Template',
+      },
+      ...out
+    ];
+  },
+
+  appEditUrl() {
+    const router = this.currentRouter();
+
+    return router.resolve({ name: router.currentRoute.name }).href;
+  },
+
+  goToAddConstraint() {
+    return (moreQuery = {}) => {
+      const constraintUrl = this.currentRouter().resolve({ name: 'c-cluster-gatekeeper-constraints-create' }).href;
+      const url = addParams(constraintUrl, {
+        [MODE]:   _CREATE,
+        ...moreQuery
+      });
+
+      this.currentRouter().push({ path: url });
+    };
+  },
+
+  goToAddTemplate() {
+    return (moreQuery = {}) => {
+      const constraintUrl = this.currentRouter().resolve({ name: 'c-cluster-resource-create', params: { resource: GATEKEEPER_CONSTRAINT_TEMPLATE } }).href;
+      const url = addParams(constraintUrl, {
+        [MODE]:   _CREATE,
+        ...moreQuery
+      });
+
+      this.currentRouter().push({ path: url });
+    };
+  },
+};

--- a/plugins/steve/resource-proxy.js
+++ b/plugins/steve/resource-proxy.js
@@ -36,7 +36,7 @@ export function proxyFor(ctx, obj, isClone = false) {
     }
   }
 
-  const model = lookup(obj.type) || ResourceInstance;
+  const model = lookup(obj.type, obj?.metadata?.name) || ResourceInstance;
 
   const proxy = new Proxy(obj, {
     get(target, name) {


### PR DESCRIPTION
When working on adding 'Add Constraint' and 'Add Template' to the
OPA Gatekeeper page I noticed that there wasn't a good way to
create custom models for specific chart app types. To fix this I went
ahead and made it so that we can load app models from the
'models/apps' directory and merge that with the 'models/app' model.
I think this will be useful for future apps like istio.

rancher/dashboard#391