### PR TITLE
Adding t() translation as a Vue instance method

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -164,3 +164,11 @@ model:
   namespace:
     project: "Project: {name}"
     notInAProject: "Not in a Project"
+
+configmapPage:
+  data:
+    title: Data
+    protip: Use this area for anything that's UTF-8 text data
+  tabs:
+    binaryData:
+      label: Binary Data

--- a/detail/configmap.vue
+++ b/detail/configmap.vue
@@ -98,15 +98,15 @@ export default {
         key="data"
         v-model="value.data"
         :mode="mode"
-        title="Data"
-        protip="Use this area for anything that's UTF-8 text data"
+        :title="t('configmapPage.data.title')"
         :initial-empty-row="true"
       />
     </div>
     <ResourceTabs v-model="value" :mode="mode">
       <template #before>
-        <Tab name="binary-data" label="Binary Data">
+        <Tab name="binary-data" :label="t('configmapPage.tabs.binaryData.label')">
           <SortableTable
+            class="binary-data"
             key-field="_key"
             :headers="binaryValuesTableHeaders"
             :rows="binaryValuesTableRows"

--- a/edit/configmap.vue
+++ b/edit/configmap.vue
@@ -37,8 +37,8 @@ export default {
           key="data"
           v-model="value.data"
           :mode="mode"
-          title="Data"
-          protip="Use this area for anything that's UTF-8 text data"
+          :title="t('configmapPage.data.title')"
+          :protip="t('configmapPage.data.protip')"
           :initial-empty-row="true"
         />
       </div>
@@ -48,7 +48,7 @@ export default {
 
     <ResourceTabs v-model="value" :mode="mode">
       <template #before>
-        <Tab label="Binary Data" name="binary-data">
+        <Tab :label="t('configmapPage.tabs.binaryData.label')" name="binary-data">
           <KeyValue
             key="binaryData"
             v-model="value.binaryData"

--- a/plugins/i18n.js
+++ b/plugins/i18n.js
@@ -21,6 +21,10 @@ function stringFor(store, key, args, raw = false) {
   }
 }
 
+Vue.prototype.t = function(key, args, raw) {
+  return stringFor(this.$store, key, args, raw);
+};
+
 function directive(el, binding, vnode /*, oldVnode */) {
   const { context } = vnode;
   const raw = binding.modifiers && binding.modifiers.raw === true;


### PR DESCRIPTION
Similar to ember I want to be able to use the same method for
translating within templates and code. If we like this we
could replace the component and the directive since this can
easily be used in place of both of those.