### PR TITLE
Add new prop to createYaml NEVER_ADD

### DIFF
--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -32,22 +32,24 @@ const ALWAYS_ADD = [
 ];
 
 const NEVER_ADD = [
-  'status',
+  'metadata.clusterName',
   'metadata.clusterName',
   'metadata.creationTimestamp',
-  'metadata.clusterName',
   'metadata.deletionGracePeriodSeconds',
-  'metadata.managedFields',
-  'metadata.generateName',
-  'metadata.generation',
   'metadata.deletionTimestamp',
   'metadata.finalizers',
+  'metadata.generateName',
+  'metadata.generation',
   'metadata.initializers',
+  'metadata.managedFields',
   'metadata.ownerReferences',
   'metadata.resourceVersion',
   'metadata.selfLink',
   'metadata.uid',
-  'stringData'
+  // CRD -> Schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource. If we allow processing we fall into inf loop on openAPIV3Schema.allOf which contains a cyclical ref of allOf props.
+  'spec.versions.schema',
+  'status',
+  'stringData',
 ];
 
 const INDENT = 2;
@@ -57,7 +59,6 @@ export function createYaml(schemas, type, data, processAlwaysAdd = true, depth =
 
   if ( !schema ) {
     return `Error loading schema for ${ type }`;
-    // throw new Error('Unknown schema for', type);
   }
 
   data = data || {};


### PR DESCRIPTION
This particular property contains a cyclical reference in the allOf property which is of the type io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps and has its own allOf property of the same type. Adding this prop to the never add list felt more appropriate than adding an arbitrary depth check.

rancher/dashboard#1843