### PR TITLE
Update workload create flow

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -176,13 +176,14 @@ containerResourceLimit:
   requestsMemory: Memory Reservation
 
 cruResource:
-  previewYaml: Preview Yaml
-  cancel: Cancelling will destroy your changes.
   back: Going back will destroy your changes.
-  confirmYaml: "No, Review Yaml"
   backToForm: Go Back To Form
-  confirmCancel: "Yes, Cancel"
+  cancel: Cancelling will destroy your changes.
   confirmBack: "Yes, Go Back"
+  confirmCancel: "Yes, Cancel"
+  reviewForm: "No, Review Form"
+  reviewYaml: "No, Review Yaml"
+  previewYaml: Preview Yaml
 
 footer:
   docs: Docs
@@ -780,6 +781,7 @@ workload:
       sysctls: Sysctls
       sysctlsKey: Name
     titles:
+      container: Define Container
       command: Command
       containers: Containers
       env: Environment Variables
@@ -797,6 +799,7 @@ workload:
     podIP: Pod IP
     podRestarts: Pod Restarts
     workload: Workload
+  hideTabs: 'Hide Advanced Options'
   job:
     activeDeadlineSeconds:
       label: Active Deadline
@@ -855,6 +858,7 @@ workload:
       label: Subdomain
       placeholder: e.g. web
   replicas: Replicas
+  showTabs: 'Show Advanced Options'
   scheduling:
     activeDeadlineSeconds: Pod Active Deadline
     activeDeadlineSecondsTip: The duration that the pod may be active before the system tries to mark it failed and kill associated containers.
@@ -914,6 +918,14 @@ workload:
       tolerationSeconds: Toleration Seconds
       value: Value
   serviceName: Service Name
+  storage:
+    title: 'Storage'
+  typeDescriptions:
+    apps.daemonset: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/" target="_blank" rel="noopener nofollow" >DaemonSets</a> run exactly one pod on every eligible node. When new nodes are added to the cluster, DaemonSets automatically deploy to them. Recommended for system-wide or vertically-scalable workloads that never need more than one pod per node.
+    apps.deployment: '<a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/" target="_blank" rel="noopener nofollow" >Deployments</a> run a scalable number of replicas of a pod distributed among the eligible nodes. Changes are rolled out incrementally and can be rolled back to the previous revision when needed. Recommended for stateless & horizontally-scalable workloads.'
+    apps.statefulset: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/" target="_blank" rel="noopener nofollow" >StatefulSets</a> manage stateful applications and provide guarantees about the ordering and uniqueness of the pods created. Recommended for workloads with persistent storage or strict identity, quorum, or upgrade order requirements.
+    batch.cronjob: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/" target="_blank" rel="noopener nofollow" >CronJobs</a> create Jobs, which then run Pods, on a repeating schedule. The schedule is expressed in standard Unix <a href="https://en.wikipedia.org/wiki/Cron" target="_blank" rel="noopener nofollow">cron</a> format, and uses the timezone of the Kubernetes control plane (typically UTC).
+    batch.job: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/job/" target="_blank" rel="noopener nofollow" >Jobs</a> create one or more pods to reliably perform a one-time task by running a pod until it exits successfully. Failed pods are automatically replaced until the specified number of completed runs has been reached. Jobs can also run multiple pods in parallel or function as a batch work queue.
   upgrading:
     activeDeadlineSeconds:
       label: Pod Active Deadline
@@ -944,27 +956,7 @@ workload:
       label: Termination Grace Period
       tip: The duration the pod needs to terminate successfully.
     title: upgrading
