### PR TITLE
Add endpoints links to Service Targets formatter

### DIFF
--- a/components/formatter/ServiceTargets.vue
+++ b/components/formatter/ServiceTargets.vue
@@ -1,38 +1,54 @@
 <script>
 import isEmpty from 'lodash/isEmpty';
+import { CATTLE_PUBLIC_ENDPOINTS } from '@/config/labels-annotations';
+import has from 'lodash/has';
+import Endpoints from '@/components/formatter/Endpoints';
 
 export default {
-  props: {
+  components: { Endpoints },
+  props:      {
     value: {
-      type:     [Array, String],
+      type:    [Array, String],
       default: null,
     },
     row: {
       type:     Object,
-      required: true
+      required: true,
     },
     col: {
       type:     Object,
-      required: true
+      required: true,
     },
   },
 
   computed: {
+    hasPublic() {
+      const { metadata: { annotations = {} } } = this.row;
+
+      if (!isEmpty(annotations) && has(annotations, CATTLE_PUBLIC_ENDPOINTS)) {
+        return true;
+      }
+
+      return false;
+    },
     parsed() {
-      const { row } = this;
+      const { row, hasPublic } = this;
       const {
+        metadata: { annotations = {} },
         spec: {
-          clusterIP = null,
-          ports = [],
-          type: serviceType,
-          externalName
+          clusterIP = null, ports = [], type: serviceType, externalName
         }
       } = row;
       const out = [];
       const isHeadless = serviceType === 'ClusterIP' && clusterIP === 'None';
-      const parsedClusterIp = !isEmpty(clusterIP) && !isHeadless ? `${ clusterIP }:` : '';
+      const parsedClusterIp =
+        !isEmpty(clusterIP) && !isHeadless ? `${ clusterIP }:` : '';
       let label = '';
       const link = '';
+
+      if (hasPublic) {
+        return annotations[CATTLE_PUBLIC_ENDPOINTS];
+      }
 
       // <CLUSTER_IP>:<PORT>/<PROTOCOL> > <TARGET PORT>
       if (isEmpty(ports)) {
@@ -40,9 +56,6 @@ export default {
           label = parsedClusterIp;
         } else if (serviceType === 'ExternalName' && !isEmpty(externalName)) {
           label = externalName;
-          // if (!isHeadless) {
-          //   link = `<a href="${ label }" target="_blank" rel="noopener nofollow">${ label }</a>`;
-          // }
         }
 
         out.push({
@@ -50,14 +63,12 @@ export default {
           link,
         });
       } else {
-        ports.forEach(( p ) => {
+        ports.forEach((p) => {
           const clusterIpAndPort = `${ parsedClusterIp }${ p.port }`;
           const protocol = p?.protocol ? ` /${ p.protocol }` : '';
           const targetPort = p?.targetPort ? ` > ${ p.targetPort }` : '';
 
           label = `${ clusterIpAndPort }${ protocol }${ targetPort }`;
-
-          // link = serviceType === 'ClusterIP' && !isEmpty(clusterIP) && !isHeadless ? `<a href="//${ clusterIP }/${ p.port }" target="_blank" rel="noopener nofollow">${ clusterIpAndPort }</a>${ protocol }${ targetPort }` : null;
 
           out.push({
             label,
@@ -74,7 +85,10 @@ export default {
 
 <template>
   <div>
-    <div v-for="( port, index ) in parsed" :key="index">
+    <div v-if="hasPublic">
+      <Endpoints v-model="parsed" :row="{}" :col="{}" />
+    </div>
+    <div v-for="(port, index) in parsed" v-else :key="index">
       <span v-if="port.link" v-html="port.link"></span>
       <span v-else>{{ port.label }}</span>
     </div>

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -5,6 +5,7 @@ export const SYSTEM_NAMESPACE = 'management.cattle.io/system-namespace';
 export const PROJECT = 'field.cattle.io/projectId';
 export const SYSTEM_PROJECT = 'authz.management.cattle.io/system-project';
 export const CONTAINER_DEFAULT_RESOURCE_LIMIT = 'field.cattle.io/containerDefaultResourceLimit';
+export const CATTLE_PUBLIC_ENDPOINTS = 'field.cattle.io/publicEndpoints';
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',


### PR DESCRIPTION
Additionally I have left the previous logic in the cases where a service does not have the public endpoints annotation to not break the previous functionality.

rancher/dashboard#1471