### PR TITLE
Fixing the presentation of keyValue in view mode

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -200,7 +200,7 @@ export default {
       });
     });
 
-    if ( !rows.length && this.initialEmptyRow ) {
+    if ( !rows.length && this.initialEmptyRow && this.mode !== _VIEW ) {
       rows.push({ [this.keyName]: '', [this.valueName]: '' });
     }
 
@@ -268,7 +268,7 @@ export default {
       this.add(fileContents.name, fileContents.value, !asciiLike(fileContents.value));
     },
 
-    download(idx) {
+    download(idx, ev) {
       const row = this.rows[idx];
       const name = row[this.keyName];
       const value = row[this.valueName];
@@ -433,7 +433,7 @@ export default {
       </div>
 
       <div v-if="valueBinary && isView" class="col">
-        <a href="#" @click="download(row)">Download</a>
+        <a href="#" @click="download(i, $event)">Download</a>
       </div>
 
       <div v-if="showRemove" class="col remove">


### PR DESCRIPTION
- The KeyValue component was adding an initial empty row even when the mode was view so this is now only done when it's not view.
- I also noticed it's possible to have empty binary data so I fixed the download button to download an empty file and prevented it from navigating away from the page

rancher/dashboard#1068

I don't think this had anything to do with my previous length changes but I think this fix is reasonable. Let me know if you would like to see something different.