### PR TITLE
Prevent Local Cluster Delete

### DIFF
--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -43,4 +43,8 @@ export default {
       return this.$rootGetters['i18n/t']('cluster.provider.importedconfig');
     }
   },
+
+  canDelete() {
+    return this.hasLink('remove') && !this?.spec?.internal;
+  },
 };

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -404,7 +404,6 @@ export default {
     const canCreate = (this.schema?.attributes?.verbs || []).includes('create') && this.$rootGetters['type-map/isCreatable'](this.type);
     const canUpdate = !!links.update && this.$rootGetters['type-map/isEditable'](this.type);
     const canViewInApi = this.$rootGetters['prefs/get'](DEV);
-    const canDelete = !!links.remove;
     const hasYaml = this.hasLink('rioview') || this.hasLink('view');
 
     const all = [
@@ -454,7 +453,7 @@ export default {
         label:      'Delete',
         icon:       'icon icon-fw icon-trash',
         bulkable:   true,
-        enabled:    canDelete,
+        enabled:    this.canDelete,
         bulkAction: 'promptRemove',
       },
       { divider: true },
@@ -477,6 +476,12 @@ export default {
 
       return val;
     };
+  },
+
+  // ------------------------------------------------------------------
+
+  canDelete() {
+    return this.hasLink('remove');
   },
 
   // ------------------------------------------------------------------

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -399,44 +399,37 @@ export default {
   },
 
   _standardActions() {
-    const links = this.links || {};
-    const customEdit = this.$rootGetters['type-map/hasCustomEdit'](this.type);
-    const canCreate = (this.schema?.attributes?.verbs || []).includes('create') && this.$rootGetters['type-map/isCreatable'](this.type);
-    const canUpdate = !!links.update && this.$rootGetters['type-map/isEditable'](this.type);
-    const canViewInApi = this.$rootGetters['prefs/get'](DEV);
-    const hasYaml = this.hasLink('rioview') || this.hasLink('view');
-
     const all = [
       {
         action:  'goToEdit',
         label:   'Edit as Form',
         icon:    'icon icon-fw icon-edit',
-        enabled:  canUpdate && customEdit,
+        enabled:  this.canUpdate && this.canCustomEdit,
       },
       {
         action:  'goToClone',
         label:   'Clone as Form',
         icon:    'icon icon-fw icon-copy',
-        enabled:  canCreate && customEdit,
+        enabled:  this.canCreate && this.canCustomEdit,
       },
       { divider: true },
       {
         action:  'goToEditYaml',
         label:   'Edit as YAML',
         icon:    'icon icon-file',
-        enabled: canUpdate && hasYaml,
+        enabled: this.canUpdate && this.canYaml,
       },
       {
         action:  'goToViewYaml',
         label:   'View as YAML',
         icon:    'icon icon-file',
-        enabled: !canUpdate && hasYaml
+        enabled: !this.canUpdate && this.canYaml
       },
       {
         action:  'cloneYaml',
         label:   'Clone as YAML',
         icon:    'icon icon-fw icon-copy',
-        enabled:  canCreate && hasYaml,
+        enabled:  this.canCreate && this.canYaml,
       },
       {
         action:     'download',
@@ -444,7 +437,7 @@ export default {
         icon:       'icon icon-fw icon-download',
         bulkable:   true,
         bulkAction: 'downloadBulk',
-        enabled:    hasYaml
+        enabled:    this.canYaml
       },
       { divider: true },
       {
@@ -461,7 +454,7 @@ export default {
         action:  'viewInApi',
         label:   'View in API',
         icon:    'icon icon-fw icon-external-link',
-        enabled:  canViewInApi && !!links.self,
+        enabled:  this.canViewInApi,
       }
     ];
 
@@ -482,6 +475,26 @@ export default {
 
   canDelete() {
     return this.hasLink('remove');
+  },
+
+  canUpdate() {
+    return this.hasLink('update') && this.$rootGetters['type-map/isEditable'](this.type);
+  },
+
+  canCustomEdit() {
+    return this.$rootGetters['type-map/hasCustomEdit'](this.type);
+  },
+
+  canCreate() {
+    return (this.schema?.attributes?.verbs || []).includes('create') && this.$rootGetters['type-map/isCreatable'](this.type);
+  },
+
+  canViewInApi() {
+    return this.hasLink('self') && this.$rootGetters['prefs/get'](DEV);
+  },
+
+  canYaml() {
+    return this.hasLink('rioview') || this.hasLink('view');
   },
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
Prevents the local cluster from being deleted by adding can check on the cluster model and looking for internal on the cluster spec.

Also refactored the `can*` checks into methods on the resource instance so they can be overridden in the future if need be. Also refactored the checks that were manually checking the links object to use the `hasLink` method. 


rancher/dashboard#530