### PR TITLE
[backport] Ensuring apiGroups have an empty value

### DIFF
--- a/shared/gatekeeper-constraint.vue
+++ b/shared/gatekeeper-constraint.vue
@@ -147,12 +147,22 @@ export default {
   },
 
   async created() {
+    this.registerBeforeHook(this.willSave, 'willSave');
     if (!this.value.save) {
       this.$emit('input', merge(await this.createConstraint(), this.value, this.emptyDefaults));
     }
   },
 
   methods: {
+    willSave() {
+      this.value.spec.match.kinds.forEach((kind) => {
+        const apiGroups = kind.apiGroups || [];
+
+        if (apiGroups.length === 0) {
+          kind.apiGroups = ['*'];
+        }
+      });
+    },
     async createConstraint() {
       const constraint = await this.$store.dispatch('cluster/create', { type: this.templateOptions[0].value });
 


### PR DESCRIPTION
OPA Constraints don't work unless there's an apiGroup present
even if it's empty. This ensures that the empty apiGroup is present
if no apiGroups were specified.

rancher/dashboard#764