### PR TITLE
Adding label support to multi-selection LabelSelect

### DIFF
--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -23,7 +23,6 @@
   .vs__open-indicator {
     cursor: not-allowed;
     color: var(--dropdown-disabled-text);
-    background-color: var(--dropdown-disabled-bg);
   }
 }
 
@@ -102,7 +101,7 @@
   flex-basis: 100%;
   flex-grow: 1;
   flex-wrap: wrap;
-  padding: 0 2px;
+  padding: 0px 0px 2px 0px;
   position: relative;
 }
 
@@ -206,7 +205,7 @@ $transition-duration: 150ms;
   border: 1px solid var(--primary);
   border-radius: 3px;
   color: var(--link-text);
-  margin: 4px 2px 0px 2px;
+  margin: 4px 4px 0px 0px;
   padding: 0.25em;
 }
 
@@ -227,7 +226,7 @@ $transition-duration: 150ms;
 .v-select.inline {
   background-color: transparent;
 
-  .vs__selected {
+  .vs--single & .vs__selected {
     color: var(--input-text);
     position: absolute;
     top: 0;
@@ -247,7 +246,7 @@ $transition-duration: 150ms;
     border: 1px solid var(--dropdown-border);
   }
 
-  .vs__selected-options {
+  .vs--single & .vs__selected-options {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -164,7 +164,7 @@ export default {
       <div v-if="isView" :class="{'no-label':!(label||'').length}" class="selected">
         {{ currentLabel }}&nbsp;
       </div>
-      <div v-else class="selected" :style="{visibility:selectedVisibility}">
+      <div v-else-if="!$attrs.multiple" :class="{'no-label':!(label||'').length}" class="selected" :style="{visibility:selectedVisibility}">
         {{ currentLabel }}&nbsp;
       </div>
     </div>
@@ -173,6 +173,7 @@ export default {
       ref="input"
       :value="value ? value : ' '"
       class="inline"
+      :class="{'no-label':!(label||'').length}"
       :disabled="isView || disabled"
       :options="options"
       :get-option-label="opt=>getOptionLabel(opt)"
@@ -186,7 +187,7 @@ export default {
       @search:blur="onBlur"
       @input="e=>$emit('input', e)"
     >
-      <template v-slot:selected-option-container>
+      <template v-if="!$attrs.multiple" v-slot:selected-option-container>
         <span style="display: none"></span>
       </template>
     </v-select>
@@ -213,12 +214,36 @@ export default {
 
   .selected {
     padding-top: 17px;
-    &.no-label{
-      padding-top:0px;
+  }
+
+  .vs__selected-options {
+    padding: 15px 0 0 0;
+  }
+
+  .selected, .vs__selected-options {
+    .vs__search, .vs__search:hover {
+      background-color: transparent;
+      padding: 2px 0 0 0;
+      flex: 1;
+    }
+  }
+
+  .no-label {
+    &.v-select:not(.vs--single) {
+      min-height: 33px;
+    }
+
+    &.selected {
+      padding-top:8px;
+      padding-bottom: 9px;
       position: relative;
       max-height:2.3em;
       overflow:hidden;
-      }
+    }
+
+    .vs__selected-options {
+      padding:8px 0 7px 0;
+    }
   }
 
   &.focused .vs__dropdown-menu {
@@ -228,26 +253,30 @@ export default {
   }
 
   .v-select.inline {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    position: initial;
 
-    &, .vs__dropdown-toggle, .vs__dropdown-toggle * {
+    &.vs--single {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+
+      .vs__search {
+        background-color: transparent;
+        padding: 17px 10px 0px 10px;
+      }
+    }
+
+    &, .vs__dropdown-toggle, .vs__dropdown-toggle > * {
       background-color: transparent;
       border:transparent;
     }
 
-    .vs__search {
-      background-color: transparent;
-      padding: 17px 10px 0px 10px;
-    }
-
     .vs__dropdown-menu {
-      top: calc(100% - 4px);
-      left: -2px;
-      width: calc(100% + 4px);
+      top: calc(100% - 2px);
+      left: -3px;
+      width: calc(100% + 6px);
     }
 
     .selected{

--- a/components/form/Security.vue
+++ b/components/form/Security.vue
@@ -3,11 +3,13 @@ import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import { _VIEW } from '@/config/query-params';
 import { mapGetters } from 'vuex';
+import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
   components: {
     RadioGroup,
     LabeledInput,
+    LabeledSelect
   },
 
   props:      {
@@ -150,38 +152,44 @@ export default {
 
     <div class="row mb-0">
       <div class="col span-6">
-        <label class="text-label"><t k="workload.container.security.addCapabilities" /></label>
         <div v-if="isView">
-          <span v-if="!add.length">n/a</span>
-          <ul v-else>
+          <label class="text-label"><t k="workload.container.security.addCapabilities" /></label>
+          <div v-if="!add.length">
+            n/a
+          </div>
+          <ul v-else class="mt-0 mb-0 pl-15">
             <li v-for="capability in add" :key="capability">
               {{ capability }}
             </li>
           </ul>
         </div>
-        <v-select
+        <LabeledSelect
           v-else
           v-model="add"
-          multiple
+          :multiple="true"
+          :label="t('workload.container.security.addCapabilities')"
           :options="allCapabilities"
           :disabled="mode==='view'"
           @input="update"
         />
       </div>
       <div class="col span-6">
-        <label class="text-label"><t k="workload.container.security.dropCapabilities" /></label>
         <div v-if="isView">
-          <span v-if="!drop.length">n/a</span>
-          <ul v-else>
+          <label class="text-label"><t k="workload.container.security.dropCapabilities" /></label>
+          <div v-if="!drop.length">
+            n/a
+          </div>
+          <ul v-else class="mt-0 mb-0 pl-15">
             <li v-for="capability in drop" :key="capability">
               {{ capability }}
             </li>
           </ul>
         </div>
-        <v-select
+        <LabeledSelect
           v-else
           v-model="drop"
-          multiple
+          :multiple="true"
+
           :options="allCapabilities"
           :disabled="mode==='view'"
           @input="update"


### PR DESCRIPTION
The Security component didn't use the LabelSelect view mode so I didn't touch the view mode yet. We may want to update the multi-selection LabelSelect to support a view like what we have here. What do you think?

rancher/dashboard#661

**Single selection without label**
![Screen Shot 2020-06-23 at 3 52 47 PM](https://user-images.githubusercontent.com/55104481/85474685-e10adb00-b569-11ea-944d-3b74740557b7.png)
**Single selection with label**
![Screen Shot 2020-06-23 at 3 51 46 PM](https://user-images.githubusercontent.com/55104481/85474687-e10adb00-b569-11ea-9170-64ce9b66d902.png)
**Multiple rows without label**
![Screen Shot 2020-06-23 at 3 51 36 PM](https://user-images.githubusercontent.com/55104481/85474688-e1a37180-b569-11ea-924d-4462a6781db3.png)
**Multiple rows with label**
![Screen Shot 2020-06-23 at 3 51 32 PM](https://user-images.githubusercontent.com/55104481/85474689-e1a37180-b569-11ea-926c-84b2e4ff54ae.png)
**Single row with label**
![Screen Shot 2020-06-23 at 3 51 00 PM](https://user-images.githubusercontent.com/55104481/85474692-e1a37180-b569-11ea-9b43-0d31882c4826.png)
**Single row without label**
![Screen Shot 2020-06-23 at 3 50 57 PM](https://user-images.githubusercontent.com/55104481/85474694-e23c0800-b569-11ea-9ff9-42d6a84ba48b.png)
**Empty without label**
![Screen Shot 2020-06-23 at 3 50 43 PM](https://user-images.githubusercontent.com/55104481/85474695-e23c0800-b569-11ea-9cd8-c3589fa79c02.png)
**Empty with label**
![Screen Shot 2020-06-23 at 3 50 40 PM](https://user-images.githubusercontent.com/55104481/85474696-e23c0800-b569-11ea-8c72-6bc6d8951639.png)
**Multi-selection view for Security**
![Screen Shot 2020-06-23 at 3 53 11 PM](https://user-images.githubusercontent.com/55104481/85474680-e0724480-b569-11ea-9955-63914453d320.png)