### PR TITLE
components/form/RadioGroup.vue: fix row mode

### DIFF
--- a/components/form/RadioGroup.vue
+++ b/components/form/RadioGroup.vue
@@ -170,7 +170,7 @@ export default {
     position: relative;
   }
 
-  .row {
+  &.row {
     display: flex;
     .radio-container {
       margin-right: 10px;


### PR DESCRIPTION
When using <RadioGroup row>, we need the CSS to match on `.radio-group.row` (that is, one element with both classes) rather than matching on `.radio-group .row` (an element that is the descendant of another).

Found this while attempting to reuse the component.  I didn't see relevant tests; if there are any, please point me at them and I'll happily adjust.