### PR TITLE
Namespace Yaml Editor Bug

### DIFF
--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -48,7 +48,6 @@ export default {
       limitsMemory:   limitsMemory ? parseSi(limitsMemory) : null,
       requestsCpu:    requestsCpu ? parseSi(requestsCpu) : null,
       requestsMemory: requestsMemory ? parseSi(requestsMemory) : null,
-      viewMode:       _VIEW,
     };
 
     const formatted = {
@@ -64,6 +63,7 @@ export default {
       requestsMemory: formatSi(parsed.requestsMemory, {
         minExponent: 2, maxExponent: 2, addSuffix: false, increment: 1024,
       }),
+      viewMode: _VIEW,
     };
 
     return { ...formatted };

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -93,6 +93,7 @@ export default {
     @error="e=>errors = e"
     @finish="save"
     @cancel="done"
+    @apply-hooks="applyHooks"
   >
     <NameNsDescription
       v-if="!isView"


### PR DESCRIPTION
Need to fire the hooks before we switch from form to yaml editor on namespaces.
Move viewMode to correct object so Vue stops complaining about a non-reactive property (i think its just a dev build complaint but still, its annoying). 