### PR TITLE
Adding pod annotations back to workloads

### DIFF
--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -232,6 +232,31 @@ export default {
       }
     },
 
+    podAnnotations: {
+      get() {
+        if (this.isCronJob) {
+          if (!this.spec.jobTemplate.metadata) {
+            this.$set( this.spec.jobTemplate, 'metadata', { annotations: {} });
+          }
+
+          return this.spec.jobTemplate.metadata.annotations;
+        } else {
+          if (!this.spec.template.metadata) {
+            this.$set(this.spec.template, 'metadata', { annotations: {} });
+          }
+
+          return this.spec.template.metadata.annotations;
+        }
+      },
+      set(neu) {
+        if (this.isCronJob) {
+          this.$set( this.spec.jobTemplate.metadata, 'annotations', neu);
+        } else {
+          this.$set(this.spec.template.metadata, 'annotations', neu);
+        }
+      }
+    },
+
     container: {
       get() {
         if (!this.podTemplateSpec.containers) {
@@ -648,10 +673,23 @@ export default {
           </div>
           <div class="bordered-section">
             <h3>{{ t('workload.container.titles.podLabels') }}</h3>
+            <div class="row mb-20">
+              <KeyValue
+                key="labels"
+                v-model="podLabels"
+                :add-label="t('labels.addLabel')"
+                :mode="mode"
+                :pad-left="false"
+                :read-allowed="false"
+                :protip="false"
+              />
+            </div>
+            <h3>{{ t('workload.container.titles.podAnnotations') }}</h3>
             <div class="row">
               <KeyValue
                 key="annotations"
-                v-model="podLabels"
+                v-model="podAnnotations"
+                :add-label="t('labels.addAnnotation')"
                 :mode="mode"
                 :pad-left="false"
                 :read-allowed="false"


### PR DESCRIPTION
Also updated the style to be more consistent with the existing Labels component.

rancher/dashboard#1394

![Screen Shot 2020-10-01 at 12 58 52 PM](https://user-images.githubusercontent.com/55104481/94857671-bd67f400-03e6-11eb-8999-16b29f928e03.png)
![Screen Shot 2020-10-01 at 12 58 37 PM](https://user-images.githubusercontent.com/55104481/94857675-be008a80-03e6-11eb-93a7-e0f95c47e8a0.png)
