### PR TITLE
fix replica display in config

### DIFF
--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -106,23 +106,6 @@ export default {
 
     const spec = this.value.spec;
 
-    if (type === WORKLOAD_TYPES.CRON_JOB) {
-      if (!spec.jobTemplate) {
-        spec.jobTemplate = { spec: { template: { spec: { restartPolicy: 'Never' } } } };
-      }
-    } else {
-      if (!spec.replicas) {
-        spec.replicas = 1;
-      }
-
-      if (!spec.template) {
-        spec.template = { spec: { restartPolicy: type === WORKLOAD_TYPES.JOB ? 'Never' : 'Always' } };
-      }
-      if (!spec.selector) {
-        spec.selector = {};
-      }
-    }
-
     return {
       allConfigMaps:     [],
       allNodes:          null,

--- a/models/workload.js
+++ b/models/workload.js
@@ -30,6 +30,30 @@ export default {
     return out;
   },
 
+  applyDefaults() {
+    return (vm, mode) => {
+      const spec = {};
+
+      if (this.type === WORKLOAD_TYPES.CRON_JOB) {
+        if (!spec.jobTemplate) {
+          spec.jobTemplate = { spec: { template: { spec: { restartPolicy: 'Never' } } } };
+        }
+      } else {
+        if (!spec.replicas && spec.replicas !== 0) {
+          spec.replicas = 1;
+        }
+
+        if (!spec.template) {
+          spec.template = { spec: { restartPolicy: this.type === WORKLOAD_TYPES.JOB ? 'Never' : 'Always' } };
+        }
+        if (!spec.selector) {
+          spec.selector = {};
+        }
+      }
+      vm.$set(this, 'spec', spec);
+    };
+  },
+
   customValidationRules() {
     const type = this._type ? this._type : this.type;
 


### PR DESCRIPTION
#2041 
```
 if (!spec.replicas) {
     spec.replicas = 1;
  }
```
changed the above  logic to account for replicas=0, and moved it into `applyDefaults` because it shoulda been there already.