### PR TITLE
scheduled scan bugs

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -351,12 +351,18 @@ cis:
       =1 { Any scheduled scans using this profile will no longer work. }
       other { Any scheduled scans using either of these profiles will no longer work. }
     }
+  deleteBenchmarkWarning: |-
+    {count, plural,
+      =1 { Any profiles using this benchmark version will no longer work. }
+      other { Any profiles using these benchmark versions will no longer work }
+    }
   downloadAllReports: Download All Saved Reports
   downloadLatestReport: Download Latest Report
   downloadReport: Download Report
   maxKubernetesVersion: Maximum allowed Kubernetes version
   minKubernetesVersion: Minimum required Kubernetes version
   noProfiles: There are no valid ClusterScanProfiles for this cluster type to select.
+  noReportFound: No scan report found
   profile: Profile
   retention: Retention Count
   reports: Reports

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -163,7 +163,7 @@ export default {
     }
 
     if ( this.mode === _CREATE ) {
-      this.value.applyDefaults(this, this.mode);
+      this.value.applyDefaults(this, realMode);
     }
   },
 

--- a/detail/cis.cattle.io.clusterscan.vue
+++ b/detail/cis.cattle.io.clusterscan.vue
@@ -2,17 +2,20 @@
 import Date from '@/components/formatter/Date';
 import SortableTable from '@/components/SortableTable';
 import Banner from '@/components/Banner';
+import LabeledSelect from '@/components/form/LabeledSelect';
 import day from 'dayjs';
 import { DATE_FORMAT, TIME_FORMAT } from '@/store/prefs';
 import { escapeHtml, randomStr } from '@/utils/string';
 import { CIS } from '@/config/types';
 import { STATE } from '@/config/table-headers';
+import { sortBy } from '@/utils/sort';
 
 export default {
   components: {
     Date,
     SortableTable,
     Banner,
+    LabeledSelect
   },
 
   props: {
@@ -162,6 +165,10 @@ export default {
 
       ];
     },
+
+    sortedReports() {
+      return sortBy(this.clusterReports, 'metadata.creationTimestamp', true);
+    }
   },
 
   watch: {
@@ -173,8 +180,10 @@ export default {
       } catch {}
     },
 
-    clusterReports(neu) {
-      this.clusterReport = neu[0];
+    sortedReports(neu) {
+      if (!this.clusterReport) {
+        this.clusterReport = neu[0];
+      }
     }
   },
 
