### PR TITLE
repopulate grafana persistence correctly on edit

### DIFF
--- a/chart/monitoring/grafana/index.vue
+++ b/chart/monitoring/grafana/index.vue
@@ -61,10 +61,24 @@ export default {
       persistentStorageTypeLabels.splice(1, 1);
     }
 
+    const { persistence = {} } = this.value.grafana;
+    let persistentStorageType;
+
+    switch (persistence.type) {
+    case 'pvc':
+      persistentStorageType = 'pvc';
+      break;
+    case 'statefulset':
+      persistentStorageType = 'statefulset';
+      break;
+    default:
+      persistentStorageType = persistence.existingClaim ? 'existing' : 'disabled';
+    }
+
     return {
       persistantStorageTypes,
       persistentStorageTypeLabels,
-      persistentStorageType: 'disabled',
+      persistentStorageType,
     };
   },
   computed: {


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/1689#issuecomment-718936362

Updated `Grafana` component to determine if persistent storage is enabled and which variety rather than always initializing as 'disabled'