### PR TITLE
Add logging CHART_NAME

### DIFF
--- a/config/product/logging.js
+++ b/config/product/logging.js
@@ -1,6 +1,7 @@
 import { DSL } from '@/store/type-map';
 
 export const NAME = 'logging';
+export const CHART_NAME = 'rancher-logging';
 
 export function init(store) {
   const {


### PR DESCRIPTION
rancher/dashboard#1345

I couldn't validate this. The redirect appeared to work with or without CHART_NAME. I was visiting https://localhost:8000/dashboard/c/local/logging and I was taken to the Logging overview page with and without.