### PR TITLE
Adding pathType to ingress rules

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -555,6 +555,7 @@ ingress:
     addPath: Add Path
     addRule: Add Rule
     headers:
+      pathType: Path Type
       path: Path
       port: Port
       target: Target Service

--- a/edit/networking.k8s.io.ingress/DefaultBackend.vue
+++ b/edit/networking.k8s.io.ingress/DefaultBackend.vue
@@ -94,7 +94,9 @@ export default {
         <LabeledSelect
           v-else
           v-model="servicePort"
+          :mode="mode"
           :options="portOptions"
+          :label="t('ingress.defaultBackend.port.label')"
           :placeholder="t('ingress.defaultBackend.port.placeholder')"
           @input="update"
         />

--- a/edit/networking.k8s.io.ingress/Rule.vue
+++ b/edit/networking.k8s.io.ingress/Rule.vue
@@ -2,6 +2,7 @@
 import RulePath from '@/edit/networking.k8s.io.ingress/RulePath';
 import LabeledInput from '@/components/form/LabeledInput';
 import { random32 } from '../../utils/string';
+
 export default {
   components: { RulePath, LabeledInput },
   props:      {
@@ -15,6 +16,10 @@ export default {
       type:    Array,
       default: () => [],
     },
+    showPathType: {
+      type:    Boolean,
+      default: false
+    }
   },
   data() {
     const { host = '', http = {} } = this.value;
@@ -73,13 +78,13 @@ export default {
       </div>
     </div>
     <div class="rule-path-headings row">
-      <div class="col span-4">
+      <div class="col" :class="{'span-6': showPathType, 'span-4': !showPathType}">
         <label>{{ t("ingress.rules.path.label") }}</label>
       </div>
-      <div class="col span-4">
+      <div class="col" :class="{'span-3': showPathType, 'span-4': !showPathType}">
         <label>{{ t("ingress.rules.target.label") }}</label>
       </div>
-      <div class="col span-3" :style="{ 'margin-right': '0px' }">
+      <div class="col" :class="{'span-2': showPathType, 'span-3': !showPathType}" :style="{ 'margin-right': '0px' }">
         <label>{{ t("ingress.rules.port.label") }}</label>
       </div>
       <div class="col" />
@@ -91,6 +96,7 @@ export default {
         :value="path"
         :rule-mode="ruleMode"
         :service-targets="serviceTargets"
+        :show-path-type="showPathType"
         @input="(e) => $set(paths, i, e)"
         @remove="(e) => removePath(i)"
       />

--- a/edit/networking.k8s.io.ingress/Rules.vue
+++ b/edit/networking.k8s.io.ingress/Rules.vue
@@ -1,5 +1,5 @@
 <script>
-import { WORKLOAD_TYPES } from '@/config/types';
+import { WORKLOAD_TYPES, INGRESS } from '@/config/types';
 import Loading from '@/components/Loading';
 import SortableTable from '@/components/SortableTable';
 import { _VIEW } from '@/config/query-params';
@@ -44,28 +44,52 @@ export default {
       return this.mode === _VIEW;
     },
     ruleHeaders() {
-      return [
+      const headers = [
         {
           name:      'path',
           label:     this.t('ingress.rules.headers.path'),
-          value:     'text'
+          value:     'path',
+          width:     '25%'
         },
         {
           name:      'target',
           label:     this.t('ingress.rules.headers.target'),
           formatter: 'Link',
           value:     'targetLink',
+          width:     '25%'
         },
         {
           name:  'port',
           label: this.t('ingress.rules.headers.port'),
-          value: 'port'
+          value: 'port',
+          width: '25%'
         }
       ];
+
+      if (this.showPathType) {
+        headers.unshift({
+          name:      'pathType',
+          label:     this.t('ingress.rules.headers.pathType'),
+          value:     'pathType',
+          width:     '25%'
+        });
+      }
+
+      return headers;
     },
     ruleRows() {
       return this.value.createRulesForDetailPage(this.workloads);
     },
+    showPathType() {
+      const ingressExpandedSchema = this.$store.getters['cluster/expandedSchema'](INGRESS);
+      const spec = ingressExpandedSchema?.expandedResourceFields?.spec;
+      const rules = spec?.expandedResourceFields?.rules;
+      const http = rules?.expandedSubType?.expandedResourceFields?.http;
+      const paths = http?.expandedResourceFields?.paths;
+      const pathType = paths?.expandedSubType?.expandedResourceFields?.pathType;
+
+      return !!pathType;
+    }
   },
 
   methods: {
@@ -107,6 +131,7 @@ export default {
       :key="i"
       :value="rule"
       :service-targets="serviceTargets"
+      :show-path-type="showPathType"
       @remove="e=>removeRule(i)"
       @input="e=>updateRule(e,i)"
     />

--- a/models/networking.k8s.io.ingress.js
+++ b/models/networking.k8s.io.ingress.js
@@ -53,7 +53,7 @@ export default {
 
   createPathForDetailPage() {
     return (workloads, path) => {
-      const text = path.path || this.$rootGetters['i18n/t']('generic.na');
+      const pathPath = path.path || this.$rootGetters['i18n/t']('generic.na');
       const serviceName = path?.backend.serviceName;
       const targetLink = {
         url:  this.targetTo(workloads, serviceName),
@@ -62,7 +62,7 @@ export default {
       const port = path?.backend?.servicePort;
 
       return {
-        text, targetLink, port
+        pathType: path.pathType, path: pathPath, targetLink, port
       };
     };
   },


### PR DESCRIPTION
Creating an ingress in k8s 1.19 was failing because we didn't
have pathType. This adds the new option as an InputWithSelect.
Because this field is present in 1.18 I'm showing this field for
all implementations.

I also fixed a small issue under DefaultBackend where
selecing a TargetService was removing the port label. The
label field was just missing from the LabeledSelect component.

rancher/dashboard#1634
https://github.com/rancher/dashboard/issues/1301#issuecomment-705052366

![Screen Shot 2020-10-07 at 11 31 48 AM](https://user-images.githubusercontent.com/55104481/95373379-c565df00-0891-11eb-9493-1747847e4fa0.png)
![Screen Shot 2020-10-07 at 11 32 10 AM](https://user-images.githubusercontent.com/55104481/95373377-c434b200-0891-11eb-972a-a20917774666.png)
![Screen Shot 2020-10-07 at 11 32 01 AM](https://user-images.githubusercontent.com/55104481/95373378-c4cd4880-0891-11eb-84ee-8d4c7315184e.png)

