### PR TITLE
Fixing cordon/uncordon on the detail page

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -96,8 +96,14 @@ export async function defaultAsyncData(ctx, resource) {
       fqid = `${ namespace }/${ fqid }`;
     }
 
-    originalModel = await store.dispatch('cluster/find', { type: resource, id: fqid });
-    model = await store.dispatch('cluster/clone', { resource: originalModel });
+    originalModel = await store.dispatch('cluster/find', {
+      type: resource, id: fqid, opt: { watch: true }
+    });
+    if (realMode === _VIEW) {
+      model = originalModel;
+    } else {
+      model = await store.dispatch('cluster/clone', { resource: originalModel });
+    }
 
     if ( realMode === _CLONE || realMode === _STAGE ) {
       cleanForNew(model);
@@ -274,7 +280,7 @@ export default {
 <template>
   <div>
     <Masthead
-      :value="model"
+      :value="originalModel"
       :mode="mode"
       :done-route="doneRoute"
       :real-mode="realMode"

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -168,6 +168,10 @@ export default {
 
     await dispatch('load', { data: res });
 
+    if ( opt.watch ) {
+      dispatch('watchType', { type });
+    }
+
     out = getters.byId(type, id);
 
     return out;


### PR DESCRIPTION
There were two issues that were causing the 409s.
1. When using cluster/find the resource wasn't being watched
    so the resource was out of date.
2. Cloned resources don't get the updates either.

This change provides an option to to allow cluster/find to
watch the resource and when in VIEW mode the resource isn't
cloned so it can receive updates.

rancher/dashboard#679