### PR TITLE
Fixed an ingress performance issue and added focus UX

### DIFF
--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -154,6 +154,8 @@ export default {
         if ( inputs && inputs.length > 0 ) {
           inputs[inputs.length - 1].focus();
         }
+
+        this.$emit('add');
       });
     },
 

--- a/components/form/ArrayListGrouped.vue
+++ b/components/form/ArrayListGrouped.vue
@@ -5,7 +5,7 @@ import InfoBox from '@/components/InfoBox';
 export default { components: { ArrayList, InfoBox } };
 </script>
 <template>
-  <ArrayList class="array-list-grouped" v-bind="$attrs" @input="$emit('input', $event)">
+  <ArrayList class="array-list-grouped" v-bind="$attrs" @input="$emit('input', $event)" @add="$emit('add')">
     <!-- Pass down templates provided by the caller -->
     <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope">
       <slot :name="slot" v-bind="scope" />

--- a/edit/networking.k8s.io.ingress/Rule.vue
+++ b/edit/networking.k8s.io.ingress/Rule.vue
@@ -46,6 +46,13 @@ export default {
     addPath(ev) {
       ev.preventDefault();
       this.paths = [...this.paths, { id: random32(1) }];
+      this.$nextTick(() => {
+        if (this.$refs.paths && this.$refs.paths.length > 0) {
+          const path = this.$refs.paths[this.$refs.paths.length - 1];
+
+          path.focus();
+        }
+      });
     },
     removePath(idx) {
       const neu = [...this.paths];
@@ -56,6 +63,9 @@ export default {
     removeRule() {
       this.$emit('remove');
     },
+    focus() {
+      this.$refs.host.focus();
+    }
   },
 };
 </script>
@@ -65,6 +75,7 @@ export default {
     <div class="row mb-20">
       <div id="host" class="col span-6">
         <LabeledInput
+          ref="host"
           v-model="host"
           :label="t('ingress.rules.requestHost.label')"
           :placeholder="t('ingress.rules.requestHost.placeholder')"
@@ -86,6 +97,7 @@ export default {
     </div>
     <template v-for="(_, i) in paths">
       <RulePath
+        ref="paths"
         :key="i"
         v-model="paths[i]"
         class="row mb-10"

--- a/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/edit/networking.k8s.io.ingress/RulePath.vue
@@ -82,6 +82,9 @@ export default {
       this.path = values.text;
       this.pathType = values.selected;
       this.update();
+    },
+    focus() {
+      this.$refs.first.focus();
     }
   }
 };
@@ -90,6 +93,7 @@ export default {
   <div class="rule-path row">
     <div v-if="ingress.showPathType" class="col span-6">
       <InputWithSelect
+        ref="first"
         class="path-type"
         :options="pathTypes"
         :placeholder="t('ingress.rules.path.placeholder', undefined, true)"
@@ -100,7 +104,7 @@ export default {
       />
     </div>
     <div v-else class="col span-4">
-      <input v-model="path" :placeholder="t('ingress.rules.path.placeholder', undefined, true)" @input="queueUpdate" />
+      <input ref="first" v-model="path" :placeholder="t('ingress.rules.path.placeholder', undefined, true)" @input="queueUpdate" />
     </div>
     <div class="col" :class="{'span-3': ingress.showPathType, 'span-4': !ingress.showPathType}">
       <Select

--- a/edit/networking.k8s.io.ingress/Rules.vue
+++ b/edit/networking.k8s.io.ingress/Rules.vue
@@ -85,6 +85,13 @@ export default {
     rows() {
       return this.value.createRulesForListPage(this.workloads, this.certificates);
     }
+  },
+  methods: {
+    onAdd() {
+      if (this.$refs.lastRule?.focus) {
+        this.$refs.lastRule.focus();
+      }
+    }
   }
 };
 </script>
@@ -102,9 +109,10 @@ export default {
     />
   </div>
   <div v-else>
-    <ArrayListGrouped v-model="value.spec.rules" :add-label="t('ingress.rules.addRule')" :default-add-value="{}">
+    <ArrayListGrouped v-model="value.spec.rules" :add-label="t('ingress.rules.addRule')" :default-add-value="{}" @add="onAdd">
       <template #default="props">
         <Rule
+          ref="lastRule"
           v-model="props.row.value"
           :service-targets="serviceTargets"
           :ingress="value"

--- a/models/networking.k8s.io.ingress.js
+++ b/models/networking.k8s.io.ingress.js
@@ -147,12 +147,28 @@ export default {
     };
   },
 
+  cache() {
+    if (!this.cacheObject) {
+      this.cacheObject = {};
+    }
+
+    return this.cacheObject;
+  },
+
   showPathType() {
-    return this.$rootGetters['cluster/pathExistsInSchema'](this.type, 'spec.rules.http.paths.pathType');
+    if (!this.cache.showPathType) {
+      this.cache.showPathType = this.$rootGetters['cluster/pathExistsInSchema'](this.type, 'spec.rules.http.paths.pathType');
+    }
+
+    return this.cache.showPathType;
   },
 
   useNestedBackendField() {
-    return this.$rootGetters['cluster/pathExistsInSchema'](this.type, 'spec.rules.http.paths.backend.service.name');
+    if (!this.cache.useNestedBackendField) {
+      this.cache.useNestedBackendField = this.$rootGetters['cluster/pathExistsInSchema'](this.type, 'spec.rules.http.paths.backend.service.name');
+    }
+
+    return this.cache.useNestedBackendField;
   },
 
   serviceNamePath() {


### PR DESCRIPTION
- showPathType/useNestedBackendField was getting called frequently so I cached/memoized the response since it's a somewhat expensive call.
- Made it so when adding a path or adding a rule it focuses the appropriate input.

rancher/dashboard#1980

Notes:
- I debated whether or not to memoize the pathExistsInSchema getter but I was concerned with the getter making a stateful change and how it would interact with ssr. If you'd prefer me to memoize there do you have any thoughts on my concern?
- The issue specifically calls out add path as the event we want to focus on but I figured we'd want the same for add rule so I added it there as well. If we don't want it there let me know and I'll remove it.