### PR TITLE
rearrange generic detail page

### DIFF
--- a/components/GenericResourceDetail.vue
+++ b/components/GenericResourceDetail.vue
@@ -146,7 +146,7 @@ export default {
     </ResourceTabs>
     <div id="yaml-container">
       <h3 class="mb-10 mt-20">
-        YAML
+        <t k="resourceDetail.masthead.yaml" />
       </h3>
       <ResourceYaml v-if="yaml.length" :value="value" mode="view" :yaml="yaml" :show-footer="false" />
     </div>

--- a/components/GenericResourceDetail.vue
+++ b/components/GenericResourceDetail.vue
@@ -137,20 +137,19 @@ export default {
         <LiveDate :value="get(value, 'metadata.deletionTimestamp')" :add-suffix="true" />
       </template>
     </DetailTop>
-
-    <div id="yaml-container">
-      <h3 class="mb-10 mt-20">
-        YAML
-      </h3>
-      <ResourceYaml v-if="yaml.length" :value="value" mode="view" :yaml="yaml" :show-footer="false" />
-    </div>
-    <ResourceTabs v-model="value" mode="view">
+    <ResourceTabs v-model="value" class="mt-20" mode="view">
       <template #before>
         <Tab v-if="!!(value.status||{}).conditions" label="Conditions" name="conditions">
           <Conditions :value="value" />
         </Tab>
       </template>
     </ResourceTabs>
+    <div id="yaml-container">
+      <h3 class="mb-10 mt-20">
+        YAML
+      </h3>
+      <ResourceYaml v-if="yaml.length" :value="value" mode="view" :yaml="yaml" :show-footer="false" />
+    </div>
   </div>
 </template>
 
@@ -165,7 +164,6 @@ export default {
     flex-basis: auto;
     -ms-overflow-style: none;
     overflow: scroll;
-    max-height: 75vh;
     min-height:0px;
 
     &::-webkit-scrollbar {


### PR DESCRIPTION
per https://github.com/rancher/dashboard/issues/542#issuecomment-639987538
The YAML is moved below tabs, and made full height (only the page scrolls)

<img width="1038" alt="Screen Shot 2020-06-08 at 9 06 06 AM" src="https://user-images.githubusercontent.com/42977925/84053827-528e3b00-a967-11ea-9d23-1afd3ef7af30.png">
