### PR TITLE
do not clean yamls for create

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -104,18 +104,18 @@ export async function defaultAsyncData(ctx, resource) {
     } else {
       model = await store.dispatch('cluster/clone', { resource: originalModel });
     }
+    const link = originalModel.hasLink('rioview') ? 'rioview' : 'view';
+
+    yaml = (await originalModel.followLink(link, { headers: { accept: 'application/yaml' } })).data;
 
     if ( realMode === _CLONE || realMode === _STAGE ) {
       cleanForNew(model);
+      yaml = model.cleanYaml(yaml, realMode);
     }
 
     if ( model.applyDefaults ) {
       model.applyDefaults(ctx, realMode);
     }
-
-    const link = originalModel.hasLink('rioview') ? 'rioview' : 'view';
-
-    yaml = (await originalModel.followLink(link, { headers: { accept: 'application/yaml' } })).data;
   }
 
   let mode = realMode;

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -64,7 +64,7 @@ export default {
     this.$router.applyQuery({ [PREVIEW]: _UNFLAG });
 
     return {
-      currentYaml:  this.value.cleanYaml(this.yaml, this.mode),
+      currentYaml:  this.yaml,
       showPreview:  false,
       errors:       null
     };
@@ -99,8 +99,12 @@ export default {
   },
 
   watch: {
-    mode(neu) {
-      this.currentYaml = this.value.cleanYaml(this.yaml, neu);
+    mode(neu, old) {
+      // if this component is changing from viewing a resource to 'creating' that resource, it must actually be cloning
+      // clean yaml accordingly
+      if (neu === _CREATE && old === _VIEW) {
+        this.currentYaml = this.value.cleanYaml(this.yaml, neu);
+      }
     }
   },
 

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -6,7 +6,7 @@ import { escapeHtml, ucFirst } from '@/utils/string';
 import { eachLimit } from '@/utils/promise';
 import {
   MODE, _EDIT, _CLONE,
-  AS_YAML, _FLAGGED, _VIEW
+  AS_YAML, _FLAGGED, _VIEW,
 } from '@/config/query-params';
 import { findBy } from '@/utils/array';
 import { DEV } from '@/store/prefs';
@@ -846,9 +846,6 @@ export default {
   // map _type to type
   cleanYaml() {
     return (yaml, mode = 'edit') => {
-      if (mode === _VIEW) {
-        return yaml;
-      }
       try {
         const obj = jsyaml.safeLoad(yaml);
 


### PR DESCRIPTION
`cleanYaml` was being called on—and obliviating commented tips from—yamls in create-from-yaml pages

this PR ensures `cleanYaml` is only called to: 
* re-map `_type` to `type` for editing
* apply `cleanForNew` logic and remap `_type` to `type` for cloning