### PR TITLE
Allowing users to configure additionalLoggingSources on the logging chart

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -692,6 +692,7 @@ logging:
       label: Outputs
   install:
     k3sContainerEngine: K3S Container Engine
+    enableAdditionalLoggingSources: Enable additional logging sources
   elasticsearch:
     host: Host
     scheme: Scheme

--- a/chart/logging/index.vue
+++ b/chart/logging/index.vue
@@ -1,9 +1,10 @@
 <script>
 import { mapGetters } from 'vuex';
 import LabeledInput from '@/components/form/LabeledInput';
+import Checkbox from '@/components/form/Checkbox';
 
 export default {
-  components: { LabeledInput },
+  components: { Checkbox, LabeledInput },
   props:      {
     value: {
       type:    Object,
@@ -30,9 +31,14 @@ export default {
 
 <template>
   <div class="logging">
-    <div v-if="provider === 'k3s'" class="row">
+    <div v-if="provider === 'k3s'" class="row mb-20">
       <div class="col span-6">
         <LabeledInput v-model="value.additionalLoggingSources.k3s.container_engine" :label="t('logging.install.k3sContainerEngine')" />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <Checkbox v-model="value.additionalLoggingSources[provider].enabled" :label="t('logging.install.enableAdditionalLoggingSources')" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
rancher/dashboard#1851

![image](https://user-images.githubusercontent.com/55104481/100707274-a5214080-3367-11eb-9934-056f87f412a3.png)
