### PR TITLE
input selects tooltips height and placements

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -359,7 +359,7 @@ export default {
       <template v-if="rows.length">
         <label class="text-label">
           {{ keyLabel }}
-          <i v-if="protip" v-tooltip="protip" class="icon icon-info" style="font-size: 14px" />
+          <i v-if="protip" v-tooltip="protip" class="icon icon-info" />
         </label>
         <label class="text-label">
           {{ valueLabel }}

--- a/components/form/LabeledTooltip.vue
+++ b/components/form/LabeledTooltip.vue
@@ -35,7 +35,6 @@ export default {
     </template>
   </div>
 </template>
-</template>
 
 <style lang='scss'>
 .labeled-tooltip {
@@ -49,14 +48,14 @@ export default {
       height: 0%;
     }
 
-    .status-icon {
-        position:  absolute;
-        right: 30px;
-        top: 16px;
-        font-size: 20px;
-        z-index: z-index(hoverOverContent);
+     .status-icon {
+         position:  absolute;
+         right: 30px;
+         top: 16px;
+         font-size: 20px;
+         z-index: z-index(hoverOverContent);
 
-    }
+     }
 
     .tooltip {
         position: absolute;

--- a/components/form/TextAreaAutoGrow.vue
+++ b/components/form/TextAreaAutoGrow.vue
@@ -120,3 +120,6 @@ export default {
     @blur="$emit('blur', $event)"
   />
 </template>
+
+<style lang='scss' scoped>
+</style>

--- a/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -101,7 +101,6 @@ export default {
           v-if="disableAddRecord"
           v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
           class="icon icon-info"
-          style="font-size: 14px"
         />
       </h3>
       <div v-if="recordingRules.length > 0" class="rules">
@@ -135,7 +134,6 @@ export default {
             v-if="disableAddAlert"
             v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
             class="icon icon-info"
-            style="font-size: 14px"
           />
         </h3>
         <Banner

--- a/edit/workload/Job.vue
+++ b/edit/workload/Job.vue
@@ -183,7 +183,7 @@ export default {
             <template #label>
               <label class="has-tooltip" :style="{'color':'var(--input-label)'}">
                 {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
-                <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" style="font-size: 14px" />
+                <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" />
               </label>
             </template>
           </UnitInput>
@@ -220,7 +220,7 @@ export default {
           <template #label>
             <label class="has-tooltip" :style="{'color':'var(--input-label)'}">
               {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
-              <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" style="font-size: 14px" />
+              <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" />
             </label>
           </template>
         </UnitInput>


### PR DESCRIPTION
@vincent99 moved tooltips to right of inputs, ideally they should be right of the labels but so far that hasn't been able to work without significantly affecting other areas
https://github.com/rancher/dashboard/issues/1724