### PR TITLE
dark theme placeholder

### DIFF
--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -82,7 +82,7 @@
 
   --input-text: #{$lightest};
   --input-label: #{$lighter};
-  --input-placeholder: #{lighten($disabled, 50%)};
+  --input-placeholder: #{$disabled};
   --input-border: var(--border);
   --input-bg: #{$dark};
   --input-hover-bg: var(--body-bg);


### PR DESCRIPTION
#2002 - placeholder color looks like input (dark theme)
before:
![Screen Shot 2020-12-07 at 12 48 50 PM](https://user-images.githubusercontent.com/42977925/101398071-c6fc5500-388a-11eb-9d10-1f82c2ae86c0.png)
 
after:
![Screen Shot 2020-12-07 at 12 41 34 PM](https://user-images.githubusercontent.com/42977925/101398058-c5cb2800-388a-11eb-98f4-eb419c1bdd03.png)


