### PR TITLE
Cluster Overview UI/UX Changes

### DIFF
--- a/assets/styles/base/_variables.scss
+++ b/assets/styles/base/_variables.scss
@@ -21,3 +21,14 @@ $z-indexes: (
 );
 
 $text-light: 300;
+
+
+// Usage Example:
+// @media only screen and (min-width: map-get($breakpoints, '--viewport-*')) {
+// }
+$breakpoints: (
+  '--viewport-4':  480px,
+  '--viewport-7':  768px,
+  '--viewport-9':  992px,
+  '--viewport-12': 1200px,
+);

--- a/assets/styles/fonts/_icons.scss
+++ b/assets/styles/fonts/_icons.scss
@@ -1,6 +1,4 @@
 
-@import "~assets/fonts/icons/variables.scss";
-
 $icomoon-font-path: '~assets/fonts/icons/fonts' !global;
 $icomoon-font-family: 'icons' !global;
 

--- a/assets/styles/global/_columns.scss
+++ b/assets/styles/global/_columns.scss
@@ -75,9 +75,9 @@ $GUTTER: 1.75%;
   flex-wrap: wrap;
 
   .flex-item-half {
-      flex-grow: 1;
-      display: flex;
-      width: 50%;
+    flex-grow: 1;
+    display: flex;
+    width: 50%;
   }
 }
 

--- a/assets/styles/vendor/vue-js-modal.scss
+++ b/assets/styles/vendor/vue-js-modal.scss
@@ -1,9 +1,6 @@
 @import 'node_modules/vue-js-modal/dist/styles.css';
-@import "~assets/styles/base/_variables.scss";
-@import "~assets/styles/base/_functions.scss";
-@import "~assets/styles/base/_mixins.scss";
 
 .v--modal-overlay {
-    background-color: var(--overlay-bg);
-    z-index: z-index('modalOverlay');
+  background-color: var(--overlay-bg);
+  z-index: z-index('modalOverlay');
 }

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -113,7 +113,7 @@ infoBoxCluster:
   memory: Memory
   pods: Pods
   provider: Provider
-  reserved: "{numerator} of {denominator} rsvd"
+  reserved: "{numerator} of {denominator} reserved"
   used: "{numerator} of {denominator} used"
   version: Kubernetes Version
   nodes:

--- a/components/ActionMenu.vue
+++ b/components/ActionMenu.vue
@@ -94,10 +94,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  @import "~assets/styles/base/_variables.scss";
-  @import "~assets/styles/base/_functions.scss";
-  @import "~assets/styles/base/_mixins.scss";
-
   .root {
     position: absolute;
   }

