### PR TITLE
Fix this error at startup:

### DIFF
--- a/assets/styles/base/_color.scss
+++ b/assets/styles/base/_color.scss
@@ -14,7 +14,7 @@
     $default-text: get-or-def($color, "default-text", contrast-color($default));
     $hover-text:   get-or-def($color, "hover-text",   saturate($lightest, 20%));
     $active-text:  get-or-def($color, "active-text",  contrast-color($active-bg));
-    $border:       get-or-def($color, "border",       $color);
+    $border:       get-or-def($color, "border",       $default);
     $banner-bg:    get-or-def($color, "banner",      rgba($default, 0.15));
 
     --#{$name}:             #{$default};


### PR DESCRIPTION
```
 error  in ./src/App.vue?vue&type=style&index=0&lang=scss&

Syntax Error: SassError: (default-text: #3D98D3, hover-text: #badaef, active-text: #1b5276, default: transparent, hover-bg: transparent, active-bg: transparent) isn't a valid CSS value.
   ╷
26 │     --#{$name}-border:      #{$border};
   │                               ^^^^^^^
   ╵
  src/assets/styles/base/_color.scss 26:31   color-variables()
  src/assets/styles/themes/_light.scss 40:3  @import
  src/assets/styles/app.scss 16:9            @import
  src/App.vue 30:9                           root stylesheet

 @ ./node_modules/vue-style-loader??ref--8-oneOf-1-0!./node_modules/css-loader/dist/cjs.js??ref--8-oneOf-1-1!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/src??ref--8-oneOf-1-2!./node_modules/sass-loader/dist/cjs.js??ref--8-oneOf-1-3!./node_modules/cache-loader/dist/cjs.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!./src/App.vue?vue&type=style&index=0&lang=scss& 4:14-416 14:3-18:5 15:22-424
 @ ./src/App.vue?vue&type=style&index=0&lang=scss&
 @ ./src/App.vue
 @ ./src/main.js
 @ multi (webpack)-dev-server/client?http://10.0.0.25:8080&sockPath=/sockjs-node (webpack)/hot/dev-server.js ./src/main.js
```

This is a fatal error for rancher/rd, which uses Electron.