### PR TITLE
Service TargetPort Accept Multiple Types

### DIFF
--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -301,9 +301,3 @@ $transition-duration: 150ms;
   display: inline-block;
   border: 0;
 }
-
-.protocol-select {
-  .vs__dropdown-toggle {
-    padding: 6px 0 6px 6px !important;
-  }
-}

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -3,9 +3,12 @@ import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { removeAt } from '@/utils/array';
 import { clone } from '@/utils/object';
+  import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
-  components: {},
+    components: {
+      LabeledSelect
+    },
   props:      {
     value: {
       type:    Array,
@@ -165,11 +168,9 @@ export default {
           </td>
           <td v-if="specType !== 'NodePort'" class="port-protocol">
             <span v-if="isView">{{ row.protocol }}</span>
-            <v-select
+            <LabeledSelect
               v-else
               v-model="row.protocol"
-              class="inline protocol-select"
-              :searchable="false"
               :options="protocolOptions"
               @input="queueUpdate"
             />
@@ -239,6 +240,11 @@ export default {
 
   .port-protocol {
     width: 100px;
+    .labeled-select {
+      &.labeled-input {
+        padding: 6px;
+      }
+    }
   }
 
   .value {

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -3,12 +3,10 @@ import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { removeAt } from '@/utils/array';
 import { clone } from '@/utils/object';
-  import LabeledSelect from '@/components/form/LabeledSelect';
+import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
-    components: {
-      LabeledSelect
-    },
+  components: { LabeledSelect },
   props:      {
     value: {
       type:    Array,

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -1,5 +1,5 @@
 <script>
-import find from 'lodash/find';
+import { isEmpty, find, isNaN } from 'lodash';
 import ArrayList from '@/components/form/ArrayList';
 import CreateEditView from '@/mixins/create-edit-view';
 import DetailTop from '@/components/DetailTop';
@@ -163,6 +163,20 @@ export default {
 
       return false;
     },
+
+    updateServicePorts(servicePorts) {
+      servicePorts.forEach((sp) => {
+        if ( !isEmpty(sp?.targetPort) ) {
+          const tpCoerced = parseInt(sp.targetPort, 10);
+
+          if (!isNaN(tpCoerced)) {
+            sp.targetPort = tpCoerced;
+          }
+        }
+      });
+
+      this.$set(this.value.spec, 'ports', servicePorts);
+    }
   },
 };
 </script>
@@ -226,7 +240,7 @@ export default {
         class="col span-12"
         :mode="mode"
         :spec-type="serviceType"
-        @input="e=>$set(value.spec, 'ports', e)"
+        @input="updateServicePorts"
       />
 
       <div class="spacer"></div>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "dagre-d3": "^0.6.3",
     "dayjs": "^1.8.16",
     "diff2html": "^2.11.2",
-    "dotenv": "^8.0.0",
     "event-target-shim": "^5.0.1",
     "express": "^4.17.1",
     "file-saver": "^2.0.2",


### PR DESCRIPTION
Services Port Rules contains a param `targetPort` that can be string or int types. I updated the logic there to parse into an int if it can be, other wise we leave it as is. 

Additionally I slipped in a couple smaller fixes:
Swap v-select with Labeled Select
Drop dotenv package as NuxtJS >=2.13.0 includes this as a dependency now.

Wonky styling on port protocol rule row
Prior:
![Screen Shot 2020-07-15 at 11 50 51 AM](https://user-images.githubusercontent.com/858614/87584028-b526d500-c691-11ea-85f0-c90da8e7ded4.png)


Now:
![Screen Shot 2020-07-15 at 11 51 45 AM](https://user-images.githubusercontent.com/858614/87584037-ba841f80-c691-11ea-89dd-7e9670ef131b.png)
