### PR TITLE
Removing the name from the constraints detail page

### DIFF
--- a/components/form/NameNsDescription.vue
+++ b/components/form/NameNsDescription.vue
@@ -29,7 +29,7 @@ export default {
       type:    Array,
       default: () => []
     },
-    extraDetailColumns: {
+    detailTopColumns: {
       type:    Array,
       default: () => []
     },
@@ -74,21 +74,6 @@ export default {
   computed: {
     nameDisabled() {
       return this.mode === _EDIT && !this.nameEditable;
-    },
-
-    detailTopColumns() {
-      const name = this.value?.metadata?.name;
-
-      const nameColumn = {
-        title:   'Name',
-        content: name
-      };
-
-      if ( name ) {
-        return [nameColumn, ...this.extraDetailColumns];
-      }
-
-      return this.extraDetailColumns;
     },
 
     namespaces() {

--- a/shared/gatekeeper-constraint.vue
+++ b/shared/gatekeeper-constraint.vue
@@ -72,7 +72,7 @@ export default {
   },
 
   computed: {
-    extraDetailColumns() {
+    detailTopColumns() {
       return [
         {
           title:   'Template',
@@ -197,7 +197,7 @@ export default {
         :mode="mode"
         :namespaced="false"
         :extra-columns="['template']"
-        :extra-detail-columns="extraDetailColumns"
+        :detail-top-columns="detailTopColumns"
       >
         <template v-slot:template>
           <LabeledSelect


### PR DESCRIPTION
Making the detail-top consistent with all the other pages and
removing the name from the constraints detail page.

rancher/dashboard#695