### PR TITLE
Fixing namespace project assignment

### DIFF
--- a/edit/namespace/index.vue
+++ b/edit/namespace/index.vue
@@ -63,11 +63,19 @@ export default {
     },
   },
 
-  watch: {
-    project(val) {
-      this.value.setLabel(PROJECT, val);
-    },
+  created() {
+    this.registerBeforeHook(this.willSave, 'willSave');
   },
+
+  methods: {
+    willSave() {
+      const cluster = this.$store.getters['currentCluster'];
+      const annotation = this.project ? `${ cluster.id }:${ this.project }` : null;
+
+      this.value.setLabel(PROJECT, this.project);
+      this.value.setAnnotation(PROJECT, annotation);
+    }
+  }
 
 };
 </script>


### PR DESCRIPTION
The project field was only being added to the label and not to the annotation. 
Because it wasn't added to the annotation it wasn't showing up in ember.

I also noticed the watch method wasn't getting called everytime so I
moved the logic to a willSave method.

rancher/dashboard#878