### PR TITLE
Pod detail feedback

### DIFF
--- a/assets/styles/base/_helpers.scss
+++ b/assets/styles/base/_helpers.scss
@@ -123,6 +123,11 @@ $spacing-property-map: (
   text-transform: capitalize;
 }
 
+.text-label {
+  color: var(--input-label);
+  font-size: 14px;
+}
+
 .hide {
   display: none !important;
 }

--- a/assets/styles/global/_labeled-input.scss
+++ b/assets/styles/global/_labeled-input.scss
@@ -6,7 +6,7 @@
 
   LABEL {
     position: absolute;
-    transform: translate(0, -12px) scale(1);
+    transform: translate(0, -10px) scale(1);
     transform-origin: top left;
     transition-property: transform, font-size;
     transition-duration: 0.1s;
@@ -68,6 +68,10 @@
   &.view > DIV:not(.addon) {
     font-size: 14px;
     padding: 17px 0 0 0;
+
+    &.no-label {
+      padding-top:0px;
+    }
   }
 
   &.create,

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -527,6 +527,10 @@ secret:
     domainName: Registry Domain Name
 
 workload:
+  tabs:
+    networking: Networking
+    scheduling: Scheduling
+    security: Security
   container:
     noResourceLimits: There are no resource requirements configured.
     titles:
@@ -594,7 +598,7 @@ workload:
       label: Network Mode
       placeholder: Select a Mode...
       options: 
-        normal: normal
+        normal: Normal
         hostNetwork: Host Network
     dnsPolicy: 
       label: DNS Policy
@@ -635,6 +639,7 @@ workload:
       tolerations: Tolerations
       priority: Priority
       advanced: Advanced
+      nodeSelector: Nodes with these labels
     activeDeadlineSeconds: Pod Active Deadline
     terminationGracePeriodSeconds: Termination Grace Period
     activeDeadlineSecondsTip: The duration that the pod may be active before the system tries to mark it failed and kill associated containers.

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -528,7 +528,9 @@ secret:
 
 workload:
   container:
+    noResourceLimits: There are no resource requirements configured.
     titles:
+      containers: Containers
       ports: Ports
       command: Command
       resources: Resources
@@ -548,7 +550,8 @@ workload:
       workingDir: WorkingDir
       env: Environment Variables
       addFromResource: Add from Resource
-    healthcheck:
+    healthCheck:
+      noHealthCheck: There is not a Readiness Check, Liveness Check or Startup Check configured.
       readinessProbe: Readiness Probe
       livenessProbe: Liveness Probe
       startupProbe: Startup Probe
@@ -585,7 +588,45 @@ workload:
       hostPID: "Use Host PID Namespace"
       hostIPC: "Use Host IPC Namespace"
       sysctls: Sysctls
-      sysctlsKey: "Name"
+      sysctlsKey: 'Name'
+  networking: 
+    networkMode:
+      label: Network Mode
+      placeholder: Select a Mode...
+      options: 
+        normal: normal
+        hostNetwork: Host Network
+    dnsPolicy: 
+      label: DNS Policy
+      placeholder: Select a Policy...
+      options:
+        default: Default
+        clusterFirst: Cluster First
+        clusterFirstWithHostNet: Cluster First With Host Network
+        none: None
+    hostname:
+      label: Hostname
+      placeholder: e.g. web
+    subdomain: 
+      label: Subdomain
+      placeholder: e.g. web
+    nameservers: 
+      label: DNS Nameservers
+      placeholder: e.g. 1.1.1.1
+      add: Add Nameserver
+    searches: 
+      label: DNS Search Domains
+      placeholder: e.g. mycompany.com
+      add: Add Search Domain
+    resolver: DNS Resolver Options
+    hostAliases: 
+      label: Host Aliases
+      tip: Additional /etc/hosts entries to be injected in the container.
+      keyLabel: IP Address
+      keyPlaceholder: e.g. 1.1.1.1
+      valueLabel: Hostname
+      valuePlaceholder: e.g. foo.com, bar.com
+      add: Add Alias
   scheduling:
     titles:
       tab: Scheduling
@@ -617,6 +658,11 @@ workload:
         preferNoSchedule: PreferNoSchedule
         noExecute: NoExecute
     affinity:
+      topologyKey:
+        label: Topology Key
+        placeholder:  e.g. failure-domain.beta.kubernetes.io/zone
+      noPodRules: There are no pod scheduling rules configured.
+      nodeName: Node Name
       specificNode: Run pods on specific node(s)
       schedulingRules: Run pods on node(s) matching these scheduling rules
       requireAny: "Require any of:"
@@ -636,7 +682,7 @@ workload:
         operator: Operator
         addRule: Add Rule
         weight: Weight
-        inNamespaces: Pods in these namespaces
+        inNamespaces: 'Pods in these namespaces:'
 
 rioConfig:
   header: Rio

--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -167,6 +167,9 @@ export default {
         />
       </span>
     </div>
+
+    <div class="spacer" />
+
     <div class="row mb-0">
       <span class="col span-6">
         <UnitInput

--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -182,7 +182,7 @@ export default {
 <template>
   <div>
     <div v-if="title" class="clearfix">
-      <label>{{ title }} <i v-if="protip" v-tooltip="protip" class="icon icon-info" style="font-size: 12px" /></label>
+      <label :style="{'color': 'var(--input-label)', 'font-size':'14px'}">{{ title }} <i v-if="protip" v-tooltip="protip" class="icon icon-info" style="font-size: 12px" /></label>
     </div>
 
     <table v-if="rows.length" class="fixed">

--- a/components/form/Command.vue
+++ b/components/form/Command.vue
@@ -168,6 +168,8 @@ export default {
       </div>
     </div>
 
+    <div class="spacer" />
+
     <div class="row">
       <div class="col span-6">
         <LabeledInput
@@ -189,6 +191,8 @@ export default {
       </div>
     </div>
 
+    <div class="spacer" />
+
     <KeyValue
       key="env"
       v-model="unreferencedValues"
@@ -200,6 +204,11 @@ export default {
       title="Environment Variables"
       class="mb-10"
     >
+      <template #title>
+        <h4>
+          {{ t('workload.container.command.env') }}
+        </h4>
+      </template>
       <template #key="{row}">
         <span v-if="row.valueFrom" />
       </template>
@@ -241,6 +250,7 @@ export default {
       v-for="(val,i) in referencedValues"
       ref="referenced"
       :key="`${i}`"
+      class="mb-10"
       :row="val"
       :all-secrets="secrets"
       :all-config-maps="configMaps"

--- a/components/form/Container.vue
+++ b/components/form/Container.vue
@@ -70,6 +70,7 @@ export default {
     isView() {
       return this.mode === _VIEW;
     },
+
     flatResources: {
       get() {
         const { limits = {}, requests = {} } = this.resources || {};
@@ -99,6 +100,20 @@ export default {
         this.resources = cleanUp(out);
       }
     },
+
+    hasResourceLimits() {
+      const {
+        limitsCpu, limitsMemory, requestsCpu, requestsMemory
+      } = this.flatResources;
+
+      return !!limitsCpu || !!limitsMemory || !!requestsCpu || !!requestsMemory;
+    },
+
+    hasHealthCheck() {
+      const { readinessProbe, livenessProbe, startupProbe } = this.healthCheck;
+
+      return !!readinessProbe || !!livenessProbe || !!startupProbe;
+    }
   },
 
   methods: {
@@ -132,13 +147,19 @@ export default {
 
     <div>
       <h3><t k="workload.container.titles.resources" /></h3>
-      <ContainerResourceLimit v-model="flatResources" :mode="mode" :show-tip="false" />
+      <ContainerResourceLimit v-if="hasResourceLimits" v-model="flatResources" :mode="mode" :show-tip="false" />
+      <div v-else>
+        <t k="workload.container.noResourceLimits" />
+      </div>
       <hr class="mt-20 mb-20" />
     </div>
 
     <div>
       <h3><t k="workload.container.titles.healthCheck" /></h3>
-      <HealthCheck v-model="healthCheck" :mode="mode" />
+      <HealthCheck v-if="hasHealthCheck" v-model="healthCheck" :mode="mode" />
+      <div v-else>
+        <t k="workload.container.healthCheck.noHealthCheck" />
+      </div>
       <hr class="mt-20 mb-20" />
     </div>
 

--- a/components/form/Container.vue
+++ b/components/form/Container.vue
@@ -137,13 +137,16 @@ export default {
     <div>
       <h3><t k="workload.container.titles.ports" /></h3>
       <WorkloadPorts v-model="ports" :mode="mode" />
-      <hr class="mt-20 mb-20" />
     </div>
+
+    <div class="spacer" />
+
     <div>
       <h3><t k="workload.container.titles.command" /></h3>
       <Command v-model="commandTab" :mode="mode" :secrets="secrets" :config-maps="configMaps" />
-      <hr class="mt-20 mb-20" />
     </div>
+
+    <div class="spacer" />
 
     <div>
       <h3><t k="workload.container.titles.resources" /></h3>
@@ -151,8 +154,9 @@ export default {
       <div v-else>
         <t k="workload.container.noResourceLimits" />
       </div>
-      <hr class="mt-20 mb-20" />
     </div>
+
+    <div class="spacer" />
 
     <div>
       <h3><t k="workload.container.titles.healthCheck" /></h3>
@@ -160,14 +164,16 @@ export default {
       <div v-else>
         <t k="workload.container.healthCheck.noHealthCheck" />
       </div>
-      <hr class="mt-20 mb-20" />
     </div>
+
+    <div class="spacer" />
 
     <div>
       <h3><t k="workload.container.titles.securityContext" /></h3>
       <Security v-model="securityContext" :mode="mode" />
     </div>
   </div>
+
   <div v-else @input="update">
     <div class="row">
       <div class="col span-4">

--- a/components/form/HealthCheck.vue
+++ b/components/form/HealthCheck.vue
@@ -34,7 +34,10 @@ export default {
         :description="t('workload.container.healthCheck.readinessTip')"
       />
     </div>
-    <hr v-if="!isView" />
+
+    <hr v-if="!isView" class="mt-40 mb-40" />
+    <div v-else class="spacer" />
+
     <div class="row">
       <Probe
         v-model="value.livenessProbe"
@@ -44,8 +47,11 @@ export default {
         :description="t('workload.container.healthCheck.livenessTip')"
       />
     </div>
-    <hr v-if="!isView" />
-    <div class="row mb-0">
+
+    <hr v-if="!isView" class="mt-40 mb-40" />
+    <div v-else class="spacer" />
+
+    <div class="row">
       <Probe
         v-model="value.startupProbe"
         class="col span-12"

--- a/components/form/HealthCheck.vue
+++ b/components/form/HealthCheck.vue
@@ -31,7 +31,7 @@ export default {
         class="col span-12"
         :mode="mode"
         label="Readiness Check"
-        :description="t('workload.container.healthcheck.readinessTip')"
+        :description="t('workload.container.healthCheck.readinessTip')"
       />
     </div>
     <hr v-if="!isView" />
@@ -41,7 +41,7 @@ export default {
         class="col span-12"
         :mode="mode"
         label="Liveness Check"
-        :description="t('workload.container.healthcheck.livenessTip')"
+        :description="t('workload.container.healthCheck.livenessTip')"
       />
     </div>
     <hr v-if="!isView" />
@@ -51,7 +51,7 @@ export default {
         class="col span-12"
         :mode="mode"
         label="Startup Check"
-        :description="t('workload.container.healthcheck.startupTip')"
+        :description="t('workload.container.healthCheck.startupTip')"
       />
     </div>
   </div>

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -42,6 +42,12 @@ export default {
       type:    String,
       default: ''
     },
+
+    titleComponent: {
+      type:    String,
+      default: 'h2'
+    },
+
     protip: {
       type:    [String, Boolean],
       default: 'ProTip: Paste lines of <code>key=value</code> or <code>key: value</code> into any key field for easy bulk entry',
@@ -356,11 +362,16 @@ export default {
 
 <template>
   <div class="key-value" :class="mode">
-    <div v-if="title" class="clearfix">
-      <h2 :style="{'display':'flex'}">
-        {{ title }} <i v-if="protip" v-tooltip="protip" class="icon icon-info" style="font-size: 12px" />
-      </h2>
-    </div>
+    <template v-if="title || !!$slots.title">
+      <div :style="{'display':'flex'}" class="clearfix">
+        <slot name="title">
+          <h2 :style="{'display':'flex'}">
+            {{ title }}
+          </h2>
+        </slot>
+        <i v-if="protip" v-tooltip="protip" class="icon icon-info" style="font-size: 12px" />
+      </div>
+    </template>
 
     <SortableTable
       :headers="headers"

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -43,11 +43,6 @@ export default {
       default: ''
     },
 
-    titleComponent: {
-      type:    String,
-      default: 'h2'
-    },
-
     protip: {
       type:    [String, Boolean],
       default: 'ProTip: Paste lines of <code>key=value</code> or <code>key: value</code> into any key field for easy bulk entry',

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -77,7 +77,7 @@ export default {
       <slot name="corner" />
     </label>
     <slot name="prefix" />
-    <div>
+    <div :class="{'no-label':!(label||'').length}">
       <span v-if="value">
         {{ value }}
         <slot name="suffix" />

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -161,10 +161,10 @@ export default {
       <label v-if="label" class="corner">
         <slot name="corner" />
       </label>
-      <div v-if="isView" class="selected">
+      <div v-if="isView" :class="{'no-label':!(label||'').length}" class="selected">
         {{ currentLabel }}&nbsp;
       </div>
-      <div v-else class="selected" :class="{'no-label':!label}" :style="{visibility:selectedVisibility}">
+      <div v-else class="selected" :style="{visibility:selectedVisibility}">
         {{ currentLabel }}&nbsp;
       </div>
     </div>
@@ -214,8 +214,8 @@ export default {
   .selected {
     padding-top: 17px;
     &.no-label{
+      padding-top:0px;
       position: relative;
-      top:-7px;
       max-height:2.3em;
       overflow:hidden;
       }

--- a/components/form/MatchExpressions.vue
+++ b/components/form/MatchExpressions.vue
@@ -222,21 +222,23 @@ export default {
           </ArrayList>
         </div>
       </div>
-      <div class="row">
-        <div class="col span-12">
-          <LabeledInput
-            :mode="mode"
-            :value="topologyKey"
-            required
-            :label="t('workload.scheduling.affinity.topologyKey.label')"
-            :placeholder="t('workload.scheduling.affinity.topologyKey.placeholder')"
-            @input="e=>$emit('update:topologyKey', e)"
-          />
-        </div>
-      </div>
+
+      <div class="spacer" />
+
+      <LabeledInput
+        :mode="mode"
+        :value="topologyKey"
+        required
+        :label="t('workload.scheduling.affinity.topologyKey.label')"
+        :placeholder="t('workload.scheduling.affinity.topologyKey.placeholder')"
+        @input="e=>$emit('update:topologyKey', e)"
+      />
     </template>
 
+    <div class="spacer" />
+
     <SortableTable
+      v-if="rules.length"
       class="match-expressions"
       :class="mode"
       :headers="tableHeaders"

--- a/components/form/MatchExpressions.vue
+++ b/components/form/MatchExpressions.vue
@@ -26,6 +26,11 @@ export default {
       default: null
     },
 
+    topologyKey: {
+      type:    String,
+      default: null
+    },
+
     // show selector weight (if present) in view mode
     weight: {
       type:    Number,
@@ -160,7 +165,6 @@ export default {
       const idx = this.rules.indexOf(row);
 
       this.rules.splice(idx, 1);
-      this.update();
     },
 
     addRule() {
@@ -201,16 +205,36 @@ export default {
       <i class="icon icon-x" />
     </button>
 
-    <div v-if="type===pod" class="row mt-20">
-      <div class="col span-12">
-        <t k="workload.scheduling.affinity.matchExpressions.inNamespaces" />
-        <ArrayList :value="namespaces" @input="e=>$emit('update:namespaces', e)">
-          <template #value="props">
-            <LabeledSelect v-model="props.row.value" :options="allNamespaces" label="Namespaces" :multiple="false" @input="props.queueUpdate" />
-          </template>
-        </ArrayList>
+    <template v-if="type===pod">
+      <div class="row mt-20">
+        <div class="col span-12">
+          <ArrayList :protip="false" :title="t('workload.scheduling.affinity.matchExpressions.inNamespaces')" :mode="mode" :value="namespaces" @input="e=>$emit('update:namespaces', e)">
+            <template #value="props">
+              <LabeledSelect
+                v-model="props.row.value"
+                :mode="mode"
+                :options="allNamespaces"
+                :label="!isView ? 'Namespaces' :''"
+                :multiple="false"
+                @input="props.queueUpdate"
+              />
+            </template>
+          </ArrayList>
+        </div>
       </div>
-    </div>
+      <div class="row">
+        <div class="col span-12">
+          <LabeledInput
+            :mode="mode"
+            :value="topologyKey"
+            required
+            :label="t('workload.scheduling.affinity.topologyKey.label')"
+            :placeholder="t('workload.scheduling.affinity.topologyKey.placeholder')"
+            @input="e=>$emit('update:topologyKey', e)"
+          />
+        </div>
+      </div>
+    </template>
 
     <SortableTable
       class="match-expressions"

--- a/components/form/Networking.vue
+++ b/components/form/Networking.vue
@@ -182,6 +182,8 @@ export default {
       </div>
     </div>
 
+    <div class="spacer" />
+
     <div class="row">
       <div class="col span-6">
         <LabeledInput
@@ -202,6 +204,8 @@ export default {
         />
       </div>
     </div>
+
+    <div class="spacer" />
 
     <div class="row">
       <div class="col span-6">
@@ -234,8 +238,20 @@ export default {
       </div>
     </div>
 
+    <div class="spacer" />
+
     <div class="row">
-      <KeyValue v-model="options" key-label="Name" :mode="mode" :title="t('workload.networking.resolver')" :read-allowed="false" />
+      <KeyValue
+        v-model="options"
+        key-label="Name"
+        :mode="mode"
+        :title="t('workload.networking.resolver')"
+        :read-allowed="false"
+      >
+        <template #title>
+          <h3>{{ t('workload.networking.resolver') }}</h3>
+        </template>
+      </KeyValue>
     </div>
 
     <div class="row">
@@ -257,7 +273,11 @@ export default {
           :pad-left="false"
           :add-label="t('workload.networking.hostAliases.add')"
           @input="updateHostAliases"
-        />
+        >
+          <template #title>
+            <h3>{{ t('workload.networking.hostAliases.label') }}</h3>
+          </template>
+        </KeyValue>
       </div>
     </div>
   </div>

--- a/components/form/Networking.vue
+++ b/components/form/Networking.vue
@@ -3,6 +3,7 @@ import ArrayList from '@/components/form/ArrayList';
 import KeyValue from '@/components/form/KeyValue';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
+import { mapGetters } from 'vuex';
 
 const CLUSTER_FIRST = 'ClusterFirst';
 const CLUSTER_FIRST_HOST = 'ClusterFirstWithHostNet';
@@ -50,23 +51,38 @@ export default {
   computed: {
     dnsPolicyChoices() {
       return [
-        { label: 'Default', value: 'Default' },
-        { label: 'ClusterFirst', value: 'Cluster First' },
-        { label: 'None', value: 'None' },
+        {
+          label: this.t('workload.networking.dnsPolicy.options.default'),
+          value: 'Default'
+        },
+        {
+          label: this.t('workload.networking.dnsPolicy.options.clusterFirst'),
+          value: 'ClusterFirst'
+        },
+        {
+          label: this.t('workload.networking.dnsPolicy.options.clusterFirstWithHostNet'),
+          value: 'ClusterFirstWithHostNet'
+        },
+        {
+          label: this.t('workload.networking.dnsPolicy.options.none'),
+          value: 'None'
+        },
       ];
     },
 
     networkModeChoices() {
       return [
-        { label: 'Normal', value: 'normal' },
-        { label: 'Host Network', value: 'host' },
+        { label: this.t('workload.networking.networkMode.options.normal'), value: false },
+        { label: this.t('workload.networking.networkMode.options.hostNetwork'), value: true },
       ];
     },
+
+    ...mapGetters({ t: 'i18n/t' })
   },
 
   watch: {
     networkMode(neu) {
-      const on = neu === 'host';
+      const on = neu;
 
       this.value.hostNetwork = on;
       if ( this.dnsPolicy === CLUSTER_FIRST ) {
@@ -80,7 +96,7 @@ export default {
 
     dnsPolicy(neu) {
       if ( neu === CLUSTER_FIRST ) {
-        if ( this.networkMode === 'host' ) {
+        if ( this.networkMode ) {
           this.value.dnsPolicy = CLUSTER_FIRST_HOST;
         } else {
           this.value.dnsPolicy = CLUSTER_FIRST;
@@ -132,7 +148,7 @@ export default {
         hostname:    this.hostname,
         hostAliases: this.hostAliases,
         subdomain:   this.subdomain,
-        hostNetwork: (this.networkMode === 'host')
+        hostNetwork: this.networkMode
       };
 
       this.$emit('input', out);
@@ -148,8 +164,8 @@ export default {
           v-model="networkMode"
           :mode="mode"
           :options="networkModeChoices"
-          label="Network Mode"
-          placeholder="Select a Mode..."
+          :label="t('workload.networking.networkMode.label')"
+          :placeholder="t('workload.networking.networkMode.placeholder')"
           @input="update"
         />
       </div>
@@ -159,8 +175,8 @@ export default {
           v-model="dnsPolicy"
           :mode="mode"
           :options="dnsPolicyChoices"
-          label="DNS Policy"
-          placeholder="Select a Policy..."
+          :label="t('workload.networking.dnsPolicy.label')"
+          :placeholder="t('workload.networking.dnsPolicy.placeholder')"
           @input="update"
         />
       </div>
@@ -170,18 +186,18 @@ export default {
       <div class="col span-6">
         <LabeledInput
           v-model="hostname"
-          label="Hostname"
           :mode="mode"
-          placeholder="e.g. web"
+          :label="t('workload.networking.hostname.label')"
+          :placeholder="t('workload.networking.hostname.placeholder')"
           @input="update"
         />
       </div>
       <div class="col span-6">
         <LabeledInput
           v-model="subdomain"
-          label="Subdomain"
           :mode="mode"
-          placeholder="e.g. web"
+          :label="t('workload.networking.subdomain.label')"
+          :placeholder="t('workload.networking.subdomain.placeholder')"
           @input="update"
         />
       </div>
@@ -192,9 +208,9 @@ export default {
         <ArrayList
           key="dnsNameservers"
           v-model="nameservers"
-          title="Nameservers"
-          value-placeholder="e.g. 1.1.1.1"
-          add-label="Add Nameserver"
+          :title="t('workload.networking.nameservers.label')"
+          :value-placeholder="t('workload.networking.nameservers.placeholder')"
+          :add-label="t('workload.networking.nameservers.add')"
           :value-multiline="false"
           :mode="mode"
           :pad-left="false"
@@ -206,9 +222,9 @@ export default {
         <ArrayList
           key="dnsSearches"
           v-model="searches"
-          title="Search Domains"
-          value-placeholder="e.g. mycompany.com"
-          add-label="Add Search Domain"
+          :title="t('workload.networking.searches.label')"
+          :value-placeholder="t('workload.networking.searches.placeholder')"
+          :add-label="t('workload.networking.searches.add')"
           :value-multiline="false"
           :mode="mode"
           :pad-left="false"
@@ -219,7 +235,7 @@ export default {
     </div>
 
     <div class="row">
-      <KeyValue v-model="options" key-label="Name" :mode="mode" title="DNS Resolver Options" :read-allowed="false" />
+      <KeyValue v-model="options" key-label="Name" :mode="mode" :title="t('workload.networking.resolver')" :read-allowed="false" />
     </div>
 
     <div class="row">
@@ -228,18 +244,18 @@ export default {
           key="hostAliases"
           v-model="hostAliases"
           :mode="mode"
-          title="Host Aliases"
-          protip="Additional /etc/hosts entries to be injected in the container."
+          :title="t('workload.networking.hostAliases.label')"
+          :protip="t('workload.networking.hostAliases.tip')"
           :read-allowed="false"
           :as-map="false"
           key-name="ip"
-          key-label="IP Address"
-          key-placeholder="e.g. 1.1.1.1"
+          :key-label="t('workload.networking.hostAliases.keyLabel')"
+          :key-placeholder="t('workload.networking.hostAliases.keyPlaceholder')"
           value-name="hostnames"
-          value-label="Hostname"
-          value-placeholder="e.g. foo.com, bar.com"
+          :value-label="t('workload.networking.hostAliases.valueLabel')"
+          :value-placeholder="t('workload.networking.hostAliases.valuePlaceholder')"
           :pad-left="false"
-          add-label="Add Alias"
+          :add-label="t('workload.networking.hostAliases.add')"
           @input="updateHostAliases"
         />
       </div>

--- a/components/form/NodeAffinity.vue
+++ b/components/form/NodeAffinity.vue
@@ -103,7 +103,7 @@ export default {
         />
       </div>
       <template v-for="(nodeSelectorTerm, key) in selectorMap">
-        <div :key="key" class="row">
+        <div :key="key">
           <MatchExpressions
             :key="key"
             :initial-empty-row="!isView"
@@ -114,6 +114,7 @@ export default {
             @remove="$delete(selectorMap, key)"
             @input="e=>updateSelector(selectorMap, key, {matchExpressions:e})"
           />
+          <div class="spacer" />
         </div>
       </template>
       <button v-if="!isView" type="button" class="btn btn-sm role-primary" @click="e=>$set(selectorMap, Math.random(), {matchExpressions:[]})">
@@ -133,7 +134,7 @@ export default {
         />
       </div>
       <template v-for="(nodeSelectorTerm, key) in weightedSelectorMap">
-        <div :key="key" class="row">
+        <div :key="key">
           <MatchExpressions
             :key="key"
             :mode="mode"
@@ -145,6 +146,7 @@ export default {
             @remove="$delete(weightedSelectorMap, key)"
             @input="e=>updateSelector(weightedSelectorMap, key, {preference:{matchExpressions:e}, weight:defaultWeight})"
           />
+          <div class="spacer" />
         </div>
       </template>
       <button v-if="!isView" type="button" class="btn btn-sm role-primary" @click="e=>$set(weightedSelectorMap, Math.random(), {preference:{matchExpressions:[]}, weight:defaultWeight})">

--- a/components/form/PodAffinity.vue
+++ b/components/form/PodAffinity.vue
@@ -109,7 +109,7 @@ export default {
         <t k="workload.scheduling.affinity.requireAny" />
       </div>
       <template v-for="(nodeSelectorTerm, key) in selectorMap">
-        <div :key="key" class="row">
+        <div :key="key">
           <MatchExpressions
             :key="key"
             :mode="mode"
@@ -133,7 +133,7 @@ export default {
         <t k="workload.scheduling.affinity.preferAny" />
       </div>
       <template v-for="(nodeSelectorTerm, key) in weightedSelectorMap">
-        <div :key="key" class="row">
+        <div :key="key">
           <MatchExpressions
             :key="key"
             :mode="mode"
@@ -146,6 +146,7 @@ export default {
             @remove="$delete(weightedSelectorMap, key)"
             @input="e=>$set(weightedSelectorMap[key].podAffinityTerm, 'labelSelector', {matchExpressions:e})"
           />
+          <div class="spacer" />
         </div>
       </template>
       <button v-if="!isView" type="button" class="btn btn-sm role-primary" @click="addWeightedSelector">

--- a/components/form/PodSecurity.vue
+++ b/components/form/PodSecurity.vue
@@ -53,13 +53,15 @@ export default {
 <template>
   <div>
     <div class="row">
-      <div class="col span-3">
+      <div class="col span-6">
         <RadioGroup v-model="shareProcessNamespace" :label="t('workload.container.security.shareProcessNamespace')" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
       </div>
-      <div class="col span-3">
+      <div class="col span-6">
         <RadioGroup v-model="runasNonRoot" :label="t('workload.container.security.runAsNonRoot')" :options="[false, true]" :labels="[t('workload.container.security.runAsNonRootOptions.noOption'), t('workload.container.security.runAsNonRootOptions.yesOption')]" :mode="mode" />
       </div>
     </div>
+
+    <div class="spacer" />
 
     <div class="row">
       <div class="col span-6">
@@ -70,12 +72,18 @@ export default {
       </div>
     </div>
 
+    <div class="spacer" />
+
     <div class="row">
       <div class="col span-6">
-        <h5> <t k="workload.container.security.supplementalGroups" /> </h5>
+        <h5 class="text-label">
+          <t k="workload.container.security.supplementalGroups" />
+        </h5>
         <ArrayList v-model="supplementalGroups" :add-label="t('workload.container.security.addGroupIDs')" :mode="mode" />
       </div>
     </div>
+
+    <div class="spacer" />
 
     <div class="row">
       <div class="col span-6">
@@ -83,18 +91,33 @@ export default {
       </div>
     </div>
 
+    <div class="spacer" />
+
     <div class="row">
-      <div class="col span-3">
+      <div class="col span-6">
         <RadioGroup v-model="hostIPC" :label="t('workload.container.security.hostIPC')" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
       </div>
-      <div class="col span-3">
+      <div class="col span-6">
         <RadioGroup v-model="hostPID" :label="t('workload.container.security.hostPID')" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
       </div>
     </div>
 
-    <div class="row mb-0">
+    <div class="spacer" />
+
+    <div class="row">
       <div class="col span-12">
-        <KeyValue v-model="sysctls" :title="t('workload.container.security.sysctls')" :key-label="t('workload.container.security.sysctlsKey')" :mode="mode" />
+        <KeyValue
+          v-model="sysctls"
+          :title="t('workload.container.security.sysctls')"
+          :key-label="t('workload.container.security.sysctlsKey')"
+          :mode="mode"
+        >
+          <template #title>
+            <h3>
+              {{ t('workload.container.security.sysctls') }}
+            </h3>
+          </template>
+        </KeyValue>
       </div>
     </div>
   </div>

--- a/components/form/PodSecurity.vue
+++ b/components/form/PodSecurity.vue
@@ -54,12 +54,10 @@ export default {
   <div>
     <div class="row">
       <div class="col span-3">
-        <h5><t k="workload.container.security.shareProcessNamespace" /></h5>
-        <RadioGroup v-model="shareProcessNamespace" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
+        <RadioGroup v-model="shareProcessNamespace" :label="t('workload.container.security.shareProcessNamespace')" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
       </div>
       <div class="col span-3">
-        <h5><t k="workload.container.security.runAsNonRoot" /></h5>
-        <RadioGroup v-model="runasNonRoot" :options="[false, true]" :labels="[t('workload.container.security.runAsNonRootOptions.noOption'), t('workload.container.security.runAsNonRootOptions.yesOption')]" :mode="mode" />
+        <RadioGroup v-model="runasNonRoot" :label="t('workload.container.security.runAsNonRoot')" :options="[false, true]" :labels="[t('workload.container.security.runAsNonRootOptions.noOption'), t('workload.container.security.runAsNonRootOptions.yesOption')]" :mode="mode" />
       </div>
     </div>
 
@@ -87,12 +85,10 @@ export default {
 
     <div class="row">
       <div class="col span-3">
-        <h5><t k="workload.container.security.hostIPC" /></h5>
-        <RadioGroup v-model="hostIPC" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
+        <RadioGroup v-model="hostIPC" :label="t('workload.container.security.hostIPC')" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
       </div>
       <div class="col span-3">
-        <h5><t k="workload.container.security.hostPID" /></h5>
-        <RadioGroup v-model="hostPID" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
+        <RadioGroup v-model="hostPID" :label="t('workload.container.security.hostPID')" :labels="['No', 'Yes']" :options="[false, true]" :mode="mode" />
       </div>
     </div>
 
@@ -102,4 +98,4 @@ export default {
       </div>
     </div>
   </div>
-</template>>
+</template>

--- a/components/form/Probe.vue
+++ b/components/form/Probe.vue
@@ -156,60 +156,51 @@ export default {
     </div>
     <div class="row mb-0">
       <div class="col span-11-of-23">
-        <div class="row" :class="{'mb-0':!kind||kind==='none'}">
-          <div class="col span-12">
-            <LabeledSelect
-              v-model="kind"
-              :mode="mode"
-              label="Type"
-              :options="kindOptions"
-              placeholder="Select a check type"
-            />
-          </div>
-        </div>
+        <LabeledSelect
+          v-model="kind"
+          :mode="mode"
+          label="Type"
+          :options="kindOptions"
+          placeholder="Select a check type"
+        />
+
+        <div v-if="kind && kind!=='none'" class="spacer" />
 
         <div v-if="kind === 'HTTP' || kind === 'HTTPS'">
-          <div class="row">
-            <div class="col span-12">
-              <LabeledInput
-                v-model.number="httpGet.port"
-                type="number"
-                min="1"
-                max="65535"
-                :mode="mode"
-                :label="t('workload.container.healthCheck.httpGet.port')"
-                placeholder="e.g. 80"
-              />
-            </div>
-          </div>
+          <LabeledInput
+            v-model.number="httpGet.port"
+            type="number"
+            min="1"
+            max="65535"
+            :mode="mode"
+            :label="t('workload.container.healthCheck.httpGet.port')"
+            placeholder="e.g. 80"
+          />
 
-          <div class="row mb-0">
-            <div class="col span-12">
-              <LabeledInput
-                v-model="httpGet.path"
-                :mode="mode"
-                :label="t('workload.container.healthCheck.httpGet.path')"
-                placeholder="e.g. /healthz"
-              />
-            </div>
-          </div>
+          <div class="spacer" />
+
+          <LabeledInput
+            v-model="httpGet.path"
+            :mode="mode"
+            :label="t('workload.container.healthCheck.httpGet.path')"
+            placeholder="e.g. /healthz"
+          />
         </div>
 
-        <div v-if="kind === 'tcp'" class="row">
-          <div class="col span-12">
-            <LabeledInput
-              v-model.number="tcpSocket.port"
-              type="number"
-              min="1"
-              max="65535"
-              :mode="mode"
-              :label="t('workload.container.healthCheck.httpGet.port')"
-              placeholder="e.g. 25"
-            />
-          </div>
+        <div v-if="kind === 'tcp'">
+          <LabeledInput
+            v-model.number="tcpSocket.port"
+            type="number"
+            min="1"
+            max="65535"
+            :mode="mode"
+            :label="t('workload.container.healthCheck.httpGet.port')"
+            placeholder="e.g. 25"
+          />
+          <div class="spacer" />
         </div>
 
-        <div v-if="kind === 'exec'" class="row">
+        <div v-if="kind === 'exec'">
           <div class="col span-12">
             <ShellInput
               v-model="exec.command"
@@ -217,6 +208,7 @@ export default {
               placeholder="e.g. cat /tmp/health"
             />
           </div>
+          <div class="spacer" />
         </div>
       </div>
 
@@ -257,6 +249,9 @@ export default {
             />
           </div>
         </div>
+
+        <div class="spacer" />
+
         <div class="row">
           <div class="col span-6">
             <LabeledInput
@@ -279,6 +274,9 @@ export default {
             />
           </div>
         </div>
+
+        <div class="spacer" />
+
         <div class="row mb-0">
           <div class="col span-12">
             <KeyValue
@@ -290,11 +288,18 @@ export default {
               :read-allowed="false"
               :title="t('workload.container.healthCheck.httpGet.headers')"
               key-label="Name"
-            />
+            >
+              <template #title>
+                <h4>
+                  {{ t('workload.container.healthCheck.httpGet.headers') }}
+                </h4>
+              </template>
+            </KeyValue>
           </div>
         </div>
       </div>
     </div>
+  </div>
   </div>
 </template>
 

--- a/components/form/Probe.vue
+++ b/components/form/Probe.vue
@@ -177,7 +177,7 @@ export default {
                 min="1"
                 max="65535"
                 :mode="mode"
-                :label="t('workload.container.healthcheck.httpGet.port')"
+                :label="t('workload.container.healthCheck.httpGet.port')"
                 placeholder="e.g. 80"
               />
             </div>
@@ -188,7 +188,7 @@ export default {
               <LabeledInput
                 v-model="httpGet.path"
                 :mode="mode"
-                :label="t('workload.container.healthcheck.httpGet.path')"
+                :label="t('workload.container.healthCheck.httpGet.path')"
                 placeholder="e.g. /healthz"
               />
             </div>
@@ -203,7 +203,7 @@ export default {
               min="1"
               max="65535"
               :mode="mode"
-              :label="t('workload.container.healthcheck.httpGet.port')"
+              :label="t('workload.container.healthCheck.httpGet.port')"
               placeholder="e.g. 25"
             />
           </div>
@@ -213,7 +213,7 @@ export default {
           <div class="col span-12">
             <ShellInput
               v-model="exec.command"
-              :label="t('workload.container.healthcheck.command.command')"
+              :label="t('workload.container.healthCheck.command.command')"
               placeholder="e.g. cat /tmp/health"
             />
           </div>
@@ -230,7 +230,7 @@ export default {
             <UnitInput
               v-model="probe.periodSeconds"
               :mode="mode"
-              :label="t('workload.container.healthcheck.checkInterval')"
+              :label="t('workload.container.healthCheck.checkInterval')"
               min="1"
               suffix="sec"
               placeholder="Default: 10"
@@ -240,7 +240,7 @@ export default {
             <UnitInput
               v-model="probe.initialDelaySeconds"
               :mode="mode"
-              :label="t('workload.container.healthcheck.initialDelay')"
+              :label="t('workload.container.healthCheck.initialDelay')"
               suffix="sec"
               min="0"
               placeholder="Default: 0"
@@ -250,7 +250,7 @@ export default {
             <UnitInput
               v-model="probe.timeoutSeconds"
               :mode="mode"
-              :label="t('workload.container.healthcheck.timeout')"
+              :label="t('workload.container.healthCheck.timeout')"
               suffix="sec"
               min="0"
               placeholder="Default: 3"
@@ -264,7 +264,7 @@ export default {
               type="number"
               min="1"
               :mode="mode"
-              :label="t('workload.container.healthcheck.successThreshold')"
+              :label="t('workload.container.healthCheck.successThreshold')"
               placeholder="Default: 1"
             />
           </div>
@@ -274,7 +274,7 @@ export default {
               type="number"
               min="1"
               :mode="mode"
-              :label="t('workload.container.healthcheck.failureThreshold')"
+              :label="t('workload.container.healthCheck.failureThreshold')"
               placeholder="Default: 3"
             />
           </div>
@@ -288,7 +288,7 @@ export default {
               :pad-left="false"
               :as-map="false"
               :read-allowed="false"
-              :title="t('workload.container.healthcheck.httpGet.headers')"
+              :title="t('workload.container.healthCheck.httpGet.headers')"
               key-label="Name"
             />
           </div>

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -143,7 +143,7 @@ export default {
     border-color: var(--input-disabled-text)
   }
 }
-.radio-label {
-  color:  var( --input-label );
-}
+// .radio-label {
+//   color:  var( --input-label );
+// }
 </style>

--- a/components/form/RadioGroup.vue
+++ b/components/form/RadioGroup.vue
@@ -1,5 +1,6 @@
 <script>
 import RadioButton from '@/components/form/RadioButton';
+import { _VIEW } from '@/config/query-params';
 
 export default {
   components: { RadioButton },
@@ -29,6 +30,11 @@ export default {
     mode: {
       type:    String,
       default: 'edit'
+    },
+
+    label: {
+      type:    String,
+      default: null
     }
   },
 
@@ -43,6 +49,10 @@ export default {
   },
 
   computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+
     // show labels if given, otherwise show values
     labelsToUse() {
       if (this.labels) {
@@ -123,37 +133,46 @@ export default {
 </script>
 
 <template>
-  <div
-    v-if="mode!=='view'"
-    ref="radio-group"
-    class="radio-group"
-    tabindex="0"
-    @focus="focusGroup"
-    @blur="blurred"
-    @keyup.39.stop="clickNext(1)"
-    @keyup.37.stop="clickNext(-1)"
-  >
-    <RadioButton
-      v-for="(option, i) in options"
-      :key="option"
-      :ref="`radio-${i}`"
-      :value="statuses[option]"
-      :label="labelsToUse[i]"
-      grouped
-      :class="{focused:focused&&selectedIndex===i}"
-      :disabled="disabled || mode=='view'"
-      @input="select(option)"
+  <div>
+    <div v-if="label" class="radio-group label" :class="{'view':isView}">
+      {{ label }}
+    </div>
+    <div
+      v-if="mode!=='view'"
+      ref="radio-group"
+      class="radio-group"
+      tabindex="0"
       @focus="focusGroup"
-    />
-  </div>
-  <div v-else>
-    {{ labelsToUse[selectedIndex] }}
+      @blur="blurred"
+      @keyup.39.stop="clickNext(1)"
+      @keyup.37.stop="clickNext(-1)"
+    >
+      <RadioButton
+        v-for="(option, i) in options"
+        :key="option"
+        :ref="`radio-${i}`"
+        :value="statuses[option]"
+        :label="labelsToUse[i]"
+        grouped
+        :class="{focused:focused&&selectedIndex===i}"
+        :disabled="disabled || mode=='view'"
+        @input="select(option)"
+        @focus="focusGroup"
+      />
+    </div>
+    <div v-else>
+      {{ labelsToUse[selectedIndex] }}
+    </div>
   </div>
 </template>
 
-<style>
+<style lang='scss'>
 .radio-group:focus{
   border:none;
   outline:none;
+}
+.radio-group.label{
+  color: var(--input-label);
+  font-size:14px;
 }
 </style>

--- a/components/form/RadioGroup.vue
+++ b/components/form/RadioGroup.vue
@@ -134,7 +134,7 @@ export default {
 
 <template>
   <div>
-    <div v-if="label" class="radio-group label" :class="{'view':isView}">
+    <div v-if="label" class="radio-group text-label" :class="{'view':isView}">
       {{ label }}
     </div>
     <div
@@ -170,9 +170,5 @@ export default {
 .radio-group:focus{
   border:none;
   outline:none;
-}
-.radio-group.label{
-  color: var(--input-label);
-  font-size:14px;
 }
 </style>

--- a/components/form/Scheduling.vue
+++ b/components/form/Scheduling.vue
@@ -5,7 +5,7 @@ import NodeAffinity from '@/components/form/NodeAffinity';
 import PodAffinity from '@/components/form/PodAffinity';
 import KeyValue from '@/components/form/KeyValue';
 import { mapGetters } from 'vuex';
-import { isEmpty, cleanUp } from '@/utils/object';
+import { isEmpty, cleanUp, get } from '@/utils/object';
 import { NODE, POD } from '@/config/types';
 import Tolerations from '@/components/form/Tolerations';
 import LabeledInput from '@/components/form/LabeledInput';
@@ -33,11 +33,6 @@ export default {
       default: () => []
     },
     mode: { type: String, default: 'edit' },
-
-    showPod: {
-      type:    Boolean,
-      default: true
-    }
   },
 
   data() {
@@ -77,6 +72,25 @@ export default {
       return this.mode === _VIEW;
     },
 
+    // hide affinity/anti-affinity sections on view mode if no selectors are defined
+    hasPodAffinity() {
+      const hasRequired = !!(get(this.podAffinity, 'requiredDuringSchedulingIgnoredDuringExecution') || []).length;
+      const hasPrefered = !!(get(this.podAffinity, 'preferredDuringSchedulingIgnoredDuringExecution') || []).length;
+
+      return (hasRequired || hasPrefered);
+    },
+
+    hasPodAntiAffinity() {
+      const hasRequired = !!(get(this.podAntiAffinity, 'requiredDuringSchedulingIgnoredDuringExecution') || []).length;
+      const hasPrefered = !!(get(this.podAntiAffinity, 'preferredDuringSchedulingIgnoredDuringExecution') || []).length;
+
+      return (hasRequired || hasPrefered);
+    },
+
+    hasPodScheduling() {
+      return this.hasPodAffinity || this.hasPodAntiAffinity;
+    },
+
     ...mapGetters({ t: 'i18n/t' })
   },
 
@@ -111,7 +125,7 @@ export default {
 <template>
   <div @input="update">
     <div>
-      <h3>Node Scheduling</h3>
+      <h3><t k="workload.scheduling.titles.nodeScheduling" /></h3>
       <h4 v-if="isView" class="mt-10 mb-10">
         {{ selectNode ? t('workload.scheduling.affinity.specificNode') : t('workload.scheduling.affinity.schedulingRules') }}
       </h4>
@@ -128,7 +142,7 @@ export default {
           <div class="col span-6">
             <LabeledSelect
               v-model="nodeName"
-              label="Node Name"
+              :label="t('workload.scheduling.affinity.nodeName')"
               :options="nodes"
               :mode="mode"
               option-label="id"
@@ -145,77 +159,88 @@ export default {
       </template>
     </div>
 
-    <template v-if="showPod">
-      <div>
-        <h3 class="mb-10">
-          Pod Scheduling
-        </h3>
-        <h4 class="mb-10">
-          <t k="workload.scheduling.affinity.affinityTitle" />
-        </h4>
-        <div class="row">
-          <PodAffinity v-model="podAffinity" :type="pod" :mode="mode" />
-        </div>
+    <div>
+      <h3 class="mb-10">
+        <t k="workload.scheduling.titles.podScheduling" />
+      </h3>
 
-        <h4 class="mb-10">
-          <t k="workload.scheduling.affinity.antiAffinityTitle" />
-        </h4>
+      <template v-if="!isView || hasPodScheduling">
+        <template v-if="!isView || hasPodAffinity">
+          <h4 class="mb-10">
+            <t k="workload.scheduling.affinity.affinityTitle" />
+          </h4>
+          <div class="row">
+            <PodAffinity v-model="podAffinity" :type="pod" :mode="mode" />
+          </div>
+        </template>
+
+        <template v-if="!isView || hasPodAntiAffinity">
+          <h4 class="mb-10">
+            <t k="workload.scheduling.affinity.antiAffinityTitle" />
+          </h4>
+          <div>
+            <PodAffinity v-model="podAntiAffinity" :type="pod" :mode="mode" />
+          </div>
+        </template>
+      </template>
+
+      <template v-else>
         <div class="row">
-          <PodAffinity v-model="podAntiAffinity" :type="pod" :mode="mode" />
+          <t k="workload.scheduling.affinity.noPodRules" />
+        </div>
+      </template>
+    </div>
+
+    <div>
+      <h3 class="mb-10">
+        <t k="workload.scheduling.titles.tolerations" />
+      </h3>
+      <div class="row">
+        <Tolerations :value="value.tolerations" :mode="mode" />
+      </div>
+    </div>
+
+    <div>
+      <h3 class="mb-10">
+        <t k="workload.scheduling.titles.priority" />
+      </h3>
+      <div class="row">
+        <div class="col span-6">
+          <LabeledInput v-model.number="value.priority" :mode="mode" :label="t('workload.scheduling.priority.priority')" />
+        </div>
+        <div class="col span-6">
+          <LabeledInput v-model="value.priorityClassname" :mode="mode" :label="t('workload.scheduling.priority.className')" />
         </div>
       </div>
+    </div>
 
-      <div>
-        <h3 class="mb-10">
-          Tolerations
-        </h3>
-        <div class="row">
-          <Tolerations :value="value.tolerations" :mode="mode" />
+    <div>
+      <h3 class="mb-10">
+        <t k="workload.scheduling.titles.advanced" />
+      </h3>
+      <div class="row">
+        <div class="col span-6">
+          <UnitInput v-model.number="value.activeDeadlineSeconds" :label="t('workload.scheduling.activeDeadlineSeconds')" :mode="mode" suffix="Seconds">
+            <template #label>
+              <label v-tooltip="t('workload.scheduling.activeDeadlineSecondsTip')" class="label-tip">
+                <t k="workload.scheduling.activeDeadlineSeconds" />
+                <i class="icon icon-info" style="font-size: 12px" />
+              </label>
+            </template>
+          </UnitInput>
+        </div>
+        <div class="col span-6">
+          <UnitInput v-model="value.terminationGracePeriodSeconds" :mode="mode" suffix="Seconds" :label="t('workload.scheduling.terminationGracePeriodSeconds')">
+            <template #label>
+              <label v-tooltip="t('workload.scheduling.terminationGracePeriodSecondsTip')" class="label-tip">
+                <t k="workload.scheduling.terminationGracePeriodSeconds" />
+                <i class="icon icon-info" style="font-size: 12px" />
+              </label>
+            </template>
+          </UnitInput>
         </div>
       </div>
-
-      <div>
-        <h3 class="mb-10">
-          Priority
-        </h3>
-        <div class="row">
-          <div class="col span-6">
-            <LabeledInput v-model.number="value.priority" :mode="mode" :label="t('workload.scheduling.priority.priority')" />
-          </div>
-          <div class="col span-6">
-            <LabeledInput v-model="value.priorityClassname" :mode="mode" :label="t('workload.scheduling.priority.className')" />
-          </div>
-        </div>
-      </div>
-
-      <div>
-        <h3 class="mb-10">
-          Advanced
-        </h3>
-        <div class="row">
-          <div class="col span-6">
-            <UnitInput v-model.number="value.activeDeadlineSeconds" :mode="mode" suffix="Seconds">
-              <template #label>
-                <label v-tooltip="t('workload.scheduling.activeDeadlineSecondsTip')" class="label-tip">
-                  <t k="workload.scheduling.activeDeadlineSeconds" />
-                  <i class="icon icon-info" style="font-size: 12px" />
-                </label>
-              </template>
-            </UnitInput>
-          </div>
-          <div class="col span-6">
-            <UnitInput v-model="value.terminationGracePeriodSeconds" :mode="mode" suffix="Seconds" :label="t('workload.scheduling.terminationGracePeriodSeconds')">
-              <template #label>
-                <label v-tooltip="t('workload.scheduling.terminationGracePeriodSecondsTip')" class="label-tip">
-                  <t k="workload.scheduling.terminationGracePeriodSeconds" />
-                  <i class="icon icon-info" style="font-size: 12px" />
-                </label>
-              </template>
-            </UnitInput>
-          </div>
-        </div>
-      </div>
-    </template>
+    </div>
   </div>
 </template>
 

--- a/components/form/Scheduling.vue
+++ b/components/form/Scheduling.vue
@@ -150,14 +150,29 @@ export default {
             />
           </div>
         </div>
+
+        <div class="spacer" />
+
         <div v-if="mode!=='view' || !isEmpty(nodeSelector)" class="row">
-          <KeyValue title="Nodes with these labels" :value="nodeSelector" :mode="mode" :initial-empty-row="true" :pro-tip="false" />
+          <KeyValue
+            title="Nodes with these labels"
+            :value="nodeSelector"
+            :mode="mode"
+            :initial-empty-row="true"
+            :pro-tip="false"
+          >
+            <template #title>
+              <h4>{{ t('workload.scheduling.titles.nodeSelector') }}</h4>
+            </template>
+          </KeyValue>
         </div>
       </template>
       <template v-else>
         <NodeAffinity v-model="nodeAffinity" :type="node" :mode="mode" @input="update" />
       </template>
     </div>
+
+    <div class="spacer" />
 
     <div>
       <h3 class="mb-10">
@@ -169,18 +184,16 @@ export default {
           <h4 class="mb-10">
             <t k="workload.scheduling.affinity.affinityTitle" />
           </h4>
-          <div class="row">
-            <PodAffinity v-model="podAffinity" :type="pod" :mode="mode" />
-          </div>
+          <PodAffinity v-model="podAffinity" :type="pod" :mode="mode" />
         </template>
+
+        <div class="spacer" />
 
         <template v-if="!isView || hasPodAntiAffinity">
           <h4 class="mb-10">
             <t k="workload.scheduling.affinity.antiAffinityTitle" />
           </h4>
-          <div>
-            <PodAffinity v-model="podAntiAffinity" :type="pod" :mode="mode" />
-          </div>
+          <PodAffinity v-model="podAntiAffinity" :type="pod" :mode="mode" />
         </template>
       </template>
 
@@ -191,6 +204,8 @@ export default {
       </template>
     </div>
 
+    <div class="spacer" />
+
     <div>
       <h3 class="mb-10">
         <t k="workload.scheduling.titles.tolerations" />
@@ -199,6 +214,8 @@ export default {
         <Tolerations :value="value.tolerations" :mode="mode" />
       </div>
     </div>
+
+    <div class="spacer" />
 
     <div>
       <h3 class="mb-10">
@@ -213,6 +230,8 @@ export default {
         </div>
       </div>
     </div>
+
+    <div class="spacer" />
 
     <div>
       <h3 class="mb-10">

--- a/components/form/Security.vue
+++ b/components/form/Security.vue
@@ -104,7 +104,7 @@ export default {
 
 <template>
   <div @input="update">
-    <div class="row mb-20">
+    <div class="row">
       <div class="col span-6">
         <RadioGroup v-model="privileged" :label="t('workload.container.security.privileged')" :options="[false,true]" :labels="['No', 'Yes: container has full access to the host']" :mode="mode" />
       </div>
@@ -119,7 +119,10 @@ export default {
         />
       </div>
     </div>
-    <div class="row mb-20">
+
+    <div class="spacer" />
+
+    <div class="row">
       <div class="col span-6">
         <RadioGroup
           :label="t('workload.container.security.runAsNonRoot')"
@@ -134,14 +137,20 @@ export default {
         <RadioGroup v-model="readOnlyRootFilesystem" :label="t('workload.container.security.readOnlyRootFilesystem')" :options="[false, true]" :labels="['No', 'Yes: container has a read-only root filesystem']" :mode="mode" />
       </div>
     </div>
-    <div class="row mb-20">
+
+    <div class="spacer" />
+
+    <div class="row">
       <div class="col span-6">
         <LabeledInput v-model.number="runAsUser" :label="t('workload.container.security.runAsUser')" :mode="mode" />
       </div>
     </div>
+
+    <div class="spacer" />
+
     <div class="row mb-0">
       <div class="col span-6">
-        <label><t k="workload.container.security.addCapabilities" /></label>
+        <label class="text-label"><t k="workload.container.security.addCapabilities" /></label>
         <div v-if="isView">
           <span v-if="!add.length">n/a</span>
           <ul v-else>
@@ -160,7 +169,7 @@ export default {
         />
       </div>
       <div class="col span-6">
-        <label><t k="workload.container.security.dropCapabilities" /></label>
+        <label class="text-label"><t k="workload.container.security.dropCapabilities" /></label>
         <div v-if="isView">
           <span v-if="!drop.length">n/a</span>
           <ul v-else>

--- a/components/form/Security.vue
+++ b/components/form/Security.vue
@@ -2,6 +2,7 @@
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import { _VIEW } from '@/config/query-params';
+import { mapGetters } from 'vuex';
 
 export default {
   components: {
@@ -71,7 +72,9 @@ export default {
   computed: {
     isView() {
       return this.mode === _VIEW;
-    }
+    },
+
+    ...mapGetters({ t: 'i18n/t' })
   },
 
   watch: {
@@ -103,24 +106,23 @@ export default {
   <div @input="update">
     <div class="row mb-20">
       <div class="col span-6">
-        <h4>
-          <t k="workload.container.security.privileged" />
-        </h4>
-        <RadioGroup v-model="privileged" :options="[false,true]" :labels="['No', 'Yes: container has full access to the host']" :mode="mode" />
+        <RadioGroup v-model="privileged" :label="t('workload.container.security.privileged')" :options="[false,true]" :labels="['No', 'Yes: container has full access to the host']" :mode="mode" />
       </div>
       <div class="col span-6">
-        <h4>
-          <t k="workload.container.security.allowPrivilegeEscalation" />
-        </h4>
-        <RadioGroup v-model="allowPrivilegeEscalation" :disabled="privileged" :options="[false,true]" :labels="['No', 'Yes: container can gain more privileges than its parent process']" :mode="mode" />
+        <RadioGroup
+          v-model="allowPrivilegeEscalation"
+          :label="t('workload.container.security.allowPrivilegeEscalation')"
+          :disabled="privileged"
+          :options="[false,true]"
+          :labels="['No', 'Yes: container can gain more privileges than its parent process']"
+          :mode="mode"
+        />
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <h4>
-          <t k="workload.container.security.runAsNonRoot" />
-        </h4>
         <RadioGroup
+          :label="t('workload.container.security.runAsNonRoot')"
           :value="!runAsRoot"
           :options="[false, true]"
           :labels="['No', 'Yes: container must run as a non-root user']"
@@ -129,10 +131,7 @@ export default {
         />
       </div>
       <div class="col span-6">
-        <h4>
-          <t k="workload.container.security.readOnlyRootFilesystem" />
-        </h4>
-        <RadioGroup v-model="readOnlyRootFilesystem" :options="[false, true]" :labels="['No', 'Yes: container has a read-only root filesystem']" :mode="mode" />
+        <RadioGroup v-model="readOnlyRootFilesystem" :label="t('workload.container.security.readOnlyRootFilesystem')" :options="[false, true]" :labels="['No', 'Yes: container has a read-only root filesystem']" :mode="mode" />
       </div>
     </div>
     <div class="row mb-20">

--- a/components/form/Tolerations.vue
+++ b/components/form/Tolerations.vue
@@ -154,7 +154,7 @@ export default {
       </template>
       <template #col:value="{row}">
         <td v-if="row.operator==='Exists'">
-          <div :style="{'padding-top':'17px'}">
+          <div>
             n/a
           </div>
         </td>

--- a/detail/pod/index.vue
+++ b/detail/pod/index.vue
@@ -163,8 +163,10 @@ export default {
       </template>
     </DetailTop>
 
-    <div class="mt-20">
-      <h3><t k="workload.container.titles.containers" /></h3>
+    <div class="spacer" />
+
+    <div>
+      <h2><t k="workload.container.titles.containers" /></h2>
       <SortableTable
         id="container-table"
         :table-actions="false"
@@ -187,15 +189,17 @@ export default {
       </SortableTable>
     </div>
 
+    <div class="spacer" />
+
     <ResourceTabs v-model="value" :mode="mode">
       <template #before>
-        <Tab name="networking" label="Networking">
+        <Tab name="networking" :label="t('workload.tabs.networking')">
           <Networking :value="value.spec" mode="view" />
         </Tab>
-        <Tab name="scheduling" label="Scheduling">
+        <Tab name="scheduling" :label="t('workload.tabs.scheduling')">
           <Scheduling :value="value.spec" mode="view" :nodes="nodes" />
         </Tab>
-        <Tab name="security" label="Security">
+        <Tab name="security" :label="t('workload.tabs.security')">
           <PodSecurity :value="value.spec" mode="view" />
         </Tab>
       </template>

--- a/detail/pod/index.vue
+++ b/detail/pod/index.vue
@@ -133,17 +133,11 @@ export default {
     },
 
     async findNode() {
-      const IP = this.value.status.hostIP;
-
-      if (!IP) {
-        return null;
-      }
+      const { nodeName } = this.value.spec;
 
       const nodes = await this.$store.dispatch('cluster/findAll', { type: NODE });
       const out = nodes.filter((node) => {
-        const { addresses } = node.status;
-
-        return !!addresses.findIndex(obj => obj.address === IP);
+        return node?.metadata?.name === nodeName;
       })[0];
 
       this.nodes = nodes;
@@ -169,7 +163,8 @@ export default {
       </template>
     </DetailTop>
 
-    <div class="row mt-20">
+    <div class="mt-20">
+      <h3><t k="workload.container.titles.containers" /></h3>
       <SortableTable
         id="container-table"
         :table-actions="false"

--- a/edit/rbac.authorization.k8s.io.clusterrole.vue
+++ b/edit/rbac.authorization.k8s.io.clusterrole.vue
@@ -70,10 +70,8 @@ export default {
 
     <div class="row">
       <div class="col span-6">
-        <label>
-          Locked
-        </label>
         <RadioGroup
+          label="Locked"
           :options="radioOptions"
           :selected="value.locked"
           :labels="lockedLabels"
@@ -81,10 +79,8 @@ export default {
         />
       </div>
       <div class="col span-6">
-        <label>
-          Cluster Creator Default
-        </label>
         <RadioGroup
+          label="Cluster Creator Default"
           :options="radioOptions"
           :selected="value.clusterCretorDefault"
           :labels="newUserDefault"

--- a/edit/rbac.authorization.k8s.io.role.vue
+++ b/edit/rbac.authorization.k8s.io.role.vue
@@ -72,10 +72,8 @@ export default {
 
     <section class="row">
       <div class="col span-6">
-        <label>
-          Locked
-        </label>
         <RadioGroup
+          label="Locked"
           :options="radioOptions"
           :selected="value.locked"
           :labels="lockedLabels"
@@ -83,10 +81,8 @@ export default {
         />
       </div>
       <div class="col span-6">
-        <label>
-          New User Default
-        </label>
         <RadioGroup
+          label="New User Default"
           :options="radioOptions"
           :selected="value.newUserDefault"
           :labels="newUserDefault"

--- a/edit/secret.vue
+++ b/edit/secret.vue
@@ -212,9 +212,8 @@ export default {
     <div class="spacer"></div>
 
     <template v-if="isRegistry">
-      <h5>Address:</h5>
       <div id="registry-type" class="row">
-        <RadioGroup :mode="mode" :options="registryAddresses" :value="registryProvider" @input="e=>registryProvider = e" />
+        <RadioGroup label="Address:" :mode="mode" :options="registryAddresses" :value="registryProvider" @input="e=>registryProvider = e" />
       </div>
       <div v-if="needsDockerServer" class="row">
         <LabeledInput v-model="registryFQDN" :label="t('secret.registry.domainName')" placeholder="e.g. index.docker.io" :mode="mode" />


### PR DESCRIPTION
per https://github.com/rancher/dashboard/issues/685#issuecomment-642424214

link to node detail in detailTop
![Screen Shot 2020-06-11 at 3 27 02 PM](https://user-images.githubusercontent.com/42977925/84533223-884f5e80-ac9c-11ea-8870-a4bf0e7fd97c.png)

update networking nameservers and and search domain labels
![Screen Shot 2020-06-12 at 11 23 06 AM](https://user-images.githubusercontent.com/42977925/84534644-2ba17300-ac9f-11ea-81bb-fb249dea0d28.png)


Show 'none configured' messages for healthcheck, resource limits, and pod affinity/anti affinity
![Screen Shot 2020-06-11 at 3 30 10 PM](https://user-images.githubusercontent.com/42977925/84533229-8c7b7c00-ac9c-11ea-8edd-430f972dc060.png)
![Screen Shot 2020-06-12 at 11 05 57 AM](https://user-images.githubusercontent.com/42977925/84534319-8f776c00-ac9e-11ea-8542-f5735ec034df.png)

Add namespaces to pod affinity
![Screen Shot 2020-06-12 at 11 18 54 AM](https://user-images.githubusercontent.com/42977925/84534329-93a38980-ac9e-11ea-988b-f0b4fdef3b37.png)

Additionally, I noticed that pod affinity/anti-affinity requires a [topologyKey](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#an-example-of-a-pod-that-uses-pod-affinity) and added a field below 'namespaces'
