### PR TITLE
select correct node pool for display info

### DIFF
--- a/components/ClusterDisplayProvider.vue
+++ b/components/ClusterDisplayProvider.vue
@@ -37,7 +37,7 @@ export default {
       if (driver && this.$store.getters['i18n/exists'](`cluster.provider.${ driver }.shortLabel`)) {
         if (driver === 'rancherkubernetesengine') {
           const pools = this.nodePools;
-          const firstNodePool = pools[0];
+          const firstNodePool = pools.find(pool => pool.spec.clusterName === cluster.id);
 
           if (firstNodePool) {
             const nodeTemplateId = firstNodePool?.spec?.nodeTemplateName;


### PR DESCRIPTION
We should be displaying the first node pool that matches our cluster id not only the first node pool. Got the stores conflated going back and forth. I forgot that we were getting all node pools not all node pools for this cluster. 

rancher/dashboard#702