### PR TITLE
Implementing logging overview

### DIFF
--- a/assets/styles/base/_helpers.scss
+++ b/assets/styles/base/_helpers.scss
@@ -238,3 +238,11 @@ $spacing-property-map: (
 .link[disabled] {
   pointer-events: none;
 }
+
+.subtle-box {
+  border: .5px solid var(--subtle-border);
+  box-shadow: 0 0 10px var(--shadow);
+  padding: 20px;
+  margin-bottom: 20px;
+  border-radius: var(--border-radius);
+}

--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -62,6 +62,7 @@
   --disabled-bg: #{$disabled};
   --disabled-text: #{$secondary};
   --box-bg: #{$darkest};
+  --subtle-border: #{$darkest};
   --border: #{$medium};
 
   --accent-btn: #{rgba($primary, 0.2)};

--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -78,6 +78,7 @@ $selected: rgba($primary, .5);
   --disabled-bg                : #{$disabled};
   --disabled-text              : #{$secondary};
   --box-bg                     : #{$lighter};
+  --subtle-border              : #{$medium};
   --border                     : #{$medium};
   --border-radius              : 4px;
   --outline                    : #{rgba($medium, 0.75)};

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -196,6 +196,10 @@ catalog:
       notes: Release Notes
       values: Values YAML
 
+chartHeading:
+  overview: Overview
+  poweredBy: "Powered by:"
+
 cluster:
   nodeDriver:
     displayName:
@@ -479,6 +483,9 @@ logging:
   install:
     deployToControlPlane: Deploy to control plane nodes
     k3sContainerEngine: K3S Container Engine
+  overview:
+    clusterLevel: Cluster-level Logging
+    namespaceLevel: Namespace-level Logging
   provider: Provider
   elasticsearch:
     host: Host
@@ -882,6 +889,9 @@ tableHeaders:
   branch: Branch
   chart: Chart
   clusterCreatorDefault: Cluster Creator Default
+  clusterFlow: Cluster Flow
+  clusterOutput: Cluster Output
+  configuredProviders: Configured Providers
   cpu: CPU
   date: Date
   destination: Target
@@ -893,6 +903,7 @@ tableHeaders:
       one { Host }
       other { Hosts }
     }
+  flow: Flow
   image: Image
   imageSize: Size
   ingressTarget: Target
@@ -904,13 +915,14 @@ tableHeaders:
   matches: Matches
   message: Message
   name: Name
-  namespace: Namespace
   nameUnlinked: Name
+  namespace: Namespace
   namespaceName: Name
   namespaceNameUnlinked: Name
   node: Node
   nodeName: Name
   object: Object
+  output: Output
   p95: 95%tile
   podImages: Image
   pods: Pods

