### PR TITLE
Chart Filtering Cluster OS Types

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -309,8 +309,8 @@ catalog:
     version: Version
     versions:
       current: '{ver} (current)'
-      linux: '{ver} (linux only)'
-      windows: '{ver} (windows only)'
+      linux: '{ver} (Linux-only)'
+      windows: '{ver} (Windows-only)'
   operation:
     tableHeaders:
       action: Action

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -307,6 +307,10 @@ catalog:
       readme: Helm README
       valuesYaml: Values YAML
     version: Version
+    versions:
+      current: '{ver} (current)'
+      linux: '{ver} (linux only)'
+      windows: '{ver} (windows only)'
   operation:
     tableHeaders:
       action: Action

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -11,56 +11,39 @@ export default {
   mixins:     [LabeledFormElement, VueSelectOverrides],
 
   props: {
-    value: {
-      type:    [String, Object, Number, Array, Boolean],
-      default: null,
-    },
-    options: {
-      type:    Array,
-      default: null,
+    disabled: {
+      default: false,
+      type:    Boolean
     },
     grouped: {
-      type:    Boolean,
       default: false,
-    },
-    disabled: {
-      type:    Boolean,
-      default: false,
-    },
-    optionKey: {
-      type:    String,
-      default: null,
-    },
-    optionLabel: {
-      type:    String,
-      default: 'label',
-    },
-    placement: {
-      type:    String,
-      default: null,
-    },
-    tooltip: {
-      type:    String,
-      default: null,
+      type:    Boolean
     },
     hoverTooltip: {
-      type:    Boolean,
       default: false,
+      type:    Boolean
     },
     localizedLabel: {
-      type:    Boolean,
       default: false,
+      type:    Boolean
     },
-    searchable: {
-      default: false,
-      type:    Boolean,
-    },
-    status: {
-      type:    String,
+    optionKey: {
       default: null,
+      type:    String
+    },
+    optionLabel: {
+      default: 'label',
+      type:    String
+    },
+    options: {
+      default: null,
+      type:    Array
+    },
+    placement: {
+      default: null,
+      type:    String
     },
     reduce: {
-      type:    Function,
       default: (e) => {
         if (e && typeof e === 'object' && e.value !== undefined) {
           return e.value;
@@ -68,7 +51,28 @@ export default {
 
         return e;
       },
+      type: Function
     },
+    searchable: {
+      default: false,
+      type:    Boolean
+    },
+    selectable: {
+      default: undefined,
+      type:    Function
+    },
+    status: {
+      default: null,
+      type:    String
+    },
+    tooltip: {
+      default: null,
+      type:    String
+    },
+    value: {
+      default: null,
+      type:    [String, Object, Number, Array, Boolean]
+    }
   },
 
   data() {
@@ -228,6 +232,7 @@ export default {
       :placeholder="placeholder"
       :reduce="(x) => reduce(x)"
       :searchable="isSearchable"
+      :selectable="selectable"
       :value="value != null ? value : ''"
       @input="(e) => $emit('input', e)"
       @search:blur="onBlur"

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -77,10 +77,18 @@ export default {
       return null;
     }
 
+    const clusterProvider = this.$rootGetters['currentCluster'].status.provider || 'other';
     const thisVersion = this.spec?.chart?.metadata?.version;
-    const newestVersion = chart.versions?.[0]?.version;
+    const newestChart = chart.versions?.[0];
+    const newestVersion = newestChart?.version;
 
     if ( !thisVersion || !newestVersion ) {
+      return null;
+    }
+
+    if (clusterProvider === 'rke.windows' && newestChart?.annotations?.['catalog.cattle.io/os'] === 'linux') {
+      return null;
+    } else if (clusterProvider !== 'rke.windows' && newestChart?.annotations?.['catalog.cattle.io/os'] === 'windows') {
       return null;
     }
 


### PR DESCRIPTION
My previous change assumed that the new annotation was on the chart itself but the annotation exists on a charts different versions. I updated the logic to add the following filtering:

Apps List Page: 
  - Chart will only be filtered from the view if all versions of the chart have the `catalog.cattle.io/os` annotation set and all versions are either linux or windows.
  - Selecting Charts will take the user to the highest version chart that either lacks the `catalog.cattle.io/os` annotation (assumed to work on any os) or has the `catalog.cattle.io/os` annotation set to the correct os provider for the cluster.


App Install/Upgrade Page:
  - Version list will list all versions of a chart, but if a particular version of the chart is incompatible with the current clusters os  the user will not be able to select that version of the chart. The label of the option will show what os it is compatible with.
  - If the current version of the chart is not in the list, we will add it, so users are never left stuck.


App List Page:
  - I added logic here to filter the notification if the upgraded chart version is not compatible with the current cluster os.


rancher/dashboard#1952



The automatic version selection logic revealed a nasty little bug in an older version of the Istio chart [here](https://github.com/rancher/dashboard/issues/2094)