### PR TITLE
default scan profile fallback

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -343,8 +343,7 @@ chartHeading:
 
 cis:
   addTest: Add Test ID
-  alertNeeded: To receive alerts, please ensure <a tabindex="0" aria-label="Link to Rancher's Monitoring" href="{link}"> Rancher's Monitoring and Alerting app</a> is installed and the Receivers and Routes are <a target="_blank" rel='noopener nofollow' href='https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/v2.5/configuration/#alertmanager-config'> configured to send out alerts.</a>
-  alertNotFound: "It looks like alerting isn't configured."
+  alertNeeded: Alerting must be enabled within the CIS chart questions.yaml. This requires that <a tabindex="0" aria-label="Link to Rancher's Monitoring" href="{link}"> Rancher's Monitoring and Alerting app</a> is installed and the Receivers and Routes are <a target="_blank" rel='noopener nofollow' href='https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/v2.5/configuration/#alertmanager-config'> configured to send out alerts.</a>
   alertOnComplete: Alert on scan completion
   alertOnFailure: Alert on scan failure
   benchmarkVersion: Benchmark Version

--- a/components/formatter/ScanResult.vue
+++ b/components/formatter/ScanResult.vue
@@ -3,7 +3,7 @@ import { get } from '@/utils/object';
 export default {
   props:      {
     value: {
-      type:    String,
+      type:    [String, Number],
       default: null,
     },
     row: {

--- a/models/cis.cattle.io.clusterscan.js
+++ b/models/cis.cattle.io.clusterscan.js
@@ -1,4 +1,4 @@
-import { _CREATE } from '@/config/query-params';
+import { _CREATE, _EDIT } from '@/config/query-params';
 import { CIS } from '@/config/types';
 import { findBy } from '@/utils/array';
 import { downloadFile, generateZip } from '@/utils/download';
@@ -50,7 +50,7 @@ export default {
 
   applyDefaults() {
     return (vm, mode) => {
-      if (mode === _CREATE) {
+      if (mode === _CREATE || mode === _EDIT) {
         const includeScheduling = this.canBeScheduled();
         const spec = this.spec || {};
 


### PR DESCRIPTION
#2088 #2092 
* fall back to cis-1.5 or cis-1.6 scan profiles if the default profile specified in the configmap isn't valid
* Warn that alerting needs to be configured on CIS install/upgrade as well as in the monitoring/alerting app