### PR TITLE
Making ingress path editable

### DIFF
--- a/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/edit/networking.k8s.io.ingress/RulePath.vue
@@ -43,7 +43,7 @@ export default {
 <template>
   <div class="rule-path row mb-0">
     <div class="col span-4">
-      <input v-model="path" :placeholder="t('ingress.rules.path.placeholder', undefined, true)" />
+      <input v-model="path" :placeholder="t('ingress.rules.path.placeholder', undefined, true)" @input="update" />
     </div>
     <div class="col span-4">
       <LabeledSelect

--- a/edit/networking.k8s.io.ingress/index.vue
+++ b/edit/networking.k8s.io.ingress/index.vue
@@ -70,7 +70,7 @@ export default {
     if (!this.value.spec.backend) {
       this.value.spec.backend = { };
     }
-    if (!this.value.spec.tls || Object.keys(this.value.spec.tls[0]).length === 0) {
+    if (!this.value.spec.tls || Object.keys(this.value.spec.tls[0] || {}).length === 0) {
       this.value.spec.tls = [];
     }
     this.registerBeforeHook(this.willSave, 'willSave');


### PR DESCRIPTION
Path could be created but not edited. update() wasn't being called from the path input field.

There was also an issue with calling Object.keys on a potentially undefined object that was resolved.

rancher/dashboard#756