### PR TITLE
Queue updates from subscribe and apply once per second

### DIFF
--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -191,12 +191,20 @@ export default {
     }
     commit('load', {
       ctx,
-      type,
       data,
       existing
     });
 
     return getters['byId'](type, data.id || existing.id);
+  },
+
+  loadMulti(ctx, entries) {
+    const { commit } = ctx;
+
+    commit('loadMulti', {
+      entries,
+      ctx,
+    });
   },
 
   loadAll(ctx, { type, data }) {

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -25,8 +25,53 @@ function registerType(state, type) {
   return cache;
 }
 
+function load(state, { data, ctx, existing }) {
+  let type = normalizeType(data.type);
+  const keyField = KEY_FIELD_FOR[type] || KEY_FIELD_FOR['default'];
+
+  const id = data[keyField];
+
+  let cache = registerType(state, type);
+
+  let entry;
+
+  if ( existing ) {
+    // A specific proxy instance to used was passed in (for create -> save),
+    // use it instead of making a new proxy
+    entry = existing;
+    Object.assign(entry, data);
+    addObject(cache.list, entry);
+    cache.map.set(id, entry);
+    // console.log('### Mutation added from existing proxy', type, id);
+  } else {
+    entry = cache.map.get(id);
+
+    if ( entry ) {
+      // There's already an entry in the store, update it
+      Object.assign(entry, data);
+      // console.log('### Mutation Updated', type, id);
+    } else {
+      // There's no entry, make a new proxy
+      entry = proxyFor(ctx, data);
+      addObject(cache.list, entry);
+      cache.map.set(id, entry);
+      // console.log('### Mutation', type, id);
+    }
+  }
+
+  if ( data.baseType ) {
+    type = normalizeType(data.baseType);
+    cache = state.types[type];
+    if ( cache ) {
+      addObject(cache.list, entry);
+      cache.map.set(id, entry);
+    }
+  }
+}
+
 export default {
   registerType,
+  load,
 
   applyConfig(state, config) {
     if ( !state.config ) {
@@ -34,6 +79,13 @@ export default {
     }
 
     Object.assign(state.config, config);
+  },
+
+  loadMulti(state, { entries, ctx }) {
+    // console.log('### Mutation loadMulti', entries.length);
+    for ( const data of entries ) {
+      load(state, { data, ctx });
+    }
   },
 
   loadAll(state, { type, data, ctx }) {
@@ -55,42 +107,6 @@ export default {
     }
 
     cache.haveAll = true;
-  },
-
-  load(state, { data, ctx, existing }) {
-    let type = normalizeType(data.type);
-    const keyField = KEY_FIELD_FOR[type] || KEY_FIELD_FOR['default'];
-
-    const id = data[keyField];
-
-    let cache = registerType(state, type);
-
-    let entry = cache.map.get(id);
-
-    if ( existing ) {
-      // A specific proxy instance to used was passed in (for create -> save),
-      // use it instead of making a new proxy
-      entry = existing;
-      Object.assign(entry, data);
-      cache.map.set(id, entry);
-    } else if ( entry ) {
-      // There's already an entry in the store, update it
-      Object.assign(entry, data);
-    } else {
-      // There's no entry, make a new proxy
-      entry = proxyFor(ctx, data);
-      addObject(cache.list, entry);
-      cache.map.set(id, entry);
-    }
-
-    if ( data.baseType ) {
-      type = normalizeType(data.baseType);
-      cache = state.types[type];
-      if ( cache ) {
-        addObject(cache.list, entry);
-        cache.map.set(id, entry);
-      }
-    }
   },
 
   remove(state, obj) {

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -490,7 +490,7 @@ export default {
   },
 
   canCreate() {
-    return (this.schema?.attributes?.verbs || []).includes('create') && this.$rootGetters['type-map/isCreatable'](this.type);
+    return this.$rootGetters['type-map/isCreatable'](this.type);
   },
 
   canViewInApi() {
@@ -621,6 +621,7 @@ export default {
 
       const res = await this.$dispatch('request', opt);
 
+      // console.log('### Resource Save', this.type, this.id);
       await this.$dispatch('load', { data: res, existing: this });
 
       return this;


### PR DESCRIPTION
- For the creating a new resource -> save() case, add the `existing` model to the array instead of just the map
- Apply all the queued changes together once a second instead of continuously so that there's not constant recomputes and rereneders under heavy change rates.
- Combine consecutive `load`s of new data into one mutation instead of many when possible
- This also indirectly addresses the problem of a `resource.create` event coming in for a resource that's being `save()`d and being added to the store from that before save has a chance to put in the `existing` entry first.