### PR TITLE
Subscribe & CIS Bugs

### DIFF
--- a/components/BadgeState.vue
+++ b/components/BadgeState.vue
@@ -2,17 +2,39 @@
 
 export default {
   props: {
+    // Set either value or color+label
+    // A resource with stateBackground and stateDisplay
     value: {
-      type:     Object,
-      required: true
-    }
+      type:    Object,
+      default: null,
+    },
+
+    color: {
+      type:    String,
+      default: null,
+    },
+
+    label: {
+      type:    String,
+      default: null,
+    },
   },
+
+  computed: {
+    bg() {
+      return this.value?.stateBackground || this.color;
+    },
+
+    msg() {
+      return this.value?.stateDisplay || this.label;
+    }
+  }
 };
 </script>
 
 <template>
-  <span :class="{'badge-state': true, [value.stateBackground]: true}">
-    {{ value.stateDisplay }}
+  <span :class="{'badge-state': true, [bg]: true}">
+    {{ msg }}
   </span>
 </template>
 

--- a/components/ResourceList/Masthead.vue
+++ b/components/ResourceList/Masthead.vue
@@ -85,6 +85,14 @@ export default {
 
 <template>
   <header>
+    <Banner
+      v-if="typeDescriptionKey"
+      class="type-banner mb-20 mt-0"
+      color="info"
+      :closable="true"
+      :label-key="typeDescriptionKey"
+      @close="hideTypeDescription"
+    />
     <h1>
       {{ typeDisplay }} <Favorite v-if="isExplorer" :resource="resource" />
     </h1>
@@ -148,13 +156,5 @@ export default {
         </template>
       </ButtonDropdown>
     </div>
-    <Banner
-      v-if="typeDescriptionKey"
-      class="state-banner mt-20 mb-0"
-      color="info"
-      :closable="true"
-      :label-key="typeDescriptionKey"
-      @close="hideTypeDescription"
-    />
   </header>
 </template>

--- a/components/SortableTable/sorting.js
+++ b/components/SortableTable/sorting.js
@@ -39,43 +39,39 @@ export default {
     let sortBy = null;
     let descending = false;
 
-    const defaultSortCol = this.headers.find(x => x.defaultSort);
+    this._defaultSortBy = this.defaultSortBy;
 
-    if (defaultSortCol) {
-      sortBy = defaultSortCol.sort;
-      descending = defaultSortCol.defaultSort;
-    } else {
-      this._defaultSortBy = this.defaultSortBy;
+    // Try to find a reasonable default sort
+    if ( !this._defaultSortBy ) {
+      const markedColumn = this.headers.find(x => !!x.defaultSort);
+      const nameColumn = this.headers.find( x => x.name === 'name');
 
-      // Try to find a reasonable default sort
-      if ( !this._defaultSortBy ) {
-        const nameColumn = this.headers.find( x => x.name === 'name');
+      if ( markedColumn ) {
+        this._defaultSortBy = markedColumn.name;
+      } else if ( nameColumn ) {
+        // Use the name column if there is one
+        this._defaultSortBy = nameColumn.name;
+      } else {
+        // The first column that isn't state
+        const first = this.headers.filter( x => x.name !== 'state' )[0];
 
-        if ( nameColumn ) {
-          // Use the name column if there is one
-          this._defaultSortBy = nameColumn.name;
+        if ( first ) {
+          this._defaultSortBy = first.name;
         } else {
-          // The first column that isn't state
-          const first = this.headers.filter( x => x.name !== 'state' )[0];
-
-          if ( first ) {
-            this._defaultSortBy = first.name;
-          } else {
-            // I give up
-            this._defaultSortBy = 'id';
-          }
+          // I give up
+          this._defaultSortBy = 'id';
         }
       }
-
-      sortBy = this.$route.query.sort;
-
-      // If the sort column doesn't exist or isn't specified, use default
-      if ( !sortBy || !this.headers.find(x => x.name === sortBy ) ) {
-        sortBy = this._defaultSortBy;
-      }
-
-      descending = (typeof this.$route.query.desc) !== 'undefined';
     }
+
+    sortBy = this.$route.query.sort;
+
+    // If the sort column doesn't exist or isn't specified, use default
+    if ( !sortBy || !this.headers.find(x => x.name === sortBy ) ) {
+      sortBy = this._defaultSortBy;
+    }
+
+    descending = (typeof this.$route.query.desc) !== 'undefined';
 
     return {
       sortBy,

--- a/components/formatter/BadgeStateFormatter.vue
+++ b/components/formatter/BadgeStateFormatter.vue
@@ -39,5 +39,8 @@ export default {
 </script>
 
 <template>
-  <BadgeState :value="arbitrary ? {stateDisplay, stateBackground} : row" />
+  <div>
+    <BadgeState v-if="arbitrary" :color="stateBackground" :label="stateDisplay" />
+    <BadgeState v-else :value="row" />
+  </div>
 </template>

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -34,36 +34,36 @@ export default {
 <template>
   <header :class="{explorer: isExplorer}">
     <div class="product">
-      <ProductSwitcher />
+      <ProductSwitcher v-if="currentCluster" />
       <div alt="Logo" class="logo">
         <img src="~/assets/images/half-logo.svg" />
       </div>
     </div>
 
     <div class="apps">
-      <nuxt-link :to="{name: 'c-cluster-apps', params: { cluster: currentCluster.id }}" class="btn role-tertiary">
+      <nuxt-link v-if="currentCluster" :to="{name: 'c-cluster-apps', params: { cluster: currentCluster.id }}" class="btn role-tertiary">
         <i class="icon icon-lg icon-marketplace pr-5" /> Apps
       </nuxt-link>
     </div>
 
     <div class="top">
-      <NamespaceFilter v-if="clusterReady && currentProduct.showNamespaceFilter" />
+      <NamespaceFilter v-if="clusterReady && currentProduct && currentProduct.showNamespaceFilter" />
     </div>
 
     <div class="back">
-      <a class="btn role-tertiary" :href="(currentProduct.inStore === 'management' ? backToRancherGlobalLink : backToRancherLink)">
+      <a v-if="currentProduct" class="btn role-tertiary" :href="(currentProduct.inStore === 'management' ? backToRancherGlobalLink : backToRancherLink)">
         {{ t('nav.backToRancher') }}
       </a>
     </div>
 
     <div class="kubectl">
-      <button v-if="currentProduct.showClusterSwitcher" :disabled="!showShell" type="button" class="btn role-tertiary" @click="currentCluster.openShell()">
+      <button v-if="currentProduct && currentProduct.showClusterSwitcher" :disabled="!showShell" type="button" class="btn role-tertiary" @click="currentCluster.openShell()">
         <i class="icon icon-terminal icon-lg" /> {{ t('nav.shell') }}
       </button>
     </div>
 
     <div class="cluster">
-      <ClusterSwitcher v-if="isMultiCluster && currentProduct.showClusterSwitcher" />
+      <ClusterSwitcher v-if="isMultiCluster && currentProduct && currentProduct.showClusterSwitcher" />
     </div>
 
     <div class="user">

--- a/config/product/cis.js
+++ b/config/product/cis.js
@@ -43,29 +43,29 @@ export function init(store) {
       sort:          ['status.lastRunScanProfileName'],
     },
     {
-      name:      'total',
+      name:   'total',
       label:  'Total',
-      value:     'status.summary.total',
+      value:  'status.summary.total',
     },
     {
-      name:      'pass',
+      name:   'pass',
       label:  'Pass',
-      value:     'status.summary.pass',
+      value:  'status.summary.pass',
     },
     {
-      name:      'fail',
+      name:   'fail',
       label:  'Fail',
-      value:     'status.summary.fail',
+      value:  'status.summary.fail',
     },
     {
-      name:      'skip',
+      name:   'skip',
       label:  'Skip',
-      value:     'status.summary.skip',
+      value:  'status.summary.skip',
     },
     {
-      name:      'notApplicable',
+      name:   'notApplicable',
       label:  'N/A',
-      value:     'status.summary.notApplicable',
+      value:  'status.summary.notApplicable',
     },
     {
       name:          'lastRunTimestamp',
@@ -73,10 +73,10 @@ export function init(store) {
       value:         'status.lastRunTimestamp',
       formatter:     'LiveDate',
       formatterOpts: { addSuffix: true },
-      sort:          'status.lastRunTimestap',
+      sort:          'status.lastRunTimestamp:desc',
       width:         150,
       align:         'right',
-      defaultSort:   'desc'
+      defaultSort:   true,
     },
   ]);
 }

--- a/detail/cis.cattle.io.clusterscan.vue
+++ b/detail/cis.cattle.io.clusterscan.vue
@@ -178,7 +178,7 @@ export default {
       const SORT_ORDER = {
         fail:          1,
         skip:          2,
-        notApplicable:    3,
+        notApplicable: 3,
         pass:          4,
         other:         5,
       };

--- a/edit/catalog.cattle.io.repo.vue
+++ b/edit/catalog.cattle.io.repo.vue
@@ -1,4 +1,0 @@
-<script>
-import ClusterRepo from './catalog.cattle.io.clusterrepo';
-export default ClusterRepo;
-</script>

--- a/edit/configmap.vue
+++ b/edit/configmap.vue
@@ -46,7 +46,7 @@ export default {
     <div class="spacer"></div>
 
     <Tabbed :side-tabs="true">
-      <Tab name="data" :label="t('configmap.tabs.data.label')" :weight="1">
+      <Tab name="data" :label="t('configmap.tabs.data.label')" :weight="2">
         <KeyValue
           key="data"
           v-model="value.data"
@@ -55,7 +55,7 @@ export default {
           :initial-empty-row="true"
         />
       </Tab>
-      <Tab name="binary-data" :label="t('configmap.tabs.binaryData.label')" :weight="2">
+      <Tab name="binary-data" :label="t('configmap.tabs.binaryData.label')" :weight="1">
         <KeyValue
           key="binaryData"
           v-model="value.binaryData"
@@ -74,7 +74,7 @@ export default {
         v-if="!isView"
         name="labels-and-annotations"
         :label="t('generic.labelsAndAnnotations')"
-        :weight="1000"
+        :weight="-1"
       >
         <Labels
           default-container-class="labels-and-annotations-container"

--- a/edit/gatekeeper-constraint.vue
+++ b/edit/gatekeeper-constraint.vue
@@ -247,7 +247,7 @@ export default {
           <div class="spacer"></div>
         </div>
         <Tabbed :side-tabs="true">
-          <Tab name="parameters" :label="t('gatekeeperConstraint.tab.parameters.title')" :weight="1">
+          <Tab name="parameters" :label="t('gatekeeperConstraint.tab.parameters.title')" :weight="4">
             <div>
               <div v-if="showParametersAsYaml">
                 <YamlEditor
@@ -279,7 +279,8 @@ export default {
               </KeyValue>
             </div>
           </Tab>
-          <Tab name="enforcement-action" :label="t('gatekeeperConstraint.tab.enforcementAction.title')" :weight="2">
+
+          <Tab name="enforcement-action" :label="t('gatekeeperConstraint.tab.enforcementAction.title')" :weight="3">
             <RadioGroup
               v-model="value.spec.enforcementAction"
               name="enforcementAction"
@@ -290,7 +291,8 @@ export default {
               @input="e=>value.spec.enforcementAction = e"
             />
           </Tab>
-          <Tab name="namespaces" :label="t('gatekeeperConstraint.tab.namespaces.title')" :weight="3">
+
+          <Tab name="namespaces" :label="t('gatekeeperConstraint.tab.namespaces.title')" :weight="2">
             <div class="row">
               <div class="col span-6">
                 <h3>{{ t('gatekeeperConstraint.tab.namespaces.sub.namespaces') }}</h3>
@@ -302,7 +304,8 @@ export default {
               </div>
             </div>
           </Tab>
-          <Tab name="selectors" :label="t('gatekeeperConstraint.tab.selectors.title')" :weight="4">
+
+          <Tab name="selectors" :label="t('gatekeeperConstraint.tab.selectors.title')" :weight="1">
             <div class="row">
               <div class="col span-6">
                 <h3>{{ t('gatekeeperConstraint.tab.selectors.sub.labelSelector.title') }}</h3>

--- a/edit/logging.banzaicloud.io.flow.vue
+++ b/edit/logging.banzaicloud.io.flow.vue
@@ -125,7 +125,7 @@ export default {
         v-if="!isView"
         name="labels-and-annotations"
         :label="t('generic.labelsAndAnnotations')"
-        :weight="1000"
+        :weight="-1"
       >
         <Labels
           default-container-class="labels-and-annotations-container"

--- a/edit/logging.banzaicloud.io.output/index.vue
+++ b/edit/logging.banzaicloud.io.output/index.vue
@@ -123,7 +123,7 @@ export default {
         :register-before-hook="registerBeforeHook"
       />
       <Tabbed ref="tabbed" :side-tabs="true">
-        <Tab v-if="!isView" name="overview" :label="t('logging.output.selectOutputs')" :weight="0">
+        <Tab v-if="!isView" name="overview" :label="t('logging.output.selectOutputs')" :weight="100">
           <Banner class="mt-0" color="info">
             {{ t('logging.output.selectBanner') }}
           </Banner>
@@ -138,7 +138,7 @@ export default {
             </ToggleGradientBox>
           </div>
         </Tab>
-        <Tab v-for="(provider, i) in enabledProviders" :key="i" :name="provider.name" :label="provider.label" :weight="i + 1">
+        <Tab v-for="(provider, i) in enabledProviders" :key="i" :name="provider.name" :label="provider.label" :weight="enabledProviders.length - i + 1">
           <div class="provider mb-10">
             <h1>
               {{ provider.label }}

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -120,7 +120,7 @@ export default {
         v-if="!isView"
         name="labels-and-annotations"
         :label="t('generic.labelsAndAnnotations')"
-        :weight="1000"
+        :weight="-1"
       >
         <Labels
           default-container-class="labels-and-annotations-container"

--- a/edit/networking.k8s.io.ingress/index.vue
+++ b/edit/networking.k8s.io.ingress/index.vue
@@ -113,13 +113,13 @@ export default {
     <div class="spacer"></div>
 
     <Tabbed :side-tabs="true">
-      <Tab :label="t('ingress.rules.title')" name="rules" :weight="0">
+      <Tab :label="t('ingress.rules.title')" name="rules" :weight="2">
         <Rules v-model="value" :mode="mode" :service-targets="serviceTargets" />
       </Tab>
       <Tab :label="t('ingress.certificates.label')" name="certificates" :weight="1">
         <Certificates v-model="value" :mode="mode" :secrets="allSecrets" />
       </Tab>
-      <Tab :label="t('ingress.defaultBackend.label')" name="default-backend" :weight="2">
+      <Tab :label="t('ingress.defaultBackend.label')" name="default-backend" :weight="0">
         <DefaultBackend v-model="value.spec.backend" :service-targets="serviceTargets" :mode="mode" />
       </Tab>
       <Tab

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -322,7 +322,7 @@ export default {
         v-if="!isView"
         name="labels-and-annotations"
         :label="t('servicesPage.labelsAnnotations.label', {}, true)"
-        :weight="1000"
+        :weight="-1"
       >
         <Labels
           :default-container-class="'labels-and-annotations-container'"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -319,7 +319,8 @@ export default {
 
     HEADER {
       display: grid;
-      grid-template-areas:  "title actions"
+      grid-template-areas:  "type-banner type-banner"
+                            "title actions"
                             "state-banner state-banner";
       grid-template-columns: "auto min-content";
       margin-bottom: 20px;
@@ -328,6 +329,10 @@ export default {
       H1 {
         grid-area: title;
         margin: 0;
+      }
+
+      .type-banner {
+        grid-area: type-banner;
       }
 
       .state-banner {

--- a/models/cis.cattle.io.clusterscan.js
+++ b/models/cis.cattle.io.clusterscan.js
@@ -1,10 +1,8 @@
 import { CIS } from '@/config/types';
 import { downloadFile } from '@/utils/download';
-import { colorForState } from '@/plugins/steve/resource-instance';
-import Papa from 'papaparse';
 
 export default {
-  availableActions() {
+  _availableActions() {
     this.getReport();
     let out = this._standardActions;
 
@@ -15,7 +13,8 @@ export default {
         return action;
       }
     });
-    const downloadLogs = {
+
+    const downloadReport = {
       action:     'downloadReport',
       enabled:    this.hasReport,
       icon:       'icon icon-fw icon-chevron-right',
@@ -23,7 +22,8 @@ export default {
       total:      1,
     };
 
-    out.unshift(downloadLogs);
+    out.unshift({ divider: true });
+    out.unshift(downloadReport);
 
     return out;
   },
@@ -44,6 +44,7 @@ export default {
   downloadReport() {
     return async() => {
       const report = await this.getReport();
+      const Papa = await import(/* webpackChunkName: "cis" */'papaparse');
 
       try {
         const testResults = report.aggregatedTests;
@@ -53,16 +54,6 @@ export default {
       } catch (err) {
         this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
       }
-    };
-  },
-
-  testState() {
-    return (state) => {
-      const color = colorForState.call(this, this.state);
-
-      const bgColor = this.color.replace('text-', 'bg-');
-
-      return { color, bgColor };
     };
   },
 };

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -43,11 +43,22 @@ function load(state, { data, ctx, existing }) {
 
   let entry;
 
+  function replace(existing, data) {
+    for ( const k of Object.keys(existing) ) {
+      delete existing[k];
+    }
+
+    for ( const k of Object.keys(data) ) {
+      Vue.set(existing, k, data[k]);
+    }
+
+    return existing;
+  }
+
   if ( existing && !existing.id ) {
     // A specific proxy instance to used was passed in (for create -> save),
     // use it instead of making a new proxy
-    entry = existing;
-    Object.assign(entry, data);
+    entry = replace(existing, data);
     addObject(cache.list, entry);
     cache.map.set(id, entry);
     // console.log('### Mutation added from existing proxy', type, id);
@@ -56,7 +67,7 @@ function load(state, { data, ctx, existing }) {
 
     if ( entry ) {
       // There's already an entry in the store, update it
-      Object.assign(entry, data);
+      replace(entry, data);
       // console.log('### Mutation Updated', type, id);
     } else {
       // There's no entry, make a new proxy

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -1352,7 +1352,11 @@ export default {
           const ns = r[`${ direction }Namespace`];
           const id = (ns ? `${ ns }/` : '') + r[`${ direction }Id`];
 
-          const matching = await this.$dispatch('find', { type, id });
+          let matching = this.$getters['byId'](type, id);
+
+          if ( !matching ) {
+            matching = await this.$dispatch('find', { type, id });
+          }
 
           if ( matching ) {
             addObject(out, matching);

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -8,7 +8,7 @@ import pickBy from 'lodash/pickBy';
 import uniq from 'lodash/uniq';
 import Vue from 'vue';
 
-import { addObject, addObjects, findBy } from '@/utils/array';
+import { addObject, addObjects, findBy, removeAt } from '@/utils/array';
 import CustomValidators from '@/utils/custom-validators';
 import { downloadFile, generateZip } from '@/utils/download';
 import { eachLimit } from '@/utils/promise';
@@ -49,9 +49,11 @@ const STRING_LIKE_TYPES = [
 const DNS_LIKE_TYPES = ['dnsLabel', 'dnsLabelRestricted', 'hostname'];
 
 const REMAP_STATE = {
-  disabled:   'inactive',
-  notapplied: 'Not Applied',
-  notready:   'Not Ready',
+  disabled:      'inactive',
+  notapplied:    'Not Applied',
+  notready:      'Not Ready',
+  waitapplied:   'Wait Applied',
+  'in-progress':   'In Progress',
 };
 
 const DEFAULT_COLOR = 'warning';
@@ -90,6 +92,7 @@ const STATES = {
   healthy:            { color: 'success', icon: 'dot-open' },
   inactive:           { color: 'error', icon: 'dot' },
   initializing:       { color: 'warning', icon: 'error' },
+  inprogress:         { color: 'info', icon: 'spinner' },
   locked:             { color: 'warning', icon: 'adjust' },
   migrating:          { color: 'info', icon: 'info' },
   modified:           { color: 'warning', icon: 'edit' },
@@ -130,6 +133,8 @@ const STATES = {
   untriggered:        { color: 'success', icon: 'tag' },
   updating:           { color: 'warning', icon: 'tag' },
   waiting:            { color: 'info', icon: 'tag' },
+  waitapplied:        { color: 'info', icon: 'tag' },
+  notready:           { color: 'warning', icon: 'tag' },
 };
 
 const SORT_ORDER = {

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -580,6 +580,14 @@ export default {
       out.pop();
     }
 
+    // Remove consecutive dividers in the middle
+    for ( let i = 1 ; i < out.length ; i++ ) {
+      if ( out[i].divider && out[i - 1].divider ) {
+        removeAt(out, i, 1);
+        i--;
+      }
+    }
+
     return out;
   },
 

--- a/plugins/steve/subscribe.js
+++ b/plugins/steve/subscribe.js
@@ -152,7 +152,7 @@ export const actions = {
     const promises = [];
 
     for ( const entry of state.started.slice() ) {
-      console.info('Reconnect', entry.type, entry.id, entry.selector); // eslint-disable-line no-console
+      console.info('Reconnect', entry.type, entry.namespace, entry.id, entry.selector); // eslint-disable-line no-console
       if ( getters.schemaFor(entry.type) ) {
         commit('setWatchStopped', entry);
         delete entry.revision;
@@ -223,9 +223,10 @@ export const actions = {
   'ws.resource.start'({ commit }, msg) {
     // console.info('Resource start:', msg.resourceType, msg.id, msg.selector); // eslint-disable-line no-console
     commit('setWatchStarted', {
-      type:     msg.resourceType,
-      id:       msg.id,
-      selector: msg.selector
+      type:      msg.resourceType,
+      namespace: msg.namespace,
+      id:        msg.id,
+      selector:  msg.selector
     });
   },
 
@@ -243,12 +244,13 @@ export const actions = {
   'ws.resource.stop'({ getters, commit, dispatch }, msg) {
     const type = msg.resourceType;
     const obj = {
-      type:     msg.resourceType,
-      id:       msg.id,
-      selector: msg.selector
+      type,
+      id:        msg.id,
+      namespace: msg.namespace,
+      selector:  msg.selector
     };
 
-    console.warn('Resource stop:', type, msg.id, msg.selector); // eslint-disable-line no-console
+    console.warn('Resource stop:', type, msg.namespace, msg.id, msg.selector); // eslint-disable-line no-console
 
     if ( getters['schemaFor'](type) && getters['watchStarted'](obj) ) {
       // Try reconnecting once


### PR DESCRIPTION
- Subscribe preserve namespace
- Flip weights
- Move type description to the top
- Wait for store updates to finish, ensure only one flush at a time
- Remove consecutive action dividers
- Only ask the server for relationships if we don't already have it
- Fleet states
- CIS bugs
- Fix default table sort
- Guard against product/cluster not being set
- Badge state standalone
- More reactive store updates
