### PR TITLE
Updating when we display metrics for HA Local clusters

### DIFF
--- a/models/node.js
+++ b/models/node.js
@@ -77,6 +77,18 @@ export default {
     return `${ this.labels[etcd] }` === 'true';
   },
 
+  hasARole() {
+    const roleLabelKeys = Object.values(NODE_ROLES);
+
+    return Object.keys(this.labels)
+      .some((labelKey) => {
+        const hasRoleLabel = roleLabelKeys.includes(labelKey);
+        const isExpectedValue = `${ this.labels[labelKey] }` === 'true';
+
+        return hasRoleLabel && isExpectedValue;
+      });
+  },
+
   roles() {
     const { isControlPlane, isWorker, isEtcd } = this;
 


### PR DESCRIPTION
We only show the live metrics for worker nodes. The HA cluster that I created on GKE doesn't add the 'node-role.kubernetes.io/...' label. The lack of this label causes us to filter out all nodes since we don't consider them to be workers.

This makes better checks to ensure we only show the metrics when they're present.

rancher/dashboard#776