### PR TITLE
do not truncate multiline key/value in view

### DIFF
--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -108,8 +108,8 @@
 
   --tabbed-border              : #{$medium};
   --tabbed-container-bg        : #{$darkest};
-  --tabbed-container-bg-contrast        : #{$dark};
 
+  --yaml-editor-bg             : #{$darkest};
 
   --wm-tabs-bg                 : #{$darker};
   --wm-tab-bg                  : #{$darkest};

--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -131,8 +131,8 @@ $selected: rgba($primary, .5);
 
   --tabbed-border              : #{$medium};
   --tabbed-container-bg        : #{$lighter};
-  --tabbed-container-bg-contrast: #{$light};
 
+  --yaml-editor-bg             : #{$lighter};
 
   --diff-border                : var(--border);
   --diff-header-bg             : var(--nav-bg);

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -9,6 +9,7 @@ buttons:
 generic:
   cancel: Cancel
   close: Close
+  clickToShow: '[Show Value]'
   comingSoon: Coming Soon
   created: Created
   customize: Customize

--- a/components/CodeMirror.vue
+++ b/components/CodeMirror.vue
@@ -23,7 +23,7 @@ export default {
       const keymap = this.$store.getters['prefs/get'](KEYMAP);
 
       const out = {
-        // codemirror options
+        // codemirror default options
         tabSize:                 2,
         indentWithTabs:          false,
         mode:                    'yaml',
@@ -36,9 +36,9 @@ export default {
         foldGutter:              true,
         styleSelectedText:       true,
         showCursorWhenSelecting: true,
-
-        ...this.options
       };
+
+      Object.assign(out, this.options);
 
       return out;
     },
@@ -85,15 +85,8 @@ export default {
 </template>
 
 <style lang="scss">
-  .code-mirror  {
-    position: relative;
-    .CodeMirror {
-      height: initial;
-      position: absolute;
-      top:0;
-      bottom:0;
-      left:0;
-      right:0;
-    }
+  .code-mirror .vue-codemirror .CodeMirror {
+    height: initial;
+    background: none
   }
 </style>

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -243,15 +243,4 @@ export default {
     padding: 20px;
     background-color: var(--tabbed-container-bg);
   }
-
-  .contrast{
-    & .tab-container {
-      background-color: var(--tabbed-container-bg-contrast);
-    }
-
-    & .tab.active{
-      background-color: var(--tabbed-container-bg-contrast);
-        border-bottom-color: var(--tabbed-container-bg-contrast);
-    }
-  }
 </style>

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -87,7 +87,7 @@ export default {
     diffMode: mapPref(DIFF),
     showCodeEditor() {
       return [EDITOR_MODES.EDIT_CODE, EDITOR_MODES.VIEW_CODE].includes(this.editorMode);
-    }
+    },
   },
   watch: {
     value(newYaml) {
@@ -199,6 +199,22 @@ export default {
   .fill {
     flex: 1;
   }
+
+  ::v-deep .code-mirror  {
+      position: relative;
+      .CodeMirror {
+        height: initial;
+        position: absolute;
+        top:0;
+        bottom:0;
+        left:0;
+        right:0;
+        background-color: var(--yaml-editor-bg);
+        & .CodeMirror-gutters {
+          background-color: var(--yaml-editor-bg);
+        }
+      }
+    }
 
   .diff-mode {
     background-color: var(--diff-header-bg);

--- a/components/chart/gatekeeper/Config.vue
+++ b/components/chart/gatekeeper/Config.vue
@@ -4,16 +4,16 @@ import AsyncButton from '@/components/AsyncButton';
 import Footer from '@/components/form/Footer';
 import InfoBox from '@/components/InfoBox';
 import { NAMESPACE } from '@/config/types';
-import { _VIEW, _EDIT } from '@/config/query-params';
+import { _EDIT } from '@/config/query-params';
 import { findBy } from '@/utils/array';
-import CodeMirror from '@/components/CodeMirror';
+import YamlEditor from '@/components/YamlEditor';
 
 export default {
   name: 'GatekeeperConfig',
 
   components: {
     AsyncButton,
-    CodeMirror,
+    YamlEditor,
     InfoBox,
     Footer,
   },
@@ -83,25 +83,6 @@ export default {
       const { namespaces } = this;
 
       return namespaces.find(ns => ns.metadata.name === 'gatekeeper-system');
-    },
-
-    cmOptions() {
-      const readOnly = this.mode === _VIEW;
-      const gutters = ['CodeMirror-lint-markers'];
-
-      if ( !readOnly ) {
-        gutters.push('CodeMirror-foldgutter');
-      }
-
-      return {
-        readOnly,
-        gutters,
-        mode:            'yaml',
-        lint:            true,
-        lineNumbers:     !readOnly,
-        extraKeys:       { 'Ctrl-Space': 'autocomplete' },
-        cursorBlinkRate: ( readOnly ? -1 : 530)
-      };
     },
 
     parsedValuesYaml() {
@@ -420,10 +401,9 @@ export default {
       </div>
     </div>
     <section v-if="showYamlEditor">
-      <CodeMirror
-        class="code-mirror"
+      <YamlEditor
+        class="yaml-editor"
         :value="config.spec.valuesYaml"
-        :options="cmOptions"
         @onInput="onInput"
         @onReady="onReady"
         @onChanges="onChanges"
@@ -440,7 +420,7 @@ export default {
 
 <style lang="scss">
 .gatekeeper-config {
-  .code-mirror {
+  .yaml-editor {
     min-height: 200px;
   }
 }

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -387,7 +387,7 @@ export default {
             :valueName="valueName"
             :isView="isView"
           >
-            <div v-if="isView" class="view">
+            <div v-if="isView" class="view" :class="{'hide-overflow':!valueMultiline}">
               {{ row[keyName] }}
             </div>
             <input
@@ -414,7 +414,7 @@ export default {
             <span v-if="valueBinary || row.binary">
               {{ row[valueName].length }} byte<span v-if="row[valueName].length !== 1">s</span>
             </span>
-            <div v-else-if="isView" class="view">
+            <div v-else-if="isView" class="view" :class="{'hide-overflow':!valueMultiline}">
               {{ row[valueName] }}
             </div>
             <TextAreaAutoGrow
@@ -523,10 +523,13 @@ export default {
     .view {
       width: 100%;
       height: 100%;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
       display: inline;
+
+      &.hide-overflow{
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
     }
 
     label {
@@ -539,9 +542,12 @@ export default {
 
     .view {
       width: 100%;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
+
+      &.hide-overflow{
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
     }
 
     label {

--- a/components/formatter/ClickExpand.vue
+++ b/components/formatter/ClickExpand.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 export default {
   props: {
     value: {
@@ -8,6 +9,14 @@ export default {
     maxLength: {
       type:    Number,
       default: 20
+    },
+    size: {
+      type:    Number,
+      default: null
+    },
+    units: {
+      type:    String,
+      default: 'Bytes'
     }
   },
   data() {
@@ -20,9 +29,14 @@ export default {
       if (this.expanded) {
         return this.value;
       } else {
+        if (!!this.size) {
+          return `${ this.size } ${ this.units }`;
+        }
+
         return this.value.slice(0, this.maxLength);
       }
-    }
+    },
+    ...mapGetters({ t: 'i18n/t' })
   },
   methods: {
     expand() {
@@ -36,8 +50,9 @@ export default {
 <template>
   <span @click.stop="expand">
     {{ preview }}
-    <span v-if="!expanded">
-      ...
-    </span>
+    <template v-if="!expanded">
+      <span v-if="!size">...</span>
+      {{ t('generic.clickToShow') }}
+    </template>
   </span>
 </template>

--- a/detail/secret.vue
+++ b/detail/secret.vue
@@ -246,7 +246,7 @@ export default {
     <template v-else>
       <div class="spacer"></div>
       <div>
-        <KeyValue :title="t('secret.data')" :value="dataRows" mode="view" :as-map="false" />
+        <KeyValue :title="t('secret.data')" :value="dataRows" mode="view" :as-map="false" :value-multiline="true" />
       </div>
       <div class="spacer"></div>
     </template>

--- a/plugins/codemirror.js
+++ b/plugins/codemirror.js
@@ -9,6 +9,8 @@ import CodeMirror from 'codemirror';
 
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/yaml/yaml.js';
+import 'codemirror/mode/javascript/javascript.js';
+
 // import 'codemirror/mode/dockerfile/dockerfile.js';
 // import 'codemirror/mode/shell/shell.js';
 // import 'codemirror/mode/markdown/markdown.js';


### PR DESCRIPTION
Per @deniseschannon request, this PR un-hides the cert data in the secret detail view of service acct tokens (and other secrets with long data values). `KeyValue` view-mode styling truncates all long `key` and `value` cells, but I think it makes sense for multiline inputs to remain multiline in view mode.
![Screen Shot 2020-06-25 at 3 34 20 PM](https://user-images.githubusercontent.com/42977925/85802341-9c15ae80-b6f9-11ea-9585-296fb32a71fe.png)
