### PR TITLE
convert serviceport to grid from table

### DIFF
--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -11,7 +11,7 @@ export default {
 
   props: {
     value: {
-      type:    [String, Object, Number, Array],
+      type:    [String, Object, Number, Array, Boolean],
       default: null,
     },
     options: {
@@ -200,7 +200,7 @@ export default {
       :options="options"
       :placeholder="placeholder"
       :reduce="x => reduce(x)"
-      :value="value ? value : false"
+      :value="value != null ? value : ''"
       @input="e=>$emit('input', e)"
       @search:blur="onBlur"
       @search:focus="onFocus"

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -200,7 +200,7 @@ export default {
       :options="options"
       :placeholder="placeholder"
       :reduce="x => reduce(x)"
-      :value="value ? value : ''"
+      :value="value ? value : false"
       @input="e=>$emit('input', e)"
       @search:blur="onBlur"
       @search:focus="onFocus"

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -49,6 +49,14 @@ export default {
       return !this.isView;
     },
 
+    showProtocol() {
+      return this.specType !== 'NodePort';
+    },
+
+    showNodePort() {
+      return this.specType === 'NodePort' || this.specType === 'LoadBalancer';
+    },
+
     protocolOptions() {
       return ['TCP', 'UDP'];
     },
@@ -112,96 +120,94 @@ export default {
       </h2>
     </div>
 
-    <table v-if="rows.length" class="fixed">
-      <thead>
-        <tr>
-          <th v-if="padLeft" class="left"></th>
-          <th class="port-name">
-            <t k="servicePorts.rules.name.label" />
-          </th>
-          <th class="port">
-            <t k="servicePorts.rules.listening.label" />
-          </th>
-          <th v-if="specType !== 'NodePort'" class="port-protocol">
-            <t k="servicePorts.rules.protocol.label" />
-          </th>
-          <th class="target-port">
-            <t k="servicePorts.rules.target.label" />
-          </th>
-          <th v-if="specType === 'NodePort' || specType === 'LoadBalancer'" class="node-port">
-            <t k="servicePorts.rules.node.label" />
-          </th>
-          <th v-if="showRemove" class="remove"></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          v-for="(row, idx) in rows"
-          :key="idx"
-        >
-          <td v-if="padLeft" class="left"></td>
-          <td class="port-name">
-            <span v-if="isView">{{ row.name }}</span>
-            <input
-              v-else
-              ref="port-name"
-              v-model.number="row.name"
-              type="text"
-              :placeholder="t('servicePorts.rules.name.placeholder')"
-              @input="queueUpdate"
-            />
-          </td>
-          <td class="port">
-            <span v-if="isView">{{ row.port }}</span>
-            <input
-              v-else
-              ref="port"
-              v-model.number="row.port"
-              type="number"
-              min="1"
-              max="65535"
-              :placeholder="t('servicePorts.rules.listening.placeholder')"
-              @input="queueUpdate"
-            />
-          </td>
-          <td v-if="specType !== 'NodePort'" class="port-protocol">
-            <span v-if="isView">{{ row.protocol }}</span>
-            <LabeledSelect
-              v-else
-              v-model="row.protocol"
-              :options="protocolOptions"
-              @input="queueUpdate"
-            />
-          </td>
-          <td class="target-port">
-            <span v-if="isView">{{ row.targetPort }}</span>
-            <input
-              v-else
-              v-model="row.targetPort"
-              :placeholder="t('servicePorts.rules.target.placeholder')"
-              @input="queueUpdate"
-            />
-          </td>
-          <td v-if="specType === 'NodePort' || specType === 'LoadBalancer'" class="node-port">
-            <span v-if="isView">{{ row.nodePort }}</span>
-            <input
-              v-else
-              v-model.number="row.nodePort"
-              type="number"
-              min="1"
-              max="65535"
-              :placeholder="t('servicePorts.rules.node.placeholder')"
-              @input="queueUpdate"
-            />
-          </td>
-          <td v-if="showRemove" class="remove">
-            <button type="button" class="btn bg-transparent role-link" @click="remove(idx)">
-              <t k="generic.remove" />
-            </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-if="rows.length">
+      <div class="ports-headers" :class="{'show-protocol':showProtocol, 'show-node-port':showNodePort}">
+        <span v-if="padLeft" class="left"></span>
+        <span class="port-name">
+          <t k="servicePorts.rules.name.label" />
+        </span>
+        <span class="port">
+          <t k="servicePorts.rules.listening.label" />
+        </span>
+        <span v-if="showProtocol" class="port-protocol">
+          <t k="servicePorts.rules.protocol.label" />
+        </span>
+        <span class="target-port">
+          <t k="servicePorts.rules.target.label" />
+        </span>
+        <span v-if="showNodePort" class="node-port">
+          <t k="servicePorts.rules.node.label" />
+        </span>
+        <span v-if="showRemove" class="remove"></span>
+      </div>
+      <div
+        v-for="(row, idx) in rows"
+        :key="idx"
+        class="ports-row"
+        :class="{'show-protocol':showProtocol, 'show-node-port':showNodePort}"
+      >
+        <div v-if="padLeft" class="left"></div>
+        <div class="port-name">
+          <span v-if="isView">{{ row.name }}</span>
+          <input
+            v-else
+            ref="port-name"
+            v-model.number="row.name"
+            type="text"
+            :placeholder="t('servicePorts.rules.name.placeholder')"
+            @input="queueUpdate"
+          />
+        </div>
+        <div class="port">
+          <span v-if="isView">{{ row.port }}</span>
+          <input
+            v-else
+            ref="port"
+            v-model.number="row.port"
+            type="number"
+            min="1"
+            max="65535"
+            :placeholder="t('servicePorts.rules.listening.placeholder')"
+            @input="queueUpdate"
+          />
+        </div>
+        <div v-if="showProtocol" class="port-protocol">
+          <span v-if="isView">{{ row.protocol }}</span>
+          <LabeledSelect
+            v-else
+            v-model="row.protocol"
+            :options="protocolOptions"
+            @input="queueUpdate"
+          />
+        </div>
+        <div class="target-port">
+          <span v-if="isView">{{ row.targetPort }}</span>
+          <input
+            v-else
+            v-model="row.targetPort"
+            :placeholder="t('servicePorts.rules.target.placeholder')"
+            @input="queueUpdate"
+          />
+        </div>
+        <div v-if="showNodePort" class="node-port">
+          <span v-if="isView">{{ row.nodePort }}</span>
+          <input
+            v-else
+            v-model.number="row.nodePort"
+            type="number"
+            min="1"
+            max="65535"
+            :placeholder="t('servicePorts.rules.node.placeholder')"
+            @input="queueUpdate"
+          />
+        </div>
+        <div v-if="showRemove" class="remove">
+          <button type="button" class="btn bg-transparent role-link" @click="remove(idx)">
+            <t k="generic.remove" />
+          </button>
+        </div>
+      </div>
+    </div>
     <div v-if="showAdd" class="footer">
       <button type="button" class="btn role-tertiary add mt-10" @click="add()">
         <t k="generic.add" />
@@ -211,7 +217,8 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  $remove: 75;
+ $remove: 75;
+  $checkbox: 75;
 
   .title {
     margin-bottom: 10px;
@@ -221,42 +228,46 @@ export default {
     }
   }
 
-  TABLE {
-    width: 100%;
-  }
+  .ports-headers, .ports-row{
+    display: grid;
+    grid-column-gap: $column-gutter;
+    margin-bottom: 10px;
+    align-items: center;
+    & .port{
+      display: flex;
+      justify-content: space-between;
+    }
 
-  TH {
-    text-align: left;
-    font-size: 12px;
-    font-weight: normal;
-    color: var(--input-label);
-  }
-
-  .left {
-    width: #{$remove}px;
-  }
-
-  .port-protocol {
-    width: 100px;
-    .labeled-select {
-      &.labeled-input {
-        padding: 6px;
+    &.show-protocol{
+      grid-template-columns: 23% 23% 10% 15% 15% 10%;
+      &:not(.show-node-port){
+        grid-template-columns: 31% 31% 10% 15% 10%;
       }
+    }
+    &.show-node-port:not(.show-protocol){
+      grid-template-columns: 28% 28% 15% 15% 10%;
     }
   }
 
-  .value {
-    vertical-align: top;
+  .ports-headers {
+    color: var(--input-label);
   }
 
-  .remove {
-    vertical-align: middle;
-    text-align: right;
-    width: #{$remove}px;
+  .toggle-host-ports {
+    color: var(--primary);
+  }
+
+  .remove BUTTON {
+    padding: 0px;
+  }
+
+  .ports-row INPUT {
+    height: 50px;
   }
 
   .footer {
     margin-top: 10px;
+    margin-left: 5px;
 
     .protip {
       float: right;

--- a/edit/resources.cattle.io.restore.vue
+++ b/edit/resources.cattle.io.restore.vue
@@ -226,8 +226,8 @@ export default {
               <LabeledSelect
                 v-if="isEncrypted"
                 v-model="value.spec.encryptionConfigSecretName"
-                status="warning"
-                :tooltip="t('backupRestoreOperator.encryptionConfigName.restoretip')"
+                :status="mode === 'view' ? null : 'warning'"
+                :tooltip="mode === 'view' ? null : t('backupRestoreOperator.encryptionConfigName.restoretip')"
                 :hover-tooltip="true"
                 :mode="mode"
                 :options="encryptionSecretNames"


### PR DESCRIPTION
#1647 #1303 #1442 
* fixed bug where `LabeledSelect` displayed the placeholder and option label if option value is `false`
* removed warning about encryption config secrets from restore view page
* converted serviceports to use grid

<img width="1280" alt="Screen Shot 2020-10-09 at 2 00 41 PM" src="https://user-images.githubusercontent.com/42977925/95631368-6f7f6b80-0a38-11eb-9f4d-4c96fe8c9e43.png">
<img width="1286" alt="Screen Shot 2020-10-09 at 2 00 53 PM" src="https://user-images.githubusercontent.com/42977925/95631375-727a5c00-0a38-11eb-8175-31bee03fc532.png">
<img width="1293" alt="Screen Shot 2020-10-09 at 2 01 01 PM" src="https://user-images.githubusercontent.com/42977925/95631377-7312f280-0a38-11eb-8b1a-8a136648be0d.png">
