### PR TITLE
Add Users & Auth / Groups page, assign Global Roles to Groups

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -106,6 +106,7 @@ suffix:
 ##############################
 # Components & Pages
 ##############################
+
 authConfig:
   accessMode:
     label: 'Configure who should be able to login and use {vendor}'
@@ -250,7 +251,12 @@ authConfig:
     enabled: '{provider} is currently enabled.'
   testAndEnable: Test and Enable Authentication
 
-
+authGroups:
+  actions:
+    refresh: Refresh Group Memberships
+    assignRoles: Assign Global Roles
+  assignEdit:
+    assignTitle: Assign Global Roles To Group
 
 assignTo:
   title: |-
@@ -290,6 +296,10 @@ asyncButton:
     action:  'Delete'
     waiting: 'Deleting&hellip;'
     success: 'Deleted'
+  remove:
+    action:  'Remove'
+    waiting: 'Removing&hellip;'
+    success: 'Removed'
   continue:
     action:  'Continue'
     waiting: 'Saving&hellip;'
@@ -1614,7 +1624,88 @@ rbac:
         defaultLabel: Project Creator Default
       noContext:
         label: No Context
-
+  globalRoles:
+    types:
+      global:
+        label: Global Permissions
+        detail: |-
+          Controls what access the {isUser, select,
+          true {user}
+          false {group}} has to administer the overall {appName} installation.
+      custom:
+        label: Custom
+        detail: Roles not created by Rancher.
+      builtin:
+        label: Built-in
+        detail: Additional roles to define more fine-grain permissions model.
+    unknownRole:
+        detail: No description provided
+    role:
+      admin:
+        label: Administrator
+        detail: Administrators have full control over the entire installation and all resources in all clusters.
+      restricted-admin:
+        label: Restricted Administrator
+        detail: Restricted Admins have full control over all resources in all downstream clusters but no access to the local cluster.
+      user:
+        label: Standard User
+        detail: Standard Users can create new clusters and manage clusters and projects they have been granted access to.
+      user-base:
+        label: User-Base
+        detail: User-Base users have login-access only.
+      clusters-create:
+        label: Create new Clusters
+        detail: Allows the user to create new clusters and become the owner of them.  Standard Users have this permission by default.
+      clustertemplates-create:
+        label: Create new RKE Cluster Templates
+        detail: Allows the user to create new RKE cluster templates and become the owner of them.
+      authn-manage:
+        label: Configure Authentication
+        detail: Allows the user to enable, configure, and disable all Authentication provider settings.
+      catalogs-manage:
+        label: Configure Catalogs
+        detail: Allows the user to add, edit, and remove Catalogs.
+      clusters-manage:
+        label: Manage all Clusters
+        detail: Allows the user to manage all clusters, including ones they are not a member of.
+      clusterscans-manage:
+        label: Manage CIS Cluster Scans
+        detail: Allows the user to launch new and manage CIS cluster scans.
+      kontainerdrivers-manage:
+        label: Create new Cluster Drivers
+        detail: Allows the user to create new cluster drivers and become the owner of them.
+      features-manage:
+        label: Configure Feature Flags
+        detail: Allows the user to enable and disable custom features via feature flag settings.
+      nodedrivers-manage:
+        label: Configure Node Drivers
+        detail: Allows the user to enable, configure, and remove all Node Driver settings.
+      nodetemplates-manage:
+        label: Manage Node Templates
+        detail: Allows the user to define, edit, and remove Node Templates.
+      podsecuritypolicytemplates-manage:
+        label: Manage Pod Security Policies (PSPs)
+        detail: Allows the user to define, edit, and remove PSPs.
+      roles-manage:
+        label: Manage Roles
+        detail: Allows the user to define, edit, and remove Role definitions.
+      settings-manage:
+        label: Manage Settings
+        detail: Allows the user to manage Rancher Settings.
+      users-manage:
+        label: Manage Users
+        detail: Allows the user to create, remove, and set passwords for all Users.
+      catalogs-use:
+        label: Use Catalogs
+        detail: Allows the user to see and deploy Templates from the Catalog.  Standard Users have this permission by default.
+      nodetemplates-use:
+        label: Use Node Templates
+        detail: Allows the user to deploy new Nodes using any existing Node Templates.
+      view-rancher-metrics:
+        label: View Rancher Metrics
+        detail: Allows the user to view Metrics through the API.
+      base:
+        label: Login Access
 
 resourceDetail:
   detailTop:
@@ -2888,6 +2979,11 @@ typeLabel:
       one { RKE2 Cluster }
       other { RKE2 Clusters }
     }
+  group.principal: |-
+    {count, plural,
+      one { Group }
+      other { Groups }
+    }
 
 action:
   clone: Clone
@@ -2905,6 +3001,7 @@ action:
   show: Show
   hide: Hide
   copy: Copy
