### PR TITLE
ResourceDetail clone fix

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -126,11 +126,11 @@ export default {
 
       if ( as === _YAML ) {
         yaml = await getYaml(originalModel);
+      }
 
-        if ( realMode === _CLONE || realMode === _STAGE ) {
-          cleanForNew(model);
-          yaml = model.cleanYaml(yaml, realMode);
-        }
+      if ( realMode === _CLONE || realMode === _STAGE ) {
+        cleanForNew(model);
+        yaml = model.cleanYaml(yaml, realMode);
       }
     }
 


### PR DESCRIPTION
#1988 - call `cleanForNew` in clone/stage mode regardless of `as` value 