### PR TITLE
Ensure originalModel is defined for create in ResourceDetail

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -85,8 +85,8 @@ export async function defaultAsyncData(ctx, resource) {
       data.metadata = { namespace };
     }
 
-    originalModel = null;
-    model = await store.dispatch('cluster/create', data);
+    originalModel = await store.dispatch('cluster/create', data);
+    model = originalModel;
 
     yaml = createYaml(schemas, resource, data);
   } else {


### PR DESCRIPTION
Switching masthead over to use originalModel broke create
pages because originalModel was null. This ensures that
originalModel is defined.