### PR TITLE
Fixing the create button

### DIFF
--- a/pages/c/_cluster/_resource/index.vue
+++ b/pages/c/_cluster/_resource/index.vue
@@ -52,7 +52,7 @@ export default {
   },
 
   data() {
-    const params = { ...this.$route.params };
+    const params = { };
     const resource = params.resource;
 
     const formRoute = { name: `${ this.$route.name }-create`, params };


### PR DESCRIPTION
If a user edited a resource and then attempted to create a new
resource they would be taken to the view page of the previously
edited resource.

This was being caused by adding the existing route params to the
location used by the create button. More specifically the existing
params contained an id which caused the mode to be computed
incorrectly.

By removing all of the existing params the create, createAsYaml, 
edit, editAsYaml, clone and view pages all appear to work.

rancher/dashboard#758