### PR TITLE
Fixing logging overview broken links

### DIFF
--- a/components/formatter/ListLink.vue
+++ b/components/formatter/ListLink.vue
@@ -4,10 +4,18 @@ import Link from './Link';
 export default {
   components: { Link },
   props:      {
+    row: {
+      type:     Object,
+      required: true,
+    },
     value: {
       type:     Array,
       default: () => []
-    }
+    },
+    options: {
+      type:    [Object, String],
+      default: null,
+    },
   },
 };
 </script>
@@ -15,7 +23,7 @@ export default {
 <template>
   <span>
     <span v-for="(el, i) in value" :key="el.key">
-      <Link :value="el" /><span v-if="i != value.length - 1">, </span>
+      <Link :row="row" :value="el" :options="options" /><span v-if="i != value.length - 1">, </span>
     </span>
   </span>
 </template>

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -52,24 +52,27 @@ export const EFFECT = {
 };
 
 export const FLOW = {
-  name:      'flow',
-  labelKey:  'tableHeaders.flow',
-  value:     'flow',
-  sort:      ['flow.name'],
-  formatter: 'Link'
+  name:          'flow',
+  labelKey:      'tableHeaders.flow',
+  value:         'flow',
+  sort:          ['flow.name'],
+  formatter:     'Link',
+  formatterOpts: { options: 'internal' },
 };
 
 export const CLUSTER_FLOW = {
   ...FLOW,
-  labelKey: 'tableHeaders.clusterFlow'
+  labelKey:      'tableHeaders.clusterFlow',
+  formatterOpts: { options: 'internal' },
 };
 
 export const OUTPUT = {
-  name:      'output',
-  labelKey:  'tableHeaders.output',
-  value:     'outputs',
-  sort:      'outputs.text',
-  formatter: 'ListLink'
+  name:          'output',
+  labelKey:      'tableHeaders.output',
+  value:         'outputs',
+  sort:          'outputs.text',
+  formatter:     'ListLink',
+  formatterOpts: { options: 'internal' },
 };
 
 export const CONFIGURED_PROVIDERS = {

--- a/pages/c/_cluster/logging/index.vue
+++ b/pages/c/_cluster/logging/index.vue
@@ -63,7 +63,6 @@ export default {
       return {
         text:    resource.nameDisplay,
         url:     resource.detailLocation,
-        options: 'internal',
         ...resource
       };
     }


### PR DESCRIPTION
Link formatter had the way options should be passed 
changed which broke the existing links. This changes
how we pass the options for outputs and flows.

I also fixed a missing 'row' warning.

rancher/dashboard#1422