### PR TITLE
Service Ports Focus in

### DIFF
--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -72,12 +72,13 @@ export default {
     }
 
     if (this.autoAddIfEmpty && this.mode !== _EDIT && this?.rows.length < 1) {
-      this.add();
+      // don't focus on mount because we'll pull focus from name/namespace input
+      this.add(false);
     }
   },
 
   methods: {
-    add() {
+    add(focus = true) {
       this.rows.push({
         name:       '',
         port:       null,
@@ -87,9 +88,9 @@ export default {
 
       this.queueUpdate();
 
-      if (this.rows.length > 1) {
+      if (this.rows.length > 0 && focus) {
         this.$nextTick(() => {
-          const inputs = this.$refs.port;
+          const inputs = this.$refs['port-name'];
 
           inputs[inputs.length - 1].focus();
         });


### PR DESCRIPTION
When adding a new service port row we'll now focus the port name field instead of the port input.
Also change the way we focus when the user has removed all rows then adds a new row. 




rancher/dashboard#1732