### PR TITLE
Refactor Tabbed Component

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -509,6 +509,11 @@ resourceList:
     create: Create
     createFromYaml: Create from YAML
 
+resourceTabs:
+  tabs:
+    labels: Labels
+    annotations: Annotations
+
 secret:
   type: Type
   data: Data

--- a/components/Tabbed/Tab.vue
+++ b/components/Tabbed/Tab.vue
@@ -8,6 +8,11 @@ export default {
     name: {
       type:     String,
       required: true,
+    },
+    weight: {
+      type:     Number,
+      default:  0,
+      required: false,
     }
   },
 

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -111,9 +111,9 @@ export default {
     select(name/* , event */) {
       const {
         filteredTabs,
-        // $router,
+        $router,
         $route: {
-          // name: routeName,
+          name: routeName,
           hash: routeHash
         },
       } = this;
@@ -125,9 +125,7 @@ export default {
       }
 
       if (routeHash !== hashName) {
-        // TODO This throws a router error, can we handle this?
-        // $router.replace({ name: routeName, hash: hashName });
-        window.location.hash = hashName;
+        $router.replace({ name: routeName, hash: hashName });
       }
 
       for ( const tab of filteredTabs ) {

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -12,11 +12,37 @@ export default {
   },
 
   data() {
-    return { tabs: null };
+    return {
+      tabs:            [],
+      initialTabOrder: []
+    };
+  },
+
+  computed: {
+    filteredTabs() {
+      // keep the tabs list ordered for dynamic tabs
+      const tabs = this.tabs;
+      const { initialTabOrder } = this;
+      const out = [];
+
+      if (isEmpty(initialTabOrder) && !isEmpty(tabs)) {
+        tabs.forEach(tab => initialTabOrder.push(tab.name));
+      }
+
+      initialTabOrder.forEach((tabId) => {
+        const match = tabs.find(t => t.name === tabId);
+
+        if (match) {
+          out.push(match);
+        }
+      });
+
+      return out;
+    }
   },
 
   watch: {
-    tabs(tabs) {
+    filteredTabs(tabs) {
       const activeTab = tabs.find(t => t.active);
       const defaultTab = this.defaultTab;
       const windowsHash = window.location.hash.slice(1);
@@ -70,7 +96,7 @@ export default {
     }
 
     if ( !tab ) {
-      tab = this.tabs[0];
+      tab = this.filteredTabs[0];
     }
 
     if ( tab ) {
@@ -88,7 +114,7 @@ export default {
     },
 
     find(name) {
-      return this.tabs.find(x => x.name === name );
+      return this.filteredTabs.find(x => x.name === name );
     },
 
     select(name, event) {
@@ -100,7 +126,7 @@ export default {
 
       window.location.hash = `#${ name }`;
 
-      for ( const tab of this.tabs ) {
+      for ( const tab of this.filteredTabs ) {
         tab.active = (tab.name === selected.name);
       }
 
@@ -108,11 +134,11 @@ export default {
     },
 
     selectNext(direction) {
-      const currentIdx = this.tabs.findIndex(x => x.active);
+      const currentIdx = this.filteredTabs.findIndex(x => x.active);
 
-      const nextIdx = currentIdx + direction >= this.tabs.length ? 0 : currentIdx + direction < 0 ? this.tabs.length - 1 : currentIdx + direction;
+      const nextIdx = currentIdx + direction >= this.filteredTabs.length ? 0 : currentIdx + direction < 0 ? this.filteredTabs.length - 1 : currentIdx + direction;
 
-      const nextName = this.tabs[nextIdx].name;
+      const nextName = this.filteredTabs[nextIdx].name;
 
       this.select(nextName);
 
@@ -135,7 +161,8 @@ export default {
       @keyup.37.stop="selectNext(-1)"
     >
       <li
-        v-for="tab in tabs"
+        v-for="tab in filteredTabs"
+        :id="tab.name"
         :key="tab.name"
         :class="{tab: true, active: tab.active, disabled: tab.disabled}"
         role="presentation"

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -1,5 +1,5 @@
 <script>
-import { isEmpty, head } from 'lodash';
+import { isEmpty, head, sortBy } from 'lodash';
 
 export default {
   name: 'Tabbed',
@@ -21,25 +21,9 @@ export default {
   computed: {
     filteredTabs() {
       // keep the tabs list ordered for dynamic tabs
-      const {
-        initialTabOrder,
-        tabs
-      } = this;
-      const out = [];
+      const { tabs } = this;
 
-      if (isEmpty(initialTabOrder) && !isEmpty(tabs)) {
-        tabs.forEach(tab => initialTabOrder.push(tab.name));
-      }
-
-      initialTabOrder.forEach((tabId) => {
-        const match = tabs.find(t => t.name === tabId);
-
-        if (match) {
-          out.push(match);
-        }
-      });
-
-      return out;
+      return sortBy(tabs, ['weight', 'label', 'name']);
     }
   },
 
@@ -127,9 +111,9 @@ export default {
     select(name/* , event */) {
       const {
         filteredTabs,
-        $router,
+        // $router,
         $route: {
-          name: routeName,
+          // name: routeName,
           hash: routeHash
         },
       } = this;
@@ -141,7 +125,9 @@ export default {
       }
 
       if (routeHash !== hashName) {
-        $router.replace({ name: routeName, hash: hashName });
+        // TODO This throws a router error, can we handle this?
+        // $router.replace({ name: routeName, hash: hashName });
+        window.location.hash = hashName;
       }
 
       for ( const tab of filteredTabs ) {
@@ -154,7 +140,7 @@ export default {
     selectNext(direction) {
       const { filteredTabs } = this;
       const currentIdx = filteredTabs.findIndex(x => x.active);
-      const nextIdx = getNextIdx(currentIdx, direction, filteredTabs.length);
+      const nextIdx = getCyclicalIdx(currentIdx, direction, filteredTabs.length);
       const nextName = filteredTabs[nextIdx].name;
 
       this.select(nextName);
@@ -163,7 +149,7 @@ export default {
         this.$refs.tablist.focus();
       });
 
-      function getNextIdx(currentIdx, direction, tabsLength) {
+      function getCyclicalIdx(currentIdx, direction, tabsLength) {
         const nxt = currentIdx + direction;
 
         if (nxt >= tabsLength) {

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -12,14 +12,11 @@ export default {
   },
 
   data() {
-    return {
-      tabs:            [],
-      initialTabOrder: []
-    };
+    return { tabs: [] };
   },
 
   computed: {
-    filteredTabs() {
+    sortedTabs() {
       // keep the tabs list ordered for dynamic tabs
       const { tabs } = this;
 
@@ -31,7 +28,8 @@ export default {
     '$route.hash'() {
       this.hashChange();
     },
-    filteredTabs(tabs) {
+
+    sortedTabs(tabs) {
       const {
         defaultTab,
         $route: { hash }
@@ -74,7 +72,7 @@ export default {
       $children,
       $route: { hash },
       defaultTab,
-      filteredTabs,
+      sortedTabs,
     } = this;
 
     this.tabs = $children;
@@ -91,7 +89,7 @@ export default {
     }
 
     if ( !tab ) {
-      tab = head(filteredTabs);
+      tab = head(sortedTabs);
     }
 
     if ( tab ) {
@@ -105,12 +103,12 @@ export default {
     },
 
     find(name) {
-      return this.filteredTabs.find(x => x.name === name );
+      return this.sortedTabs.find(x => x.name === name );
     },
 
     select(name/* , event */) {
       const {
-        filteredTabs,
+        sortedTabs,
         $router,
         $route: {
           name: routeName,
@@ -128,7 +126,7 @@ export default {
         $router.replace({ name: routeName, hash: hashName });
       }
 
-      for ( const tab of filteredTabs ) {
+      for ( const tab of sortedTabs ) {
         tab.active = (tab.name === selected.name);
       }
 
@@ -136,10 +134,10 @@ export default {
     },
 
     selectNext(direction) {
-      const { filteredTabs } = this;
-      const currentIdx = filteredTabs.findIndex(x => x.active);
-      const nextIdx = getCyclicalIdx(currentIdx, direction, filteredTabs.length);
-      const nextName = filteredTabs[nextIdx].name;
+      const { sortedTabs } = this;
+      const currentIdx = sortedTabs.findIndex(x => x.active);
+      const nextIdx = getCyclicalIdx(currentIdx, direction, sortedTabs.length);
+      const nextName = sortedTabs[nextIdx].name;
 
       this.select(nextName);
 
@@ -174,7 +172,7 @@ export default {
       @keyup.37.stop="selectNext(-1)"
     >
       <li
-        v-for="tab in filteredTabs"
+        v-for="tab in sortedTabs"
         :id="tab.name"
         :key="tab.name"
         :class="{tab: true, active: tab.active, disabled: tab.disabled}"

--- a/components/form/ResourceTabs/index.vue
+++ b/components/form/ResourceTabs/index.vue
@@ -38,7 +38,11 @@ export default {
 <template>
   <Tabbed v-bind="$attrs">
     <slot name="before" />
-    <Tab name="labels" :label="t('resourceTabs.tabs.labels')">
+    <Tab
+      name="labels"
+      :weight="4"
+      :label="t('resourceTabs.tabs.labels')"
+    >
       <KeyValue
         key="labels"
         v-model="labels"
@@ -49,7 +53,11 @@ export default {
         :protip="false"
       />
     </Tab>
-    <Tab name="annotations" :label="t('resourceTabs.tabs.annotations')">
+    <Tab
+      name="annotations"
+      :weight="5"
+      :label="t('resourceTabs.tabs.annotations')"
+    >
       <KeyValue
         key="annotations"
         v-model="annotations"

--- a/components/form/ResourceTabs/index.vue
+++ b/components/form/ResourceTabs/index.vue
@@ -38,7 +38,7 @@ export default {
 <template>
   <Tabbed v-bind="$attrs">
     <slot name="before" />
-    <Tab name="Labels" label="Labels">
+    <Tab name="labels" :label="t('resourceTabs.tabs.labels')">
       <KeyValue
         key="labels"
         v-model="labels"
@@ -49,7 +49,7 @@ export default {
         :protip="false"
       />
     </Tab>
-    <Tab name="annotations" label="Annotations">
+    <Tab name="annotations" :label="t('resourceTabs.tabs.annotations')">
       <KeyValue
         key="annotations"
         v-model="annotations"

--- a/components/form/ResourceTabs/index.vue
+++ b/components/form/ResourceTabs/index.vue
@@ -60,6 +60,5 @@ export default {
         :protip="false"
       />
     </Tab>
-    <slot name="after" />
   </Tabbed>
 </template>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -236,6 +236,7 @@ export default {
           <Tab
             v-if="!checkTypeIs('ExternalName')"
             name="selectors"
+            :weight="1"
             :label="t('servicesPage.selectors.label')"
           >
             <div class="row">
@@ -258,7 +259,11 @@ export default {
               </div>
             </div>
           </Tab>
-          <Tab name="ips" :label="t('servicesPage.ips.label')">
+          <Tab
+            name="ips"
+            :label="t('servicesPage.ips.label')"
+            :weight="2"
+          >
             <div class="row">
               <div class="col span-12">
                 <Banner color="warning" :label="t('servicesPage.ips.helpText')" />
@@ -300,6 +305,7 @@ export default {
             v-if="!checkTypeIs('NodePort') && !checkTypeIs('ExternalName') && !checkTypeIs('Headless')"
             name="session-affinity"
             :label="t('servicesPage.affinity.label')"
+            :weight="3"
           >
             <div class="col span-12">
               <Banner color="info" :label="t('servicesPage.affinity.helpText')" />


### PR DESCRIPTION
The main drive behind the refactor was dynamic tabs. `vm.$children` does not return an ordered list. When tabs were added or removed dynamically the order would get funky. Rather than refactor the component, and thus its implementations, to take a list of tabs and their data I built on the `vm.$children` concept.  `filteredTabs` now runs the show and maintains a list of the initial tab order (which is the order on render). The method returns an re-ordered list that matches the initial order. rancher/dashboard#716

I refactored out the window `hashChange` events we were setting up in favor of Vue's built-in watching the `$route`s hash. Other window hash references changed in favor of Vue built-in's.

Refactored a nested ternary in favor of a functional check, it's more verbose but easier to understand IMO. 

Fixed labels and translations I found along the way.