### PR TITLE
Removing the doneOverride from constraint templates

### DIFF
--- a/models/templates.gatekeeper.sh.constrainttemplate.js
+++ b/models/templates.gatekeeper.sh.constrainttemplate.js
@@ -16,10 +16,4 @@ export default {
       return `There are still constaints using this template. You cannot delete this template while it's in use.`;
     }
   },
-
-  doneOverride() {
-    return () => {
-      this.currentRouter().replace({ name: 'c-cluster-gatekeeper-templates' });
-    };
-  }
 };


### PR DESCRIPTION
The route is no longer correct and redirects the user to a 404.

rancher/dashboard#1778