### PR TITLE
Changing how we set empty defaults

### DIFF
--- a/models/gatekeeper-constraint.js
+++ b/models/gatekeeper-constraint.js
@@ -1,26 +1,9 @@
-import { set } from '@/utils/object';
-
 export const ENFORCEMENT_ACTION_VALUES = {
   DENY:   'deny',
   DRYRUN: 'dryrun'
 };
 
 export default {
-  applyDefaults() {
-    const spec = this.spec || {};
-
-    spec.match = spec.match || {};
-    spec.match.labelSelector = spec.match.labelSelector || {};
-    spec.match.labelSelector.matchExpressions = spec.match.labelSelector.matchExpressions || [];
-
-    spec.match = spec.match || {};
-    spec.match.namespaceSelector = spec.match.namespaceSelector || {};
-    spec.match.namespaceSelector.matchExpressions = spec.match.namespaceSelector.matchExpressions || [];
-
-    spec.enforcementAction = spec.enforcementAction || ENFORCEMENT_ACTION_VALUES.DENY;
-
-    set(this, 'spec', spec);
-  },
   doneOverride() {
     return () => {
       this.currentRouter().replace({ name: 'c-cluster-gatekeeper-constraints' });


### PR DESCRIPTION
- Removed applyDefaults in favor of using the existing empty spec. I don't think the intended purpose of applyDefaults is really to hydrate the object with empty structures just to support the components. I think it's really intended to provide the default values we want to display when creating a new resource.
- Fixed an issues with parameters not resizing due to a misplaced &.

rancher/dashboard#1194