### PR TITLE
fix fixing of doneParams in ResourceDetail

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -238,9 +238,12 @@ export default {
     },
 
     doneParams() {
-      return Object.keys(this.$route.params).filter((param) => {
-        return param !== 'id' && param !== 'namespace';
-      });
+      const out = { ...this.$route.params };
+
+      delete out.namespace;
+      delete out.id;
+
+      return out;
     },
 
     showComponent() {


### PR DESCRIPTION
When I (attempted to) fix `doneParams()` previously I changed the function to return an array instead of an object.
:( 