### PR TITLE
Making the Gatekeeper Overview page only active when on the overview page

### DIFF
--- a/config/product/gatekeeper.js
+++ b/config/product/gatekeeper.js
@@ -33,6 +33,7 @@ export function init(store) {
     namespaced: false,
     name:       'gatekeeper-overview',
     route:      { name: 'c-cluster-gatekeeper' },
+    exact:      true,
     weight:     3
   });
 


### PR DESCRIPTION

rancher/dashboard#1487

![Screen Shot 2020-09-29 at 11 00 03 AM](https://user-images.githubusercontent.com/55104481/94597845-f10a1900-0242-11eb-8590-e5b2e9e2ca66.png)