### PR TITLE
Update Namespace Selector Defaults

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -792,10 +792,10 @@ monitoring:
       resourceLimits: Resource Limits
       scrape: Scrape Interval
       ignoreNamespaceSelectors:
-        label: Use Namespace Selectors
+        label: Namespace Selectors
         radio:
-          enforced: "Use: Monitors can access resources in the namespace specified in the namespaceSelector field"
-          ignored: "Ignore: Monitors can only access resources in the deployed namespace that they are deployed in"
+          enforced: "Use: Monitors can access resources based on namespaces that match the namespace selector field"
+          ignored: "Ignore: Monitors can only access resources in the namespace they are deployed in"
         help: Ignoring Namespace Selectors allows Cluster Admins to limit teams from monitoring resources outside of namespaces they have permissions to but can break the functionality of Apps that rely on setting up Monitors that scrape targets across multiple namespaces, such as Istio.
     storage:
       className: Storage Class Name

--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -204,7 +204,7 @@ export default {
             :label="t('monitoring.prometheus.config.ignoreNamespaceSelectors.label')"
             :labels="[t('monitoring.prometheus.config.ignoreNamespaceSelectors.radio.enforced'),t('monitoring.prometheus.config.ignoreNamespaceSelectors.radio.ignored')]"
             :mode="mode"
-            :options="[true, false]"
+            :options="[false, true]"
           >
             <template #corner>
               <i v-tooltip="t('monitoring.prometheus.config.ignoreNamespaceSelectors.help', {}, true)" class="icon icon-info" />

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -6,7 +6,7 @@ import BadgeState from '@/components/BadgeState';
 import Banner from '@/components/Banner';
 import { get } from '@/utils/object';
 import { NAME as FLEET_NAME } from '@/config/product/fleet';
-import { _EDIT, _VIEW } from '@/config/query-params';
+import { _CREATE, _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   components: {
@@ -73,6 +73,10 @@ export default {
 
     isEdit() {
       return this.mode === _EDIT;
+    },
+
+    isCreate() {
+      return this.mode === _CREATE;
     },
 
     isNamespace() {
@@ -187,19 +191,19 @@ export default {
   <header class="masthead">
     <div class="title">
       <div class="primaryheader">
-        <h1 v-if="isEdit">
+        <h1 v-if="isCreate || isEdit || isView">
           <nuxt-link :to="parent.location">
             {{ parent.displayName }}:
           </nuxt-link>
-          <t k="resourceDetail.header.edit" />
+          <t v-if="isCreate" k="resourceDetail.header.create" />
+          <t v-if="isEdit" k="resourceDetail.header.edit" />
           <span v-if="resourceSubtype" v-html="resourceSubtype" />
-          {{ value.nameDisplay }}
+          <span v-if="!isCreate" v-html="value.nameDisplay" />
         </h1>
         <h1 v-else>
           <nuxt-link :to="parent.location">
             {{ parent.displayName }}:
           </nuxt-link>
-          <span v-if="resourceSubtype" v-html="resourceSubtype" />
           <span v-html="h1" />
         </h1>
         <BadgeState v-if="isView" :value="value" />

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -139,6 +139,8 @@ export default {
  .radio-custom {
     height: 14px;
     width: 14px;
+    min-height: 14px;
+    min-width: 14px;
     background-color: var(--input-bg);
     border-radius: 50%;
     transition: all 0.3s ease-out;

--- a/mixins/create-edit-view.js
+++ b/mixins/create-edit-view.js
@@ -22,6 +22,11 @@ export default {
       type:     Object,
       default: null,
     },
+
+    moreDetails: {
+      type:    Array,
+      default: null
+    }
   },
 
   data() {
@@ -51,7 +56,6 @@ export default {
       errors:                   [],
       labelsToIgnoreRegex:      LABELS_TO_IGNORE_REGEX,
       annotationsToIgnoreRegex: ANNOTATIONS_TO_IGNORE_REGEX,
-      moreDetails:              null,
     };
   },
 


### PR DESCRIPTION
Updates the `ignoreNamespaceSelector` radio group on install chart page for Monitoring v2. 
rancher/dashboard#1129

![Screen Shot 2020-10-23 at 10 17 24 AM](https://user-images.githubusercontent.com/858614/97034625-0d376800-151a-11eb-8b6e-6ce6898eac22.png)

Also added a fix for the radio group "radio" span. I noticed certain screens the size would squish up causing lopsided radios. 
![Screen Shot 2020-10-23 at 10 19 07 AM](https://user-images.githubusercontent.com/858614/97034816-54bdf400-151a-11eb-97ad-3b0a9c5388d0.png)
![Screen Shot 2020-10-23 at 10 19 13 AM](https://user-images.githubusercontent.com/858614/97034824-5687b780-151a-11eb-9567-c69c087824f0.png)

Also fixed a small bug in masthead that denise found. 
Also fixed the console error being thrown by Vue in dev mode for the moreDetails prop, changed the mixin that declared it as a data prop to make it a vue prop on the mixin. 