--- a/components/ChartHeading.vue
+++ b/components/ChartHeading.vue
@@ -1,0 +1,21 @@
+<script>
+export default {
+  props: {
+    label: {
+      type:     String,
+      required: true
+    },
+    url: {
+      type:     String,
+      required: true
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="chart-heading">
+    <h1>{{ t('chartHeading.overview') }}</h1>
+    {{ t('chartHeading.poweredBy') }} <a :href="url" rel="nofollow noopener noreferrer" target="_blank">{{ label }}</a>
+  </div>
+</template>

--- a/components/CountGauge.vue
+++ b/components/CountGauge.vue
@@ -65,7 +65,7 @@ export default {
 </script>
 
 <template>
-  <GradientBox class="resource-gauge" :class="{clickable}" :primary-color-var="primaryColorVar" @click.native="visitLocation()">
+  <GradientBox class="count-gauge" :class="{clickable}" :primary-color-var="primaryColorVar" @click.native="visitLocation()">
     <div class="graphical">
       <GraphCircle :primary-stroke-color="`rgba(var(${primaryColorVar}))`" secondary-stroke-color="rgb(var(--resource-gauge-back-circle))" :percentage="percentage" />
     </div>
@@ -85,7 +85,7 @@ export default {
 </template>
 
 <style lang="scss">
-    .resource-gauge {
+    .count-gauge {
         $padding: 10px;
 
         padding: $padding;

--- a/components/ResourceGauge.vue
+++ b/components/ResourceGauge.vue
@@ -1,0 +1,87 @@
+<script>
+import CountGauge from '@/components/CountGauge';
+import { NAME as EXPLORER } from '@/config/product/explorer';
+import { COUNT } from '@/config/types';
+import { colorForState } from '@/plugins/steve/resource-instance';
+
+export function colorToCountName(color) {
+  switch (color) {
+  case 'text-success':
+  case 'text-info':
+    return 'useful';
+  case 'text-warning':
+    return 'warningCount';
+  default:
+    return 'errorCount';
+  }
+}
+
+export function resourceCounts(store, resource) {
+  const clusterCounts = store.getters['cluster/all'](COUNT)[0].counts;
+  const summary = clusterCounts[resource].summary;
+
+  const counts = {
+    total:        summary.count || 0,
+    useful:       0,
+    warningCount: 0,
+    errorCount:   0
+  };
+
+  Object.entries(summary.states || {}).forEach((entry) => {
+    const color = colorForState(entry[0]);
+    const count = entry[1];
+    const countName = colorToCountName(color);
+
+    counts[countName] += count;
+  });
+
+  return counts;
+}
+
+export default {
+  components: { CountGauge },
+  props:      {
+    resource: {
+      type:     String,
+      required: true
+    },
+    primaryColorVar: {
+      type:     String,
+      required: true
+    },
+  },
+
+  computed: {
+    resourceCounts() {
+      return resourceCounts(this.$store, this.resource);
+    },
+
+    location() {
+      return {
+        name:     'c-cluster-product-resource',
+        params:   { product: EXPLORER, resource: this.resource }
+      };
+    },
+
+    name() {
+      const schema = this.$store.getters['cluster/schemaFor'](this.resource);
+
+      return this.$store.getters['type-map/labelFor'](schema, this.resourceCounts.useful);
+    },
+
+    input() {
+      return {
+        name:            this.name,
+        location:        this.location,
+        primaryColorVar: this.primaryColorVar,
+        ...this.resourceCounts
+      };
+    },
+  },
+
+};
+</script>
+
+<template>
+  <CountGauge class="resource-gauge-two" v-bind="input" />
+</template>

--- a/components/formatter/ListLink.vue
+++ b/components/formatter/ListLink.vue
@@ -1,0 +1,21 @@
+<script>
+import Link from './Link';
+
+export default {
+  components: { Link },
+  props:      {
+    value: {
+      type:     Array,
+      default: () => []
+    }
+  },
+};
+</script>
+
+<template>
+  <span>
+    <span v-for="(el, i) in value" :key="el.key">
+      <Link :value="el" /><span v-if="i != value.length - 1">, </span>
+    </span>
+  </span>
+</template>

--- a/config/product/logging.js
+++ b/config/product/logging.js
@@ -6,11 +6,13 @@ export function init(store) {
   const {
     product,
     basicType,
+    virtualType
   } = DSL(store, NAME);
 
   product({ ifHaveGroup: /^(.*\.)?logging\.banzaicloud\.io$/ });
 
   basicType([
+    'logging-overview',
     'logging.banzaicloud.io.logging',
     'logging.banzaicloud.io.common',
     'logging.banzaicloud.io.clusterflow',
@@ -18,4 +20,11 @@ export function init(store) {
     'logging.banzaicloud.io.flow',
     'logging.banzaicloud.io.output',
   ]);
+
+  virtualType({
+    label:      'Overview',
+    namespaced: false,
+    name:       'logging-overview',
+    route:      { name: 'c-cluster-logging' },
+  });
 }

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -48,12 +48,53 @@ export const EFFECT = {
   sort:     ['effect'],
 };
 
+export const FLOW = {
+  name:      'flow',
+  labelKey:  'tableHeaders.flow',
+  value:     'flow',
+  sort:      ['flow.name'],
+  formatter: 'Link'
+};
+
+export const CLUSTER_FLOW = {
+  ...FLOW,
+  labelKey: 'tableHeaders.clusterFlow'
+};
+
+export const OUTPUT = {
+  name:      'output',
+  labelKey:  'tableHeaders.output',
+  value:     'outputs',
+  sort:      'outputs.text',
+  formatter: 'ListLink'
+};
+
+export const CONFIGURED_PROVIDERS = {
+  name:      'configuredProviders',
+  labelKey:  'tableHeaders.configuredProviders',
+  value:     'providers',
+  sort:      'providers',
+  formatter: 'List'
+};
+
+export const CLUSTER_OUTPUT = {
+  ...OUTPUT,
+  labelKey: 'tableHeaders.clusterOutput',
+};
+
 export const NAME_UNLINKED = {
   name:          'name',
   labelKey:      'tableHeaders.nameUnlinked',
   value:         'nameDisplay',
   sort:          ['nameSort'],
   canBeVariable: true,
+};
+
+export const NAMESPACE = {
+  name:     'namespace',
+  labelKey: 'tableHeaders.namespace',
+  value:    'metadata.namespace',
+  sort:     'namespace',
 };
 
 export const NAMESPACE_NAME_UNLINKED = {

--- a/config/types.js
+++ b/config/types.js
@@ -130,3 +130,11 @@ export const RIO = {
 
   SYSTEM_NAMESPACE: 'rio-system',
 };
+
+export const LOGGING = {
+  LOGGINGS:        'logging.banzaicloud.io.logging',
+  CLUSTER_FLOWS:   'logging.banzaicloud.io.clusterflow',
+  CLUSTER_OUTPUTS: 'logging.banzaicloud.io.clusteroutput',
+  FLOWS:           'logging.banzaicloud.io.flow',
+  OUTPUTS:         'logging.banzaicloud.io.output'
+};

--- a/pages/c/_cluster/logging/index.vue
+++ b/pages/c/_cluster/logging/index.vue
@@ -1,10 +1,115 @@
 <script>
 import { NAME, CHART_NAME } from '@/config/product/logging';
 import InstallRedirect from '@/utils/install-redirect';
+import { LOGGING } from '@/config/types';
+import SortableTable from '@/components/SortableTable';
+import { allHash } from '@/utils/promise';
+import {
+  FLOW, CONFIGURED_PROVIDERS, CLUSTER_FLOW, CLUSTER_OUTPUT, OUTPUT, NAMESPACE
+} from '@/config/table-headers';
+import ChartHeading from '@/components/ChartHeading';
+import uniq from 'lodash/uniq';
 
-export default { middleware: InstallRedirect(NAME, CHART_NAME) };
+export default {
+  middleware: InstallRedirect(NAME, CHART_NAME),
+  components: { ChartHeading, SortableTable },
+  async fetch() {
+    const hash = await allHash({
+      clusterFlows:   this.$store.dispatch('cluster/findAll', { type: LOGGING.CLUSTER_FLOWS }),
+      flows:          this.$store.dispatch('cluster/findAll', { type: LOGGING.FLOWS }),
+      clusterOutputs: this.$store.dispatch('cluster/findAll', { type: LOGGING.CLUSTER_OUTPUTS }),
+      outputs:         this.$store.dispatch('cluster/findAll', { type: LOGGING.OUTPUTS }),
+    });
+
+    this.clusterFlows = hash.clusterFlows || [];
+    this.flows = hash.flows || [];
+    this.clusterOutputs = hash.clusterOutputs || [];
+    this.outputs = hash.outputs || [];
+  },
+
+  data() {
+    return {
+      clusterFlows:              [],
+      flows:                     [],
+      clusterOutputs:            [],
+      outputs:                   [],
+      namespaceFlowTableHeaders: [
+        { ...NAMESPACE, value: 'flow.metadata.namespace' },
+        FLOW,
+        OUTPUT,
+        CONFIGURED_PROVIDERS
+      ],
+      clusterFlowTableHeaders: [
+        CLUSTER_FLOW, CLUSTER_OUTPUT, CONFIGURED_PROVIDERS
+      ]
+    };
+  },
+
+  computed: {
+    clusterLevelLogging() {
+      return this.mapFlows(this.clusterFlows, this.clusterOutputs);
+    },
+
+    namespaceLevelLogging() {
+      return this.mapFlows(this.flows, this.outputs);
+    }
+  },
+
+  methods: {
+    mapFlows(flows, outputs) {
+      return flows.map((flow) => {
+        const outputRefs = flow.spec.outputRefs;
+        const linkedOutputs = outputs.filter((output) => {
+          return outputRefs.includes(output.metadata.name);
+        }).map(this.link);
+
+        const providers = linkedOutputs
+          .flatMap(output => Object.keys(output.spec))
+          .filter(provider => provider !== 'loggingRef');
+
+        return {
+          flow: this.link(flow), outputs: linkedOutputs, providers: uniq(providers)
+        };
+      });
+    },
+
+    link(resource) {
+      return {
+        text:    resource.nameDisplay,
+        url:     resource.detailLocation,
+        options: 'internal',
+        ...resource
+      };
+    }
+  }
+};
 </script>
 
 <template>
-  <div>This is logging.</div>
+  <div class="logging">
+    <ChartHeading label="Banzai Cloud" url="https://github.com/banzaicloud/logging-operator" />
+    <div class="spacer" />
+    <h2>{{ t('logging.overview.clusterLevel') }}</h2>
+    <SortableTable
+      class="sortable-table"
+      :headers="clusterFlowTableHeaders"
+      :rows="clusterLevelLogging"
+      :row-actions="false"
+      :search="false"
+      :table-actions="false"
+      key-field="id"
+    />
+    <h2 class="mt-20">
+      {{ t('logging.overview.namespaceLevel') }}
+    </h2>
+    <SortableTable
+      class="sortable-table"
+      :headers="namespaceFlowTableHeaders"
+      :rows="namespaceLevelLogging"
+      :row-actions="false"
+      :search="false"
+      :table-actions="false"
+      key-field="id"
+    />
+  </div>
 </template>


### PR DESCRIPTION
- Made a generic CountGauge
- Made ResourceGauge a specialization of CountGauge
- Swapped the cluster overview page to using the counts instead of requesting the resources

rancher/dashboard#1089

![Screen Shot 2020-09-03 at 5 23 08 PM](https://user-images.githubusercontent.com/55104481/92186342-5701ad00-ee0b-11ea-8788-564e45f8a153.png)
