### PR TITLE
Updating label/annotation ignore regex

### DIFF
--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -38,7 +38,7 @@ export const CATALOG = {
   COMPONENT: 'catalog.cattle.io/ui-component',
 };
 
-const CATTLE_REGEX = /.*\.cattle\.io\//;
+const CATTLE_REGEX = /cattle\.io\//;
 
 export const RKE = { EXTERNAL_IP: 'rke.cattle.io/external-ip' };
 


### PR DESCRIPTION
The regex expected there to be a prefix i.e. field.cattle.io/description
and wouldn't ignore something like cattle.io/something