### PR TITLE
Adding the index and source fields to the splunk output provider

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -774,6 +774,8 @@ logging:
     clientCert: Client Cert
     clientKey: Client Key
     insecureSsl: Insecure SSL
+    indexName: Index Name
+    source: Source
   forward:
     host: Host
     port: Port

--- a/edit/logging.banzaicloud.io.output/providers/splunkHec.vue
+++ b/edit/logging.banzaicloud.io.output/providers/splunkHec.vue
@@ -47,7 +47,7 @@ export default {
   <div class="splunk">
     <div class="bordered-section">
       <h3>{{ t('logging.output.sections.target') }}</h3>
-      <div class="row">
+      <div class="row mb-20">
         <div class="col span-2">
           <LabeledSelect v-model="value.protocol" :mode="mode" :disabled="disabled" :options="protocolOptions" :label="t('logging.splunk.protocol')" />
         </div>
@@ -56,6 +56,14 @@ export default {
         </div>
         <div class="col span-2">
           <LabeledInput v-model="port" :mode="mode" :disabled="disabled" type="number" :label="t('logging.splunk.port')" />
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <LabeledInput v-model="value.index" :mode="mode" :disabled="disabled" :label="t('logging.splunk.indexName')" />
+        </div>
+        <div class="col span-6">
+          <LabeledInput v-model="value.source" :mode="mode" :disabled="disabled" :label="t('logging.splunk.source')" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
rancher/dashboard#1703

![image](https://user-images.githubusercontent.com/55104481/100794397-c111fa00-33da-11eb-824c-890c602f4517.png)

The view mode doesn't work for any of the providers anymore. I'll be addressing that as part of the Logging Polishing issue.