### PR TITLE
Only disable namespace lists for cluster scope in constraints

### DIFF
--- a/assets/styles/global/_select.scss
+++ b/assets/styles/global/_select.scss
@@ -86,6 +86,9 @@
   border: solid var(--outline-width) var(--input-border);
   color: var(--input-text);
 
+  // Here to match the min height of the labeled select.
+  min-height: $input-height; 
+
   .vs--single .vs__selected-options {
     flex-wrap: nowrap;
   }

--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -64,6 +64,7 @@
   clear: both;
   color: var(--dropdown-text);
   white-space: nowrap;
+  z-index: 1000;
 
   &:hover {
     cursor: pointer;

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -253,12 +253,6 @@ export default {
 
 <style lang='scss' scoped>
 .labeled-select {
-  &.hoverable ::v-deep {
-    .v-select * {
-      z-index: z-index('overContent');
-    }
-  }
-
   .labeled-container {
     padding: 8px 0 0 8px;
 

--- a/edit/constraints.gatekeeper.sh.constraint/NamespaceList.vue
+++ b/edit/constraints.gatekeeper.sh.constraint/NamespaceList.vue
@@ -29,6 +29,14 @@ export default {
     addLabel: {
       type:    String,
       default: null
+    },
+    label: {
+      type:    String,
+      default: 'Namespace'
+    },
+    tooltip: {
+      type:    String,
+      default: null
     }
   },
 
@@ -60,7 +68,9 @@ export default {
     :mode="mode"
     :multiple="true"
     :options="namespaceOptions"
-    label="Namespace"
+    :label="label"
+    :tooltip="tooltip"
+    :hover-tooltip="!!tooltip"
     @input="(e) => $emit('input', e)"
   />
 </template>

--- a/edit/constraints.gatekeeper.sh.constraint/Scope.vue
+++ b/edit/constraints.gatekeeper.sh.constraint/Scope.vue
@@ -25,5 +25,13 @@ export default {
 </script>
 
 <template>
-  <LabeledSelect :value="value" :mode="mode" :options="SCOPE_OPTIONS" @input="e=>$emit('input', e)" />
+  <LabeledSelect
+    :label="t('gatekeeperConstraint.tab.namespaces.sub.scope.title')"
+    :hover-tooltip="true"
+    tooltip="Determines if cluster-scoped and/or namesapced-scoped resources are selected."
+    :value="value"
+    :mode="mode"
+    :options="SCOPE_OPTIONS"
+    @input="e=>$emit('input', e)"
+  />
 </template>

--- a/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -171,7 +171,7 @@ export default {
       return !this.isCreate;
     },
     areNamespacesDisabled() {
-      return this.value.spec.match.scope !== 'Namespaced';
+      return this.value.spec.match.scope === 'Cluster';
     }
   },
 
@@ -227,7 +227,7 @@ export default {
       this.value.kind = subType;
     },
     onScopeChange(newScope) {
-      if (newScope !== 'Namespaced') {
+      if (newScope === 'Cluster') {
         this.value.spec.match.namespaces = [];
         this.value.spec.match.excludedNamespaces = [];
       }
@@ -275,20 +275,32 @@ export default {
           <Tab name="namespaces" :label="t('gatekeeperConstraint.tab.namespaces.title')" :weight="3">
             <div class="row">
               <div class="col span-6">
-                <h3>{{ t('gatekeeperConstraint.tab.namespaces.sub.scope.title') }} <i v-tooltip="'Determines if cluster-scoped and/or namesapced-scoped resources are selected.'" class="icon icon-info" /></h3>
                 <Scope v-model="value.spec.match.scope" :mode="mode" @input="onScopeChange($event)" />
               </div>
             </div>
-            <div class="row mt-40">
+            <div class="row mt-20">
               <div class="col span-12">
-                <h3>{{ t('gatekeeperConstraint.tab.namespaces.sub.namespaces') }} <i v-tooltip="'If defined, a constraint will only apply to resources in a listed namespace.'" class="icon icon-info" /></h3>
-                <NamespaceList v-model="value.spec.match.namespaces" :mode="mode" :namespace-filter="NAMESPACE_FILTERS.nonSystem" :disabled="areNamespacesDisabled" add-label="Add Namespace" />
+                <NamespaceList
+                  v-model="value.spec.match.namespaces"
+                  :label="t('gatekeeperConstraint.tab.namespaces.sub.namespaces')"
+                  tooltip="If defined, a constraint will only apply to resources in a listed namespace."
+                  :mode="mode"
+                  :namespace-filter="NAMESPACE_FILTERS.nonSystem"
+                  :disabled="areNamespacesDisabled"
+                  add-label="Add Namespace"
+                />
               </div>
             </div>
-            <div class="row mt-40">
+            <div class="row mt-20">
               <div class="col span-12">
-                <h3>{{ t('gatekeeperConstraint.tab.namespaces.sub.excludedNamespaces') }} <i v-tooltip="'If defined, a constraint will only apply to resources not in a listed namespace.'" class="icon icon-info" /></h3>
-                <NamespaceList v-model="value.spec.match.excludedNamespaces" :mode="mode" :disabled="areNamespacesDisabled" add-label="Add Excluded Namespace" />
+                <NamespaceList
+                  v-model="value.spec.match.excludedNamespaces"
+                  :label="t('gatekeeperConstraint.tab.namespaces.sub.excludedNamespaces')"
+                  tooltip="If defined, a constraint will only apply to resources not in a listed namespace."
+                  :mode="mode"
+                  :disabled="areNamespacesDisabled"
+                  add-label="Add Excluded Namespace"
+                />
               </div>
             </div>
             <div class="row mt-40">


### PR DESCRIPTION
- Switched the LabeledSelects to use the tooltip rather than having a separate header and `<v-tooltip>` now that it's supported.
- Fixed an issue with `<Select>` not having a min-height.
- Fixed an issue where `<LabeledSelect>` hover tooltips caused the menu to go behind the :multiple selection of other LabeledSelect

rancher/dashboard#1892

![image](https://user-images.githubusercontent.com/55104481/100157612-0cbb2580-2e68-11eb-9b27-54d9e2ce2484.png)

