### PR TITLE
Monitoring V2 Missing Options

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -453,11 +453,13 @@ logging:
   syslog:
     address: Address
     cluster: Cluster
-    rootCa: 
+    rootCa:
       label: Root CA
       placeholder: Paste in the Root CA
 
 monitoring:
+  createDefaultRoles: Create Default Monitoring Cluster Roles
+  aggrigateDefaultRoles: Aggregate to Default Kubernetes Roles
   accessModes:
     many: ReadWriteMany
     once: ReadWriteOnce

--- a/chart/monitoring/grafana/index.vue
+++ b/chart/monitoring/grafana/index.vue
@@ -209,6 +209,34 @@ export default {
             />
           </div>
         </div>
+        <div class="mt-20">
+          <div class="mb-5 mt-5">
+            <label class="text-label mb-10">{{ t('monitoring.grafana.storage.annotations') }}</label>
+          </div>
+          <div class="row">
+            <div class="col span-12">
+              <KeyValue
+                v-model="value.grafana.persistence.annotations"
+                :mode="mode"
+                :pad-left="false"
+                :protip="true"
+                :read-allowed="false"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="row mt-20">
+          <div class="col span-12">
+            <ArrayList
+              v-model="value.grafana.persistence.finalizers"
+              table-class="fixed"
+              :mode="mode"
+              :pad-left="false"
+              :protip="true"
+              :title="t('monitoring.grafana.storage.finalizers')"
+            />
+          </div>
+        </div>
       </template>
       <template v-else-if="persistentStorageType === 'statefulset'">
         <div class="row">
@@ -245,34 +273,6 @@ export default {
               v-model="value.grafana.persistence.subPath"
               :label="t('monitoring.grafana.storage.subpath')"
               :mode="mode"
-            />
-          </div>
-        </div>
-        <div class="mt-20">
-          <div class="mb-5 mt-5">
-            <label class="text-label mb-10">{{ t('monitoring.grafana.storage.annotations') }}</label>
-          </div>
-          <div class="row">
-            <div class="col span-12">
-              <KeyValue
-                v-model="value.grafana.persistence.annotations"
-                :mode="mode"
-                :pad-left="false"
-                :protip="true"
-                :read-allowed="false"
-              />
-            </div>
-          </div>
-        </div>
-        <div class="row mt-20">
-          <div class="col span-12">
-            <ArrayList
-              v-model="value.grafana.persistence.finalizers"
-              table-class="fixed"
-              :mode="mode"
-              :pad-left="false"
-              :protip="true"
-              :title="t('monitoring.grafana.storage.finalizers')"
             />
           </div>
         </div>

--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -1,6 +1,7 @@
 <script>
 import { STORAGE_CLASS, PVC } from '@/config/types';
 import merge from 'lodash/merge';
+import RadioGroup from '@/components/form/RadioGroup';
 import ClusterSelector from './ClusterSelector';
 import Prometheus from './prometheus';
 import Grafana from './grafana';
@@ -8,8 +9,9 @@ import Grafana from './grafana';
 export default {
   components: {
     ClusterSelector,
-    Prometheus,
     Grafana,
+    Prometheus,
+    RadioGroup,
   },
   props: {
     mode: {
@@ -41,24 +43,39 @@ export default {
           label: 'monitoring.accessModes.many',
         },
       ],
-      storageClasses: [],
-      pvcs:           [],
+      enableDisableLabels: [this.t('generic.disabled'), this.t('generic.enabled')],
+      pvcs:                [],
+      storageClasses:      [],
     };
   },
 
-  mounted() {
+  created() {
     if (this.mode === 'create') {
-      const defaultPrometheusSpec = {
-        scrapeInterval:     '1m',
-        evaluationInterval: '1m',
-        retention:          '10d',
-        retentionSize:      '50Gib',
-        enableAdminAPI:     false,
+      const extendedDefaults = {
+        global: {
+          rbac: {
+            userRoles: {
+              create:                  true,
+              aggregateToDefaultRoles: true
+            }
+          }
+        },
+        prometheus: {
+          prometheusSpec: {
+            scrapeInterval:     '1m',
+            evaluationInterval: '1m',
+            retention:          '10d',
+            retentionSize:      '50Gib',
+            enableAdminAPI:     false,
+          }
+        }
       };
 
-      merge(this.value.prometheus.prometheusSpec, defaultPrometheusSpec);
+      merge(this.value, extendedDefaults);
     }
+  },
 
+  mounted() {
     this.fetchDeps();
   },
 
@@ -81,7 +98,29 @@ export default {
 <template>
   <div class="config-monitoring-container">
     <section class="config-cluster-general">
-      <ClusterSelector :value="value" :mode="mode" />
+      <div class="row mb-20">
+        <ClusterSelector :value="value" :mode="mode" />
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <RadioGroup
+            v-model="value.global.rbac.userRoles.create"
+            :label="t('monitoring.createDefaultRoles')"
+            :labels="enableDisableLabels"
+            :mode="mode"
+            :options="[false, true]"
+          />
+        </div>
+        <div class="col span-6">
+          <RadioGroup
+            v-model="value.global.rbac.userRoles.aggregateToDefaultRoles"
+            :label="t('monitoring.aggrigateDefaultRoles')"
+            :labels="enableDisableLabels"
+            :mode="mode"
+            :options="[false, true]"
+          />
+        </div>
+      </div>
     </section>
     <section class="config-prometheus-container">
       <Prometheus


### PR DESCRIPTION
There were a couple fields int he ticket that were not available yet but I've exposed them and the object the require on create so the options are available now. These fields defaults will be in [with this pr](https://github.com/rancher/charts/pull/507/commits/28977f3869bd23fdfe7217fa53eb994dca0b36aa#diff-ed5b5b87cf149adc6a6408bf81993efdR1331-R1335).

Also moves the PVC Annotations and Finalizers input locations. 


rancher/dashboard#908