### PR TITLE
Feature - Generic Create Component

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -174,6 +174,15 @@ containerResourceLimit:
   requestsCpu: CPU Reservation
   requestsMemory: Memory Reservation
 
+cruResource:
+  previewYaml: Preview Yaml
+  cancel: Cancelling will destroy your changes.
+  back: Going back will destroy your changes.
+  confirmYaml: "No, Review Yaml"
+  backToForm: Go Back To Form
+  confirmCancel: "Yes, Cancel"
+  confirmBack: "Yes, Go Back"
+
 footer:
   docs: Docs
   download: Download CLI

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4,7 +4,7 @@
 generic:
   add: Add
   cancel: Cancel
-  clickToShow: '[Show Value]'
+  clickToShow: "[Show Value]"
   close: Close
   comingSoon: Coming Soon
   create: Create
@@ -37,10 +37,10 @@ nav:
   ns:
     all: All Namespaces
     clusterLevel: Only Cluster Resources
-    namespace: '{name}'
+    namespace: "{name}"
     namespaced: Only Namespaced Resources
     orphan: Not in a Project
-    project: 'Project: {name}'
+    project: "Project: {name}"
     system: Only System Namespaces
     user: Only User Namespaces
 
@@ -133,7 +133,7 @@ cluster:
 
 clusterIndexPage:
   hardwareResourceGauge:
-    consumption: '{useful} of {total} {units} {suffix}'
+    consumption: "{useful} of {total} {units} {suffix}"
     coresReserved: Cores Reserved
     coresUsed: Cores Used
     podsReserved: Pods Reserved
@@ -249,7 +249,7 @@ ingress:
       placeholder: e.g. 80 or http
     targetService:
       label: Target Service
-    warning: 'Warning: Default backend is used globally for the entire cluster.'
+    warning: "Warning: Default backend is used globally for the entire cluster."
   rules:
     addPath: Add Path
     addRule: Add Rule
@@ -284,7 +284,7 @@ node:
       version: Version
     glance:
       consumptionGauge:
-        amount: '{used} of {total} {unit} used'
+        amount: "{used} of {total} {unit} used"
         cpu: CPU
         memory: MEMORY
         pods: PODS
@@ -306,8 +306,8 @@ promptRemove:
     =1 {, and one other.}
     other {, and {count} others.}
     }
-  attemptingToRemove: 'You are attemping to remove the {type}'
-  protip: 'protip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation'
+  attemptingToRemove: "You are attemping to remove the {type}"
+  protip: "protip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
 
 resourceDetail:
   detailTop:
@@ -322,11 +322,11 @@ resourceDetail:
       =1 {Show annotation}
       other {Show {annotations} annotations}}
   header:
-    clone: 'Clone from {type}: {name}'
+    clone: "Clone from {type}: {name}"
     create: Create
-    edit: 'Edit {type}: {name}'
-    stage: 'Stage from {type}: {name}'
-    view: '{name}'
+    edit: "Edit {type}: {name}"
+    stage: "Stage from {type}: {name}"
+    view: "{name}"
   masthead:
     age: Age
     defaultBannerMessage:
@@ -341,14 +341,14 @@ resourceList:
   head:
     create: Create
     createFromYaml: Create from YAML
-    createResource: 'Create {resourceName}'
+    createResource: "Create {resourceName}"
 
 resourceTable:
   groupLabel:
-    namespace: '<span>Namespace:</span> {name}'
+    namespace: "<span>Namespace:</span> {name}"
     notInANamespace: Not Namespaced
     notInAProject: Not in a Project
-    project: '<span>Project:</span> {name}'
+    project: "<span>Project:</span> {name}"
 
 resourceTabs:
   tabs:
@@ -365,7 +365,7 @@ rioConfig:
     description: Description
     helpText:
       listItem1: The application deployment engine for Kubernetes.
-      listItem2: 'Rio makes it faster and easier for DevOps to build, test, deploy, scale and version stateless applications'
+      listItem2: "Rio makes it faster and easier for DevOps to build, test, deploy, scale and version stateless applications"
     requirements:
       header: Requirements
       helpText:
@@ -381,7 +381,7 @@ secret:
     cn: Domain Name
     expires: Expires
     issuer: Issuer
-    plusMore: '+ {n} more'
+    plusMore: "+ {n} more"
     privateKey: Private Key
     readFromFile: Read from File
   data: Data
@@ -429,7 +429,7 @@ servicesPage:
       label: Session Sticky Time
       placeholder: e.g. 10800
   externalName:
-    helpText: 'External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service.'
+    helpText: "External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service."
     label: External Name
     placeholder: e.g. my.database.example.com
   ips:
@@ -438,27 +438,42 @@ servicesPage:
       label: External IPs
       placeholder: e.g. 1.1.1.1
       protip: List of IP addresses for which nodes in the cluster will also accept traffic for this service.
-    helpText: 'Warning: Configuring additional listener IPs is an advanced use case.'
+    helpText: "Warning: Configuring additional listener IPs is an advanced use case."
     input:
       label: Cluster IP
       placeholder: e.g. 10.0.171.239
     label: Listener IPs
   selectors:
-    helpText: 'If no selector is created, manual endpoints must be made.'
+    helpText: "If no selector is created, manual endpoints must be made."
     label: Selectors
   serviceTypes:
-    clusterIp: Cluster IP
-    externalName: External Name
-    headless: Headless
-    loadBalancer: Load Balancer
-    nodePort: Node Port
+    clusterIp:
+      abbrv: IP
+      label: Cluster IP
+      description: Exposes the service on a cluster-internal IP. Choosing this value makes the service only reachable from within the cluster. This is the default type.
+    externalName:
+      abbrv: EN
+      label: External Name
+      description: "Maps the service to the contents of the `externalName` field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up."
+    headless:
+      abbrv: H
+      label: Headless
+      description: Neither a cluster IP or load balancer is defined. These are used to interface with other service discovery mechanisms outside of Kubernetes implementation. A cluster IP is not allocated and kube-proxy does not handle these services.
+    loadBalancer:
+      abbrv: LB
+      label: Load Balancer
+      description: Exposes the service externally using a cloud provider's load balancer.
+    nodePort:
+      abbrv: NP
+      label: Node Port
+      description: "Exposes the service on each node's IP at a static port (the `NodePort`). You'll be able to contact this type of service, from outside the cluster, by requesting `<NodeIP>:<NodePort>`."
   typeOpts:
     label: Service Type
 
 sortableTable:
   actionAvailability:
-    selected: '{actionable} selected'
-    some: 'Available for {actionable} of the {total} selected'
+    selected: "{actionable} selected"
+    some: "Available for {actionable} of the {total} selected"
   noData: There are no rows which match your search query.
   noRows: There are no rows to show.
   paging:
@@ -547,7 +562,7 @@ validation:
     min: '"{key}" should contain at least {count} {count, plural, =1 {item} other {items}}'
   chars: '"{key}" contains {count, plural, =1 {an invalid character} other {# invalid characters}}: {chars}'
   custom:
-    missing: 'No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?'
+    missing: "No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?"
   dns:
     doubleHyphen: '"{key}" Cannot contain two or more consecutive hyphens'
     hostname:
@@ -586,17 +601,17 @@ validation:
   service:
     ports:
       name:
-        required: 'Port Rule [{position}] - Name is required.'
+        required: "Port Rule [{position}] - Name is required."
       nodePort:
-        requriedInt: 'Port Rule [{position}] - Node Port must be interger values if included.'
+        requriedInt: "Port Rule [{position}] - Node Port must be interger values if included."
       port:
-        required: 'Port Rule [{position}] - Port is required.'
-        requriedInt: 'Port Rule [{position}] - Port must be interger values if included.'
+        required: "Port Rule [{position}] - Port is required."
+        requriedInt: "Port Rule [{position}] - Port must be interger values if included."
       targetPort:
-        between: 'Port Rule [{position}] - Target Port must be between 1 and 65535'
-        iana: 'Port Rule [{position}] - Target Port must be an IANA Service Name or Integer'
-        ianaAt: 'Port Rule [{position}] - Target Port '
-        required: 'Port Rule [{position}] - Target Port is required'
+        between: "Port Rule [{position}] - Target Port must be between 1 and 65535"
+        iana: "Port Rule [{position}] - Target Port must be an IANA Service Name or Integer"
+        ianaAt: "Port Rule [{position}] - Target Port "
+        required: "Port Rule [{position}] - Target Port is required"
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
     exactly: '"{key}" should be {count, plural, =1 {# character} other {# characters}}'
@@ -609,7 +624,7 @@ wizard:
   back: Back
   finish: Finish
   next: Next
-  step: 'Step {number}:'
+  step: "Step {number}:"
 
 wm:
   connection:
@@ -619,7 +634,7 @@ wm:
     error: Error
   containerLogs:
     clear: Clear
-    containerName: 'Container: {label}'
+    containerName: "Container: {label}"
     download: Download
     follow: Follow
     noData: There are no log entries to show in the current range.
@@ -634,7 +649,7 @@ wm:
         other {Hours}
         }
       label: Show the last
