### PR TITLE
Making the style of the ArrayListGroup more targeted

### DIFF
--- a/components/form/ArrayListGrouped.vue
+++ b/components/form/ArrayListGrouped.vue
@@ -20,21 +20,21 @@ export default { components: { ArrayList, InfoBox } };
 </template>
 <style lang="scss">
 .array-list-grouped {
-    .box {
+    & > .box {
       position: relative;
-    }
 
-    .remove {
-      position: absolute;
+      & > .remove {
+        position: absolute;
 
-      padding: 0px;
+        padding: 0px;
 
-      top: 0;
-      right: 0;
-    }
+        top: 0;
+        right: 0;
+      }
 
-    .info-box {
+      & > .info-box {
         margin-bottom: 0;
+      }
     }
 }
 </style>


### PR DESCRIPTION
Increased the specificity of the scss selectors so it wouldn't style sublists.