### PR TITLE
validate pod affinity/antiafiinity

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1326,6 +1326,16 @@ validation:
     exactly: '"{key}" should be exactly {val}'
     max: '"{key}" should be at most {val}'
     min: '"{key}" should be at least {val}'
+  podAffinity:
+    affinityTitle: Pod Affinity
+    antiAffinityTitle: Pod Anti-Affinity
+    requiredDuringSchedulingIgnoredDuringExecution: required rules
+    preferredDuringSchedulingIgnoredDuringExecution: preferred rules
+    topologyKey: Rule [{index}] of {group} {rules} - Topology key is required.
+    matchExpressions:
+      operator: Rule [{index}] of {group} {rules} - operator must be one of 'In', 'NotIn', 'Exists', 'DoesNotExist'
+      valueMustBeEmpty: Rule [{index}] of {group} {rules} - value must be empty if operator is 'Exists' or 'DoesNotExist'
+      valuesMustBeDefined: Rule [{index}] of {group} {rules} - value must be defined if operator is 'In' or 'NotIn'
   prometheusRule:
     groups:
       required: At least one rule group is required.

--- a/models/workload.js
+++ b/models/workload.js
@@ -27,6 +27,9 @@ export default {
   },
 
   customValidationRules() {
+    const type = this._type ? this._type : this.type;
+
+    const podSpecPath = type === WORKLOAD_TYPES.CRON_JOB ? 'spec.jobTemplate.spec.template.spec' : 'spec.template.spec';
     const out = [
       {
         nullable:       false,
@@ -41,10 +44,14 @@ export default {
         required:       true,
         type:           'object',
         validators:     ['containerImages'],
+      },
+      {
+        nullable:       true,
+        path:           `${ podSpecPath }.affinity`,
+        type:           'object',
+        validators:     ['podAffinity'],
       }
     ];
-
-    const type = this._type ? this._type : this.type;
 
     switch (type) {
     case WORKLOAD_TYPES.DEPLOYMENT:

--- a/utils/custom-validators.js
+++ b/utils/custom-validators.js
@@ -4,6 +4,7 @@ import { ruleGroups, groupsAreValid } from '@/utils/validators/prometheusrule';
 import { interval, matching } from '@/utils/validators/monitoring-route';
 import { containerImages } from '@/utils/validators/container-images';
 import { cronSchedule } from '@/utils/validators/cron-schedule';
+import { podAffinity } from '@/utils/validators/pod-affinity';
 
 /**
 * Custom validation functions beyond normal scalr types
@@ -20,5 +21,6 @@ export default {
   servicePort,
   matching,
   containerImages,
-  cronSchedule
+  cronSchedule,
+  podAffinity
 };

--- a/utils/validators/pod-affinity.js
+++ b/utils/validators/pod-affinity.js
@@ -1,0 +1,125 @@
+import { isEmpty } from '@/utils/object';
+
+// spec = podSpec.affinity
+export function podAffinity(spec, getters, errors) {
+  const { podAffinity, podAntiAffinity } = spec;
+
+  // pod affinity
+  if (podAffinity && !isEmpty(podAffinity)) {
+    const { preferredDuringSchedulingIgnoredDuringExecution = [], requiredDuringSchedulingIgnoredDuringExecution = [] } = podAffinity;
+
+    preferredDuringSchedulingIgnoredDuringExecution.forEach((term, i) => {
+      const errorOpts = {
+        index: i,
+        group: getters['i18n/t']('validation.podAffinity.affinityTitle'),
+        rules: getters['i18n/t']('validation.podAffinity.preferredDuringSchedulingIgnoredDuringExecution')
+      };
+
+      validateTermWeight(term, errorOpts, getters, errors);
+
+      const { podAffinityTerm = {} } = term;
+
+      validateTopologyKey(podAffinityTerm, errorOpts, getters, errors);
+      validateLabelSelector(podAffinityTerm, errorOpts, getters, errors);
+    });
+
+    requiredDuringSchedulingIgnoredDuringExecution.forEach((term, i) => {
+      const errorOpts = {
+        index: i,
+        group: getters['i18n/t']('validation.podAffinity.affinityTitle'),
+        rules: getters['i18n/t']('validation.podAffinity.requiredDuringSchedulingIgnoredDuringExecution')
+      };
+
+      validateTopologyKey(term, errorOpts, getters, errors);
+      validateLabelSelector(term, errorOpts, getters, errors);
+    });
+  }
+
+  // pod antiaffinity
+  if (podAntiAffinity && !isEmpty(podAntiAffinity)) {
+    const { preferredDuringSchedulingIgnoredDuringExecution = [], requiredDuringSchedulingIgnoredDuringExecution = [] } = podAntiAffinity;
+
+    preferredDuringSchedulingIgnoredDuringExecution.forEach((term, i) => {
+      const errorOpts = {
+        index: i,
+        group: getters['i18n/t']('validation.podAffinity.antiAffinityTitle'),
+        rules: getters['i18n/t']('validation.podAffinity.preferredDuringSchedulingIgnoredDuringExecution')
+      };
+
+      validateTermWeight(term, errorOpts, getters, errors);
+
+      const { podAffinityTerm = {} } = term;
+
+      validateTopologyKey(podAffinityTerm, errorOpts, getters, errors);
+
+      validateLabelSelector(podAffinityTerm, errorOpts, getters, errors);
+    });
+
+    requiredDuringSchedulingIgnoredDuringExecution.forEach((term, i) => {
+      const errorOpts = {
+        index: i,
+        group: getters['i18n/t']('validation.podAffinity.antiAffinityTitle'),
+        rules: getters['i18n/t']('validation.podAffinity.requiredDuringSchedulingIgnoredDuringExecution')
+      };
+
+      validateTopologyKey(term, errorOpts, getters, errors);
+
+      validateLabelSelector(term, errorOpts, getters, errors);
+    });
+  }
+}
+
+// verify weight (if present) is integer 1-100
+function validateTermWeight(affinityTerm, errorOpts, getters, errors) {
+  const { weight = 1 } = affinityTerm;
+
+  if (typeof weight !== 'number' || weight > 100 || weight < 1 ) {
+    errors.push(getters['i18n/t']('validation.number.between', {
+      key: getters['i18n/t']('workload.scheduling.matchExpressions.weight'),
+      min: 1,
+      max: 100,
+      ...errorOpts
+    }));
+  }
+}
+
+// verify topology key is present and matches regexp for labels
+function validateTopologyKey(affinityTerm, errorOpts, getters, errors) {
+  const { topologyKey } = affinityTerm;
+  const regexp = RegExp('([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]');
+
+  if (!topologyKey || !regexp.test(topologyKey)) {
+    errors.push(getters['i18n/t']('validation.podAffinity.topologyKey', errorOpts));
+  }
+}
+
+/*
+    verify that each matchExpression in labelSelector:
+    operator is one of ['In', 'NotIn', 'Exists', 'DoesNotExist']
+    values is defined if operator is In or NotIn
+    values is empty if operator is Exists or DoesNotExist
+ */
+function validateLabelSelector(affinityTerm, errorOpts, getters, errors) {
+  const validOperators = ['In', 'NotIn', 'Exists', 'DoesNotExist'];
+
+  const { labelSelector } = affinityTerm;
+
+  if (labelSelector && !isEmpty(labelSelector)) {
+    const { matchExpressions = [] } = labelSelector;
+
+    matchExpressions.forEach((rule, i) => {
+      const { operator, values } = rule;
+
+      if (!validOperators.includes(operator)) {
+        errors.push(getters['i18n/t']('validation.podAffinity.matchExpressions.operator', errorOpts));
+      }
+      if (operator === 'In' || operator === 'NotIn') {
+        if (!values || !values.length) {
+          errors.push(getters['i18n/t']('validation.podAffinity.matchExpressions.valuesMustBeDefined', errorOpts));
+        }
+      } else if (values && values.length) {
+        errors.push(getters['i18n/t']('validation.podAffinity.matchExpressions.valueMustBeEmpty', errorOpts));
+      }
+    });
+  }
+}


### PR DESCRIPTION
#1286 - adds some validation to pod affinity:
* `topologyKey` must be defined and a valid label
* matchExpression `operator` must be one of In, NotIn, Exists, DoesNotExist
* `weight` must be integer between 1-100
* `matchExpression.values` must be a non-empty array if `operator` is In or NotIn
* `matchExpression.values` must be an empty array if `operator` is Exists or DoesNotExist