-      lines: '{value, number} Lines'
+      lines: "{value, number} Lines"
       minutes: |
         {value, number} {value, plural,
         =1 {Minute}
@@ -645,9 +660,9 @@ wm:
     wrap: Wrap Lines
   containerShell:
     clear: Clear
-    containerName: 'Container: {label}'
+    containerName: "Container: {label}"
   kubectlShell:
-    title: 'Kubectl: {name}'
+    title: "Kubectl: {name}"
 
 workload:
   container:
@@ -679,7 +694,7 @@ workload:
       initialDelay: Initial Delay
       livenessProbe: Liveness Probe
       livenessTip: Containers will be restarted when this check is failing.  Not recommended for most uses.
-      noHealthCheck: 'There is not a Readiness Check, Liveness Check or Startup Check configured.'
+      noHealthCheck: "There is not a Readiness Check, Liveness Check or Startup Check configured."
       readinessProbe: Readiness Probe
       readinessTip: Containers will be removed from service endpoints when this check is failing.  Recommended.
       startupProbe: Startup Probe
@@ -708,8 +723,8 @@ workload:
       runAsGroup: Run as Group ID
       runAsNonRoot: Run as Non-Root
       runAsNonRootOptions:
-        noOption: 'No'
-        yesOption: 'Yes: containers must run as non-root-user'
+        noOption: "No"
+        yesOption: "Yes: containers must run as non-root-user"
       runAsUser: Run as User ID
       shareProcessNamespace: Share single process namespace
       supplementalGroups: Additional Group IDs
@@ -768,7 +783,7 @@ workload:
       label: Host Aliases
       tip: Additional /etc/hosts entries to be injected in the container.
       valueLabel: Hostname
-      valuePlaceholder: 'e.g. foo.com, bar.com'
+      valuePlaceholder: "e.g. foo.com, bar.com"
     hostname:
       label: Hostname
       placeholder: e.g. web
@@ -802,9 +817,9 @@ workload:
         addRule: Add Rule
         doesNotExist: Does Not Exist
         exists: Exists
-        greaterThan: '>'
+        greaterThan: ">"
         in: =
-        inNamespaces: 'Pods in these namespaces:'
+        inNamespaces: "Pods in these namespaces:"
         key: Key
         lessThan: <
         notIn: ≠
@@ -813,8 +828,8 @@ workload:
         weight: Weight
       noPodRules: There are no pod scheduling rules configured.
       nodeName: Node Name
-      preferAny: 'Prefer any of:'
-      requireAny: 'Require any of:'
+      preferAny: "Prefer any of:"
+      requireAny: "Require any of:"
       schedulingRules: Run pods on node(s) matching these scheduling rules
       specificNode: Run pods on specific node(s)
       thisPodNamespace: This pod's namespace
@@ -840,7 +855,7 @@ workload:
       effectOptions:
         all: All
         noExecute: NoExecute
-        noSchedule: 'NoSchedule,'
+        noSchedule: "NoSchedule,"
         preferNoSchedule: PreferNoSchedule
       labelKey: Label Key
       operator: Operator
@@ -873,9 +888,9 @@ workload:
       tip: The number of old ReplicaSets to retain for rollback.
     strategies:
       labels:
-        delete: 'On Delete: New pods are only created when old pods are manually deleted.'
-        recreate: 'Recreate: Kill ALL pods, then start new pods.'
-        rollingUpdate: 'Rolling Update: Create new pods, until max surge is reached, before deleting old pods. Don''t stop more pods than max unavailable.'
+        delete: "On Delete: New pods are only created when old pods are manually deleted."
+        recreate: "Recreate: Kill ALL pods, then start new pods."
+        rollingUpdate: "Rolling Update: Create new pods, until max surge is reached, before deleting old pods. Don't stop more pods than max unavailable."
     terminationGracePeriodSeconds:
       label: Termination Grace Period
       tip: The duration the pod needs to terminate successfully.
@@ -888,22 +903,19 @@ workload:
       batch.cronjob: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/" target="_blank" rel="noopener nofollow" >CronJobs</a> create Jobs, which then run Pods, on a repeating schedule. The schedule is expressed in standard Unix <a href="https://en.wikipedia.org/wiki/Cron">cron</a> format, and uses the timezone of the Kubernetes control plane (typically UTC).
       batch.job: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/job/" target="_blank" rel="noopener nofollow" >Jobs</a> create one or more pods to reliably perform a one-time task by running a pod until it exits successfully. Failed pods are automatically replaced until the specified number of completed runs has been reached. Jobs can also run multiple pods in parallel or function as a batch work queue.
     titles:
-      advanced: 
+      advanced:
         title: Advanced
         subtitle: Define the advanced options. Each pod has additional options that can be defined as part of the container, part of the pod and part of the workload type. We recommends reading the detailed Kubernetes documentation before attempting to configure these.
-      defineContainer: 
+      defineContainer:
         title: Define Container
         subtitle: Define the container of the pod. Each workload type ultimately deploys pods, which are the smallest unit of compute managed by Kubernetes. The main definition of the pod is the container. These are the basic fields defined on a container, but there are more fields that can be defined in the Advanced step or in the raw yaml.
       scaling: Scaling/Upgrade Policy
-      selectType: 
+      selectType:
         title: Select a Workload Type
         subtitle: Select the type of <a href="https://kubernetes.io/docs/concepts/workloads/" target="_blank" rel="noopener nofollow">workload</a> to create. Each type has unique properties that define where the pods will be run, how they will be maintained or scaled, and what happens when they fail.
-      storage: 
+      storage:
         title: Storage
         subtitle: Pods only have their own local ephemeral storage by default, which will be wiped out when the pod dies. To persist data that survives beyond the life of a single pod, you can attach external <a href='https://kubernetes.io/docs/concepts/storage/' target="_blank" rel="noopener nofollow">storage</a> (e.g. block devices or NFS shares) from a provider and make it available to the pod.
-    
-
-
 
 ##############################
 # Model Properties
@@ -917,7 +929,7 @@ model:
       registeredAgent: Registered Agent
       service: Service
       user: User
-  'catalog.cattle.io.release':
+  "catalog.cattle.io.release":
     firstDeployed: First Deployed
     lastDeployed: Last Deployed
   cluster:
@@ -928,7 +940,7 @@ model:
       localUser: Local User
       org: Organization
       team: Team
-      unknown: '{type}?'
+      unknown: "{type}?"
       user: User
   ingress:
     displayKind: L7 Ingress
@@ -941,7 +953,7 @@ model:
     domain:
       help: Only users below this base will be used.
       label: User Search Base
-      placeholder: 'e.g. ou=Users,dc=mycompany,dc=com'
+      placeholder: "e.g. ou=Users,dc=mycompany,dc=com"
     server:
       label: Hostname or IP Address
     serviceAccountPassword:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3,6 +3,7 @@
 ##############################
 generic:
   add: Add
+  back: Back
   cancel: Cancel
   clickToShow: "[Show Value]"
   close: Close

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -429,10 +429,12 @@ servicesPage:
       label: Session Sticky Time
       placeholder: e.g. 10800
   externalName:
+    define: Define External Name
     helpText: "External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service."
     label: External Name
     placeholder: e.g. my.database.example.com
   ips:
+    define: Define Service Ports
     clusterIpHelpText: The Cluster IP address must be within the CIDR range configured for the API server.
     external:
       label: External IPs
@@ -449,24 +451,24 @@ servicesPage:
   serviceTypes:
     clusterIp:
       abbrv: IP
-      label: Cluster IP
       description: Exposes the service on a cluster-internal IP. Choosing this value makes the service only reachable from within the cluster. This is the default type.
+      label: Cluster IP
     externalName:
       abbrv: EN
-      label: External Name
       description: "Maps the service to the contents of the `externalName` field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up."
+      label: External Name
     headless:
       abbrv: H
-      label: Headless
       description: Neither a cluster IP or load balancer is defined. These are used to interface with other service discovery mechanisms outside of Kubernetes implementation. A cluster IP is not allocated and kube-proxy does not handle these services.
+      label: Headless
     loadBalancer:
       abbrv: LB
-      label: Load Balancer
       description: Exposes the service externally using a cloud provider's load balancer.
+      label: Load Balancer
     nodePort:
       abbrv: NP
-      label: Node Port
       description: "Exposes the service on each node's IP at a static port (the `NodePort`). You'll be able to contact this type of service, from outside the cluster, by requesting `<NodeIP>:<NodePort>`."
+      label: Node Port
   typeOpts:
     label: Service Type
 

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5,7 +5,7 @@ generic:
   add: Add
   back: Back
   cancel: Cancel
-  clickToShow: "[Show Value]"
+  clickToShow: '[Show Value]'
   close: Close
   comingSoon: Coming Soon
   create: Create
@@ -19,6 +19,7 @@ generic:
     one  {resource}
     other {resources}
     }
+  save: Save
   type: Type
   unknown: Unknown
 
@@ -38,10 +39,10 @@ nav:
   ns:
     all: All Namespaces
     clusterLevel: Only Cluster Resources
-    namespace: "{name}"
+    namespace: '{name}'
     namespaced: Only Namespaced Resources
     orphan: Not in a Project
-    project: "Project: {name}"
+    project: 'Project: {name}'
     system: Only System Namespaces
     user: Only User Namespaces
 
@@ -134,7 +135,7 @@ cluster:
 
 clusterIndexPage:
   hardwareResourceGauge:
-    consumption: "{useful} of {total} {units} {suffix}"
+    consumption: '{useful} of {total} {units} {suffix}'
     coresReserved: Cores Reserved
     coresUsed: Cores Used
     podsReserved: Pods Reserved
@@ -178,10 +179,10 @@ cruResource:
   previewYaml: Preview Yaml
   cancel: Cancelling will destroy your changes.
   back: Going back will destroy your changes.
-  confirmYaml: "No, Review Yaml"
+  confirmYaml: 'No, Review Yaml'
   backToForm: Go Back To Form
-  confirmCancel: "Yes, Cancel"
-  confirmBack: "Yes, Go Back"
+  confirmCancel: 'Yes, Cancel'
+  confirmBack: 'Yes, Go Back'
 
 footer:
   docs: Docs
@@ -259,7 +260,7 @@ ingress:
       placeholder: e.g. 80 or http
     targetService:
       label: Target Service
-    warning: "Warning: Default backend is used globally for the entire cluster."
+    warning: 'Warning: Default backend is used globally for the entire cluster.'
   rules:
     addPath: Add Path
     addRule: Add Rule
@@ -294,7 +295,7 @@ node:
       version: Version
     glance:
       consumptionGauge:
-        amount: "{used} of {total} {unit} used"
+        amount: '{used} of {total} {unit} used'
         cpu: CPU
         memory: MEMORY
         pods: PODS
@@ -316,8 +317,8 @@ promptRemove:
     =1 {, and one other.}
     other {, and {count} others.}
     }
-  attemptingToRemove: "You are attemping to remove the {type}"
-  protip: "protip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
+  attemptingToRemove: 'You are attemping to remove the {type}'
+  protip: 'protip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation'
 
 resourceDetail:
   detailTop:
@@ -332,11 +333,11 @@ resourceDetail:
       =1 {Show annotation}
       other {Show {annotations} annotations}}
   header:
-    clone: "Clone from {type}: {name}"
+    clone: 'Clone from {type}: {name}'
     create: Create
-    edit: "Edit {type}: {name}"
-    stage: "Stage from {type}: {name}"
-    view: "{name}"
+    edit: 'Edit {type}: {name}'
+    stage: 'Stage from {type}: {name}'
+    view: '{name}'
   masthead:
     age: Age
     defaultBannerMessage:
@@ -351,14 +352,14 @@ resourceList:
   head:
     create: Create
     createFromYaml: Create from YAML
-    createResource: "Create {resourceName}"
+    createResource: 'Create {resourceName}'
 
 resourceTable:
   groupLabel:
-    namespace: "<span>Namespace:</span> {name}"
+    namespace: '<span>Namespace:</span> {name}'
     notInANamespace: Not Namespaced
     notInAProject: Not in a Project
-    project: "<span>Project:</span> {name}"
+    project: '<span>Project:</span> {name}'
 
 resourceTabs:
   tabs:
@@ -375,7 +376,7 @@ rioConfig:
     description: Description
     helpText:
       listItem1: The application deployment engine for Kubernetes.
-      listItem2: "Rio makes it faster and easier for DevOps to build, test, deploy, scale and version stateless applications"
+      listItem2: 'Rio makes it faster and easier for DevOps to build, test, deploy, scale and version stateless applications'
     requirements:
       header: Requirements
       helpText:
@@ -391,7 +392,7 @@ secret:
     cn: Domain Name
     expires: Expires
     issuer: Issuer
-    plusMore: "+ {n} more"
+    plusMore: '+ {n} more'
     privateKey: Private Key
     readFromFile: Read from File
   data: Data
@@ -440,7 +441,7 @@ servicesPage:
       placeholder: e.g. 10800
   externalName:
     define: Define External Name
-    helpText: "External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service."
+    helpText: 'External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service.'
     label: External Name
     placeholder: e.g. my.database.example.com
   ips:
@@ -450,13 +451,13 @@ servicesPage:
       label: External IPs
       placeholder: e.g. 1.1.1.1
       protip: List of IP addresses for which nodes in the cluster will also accept traffic for this service.
-    helpText: "Warning: Configuring additional listener IPs is an advanced use case."
+    helpText: 'Warning: Configuring additional listener IPs is an advanced use case.'
     input:
       label: Cluster IP
       placeholder: e.g. 10.0.171.239
     label: Listener IPs
   selectors:
