### PR TITLE
Add new Accounts & API Keys Page containing new change password feature

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1410,6 +1410,35 @@ prefs:
   hideDesc:
     label: Hide All Type Description Boxes
 
+accountAndKeys:
+  title: Account and API Keys
+  account:
+    title: Account
+    name: Name
+    username: Username
+    change: Change Password
+  keys:
+    title: API Keys
+
+changePassword:
+  title: Change Password
+  cancel: Cancel
+  keys: Delete all existing API keys
+  generatePassword: Generate a random password
+  newGeneratedPassword: Suggest a password
+  currentPassword: Current Password
+  userGen:
+    newPassword: New Password
+    confirmPassword: Confirm Password
+  randomGen:
+    copy: Copy to Clipboard
+    generated: Generated Password
+  errors:
+    missmatchedPassword: Passwords do not match
+    failedToChange: Failed to change password
+    failedDeleteKey: Failed to delete key
+    failedDeleteKeys: Failed to delete keys
+
 principal:
   loading: Loading&hellip;
   error: Unable to fetch principal info
@@ -2659,6 +2688,9 @@ action:
   view: View Config
   viewInApi: View in API
   viewYaml: View YAML
+  show: Show
+  hide: Hide
+  copy: Copy
 
 unit:
   sec: secs

--- a/components/PromptChangePassword.vue
+++ b/components/PromptChangePassword.vue
@@ -1,0 +1,106 @@
+<script>
+import { mapGetters } from 'vuex';
+import ChangePassword from '@/components/form/ChangePassword';
+import Card from '@/components/Card';
+import AsyncButton from '@/components/AsyncButton';
+
+export default {
+  components: {
+    Card, AsyncButton, ChangePassword
+  },
+  data() {
+    return { valid: false, password: '' };
+  },
+  computed:   { ...mapGetters({ t: 'i18n/t' }) },
+  methods:  {
+    show(show) {
+      if (show) {
+        this.$modal.show('password-modal');
+      } else {
+        this.$modal.hide('password-modal');
+      }
+    },
+    async submit(buttonCb) {
+      try {
+        await this.$refs.changePassword.submit();
+        this.show(false);
+        buttonCb(true);
+      } catch (err) {
+        buttonCb(false);
+      }
+    }
+  },
+};
+</script>
+
+<template>
+  <modal
+    class="change-password-modal"
+    name="password-modal"
+    :width="500"
+    :height="445"
+  >
+    <Card class="prompt-password" :show-highlight-border="false">
+      <h4 slot="title" class="text-default-text">
+        {{ t("changePassword.title") }}
+      </h4>
+      <div slot="body">
+        <form @submit.prevent>
+          <ChangePassword ref="changePassword" v-model="password" @valid="valid = $event" />
+        </form>
+      </div>
+
+      <template #actions>
+        <!-- type reset is required by lastpass -->
+        <button class="btn role-secondary" type="reset" @click="show(false)">
+          {{ t("changePassword.cancel") }}
+        </button>
+        <AsyncButton
+          type="submit"
+          mode="apply"
+          class="btn bg-error ml-10"
+          :disabled="!valid"
+          value="LOGIN"
+          @click="submit"
+        />
+      </template>
+    </Card>
+  </modal>
+</template>
+
+<style lang="scss" scoped>
+    .change-password-modal {
+      ::v-deep .v--modal {
+        display: flex;
+
+        .card-wrap {
+          display: flex;
+          flex-direction: column;
+
+          .card-body {
+            flex: 1;
+            justify-content: start;
+            & > div {
+              flex: 1;
+              display: flex;
+            }
+          }
+
+          .card-actions {
+            display: flex;
+            justify-content: flex-end;
+            width: 100%;
+          }
+        }
+      }
+    }
+
+    .prompt-password {
+      flex: 1;
+      display: flex;
+      form {
+        flex: 1;
+      }
+    }
+
+</style>

