### PR TITLE
[2.5.2] Prometheus Rules Custom UI

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -901,6 +901,59 @@ prefs:
   dev:
     label: Enable Developer Tools
 
+prometheusRule:
+  promQL:
+    label: PromQL Expression
+  groups:
+    add: Add Rule Group
+    none: Please add at least one rule group that contains at least one alerting or one recording rule.
+    label: Rule Groups
+    removeGroup: Remove Group
+    name: Group Name
+    groupInterval:
+      label: Override Group Interval
+      placeholder: '60'
+    responseStrategy:
+      label: Partial Response Strategy
+  recordingRules:
+    label: Recording Rules
+    addLabel: Add Record
+    removeRecord: Remove Record
+    name: Time Series Name
+    labels: Labels
+  alertingRules:
+    name: Alert Name
+    for:
+      label: Wait to fire for
+      placeholder: '60'
+    label: Alerting Rules
+    addLabel: Add Alert
+    bannerText: When firing alerts, the annotations and labels will be passed to the configured AlertManagers to allow them to construct the notification that will be sent to any configured Receivers.
+    removeAlert: Remove Alert
+    labels:
+      label: Labels
+      severity:
+        label: Severity
+        choices:
+          label: Severity Label Value
+          critical: critical
+          warning: warning
+          none: none
+    annotations:
+      label: Annotations
+      summary:
+        label: Summary
+        input: Summary Annotation Value
+      message:
+        label: Message
+        input: Message Annotation Value
+      description:
+        label: Description
+        input: Description Annotation Value
+      runbook:
+        label: Runbook URL
+        input: Runbook URL Annotation Value
+
 promptRemove:
   andOthers: |-
     {count, plural,
@@ -1214,7 +1267,7 @@ validation:
     min: '"{key}" should contain at least {count} {count, plural, =1 {item} other {items}}'
   chars: '"{key}" contains {count, plural, =1 {an invalid character} other {# invalid characters}}: {chars}'
   custom:
-    missing: "No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?"
+    missing: 'No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?'
   dns:
     doubleHyphen: '"{key}" Cannot contain two or more consecutive hyphens'
     hostname:
@@ -1234,8 +1287,8 @@ validation:
       startNumber: '"{key}" cannot start with a number'
       tooLongLabel: '"{key}" cannot be more than {max} characters'
   flowOutput:
-    global: Requires "Cluster Output" to be selected.
     both: Requires "Output" or "Cluster Output" to be selected.
+    global: Requires "Cluster Output" to be selected.
   k8s:
     identifier:
       emptyLabel: '"{key}" cannot have an empty key'
@@ -1251,24 +1304,36 @@ validation:
     exactly: '"{key}" should be exactly {val}'
     max: '"{key}" should be at most {val}'
     min: '"{key}" should be at least {val}'
+  prometheusRule:
+    groups:
+      required: At least one rule group is required.
+      singleAlert: A rule may contain alert rules or recording rules but not both.
+      valid:
+        name: 'Name is required for group {index}.'
+        rule:
+          alertName: 'Rule Group {groupIndex} Rule {ruleIndex} requires a Alert Name.'
+          expr: 'Rule Group {groupIndex} Rule {ruleIndex} requires a PromQL Expression.'
+          labels: 'Rule Group {groupIndex} Rule {ruleIndex} requires at least one label. Severity is recommended.'
+          recordName: 'Rule Group {groupIndex} Rule {ruleIndex} requires a Time Series Name.'
+        singleEntry: 'At least one alert rule or one recording rule is required in rule group {index}.'
   required: '"{key}" is required'
   requiredOrOverride: '"{key}" is required or must allow override'
   service:
     externalName:
-      none: 'External Name is required on an ExternalName Service.'
+      none: External Name is required on an ExternalName Service.
     ports:
       name:
-        required: "Port Rule [{position}] - Name is required."
+        required: 'Port Rule [{position}] - Name is required.'
       nodePort:
-        requriedInt: "Port Rule [{position}] - Node Port must be interger values if included."
+        requriedInt: 'Port Rule [{position}] - Node Port must be interger values if included.'
       port:
-        required: "Port Rule [{position}] - Port is required."
-        requriedInt: "Port Rule [{position}] - Port must be interger values if included."
+        required: 'Port Rule [{position}] - Port is required.'
+        requriedInt: 'Port Rule [{position}] - Port must be interger values if included.'
       targetPort:
-        between: "Port Rule [{position}] - Target Port must be between 1 and 65535"
-        iana: "Port Rule [{position}] - Target Port must be an IANA Service Name or Integer"
-        ianaAt: "Port Rule [{position}] - Target Port "
-        required: "Port Rule [{position}] - Target Port is required"
+        between: 'Port Rule [{position}] - Target Port must be between 1 and 65535'
+        iana: 'Port Rule [{position}] - Target Port must be an IANA Service Name or Integer'
+        ianaAt: 'Port Rule [{position}] - Target Port '
+        required: 'Port Rule [{position}] - Target Port is required'
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
     exactly: '"{key}" should be {count, plural, =1 {# character} other {# characters}}'

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -902,57 +902,58 @@ prefs:
     label: Enable Developer Tools
 
 prometheusRule:
-  promQL:
-    label: PromQL Expression
-  groups:
-    add: Add Rule Group
-    none: Please add at least one rule group that contains at least one alerting or one recording rule.
-    label: Rule Groups
-    removeGroup: Remove Group
-    name: Group Name
-    groupInterval:
-      label: Override Group Interval
-      placeholder: '60'
-    responseStrategy:
-      label: Partial Response Strategy
-  recordingRules:
-    label: Recording Rules
-    addLabel: Add Record
-    removeRecord: Remove Record
-    name: Time Series Name
-    labels: Labels
   alertingRules:
-    name: Alert Name
+    addLabel: Add Alert
+    annotations:
+      description:
+        input: Description Annotation Value
+        label: Description
+      label: Annotations
+      message:
+        input: Message Annotation Value
+        label: Message
+      runbook:
+        input: Runbook URL Annotation Value
+        label: Runbook URL
+      summary:
+        input: Summary Annotation Value
+        label: Summary
+    bannerText: 'When firing alerts, the annotations and labels will be passed to the configured AlertManagers to allow them to construct the notification that will be sent to any configured Receivers.'
     for:
       label: Wait to fire for
       placeholder: '60'
     label: Alerting Rules
-    addLabel: Add Alert
-    bannerText: When firing alerts, the annotations and labels will be passed to the configured AlertManagers to allow them to construct the notification that will be sent to any configured Receivers.
-    removeAlert: Remove Alert
     labels:
       label: Labels
       severity:
-        label: Severity
         choices:
-          label: Severity Label Value
           critical: critical
-          warning: warning
+          label: Severity Label Value
           none: none
-    annotations:
-      label: Annotations
-      summary:
-        label: Summary
-        input: Summary Annotation Value
-      message:
-        label: Message
-        input: Message Annotation Value
-      description:
-        label: Description
-        input: Description Annotation Value
-      runbook:
-        label: Runbook URL
-        input: Runbook URL Annotation Value
+          warning: warning
+        label: Severity
+    name: Alert Name
+    removeAlert: Remove Alert
+  groups:
+    add: Add Rule Group
+    groupRowLabel: Rule Group {index}
+    groupInterval:
+      label: Override Group Interval
+      placeholder: '60'
+    label: Rule Groups
+    name: Group Name
+    none: Please add at least one rule group that contains at least one alerting or one recording rule.
+    removeGroup: Remove Group
+    responseStrategy:
+      label: Partial Response Strategy
+  promQL:
+    label: PromQL Expression
+  recordingRules:
+    addLabel: Add Record
+    label: Recording Rules
+    labels: Labels
+    name: Time Series Name
+    removeRecord: Remove Record
 
 promptRemove:
   andOthers: |-
@@ -1309,12 +1310,12 @@ validation:
       required: At least one rule group is required.
       singleAlert: A rule may contain alert rules or recording rules but not both.
       valid:
-        name: 'Name is required for group {index}.'
+        name: 'Name is required for rule group {index}.'
         rule:
-          alertName: 'Rule Group {groupIndex} Rule {ruleIndex} requires a Alert Name.'
-          expr: 'Rule Group {groupIndex} Rule {ruleIndex} requires a PromQL Expression.'
-          labels: 'Rule Group {groupIndex} Rule {ruleIndex} requires at least one label. Severity is recommended.'
-          recordName: 'Rule Group {groupIndex} Rule {ruleIndex} requires a Time Series Name.'
+          alertName: 'Rule group {groupIndex} rule {ruleIndex} requires a Alert Name.'
+          expr: 'Rule group {groupIndex} rule {ruleIndex} requires a PromQL Expression.'
+          labels: 'Rule group {groupIndex} rule {ruleIndex} requires at least one label. Severity is recommended.'
+          recordName: 'Rule group {groupIndex} rule {ruleIndex} requires a Time Series Name.'
         singleEntry: 'At least one alert rule or one recording rule is required in rule group {index}.'
   required: '"{key}" is required'
   requiredOrOverride: '"{key}" is required or must allow override'
@@ -1532,7 +1533,7 @@ workload:
         normal: Normal
       placeholder: Select a Mode...
     dns: DNS
-    resolver: 
+    resolver:
       label: Resolver Options
       add: Add Option
     searches:

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -3,6 +3,7 @@ import head from 'lodash/head';
 import isEmpty from 'lodash/isEmpty';
 import { addObject, removeObject, findBy } from '@/utils/array';
 import { sortBy } from '@/utils/sort';
+import findIndex from 'lodash/findIndex';
 
 export default {
   name: 'Tabbed',
@@ -14,6 +15,11 @@ export default {
     },
 
     sideTabs: {
+      type:    Boolean,
+      default: false
+    },
+
+    showTabsAddRemove: {
       type:    Boolean,
       default: false
     },
@@ -233,7 +239,15 @@ export default {
           return nxt;
         }
       }
-    }
+    },
+    tabAddClicked() {
+      this.$emit('addTab');
+    },
+    tabRemoveClicked() {
+      const activeTabIndex = findIndex(this.tabs, tab => tab.active);
+
+      this.$emit('removeTab', activeTabIndex);
+    },
   },
 };
 </script>