@@ -237,11 +246,19 @@ export default {
         </h3>
       </div>
       <div class="col span-4">
-        <v-select v-model="clusterReport" class="inline" :options="clusterReports" :get-option-label="reportLabel" :get-option-key="report=>report.id" />
+        <LabeledSelect
+          v-model="clusterReport"
+          :label="t('cis.reports')"
+          class="inline"
+          :options="sortedReports"
+          :get-option-label="reportLabel"
+          :get-option-key="report=>report.id"
+        />
       </div>
     </div>
-    <div v-if="results.length">
+    <div v-if="results && !!value.status.summary">
       <SortableTable
+        no-rows-key="cis.noReportFound"
         default-sort-by="state"
         :search="false"
         :row-actions="false"

--- a/edit/cis.cattle.io.clusterscan.vue
+++ b/edit/cis.cattle.io.clusterscan.vue
@@ -63,6 +63,7 @@ export default {
     if (!this.value.spec.scheduledScanConfig) {
       this.$set(this.value.spec, 'scheduledScanConfig', { });
     }
+    const isScheduled = !!get(this.value, 'spec.scheduledScanConfig.cronSchedule');
 
     return {
       allProfiles:         [],
@@ -70,7 +71,7 @@ export default {
       scheduledScanConfig: this.value.spec.scheduledScanConfig,
       scanAlertRule:       this.value.spec.scheduledScanConfig.scanAlertRule,
       hasAlertManager:     false,
-      isScheduled:         !!get(this.value, 'scheduledScanConfig.cronSchedule')
+      isScheduled
     };
   },
 
@@ -214,7 +215,7 @@ export default {
             <span class="text-muted">{{ cronLabel }}</span>
           </div>
           <div class="col span-6">
-            <UnitInput v-model.number="scheduledScanConfig.retention" :suffix="t('cis.reports')" type="number" :mode="mode" :label="t('cis.retention')" />
+            <UnitInput v-model.number="scheduledScanConfig.retentionCount" :suffix="t('cis.reports')" type="number" :mode="mode" :label="t('cis.retention')" />
           </div>
         </div>
         <h3>

--- a/models/cis.cattle.io.clusterscan.js
+++ b/models/cis.cattle.io.clusterscan.js
@@ -1,8 +1,10 @@
+import { _CREATE } from '@/config/query-params';
 import { CIS } from '@/config/types';
 import { findBy } from '@/utils/array';
 import { downloadFile, generateZip } from '@/utils/download';
 import { isEmpty, set } from '@/utils/object';
 import { sortBy } from '@/utils/sort';
+import day from 'dayjs';
 
 export default {
   _availableActions() {
@@ -47,13 +49,15 @@ export default {
   },
 
   applyDefaults() {
-    return () => {
-      const spec = this.spec || {};
+    return (vm, mode) => {
+      if (mode === _CREATE) {
+        const spec = this.spec || {};
 
-      spec.scanProfileName = null;
-      spec.scoreWarning = 'pass';
-      spec.scheduledScanConfig = { scanAlertRule: {}, retention: 3 };
-      set(this, 'spec', spec);
+        spec.scanProfileName = null;
+        spec.scoreWarning = 'pass';
+        spec.scheduledScanConfig = { scanAlertRule: {}, retentionCount: 3 };
+        set(this, 'spec', spec);
+      }
     };
   },
 
@@ -86,7 +90,7 @@ export default {
 
         const csv = Papa.unparse(testResults);
 
-        downloadFile(`${ report.id }.csv`, csv, 'application/csv');
+        downloadFile(`${ labelFor(report, this.id) }.csv`, csv, 'application/csv');
       } catch (err) {
         this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
       }
@@ -105,7 +109,7 @@ export default {
 
           const csv = Papa.unparse(testResults);
 
-          toZip[`${ report.id }.csv`] = csv;
+          toZip[`${ labelFor(report, this.id) }.csv`] = csv;
         } catch (err) {
           this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
         }
@@ -118,4 +122,12 @@ export default {
     };
   }
 
+};
+
+const labelFor = (report, id) => {
+  const { creationTimestamp } = report.metadata;
+
+  const date = day(creationTimestamp).format('YYYY-MM-DD-HHMMss');
+
+  return `${ id }-report--${ date }`;
 };

--- a/models/cis.cattle.io.clusterscanbenchmark.js
+++ b/models/cis.cattle.io.clusterscanbenchmark.js
@@ -1,0 +1,7 @@
+export default {
+  warnDeletionMessage() {
+    return (toRemove = []) => {
+      return this.$rootGetters['i18n/t']('cis.deleteBenchmarkWarning', { count: toRemove.length });
+    };
+  },
+};


### PR DESCRIPTION
#1995 - fix order of reports in scheduled scan detail page; use scan name and timestamp to generate report .csv file names
 
#2003 #1996 #1997  - Fix scan create/edit form repopulating

#2005 Add warning message to benchmark deletion prompt
![Screen Shot 2020-12-07 at 12 26 28 PM](https://user-images.githubusercontent.com/42977925/101395625-720b0f80-3887-11eb-87ac-3ac85fa230bf.png)

#1998 - give some indication that the report resource couldn't be found
![Screen Shot 2020-12-07 at 12 27 39 PM](https://user-images.githubusercontent.com/42977925/101395781-a8488f00-3887-11eb-8ad3-1d75fed875e9.png)
