### PR TITLE
Improving rbac of Logging overview and flow pages

### DIFF
--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -67,7 +67,7 @@ export const CLUSTER_FLOW = {
 };
 
 export const OUTPUT = {
-  name:          'output',
+  name:          'localOutputRefs',
   labelKey:      'tableHeaders.output',
   value:         'outputs',
   sort:          'outputs.text',
@@ -85,6 +85,8 @@ export const CONFIGURED_PROVIDERS = {
 
 export const CLUSTER_OUTPUT = {
   ...OUTPUT,
+  name:     'globalOutputRefs',
+  value:    'clusterOutputs',
   labelKey: 'tableHeaders.clusterOutput',
 };
 

--- a/models/logging.banzaicloud.io.flow.js
+++ b/models/logging.banzaicloud.io.flow.js
@@ -54,14 +54,25 @@ export default {
     return this.$rootGetters['cluster/all'](LOGGING.OUTPUT) || [];
   },
 
-  outputs() {
-    const outputRefs = this?.spec?.outputRefs || this?.spec?.localOutputRefs || [];
+  allClusterOutputs() {
+    return this.$rootGetters['cluster/all'](LOGGING.CLUSTER_OUTPUT) || [];
+  },
 
-    return this.allOutputs.filter(output => outputRefs.includes(output.name));
+  outputs() {
+    const localOutputRefs = this.spec?.localOutputRefs || [];
+
+    return this.allOutputs.filter(output => localOutputRefs.includes(output.name));
+  },
+
+  clusterOutputs() {
+    const globalOutputRefs = this.spec?.globalOutputRefs || [];
+
+    return this.allClusterOutputs.filter(output => globalOutputRefs.includes(output.name));
   },
 
   outputProviders() {
-    const duplicatedProviders = this.outputs
+    const combinedOutputs = [...this.outputs, ...this.clusterOutputs];
+    const duplicatedProviders = combinedOutputs
       .flatMap(output => output.providers);
 
     return uniq(duplicatedProviders) || [];


### PR DESCRIPTION
Check to see if the resources are available before requesting them
and give appropriate defaults when not available

rancher/dashboard#1524

Notes:
While working on the flow page I noticed that there were a few problems with the overview page that I resolved.
- It was failing due to some resources not being available because of rbac
- We weren't using the new local/globalOutputRefs for the flows 
- We weren't showing the globalOutputRefs so I added a Cluster Output column. _We may want to add a separate column for the cluster providers too but I'll leave that for later_
- I decided to hide the cluster level table if the user didn't have access to cluster flows. 


![image](https://user-images.githubusercontent.com/55104481/94751460-7eca2f00-033d-11eb-9647-245ee449ea86.png)
![image](https://user-images.githubusercontent.com/55104481/94751516-b46f1800-033d-11eb-8aed-0a23e1852d29.png)


