### PR TITLE
fix resourcedetail params

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -238,7 +238,9 @@ export default {
     },
 
     doneParams() {
-      return this.$route.params;
+      return Object.keys(this.$route.params).filter((param) => {
+        return param !== 'id' && param !== 'namespace';
+      });
     },
 
     showComponent() {
@@ -261,7 +263,7 @@ export default {
   watch: {
     asYamlInit(neu) {
       this.asYaml = neu;
-    }
+    },
   },
 
   methods: {

--- a/mixins/create-edit-view.js
+++ b/mixins/create-edit-view.js
@@ -154,7 +154,6 @@ export default {
       if ( !this.doneRoute ) {
         return;
       }
-
       this.$router.replace({
         name:   this.doneRoute,
         params: this.doneParams || { resource: this.value.type }

--- a/pages/c/_cluster/_resource/index.vue
+++ b/pages/c/_cluster/_resource/index.vue
@@ -52,7 +52,7 @@ export default {
   },
 
   data() {
-    const params = { };
+    const params = { ...this.$route.params };
     const resource = params.resource;
 
     const formRoute = { name: `${ this.$route.name }-create`, params };
@@ -112,6 +112,7 @@ export default {
       return this.$store.getters['type-map/isCreatable'](this.$route.params.resource);
     }
   },
+
 }; </script>
 
 <template>


### PR DESCRIPTION
Removing `$route.params` from the list page was causing all the data in that page dependent on params to be computed incorrectly e.g. `hasCustomListComponent` always returns `false`

The create/edit routing bug appears to be from `doneParams` in `ResourceDetail` — used to redirect after cancel/create/save in `create-edit-view` —  which was computed using the current page's route params, including `namespace` and `id`. Filtering these out ensures that the router action to return to list view does not include any create/edit/view-specific params