### PR TITLE
Repopulate Prometheus Storage Spec on Edit

### DIFF
--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -69,7 +69,7 @@ export default {
           label: 'monitoring.volume.modes.block',
         },
       ],
-      enablePersistantStorage: false,
+      enablePersistantStorage: !!this.value?.prometheus?.prometheusSpec?.storageSpec?.volumeClaimTemplate?.spec,
       warnUser:                false,
     };
   },
@@ -358,7 +358,7 @@ export default {
                 {{ t('monitoring.prometheus.storage.selector') }}
               </h4>
             </div>
-            <Banner color="warning" :label="t('monitoring.prometheus.storage.selectorWarning')" />
+            <Banner color="warning" :label="t('monitoring.prometheus.storage.selectorWarning', {}, true)" />
             <MatchExpressions
               :initial-empty-row="false"
               :mode="mode"

--- a/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -11,6 +11,7 @@ import Tab from '@/components/Tabbed/Tab';
 import Tabbed from '@/components/Tabbed';
 import UnitInput from '@/components/form/UnitInput';
 import { _CREATE } from '@/config/query-params';
+import isString from 'lodash/isString';
 import GroupRules from './GroupRules';
 
 export default {
@@ -79,7 +80,13 @@ export default {
         if (group.interval === null || group.interval === '') {
           delete group.interval;
         } else {
-          this.$set(group, 'interval', `${ group.interval }`);
+          const interval = group.interval;
+
+          if (isString(interval)) {
+            this.$set(group, 'interval', interval.includes('s') ? interval : `${ interval }s`);
+          } else {
+            this.$set(group, 'interval', `${ interval }s`);
+          }
         }
       });
 
@@ -145,13 +152,6 @@ export default {
                 :label="t('prometheusRule.groups.groupInterval.label')"
                 :mode="mode"
                 @input="(e) => $set(filteredGroups[idx], 'interval', e)"
-              />
-            </div>
-            <div class="col span-6">
-              <LabeledInput
-                v-model="group.partialResponseStrategy"
-                :label="t('prometheusRule.groups.responseStrategy.label')"
-                :mode="mode"
               />
             </div>
           </div>


### PR DESCRIPTION
Set persistence enabled on upgrade/edit if set on the chart so the options show up correctly in the form.
Also make sure the selector warning shows the escaped translation.

rancher/dashboard#1764
rancher/dashboard#1757


Additionally I want to slip in a small change for Prometheus rules. Ensure that we append the unit to the string before we send. 

rancher/dashboard#811