-    helpText: "If no selector is created, manual endpoints must be made."
+    helpText: 'If no selector is created, manual endpoints must be made.'
     label: Selectors
   serviceTypes:
     clusterIp:
@@ -465,7 +466,7 @@ servicesPage:
       label: Cluster IP
     externalName:
       abbrv: EN
-      description: "Maps the service to the contents of the `externalName` field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up."
+      description: 'Maps the service to the contents of the `externalName` field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.'
       label: External Name
     headless:
       abbrv: H
@@ -484,8 +485,8 @@ servicesPage:
 
 sortableTable:
   actionAvailability:
-    selected: "{actionable} selected"
-    some: "Available for {actionable} of the {total} selected"
+    selected: '{actionable} selected'
+    some: 'Available for {actionable} of the {total} selected'
   noData: There are no rows which match your search query.
   noRows: There are no rows to show.
   paging:
@@ -574,7 +575,7 @@ validation:
     min: '"{key}" should contain at least {count} {count, plural, =1 {item} other {items}}'
   chars: '"{key}" contains {count, plural, =1 {an invalid character} other {# invalid characters}}: {chars}'
   custom:
-    missing: "No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?"
+    missing: 'No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?'
   dns:
     doubleHyphen: '"{key}" Cannot contain two or more consecutive hyphens'
     hostname:
@@ -613,17 +614,17 @@ validation:
   service:
     ports:
       name:
-        required: "Port Rule [{position}] - Name is required."
+        required: 'Port Rule [{position}] - Name is required.'
       nodePort:
-        requriedInt: "Port Rule [{position}] - Node Port must be interger values if included."
+        requriedInt: 'Port Rule [{position}] - Node Port must be interger values if included.'
       port:
-        required: "Port Rule [{position}] - Port is required."
-        requriedInt: "Port Rule [{position}] - Port must be interger values if included."
+        required: 'Port Rule [{position}] - Port is required.'
+        requriedInt: 'Port Rule [{position}] - Port must be interger values if included.'
       targetPort:
-        between: "Port Rule [{position}] - Target Port must be between 1 and 65535"
-        iana: "Port Rule [{position}] - Target Port must be an IANA Service Name or Integer"
-        ianaAt: "Port Rule [{position}] - Target Port "
-        required: "Port Rule [{position}] - Target Port is required"
+        between: 'Port Rule [{position}] - Target Port must be between 1 and 65535'
+        iana: 'Port Rule [{position}] - Target Port must be an IANA Service Name or Integer'
+        ianaAt: 'Port Rule [{position}] - Target Port '
+        required: 'Port Rule [{position}] - Target Port is required'
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
     exactly: '"{key}" should be {count, plural, =1 {# character} other {# characters}}'
@@ -636,7 +637,7 @@ wizard:
   back: Back
   finish: Finish
   next: Next
-  step: "Step {number}:"
+  step: 'Step {number}:'
 
 wm:
   connection:
@@ -646,7 +647,7 @@ wm:
     error: Error
   containerLogs:
     clear: Clear
-    containerName: "Container: {label}"
+    containerName: 'Container: {label}'
     download: Download
     follow: Follow
     noData: There are no log entries to show in the current range.
@@ -661,7 +662,7 @@ wm:
         other {Hours}
         }
       label: Show the last
-      lines: "{value, number} Lines"
+      lines: '{value, number} Lines'
       minutes: |
         {value, number} {value, plural,
         =1 {Minute}
@@ -672,9 +673,9 @@ wm:
     wrap: Wrap Lines
   containerShell:
     clear: Clear
-    containerName: "Container: {label}"
+    containerName: 'Container: {label}'
   kubectlShell:
-    title: "Kubectl: {name}"
+    title: 'Kubectl: {name}'
 
 workload:
   container:
@@ -706,7 +707,7 @@ workload:
       initialDelay: Initial Delay
       livenessProbe: Liveness Probe
       livenessTip: Containers will be restarted when this check is failing.  Not recommended for most uses.
-      noHealthCheck: "There is not a Readiness Check, Liveness Check or Startup Check configured."
+      noHealthCheck: 'There is not a Readiness Check, Liveness Check or Startup Check configured.'
       readinessProbe: Readiness Probe
       readinessTip: Containers will be removed from service endpoints when this check is failing.  Recommended.
       startupProbe: Startup Probe
@@ -735,8 +736,8 @@ workload:
       runAsGroup: Run as Group ID
       runAsNonRoot: Run as Non-Root
       runAsNonRootOptions:
-        noOption: "No"
-        yesOption: "Yes: containers must run as non-root-user"
+        noOption: 'No'
+        yesOption: 'Yes: containers must run as non-root-user'
       runAsUser: Run as User ID
       shareProcessNamespace: Share single process namespace
       supplementalGroups: Additional Group IDs
@@ -795,7 +796,7 @@ workload:
       label: Host Aliases
       tip: Additional /etc/hosts entries to be injected in the container.
       valueLabel: Hostname
-      valuePlaceholder: "e.g. foo.com, bar.com"
+      valuePlaceholder: 'e.g. foo.com, bar.com'
     hostname:
       label: Hostname
       placeholder: e.g. web
@@ -829,9 +830,9 @@ workload:
         addRule: Add Rule
         doesNotExist: Does Not Exist
         exists: Exists
-        greaterThan: ">"
+        greaterThan: '>'
         in: =
-        inNamespaces: "Pods in these namespaces:"
+        inNamespaces: 'Pods in these namespaces:'
         key: Key
         lessThan: <
         notIn: ≠
@@ -840,8 +841,8 @@ workload:
         weight: Weight
       noPodRules: There are no pod scheduling rules configured.
       nodeName: Node Name
-      preferAny: "Prefer any of:"
-      requireAny: "Require any of:"
+      preferAny: 'Prefer any of:'
+      requireAny: 'Require any of:'
       schedulingRules: Run pods on node(s) matching these scheduling rules
       specificNode: Run pods on specific node(s)
       thisPodNamespace: This pod's namespace
@@ -867,7 +868,7 @@ workload:
       effectOptions:
         all: All
         noExecute: NoExecute
-        noSchedule: "NoSchedule,"
+        noSchedule: 'NoSchedule,'
         preferNoSchedule: PreferNoSchedule
       labelKey: Label Key
       operator: Operator
@@ -900,8 +901,8 @@ workload:
       tip: The number of old ReplicaSets to retain for rollback.
     strategies:
       labels:
-        delete: "On Delete: New pods are only created when old pods are manually deleted."
-        recreate: "Recreate: Kill ALL pods, then start new pods."
+        delete: 'On Delete: New pods are only created when old pods are manually deleted.'
+        recreate: 'Recreate: Kill ALL pods, then start new pods.'
         rollingUpdate: "Rolling Update: Create new pods, until max surge is reached, before deleting old pods. Don't stop more pods than max unavailable."
     terminationGracePeriodSeconds:
       label: Termination Grace Period
@@ -941,7 +942,7 @@ model:
       registeredAgent: Registered Agent
       service: Service
       user: User
-  "catalog.cattle.io.release":
+  'catalog.cattle.io.release':
     firstDeployed: First Deployed
     lastDeployed: Last Deployed
   cluster:
@@ -952,7 +953,7 @@ model:
       localUser: Local User
       org: Organization
       team: Team
-      unknown: "{type}?"
+      unknown: '{type}?'
       user: User
   ingress:
     displayKind: L7 Ingress
@@ -965,7 +966,7 @@ model:
     domain:
       help: Only users below this base will be used.
       label: User Search Base
-      placeholder: "e.g. ou=Users,dc=mycompany,dc=com"
+      placeholder: 'e.g. ou=Users,dc=mycompany,dc=com'
     server:
       label: Hostname or IP Address
     serviceAccountPassword:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5,7 +5,7 @@ generic:
   add: Add
   back: Back
   cancel: Cancel
-  clickToShow: '[Show Value]'
+  clickToShow: "[Show Value]"
   close: Close
   comingSoon: Coming Soon
   create: Create
@@ -39,10 +39,10 @@ nav:
   ns:
     all: All Namespaces
     clusterLevel: Only Cluster Resources
-    namespace: '{name}'
+    namespace: "{name}"
     namespaced: Only Namespaced Resources
     orphan: Not in a Project
-    project: 'Project: {name}'
+    project: "Project: {name}"
     system: Only System Namespaces
     user: Only User Namespaces
 
@@ -135,7 +135,7 @@ cluster:
 
 clusterIndexPage:
   hardwareResourceGauge:
-    consumption: '{useful} of {total} {units} {suffix}'
+    consumption: "{useful} of {total} {units} {suffix}"
     coresReserved: Cores Reserved
     coresUsed: Cores Used
     podsReserved: Pods Reserved
@@ -179,10 +179,10 @@ cruResource:
   previewYaml: Preview Yaml
   cancel: Cancelling will destroy your changes.
   back: Going back will destroy your changes.
-  confirmYaml: 'No, Review Yaml'
+  confirmYaml: "No, Review Yaml"
   backToForm: Go Back To Form
-  confirmCancel: 'Yes, Cancel'
-  confirmBack: 'Yes, Go Back'
+  confirmCancel: "Yes, Cancel"
+  confirmBack: "Yes, Go Back"
 
 footer:
   docs: Docs
@@ -260,7 +260,7 @@ ingress:
       placeholder: e.g. 80 or http
     targetService:
       label: Target Service
-    warning: 'Warning: Default backend is used globally for the entire cluster.'
+    warning: "Warning: Default backend is used globally for the entire cluster."
   rules:
     addPath: Add Path
     addRule: Add Rule
@@ -295,7 +295,7 @@ node:
       version: Version
     glance:
       consumptionGauge:
-        amount: '{used} of {total} {unit} used'
+        amount: "{used} of {total} {unit} used"
         cpu: CPU
         memory: MEMORY
         pods: PODS
@@ -317,8 +317,8 @@ promptRemove:
     =1 {, and one other.}
     other {, and {count} others.}
     }
-  attemptingToRemove: 'You are attemping to remove the {type}'
-  protip: 'protip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation'
+  attemptingToRemove: "You are attemping to remove the {type}"
+  protip: "protip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
 
 resourceDetail:
   detailTop:
@@ -333,11 +333,11 @@ resourceDetail:
       =1 {Show annotation}
       other {Show {annotations} annotations}}
   header:
-    clone: 'Clone from {type}: {name}'
+    clone: "Clone from {type}: {name}"
     create: Create
-    edit: 'Edit {type}: {name}'
-    stage: 'Stage from {type}: {name}'
-    view: '{name}'
+    edit: "Edit {type}: {name}"
+    stage: "Stage from {type}: {name}"
+    view: "{name}"
   masthead:
     age: Age
     defaultBannerMessage:
@@ -352,14 +352,14 @@ resourceList:
   head:
     create: Create
     createFromYaml: Create from YAML
-    createResource: 'Create {resourceName}'
+    createResource: "Create {resourceName}"
 
 resourceTable:
   groupLabel:
-    namespace: '<span>Namespace:</span> {name}'
+    namespace: "<span>Namespace:</span> {name}"
     notInANamespace: Not Namespaced
     notInAProject: Not in a Project
