### PR TITLE
Chart Install Yaml Refactor

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -477,7 +477,7 @@ monitoring:
     once: ReadWriteOnce
     readOnlyMany: ReadOnlyMany
   clusterType:
-    k3s: 'K3s,'
+    k3s: 'K3s'
     kubeAdmin: KubeADM
     label: Cluster Type
     managed: 'Managed Cluster (EKS, GKE, AKS, etc.)'

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -286,9 +286,9 @@ containerResourceLimit:
   requestsMemory: Memory Reservation
 
 cruResource:
-  back: Going back will destroy your changes.
-  backToForm: Go Back To Form
-  cancel: Cancelling will destroy your changes.
+  backBody: Going back will destroy your changes.
+  backToForm: Back To Form
+  cancelBody: Cancelling will destroy your changes.
   confirmBack: "Yes, Go Back"
   confirmCancel: "Yes, Cancel"
   reviewForm: "No, Review Form"
@@ -443,13 +443,13 @@ logging:
     scramMechanism: Scram Mechanism
     username: Username
     password: Password
-    sslCaCert: 
+    sslCaCert:
       label: SSL CA Cert
       placeholder: Paste in the CA certificate
-    sslClientCert: 
+    sslClientCert:
       label: SSL Client Cert
       placeholder: Paste in the client cert
-    sslClientCertChain: 
+    sslClientCertChain:
       label: SSL Client Cert Chain
       placeholder: Paste in the client cert chain
     sslClientCertKey: SSL Client Cert Key
@@ -551,7 +551,7 @@ node:
       memoryPressure: Memory Pressure
       pidPressure: PID Pressure
     tab:
