### PR TITLE
Better parsing for a cluster provider info

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -23,15 +23,39 @@ nav:
 
 cluster:
   provider:
-    aliyunengineconfig: Alibaba ACK
-    amazonelasticcontainerserviceconfig: Amazon EKS
-    azurekubernetesserviceconfig: Azure AKS
-    googlekubernetesengineconfig: Google GKE
-    huaweiengineconfig: Huawei CCE
-    importedconfig: Import
-    rancherkubernetesengineconfig: Rancher RKE
-    tencentengineconfig: Tencent TKE
-    baiduengineconfig: Baidu CCE
+    amazonelasticcontainerservice:
+      label: Amazon Elastic Container Service for Kubernetes
+      shortLabel: Amazon EKS
+    tencentengine:
+      label: Tencent Kubernetes Engine
+      shortLabel: Tencent TKE
+    azurekubernetesservice:
+      label: Azure Container Service
+      shortLabel: Azure AKS
+    aliyunengine:
+      label: Aliyun Kubernetes Container Service
+      shortLabel: Alibaba ACK
+    googlekubernetesengine:
+      label: Google Kubernetes Engine
+      shortLabel: Google GKE
+    k3simport:
+      label: Rancher K3S
+      shortLabel: K3S
+    huaweiengine:
+      label: Huawei Cloud Container Engine
+      shortLabel: Huawei CCE
+    oracleokeengine:
+      label: Oracle Container Engine long
+      shortLabel: Oracle OKE
+    rancherkubernetesengine:
+      label: Rancher Kubernetes Engine
+      shortLabel: Custom
+    custom:
+      label: From existing nodes (Custom)
+      shortLabel: Custom
+    imported:
+      label: Import an existing cluster
+      shortLabel: Imported
 
 footer:
   docs: Docs

