### PR TITLE
Dropdown Dark/Light Theme Bug 

### DIFF
--- a/assets/styles/global/_select.scss
+++ b/assets/styles/global/_select.scss
@@ -83,6 +83,7 @@
       // Can toggle this to get full width dd - maybe make an option?
       .vs__dropdown-menu {
         min-width: max-content;
+        background: var(--dropdown-bg);
       }
     }
   }
@@ -102,7 +103,7 @@
   }
 
   .v-select {
-    
+
     &.inline {
       height: 100%;
 

--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -79,6 +79,7 @@
   --dropdown-hover-text: #{$lightest};
   --dropdown-hover-bg: #{$link};
   --dropdown-disabled-bg: #{$disabled};
+  --dropdown-disabled-text: #{$disabled};
 
   --input-text: #{$lightest};
   --input-label: #{$lighter};

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -35,7 +35,7 @@ export default {
     },
 
     tooltip: {
-      type:    String,
+      type:    [String, Object],
       default: null
     },
 


### PR DESCRIPTION
In light mode disabled options we're not visible because the text was too light. Additionally no background was set on the dd so the hover background of the select input was showing through making it even worse. 
In dark mode dropdowns didn't have a disabled text var so the text was white and not really distinguishable from enabled options until hover. 


rancher/dashboard#2101

Also threw in a small change for the checkbox tooltip property. Since this property is essentially just passed through to v-select the property signature needed to be able to accept objects which v-select accepts. This was manifesting as a prop type check error on the Monitoring config page for aggregate roles. 


