### PR TITLE
Bugfix delete alt action

### DIFF
--- a/components/ActionMenu.vue
+++ b/components/ActionMenu.vue
@@ -75,13 +75,11 @@ export default {
     },
 
     execute(action, event, args) {
-      if (isAlternate(event)) {
-        if (!args) {
-          args = {};
-        }
-        args.alt = true;
-      }
-      this.$store.dispatch('action-menu/execute', { action, args });
+      const opts = { alt: isAlternate(event) };
+
+      this.$store.dispatch('action-menu/execute', {
+        action, args, opts
+      });
       this.hide();
     }
   },

--- a/components/ActionMenu.vue
+++ b/components/ActionMenu.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 import $ from 'jquery';
 import { AUTO, CENTER, fitOnScreen } from '@/utils/position';
+import { isAlternate } from '@/utils/platform';
 
 const HIDDEN = 'hide';
 const CALC = 'calculate';
@@ -73,7 +74,13 @@ export default {
       }
     },
 
-    execute(action, args) {
+    execute(action, event, args) {
+      if (isAlternate(event)) {
+        if (!args) {
+          args = {};
+        }
+        args.alt = true;
+      }
       this.$store.dispatch('action-menu/execute', { action, args });
       this.hide();
     }
@@ -85,7 +92,7 @@ export default {
   <div v-if="showing">
     <div class="background" @click="hide" @contextmenu.prevent></div>
     <ul class="list-unstyled menu" :style="style">
-      <li v-for="opt in options" :key="opt.action" :class="{divider: opt.divider}" @click="execute(opt)">
+      <li v-for="opt in options" :key="opt.action" :class="{divider: opt.divider}" @click="execute(opt, $event)">
         <i v-if="opt.icon" :class="{icon: true, [opt.icon]: true}" />
         {{ opt.label }}
       </li>

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -146,7 +146,7 @@ export default {
         }
 
         Promise.all(this.toRemove.map(resource => resource.remove())).then((results) => {
-          if ( !isEmpty(goTo) ) {
+          if ( goTo && !isEmpty(goTo) ) {
             this.currentRouter.push(goTo);
           }
 

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -390,7 +390,7 @@ export default {
     focusSearch() {
       this.$refs.searchQuery.focus();
       this.$refs.searchQuery.select();
-    }
+    },
   }
 };
 </script>

--- a/components/SortableTable/selection.js
+++ b/components/SortableTable/selection.js
@@ -349,14 +349,12 @@ export default {
       }
     },
 
-    applyTableAction(action, args = {}, event) {
-      if (isAlternate(event)) {
-        if (!args) {
-          args = {};
-        }
-        args.alt = true;
-      }
-      this.$store.dispatch(`${ this.storeName }/executeTable`, { action, args });
+    applyTableAction(action, args, event) {
+      const opts = { alt: isAlternate(event) };
+
+      this.$store.dispatch(`${ this.storeName }/executeTable`, {
+        action, args, opts
+      });
       this.$store.commit(`${ this.storeName }/setBulkActionOfInterest`, null);
     }
   }

--- a/components/SortableTable/selectionStore.js
+++ b/components/SortableTable/selectionStore.js
@@ -248,12 +248,12 @@ function _filter(map, disableAll = false) {
 }
 
 function _execute(resources, action, args) {
-  args = args || [];
-  if ( resources.length > 1 && action.bulkAction ) {
+  args = args || {};
+  if ( resources.length > 1 && action.bulkAction && !args.alt ) {
     const fn = resources[0][action.bulkAction];
 
     if ( fn ) {
-      return fn.call(resources[0], resources, ...args);
+      return fn.call(resources[0], resources, args);
     }
   }
 

--- a/components/SortableTable/selectionStore.js
+++ b/components/SortableTable/selectionStore.js
@@ -184,10 +184,10 @@ export const mutations = {
 };
 
 export const actions = {
-  executeTable({ state }, { action, args }) {
+  executeTable({ state }, { action, args, opts }) {
     const executableSelection = state.tableSelected.filter(getters.canRunBulkActionOfInterest(state));
 
-    return _execute(executableSelection, action, args);
+    return _execute(executableSelection, action, args, opts);
   },
 
   execute({ state }, { action, args }) {
@@ -247,13 +247,13 @@ function _filter(map, disableAll = false) {
   return out;
 }
 
-function _execute(resources, action, args) {
-  args = args || {};
-  if ( resources.length > 1 && action.bulkAction && !args.alt ) {
+function _execute(resources, action, args, opts = {}) {
+  args = args || [];
+  if ( resources.length > 1 && action.bulkAction && !opts.alt ) {
     const fn = resources[0][action.bulkAction];
 
     if ( fn ) {
-      return fn.call(resources[0], resources, args);
+      return fn.call(resources[0], resources, ...args);
     }
   }
 
@@ -262,7 +262,7 @@ function _execute(resources, action, args) {
   for ( const resource of resources ) {
     let fn;
 
-    if (args.alt && action.altAction) {
+    if (opts.alt && action.altAction) {
       fn = resource[action.altAction];
     } else {
       fn = resource[action.action];

--- a/store/action-menu.js
+++ b/store/action-menu.js
@@ -135,12 +135,12 @@ function _filter(map, disableAll = false) {
 }
 
 function _execute(resources, action, args) {
-  args = args || [];
-  if ( resources.length > 1 && action.bulkAction ) {
+  args = args || {};
+  if ( resources.length > 1 && action.bulkAction && !args.alt ) {
     const fn = resources[0][action.bulkAction];
 
     if ( fn ) {
-      return fn.call(resources[0], resources, ...args);
+      return fn.call(resources[0], resources, args);
     }
   }
 

--- a/store/action-menu.js
+++ b/store/action-menu.js
@@ -81,8 +81,8 @@ export const actions = {
     return _execute(state.tableSelected, action, args);
   },
 
-  execute({ state }, { action, args }) {
-    return _execute(state.resources, action, args);
+  execute({ state }, { action, args, opts }) {
+    return _execute(state.resources, action, args, opts);
   },
 };
 
@@ -134,13 +134,13 @@ function _filter(map, disableAll = false) {
   return out;
 }
 
-function _execute(resources, action, args) {
-  args = args || {};
-  if ( resources.length > 1 && action.bulkAction && !args.alt ) {
+function _execute(resources, action, args, opts = {}) {
+  args = args || [];
+  if ( resources.length > 1 && action.bulkAction && !opts.alt ) {
     const fn = resources[0][action.bulkAction];
 
     if ( fn ) {
-      return fn.call(resources[0], resources, args);
+      return fn.call(resources[0], resources, ...args);
     }
   }
 
@@ -149,7 +149,7 @@ function _execute(resources, action, args) {
   for ( const resource of resources ) {
     let fn;
 
-    if (args.alt && action.altAction) {
+    if (opts.alt && action.altAction) {
       fn = resource[action.altAction];
     } else {
       fn = resource[action.action];


### PR DESCRIPTION
The alt action (skip prompt) for delete was only working on single resources because of the spread operator used in the bulk action `.call()`.  Every other use of `_execute` appears unaffected by this change. I couldn't find anywhere else `args` were potentially used in an action and I'm not really sure why they were being spread on [bulk actions](https://github.com/rancher/dashboard/blob/cb883b69c9242ff531a0f15fbd083aa1f24ef7aa/components/SortableTable/selectionStore.js#L256) and not [regular actions](https://github.com/rancher/dashboard/blob/cb883b69c9242ff531a0f15fbd083aa1f24ef7aa/components/SortableTable/selectionStore.js#L272).

It's worth noting that while this fixes the delete functionality, the resource list might not reflect that still.