### PR TITLE
Prefixing the alertmanager secretId with the appropriate namespace

### DIFF
--- a/utils/alertmanagerconfig.js
+++ b/utils/alertmanagerconfig.js
@@ -13,7 +13,11 @@ export const FILENAME = 'alertmanager.yaml';
 export async function getSecretId(dispatch) {
   const alertManager = await dispatch('cluster/find', { type: MONITORING.ALERTMANAGER, id: ALERTMANAGER_ID }, { root: true });
 
-  return alertManager?.spec?.configSecret || DEFAULT_SECRET_ID;
+  if (alertManager?.spec?.configSecret) {
+    return `${ alertManager.namespace }/${ alertManager?.spec?.configSecret }`;
+  }
+
+  return DEFAULT_SECRET_ID;
 }
 
 export async function getSecret(dispatch) {


### PR DESCRIPTION
When alertManager.spec.configSecret was present it didn't include the namespace which caused subsequent lookups of the secret to fail. This corrects the id by prefixing the namespace to it.

rancher/dashboard#1845
rancher/dashboard#1805