### PR TITLE
Preventing receiver deletion when a route depends on the receiver

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -17,12 +17,16 @@ export default {
       type:    String,
       default: 'go'
     },
+    showHighlightBorder: {
+      type:    Boolean,
+      default: true
+    }
   }
 };
 </script>
 
 <template>
-  <div class="card-container">
+  <div class="card-container" :class="{'highlight-border': showHighlightBorder}">
     <div class="card-wrap">
       <div class="card-title">
         <slot name="title">
@@ -48,7 +52,11 @@ export default {
 
 <style lang='scss'>
  .card-container {
-  border-left: 5px solid var(--primary);
+
+  &.highlight-border {
+    border-left: 5px solid var(--primary);
+  }
+
   border-radius: var(--border-radius);
   display: flex;
   flex-basis: 40%;

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -2,13 +2,13 @@
 import { mapState, mapGetters } from 'vuex';
 import { get, isEmpty } from '@/utils/object';
 import { NAMESPACE, RIO } from '@/config/types';
-import InfoBox from '@/components/InfoBox';
+import Card from '@/components/Card';
 import { alternateLabel } from '@/utils/platform';
 import LinkDetail from '@/components/formatter/LinkDetail';
 import { uniq } from '@/utils/array';
 
 export default {
-  components: { InfoBox, LinkDetail },
+  components: { Card, LinkDetail },
   data() {
     return {
       confirmName: '', error: '', warning: '', preventDelete: false
@@ -122,6 +122,8 @@ export default {
       let message;
       const preventDeletionMessages = neu.filter(item => item.preventDeletionMessage);
 
+      this.preventDelete = false;
+
       if (!!preventDeletionMessages.length) {
         this.preventDelete = true;
         message = preventDeletionMessages[0].preventDeletionMessage;
@@ -232,11 +234,11 @@ export default {
     height="auto"
     styles="background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 100vh;"
   >
-    <InfoBox class="mb-0">
+    <Card class="prompt-remove" :show-highlight-border="false">
       <h4 slot="title" class="text-default-text">
         Are you sure?
       </h4>
-      <div>
+      <div slot="body">
         <div class="mb-10">
           {{ t('promptRemove.attemptingToRemove', {type}) }} <template v-for="(resource, i) in names">
             <template v-if="i<5">
@@ -244,39 +246,54 @@ export default {
               <span v-if="i===names.length-1" :key="resource+2">{{ plusMore }}</span><span v-else :key="resource+1">{{ i === toRemove.length-2 ? ', and ' : ', ' }}</span>
             </template>
           </template>
-          <span class="text-warning">
-            {{ warning }}
-          </span>
           <span v-if="needsConfirm" :key="resource">Re-enter its name below to confirm:</span>
         </div>
         <input v-if="needsConfirm" id="confirm" v-model="confirmName" type="text" />
-
-        <span class="text-error">{{ error }}</span>
-        <span v-if="!needsConfirm" class="text-info mt-20">{{ protip }}</span>
+        <div class="mb-10">
+          {{ warning }}
+        </div>
+        <div class="text-error mb-10">
+          {{ error }}
+        </div>
+        <div v-if="!needsConfirm" class="text-info mt-20">
+          {{ protip }}
+        </div>
       </div>
-      <template>
+      <template #actions>
         <button class="btn role-secondary" @click="close">
           Cancel
         </button>
-        <button class="btn bg-error" :disabled="preventDelete" @click="remove">
+        <button class="btn bg-error ml-10" :disabled="preventDelete" @click="remove">
           Delete
         </button>
       </template>
-    </InfoBox>
+    </Card>
   </modal>
 </template>
 
 <style lang='scss'>
+  .prompt-remove {
     #confirm {
-        width: 90%;
-        margin-left: 3px;
+      width: 90%;
+      margin-left: 3px;
     }
+
     .remove-modal {
-       border-radius: var(--border-radius);
-       overflow: scroll;
-       max-height: 100vh;
-       & ::-webkit-scrollbar-corner {
-         background: rgba(0,0,0,0);
-         }
+        border-radius: var(--border-radius);
+        overflow: scroll;
+        max-height: 100vh;
+        & ::-webkit-scrollbar-corner {
+          background: rgba(0,0,0,0);
+        }
     }
+
+    .actions {
+      text-align: right;
+    }
+
+    .card-actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
 </style>

--- a/edit/monitoring.coreos.com.receiver/index.vue
+++ b/edit/monitoring.coreos.com.receiver/index.vue
@@ -19,6 +19,9 @@ export default {
     ArrayListGrouped, Banner, CruResource, GradientBox, LabeledInput, Loading, Tabbed, Tab, YamlEditor
   },
   mixins: [CreateEditView],
+  async fetch() {
+    await this.$store.dispatch('cluster/findAll', { type: MONITORING.SPOOFED.ROUTE });
+  },
   asyncData(ctx) {
     function yamlSave(value, originalValue) {
       originalValue.yamlSaveOverride(value, originalValue);

--- a/list/monitoring.coreos.com.receiver.vue
+++ b/list/monitoring.coreos.com.receiver.vue
@@ -1,0 +1,33 @@
+<script>
+import ResourceTable from '@/components/ResourceTable';
+import Loading from '@/components/Loading';
+import { MONITORING } from '@/config/types';
+
+export default {
+  name:       'ListReceiver',
+  components: { Loading, ResourceTable },
+
+  props: {
+    schema: {
+      type:     Object,
+      required: true,
+    },
+  },
+
+  async fetch() {
+    const routes = this.$store.dispatch('cluster/findAll', { type: MONITORING.SPOOFED.ROUTE });
+
+    this.rows = await this.$store.dispatch('cluster/findAll', { type: MONITORING.SPOOFED.RECEIVER });
+    await routes;
+  },
+
+  data() {
+    return { rows: null };
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <ResourceTable v-else :schema="schema" :rows="rows" />
+</template>

--- a/models/monitoring.coreos.com.receiver.js
+++ b/models/monitoring.coreos.com.receiver.js
@@ -1,5 +1,6 @@
 import { canCreate, updateConfig } from '@/utils/alertmanagerconfig';
 import { isEmpty } from '@/utils/object';
+import { MONITORING } from '@/config/types';
 
 export const RECEIVERS_TYPES = [
   {
@@ -150,6 +151,24 @@ export default {
     ];
 
     return rules;
+  },
+
+  routes() {
+    if (!this.$rootGetters['cluster/haveAll'](MONITORING.SPOOFED.ROUTE)) {
+      throw new Error('The routes have not been loaded');
+    }
+
+    return this.$rootGetters['cluster/all'](MONITORING.SPOOFED.ROUTE);
+  },
+
+  hasDependentRoutes() {
+    return !!this.routes.find(route => route.spec.receiver === this.id);
+  },
+
+  preventDeletionMessage() {
+    if (this.hasDependentRoutes) {
+      return `There are still routes using this receiver. You cannot delete this receiver while it's in use.`;
+    }
   },
 
 };


### PR DESCRIPTION
- Updated some of the styling on the PromprRemove with help of Lauren.
   - Added spacing between sections
   - Removed the warning styling
   - Added spacing between the action buttons
   - Aligned the action buttons to the right

- Fixed a problem where preventDelete was never reset so if it got set to true no other resources could be deleted.

   rancher/dashboard#1707

![image](https://user-images.githubusercontent.com/55104481/100671205-518a0500-331d-11eb-9513-90cbcf69fc02.png)
