### PR TITLE
Service Create Selectors - Show Target Pods Real Time

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1606,8 +1606,15 @@ servicesPage:
   ports:
     label: Ports
   selectors:
-    helpText: "If no selector is created, manual endpoints must be made."
+    helpText: ""
     label: Selectors
+    matchingPods:
+      matchesSome: |-
+        {matched, plural,
+          =0 {Matches 0 of {total, number} pods. If no selector is created, manual endpoints must be made.}
+          =1 {Matches 1 of {total, number} pods: "{sample}"}
+          other {Matches {matched, number} of {total, number} existing pods, including "{sample}"}
+        }
   serviceTypes:
     clusterIp:
       abbrv: IP

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -226,6 +226,7 @@ export default {
               :mode="mode"
               :label="t('servicesPage.externalName.input.label')"
               :placeholder="t('servicesPage.externalName.placeholder')"
+              :required="true"
               type="text"
             />
           </div>

--- a/edit/service.vue
+++ b/edit/service.vue
@@ -1,5 +1,6 @@
 <script>
 import { isEmpty } from 'lodash';
+import throttle from 'lodash/throttle';
 import ArrayList from '@/components/form/ArrayList';
 import CreateEditView from '@/mixins/create-edit-view';
 import KeyValue from '@/components/form/KeyValue';
@@ -16,18 +17,23 @@ import CruResource from '@/components/CruResource';
 import Banner from '@/components/Banner';
 import Labels from '@/components/form/Labels';
 import { clone } from '@/utils/object';
+import { POD } from '@/config/types';
+import Poller from '@/utils/poller';
+import { matching } from '@/utils/selector';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:     'None',
-  CLIENTIP: 'ClientIP'
+  CLIENTIP: 'ClientIP',
 };
 
 const SESSION_AFFINITY_ACTION_LABELS = {
   NONE:     'servicesPage.affinity.actionLabels.none',
-  CLIENTIP: 'servicesPage.affinity.actionLabels.clientIp'
+  CLIENTIP: 'servicesPage.affinity.actionLabels.clientIp',
 };
 
 const SESSION_STICKY_TIME_DEFAULT = 10800;
+const POD_POLL_RATE_MS = 30000;
+const MAX_FAILURES = 2;
 
 export default {
   // Props are found in CreateEditView
@@ -45,7 +51,7 @@ export default {
     ServicePorts,
     Tab,
     Tabbed,
-    UnitInput
+    UnitInput,
   },
 
   mixins: [CreateEditView],
@@ -55,20 +61,31 @@ export default {
       if (!this.value?.spec) {
         this.$set(this.value, 'spec', {
           ports:           [],
-          sessionAffinity: 'None'
+          sessionAffinity: 'None',
         });
       }
     }
 
+    const matchingPods = {
+      matched: 0,
+      matches: [],
+      none:    true,
+      sample:  null,
+      total:   0,
+    };
+
     return {
+      matchingPods,
+      allPods:                     [],
       defaultServiceTypes:         DEFAULT_SERVICE_TYPES,
+      podPoller:                   new Poller(this.loadPods, POD_POLL_RATE_MS, MAX_FAILURES),
       saving:                      false,
       sessionAffinityActionLabels: Object.values(SESSION_AFFINITY_ACTION_LABELS)
         .map(v => this.$store.getters['i18n/t'](v))
         .map(ucFirst),
       sessionAffinityActionOptions: Object.values(
         SESSION_AFFINITY_ACTION_VALUES
-      )
+      ),
     };
   },
 
@@ -112,18 +129,26 @@ export default {
 
           this.$set(this.value.spec, 'type', serviceType);
         }
-      }
+      },
     },
     showAffinityTimeout() {
-      return this.value.spec.sessionAffinity === 'ClientIP' && !isEmpty(this.value.spec.sessionAffinityConfig);
+      return (
+        this.value.spec.sessionAffinity === 'ClientIP' &&
+        !isEmpty(this.value.spec.sessionAffinityConfig)
+      );
     },
 
     hasClusterIp() {
-      return this.checkTypeIs('ClusterIP') || this.checkTypeIs('LoadBalancer') || this.checkTypeIs('NodePort');
-    }
+      return (
+        this.checkTypeIs('ClusterIP') ||
+        this.checkTypeIs('LoadBalancer') ||
+        this.checkTypeIs('NodePort')
+      );
+    },
   },
 
   watch: {
+    'value.spec.selector': 'udpateMatchingPods',
     'value.spec.sessionAffinity'(val) {
       if (val === 'ClientIP') {
         this.value.spec.sessionAffinityConfig = { clientIP: { timeoutSeconds: null } };
@@ -139,7 +164,7 @@ export default {
       ) {
         delete this.value.spec.sessionAffinityConfig.clientIP.timeoutSeconds;
       }
-    }
+    },
   },
 
   created() {
@@ -150,9 +175,46 @@ export default {
     const initialType = this.serviceType;
 
     this.$set(this, 'serviceType', initialType);
+
+    this.podPoller.start();
+  },
+
+  beforeDestroy() {
+    this.podPoller.stop();
   },
 
   methods: {
+    udpateMatchingPods: throttle(function() {
+      const { allPods, value: { spec: { selector = { } } } } = this;
+
+      if (isEmpty(selector)) {
+        this.matchingPods = {
+          matched: 0,
+          total:   allPods.length,
+          none:    true,
+          sample:  null,
+        };
+      } else {
+        const match = matching(allPods, selector);
+
+        this.matchingPods = {
+          matched: match.length,
+          total:   allPods.length,
+          none:    match.length === 0,
+          sample:  match[0] ? match[0].nameDisplay : null,
+        };
+      }
+    }, 250, { leading: true }),
+
+    async loadPods() {
+      try {
+        const inStore = this.$store.getters['currentProduct'].inStore;
+
+        this.allPods = await this.$store.dispatch(`${ inStore }/findAll`, { type: POD });
+        this.matchingPods.total = this.allPods.length;
+      } catch (e) { }
+    },
+
     checkTypeIs(typeIn) {
       const { serviceType } = this;
 
@@ -187,8 +249,7 @@ export default {
         this.value.spec.ports = this.targetPortsStrOrInt(this.value.spec.ports);
       }
     },
-
-  }
+  },
 };
 </script>
 
