### PR TITLE
Dropdown Bugs

### DIFF
--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -100,6 +100,7 @@ export default {
   },
 
   methods: {
+    // resizeHandler = in mixin
     focusSearch() {
       this.$nextTick(() => {
         const el = this.$refs.input?.searchEl;
@@ -178,13 +179,6 @@ export default {
        */
       return () => popper.destroy();
     },
-    open() {
-      const input = this.$refs.input;
-
-      if (input) {
-        input.open = true;
-      }
-    },
     get,
   },
 };
@@ -192,6 +186,7 @@ export default {
 
 <template>
   <div
+    ref="select"
     class="labeled-select"
     :class="{
       disabled: isView || disabled,
@@ -238,6 +233,7 @@ export default {
       v-on="$listeners"
       @search:blur="onBlur"
       @search:focus="onFocus"
+      @open="resizeHandler"
     >
       <!-- Pass down templates provided by the caller -->
       <template v-for="(_, slot) of $scopedSlots" #[slot]="scope">

--- a/components/form/Select.vue
+++ b/components/form/Select.vue
@@ -9,6 +9,10 @@ export default {
   components: { LabeledTooltip },
   mixins:     [LabeledFormElement, VueSelectOverrides],
   props:      {
+    appendToBody: {
+      default: true,
+      type:    Boolean,
+    },
     disabled: {
       default: false,
       type:    Boolean,
@@ -95,12 +99,14 @@ export default {
       if (this.popperOverride) {
         return this.popperOverride(dropdownList, component, { width });
       }
-
       /**
        * We need to explicitly define the dropdown width since
        * it is usually inherited from the parent with CSS.
        */
-      dropdownList.style.width = width;
+      const componentWidth = $(component.$parent.$el).width();
+
+      dropdownList.style['min-width'] = `${ componentWidth }px`;
+      dropdownList.style.width = 'min-content';
 
       /**
        * Here we position the dropdownList relative to the $refs.toggle Element.
@@ -113,7 +119,7 @@ export default {
        * above.
        */
       const popper = createPopper(component.$refs.toggle, dropdownList, {
-        placement: this.placement,
+        placement: this.placement || 'bottom-start',
         modifiers: [
           {
             name:    'offset',
@@ -126,7 +132,7 @@ export default {
             fn({ state }) {
               component.$el.setAttribute('x-placement', state.placement);
             },
-          },
+          }
         ],
       });
 
@@ -173,7 +179,7 @@ export default {
       v-bind="$attrs"
       class="inline"
       :autoscroll="true"
-      :append-to-body="!!placement"
+      :append-to-body="appendToBody"
       :calculate-position="placement ? withPopper : undefined"
       :disabled="isView || disabled"
       :get-option-key="(opt) => (optionKey ? get(opt, optionKey) : getOptionLabel(opt))"

--- a/components/form/Select.vue
+++ b/components/form/Select.vue
@@ -76,6 +76,7 @@ export default {
   },
 
   methods: {
+    // resizeHandler = in mixin
     getOptionLabel(option) {
       if (this.$attrs['get-option-label']) {
         return this.$attrs['get-option-label'](option);
@@ -153,6 +154,7 @@ export default {
 
 <template>
   <div
+    ref="select"
     class="unlabeled-select"
     :class="{
       disabled: disabled && !isView,
@@ -187,6 +189,7 @@ export default {
       @input="(e) => $emit('input', e)"
       @search:blur="onBlur"
       @search:focus="onFocus"
+      @open="resizeHandler"
     >
       <!-- Pass down templates provided by the caller -->
       <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope">

--- a/components/form/Select.vue
+++ b/components/form/Select.vue
@@ -4,6 +4,7 @@ import { get } from '@/utils/object';
 import LabeledFormElement from '@/mixins/labeled-form-element';
 import VueSelectOverrides from '@/mixins/vue-select-overrides';
 import LabeledTooltip from '@/components/form/LabeledTooltip';
+import $ from 'jquery';
 
 export default {
   components: { LabeledTooltip },

--- a/components/nav/ClusterSwitcher.vue
+++ b/components/nav/ClusterSwitcher.vue
@@ -63,6 +63,7 @@ export default {
       ref="select"
       key="cluster"
       v-model="value"
+      :append-to-body="false"
       :searchable="true"
       :selectable="(option) => option.ready"
       :clearable="false"

--- a/components/nav/ClusterSwitcher.vue
+++ b/components/nav/ClusterSwitcher.vue
@@ -137,7 +137,7 @@ export default {
     .dropdown-option {
       display: grid;
       width: 100%;
-      grid-template-columns: 35% fit-content(100%);
+      grid-template-columns: 25px fit-content(100%);
     }
   }
 

--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -314,6 +314,7 @@ export default {
     <Select
       ref="select"
       v-model="value"
+      :append-to-body="false"
       :class="{
         'has-more': showGroupedOptions,
       }"

--- a/components/nav/WorkspaceSwitcher.vue
+++ b/components/nav/WorkspaceSwitcher.vue
@@ -46,6 +46,7 @@ export default {
       ref="select"
       v-model="value"
       label="label"
+      :append-to-body="false"
       :options="options"
       :clearable="false"
       :reduce="(opt) => opt.value"

--- a/mixins/labeled-form-element.js
+++ b/mixins/labeled-form-element.js
@@ -1,4 +1,5 @@
 import { _EDIT, _VIEW } from '@/config/query-params';
+import $ from 'jquery';
 
 export default {
   inheritAttrs: false,
@@ -88,6 +89,18 @@ export default {
   },
 
   methods: {
+    resizeHandler(e) {
+      // since the DD is positioned there is no way to 'inherit' the size of the input, this calcs the size of the parent and set the dd width if it is smaller. If not let it grow with the regular styles
+      this.$nextTick(() => {
+        const DD = $(this.$refs.select).find('ul.vs__dropdown-menu');
+        const selectWidth = $(this.$refs.select).width();
+        const dropWidth = DD.width();
+
+        if (dropWidth < selectWidth) {
+          DD.width(selectWidth);
+        }
+      });
+    },
     onFocus() {
       this.$emit('on-focus');
 

--- a/mixins/vue-select-overrides.js
+++ b/mixins/vue-select-overrides.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 
 export default {
   methods: {

--- a/mixins/vue-select-overrides.js
+++ b/mixins/vue-select-overrides.js
@@ -8,6 +8,11 @@ export default {
 
       // tab
       (out[9] = (e) => {
+        // user esc'd
+        if (!vm.open) {
+          return;
+        }
+
         e.preventDefault();
 
         const optsLen = vm.filteredOptions.length;
@@ -15,17 +20,74 @@ export default {
 
         if (e.shiftKey) {
           if (typeAheadPointer === 0) {
-            vm.$refs.search.focus();
-
             return vm.onEscape();
           }
 
           return vm.typeAheadUp();
         }
         if (typeAheadPointer + 1 === optsLen) {
-          $(vm.$el).next().focus();
-
           return vm.onEscape();
+        }
+
+        return vm.typeAheadDown();
+      });
+
+      (out[27] = (e) => {
+        vm.open = false;
+        vm.search = '';
+
+        return false;
+      });
+
+      (out[13] = (e, opt) => {
+        if (!vm.open) {
+          vm.open = true;
+
+          return;
+        }
+
+        let option = vm.filteredOptions[vm.typeAheadPointer];
+
+        vm.$emit('option:selecting', option);
+
+        if (!vm.isOptionSelected(option)) {
+          if (vm.taggable && !vm.optionExists(option)) {
+            vm.$emit('option:created', option);
+          }
+          if (vm.multiple) {
+            option = vm.selectedValue.concat(option);
+          }
+          vm.updateValue(option);
+          vm.$emit('option:selected', option);
+
+          if (vm.closeOnSelect) {
+            vm.open = false;
+            vm.typeAheadPointer = -1;
+          }
+
+          if (vm.clearSearchOnSelect) {
+            vm.search = '';
+          }
+        }
+      });
+
+      //  up.prevent
+      (out[38] = (e) => {
+        e.preventDefault();
+
+        if (!vm.open) {
+          vm.open = true;
+        }
+
+        return vm.typeAheadUp();
+      });
+
+      //  down.prevent
+      (out[40] = (e) => {
+        e.preventDefault();
+
+        if (!vm.open) {
+          vm.open = true;
         }
 
         return vm.typeAheadDown();

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "vue-codemirror": "^4.0.6",
     "vue-js-modal": "^1.3.31",
     "vue-resize": "^0.4.5",
-    "vue-select": "^3.9.1",
+    "vue-select": "^3.11.2",
     "vue-shortkey": "^3.1.7",
     "vue2-transitions": "^0.3.0",
     "xterm": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,15 +3114,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097:
-  version "1.0.30001100"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001100.tgz#2a58615e0c01cf716ab349b20ca4d86ef944aa4e"
-  integrity sha512-0eYdp1+wFCnMlCj2oudciuQn2B9xAFq3WpgpcBIZTxk/1HNA/O2YA7rpeYhnOqsqAJq1AHUgx6i1jtafg7m2zA==
-
-caniuse-lite@^1.0.30001133:
-  version "1.0.30001135"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz#995b1eb94404a3c9a0d7600c113c9bb27f2cd8aa"
-  integrity sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097, caniuse-lite@^1.0.30001133:
+  version "1.0.30001173"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz"
+  integrity sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -12419,10 +12414,10 @@ vue-router@^3.4.3:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.3.tgz#fa93768616ee338aa174f160ac965167fa572ffa"
   integrity sha512-BADg1mjGWX18Dpmy6bOGzGNnk7B/ZA0RxuA6qedY/YJwirMfKXIDzcccmHbQI0A6k5PzMdMloc0ElHfyOoX35A==
 
-vue-select@^3.9.1:
-  version "3.10.7"
-  resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-3.10.7.tgz#58d756a7159bf923ce99abf74c5d6309ea998136"
-  integrity sha512-6rvIYBNEp9y0xK/sq2ZzDCxKA2BoVNliyctOeMtzarQzvpLlab7l8zvqr2jhGZOxozp7jd2AvZxpF3Ivems2wQ==
+vue-select@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-3.11.2.tgz#3ef93e3f2707e133c2df0b2920a05eea78764d18"
+  integrity sha512-pIOcY8ajWNSwg8Ns4eHVr5ZWwqKCSZeQRymTnlUI8i+3QiQXF6JIM4lylK6mVfbccs4S6vOyxB7zmJBpp7tDUg==
 
 vue-server-renderer@^2.6.12:
   version "2.6.12"


### PR DESCRIPTION
Updates the mapped keys handlers to deal with focus lost issues. 
Adds fixes to prevent the dropdown from growing the page height if dropdown would overflow.
Adds fixes for the dropdown width being smaller than the select. Now dropdown will be at min the width of the select and if content in dropdown is larger the dropdown will grow to fit the content.
Updates v-select dep to latest version.
Updates `can-i-use` to latest version. 



Tracked Issues:
https://github.com/rancher/dashboard/issues/2008
https://github.com/rancher/dashboard/issues/2009
https://github.com/rancher/dashboard/issues/2031


