### PR TITLE
Add resource subtype to masthead

### DIFF
--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -43,6 +43,11 @@ export default {
     parentOverride: {
       type:    Object,
       default: null
+    },
+
+    resourceSubtype: {
+      type:    String,
+      default: null,
     }
   },
 
@@ -183,6 +188,7 @@ export default {
             {{ parent.displayName }}:
           </nuxt-link>
           <span v-html="h1" />
+          <span v-if="resourceSubtype" v-html="resourceSubtype" />
         </h1>
         <BadgeState v-if="isView" :value="value" />
       </div>

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -228,6 +228,7 @@ export default {
       currentValue,
       detailComponent: this.$store.getters['type-map/importDetail'](this.resource),
       editComponent:   this.$store.getters['type-map/importEdit'](this.resource),
+      resourceSubtype: null,
     };
   },
 
@@ -309,6 +310,10 @@ export default {
       if (component) {
         component.updateValue(value);
       }
+    },
+
+    setSubtype(subtype) {
+      this.resourceSubtype = subtype;
     }
   }
 };
@@ -328,6 +333,7 @@ export default {
       :as-yaml.sync="asYaml"
       :parent-override="parentOverride"
       :has-detail-or-edit="(hasCustomDetail || (hasCustomEdit && !yamlOnlyDetail))"
+      :resource-subtype="resourceSubtype"
     >
       <template v-if="!isView && asYaml" #right>
         <div class="text-right">
@@ -355,13 +361,14 @@ export default {
       <component
         :is="showComponent"
         v-model="model"
-        :original-value="originalModel"
-        :done-route="doneRoute"
+        v-bind="_data"
         :done-params="doneParams"
+        :done-route="doneRoute"
         :mode="mode"
+        :original-value="originalModel"
         :real-mode="realMode"
         :value="model"
-        v-bind="_data"
+        @set-subtype="setSubtype"
       />
     </template>
   </div>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -16,6 +16,7 @@ import CruResource from '@/components/CruResource';
 import InfoBox from '@/components/InfoBox';
 import Banner from '@/components/Banner';
 import Labels from '@/components/form/Labels';
+import { _EDIT } from '@/config/query-params';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:     'None',
@@ -91,6 +92,8 @@ export default {
       },
 
       set(serviceType) {
+        this.$emit('set-subtype', serviceType);
+
         if (serviceType === HEADLESS) {
           this.$set(this.value.spec, 'type', CLUSTERIP);
           this.$set(this.value.spec, 'clusterIP', 'None');
@@ -129,6 +132,14 @@ export default {
       ) {
         delete this.value.spec.sessionAffinityConfig.clientIP.timeoutSeconds;
       }
+    }
+  },
+
+  mounted() {
+    if (this.mode === _EDIT) {
+      const initialType = this.serviceType;
+
+      this.$set(this, 'serviceType', initialType);
     }
   },
 


### PR DESCRIPTION
Some resources like Service and Secret have a type (`service`) but also a Subtype (`ClusterIP`). This exposes the mechanism to set that from the resource.

_Note:_ I personally not sure I like the view on edit. Long names and mixed caps look weird to me but I am not sure there is much to do unless we dont want to display it on edit at all? Open to suggestions. 

rancher/dashboard#1073

View On New:
![Screen Shot 2020-10-08 at 10 18 20 AM](https://user-images.githubusercontent.com/858614/95494740-3c16e100-0953-11eb-8b51-1e86395efc8c.png)

View on Edit:
![Screen Shot 2020-10-08 at 10 40 33 AM](https://user-images.githubusercontent.com/858614/95494751-4042fe80-0953-11eb-9c29-85e2f5a6276e.png)
