### PR TITLE
Visual updates to the cluster overview page

### DIFF
--- a/assets/styles/global/_tooltip.scss
+++ b/assets/styles/global/_tooltip.scss
@@ -133,8 +133,10 @@
 
 .tooltip, .popover {
   &[aria-hidden='true'] {
+    // This removes it from the layout of ButtondropDown (so it doesn't render huge for SSR) but 
+    // still allows it to maintain it's dimensions for v-tooltip to calculate the appropriate position.
+    position: absolute;
     visibility: hidden;
-    display: none !important;
     opacity: 0;
     transition: opacity .15s, visibility .15s;
   }

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -319,8 +319,8 @@ gatekeeperIndex:
   violations: Violations
 
 glance:
+  age: Age
   cpu: CPU Usage
-  created: Created
   memory: Memory
   nodes:
     total:

--- a/pages/c/_cluster/explorer/Glance.vue
+++ b/pages/c/_cluster/explorer/Glance.vue
@@ -39,8 +39,8 @@ export default {
       <label>{{ t('glance.nodes.total.label') }}</label>
     </div>
     <div class="tile">
-      <h1><LiveDate :value="created" :add-suffix="true" :show-tooltip="false" /></h1>
-      <label>{{ t('glance.created') }}</label>
+      <h1><LiveDate :value="created" :add-suffix="true" :show-tooltip="true" /></h1>
+      <label>{{ t('glance.age') }}</label>
     </div>
   </GradientBox>
 </template>

--- a/pages/c/_cluster/explorer/ResourceGauge.vue
+++ b/pages/c/_cluster/explorer/ResourceGauge.vue
@@ -45,6 +45,11 @@ export default {
     },
     clickable() {
       return !!this.location;
+    },
+    showAlerts() {
+      const total = this.warningCount + this.errorCount;
+
+      return total > 0;
     }
   },
   methods: {
@@ -67,7 +72,7 @@ export default {
     <div class="data">
       <h1>{{ useful }}</h1>
       <label>{{ name }}</label>
-      <div class="alerts">
+      <div v-if="showAlerts" class="alerts">
         <span class="text-warning">
           <i class="icon icon-warning" /><span class="count">{{ warningCount }}</span>
         </span>
@@ -128,6 +133,7 @@ export default {
             position: absolute;
             right: $padding;
             top: $padding / 2;
+            font-size: 15px;
 
             .text-error {
               margin-left: 5px;

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -97,7 +97,11 @@ export default {
   },
 
   data() {
-    const reason = { ...REASON, ...{ canBeVariable: true } };
+    const reason = {
+      ...REASON,
+      ...{ canBeVariable: true },
+      width: 100
+    };
     const message = { ...MESSAGE, ...{ canBeVariable: true } };
     const eventHeaders = [
       reason,
@@ -108,6 +112,7 @@ export default {
         sort:          ['involvedObject.kind', 'involvedObject.name'],
         canBeVariable: true,
         formatter:     'LinkDetail',
+        width:         200
       },
       message,
       {


### PR DESCRIPTION
- Increased alert text size by 2px
- Hide alerts if there aren't any
- Switched from created to age
- Adjusted event column widths
- Fixed a tooltip position bug

rancher/dashboard#925
![Screen Shot 2020-08-10 at 4 41 18 PM](https://user-images.githubusercontent.com/55104481/89841644-59ccf300-db28-11ea-841b-39fafd368774.png)
![Screen Shot 2020-08-10 at 4 41 22 PM](https://user-images.githubusercontent.com/55104481/89841643-59345c80-db28-11ea-8d02-9217e67c2dff.png)
![Screen Shot 2020-08-10 at 4 39 59 PM](https://user-images.githubusercontent.com/55104481/89841578-2ab68180-db28-11ea-9048-85b46e110759.png)
![Screen Shot 2020-08-10 at 3 33 26 PM](https://user-images.githubusercontent.com/55104481/89841528-ff339700-db27-11ea-897e-be9af0812bec.png)
![Screen Shot 2020-08-10 at 4 34 07 PM](https://user-images.githubusercontent.com/55104481/89841526-fe026a00-db27-11ea-9cd9-4a4b8e03a84f.png)
