### PR TITLE
Fix renamed variable reference Windows Apps

### DIFF
--- a/pages/c/_cluster/apps/charts.vue
+++ b/pages/c/_cluster/apps/charts.vue
@@ -40,7 +40,7 @@ export default {
   data() {
     return {
       allRepos:            null,
-      catalogOSAnnotation: CATALOG.OS,
+      catalogOSAnnotation: CATALOG.SUPPORTED_OS,
       category:            null,
       searchQuery:         null,
       showDeprecated:      null,


### PR DESCRIPTION
I renamed the label constant for catalog os from OS to SUPPORTED_OS and missed the implementation.

rancher/dashboard#1952