### PR TITLE
fix: actionMenu doesn't disappear

### DIFF
--- a/components/ActionMenu.vue
+++ b/components/ActionMenu.vue
@@ -46,6 +46,10 @@ export default {
           this.phase = HIDDEN;
         }
       },
+    },
+
+    '$route.path'(val, old) {
+      this.hide();
     }
   },
 


### PR DESCRIPTION
### Proposed changes
When the user clicks on the menu and leaves the current route, the menu will not disappear