-  wizard:
-    descriptions:
-      apps.daemonset: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/" target="_blank" rel="noopener nofollow" >DaemonSets</a> run exactly one pod on every eligible node. When new nodes are added to the cluster, DaemonSets automatically deploy to them. Recommended for system-wide or vertically-scalable workloads that never need more than one pod per node.
-      apps.deployment: '<a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/" target="_blank" rel="noopener nofollow" >Deployments</a> run a scalable number of replicas of a pod distributed among the eligible nodes. Changes are rolled out incrementally and can be rolled back to the previous revision when needed. Recommended for stateless & horizontally-scalable workloads.'
-      apps.statefulset: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/" target="_blank" rel="noopener nofollow" >StatefulSets</a> manage stateful applications and provide guarantees about the ordering and uniqueness of the pods created. Recommended for workloads with persistent storage or strict identity, quorum, or upgrade order requirements.
-      batch.cronjob: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/" target="_blank" rel="noopener nofollow" >CronJobs</a> create Jobs, which then run Pods, on a repeating schedule. The schedule is expressed in standard Unix <a href="https://en.wikipedia.org/wiki/Cron" target="_blank" rel="noopener nofollow">cron</a> format, and uses the timezone of the Kubernetes control plane (typically UTC).
-      batch.job: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/job/" target="_blank" rel="noopener nofollow" >Jobs</a> create one or more pods to reliably perform a one-time task by running a pod until it exits successfully. Failed pods are automatically replaced until the specified number of completed runs has been reached. Jobs can also run multiple pods in parallel or function as a batch work queue.
-    titles:
-      advanced:
-        title: Advanced
-        subtitle: Define the advanced options. Each pod has additional options that can be defined as part of the container, part of the pod and part of the workload type. We recommends reading the detailed Kubernetes documentation before attempting to configure these.
-      defineContainer:
-        title: Define Container
-        subtitle: Define the container of the pod. Each workload type ultimately deploys pods, which are the smallest unit of compute managed by Kubernetes. The main definition of the pod is the container. These are the basic fields defined on a container, but there are more fields that can be defined in the Advanced step or in the raw yaml.
-      scaling: Scaling/Upgrade Policy
-      selectType:
-        title: Select a Workload Type
-        subtitle: Select the type of <a href="https://kubernetes.io/docs/concepts/workloads/" target="_blank" rel="noopener nofollow">workload</a> to create. Each type has unique properties that define where the pods will be run, how they will be maintained or scaled, and what happens when they fail.
-      storage:
-        title: Storage
-        subtitle: Pods only have their own local ephemeral storage by default, which will be wiped out when the pod dies. To persist data that survives beyond the life of a single pod, you can attach external <a href='https://kubernetes.io/docs/concepts/storage/' target="_blank" rel="noopener nofollow">storage</a> (e.g. block devices or NFS shares) from a provider and make it available to the pod.
+
 
 ##############################
 # Model Properties

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -10,7 +10,6 @@ import { SCHEMA } from '@/config/types';
 import { createYaml } from '@/utils/create-yaml';
 import Masthead from '@/components/ResourceDetail/Masthead';
 import DetailTop from '@/components/DetailTop';
-import isFunction from 'lodash/isFunction';
 import GenericResourceDetail from './Generic';
 
 // Components can't have asyncData, only pages.
