### PR TITLE
workload detail fixes

### DIFF
--- a/detail/workload/index.vue
+++ b/detail/workload/index.vue
@@ -93,7 +93,7 @@ export default {
       const entries = this.value?.status?.active || [];
 
       return entries.map((obj) => {
-        return this.$store.getters['cluster/byId'](WORKLOAD_TYPES.JOB, `${ obj.namespace }/${ obj.id }`);
+        return this.$store.getters['cluster/byId'](WORKLOAD_TYPES.JOB, `${ obj.namespace }/${ obj.name }`);
       }).filter(x => !!x);
     },
 
@@ -231,7 +231,7 @@ export default {
           :search="false"
         />
       </Tab>
-      <Tab v-else name="pods" :label="t('tableHeaders.pods')">
+      <Tab v-else-if="pods && pods.length" name="pods" :label="t('tableHeaders.pods')">
         <ResourceTable
           v-if="pods"
           :rows="pods"

--- a/models/workload.js
+++ b/models/workload.js
@@ -229,7 +229,7 @@ export default {
 
   workloadSelector() {
     return {
-      'workload.user.cattle.io/workloadselector': `${ 'deployment' }-${
+      'workload.user.cattle.io/workloadselector': `${ this._type ? this._type : this.type }-${
         this.metadata.namespace
       }-${ this.metadata.name }`
     };


### PR DESCRIPTION
#1940 
#1922 - this was a problem with how workloads are being made in the UI (the `workload.user.cattle.io/workloadselector` label used to find pods wasn't specific enough) so it wont be applied retroactively