--- a/components/ClusterDisplayProvider.vue
+++ b/components/ClusterDisplayProvider.vue
@@ -1,0 +1,70 @@
+<script>
+import { capitalize } from 'lodash';
+
+export default {
+  props: {
+    /**
+     * The cluster for info
+     */
+    cluster: {
+      type:     Object,
+      required: true,
+    },
+    /**
+     * The node pools belonging to this cluster.
+     * Node pools gives us the node template id use to launch the node pool
+     */
+    nodePools: {
+      type:     Array,
+      default:  () => [],
+    },
+    /**
+     * The node templates used to launch node pools for this cluster.
+     * Node Templates give us the provider name if the cluster is RKE based.
+     */
+    nodeTemplates: {
+      type:     Array,
+      default:  () => [],
+    },
+  },
+
+  computed: {
+    displayProvider() {
+      const cluster = this.cluster;
+      const driver = cluster.status?.driver.toLowerCase();
+
+      if (driver && this.$store.getters['i18n/exists'](`cluster.provider.${ driver }.shortLabel`)) {
+        if (driver === 'rancherkubernetesengine') {
+          const pools = this.nodePools;
+          const firstNodePool = pools[0];
+
+          if (firstNodePool) {
+            const nodeTemplateId = firstNodePool?.spec?.nodeTemplateName;
+            const normalizedId = nodeTemplateId.split(':').join('/');
+            const nodeTemplate = this.nodeTemplates.find(nt => nt.id === normalizedId);
+
+            if (nodeTemplate?.spec?.driver) {
+              return capitalize( nodeTemplate.spec.driver );
+            } else {
+              // things are not good if we get here
+              return this.$store.getters['i18n/t']('cluster.provider.rancherkubernetesengine.shortLabel');
+            }
+          }
+        }
+
+        return this.$store.getters['i18n/t'](`cluster.provider.${ driver }.shortLabel`);
+      } else if (driver) {
+        return capitalize(driver);
+      } else {
+        return this.$store.getters['i18n/t']('cluster.provider.imported.shortLabel');
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <span>
+    {{ displayProvider }}
+  </span>
+</template>

--- a/components/GatekeeperConfig.vue
+++ b/components/GatekeeperConfig.vue
@@ -363,15 +363,15 @@ export default {
             <label><t k="gatekeeperConfig.infoBox.constraintViolationsLimit" />: </label>
             {{ parsedValuesYaml.constraintViolationsLimit }}
           </div>
-          <div class="info-row">
-            <label><t k="gatekeeperConfig.infoBox.replicas" />: </label>
-            {{ parsedValuesYaml.replicas }}
-          </div>
         </div>
         <div class="col span-6 info-column">
           <div class="info-row">
             <label><t k="gatekeeperConfig.infoBox.imageRepository" />: </label>
             {{ parsedValuesYaml.image.repository }}
+          </div>
+          <div class="info-row">
+            <label><t k="gatekeeperConfig.infoBox.replicas" />: </label>
+            {{ parsedValuesYaml.replicas }}
           </div>
           <div class="info-row">
             <label><t k="gatekeeperConfig.infoBox.imageTag" />: </label>

--- a/components/InfoBoxCluster.vue
+++ b/components/InfoBoxCluster.vue
@@ -2,6 +2,7 @@
 import { isEmpty } from 'lodash';
 import InfoBox from '@/components/InfoBox';
 import PercentageBar from '@/components/PercentageBar';
+import ClusterDisplayProvider from '@/components/ClusterDisplayProvider';
 import { parseSi, formatSi, exponentNeeded } from '@/utils/units';
 
 const PARSE_RULES = {
@@ -21,22 +22,46 @@ const PARSE_RULES = {
 
 export default {
   components: {
+    ClusterDisplayProvider,
     InfoBox,
     PercentageBar,
   },
 
   props: {
+    /**
+     * The cluster for info
+     */
     cluster: {
       type:     Object,
       required: true,
     },
+    /**
+     * The node metrics used for parsing CPU/MEM graphs
+     */
     metrics: {
       type:     Array,
       required: true,
     },
+    /**
+     * The nodes belonging to this cluster
+     */
     nodes: {
       type:     Array,
       required: true,
+      default:  () => [],
+    },
+    /**
+     * The node pools belonging to this cluster
+     */
+    nodePools: {
+      type:     Array,
+      default:  () => [],
+    },
+    /**
+     * The node templates used to launch node pools for this cluster.
+     */
+    nodeTemplates: {
+      type:     Array,
       default:  () => [],
     }
   },
@@ -160,7 +185,11 @@ export default {
           <t k="infoBoxCluster.provider" />:
         </label>
         <span class="info-row-data">
-          {{ cluster.displayProvider }}
+          <ClusterDisplayProvider
+            :cluster="cluster"
+            :node-templates="nodeTemplates"
+            :node-pools="nodePools"
+          />
         </span>
       </div>
       <div class="info-row">

--- a/config/types.js
+++ b/config/types.js
@@ -45,11 +45,13 @@ export const NORMAN = {
 
 // Rancher Management API via Steve, /v1
 export const MANAGEMENT = {
-  // CATALOG:          'management.cattle.io.catalog',
+  CATALOG:          'management.cattle.io.catalog',
   CATALOG_TEMPLATE: 'management.cattle.io.catalogtemplate',
   CLUSTER:          'management.cattle.io.cluster',
-  // USER:             'management.cattle.io.user',
-  PREFERENCE:       'userpreference'
+  USER:             'management.cattle.io.user',
+  PREFERENCE:       'userpreference',
+  NODE_POOL:        'management.cattle.io.nodepool',
+  NODE_TEMPLATE:    'management.cattle.io.nodetemplate',
 };
 
 // Rancher cluster-scoped things that actually live in management plane

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -30,20 +30,6 @@ export default {
     return day(this.metadata.creationTimestamp).format(`${ dateFormat }`);
   },
 
-  displayProvider() {
-    const configName = this.configName?.toLowerCase();
-    const driver = this.status?.driver;
-    const key = `cluster.provider.${ configName }`;
-
-    if ( this.$rootGetters['i18n/exists'](key) ) {
-      return this.$rootGetters['i18n/t'](key);
-    } else if (driver && configName) {
-      return capitalize(driver);
-    } else {
-      return this.$rootGetters['i18n/t']('cluster.provider.importedconfig');
-    }
-  },
-
   canDelete() {
     return this.hasLink('remove') && !this?.spec?.internal;
   },

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -1,4 +1,3 @@
-import { capitalize } from 'lodash';
 import day from 'dayjs';
 import { escapeHtml } from '@/utils/string';
 import { DATE_FORMAT } from '@/store/prefs';
@@ -16,9 +15,8 @@ export default {
   },
 
   kubernetesVersion() {
-    const configName = this.configName;
-    const k8sVersion = this.spec[configName]
-      ? this.spec[configName].kubernetesVersion
+    const k8sVersion = this?.status?.version?.gitVersion
+      ? this.status.version.gitVersion
       : this.$rootGetters['i18n/t']('generic.unknown');
 
     return k8sVersion;

--- a/pages/c/_cluster/index.vue
+++ b/pages/c/_cluster/index.vue
@@ -134,9 +134,11 @@ export default {
 
     return {
       constraints:       [],
-      nodes:             [],
       events:            [],
       nodeMetrics:       [],
+      nodePools:         [],
+      nodeTemplates:     [],
+      nodes:             [],
       pollingErrorCount: 0,
       cluster,
       gatekeeperEnabled,
@@ -145,14 +147,18 @@ export default {
 
   async created() {
     const resourcesHash = await allHash({
-      allNodes:       this.fetchClusterResources(NODE),
-      allEvents:      this.fetchClusterResources(EVENT),
-      rawConstraints: this.fetchConstraints(),
+      allNodes:         this.fetchClusterResources(NODE),
+      allEvents:        this.fetchClusterResources(EVENT),
+      rawConstraints:   this.fetchConstraints(),
+      allNodeTemplates: this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE }),
+      allNodePools:     this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL }),
     });
 
     this.constraints = resourcesHash.rawConstraints;
     this.events = resourcesHash.allEvents;
     this.nodes = resourcesHash.allNodes;
+    this.nodePools = resourcesHash.allNodePools;
+    this.nodeTemplates = resourcesHash.allNodeTemplates;
   },
 
   mounted() {
@@ -260,6 +266,8 @@ export default {
       :cluster="cluster"
       :metrics="nodeMetrics"
       :nodes="nodes"
+      :node-templates="nodeTemplates"
+      :node-pools="nodePools"
     />
     <div class="row">
       <div class="col span-6 equal-height">


### PR DESCRIPTION
I chose to make the display provider a component rather than a computed property on the model for a couple reasons.

1. Given we have to traverse 3 apis (cluster->node pools->node templates) to get the provider info for an RKE based cluster and we dont `Load All The Things ™️` or have the convenience methods of `hasMany`, `reference` etc that ember-api-store has, it makes more sense to pass the data down rather than place it on the cluster model and hope we loaded everything before we need the property. 
2. We'll need this info in the future in other places. 

rancher/dashboard#478


I also put in a fix for OPA to even out the 4vs3 items in the info

rancher/dashboard#392

Additionally this also fixes where we grab the cluster k8s version from.
https://github.com/rancher/dashboard/issues/534