### PR TITLE
fix wizard nav

### DIFF
--- a/components/Wizard.vue
+++ b/components/Wizard.vue
@@ -121,6 +121,7 @@ export default {
       this.goToStep(neu[STEP]);
     },
   },
+
   created() {
     this.goToStep(this.activeStepIndex + 1);
   },
@@ -148,12 +149,12 @@ export default {
       }
 
       if (queryStep !== number) {
-        this.$router.replace({ query: { [STEP]: number } }).catch((e) => {
+        this.$router.replace({ query: { ...this.$route.query, [STEP]: number } }).catch((e) => {
           if (e?.name === 'NavigationDuplicated') {
             // ignore this
           } else if (e.message.includes('with a new navigation')) {
             // route changed by tabs; retry
-            this.$router.applyQuery({ [STEP]: number });
+            this.$router.applyQuery({ ...this.$route.query, [STEP]: number });
           }
         });
       }

--- a/components/form/NodeScheduling.vue
+++ b/components/form/NodeScheduling.vue
@@ -4,6 +4,7 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import KeyValue from '@/components/form/KeyValue';
 import NodeAffinity from '@/components/form/NodeAffinity';
 import { _VIEW } from '@/config/query-params';
+import { isEmpty } from '@/utils/object';
 
 export default {
   components: {
@@ -75,6 +76,7 @@ export default {
         delete this.value.nodeSelector;
       }
     },
+    isEmpty
   }
 };
 </script>

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -150,7 +150,7 @@ export default {
       allSecrets:       [],
       headlessServices: [],
       allNodes:         null,
-      showTabs:         false
+      showTabs:         false,
     };
   },
 
@@ -195,7 +195,15 @@ export default {
 
     // TODO better validation
     containerIsReady() {
-      return (!!this.container.image && !!this.container.imagePullPolicy && !!this.value.metadata.name);
+      const required = [this.container.image, this.container.imagePullPolicy];
+
+      if (this.isReplicable) {
+        required.push(this.spec.replicas);
+      } else if (this.isCronJob) {
+        required.push(this.spec.schedule);
+      }
+
+      return required.filter(prop => !!prop).length === required.length;
     },
 
     // if this is a cronjob, grab pod spec from within job template spec
@@ -401,7 +409,8 @@ export default {
 
     containerIsReady(neu) {
       this.steps[1].ready = neu;
-    }
+    },
+
   },
 
   created() {


### PR DESCRIPTION
The wizard was obliterating other query params on initial load, which prevented going to edit/clone views.

Also, I included `spec.replicas` and `spec.schedule` as necessary to advance beyond the first step where applicable. Checking for `metadata.name` needs more work as it isn't being assigned a value reactively, but I'd like to hold off on going down that road until we have clearer goals for workload creation & wizards in general. 