### PR TITLE
Yaml edit

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -110,7 +110,7 @@ export async function defaultAsyncData(ctx, resource) {
 
     const originalYaml = (await originalModel.followLink(link, { headers: { accept: 'application/yaml' } })).data;
 
-    yaml = model.cleanyaml(originalYaml, realMode);
+    yaml = model.cleanYaml(originalYaml, realMode);
   }
 
   let mode = realMode;

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -69,6 +69,7 @@ export async function defaultAsyncData(ctx, resource) {
   const hasCustomEdit = store.getters['type-map/hasCustomEdit'](resource);
   const asYamlInit = (route.query[AS_YAML] === _FLAGGED) || (realMode === _VIEW && !hasCustomDetail) || (realMode !== _VIEW && !hasCustomEdit);
   const schema = store.getters['cluster/schemaFor'](resource);
+  const schemas = store.getters['cluster/all'](SCHEMA);
 
   let originalModel, model, yaml;
 
@@ -76,8 +77,6 @@ export async function defaultAsyncData(ctx, resource) {
     if ( !namespace ) {
       namespace = store.getters['defaultNamespace'];
     }
-
-    const schemas = store.getters['cluster/all'](SCHEMA);
 
     const data = { type: resource };
 
@@ -109,7 +108,9 @@ export async function defaultAsyncData(ctx, resource) {
 
     const link = originalModel.hasLink('rioview') ? 'rioview' : 'view';
 
-    yaml = (await originalModel.followLink(link, { headers: { accept: 'application/yaml' } })).data;
+    const originalYaml = (await originalModel.followLink(link, { headers: { accept: 'application/yaml' } })).data;
+
+    yaml = model.cleanyaml(originalYaml, realMode);
   }
 
   let mode = realMode;
@@ -274,9 +275,9 @@ export default {
       </div>
       <ResourceYaml
         ref="resourceyaml"
-        :model="model"
+        :value="model"
         :mode="mode"
-        :value="yaml"
+        :yaml="yaml"
         :offer-preview="offerPreview"
         :done-route="doneRoute"
       />

--- a/models/secret.js
+++ b/models/secret.js
@@ -107,5 +107,5 @@ export default {
     }
 
     return null;
-  }
+  },
 };

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -809,7 +809,7 @@ export default {
 
   // convert yaml to object, clean for new if creating/cloning
   // map _type to type
-  cleanyaml() {
+  cleanYaml() {
     return (yaml, mode = 'edit') => {
       try {
         const obj = jsyaml.safeLoad(yaml);

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -1,4 +1,6 @@
 import Vue from 'vue';
+import jsyaml from 'js-yaml';
+import { cleanForNew } from './normalize';
 import { sortableNumericSuffix } from '@/utils/sort';
 import { generateZip, downloadFile } from '@/utils/download';
 import { ucFirst } from '@/utils/string';
@@ -804,4 +806,46 @@ export default {
 
     return url;
   },
+
+  // convert yaml to object, clean for new if creating/cloning
+  // map _type to type
+  cleanyaml() {
+    return (yaml, mode = 'edit') => {
+      try {
+        const obj = jsyaml.safeLoad(yaml);
+
+        if (mode !== 'edit') {
+          cleanForNew(obj);
+        }
+
+        if (obj._type) {
+          obj.type = obj._type;
+          delete obj._type;
+        }
+        const out = jsyaml.safeDump(obj, { skipInvalid: true });
+
+        return out;
+      } catch (e) {
+        return null;
+      }
+    };
+  },
+
+  yamlForSave() {
+    return (yaml) => {
+      try {
+        const obj = jsyaml.safeLoad(yaml);
+
+        if (obj) {
+          if (this._type) {
+            obj._type = obj.type;
+          }
+
+          return jsyaml.safeDump(obj);
+        }
+      } catch (e) {
+        return null;
+      }
+    };
+  }
 };

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -152,7 +152,6 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
   function stringifyField(key) {
     const field = schema.resourceFields[key];
     const type = typeMunge(field.type);
-
     const mapOf = typeRef('map', type);
     const arrayOf = typeRef('array', type);
     const referenceTo = typeRef('reference', type);

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -46,6 +46,7 @@ const NEVER_ADD = [
   'metadata.resourceVersion',
   'metadata.selfLink',
   'metadata.uid',
+  'stringData'
 ];
 
 const INDENT = 2;
@@ -96,7 +97,7 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
   const commentFields = Object.keys(schema.resourceFields || {});
 
   commentFields.forEach((key) => {
-    if ( typeof data[key] !== 'undefined' ) {
+    if ( typeof data[key] !== 'undefined' || key === '_type' ) {
       addObject(regularFields, key);
     }
   });
@@ -157,6 +158,11 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
     const referenceTo = typeRef('reference', type);
 
     let out = `${ key }:`;
+
+    // '_type' in steve maps to kubernetes 'type' field; show 'type' field in yaml
+    if (key === '_type') {
+      out = 'type:';
+    }
 
     if ( !field ) {
       // Not much to do here...


### PR DESCRIPTION
#615 
#608 

use js-yaml to create a yaml from resource proxy objects in order to:
* map _type to type
* hide 'stringData' field on secrets
* skip 'resourceVersion' field when cloning as yaml
* skip 'state' field when cloning as yaml
