### PR TITLE
Seed Yaml Editor Content

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -127,11 +127,12 @@ export default {
       }
     },
 
-    showPreviewYaml() {
+    async showPreviewYaml() {
+      await this.$emit('apply-hooks');
+
       const schemas = this.$store.getters['cluster/all'](SCHEMA);
       const { resource } = this;
       const clonedResource = clone(resource);
-
       const resourceYaml = createYaml(schemas, resource.type, clonedResource);
 
       this.resourceYaml = resourceYaml;

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -170,6 +170,7 @@ export default {
     @finish="save"
     @cancel="done"
     @select-type="(st) => serviceType = st"
+    @apply-hooks="() => applyHooks('_beforeSaveHooks')"
   >
     <template #define>
       <NameNsDescription v-if="!isView" :value="value" :mode="mode" />
@@ -180,7 +181,7 @@ export default {
         <Tab
           v-if="checkTypeIs('ExternalName')"
           name="define-external-name"
-          :label="t('servicesPage.selectors.define')"
+          :label="t('servicesPage.externalName.define')"
         >
           <div class="clearfix">
             <h4>

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
     "xterm-addon-fit": "^0.4.0",
     "xterm-addon-search": "^0.7.0",
     "xterm-addon-web-links": "^0.4.0",
-    "xterm-addon-webgl": "^0.8.0",
-    "yaml-js": "^0.2.3"
+    "xterm-addon-webgl": "^0.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -1,5 +1,6 @@
 import { indent as _indent } from '@/utils/string';
 import { addObject, removeObject, removeObjects } from '@/utils/array';
+import jsyaml from 'js-yaml';
 
 const SIMPLE_TYPES = [
   'string',
@@ -169,6 +170,15 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
     }
 
     if ( mapOf ) {
+      if (data[key]) {
+        try {
+          const parsedData = jsyaml.safeDump(data[key]);
+
+          out += `\n${ indent(parsedData.trim()) }`;
+        } catch (e) {
+        }
+      }
+
       if ( SIMPLE_TYPES.includes(mapOf) ) {
         out += `\n#  key: ${ mapOf }`;
       } else {
@@ -184,6 +194,15 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
     }
 
     if ( arrayOf ) {
+      if (data[key]) {
+        try {
+          const parsedData = jsyaml.safeDump(data[key]);
+
+          out += `\n${ indent(parsedData.trim()) }`;
+        } catch (e) {
+        }
+      }
+
       if ( SIMPLE_TYPES.includes(arrayOf) ) {
         out += `\n#  - ${ arrayOf }`;
       } else {
@@ -205,7 +224,9 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
     }
 
     if ( SIMPLE_TYPES.includes(type) ) {
-      if ( typeof data[key] === 'undefined' ) {
+      if (key === '_type' && typeof data[key] === 'undefined' && typeof data['type'] !== 'undefined') {
+        out += ` ${ data['type'] }`;
+      } else if ( typeof data[key] === 'undefined' ) {
         out += ` #${ type }`;
       } else {
         out += ` ${ data[key] }`;

--- a/utils/object.js
+++ b/utils/object.js
@@ -199,3 +199,27 @@ export function diff(from, to) {
 
   return out;
 }
+
+export function nonEmptyValueKeys(obj) {
+  const validKeys = Object.keys(obj).map((key) => {
+    const val = obj[key];
+
+    if ( isObject(val) ) {
+      const recursed = nonEmptyValueKeys(val);
+
+      if (recursed) {
+        return recursed.map((subkey) => {
+          return `"${ key }"."${ subkey }"`;
+        });
+      }
+    } else if ( Array.isArray(val) ) {
+      if (compact(val).length) {
+        return key;
+      }
+    } else if (!!val || val === false || val === 0) {
+      return key;
+    }
+  });
+
+  return compact(flattenDeep(validKeys));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16720,11 +16720,6 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml-js@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/yaml-js/-/yaml-js-0.2.3.tgz#f4cf6c1b3c784f59f55547d7dfcdd06418303291"
-  integrity sha512-6xUQtVKl1qcd0EXtTEzUDVJy9Ji1fYa47LtkDtYKlIjhibPE9knNPmoRyf6SGREFHlOAUyDe9OdYqRP4DuSi5Q==
-
 yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"


### PR DESCRIPTION
Updates the yaml editor component to seed  the content of yaml with data from the form if it exists. This is needed for the preview yaml functionality. 
Revives `nonEmptyValueKeys` function but I do not use it in this PR. I think we should leave this function around though as getting the dot paths of an objects keys can come in handy and this function supports quoted paths as well which the alternatives I've found do not. 
Exposes applyHooks to the CruResource Yaml preview.
Also fixes  a small translation error I found while deving.
Removes yaml-js dependency we were not using. 

This does not expose the YAML editor on the Chart yet. These changes felt distinct enough to warrant its own PR. 