### PR TITLE
Made the cluster overview page more responsive

### DIFF
--- a/pages/c/_cluster/explorer/Glance.vue
+++ b/pages/c/_cluster/explorer/Glance.vue
@@ -46,37 +46,49 @@ export default {
 </template>
 
 <style lang="scss">
-    .glance {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-evenly;
-        padding: 11px;
+  .glance {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-evenly;
+      padding: 11px;
 
-        .tile {
-            display: flex;
-            flex: 1;
-            flex-direction: column;
-            align-items: flex-start;
-            padding: 9px 0 3px 0;
+      .tile {
+          display: flex;
+          flex: 1;
+          flex-direction: column;
+          align-items: flex-start;
+          padding: 9px 0 3px 0;
 
-            &:not(:last-of-type) {
-                border-right: 1px solid;
-                border-color: var(--glance-divider);
-            }
+          &:not(:last-of-type) {
+              border-right: 1px solid;
+              border-color: var(--glance-divider);
+          }
 
-            &:not(:first-of-type) {
-                padding-left: 20px;
-            }
-        }
+          &:not(:first-of-type) {
+              padding-left: 20px;
+          }
+      }
+      h1 {
+        font-size: 15px;
+        line-height: 3px;
+      }
 
+      @media only screen and (min-width: map-get($breakpoints, '--viewport-9')) {
         h1 {
-            font-size: 30px;
-            line-height: 28px;
+          font-size: 25px;
+          line-height: 14px;
         }
+      }
+      @media only screen and (min-width: map-get($breakpoints, '--viewport-12')) {
+        h1 {
+          font-size: 30px;
+          line-height: 28px;
+        }
+      }
 
-        label {
-            font-size: 12px;
-            opacity: 0.7;
-        }
-    }
+      label {
+          font-size: 12px;
+          opacity: 0.7;
+      }
+  }
 </style>

--- a/pages/c/_cluster/explorer/HardwareResourceGauge.vue
+++ b/pages/c/_cluster/explorer/HardwareResourceGauge.vue
@@ -107,7 +107,7 @@ export default {
             position: relative;
             margin: $large-spacing auto 0 auto;
             padding-bottom: $large-spacing;
-            width: 245px;
+            max-width: 245px;
             height: 122.5px + $large-spacing;
             border-bottom: 2px solid var(--simple-box-divider);
 

--- a/pages/c/_cluster/explorer/ResourceGauge.vue
+++ b/pages/c/_cluster/explorer/ResourceGauge.vue
@@ -111,10 +111,17 @@ export default {
         }
 
         h1 {
-          font-size: 40px;
-          line-height: 36px;
+          font-size: 28px;
+          line-height: 28px;
           border-bottom: 2px solid var(--gauge-divider);
           padding-bottom: $padding / 2;
+        }
+
+        @media only screen and (min-width: map-get($breakpoints, '--viewport-7')) {
+          h1 {
+            font-size: 40px;
+            line-height: 36px;
+          }
         }
 
         .alerts {

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -53,7 +53,6 @@ const METRICS_POLL_RATE_MS = 30000;
 const MAX_FAILURES = 2;
 
 const RESOURCES = [NAMESPACE, INGRESS, PV, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.DAEMON_SET, SERVICE];
-const RESOURCES_PER_ROW = 5;
 
 export default {
   components: {
@@ -252,16 +251,6 @@ export default {
       return [total, ...gauges];
     },
 
-    resourceGaugesFiller() {
-      const lastRowCount = this.resourceGauges.length % RESOURCES_PER_ROW;
-
-      if (lastRowCount === 0) {
-        return 0;
-      }
-
-      return [...Array( RESOURCES_PER_ROW - lastRowCount)];
-    },
-
     cpuReserved() {
       return {
         total:  parseSi(this.cluster?.status?.allocatable?.cpu),
@@ -450,7 +439,6 @@ export default {
     <Glance :provider="displayProvider" :kubernetes-version="cluster.kubernetesVersion" :total-nodes="(nodes || []).length" :created="cluster.metadata.creationTimestamp" />
     <div class="resource-gauges">
       <ResourceGauge v-for="resourceGauge in resourceGauges" :key="resourceGauge.name" v-bind="resourceGauge" />
-      <div v-for="(filler, i) in resourceGaugesFiller" :key="i" class="filler" />
     </div>
     <div v-if="showReservedMetrics" class="hardware-resource-gauges">
       <HardwareResourceGauge name="Pods Reserved" :total="podsReserved.total" :useful="podsReserved.useful" :suffix="t('clusterIndexPage.hardwareResourceGauge.podsReserved')" />
@@ -478,44 +466,62 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  section {
-    min-width: 1140px;
-  }
-
   .actions-span {
     align-self: center;
   }
 
+  @media only screen and (min-width: map-get($breakpoints, '--viewport-7')) {
+    .resource-gauges {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    .hardware-resource-gauges {
+      &, &.live {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+  @media only screen and (min-width: map-get($breakpoints, '--viewport-9')) {
+    .resource-gauges {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+
+    .hardware-resource-gauges {
+      grid-template-columns: 1fr 1fr 1fr;
+
+      &.live {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+  }
+  @media only screen and (min-width: map-get($breakpoints, '--viewport-12')) {
+    .resource-gauges {
+      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+    }
+  }
+
   .resource-gauges {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    display: grid;
+    grid-column-gap: 10px;
+    grid-row-gap: 15px;
+    margin-top: 25px;
 
     & > * {
-      min-width: 210px;
-      max-width: calc(20% - 10px);
       width: 100%;
-      margin: 10px 0 0 0;
     }
   }
 
   .hardware-resource-gauges {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    margin-top: 50px;
-
-    & > * {
-      min-width: 352px;
-      width: calc(33.333% - 10px);
+    display: grid;
+    grid-column-gap: 15px;
+    grid-row-gap: 20px;
+    margin-top: 30px;
+    &:first-of-type {
+      margin-top: 35px;
     }
 
-    &.live {
-      margin-top: 30px;
-      & > * {
-        width: calc(50% - 8px);
-      }
+    & > * {
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
This uses already established breakpoints and makes reasonable looking
renders past the point of the navigation header breaking.

Depending on how navigation is updated we may need to make one more 
breakpoint at a smaller resolution.

rancher/dashboard#892


![](https://media0.giphy.com/media/gL96U1YxsHNK4azLk3/giphy.gif)