### PR TITLE
2.5 Alpha Bugs

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -940,6 +940,7 @@ resourceDetail:
     overview: Overview
     project: Project
     yaml: YAML
+    managedWarning: This {type} is managed by the {managedBy} app {appName}; changes made here will likely be overwritten the next time the app is changed.
 
 resourceList:
   head:

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -11,6 +11,8 @@ import { createYaml } from '@/utils/create-yaml';
 import Masthead from '@/components/ResourceDetail/Masthead';
 import DetailTop from '@/components/DetailTop';
 import FileSelector from '@/components/form/FileSelector';
+import { KUBERNETES } from '@/config/labels-annotations';
+import Banner from '@/components/Banner';
 import GenericResourceDetail from './Generic';
 
 // Components can't have asyncData, only pages.
@@ -159,7 +161,7 @@ export const watchQuery = [MODE, AS_YAML];
 
 export default {
   components: {
-    DetailTop, FileSelector, ResourceYaml, Masthead, GenericResourceDetail
+    Banner, DetailTop, FileSelector, ResourceYaml, Masthead, GenericResourceDetail
   },
   mixins: [CreateEditView],
 
@@ -262,6 +264,27 @@ export default {
 
       return null;
     },
+
+    showManagedWarning() {
+      const { value: model, mode } = this;
+      const managedLabel = model?.metadata?.labels ? model.metadata.labels[KUBERNETES.MANAGED_BY] : false;
+
+      if (mode === _EDIT && managedLabel && managedLabel.toLowerCase() === 'helm') {
+        return true;
+      }
+
+      return false;
+    },
+
+    managedWarningOptions() {
+      const { value } = this;
+
+      return {
+        type:      value?.kind || '',
+        managedBy: value?.metadata?.labels[KUBERNETES.MANAGED_BY] || '',
+        appName:   value?.metadata?.labels?.release || '',
+      };
+    },
   },
 
   watch: {
@@ -289,6 +312,11 @@ export default {
 
 <template>
   <div>
+    <Banner
+      v-if="showManagedWarning"
+      color="warning"
+      :label="t('resourceDetail.masthead.managedWarning', managedWarningOptions)"
+    />
     <Masthead
       :value="originalModel"
       :mode="mode"

--- a/components/formatter/ServiceTargets.vue
+++ b/components/formatter/ServiceTargets.vue
@@ -32,7 +32,7 @@ export default {
       const isHeadless = serviceType === 'ClusterIP' && clusterIP === 'None';
       const parsedClusterIp = !isEmpty(clusterIP) && !isHeadless ? `${ clusterIP }:` : '';
       let label = '';
-      let link = '';
+      const link = '';
 
       // <CLUSTER_IP>:<PORT>/<PROTOCOL> > <TARGET PORT>
       if (isEmpty(ports)) {
@@ -40,9 +40,9 @@ export default {
           label = parsedClusterIp;
         } else if (serviceType === 'ExternalName' && !isEmpty(externalName)) {
           label = externalName;
-          if (!isHeadless) {
-            link = `<a href="${ label }" target="_blank" rel="noopener nofollow">${ label }</a>`;
-          }
+          // if (!isHeadless) {
+          //   link = `<a href="${ label }" target="_blank" rel="noopener nofollow">${ label }</a>`;
+          // }
         }
 
         out.push({
@@ -57,7 +57,7 @@ export default {
 
           label = `${ clusterIpAndPort }${ protocol }${ targetPort }`;
 
-          link = serviceType === 'ClusterIP' && !isEmpty(clusterIP) && !isHeadless ? `<a href="//${ clusterIP }/${ p.port }" target="_blank" rel="noopener nofollow">${ clusterIpAndPort }</a>${ protocol }${ targetPort }` : null;
+          // link = serviceType === 'ClusterIP' && !isEmpty(clusterIP) && !isHeadless ? `<a href="//${ clusterIP }/${ p.port }" target="_blank" rel="noopener nofollow">${ clusterIpAndPort }</a>${ protocol }${ targetPort }` : null;
 
           out.push({
             label,

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -8,7 +8,8 @@ export const CONTAINER_DEFAULT_RESOURCE_LIMIT = 'field.cattle.io/containerDefaul
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',
-  SERVICE_ACCOUNT_NAME: 'kubernetes.io/service-account.name'
+  SERVICE_ACCOUNT_NAME: 'kubernetes.io/service-account.name',
+  MANAGED_BY:           'app.kubernetes.io/managed-by',
 };
 
 export const RIO = { STACK: 'rio.cattle.io/stack' };


### PR DESCRIPTION
Add a managed by warning when editing resources with matching labels
rancher/dashboard#992


Removes link functionality for service targets. There is a plan to revisit this post 2.5.0 so I only commented out the link logic for  now. I would think certain cases would call for it to still be present. 

rancher/dashboard#1513