### PR TITLE
Generic Cru Component - PR feedback items

### DIFF
--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -293,7 +293,14 @@ export default {
       @onReady="onReady"
       @onChanges="onChanges"
     />
-    <slot name="yamlFooter" :yamlSave="save" :yamlDone="done">
+    <slot
+      name="yamlFooter"
+      :currentYaml="currentYaml"
+      :showPreview="showPreview"
+      :yamlPreview="preview"
+      :yamlSave="save"
+      :yamlUnpreview="unpreview"
+    >
       <Footer
         v-if="showFooter"
         :mode="mode"

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -159,12 +159,12 @@ export default {
 
 <template>
   <CruResource
-    :can-create="true"
     :done-route="doneRoute"
     :mode="mode"
     :resource="value"
     :selected-subtype="serviceType"
     :subtypes="defaultServiceTypes"
+    :validation-passed="true"
     @finish="save"
     @cancel="done"
     @selectType="(st) => serviceType = st"


### PR DESCRIPTION
Refactor `canCreate` to `validationPassed` to make variable intention clear.
Refactor markup so subtype selection is not limited to form only view.
Refactor to offer Yaml preview on edit.