### PR TITLE
Adding a state banner to the mastehead

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -275,6 +275,9 @@ resourceDetail:
     project: "Project"
     yaml: "YAML"
     overview: "Overview"
+    defaultBannerMessage:
+      error: "This resource is currently in error but there isn't a detailed message available."
+      transitioning: "This resource is currently transitioning but there isn't a detailed message available."
   detailTop:
     created: Created
     deleted: Deleted

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -4,10 +4,11 @@ import BreadCrumbs from '@/components/BreadCrumbs';
 import { NAMESPACE, EXTERNAL } from '@/config/types';
 import ButtonGroup from '@/components/ButtonGroup';
 import BadgeState from '@/components/BadgeState';
+import Banner from '@/components/Banner';
 
 export default {
   components: {
-    BadgeState, BreadCrumbs, ButtonGroup
+    BadgeState, Banner, BreadCrumbs, ButtonGroup
   },
   props:      {
     value: {
@@ -92,6 +93,28 @@ export default {
       } else {
         return null;
       }
+    },
+
+    banner() {
+      if (this.value?.metadata?.state?.error) {
+        const defaultErrorMessage = this.t('resourceDetail.masthead.defaultBannerMessage.error', undefined, true);
+
+        return {
+          color:   'error',
+          message: this.value.metadata.state.message || defaultErrorMessage
+        };
+      }
+
+      if (this.value?.metadata?.state?.transitioning) {
+        const defaultTransitioningMessage = this.t('resourceDetail.masthead.defaultBannerMessage.transitioning', undefined, true);
+
+        return {
+          color:   'info',
+          message: this.value.metadata.state.message || defaultTransitioningMessage
+        };
+      }
+
+      return null;
     }
   },
   methods: {
@@ -134,6 +157,9 @@ export default {
         <i class="icon icon-actions" />
       </button>
     </div>
+    <div class="state-banner">
+      <Banner v-if="banner" class="state-banner" :color="banner.color" :label="banner.message" />
+    </div>
   </header>
 </template>
 
@@ -171,6 +197,10 @@ export default {
       & .btn-group {
         margin-right: 5px;
       }
+    }
+
+    .state-banner {
+      margin: 3px 0 0 0;
     }
   }
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -269,7 +269,8 @@ export default {
     HEADER {
       display: grid;
       grid-template-areas:  "breadcrumbs breadcrumbs"
-                            "title actions";
+                            "title actions"
+                            "state-banner state-banner";
       grid-template-columns: "auto min-content";
       margin-bottom: 20px;
 
@@ -281,6 +282,10 @@ export default {
         .nuxt-link-active {
           padding-right: 10px;
         }
+      }
+
+      .state-banner {
+        grid-area: state-banner;
       }
 
       .actions {


### PR DESCRIPTION
If the resource is in error or transitioning display a banner with a
message provided by the backend.

rancher/dashboard#628


![Screen Shot 2020-06-15 at 4 03 44 PM](https://user-images.githubusercontent.com/55104481/84714477-a0381400-af22-11ea-9280-b93380abb1b8.png)
![Screen Shot 2020-06-15 at 4 02 38 PM](https://user-images.githubusercontent.com/55104481/84714480-a1694100-af22-11ea-8757-443d01149bbe.png)
![Screen Shot 2020-06-15 at 4 01 11 PM](https://user-images.githubusercontent.com/55104481/84714481-a1694100-af22-11ea-9ba8-c698cbc23607.png)
![Screen Shot 2020-06-15 at 3 58 46 PM](https://user-images.githubusercontent.com/55104481/84714483-a201d780-af22-11ea-9b2c-43d8f4ef6436.png)