### PR TITLE
cis pr feedback

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1646,6 +1646,21 @@ typeDescription:
   #       target="_blank" rel="noopener noreferrer nofollow"
 
 typeLabel:
+  cis.cattle.io.clusterscan: |-
+    {count, plural,
+      one { Scan }
+      other { Scans }
+    }
+  cis.cattle.io.clusterscanprofile: |-
+    {count, plural,
+      one { Profile }
+      other { Profiles }
+    }
+  cis.cattle.io.clusterscanbenchmark: |-
+    {count, plural,
+      one { Benchmark Version }
+      other { Benchmark Versions }
+    }
   catalog.cattle.io.operation: |-
     {count, plural,
       one { Recent Operation }

--- a/components/SortableTable/sorting.js
+++ b/components/SortableTable/sorting.js
@@ -39,36 +39,43 @@ export default {
     let sortBy = null;
     let descending = false;
 
-    this._defaultSortBy = this.defaultSortBy;
+    const defaultSortCol = this.headers.find(x => x.defaultSort);
 
-    // Try to find a reasonable default sort
-    if ( !this._defaultSortBy ) {
-      const nameColumn = this.headers.find( x => x.name === 'name');
+    if (defaultSortCol) {
+      sortBy = defaultSortCol.sort;
+      descending = defaultSortCol.defaultSort;
+    } else {
+      this._defaultSortBy = this.defaultSortBy;
 
-      if ( nameColumn ) {
-        // Use the name column if there is one
-        this._defaultSortBy = nameColumn.name;
-      } else {
-        // The first column that isn't state
-        const first = this.headers.filter( x => x.name !== 'state' )[0];
+      // Try to find a reasonable default sort
+      if ( !this._defaultSortBy ) {
+        const nameColumn = this.headers.find( x => x.name === 'name');
 
-        if ( first ) {
-          this._defaultSortBy = first.name;
+        if ( nameColumn ) {
+          // Use the name column if there is one
+          this._defaultSortBy = nameColumn.name;
         } else {
-          // I give up
-          this._defaultSortBy = 'id';
+          // The first column that isn't state
+          const first = this.headers.filter( x => x.name !== 'state' )[0];
+
+          if ( first ) {
+            this._defaultSortBy = first.name;
+          } else {
+            // I give up
+            this._defaultSortBy = 'id';
+          }
         }
       }
+
+      sortBy = this.$route.query.sort;
+
+      // If the sort column doesn't exist or isn't specified, use default
+      if ( !sortBy || !this.headers.find(x => x.name === sortBy ) ) {
+        sortBy = this._defaultSortBy;
+      }
+
+      descending = (typeof this.$route.query.desc) !== 'undefined';
     }
-
-    sortBy = this.$route.query.sort;
-
-    // If the sort column doesn't exist or isn't specified, use default
-    if ( !sortBy || !this.headers.find(x => x.name === sortBy ) ) {
-      sortBy = this._defaultSortBy;
-    }
-
-    descending = (typeof this.$route.query.desc) !== 'undefined';
 
     return {
       sortBy,

--- a/components/form/NameNsDescription.vue
+++ b/components/form/NameNsDescription.vue
@@ -166,10 +166,6 @@ export default {
       return out;
     },
 
-    hasName() {
-      return !!this.name;
-    },
-
     isView() {
       return this.mode === _VIEW;
     },

--- a/components/formatter/Link.vue
+++ b/components/formatter/Link.vue
@@ -18,6 +18,11 @@ export default {
       required: true
     },
 
+    to: {
+      type:    Object,
+      default: null
+    },
+
     urlKey: {
       type:    String,
       default: null,
@@ -58,6 +63,18 @@ export default {
     href() {
       if ( this.urlKey ) {
         return get(this.row, this.urlKey);
+      }
+
+      if ((this.options === 'internal' || this.options?.internal) && this.to) {
+        const defaultParams = this.$route.params;
+        const toParams = this.to.params || {};
+
+        return {
+          ...this.to,
+          params: {
+            id: this.value, ...defaultParams, ...toParams
+          }
+        };
       }
 
       return this.value?.url;

--- a/config/product/rancher-cis-benchmark.js
+++ b/config/product/rancher-cis-benchmark.js
@@ -1,5 +1,6 @@
 import { DSL } from '@/store/type-map';
 import { CIS } from '@/config/types';
+import { STATE, NAME as NAME_HEADER } from '@/config/table-headers';
 
 export const NAME = 'cis';
 export const CHART_NAME = 'rancher-cis-benchmark';
@@ -9,11 +10,13 @@ export function init(store) {
     product,
     basicType,
     weightType,
+    formOnlyType,
+    headers
   } = DSL(store, NAME);
 
   product({
     ifHaveGroup: /^(.*\.)*cis\.cattle\.io$/,
-    icon:        'cis',
+    // icon:        'cis',
   });
 
   weightType(CIS.CLUSTER_SCAN, 3, true);
@@ -24,5 +27,56 @@ export function init(store) {
     'cis.cattle.io.clusterscan',
     'cis.cattle.io.clusterscanprofile',
     'cis.cattle.io.clusterscanbenchmark',
+  ]);
+
+  formOnlyType(CIS.CLUSTER_SCAN);
+
+  headers(CIS.CLUSTER_SCAN, [
+    STATE,
+    NAME_HEADER,
+    {
+      name:          'clusterScanProfile',
+      label:         'Profile',
+      value:         'status.lastRunScanProfileName',
+      formatter:     'Link',
+      formatterOpts: { options: 'internal', to: { name: 'c-cluster-product-resource-id', params: { resource: CIS.CLUSTER_SCAN_PROFILE } } },
+      sort:          ['status.lastRunScanProfileName'],
+    },
+    {
+      name:      'total',
+      label:  'Total',
+      value:     'status.summary.total',
+    },
+    {
+      name:      'pass',
+      label:  'Pass',
+      value:     'status.summary.pass',
+    },
+    {
+      name:      'fail',
+      label:  'Fail',
+      value:     'status.summary.fail',
+    },
+    {
+      name:      'skip',
+      label:  'Skip',
+      value:     'status.summary.skip',
+    },
+    {
+      name:      'notApplicable',
+      label:  'N/A',
+      value:     'status.summary.notApplicable',
+    },
+    {
+      name:          'lastRunTimestamp',
+      label:         'Last Run',
+      value:         'status.lastRunTimestamp',
+      formatter:     'LiveDate',
+      formatterOpts: { addSuffix: true },
+      sort:          'status.lastRunTimestap',
+      width:         150,
+      align:         'right',
+      defaultSort:   'desc'
+    },
   ]);
 }

--- a/edit/cis.cattle.io.clusterscan.vue
+++ b/edit/cis.cattle.io.clusterscan.vue
@@ -98,7 +98,7 @@ export default {
       const clusterVersion = currentCluster.kubernetesVersion;
 
       if (!!benchmark?.spec?.clusterProvider) {
-        return benchmark?.spec?.clusterProvider === currentCluster.provider;
+        return benchmark?.spec?.clusterProvider === currentCluster.status.provider;
       }
       if (benchmark?.spec?.minKubernetesVersion) {
         if (semver.gt(benchmark?.spec?.minKubernetesVersion, clusterVersion)) {

--- a/edit/cis.cattle.io.clusterscanprofile.vue
+++ b/edit/cis.cattle.io.clusterscanprofile.vue
@@ -114,7 +114,7 @@ export default {
         <div class="row">
           <div class="col span-6">
             <h3>{{ t('cis.testsToSkip') }}</h3>
-            <ArrayList v-model="value.skipTests" :value-label="t('cis.testID')" :show-header="true" :add-label="t('cis.addTest')" :mode="mode" />
+            <ArrayList v-model="value.spec.skipTests" :value-label="t('cis.testID')" :show-header="true" :add-label="t('cis.addTest')" :mode="mode" />
           </div>
         </div>
       </template>

--- a/models/cis.cattle.io.clusterscan.js
+++ b/models/cis.cattle.io.clusterscan.js
@@ -1,30 +1,58 @@
 import { CIS } from '@/config/types';
 import { downloadFile } from '@/utils/download';
 import { colorForState } from '@/plugins/steve/resource-instance';
+import Papa from 'papaparse';
 
 export default {
   availableActions() {
-    const out = this._standardActions;
+    this.getReport();
+    let out = this._standardActions;
+
+    const toFilter = ['cloneYaml', 'goToEditYaml', 'download'];
+
+    out = out.filter((action) => {
+      if (!toFilter.includes(action.action)) {
+        return action;
+      }
+    });
     const downloadLogs = {
       action:     'downloadReport',
-      enabled:    true,
+      enabled:    this.hasReport,
       icon:       'icon icon-fw icon-chevron-right',
       label:      'Download Report',
       total:      1,
     };
 
-    out.push(downloadLogs);
+    out.unshift(downloadLogs);
 
     return out;
   },
 
-  downloadReport() {
+  hasReport: false,
+
+  getReport() {
     return async() => {
       const owned = await this.getOwned();
       const reportCRD = owned.filter(each => each.type === CIS.REPORT)[0];
-      const JSON = reportCRD?.spec?.reportJSON;
 
-      downloadFile(`${ reportCRD.id }.json`, JSON, 'application/json');
+      this.hasReport = !!reportCRD;
+
+      return reportCRD;
+    };
+  },
+
+  downloadReport() {
+    return async() => {
+      const report = await this.getReport();
+
+      try {
+        const testResults = report.aggregatedTests;
+        const csv = Papa.unparse(testResults);
+
+        downloadFile(`${ report.id }.csv`, csv, 'application/csv');
+      } catch (err) {
+        this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+      }
     };
   },
 

--- a/models/cis.cattle.io.clusterscanreport.js
+++ b/models/cis.cattle.io.clusterscanreport.js
@@ -1,0 +1,29 @@
+export default {
+  aggregatedTests() {
+    const json = this.reportJSON;
+    const results = json?.results;
+
+    return results ? results.reduce((all, each) => {
+      if (each.checks) {
+        all.push(...each.checks);
+      }
+
+      return all;
+    }, []) : null;
+  },
+
+  nodes() {
+    return this.reportJSON ? this.reportJSON.nodes : {};
+  },
+
+  reportJSON() {
+    try {
+      const json = this.spec?.reportJSON;
+
+      const parsed = JSON.parse(json);
+
+      return parsed;
+    } catch (e) {
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "marked": "^1.1.1",
     "node-sass": "^4.12.0",
     "nuxt": "2.14.5",
+    "papaparse": "^5.3.0",
     "portal-vue": "^2.1.5",
     "require-extension-hooks": "^0.3.3",
     "require-extension-hooks-babel": "^1.0.0-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11861,6 +11861,11 @@ pako@~1.0.2, pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
+papaparse@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.0.tgz#ab1702feb96e79ab4309652f36db9536563ad05a"
+  integrity sha512-Lb7jN/4bTpiuGPrYy4tkKoUS8sTki8zacB5ke1p5zolhcSE4TlWgrlsxjrDTbG/dFVh07ck7X36hUf/b5V68pg==
+
 parallel-transform@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.2.0.tgz#9049ca37d6cb2182c3b1d2c720be94d14a5814fc"


### PR DESCRIPTION
#1035 #1036 
- fixed clusterscanprofile skipTests in yaml view
- fixed clusterscanprofile selected in the clusterscan create page
- fixed clusterscan table formatters 
- 'download report' downloads a csv
- hid download report when there's no report generated
- hid various yaml options as they aren't useful here

The issue of state not updating without a page refresh doesn't appear specific to CIS.

<img width="1209" alt="Screen Shot 2020-09-21 at 2 38 28 PM" src="https://user-images.githubusercontent.com/42977925/93824665-aa9c3500-fc18-11ea-8352-34d9a7d6f223.png">
<img width="1465" alt="Screen Shot 2020-09-21 at 2 32 53 PM" src="https://user-images.githubusercontent.com/42977925/93824667-ac65f880-fc18-11ea-8034-a53c837cd661.png">

