### PR TITLE
update tab order

### DIFF
--- a/components/Questions/index.vue
+++ b/components/Questions/index.vue
@@ -192,7 +192,7 @@ export default {
     groups() {
       const map = {};
       const defaultGroup = 'Questions';
-      let weight = 1;
+      let weight = this.shownQuestions.length;
 
       for ( const q of this.shownQuestions ) {
         if ( q.group ) {
@@ -202,7 +202,7 @@ export default {
             map[normalized] = {
               name:      q.group || defaultGroup,
               questions: [],
-              weight:    weight++,
+              weight:    weight--,
             };
           }
 


### PR DESCRIPTION
#2107 - updated the tab order so 'other settings' is last, and tabs that appear conditionally show up below the current tab (images settings and csi driver settings)
![Screen Shot 2021-01-21 at 12 34 54 PM](https://user-images.githubusercontent.com/42977925/105402786-16050c00-5be5-11eb-9bda-ec987bc950c2.png)
