### PR TITLE
Remove Istio monitoring warning

### DIFF
--- a/assets/styles/global/_cards.scss
+++ b/assets/styles/global/_cards.scss
@@ -23,7 +23,7 @@
       box-shadow: 0px 0px 1px var(--outline-width) var(--outline);
     }
 
-    > a {
+    > * {
       align-items: center;
       display: flex;
       flex: 1 0;
@@ -63,8 +63,8 @@
         margin-top: 10px;
         display: -webkit-box;
         -webkit-box-orient: vertical;
-        -webkit-line-clamp: 3;
-        line-clamp: 3;
+        // -webkit-line-clamp: 3;
+        // line-clamp: 3;
         text-overflow: ellipsis;
         color: var(--secondary);
       }

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -582,7 +582,7 @@ internalExternalIP:
 istio:
   links:
     label: Kiali
-    description: Visualization of services within a service mesh and how they are connected
+    description: Visualization of services within a service mesh and how they are connected. For Kiali to display data, you need Prometheus installed. If you need a monitoring solution, install <a rel="noopener noreferrer nofollow" href="{link}"> Rancher's monitoring</a>.
   cni: Enabled CNI
   customOverlayFile:
     label: Custom Overlay File

--- a/chart/istio.vue
+++ b/chart/istio.vue
@@ -7,7 +7,6 @@ import { mapGetters } from 'vuex';
 import FileSelector from '@/components/form/FileSelector';
 import Tab from '@/components/Tabbed/Tab';
 import Banner from '@/components/Banner';
-import { SERVICE } from '@/config/types';
 
 const defaultOverlayFile = `#apiVersion: install.istio.io/v1alpha1
 #kind: IstioOperator
@@ -70,18 +69,6 @@ export default {
     }
   },
 
-  async fetch() {
-    try {
-      const svc = await this.$store.dispatch('cluster/find', { type: SERVICE, id: 'istio-system/istio-pilot' });
-
-      if ( svc ) {
-        this.v1Installed = true;
-      }
-    } catch (e) {
-      this.v1Installed = false;
-    }
-  },
-
   data() {
     let overlayFile = this.value.overlayFile;
 
@@ -89,10 +76,7 @@ export default {
       overlayFile = defaultOverlayFile;
     }
 
-    return {
-      overlayFile,
-      v1Installed: false
-    };
+    return { overlayFile };
   },
 
   computed: {
@@ -118,14 +102,6 @@ export default {
     },
 
     ...mapGetters({ t: 'i18n/t' })
-  },
-
-  watch: {
-    v1Installed(neu, old) {
-      if (!!neu && !old) {
-        this.$emit('warn', this.t('istio.v1Warning', {}, true));
-      }
-    }
   },
 
   methods: {

--- a/pages/c/_cluster/istio/index.vue
+++ b/pages/c/_cluster/istio/index.vue
@@ -30,6 +30,10 @@ export default {
       return this.kialiService ? this.kialiService.proxyUrl('http', '20001') : null;
     },
 
+    monitoringUrl() {
+      return this.$route.fullPath.replace('/istio', '/monitoring');
+    },
+
     target() {
       return '_blank';
     },
@@ -40,7 +44,10 @@ export default {
   },
 
   methods: {
-    launchKiali() {
+    launchKiali(e) {
+      if (e.srcElement?.tagName === 'A') {
+        return;
+      }
       this.$refs.kiali.click();
     },
   },
@@ -52,25 +59,31 @@ export default {
     <h1>Overview</h1>
     <h4 v-html="t('istio.poweredBy', {}, true)" />
     <div class="links">
-      <div :class="{'disabled':!kialiUrl}" class="box link-container" @click="launchKiali">
-        <a
-          ref="kiali"
-          :disabled="!kialiUrl"
+      <div :class="{'disabled':!kialiUrl}" class="box link-container">
+        <span
           class="link-content pull-right"
-          :href="kialiUrl"
-          :target="target"
-          :rel="rel"
+          @click="launchKiali"
         >
           <div class="link-logo">
             <img :src="kialiLogo" />
           </div>
           <div class="link-content">
-            <t k="istio.links.label" />
-            <i class="icon icon-external-link pull-right" />
+            <a
+              ref="kiali"
+              :disabled="!kialiUrl"
+              :href="kialiUrl"
+              :target="target"
+              :rel="rel"
+            >
+              <t k="istio.links.label" />
+              <i class="icon icon-external-link pull-right" />
+            </a>
             <hr />
-            <div class="description"><t k="istio.links.description" /></div>
+            <div class="description">
+              <span v-html="t('istio.links.description', {link:monitoringUrl}, true)" />
+            </div>
           </div>
-        </a>
+        </span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#1170 #1646 

* removed monitoring warning from the Istio install page
* added note about monitoring and link to rancher monitoring to the Istio overview page:
<img width="660" alt="Screen Shot 2020-10-09 at 12 59 18 PM" src="https://user-images.githubusercontent.com/42977925/95626606-748bed00-0a2f-11eb-827c-4db8f449e931.png">
