### PR TITLE
Services - Create & Edit

### DIFF
--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -291,3 +291,9 @@ $transition-duration: 150ms;
   display: inline-block;
   border: 0;
 }
+
+.protocol-select {
+  .vs__dropdown-toggle {
+    padding: 5px !important;
+  }
+}

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2,6 +2,10 @@ locale:
   none: (None)
   en-us: English
 
+buttons:
+  add: Add
+  remove: Remove
+
 generic:
   close: Close
   comingSoon: Coming Soon
@@ -13,6 +17,7 @@ generic:
 suffix:
   ib: iB
   cpus: CPUs
+  seconds: Seconds
 
 header:
   backToRancher: "← Back to Rancher"
@@ -83,6 +88,41 @@ footer:
   issue: File an Issue
   download: Download CLI
 
+servicesPage:
+  typeOpts:
+    label: Service Type
+  serviceTypes:
+    clusterIp: Cluster IP
+    externalName: External Name
+    headless: Headless
+    loadBalancer: Load Balancer
+    nodePort: Node Port
+  externalName:
+    label: External Name
+    helpText: External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service.
+    placeholder: e.g. my.database.example.com
+  selectors:
+    label: Selectors
+    helpText:  If no selector is created, manual endpoints must be made.
+  ips:
+    label: IPs
+    helpText: The IP address must be within the CIDR range configured for the API server.
+    input:
+      label: Cluster IP
+      placeholder: e.g. 10.0.171.239
+    external:
+      label: External IPs
+      placeholder: e.g. 1.1.1.1
+  affinity:
+    label: Session Affinity
+    helpText: Map connections to a consistent target based on their source IP.
+    actionLabels:
+      none: None
+      clusterIp: ClusterIP
+    timeout:
+      label: Session Sticky Time
+      placeholder: e.g. 10800
+
 clusterIndexPage:
   header: "Cluster: {name}"
   sections:
@@ -148,10 +188,10 @@ gatekeeperConstraint:
     selectors:
       title: Selectors
       sub:
-        labelSelector: 
+        labelSelector:
           title: Label Selector
           addLabel: Add Label
-        namespaceSelector: 
+        namespaceSelector:
           title: Namespace Selector
           addNamespace: Add Namespace
     kinds:
@@ -181,16 +221,33 @@ infoBoxCluster:
 
 resourceDetail:
   header:
-    view: '{name}'
-    create: 'Create {type}'
-    edit: 'Edit {type}: {name}'
-    clone: 'Clone from {type}: {name}'
-    stage: 'Stage from {type}: {name}'
+    view: "{name}"
+    create: "Create {type}"
+    edit: "Edit {type}: {name}"
+    clone: "Clone from {type}: {name}"
+    stage: "Stage from {type}: {name}"
   masthead:
-    namespace: 'Namespace'
-    project: 'Project'
-    yaml: 'YAML'
-    overview: 'Overview'
+    namespace: "Namespace"
+    project: "Project"
+    yaml: "YAML"
+    overview: "Overview"
+
+servicePorts:
+  header:
+    label: Port Rules
+  rules:
+    name:
+      label: Port Name
+      placeholder: e.g. myport
+    listening:
+      label: Listening Port
+      placeholder: e.g. 8080
+    protocol:
+      label: Protocol
+    target:
+      label: Target Port
+    node:
+      label: Node Port
 
 sortableTable:
   noRows: "There are no rows to show."
@@ -231,10 +288,10 @@ wm:
     disconnected: Disconnected
     error: Error
   containerShell:
-    containerName: 'Container: {label}'
+    containerName: "Container: {label}"
     clear: Clear
   containerLogs:
-    containerName: 'Container: {label}'
+    containerName: "Container: {label}"
     clear: Clear
     download: Download
     follow: Follow
@@ -337,7 +394,7 @@ node:
         cpu: CPU
         memory: MEMORY
         pods: PODS
