### PR TITLE
[2.5.2] Monitoring ignoreNamespaceSelectors

### DIFF
--- a/assets/styles/global/_tooltip.scss
+++ b/assets/styles/global/_tooltip.scss
@@ -5,6 +5,7 @@
 
   display: block !important;
   z-index: z-index('tooltip');
+  max-width: 50vw;
 
   .tooltip-inner {
     background: var(--tooltip-bg);
@@ -101,7 +102,7 @@
       background: var(--tooltip-bg-warning);
       color: var(--tooltip-text-warning);
     }
-  
+
     &[x-placement^="top"] {
       .tooltip-arrow {
         &:after {
@@ -109,8 +110,8 @@
         }
       }
     }
-  
-  
+
+
     &[x-placement^="bottom"] {
       .tooltip-arrow {
         &:after {
@@ -118,7 +119,7 @@
         }
       }
     }
-  
+
     &[x-placement^="right"] {
       .tooltip-arrow {
         &:after {
@@ -126,7 +127,7 @@
         }
       }
     }
-  
+
     &[x-placement^="left"] {
       .tooltip-arrow {
         &:after {
@@ -165,7 +166,7 @@
 
 .tooltip, .popover {
   &[aria-hidden='true'] {
-    // This removes it from the layout of ButtondropDown (so it doesn't render huge for SSR) but 
+    // This removes it from the layout of ButtondropDown (so it doesn't render huge for SSR) but
     // still allows it to maintain it's dimensions for v-tooltip to calculate the appropriate position.
     position: absolute;
     visibility: hidden;

--- a/assets/styles/global/_tooltip.scss
+++ b/assets/styles/global/_tooltip.scss
@@ -5,7 +5,6 @@
 
   display: block !important;
   z-index: z-index('tooltip');
-  max-width: 50vw;
 
   .tooltip-inner {
     background: var(--tooltip-bg);

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -14,6 +14,8 @@ generic:
   default: Default
   disabled: Disabled
   enabled: Enabled
+  enforced: Enforced
+  ignored: Ignored
   labelsAndAnnotations: Labels and Annotations
   na: n/a
   name: Name
@@ -783,10 +785,11 @@ monitoring:
       resourceLimits: Resource Limits
       scrape: Scrape Interval
       ignoreNamespaceSelectors:
-        label: Ignore Namespace Selectors
-        help: |+
-          If true, ServiceMonitors and PodMonitors will only be able to discover resources in the namespace they are deployed into. <br />
-          Disabling Ignore Namespace Selectors may be required to support scrape configurations declared by other charts via ServiceMonitors / PodMonitors if those charts require resources to be monitored across namespaces.
+        label: Use Namespace Selectors
+        radio:
+          enforced: "Use: Monitors can access resources in the namespace specified in the namespaceSelector field"
+          ignored: "Ignore: Monitors can only access resources in the deployed namespace that they are deployed in"
+        help: Ignoring Namespace Selectors allows Cluster Admins to limit teams from monitoring resources outside of namespaces they have permissions to but can break the functionality of Apps that rely on setting up Monitors that scrape targets across multiple namespaces, such as Istio.
     storage:
       className: Storage Class Name
       label: Persistent Storage for Prometheus

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -159,6 +159,7 @@ backupRestoreOperator:
       tip: Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.
       storageClass:
         label: Storage Class
+        tip: Use a storage class with a <code>Retain</code> reclaim polciy to avoid losing backups.
       persistentVolume:
         label: Persistent Volume
       label: Default Storage Location
@@ -782,6 +783,11 @@ monitoring:
       retentionSize: Retention Size
       resourceLimits: Resource Limits
       scrape: Scrape Interval
+      ignoreNamespaceSelectors:
+        label: Ignore Namespace Selectors
+        help: |+
+          If true, ServiceMonitors and PodMonitors will only be able to discover resources in the namespace they are deployed into. <br />
+          Disabling Ignore Namespace Selectors may be required to support scrape configurations declared by other charts via ServiceMonitors / PodMonitors if those charts require resources to be monitored across namespaces.
     storage:
       className: Storage Class Name
       label: Persistent Storage for Prometheus
@@ -1214,7 +1220,7 @@ validation:
       startHyphen: '"{key}" cannot start with a hyphen'
       startNumber: '"{key}" cannot start with a number'
       tooLongLabel: '"{key}" cannot be more than {max} characters'
-  flowOutput: 
+  flowOutput:
     global: Requires "Cluster Output" to be selected.
     both: Requires "Output" or "Cluster Output" to be selected.
   k8s:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -159,7 +159,6 @@ backupRestoreOperator:
       tip: Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.
       storageClass:
         label: Storage Class
-        tip: Use a storage class with a <code>Retain</code> reclaim polciy to avoid losing backups.
       persistentVolume:
         label: Persistent Volume
       label: Default Storage Location

--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -8,6 +8,7 @@ import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import MatchExpressions from '@/components/form/MatchExpressions';
 import StorageClassSelector from '@/chart/monitoring/StorageClassSelector';
+import RadioGroup from '@/components/form/RadioGroup';
 
 import { set } from '@/utils/object';
 import { simplify } from '@/utils/selector';
@@ -20,6 +21,7 @@ export default {
     LabeledInput,
     LabeledSelect,
     MatchExpressions,
+    RadioGroup,
     StorageClassSelector,
   },
 
@@ -193,12 +195,18 @@ export default {
           <Checkbox v-model="value.prometheus.prometheusSpec.enableAdminAPI" :label="t('monitoring.prometheus.config.adminApi')" />
         </div>
         <div class="col span-6 col-full-height">
-          <Checkbox v-model="value.prometheus.prometheusSpec.ignoreNamespaceSelectors" :label="t('monitoring.prometheus.config.ignoreNamespaceSelectors.label')">
-            <template #label>
-              <t k="monitoring.prometheus.config.ignoreNamespaceSelectors.label" />
-              <i v-tooltip="t('monitoring.prometheus.config.ignoreNamespaceSelectors.help', {}, true)" class="icon icon-info"></i>
+          <RadioGroup
+            v-model="value.prometheus.prometheusSpec.ignoreNamespaceSelectors"
+            name="ignoreNamespaceSelectors"
+            :label="t('monitoring.prometheus.config.ignoreNamespaceSelectors.label')"
+            :labels="[t('monitoring.prometheus.config.ignoreNamespaceSelectors.radio.enforced'),t('monitoring.prometheus.config.ignoreNamespaceSelectors.radio.ignored')]"
+            :mode="mode"
+            :options="[true, false]"
+          >
+            <template #corner>
+              <i v-tooltip="t('monitoring.prometheus.config.ignoreNamespaceSelectors.help', {}, true)" class="icon icon-info" />
             </template>
-          </Checkbox>
+          </RadioGroup>
         </div>
       </div>
       <div class="row">

--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -192,6 +192,14 @@ export default {
         <div class="col span-6 col-full-height">
           <Checkbox v-model="value.prometheus.prometheusSpec.enableAdminAPI" :label="t('monitoring.prometheus.config.adminApi')" />
         </div>
+        <div class="col span-6 col-full-height">
+          <Checkbox v-model="value.prometheus.prometheusSpec.ignoreNamespaceSelectors" :label="t('monitoring.prometheus.config.ignoreNamespaceSelectors.label')">
+            <template #label>
+              <t k="monitoring.prometheus.config.ignoreNamespaceSelectors.label" />
+              <i v-tooltip="t('monitoring.prometheus.config.ignoreNamespaceSelectors.help', {}, true)" class="icon icon-info"></i>
+            </template>
+          </Checkbox>
+        </div>
       </div>
       <div class="row">
         <div class="col span-6">


### PR DESCRIPTION
Exposes the `ignoreNamespaceSelectors` field to the prometheus config.

Additionally this sets max-width on our tooltips. I find long tooltips on a wide screen hard to read and super obtrusive. 50vw sets a nice middle ground. This can be backed out though if we'd like to discuss it further. 

rancher/dashboard#1129