### PR TITLE
Monitoring Fixes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -715,7 +715,7 @@ monitoring:
     many: ReadWriteMany
     once: ReadWriteOnce
     readOnlyMany: ReadOnlyMany
-  aggregateDefaultRoles: 
+  aggregateDefaultRoles:
     label: Aggregate to Default Kubernetes Roles
     tip: Adds labels to the ClusterRoles deployed by the Monitoring chart to <a target="_blank" rel="noopener nofollow noreferrer" href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles"> aggregate to the corresponding default k8s admin, edit, and view ClusterRoles.</a>
   alerting:
@@ -744,7 +744,7 @@ monitoring:
   clusterType:
     label: Cluster Type
     placeholder: Select cluster type
-  createDefaultRoles: 
+  createDefaultRoles:
     label: Create Default Monitoring Cluster Roles
     tip: Creates <code>monitoring-admin</code>, <code>monitoring-edit</code>, and <code>monitoring-view</code> ClusterRoles that can be assigned to users to provide permissions to CRDs installed by the Monitoring chart.
   grafana:
@@ -812,6 +812,7 @@ monitoring:
       label: Persistent Storage for Prometheus
       mode: Access Mode
       selector: Selector
+      selectorWarning: If you are using a dynamic provisioner (e.g. Longhorn), no Selectors should be specified since a PVC with a non-empty selector can't have a PV dynamically provisioned for it.
       size: Size
       volumeMode: Volume Mode
       volumeName: Volume Name

--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -108,6 +108,8 @@ export default {
 
       merge(this.value, extendedDefaults);
     }
+
+    this.$emit('register-before-hook', this.willSave, 'willSave');
   },
 
   mounted() {
@@ -161,6 +163,15 @@ export default {
 
       if (!isEmpty(hash.secrets)) {
         this.secrets = hash.secrets;
+      }
+    },
+
+    willSave() {
+      const { prometheusSpec } = this.value.prometheus;
+      const selector = prometheusSpec?.storageSpec?.volumeClaimTemplate?.spec?.selector;
+
+      if (selector && isEmpty(selector.matchExpressions) && isEmpty(selector.matchLabels)) {
+        delete this.value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.selector;
       }
     },
   },

--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -358,6 +358,7 @@ export default {
                 {{ t('monitoring.prometheus.storage.selector') }}
               </h4>
             </div>
+            <Banner color="warning" :label="t('monitoring.prometheus.storage.selectorWarning')" />
             <MatchExpressions
               :initial-empty-row="false"
               :mode="mode"
@@ -366,6 +367,7 @@ export default {
               :show-remove="false"
               @input="matchChanged($event)"
             />
+            </banner>
           </div>
         </div>
       </template>

--- a/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
@@ -68,9 +68,9 @@ export default {
       set(value) {
         if (value) {
           if (isEmpty(this.value?.labels)) {
-            this.$set(this.value, 'labels', { severity: 'critical' });
+            this.$set(this.value, 'labels', { severity: 'none' });
           } else {
-            this.$set(this.value.labels, 'severity', 'critical');
+            this.$set(this.value.labels, 'severity', 'none');
           }
         } else {
           this.$set(this.value.labels, 'severity', '');

--- a/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -78,7 +78,7 @@ export default {
           alert:  '',
           expr:   '',
           for:    '0s',
-          labels: { severity: 'critical' },
+          labels: { severity: 'none' },
         });
         break;
       default:

--- a/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -76,8 +76,10 @@ export default {
     },
     willSave() {
       this.value.spec.groups.forEach((group) => {
-        if (group.interval === null) {
+        if (group.interval === null || group.interval === '') {
           delete group.interval;
+        } else {
+          this.$set(group, 'interval', `${ group.interval }`);
         }
       });
 
@@ -111,7 +113,7 @@ export default {
       <Tabbed
         v-if="filteredGroups.length > 0"
         :side-tabs="true"
-        :show-tabs-add-remove="true"
+        :show-tabs-add-remove="mode !== 'view'"
         @addTab="addRuleGroup"
         @removeTab="removeGroupRule"
       >


### PR DESCRIPTION
The PR addresses a few Monitoring V2 bugs:

Changes default severity label to `none`
On save of a Prometheus rule, the group override interval will be converted to string.
Hides the side tabs add/remove buttons on `view` mode.

Additionally this adds one fix for Prometheus rules: 
When installing the chart, if the user has not input storage selectors for the Prometheus storage option, we will drop the values from the data.


rancher/dashboard#811
rancher/dashboard#1757