-      address: 
+      address:
         label: Address
         externalIp: ExternalIP
       conditions: Conditions

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -282,7 +282,7 @@ export default {
                     </div>
                     <div v-if="selectedSubtype || !subtypes.length" class="controls-right">
                       <button type="button" class="btn role-secondary" @click="checkCancel(false)">
-                        <t k="generic.back" />
+                        <t k="cruResource.backToForm" />
                       </button>
                       <AsyncButton
                         v-if="!showSubtypeSelection"

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -209,7 +209,7 @@ export default {
               <template #default>
                 <div>
                   <button
-                    v-if="canYaml && (selectedSubtype || !subtypes.length)"
+                    v-if="!isEdit && canYaml && (selectedSubtype || !subtypes.length)"
                     type="button"
                     class="btn role-secondary"
                     @click="showPreviewYaml"

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -146,7 +146,7 @@ export default {
       const schemas = this.$store.getters['cluster/all'](SCHEMA);
       const { resource } = this;
       const clonedResource = clone(resource);
-      const resourceYaml = createYaml(schemas, resource.type, clonedResource);
+      const resourceYaml = createYaml(schemas, resource.type, clonedResource, false);
 
       this.resourceYaml = resourceYaml;
       this.showAsForm = false;

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -80,6 +80,19 @@ export default {
   },
 
   computed: {
+    canSave() {
+      const { validationPassed, showAsForm } = this;
+
+      if (showAsForm) {
+        if (validationPassed) {
+          return true;
+        }
+      } else {
+        return true;
+      }
+
+      return false;
+    },
     isView() {
       return this.mode === _VIEW;
     },
@@ -226,7 +239,7 @@ export default {
                   </button>
                   <AsyncButton
                     v-if="!showSubtypeSelection"
-                    :disabled="!validationPassed"
+                    :disabled="!canSave"
                     :mode="finishButtonMode || mode"
                     @click="$emit('finish', $event)"
                   />
@@ -286,7 +299,7 @@ export default {
                       </button>
                       <AsyncButton
                         v-if="!showSubtypeSelection"
-                        :disabled="!validationPassed"
+                        :disabled="!canSave"
                         :action-label="isEdit ? t('generic.save') : t('generic.create')"
                         @click="cb=>yamlSave(cb)"
                       />

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -9,6 +9,7 @@ import AsyncButton from '@/components/AsyncButton';
 import { mapGetters } from 'vuex';
 import { stringify } from '@/utils/error';
 import CruResourceFooter from '@/components/CruResourceFooter';
+import { _EDIT } from '@/config/query-params';
 
 export default {
   components: {
@@ -79,6 +80,10 @@ export default {
   },
 
   computed: {
+    isEdit() {
+      return this.mode === _EDIT;
+    },
+
     showSubtypeSelection() {
       const { selectedSubtype, subtypes } = this;
 
@@ -233,7 +238,7 @@ export default {
           :value="resource"
           :mode="mode"
           :yaml="resourceYaml"
-          :offer-preview="mode==='edit'"
+          :offer-preview="isEdit"
           :done-route="doneRoute"
           :done-override="resource.doneOverride"
           @error="e=>$emit('error', e)"
@@ -258,7 +263,7 @@ export default {
                         <t k="resourceYaml.buttons.continue" />
                       </button>
                       <button
-                        v-if="!showPreview"
+                        v-if="!showPreview && isEdit"
                         :disabled="resourceYaml === currentYaml"
                         type="button"
                         class="btn role-secondary"
@@ -274,7 +279,7 @@ export default {
                       <AsyncButton
                         v-if="!showSubtypeSelection"
                         :disabled="!validationPassed"
-                        :action-label="mode==='edit' ? t('generic.save') : t('generic.create')"
+                        :action-label="isEdit ? t('generic.save') : t('generic.create')"
                         @click="cb=>yamlSave(cb)"
                       />
                     </div>

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -199,7 +199,7 @@ export default {
               :done-route="doneRoute"
               :mode="mode"
               :is-form="showAsForm"
-              @cancelConfirmed="confirmCancel"
+              @cancel-confirmed="confirmCancel"
             >
               <template #default>
                 <div>
@@ -245,7 +245,7 @@ export default {
                   :done-route="doneRoute"
                   :mode="mode"
                   :is-form="showAsForm"
-                  @cancelConfirmed="confirmCancel"
+                  @cancel-confirmed="confirmCancel"
                 >
                   <template #default="{checkCancel}">
                     <div class="controls-middle">

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -10,6 +10,7 @@ import { mapGetters } from 'vuex';
 import { stringify } from '@/utils/error';
 import CruResourceFooter from '@/components/CruResourceFooter';
 import { _EDIT, _VIEW } from '@/config/query-params';
+import { BEFORE_SAVE_HOOKS } from '@/mixins/child-hook';
 
 export default {
   components: {
@@ -141,7 +142,7 @@ export default {
     },
 
     async showPreviewYaml() {
-      await this.$emit('apply-hooks');
+      await this.$emit('apply-hooks', BEFORE_SAVE_HOOKS);
 
       const schemas = this.$store.getters['cluster/all'](SCHEMA);
       const { resource } = this;
@@ -262,6 +263,8 @@ export default {
           :offer-preview="isEdit"
           :done-route="doneRoute"
           :done-override="resource.doneOverride"
+          :errors="errors"
+          @apply-hooks="$emit('apply-hooks', $event)"
           @error="e=>$emit('error', e)"
         >
           <template #yamlFooter="{currentYaml, yamlSave, showPreview, yamlPreview, yamlUnpreview}">

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -9,7 +9,7 @@ import AsyncButton from '@/components/AsyncButton';
 import { mapGetters } from 'vuex';
 import { stringify } from '@/utils/error';
 import CruResourceFooter from '@/components/CruResourceFooter';
-import { _EDIT } from '@/config/query-params';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   components: {
@@ -80,6 +80,10 @@ export default {
   },
 
   computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+
     isEdit() {
       return this.mode === _EDIT;
     },
@@ -103,19 +107,23 @@ export default {
   methods: {
     stringify,
 
-    confirmCancel(isCancel) {
-      if (isCancel) {
-        if ( this.cancelEvent ) {
-          this.$emit('cancel');
-        } else {
-          this.$router.replace({
-            name:   this.doneRoute,
-            params: { resource: this.resource.type }
-          });
-        }
-      } else {
+    confirmCancel(isCancelNotBack = true) {
+      if (isCancelNotBack) {
+        this.emitOrRoute();
+      } else if (!this.showAsForm) {
         this.resourceYaml = null;
         this.showAsForm = true;
+      }
+    },
+
+    emitOrRoute() {
+      if ( this.cancelEvent ) {
+        this.$emit('cancel');
+      } else {
+        this.$router.replace({
+          name:   this.doneRoute,
+          params: { resource: this.resource.type }
+        });
       }
     },
 
@@ -207,7 +215,7 @@ export default {
               @cancel-confirmed="confirmCancel"
             >
               <template #default>
-                <div>
+                <div v-if="!isView">
                   <button
                     v-if="!isEdit && canYaml && (selectedSubtype || !subtypes.length)"
                     type="button"

--- a/components/CruResourceFooter.vue
+++ b/components/CruResourceFooter.vue
@@ -1,0 +1,133 @@
+<script>
+import { mapGetters } from 'vuex';
+
+import AsyncButton from '@/components/AsyncButton';
+
+export default {
+  components: { AsyncButton },
+  props:      {
+    doneRoute: {
+      type:     String,
+      required: true,
+    },
+
+    mode: {
+      type:     String,
+      default:  'create'
+    },
+
+    isForm: {
+      type:    Boolean,
+      default: true,
+    },
+
+    // Override the set of labels shown on the button from teh default save/create.
+    finishButtonMode: {
+      type:    String,
+      default: null,
+    },
+  },
+
+  data() {
+    return { isCancelModal: false };
+  },
+
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
+
+  methods: {
+    checkCancel(isCancel) {
+      if (isCancel) {
+        this.isCancelModal = true;
+      } else {
+        this.isCancelModal = false;
+      }
+
+      this.$modal.show('cancel-modal');
+    },
+
+    confirmCancel(isCancel) {
+      this.$modal.hide('cancel-modal');
+
+      this.$emit('cancelConfirmed', isCancel);
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="cru-resource-footer">
+    <slot name="cancel">
+      <button type="button" class="btn role-secondary" @click="checkCancel(true)">
+        <t k="generic.cancel" />
+      </button>
+    </slot>
+    <slot :checkCancel="checkCancel">
+      <AsyncButton :mode="finishButtonMode || mode" @click="$emit('finish', $event)" />
+    </slot>
+
+    <modal class="confirm-modal" name="cancel-modal" :width="400" height="auto">
+      <div class="header">
+        <h4 class="text-default-text">
+          <t v-if="isCancelModal" k="generic.cancel" />
+          <span v-else>{{ t("cruResource.backToForm") }}</span>
+        </h4>
+      </div>
+      <div class="body">
+        <p v-if="isCancelModal">
+          <t k="cruResource.cancel" />
+        </p>
+        <p v-else>
+          <t k="cruResource.back" />
+        </p>
+      </div>
+      <div class="footer">
+        <button
+          type="button"
+          class="btn role-secondary"
+          @click="$modal.hide('cancel-modal')"
+        >
+          {{ isForm ? t("cruResource.reviewForm") : t("cruResource.reviewYaml") }}
+        </button>
+        <button type="button" class="btn role-primary" @click="confirmCancel(isCancelModal)">
+          <span v-if="isCancelModal">{{ t("cruResource.confirmCancel") }}</span>
+          <span v-else>{{ t("cruResource.confirmBack") }}</span>
+        </button>
+      </div>
+    </modal>
+  </div>
+</template>
+
+<style lang="scss">
+.cru-resource-footer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+.confirm-modal {
+  .v--modal-box {
+    background-color: var(--default);
+    box-shadow: none;
+    min-height: 200px;
+    .body {
+      min-height: 75px;
+      padding: 10px 0 0 15px;
+      p {
+        margin-top: 10px;
+      }
+    }
+    .header {
+      background-color: #4f3335;
+      padding: 15px 0 0 15px;
+    }
+    .header,
+    .footer {
+      height: 50px;
+    }
+    .footer {
+      border-top: 1px solid var(--border);
+      text-align: center;
+      padding: 10px 0 0 15px;
+    }
+  }
+}
+</style>

--- a/components/CruResourceFooter.vue
+++ b/components/CruResourceFooter.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 
 import AsyncButton from '@/components/AsyncButton';
+import { _VIEW } from '@/config/query-params';
 
 export default {
   components: { AsyncButton },
@@ -12,8 +13,8 @@ export default {
     },
 
     mode: {
-      type:     String,
-      default:  'create'
+      type:    String,
+      default: 'create',
     },
 
     isForm: {
@@ -29,20 +30,26 @@ export default {
 
     confirmCancelRequired: {
       type:    Boolean,
-      default: false
+      default: false,
     },
 
     confirmBackRequired: {
       type:    Boolean,
       default: true,
-    }
+    },
   },
 
   data() {
     return { isCancelModal: false };
   },
 
-  computed: { ...mapGetters({ t: 'i18n/t' }) },
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+
+    isView() {
+      return this.mode === _VIEW;
+    },
+  },
 
   methods: {
     checkCancel(isCancel) {
@@ -67,12 +74,20 @@ export default {
 <template>
   <div class="cru-resource-footer">
     <slot name="cancel">
-      <button type="button" class="btn role-secondary" @click="confirmCancelRequired ? checkCancel(true) : $emit('cancel-confirmed')">
+      <button
+        type="button"
+        class="btn role-secondary"
+        @click="confirmCancelRequired ? checkCancel(true) : $emit('cancel-confirmed', true)"
+      >
         <t k="generic.cancel" />
       </button>
     </slot>
     <slot :checkCancel="checkCancel">
-      <AsyncButton :mode="finishButtonMode || mode" @click="$emit('finish', $event)" />
+      <AsyncButton
+        v-if="!isView"
+        :mode="finishButtonMode || mode"
+        @click="$emit('finish', $event)"
+      />
     </slot>
 
     <modal class="confirm-modal" name="cancel-modal" :width="400" height="auto">

--- a/components/CruResourceFooter.vue
+++ b/components/CruResourceFooter.vue
@@ -26,6 +26,16 @@ export default {
       type:    String,
       default: null,
     },
+
+    confirmCancelRequired: {
+      type:    Boolean,
+      default: false
+    },
+
+    confirmBackRequired: {
+      type:    Boolean,
+      default: true,
+    }
   },
 
   data() {
@@ -48,7 +58,7 @@ export default {
     confirmCancel(isCancel) {
       this.$modal.hide('cancel-modal');
 
-      this.$emit('cancelConfirmed', isCancel);
+      this.$emit('cancel-confirmed', isCancel);
     },
   },
 };
@@ -57,7 +67,7 @@ export default {
 <template>
   <div class="cru-resource-footer">
     <slot name="cancel">
-      <button type="button" class="btn role-secondary" @click="checkCancel(true)">
+      <button type="button" class="btn role-secondary" @click="confirmCancelRequired ? checkCancel(true) : $emit('cancel-confirmed')">
         <t k="generic.cancel" />
       </button>
     </slot>

--- a/components/CruResourceFooter.vue
+++ b/components/CruResourceFooter.vue
@@ -99,10 +99,10 @@ export default {
       </div>
       <div class="body">
         <p v-if="isCancelModal">
-          <t k="cruResource.cancel" />
+          <t k="cruResource.cancelBody" />
         </p>
         <p v-else>
-          <t k="cruResource.back" />
+          <t k="cruResource.backBody" />
         </p>
       </div>
       <div class="footer">

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -118,12 +118,13 @@ export default {
     },
 
     onReady(cm) {
-      if ( this.isCreate ) {
-        cm.getMode().fold = 'yamlcomments';
-        cm.execCommand('foldAll');
-      } else if ( this.isEdit ) {
+      if ( this.isEdit ) {
         cm.foldLinesMatching(/^status:\s*$/);
       }
+
+      // regardless of edit or create we should probably fold all the comments so they dont get out of hand.
+      cm.getMode().fold = 'yamlcomments';
+      cm.execCommand('foldAll');
 
       try {
         const parsed = jsyaml.safeLoad(this.currentYaml);

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -13,6 +13,7 @@ import {
   _UNFLAG,
   _EDIT,
 } from '@/config/query-params';
+import { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
 import { exceptionToErrorsArray } from '../utils/error';
 
 export default {
@@ -225,6 +226,12 @@ export default {
       let res;
 
       try {
+        await this.$emit('apply-hooks', BEFORE_SAVE_HOOKS);
+
+        if (this._isBeingDestroyed || this._isDestroyed) {
+          return;
+        }
+
         if ( this.isCreate ) {
           res = await this.schema.followLink('collection', {
             method:  'POST',
@@ -251,6 +258,7 @@ export default {
           await this.$store.dispatch('cluster/load', { data: res, existing: (this.isCreate ? this.value : undefined) });
         }
 
+        await this.$emit('apply-hooks', AFTER_SAVE_HOOKS);
         buttonDone(true);
         this.done();
       } catch (err) {

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -149,10 +149,6 @@ export default {
       if ( !tab ) {
         tab = head(sortedTabs);
       }
-
-      if ( tab ) {
-        this.select(tab.name);
-      }
     });
   },
 

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -180,10 +180,8 @@ export default {
       const {
         sortedTabs,
         tabsUseHistoryReplace,
-        $route: {
-          hash: routeHash,
-          fullPath
-        },
+        $route: { hash: routeHash },
+        $router: { currentRoute },
       } = this;
 
       const selected = this.find(name);
@@ -198,12 +196,14 @@ export default {
       }
 
       if (routeHash !== hashName) {
-        if (tabsUseHistoryReplace) {
-          const fullPathWOHash = fullPath.includes('#') ? fullPath.split('#')[0] : fullPath;
+        const kurrentRoute = { ...currentRoute };
 
-          window.history.replaceState(null, '', `${ fullPathWOHash }#${ name }`);
+        kurrentRoute.hash = hashName;
+
+        if (tabsUseHistoryReplace) {
+          this.$router.replace(kurrentRoute);
         } else {
-          window.location.hash = `#${ name }`;
+          this.$router.push(kurrentRoute);
         }
       }
 

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -1,6 +1,7 @@
 <script>
 import jsyaml from 'js-yaml';
 import { mapPref, DIFF } from '@/store/prefs';
+import isEmpty from 'lodash/isEmpty';
 import CodeMirror from './CodeMirror';
 import FileDiff from './FileDiff';
 
@@ -16,10 +17,6 @@ export default {
     FileDiff
   },
   props: {
-    value: {
-      type:     String,
-      required:  true,
-    },
     editorMode: {
       type:      String,
       default:  EDITOR_MODES.EDIT_CODE,
@@ -27,14 +24,28 @@ export default {
         return Object.values(EDITOR_MODES).includes(value);
       }
     },
+
+    initialYamlValues: {
+      type:    String,
+      default: '',
+    },
+
     scrolling: {
       type:    Boolean,
       default: true,
     },
+
+    value: {
+      type:     String,
+      required:  true,
+    },
   },
 
   data() {
-    return { original: this.value };
+    const { initialYamlValues, value } = this;
+    const original = isEmpty(initialYamlValues) ? value : initialYamlValues;
+
+    return { original };
   },
   computed: {
     cmOptions() {

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -392,6 +392,10 @@ export default {
     },
   },
 
+  created() {
+    this.registerBeforeHook(this.saveWorkload, 'willSaveWorkload');
+  },
+
   methods: {
     nameDisplayFor(type) {
       const schema = this.$store.getters['cluster/schemaFor'](type);
@@ -411,7 +415,7 @@ export default {
       this.done();
     },
 
-    saveWorkload(cb) {
+    saveWorkload() {
       if (!this.spec.selector && this.type !== WORKLOAD_TYPES.JOB) {
         this.spec.selector = { matchLabels: this.workloadSelector };
       }
@@ -442,7 +446,6 @@ export default {
       }
 
       Object.assign(this.value, { spec: this.spec });
-      this.save(cb);
     },
 
     // node and pod affinity are formatted incorrectly from API; fix before saving
@@ -517,9 +520,10 @@ export default {
       :errors="errors"
       :done-route="doneRoute"
       :subtypes="workloadSubTypes"
-      @finish="cb=>saveWorkload(cb)"
+      @finish="save"
       @select-type="e=>type=e"
       @error="e=>errors = e"
+      @apply-hooks="applyHooks"
     >
       <template #define>
         <div class="row">

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -733,7 +733,7 @@ export default {
             class="btn role-secondary"
             @click="valuesYaml === cleanValuesYaml ? resetFromBack() : checkCancel(false)"
           >
-            <t k="generic.back" />
+            <t k="cruResource.backToForm" />
           </button>
 
           <AsyncButton

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -2,6 +2,7 @@
 import jsyaml from 'js-yaml';
 import merge from 'lodash/merge';
 import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
 import has from 'lodash/has';
 
 import AsyncButton from '@/components/AsyncButton';
@@ -187,9 +188,11 @@ export default {
 
       return false;
     },
+
     tabName() {
       return this.selectedTabName;
     },
+
     charts() {
       return this.$store.getters['catalog/charts'].filter(x => !x.deprecated);
     },
@@ -212,6 +215,18 @@ export default {
 
     showVersions() {
       return this.chart?.versions.length > 1;
+    },
+
+    showBackButton() {
+      const { selectedTabName, showValuesComponent, valuesComponent } = this;
+
+      if (isEmpty(valuesComponent)) {
+        return false;
+      } else if (selectedTabName === 'values-yaml' && !showValuesComponent) {
+        return true;
+      }
+
+      return false;
     },
 
     targetNamespace() {
@@ -312,10 +327,11 @@ export default {
         this.valuesYaml = jsyaml.safeDump(chartValues);
 
         if (showValuesComponent) {
+          this.tabChanged({ tab: { name: 'values-yaml' } });
           this.showValuesComponent = false;
         } else {
+          this.tabChanged({ tab: { name: 'values-form' } });
           this.showValuesComponent = true;
-          // this.originalYamlValues = null;
         }
       }
     },
@@ -743,7 +759,7 @@ export default {
 
         <div>
           <button
-            v-if="!showValuesComponent"
+            v-if="showBackButton"
             type="button"
             class="btn role-secondary"
             @click="valuesYaml === originalYamlValues ? resetFromBack() : checkCancel(false)"

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -140,42 +140,54 @@ export default {
 
   data() {
     return {
+      chart:           null,
+      chartValues:     null,
+      cleanValuesYaml: null,
+      errors:          null,
+      existing:        null,
+      forceNamespace:  null,
+      loadedVersion:   null,
       mode:            null,
       value:           null,
-      existing:        null,
-      chart:           null,
+      valuesComponent: null,
+      valuesYaml:      null,
       version:         null,
       versionInfo:     null,
-      valuesYaml:      null,
-      cleanValuesYaml: null,
 
-      forceNamespace: null,
-      nameDisabled:   false,
-
-      errors:              null,
-      valuesComponent:     null,
+      atomic:              false,
+      cleanupOnFail:       false,
+      crds:                true,
+      dryRun:              false,
+      force:               false,
+      hooks:               true,
+      nameDisabled:        false,
+      openApi:             true,
+      resetValues:         false,
+      reuseValues:         false,
+      selectedTabName:     'readme',
+      showPreview:         false,
       showValuesComponent: false,
       valuesTabs:          false,
-      chartValues:         null,
-      loadedVersion:       null,
-      showPreview:         false,
+      wait:                true,
 
-      openApi:       true,
-      hooks:         true,
-      crds:          true,
-      wait:          true,
-      historyMax:    5,
-      timeout:       0,
-      atomic:        false,
-      cleanupOnFail: false,
-      dryRun:        false,
-      force:         false,
-      resetValues:   false,
-      reuseValues:   false,
+      historyMax: 5,
+      timeout:    0,
     };
   },
 
   computed: {
+    isEntryTab() {
+      const { tabName } = this;
+
+      if (tabName === 'values-form' || tabName === 'values-yaml') {
+        return true;
+      }
+
+      return false;
+    },
+    tabName() {
+      return this.selectedTabName;
+    },
     charts() {
       return this.$store.getters['catalog/charts'].filter(x => !x.deprecated);
     },
@@ -478,6 +490,8 @@ export default {
     tabChanged({ tab }) {
       window.scrollTop = 0;
 
+      this.selectedTabName = tab.name;
+
       if ( tab.name === 'values-yaml' ) {
         this.$nextTick(() => {
           if ( this.$refs.yaml ) {
@@ -684,7 +698,7 @@ export default {
       <template #default="{checkCancel}">
         <template v-if="!showValuesComponent">
           <button
-            v-if="showPreview"
+            v-if="showPreview && isEntryTab"
             type="button"
             class="btn role-secondary"
             @click="unpreview"
@@ -693,7 +707,7 @@ export default {
           </button>
 
           <button
-            v-else
+            v-if="isEntryTab && !showPreview"
             :disabled="valuesYaml === cleanValuesYaml"
             type="button"
             class="btn role-secondary"
@@ -704,7 +718,7 @@ export default {
         </template>
 
         <button
-          v-if="$route.hash === '#values-form' && showValuesComponent"
+          v-if="isEntryTab && showValuesComponent"
           type="button"
           class="btn role-secondary"
           @click="showPreviewYaml"

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -679,7 +679,7 @@ export default {
       :mode="mode"
       :finish-button-mode="(existing ? 'upgrade' : 'install')"
       :is-form="!!showValuesComponent"
-      @cancelConfirmed="cancel"
+      @cancel-confirmed="cancel"
     >
       <template #default="{checkCancel}">
         <template v-if="!showValuesComponent">

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -2,23 +2,25 @@
 import jsyaml from 'js-yaml';
 import merge from 'lodash/merge';
 import isEqual from 'lodash/isEqual';
+import has from 'lodash/has';
 
+import AsyncButton from '@/components/AsyncButton';
 import Loading from '@/components/Loading';
 import NameNsDescription from '@/components/form/NameNsDescription';
 import UnitInput from '@/components/form/UnitInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import LazyImage from '@/components/LazyImage';
 import Markdown from '@/components/Markdown';
-import CruResource from '@/components/CruResource';
 import Tab from '@/components/Tabbed/Tab';
 import Tabbed from '@/components/Tabbed';
-import YamlEditor from '@/components/YamlEditor';
+import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import Checkbox from '@/components/form/Checkbox';
 import Questions from '@/components/Questions';
+import CruResourceFooter from '@/components/CruResourceFooter';
 
 import { CATALOG } from '@/config/types';
 import {
-  REPO_TYPE, REPO, CHART, VERSION, NAMESPACE, NAME, DESCRIPTION as DESCRIPTION_QUERY, _CREATE, _EDIT,
+  REPO_TYPE, REPO, CHART, VERSION, NAMESPACE, NAME, DESCRIPTION as DESCRIPTION_QUERY, _CREATE, _EDIT, PREVIEW, _UNFLAG, _FLAGGED
 } from '@/config/query-params';
 import { CATALOG as CATALOG_ANNOTATIONS, DESCRIPTION as DESCRIPTION_ANNOTATION } from '@/config/labels-annotations';
 import { exceptionToErrorsArray } from '@/utils/error';
@@ -29,16 +31,17 @@ export default {
   name: 'Install',
 
   components: {
+    AsyncButton,
     Checkbox,
-    UnitInput,
+    CruResourceFooter,
     LabeledSelect,
     LazyImage,
     Loading,
     Markdown,
     NameNsDescription,
-    CruResource,
-    Tabbed,
     Tab,
+    Tabbed,
+    UnitInput,
     YamlEditor,
     Questions,
   },
@@ -137,22 +140,25 @@ export default {
 
   data() {
     return {
-      mode:        null,
-      value:       null,
-      existing:    null,
-      chart:       null,
-      version:     null,
-      versionInfo: null,
-      valuesYaml:  null,
+      mode:            null,
+      value:           null,
+      existing:        null,
+      chart:           null,
+      version:         null,
+      versionInfo:     null,
+      valuesYaml:      null,
+      cleanValuesYaml: null,
 
       forceNamespace: null,
       nameDisabled:   false,
 
-      errors:          null,
-      valuesComponent: null,
-      valuesTabs:      false,
-      chartValues:     null,
-      loadedVersion:   null,
+      errors:              null,
+      valuesComponent:     null,
+      showValuesComponent: false,
+      valuesTabs:          false,
+      chartValues:         null,
+      loadedVersion:       null,
+      showPreview:         false,
 
       openApi:       true,
       hooks:         true,
@@ -202,12 +208,20 @@ export default {
       }
 
       return 'default';
-    }
+    },
+
+    editorMode() {
+      if ( this.showPreview ) {
+        return EDITOR_MODES.DIFF_CODE;
+      }
+
+      return EDITOR_MODES.EDIT_CODE;
+    },
   },
 
   watch: {
     '$route.query'(neu, old) {
-      if ( !isEqual(neu, old) ) {
+      if ( !isEqual(neu, old) && !has(neu, 'preview') ) {
         this.$fetch();
       }
     },
@@ -237,14 +251,17 @@ export default {
 
           const loaded = await this.valuesComponent();
 
+          this.showValuesComponent = true;
           this.valuesTabs = loaded?.default?.hasTabs || false;
         } else {
           this.valuesComponent = null;
           this.valuesTabs = false;
+          this.showValuesComponent = false;
         }
       } else {
         this.valuesComponent = null;
         this.valuesTabs = false;
+        this.showValuesComponent = false;
       }
     },
 
@@ -263,6 +280,35 @@ export default {
       this.$router.applyQuery({ [VERSION]: version });
     },
 
+    showPreviewYaml() {
+      const { valuesComponent, showValuesComponent } = this;
+
+      if (!!valuesComponent) {
+        if (!this.cleanValuesYaml) {
+          // seed the yaml with any entered info
+          this.valuesYaml = jsyaml.safeDump(this.chartValues);
+          this.cleanValuesYaml = this.valuesYaml;
+        }
+
+        if (showValuesComponent) {
+          this.showValuesComponent = false;
+        } else {
+          this.showValuesComponent = true;
+          this.cleanValuesYaml = null;
+        }
+      }
+    },
+
+    preview() {
+      this.showPreview = true;
+      this.$router.applyQuery({ [PREVIEW]: _FLAGGED });
+    },
+
+    unpreview() {
+      this.showPreview = false;
+      this.$router.applyQuery({ [PREVIEW]: _UNFLAG });
+    },
+
     yamlChanged(str) {
       try {
         jsyaml.safeLoad(str);
@@ -273,12 +319,23 @@ export default {
       }
     },
 
-    cancel() {
+    cancel(reallyCancel) {
+      if (!reallyCancel && !this.showValuesComponent) {
+        return this.resetFromBack();
+      }
+
       if ( this.existing ) {
         this.done();
       } else {
         this.$router.replace({ name: 'c-cluster-apps' });
       }
+    },
+
+    resetFromBack() {
+      this.showValuesComponent = true;
+      this.valuesYaml = this.cleanValuesYaml;
+      this.cleanValuesYaml = null;
+      window.location.hash = `#values-form`;
     },
 
     done() {
@@ -447,96 +504,95 @@ export default {
     </h1>
 
     <Loading v-if="$fetchState.pending" />
-    <CruResource
-      v-else
-      :can-create="true"
-      :can-yaml="false"
-      done-route="c-cluster-apps"
-      :mode="mode"
-      :resource="value"
-      :subtypes="[]"
-      :finish-button-mode="(existing ? 'upgrade' : 'install')"
-      :errors="errors"
-      :cancel-event="true"
-      @error="e=>errors = e"
-      @finish="finish($event)"
-      @cancel="cancel"
-    >
-      <template #define>
-        <div v-if="chart" class="chart-info mb-20">
-          <div class="logo-container">
-            <div class="logo-bg">
-              <LazyImage :src="chart.icon" class="logo" />
-            </div>
-          </div>
-          <div class="description">
-            <Markdown v-if="versionInfo && versionInfo.appReadme" v-model="versionInfo.appReadme" class="md md-desc" />
-            <p v-else-if="chart.description">
-              {{ chart.description }}
-            </p>
+
+    <template v-else>
+      <div v-if="chart" class="chart-info mb-20">
+        <div class="logo-container">
+          <div class="logo-bg">
+            <LazyImage :src="chart.icon" class="logo" />
           </div>
         </div>
-
-        <div v-if="existing && chart" class="row mb-20">
-          <div class="col span-6">
-            <LabeledSelect
-              label="Chart"
-              :value="$route.query.chart"
-              option-label="chartName"
-              option-key="key"
-              :reduce="opt=>opt.key"
-              :options="charts"
-              @input="selectChart($event)"
-            />
-          </div>
-          <div v-if="chart" class="col span-6">
-            <LabeledSelect
-              label="Version"
-              :value="$route.query.version"
-              option-label="version"
-              option-key="version"
-              :reduce="opt=>opt.version"
-              :options="chart.versions"
-              @input="selectVersion($event)"
-            />
-          </div>
+        <div class="description">
+          <Markdown v-if="versionInfo && versionInfo.appReadme" v-model="versionInfo.appReadme" class="md md-desc" />
+          <p v-else-if="chart.description">
+            {{ chart.description }}
+          </p>
         </div>
-        <NameNsDescription
-          v-else
-          v-show="showNameEditor"
-          v-model="value"
-          :mode="mode"
-          :name-disabled="nameDisabled"
-          :force-namespace="forceNamespace"
-          :extra-columns="showVersions ? ['versions'] : []"
-        >
-          <template v-if="showVersions" #versions>
-            <LabeledSelect
-              label="Chart Version"
-              :value="$route.query.version"
-              option-label="version"
-              option-key="version"
-              :reduce="opt=>opt.version"
-              :options="chart.versions"
-              @input="selectVersion($event)"
-            />
-          </template>
-        </NameNsDescription>
+      </div>
 
-        <Tabbed
-          :side-tabs="true"
-          :class="{'with-name': showNameEditor}"
-          @changed="tabChanged($event)"
-        >
-          <Tab v-if="showReadme" name="readme" :label="t('catalog.install.section.readme')" :weight="-1">
-            <!-- Negative weight makes it go before any valuesComponent tabs with no weight set -->
-            <Markdown v-if="showReadme" ref="readme" v-model="versionInfo.readme" class="md readme" />
-          </Tab>
+      <div v-if="existing && chart" class="row mb-20">
+        <div class="col span-6">
+          <LabeledSelect
+            label="Chart"
+            :value="$route.query.chart"
+            option-label="chartName"
+            option-key="key"
+            :reduce="opt=>opt.key"
+            :options="charts"
+            @input="selectChart($event)"
+          />
+        </div>
+        <div v-if="chart" class="col span-6">
+          <LabeledSelect
+            label="Version"
+            :value="$route.query.version"
+            option-label="version"
+            option-key="version"
+            :reduce="opt=>opt.version"
+            :options="chart.versions"
+            @input="selectVersion($event)"
+          />
+        </div>
+      </div>
+      <NameNsDescription
+        v-else
+        v-show="showNameEditor"
+        v-model="value"
+        :mode="mode"
+        :name-disabled="nameDisabled"
+        :force-namespace="forceNamespace"
+        :extra-columns="showVersions ? ['versions'] : []"
+      >
+        <template v-if="showVersions" #versions>
+          <LabeledSelect
+            label="Chart Version"
+            :value="$route.query.version"
+            option-label="version"
+            option-key="version"
+            :reduce="opt=>opt.version"
+            :options="chart.versions"
+            @input="selectVersion($event)"
+          />
+        </template>
+      </NameNsDescription>
 
-          <template v-if="valuesComponent">
+      <Tabbed
+        :side-tabs="true"
+        :class="{'with-name': showNameEditor}"
+        @changed="tabChanged($event)"
+      >
+        <Tab v-if="showReadme" name="readme" :label="t('catalog.install.section.readme')" :weight="-1">
+          <!-- Negative weight makes it go before any valuesComponent tabs with no weight set -->
+          <Markdown v-if="showReadme" ref="readme" v-model="versionInfo.readme" class="md readme" />
+        </Tab>
+
+        <template v-if="valuesComponent && showValuesComponent">
+          <component
+            :is="valuesComponent"
+            v-if="valuesTabs"
+            v-model="chartValues"
+            :chart="chart"
+            :version="version"
+            :version-info="versionInfo"
+          />
+          <Tab
+            v-else
+            name="values-form"
+            :label="t('catalog.install.section.chartOptions')"
+          >
             <component
               :is="valuesComponent"
-              v-if="valuesTabs"
+              v-if="valuesComponent"
               v-model="chartValues"
               :chart="chart"
               :version="version"
@@ -556,66 +612,124 @@ export default {
                 :version-info="versionInfo"
               />
             </Tab>
-          </template>
-          <Questions
-            v-else-if="versionInfo && versionInfo.questions"
-            v-model="chartValues"
-            :chart="chart"
-            :version="version"
-            :version-info="versionInfo"
-            :target-namespace="targetNamespace"
+          </tab>
+        </template>
+        <Questions
+          v-else-if="versionInfo && versionInfo.questions"
+          v-model="chartValues"
+          :chart="chart"
+          :version="version"
+          :version-info="versionInfo"
+          :target-namespace="targetNamespace"
+        />
+        <Tab v-else name="values-yaml" :label="t('catalog.install.section.valuesYaml')">
+          <YamlEditor
+            ref="yaml"
+            :scrolling="false"
+            :value="valuesYaml"
+            :editor-mode="editorMode"
+            @onInput="yamlChanged"
           />
-          <Tab v-else name="values-yaml" :label="t('catalog.install.section.valuesYaml')">
-            <YamlEditor
-              ref="yaml"
-              :scrolling="false"
-              :value="valuesYaml"
-              @onInput="yamlChanged"
-            />
-          </Tab>
+        </Tab>
 
-          <Tab name="helm" :label="t('catalog.install.section.helm')" :weight="100">
-            <div v-if="existing">
-              <div><Checkbox v-model="atomic" :label="t('catalog.install.helm.atomic')" /></div>
-              <div><Checkbox v-model="cleanupOnFail" :label="t('catalog.install.helm.cleanupOnFail')" /></div>
-              <div><Checkbox v-model="dryRun" :label="t('catalog.install.helm.dryRun')" /></div>
-              <div><Checkbox v-model="force" :label="t('catalog.install.helm.force')" /></div>
-              <div><Checkbox v-model="hooks" :label="t('catalog.install.helm.hooks')" /></div>
-              <div><Checkbox v-model="resetValues" :label="t('catalog.install.helm.resetValues')" /></div>
-              <div><Checkbox v-model="reuseValues" :label="t('catalog.install.helm.reuseValues')" /></div>
-              <div><Checkbox v-model="wait" :label="t('catalog.install.helm.wait')" /></div>
-              <div style="display: inline-block; max-width: 400px;">
-                <UnitInput
-                  v-model.number="historyMax"
-                  :label="t('catalog.install.helm.historyMax.label')"
-                  :suffix="t('catalog.install.helm.historyMax.unit')"
-                />
-              </div>
-              <div style="display: inline-block; max-width: 400px;">
-                <UnitInput
-                  v-model.number="timeout"
-                  :label="t('catalog.install.helm.timeout.label')"
-                  :suffix="t('catalog.install.helm.timeout.unit')"
-                />
-              </div>
+        <Tab name="helm" :label="t('catalog.install.section.helm')" :weight="100">
+          <div v-if="existing">
+            <div><Checkbox v-model="atomic" :label="t('catalog.install.helm.atomic')" /></div>
+            <div><Checkbox v-model="cleanupOnFail" :label="t('catalog.install.helm.cleanupOnFail')" /></div>
+            <div><Checkbox v-model="dryRun" :label="t('catalog.install.helm.dryRun')" /></div>
+            <div><Checkbox v-model="force" :label="t('catalog.install.helm.force')" /></div>
+            <div><Checkbox v-model="hooks" :label="t('catalog.install.helm.hooks')" /></div>
+            <div><Checkbox v-model="resetValues" :label="t('catalog.install.helm.resetValues')" /></div>
+            <div><Checkbox v-model="reuseValues" :label="t('catalog.install.helm.reuseValues')" /></div>
+            <div><Checkbox v-model="wait" :label="t('catalog.install.helm.wait')" /></div>
+            <div style="display: inline-block; max-width: 400px;">
+              <UnitInput
+                v-model.number="historyMax"
+                :label="t('catalog.install.helm.historyMax.label')"
+                :suffix="t('catalog.install.helm.historyMax.unit')"
+              />
             </div>
-            <div v-else>
-              <div><Checkbox v-model="openApi" :label="t('catalog.install.helm.openapi')" /></div>
-              <div><Checkbox v-model="hooks" :label="t('catalog.install.helm.hooks')" /></div>
-              <div><Checkbox v-model="crds" :label="t('catalog.install.helm.crds')" /></div>
-              <div><Checkbox v-model="wait" :label="t('catalog.install.helm.wait')" /></div>
-              <div style="display: inline-block; max-width: 400px;">
-                <UnitInput
-                  v-model.number="timeout"
-                  :label="t('catalog.install.helm.timeout.label')"
-                  :suffix="t('catalog.install.helm.timeout.unit')"
-                />
-              </div>
+            <div style="display: inline-block; max-width: 400px;">
+              <UnitInput
+                v-model.number="timeout"
+                :label="t('catalog.install.helm.timeout.label')"
+                :suffix="t('catalog.install.helm.timeout.unit')"
+              />
             </div>
-          </Tab>
-        </Tabbed>
+          </div>
+          <div v-else>
+            <div><Checkbox v-model="openApi" :label="t('catalog.install.helm.openapi')" /></div>
+            <div><Checkbox v-model="hooks" :label="t('catalog.install.helm.hooks')" /></div>
+            <div><Checkbox v-model="crds" :label="t('catalog.install.helm.crds')" /></div>
+            <div><Checkbox v-model="wait" :label="t('catalog.install.helm.wait')" /></div>
+            <div style="display: inline-block; max-width: 400px;">
+              <UnitInput
+                v-model.number="timeout"
+                :label="t('catalog.install.helm.timeout.label')"
+                :suffix="t('catalog.install.helm.timeout.unit')"
+              />
+            </div>
+          </div>
+        </Tab>
+      </Tabbed>
+    </template>
+
+    <CruResourceFooter
+      done-route="c-cluster-apps"
+      :mode="mode"
+      :finish-button-mode="(existing ? 'upgrade' : 'install')"
+      :is-form="!!showValuesComponent"
+      @cancelConfirmed="cancel"
+    >
+      <template #default="{checkCancel}">
+        <template v-if="!showValuesComponent">
+          <button
+            v-if="showPreview"
+            type="button"
+            class="btn role-secondary"
+            @click="unpreview"
+          >
+            <t k="resourceYaml.buttons.continue" />
+          </button>
+
+          <button
+            v-else
+            :disabled="valuesYaml === cleanValuesYaml"
+            type="button"
+            class="btn role-secondary"
+            @click="preview"
+          >
+            <t k="resourceYaml.buttons.diff" />
+          </button>
+        </template>
+
+        <button
+          v-if="$route.hash === '#values-form' && showValuesComponent"
+          type="button"
+          class="btn role-secondary"
+          @click="showPreviewYaml"
+        >
+          {{ t("cruResource.previewYaml") }}
+        </button>
+
+        <div>
+          <button
+            v-if="!showValuesComponent"
+            type="button"
+            class="btn role-secondary"
+            @click="valuesYaml === cleanValuesYaml ? resetFromBack() : checkCancel(false)"
+          >
+            <t k="generic.back" />
+          </button>
+
+          <AsyncButton
+            :disabled="false"
+            :mode="(existing ? 'upgrade' : 'install') || mode"
+            @click="finish"
+          />
+        </div>
       </template>
-    </CruResource>
+    </CruResourceFooter>
   </div>
 </template>
 

--- a/plugins/extend-router.js
+++ b/plugins/extend-router.js
@@ -3,12 +3,13 @@ import isEqual from 'lodash/isEqual';
 
 VueRouter.prototype.applyQuery = function(qp, defaults = {}) {
   const query = queryParamsFor(this.currentRoute.query, qp, defaults);
+  const hash = this.currentRoute.hash || '';
 
   if ( isEqual(query, this.currentRoute.query) ) {
     return;
   }
 
-  this.replace({ query }).catch((err) => {
+  this.replace({ query, hash }).catch((err) => {
     if ( err?.name === 'NavigationDuplicated' ) {
       // Do nothing, this is fine...
       // https://github.com/vuejs/vue-router/issues/2872

--- a/plugins/extend-router.js
+++ b/plugins/extend-router.js
@@ -9,7 +9,7 @@ VueRouter.prototype.applyQuery = function(qp, defaults = {}) {
     return;
   }
 
-  this.replace({ query, hash }).catch((err) => {
+  return this.replace({ query, hash }).catch((err) => {
     if ( err?.name === 'NavigationDuplicated' ) {
       // Do nothing, this is fine...
       // https://github.com/vuejs/vue-router/issues/2872

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -1,6 +1,7 @@
 import { indent as _indent } from '@/utils/string';
 import { addObject, removeObject, removeObjects } from '@/utils/array';
 import jsyaml from 'js-yaml';
+import { cleanUp } from '@/utils/object';
 
 const SIMPLE_TYPES = [
   'string',
@@ -172,10 +173,12 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
     if ( mapOf ) {
       if (data[key]) {
         try {
-          const parsedData = jsyaml.safeDump(data[key]);
+          const cleaned = cleanUp(data);
+          const parsedData = jsyaml.safeDump(cleaned[key]);
 
           out += `\n${ indent(parsedData.trim()) }`;
         } catch (e) {
+          console.error(`Error: Unale to parse map data for yaml of type: ${ type }`, e); // eslint-disable-line no-console
         }
       }
 
@@ -196,10 +199,12 @@ export function createYaml(schemas, type, data, populate = true, depth = 0, path
     if ( arrayOf ) {
       if (data[key]) {
         try {
-          const parsedData = jsyaml.safeDump(data[key]);
+          const cleaned = cleanUp(data);
+          const parsedData = jsyaml.safeDump(cleaned[key]);
 
           out += `\n${ indent(parsedData.trim()) }`;
         } catch (e) {
+          console.error(`Error: Unale to parse array data for yaml of type: ${ type }`, e); // eslint-disable-line no-console
         }
       }
 


### PR DESCRIPTION
This PR exposes the `Preview Yaml` functionality on the `apps/install` page. 

While I was working on adding the yaml preview functionality it became pretty clear that CruResource doesn't really work with the chart resource. The main reason being, CruResource expects a standard resource where its fields exist on a schema for ResourceYaml to work correctly. In this respect a chart doesn't fit the expectations of CruResource as resource values are derived from the chart values which have a schema of sorts but a schema not in the manner CruResource expects. I also found that the install page is not using the other major feature of CruResource, the subtype picker. Additionally the logic for parsing and saving a chart as yaml already exists in the install page. 

Rather than try to shoehorn the chart resource into CruResource I pulled out the shared functionality into a `CruResourceFooter` component. This component manages the footer buttons and and the cancel logic/modal.

![Screen Shot 2020-08-17 at 4 42 45 PM](https://user-images.githubusercontent.com/858614/90454729-f18e8c00-e0a8-11ea-89ce-72f5dbf5bfd4.png)
![Screen Shot 2020-08-17 at 4 42 57 PM](https://user-images.githubusercontent.com/858614/90454732-f3584f80-e0a8-11ea-9697-d1baea2f4320.png)
![Screen Shot 2020-08-17 at 4 43 09 PM](https://user-images.githubusercontent.com/858614/90454739-f5baa980-e0a8-11ea-8cee-55f43c48544c.png)
![Screen Shot 2020-08-17 at 4 43 27 PM](https://user-images.githubusercontent.com/858614/90454748-f7846d00-e0a8-11ea-850c-e2819ac40744.png)
![Screen Shot 2020-08-17 at 4 44 19 PM](https://user-images.githubusercontent.com/858614/90454752-f94e3080-e0a8-11ea-8263-70268eb2b9b2.png)