@@ -53,7 +52,7 @@ function realModeFor(query, id) {
 
 // You can pass in a resource from a edit/someType.vue to use this but with a different type
 // e.g. for workload to create a deployment
-export async function defaultAsyncData(ctx, resource) {
+export async function defaultAsyncData(ctx, resource, parentOverride) {
   const { store, params, route } = ctx;
 
   // eslint-disable-next-line prefer-const
@@ -132,6 +131,7 @@ export async function defaultAsyncData(ctx, resource) {
    * Important: these need to be declared below as props too if you want to use them
    *******/
   const out = {
+    parentOverride,
     hasCustomDetail,
     hasCustomEdit,
     resource,
@@ -253,14 +253,6 @@ export default {
 
       return null;
     },
-
-    showMasthead() {
-      if (isFunction(this.currentValue.showMasthead)) {
-        return this.currentValue.showMasthead(this.mode);
-      } else {
-        return true;
-      }
-    }
   },
 
   watch: {
@@ -285,7 +277,6 @@ export default {
 <template>
   <div>
     <Masthead
-      v-if="showMasthead"
       :value="originalModel"
       :mode="mode"
       :real-mode="realMode"

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -13,6 +13,7 @@ import {
   _UNFLAG,
   _EDIT,
 } from '@/config/query-params';
+import { exceptionToErrorsArray } from '../utils/error';
 
 export default {
   components: {
@@ -263,7 +264,9 @@ export default {
         } else {
           this.errors = [err];
         }
-        buttonDone(false, this.errors);
+        buttonDone(false);
+
+        this.$emit('error', exceptionToErrorsArray(err));
       }
     },
     done() {

--- a/components/Tabbed/Tab.vue
+++ b/components/Tabbed/Tab.vue
@@ -13,6 +13,10 @@ export default {
       type:     Number,
       default:  0,
       required: false,
+    },
+    canToggle: {
+      type:    Boolean,
+      default: false
     }
   },
 

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -165,9 +165,11 @@ export default {
     :selected-subtype="serviceType"
     :subtypes="defaultServiceTypes"
     :validation-passed="true"
+    :errors="errors"
+    @error="e=>errors = e"
     @finish="save"
     @cancel="done"
-    @selectType="(st) => serviceType = st"
+    @select-type="(st) => serviceType = st"
   >
     <template #define>
       <NameNsDescription v-if="!isView" :value="value" :mode="mode" />

--- a/mixins/create-edit-view.js
+++ b/mixins/create-edit-view.js
@@ -50,7 +50,7 @@ export default {
 
     // keep label and annotation filters in data so each resource CRUD page can alter individiaully
     return {
-      errors:                      null,
+      errors:                      [],
       labelPrefixToIgnore:         LABEL_PREFIX_TO_IGNORE,
       annotationsToIgnoreContains: ANNOTATIONS_TO_IGNORE_CONTAINS,
       annotationsToIgnorePrefix:   ANNOTATIONS_TO_IGNORE_PREFIX

--- a/models/workload.js
+++ b/models/workload.js
@@ -1,7 +1,6 @@
 import { insertAt } from '@/utils/array';
 import { TIMESTAMP } from '@/config/labels-annotations';
 import { WORKLOAD_TYPES } from '@/config/types';
-import { _VIEW } from '@/config/query-params';
 
 export default {
   // remove clone as yaml/edit as yaml until API supported
@@ -74,15 +73,4 @@ export default {
     this.setAnnotation(TIMESTAMP, now);
     this.save();
   },
-
-  // Hide resource detail masthead in create/edit/clone because it's redundant with the wizard
-  showMasthead() {
-    return (mode) => {
-      if (mode !== _VIEW) {
-        return false;
-      } else {
-        return true;
-      }
-    };
-  }
 };

--- a/pages/c/_cluster/_product/_resource/_id.vue
+++ b/pages/c/_cluster/_product/_resource/_id.vue
@@ -2,8 +2,8 @@
 import ResourceDetail, { watchQuery, asyncData } from '@/components/ResourceDetail';
 
 export default {
-  name:       'ClusterResourcedId',
-  components: { ResourceDetail },
+  name:        'ClusterResourcedId',
+  components:  { ResourceDetail },
   asyncData,
   watchQuery,
 };


### PR DESCRIPTION
#964 

Implemented `CruResource` in workload create instead of `Wizard`, and added toggle-able tabs:
<img width="1188" alt="Screen Shot 2020-08-05 at 3 31 02 PM" src="https://user-images.githubusercontent.com/42977925/89470473-b6976a80-d730-11ea-8b0a-69aaaf48398d.png">
<img width="1158" alt="Screen Shot 2020-08-05 at 3 31 38 PM" src="https://user-images.githubusercontent.com/42977925/89470503-c8790d80-d730-11ea-828c-21bf01454225.png">
<img width="1192" alt="Screen Shot 2020-08-05 at 3 32 35 PM" src="https://user-images.githubusercontent.com/42977925/89470563-ef374400-d730-11ea-871a-672fac3ce3eb.png">


Changes to CruResource:
* Allow anchor tags in subType description
* Do not abbreviate `bannerAbbrv`
* Cancel button shows confirmation modal on both yaml and form view
* Yaml and form view both use AsyncButton with correct mode (create/save)
* AsyncButton shows error state instead of returning to list view
* Display save errors from yaml and form view in CruResource
* ShowDiff button is hidden when diff is showing
* kebab-case `select-type` event (lint complained)



