### PR TITLE
Adding a custom page for the logging chart

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -291,6 +291,23 @@ istio:
     customAnswers: Custom Answers
     advanced: Advanced Settings
 
+logging:
+  provider: Provider
+  elasticsearch:
+    host: Host
+    scheme: Scheme
+    port: Port
+    clusterName: Cluster Name
+    user: User
+    password: Password
+    clientCert: 
+      label: Client Cert
+      placeholder: Paste in the CA certificate
+    clientKey: 
+      label: Client Key
+      placeholder: Paste in the client key
+    clientKeyPass: Client Key Pass
+
 
 node:
   detail:

--- a/chart/logging/index.vue
+++ b/chart/logging/index.vue
@@ -1,0 +1,67 @@
+<script>
+import LabeledSelect from '@/components/form/LabeledSelect';
+
+export default {
+  components: { LabeledSelect },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    }
+  },
+
+  data() {
+    const providers = [{
+      label: 'Elasticsearch',
+      value: 'elasticsearch'
+    }];
+    const provider = providers[0].value;
+
+    this.value[this.providerKey(provider)].enabled = true;
+
+    return {
+      provider,
+      providers
+    };
+  },
+
+  computed: {
+    component() {
+      return require(`./providers/${ this.provider }`).default;
+    }
+  },
+
+  watch: {
+    provider(newValue, oldValue) {
+      this.value[this.providerKey(newValue)].enabled = true;
+      this.value[this.providerKey(oldValue)].enabled = false;
+    }
+  },
+
+  methods: {
+    providerKey(provider) {
+      return provider.toLowerCase();
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="logging">
+    <LabeledSelect v-model="provider" class="provider" :label="t('logging.provider')" :options="providers" />
+    <component :is="component" v-model="value" />
+  </div>
+</template>
+
+<style lang="scss">
+.logging {
+  width: 60%;
+  margin: 0 auto;
+
+  .provider {
+      margin-bottom: 20px;
+  }
+}
+</style>

--- a/chart/logging/providers/elasticsearch.vue
+++ b/chart/logging/providers/elasticsearch.vue
@@ -1,0 +1,109 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+
+export default {
+  name:       'ElasticsearchProvider',
+  components: { LabeledInput, LabeledSelect },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    }
+  },
+
+  data() {
+    return {
+
+      schemes:       ['http', 'https'],
+      toUpload:      '',
+      values:   { ...this.value.elasticsearch }
+    };
+  },
+
+  watch: {
+    values: {
+      deep: true,
+      handler() {
+        Object.assign(this.value.elasticsearch, this.values);
+      }
+    }
+  },
+
+  methods: {
+    fileUpload(field) {
+      this.toUpload = field;
+      this.$refs.uploader.click();
+    },
+
+    fileChange(event) {
+      const input = event.target;
+      const handles = input.files;
+      const names = [];
+
+      if ( handles ) {
+        for ( let i = 0 ; i < handles.length ; i++ ) {
+          const reader = new FileReader();
+
+          reader.onload = (loaded) => {
+            const value = loaded.target.result;
+
+            this.values[this.toUpload] = value;
+          };
+
+          reader.onerror = (err) => {
+            this.$dispatch('growl/fromError', { title: 'Error reading file', err }, { root: true });
+          };
+
+          names[i] = handles[i].name;
+          reader.readAsText(handles[i]);
+        }
+
+        input.value = '';
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="elasticsearch">
+    <LabeledInput v-model="values.host" :label="t('logging.elasticsearch.host')" />
+    <LabeledSelect v-model="values.scheme" :options="schemes" :label="t('logging.elasticsearch.scheme')" />
+    <LabeledInput v-model="values.port" :label="t('logging.elasticsearch.port')" />
+    <LabeledInput v-model="values.index_name" :label="t('logging.elasticsearch.clusterName')" />
+    <LabeledInput v-model="values.user" :label="t('logging.elasticsearch.user')" />
+    <LabeledInput v-model="values.password" :label="t('logging.elasticsearch.password')" type="password" />
+    <div class="cert row">
+      <div class="col span-6">
+        <LabeledInput v-model="values.client_cert" type="multiline" :label="t('logging.elasticsearch.clientCert.label')" :placeholder="t('logging.elasticsearch.clientCert.placeholder')" />
+        <button type="button" class="btn btn-sm bg-primary mt-10" @click="fileUpload('client_cert')">
+          {{ t('secret.certificate.readFromFile') }}
+        </button>
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="values.client_key" type="multiline" :label="t('logging.elasticsearch.clientKey.label')" :placeholder="t('logging.elasticsearch.clientKey.placeholder')" />
+        <button type="button" class="btn btn-sm bg-primary mt-10" @click="fileUpload('client_key')">
+          {{ t('secret.certificate.readFromFile') }}
+        </button>
+      </div>
+    </div>
+    <LabeledInput v-model="values.client_key_pass" :label="t('logging.elasticsearch.clientKeyPass')" type="password" />
+    <input
+      ref="uploader"
+      type="file"
+      class="hide"
+      @change="fileChange"
+    />
+  </div>
+</template>
+
+<style lang="scss">
+.elasticsearch {
+    & > * {
+        margin-top: 10px;
+    }
+}
+</style>

--- a/edit/chartInstallAction.vue
+++ b/edit/chartInstallAction.vue
@@ -97,7 +97,10 @@ export default {
         repoType, repoName, chartName, version
       });
 
-      const component = this.version?.annotations?.[CATALOG.COMPONENT];
+      // TODO: Remove
+      // This is only in place until logging changes the component annotation to component-ui
+      const stopGapComponentKey = 'catalog.cattle.io/component';
+      const component = this.version?.annotations?.[CATALOG.COMPONENT] || this.version?.annotations?.[stopGapComponentKey];
 
       if ( component ) {
         if ( this.$store.getters['catalog/haveComponent'](component) ) {


### PR DESCRIPTION
rancher/dashboard#895

Notes:
- I added a stopgap to chartInstallAction to account for the wrong annotation but we should be able to remove that shortly.
- It looks like the modifications to `values` isn't getting saved. I checked istio and it seemed to be the same over there so I left it for now since I think the chart framework is still being worked on. I poked around a little and I think we're overwriting the `values` with the `valuesYaml`.

![Screen Shot 2020-08-03 at 4 07 52 PM](https://user-images.githubusercontent.com/55104481/89236427-63dd7780-d5a5-11ea-884c-1b481933ba48.png)
