### PR TITLE
Namespace polish and details page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1155,6 +1155,7 @@ namespace:
   containerResourceLimit: Container Resource Limit
   project:
     label: Project
+  resources: Resources
 
 namespaceFilter:
   selected:

--- a/components/FleetSummary.vue
+++ b/components/FleetSummary.vue
@@ -1,20 +1,7 @@
 <script>
+import capitalize from 'lodash/capitalize';
 import CountBox from '@/components/CountBox';
-
-const KEYS = {
-  errApplied:    'error',
-  modified:      'warning',
-  notReady:      'warning',
-  outOfSync:     'warning',
-  pending:       'info',
-  waitApplied:   'info',
-  ready:         'success',
-  other:         'unknown',
-  desiredReady:  false,
-  missing:      'warning',
-  orphaned:     'info',
-  unknown:      'unknown',
-};
+import { STATES } from '@/plugins/steve/resource-instance';
 
 export default {
   components: { CountBox },
@@ -23,43 +10,68 @@ export default {
     value: {
       type:     Object,
       required: true,
-    }
+    },
   },
 
   computed: {
     counts() {
       const out = {
-        success: 0,
-        info:    0,
-        warning: 0,
-        error:   0,
-        unknown: 0,
+        success: {
+          count: 0,
+          color: 'success'
+        },
+        info:    {
+          count: 0,
+          color: 'info'
+        },
+        warning: {
+          count: 0,
+          color: 'warning'
+        },
+        error:   {
+          count: 0,
+          color: 'error'
+        },
+        unknown: {
+          count: 0,
+          color: 'warning'
+        },
       };
 
-      for ( const k in this.value ) {
-        if ( k.startsWith('desired') ) {
+      for (const k in this.value) {
+        if (k.startsWith('desired')) {
           continue;
         }
 
-        const mapped = KEYS[k] || KEYS['other'];
+        const mapped = STATES[k] || STATES['other'];
 
-        if ( mapped === false ) {
-          continue;
+        if (out[k]) {
+          out[k].count += this.value[k] || 0;
+          out[k].color = mapped.color;
+        } else {
+          out[k] = {
+            count: this.value[k] || 0,
+            color: mapped.color,
+          };
         }
-
-        out[mapped] += this.value[k] || 0;
       }
 
       return out;
     },
-  }
+  },
+
+  methods: { capitalize },
 };
 </script>
 
 <template>
   <div class="row">
     <div v-for="(v, k) in counts" :key="k" class="col span-2-of-10">
-      <CountBox :count="v" :name="t(`fleet.fleetSummary.state.${k}`)" :primary-color-var="'--sizzle-'+k" />
+      <CountBox
+        :count="v['count']"
+        :name="capitalize(k)"
+        :primary-color-var="'--sizzle-' + v.color"
+      />
     </div>
   </div>
 </template>

--- a/detail/namespace.vue
+++ b/detail/namespace.vue
@@ -1,0 +1,100 @@
+<script>
+import findKey from 'lodash/findKey';
+import has from 'lodash/has';
+import reduce from 'lodash/reduce';
+
+import CreateEditView from '@/mixins/create-edit-view';
+import FleetSummary from '@/components/FleetSummary';
+import ResourceTabs from '@/components/form/ResourceTabs';
+
+import { COUNT } from '@/config/types';
+import { getStatesByType } from '@/plugins/steve/resource-instance';
+
+export default {
+  components: {
+    FleetSummary,
+    ResourceTabs,
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    mode: {
+      default: 'create',
+      type:    String,
+    },
+    value: {
+      required: true,
+      type:     Object,
+    },
+  },
+
+  data() {
+    return { resourceTypes: [] };
+  },
+
+  computed: {
+    namespacedCounts() {
+      const allClusterResourceCounts = this.$store.getters[`cluster/all`](COUNT)[0].counts;
+      const statesByType = getStatesByType();
+      const totalCountsOut = {
+        success: 0,
+        info:    0,
+        warning: 0,
+        error:   0,
+        unknown: 0,
+      };
+
+      Object.keys(allClusterResourceCounts).forEach((resourceCount) => {
+        if (allClusterResourceCounts?.[resourceCount]?.namespaces?.[this.value.id]) {
+          const namespacedCounts = { ...allClusterResourceCounts[resourceCount].namespaces[this.value.id] };
+          let total = namespacedCounts?.count || 0;
+
+          if (namespacedCounts?.states) {
+            const notSuccessful = reduce(
+              namespacedCounts.states,
+              (sum, value) => sum + value,
+              0
+            );
+
+            if (notSuccessful && notSuccessful > 0) {
+              total = total - notSuccessful;
+            }
+
+            Object.keys(namespacedCounts.states).forEach((state) => {
+              if (has(totalCountsOut, state)) {
+                totalCountsOut[state] += namespacedCounts.states[state];
+              } else {
+                const missingStateKey = findKey(
+                  statesByType,
+                  (stateNames, stateName) => stateNames.includes(state)
+                );
+
+                if (missingStateKey) {
+                  totalCountsOut[missingStateKey] += namespacedCounts.states[state];
+                } else {
+                  totalCountsOut.unknown += namespacedCounts.states[state];
+                }
+              }
+            });
+          }
+
+          totalCountsOut.success += total;
+        }
+      });
+
+      return totalCountsOut;
+    },
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="mb-20">
+      <h3>{{ t('namespace.resources') }}</h3>
+      <FleetSummary :value="namespacedCounts" />
+    </div>
+    <ResourceTabs v-model="value" :mode="mode" />
+  </div>
+</template>

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -5,6 +5,7 @@ import isString from 'lodash/isString';
 import jsyaml from 'js-yaml';
 import omitBy from 'lodash/omitBy';
 import pickBy from 'lodash/pickBy';
+import forIn from 'lodash/forIn';
 import uniq from 'lodash/uniq';
 import Vue from 'vue';
 
@@ -66,7 +67,7 @@ const DEFAULT_ICON = 'x';
 const DEFAULT_WAIT_INTERVAL = 1000;
 const DEFAULT_WAIT_TMIMEOUT = 30000;
 
-const STATES = {
+export const STATES = {
   'in-progress':      { color: 'info', icon: 'tag' },
   'pending-rollback': { color: 'info', icon: 'dot-half' },
   'pending-upgrade':  { color: 'info', icon: 'dot-half' },
@@ -79,6 +80,7 @@ const STATES = {
   building:           { color: 'success', icon: 'dot-open' },
   completed:          { color: 'success', icon: 'dot' },
   cordoned:           { color: 'info', icon: 'tag' },
+  count:              { color: 'success', icon: 'dot-open' },
   created:            { color: 'info', icon: 'tag' },
   creating:           { color: 'info', icon: 'tag' },
   deactivating:       { color: 'info', icon: 'adjust' },
@@ -87,23 +89,29 @@ const STATES = {
   deployed:           { color: 'success', icon: 'dot-open' },
   disabled:           { color: 'warning', icon: 'error' },
   disconnected:       { color: 'warning', icon: 'error' },
-  error:              { color: 'error', icon: 'error' },
   errapplied:         { color: 'error', icon: 'error' },
+  error:              { color: 'error', icon: 'error' },
   erroring:           { color: 'error', icon: 'error' },
+  errors:             { color: 'error', icon: 'error' },
   expired:            { color: 'warning', icon: 'error' },
-  failed:             { color: 'error', icon: 'error' },
   fail:               { color: 'error', icon: 'error' },
+  failed:             { color: 'error', icon: 'error' },
   healthy:            { color: 'success', icon: 'dot-open' },
   inactive:           { color: 'error', icon: 'dot' },
   initializing:       { color: 'warning', icon: 'error' },
   inprogress:         { color: 'info', icon: 'spinner' },
   locked:             { color: 'warning', icon: 'adjust' },
   migrating:          { color: 'info', icon: 'info' },
+  missing:            { color: 'warning', icon: 'adjust' },
   modified:           { color: 'warning', icon: 'edit' },
+  notApplicable:      { color: 'warning', icon: 'tag' },
   notapplied:         { color: 'warning', icon: 'tag' },
-  notApplicable:         { color: 'warning', icon: 'tag' },
-  passed:             { color: 'success', icon: 'dot-dotfill' },
+  notready:           { color: 'warning', icon: 'tag' },
+  orphaned:           { color: 'warning', icon: 'tag' },
+  other:              { color: 'info', icon: 'info' },
+  outofsync:          { color: 'warning', icon: 'tag' },
   pass:               { color: 'success', icon: 'dot-dotfill' },
+  passed:             { color: 'success', icon: 'dot-dotfill' },
   paused:             { color: 'info', icon: 'info' },
   pending:            { color: 'info', icon: 'tag' },
   provisioning:       { color: 'info', icon: 'dot' },
@@ -120,8 +128,8 @@ const STATES = {
   restarting:         { color: 'info', icon: 'adjust' },
   restoring:          { color: 'info', icon: 'medicalcross' },
   running:            { color: 'success', icon: 'dot-open' },
-  skipped:            { color: 'info', icon: 'dot-open' },
   skip:               { color: 'info', icon: 'dot-open' },
+  skipped:            { color: 'info', icon: 'dot-open' },
   starting:           { color: 'info', icon: 'adjust' },
   stopped:            { color: 'error', icon: 'dot' },
   stopping:           { color: 'info', icon: 'adjust' },
@@ -136,11 +144,33 @@ const STATES = {
   unknown:            { color: 'warning', icon: 'x' },
   untriggered:        { color: 'success', icon: 'tag' },
   updating:           { color: 'warning', icon: 'tag' },
-  waiting:            { color: 'info', icon: 'tag' },
   waitapplied:        { color: 'info', icon: 'tag' },
   waitcheckin:        { color: 'warning', icon: 'tag' },
-  notready:           { color: 'warning', icon: 'tag' },
+  waiting:            { color: 'info', icon: 'tag' },
+  warning:            { color: 'warning', icon: 'error' },
 };
+
+export function getStatesByType(type = 'info') {
+  const out = {
+    info:    [],
+    error:   [],
+    success: [],
+    warning: [],
+    unknown: [],
+  };
+
+  forIn(STATES, (state, stateKey) => {
+    if (state.color) {
+      if (out[state.color]) {
+        out[state.color].push(stateKey);
+      } else {
+        out.unknown.push(stateKey);
+      }
+    }
+  });
+
+  return out;
+}
 
 const SORT_ORDER = {
   error:   1,


### PR DESCRIPTION
Adds the Namespace detail page.
Updates Fleetsummary component logic to use the real state colors from the resource instance.
Adds a new `getStatesByType` which returns a map of the 4 + 1 (unknown) basic types to facilitate looking up a random statename from the collection of states we keep. 

rancher/dashboard#1784
rancher/dashboard#1870


![Screen Shot 2021-01-11 at 11 32 30 AM](https://user-images.githubusercontent.com/858614/104224144-cdd63480-5401-11eb-9482-b57249d1a4dc.png)
