### PR TITLE
Add resource subtype to masthead v2

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -912,7 +912,7 @@ resourceDetail:
   header:
     clone: "Clone from {type}: {name}"
     create: Create
-    edit: "Edit {type}: {name}"
+    edit: Edit
     stage: "Stage from {type}: {name}"
     view: "{name}"
   masthead:
@@ -1214,7 +1214,7 @@ validation:
       startHyphen: '"{key}" cannot start with a hyphen'
       startNumber: '"{key}" cannot start with a number'
       tooLongLabel: '"{key}" cannot be more than {max} characters'
-  flowOutput: 
+  flowOutput:
     global: Requires "Cluster Output" to be selected.
     both: Requires "Output" or "Cluster Output" to be selected.
   k8s:

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -43,6 +43,11 @@ export default {
     parentOverride: {
       type:    Object,
       default: null
+    },
+
+    resourceSubtype: {
+      type:    String,
+      default: null,
     }
   },
 
@@ -183,6 +188,7 @@ export default {
             {{ parent.displayName }}:
           </nuxt-link>
           <span v-html="h1" />
+          <span v-if="resourceSubtype" v-html="resourceSubtype" />
         </h1>
         <BadgeState v-if="isView" :value="value" />
       </div>

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -188,19 +188,19 @@ export default {
     <div class="title">
       <div class="primaryheader">
         <h1 v-if="isEdit">
-          <t k="resourceDetail.header.edit" />
-          <span v-if="resourceSubtype" v-html="resourceSubtype" />
           <nuxt-link :to="parent.location">
             {{ parent.displayName }}:
           </nuxt-link>
+          <t k="resourceDetail.header.edit" />
+          <span v-if="resourceSubtype" v-html="resourceSubtype" />
           {{ value.nameDisplay }}
         </h1>
         <h1 v-else>
           <nuxt-link :to="parent.location">
             {{ parent.displayName }}:
           </nuxt-link>
-          <span v-html="h1" />
           <span v-if="resourceSubtype" v-html="resourceSubtype" />
+          <span v-html="h1" />
         </h1>
         <BadgeState v-if="isView" :value="value" />
       </div>

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -6,7 +6,8 @@ import BadgeState from '@/components/BadgeState';
 import Banner from '@/components/Banner';
 import { get } from '@/utils/object';
 import { NAME as FLEET_NAME } from '@/config/product/fleet';
-import { _VIEW } from '@/config/query-params';
+import { _CREATE, _EDIT, _VIEW } from '@/config/query-params';
+import isEmpty from 'lodash/isEmpty';
 
 export default {
   components: {
@@ -69,6 +70,10 @@ export default {
 
     isView() {
       return this.mode === _VIEW;
+    },
+
+    isEdit() {
+      return this.mode === _EDIT;
     },
 
     isNamespace() {
@@ -183,7 +188,15 @@ export default {
   <header class="masthead">
     <div class="title">
       <div class="primaryheader">
-        <h1>
+        <h1 v-if="isEdit">
+          <t k="resourceDetail.header.edit" />
+          <span v-if="resourceSubtype" v-html="resourceSubtype" />
+          <nuxt-link :to="parent.location">
+            {{ parent.displayName }}:
+          </nuxt-link>
+          {{ value.nameDisplay }}
+        </h1>
+        <h1 v-else>
           <nuxt-link :to="parent.location">
             {{ parent.displayName }}:
           </nuxt-link>

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -6,8 +6,7 @@ import BadgeState from '@/components/BadgeState';
 import Banner from '@/components/Banner';
 import { get } from '@/utils/object';
 import { NAME as FLEET_NAME } from '@/config/product/fleet';
-import { _CREATE, _EDIT, _VIEW } from '@/config/query-params';
-import isEmpty from 'lodash/isEmpty';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   components: {

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -228,6 +228,7 @@ export default {
       currentValue,
       detailComponent: this.$store.getters['type-map/importDetail'](this.resource),
       editComponent:   this.$store.getters['type-map/importEdit'](this.resource),
+      resourceSubtype: null,
     };
   },
 
@@ -309,6 +310,10 @@ export default {
       if (component) {
         component.updateValue(value);
       }
+    },
+
+    setSubtype(subtype) {
+      this.resourceSubtype = subtype;
     }
   }
 };
@@ -328,6 +333,7 @@ export default {
       :as-yaml.sync="asYaml"
       :parent-override="parentOverride"
       :has-detail-or-edit="(hasCustomDetail || (hasCustomEdit && !yamlOnlyDetail))"
+      :resource-subtype="resourceSubtype"
     >
       <template v-if="!isView && asYaml" #right>
         <div class="text-right">
@@ -355,13 +361,14 @@ export default {
       <component
         :is="showComponent"
         v-model="model"
-        :original-value="originalModel"
-        :done-route="doneRoute"
+        v-bind="_data"
         :done-params="doneParams"
+        :done-route="doneRoute"
         :mode="mode"
+        :original-value="originalModel"
         :real-mode="realMode"
         :value="model"
-        v-bind="_data"
+        @set-subtype="setSubtype"
       />
     </template>
   </div>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -15,6 +15,7 @@ import { ucFirst } from '@/utils/string';
 import CruResource from '@/components/CruResource';
 import Banner from '@/components/Banner';
 import Labels from '@/components/form/Labels';
+import { _EDIT } from '@/config/query-params';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:     'None',
@@ -89,6 +90,8 @@ export default {
       },
 
       set(serviceType) {
+        this.$emit('set-subtype', serviceType);
+
         if (serviceType === HEADLESS) {
           this.$set(this.value.spec, 'type', CLUSTERIP);
           this.$set(this.value.spec, 'clusterIP', 'None');
@@ -127,6 +130,14 @@ export default {
       ) {
         delete this.value.spec.sessionAffinityConfig.clientIP.timeoutSeconds;
       }
+    }
+  },
+
+  mounted() {
+    if (this.mode === _EDIT) {
+      const initialType = this.serviceType;
+
+      this.$set(this, 'serviceType', initialType);
     }
   },
 

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -15,7 +15,6 @@ import { ucFirst } from '@/utils/string';
 import CruResource from '@/components/CruResource';
 import Banner from '@/components/Banner';
 import Labels from '@/components/form/Labels';
-import { _EDIT } from '@/config/query-params';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:     'None',
@@ -134,11 +133,9 @@ export default {
   },
 
   mounted() {
-    if (this.mode === _EDIT) {
-      const initialType = this.serviceType;
+    const initialType = this.serviceType;
 
-      this.$set(this, 'serviceType', initialType);
-    }
+    this.$set(this, 'serviceType', initialType);
   },
 
   methods: {


### PR DESCRIPTION
Weirdness with the old PR made me close that but for ref [here it is](https://github.com/rancher/dashboard/pull/1649)

Some resources like Service and Secret have a type (`service`) but also a Subtype (`ClusterIP`). This exposes the mechanism to set that from the resource.

@vincent99 @lvuch Would it make sense to change create to match edit now?
rancher/dashboard#1073

![Screen Shot 2020-10-09 at 2 37 11 PM](https://user-images.githubusercontent.com/858614/95634834-ac029580-0a3f-11eb-9748-dd30eb61d19b.png)
![Screen Shot 2020-10-09 at 2 36 48 PM](https://user-images.githubusercontent.com/858614/95634839-aefd8600-0a3f-11eb-8f2b-c216c3353161.png)
![Screen Shot 2020-10-09 at 2 36 32 PM](https://user-images.githubusercontent.com/858614/95634841-b0c74980-0a3f-11eb-8ef5-b66aab5599b0.png)

