### PR TITLE
Fixing generic list page use of masthead

### DIFF
--- a/pages/c/_cluster/_resource/index.vue
+++ b/pages/c/_cluster/_resource/index.vue
@@ -121,8 +121,8 @@ export default {
       :type-display="typeDisplay"
       :is-yaml-creatable="schema && isCreatable"
       :is-creatable="hasEditComponent && isCreatable"
-      :yaml-create-location="{path: yamlRoute}"
-      :create-location="{path: formRoute}"
+      :yaml-create-location="yamlRoute"
+      :create-location="formRoute"
     />
 
     <div v-if="hasListComponent">


### PR DESCRIPTION
The routes were erroneously being wrapped in an object.