### PR TITLE
Gatekeeper Download Yaml

### DIFF
--- a/models/apps/rancher-gatekeeper-operator.js
+++ b/models/apps/rancher-gatekeeper-operator.js
@@ -5,28 +5,24 @@ import { downloadFile } from '@/utils/download';
 
 export default {
   availableActions() {
-    let out = this._availableActions;
-    const downloadAction = {
-      action:     'download',
-      label:      'Download YAML',
-      icon:       'icon icon-fw icon-download',
-      bulkable:   false,
-      enabled:    true
-    };
-
     const toFilter = ['cloneYaml'];
+    let out = this._availableActions;
+    const downloadAction = out.find(a => a?.action === 'download');
+    const removeMatch = out.find(a => a.action === 'promptRemove');
+
+    if (downloadAction) {
+      downloadAction.enabled = true;
+    }
+
+    if (removeMatch) {
+      removeMatch.label = 'Disable';
+    }
 
     out = out.filter((action) => {
       if (!toFilter.includes(action.action)) {
         return action;
       }
     });
-
-    const removeMatch = out.find(a => a.action === 'promptRemove');
-
-    if (removeMatch) {
-      removeMatch.label = 'Disable';
-    }
 
     return [
       {
@@ -38,7 +34,6 @@ export default {
         label:   'Add Template',
       },
       ...out,
-      downloadAction,
     ];
   },
 

--- a/models/apps/rancher-gatekeeper-operator.js
+++ b/models/apps/rancher-gatekeeper-operator.js
@@ -1,10 +1,18 @@
 import { MODE, _CREATE } from '@/config/query-params';
 import { addParams } from '@/utils/url';
 import { GATEKEEPER_CONSTRAINT_TEMPLATE } from '@/config/types';
+import { downloadFile } from '@/utils/download';
 
 export default {
   availableActions() {
     let out = this._availableActions;
+    const downloadAction = {
+      action:     'download',
+      label:      'Download YAML',
+      icon:       'icon icon-fw icon-download',
+      bulkable:   false,
+      enabled:    true
+    };
 
     const toFilter = ['cloneYaml'];
 
@@ -29,7 +37,8 @@ export default {
         action:  'goToAddTemplate',
         label:   'Add Template',
       },
-      ...out
+      ...out,
+      downloadAction,
     ];
   },
 
@@ -61,5 +70,9 @@ export default {
 
       this.currentRouter().push({ path: url });
     };
+  },
+
+  download() {
+    downloadFile(`${ this.nameDisplay }.yaml`, this.spec.valuesYaml, 'application/yaml');
   },
 };

--- a/pages/prefs.vue
+++ b/pages/prefs.vue
@@ -120,7 +120,12 @@ export default {
     <h4 class="mb-10">
       Advanced
     </h4>
-    <label class="checkbox-container" mode="create" type="checkbox"><label class="checkbox-box"><input type="checkbox" tabindex="-1"> <span tabindex="0" aria-label="Interactive" role="checkbox" class="checkbox-custom"></span></label><span class="checkbox-label">Enable Developer Tools</span></label>
+    <label class="checkbox-container" mode="create" type="checkbox">
+      <label class="checkbox-box">
+        <input v-model="dev" type="checkbox" tabindex="-1"> <span tabindex="0" aria-label="Interactive" role="checkbox" class="checkbox-custom"></span>
+      </label>
+      <span class="checkbox-label">Enable Developer Tools</span>
+    </label>
   </div>
 </template>
 


### PR DESCRIPTION
Adds action for downloading the gatekeeper app spec as yaml.

Also fixes `viewInApi` button that was tweaked and broke in a previous commit. 