--- a/components/form/ChangePassword.vue
+++ b/components/form/ChangePassword.vue
@@ -1,0 +1,266 @@
+<script>
+import { mapGetters } from 'vuex';
+import Banner from '@/components/Banner';
+import Checkbox from '@/components/form/Checkbox';
+import Password from '@/components/form/Password';
+import { NORMAN } from '@/config/types';
+
+export default {
+  components: {
+    Checkbox, Banner, Password
+  },
+  props: {
+    value: {
+      type:    [String],
+      default: ''
+    },
+  },
+  async fetch() {
+    if (this.principal.provider === 'local' && !!this.principal.loginName) {
+      this.username = this.principal.loginName;
+    }
+
+    const users = await this.$store.dispatch('rancher/findAll', {
+      type: NORMAN.USER,
+      opt:  { url: '/v3/users', filter: { me: true } }
+    });
+
+    if (users && users.length === 1) {
+      this.username = users[0].username;
+    }
+  },
+  data(ctx) {
+    return {
+      username:                    '',
+      errorMessages:               [],
+      pCanShowMissmatchedPassword: false,
+      pIsRandomGenerated:            false,
+      form:                        {
+        deleteKeys: false,
+        currentP:   '',
+        newP:       '',
+        genP:       '',
+        confirmP:   ''
+      },
+    };
+  },
+  computed:   {
+    ...mapGetters({ t: 'i18n/t' }),
+
+    isRandomGenerated: {
+      get() {
+        return this.pIsRandomGenerated;
+      },
+
+      set(isRandomGenerated) {
+        this.pIsRandomGenerated = isRandomGenerated;
+        this.errorMessages = [];
+        this.validate();
+      }
+    },
+
+    passwordGen: {
+      get() {
+        return this.form.genP;
+      },
+
+      set(p) {
+        this.form.genP = p;
+        this.validate();
+      }
+    },
+
+    passwordCurrent: {
+      get() {
+        return this.form.currentP;
+      },
+
+      set(p) {
+        this.form.currentP = p;
+        this.validate();
+      }
+    },
+
+    passwordNew: {
+      get() {
+        return this.form.newP;
+      },
+
+      set(p) {
+        this.form.newP = p;
+        this.validate();
+      }
+    },
+
+    passwordConfirm: {
+      get() {
+        return this.form.confirmP;
+      },
+
+      set(p) {
+        this.form.confirmP = p;
+        this.validate();
+      }
+    },
+
+    passwordConfirmBlurred: {
+      get() {
+        return this.pCanShowMissmatchedPassword;
+      },
+
+      set(p) {
+        this.pCanShowMissmatchedPassword = p;
+        this.validate();
+      }
+    },
+
+    password() {
+      return this.isRandomGenerated ? this.passwordGen : this.passwordNew;
+    },
+
+    principal() {
+      return this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.$store.getters['auth/principalId']) || {};
+    },
+  },
+  methods: {
+    passwordsMatch() {
+      const match = this.passwordNew === this.passwordConfirm;
+
+      this.errorMessages = this.passwordConfirmBlurred && !match ? [this.t('changePassword.errors.missmatchedPassword')] : [];
+
+      return match;
+    },
+    validate() {
+      this.$emit('valid', this.isRandomGenerated ? !!this.passwordCurrent : this.passwordsMatch() && !!this.passwordCurrent && this.passwordNew);
+      this.$emit('input', this.password);
+    },
+    async submit() {
+      await this.changePassword();
+      if (this.form.deleteKeys) {
+        await this.deleteKeys();
+      }
+    },
+    async changePassword() {
+      try {
+        await this.$store.dispatch('rancher/collectionAction', {
+          type:       NORMAN.USER,
+          actionName: 'changepassword',
+          body:          {
+            currentPassword: this.form.currentP,
+            newPassword:     this.isRandomGenerated ? this.form.genP : this.form.newP
+          },
+        });
+      } catch (err) {
+        this.errorMessages = [err.message || this.t('changePassword.errors.failedToChange')];
+        throw err;
+      }
+    },
+    async deleteKeys() {
+      try {
+        const tokens = await this.$store.dispatch('rancher/findAll', {
+          type: NORMAN.TOKEN,
+          opt:  {
+            // Ensure we have any new tokens since last fetched... and that we don't attempt to delete previously deleted tokens
+            force: true
+          }
+        });
+
+        await Promise.all(tokens.reduce((res, token) => {
+          if (!token.current) {
+            res.push(token.remove());
+          }
+
+          return res;
+        }, []));
+      } catch (err) {
+        if (err.message) {
+          this.errorMessages = [err.message];
+        } else if (err.length > 1) {
+          this.errorMessages = [this.t('changePassword.errors.failedDeleteKeys')];
+        } else {
+          this.errorMessages = [this.t('changePassword.errors.failedDeleteKey')];
+        }
+        throw err;
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="change-password">
+    <div class="form">
+      <div class="fields">
+        <Checkbox v-model="form.deleteKeys" :label="t('changePassword.keys')" class="mt-10" />
+        <input
+          id="username"
+          type="text"
+          name="username"
+          autocomplete="username"
+          :value="username"
+          tabindex="-1"
+        >
+        <input
+          id="password"
+          type="password"
+          name="password"
+          autocomplete="password"
+          :value="password"
+          tabindex="-1"
+        >
+        <Password
+          v-model="passwordCurrent"
+          class="mt-10"
+          :label="t('changePassword.currentPassword')"
+        ></Password>
+        <Password
+          v-if="isRandomGenerated"
+          v-model="passwordGen"
+          class="mt-10"
+          :is-random="true"
+          :label="t('changePassword.randomGen.generated')"
+        />
+        <div v-else class="userGen">
+          <Password
+            v-model="passwordNew"
+            class="mt-10"
+            :label="t('changePassword.userGen.newPassword')"
+          />
+          <Password
+            v-model="passwordConfirm"
+            class="mt-10"
+            :label="t('changePassword.userGen.confirmPassword')"
+            @blur="passwordConfirmBlurred = true"
+          />
+        </div>
+      </div>
+      <Checkbox v-model="isRandomGenerated" :label="t('changePassword.generatePassword')" class="mt-10 type" />
+    </div>
+    <div v-if="errorMessages && errorMessages.length" class="text-error">
+      <Banner v-for="(err, i) in errorMessages" :key="i" color="error" :label="err" class="mb-0" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .change-password {
+    display: flex;
+    flex-direction: column;
+
+    .form {
+      display: flex;
+      flex-direction: column;
+      .fields{
+        height: 215px;
+        #username, #password {
+          height: 0;
+          width: 0;
+          background-size: 0;
+          padding: 0;
+          border: none;
+        }
+      }
+    }
+  }
+
+</style>

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -80,6 +80,7 @@ export default {
     },
 
     onBlur() {
+      this.$emit('blur');
       this.onBlurLabeled();
     },
 

--- a/components/form/Password.vue
+++ b/components/form/Password.vue
@@ -1,0 +1,117 @@
+<script>
+import { mapGetters } from 'vuex';
+import LabeledInput from '@/components/form/LabeledInput';
+import { CHARSET, randomStr } from '@/utils/string';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value: {
+      default: '',
+      type:    String,
+    },
+    isRandom: {
+      default: false,
+      type:    Boolean,
+    },
+    label: {
+      default: '',
+      type:    String,
+    },
+    name: {
+      default: '',
+      type:     String
+    },
+    autocomplete: {
+      type:      String,
+      default:   ''
+    }
+  },
+  data() {
+    return { reveal: false };
+  },
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+    password: {
+      get() {
+        return this.value;
+      },
+      set(val) {
+        this.$emit('input', val);
+      }
+    },
+    attributes() {
+      const attributes = { };
+
+      if (this.name) {
+        attributes.id = this.name;
+        attributes.name = this.name;
+      }
+      if (this.autocomplete) {
+        attributes.autocomplete = this.autocomplete;
+      }
+
+      return attributes;
+    }
+  },
+  created() {
+    if (this.isRandom) {
+      this.generatePassword();
+    }
+  },
+  methods: {
+    generatePassword() {
+      this.password = randomStr(16, CHARSET.ALPHA_NUM);
+    },
+    show(reveal) {
+      this.reveal = reveal;
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="password">
+    <LabeledInput
+      v-model="password"
+      v-bind="attributes"
+      :type="isRandom || reveal ? 'text' : 'password'"
+      :readonly="isRandom"
+      :label="label"
+      :required="!isRandom"
+      :disabled="isRandom"
+      @blur="$emit('blur', $event)"
+    >
+      <template #suffix>
+        <div v-if="isRandom" class="addon">
+          <a href="#" @click.prevent.stop="$copyText(password)">{{ t('action.copy') }}</a>
+        </div>
+        <div v-else class="addon">
+          <a v-if="reveal" href="#" @click.prevent.stop="reveal = false">{{ t('action.hide') }}</a>
+          <a v-else href="#" @click.prevent.stop="reveal=true">{{ t('action.show') }}</a>
+        </div>
+      </template>
+    </LabeledInput>
+    <div v-if="isRandom" class="mt-10 genPassword">
+      <a href="#" @click.prevent.stop="generatePassword"><i class="icon icon-refresh" /> {{ t('changePassword.newGeneratedPassword') }}</a>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .password {
+    display: flex;
+    flex-direction: column;
+    .labeled-input {
+      .addon {
+          padding-left: 12px;
+          min-width: 65px;
+      }
+    }
+    .genPassword {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+
+</style>

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -109,6 +109,9 @@ export default {
               <nuxt-link tag="li" :to="{name: 'prefs'}" class="hand">
                 <a>Preferences <i class="icon icon-fw icon-gear" /></a>
               </nuxt-link>
+              <nuxt-link tag="li" :to="{name: 'account'}" class="hand">
+                <a>Account &amp; API Keys <i class="icon icon-fw icon-user" /></a>
+              </nuxt-link>
               <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'auth-logout'}" class="pt-5 pb-5 hand">
                 <a @blur="showMenu(false)">Log Out <i class="icon icon-fw icon-close" /></a>
               </nuxt-link>

--- a/config/types.js
+++ b/config/types.js
@@ -14,6 +14,8 @@ export const STEVE = {
 export const NORMAN = {
   AUTH_CONFIG: 'authconfig',
   PRINCIPAL:   'principal',
+  USER:        'user',
+  TOKEN:        'token',
 };
 
 // Public (via Norman)
@@ -125,6 +127,7 @@ export const MANAGEMENT = {
   PROJECT:          'management.cattle.io.project',
   SETTING:          'management.cattle.io.setting',
   USER:             'management.cattle.io.user',
+  TOKEN:            'management.cattle.io.token',
 };
 
 export const CAPI = {

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -1,0 +1,83 @@
+<script>
+import PromptChangePassword from '@/components/PromptChangePassword';
+import { NORMAN } from '@/config/types';
+import Loading from '@/components/Loading';
+
+export default {
+  components: { PromptChangePassword, Loading },
+  async fetch() {
+    this.canChangePassword = await this.calcCanChangePassword();
+  },
+  data() {
+    return { canChangePassword: false };
+  },
+  computed:   {
+    principal() {
+      return this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.$store.getters['auth/principalId']) || {};
+    },
+  },
+  methods: {
+    async calcCanChangePassword() {
+      if (!this.$store.getters['auth/enabled']) {
+        return false;
+      }
+
+      if (this.principal.provider === 'local') {
+        return !!this.principal.loginName;
+      }
+
+      const users = await this.$store.dispatch('rancher/findAll', {
+        type: NORMAN.USER,
+        opt:  { url: '/v3/users', filter: { me: true } }
+      });
+
+      if (users && users.length === 1) {
+        return !!users[0].username;
+      }
+
+      return false;
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <h1 v-t="'accountAndKeys.title'" />
+    <section class="account">
+      <h4 v-t="'accountAndKeys.account.title'" />
+      <div class="content">
+        <div class="col mt-10">
+          <div><t k="accountAndKeys.account.name" />: {{ principal.name }}</div>
+          <div><t k="accountAndKeys.account.username" />: {{ principal.loginName }}</div>
+        </div>
+        <button
+          v-if="canChangePassword"
+          type="button"
+          class="btn role-secondary"
+          @click="$refs.promptChangePassword.show(true)"
+        >
+          {{ t("accountAndKeys.account.change") }}
+        </button>
+      </div>
+      <PromptChangePassword ref="promptChangePassword" />
+    </section>
+
+    <section>
+      <h4 v-t="'accountAndKeys.keys.title'" />
+    </section>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+  section {
+    margin-bottom: 10px;
+  }
+
+  .account {
+    .content {
+      display: flex;
+    }
+  }
+</style>

--- a/pages/prefs.vue
+++ b/pages/prefs.vue
@@ -166,7 +166,6 @@ export default {
       </div>
     </div>
   </div>
-  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/plugins/steve/index.js
+++ b/plugins/steve/index.js
@@ -21,6 +21,7 @@ function SteveFactory(namespace, baseUrl) {
         },
         types:        {},
         socket:       null,
+        queue:        [],
         wantSocket:   false,
         pendingSends: [],
         started:      [],


### PR DESCRIPTION
- Add a new Accounts and API Keys page accessible via user avatar drop down
- Add new change password feature to Accounts page
- This contains a placeholder for the API Keys table which will be populated via rancher/dashboard#2214