### PR TITLE
fix PromptRemove slot names

### DIFF
--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -232,11 +232,11 @@ export default {
     height="auto"
     styles="background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 100vh;"
   >
-    <InfoBox>
+    <InfoBox class="mb-0">
       <h4 slot="title" class="text-default-text">
         Are you sure?
       </h4>
-      <div slot="body">
+      <div>
         <div class="mb-10">
           {{ t('promptRemove.attemptingToRemove', {type}) }} <template v-for="(resource, i) in names">
             <template v-if="i<5">
@@ -254,7 +254,7 @@ export default {
         <span class="text-error">{{ error }}</span>
         <span v-if="!needsConfirm" class="text-info mt-20">{{ protip }}</span>
       </div>
-      <template slot="actions">
+      <template>
         <button class="btn role-secondary" @click="close">
           Cancel
         </button>


### PR DESCRIPTION
`PromptRemove` contents disappeared when it switched from `Card` to `InfoBox` because InfoBox doesn't have the same named slots.
before/after:
![Screen Shot 2020-11-24 at 8 50 44 AM](https://user-images.githubusercontent.com/42977925/100121148-057b2400-2e36-11eb-84af-fc2633bd7f2f.png)
![Screen Shot 2020-11-24 at 8 51 26 AM](https://user-images.githubusercontent.com/42977925/100121153-06ac5100-2e36-11eb-80c8-d28af2ff0c2f.png)

