### PR TITLE
labels and annotations consistent on every create/detail page

### DIFF
--- a/components/form/ResourceTabs.vue
+++ b/components/form/ResourceTabs.vue
@@ -1,0 +1,65 @@
+<script>
+/*
+    Tab component for resource CRU pages featuring:
+    Labels and Annotation tabs with content filtered by create-edit-view mixin
+    Slots for more tabs, 'before' and 'after' labels and annotations
+*/
+import Tabbed from '@/components/Tabbed';
+import Tab from '@/components/Tabbed/Tab';
+import CreateEditView from '@/mixins/create-edit-view';
+import KeyValue from '@/components/form/KeyValue';
+
+export default {
+  components: {
+    Tabbed,
+    Tab,
+    KeyValue
+  },
+
+  mixins:     [CreateEditView],
+
+  props: {
+    // resource instance
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+    // create-edit-view mode
+    mode: {
+      type:    String,
+      default: 'create'
+    }
+  }
+};
+</script>
+
+<template>
+  <Tabbed v-bind="$attrs">
+    <slot name="before" />
+    <Tab name="Labels" label="Labels">
+      <KeyValue
+        key="labels"
+        v-model="labels"
+        :mode="mode"
+        :initial-empty-row="true"
+        :pad-left="false"
+        :read-allowed="false"
+        :protip="false"
+      />
+    </Tab>
+    <Tab name="annotations" label="Annotations">
+      <KeyValue
+        key="annotations"
+        v-model="annotations"
+        :mode="mode"
+        :initial-empty-row="true"
+        :pad-left="false"
+        :read-allowed="false"
+        :protip="false"
+      />
+    </Tab>
+    <slot name="after" />
+  </Tabbed>
+</template>

