### PR TITLE
various workload bug fixes

### DIFF
--- a/components/form/Command.vue
+++ b/components/form/Command.vue
@@ -96,17 +96,16 @@ export default {
     update() {
       const out = {
         ...this.value,
-        ...cleanUp({
-          stdin:      this.stdin,
-          stdinOnce:  this.stdinOnce,
-          command:    this.command,
-          args:       this.args,
-          workingDir: this.workingDir,
-          tty:        this.tty,
-        }),
+        stdin:      this.stdin,
+        stdinOnce:  this.stdinOnce,
+        command:    this.command,
+        args:       this.args,
+        workingDir: this.workingDir,
+        tty:        this.tty,
+
       };
 
-      this.$emit('input', out);
+      this.$emit('input', cleanUp(out) );
     },
   },
 };

--- a/components/form/ShellInput.vue
+++ b/components/form/ShellInput.vue
@@ -26,7 +26,7 @@ export default {
       let out = null;
 
       if ( userValue ) {
-        out = userValue.split(/ /);
+        out = userValue.match(/(\"[^\"]+\")|\S+/g).map(string => string.replace(/^"|"$/g, ''));
       }
 
       this.$emit('input', out);

--- a/edit/workload/Job.vue
+++ b/edit/workload/Job.vue
@@ -29,7 +29,7 @@ export default {
   },
   data() {
     const {
-      failedJobsHistoryLimit, successfulJobsHistoryLimit, suspend = false, schedule
+      failedJobsHistoryLimit, successfulJobsHistoryLimit, suspend = false, schedule,
     } = this.value;
 
     if (this.type === WORKLOAD_TYPES.CRON_JOB) {
@@ -38,19 +38,22 @@ export default {
       }
       const { concurrencyPolicy = 'Allow', startingDeadlineSeconds } = this.value;
       const {
-        completions, parallelism, backoffLimit, activeDeadlineSeconds
+        completions, parallelism, backoffLimit, activeDeadlineSeconds,
+        template:{ spec: { terminationGracePeriodSeconds } }
+
       } = this.value.jobTemplate.spec;
 
       return {
-        completions, parallelism, backoffLimit, activeDeadlineSeconds, failedJobsHistoryLimit, successfulJobsHistoryLimit, suspend, schedule, concurrencyPolicy, startingDeadlineSeconds
+        completions, parallelism, backoffLimit, activeDeadlineSeconds, failedJobsHistoryLimit, successfulJobsHistoryLimit, suspend, schedule, concurrencyPolicy, startingDeadlineSeconds, terminationGracePeriodSeconds
       };
     } else {
       const {
-        completions, parallelism, backoffLimit, activeDeadlineSeconds
+        completions, parallelism, backoffLimit, activeDeadlineSeconds,
+        template:{ spec: { terminationGracePeriodSeconds } }
       } = this.value;
 
       return {
-        completions, parallelism, backoffLimit, activeDeadlineSeconds, failedJobsHistoryLimit, successfulJobsHistoryLimit, suspend, schedule
+        completions, parallelism, backoffLimit, activeDeadlineSeconds, failedJobsHistoryLimit, successfulJobsHistoryLimit, suspend, schedule, terminationGracePeriodSeconds
       };
     }
   },
@@ -73,6 +76,8 @@ export default {
           activeDeadlineSeconds: this.activeDeadlineSeconds,
         };
 
+        spec.template.spec.terminationGracePeriodSeconds = this.terminationGracePeriodSeconds;
+
         this.$emit('input', spec);
       } else {
         const spec = {
@@ -87,9 +92,12 @@ export default {
             completions:           this.completions,
             parallelism:           this.parallelism,
             backoffLimit:          this.backoffLimit,
-            activeDeadlineSeconds: this.activeDeadlineSeconds
+            activeDeadlineSeconds: this.activeDeadlineSeconds,
+
           }
         };
+
+        spec.jobTemplate.spec.template.spec.terminationGracePeriodSeconds = this.terminationGracePeriodSeconds;
 
         this.$emit('input', spec);
       }
@@ -144,8 +152,9 @@ export default {
         </UnitInput>
       </div>
     </div>
+
     <template v-if="isCronJob">
-      <div class="row mb-20">
+      <div class="row  mb-20">
         <div class="col span-6">
           <LabeledInput v-model.number="successfulJobsHistoryLimit" :mode="mode">
             <template #label>
@@ -179,15 +188,14 @@ export default {
           </UnitInput>
         </div>
         <div class="col span-6">
-          <RadioGroup
-            v-model="suspend"
-            :mode="mode"
-            :label="t('workload.job.suspend')"
-            name="suspend"
-            :options="[true, false]"
-            :labels="['Yes', 'No']"
-            @input="update"
-          />
+          <UnitInput v-model="terminationGracePeriodSeconds" :suffix="terminationGracePeriodSeconds == 1 ? 'Second' : 'Seconds'" :label="t('workload.upgrading.activeDeadlineSeconds.label')" :mode="mode">
+            <template #label>
+              <label class="has-tooltip" :style="{'color':'var(--input-label)'}">
+                {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
+                <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" style="font-size: 14px" />
+              </label>
+            </template>
+          </UnitInput>
         </div>
       </div>
       <div class="row">
@@ -202,7 +210,30 @@ export default {
             @input="update"
           />
         </div>
+        <div class="col span-6">
+          <RadioGroup
+            v-model="suspend"
+            :mode="mode"
+            :label="t('workload.job.suspend')"
+            name="suspend"
+            :options="[true, false]"
+            :labels="['Yes', 'No']"
+            @input="update"
+          />
+        </div>
       </div>
     </template>
+    <div v-else class="row">
+      <div class="col span-6">
+        <UnitInput v-model="terminationGracePeriodSeconds" :suffix="terminationGracePeriodSeconds == 1 ? 'Second' : 'Seconds'" :label="t('workload.upgrading.activeDeadlineSeconds.label')" :mode="mode">
+          <template #label>
+            <label class="has-tooltip" :style="{'color':'var(--input-label)'}">
+              {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
+              <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" style="font-size: 14px" />
+            </label>
+          </template>
+        </UnitInput>
+      </div>
+    </div>
   </form>
 </template>

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -609,7 +609,7 @@ export default {
               <span class="cron-hint text-small">{{ cronLabel }}</span>
             </template>
             <template #replicas>
-              <LabeledInput v-model="spec.replicas" type="number" required :mode="mode" :label="t('workload.replicas')" />
+              <LabeledInput v-model.number="spec.replicas" type="number" required :mode="mode" :label="t('workload.replicas')" />
             </template>
             <template #service>
               <LabeledSelect

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -18,7 +18,7 @@ import Networking from '@/components/form/Networking';
 import VolumeClaimTemplate from '@/edit/workload/VolumeClaimTemplate';
 import Job from '@/edit/workload/Job';
 import { defaultAsyncData } from '@/components/ResourceDetail';
-import { _EDIT } from '@/config/query-params';
+import { _EDIT, _CREATE } from '@/config/query-params';
 import WorkloadPorts from '@/components/form/WorkloadPorts';
 import ContainerResourceLimit from '@/components/ContainerResourceLimit';
 import KeyValue from '@/components/form/KeyValue';
@@ -249,7 +249,7 @@ export default {
       get() {
         if (!this.podTemplateSpec.containers) {
           this.$set(this.podTemplateSpec, 'containers', [
-            { name: this.value?.metadata?.name, imagePullPolicy: 'Always' }
+            { imagePullPolicy: 'Always' }
           ]);
         }
 
@@ -507,7 +507,7 @@ export default {
 
       delete this.value.kind;
 
-      if (!this.container.name) {
+      if (!this.container.name || this.mode === _CREATE) {
         this.$set(this.container, 'name', this.value.metadata.name);
       }
 


### PR DESCRIPTION
#1816 - `terminationGracePeriodSeconds` field was missing from cronjob/job workloads, which have different scaling/upgrading tab content. 
#1841 - fixed change detection in `Command` component
#1880 - updated workload creation to always set container name to workload name on initial create
#1832 - updated `ShellInput` component so that it doesn't split the input string on spaces contained in quotes. eg previously we had:
`-c "sleep 3600" -> ['-c', '"sleep', '3600"']`
Now we have:
`-c "sleep 3600" -> ['-c', 'sleep 3600']`