### PR TITLE
cis fixes, cron input type

### DIFF
--- a/assets/styles/global/_labeled-input.scss
+++ b/assets/styles/global/_labeled-input.scss
@@ -106,4 +106,12 @@
   &.suffix INPUT {
     padding-right: 8px;
   }
+
+  .cron-label{
+    position: absolute;
+    top: 100%;
+    padding-top: 5px;
+    left: 0;
+    color: var(--input-label);
+  }
 }

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1531,7 +1531,6 @@ tableHeaders:
   configuredProviders: Configured Providers
   cpu: CPU
   date: Date
-  default: Default
   destination: Target
   download: Download
   effect: Effect

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -15,6 +15,7 @@ generic:
   disabled: Disabled
   enabled: Enabled
   ignored: Ignored
+  invalidCron: Invalid cron schedule
   labelsAndAnnotations: Labels and Annotations
   members: Members
   na: n/a
@@ -376,6 +377,7 @@ cis:
     notApplicable: 'N/A'
     number: Number
     pass: Pass
+    scanDate: Scan Date
     scanReport: Scan Report
     skip: Skip
     total: Total

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -3,6 +3,7 @@ import LabeledFormElement from '@/mixins/labeled-form-element';
 import TextAreaAutoGrow from '@/components/form/TextAreaAutoGrow';
 import LabeledTooltip from '@/components/form/LabeledTooltip';
 import { escapeHtml } from '@/utils/string';
+import cronstrue from 'cronstrue';
 
 export default {
   components: { LabeledTooltip, TextAreaAutoGrow },
@@ -38,6 +39,19 @@ export default {
     hasSuffix() {
       return !!this.$slots.suffix;
     },
+
+    cronHint() {
+      if (this.type !== 'cron' || !this.value) {
+        return;
+      }
+      try {
+        const hint = cronstrue.toString(this.value);
+
+        return hint;
+      } catch (e) {
+        return this.t('generic.invalidCron');
+      }
+    }
   },
 
   methods: {
@@ -102,7 +116,7 @@ export default {
         :class="{'no-label': !hasLabel}"
         v-bind="$attrs"
         :disabled="isDisabled"
-        :type="type"
+        :type="type === 'cron' ? 'text' : type"
         :value="value"
         :placeholder="placeholder"
         autocomplete="off"
@@ -125,5 +139,6 @@ export default {
       :value="tooltip"
       :status="status"
     />
+    <label v-if="cronHint" class="cron-label">{{ cronHint }}</label>
   </div>
 </template>

--- a/config/product/cis.js
+++ b/config/product/cis.js
@@ -136,7 +136,7 @@ export function init(store) {
     },
     {
       name:          'isDefault',
-      labelKey:      'tableHeaders.default',
+      labelKey:      'tableHeaders.builtIn',
       formatter:     'Checked',
       value:     'isDefault'
     },

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -1,7 +1,6 @@
 <script>
 import omitBy from 'lodash/omitBy';
 import { cleanUp } from '@/utils/object';
-import cronstrue from 'cronstrue';
 import {
   CONFIG_MAP, SECRET, WORKLOAD_TYPES, NODE, SERVICE, PVC
 } from '@/config/types';
@@ -309,23 +308,6 @@ export default {
       return this.$store.getters['cluster/schemaFor'](this.type);
     },
 
-    // show cron schedule in human-readable format
-    cronLabel() {
-      const { schedule } = this.spec;
-
-      if (!this.isCronJob || !schedule) {
-        return null;
-      }
-
-      try {
-        const hint = cronstrue.toString(schedule);
-
-        return hint;
-      } catch (e) {
-        return 'invalid cron expression';
-      }
-    },
-
     namespacedSecrets() {
       const namespace = this.value?.metadata?.namespace;
 
@@ -588,8 +570,14 @@ export default {
         <div class="col span-12">
           <NameNsDescription :value="value" :extra-columns="nameNsColumns" :mode="mode" @change="name=value.metadata.name">
             <template #schedule>
-              <LabeledInput v-model="spec.schedule" required :mode="mode" :label="t('workload.cronSchedule')" placeholder="0 * * * *" />
-              <span class="cron-hint text-small">{{ cronLabel }}</span>
+              <LabeledInput
+                v-model="spec.schedule"
+                type="cron"
+                required
+                :mode="mode"
+                :label="t('workload.cronSchedule')"
+                placeholder="0 * * * *"
+              />
             </template>
             <template #replicas>
               <LabeledInput v-model.number="spec.replicas" type="number" required :mode="mode" :label="t('workload.replicas')" />
@@ -776,11 +764,6 @@ export default {
 
 .type-description{
   color: var(--input-label)
-}
-
-.cron-hint {
-  color: var(--disabled-text);
-  padding: 3px;
 }
 
 .next-dropdown{

--- a/models/cis.cattle.io.clusterscanreport.js
+++ b/models/cis.cattle.io.clusterscanreport.js
@@ -55,5 +55,5 @@ export default {
       return parsed;
     } catch (e) {
     }
-  }
+  },
 };


### PR DESCRIPTION
Added a 'cron' type input with human-readable label:
![Screen Shot 2020-12-11 at 7 51 23 AM](https://user-images.githubusercontent.com/42977925/101917608-adf2ed00-3b85-11eb-8482-8e5a6cfc984e.png)
#1995 - updated report names to be more consistent between ui and file names
![Screen Shot 2020-12-10 at 1 03 04 PM](https://user-images.githubusercontent.com/42977925/101917543-974c9600-3b85-11eb-9737-a3a97076c171.png)
#2054, #2052 - per conversation with @sowmyav27, the scheduling/alerting fields and anything related to 'warn' test results shouldn't be available if the installed version of cis doesn't support scheduling. I added some of this functionality earlier this week but it was dependent on access to the cis app resource, which the cis-admin role doesn't have. This updated version should work for all users with permission to view scans.

Other fixes: #2057 #2042 #2036 