+  unassign: 'Unassign'
 
 unit:
   sec: secs

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -152,6 +152,7 @@ export default {
       await Promise.all(existingBindings.map(existingBinding => existingBinding.remove()));
     },
     async save() {
+      // Ensure roles are added before removed (in case by removing one user is unable to add another)
       await this.saveAddedRoles();
       await this.saveRemovedRoles();
     }

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -136,7 +136,7 @@ export default {
     async saveAddedRoles() {
       const newBindings = await Promise.all(this.roleChanges.addRoles.map(role => this.$store.dispatch(`management/create`, {
         type:               RBAC.GLOBAL_ROLE_BINDING,
-        metadata:           { generateName: `ui-` },
+        metadata:           { generateName: `grb-` },
         globalRoleName:     role,
         groupPrincipalName: this.principalId,
       })));

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -1,0 +1,220 @@
+
+<script>
+import { mapGetters } from 'vuex';
+import { RBAC } from '@/config/types';
+import Checkbox from '@/components/form/Checkbox';
+import { _VIEW } from '@/config/query-params';
+import Loading from '@/components/Loading';
+
+export default {
+  components: {
+    Checkbox,
+    Loading,
+  },
+  props:      {
+    mode: {
+      type:    String,
+      default: _VIEW,
+    },
+    principalId: {
+      type:     String,
+      default: ''
+    },
+  },
+  async fetch() {
+    try {
+      this.allRoles = await this.$store.dispatch('management/findAll', { type: RBAC.GLOBAL_ROLE });
+
+      if (!this.sortedRoles) {
+        this.sortedRoles = {
+          global:  {},
+          builtin: {},
+          custom:  {}
+        };
+
+        this.allRoles.forEach((role) => {
+          const type = this.getRoleType(role);
+
+          if (type) {
+            this.sortedRoles[type][role.id] = {
+              label:       this.t(`rbac.globalRoles.role.${ role.id }.label`) || role.displayName,
+              description: this.t(`rbac.globalRoles.role.${ role.id }.detail`) || role.description || this.t(`rbac.globalRoles.unknownRole.detail`),
+              id:          role.id,
+              role,
+            };
+          }
+        });
+
+        // Moving this out into the watch has issues....
+        this.globalRoleBindings = await this.$store.dispatch('management/findAll', { type: RBAC.GLOBAL_ROLE_BINDING });
+
+        this.update();
+      }
+    } catch (e) { }
+  },
+  data() {
+    return {
+      globalPermissions: [
+        'admin',
+        'restricted-admin',
+        'user',
+        'user-base',
+      ],
+      user:               null, // TODO: Populate in edit user mode
+      globalRoleBindings: null,
+      sortedRoles:        null,
+      selectedRoles:      [],
+      roleChanges:        {}
+    };
+  },
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
+  watch:    {
+    principalId(principalId, oldPrincipalId) {
+      if (principalId === oldPrincipalId) {
+        return;
+      }
+      this.update();
+    }
+  },
+  methods: {
+    getRoleType(role) {
+      if (this.globalPermissions.find(p => p === role.id)) {
+        return 'global';
+      } else if (role.hidden) {
+        return null;
+      } else if (role.builtin) {
+        return 'builtin';
+      } else {
+        return 'custom';
+      }
+    },
+    getUnique(...ids) {
+      return `${ this.principalId }-${ ids.join('-') }`;
+    },
+    update() {
+      if (!this.principalId) {
+        return;
+      }
+
+      this.selectedRoles = [];
+      this.startingSelectedRoles = [];
+
+      const boundRoles = this.globalRoleBindings.filter(globalRoleBinding => globalRoleBinding.groupPrincipalName === this.principalId);
+
+      Object.entries(this.sortedRoles).forEach(([type, types]) => {
+        Object.entries(types).forEach(([roleId, mappedRole]) => {
+          const boundRole = boundRoles.find(boundRole => boundRole.globalRoleName === roleId);
+
+          if (!!boundRole) {
+            this.selectedRoles.push(roleId);
+            this.startingSelectedRoles.push({
+              roleId,
+              bindingId: boundRole.id
+            });
+          }
+        });
+      });
+
+      // TODO: If in create user mode... apply default selection using role.newUserDefault
+      // TODO: If in create/edit user mode... apply validation as per rancher/ui lib/global-admin/addon/components/form-global-roles/component.js
+      // Should validation come in via validationErrors property on model?
+    },
+    checkboxChanged() {
+      const addRoles = this.selectedRoles
+        .filter(selected => !this.startingSelectedRoles.find(startingRole => startingRole.roleId === selected));
+      const removeBindings = this.startingSelectedRoles
+        .filter(startingRole => !this.selectedRoles.find(selected => selected === startingRole.roleId))
+        .map(startingRole => startingRole.bindingId);
+
+      this.roleChanges = {
+        initialRoles: this.startingSelectedRoles,
+        addRoles,
+        removeBindings
+      };
+      this.$emit('changed', this.roleChanges);
+    },
+    async saveAddedRoles() {
+      const newBindings = await Promise.all(this.roleChanges.addRoles.map(role => this.$store.dispatch(`management/create`, {
+        type:               RBAC.GLOBAL_ROLE_BINDING,
+        metadata:           { generateName: `ui-` },
+        globalRoleName:     role,
+        groupPrincipalName: this.principalId,
+      })));
+
+      await Promise.all(newBindings.map(newBinding => newBinding.save()));
+    },
+    async saveRemovedRoles() {
+      const existingBindings = await Promise.all(this.roleChanges.removeBindings.map(bindingId => this.$store.dispatch('management/find', {
+        type: RBAC.GLOBAL_ROLE_BINDING,
+        id:   bindingId
+      })));
+
+      await Promise.all(existingBindings.map(existingBinding => existingBinding.remove()));
+    },
+    async save() {
+      await this.saveAddedRoles();
+      await this.saveRemovedRoles();
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+
+  <div v-else>
+    <form v-if="selectedRoles">
+      <div v-for="(sortedRole, type) in sortedRoles" :key="getUnique(type)" class="role-group mb-10">
+        <template v-if="Object.keys(sortedRole).length">
+          <h2>{{ t(`rbac.globalRoles.types.${type}.label`) }}</h2>
+          <div class="type-description mb-10">
+            {{ t(`rbac.globalRoles.types.${type}.detail`, { type: 'Application', isUser: !!user }) }}
+          </div>
+          <div class="checkbox-section" :class="'checkbox-section--' + type">
+            <div v-for="(role, roleId) in sortedRoles[type]" :key="getUnique(type, roleId)" class="checkbox mb-10 mr-10">
+              <Checkbox
+                :key="getUnique(type, roleId, 'checkbox')"
+                v-model="selectedRoles"
+                :value-when-true="roleId"
+                :label="role.label"
+                :mode="mode"
+                @input="checkboxChanged"
+              />
+              <div class="description">
+                {{ role.description }}
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </form>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+  $detailSize: 11px;
+  .role-group {
+    .type-description {
+      font-size: $detailSize;
+    }
+    .checkbox-section {
+      display: grid;
+
+      grid-template-columns: repeat(3, 1fr);
+
+      &--global {
+        grid-template-columns: 100%;
+      }
+
+      .checkbox {
+        display: flex;
+        flex-direction: column;
+
+        .description {
+          font-size: $detailSize;
+          margin-top: 5px;
+        }
+      }
+    }
+  }
+</style>

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -269,7 +269,7 @@ export default {
         <button class="btn role-secondary" @click="close">
           Cancel
         </button>
-        <AsyncButton mode="remove" class="btn bg-error ml-10" :disabled="preventDelete" @click="remove" />
+        <AsyncButton mode="delete" class="btn bg-error ml-10" :disabled="preventDelete" @click="remove" />
       </template>
     </Card>
   </modal>

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -269,7 +269,7 @@ export default {
         <button class="btn role-secondary" @click="close">
           Cancel
         </button>
-        <AsyncButton mode="delete" class="btn bg-error ml-10" :disabled="preventDelete" @click="remove" />
+        <AsyncButton mode="remove" class="btn bg-error ml-10" :disabled="preventDelete" @click="remove" />
       </template>
     </Card>
   </modal>

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -22,6 +22,17 @@ export default {
       default() {
         return ['group'];
       },
+    },
+
+    // either 'user' or 'group'
+    searchGroupTypes: {
+      type:    String,
+      default: null,
+    },
+
+    retainSelection: {
+      type:    Boolean,
+      default: false
     }
   },
 
@@ -68,7 +79,9 @@ export default {
   methods: {
     add(id) {
       this.$emit('add', id);
-      this.newValue = '';
+      if (!this.retainSelection) {
+        this.newValue = '';
+      }
     },
 
     onSearch(str, loading, vm) {
@@ -97,7 +110,10 @@ export default {
           type:       NORMAN.PRINCIPAL,
           actionName: 'search',
           opt:        { url: '/v3/principals?action=search' },
-          body:       { name: str }
+          body:       {
+            name:          str,
+            principalType: this.searchGroupTypes
+          }
         });
 
         if ( this.searchStr === str ) {
@@ -113,18 +129,18 @@ export default {
   }
 };
 </script>
-}
-</script>
 
 <template>
   <LabeledSelect
     v-model="newValue"
     :mode="mode"
-    label="Add Member"
+    :label="retainSelection ? `Select Member` : `Add Member`"
     placeholder="Start typing to search for principals"
     :options="options"
     :searchable="true"
     :filterable="false"
+    class="select-principal"
+    :class="{'retain-selection': retainSelection}"
     @input="add"
     @search="onSearch"
   >
@@ -137,5 +153,22 @@ export default {
     <template #option="option">
       <Principal :key="option.label" :value="option.label" :use-muted="false" />
     </template>
+
+    <template v-if="retainSelection" #selected-option="option">
+      <Principal :key="option.label" :value="option.label" :use-muted="false" class="mt-10 mb-10" />
+    </template>
   </LabeledSelect>
 </template>
+
+<style lang="scss" scoped>
+  .select-principal {
+    &.retain-selection {
+      min-height: 84px;
+      &.focused {
+        .principal {
+          display: none;
+        }
+      }
+    }
+  }
+</style>

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -1,11 +1,11 @@
 <script>
 import $ from 'jquery';
-import { _EDIT } from '@/config/query-params';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   props: {
     value: {
-      type:    Boolean,
+      type:    [Boolean, Array],
       default: false
     },
 
@@ -43,11 +43,19 @@ export default {
       type:    String,
       default: null
     },
+
+    valueWhenTrue: {
+      type:    null,
+      default: true
+    },
   },
 
   computed: {
     isDisabled() {
-      return (this.disabled || this.mode === 'view' );
+      return (this.disabled || this.mode === _VIEW );
+    },
+    isChecked() {
+      return this.isMulti() ? this.value.find(v => v === this.valueWhenTrue) : this.value === this.valueWhenTrue;
     }
   },
 
@@ -61,9 +69,22 @@ export default {
         click.ctrlKey = event.ctrlKey;
         click.metaKey = event.metaKey;
 
-        this.$emit('input', !this.value);
-        $(this.$el).trigger(click);
+        // Flip the value
+        if (this.isMulti()) {
+          if (this.isChecked) {
+            this.value.splice(this.value.indexOf(this.valueWhenTrue), 1);
+          } else {
+            this.value.push(this.valueWhenTrue);
+          }
+          this.$emit('input', this.value);
+        } else {
+          this.$emit('input', !this.value);
+          $(this.$el).trigger(click);
+        }
       }
+    },
+    isMulti() {
+      return Array.isArray(this.value);
     }
   }
 };
@@ -72,14 +93,15 @@ export default {
 <template>
   <label
     class="checkbox-container"
-    :class="{disabled}"
+    :class="{ 'disabled': isDisabled}"
     @keydown.enter.prevent="clicked($event)"
     @keydown.space.prevent="clicked($event)"
     @click.stop.prevent="clicked($event)"
   >
     <input
-      :checked="value"
-      :v-model="value"
+      v-model="value"
+      :checked="isChecked"
+      :value="valueWhenTrue"
       type="checkbox"
       :tabindex="-1"
       @click.stop.prevent

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -1,6 +1,7 @@
 <script>
 import $ from 'jquery';
 import { _EDIT, _VIEW } from '@/config/query-params';
+import { addObject, removeObject } from '@/utils/array';
 
 export default {
   props: {
@@ -72,9 +73,9 @@ export default {
         // Flip the value
         if (this.isMulti()) {
           if (this.isChecked) {
-            this.value.splice(this.value.indexOf(this.valueWhenTrue), 1);
+            removeObject(this.value, this.valueWhenTrue);
           } else {
-            this.value.push(this.valueWhenTrue);
+            addObject(this.value, this.valueWhenTrue);
           }
           this.$emit('input', this.value);
         } else {

--- a/components/formatter/Principal.vue
+++ b/components/formatter/Principal.vue
@@ -1,0 +1,19 @@
+<script>
+import PrincipalComponent from '@/components/auth/Principal';
+
+export default {
+  components: { PrincipalComponent },
+  props:      {
+    value: {
+      type:     String,
+      default: ''
+    },
+  },
+};
+</script>
+
+<template>
+  <div>
+    <PrincipalComponent :key="value" :value="value" :use-muted="false" />
+  </div>
+</template>

--- a/components/formatter/PrincipalGroupBindings.vue
+++ b/components/formatter/PrincipalGroupBindings.vue
@@ -1,0 +1,53 @@
+<script>
+import { NORMAN, RBAC } from '@/config/types';
+
+export default {
+  props:      {
+    value: {
+      type:     String,
+      default: ''
+    },
+  },
+  computed: {
+
+    boundRoles() {
+      const principal = this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.value);
+      const globalRoleBindings = this.$store.getters['management/all'](RBAC.GLOBAL_ROLE_BINDING);
+
+      return globalRoleBindings
+        // Bindings for this group
+        .filter(globalRoleBinding => globalRoleBinding.groupPrincipalName === principal.id)
+        // Display name of role associated with binding
+        .map((binding) => {
+          const role = this.$store.getters['management/byId'](RBAC.GLOBAL_ROLE, binding.globalRoleName);
+
+          return {
+            detailLocation: role.detailLocation,
+            label:          role ? role.displayName : role.id, // nameDisplay contains principal name, not required here
+          };
+        })
+        .sort((a, b) => a.label.localeCompare(b.label));
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="pgb">
+    <template v-for="(role, i) in boundRoles">
+      <nuxt-link :key="role.id" :to="role.detailLocation">
+        {{ role.label }}
+      </nuxt-link>
+      <template v-if="i + 1 < boundRoles.length">
+        ,&nbsp;
+      </template>
+    </template>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.pgb{
+  display: flex;
+  flex-wrap: wrap;
+}
+</style>

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -49,10 +49,22 @@ export function init(store) {
       }
     ],
     getInstances: async() => {
+      const schemaCan = (schema, type, verb) => schema?.[type]?.indexOf(verb) >= 0;
+
+      // Determine if the user can get fetch global roles & global role bindings
+      const canFetchGlobalRoles = schemaCan(store.getters[`management/schemaFor`](RBAC.GLOBAL_ROLE), 'collectionMethods', 'GET' );
+      const canFetchGlobalRoleBindings = schemaCan(store.getters[`management/schemaFor`](RBAC.GLOBAL_ROLE_BINDING), 'collectionMethods', 'GET' );
+
+      if (!canFetchGlobalRoles || !canFetchGlobalRoleBindings) {
+        return [];
+      }
+
+      // Groups are a list of principals filtered via those that have group roles bound to them
       const principals = await store.dispatch('rancher/findAll', {
         type: NORMAN.PRINCIPAL,
         opt:  { url: '/v3/principals' }
       });
+
       const globalRoleBindings = await store.dispatch('management/findAll', {
         type: RBAC.GLOBAL_ROLE_BINDING,
         opt:  { force: true }

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -49,11 +49,9 @@ export function init(store) {
       }
     ],
     getInstances: async() => {
-      const schemaCan = (schema, type, verb) => schema?.[type]?.indexOf(verb) >= 0;
-
-      // Determine if the user can get fetch global roles & global role bindings
-      const canFetchGlobalRoles = schemaCan(store.getters[`management/schemaFor`](RBAC.GLOBAL_ROLE), 'collectionMethods', 'GET' );
-      const canFetchGlobalRoleBindings = schemaCan(store.getters[`management/schemaFor`](RBAC.GLOBAL_ROLE_BINDING), 'collectionMethods', 'GET' );
+      // Determine if the user can get fetch global roles & global role bindings. If not there's not much point in showing the table
+      const canFetchGlobalRoles = !!store.getters[`management/schemaFor`](RBAC.GLOBAL_ROLE);
+      const canFetchGlobalRoleBindings = !!store.getters[`management/schemaFor`](RBAC.GLOBAL_ROLE_BINDING);
 
       if (!canFetchGlobalRoles || !canFetchGlobalRoleBindings) {
         return [];

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -1,6 +1,7 @@
 import { DSL } from '@/store/type-map';
 // import { STATE, NAME as NAME_COL, AGE } from '@/config/table-headers';
-import { MANAGEMENT } from '@/config/types';
+import { MANAGEMENT, NORMAN, RBAC } from '@/config/types';
+import { GROUP_NAME, GROUP_ROLE_NAME } from '@/config/table-headers';
 
 export const NAME = 'auth';
 
@@ -8,11 +9,12 @@ export function init(store) {
   const {
     product,
     basicType,
-    // weightType,
+    weightType,
     configureType,
     componentForType,
-    // headers,
-    // mapType,
+    headers,
+    mapType,
+    spoofedType,
     virtualType,
   } = DSL(store, NAME);
 
@@ -21,7 +23,7 @@ export function init(store) {
     inStore:             'management',
     icon:                'user',
     removable:           false,
-    weight:              -1,
+    weight:              50,
     showClusterSwitcher: false,
   });
 
@@ -34,6 +36,54 @@ export function init(store) {
     route:       { name: 'c-cluster-auth-config' },
   });
 
+  spoofedType({
+    label:             store.getters['type-map/labelFor']({ id: NORMAN.SPOOFED.GROUP_PRINCIPAL }, 2),
+    type:              NORMAN.SPOOFED.GROUP_PRINCIPAL,
+    collectionMethods: [],
+    schemas:           [
+      {
+        id:                NORMAN.SPOOFED.GROUP_PRINCIPAL,
+        type:              'schema',
+        collectionMethods: [],
+        resourceFields:    {},
+      }
+    ],
+    getInstances: async() => {
+      const principals = await store.dispatch('rancher/findAll', {
+        type: NORMAN.PRINCIPAL,
+        opt:  { url: '/v3/principals' }
+      });
+      const globalRoleBindings = await store.dispatch('management/findAll', {
+        type: RBAC.GLOBAL_ROLE_BINDING,
+        opt:  { force: true }
+      });
+
+      // Up front fetch all global roles, instead of individually when needed (results in many duplicated requests)
+      await store.dispatch('management/findAll', { type: RBAC.GLOBAL_ROLE });
+
+      return principals
+        .filter(principal => principal.principalType === 'group' &&
+          !!globalRoleBindings.find(globalRoleBinding => globalRoleBinding.groupPrincipalName === principal.id)
+        )
+        .map(principal => ({
+          ...principal,
+          type: NORMAN.SPOOFED.GROUP_PRINCIPAL
+        }));
+    }
+  });
+  configureType(NORMAN.SPOOFED.GROUP_PRINCIPAL, {
+    isCreatable:      false,
+    showAge:          false,
+    showState:        false,
+    isRemovable:      false,
+    showListMasthead: false,
+  });
+
+  // Use labelFor... so lookup succeeds with .'s in path.... and end result is 'trimmed' as per other entries
+  mapType(NORMAN.SPOOFED.GROUP_PRINCIPAL, store.getters['type-map/labelFor']({ id: NORMAN.SPOOFED.GROUP_PRINCIPAL }, 2));
+
+  weightType(NORMAN.SPOOFED.GROUP_PRINCIPAL, -1, true);
+  weightType(MANAGEMENT.USER, 100);
   configureType(MANAGEMENT.USER, { showListMasthead: false });
 
   configureType(MANAGEMENT.AUTH_CONFIG, {
@@ -57,6 +107,11 @@ export function init(store) {
   basicType([
     'config',
     MANAGEMENT.USER,
-    // MANAGEMENT.GROUP,
+    NORMAN.SPOOFED.GROUP_PRINCIPAL
+  ]);
+
+  headers(NORMAN.SPOOFED.GROUP_PRINCIPAL, [
+    GROUP_NAME,
+    GROUP_ROLE_NAME
   ]);
 }

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -704,3 +704,19 @@ export const CONFIGURED_RECEIVER = {
   formatter:     'Link',
   formatterOpts: { options: { internal: true } },
 };
+
+export const GROUP_NAME = {
+  name:      'group-name',
+  label:     'Group Name',
+  value:     'id',
+  sort:      ['name'],
+  search:    ['name'],
+  formatter: 'Principal',
+  width:     350
+};
+export const GROUP_ROLE_NAME = {
+  name:      'group-role-names',
+  label:     'Group Role Names',
+  value:     'id',
+  formatter: 'PrincipalGroupBindings',
+};

--- a/config/types.js
+++ b/config/types.js
@@ -15,7 +15,9 @@ export const NORMAN = {
   AUTH_CONFIG: 'authconfig',
   PRINCIPAL:   'principal',
   USER:        'user',
-  TOKEN:        'token',
+  TOKEN:       'token',
+  GROUP:       'group',
+  SPOOFED:     { GROUP_PRINCIPAL: 'group.principal' }
 };
 
 // Public (via Norman)

--- a/edit/group.principal.vue
+++ b/edit/group.principal.vue
@@ -1,0 +1,63 @@
+<script>
+import CreateEditView from '@/mixins/create-edit-view';
+import GlobalRoleBindings from '@/components/GlobalRoleBindings.vue';
+import CruResource from '@/components/CruResource';
+import { exceptionToErrorsArray } from '@/utils/error';
+import { NORMAN } from '@/config/types';
+
+export default {
+  components: {
+    GlobalRoleBindings,
+    CruResource
+  },
+  mixins: [CreateEditView],
+  data() {
+    return {
+      errors:       [],
+      valid:  false,
+    };
+  },
+  methods:  {
+    async save(buttonDone) {
+      this.errors = [];
+
+      try {
+        await this.$refs.grb.save();
+
+        await this.$store.dispatch('cluster/findAll', {
+          type: NORMAN.SPOOFED.GROUP_PRINCIPAL,
+          opt:  { force: true }
+        }, { root: true }); // See PromptRemove.vue
+
+        this.$router.replace({ name: this.doneRoute });
+        buttonDone(true);
+      } catch (err) {
+        this.errors = exceptionToErrorsArray(err);
+        buttonDone(false);
+      }
+    },
+    changed(changes) {
+      this.valid = !!changes.addRoles.length || !!changes.removeBindings.length;
+    },
+  }
+};
+</script>
+
+<template>
+  <div>
+    <CruResource
+      :done-route="doneRoute"
+      :mode="mode"
+      :resource="value"
+      :validation-passed="valid"
+      :errors="errors"
+      :can-yaml="false"
+      @finish="save"
+    >
+      <GlobalRoleBindings ref="grb" :principal-id="value.id" :mode="mode" @changed="changed" />
+    </CruResource>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+</style>

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -49,9 +49,8 @@ export default {
           data:          { },
         });
 
-        // In SPA this is not needed. In SSR I think this runs client side... where this has not been called (not sure how not...)
-        // If this is not here... when cluster/findAll is dispatched... we fail to find the spoofed type's getInstance fn as it hasn't been
-        // registered yet
+        // This is needed in SSR, but not SPA. If this is not here... when cluster/findAll is dispatched... we fail to find the spoofed
+        // type's `getInstance` fn as it hasn't been registered (`instanceMethods` in type-map file is empty)
         await applyProducts(this.$store);
 
         this.rows = await this.$store.dispatch('cluster/findAll', {

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -25,21 +25,20 @@ export default {
   },
   async fetch() {
     this.rows = await this.$store.dispatch('cluster/findAll', { type: NORMAN.SPOOFED.GROUP_PRINCIPAL }, { root: true }); // See PromptRemove.vue
+
+    const principals = await this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL, opt: { url: '/v3/principals' } });
+
+    this.hasGroups = principals.filter(principal => principal.principalType === 'group')?.length;
   },
   data() {
     return {
       rows:           null,
+      hasGroups:      false,
       assignLocation:  {
-        // TODO: Q
         path:   `/c/local/${ NAME }/${ NORMAN.SPOOFED.GROUP_PRINCIPAL }/assign-edit`,
         query: { [MODE]: _EDIT }
       }
     };
-  },
-  computed: {
-    hasRows() {
-      return this.rows?.length > 0;
-    }
   },
   methods: {
     async refreshGroupMemberships(buttonDone) {
@@ -88,7 +87,7 @@ export default {
           @click="refreshGroupMemberships"
         />
         <n-link
-          v-if="hasRows"
+          v-if="hasGroups"
           :to="assignLocation"
           class="btn role-primary"
         >

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -30,9 +30,8 @@ export default {
 
     this.hasGroups = principals.filter(principal => principal.principalType === 'group')?.length;
 
-    const userSchema = this.$store.getters[`rancher/schemaFor`](NORMAN.USER);
-
-    this.canRefresh = !!userSchema.collectionActions?.refreshauthprovideraccess;
+    this.canRefresh = await this.$store.dispatch('rancher/request', { url: '/v3/users?limit=0' })
+      .then(res => !!res?.actions?.refreshauthprovideraccess);
   },
   data() {
     return {

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -29,11 +29,16 @@ export default {
     const principals = await this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL, opt: { url: '/v3/principals' } });
 
     this.hasGroups = principals.filter(principal => principal.principalType === 'group')?.length;
+
+    const userSchema = this.$store.getters[`rancher/schemaFor`](NORMAN.USER);
+
+    this.canRefresh = !!userSchema.collectionActions?.refreshauthprovideraccess;
   },
   data() {
     return {
       rows:           null,
       hasGroups:      false,
+      canRefresh:     false,
       assignLocation:  {
         path:   `/c/local/${ NAME }/${ NORMAN.SPOOFED.GROUP_PRINCIPAL }/assign-edit`,
         query: { [MODE]: _EDIT }
@@ -78,6 +83,7 @@ export default {
     >
       <template slot="extraActions">
         <AsyncButton
+          v-if="canRefresh"
           mode="refresh"
           :action-label="t('authGroups.actions.refresh')"
           :waiting-label="t('authGroups.actions.refresh')"

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -1,0 +1,102 @@
+<script>
+import ResourceTable from '@/components/ResourceTable';
+import Loading from '@/components/Loading';
+import Masthead from '@/components/ResourceList/Masthead';
+import { NORMAN } from '@/config/types';
+import AsyncButton from '@/components/AsyncButton';
+import { applyProducts } from '@/store/type-map';
+import { NAME } from '@/config/product/auth';
+import { MODE, _EDIT } from '@/config/query-params';
+
+export default {
+  components: {
+    AsyncButton, ResourceTable, Masthead, Loading
+  },
+  props: {
+    resource: {
+      type:     String,
+      required: true,
+    },
+
+    schema: {
+      type:     Object,
+      required: true,
+    },
+  },
+  async fetch() {
+    this.rows = await this.$store.dispatch('cluster/findAll', { type: NORMAN.SPOOFED.GROUP_PRINCIPAL }, { root: true }); // See PromptRemove.vue
+  },
+  data() {
+    return {
+      rows:           null,
+      assignLocation:  {
+        // TODO: Q
+        path:   `/c/local/${ NAME }/${ NORMAN.SPOOFED.GROUP_PRINCIPAL }/assign-edit`,
+        query: { [MODE]: _EDIT }
+      }
+    };
+  },
+  computed: {
+    hasRows() {
+      return this.rows?.length > 0;
+    }
+  },
+  methods: {
+    async refreshGroupMemberships(buttonDone) {
+      try {
+        await this.$store.dispatch('rancher/request', {
+          url:           '/v3/users?action=refreshauthprovideraccess',
+          method:        'post',
+          data:          { },
+        });
+
+        // In SPA this is not needed. In SSR I think this runs client side... where this has not been called (not sure how not...)
+        // If this is not here... when cluster/findAll is dispatched... we fail to find the spoofed type's getInstance fn as it hasn't been
+        // registered yet
+        await applyProducts(this.$store);
+
+        this.rows = await this.$store.dispatch('cluster/findAll', {
+          type: NORMAN.SPOOFED.GROUP_PRINCIPAL,
+          opt:  { force: true }
+        }, { root: true });
+
+        buttonDone(true);
+      } catch (err) {
+        this.$store.dispatch('growl/fromError', { title: 'Error refreshing group memberships', err }, { root: true });
+        buttonDone(false);
+      }
+    },
+  },
+
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <Masthead
+      :schema="schema"
+      :resource="resource"
+    >
+      <template slot="extraActions">
+        <AsyncButton
+          mode="refresh"
+          :action-label="t('authGroups.actions.refresh')"
+          :waiting-label="t('authGroups.actions.refresh')"
+          :success-label="t('authGroups.actions.refresh')"
+          :error-label="t('authGroups.actions.refresh')"
+          @click="refreshGroupMemberships"
+        />
+        <n-link
+          v-if="hasRows"
+          :to="assignLocation"
+          class="btn role-primary"
+        >
+          {{ t("authGroups.actions.assignRoles") }}
+        </n-link>
+      </template>
+    </Masthead>
+
+    <ResourceTable :schema="schema" :rows="rows" />
+  </div>
+</template>

--- a/models/group.principal.js
+++ b/models/group.principal.js
@@ -1,0 +1,61 @@
+import { NORMAN, RBAC } from '@/config/types';
+import { clone } from '@/utils/object';
+import principal from './principal';
+
+export default {
+
+  ...principal,
+
+  canViewInApi() {
+    return false;
+  },
+
+  nameDisplay() {
+    return this.principalNameDisplay;
+  },
+
+  principalNameDisplay() {
+    const principal = this.$rootGetters['rancher/byId'](NORMAN.PRINCIPAL, this.id);
+
+    return `${ principal.name } (${ principal.displayType })`;
+  },
+
+  detailLocation() {
+    const detailLocation = clone(this._detailLocation);
+
+    detailLocation.params.id = this.id; // Base fn removes part of the id (`github_team://3375666` --> `3375666`)
+
+    return detailLocation;
+  },
+
+  availableActions() {
+    return [
+      {
+        action:  'goToEdit',
+        label:   this.t('action.edit'),
+        icon:    'icon icon-edit',
+        enabled:  true,
+      },
+      {
+        action:     'unassignGroupRoles',
+        label:      this.t('action.unassign'),
+        icon:       'icon icon-trash',
+        bulkable:   true,
+        enabled:    true,
+        bulkAction: 'unassignGroupRoles',
+      },
+    ];
+  },
+
+  unassignGroupRoles() {
+    return (resources = this) => {
+      const principals = Array.isArray(resources) ? resources : [resources];
+
+      const globalRoleBindings = this.$rootGetters['management/all'](RBAC.GLOBAL_ROLE_BINDING)
+        .filter(globalRoleBinding => principals.find(principal => principal.id === globalRoleBinding.groupPrincipalName));
+
+      this.$dispatch('promptRemove', globalRoleBindings);
+    };
+  },
+
+};

--- a/models/management.cattle.io.globalrolebinding.js
+++ b/models/management.cattle.io.globalrolebinding.js
@@ -1,0 +1,21 @@
+import { NORMAN, RBAC } from '@/config/types';
+
+export default {
+  nameDisplay() {
+    const roleName = this.$getters['byId'](RBAC.GLOBAL_ROLE, this.globalRoleName);
+
+    const ownersName = this.groupPrincipalName ? this._displayPrincipal : this._displayUser;
+
+    return `${ roleName.displayName } (${ ownersName })` ;
+  },
+
+  _displayPrincipal() {
+    const principal = this.$rootGetters['rancher/byId'](NORMAN.PRINCIPAL, this.groupPrincipalName);
+
+    return `${ principal.name } - ${ principal.displayType }`;
+  },
+
+  _displayUser() {
+    return this.user;
+  }
+};

--- a/pages/c/_cluster/auth/group.principal/assign-edit.vue
+++ b/pages/c/_cluster/auth/group.principal/assign-edit.vue
@@ -1,0 +1,115 @@
+<script>
+import FooterComponent from '@/components/form/Footer';
+import SelectPrincipal from '@/components/auth/SelectPrincipal.vue';
+import GlobalRoleBindings from '@/components/GlobalRoleBindings.vue';
+import { NORMAN } from '@/config/types';
+import { _VIEW } from '@/config/query-params';
+import { exceptionToErrorsArray } from '@/utils/error';
+import { NAME } from '@/config/product/auth';
+
+export default {
+  components: {
+    SelectPrincipal,
+    FooterComponent,
+    GlobalRoleBindings,
+  },
+  data() {
+    return {
+      errors:       [],
+      principalId:  null,
+    };
+  },
+  computed: {
+    mode() {
+      return !this.principalId ? _VIEW : this.$route.query.mode || _VIEW;
+    }
+  },
+  methods: {
+    setPrincipal(id) {
+      this.principalId = id;
+
+      return true;
+    },
+    async cancel() {
+      await this.return();
+    },
+    async save(buttonDone) {
+      this.errors = [];
+
+      try {
+        await this.$refs.grb.save();
+
+        await this.$store.dispatch('cluster/findAll', {
+          type: NORMAN.SPOOFED.GROUP_PRINCIPAL,
+          opt:  { force: true }
+        }, { root: true }); // See PromptRemove.vue
+
+        this.$router.replace({
+          name:   `c-cluster-product-resource`,
+          params: {
+            cluster:  'local',
+            product:  NAME,
+            resource: NORMAN.SPOOFED.GROUP_PRINCIPAL,
+          },
+        });
+
+        buttonDone(true);
+      } catch (err) {
+        this.errors = exceptionToErrorsArray(err);
+        buttonDone(false);
+      }
+    },
+  }
+};
+
+</script>
+
+<template>
+  <div>
+    <div>
+      <div class="masthead">
+        <header>
+          <div class="title">
+            <h1 class="m-0">
+              {{ t('authGroups.assignEdit.assignTitle') }}
+            </h1>
+          </div>
+        </header>
+      </div>
+
+      <form>
+        <SelectPrincipal :retain-selection="true" class="mb-20" :show-my-group-types="['group']" :search-group-types="'group'" @add="setPrincipal" />
+
+        <GlobalRoleBindings ref="grb" :principal-id="principalId" :mode="mode" />
+
+        <FooterComponent
+          :mode="mode"
+          :errors="errors"
+          @save="save"
+          @done="cancel"
+        >
+        </footercomponent>
+      </form>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .masthead {
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 10px;
+  }
+  HEADER {
+    margin: 0;
+  }
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items:center;
+
+    .btn {
+      margin-left: 10px;
+    }
+  }
+</style>

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -13,7 +13,8 @@ export default {
     // Spoofing is handled here to ensure it's done for both yaml and form editing.
     // It became apparent that this was the only place that both intersected
     if (opt.url.includes(SPOOFED_PREFIX) || opt.url.includes(SPOOFED_API_PREFIX)) {
-      const [empty, scheme, type, id] = opt.url.split('/'); // eslint-disable-line no-unused-vars
+      const [empty, scheme, type, ...rest] = opt.url.split('/'); // eslint-disable-line no-unused-vars
+      const id = rest.join('/'); // Cover case where id contains '/'
       const isApi = scheme === SPOOFED_API_PREFIX;
       const typemapGetter = id ? 'getSpoofedInstance' : 'getSpoofedInstances';
       const schemas = await rootGetters['cluster/all'](SCHEMA);


### PR DESCRIPTION
- Add groups page with table to the auth product
- Allow user to assign roles to groups previously without roles or edit groups with existing roles


Comments
- I haven't added any special ux for the case where there's no auth provider and therefore no groups
- ./components/GlobalRoleBindings.vue will be updated when the same  component is used for assign global roles to a user principal
- ~~./components/GlobalRoleBindings.vue ln 139 Couldn't create a binding without the generateName metadata property. Have given this a `ui-` prefix. Is this correct?~~ updated to `grb-`
- In order to determine which global roles are bound to each principal (so we can filter by principals that have them).. we go out and fetch ALL role bindings. Is this too costly?
- On the groups page the 'refresh' button is quite big, we should consider reducing this