### PR TITLE
Service Bugs

### DIFF
--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -38,6 +38,11 @@ export default {
     scrollOnChange: {
       type:    Boolean,
       default: false
+    },
+
+    tabsUseHistoryReplace: {
+      type:    Boolean,
+      default: true,
     }
   },
 
@@ -168,7 +173,11 @@ export default {
     select(name/* , event */) {
       const {
         sortedTabs,
-        $route: { hash: routeHash },
+        tabsUseHistoryReplace,
+        $route: {
+          hash: routeHash,
+          fullPath
+        },
       } = this;
 
       const selected = this.find(name);
@@ -183,7 +192,13 @@ export default {
       }
 
       if (routeHash !== hashName) {
-        window.location.hash = `#${ name }`;
+        if (tabsUseHistoryReplace) {
+          const fullPathWOHash = fullPath.includes('#') ? fullPath.split('#')[0] : fullPath;
+
+          window.history.replaceState(null, '', `${ fullPathWOHash }#${ name }`);
+        } else {
+          window.location.hash = `#${ name }`;
+        }
       }
 
       for ( const tab of sortedTabs ) {

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -125,7 +125,7 @@ export default {
           <th v-if="specType !== 'NodePort'" class="port-protocol">
             <t k="servicePorts.rules.protocol.label" />
           </th>
-          <th v-if="specType !== 'Headless'" class="target-port">
+          <th class="target-port">
             <t k="servicePorts.rules.target.label" />
           </th>
           <th v-if="specType === 'NodePort' || specType === 'LoadBalancer'" class="node-port">
@@ -173,7 +173,7 @@ export default {
               @input="queueUpdate"
             />
           </td>
-          <td v-if="specType !== 'Headless'" class="target-port">
+          <td class="target-port">
             <span v-if="isView">{{ row.targetPort }}</span>
             <input
               v-else

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -325,7 +325,7 @@ export default {
           <div class="row labels-row">
             <Labels
               :default-container-class="'labels-and-annotations-container'"
-              :value="value.spec"
+              :value="value"
               :mode="mode"
               :display-side-by-side="false"
             />

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -204,7 +204,7 @@ export default {
             </div>
           </div>
         </Tab>
-        <Tab v-else name="define-external-name" :label="t('servicesPage.ips.define')">
+        <Tab v-else name="define-service-ports" :label="t('servicesPage.ips.define')">
           <ServicePorts
             v-model="value.spec.ports"
             class="col span-12"


### PR DESCRIPTION
Updated the path to value in Service create to use the correct value path for the Labels component.

rancher/dashboard#985

Remove headless check on target port input

rancher/dashboard#1028

Update Tabbed component to use the history replace state rather than push state by default with an option to revert back to old design if desired. This one is not necessarily related to services, the bug calls out services though so that why i've slipped it into this PR. 
rancher/dashboard#820