### PR TITLE
yaml save button error display

### DIFF
--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -255,7 +255,7 @@ export default {
         await this.$emit('apply-hooks', BEFORE_SAVE_HOOKS);
 
         try {
-          this.value.saveYaml(yaml);
+          await this.value.saveYaml(yaml);
         } catch (err) {
           return onError.call(this, err);
         }

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -30,7 +30,7 @@ import {
 
 import { ANNOTATIONS_TO_IGNORE_REGEX, DESCRIPTION, LABELS_TO_IGNORE_REGEX } from '@/config/labels-annotations';
 import {
-  AS, _YAML, MODE, _CLONE, _EDIT, _VIEW, _UNFLAG
+  AS, _YAML, MODE, _CLONE, _EDIT, _VIEW, _UNFLAG, _CONFIG
 } from '@/config/query-params';
 
 import { cleanForNew, normalizeType } from './normalize';
@@ -618,13 +618,13 @@ export default {
     const all = [
       { divider: true },
       {
-        action:  'goToEdit',
+        action:  this.canUpdate ? 'goToEdit' : 'goToViewConfig',
         label:   this.t(this.canUpdate ? 'action.edit' : 'action.view'),
         icon:    'icon icon-edit',
         enabled:  this.canCustomEdit,
       },
       {
-        action:  'goToEditYaml',
+        action:  this.canUpdate ? 'goToEditYaml' : 'goToViewYaml',
         label:   this.t(this.canUpdate ? 'action.editYaml' : 'action.viewYaml'),
         icon:    'icon icon-file',
         enabled: this.canYaml,
@@ -939,6 +939,21 @@ export default {
         ...location.query,
         [MODE]: _EDIT,
         [AS]:   _UNFLAG,
+        ...moreQuery
+      };
+
+      this.currentRouter().push(location);
+    };
+  },
+
+  goToViewConfig() {
+    return (moreQuery = {}) => {
+      const location = this.detailLocation;
+
+      location.query = {
+        ...location.query,
+        [MODE]:  _VIEW,
+        [AS]:   _CONFIG,
         ...moreQuery
       };
 


### PR DESCRIPTION
#2100 
Two parts to this bug, neither CIS specific: 
1) 'view config' action menu item was calling 'goToEdit' and therefore showing cancel/yaml/save buttons to users without permission to edit the resource 
2) the edit-as-yaml save button wasn't waiting for & showing errors