### PR TITLE
saml auth pr feedback

### DIFF
--- a/mixins/auth.js
+++ b/mixins/auth.js
@@ -93,9 +93,7 @@ export default {
             await this.model.save();
             await this.$store.dispatch('auth/test', { provider: this.model.id, body: this.model });
 
-            this.model.enabled = true;
-
-            await this.model.save();
+            await this.reloadModel();
           } else {
             this.model.enabled = true;
             if (!this.model.accessMode) {


### PR DESCRIPTION
per conversation here:
https://github.com/rancher/dashboard/pull/2244#discussion_r566309595

I checked, and `model.enabled` is indeed set by the backend during `testAndEnable`. This PR removes the extra save call.