-    project: '<span>Project:</span> {name}'
+    project: "<span>Project:</span> {name}"
 
 resourceTabs:
   tabs:
@@ -376,7 +376,7 @@ rioConfig:
     description: Description
     helpText:
       listItem1: The application deployment engine for Kubernetes.
-      listItem2: 'Rio makes it faster and easier for DevOps to build, test, deploy, scale and version stateless applications'
+      listItem2: "Rio makes it faster and easier for DevOps to build, test, deploy, scale and version stateless applications"
     requirements:
       header: Requirements
       helpText:
@@ -392,7 +392,7 @@ secret:
     cn: Domain Name
     expires: Expires
     issuer: Issuer
-    plusMore: '+ {n} more'
+    plusMore: "+ {n} more"
     privateKey: Private Key
     readFromFile: Read from File
   data: Data
@@ -430,6 +430,8 @@ serviceTypes:
   nodeport: Node Port
 
 servicesPage:
+  labelsAnnotations:
+    label: Labels & Annotations
   affinity:
     actionLabels:
       clusterIp: ClusterIP
@@ -441,7 +443,7 @@ servicesPage:
       placeholder: e.g. 10800
   externalName:
     define: Define External Name
-    helpText: 'External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service.'
+    helpText: "External Name is intended to specify a canonical DNS name. To hardcode an IP address, use a Headless service."
     label: External Name
     placeholder: e.g. my.database.example.com
   ips:
@@ -451,13 +453,13 @@ servicesPage:
       label: External IPs
       placeholder: e.g. 1.1.1.1
       protip: List of IP addresses for which nodes in the cluster will also accept traffic for this service.
-    helpText: 'Warning: Configuring additional listener IPs is an advanced use case.'
+    helpText: "Warning: Configuring additional listener IPs is an advanced use case."
     input:
       label: Cluster IP
       placeholder: e.g. 10.0.171.239
     label: Listener IPs
   selectors:
-    helpText: 'If no selector is created, manual endpoints must be made.'
+    helpText: "If no selector is created, manual endpoints must be made."
     label: Selectors
   serviceTypes:
     clusterIp:
@@ -466,7 +468,7 @@ servicesPage:
       label: Cluster IP
     externalName:
       abbrv: EN
-      description: 'Maps the service to the contents of the `externalName` field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.'
+      description: "Maps the service to the contents of the `externalName` field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up."
       label: External Name
     headless:
       abbrv: H
@@ -485,8 +487,8 @@ servicesPage:
 
 sortableTable:
   actionAvailability:
-    selected: '{actionable} selected'
-    some: 'Available for {actionable} of the {total} selected'
+    selected: "{actionable} selected"
+    some: "Available for {actionable} of the {total} selected"
   noData: There are no rows which match your search query.
   noRows: There are no rows to show.
   paging:
@@ -575,7 +577,7 @@ validation:
     min: '"{key}" should contain at least {count} {count, plural, =1 {item} other {items}}'
   chars: '"{key}" contains {count, plural, =1 {an invalid character} other {# invalid characters}}: {chars}'
   custom:
-    missing: 'No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?'
+    missing: "No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?"
   dns:
     doubleHyphen: '"{key}" Cannot contain two or more consecutive hyphens'
     hostname:
@@ -614,17 +616,17 @@ validation:
   service:
     ports:
       name:
-        required: 'Port Rule [{position}] - Name is required.'
+        required: "Port Rule [{position}] - Name is required."
       nodePort:
-        requriedInt: 'Port Rule [{position}] - Node Port must be interger values if included.'
+        requriedInt: "Port Rule [{position}] - Node Port must be interger values if included."
       port:
-        required: 'Port Rule [{position}] - Port is required.'
-        requriedInt: 'Port Rule [{position}] - Port must be interger values if included.'
+        required: "Port Rule [{position}] - Port is required."
+        requriedInt: "Port Rule [{position}] - Port must be interger values if included."
       targetPort:
-        between: 'Port Rule [{position}] - Target Port must be between 1 and 65535'
-        iana: 'Port Rule [{position}] - Target Port must be an IANA Service Name or Integer'
-        ianaAt: 'Port Rule [{position}] - Target Port '
-        required: 'Port Rule [{position}] - Target Port is required'
+        between: "Port Rule [{position}] - Target Port must be between 1 and 65535"
+        iana: "Port Rule [{position}] - Target Port must be an IANA Service Name or Integer"
+        ianaAt: "Port Rule [{position}] - Target Port "
+        required: "Port Rule [{position}] - Target Port is required"
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
     exactly: '"{key}" should be {count, plural, =1 {# character} other {# characters}}'
@@ -637,7 +639,7 @@ wizard:
   back: Back
   finish: Finish
   next: Next
-  step: 'Step {number}:'
+  step: "Step {number}:"
 
 wm:
   connection:
@@ -647,7 +649,7 @@ wm:
     error: Error
   containerLogs:
     clear: Clear
-    containerName: 'Container: {label}'
+    containerName: "Container: {label}"
     download: Download
     follow: Follow
     noData: There are no log entries to show in the current range.
@@ -662,7 +664,7 @@ wm:
         other {Hours}
         }
       label: Show the last
