### PR TITLE
Improving the edit and view pages of ingress

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -567,6 +567,7 @@ ingress:
       path: Path
       port: Port
       target: Target Service
+      certificates: Certificates
     hostname: Hostname
     path:
       label: Path
@@ -582,6 +583,9 @@ ingress:
       label: Target Service
       doesntExist: The selected service does not exist
     title: Rules
+  rulesAndCertificates:
+    title: Rules and Certificates
+    defaultCertificate: default
   target:
     default: Default
 

--- a/components/formatter/IngressFullPath.vue
+++ b/components/formatter/IngressFullPath.vue
@@ -1,0 +1,17 @@
+<script>
+export default {
+  props:  {
+    row: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    }
+  },
+};
+</script>
+
+<template>
+  <a v-if="row.isUrl" rel="nofollow noopener noreferrer" target="_blank" :href="`${row.fullPath}`">{{ row.fullPath }}</a>
+  <span v-else>{{ row.fullPath }}</span>
+</template>

--- a/components/formatter/IngressTarget.vue
+++ b/components/formatter/IngressTarget.vue
@@ -1,8 +1,10 @@
 <script>
 import { WORKLOAD_TYPES } from '@/config/types';
+import IngressFullPath from '@/components/formatter/IngressFullPath';
 
 export default {
-  props:  {
+  components: { IngressFullPath },
+  props:      {
     value: {
       type:     Object,
       required: true
@@ -36,8 +38,7 @@ export default {
 <template>
   <div v-if="value" class="ingress-target" :reactivity="workloads.length">
     <div v-for="(path, i) in paths" :key="i" class="target">
-      <a v-if="path.isUrl" rel="nofollow noopener noreferrer" target="_blank" :href="`${path.target}`">{{ path.target }}</a>
-      <span v-else>{{ path.target }}</span>
+      <IngressFullPath :row="path" />
       <i class="icon icon-chevron-right" />
       <nuxt-link v-if="path.serviceName && path.serviceTargetTo" :to="path.serviceTargetTo">
         {{ path.serviceName }}
@@ -47,11 +48,12 @@ export default {
       </span>
     </div>
     <div v-if="defaultService" class="target">
+      {{ t('ingress.target.default') }} <i class="icon icon-chevron-right" />
       <nuxt-link v-if="defaultService.targetTo" :to="defaultService.targetTo">
-        {{ t('ingress.target.default') }} <i class="icon icon-chevron-right" /> {{ defaultService.name }}
+        {{ defaultService.name }}
       </nuxt-link>
       <span v-else>
-        {{ t('ingress.target.default') }} <i class="icon icon-chevron-right" /> {{ defaultService.name }}
+        {{ defaultService.name }}
       </span>
     </div>
   </div>

--- a/components/formatter/Link.vue
+++ b/components/formatter/Link.vue
@@ -65,7 +65,7 @@ export default {
         return get(this.row, this.urlKey);
       }
 
-      if ((this.options === 'internal' || this.options?.internal) && this.to) {
+      if (this.isInternal && this.to) {
         const defaultParams = this.$route.params;
         const toParams = this.to.params || {};
 
@@ -124,21 +124,25 @@ export default {
       }
 
       return this.afterIcon;
+    },
+
+    isInternal() {
+      return this.options?.internal;
     }
   }
 };
 </script>
 
 <template>
-  <nuxt-link v-if="options === 'internal' && href" :to="href">
+  <n-link v-if="isInternal && href" :to="href">
     <i v-if="beforeIconClass" :class="beforeIconClass" style="position: relative; top: -2px;" />
     {{ label }}
     <i v-if="afterIconClass" :class="afterIconClass" style="position: relative; top: -2px;" />
-  </nuxt-link>
+  </n-link>
   <a v-else-if="href" :href="href" :rel="rel" :target="target">
     <i v-if="beforeIconClass" :class="beforeIconClass" style="position: relative; top: -2px;" />
     {{ label }}
     <i v-if="afterIconClass" :class="afterIconClass" style="position: relative; top: -2px;" />
   </a>
-  <span v-else>{{ label }}</span>
+  <span v-else> {{ href }} {{ label }}</span>
 </template>

--- a/components/formatter/ListLink.vue
+++ b/components/formatter/ListLink.vue
@@ -23,7 +23,7 @@ export default {
 <template>
   <span>
     <span v-for="(el, i) in value" :key="el.key">
-      <Link :row="el" :value="el" :options="options" /><span v-if="i != value.length - 1">, </span>
+      <Link :row="el" :value="el" :options="el.options || options" v-bind="el" /><span v-if="i != value.length - 1">, </span>
     </span>
   </span>
 </template>

--- a/components/formatter/ListLinkDetail.vue
+++ b/components/formatter/ListLinkDetail.vue
@@ -7,6 +7,12 @@ export default {
     value: {
       type:     Array,
       default: () => []
+    },
+    row: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
     }
   },
 };
@@ -14,6 +20,6 @@ export default {
 
 <template>
   <span>
-    <LinkDetail v-for="el in value" :key="el.key" v-bind="el" />
+    <LinkDetail v-for="el in value" :key="el.key" :row="row" v-bind="el" />
   </span>
 </template>

--- a/config/product/cis.js
+++ b/config/product/cis.js
@@ -39,7 +39,7 @@ export function init(store) {
       label:         'Profile',
       value:         'status.lastRunScanProfileName',
       formatter:     'Link',
-      formatterOpts: { options: 'internal', to: { name: 'c-cluster-product-resource-id', params: { resource: CIS.CLUSTER_SCAN_PROFILE } } },
+      formatterOpts: { options: { internal: true }, to: { name: 'c-cluster-product-resource-id', params: { resource: CIS.CLUSTER_SCAN_PROFILE } } },
       sort:          ['status.lastRunScanProfileName'],
     },
     {

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -66,7 +66,7 @@ export const OUTPUT = {
   value:         'outputs',
   sort:          ['outputsSortable'],
   formatter:     'ListLink',
-  formatterOpts: { options: 'internal' },
+  formatterOpts: { options: { internal: true } },
 };
 
 export const CONFIGURED_PROVIDERS = {

--- a/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/edit/networking.k8s.io.ingress/Certificate.vue
@@ -1,8 +1,12 @@
 <script>
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
+import InfoBox from '@/components/InfoBox';
+
 export default {
-  components: { LabeledInput, LabeledSelect },
+  components: {
+    InfoBox, LabeledInput, LabeledSelect
+  },
   props:      {
     value: {
       type:    Object,
@@ -57,9 +61,7 @@ export default {
 </script>
 
 <template>
-  <div class="cert" @input="update">
-    <div class="spacer">
-    </div>
+  <InfoBox class="cert" @input="update">
     <div class="row">
       <div class="col span-6">
         <LabeledSelect
@@ -106,13 +108,13 @@ export default {
     <button class="btn role-link close" @click="$emit('remove')">
       <i class="icon icon-2x icon-x" />
     </button>
-  </div>
+  </InfoBox>
 </template>
 
 <style lang="scss" scoped>
 .close {
-  top: -5px;
-  right: -5px;
+  top: 10px;
+  right: 10px;
   padding:0;
   position: absolute;
 }
@@ -121,9 +123,8 @@ export default {
   position: relative;
 
   &:not(:last-of-type) {
-  padding-bottom: 10px;
-  margin-bottom: 30px;
-  border-bottom: 1px solid var(--border);
-}
+    padding-bottom: 10px;
+    margin-bottom: 30px;
+  }
 }
 </style>

--- a/edit/networking.k8s.io.ingress/Rule.vue
+++ b/edit/networking.k8s.io.ingress/Rule.vue
@@ -89,15 +89,14 @@ export default {
       </div>
       <div class="col" />
     </div>
-    <template v-for="(path, i) in paths">
+    <template v-for="(_, i) in paths">
       <RulePath
-        :key="path.id"
+        :key="i"
+        v-model="paths[i]"
         class="row mb-10"
-        :value="path"
         :rule-mode="ruleMode"
         :service-targets="serviceTargets"
         :ingress="ingress"
-        @input="(e) => $set(paths, i, e)"
         @remove="(e) => removePath(i)"
       />
     </template>

--- a/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/edit/networking.k8s.io.ingress/RulePath.vue
@@ -97,6 +97,7 @@ export default {
         :status="serviceTargetStatus"
         :taggable="true"
         :tooltip="serviceTargetTooltip"
+        :hover-tooltip="true"
         @input="update(); servicePort = ''"
       />
     </div>

--- a/edit/networking.k8s.io.ingress/index.vue
+++ b/edit/networking.k8s.io.ingress/index.vue
@@ -4,7 +4,6 @@ import { SECRET, SERVICE } from '@/config/types';
 import NameNsDescription from '@/components/form/NameNsDescription';
 import CreateEditView from '@/mixins/create-edit-view';
 import Tab from '@/components/Tabbed/Tab';
-import { _VIEW } from '@/config/query-params';
 import CruResource from '@/components/CruResource';
 import Labels from '@/components/form/Labels';
 import Tabbed from '@/components/Tabbed';
@@ -51,9 +50,6 @@ export default {
     return { allSecrets: [], allServices: [] };
   },
   computed: {
-    isView() {
-      return this.mode === _VIEW;
-    },
     serviceTargets() {
       return this.filterByCurrentResourceNamespace(this.allServices)
         .map(service => ({
@@ -61,7 +57,10 @@ export default {
           value: service.metadata.name,
           ports: service.spec.ports?.map(p => p.port)
         }));
-    }
+    },
+    firstTabLabel() {
+      return this.isView ? this.t('ingress.rulesAndCertificates.title') : this.t('ingress.rules.title');
+    },
   },
   created() {
     if (!this.value.spec) {
@@ -90,7 +89,9 @@ export default {
       const servicePort = get(backend, this.value.servicePortPath);
 
       if (backend && (!serviceName || !servicePort)) {
-        set(this.value.spec, this.value.defaultbackendPath, null);
+        const path = this.value.defaultBackendPath;
+
+        set(this.value.spec, path, null);
       }
     },
   }
@@ -118,14 +119,14 @@ export default {
     <div class="spacer"></div>
 
     <Tabbed :side-tabs="true">
-      <Tab :label="t('ingress.rules.title')" name="rules" :weight="3">
+      <Tab :label="firstTabLabel" name="rules" :weight="3">
         <Rules v-model="value" :mode="mode" :service-targets="serviceTargets" />
       </Tab>
-      <Tab :label="t('ingress.certificates.label')" name="certificates" :weight="2">
-        <Certificates v-model="value" :mode="mode" :secrets="allSecrets" />
-      </Tab>
-      <Tab :label="t('ingress.defaultBackend.label')" name="default-backend" :weight="1">
+      <Tab :label="t('ingress.defaultBackend.label')" name="default-backend" :weight="2">
         <DefaultBackend v-model="value" :service-targets="serviceTargets" :mode="mode" />
+      </Tab>
+      <Tab v-if="!isView" :label="t('ingress.certificates.label')" name="certificates" :weight="1">
+        <Certificates v-model="value" :mode="mode" :secrets="allSecrets" />
       </Tab>
       <Tab
         name="labels-and-annotations"


### PR DESCRIPTION
- Move the default backend tab to be after rule
- Validation of the "target service" should be a tool tip and color
- Putting a "/" de-focuses
- Combine the rule and certs into one table instead of multiple boxes, need a name

rancher/dashboard#1755

![Screen Shot 2020-11-03 at 12 35 32 PM](https://user-images.githubusercontent.com/55104481/98032592-77c98d00-1dd1-11eb-9932-4815c3cf7625.png)
![Screen Shot 2020-11-03 at 12 35 03 PM](https://user-images.githubusercontent.com/55104481/98032596-78faba00-1dd1-11eb-8912-70594f12faa1.png)
![Screen Shot 2020-11-03 at 12 34 53 PM](https://user-images.githubusercontent.com/55104481/98032599-79935080-1dd1-11eb-8daa-bf78a0d21ef7.png)
![Screen Shot 2020-11-03 at 12 34 39 PM](https://user-images.githubusercontent.com/55104481/98032602-7a2be700-1dd1-11eb-8b81-dd27ff36f2dc.png)
