### PR TITLE
Receiver and Route fixes

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -279,6 +279,7 @@ export default {
           :offer-preview="isEdit"
           :done-route="doneRoute"
           :done-override="resource.doneOverride"
+          :save-override="resource.yamlSaveOverride"
           :errors="errors"
           @apply-hooks="$emit('apply-hooks', $event)"
           @error="e=>$emit('error', e)"

--- a/edit/monitoring.coreos.com.receiver/index.vue
+++ b/edit/monitoring.coreos.com.receiver/index.vue
@@ -22,8 +22,7 @@ export default {
   mixins: [CreateEditView],
   asyncData(ctx) {
     function yamlSave(value, originalValue) {
-      Object.assign(originalValue, value);
-      originalValue.save();
+      originalValue.yamlSaveOverride(value, originalValue);
     }
 
     return defaultAsyncData(ctx, null, {

--- a/edit/monitoring.coreos.com.receiver/types/email.vue
+++ b/edit/monitoring.coreos.com.receiver/types/email.vue
@@ -43,7 +43,7 @@ export default {
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.smartHost" :mode="mode" label="Host" placeholder="e.g. 192.168.1.121:587" />
+        <LabeledInput v-model="value.smarthost" :mode="mode" label="Host" placeholder="e.g. 192.168.1.121:587" />
       </div>
       <div class="col span-6">
         <Checkbox v-model="value.require_tls" :mode="mode" class="mt-20" label="Use TLS" />

--- a/edit/monitoring.coreos.com.receiver/types/webhook.vue
+++ b/edit/monitoring.coreos.com.receiver/types/webhook.vue
@@ -17,7 +17,6 @@ export default {
   data() {
     this.$set(this.value, 'http_config', this.value.http_config || {});
     this.$set(this.value, 'send_resolved', this.value.send_resolved || false);
-    this.$set(this.value, 'require_tls', this.value.require_tls || false);
 
     return {};
   },

--- a/models/monitoring.coreos.com.receiver.js
+++ b/models/monitoring.coreos.com.receiver.js
@@ -109,5 +109,12 @@ export default {
 
   updateReceivers() {
     return fn => updateConfig(this.$dispatch, 'receivers', this.type, fn);
+  },
+
+  yamlSaveOverride() {
+    return (value, originalValue) => {
+      Object.assign(originalValue, value);
+      originalValue.save();
+    };
   }
 };

--- a/models/monitoring.coreos.com.route.js
+++ b/models/monitoring.coreos.com.route.js
@@ -1,5 +1,5 @@
 import { isEmpty, set } from '@/utils/object';
-import { areRoutesSupportedFormat, canCreate, updateConfig } from '@/utils/alertmanagerconfig';
+import { areRoutesSupportedFormat, canCreate, createDefaultRouteName, updateConfig } from '@/utils/alertmanagerconfig';
 
 export const ROOT_NAME = 'root';
 
@@ -26,7 +26,9 @@ export default {
   remove() {
     return () => {
       return this.updateRoutes((currentRoutes) => {
-        return currentRoutes.filter(r => r.name !== this.spec?.name);
+        return currentRoutes.filter((route, i) => {
+          return createDefaultRouteName(i) !== this.id;
+        });
       });
     };
   },
@@ -40,7 +42,9 @@ export default {
       }
 
       await this.updateRoutes((currentRoutes) => {
-        const existingRoute = currentRoutes.find(r => r.name === this.spec?.name);
+        const existingRoute = currentRoutes.find((route, i) => {
+          return createDefaultRouteName(i) === this.id;
+        });
 
         if (existingRoute) {
           Object.assign(existingRoute, this.spec);
@@ -83,12 +87,6 @@ export default {
     const rules = [
       {
         nullable:       false,
-        path:           'spec.name',
-        required:       true,
-        translationKey: 'generic.name'
-      },
-      {
-        nullable:       false,
         path:           'spec.receiver',
         required:       true,
         translationKey: 'monitoring.route.fields.receiver'
@@ -126,5 +124,12 @@ export default {
 
   isRoot() {
     return this.id === ROOT_NAME;
+  },
+
+  yamlSaveOverride() {
+    return (value, originalValue) => {
+      Object.assign(originalValue, value);
+      originalValue.save();
+    };
   }
 };


### PR DESCRIPTION
Change how we handle nameless routes and how we save yaml
- We just filtered out nameless routes which caused problems with default routes and manually created routes. This now gives a default name of `route-${i}` which if saved will add the name to the route.
   - Verified that editing and deleting still works when order has changed and new routes are present.
- Made the yamlSaveOverride consistent with receivers since it wasn't working when going to edit as yaml from the create page.
   

Resolving receiver issues    
- Edit as yaml on a created resource wasn't calling the yamlSaveOverride
- Erroneously set required_tls default for webhooks
- camel cased a field that wasn't supposed to be


rancher/dsahboard#1239
rancher/dashboard#1238

![Screen Shot 2020-11-03 at 3 07 39 PM](https://user-images.githubusercontent.com/55104481/98046354-51aee780-1de7-11eb-9efc-9787cd396aeb.png)
