### PR TITLE
secrets tab headers

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1226,6 +1226,7 @@ rioConfig:
     buttonText: Customize
 
 secret:
+  authentication: Authentication
   certificate:
     certificate: Certificate
     cn: Domain Name
@@ -1243,6 +1244,7 @@ secret:
     password: Password
     username: Username
   ssh:
+    keys: Keys
     public: Public Key
     private: Private Key
   serviceAcct:

--- a/detail/secret.vue
+++ b/detail/secret.vue
@@ -154,13 +154,26 @@ export default {
 
       return false;
     },
+
+    dataLabel() {
+      switch (this.value._type) {
+      case TYPES.TLS:
+        return this.t('secret.certificate.certificate');
+      case TYPES.SSH:
+        return this.t('secret.ssh.keys');
+      case TYPES.BASIC:
+        return this.t('secret.authentication');
+      default:
+        return this.t('secret.data');
+      }
+    }
   },
 };
 </script>
 
 <template>
   <ResourceTabs v-model="value" :mode="mode">
-    <Tab name="data" label-key="secret.data">
+    <Tab name="data" :label="dataLabel">
       <template v-if="isRegistry || isBasicAuth">
         <div v-if="isRegistry" class="row">
           <div class="col span-12">


### PR DESCRIPTION
#1891 - @lvuch I'm not sure what exact styling is desired for the first checkbox, the secret subtype in header; I implemented it the same way as service subtype headers.

<img width="1109" alt="Screen Shot 2020-12-04 at 9 33 40 AM" src="https://user-images.githubusercontent.com/42977925/101189581-7bd90c80-3614-11eb-8bb6-b7da11dcc1f0.png">
<img width="1077" alt="Screen Shot 2020-12-04 at 9 34 02 AM" src="https://user-images.githubusercontent.com/42977925/101189584-7c71a300-3614-11eb-81b7-1831aacb95ff.png">
<img width="1103" alt="Screen Shot 2020-12-04 at 9 34 17 AM" src="https://user-images.githubusercontent.com/42977925/101189585-7d0a3980-3614-11eb-844b-bfa610f778db.png">
<img width="1114" alt="Screen Shot 2020-12-04 at 9 34 29 AM" src="https://user-images.githubusercontent.com/42977925/101189587-7d0a3980-3614-11eb-8ac9-337396cfa862.png">