-        amount: '{used} of {total} {unit} used'
+        amount: "{used} of {total} {unit} used"
     tab:
       conditions: Conditions
       info: Info

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -17,23 +17,36 @@ export default {
 
   watch: {
     tabs(tabs) {
-      const activeTab = tabs.filter(t => t.active);
+      const activeTab = tabs.find(t => t.active);
       const defaultTab = this.defaultTab;
+      const windowsHash = window.location.hash.slice(1);
+      const windowHashTabMatch = tabs.find(t => t.name === windowsHash && !t.active);
+      const firstTab = tabs.length > 0 ? tabs[0] : null;
 
       if (isEmpty(activeTab)) {
-        if (defaultTab) {
-          this.$nextTick(() => {
-            this.select(defaultTab);
-          });
+        if (defaultTab && !isEmpty(tabs.find(t => t.name === defaultTab))) {
+          this.select(defaultTab);
         } else {
-          const firstTab = tabs.length > 0 ? tabs[0] : null;
+          if (!isEmpty(windowHashTabMatch)) {
+            this.select(windowHashTabMatch.name);
+
+            return;
+          }
 
           if (firstTab) {
-            this.$nextTick(() => {
-              this.select(firstTab._props.name);
-            });
+            this.select(firstTab.name);
+
+            return;
           }
         }
+      }
+
+      if (activeTab.name === windowsHash) {
+        this.select(activeTab.name);
+      } else if (!isEmpty(windowHashTabMatch)) {
+        this.select(windowHashTabMatch.name);
+      } else {
+        this.select(firstTab.name);
       }
     },
   },

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -1,4 +1,6 @@
 <script>
+import { isEmpty } from 'lodash';
+
 export default {
   name: 'Tabbed',
 
@@ -11,6 +13,29 @@ export default {
 
   data() {
     return { tabs: null };
+  },
+
+  watch: {
+    tabs(tabs) {
+      const activeTab = tabs.filter(t => t.active);
+      const defaultTab = this.defaultTab;
+
+      if (isEmpty(activeTab)) {
+        if (defaultTab) {
+          this.$nextTick(() => {
+            this.select(defaultTab);
+          });
+        } else {
+          const firstTab = tabs.length > 0 ? tabs[0] : null;
+
+          if (firstTab) {
+            this.$nextTick(() => {
+              this.select(firstTab._props.name);
+            });
+          }
+        }
+      }
+    },
   },
 
   created() {

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -36,6 +36,10 @@ export default {
       type:    String,
       default: null,
     },
+    localizedLabel: {
+        type:    Boolean,
+        default: false
+    },
   },
 
   data() {
@@ -91,7 +95,11 @@ export default {
 
     getOptionLabel(option) {
       if (get(option, this.optionLabel)) {
-        return get(option, this.optionLabel);
+        if (this.localizedLabel) {
+          return this.$store.getters['i18n/t'](get(option, this.optionLabel));
+        } else {
+          return get(option, this.optionLabel);
+        }
       } else {
         return option;
       }

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -37,8 +37,8 @@ export default {
       default: null,
     },
     localizedLabel: {
-        type:    Boolean,
-        default: false
+      type:    Boolean,
+      default: false
     },
   },
 

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -1,0 +1,272 @@
+<script>
+import { debounce } from 'lodash';
+import { _EDIT, _VIEW } from '@/config/query-params';
+import { removeAt } from '@/utils/array';
+import { clone } from '@/utils/object';
+
+export default {
+  components: {},
+  props:      {
+    value: {
+      type:    Array,
+      default: null,
+    },
+    mode: {
+      type:    String,
+      default: _EDIT,
+    },
+    specType: {
+      type:    String,
+      default: 'ClusterIP',
+    },
+    padLeft: {
+      type:    Boolean,
+      default: false,
+    }
+  },
+
+  data() {
+    const rows = clone(this.value || []);
+
+    return { rows };
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+
+    showAdd() {
+      return !this.isView;
+    },
+
+    showRemove() {
+      return !this.isView;
+    },
+
+    protocolOptions() {
+      const { specType } = this;
+
+      switch (specType) {
+      case 'ClusterIP':
+      case 'Headless':
+      default:
+        return ['TCP', 'UDP', 'HTTP', 'PROXY'];
+      case 'LoadBalancer':
+        return ['TCP', 'UDP'];
+      }
+    },
+  },
+
+  created() {
+    this.queueUpdate = debounce(this.update, 500);
+  },
+
+  methods: {
+    add() {
+      this.rows.push({
+        hostPort:   false,
+        name:       '',
+        port:       null,
+        protocol:   'TCP',
+        targetPort: null,
+      });
+
+      this.queueUpdate();
+
+      this.$nextTick(() => {
+        const inputs = this.$refs.port;
+
+        inputs[inputs.length - 1].focus();
+      });
+    },
+
+    remove(idx) {
+      removeAt(this.rows, idx);
+      this.queueUpdate();
+    },
+
+    update() {
+      if ( this.isView ) {
+        return;
+      }
+
+      const out = [];
+
+      for ( const row of this.rows ) {
+        const value = clone(row);
+
+        if ( value.port ) {
+          out.push(value);
+        }
+      }
+      this.$emit('input', out);
+    }
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="title clearfix">
+      <h4>
+        <t k="servicePorts.header.label" />
+      </h4>
+    </div>
+
+    <table v-if="rows.length" class="fixed">
+      <thead>
+        <tr>
+          <th v-if="padLeft" class="left"></th>
+          <th class="port-name">
+            <t k="servicePorts.rules.name.label" />
+          </th>
+          <th class="port">
+            <t k="servicePorts.rules.listening.label" />
+          </th>
+          <th v-if="specType !== 'NodePort'" class="port-protocol">
+            <t k="servicePorts.rules.protocol.label" />
+          </th>
+          <th class="target-port">
+            <t k="servicePorts.rules.target.label" />
+          </th>
+          <th v-if="specType === 'NodePort'" class="node-port">
+            <t k="servicePorts.rules.node.label" />
+          </th>
+          <th v-if="showRemove" class="remove"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(row, idx) in rows"
+          :key="idx"
+        >
+          <td v-if="padLeft" class="left"></td>
+          <td class="port-name">
+            <span v-if="isView">{{ row.name }}</span>
+            <input
+              v-else
+              ref="port-name"
+              v-model.number="row.name"
+              type="text"
+              :placeholder="t('servicePorts.rules.name.placeholder')"
+              @input="queueUpdate"
+            />
+          </td>
+          <td class="port">
+            <span v-if="isView">{{ row.port }}</span>
+            <input
+              v-else
+              ref="port"
+              v-model.number="row.port"
+              type="number"
+              min="1"
+              max="65535"
+              :placeholder="t('servicePorts.rules.listening.placeholder')"
+              @input="queueUpdate"
+            />
+          </td>
+          <td v-if="specType !== 'NodePort'" class="port-protocol">
+            <span v-if="isView">{{ row.protocol }}</span>
+            <v-select
+              v-else
+              v-model="row.protocol"
+              class="inline protocol-select"
+              :searchable="false"
+              :options="protocolOptions"
+              @input="queueUpdate"
+            />
+          </td>
+          <td class="target-port">
+            <span v-if="isView">{{ row.targetPort }}</span>
+            <input
+              v-else
+              v-model.number="row.targetPort"
+              type="number"
+              min="1"
+              max="65535"
+              placeholder="e.g. 80"
+              @input="queueUpdate"
+            />
+          </td>
+          <td v-if="specType === 'NodePort'" class="node-port">
+            <span v-if="isView">{{ row.nodePort }}</span>
+            <input
+              v-else
+              v-model.number="row.nodePort"
+              type="number"
+              min="1"
+              max="65535"
+              placeholder="e.g. 80"
+              @input="queueUpdate"
+            />
+          </td>
+          <td v-if="showRemove" class="remove">
+            <button type="button" class="btn bg-transparent role-link" @click="remove(idx)">
+              <t k="buttons.remove" />
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div v-if="showAdd" class="footer">
+      <button type="button" class="btn role-tertiary add" @click="add()">
+        <t k="buttons.add" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  $remove: 75;
+
+  .title {
+    margin-bottom: 10px;
+
+    .read-from-file {
+      float: right;
+    }
+  }
+
+  TABLE {
+    width: 100%;
+  }
+
+  TH {
+    text-align: left;
+    font-size: 12px;
+    font-weight: normal;
+    color: var(--input-label);
+  }
+
+  .left {
+    width: #{$remove}px;
+  }
+
+  .port-protocol {
+    width: 100px;
+  }
+
+  .node-port, .target-port {
+    text-align: center;
+  }
+
+  .value {
+    vertical-align: top;
+  }
+
+  .remove {
+    vertical-align: middle;
+    text-align: right;
+    width: #{$remove}px;
+  }
+
+  .footer {
+    margin-top: 10px;
+
+    .protip {
+      float: right;
+      padding: 5px 0;
+    }
+  }
+</style>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -1,0 +1,303 @@
+<script>
+import { find } from 'lodash';
+import { ucFirst } from '@/utils/string';
+import CreateEditView from '@/mixins/create-edit-view';
+import ArrayList from '@/components/form/ArrayList';
+import Footer from '@/components/form/Footer';
+import KeyValue from '@/components/form/KeyValue';
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import NameNsDescription from '@/components/form/NameNsDescription';
+import RadioGroup from '@/components/form/RadioGroup';
+import ResourceTabs from '@/components/form/ResourceTabs';
+import ServicePorts from '@/components/form/ServicePorts';
+import Tab from '@/components/Tabbed/Tab';
+import UnitInput from '@/components/form/UnitInput';
+
+export const DEFAULT_SERVICE_TYPES = [
+  {
+    id:               'ClusterIP',
+    translationLabel: 'servicesPage.serviceTypes.clusterIp'
+  },
+  {
+    id:               'ExternalName',
+    translationLabel: 'servicesPage.serviceTypes.externalName'
+  },
+  {
+    id:               'Headless',
+    translationLabel: 'servicesPage.serviceTypes.headless'
+  },
+  {
+    id:               'LoadBalancer',
+    translationLabel: 'servicesPage.serviceTypes.loadBalancer'
+  },
+  {
+    id:               'NodePort',
+    translationLabel: 'servicesPage.serviceTypes.nodePort'
+  },
+];
+
+const SESSION_AFFINITY_ACTION_VALUES = {
+  NONE:      'None',
+  CLUSTERIP: 'ClusterIP'
+};
+
+const SESSION_AFFINITY_ACTION_LABELS = {
+  NONE:      'servicesPage.affinity.actionLabels.none',
+  CLUSTERIP: 'servicesPage.affinity.actionLabels.clusterIp'
+};
+
+const SESSION_STICKY_TIME_DEFAULT = 10800;
+
+export default {
+  components: {
+    ArrayList,
+    Footer,
+    KeyValue,
+    LabeledInput,
+    LabeledSelect,
+    NameNsDescription,
+    RadioGroup,
+    ResourceTabs,
+    ServicePorts,
+    Tab,
+    UnitInput,
+  },
+
+  mixins:     [CreateEditView],
+
+  data() {
+    if (!this?.value?.spec?.type) {
+      const defaultService = find(DEFAULT_SERVICE_TYPES, ['id', 'ClusterIP']);
+
+      if (!this?.value?.spec) {
+        this.$set(this.value, 'spec', {
+          ports:           [],
+          sessionAffinity: 'None',
+          type:            defaultService.id,
+        });
+      } else {
+        this.$set(this.value.spec, 'type', defaultService.id);
+      }
+    }
+
+    return {
+      sessionAffinityActionOptions: Object.values(SESSION_AFFINITY_ACTION_VALUES),
+      sessionAffinityActionLabels:  Object.values(SESSION_AFFINITY_ACTION_LABELS).map(v => this.$store.getters['i18n/t'](v)).map(ucFirst),
+      defaultServiceTypes:          DEFAULT_SERVICE_TYPES,
+    };
+  },
+
+  computed: {
+    extraColumns() {
+      return ['type-col'];
+    },
+  },
+
+  watch: {
+    'value.spec.type'(val) {
+      if (val === 'ExternalName') {
+        this.value.spec.ports = null;
+      }
+
+      if (val === 'Headless') {
+        this.value.spec.clusterIP = 'None';
+      } else if (val !== 'Headless' && this.value.spec.clusterIP === 'None') {
+        this.value.spec.clusterIP = null;
+      }
+    },
+
+    'value.spec.sessionAffinity'(val) {
+      if (val === 'ClusterIP') {
+        this.value.spec.sessionAffinityConfig = { clientIP: { timeoutSeconds: null } };
+
+        // set it null and then set it with vue to make reactive.
+        this.$set(this.value.spec.sessionAffinityConfig.clientIP, 'timeoutSeconds', SESSION_STICKY_TIME_DEFAULT);
+      } else if (this.value?.spec?.sessionAffinityConfig?.clientIP?.timeoutSeconds) {
+        delete this.value.spec.sessionAffinityConfig.clientIP.timeoutSeconds;
+      }
+    }
+  },
+
+  methods: {
+    checkTypeIs(typeIn) {
+      const { value: { spec: { type } } } = this;
+
+      if (type === typeIn) {
+        return true;
+      }
+
+      return false;
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <form>
+      <NameNsDescription
+        :value="value"
+        :namespaced="false"
+        :mode="mode"
+        :extra-columns="extraColumns"
+      >
+        <template #type-col>
+          <LabeledSelect
+            option-key="id"
+            option-label="translationLabel"
+            :label="t('servicesPage.typeOpts.label')"
+            :localized-label="true"
+            :mode="mode"
+            :options="defaultServiceTypes"
+            :value="value.spec.type"
+            @input="e=>$set(value.spec, 'type', e.id)"
+          />
+        </template>
+      </NameNsDescription>
+
+      <div class="spacer"></div>
+
+      <div v-if="checkTypeIs('ExternalName')">
+        <div class="title clearfix">
+          <h4>
+            <t k="servicesPage.externalName.label" />
+          </h4>
+          <p class="helper-text">
+            <t k="servicesPage.externalName.helpText" />
+          </p>
+        </div>
+        <div class="row mt-10">
+          <div class="col span-6">
+            <span v-if="isView">{{ value.spec.externalName }}</span>
+            <input
+              v-else
+              ref="external-name"
+              v-model.number="value.spec.externalName"
+              type="text"
+              :placeholder="t('servicesPage.externalName.placeholder')"
+              @input="e=>$set(value.spec, 'externalName', e)"
+            />
+          </div>
+        </div>
+      </div>
+      <ServicePorts
+        v-else
+        v-model="value.spec.ports"
+        class="col span-12"
+        :mode="mode"
+        :spec-type="value.spec.type"
+      />
+
+      <div class="spacer"></div>
+
+      <ResourceTabs v-model="value" :mode="mode">
+        <template #before>
+          <Tab
+            v-if="!checkTypeIs('NodePort') && !checkTypeIs('ExternalName')"
+            name="selectors"
+            :label="t('servicesPage.selectors.label')"
+          >
+            <div class="row">
+              <div class="col span-12">
+                <p class="helper-text">
+                  <t k="servicesPage.selectors.helpText" />
+                </p>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col span-12">
+                <KeyValue
+                  key="selectors"
+                  v-model="value.spec.selector"
+                  :title="t('servicesPage.selectors.label')"
+                  :mode="mode"
+                  :initial-empty-row="true"
+                  :pad-left="false"
+                  :read-allowed="false"
+                  :protip="false"
+                  @input="e=>$set(value.spec, 'selector', e)"
+                />
+              </div>
+            </div>
+          </Tab>
+          <Tab name="ips" :label="t('servicesPage.ips.label')">
+            <div v-if="checkTypeIs('ClusterIP') || checkTypeIs('LoadBalancer')" class="row">
+              <div class="col span-12">
+                <p class="helper-text">
+                  <t k="servicesPage.ips.helpText" />
+                </p>
+              </div>
+            </div>
+            <div v-if="checkTypeIs('ClusterIP') || checkTypeIs('LoadBalancer')" class="row mb-20">
+              <div class="col span-6">
+                <LabeledInput
+                  v-model="value.spec.clusterIP"
+                  :label="t('servicesPage.ips.input.label')"
+                  :placeholder="t('servicesPage.ips.input.placeholder')"
+                  @input="e=>$set(value.spec, 'clusterIP', e)"
+                />
+              </div>
+            </div>
+            <div class="row">
+              <div class="col span-6">
+                <ArrayList
+                  key="clusterExternalIpAddresses"
+                  v-model="value.spec.externalIPs"
+                  :title="t('servicesPage.ips.external.label')"
+                  :value-placeholder="t('servicesPage.ips.external.placeholder')"
+                  :value-multiline="false"
+                  :mode="mode"
+                  :pad-left="false"
+                  :protip="false"
+                  @input="e=>$set(value.spec, 'externalIPs', e)"
+                />
+              </div>
+            </div>
+          </Tab>
+          <Tab
+            v-if="!checkTypeIs('NodePort') && !checkTypeIs('ExternalName')"
+            name="session-affinity"
+            :label="t('servicesPage.affinity.label')"
+          >
+            <div class="row">
+              <div class="col span-12">
+                <p class="helper-text">
+                  <t k="servicesPage.affinity.helpText" />
+                </p>
+              </div>
+            </div>
+            <div class="row session-affinity">
+              <div class="col span-6">
+                <RadioGroup
+                  v-model="value.spec.sessionAffinity"
+                  class="enforcement-action"
+                  :options="sessionAffinityActionOptions"
+                  :labels="sessionAffinityActionLabels"
+                  :mode="mode"
+                  @input="e=>value.spec.sessionAffinity = e"
+                />
+              </div>
+              <div v-if="value.spec.sessionAffinity === 'ClusterIP'" class="col span-6">
+                <UnitInput
+                  v-model="value.spec.sessionAffinityConfig.clientIP.timeoutSeconds"
+                  :suffix="t('suffix.seconds')"
+                  :label="t('servicesPage.affinity.timeout.label')"
+                  :placeholder="t('servicesPage.affinity.timeout.placeholder')"
+                  @input="e=>$set(value.spec.sessionAffinityConfig.clientIP, 'timeoutSeconds', e)"
+                />
+              </div>
+            </div>
+          </Tab>
+        </template>
+      </ResourceTabs>
+
+      <Footer
+        :mode="mode"
+        :errors="errors"
+        @save="save"
+        @done="done"
+      />
+    </form>
+  </div>
+</template>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -210,7 +210,6 @@ export default {
                 <KeyValue
                   key="selectors"
                   v-model="value.spec.selector"
-                  :title="t('servicesPage.selectors.label')"
                   :mode="mode"
                   :initial-empty-row="true"
                   :pad-left="false"


### PR DESCRIPTION
This PR adds the Create and Edit page for the Service resource. 

rancher/dashboard#583

Added some updates to the Tabbed component to handle selecting a tab when an active tab is dynamically removed from the slot as is the case for services where we need to hide certain tabs based on the service type.
Added logic to labeled input to take a localized label. 

### Images
#### Create Service (Default View)
![Screenshot 2020-05-12 12 54 24](https://user-images.githubusercontent.com/858614/81739191-bf3d1500-944f-11ea-8fb7-d66527ccc83f.png)
#### Create Service (IPs tab selected)
![Screenshot 2020-05-12 11 28 55](https://user-images.githubusercontent.com/858614/81738131-0de9af80-944e-11ea-9414-9fa82a9b55e0.png)
#### Create Service (Session Affinity tab selected)
![Screenshot 2020-05-12 11 29 11](https://user-images.githubusercontent.com/858614/81738155-19d57180-944e-11ea-999c-7976fefce990.png)
#### Create Service - External Name
![Screenshot 2020-05-12 11 36 47](https://user-images.githubusercontent.com/858614/81738202-2fe33200-944e-11ea-8369-784f7fa29249.png)
#### Create Service - Load Balancer
![Screenshot 2020-05-12 12 56 05](https://user-images.githubusercontent.com/858614/81739325-ff9c9300-944f-11ea-92b6-255a4c21e2b8.png)
#### Create Service - Headless
![Screenshot 2020-05-12 12 56 12](https://user-images.githubusercontent.com/858614/81739333-04614700-9450-11ea-830e-e4c35a8f5339.png)

#### Create Service - NodePort
![Screenshot 2020-05-12 11 38 28](https://user-images.githubusercontent.com/858614/81738340-6caf2900-944e-11ea-8dcd-9a974112fad4.png)

