### PR TITLE
Service Port Validation Fixes

### DIFF
--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -195,8 +195,8 @@ export default {
             v-else
             v-model.number="row.nodePort"
             type="number"
-            min="1"
-            max="65535"
+            min="30000"
+            max="32767"
             :placeholder="t('servicePorts.rules.node.placeholder')"
             @input="queueUpdate"
           />

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -195,8 +195,8 @@ export default {
             v-else
             v-model.number="row.nodePort"
             type="number"
-            min="30000"
-            max="32767"
+            min="1"
+            max="65535"
             :placeholder="t('servicePorts.rules.node.placeholder')"
             @input="queueUpdate"
           />

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -164,11 +164,7 @@ export default {
 
       neu.forEach((port, idx) => {
         if (port?.targetPort && isNumeric.test(port.targetPort)) {
-          try {
-            port.targetPort = parseInt(port.targetPort, 10);
-          } catch (err) {
-            console.warn(`Could not cast target port to int`, port, idx, err); // eslint-disable-line no-console
-          }
+          port.targetPort = parseInt(port.targetPort, 10);
         }
       });
 


### PR DESCRIPTION
Added logic to cast the target port on a service port resource to a int if the string contains all numeric values else it leaves the value as a string. 

also changed the min max on nodePorts as the range was not valid before

rancher/dashboard#1694