@@ -290,6 +304,16 @@ export default {
           </a>
         </li>
       </template>
+      <ul v-if="sideTabs && showTabsAddRemove" class="tab-list-footer">
+        <li>
+          <button type="button" class="btn bg-transparent" @click="tabAddClicked">
+            <i class="icon icon-plus" />
+          </button>
+          <button type="button" class="btn bg-transparent" @click="tabRemoveClicked">
+            <i class="icon icon-minus" />
+          </button>
+        </li>
+      </ul>
     </ul>
     <div class="tab-container">
       <slot />
@@ -361,6 +385,9 @@ export default {
     & .tabs {
       width: $sideways-tabs-width;
       min-width: $sideways-tabs-width;
+      display: flex;
+      flex: 1 0;
+      flex-direction: column;
 
       & .tab {
         width: 100%;
@@ -381,6 +408,31 @@ export default {
           & A{
             color: var(--input-label);
           }
+        }
+      }
+      .tab-list-footer {
+        list-style: none;
+        padding: 0;
+        margin-top: auto;
+
+        li {
+          display: flex;
+          flex: 1;
+
+          .btn {
+            flex: 1 1;
+          }
+
+          button:first-of-type {
+            border-top: solid thin var(--border);
+            border-right: solid thin var(--border);
+            border-top-right-radius: 0;
+          }
+          button:last-of-type {
+            border-top: solid thin var(--border);
+            border-top-left-radius: 0;
+          }
+
         }
       }
     }

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -79,6 +79,7 @@ export default {
     @click.stop="clicked($event)"
   >
     <input
+      :id="_uid+'-radio'"
       :disabled="disabled"
       :name="name"
       :value="''+val"
@@ -154,13 +155,15 @@ export default {
     display: none;
   }
 
-  input:checked ~ .radio-custom {
+  .radio-custom {
+    &[aria-checked="true"] {
       background-color: var(--dropdown-text);
       -webkit-transform: rotate(0deg) scale(1);
       -ms-transform: rotate(0deg) scale(1);
       transform: rotate(0deg) scale(1);
       opacity:1;
       border: 1.5px solid var(--dropdown-text);
+    }
   }
 
   input:disabled ~ .radio-custom {

--- a/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
@@ -1,0 +1,502 @@
+<script>
+import debounce from 'lodash/debounce';
+import has from 'lodash/has';
+import isEmpty from 'lodash/isEmpty';
+import pickBy from 'lodash/pickBy';
+
+import Checkbox from '@/components/form/Checkbox';
+import CodeMirror from '@/components/CodeMirror';
+import KeyValue from '@/components/form/KeyValue';
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import UnitInput from '@/components/form/UnitInput';
+import { _VIEW } from '@/config/query-params';
+
+const INGORED_ANNOTATIONS = [
+  'summary',
+  'message',
+  'description',
+  'runbook_url',
+];
+
+export default {
+  components: {
+    Checkbox,
+    CodeMirror,
+    KeyValue,
+    LabeledInput,
+    LabeledSelect,
+    UnitInput,
+  },
+
+  props: {
+    value: {
+      type:    Object,
+      default: () => ({}),
+    },
+
+    mode: {
+      type:    String,
+      default: 'create',
+    },
+
+    ruleIndex: {
+      type:    Number,
+      default: 0,
+    },
+  },
+
+  data() {
+    return {
+      selectedSeverityLabel: null,
+      ignoredAnnotations:    INGORED_ANNOTATIONS,
+    };
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+    severityLabelChecked: {
+      get() {
+        if (has(this.value?.labels, 'severity')) {
+          return true;
+        }
+
+        return false;
+      },
+      set(value) {
+        if (value) {
+          if (isEmpty(this.value?.labels)) {
+            this.$set(this.value, 'labels', { severity: 'critical' });
+          } else {
+            this.$set(this.value.labels, 'severity', 'critical');
+          }
+        } else {
+          this.$set(this.value.labels, 'severity', '');
+          delete this.value.labels.severity;
+        }
+      },
+    },
+
+    summaryAnnotationChecked: {
+      get() {
+        if (has(this.value?.annotations, 'summary')) {
+          return true;
+        }
+
+        return false;
+      },
+      set(value) {
+        if (value) {
+          if (isEmpty(this.value?.annotations)) {
+            this.$set(this.value, 'annotations', { summary: '' });
+          } else {
+            this.$set(this.value.annotations, 'summary', '');
+          }
+        } else {
+          this.$set(this.value.annotations, 'summary', '');
+          delete this.value.annotations.summary;
+        }
+      },
+    },
+
+    messageAnnotationChecked: {
+      get() {
+        if (has(this.value?.annotations, 'message')) {
+          return true;
+        }
+
+        return false;
+      },
+      set(value) {
+        if (value) {
+          if (isEmpty(this.value?.annotations)) {
+            this.$set(this.value, 'annotations', { message: '' });
+          } else {
+            this.$set(this.value.annotations, 'message', '');
+          }
+        } else {
+          this.$set(this.value.annotations, 'message', '');
+          delete this.value.annotations.message;
+        }
+      },
+    },
+
+    descriptionAnnotationChecked: {
+      get() {
+        if (has(this.value?.annotations, 'description')) {
+          return true;
+        }
+
+        return false;
+      },
+      set(value) {
+        if (value) {
+          if (isEmpty(this.value?.annotations)) {
+            this.$set(this.value, 'annotations', { description: '' });
+          } else {
+            this.$set(this.value.annotations, 'description', '');
+          }
+        } else {
+          this.$set(this.value.annotations, 'description', '');
+          delete this.value.annotations.description;
+        }
+      },
+    },
+
+    runbookAnnotationChecked: {
+      get() {
+        if (has(this.value?.annotations, 'runbook_url')) {
+          return true;
+        }
+
+        return false;
+      },
+      set(value) {
+        if (value) {
+          if (isEmpty(this.value?.annotations)) {
+            this.$set(this.value, 'annotations', { runbook_url: '' });
+          } else {
+            this.$set(this.value.annotations, 'runbook_url', '');
+          }
+        } else {
+          this.$set(this.value.annotations, 'runbook_url', '');
+          delete this.value.annotations.runbook_url;
+        }
+      },
+    },
+
+    filteredAnnotations() {
+      const { ignoredAnnotations } = this;
+      const annotations = this.value?.annotations;
+
+      return pickBy(annotations, (value, key) => {
+        return !ignoredAnnotations.includes(key);
+      });
+    },
+
+    filteredLabels() {
+      const labels = this.value?.labels;
+
+      return pickBy(labels, (value, key) => {
+        return key !== 'severity';
+      });
+    },
+
+    showCustomSeverityInput() {
+      const { selectedSeverityLabel } = this;
+
+      if (selectedSeverityLabel === 'custom') {
+        return true;
+      }
+
+      return false;
+    },
+  },
+
+  watch: {
+    selectedSeverityLabel(value /* , oldValue */) {
+      const neu = value === 'custom' ? '' : value;
+
+      if (this.value?.labels) {
+        this.$set(this.value.labels, 'severity', neu);
+      } else {
+        this.$set(this.value, 'labels', { severity: neu });
+      }
+    },
+  },
+
+  created() {
+    this.queueUpdate = debounce(this.updateExpression, 500);
+    this.queueLabelUpdate = debounce(this.updateLabels, 500);
+    this.queueAnnotationUpdate = debounce(this.updateAnnotations, 500);
+  },
+
+  mounted() {
+    this.$nextTick(() => {
+      if (this.value?.labels?.severity) {
+        this.selectedSeverityLabel = this.value.labels.severity;
+      }
+    });
+  },
+
+  methods: {
+    updateLabels(value) {
+      const neu = { ...value };
+
+      if (this.selectedSeverityLabel) {
+        neu['severity'] = this.selectedSeverityLabel;
+      }
+
+      this.$set(this.value, 'labels', neu);
+    },
+    updateAnnotations(value) {
+      const {
+        ignoredAnnotations,
+        value: { annotations = {} },
+      } = this;
+      const neu = { ...value };
+
+      ignoredAnnotations.forEach((anno) => {
+        if (has(annotations, anno)) {
+          neu[anno] = annotations[anno];
+        }
+      });
+
+      this.$set(this.value, 'annotations', neu);
+    },
+    updateExpression(value) {
+      this.$set(this.value, 'expr', value);
+    },
+    remove() {
+      this.$emit('removeRule', this.ruleIndex);
+    },
+  },
+};
+</script>
+
+<template>
+  <div>
+    <button
+      v-if="!isView"
+      v-tooltip="t('prometheusRule.alertingRules.removeAlert')"
+      type="button"
+      class="btn btn-sm bg-transparent remove"
+      @click="remove"
+    >
+      <i class="icon icon-x icon-2x" />
+    </button>
+    <div class="row mt-25">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.alert"
+          :label="t('prometheusRule.alertingRules.name')"
+          :required="true"
+          :mode="mode"
+        />
+      </div>
+      <div class="col span-6">
+        <UnitInput
+          v-model="value.for"
+          :suffix="t('suffix.seconds')"
+          :placeholder="t('prometheusRule.alertingRules.for.placeholder')"
+          :label="t('prometheusRule.alertingRules.for.label')"
+          :mode="mode"
+          @input="(e) => $set(value, 'for', `${e}s`)"
+        />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-12">
+        <LabeledInput
+          v-model="value.expr"
+          :label="t('prometheusRule.promQL.label')"
+          :required="true"
+          :mode="mode"
+        >
+          <template #field>
+            <CodeMirror
+              class="mt-20"
+              :value="value.expr"
+              :options="{
+                mode: null,
+                foldGutter: false,
+                readOnly: mode === 'view',
+              }"
+              @onInput="queueUpdate"
+            />
+          </template>
+        </LabeledInput>
+      </div>
+    </div>
+    <div class="suggested-labels">
+      <div class="row mb-0 mt-30">
+        <div class="col span-12">
+          <h3 class="mb-0">
+            <t k="prometheusRule.alertingRules.labels.label" />
+          </h3>
+        </div>
+      </div>
+      <div :class="[{ hide: isView && !severityLabelChecked }, 'row']">
+        <div v-if="isView && severityLabelChecked" class="col span-6 severity">
+          <label><t k="prometheusRule.alertingRules.labels.severity.label" /></label>
+          <div>{{ value.labels.severity }}</div>
+        </div>
+        <div v-else class="severity col span-6">
+          <Checkbox
+            v-model="severityLabelChecked"
+            :mode="mode"
+            :label="t('prometheusRule.alertingRules.labels.severity.label')"
+          />
+          <LabeledSelect
+            v-if="severityLabelChecked"
+            v-model="value.labels.severity"
+            class="mt-10"
+            :mode="mode"
+            :label="t('prometheusRule.alertingRules.labels.severity.choices.label')"
+            :localized-label="false"
+            :options="[
+              t('prometheusRule.alertingRules.labels.severity.choices.critical'),
+              t('prometheusRule.alertingRules.labels.severity.choices.warning'),
+              t('prometheusRule.alertingRules.labels.severity.choices.none'),
+            ]"
+          />
+        </div>
+      </div>
+      <div :class="[{ hide: isView && Object.keys(filteredLabels).length === 0}, 'row', 'mt-0']">
+        <div class="col span-12">
+          <KeyValue
+            key="labels"
+            :value="filteredLabels"
+            :add-label="t('labels.addLabel')"
+            :mode="mode"
+            :pad-left="false"
+            :read-allowed="false"
+            :value-multiline="false"
+            @input="queueLabelUpdate"
+          />
+        </div>
+      </div>
+      <div class="suggested-annotations">
+        <div class="row mb-0 mt-30">
+          <div class="col span-12">
+            <h3 class="mb-0">
+              <t k="prometheusRule.alertingRules.annotations.label" />
+            </h3>
+          </div>
+        </div>
+        <div class="row mt-0 mb-0">
+          <div class="col span-12">
+            <div :class="[{ hide: isView && !summaryAnnotationChecked }, 'row']">
+              <div
+                v-if="isView && summaryAnnotationChecked"
+                class="col span-6 annotation-checkbox-container"
+              >
+                <label>
+                  <t k="prometheusRule.alertingRules.annotations.summary.label" />
+                </label>
+                <div>{{ value.annotations.summary }}</div>
+              </div>
+              <div v-else class="col span-6 annotation-checkbox-container">
+                <Checkbox
+                  v-model="summaryAnnotationChecked"
+                  :mode="mode"
+                  :label="t('prometheusRule.alertingRules.annotations.summary.label')"
+                />
+                <LabeledInput
+                  v-if="summaryAnnotationChecked"
+                  v-model="value.annotations.summary"
+                  class="mt-5"
+                  :label="t('prometheusRule.alertingRules.annotations.summary.input')"
+                  type="multiline"
+                  :mode="mode"
+                />
+              </div>
+            </div>
+            <div :class="[{ hide: isView && !messageAnnotationChecked }, 'row']">
+              <div
+                v-if="isView && messageAnnotationChecked"
+                class="col span-6 annotation-checkbox-container"
+              >
+                <label><t
+                  k="prometheusRule.alertingRules.annotations.message.label"
+                /></label>
+                <div>{{ value.annotations.message }}</div>
+              </div>
+              <div v-else class="col span-6 annotation-checkbox-container">
+                <Checkbox
+                  v-model="messageAnnotationChecked"
+                  :mode="mode"
+                  :label="t('prometheusRule.alertingRules.annotations.message.label')"
+                />
+                <LabeledInput
+                  v-if="messageAnnotationChecked"
+                  v-model="value.annotations.message"
+                  class="mt-5"
+                  :label="t('prometheusRule.alertingRules.annotations.message.input')"
+                  type="multiline"
+                  :mode="mode"
+                />
+              </div>
+            </div>
+            <div :class="[ { hide: isView && !descriptionAnnotationChecked }, 'row']">
+              <div
+                v-if="isView && descriptionAnnotationChecked"
+                class="col span-6 annotation-checkbox-container"
+              >
+                <label><t
+                  k="prometheusRule.alertingRules.annotations.description.label"
+                /></label>
+                <div>{{ value.annotations.description }}</div>
+              </div>
+              <div v-else class="col span-6 annotation-checkbox-container">
+                <Checkbox
+                  v-model="descriptionAnnotationChecked"
+                  :mode="mode"
+                  :label="t('prometheusRule.alertingRules.annotations.description.label')"
+                />
+                <LabeledInput
+                  v-if="descriptionAnnotationChecked"
+                  v-model="value.annotations.description"
+                  class="mt-5"
+                  :label="t('prometheusRule.alertingRules.annotations.description.input')"
+                  type="multiline"
+                  :mode="mode"
+                />
+              </div>
+            </div>
+            <div :class="[{ hide: isView && !runbookAnnotationChecked }, 'row']">
+              <div
+                v-if="isView && runbookAnnotationChecked"
+                class="col span-6 annotation-checkbox-container"
+              >
+                <label>
+                  <t k="prometheusRule.alertingRules.annotations.runbook.label" />
+                </label>
+                <div>{{ value.annotations.runbook_url }}</div>
+              </div>
+              <div v-else class="col span-6 annotation-checkbox-container">
+                <Checkbox
+                  v-model="runbookAnnotationChecked"
+                  :mode="mode"
+                  :label="t('prometheusRule.alertingRules.annotations.runbook.label')"
+                />
+                <LabeledInput
+                  v-if="runbookAnnotationChecked"
+                  v-model="value.annotations.runbook_url"
+                  class="mt-5"
+                  :label="t('prometheusRule.alertingRules.annotations.runbook.input')"
+                  type="multiline"
+                  :mode="mode"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div :class="[{ hide: isView && Object.keys(filteredAnnotations).length === 0}, 'row', 'mt-0']">
+          <KeyValue
+            key="annotations"
+            :value="filteredAnnotations"
+            :add-label="t('labels.addAnnotation')"
+            :mode="mode"
+            :pad-left="false"
+            :read-allowed="false"
+            @input="queueAnnotationUpdate"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.row {
+  margin: 20px 0;
+}
+.remove {
+  position: absolute;
+  top: 0;
+  right: 5px;
+}
+</style>

--- a/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -1,0 +1,181 @@
+<script>
+import has from 'lodash/has';
+
+import Banner from '@/components/Banner';
+import { removeAt } from '@/utils/array';
+import { _VIEW } from '@/config/query-params';
+import AlertingRule from './AlertingRule';
+import RecordingRule from './RecordingRule';
+
+export default {
+  components: {
+    AlertingRule,
+    Banner,
+    RecordingRule,
+  },
+
+  props: {
+    value: {
+      type:    Array,
+      default: () => [],
+    },
+
+    mode: {
+      type:    String,
+      default: 'create',
+    },
+  },
+
+  computed: {
+    recordingRules() {
+      const { value: rules } = this;
+
+      return rules.filter(rule => has(rule, 'record'));
+    },
+    alertingRules() {
+      const { value: rules } = this;
+
+      return rules.filter(rule => has(rule, 'alert'));
+    },
+    customRules() {
+      const { value: rules } = this;
+
+      return rules.filter(
+        rule => !has(rule, 'alert') && !has(rule, 'record')
+      );
+    },
+    hideRecordingRulesOnView() {
+      return this.isView && (this.recordingRules || []).length === 0;
+    },
+    hideAlertingRulesOnView() {
+      return this.isView && (this.alertingRules || []).length === 0;
+    },
+    isView() {
+      return this.mode === _VIEW;
+    },
+    disableAddRecord() {
+      const { value: rules } = this;
+
+      return rules.find(rule => has(rule, 'alert'));
+    },
+    disableAddAlert() {
+      const { value: rules } = this;
+
+      return rules.find(rule => has(rule, 'record'));
+    },
+  },
+
+  methods: {
+    addRule(ruleType) {
+      const { value } = this;
+
+      switch (ruleType) {
+      case 'record':
+        value.push({ record: '', expr: '' });
+        break;
+      case 'alert':
+        value.push({
+          alert:  '',
+          expr:   '',
+          for:    '0s',
+          labels: { severity: 'critical' },
+        });
+        break;
+      default:
+        break;
+      }
+    },
+    removeRule(ruleIndex) {
+      removeAt(this.value, ruleIndex);
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="container-group-rules">
+    <div :class="[{ hide: hideRecordingRulesOnView }, 'container-recording-rules']">
+      <h3 class="mt-20 mb-20">
+        <t k="prometheusRule.recordingRules.label" />
+        <i
+          v-if="disableAddRecord"
+          v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
+          class="icon icon-info"
+          style="font-size: 14px"
+        />
+      </h3>
+      <div v-if="recordingRules.length > 0" class="rules">
+        <template v-for="(record, idx) in recordingRules">
+          <RecordingRule
+            :key="'recordind-rule-' + idx"
+            class="rule"
+            :value="record"
+            :mode="mode"
+            :rule-index="idx"
+            @removeRule="removeRule"
+          />
+        </template>
+      </div>
+
+      <button
+        v-if="!isView"
+        :disabled="disableAddRecord"
+        type="button"
+        class="btn btn-sm role-secondary"
+        @click="addRule('record')"
+      >
+        <t k="prometheusRule.recordingRules.addLabel" />
+      </button>
+    </div>
+    <div :class="[{ hide: hideAlertingRulesOnView }, 'container-alerting-rules']">
+      <div class="mt-20 mb-20">
+        <h3 class="mb-0">
+          <t k="prometheusRule.alertingRules.label" />
+          <i
+            v-if="disableAddAlert"
+            v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
+            class="icon icon-info"
+            style="font-size: 14px"
+          />
+        </h3>
+        <Banner
+          v-if="!isView"
+          color="info"
+          :label="t('prometheusRule.alertingRules.bannerText')"
+        />
+      </div>
+      <div v-if="alertingRules.length > 0" class="rules">
+        <template v-for="(record, idx) in alertingRules">
+          <AlertingRule
+            :key="'alerting-rule-' + idx"
+            class="rule"
+            :value="record"
+            :mode="mode"
+            :rule-index="idx"
+            @removeRule="removeRule"
+          />
+        </template>
+      </div>
+      <button
+        v-if="!isView"
+        :disabled="disableAddAlert"
+        type="button"
+        class="btn btn-sm role-secondary"
+        @click="addRule('alert')"
+      >
+        <t k="prometheusRule.alertingRules.addLabel" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.rules {
+  .rule {
+    border: solid thin var(--border);
+    padding: 20px;
+    margin-bottom: 20px;
+    position: relative;
+  }
+}
+</style>

--- a/edit/monitoring.coreos.com.prometheusrule/RecordingRule.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/RecordingRule.vue
@@ -1,0 +1,129 @@
+<script>
+import debounce from 'lodash/debounce';
+
+import CodeMirror from '@/components/CodeMirror';
+import LabeledInput from '@/components/form/LabeledInput';
+import KeyValue from '@/components/form/KeyValue';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  components: {
+    CodeMirror,
+    LabeledInput,
+    KeyValue,
+  },
+
+  props: {
+    value: {
+      type:    Object,
+      default: () => ({}),
+    },
+
+    mode: {
+      type:    String,
+      default: 'create',
+    },
+
+    ruleIndex: {
+      type:    Number,
+      default: 0,
+    },
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+    labels() {
+      return (this.value?.labels || {});
+    },
+  },
+
+  created() {
+    this.queueUpdate = debounce(this.updateExpression, 500);
+    this.queueLabelUpdate = debounce(this.updateLabels, 500);
+  },
+
+  methods: {
+    updateExpression(value) {
+      this.$set(this.value, 'expr', value);
+    },
+    updateLabels(value) {
+      this.$set(this.value, 'labels', value);
+    },
+    remove() {
+      this.$emit('removeRule', this.ruleIndex);
+    },
+  }
+};
+</script>
+
+<template>
+  <div>
+    <button
+      v-if="!isView"
+      v-tooltip="t('prometheusRule.recordingRules.removeRecord')"
+      type="button"
+      class="btn btn-sm bg-transparent remove"
+      @click="remove"
+    >
+      <i class="icon icon-x icon-2x" />
+    </button>
+    <div class="row mt-25">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.record"
+          :label="t('prometheusRule.recordingRules.name')"
+          :required="true"
+        />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-12">
+        <LabeledInput
+          v-model="value.expr"
+          :label="t('prometheusRule.promQL.label')"
+          :required="true"
+        >
+          <template #field>
+            <CodeMirror
+              class="mt-20"
+              :value="value.expr"
+              :options="{
+                mode: null,
+                foldGutter: false,
+                readOnly: mode === 'view',
+              }"
+              @onInput="queueUpdate"
+            />
+          </template>
+        </LabeledInput>
+      </div>
+    </div>
+    <div :class="[{ hide: isView && Object.keys(labels).length === 0}, 'row']">
+      <div class="col span-12">
+        <KeyValue
+          key="labels"
+          :value="value.labels"
+          :add-label="t('labels.addLabel')"
+          :mode="mode"
+          :title="t('prometheusRule.recordingRules.labels')"
+          :pad-left="false"
+          :read-allowed="false"
+          @input="queueLabelUpdate"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.row {
+  margin: 20px 0;
+}
+.remove {
+  position: absolute;
+  top: 0;
+  right: 5px;
+}
+</style>

--- a/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -71,6 +71,9 @@ export default {
     removeGroupRule(idx) {
       removeAt(this.value.spec.groups, idx);
     },
+    ruleGroupLabel(idx) {
+      return this.t('prometheusRule.groups.groupRowLabel', { index: idx + 1 });
+    },
     willSave() {
       this.value.spec.groups.forEach((group) => {
         if (group.interval === null) {
@@ -110,7 +113,7 @@ export default {
           v-for="(group, idx) in filteredGroups"
           :key="'filtered-group-' + idx"
           :name="'group-' + idx"
-          :label="'Rule Group ' + idx"
+          :label="ruleGroupLabel(idx)"
           class="container-group"
         >
           <button

--- a/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -82,7 +82,7 @@ export default {
       });
 
       return true;
-    }
+    },
   },
 };
 </script>
@@ -108,7 +108,13 @@ export default {
       </div>
     </div>
     <div>
-      <Tabbed v-if="filteredGroups.length > 0" :side-tabs="true">
+      <Tabbed
+        v-if="filteredGroups.length > 0"
+        :side-tabs="true"
+        :show-tabs-add-remove="true"
+        @addTab="addRuleGroup"
+        @removeTab="removeGroupRule"
+      >
         <Tab
           v-for="(group, idx) in filteredGroups"
           :key="'filtered-group-' + idx"
@@ -116,17 +122,6 @@ export default {
           :label="ruleGroupLabel(idx)"
           class="container-group"
         >
-          <button
-            v-if="!isView"
-            type="button"
-            class="btn btn-sm bg-transparent remove"
-            @click="removeGroupRule(idx)"
-          >
-            <i
-              v-tooltip="t('prometheusRule.groups.removeGroup')"
-              class="icon icon-x icon-2x"
-            />
-          </button>
           <div class="row">
             <div class="col span-6">
               <LabeledInput
@@ -142,7 +137,9 @@ export default {
               <UnitInput
                 v-model="group.interval"
                 :suffix="t('suffix.seconds')"
-                :placeholder="t('prometheusRule.groups.groupInterval.placeholder')"
+                :placeholder="
+                  t('prometheusRule.groups.groupInterval.placeholder')
+                "
                 :label="t('prometheusRule.groups.groupInterval.label')"
                 :mode="mode"
                 @input="(e) => $set(filteredGroups[idx], 'interval', e)"
@@ -159,23 +156,7 @@ export default {
           <GroupRules v-model="group.rules" class="mb-20" :mode="mode" />
         </Tab>
       </Tabbed>
-      <Banner
-        v-else
-        color="warning"
-        :label="t('prometheusRule.groups.none')"
-      />
-    </div>
-    <div class="row mt-20">
-      <div class="col span-12">
-        <button
-          v-if="!isView"
-          type="button"
-          class="btn btn-sm role-secondary"
-          @click="addRuleGroup"
-        >
-          <t k="prometheusRule.groups.add" />
-        </button>
-      </div>
+      <Banner v-else color="warning" :label="t('prometheusRule.groups.none')" />
     </div>
   </CruResource>
 </template>

--- a/models/monitoring.coreos.com.prometheusrule.js
+++ b/models/monitoring.coreos.com.prometheusrule.js
@@ -1,0 +1,28 @@
+export default {
+  // if not a function it does exist, why?
+  customValidationRules() {
+    return [
+      {
+        nullable:       false,
+        path:           'metadata.name',
+        required:       true,
+        translationKey: 'generic.name',
+        type:           'dnsLabel',
+      },
+      {
+        nullable:   false,
+        path:       'spec',
+        required:   true,
+        type:       'array',
+        validators: ['ruleGroups'],
+      },
+      {
+        nullable:   false,
+        path:       'spec.groups',
+        required:   true,
+        type:       'array',
+        validators: ['groupsAreValid'],
+      },
+    ];
+  },
+};

--- a/utils/custom-validators.js
+++ b/utils/custom-validators.js
@@ -1,5 +1,6 @@
 import { flowOutput } from '@/utils/validators/flow-output';
 import { clusterIp, externalName, servicePort } from '@/utils/validators/service';
+import { ruleGroups, groupsAreValid } from '@/utils/validators/prometheusrule';
 
 /**
 * Custom validation functions beyond normal scalr types
@@ -10,5 +11,7 @@ export default {
   clusterIp,
   externalName,
   flowOutput,
+  groupsAreValid,
+  ruleGroups,
   servicePort,
 };

--- a/utils/validators/prometheusrule.js
+++ b/utils/validators/prometheusrule.js
@@ -10,27 +10,61 @@ export function ruleGroups(spec, getters, errors, validatorArgs) {
 
 export function groupsAreValid(groups, getters, errors, validatorArgs) {
   groups.forEach((group, groupIndex) => {
+    const readableGroupIndex = groupIndex + 1; // oh that ol zero based array index....
+
     if (isEmpty(group?.name)) {
-      errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.name', { index: groupIndex }));
+      errors.push(
+        getters['i18n/t']('validation.prometheusRule.groups.valid.name', { index: readableGroupIndex })
+      );
     }
 
     if (isEmpty(group?.rules)) {
-      errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.singleEntry', { index: groupIndex }));
+      errors.push(
+        getters['i18n/t'](
+          'validation.prometheusRule.groups.valid.singleEntry',
+          { index: readableGroupIndex }
+        )
+      );
     } else {
       group.rules.forEach((rule, ruleIndex) => {
+        const readableRuleIndex = ruleIndex + 1; // oh that ol zero based array index....
+
         if (has(rule, 'alert') && isEmpty(rule?.alert)) {
-          errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.alertName', { groupIndex, ruleIndex }));
+          errors.push(
+            getters['i18n/t'](
+              'validation.prometheusRule.groups.valid.rule.alertName',
+              { groupIndex: readableGroupIndex, ruleIndex: readableRuleIndex }
+            )
+          );
         } else if (has(rule, 'record') && isEmpty(rule?.record)) {
-          errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.recordName', { groupIndex, ruleIndex }));
+          errors.push(
+            getters['i18n/t'](
+              'validation.prometheusRule.groups.valid.rule.recordName',
+              { groupIndex: readableGroupIndex, ruleIndex: readableRuleIndex }
+            )
+          );
         }
 
         if ((has(rule, 'expr') && isEmpty(rule.expr)) || !has(rule, 'expr')) {
-          errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.expr', { groupIndex, ruleIndex }));
+          errors.push(
+            getters['i18n/t'](
+              'validation.prometheusRule.groups.valid.rule.expr',
+              { groupIndex: readableGroupIndex, ruleIndex: readableRuleIndex }
+            )
+          );
         }
 
         if (has(rule, 'alert')) {
-          if ((has(rule, 'labels') && isEmpty(rule.labels)) || !has(rule, 'labels')) {
-            errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.labels', { groupIndex, ruleIndex }));
+          if (
+            (has(rule, 'labels') && isEmpty(rule.labels)) ||
+            !has(rule, 'labels')
+          ) {
+            errors.push(
+              getters['i18n/t'](
+                'validation.prometheusRule.groups.valid.rule.labels',
+                { groupIndex: readableGroupIndex, ruleIndex: readableRuleIndex }
+              )
+            );
           }
         }
       });

--- a/utils/validators/prometheusrule.js
+++ b/utils/validators/prometheusrule.js
@@ -1,0 +1,41 @@
+import { has, isEmpty } from 'lodash';
+
+export function ruleGroups(spec, getters, errors, validatorArgs) {
+  if (isEmpty(spec?.groups)) {
+    errors.push(getters['i18n/t']('validation.prometheusRule.groups.required'));
+  }
+
+  return errors;
+}
+
+export function groupsAreValid(groups, getters, errors, validatorArgs) {
+  groups.forEach((group, groupIndex) => {
+    if (isEmpty(group?.name)) {
+      errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.name', { index: groupIndex }));
+    }
+
+    if (isEmpty(group?.rules)) {
+      errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.singleEntry', { index: groupIndex }));
+    } else {
+      group.rules.forEach((rule, ruleIndex) => {
+        if (has(rule, 'alert') && isEmpty(rule?.alert)) {
+          errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.alertName', { groupIndex, ruleIndex }));
+        } else if (has(rule, 'record') && isEmpty(rule?.record)) {
+          errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.recordName', { groupIndex, ruleIndex }));
+        }
+
+        if ((has(rule, 'expr') && isEmpty(rule.expr)) || !has(rule, 'expr')) {
+          errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.expr', { groupIndex, ruleIndex }));
+        }
+
+        if (has(rule, 'alert')) {
+          if ((has(rule, 'labels') && isEmpty(rule.labels)) || !has(rule, 'labels')) {
+            errors.push(getters['i18n/t']('validation.prometheusRule.groups.valid.rule.labels', { groupIndex, ruleIndex }));
+          }
+        }
+      });
+    }
+  });
+
+  return errors;
+}


### PR DESCRIPTION
Adds the custom UI for the Prometheus Rules. 

I left out the custom redirect to yaml requirement at the bottom of the ticket though. I am having trouble making the redirect happen. In every lifecycle hook i tried I first had to let the route fully load then replace to the yaml view for it to work. This looks ugly. But as I was attempting to get this working I started to find it really odd that we'd redirect a user to the yaml view with out notifying them why. As this would only happen on edit and from my understanding of the requirements, I don't think it would hurt to allow the user to view the form in this case.

@vincent99 I wasn't quite sure if the add group button was quite what you wanted (see pic below)? Let me know if we want to implement a different design. 

rancher/dashboard#811


![Screen Shot 2020-10-21 at 11 06 52 AM](https://user-images.githubusercontent.com/858614/96766202-940c0980-138f-11eb-9df9-2a2bb14c42d8.png)
![Screen Shot 2020-10-21 at 11 07 03 AM](https://user-images.githubusercontent.com/858614/96766208-966e6380-138f-11eb-844b-f336dfb61562.png)
![Screen Shot 2020-10-21 at 11 07 45 AM](https://user-images.githubusercontent.com/858614/96766216-98d0bd80-138f-11eb-9fa0-58eb72a9f2d7.png)
![Screen Shot 2020-10-21 at 11 10 14 AM](https://user-images.githubusercontent.com/858614/96766227-9a9a8100-138f-11eb-9589-6438d430d1af.png)
![Screen Shot 2020-10-21 at 11 22 08 AM](https://user-images.githubusercontent.com/858614/96766290-b2720500-138f-11eb-9fc6-cb440b7ad16e.png)
