### PR TITLE
always show close 'x' in logs tabs

### DIFF
--- a/components/nav/WindowManager/index.vue
+++ b/components/nav/WindowManager/index.vue
@@ -174,7 +174,7 @@ export default {
         @click="switchTo(tab.id)"
       >
         <i v-if="tab.icon" class="icon" :class="{['icon-'+ tab.icon]: true}" />
-        {{ tab.label }}
+        <span class="tab-label"> {{ tab.label }}</span>
         <i class="closer icon icon-fw icon-x" @click="close(tab.id)" />
       </div>
       <div
@@ -237,6 +237,13 @@ export default {
         overflow: hidden;
         text-overflow: ellipsis;
         margin: 0;
+        display: flex;
+        min-width: 0;
+
+        .tab-label{
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
 
         &.active {
           position: relative;


### PR DESCRIPTION
#2138 

before/after
![Screen Shot 2021-01-07 at 12 50 31 PM](https://user-images.githubusercontent.com/42977925/103938115-fb13a180-50e6-11eb-9d1f-d2e1f5110991.png)
![Screen Shot 2021-01-07 at 12 44 27 PM](https://user-images.githubusercontent.com/42977925/103937682-5a24e680-50e6-11eb-9517-fdfca1d74a6c.png)
