### PR TITLE
Group charts by repo in install

### DIFF
--- a/models/catalog.cattle.io.clusterrepo.js
+++ b/models/catalog.cattle.io.clusterrepo.js
@@ -114,11 +114,7 @@ export default {
     const name = this.metadata?.name;
     const key = `catalog.repo.name."${ name }"`;
 
-    if ( this.$rootGetters['i18n/exists'](key) ) {
-      return this.$rootGetters['i18n/t'](key);
-    }
-
-    return name;
+    return this.$rootGetters['i18n/withFallback'](key, null, name);
   },
 
   urlDisplay() {

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -392,6 +392,7 @@ function addChart(ctx, map, chart, repo) {
       sideLabel,
       repoType,
       repoName,
+      repoNameDisplay:  ctx.rootGetters['i18n/withFallback'](`catalog.repo.name."${repoName}"`, null, repoName),
       certifiedSort:    CERTIFIED_SORTS[certified] || 99,
       icon:             chart.icon,
       color:            repo.color,


### PR DESCRIPTION
- Show hidden charts which match the name of the expected repo
- Add support for `hidden` and `deprecated` query params on edit