### PR TITLE
Making the rest of input elements 100% height to match Labeled/Select

### DIFF
--- a/assets/styles/global/_form.scss
+++ b/assets/styles/global/_form.scss
@@ -16,6 +16,7 @@ TEXTAREA,
   position: relative;
   display: block;
   box-sizing: border-box;
+  height: 100%;
   width: 100%;
   padding: 8px;
   background-color: var(--input-bg);


### PR DESCRIPTION
While testing rancher/dashboard#1836 I noticed the `<InputSelect>'s` `<input>` wasn't  the appropriate height.