### PR TITLE
Allowing arraylist to update when there's a defaultAddValue

### DIFF
--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -150,7 +150,9 @@ export default {
   methods: {
     add() {
       this.rows.push({ value: this.defaultAddValue });
-      // this.queueUpdate();
+      if (this.defaultAddValue) {
+        this.queueUpdate();
+      }
 
       this.$nextTick(() => {
         const inputs = this.$refs.value;


### PR DESCRIPTION
NamespaceList relied upon getting the updates when a default value was specified.
rancher/dashboard#1229

I spoke with @mantis-toboggan-md  about this several weeks ago but somehow never got this change in. The reason this was commented out was because

> It was causing an error in pod affinity; if a user adds a namespace field and doesn't use it, then the pod affinity spec doesn't pass validation because it has [""] listed for namespaces...ArrayList should now update only when there's a value beyond the default added/removed

I attempted to verify this change against PodAffinity but with or without this change I didn't see any namespaces getting added. If this reintroduces a problem I think that this should either be resolved with a custom @input in PodAffinity/MatchExpressions or within a willSave further up the component chain.