### PR TITLE
Updating how we filter labels and annotations

### DIFF
--- a/components/form/Labels.vue
+++ b/components/form/Labels.vue
@@ -33,17 +33,7 @@ export default {
     sectionClass() {
       return this.displaySideBySide ? 'col span-6' : 'row';
     }
-  },
-
-  created() {
-    if ( !this.value.metadata ) {
-      this.$set(this.value, 'metadata', {});
-    }
-
-    if ( !this.value.annotations ) {
-      this.$set(this.value, 'annotations', {});
-    }
-  },
+  }
 };
 </script>
 <template>
@@ -51,23 +41,25 @@ export default {
     <div :class="sectionClass">
       <KeyValue
         key="labels"
-        v-model="value.metadata.labels"
+        :value="value.labels"
         :mode="mode"
         title="Labels"
         :initial-empty-row="true"
         :pad-left="false"
         :read-allowed="false"
+        @input="value.setLabels"
       />
     </div>
     <div :class="sectionClass">
       <KeyValue
         key="annotations"
-        v-model="value.metadata.annotations"
+        :value="value.annotations"
         :mode="mode"
         title="Annotations"
         :initial-empty-row="true"
         :pad-left="false"
         :read-allowed="false"
+        @input="value.setAnnotations"
       />
     </div>
   </div>

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -38,17 +38,16 @@ export const CATALOG = {
   COMPONENT: 'catalog.cattle.io/ui-component',
 };
 
+const CATTLE_REGEX = /.*\.cattle\.io\//;
+
 export const RKE = { EXTERNAL_IP: 'rke.cattle.io/external-ip' };
 
-// TODO consult w/ backend about what labels & annotations to hide from editing
-export const LABEL_PREFIX_TO_IGNORE = [
+export const LABELS_TO_IGNORE_REGEX = [
+  CATTLE_REGEX
 ];
 
-export const ANNOTATIONS_TO_IGNORE_CONTAINS = [
-];
-
-export const ANNOTATIONS_TO_IGNORE_PREFIX = [
-  DESCRIPTION
+export const ANNOTATIONS_TO_IGNORE_REGEX = [
+  CATTLE_REGEX
 ];
 
 export const ANNOTATIONS_TO_FOLD = [

--- a/mixins/create-edit-view.js
+++ b/mixins/create-edit-view.js
@@ -1,8 +1,6 @@
-import pickBy from 'lodash/pickBy';
 import { _CREATE, _EDIT, _VIEW } from '@/config/query-params';
 import { LAST_NAMESPACE } from '@/store/prefs';
-import { LABEL_PREFIX_TO_IGNORE, ANNOTATIONS_TO_IGNORE_CONTAINS, ANNOTATIONS_TO_IGNORE_PREFIX } from '@/config/labels-annotations';
-import { matchesSomePrefix, containsSomeString } from '@/utils/string';
+import { ANNOTATIONS_TO_IGNORE_REGEX, LABELS_TO_IGNORE_REGEX } from '@/config/labels-annotations';
 import { exceptionToErrorsArray } from '@/utils/error';
 import ChildHook, { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from './child-hook';
 
@@ -50,10 +48,9 @@ export default {
 
     // keep label and annotation filters in data so each resource CRUD page can alter individiaully
     return {
-      errors:                      [],
-      labelPrefixToIgnore:         LABEL_PREFIX_TO_IGNORE,
-      annotationsToIgnoreContains: ANNOTATIONS_TO_IGNORE_CONTAINS,
-      annotationsToIgnorePrefix:   ANNOTATIONS_TO_IGNORE_PREFIX
+      errors:                   [],
+      labelsToIgnoreRegex:      LABELS_TO_IGNORE_REGEX,
+      annotationsToIgnoreRegex: ANNOTATIONS_TO_IGNORE_REGEX
 
     };
   },
@@ -84,13 +81,7 @@ export default {
         return this.value?.labels;
       },
       set(neu) {
-        const all = this.value?.metadata?.labels || {};
-
-        const wasIgnored = pickBy(all, (value, key) => {
-          return matchesSomePrefix(key, this.labelPrefixToIgnore);
-        });
-
-        this.$set(this.value.metadata, 'labels', { ...neu, ...wasIgnored });
+        this.value.setLabels(neu);
       }
     },
 
@@ -99,13 +90,7 @@ export default {
         return this.value?.annotations;
       },
       set(neu) {
-        const all = this.value?.metadata?.annotations || {};
-
-        const wasIgnored = pickBy(all, (value, key) => {
-          return (matchesSomePrefix(key, this.annotationsToIgnorePrefix) || containsSomeString(key, this.annotationsToIgnoreContains));
-        });
-
-        this.$set(this.value.metadata, 'annotations', { ...neu, ...wasIgnored });
+        this.value.setAnnotations(neu);
       }
     },
 

--- a/utils/string.js
+++ b/utils/string.js
@@ -226,28 +226,13 @@ export function coerceStringTypeToScalarType(val, type) {
   return val;
 }
 
-// return true if the string starts with one of the values in prefixes array
-export function matchesSomePrefix(string, prefixes) {
-  for (const prefix of prefixes) {
-    const regex = new RegExp(`^${ prefix }`);
+export function matchesSomeRegex(stringRaw, regexes = []) {
+  return regexes.some((regexRaw) => {
+    const string = stringRaw || '';
+    const regex = ensureRegex(regexRaw);
 
-    if (string.match(regex)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-// return true if string includes at least one of the strings in matchStrings array
-export function containsSomeString(string, matchStrings) {
-  for (const matchString of matchStrings) {
-    if (string.includes(matchString)) {
-      return true;
-    }
-  }
-
-  return false;
+    return string.match(regex);
+  });
 }
 
 export function ensureRegex(strOrRegex, exact = true) {


### PR DESCRIPTION
- Replace prefix and contain lists with regex lists
- Allow each resource to override the filtering by overriding labelsToIgnoreRegexes/annotationsToIgnoreRegexes
- Hide the labels and annotations both from the view and edit of Labels and DetailTop components
- Allow users to modify filtered labels and annotations by entering them manually

rancher/dashboard#556
rancher/dashboard#876