### PR TITLE
Hide DetailTop on yaml view and prevent Show # Annotations from navigating away from the page

### DIFF
--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -51,7 +51,8 @@ export default {
     }
   },
   methods: {
-    showAnnotations() {
+    showAnnotations(ev) {
+      ev.preventDefault();
       this.annotationsVisible = true;
     }
   }

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -280,7 +280,7 @@ export default {
         </div>
       </template>
     </Masthead>
-    <DetailTop v-if="isView" :details="originalModel.details" :description="originalModel.description" :labels="originalModel.labels" :annotations="originalModel.annotations" />
+    <DetailTop v-if="isView && !asYaml" :details="originalModel.details" :description="originalModel.description" :labels="originalModel.labels" :annotations="originalModel.annotations" />
     <template v-if="asYaml">
       <ResourceYaml
         ref="resourceyaml"


### PR DESCRIPTION
It looks like the nuxt changes caused the use of href="#" to navigate away from the current page. This change prevents the default action and keeps the user on the page when clicking Show # Annotations.

We also wanted to hide DetailTop on the yaml page.

rancher/dashboard#867

![Screen Shot 2020-07-21 at 5 28 46 PM](https://user-images.githubusercontent.com/55104481/88121119-9a64cc80-cb79-11ea-8e9e-b117a9e28bec.png)
