### PR TITLE
Fix Git Repo Path input box placeholder

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -418,7 +418,7 @@ fleet:
       custom: Secret Name
     paths:
       label: Paths
-      placeholder: e.g. /directory/in/your/repo
+      placeholder: e.g. directory/in/your/repo
       addLabel: Add Path
     repo:
       label: Repository URL


### PR DESCRIPTION
Fix Git Repo Path input box placeholder

The path must not have a leading /.