--- a/detail/namespace.vue
+++ b/detail/namespace.vue
@@ -4,11 +4,12 @@ import { get } from '@/utils/object';
 import createEditView from '@/mixins/create-edit-view';
 import ResourceQuota from '@/edit/namespace/ResourceQuota';
 import { DESCRIPTION } from '@/config/labels-annotations';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 export default {
   name: 'DetailNamespace',
 
-  components: { ResourceQuota },
+  components: { ResourceQuota, ResourceTabs },
 
   mixins:     [createEditView],
 
@@ -98,29 +99,6 @@ export default {
     </ResourceQuota>
     <div class="spacer"></div>
 
-    <Tabbed default-tab="labels">
-      <Tab name="labels" label="Labels">
-        <KeyValue
-          key="labels"
-          v-model="labels"
-          :mode="mode"
-          title="Labels"
-          :initial-empty-row="true"
-          :pad-left="false"
-          :read-allowed="false"
-        />
-      </Tab>
-      <Tab name="annotations" label="Annotations">
-        <KeyValue
-          key="annotations"
-          v-model="annotations"
-          :mode="mode"
-          title="Annotations"
-          :initial-empty-row="true"
-          :pad-left="false"
-          :read-allowed="false"
-        />
-      </Tab>
-    </Tabbed>
+    <ResourceTabs v-model="value" />
   </div>
 </template>

--- a/detail/pod.vue
+++ b/detail/pod.vue
@@ -3,16 +3,12 @@ import { get } from '../utils/object';
 import { VALUE } from '../config/table-headers';
 import createEditView from '@/mixins/create-edit-view';
 import DetailTop from '@/components/DetailTop';
-import Tabbed from '@/components/Tabbed';
-import Tab from '@/components/Tabbed/Tab';
-import SortableTable from '@/components/SortableTable';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 export default {
   components: {
     DetailTop,
-    Tabbed,
-    Tab,
-    SortableTable
+    ResourceTabs
   },
   mixins:     [createEditView],
   computed:   {
@@ -94,13 +90,6 @@ export default {
       </template>
     </DetailTop>
 
-    <Tabbed default-tab="labels">
-      <Tab label="Labels" name="labels">
-        <SortableTable :rows="labels" :headers="KVHeaders" key-field="value" :search="false" :table-actions="false" />
-      </Tab>
-      <Tab label="Annotations" name="annotations">
-        <SortableTable :rows="annotations" :headers="KVHeaders" key-field="value" :search="false" :table-actions="false" />
-      </Tab>
-    </Tabbed>
+    <ResourceTabs v-model="value" />
   </div>
 </template>

--- a/detail/rbac.authorization.k8s.io.clusterrole.vue
+++ b/detail/rbac.authorization.k8s.io.clusterrole.vue
@@ -4,6 +4,7 @@ import DetailTop from '@/components/DetailTop';
 import VStack from '@/components/Layout/Stack/VStack';
 import TableRbacRules from '@/components/TableRbacRules';
 import { DESCRIPTION } from '@/config/labels-annotations';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 /**
  * Detail view for RBAC Cluster Role
@@ -16,6 +17,7 @@ export default {
     DetailTop,
     TableRbacRules,
     VStack,
+    ResourceTabs
   },
 
   mixins:     [createEditView],
@@ -111,5 +113,6 @@ t>
     <div class="row mt-50">
       <TableRbacRules :role="value" />
     </div>
+    <ResourceTabs v-model="value" />
   </VStack>
 </template>

--- a/detail/rbac.authorization.k8s.io.role.vue
+++ b/detail/rbac.authorization.k8s.io.role.vue
@@ -4,6 +4,7 @@ import DetailTop from '@/components/DetailTop';
 import VStack from '@/components/Layout/Stack/VStack';
 import TableRbacRules from '@/components/TableRbacRules';
 import { DESCRIPTION } from '@/config/labels-annotations';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 /**
  * Detail view for RBAC Role
@@ -16,6 +17,7 @@ export default {
     DetailTop,
     TableRbacRules,
     VStack,
+    ResourceTabs
   },
 
   mixins:     [createEditView],
@@ -110,5 +112,6 @@ export default {
     <div class="row mt-50">
       <TableRbacRules :role="value" />
     </div>
+    <ResourceTabs v-model="value" />
   </VStack>
 </template>

--- a/detail/secret.vue
+++ b/detail/secret.vue
@@ -7,11 +7,13 @@ import SortableTable from '@/components/SortableTable';
 import { KEY, VALUE } from '@/config/table-headers';
 import { base64Decode } from '@/utils/crypto';
 import CreateEditView from '@/mixins/create-edit-view';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 export default {
   components: {
     DetailTop,
     SortableTable,
+    ResourceTabs
   },
   mixins:     [CreateEditView],
   props:      {
@@ -150,29 +152,6 @@ export default {
         />
       </div>
     </template>
-    <Tabbed default-tab="labels">
-      <Tab name="labels" label="Labels">
-        <KeyValue
-          key="labels"
-          v-model="labels"
-          :mode="mode"
-          title="Labels"
-          :initial-empty-row="true"
-          :pad-left="false"
-          :read-allowed="false"
-        />
-      </Tab>
-      <Tab name="annotations" label="Annotations">
-        <KeyValue
-          key="annotations"
-          v-model="annotations"
-          :mode="mode"
-          title="Annotations"
-          :initial-empty-row="true"
-          :pad-left="false"
-          :read-allowed="false"
-        />
-      </Tab>
-    </Tabbed>
+    <ResourceTabs v-model="value" />
   </div>
 </template>

--- a/edit/namespace/index.vue
+++ b/edit/namespace/index.vue
@@ -7,13 +7,15 @@ import Footer from '@/components/form/Footer';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import { EXTERNAL } from '@/config/types';
 import { PROJECT } from '@/config/labels-annotations';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 export default {
   components: {
     ResourceQuota,
     Footer,
     LabeledSelect,
-    NameNsDescription
+    NameNsDescription,
+    ResourceTabs
   },
 
   mixins:     [CreateEditView],
@@ -95,30 +97,8 @@ export default {
         />
       </div>
 
-      <Tabbed default-tab="labels">
-        <Tab name="labels" label="Labels">
-          <KeyValue
-            key="labels"
-            v-model="labels"
-            :mode="mode"
-            title="Labels"
-            :initial-empty-row="true"
-            :pad-left="false"
-            :read-allowed="false"
-          />
-        </Tab>
-        <Tab name="annotations" label="Annotations">
-          <KeyValue
-            key="annotations"
-            v-model="annotations"
-            :mode="mode"
-            title="Annotations"
-            :initial-empty-row="true"
-            :pad-left="false"
-            :read-allowed="false"
-          />
-        </Tab>
-      </Tabbed>
+      <ResourceTabs v-model="value" />
+
       <Footer :mode="mode" :errors="errors" @save="save" @done="done" />
     </form>
   </div>

--- a/edit/rbac.authorization.k8s.io.clusterrole.vue
+++ b/edit/rbac.authorization.k8s.io.clusterrole.vue
@@ -5,6 +5,7 @@ import NameNsDescription from '@/components/form/NameNsDescription';
 import Footer from '@/components/form/Footer';
 import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 /**
  * Edit view for RBAC Cluster Role
@@ -19,6 +20,7 @@ export default {
     NameNsDescription,
     RadioGroup,
     RbacPermissions,
+    ResourceTabs
   },
 
   mixins:     [CreateEditView],
@@ -103,6 +105,7 @@ export default {
         />
       </div>
     </section>
+    <ResourceTabs v-model="value" />
 
     <Footer :mode="mode" :errors="errors" @save="save" @done="done" />
   </form>

--- a/edit/rbac.authorization.k8s.io.role.vue
+++ b/edit/rbac.authorization.k8s.io.role.vue
@@ -4,6 +4,7 @@ import CreateEditView from '@/mixins/create-edit-view';
 import NameNsDescription from '@/components/form/NameNsDescription';
 import Footer from '@/components/form/Footer';
 import RadioGroup from '@/components/form/RadioGroup';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 /**
  * Edit view for RBAC Role
@@ -17,6 +18,7 @@ export default {
     NameNsDescription,
     RadioGroup,
     RbacPermissions,
+    ResourceTabs
   },
 
   mixins:     [CreateEditView],
@@ -105,6 +107,7 @@ export default {
         />
       </div>
     </section>
+    <ResourceTabs v-model="value" />
 
     <Footer
       :mode="mode"

--- a/edit/secret.vue
+++ b/edit/secret.vue
@@ -9,8 +9,7 @@ import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';
 import NameNsDescription from '@/components/form/NameNsDescription';
 import LabeledSelect from '@/components/form/LabeledSelect';
-import Tab from '@/components/Tabbed/Tab';
-import Tabbed from '@/components/Tabbed';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 const types = [
   { label: 'Certificate', value: TLS },
@@ -31,8 +30,7 @@ export default {
     LabeledSelect,
     RadioGroup,
     NameNsDescription,
-    Tabbed,
-    Tab,
+    ResourceTabs
   },
 
   mixins:     [CreateEditView],
@@ -230,30 +228,7 @@ export default {
       />
     </div>
 
-    <Tabbed default-tab="labels">
-      <Tab name="labels" label="Labels">
-        <KeyValue
-          key="labels"
-          v-model="labels"
-          :mode="mode"
-          title="Labels"
-          :initial-empty-row="true"
-          :pad-left="false"
-          :read-allowed="false"
-        />
-      </Tab>
-      <Tab name="annotations" label="Annotations">
-        <KeyValue
-          key="annotations"
-          v-model="annotations"
-          :mode="mode"
-          title="Annotations"
-          :initial-empty-row="true"
-          :pad-left="false"
-          :read-allowed="false"
-        />
-      </Tab>
-    </Tabbed>
+    <ResourceTabs v-model="value" />
 
     <input
       ref="uploader"

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -3,7 +3,6 @@ import cronstrue from 'cronstrue';
 import { CONFIG_MAP, SECRET, WORKLOAD_TYPES, NODE } from '@/config/types';
 import LoadDeps from '@/mixins/load-deps';
 import Tab from '@/components/Tabbed/Tab';
-import Tabbed from '@/components/Tabbed';
 import CreateEditView from '@/mixins/create-edit-view';
 import { allHash } from '@/utils/promise';
 import NameNsDescription from '@/components/form/NameNsDescription';
@@ -17,10 +16,10 @@ import Upgrading from '@/edit/workload/Upgrading';
 import Networking from '@/edit/workload/Networking';
 import Footer from '@/components/form/Footer';
 import Job from '@/edit/workload/Job';
-import Labels from '@/components/form/Labels';
 import WorkloadPorts from '@/edit/workload/WorkloadPorts';
 import { defaultAsyncData } from '@/components/ResourceDetail.vue';
 import { _EDIT } from '@/config/query-params';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 const workloadTypeOptions = [
   { value: WORKLOAD_TYPES.DEPLOYMENT, label: 'Deployment' },
@@ -45,18 +44,17 @@ export default {
     NameNsDescription,
     LabeledSelect,
     LabeledInput,
-    Tabbed,
     Tab,
     HealthCheck,
     Command,
     Security,
     Scheduling,
     Upgrading,
-    Labels,
     Networking,
     Footer,
     Job,
     WorkloadPorts,
+    ResourceTabs
   },
 
   mixins:     [CreateEditView, LoadDeps],
@@ -308,42 +306,42 @@ export default {
         <WorkloadPorts v-model="containerPorts" :mode="mode" />
       </div>
     </slot>
-    <Tabbed :default-tab="isJob ? 'job' : 'command'">
-      <Tab v-if="isJob" label="Job Configuration" name="job">
-        <Job v-model="spec" :mode="mode" :type="type" />
-      </Tab>
-      <Tab label="Command" name="command">
-        <Command
-          v-if="allConfigMaps"
-          v-model="container"
-          :spec="container"
-          :secrets="allSecrets"
-          :config-maps="allConfigMaps"
-          :mode="mode"
-          :namespace="value.metadata.namespace"
-        />
-      </Tab>
-      <Tab label="Networking" name="networking">
-        <Networking v-model="podTemplateSpec" :mode="mode" />
-      </Tab>
-      <Tab label="Health" name="health">
-        <HealthCheck :spec="container" :mode="mode" />
-      </Tab>
-      <Tab label="Security" name="security">
-        <Security v-model="podTemplateSpec" :mode="mode" />
-      </Tab>
 
-      <Tab label="Node Scheduling" name="scheduling">
-        <Scheduling v-model="podTemplateSpec" :mode="mode" />
-      </Tab>
-      <Tab label="Scaling/Upgrade Policy" name="upgrading">
-        <Upgrading v-model="spec" :mode="mode" />
-      </Tab>
+    <ResourceTabs v-model="value" :default-tab="isJob ? 'job' : 'command'">
+      <template #before>
+        <Tab v-if="isJob" label="Job Configuration" name="job">
+          <Job v-model="spec" :mode="mode" :type="type" />
+        </Tab>
+        <Tab label="Command" name="command">
+          <Command
+            v-if="allConfigMaps"
+            v-model="container"
+            :spec="container"
+            :secrets="allSecrets"
+            :config-maps="allConfigMaps"
+            :mode="mode"
+            :namespace="value.metadata.namespace"
+          />
+        </Tab>
+        <Tab label="Networking" name="networking">
+          <Networking v-model="podTemplateSpec" :mode="mode" />
+        </Tab>
+        <Tab label="Health" name="health">
+          <HealthCheck :spec="container" :mode="mode" />
+        </Tab>
+        <Tab label="Security" name="security">
+          <Security v-model="podTemplateSpec" :mode="mode" />
+        </Tab>
 
-      <Tab label="Labels" name="labelsAndAnnotations">
-        <Labels :spec="value" :mode="mode" />
-      </Tab>
-    </Tabbed>
+        <Tab label="Node Scheduling" name="scheduling">
+          <Scheduling v-model="podTemplateSpec" :mode="mode" />
+        </Tab>
+        <Tab label="Scaling/Upgrade Policy" name="upgrading">
+          <Upgrading v-model="spec" :mode="mode" />
+        </Tab>
+      </template>
+    </ResourceTabs>
+
     <Footer v-if="mode!= 'view'" :errors="errors" :mode="mode" @save="saveWorkload" @done="done" />
   </form>
 </template>

--- a/shared/gatekeeper-constraint.vue
+++ b/shared/gatekeeper-constraint.vue
@@ -19,6 +19,7 @@ import RuleSelector from '@/components/form/RuleSelector';
 import RadioGroup from '@/components/form/RadioGroup';
 import { ucFirst } from '@/utils/string';
 import { isSimpleKeyValue } from '@/utils/object';
+import ResourceTabs from '@/components/form/ResourceTabs';
 
 function findConstraintTypes(schemas) {
   return schemas
@@ -48,8 +49,8 @@ export default {
     RuleSelector,
     RadioGroup,
     Tab,
-    Tabbed,
-    YamlEditor
+    YamlEditor,
+    ResourceTabs
   },
 
   extends: CreateEditView,
@@ -249,43 +250,46 @@ export default {
     <br />
     <div class="match">
       <h2>Match</h2>
-      <Tabbed default-tab="labels">
-        <Tab name="namespaces" label="Namespaces">
-          <div class="row">
-            <div class="col span-6">
-              <h4>Namespaces</h4>
-              <NamespaceList v-model="value.spec.match.namespaces" :mode="mode" :namespace-filter="NAMESPACE_FILTERS.nonSystem" />
+
+      <ResourceTabs v-model="value" default-tab="labels">
+        <template #before>
+          <Tab name="namespaces" label="Namespaces">
+            <div class="row">
+              <div class="col span-6">
+                <h4>Namespaces</h4>
+                <NamespaceList v-model="value.spec.match.namespaces" :mode="mode" :namespace-filter="NAMESPACE_FILTERS.nonSystem" />
+              </div>
+              <div class="col span-6">
+                <h4>Excluded Namespaces</h4>
+                <NamespaceList v-model="value.spec.match.excludedNamespaces" :mode="mode" />
+              </div>
             </div>
-            <div class="col span-6">
-              <h4>Excluded Namespaces</h4>
-              <NamespaceList v-model="value.spec.match.excludedNamespaces" :mode="mode" />
+          </Tab>
+          <Tab name="selectors" label="Selectors">
+            <div class="row">
+              <div class="col span-6">
+                <h4>Label Selector</h4>
+                <RuleSelector
+                  v-model="value.spec.match.labelSelector.matchExpressions"
+                  add-label="Add Label"
+                  :mode="mode"
+                />
+              </div>
+              <div class="col span-6">
+                <h4>Namespace Selector</h4>
+                <RuleSelector
+                  v-model="value.spec.match.namespaceSelector.matchExpressions"
+                  add-label="Add Namespace"
+                  :mode="mode"
+                />
+              </div>
             </div>
-          </div>
-        </Tab>
-        <Tab name="selectors" label="Selectors">
-          <div class="row">
-            <div class="col span-6">
-              <h4>Label Selector</h4>
-              <RuleSelector
-                v-model="value.spec.match.labelSelector.matchExpressions"
-                add-label="Add Label"
-                :mode="mode"
-              />
-            </div>
-            <div class="col span-6">
-              <h4>Namespace Selector</h4>
-              <RuleSelector
-                v-model="value.spec.match.namespaceSelector.matchExpressions"
-                add-label="Add Namespace"
-                :mode="mode"
-              />
-            </div>
-          </div>
-        </Tab>
-        <Tab name="kinds" label="Kinds">
-          <MatchKinds v-model="value.spec.match.kinds" :mode="mode" />
-        </Tab>
-      </Tabbed>
+          </Tab>
+          <Tab name="kinds" label="Kinds">
+            <MatchKinds v-model="value.spec.match.kinds" :mode="mode" />
+          </Tab>
+        </template>
+      </ResourceTabs>
     </div>
     <Footer :mode="mode" :errors="errors" @save="save" @done="done" />
   </div>

--- a/shared/gatekeeper-constraint.vue
+++ b/shared/gatekeeper-constraint.vue
@@ -11,7 +11,6 @@ import KeyValue from '@/components/form/KeyValue';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import NamespaceList, { NAMESPACE_FILTERS } from '@/components/form/NamespaceList';
 import Tab from '@/components/Tabbed/Tab';
-import Tabbed from '@/components/Tabbed';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import Footer from '@/components/form/Footer';
 import GatekeeperViolationsTable from '@/components/GatekeeperViolationsTable';


### PR DESCRIPTION
Since every create/detail page will have labels and annotations in tabs, I've added a ResourceTabs component with those two tabs and slots for more before and after