### PR TITLE
Fix create buttons

### DIFF
--- a/components/formatter/LinkNode.vue
+++ b/components/formatter/LinkNode.vue
@@ -28,7 +28,7 @@ export default {
       const name = 'c-cluster-resource-id';
       const params = { resource: NODE, id: this.value };
 
-      this.url = this.$router.resolve({ name, params }).href;
+      this.url = { name, params };
     }
   }
 };

--- a/detail/networking.k8s.io.ingress.vue
+++ b/detail/networking.k8s.io.ingress.vue
@@ -101,7 +101,7 @@ export default {
             resource:  SECRET
           };
 
-          const url = this.$router.resolve({ name, params }).href;
+          const url = { name, params };
 
           cert.link = { url, text: cert.secretName };
         } else {
@@ -135,7 +135,7 @@ export default {
           };
         }
 
-        const targetUrl = this.$router.resolve({ name, params }).href;
+        const targetUrl = { name, params };
         const pathUrl = `https://${ host }${ path?.path }`;
 
         path.targetLink = {

--- a/pages/c/_cluster/_resource/index.vue
+++ b/pages/c/_cluster/_resource/index.vue
@@ -15,7 +15,7 @@ export default {
     const params = { ...this.$route.params };
     const resource = params.resource;
 
-    const formRoute = this.$router.resolve({ name: `${ this.$route.name }-create`, params }).href;
+    const formRoute = { name: `${ this.$route.name }-create`, params };
 
     const query = { [AS_YAML]: _FLAGGED };
 
@@ -26,11 +26,11 @@ export default {
       listComponent = this.$store.getters['type-map/importList'](resource);
     }
 
-    const yamlRoute = this.$router.resolve({
+    const yamlRoute = {
       name: `${ this.$route.name }-create`,
       params,
       query
-    }).href;
+    };
 
     return {
       route:   this.$route,
@@ -127,7 +127,7 @@ export default {
       <div class="actions">
         <nuxt-link
           v-if="schema && isCreatable"
-          :to="{path: yamlRoute}"
+          :to="yamlRoute"
           tag="button"
           type="button"
           class="btn bg-primary mr-10"
@@ -136,7 +136,7 @@ export default {
         </nuxt-link>
         <nuxt-link
           v-if="hasEditComponent && isCreatable"
-          :to="{path: formRoute}"
+          :to="formRoute"
           tag="button"
           type="button"
           class="btn bg-primary"


### PR DESCRIPTION
Create buttons were still using a relative url instead of a location.
This switches over to locations so we don't get end up with
/dashboard/dashboard/

rancher/dashboard#657