### PR TITLE
Monitoring Config Updates

### DIFF
--- a/chart/monitoring/grafana/index.vue
+++ b/chart/monitoring/grafana/index.vue
@@ -67,6 +67,13 @@ export default {
       persistentStorageType: 'disabled',
     };
   },
+  computed: {
+    showStorageClasses() {
+      const { storageClasses } = this;
+
+      return (storageClasses || []).length >= 1;
+    },
+  },
   watch: {
     persistentStorageType(newType, oldType) {
       let newValsOut;
@@ -138,7 +145,7 @@ export default {
       this.$set(this.value.grafana, 'persistence', resetValsOut);
       this.$set(this.value.grafana, 'persistence', newValsOut);
     },
-  },
+  }
 };
 </script>
 
@@ -183,6 +190,19 @@ export default {
             />
           </div>
           <div class="col span-6">
+            <div v-if="showStorageClasses">
+              <StorageClassSelector
+                :value="value.grafana.persistence.storageClassName"
+                :mode="mode"
+                :options="storageClasses"
+                :label="t('monitoring.prometheus.storage.className')"
+                @updateName="(name) => $set(value.grafana.persistence, 'storageClassName', name)"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col span-6">
             <LabeledSelect
               v-model="value.grafana.persistence.accessModes"
               :label="t('monitoring.grafana.storage.mode')"
@@ -191,18 +211,6 @@ export default {
               :multiple="true"
               :options="accessModes"
               :reduce="({id})=> id"
-            />
-          </div>
-        </div>
-        <div class="row">
-          <div class="col span-6">
-            <StorageClassSelector
-              v-if="storageClasses.length > 0"
-              :value="value.grafana.persistence.storageClassName"
-              :mode="mode"
-              :options="storageClasses"
-              :label="t('monitoring.prometheus.storage.className')"
-              @updateName="(name) => $set(value.grafana.persistence, 'storageClassName', name)"
             />
           </div>
         </div>
@@ -245,6 +253,19 @@ export default {
             />
           </div>
           <div class="col span-6">
+            <div v-if="showStorageClasses">
+              <StorageClassSelector
+                :value="value.grafana.persistence.storageClassName"
+                :mode="mode"
+                :options="storageClasses"
+                :label="t('monitoring.prometheus.storage.className')"
+                @updateName="(name) => $set(value.grafana.persistence, 'storageClassName', name)"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col span-6">
             <LabeledSelect
               v-model="value.grafana.persistence.accessModes"
               :label="t('monitoring.grafana.storage.mode')"
@@ -253,18 +274,6 @@ export default {
               :multiple="true"
               :options="accessModes"
               :reduce="({id})=> id"
-            />
-          </div>
-        </div>
-        <div class="row">
-          <div class="col span-6">
-            <StorageClassSelector
-              v-if="storageClasses.length > 0"
-              :value="value.grafana.persistence.storageClassName"
-              :mode="mode"
-              :options="storageClasses"
-              :label="t('monitoring.prometheus.storage.className')"
-              @updateName="(name) => $set(value.grafana.persistence, 'storageClassName', name)"
             />
           </div>
         </div>

--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -266,25 +266,14 @@ export default {
         <div class="col span-6">
           <Checkbox v-model="enablePersistantStorage" :label="t('monitoring.prometheus.storage.label')" />
         </div>
-        <div v-if="enablePersistantStorage" class="col span-6">
-          <LabeledInput
-            v-model="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
-            :label="t('monitoring.prometheus.storage.size')"
-            :mode="mode"
-          />
-        </div>
       </div>
       <template v-if="enablePersistantStorage">
         <div class="row">
           <div class="col span-6">
-            <LabeledSelect
-              v-model="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.accessModes"
-              :label="t('monitoring.prometheus.storage.mode')"
-              :localized-label="true"
+            <LabeledInput
+              v-model="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage"
+              :label="t('monitoring.prometheus.storage.size')"
               :mode="mode"
-              :multiple="true"
-              :options="accessModes"
-              :reduce="({id})=> id"
             />
           </div>
           <div class="col span-6">
@@ -300,6 +289,17 @@ export default {
           </div>
         </div>
         <div class="row">
+          <div class="col span-6">
+            <LabeledSelect
+              v-model="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.accessModes"
+              :label="t('monitoring.prometheus.storage.mode')"
+              :localized-label="true"
+              :mode="mode"
+              :multiple="true"
+              :options="accessModes"
+              :reduce="({id})=> id"
+            />
+          </div>
           <div class="col span-6">
             <LabeledSelect
               v-model="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.volumeMode"

--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -127,6 +127,12 @@ export default {
 
       return pods;
     },
+
+    showStorageClasses() {
+      const { storageClasses } = this;
+
+      return (storageClasses || []).length >= 1;
+    },
   },
 
   watch: {
@@ -282,14 +288,15 @@ export default {
             />
           </div>
           <div class="col span-6">
-            <StorageClassSelector
-              :v-if="storageClasses.length > 0"
-              :mode="mode"
-              :options="storageClasses"
-              :value="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName"
-              :label="t('monitoring.prometheus.storage.className')"
-              @updateName="(name) => $set(value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec, 'storageClassName', name)"
-            />
+            <div v-if="showStorageClasses">
+              <StorageClassSelector
+                :mode="mode"
+                :options="storageClasses"
+                :value="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName"
+                :label="t('monitoring.prometheus.storage.className')"
+                @updateName="(name) => $set(value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec, 'storageClassName', name)"
+              />
+            </div>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Updated the check to show/hide storage class name input to computed property and wrapped in a div as it wasn't hiding properly otherwise.

Ive adjusted the markup a little for the storage configuration sections so they are all consistent with eachother. This doesn't change functionality, only layout.

| size | storage class (if shown) |
| access modes | volume mode (only prometheus) |

With storage classes:
![Screen Shot 2020-09-30 at 12 23 03 PM](https://user-images.githubusercontent.com/858614/94731094-15d0c000-0319-11eb-9ec5-192f4444ec6d.png)

Without: 
![Screen Shot 2020-09-30 at 12 21 12 PM](https://user-images.githubusercontent.com/858614/94731125-1d906480-0319-11eb-9345-b544f384745b.png)
