### PR TITLE
Add disabled state for buttons in the Header

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -163,6 +163,12 @@ export default {
       border: 1px solid var(--header-btn-bg);
       background: rgba(0,0,0,.05);
       color: var(--header-btn-text);
+
+      &[disabled=disabled] {
+        background-color: var(--header-btn-bg) !important;
+        color: var(--header-btn-text) !important;
+        opacity: 0.7;
+      }
     }
 
     grid-template-areas:  "product top back import kubectl cluster user";


### PR DESCRIPTION
This PR adds a disabled state for buttons in the Header bar - I was seeing this with the import yaml button - this won't be the case if your backend is up to date, but adding this style anyway in case we encounter the need to disable buttons in the header in the future.

Before:

![Screenshot 2021-01-29 at 09 47 38](https://user-images.githubusercontent.com/1955897/106259405-1752bc00-6217-11eb-8ed1-75d3622d955a.png)

After:

![Screenshot 2021-01-29 at 09 45 41](https://user-images.githubusercontent.com/1955897/106259222-d65aa780-6216-11eb-9e00-6f80c2de8c47.png)
