### PR TITLE
Clarify custerscan's default profile in dropdown

### DIFF
--- a/edit/cis.cattle.io.clusterscan.vue
+++ b/edit/cis.cattle.io.clusterscan.vue
@@ -66,10 +66,6 @@ export default {
         return { label: profile.id, value: profile.id };
       });
 
-      if (profileNames.length !== 1 && this.defaultProfile) {
-        profileNames.unshift({ label: this.t('generic.default'), value: this.defaultProfile });
-      }
-
       return profileNames;
     },
 
@@ -78,7 +74,11 @@ export default {
         const profiles = this.defaultConfigMap.data;
         const provider = this.currentCluster.status.provider;
 
-        return profiles[provider] || profiles.default;
+        const name = profiles[provider] || profiles.default;
+
+        if (name) {
+          return this.allProfiles.find(profile => profile.id === name);
+        }
       }
 
       return null;
@@ -86,9 +86,9 @@ export default {
   },
 
   watch: {
-    validProfiles(neu) {
+    defaultProfile(neu) {
       if (neu && !this.scanProfileName) {
-        this.scanProfileName = neu[0]?.value;
+        this.scanProfileName = neu?.id;
       }
     },
   },
@@ -133,7 +133,13 @@ export default {
 
       <div v-else class="row">
         <div class="col span-6">
-          <LabeledSelect v-model="scanProfileName" :mode="mode" :label="t('cis.profile')" :options="validProfiles" @input="value.spec.scanProfileName = $event" />
+          <LabeledSelect
+            v-model="scanProfileName"
+            :mode="mode"
+            :label="t('cis.profile')"
+            :options="validProfiles"
+            @input="value.spec.scanProfileName = $event"
+          />
         </div>
       </div>
     </template>


### PR DESCRIPTION
#1521 #1583 

Per the original issue #1036 there is a 'Default' option in the profile dropdown that selects a clusterscanprofile id based off the configmap `cis-operator-system/default-clusterscanprofiles` 
This looks confusing when that profile id is also available in the dropdown. I've updated the page to remove the 'Default' option and select appropriate the profile id by default instead.