### PR TITLE
Gatekeeper Config Bugs

### DIFF
--- a/components/AsyncButton.vue
+++ b/components/AsyncButton.vue
@@ -1,4 +1,6 @@
 <script>
+import { _CREATE } from '@/config/query-params';
+
 const ACTION = 'action';
 const WAITING = 'waiting';
 const SUCCESS = 'success';
@@ -39,6 +41,12 @@ const LABEL = {
     action:  'Done',
     waiting: 'Saving&hellip;',
     success: 'Saved',
+    error:   'Error',
+  },
+  enable: {
+    action:  'Enable',
+    waiting: 'Enabling&hellip;',
+    success: 'Enabled',
     error:   'Error',
   }
 };
@@ -112,6 +120,14 @@ export default {
     showLabel: {
       type:    Boolean,
       default: true,
+    },
+
+    /**
+     * Use the enabled labels instead of the default create labels
+     */
+    useEnableLabel: {
+      type:    Boolean,
+      default: false
     }
   },
 
@@ -142,7 +158,15 @@ export default {
         return override;
       }
 
-      return LABEL[this.mode][this.phase];
+      let mode = null;
+
+      if (this.mode === _CREATE && this.useEnableLabel) {
+        mode = 'enable';
+      } else {
+        mode = this.mode;
+      }
+
+      return LABEL[mode] ? LABEL[mode][this.phase] : '';
     },
 
     isSpinning() {

--- a/components/AsyncButton.vue
+++ b/components/AsyncButton.vue
@@ -1,6 +1,4 @@
 <script>
-import { _CREATE } from '@/config/query-params';
-
 const ACTION = 'action';
 const WAITING = 'waiting';
 const SUCCESS = 'success';
@@ -53,6 +51,9 @@ const LABEL = {
 
 export default {
   props: {
+    /**
+     * Mode maps to key in LABEL map for phase labels of button
+     */
     mode: {
       type:    String,
       default: 'edit',
@@ -121,14 +122,6 @@ export default {
       type:    Boolean,
       default: true,
     },
-
-    /**
-     * Use the enabled labels instead of the default create labels
-     */
-    useEnableLabel: {
-      type:    Boolean,
-      default: false
-    }
   },
 
   data() {
@@ -158,15 +151,7 @@ export default {
         return override;
       }
 
-      let mode = null;
-
-      if (this.mode === _CREATE && this.useEnableLabel) {
-        mode = 'enable';
-      } else {
-        mode = this.mode;
-      }
-
-      return LABEL[mode] ? LABEL[mode][this.phase] : '';
+      return LABEL[this.mode][this.phase];
     },
 
     isSpinning() {

--- a/components/GatekeeperConfig.vue
+++ b/components/GatekeeperConfig.vue
@@ -136,7 +136,6 @@ export default {
         const meta = gatekeeper?.metadata;
 
         // this doesn't seeem right but the only way I can see to check that it was removed before the object goes away
-        // TODO - perhaps the way to solve this is to fall into this branch, then watch the namespace for delete?
         if (meta && Object.prototype.hasOwnProperty.call(meta, 'deletionTimestamp')) {
           this.gatekeeperEnabled = false;
           this.$emit('gatekeeperEnabled', this.gatekeeperEnabled);
@@ -434,6 +433,10 @@ export default {
         @onChanges="onChanges"
       />
       <Footer
+        create-action-label="Enable"
+        create-waiting-label="Enabling"
+        create-success-label="Enabled"
+        create-error-label="Error enabling"
         :mode="mode"
         @errors="errors"
         @save="enable"

--- a/components/GatekeeperConfig.vue
+++ b/components/GatekeeperConfig.vue
@@ -184,7 +184,7 @@ export default {
      *
      * @param {buttonCb} Callback to be called on success or fail
      */
-    async enable(buttonCb) {
+    async enableGatekeeper(buttonCb) {
       try {
         this.saving = true;
         await this.ensureNamespace();
@@ -411,11 +411,10 @@ export default {
             <t k="generic.customize" />
           </button>
           <AsyncButton
-            :mode="mode"
+            mode="enable"
             :disabled="showYamlEditor"
-            :use-enable-label="true"
             v-bind="$attrs"
-            @click="enable"
+            @click="enableGatekeeper"
           />
         </div>
       </div>
@@ -430,10 +429,9 @@ export default {
         @onChanges="onChanges"
       />
       <Footer
-        :mode="mode"
-        :use-enable-label-for-create="true"
+        mode="enable"
         @errors="errors"
-        @save="enable"
+        @save="enableGatekeeper"
         @done="openYamlEditor"
       />
     </section>

--- a/components/GatekeeperConfig.vue
+++ b/components/GatekeeperConfig.vue
@@ -412,11 +412,8 @@ export default {
           </button>
           <AsyncButton
             :mode="mode"
-            action-label="Enable"
-            waiting-label="Enabling"
-            success-label="Enabled"
-            error-label="Error enabling"
             :disabled="showYamlEditor"
+            :use-enable-label="true"
             v-bind="$attrs"
             @click="enable"
           />
@@ -433,11 +430,8 @@ export default {
         @onChanges="onChanges"
       />
       <Footer
-        create-action-label="Enable"
-        create-waiting-label="Enabling"
-        create-success-label="Enabled"
-        create-error-label="Error enabling"
         :mode="mode"
+        :use-enable-label-for-create="true"
         @errors="errors"
         @save="enable"
         @done="openYamlEditor"

--- a/components/form/Footer.vue
+++ b/components/form/Footer.vue
@@ -6,6 +6,10 @@ export default {
   components: { AsyncButton },
 
   props: {
+    /**
+     * Current mode of the page
+     * passed to asyncButton to determine lables of the button
+     */
     mode: {
       type:     String,
       required: true,
@@ -15,19 +19,11 @@ export default {
       type:    Array,
       default: null,
     },
-
-    /**
-     * A value to tell async button to use the enabled labels instead of the default create labels
-     */
-    useEnableLabelForCreate: {
-      type:    Boolean,
-      default: false
-    }
   },
 
   computed: {
     isCreate() {
-      return this.mode === _CREATE;
+      return this.mode === _CREATE || this.mode === 'enable'; // not a query param but still a valid create mode, enable only affects lables of buttons
     },
 
     isEdit() {
@@ -69,16 +65,8 @@ export default {
       <slot name="middle" />
       <slot name="save">
         <AsyncButton
-          v-if="isEdit"
-          key="edit"
-          mode="edit"
-          @click="save"
-        />
-        <AsyncButton
-          v-if="isCreate"
-          key="create"
-          mode="create"
-          :use-enable-label="useEnableLabelForCreate"
+          v-if="!isView"
+          :mode="mode"
           @click="save"
         />
       </slot>

--- a/components/form/Footer.vue
+++ b/components/form/Footer.vue
@@ -14,7 +14,47 @@ export default {
     errors: {
       type:    Array,
       default: null,
-    }
+    },
+
+    createActionLabel: {
+      type:    String,
+      default: null,
+    },
+
+    createWaitingLabel: {
+      type:    String,
+      default: null,
+    },
+
+    createSuccessLabel: {
+      type:    String,
+      default: null,
+    },
+
+    createErrorLabel: {
+      type:    String,
+      default: null,
+    },
+
+    editActionLabel: {
+      type:    String,
+      default: null,
+    },
+
+    editWaitingLabel: {
+      type:    String,
+      default: null,
+    },
+
+    editSuccessLabel: {
+      type:    String,
+      default: null,
+    },
+
+    editErrorLabel: {
+      type:    String,
+      default: null,
+    },
   },
 
   computed: {
@@ -60,8 +100,26 @@ export default {
       </slot>
       <slot name="middle" />
       <slot name="save">
-        <AsyncButton v-if="isEdit" key="edit" mode="edit" @click="save" />
-        <AsyncButton v-if="isCreate" key="create" mode="create" @click="save" />
+        <AsyncButton
+          v-if="isEdit"
+          key="edit"
+          mode="edit"
+          :action-label="editActionLabel"
+          :error-label="editErrorLabel"
+          :success-label="editSuccessLabel"
+          :waiting-label="editWaitingLabel"
+          @click="save"
+        />
+        <AsyncButton
+          v-if="isCreate"
+          key="create"
+          mode="create"
+          :action-label="createActionLabel"
+          :error-label="createErrorLabel"
+          :success-label="createSuccessLabel"
+          :waiting-label="createWaitingLabel"
+          @click="save"
+        />
       </slot>
       <slot name="right" />
     </div>

--- a/components/form/Footer.vue
+++ b/components/form/Footer.vue
@@ -16,45 +16,13 @@ export default {
       default: null,
     },
 
-    createActionLabel: {
-      type:    String,
-      default: null,
-    },
-
-    createWaitingLabel: {
-      type:    String,
-      default: null,
-    },
-
-    createSuccessLabel: {
-      type:    String,
-      default: null,
-    },
-
-    createErrorLabel: {
-      type:    String,
-      default: null,
-    },
-
-    editActionLabel: {
-      type:    String,
-      default: null,
-    },
-
-    editWaitingLabel: {
-      type:    String,
-      default: null,
-    },
-
-    editSuccessLabel: {
-      type:    String,
-      default: null,
-    },
-
-    editErrorLabel: {
-      type:    String,
-      default: null,
-    },
+    /**
+     * A value to tell async button to use the enabled labels instead of the default create labels
+     */
+    useEnableLabelForCreate: {
+      type:    Boolean,
+      default: false
+    }
   },
 
   computed: {
@@ -104,20 +72,13 @@ export default {
           v-if="isEdit"
           key="edit"
           mode="edit"
-          :action-label="editActionLabel"
-          :error-label="editErrorLabel"
-          :success-label="editSuccessLabel"
-          :waiting-label="editWaitingLabel"
           @click="save"
         />
         <AsyncButton
           v-if="isCreate"
           key="create"
           mode="create"
-          :action-label="createActionLabel"
-          :error-label="createErrorLabel"
-          :success-label="createSuccessLabel"
-          :waiting-label="createWaitingLabel"
+          :use-enable-label="useEnableLabelForCreate"
           @click="save"
         />
       </slot>

--- a/components/form/Footer.vue
+++ b/components/form/Footer.vue
@@ -1,5 +1,5 @@
 <script>
-import { _CREATE, _EDIT, _VIEW } from '@/config/query-params';
+import { _VIEW } from '@/config/query-params';
 import AsyncButton from '@/components/AsyncButton';
 
 export default {
@@ -22,14 +22,6 @@ export default {
   },
 
   computed: {
-    isCreate() {
-      return this.mode === _CREATE || this.mode === 'enable'; // not a query param but still a valid create mode, enable only affects lables of buttons
-    },
-
-    isEdit() {
-      return this.mode === _EDIT;
-    },
-
     isView() {
       return this.mode === _VIEW;
     },


### PR DESCRIPTION
When enabling gatekeeper I used to watch the state but that doesn't seem to be present any longer or it never was. The way that the config observer was working hid the state watcher failure. Rather than watch the state I've refactored to watch the condition `Deployed`. I've also refactored the config observer so that it won't mask the failure of wait for condition if takes too long but it also wont disguise the app never deploying scenario. 

Additionally I exposed the async button label params in the form/footer component so when we're in the customize view it doesn't say create but enable like it does when just configuring it. 


rancher/dashboard#371