-      lines: '{value, number} Lines'
+      lines: "{value, number} Lines"
       minutes: |
         {value, number} {value, plural,
         =1 {Minute}
@@ -673,9 +675,9 @@ wm:
     wrap: Wrap Lines
   containerShell:
     clear: Clear
-    containerName: 'Container: {label}'
+    containerName: "Container: {label}"
   kubectlShell:
-    title: 'Kubectl: {name}'
+    title: "Kubectl: {name}"
 
 workload:
   container:
@@ -707,7 +709,7 @@ workload:
       initialDelay: Initial Delay
       livenessProbe: Liveness Probe
       livenessTip: Containers will be restarted when this check is failing.  Not recommended for most uses.
-      noHealthCheck: 'There is not a Readiness Check, Liveness Check or Startup Check configured.'
+      noHealthCheck: "There is not a Readiness Check, Liveness Check or Startup Check configured."
       readinessProbe: Readiness Probe
       readinessTip: Containers will be removed from service endpoints when this check is failing.  Recommended.
       startupProbe: Startup Probe
@@ -736,8 +738,8 @@ workload:
       runAsGroup: Run as Group ID
       runAsNonRoot: Run as Non-Root
       runAsNonRootOptions:
-        noOption: 'No'
-        yesOption: 'Yes: containers must run as non-root-user'
+        noOption: "No"
+        yesOption: "Yes: containers must run as non-root-user"
       runAsUser: Run as User ID
       shareProcessNamespace: Share single process namespace
       supplementalGroups: Additional Group IDs
@@ -796,7 +798,7 @@ workload:
       label: Host Aliases
       tip: Additional /etc/hosts entries to be injected in the container.
       valueLabel: Hostname
-      valuePlaceholder: 'e.g. foo.com, bar.com'
+      valuePlaceholder: "e.g. foo.com, bar.com"
     hostname:
       label: Hostname
       placeholder: e.g. web
@@ -830,9 +832,9 @@ workload:
         addRule: Add Rule
         doesNotExist: Does Not Exist
         exists: Exists
-        greaterThan: '>'
+        greaterThan: ">"
         in: =
-        inNamespaces: 'Pods in these namespaces:'
+        inNamespaces: "Pods in these namespaces:"
         key: Key
         lessThan: <
         notIn: ≠
@@ -841,8 +843,8 @@ workload:
         weight: Weight
       noPodRules: There are no pod scheduling rules configured.
       nodeName: Node Name
-      preferAny: 'Prefer any of:'
-      requireAny: 'Require any of:'
+      preferAny: "Prefer any of:"
+      requireAny: "Require any of:"
       schedulingRules: Run pods on node(s) matching these scheduling rules
       specificNode: Run pods on specific node(s)
       thisPodNamespace: This pod's namespace
@@ -868,7 +870,7 @@ workload:
       effectOptions:
         all: All
         noExecute: NoExecute
-        noSchedule: 'NoSchedule,'
+        noSchedule: "NoSchedule,"
         preferNoSchedule: PreferNoSchedule
       labelKey: Label Key
       operator: Operator
@@ -901,8 +903,8 @@ workload:
       tip: The number of old ReplicaSets to retain for rollback.
     strategies:
       labels:
-        delete: 'On Delete: New pods are only created when old pods are manually deleted.'
-        recreate: 'Recreate: Kill ALL pods, then start new pods.'
+        delete: "On Delete: New pods are only created when old pods are manually deleted."
+        recreate: "Recreate: Kill ALL pods, then start new pods."
         rollingUpdate: "Rolling Update: Create new pods, until max surge is reached, before deleting old pods. Don't stop more pods than max unavailable."
     terminationGracePeriodSeconds:
       label: Termination Grace Period
@@ -942,7 +944,7 @@ model:
       registeredAgent: Registered Agent
       service: Service
       user: User
-  'catalog.cattle.io.release':
+  "catalog.cattle.io.release":
     firstDeployed: First Deployed
     lastDeployed: Last Deployed
   cluster:
@@ -953,7 +955,7 @@ model:
       localUser: Local User
       org: Organization
       team: Team
-      unknown: '{type}?'
+      unknown: "{type}?"
       user: User
   ingress:
     displayKind: L7 Ingress
@@ -966,7 +968,7 @@ model:
     domain:
       help: Only users below this base will be used.
       label: User Search Base
-      placeholder: 'e.g. ou=Users,dc=mycompany,dc=com'
+      placeholder: "e.g. ou=Users,dc=mycompany,dc=com"
     server:
       label: Hostname or IP Address
     serviceAccountPassword:

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -40,7 +40,7 @@ export default {
     return {
       isCancelModal: false,
       showAsForm:    true,
-      resourceYaml:   '',
+      resourceYaml:  ''
     };
   },
   methods: {
@@ -48,12 +48,17 @@ export default {
       if (isCancel) {
         // this.$modal.show('cancel') pass translation options
         this.isCancelModal = true;
+      } else {
+        this.isCancelModal = false;
       }
 
       this.$modal.show('cancel-modal');
     },
     confirmCancel(isCancel) {
+      this.$modal.hide('cancel-modal');
+
       if (isCancel) {
+        this.isCancelModal = false;
         this.$router.replace({
           name:   this.doneRoute,
           params: { resource: this.resource.type }
@@ -78,157 +83,152 @@ export default {
 </script>
 
 <template>
-  <form
-    v-if="showAsForm"
-    class="create-resource-container"
-  >
-    <div v-if="subtypes.length && !selectedSubtype" class="subtypes-container">
-      <slot name="subtypes">
-        <div
-          v-for="subtype in subtypes"
-          :key="subtype.id"
-          class="subtype-banner"
-          :class="{ selected: subtype.id === selectedSubtype }"
-          @click="$emit('selectType', subtype.id)"
-        >
-          <slot name="subtype-logo">
-            <div class="subtype-logo round-image">
-              <img
-                v-if="subtype.bannerImage"
-                src="subtype.bannerImage"
-                alt="${ resource.type }: ${ subtype.label }"
-              />
-              <div v-else-if="subtype.bannerAbbrv" class="banner-abbrv">
-                <span
-                  v-if="$store.getters['i18n/exists'](subtype.bannerAbbrv)"
-                >{{ t(subtype.bannerAbbrv) }}</span>
-                <span v-else>{{ subtype.bannerAbbrv.slice(0, 1).toUpperCase() }}</span>
-              </div>
-              <div v-else>
-                {{ subtype.id.slice(0, 1).toUpperCase() }}
-              </div>
-            </div>
-          </slot>
-          <slot name="subtype-content">
-            <div class="subtype-content">
-              <div class="title">
-                <h5>
-                  <span
-                    v-if="$store.getters['i18n/exists'](subtype.label)"
-                    v-html="t(subtype.label)"
-                  ></span>
-                  <span v-else>{{ subtype.label }}</span>
-                </h5>
-              </div>
-              <div class="description">
-                <span
-                  v-if="$store.getters['i18n/exists'](subtype.description)"
-                  v-html="t(subtype.description)"
-                ></span>
-                <span v-else>{{ subtype.description }}</span>
-              </div>
-            </div>
-          </slot>
-        </div>
-      </slot>
-    </div>
-
-    <div v-if="selectedSubtype || !subtypes.length" class="resource-container">
-      <slot name="define" />
-    </div>
-
-    <div class="controls-row">
-      <slot name="form-footer">
-        <button type="button" class="btn role-secondary" @click="$emit('cancel')">
-          <t k="generic.cancel" />
-        </button>
-
-        <div>
-          <button v-if="selectedSubtype || !subtypes.length" type="button" class="btn role-secondary" @click="showPreviewYaml">
-            Preview Yaml
-          </button>
-          <button
-            :disabled="!canCreate"
-            type="button"
-            class="btn role-primary"
-            @click="$emit('finish')"
+  <section>
+    <form v-if="showAsForm" class="create-resource-container">
+      <div v-if="subtypes.length && !selectedSubtype" class="subtypes-container">
+        <slot name="subtypes">
+          <div
+            v-for="subtype in subtypes"
+            :key="subtype.id"
+            class="subtype-banner"
+            :class="{ selected: subtype.id === selectedSubtype }"
+            @click="$emit('selectType', subtype.id)"
           >
-            <t k="generic.create" />
+            <slot name="subtype-logo">
+              <div class="subtype-logo round-image">
+                <img
+                  v-if="subtype.bannerImage"
+                  src="subtype.bannerImage"
+                  alt="${ resource.type }: ${ subtype.label }"
+                />
+                <div v-else-if="subtype.bannerAbbrv" class="banner-abbrv">
+                  <span
+                    v-if="$store.getters['i18n/exists'](subtype.bannerAbbrv)"
+                  >{{ t(subtype.bannerAbbrv) }}</span>
+                  <span v-else>{{ subtype.bannerAbbrv.slice(0, 1).toUpperCase() }}</span>
+                </div>
+                <div v-else>
+                  {{ subtype.id.slice(0, 1).toUpperCase() }}
+                </div>
+              </div>
+            </slot>
+            <slot name="subtype-content">
+              <div class="subtype-content">
+                <div class="title">
+                  <h5>
+                    <span
+                      v-if="$store.getters['i18n/exists'](subtype.label)"
+                      v-html="t(subtype.label)"
+                    ></span>
+                    <span v-else>{{ subtype.label }}</span>
+                  </h5>
+                </div>
+                <div class="description">
+                  <span
+                    v-if="$store.getters['i18n/exists'](subtype.description)"
+                    v-html="t(subtype.description)"
+                  ></span>
+                  <span v-else>{{ subtype.description }}</span>
+                </div>
+              </div>
+            </slot>
+          </div>
+        </slot>
+      </div>
+
+      <div v-if="selectedSubtype || !subtypes.length" class="resource-container">
+        <slot name="define" />
+      </div>
+
+      <div class="controls-row">
+        <slot name="form-footer">
+          <button type="button" class="btn role-secondary" @click="$emit('cancel')">
+            <t k="generic.cancel" />
           </button>
-        </div>
-      </slot>
-    </div>
-  </form>
 
-  <section v-else>
-    <ResourceYaml
-      ref="resourceyaml"
-      :value="resource"
-      :mode="mode"
-      :yaml="resourceYaml"
-      :offer-preview="false"
-      :done-route="doneRoute"
-      :done-override="resource.doneOverride"
-    >
-      <template #yamlFooter="{yamlSave}">
-        <div class="controls-row">
-          <slot name="cru-yaml-footer">
-            <button type="button" class="btn role-secondary" @click="checkCancel(true)">
-              <t k="generic.cancel" />
+          <div>
+            <button
+              v-if="selectedSubtype || !subtypes.length"
+              type="button"
+              class="btn role-secondary"
+              @click="showPreviewYaml"
+            >
+              <t k="cruResource.previewYaml" />
             </button>
+            <button
+              :disabled="!canCreate"
+              type="button"
+              class="btn role-primary"
+              @click="$emit('finish')"
+            >
+              <t k="generic.create" />
+            </button>
+          </div>
+        </slot>
+      </div>
+    </form>
 
-            <div v-if="selectedSubtype || !subtypes.length">
-              <button type="button" class="btn role-secondary" @click="checkCancel(false)">
-                <t k="generic.back" />
+    <section v-else>
+      <ResourceYaml
+        ref="resourceyaml"
+        :value="resource"
+        :mode="mode"
+        :yaml="resourceYaml"
+        :offer-preview="false"
+        :done-route="doneRoute"
+        :done-override="resource.doneOverride"
+      >
+        <template #yamlFooter="{yamlSave}">
+          <div class="controls-row">
+            <slot name="cru-yaml-footer">
+              <button type="button" class="btn role-secondary" @click="checkCancel(true)">
+                <t k="generic.cancel" />
               </button>
-              <button
-                type="button"
-                class="btn role-primary"
-                @click="yamlSave"
-              >
-                <t k="generic.create" />
-              </button>
-            </div>
-          </slot>
-        </div>
-      </template>
-    </ResourceYaml>
+
+              <div v-if="selectedSubtype || !subtypes.length">
+                <button type="button" class="btn role-secondary" @click="checkCancel(false)">
+                  <t k="generic.back" />
+                </button>
+                <button type="button" class="btn role-primary" @click="yamlSave">
+                  <t k="generic.create" />
+                </button>
+              </div>
+            </slot>
+          </div>
+        </template>
+      </ResourceYaml>
+    </section>
 
     <modal
       class="confirm-modal"
       name="cancel-modal"
-      :width="350"
+      :width="400"
       height="auto"
-      styles="background-color: var(--nav-bg); border-radius: var(--border-radius); overflow: scroll; max-height: 100vh;"
     >
       <div class="header">
         <h4 class="text-default-text">
-          Go Back To Form
+          <t k="cruResource.backToForm" />
         </h4>
       </div>
       <div class="body">
         <p v-if="isCancelModal">
-          Cancelling will destroy your changes.
+          <t k="cruResource.cancel" />
         </p>
         <p v-else>
-          Going back will destroy your changes.
+          <t k="cruResource.back" />
         </p>
       </div>
       <div class="footer">
-        <button type="button" class="btn role-secondary" @click="$modal.hide('cancel-modal')">
-          No, Review Yaml
-        </button>
         <button
           type="button"
-          class="btn role-primary"
-          @click="confirmCancel(isCancelModal)"
+          class="btn role-secondary"
+          @click="$modal.hide('cancel-modal')"
         >
-          <span v-if="isCancelModal">
-            Yes, Cancel.
-          </span>
-          <span v-else>
-            Yes, go back.
-          </span>
+          <t k="cruResource.confirmYaml" />
+        </button>
+        <button type="button" class="btn role-primary" @click="confirmCancel(isCancelModal)">
+          <span v-if="isCancelModal"><t k="cruResource.confirmCancel" /></span>
+          <span v-else><t k="cruResource.confirmBack" /></span>
         </button>
       </div>
     </modal>
@@ -236,6 +236,33 @@ export default {
 </template>
 
 <style lang='scss'>
+.confirm-modal {
+  .v--modal-box {
+    background-color: var(--default);
+    box-shadow: none;
+    min-height: 200px;
+    .body {
+      min-height: 75px;
+      padding: 10px 0 0 15px;
+      p {
+        margin-top: 10px;
+      }
+    }
+    .header {
+      background-color: #4F3335;
+      padding: 15px 0 0 15px;
+    }
+    .header,
+    .footer {
+      height: 50px;
+    }
+    .footer {
+      border-top: 1px solid var(--border);
+      text-align: center;
+      padding: 10px 0 0 15px;
+    }
+  }
+}
 .subtypes-container {
   display: flex;
   flex-wrap: wrap;

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -1,4 +1,6 @@
 <script>
+import { SCHEMA } from '@/config/types';
+
 export default {
   props: {
     resource: {
@@ -14,19 +16,31 @@ export default {
     selectedSubtype: {
       type:    String,
       default: null
+    },
+
+    canCreate: {
+      type:    Boolean,
+      default: false
     }
   },
   data() {
     return {};
   },
-  methods: {}
+  methods: {
+    showPreviewYaml() {
+      // const schemas = this.$store.getters['cluster/all'](SCHEMA);
+      // const { resource } = this;
+
+      // const resourceYaml = createYaml(schemas, resource.type, resource);
+    }
+  }
 };
 </script>
 
 <template>
-  <form>
-    <div class="subtypes-container">
-      <slot v-if="subtypes.length && !selectedSubtype" name="subtypes">
+  <form class="create-resource-container">
+    <div v-if="subtypes.length && !selectedSubtype" class="subtypes-container">
+      <slot name="subtypes">
         <div
           v-for="subtype in subtypes"
           :key="subtype.id"
@@ -76,7 +90,35 @@ export default {
       </slot>
     </div>
 
-    <slot v-if="selectedSubtype || !subtypes.length" name="define" class="resource-container"></slot>
+    <div v-if="selectedSubtype || !subtypes.length" class="resource-container">
+      <slot name="define" />
+    </div>
+
+    <div class="controls-row">
+      <slot name="footer">
+        <slot name="left-controls">
+          <button type="button" class="btn role-secondary" @click="$emit('cancel')">
+            <t k="generic.cancel" />
+          </button>
+        </slot>
+
+        <div>
+          <slot v-if="selectedSubtype || !subtypes.length" name="right-controls">
+            <button type="button" class="btn role-secondary" @click="showPreviewYaml">
+              <t k="wizard.back" />
+            </button>
+            <button
+              :disabled="!canCreate"
+              type="button"
+              class="btn role-primary"
+              @click="$emit('finish')"
+            >
+              <t k="generic.create" />
+            </button>
+          </slot>
+        </div>
+      </slot>
+    </div>
   </form>
 </template>
 
@@ -163,5 +205,11 @@ export default {
     justify-content: center;
     width: 100%;
   }
+}
+
+.controls-row {
+  margin-top: 20px;
+  display: flex;
+  justify-content: space-between;
 }
 </style>

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -1,0 +1,164 @@
+<script>
+export default {
+  props: {
+    resource: {
+      type:     Object,
+      required: true
+    },
+
+    subtypes: {
+      type:    Array,
+      default: null
+    }
+  },
+  data() {
+    return { selectedSubtype: '' };
+  },
+  methods: {}
+};
+</script>
+
+<template>
+  <form>
+    <div class="subtypes-container">
+      <slot v-if="subtypes.length" name="subtypes">
+        <div
+          v-for="subtype in subtypes"
+          :key="subtype.id"
+          class="subtype-banner"
+          :class="{ seclectd: subtype === selectedSubtype }"
+          @click="$emit('selectType', subtype)"
+        >
+          <slot name="subtype-logo">
+            <div class="subtype-logo round-image">
+              <img
+                v-if="subtype.bannerImage"
+                src="subtype.bannerImage"
+                alt="${ resource.type }: ${ subtype.label }"
+              />
+              <div v-else-if="subtype.bannerAbbrv" class="banner-abbrv">
+                <span
+                  v-if="$store.getters['i18n/exists'](subtype.bannerAbbrv)"
+                >
+                  {{ t(subtype.bannerAbbrv) }}
+                </span>
+                <span v-else>{{ subtype.bannerAbbrv.slice(0, 1).toUpperCase() }}</span>
+              </div>
+              <div v-else>
+                {{ subtype.id.slice(0, 1).toUpperCase() }}
+              </div>
+            </div>
+          </slot>
+          <slot name="subtype-content">
+            <div class="subtype-content">
+              <div class="title">
+                <h5>
+                  <span
+                    v-if="$store.getters['i18n/exists'](subtype.label)"
+                    v-html="t(subtype.label)"
+                  ></span>
+                  <span v-else>{{ subtype.label }}</span>
+                </h5>
+              </div>
+              <div class="description">
+                <span
+                  v-if="$store.getters['i18n/exists'](subtype.description)"
+                  v-html="t(subtype.description)"
+                ></span>
+                <span v-else>{{ subtype.description }}</span>
+              </div>
+            </div>
+          </slot>
+        </div>
+      </slot>
+    </div>
+
+    <slot name="define" class="resource-container"></slot>
+  </form>
+</template>
+
+<style lang='scss'>
+.subtypes-container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.subtype-banner {
+  border-left: 5px solid var(--primary);
+  border-radius: var(--border-radius);
+  display: flex;
+  flex-basis: 40%;
+  margin: 10px;
+  min-height: 100px;
+  padding: 10px;
+
+  &.selected {
+    background-color: var(--accent-btn);
+  }
+
+  &.top {
+    background-image: linear-gradient(
+      -90deg,
+      var(--body-bg),
+      var(--accent-btn)
+    );
+
+    H2 {
+      margin: 0px;
+    }
+
+    .title {
+      align-items: center;
+      border-right: 1px solid var(--primary);
+      display: flex;
+      flex-basis: 10%;
+      justify-content: space-evenly;
+      margin-right: 20px;
+      padding-right: 20px;
+    }
+
+    .description {
+      color: var(--input-label);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+  }
+
+  .description {
+    color: var(--input-label);
+  }
+
+  &:not(.top) {
+    align-items: center;
+    box-shadow: 0px 0px 12px 3px var(--box-bg);
+    flex-direction: row;
+    justify-content: start;
+    &:hover {
+      cursor: pointer;
+      box-shadow: 0px 0px 1px var(--outline-width) var(--outline);
+    }
+  }
+
+  .round-image {
+    background-color: var(--primary);
+    border-radius: 50%;
+    height: 50px;
+    margin: 10px;
+    min-width: 50px;
+    overflow: hidden;
+  }
+
+  .banner-abbrv {
+    align-items: center;
+    background-color: var(--primary);
+    color: white;
+    display: flex;
+    font-size: 2.5em;
+    height: 100%;
+    justify-content: center;
+    width: 100%;
+  }
+}
+</style>

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -203,7 +203,7 @@ export default {
             <AsyncButton
               v-if="!showSubtypeSelection"
               :disabled="!canCreate"
-              :action-label="t('generic.create')"
+              :action-label="mode==='edit' ? t('generic.save') : t('generic.create')"
               @click="$emit('finish', done)"
             />
           </div>
@@ -211,7 +211,7 @@ export default {
       </div>
     </form>
 
-    <section v-else>
+    <section v-else class="cru-resource-yaml-container">
       <ResourceYaml
         ref="resourceyaml"
         :value="resource"
@@ -248,7 +248,8 @@ export default {
     <modal class="confirm-modal" name="cancel-modal" :width="400" height="auto">
       <div class="header">
         <h4 class="text-default-text">
-          <t k="cruResource.backToForm" />
+          <t v-if="isCancelModal" k="generic.cancel" />
+          <t v-else k="cruResource.backToForm" />
         </h4>
       </div>
       <div class="body">
@@ -277,6 +278,13 @@ export default {
 </template>
 
 <style lang='scss'>
+.cru-resource-yaml-container {
+  .resource-yaml {
+    .yaml-editor {
+      min-height: 400px;
+    }
+  }
+}
 .confirm-modal {
   .v--modal-box {
     background-color: var(--default);

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -9,10 +9,12 @@ import AsyncButton from '@/components/AsyncButton';
 
 export default {
   components: {
-    Banner, ResourceYaml, AsyncButton
+    Banner,
+    ResourceYaml,
+    AsyncButton
   },
 
-  props:      {
+  props: {
     doneRoute: {
       type:     String,
       required: true
@@ -41,7 +43,7 @@ export default {
     canCreate: {
       type:    Boolean,
       default: false
-    },
+    }
   },
 
   data() {
@@ -49,7 +51,7 @@ export default {
       isCancelModal: false,
       showAsForm:    true,
       resourceYaml:  '',
-      errors:        [],
+      errors:        []
     };
   },
 
@@ -66,7 +68,7 @@ export default {
       }
 
       return false;
-    },
+    }
   },
 
   methods: {
@@ -109,18 +111,18 @@ export default {
     },
 
     yamlCb(success, errors) {
-      success ? this.done() : this.errors = errors;
+      success ? this.done() : (this.errors = errors);
     },
 
     done() {
-      if ( !this.doneRoute ) {
+      if (!this.doneRoute) {
         return;
       }
       this.$router.replace({
         name:   this.doneRoute,
         params: { resource: this.resource.type }
       });
-    },
+    }
   }
 };
 </script>
@@ -243,12 +245,7 @@ export default {
       <Banner color="error" :label="err" />
     </div>
 
-    <modal
-      class="confirm-modal"
-      name="cancel-modal"
-      :width="400"
-      height="auto"
-    >
+    <modal class="confirm-modal" name="cancel-modal" :width="400" height="auto">
       <div class="header">
         <h4 class="text-default-text">
           <t k="cruResource.backToForm" />
@@ -263,20 +260,19 @@ export default {
         </p>
       </div>
       <div class="footer">
-        <button
-          type="button"
-          class="btn role-secondary"
-          @click="$modal.hide('cancel-modal')"
-        >
+        <button type="button" class="btn role-secondary" @click="$modal.hide('cancel-modal')">
           <t k="cruResource.confirmYaml" />
         </button>
         <button type="button" class="btn role-primary" @click="confirmCancel(isCancelModal)">
-          <span v-if="isCancelModal"><t k="cruResource.confirmCancel" /></span>
-          <span v-else><t k="cruResource.confirmBack" /></span>
+          <span v-if="isCancelModal">
+            <t k="cruResource.confirmCancel" />
+          </span>
+          <span v-else>
+            <t k="cruResource.confirmBack" />
+          </span>
         </button>
       </div>
     </modal>
-  </section>
   </section>
 </template>
 
@@ -294,7 +290,7 @@ export default {
       }
     }
     .header {
-      background-color: #4F3335;
+      background-color: #4f3335;
       padding: 15px 0 0 15px;
     }
     .header,

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -9,10 +9,15 @@ export default {
     subtypes: {
       type:    Array,
       default: null
+    },
+
+    selectedSubtype: {
+      type:    String,
+      default: null
     }
   },
   data() {
-    return { selectedSubtype: '' };
+    return {};
   },
   methods: {}
 };
@@ -21,13 +26,13 @@ export default {
 <template>
   <form>
     <div class="subtypes-container">
-      <slot v-if="subtypes.length" name="subtypes">
+      <slot v-if="subtypes.length && !selectedSubtype" name="subtypes">
         <div
           v-for="subtype in subtypes"
           :key="subtype.id"
           class="subtype-banner"
-          :class="{ seclectd: subtype === selectedSubtype }"
-          @click="$emit('selectType', subtype)"
+          :class="{ selected: subtype.id === selectedSubtype }"
+          @click="$emit('selectType', subtype.id)"
         >
           <slot name="subtype-logo">
             <div class="subtype-logo round-image">
@@ -39,9 +44,7 @@ export default {
               <div v-else-if="subtype.bannerAbbrv" class="banner-abbrv">
                 <span
                   v-if="$store.getters['i18n/exists'](subtype.bannerAbbrv)"
-                >
-                  {{ t(subtype.bannerAbbrv) }}
-                </span>
+                >{{ t(subtype.bannerAbbrv) }}</span>
                 <span v-else>{{ subtype.bannerAbbrv.slice(0, 1).toUpperCase() }}</span>
               </div>
               <div v-else>
@@ -73,7 +76,7 @@ export default {
       </slot>
     </div>
 
-    <slot name="define" class="resource-container"></slot>
+    <slot v-if="selectedSubtype || !subtypes.length" name="define" class="resource-container"></slot>
   </form>
 </template>
 

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -263,7 +263,7 @@ export default {
         } else {
           this.errors = [err];
         }
-        buttonDone(false);
+        buttonDone(false, this.errors);
       }
     },
     done() {

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -293,33 +293,35 @@ export default {
       @onReady="onReady"
       @onChanges="onChanges"
     />
-    <Footer
-      v-if="showFooter"
-      :mode="mode"
-      :errors="errors"
-      @save="save"
-      @done="done"
-    >
-      <template v-if="!isView" #middle>
-        <button
-          v-if="showPreview"
-          type="button"
-          class="btn role-secondary"
-          @click="unpreview"
-        >
-          <t k="resourceYaml.buttons.continue" />
-        </button>
-        <button
-          v-else-if="offerPreview"
-          :disabled="yaml === currentYaml"
-          type="button"
-          class="btn role-secondary"
-          @click="preview"
-        >
-          <t k="resourceYaml.buttons.diff" />
-        </button>
-      </template>
-    </Footer>
+    <slot name="yamlFooter" :yamlSave="save" :yamlDone="done">
+      <Footer
+        v-if="showFooter"
+        :mode="mode"
+        :errors="errors"
+        @save="save"
+        @done="done"
+      >
+        <template v-if="!isView" #middle>
+          <button
+            v-if="showPreview"
+            type="button"
+            class="btn role-secondary"
+            @click="unpreview"
+          >
+            <t k="resourceYaml.buttons.continue" />
+          </button>
+          <button
+            v-else-if="offerPreview"
+            :disabled="yaml === currentYaml"
+            type="button"
+            class="btn role-secondary"
+            @click="preview"
+          >
+            <t k="resourceYaml.buttons.diff" />
+          </button>
+        </template>
+      </Footer>
+    </slot>
   </div>
 </template>
 

--- a/components/form/Labels.vue
+++ b/components/form/Labels.vue
@@ -16,12 +16,20 @@ export default {
     displaySideBySide: {
       type:    Boolean,
       default: false,
+    },
+    defaultContainerClass: {
+      type:    String,
+      default: '',
     }
   },
 
   computed: {
     containerClass() {
-      return this.displaySideBySide ? 'row' : '';
+      const { defaultContainerClass } = this;
+
+      debugger;
+
+      return this.displaySideBySide ? `row ${ defaultContainerClass }` : `${ defaultContainerClass }`;
     },
 
     sectionClass() {

--- a/components/form/Labels.vue
+++ b/components/form/Labels.vue
@@ -27,8 +27,6 @@ export default {
     containerClass() {
       const { defaultContainerClass } = this;
 
-      debugger;
-
       return this.displaySideBySide ? `row ${ defaultContainerClass }` : `${ defaultContainerClass }`;
     },
 

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -142,11 +142,14 @@ export default {
 
 <template>
   <CruResource
-    :resource="value"
-    :subtypes="defaultServiceTypes"
-    :selected-subtype="serviceType"
+    :can-create="true"
     :done-route="doneRoute"
     :mode="mode"
+    :resource="value"
+    :selected-subtype="serviceType"
+    :subtypes="defaultServiceTypes"
+    @finish="save"
+    @cancel="done"
     @selectType="(st) => serviceType = st"
   >
     <template #define>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -12,8 +12,9 @@ import Tabbed from '@/components/Tabbed';
 import UnitInput from '@/components/form/UnitInput';
 import { DEFAULT_SERVICE_TYPES, HEADLESS, CLUSTERIP } from '@/models/service';
 import { ucFirst } from '@/utils/string';
-import Banner from '@/components/Banner';
 import CruResource from '@/components/CruResource';
+import InfoBox from '@/components/InfoBox';
+import Banner from '@/components/Banner';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:      'None',
@@ -35,6 +36,7 @@ export default {
     ArrayList,
     Banner,
     CruResource,
+    InfoBox,
     KeyValue,
     LabeledInput,
     NameNsDescription,
@@ -42,7 +44,7 @@ export default {
     ServicePorts,
     Tab,
     Tabbed,
-    UnitInput,
+    UnitInput
   },
 
   mixins: [CreateEditView],
@@ -52,16 +54,20 @@ export default {
       if (!this.value?.spec) {
         this.$set(this.value, 'spec', {
           ports:           [],
-          sessionAffinity: 'None',
+          sessionAffinity: 'None'
         });
       }
     }
 
     return {
-      defaultServiceTypes:          DEFAULT_SERVICE_TYPES,
-      saving:                       false,
-      sessionAffinityActionLabels:  Object.values(SESSION_AFFINITY_ACTION_LABELS).map(v => this.$store.getters['i18n/t'](v)).map(ucFirst),
-      sessionAffinityActionOptions: Object.values(SESSION_AFFINITY_ACTION_VALUES),
+      defaultServiceTypes:         DEFAULT_SERVICE_TYPES,
+      saving:                      false,
+      sessionAffinityActionLabels: Object.values(SESSION_AFFINITY_ACTION_LABELS)
+        .map(v => this.$store.getters['i18n/t'](v))
+        .map(ucFirst),
+      sessionAffinityActionOptions: Object.values(
+        SESSION_AFFINITY_ACTION_VALUES
+      )
     };
   },
 
@@ -87,7 +93,10 @@ export default {
           this.$set(this.value.spec, 'type', CLUSTERIP);
           this.$set(this.value.spec, 'clusterIP', 'None');
         } else {
-          if (serviceType !== HEADLESS && this.value?.spec?.clusterIP === 'None') {
+          if (
+            serviceType !== HEADLESS &&
+            this.value?.spec?.clusterIP === 'None'
+          ) {
             this.$set(this.value.spec, 'clusterIP', null);
           } else if (serviceType === 'ExternalName') {
             this.$set(this.value.spec, 'ports', null);
@@ -95,8 +104,8 @@ export default {
 
           this.$set(this.value.spec, 'type', serviceType);
         }
-      },
-    },
+      }
+    }
   },
 
   watch: {
@@ -105,8 +114,14 @@ export default {
         this.value.spec.sessionAffinityConfig = { clientIP: { timeoutSeconds: null } };
 
         // set it null and then set it with vue to make reactive.
-        this.$set(this.value.spec.sessionAffinityConfig.clientIP, 'timeoutSeconds', SESSION_STICKY_TIME_DEFAULT);
-      } else if (this.value?.spec?.sessionAffinityConfig?.clientIP?.timeoutSeconds) {
+        this.$set(
+          this.value.spec.sessionAffinityConfig.clientIP,
+          'timeoutSeconds',
+          SESSION_STICKY_TIME_DEFAULT
+        );
+      } else if (
+        this.value?.spec?.sessionAffinityConfig?.clientIP?.timeoutSeconds
+      ) {
         delete this.value.spec.sessionAffinityConfig.clientIP.timeoutSeconds;
       }
     }
@@ -125,7 +140,7 @@ export default {
 
     updateServicePorts(servicePorts) {
       servicePorts.forEach((sp) => {
-        if ( !isEmpty(sp?.targetPort) ) {
+        if (!isEmpty(sp?.targetPort)) {
           const tpCoerced = parseInt(sp.targetPort, 10);
 
           if (!isNaN(tpCoerced)) {
@@ -136,7 +151,7 @@ export default {
 
       this.$set(this.value.spec, 'ports', servicePorts);
     }
-  },
+  }
 };
 </script>
 
@@ -153,11 +168,7 @@ export default {
     @selectType="(st) => serviceType = st"
   >
     <template #define>
-      <NameNsDescription
-        v-if="!isView"
-        :value="value"
-        :mode="mode"
-      />
+      <NameNsDescription v-if="!isView" :value="value" :mode="mode" />
 
       <div class="spacer"></div>
 
@@ -171,7 +182,9 @@ export default {
             <h4>
               <t k="servicesPage.externalName.label" />
             </h4>
-            <Banner color="info" :label="t('servicesPage.externalName.helpText')" />
+            <InfoBox>
+              <div>{{ t('servicesPage.externalName.helpText') }}</div>
+            </InfoBox>
           </div>
           <div class="row mt-10">
             <div class="col span-6">
@@ -186,11 +199,7 @@ export default {
             </div>
           </div>
         </Tab>
-        <Tab
-          v-else
-          name="define-external-name"
-          :label="t('servicesPage.ips.define')"
-        >
+        <Tab v-else name="define-external-name" :label="t('servicesPage.ips.define')">
           <ServicePorts
             v-model="value.spec.ports"
             class="col span-12"
@@ -206,7 +215,9 @@ export default {
         >
           <div class="row">
             <div class="col span-12">
-              <Banner color="info" :label="t('servicesPage.selectors.helpText')" />
+              <InfoBox>
+                <div>{{ t('servicesPage.selectors.helpText') }}</div>
+              </InfoBox>
             </div>
           </div>
           <div class="row">
@@ -224,21 +235,16 @@ export default {
             </div>
           </div>
         </Tab>
-        <Tab
-          name="ips"
-          :label="t('servicesPage.ips.label')"
-        >
+        <Tab name="ips" :label="t('servicesPage.ips.label')">
           <div class="row">
             <div class="col span-12">
               <Banner color="warning" :label="t('servicesPage.ips.helpText')" />
-              <Banner
-                v-if="checkTypeIs('ClusterIP') || checkTypeIs('LoadBalancer') || checkTypeIs('NodePort')"
-                color="info"
-                :label="t('servicesPage.ips.clusterIpHelpText')"
-              />
             </div>
           </div>
-          <div v-if="checkTypeIs('ClusterIP') || checkTypeIs('LoadBalancer') || checkTypeIs('NodePort')" class="row mb-20">
+          <div
+            v-if="checkTypeIs('ClusterIP') || checkTypeIs('LoadBalancer') || checkTypeIs('NodePort')"
+            class="row mb-20"
+          >
             <div class="col span-6">
               <LabeledInput
                 v-model="value.spec.clusterIP"
@@ -246,7 +252,16 @@ export default {
                 :label="t('servicesPage.ips.input.label')"
                 :placeholder="t('servicesPage.ips.input.placeholder')"
                 @input="e=>$set(value.spec, 'clusterIP', e)"
-              />
+              >
+                <template #corner>
+                  <i
+                    v-if="checkTypeIs('ClusterIP') || checkTypeIs('LoadBalancer') || checkTypeIs('NodePort')"
+                    v-tooltip="t('servicesPage.ips.clusterIpHelpText')"
+                    class="icon icon-info"
+                    style="font-size: 12px"
+                  />
+                </template>
+              </LabeledInput>
             </div>
           </div>
           <div class="row">
@@ -271,7 +286,9 @@ export default {
           :label="t('servicesPage.affinity.label')"
         >
           <div class="col span-12">
-            <Banner color="info" :label="t('servicesPage.affinity.helpText')" />
+            <InfoBox>
+              <div>{{ t('servicesPage.affinity.helpText') }}</div>
+            </InfoBox>
           </div>
           <div class="row session-affinity">
             <div class="col span-6">

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -1,20 +1,19 @@
 <script>
-import { isEmpty, find, isNaN } from 'lodash';
-// import ArrayList from '@/components/form/ArrayList';
+import { isEmpty, isNaN } from 'lodash';
+import ArrayList from '@/components/form/ArrayList';
 import CreateEditView from '@/mixins/create-edit-view';
-// import Footer from '@/components/form/Footer';
-// import KeyValue from '@/components/form/KeyValue';
-// import LabeledInput from '@/components/form/LabeledInput';
-// import LabeledSelect from '@/components/form/LabeledSelect';
-// import NameNsDescription from '@/components/form/NameNsDescription';
-// import RadioGroup from '@/components/form/RadioGroup';
-// import ResourceTabs from '@/components/form/ResourceTabs';
-// import ServicePorts from '@/components/form/ServicePorts';
-// import Tab from '@/components/Tabbed/Tab';
-// import UnitInput from '@/components/form/UnitInput';
+import Footer from '@/components/form/Footer';
+import KeyValue from '@/components/form/KeyValue';
+import LabeledInput from '@/components/form/LabeledInput';
+import NameNsDescription from '@/components/form/NameNsDescription';
+import RadioGroup from '@/components/form/RadioGroup';
+import ResourceTabs from '@/components/form/ResourceTabs';
+import ServicePorts from '@/components/form/ServicePorts';
+import Tab from '@/components/Tabbed/Tab';
+import UnitInput from '@/components/form/UnitInput';
 import { DEFAULT_SERVICE_TYPES, HEADLESS, CLUSTERIP } from '@/models/service';
 import { ucFirst } from '@/utils/string';
-// import Banner from '@/components/Banner';
+import Banner from '@/components/Banner';
 import CruResource from '@/components/CruResource';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
@@ -34,19 +33,18 @@ export default {
   // props: {},
 
   components: {
-    // ArrayList,
-    // Banner,
+    ArrayList,
+    Banner,
     CruResource,
-    // Footer,
-    // KeyValue,
-    // LabeledInput,
-    // LabeledSelect,
-    // NameNsDescription,
-    // RadioGroup,
-    // ResourceTabs,
-    // ServicePorts,
-    // Tab,
-    // UnitInput,
+    Footer,
+    KeyValue,
+    LabeledInput,
+    NameNsDescription,
+    RadioGroup,
+    ResourceTabs,
+    ServicePorts,
+    Tab,
+    UnitInput,
   },
 
   mixins: [CreateEditView],
@@ -54,14 +52,14 @@ export default {
   data() {
     if (!this?.value?.spec?.type) {
       if (!this.value?.spec) {
-        const defaultService = find(DEFAULT_SERVICE_TYPES, ['id', CLUSTERIP]);
+        // const defaultService = find(DEFAULT_SERVICE_TYPES, ['id', CLUSTERIP]);
 
         this.$set(this.value, 'spec', {
           ports:           [],
           sessionAffinity: 'None',
         });
 
-        this.serviceType = defaultService.id;
+        // this.serviceType = defaultService.id;
       }
     }
 
@@ -82,7 +80,7 @@ export default {
       get() {
         const serviceType = this.value?.spec?.type;
         const clusterIp = this.value?.spec?.clusterIP;
-        const defaultService = find(DEFAULT_SERVICE_TYPES, ['id', CLUSTERIP]);
+        // const defaultService = find(DEFAULT_SERVICE_TYPES, ['id', CLUSTERIP]);
 
         if (serviceType) {
           if (serviceType === CLUSTERIP && clusterIp === 'None') {
@@ -92,7 +90,7 @@ export default {
           }
         }
 
-        return defaultService;
+        return serviceType;
       },
 
       set(serviceType) {
@@ -158,30 +156,15 @@ export default {
     :resource="value"
     :subtypes="defaultServiceTypes"
     :selected-subtype="serviceType"
-    @selectType="serviceType"
+    @selectType="(st) => serviceType = st"
   >
-  </CruResource>
-  <!-- <div>
-    <form>
+    <template #define>
       <NameNsDescription
         v-if="!isView"
         :value="value"
         :mode="mode"
         :extra-columns="extraColumns"
-      >
-        <template #type-col>
-          <LabeledSelect
-            option-key="id"
-            option-label="translationLabel"
-            :label="t('servicesPage.typeOpts.label')"
-            :localized-label="true"
-            :mode="mode"
-            :options="defaultServiceTypes"
-            :value="serviceType"
-            @input="e=>serviceType = e.id"
-          />
-        </template>
-      </NameNsDescription>
+      />
 
       <div class="spacer"></div>
 
@@ -327,6 +310,11 @@ export default {
         @save="save"
         @done="done"
       />
+      </namensdescription>
+    </template>
+  </CruResource>
+  <!-- <div>
+    <form>
     </form>
   </div> -->
 </template>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -1,20 +1,21 @@
 <script>
 import { isEmpty, find, isNaN } from 'lodash';
-import ArrayList from '@/components/form/ArrayList';
+// import ArrayList from '@/components/form/ArrayList';
 import CreateEditView from '@/mixins/create-edit-view';
-import Footer from '@/components/form/Footer';
-import KeyValue from '@/components/form/KeyValue';
-import LabeledInput from '@/components/form/LabeledInput';
-import LabeledSelect from '@/components/form/LabeledSelect';
-import NameNsDescription from '@/components/form/NameNsDescription';
-import RadioGroup from '@/components/form/RadioGroup';
-import ResourceTabs from '@/components/form/ResourceTabs';
-import ServicePorts from '@/components/form/ServicePorts';
-import Tab from '@/components/Tabbed/Tab';
-import UnitInput from '@/components/form/UnitInput';
+// import Footer from '@/components/form/Footer';
+// import KeyValue from '@/components/form/KeyValue';
+// import LabeledInput from '@/components/form/LabeledInput';
+// import LabeledSelect from '@/components/form/LabeledSelect';
+// import NameNsDescription from '@/components/form/NameNsDescription';
+// import RadioGroup from '@/components/form/RadioGroup';
+// import ResourceTabs from '@/components/form/ResourceTabs';
+// import ServicePorts from '@/components/form/ServicePorts';
+// import Tab from '@/components/Tabbed/Tab';
+// import UnitInput from '@/components/form/UnitInput';
 import { DEFAULT_SERVICE_TYPES, HEADLESS, CLUSTERIP } from '@/models/service';
 import { ucFirst } from '@/utils/string';
-import Banner from '@/components/Banner';
+// import Banner from '@/components/Banner';
+import CruResource from '@/components/CruResource';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:      'None',
@@ -33,18 +34,19 @@ export default {
   // props: {},
 
   components: {
-    ArrayList,
-    Banner,
-    Footer,
-    KeyValue,
-    LabeledInput,
-    LabeledSelect,
-    NameNsDescription,
-    RadioGroup,
-    ResourceTabs,
-    ServicePorts,
-    Tab,
-    UnitInput,
+    // ArrayList,
+    // Banner,
+    CruResource,
+    // Footer,
+    // KeyValue,
+    // LabeledInput,
+    // LabeledSelect,
+    // NameNsDescription,
+    // RadioGroup,
+    // ResourceTabs,
+    // ServicePorts,
+    // Tab,
+    // UnitInput,
   },
 
   mixins: [CreateEditView],
@@ -152,7 +154,14 @@ export default {
 </script>
 
 <template>
-  <div>
+  <CruResource
+    :resource="value"
+    :subtypes="defaultServiceTypes"
+    :selected-subtype="serviceType"
+    @selectType="serviceType"
+  >
+  </CruResource>
+  <!-- <div>
     <form>
       <NameNsDescription
         v-if="!isView"
@@ -319,5 +328,5 @@ export default {
         @done="done"
       />
     </form>
-  </div>
+  </div> -->
 </template>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -321,6 +321,7 @@ export default {
         >
           <div class="row labels-row">
             <Labels
+              :default-container-class="'labels-and-annotations-container'"
               :spec="value.spec"
               :mode="mode"
               :display-side-by-side="false"
@@ -331,3 +332,13 @@ export default {
     </template>
   </CruResource>
 </template>
+
+<style lang="scss">
+.labels-and-annotations-container {
+  > div:last-child {
+    border-top: 1px solid var(--border);
+    margin-top: 20px;
+    padding-top: 20px;
+  }
+}
+</style>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -15,6 +15,7 @@ import { ucFirst } from '@/utils/string';
 import CruResource from '@/components/CruResource';
 import InfoBox from '@/components/InfoBox';
 import Banner from '@/components/Banner';
+import Labels from '@/components/form/Labels';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:      'None',
@@ -38,6 +39,7 @@ export default {
     CruResource,
     InfoBox,
     KeyValue,
+    Labels,
     LabeledInput,
     NameNsDescription,
     RadioGroup,
@@ -310,6 +312,19 @@ export default {
                 @input="e=>$set(value.spec.sessionAffinityConfig.clientIP, 'timeoutSeconds', e)"
               />
             </div>
+          </div>
+        </Tab>
+        <Tab
+          name="labels-and-annotations"
+          :label="t('servicesPage.labelsAnnotations.label', {}, true)"
+          :weight="1000"
+        >
+          <div class="row labels-row">
+            <Labels
+              :spec="value.spec"
+              :mode="mode"
+              :display-side-by-side="false"
+            />
           </div>
         </Tab>
       </Tabbed>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -145,6 +145,8 @@ export default {
     :resource="value"
     :subtypes="defaultServiceTypes"
     :selected-subtype="serviceType"
+    :done-route="doneRoute"
+    :mode="mode"
     @selectType="(st) => serviceType = st"
   >
     <template #define>

--- a/models/service.js
+++ b/models/service.js
@@ -2,24 +2,34 @@ import find from 'lodash/find';
 
 export const DEFAULT_SERVICE_TYPES = [
   {
-    id:               'ClusterIP',
-    translationLabel: 'serviceTypes.clusterip'
+    id:          'ClusterIP',
+    label:       'servicesPage.serviceTypes.clusterIp.label',
+    description: 'servicesPage.serviceTypes.clusterIp.description',
+    bannerAbbrv: 'servicesPage.serviceTypes.clusterIp.abbrv',
   },
   {
-    id:               'ExternalName',
-    translationLabel: 'serviceTypes.externalname'
+    id:          'ExternalName',
+    label:       'servicesPage.serviceTypes.externalName.label',
+    description: 'servicesPage.serviceTypes.externalName.description',
+    bannerAbbrv: 'servicesPage.serviceTypes.externalName.abbrv',
   },
   {
-    id:               'Headless',
-    translationLabel: 'serviceTypes.headless'
+    id:          'Headless',
+    label:       'servicesPage.serviceTypes.headless.label',
+    description: 'servicesPage.serviceTypes.headless.description',
+    bannerAbbrv: 'servicesPage.serviceTypes.headless.abbrv',
   },
   {
-    id:               'LoadBalancer',
-    translationLabel: 'serviceTypes.loadbalancer'
+    id:          'LoadBalancer',
+    label:       'servicesPage.serviceTypes.loadBalancer.label',
+    description: 'servicesPage.serviceTypes.loadBalancer.description',
+    bannerAbbrv: 'servicesPage.serviceTypes.loadBalancer.abbrv',
   },
   {
-    id:               'NodePort',
-    translationLabel: 'serviceTypes.nodeport'
+    id:          'NodePort',
+    label:       'servicesPage.serviceTypes.nodePort.label',
+    description: 'servicesPage.serviceTypes.nodePort.description',
+    bannerAbbrv: 'servicesPage.serviceTypes.nodePort.abbrv',
   },
 ];
 


### PR DESCRIPTION
Adds a generic `CruResource` component. 

`CruResource` has 3 states:

Subtype selection: If the resource has subtypes that can be selected, e.g. service cluster ip/external name/ etc, it will show this on create. On edit the user will bypass subtype selection and proceed directly to the form view.

Form Editor: Exposes a define slot which allows the consumer to pass in the form. This was made to be as generic as possible but this could be updated to include the tabbed/tab and build the forms but imo would make the component much less dynamic so I opted for using a slot here where we can pass tabbed/tab down.

Yaml Editor: Exposes a yaml-review action where the user can further modify the resources yaml. Cancelling/back from this state will trigger confirmation modals.

Screens:
Initial State:
![Screen Shot 2020-08-03 at 10 58 43-fullpage](https://user-images.githubusercontent.com/858614/89214214-44315980-d57b-11ea-857c-9c1a9f203792.png)

Form Edit:
![Screen Shot 2020-08-03 at 10 58 52-fullpage](https://user-images.githubusercontent.com/858614/89214219-47c4e080-d57b-11ea-93ad-6c910c334be6.png)

Yaml Edit:
![Screen Shot 2020-08-03 at 10 59 32-fullpage](https://user-images.githubusercontent.com/858614/89214226-4a273a80-d57b-11ea-902d-2ac0a6bcb97a.png)

Go Back Modal State:
![Screen Shot 2020-08-03 at 10 59 37-fullpage](https://user-images.githubusercontent.com/858614/89214234-4d222b00-d57b-11ea-915c-aa48e26ef073.png)

Cancel Modal State:
![Screen Shot 2020-08-03 at 11 22 40-fullpage](https://user-images.githubusercontent.com/858614/89214479-bb66ed80-d57b-11ea-8a6b-9d70889f1bc8.png)

Edit Form State:
![Screen Shot 2020-08-03 at 11 00 00-fullpage](https://user-images.githubusercontent.com/858614/89214251-53b0a280-d57b-11ea-91e8-4cd101efd6d9.png)

Edit Preview Yaml State:
![Screen Shot 2020-08-03 at 11 00 05-fullpage](https://user-images.githubusercontent.com/858614/89214256-557a6600-d57b-11ea-8c41-27655d2fc0b0.png)