--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -12,7 +12,7 @@ export default {
 <template>
   <div class="detail-top">
     <div v-for="col in columns" :key="col.title">
-      <span>{{ col.title }}: </span>
+      <label>{{ col.title }}:</label>
       <slot :name="col.name">
         <span>{{ col.content || col.content===0 ? col.content : col.fallback || 'n/a' }}</span>
       </slot>
@@ -21,22 +21,55 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-.detail-top {
-    display: flex;
-    flex-wrap: wrap;
+  $sm-screen-grid: 1fr;
+  $md-screen-grid: 1fr 1fr;
+  $default-screen-grid: 1fr 1fr 1fr 1fr;
+
+  .detail-top {
+    display: grid;
+    grid-template-columns: $default-screen-grid;
     border-top: solid thin var(--border);
     border-bottom: solid thin var(--border);
     padding: 15px 0;
 
     & > * {
-        padding: 0 10px;
-        & >:first-child {
-            color: var(--input-placeholder);
-        }
+      display: flex;
+      align-items: center;
+      padding: 0 10px;
 
-        &:last-child {
-            padding-right: 0;
-        }
+      & > label {
+        color: var(--input-placeholder);
+        display: flex;
+        padding-right: 5px;
+      }
+
+      & > :not(label) {
+        display: flex;
+        flex: 1;
+      }
+
+      & :last-child {
+        padding-right: 0;
+      }
     }
-}
+  }
+
+  @media only screen and (min-width: map-get($breakpoints, '--viewport-4')) {
+    .detail-top {
+      grid-template-columns: $sm-screen-grid;
+    }
+  }
+
+  @media only screen and (min-width: map-get($breakpoints, '--viewport-7')) {
+    .detail-top {
+      grid-template-columns: $md-screen-grid;
+    }
+  }
+
+  @media only screen and (min-width: map-get($breakpoints, '--viewport-9')) {
+    .detail-top {
+      grid-template-columns: $default-screen-grid;
+    }
+  }
+
 </style>

--- a/components/InfoBoxCluster.vue
+++ b/components/InfoBoxCluster.vue
@@ -2,7 +2,6 @@
 import { isEmpty } from 'lodash';
 import InfoBox from '@/components/InfoBox';
 import PercentageBar from '@/components/PercentageBar';
-import ClusterDisplayProvider from '@/components/ClusterDisplayProvider';
 import { parseSi, formatSi, exponentNeeded } from '@/utils/units';
 
 const PARSE_RULES = {
@@ -22,7 +21,6 @@ const PARSE_RULES = {
 
 export default {
   components: {
-    ClusterDisplayProvider,
     InfoBox,
     PercentageBar,
   },
@@ -50,35 +48,9 @@ export default {
       required: true,
       default:  () => [],
     },
-    /**
-     * The node pools belonging to this cluster
-     */
-    nodePools: {
-      type:     Array,
-      default:  () => [],
-    },
-    /**
-     * The node templates used to launch node pools for this cluster.
-     */
-    nodeTemplates: {
-      type:     Array,
-      default:  () => [],
-    }
   },
 
   computed: {
-    nodeCounts() {
-      const nodes = this.nodes;
-      const countsOut = {
-        workerNodes:       nodes.filter(n => n.isWorker).length || 0,
-        etcdNodes:         nodes.filter(n => n.isEtcd).length || 0,
-        controlPlaneNodes: nodes.filter(n => n.isControlPlane).length || 0,
-        total:             nodes.length,
-      };
-
-      return countsOut;
-    },
-
     liveNodeUsage() {
       const clusterCapacityCpu = this.cluster?.status?.capacity?.cpu;
 
@@ -178,181 +150,76 @@ export default {
 </script>
 
 <template>
-  <InfoBox class="row">
-    <div class="col span-3 info-column">
-      <div class="info-row">
-        <label class="info-row-label">
-          <t k="infoBoxCluster.provider" />:
-        </label>
-        <span class="info-row-data">
-          <ClusterDisplayProvider
-            :cluster="cluster"
-            :node-templates="nodeTemplates"
-            :node-pools="nodePools"
-          />
-        </span>
-      </div>
-      <div class="info-row">
-        <label class="info-row-label">
-          <t k="infoBoxCluster.version" />:
-        </label>
-        <span class="info-row-data">
-          {{ cluster.kubernetesVersion }}
-        </span>
-      </div>
-      <div class="info-row">
-        <label class="info-row-label">
-          <t k="infoBoxCluster.created" />:
-        </label>
-        <span class="info-row-data">
-          <LiveDate
-            :value="cluster.metadata.creationTimestamp"
-            :add-suffix="true"
-          />
-        </span>
-      </div>
-    </div>
-    <div class="col span-3 info-column">
+  <InfoBox>
+    <div class="info-column">
       <label>
         <h5>
           <t k="infoBoxCluster.cpu" />
         </h5>
       </label>
-      <div class="container-flex-center mb-10">
-        <div class="flex-item-half">
-          <label>
-            <t
-              k="infoBoxCluster.reserved"
-              :numerator="nodeUsageReserved.requested"
-              :denominator="nodeUsageReserved.allocatable"
-            />
-          </label>
-        </div>
-        <div class="flex-item-half flex-justify-start pl-5">
-          <PercentageBar class="container-flex-center" :value="nodeUsageReserved.percentage" />
-        </div>
+      <div class="info-column-data mb-10">
+        <label>
+          <t
+            k="infoBoxCluster.reserved"
+            :numerator="nodeUsageReserved.requested"
+            :denominator="nodeUsageReserved.allocatable"
+          />
+        </label>
+        <PercentageBar :value="nodeUsageReserved.percentage" />
       </div>
-      <div class="container-flex-center mb-10">
-        <div class="flex-item-half">
-          <label>
-            <t
-              k="infoBoxCluster.used"
-              :numerator="liveNodeUsage.nodeUsage"
-              :denominator="liveNodeUsage.clusterCapacity"
-            />
-          </label>
-        </div>
-        <div class="flex-item-half flex-justify-start pl-5">
-          <PercentageBar class="container-flex-center" :value="liveNodeUsage.percentage" />
-        </div>
+      <div class="info-column-data mb-10">
+        <label>
+          <t
+            k="infoBoxCluster.used"
+            :numerator="liveNodeUsage.nodeUsage"
+            :denominator="liveNodeUsage.clusterCapacity"
+          />
+        </label>
+        <PercentageBar :value="liveNodeUsage.percentage" />
       </div>
-      <label class="mt-20">
+    </div>
+    <div class="info-column">
+      <label>
         <h5>
           <t k="infoBoxCluster.memory" />
         </h5>
       </label>
-      <div class="container-flex-center mb-10">
-        <div class="flex-item-half">
-          <label>
-            <t
-              k="infoBoxCluster.reserved"
-              :numerator="nodeUsageMemReserved.requested"
-              :denominator="nodeUsageMemReserved.allocatable"
-            />
-          </label>
-        </div>
-        <div class="flex-item-half flex-justify-start pl-5">
-          <PercentageBar class="container-flex-center" :value="nodeUsageMemReserved.percentage" />
-        </div>
+      <div class="info-column-data mb-10">
+        <label>
+          <t
+            k="infoBoxCluster.reserved"
+            :numerator="nodeUsageMemReserved.requested"
+            :denominator="nodeUsageMemReserved.allocatable"
+          />
+        </label>
+        <PercentageBar :value="nodeUsageMemReserved.percentage" />
       </div>
-      <div class="container-flex-center mb-10">
-        <div class="flex-item-half">
-          <label>
-            <t
-              k="infoBoxCluster.used"
-              :numerator="liveNodeMemUsage.nodeUsage"
-              :denominator="liveNodeMemUsage.clusterCapacity"
-            />
-          </label>
-        </div>
-        <div class="flex-item-half flex-justify-start pl-5">
-          <PercentageBar class="container-flex-center" :value="liveNodeMemUsage.percentage" />
-        </div>
+      <div class="info-column-data mb-10">
+        <label>
+          <t
+            k="infoBoxCluster.used"
+            :numerator="liveNodeMemUsage.nodeUsage"
+            :denominator="liveNodeMemUsage.clusterCapacity"
+          />
+        </label>
+        <PercentageBar :value="liveNodeMemUsage.percentage" />
       </div>
     </div>
-    <div class="col span-3 info-column">
+    <div class="info-column">
       <label>
         <h5>
           <t k="infoBoxCluster.pods" />
         </h5>
       </label>
-      <div class="container-flex-center mb-10">
-        <div class="flex-item-half">
-          <label>
-            <t
-              k="infoBoxCluster.used"
-              :numerator="nodeUsagePodReserved.nodeUsage"
-              :denominator="nodeUsagePodReserved.clusterCapacity"
-            />
-          </label>
-        </div>
-        <div class="flex-item-half flex-justify-start pl-5">
-          <PercentageBar class="container-flex-center" :value="nodeUsagePodReserved.percentage" />
-        </div>
-      </div>
-    </div>
-    <div class="col span-3 info-column">
-      <label>
-        <h5>
-          <t k="infoBoxCluster.nodes.label" />
-        </h5>
-      </label>
-      <div class="container-flex-center mb-10">
-        <div class="flex-item-half">
-          <label>
-            <t k="infoBoxCluster.nodes.total.label" />:
-          </label>
-        </div>
-        <div class="flex-item-half flex-justify-start pl-5">
-          <span>
-            {{ nodeCounts.total }}
-          </span>
-        </div>
-      </div>
-
-      <hr class="mt-40 mb-40" />
-
-      <div class="row">
-        <div class="col span-3">
-          <div class="text-center mb-10">
-            {{ nodeCounts.workerNodes }}
-          </div>
-          <div class="text-center">
-            <label>
-              <t k="infoBoxCluster.nodes.worker.label" />
-            </label>
-          </div>
-        </div>
-        <div class="col span-4 offset-1">
-          <div class="text-center mb-10">
-            {{ nodeCounts.etcdNodes }}
-          </div>
-          <div class="text-center">
-            <label>
-              <t k="infoBoxCluster.nodes.etcd.label" />
-            </label>
-          </div>
-        </div>
-        <div class="col span-5">
-          <div class="text-center mb-10">
-            {{ nodeCounts.controlPlaneNodes }}
-          </div>
-          <div class="text-center">
-            <label>
-              <t k="infoBoxCluster.nodes.controlPlane.label" />
-            </label>
-          </div>
-        </div>
+      <div class="info-column-data mb-10">
+        <label>
+          <t
+            k="infoBoxCluster.reserved"
+            :numerator="nodeUsagePodReserved.nodeUsage"
+            :denominator="nodeUsagePodReserved.clusterCapacity"
+          />
+        </label>
+        <PercentageBar :value="nodeUsagePodReserved.percentage" />
       </div>
     </div>
   </InfoBox>
@@ -360,13 +227,44 @@ export default {
 
 <style lang="scss" scoped>
   .info-box {
-    &.row {
-      flex-grow: 0;
-    }
+    // reset infobox flex styles
+    display: grid;
+    grid-template-columns: 1fr;
+    flex-grow: 0;
+    flex-basis: 0;
+    margin-bottom: 20px;
+
     .info-column {
+      padding-left: 10%;
+      &:not(:last-child) {
+        border-right: 0;
+        border-bottom: 1px solid var(--tabbed-border);
+        margin-bottom: 10px;
+      }
+      .info-column-data {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        align-items: center;
+      }
       > label {
         margin-bottom: 5px;
         display: inline-block;
+      }
+    }
+  }
+
+  @media only screen and (min-width: map-get($breakpoints, '--viewport-7')) {
+    .info-box {
+      grid-template-columns: 1fr 1fr 1fr;
+      .info-column {
+        .info-column-data {
+          grid-template-columns: 1fr 1fr;
+        }
+        &:not(:last-child) {
+          border-right: 1px solid var(--tabbed-border);
+          border-bottom: 0;
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -24,10 +24,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  @import "~assets/styles/base/_variables.scss";
-  @import "~assets/styles/base/_functions.scss";
-  @import "~assets/styles/base/_mixins.scss";
-
   .overlay {
     z-index: z-index('loadingOverlay');
     background-color: var(--overlay-bg);

--- a/components/PercentageBar.vue
+++ b/components/PercentageBar.vue
@@ -66,7 +66,7 @@ export default {
       width: 32px;
     }
     .bar {
-      vertical-align: middle;
+      vertical-align: -5px; // this will align percentage-text in the center without having to change the line height
       margin-left: 3px;
       .tick {
         display: inline-block;

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -263,9 +263,6 @@ export default {
 </template>
 
 <style lang="scss">
-@import "~assets/styles/base/_variables.scss";
-@import "~assets/styles/base/_functions.scss";
-@import "~assets/styles/base/_mixins.scss";
 .resource-yaml {
   flex: 1;
   display: flex;

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -509,9 +509,6 @@ export default {
 </template>
 
 <style lang="scss">
-@import "~assets/styles/base/_variables.scss";
-@import "~assets/styles/base/_functions.scss";
-@import "~assets/styles/base/_mixins.scss";
 //
 // Important: Almost all selectors in here need to be ">"-ed together so they
 // apply only to the current table, not one nested inside another table.

--- a/components/formatter/BadgeState.vue
+++ b/components/formatter/BadgeState.vue
@@ -25,8 +25,6 @@ export default {
 </template>
 
 <style lang="scss">
-  @import "~assets/styles/base/_mixins.scss";
-
   .badge-state {
     padding: 5px 5px 5px 0;
     border: 1px solid transparent;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -69,6 +69,18 @@ module.exports = {
 
   buildDir: dev ? '.nuxt' : '.nuxt-prod',
 
+  buildModules: [
+    '@nuxtjs/style-resources',
+  ],
+  styleResources: {
+    // only import functions, mixins, or variables, NEVER import full styles https://github.com/nuxt-community/style-resources-module#warning
+    scss: [
+      '~assets/styles/base/_variables.scss',
+      '~assets/styles/base/_functions.scss',
+      '~assets/styles/base/_mixins.scss',
+    ],
+  },
+
   // mode:    'spa', --- Use --spa CLI flag, or ?spa query param.
 
   loading: '~/components/Loading.vue',

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@babel/runtime-corejs3": "^7.8.3",
     "@nuxtjs/eslint-config": "^1.1.2",
     "@nuxtjs/eslint-module": "^1.1.0",
+    "@nuxtjs/style-resources": "^1.0.0",
     "@storybook/addon-actions": "^6.0.0-alpha.30",
     "@storybook/addon-docs": "^6.0.0-alpha.30",
     "@storybook/addon-knobs": "^6.0.0-alpha.30",

--- a/pages/c/_cluster/index.vue
+++ b/pages/c/_cluster/index.vue
@@ -4,6 +4,8 @@ import { get } from '@/utils/object';
 import InfoBoxCluster from '@/components/InfoBoxCluster';
 import InfoBox from '@/components/InfoBox';
 import SortableTable from '@/components/SortableTable';
+import DetailTop from '@/components/DetailTop';
+import ClusterDisplayProvider from '@/components/ClusterDisplayProvider';
 import {
   MESSAGE,
   NAME,
@@ -27,6 +29,8 @@ import { allHash } from '@/utils/promise';
 
 export default {
   components: {
+    DetailTop,
+    ClusterDisplayProvider,
     InfoBox,
     InfoBoxCluster,
     SortableTable
@@ -86,6 +90,26 @@ export default {
   },
 
   computed: {
+    detailTopColumns() {
+      return [
+        {
+          title:   this.$store.getters['i18n/t']('infoBoxCluster.provider'),
+          name:    'cluster-provider',
+        },
+        {
+          title:   this.$store.getters['i18n/t']('infoBoxCluster.version'),
+          content: this.cluster.kubernetesVersion
+        },
+        {
+          title:   this.$store.getters['i18n/t']('infoBoxCluster.nodes.total.label'),
+          content: ( this.nodes || [] ).length
+        },
+        {
+          title:   this.$store.getters['i18n/t']('infoBoxCluster.created'),
+          name:    'live-date',
+        },
+      ];
+    },
     filteredNodes() {
       const allNodes = ( this.nodes || [] ).slice();
 
@@ -262,6 +286,14 @@ export default {
         </button>
       </div>
     </header>
+    <DetailTop :columns="detailTopColumns" class="mb-20">
+      <template v-slot:cluster-provider>
+        <ClusterDisplayProvider :cluster="cluster" :node-templates="nodeTemplates" :node-pools="nodePools" />
+      </template>
+      <template v-slot:live-date>
+        <LiveDate :value="cluster.metadata.creationTimestamp" :add-suffix="true" />
+      </template>
+    </DetailTop>
     <InfoBoxCluster
       :cluster="cluster"
       :metrics="nodeMetrics"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,22 @@
     "@ava/babel-plugin-throws-helper" "^4.0.0"
     babel-plugin-espower "^3.0.1"
 
+"@babel/cli@^7.4.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.4.tgz#505fb053721a98777b2b175323ea4f090b7d3c1c"
+  integrity sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==
+  dependencies:
+    commander "^4.0.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.13"
+    make-dir "^2.1.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    chokidar "^2.1.8"
+
 "@babel/code-frame@7.8.3", "@babel/code-frame@^7.8.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -55,6 +71,15 @@
   integrity sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==
   dependencies:
     browserslist "^4.9.1"
+    invariant "^2.2.4"
+    semver "^5.5.0"
+
+"@babel/compat-data@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.6.tgz#3f604c40e420131affe6f2c8052e9a275ae2049b"
+  integrity sha512-5QPTrNen2bm7RBc7dsOmcA5hbrS4O2Vhmk5XOL4zWW/zD/hV0iinpefDlkm+tBBy8kDtFaaeEvmAqt+nURAV2g==
+  dependencies:
+    browserslist "^4.11.1"
     invariant "^2.2.4"
     semver "^5.5.0"
 
@@ -146,6 +171,16 @@
   integrity sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==
   dependencies:
     "@babel/types" "^7.9.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
+  integrity sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==
+  dependencies:
+    "@babel/types" "^7.9.6"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -245,6 +280,17 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
+"@babel/helper-compilation-targets@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.9.6.tgz#1e05b7ccc9d38d2f8b40b458b380a04dcfadd38a"
+  integrity sha512-x2Nvu0igO0ejXzx09B/1fGBxY9NXQlBW2kZsSxCJft+KHN8t9XWzIvFxtPHnBOAXpVsdxZKZFbRUC8TsNKajMw==
+  dependencies:
+    "@babel/compat-data" "^7.9.6"
+    browserslist "^4.11.1"
+    invariant "^2.2.4"
+    levenary "^1.1.1"
+    semver "^5.5.0"
+
 "@babel/helper-create-class-features-plugin@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz#5b94be88c255f140fd2c10dd151e7f98f4bff397"
@@ -325,6 +371,15 @@
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/helper-function-name@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz#2b53820d35275120e1874a82e5aabe1376920a5c"
+  integrity sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.9.5"
 
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
@@ -549,6 +604,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
   integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
 
+"@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -614,6 +674,11 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.3.tgz#790874091d2001c9be6ec426c2eed47bc7679081"
   integrity sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
+
+"@babel/parser@^7.7.0", "@babel/parser@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
+  integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
 
 "@babel/parser@^7.8.4", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
   version "7.9.4"
@@ -742,6 +807,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.6.tgz#7a093586fcb18b08266eb1a7177da671ac575b63"
+  integrity sha512-Ga6/fhGqA9Hj+y6whNpPv8psyaK5xzrQwSPsGPloVkvmH+PqW1ixdnfJ9uIO06OjQNYol3PMnfmJ8vfZtkzF+A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-transform-parameters" "^7.9.5"
 
 "@babel/plugin-proposal-optional-catch-binding@^7.2.0":
   version "7.2.0"
@@ -1058,6 +1132,20 @@
     "@babel/helper-split-export-declaration" "^7.8.3"
     globals "^11.1.0"
 
+"@babel/plugin-transform-classes@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz#800597ddb8aefc2c293ed27459c1fcc935a26c2c"
+  integrity sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.8.3"
+    "@babel/helper-define-map" "^7.8.3"
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-optimise-call-expression" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/helper-replace-supers" "^7.8.6"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    globals "^11.1.0"
+
 "@babel/plugin-transform-computed-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da"
@@ -1083,6 +1171,13 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz#20ddfbd9e4676906b1056ee60af88590cc7aaa0b"
   integrity sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-destructuring@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz#72c97cf5f38604aea3abf3b935b0e17b1db76a50"
+  integrity sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -1233,6 +1328,15 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
+"@babel/plugin-transform-modules-amd@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.6.tgz#8539ec42c153d12ea3836e0e3ac30d5aae7b258e"
+  integrity sha512-zoT0kgC3EixAyIAU+9vfaUVKTv9IxBDSabgHoUCBP6FqEJ+iNiN7ip7NBKcYqbfUDfuC2mFCbM7vbu4qJgOnDw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
 "@babel/plugin-transform-modules-commonjs@^7.5.0", "@babel/plugin-transform-modules-commonjs@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz#39dfe957de4420445f1fcf88b68a2e4aa4515486"
@@ -1263,6 +1367,16 @@
     "@babel/helper-simple-access" "^7.8.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
+"@babel/plugin-transform-modules-commonjs@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.6.tgz#64b7474a4279ee588cacd1906695ca721687c277"
+  integrity sha512-7H25fSlLcn+iYimmsNe3uK1at79IE6SKW9q0/QeEHTMC9MdOZ+4bA+T1VFB5fgOqBWoqlifXRzYD0JPdmIrgSQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/helper-simple-access" "^7.8.3"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
 "@babel/plugin-transform-modules-systemjs@^7.5.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz#e75266a13ef94202db2a0620977756f51d52d249"
@@ -1291,6 +1405,16 @@
     "@babel/helper-module-transforms" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
     babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.6.tgz#207f1461c78a231d5337a92140e52422510d81a4"
+  integrity sha512-NW5XQuW3N2tTHim8e1b7qGy7s0kZ2OH3m5octc49K1SdAKGxYxeIx7hiIz05kS1R2R+hOWcsr1eYwcGhrdHsrg==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.8.3"
+    "@babel/helper-module-transforms" "^7.9.0"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-umd@^7.2.0":
   version "7.2.0"
@@ -1382,6 +1506,14 @@
   version "7.9.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz#3028d0cc20ddc733166c6e9c8534559cee09f54a"
   integrity sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-transform-parameters@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz#173b265746f5e15b2afe527eeda65b73623a0795"
+  integrity sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==
   dependencies:
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
@@ -1739,6 +1871,72 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/preset-env@^7.4.5":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.9.6.tgz#df063b276c6455ec6fcfc6e53aacc38da9b0aea6"
+  integrity sha512-0gQJ9RTzO0heXOhzftog+a/WyOuqMrAIugVYxMYf83gh1CQaQDjMtsOpqOwXyDL/5JcWsrCm8l4ju8QC97O7EQ==
+  dependencies:
+    "@babel/compat-data" "^7.9.6"
+    "@babel/helper-compilation-targets" "^7.9.6"
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-proposal-async-generator-functions" "^7.8.3"
+    "@babel/plugin-proposal-dynamic-import" "^7.8.3"
+    "@babel/plugin-proposal-json-strings" "^7.8.3"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-proposal-numeric-separator" "^7.8.3"
+    "@babel/plugin-proposal-object-rest-spread" "^7.9.6"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-proposal-optional-chaining" "^7.9.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.8.3"
+    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/plugin-syntax-top-level-await" "^7.8.3"
+    "@babel/plugin-transform-arrow-functions" "^7.8.3"
+    "@babel/plugin-transform-async-to-generator" "^7.8.3"
+    "@babel/plugin-transform-block-scoped-functions" "^7.8.3"
+    "@babel/plugin-transform-block-scoping" "^7.8.3"
+    "@babel/plugin-transform-classes" "^7.9.5"
+    "@babel/plugin-transform-computed-properties" "^7.8.3"
+    "@babel/plugin-transform-destructuring" "^7.9.5"
+    "@babel/plugin-transform-dotall-regex" "^7.8.3"
+    "@babel/plugin-transform-duplicate-keys" "^7.8.3"
+    "@babel/plugin-transform-exponentiation-operator" "^7.8.3"
+    "@babel/plugin-transform-for-of" "^7.9.0"
+    "@babel/plugin-transform-function-name" "^7.8.3"
+    "@babel/plugin-transform-literals" "^7.8.3"
+    "@babel/plugin-transform-member-expression-literals" "^7.8.3"
+    "@babel/plugin-transform-modules-amd" "^7.9.6"
+    "@babel/plugin-transform-modules-commonjs" "^7.9.6"
+    "@babel/plugin-transform-modules-systemjs" "^7.9.6"
+    "@babel/plugin-transform-modules-umd" "^7.9.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.8.3"
+    "@babel/plugin-transform-new-target" "^7.8.3"
+    "@babel/plugin-transform-object-super" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.9.5"
+    "@babel/plugin-transform-property-literals" "^7.8.3"
+    "@babel/plugin-transform-regenerator" "^7.8.7"
+    "@babel/plugin-transform-reserved-words" "^7.8.3"
+    "@babel/plugin-transform-shorthand-properties" "^7.8.3"
+    "@babel/plugin-transform-spread" "^7.8.3"
+    "@babel/plugin-transform-sticky-regex" "^7.8.3"
+    "@babel/plugin-transform-template-literals" "^7.8.3"
+    "@babel/plugin-transform-typeof-symbol" "^7.8.4"
+    "@babel/plugin-transform-unicode-regex" "^7.8.3"
+    "@babel/preset-modules" "^0.1.3"
+    "@babel/types" "^7.9.6"
+    browserslist "^4.11.1"
+    core-js-compat "^3.6.2"
+    invariant "^2.2.2"
+    levenary "^1.1.1"
+    semver "^5.5.0"
+
 "@babel/preset-env@^7.8.4":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.9.0.tgz#a5fc42480e950ae8f5d9f8f2bbc03f52722df3a8"
@@ -1952,6 +2150,21 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.0":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
+  integrity sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.6"
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.6"
+    "@babel/types" "^7.9.6"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.0", "@babel/traverse@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.3.tgz#a826215b011c9b4f73f3a893afbc05151358bf9a"
@@ -1988,6 +2201,15 @@
   integrity sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==
   dependencies:
     esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
+  integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -2601,6 +2823,15 @@
   dependencies:
     consola "^2.5.6"
     http-proxy-middleware "^0.19.1"
+
+"@nuxtjs/style-resources@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/style-resources/-/style-resources-1.0.0.tgz#7c4d6be19d7f7cc5d687d689f2ab16c0b94773a1"
+  integrity sha512-tDRcC/pm8B0Kpxtzb/1/HOBkv3/kPD+2FiCiUBGMB7YriRud9OUPw1pnYCsAH9ftwpMJS4k4XOyUY8FCTk6OxA==
+  dependencies:
+    consola "^2.4.0"
+    glob-all "^3.1.0"
+    sass-resources-loader "^2.0.0"
 
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
@@ -4554,6 +4785,11 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
+  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -4725,6 +4961,18 @@ babel-eslint@^10.0.1:
     eslint-visitor-keys "^1.0.0"
     resolve "^1.12.0"
 
+babel-eslint@^10.0.2:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
+
 babel-helper-evaluate-path@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz#a62fa9c4e64ff7ea5cea9353174ef023a900a67c"
@@ -4792,6 +5040,13 @@ babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
   integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
+  dependencies:
+    object.assign "^4.1.0"
+
+babel-plugin-dynamic-import-node@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
+  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
   dependencies:
     object.assign "^4.1.0"
 
@@ -5385,6 +5640,16 @@ browserslist@^4.0.0, browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.7
     electron-to-chromium "^1.3.284"
     node-releases "^1.1.36"
 
+browserslist@^4.11.1:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.12.0.tgz#06c6d5715a1ede6c51fc39ff67fd647f740b656d"
+  integrity sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==
+  dependencies:
+    caniuse-lite "^1.0.30001043"
+    electron-to-chromium "^1.3.413"
+    node-releases "^1.1.53"
+    pkg-up "^2.0.0"
+
 browserslist@^4.8.2, browserslist@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.3.tgz#65802fcd77177c878e015f0e3189f2c4f627ba44"
@@ -5664,7 +5929,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@1.0.30001040, caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000999, caniuse-lite@^1.0.30001016, caniuse-lite@^1.0.30001017, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001038:
+caniuse-lite@1.0.30001040, caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000999, caniuse-lite@^1.0.30001016, caniuse-lite@^1.0.30001017, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001043:
   version "1.0.30001040"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz#103fc8e6eb1d7397e95134cd0e996743353d58ea"
   integrity sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ==
@@ -5764,7 +6029,7 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-chokidar@^2.0.2:
+chokidar@^2.0.2, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -6264,6 +6529,11 @@ consola@^2.10.1, consola@^2.11.1:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.11.1.tgz#1df259c0a7aef44c9eb4f448e3a20ba0850a65e7"
   integrity sha512-zFH/xFAE/KHJiWqwyTEDmdFe34Swc0pqMKJeowTvR3irepx8kKPu8bjaKzRd+RLjLH+0TvFxFBnohbSUQ+hOsw==
+
+consola@^2.4.0:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/consola/-/consola-2.11.3.tgz#f7315836224c143ac5094b47fd4c816c2cd1560e"
+  integrity sha512-aoW0YIIAmeftGR8GSpw6CGQluNdkWMWh3yEFjH/hmynTYnMtibXszii3lxCXmk8YxJtI3FAK5aTiquA5VH68Gw==
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -7662,6 +7932,11 @@ electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.390:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.397.tgz#db640c2e67b08d590a504c20b56904537aa2bafa"
   integrity sha512-zcUd1p/7yzTSdWkCTrqGvbnEOASy96d0RJL/lc5BDJoO23Z3G/VHd0yIPbguDU9n8QNUTCigLO7oEdtOb7fp2A==
 
+electron-to-chromium@^1.3.413:
+  version "1.3.423"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.423.tgz#1dcc9e54d642dd9b354c6609848abf8ba7b2570f"
+  integrity sha512-jXdnLcawJ/EMdN+j77TC3YyeAWiIjo1U63DFCKrjtLv4cu8ToyoF4HYXtFvkVVHhEtIl7lU1uDd307Xj1/YDjw==
+
 element-matches@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/element-matches/-/element-matches-0.1.2.tgz#7345cb71e965bd2b12f725e524591c102198361a"
@@ -8932,6 +9207,11 @@ fs-minipass@^2.0.0:
   dependencies:
     minipass "^3.0.0"
 
+fs-readdir-recursive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+  integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -9097,6 +9377,14 @@ github-slugger@^1.0.0:
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
 
+glob-all@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/glob-all/-/glob-all-3.2.1.tgz#082ca81afd2247cbd3ed2149bb2630f4dc877d95"
+  integrity sha512-x877rVkzB3ipid577QOp+eQCR6M5ZyiwrtaYgrX/z3EThaSPFtLDwBXFHc3sH1cG0R0vFYI5SRYeWMMSEyXkUw==
+  dependencies:
+    glob "^7.1.2"
+    yargs "^15.3.1"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -9132,7 +9420,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.6, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -11230,6 +11518,15 @@ loader-utils@^0.2.16:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
+
+loader-utils@^1.0.4:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
 
 loader-utils@^2.0.0:
   version "2.0.0"
@@ -15338,6 +15635,19 @@ sass-loader@^8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
+sass-resources-loader@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/sass-resources-loader/-/sass-resources-loader-2.0.3.tgz#585636b357d9c27d02fa359c175fafe3e3d66ce4"
+  integrity sha512-kYujKXFPZvh5QUT+0DO35P93G6GeIRMP4c941Ilbvey5lo+iICFs2H4hP2CFHl68Llg7h2iXqe0RQpDoUzjUSw==
+  dependencies:
+    "@babel/cli" "^7.4.4"
+    "@babel/preset-env" "^7.4.5"
+    async "^3.0.1"
+    babel-eslint "^10.0.2"
+    chalk "^2.4.2"
+    glob "^7.1.1"
+    loader-utils "^1.0.4"
+
 sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -15668,6 +15978,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -18055,6 +18370,14 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.1:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
@@ -18078,6 +18401,23 @@ yargs@^15.0.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^16.1.0"
+
+yargs@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
There was more feedback on the cluster overview page [here](https://github.com/rancher/dashboard/issues/580).

This PR also adds a dependency `nuxtjs/style-resources` which allows us to push scss resources into a global space that nuxt is aware of which nigates the need to import any functions/mixins/variables in to the individual Vue components (I did not go back and remove imports that were already present, I can do this if we'd like though). 

Also changes the styles of detail top to use css grid instead of flex box. Grid allows for a more uniform alignment when wrapping elements whereas flexbox will just wrap on what ever. The col/rows were buggy and had alignment issues on different widths. IMO the styles and markup are much easier to reason about here when using grid. 

Additionally I also made `InfoBoxCluster` use grid, while `InfoBox` still uses flex. I didn't want to make a sweeping change to InfoBox if others are using the flex styles and they work on the page, but the cluster info box has a fairly strait forward grid layout of 3 columns across. Also I found the logic and reasoning around the sub-item layout to be much simpler and less buggy on different screen sizes when using grid. 

_note:_ I added media breakpoints here to adjust the size of the grid elements across the different browsers. There has not been a concerted effort to add mobile to the new dashboard UI so I can comment these out until we focus on that if we'd like to ensure the mobile story is consistent. I discussed the breakpoints widths with @lvuch and after some some reading on current breakpoint best practices these widths made sense to us but again these could be adjusted. 