### PR TITLE
statefulset create-yaml error

### DIFF
--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -56,7 +56,8 @@ export function createYaml(schemas, type, data, processAlwaysAdd = true, depth =
   const schema = schemas.find(x => x.id === type);
 
   if ( !schema ) {
-    throw new Error('Unknown schema for', type);
+    return `Error loading schema for ${ type }`;
+    // throw new Error('Unknown schema for', type);
   }
 
   data = data || {};


### PR DESCRIPTION
I updated `create-yaml` to return "Error loading schema for <type>" so the whole page doesn't break if part of it fails to load:
<img width="1178" alt="Screen Shot 2020-09-21 at 2 59 38 PM" src="https://user-images.githubusercontent.com/42977925/93825943-17183380-fc1b-11ea-8b7b-1103dc786fba.png">

This will allow the Statefulset forms to load correctly #921 but doesn't address whatever underlying issue there is with the schema.