### PR TITLE
Local k8s cluster issues

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5,6 +5,7 @@ locale:
 generic:
   customize: Customize
   comingSoon: Coming Soon
+  unknown: Unknown
 
 header:
   backToRancher: "← Back to Rancher"

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -17,8 +17,11 @@ export default {
 
   kubernetesVersion() {
     const configName = this.configName;
+    const k8sVersion = this.spec[configName]
+      ? this.spec[configName]
+      : this.$rootGetters['i18n/t']('generic.unknown');
 
-    return this.spec[configName].kubernetesVersion;
+    return k8sVersion;
   },
 
   createdDisplay() {
@@ -28,7 +31,7 @@ export default {
   },
 
   displayProvider() {
-    const configName = this.configName.toLowerCase();
+    const configName = this.configName?.toLowerCase();
     const driver = this.status?.driver;
     const key = `cluster.provider.${ configName }`;
 
@@ -37,7 +40,7 @@ export default {
     } else if (driver && configName) {
       return capitalize(driver);
     } else {
-      return this.$rootGetters['i18n/t']('cluster.provider.imported');
+      return this.$rootGetters['i18n/t']('cluster.provider.importedconfig');
     }
   },
 };


### PR DESCRIPTION
Local k8s clusters do not have a key with `config` so the method to display provider would fail with an `undefined` error. Instead we should mimic the logic of classic rancher ui and display the imported provider info. Additionally we'd have a similar issue with k8s version so we should display something, in this case I've chosen `unknown`. 

rancher/dashboard#529