@@ -201,10 +262,10 @@ export default {
     :subtypes="defaultServiceTypes"
     :validation-passed="true"
     :errors="errors"
-    @error="e=>errors = e"
+    @error="(e) => (errors = e)"
     @finish="save"
     @cancel="done"
-    @select-type="(st) => serviceType = st"
+    @select-type="(st) => (serviceType = st)"
     @apply-hooks="() => applyHooks('_beforeSaveHooks')"
   >
     <NameNsDescription v-if="!isView" :value="value" :mode="mode" />
@@ -232,7 +293,12 @@ export default {
           </div>
         </div>
       </Tab>
-      <Tab v-else name="define-service-ports" :label="t('servicesPage.ips.define')" :weight="10">
+      <Tab
+        v-else
+        name="define-service-ports"
+        :label="t('servicesPage.ips.define')"
+        :weight="10"
+      >
         <ServicePorts
           v-model="value.spec.ports"
           class="col span-12"
@@ -248,7 +314,9 @@ export default {
       >
         <div class="row">
           <div class="col span-12">
-            <Banner v-if="showSelectorWarning" color="warning" :label="t('servicesPage.selectors.helpText')" />
+            <Banner :color="(matchingPods.none ? 'warning' : 'success')">
+              <span v-html="t('servicesPage.selectors.matchingPods.matchesSome', matchingPods)" />
+            </Banner>
           </div>
         </div>
         <div class="row">
@@ -259,24 +327,27 @@ export default {
               :mode="mode"
               :initial-empty-row="true"
               :protip="false"
-              @input="e=>$set(value.spec, 'selector', e)"
+              @input="(e) => $set(value.spec, 'selector', e)"
             />
           </div>
         </div>
       </Tab>
-      <Tab name="ips" :label="t('servicesPage.ips.label')" :tooltip="t('servicesPage.ips.external.protip')">
-        <div
-          v-if="hasClusterIp"
-          class="row mb-20"
-        >
+      <Tab
+        name="ips"
+        :label="t('servicesPage.ips.label')"
+        :tooltip="t('servicesPage.ips.external.protip')"
+      >
+        <div v-if="hasClusterIp" class="row mb-20">
           <div class="col span-6">
             <LabeledInput
               v-model="value.spec.clusterIP"
               :mode="mode"
               :label="t('servicesPage.ips.input.label')"
               :placeholder="t('servicesPage.ips.input.placeholder')"
-              :tooltip-key="hasClusterIp ? 'servicesPage.ips.clusterIpHelpText' : null"
-              @input="e=>$set(value.spec, 'clusterIP', e)"
+              :tooltip-key="
+                hasClusterIp ? 'servicesPage.ips.clusterIpHelpText' : null
+              "
+              @input="(e) => $set(value.spec, 'clusterIP', e)"
             />
           </div>
         </div>
@@ -289,7 +360,7 @@ export default {
               :value-placeholder="t('servicesPage.ips.external.placeholder')"
               :mode="mode"
               :protip="false"
-              @input="e=>$set(value.spec, 'externalIPs', e)"
+              @input="(e) => $set(value.spec, 'externalIPs', e)"
             />
           </div>
         </div>
@@ -314,10 +385,22 @@ export default {
           <div v-if="showAffinityTimeout" class="col span-6">
             <UnitInput
               v-model="value.spec.sessionAffinityConfig.clientIP.timeoutSeconds"
-              :suffix="t('suffix.seconds', {count: value.spec.sessionAffinityConfig.clientIP.timeoutSeconds})"
+              :suffix="
+                t('suffix.seconds', {
+                  count:
+                    value.spec.sessionAffinityConfig.clientIP.timeoutSeconds,
+                })
+              "
               :label="t('servicesPage.affinity.timeout.label')"
               :placeholder="t('servicesPage.affinity.timeout.placeholder')"
-              @input="e=>$set(value.spec.sessionAffinityConfig.clientIP, 'timeoutSeconds', e)"
+              @input="
+                (e) =>
+                  $set(
+                    value.spec.sessionAffinityConfig.clientIP,
+                    'timeoutSeconds',
+                    e
+                  )
+              "
             />
           </div>
         </div>


### PR DESCRIPTION
Adds a banner message similar to Fleet Cluster Groups that shows the live pod count for the selectors section of service create.
Adds required to External Name input.


rancher/dashboard#717
rancher/dashboard#2179


![Screen Shot 2021-01-11 at 3 36 58 PM](https://user-images.githubusercontent.com/858614/104247330-d3914180-5424-11eb-8cdc-0ff0b11143fc.png)
![Screen Shot 2021-01-11 at 3 36 46 PM](https://user-images.githubusercontent.com/858614/104247338-d5f39b80-5424-11eb-93f6-989706ea0309.png)
