### PR TITLE
prevent 2 kiali tabs opening

### DIFF
--- a/pages/c/_cluster/istio/index.vue
+++ b/pages/c/_cluster/istio/index.vue
@@ -78,6 +78,7 @@ export default {
               :href="kialiUrl"
               :target="target"
               :rel="rel"
+              @click.stop
             >
               <t k="istio.links.label" />
               <i class="icon icon-external-link pull-right" />


### PR DESCRIPTION
#1820 - The Kiali description box on the Istio overview page has a click event listener on the whole description and an `<a>` tag; this prevents both from firing when the link is clicked.