### PR TITLE
Improve the presentation of Checkboxes

### DIFF
--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -71,6 +71,12 @@
   --overlay-bg: #{rgba($darkest, 0.75)};
   --shadow: #{rgba($darkest, 0.9)};
 
+  --checkbox-tick              : #{$lightest};
+  --checkbox-border            : #{$medium};
+  --checkbox-tick-disabled     : #{lighten($disabled, 20%)};
+  --checkbox-disabled-bg       : #{$disabled};
+  --checkbox-ticked-bg         : #{$link};
+
   --dropdown-bg: #{mix($medium, $dark, 10%)};
   --dropdown-border: #{$light};
   --dropdown-divider: #{$light};

--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -91,6 +91,11 @@ $selected: rgba($primary, .5);
   --overlay-bg                 : #{rgba($lighter, 0.75)};
   --shadow                     : #{rgba($medium, 0.85)};
 
+  --checkbox-tick              : #{$lightest};
+  --checkbox-border            : #{$medium};
+  --checkbox-tick-disabled     : #{darken($disabled, 20%)};
+  --checkbox-disabled-bg       : #{$disabled};
+  --checkbox-ticked-bg         : #{$link};
 
   --dropdown-bg                : #{$lightest};
   --dropdown-border            : #{$medium};

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -98,8 +98,8 @@ export default {
       <slot name="label">
         <t v-if="labelKey" :k="labelKey" />
         <template v-else-if="label">{{ label }}</template>
-        <i v-if="tooltipKey" v-tooltip="t(tooltipKey)" class="icon icon-info icon-lg" />
-        <i v-else-if="tooltip" v-tooltip="tooltip" class="icon icon-info icon-lg" />
+        <i v-if="tooltipKey" v-tooltip="t(tooltipKey)" class="checkbox-info icon icon-info icon-lg" />
+        <i v-else-if="tooltip" v-tooltip="tooltip" class="checkbox-info icon icon-info icon-lg" />
       </slot>
     </span>
   </label>
@@ -118,7 +118,13 @@ export default {
 
   .checkbox-label {
     color: var(--input-label);
+    display: inline-flex;
     margin: 0px 10px 0px 5px;
+  }
+
+  .checkbox-info {
+    line-height: normal;
+    margin-left: 2px;
   }
 
  .checkbox-custom {
@@ -140,13 +146,15 @@ export default {
       -ms-transform: rotate(0deg) scale(1);
       transform: rotate(0deg) scale(1);
       opacity:1;
-      border: 1px solid var(--input-label);
+      border: 1px solid var(--dropdown-text);
+
       &.indeterminate{
         background-color: transparent;
         border: 1px solid var(--border)
       }
   }
 
+  // Custom Checkbox tick
   .checkbox-custom::after {
       position: absolute;
       content: "";
@@ -173,7 +181,7 @@ export default {
     width: 4px;
     height: 10px;
     border: solid;
-    border-color: var(--input-text);
+    border-color: var(--checkbox-tick);
     border-width: 0 2px 2px 0;
     background-color: transparent;
   }
@@ -188,13 +196,24 @@ export default {
     width: 7px;
     height: 5px;
     border: solid;
-    border-color: var(--dropdown-text);
+    border-color: var(--checkbox-ticked-bg);
     border-width: 0 0 2px 0;
     background-color: transparent;
   }
 
-  input:disabled  ~ .checkbox-custom {
-    background-color: var(--disabled-bg);
+  // Disabled styles
+  &.disabled {
+    .checkbox-custom {
+      background-color: var(--checkbox-disabled-bg);
+      border-color: var(--checkbox-disabled-bg);
+    }
+    input:checked ~ .checkbox-custom {
+      background-color: var(--checkbox-disabled-bg);
+      border-color: var(--checkbox-disabled-bg);
+      &::after {
+        border-color: var(--checkbox-tick-disabled);
+      }
+    }
   }
 
   &.disabled {

--- a/pages/design-system/form-controls.vue
+++ b/pages/design-system/form-controls.vue
@@ -179,34 +179,34 @@ export default {
       />
     </div>
     <div class="m-20">
-      <Checkbox 
+      <Checkbox
         v-model="cb"
         label="Test checkbox (toggle-able)"
         :mode="mode"
       />
-      <Checkbox 
+      <Checkbox
         :value="false"
         label="Test checkbox (not checked)"
         :mode="mode"
       />
-      <Checkbox 
+      <Checkbox
         :value="true"
         label="Test checkbox (checked)"
         :mode="mode"
       />
-      <Checkbox 
+      <Checkbox
         :value="false"
         label="Test checkbox (disabled)"
         :disabled="true"
         :mode="mode"
       />
-      <Checkbox 
+      <Checkbox
         :value="true"
         label="Test checkbox (disabled, checked)"
         :disabled="true"
         :mode="mode"
       />
-      <Checkbox 
+      <Checkbox
         :value="true"
         label="Test checkbox with tooltip"
         :disabled="false"
@@ -215,32 +215,32 @@ export default {
       />
     </div>
     <div class="m-20">
-      <Checkbox 
+      <Checkbox
         v-model="cb"
         label="Test checkbox (indeterminate)"
         :mode="mode"
         :indeterminate="true"
       />
-      <Checkbox 
+      <Checkbox
         :value="false"
         label="Test checkbox (indeterminate, not checked)"
         :mode="mode"
         :indeterminate="true"
       />
-      <Checkbox 
+      <Checkbox
         :value="true"
         label="Test checkbox (indeterminate, checked)"
         :mode="mode"
         :indeterminate="true"
       />
-      <Checkbox 
+      <Checkbox
         :value="false"
         label="Test checkbox (indeterminate, not checked, disabled)"
         :mode="mode"
         :disabled="true"
         :indeterminate="true"
       />
-      <Checkbox 
+      <Checkbox
         :value="true"
         label="Test checkbox (indeterminate, checked, disabled)"
         :mode="mode"

--- a/pages/design-system/form-controls.vue
+++ b/pages/design-system/form-controls.vue
@@ -5,6 +5,7 @@ import UnitInput from '@/components/form/UnitInput';
 import Select from '@/components/form/Select';
 import SecretSelector from '@/components/form/SecretSelector';
 import InputWithSelect from '@/components/form/InputWithSelect';
+import Checkbox from '@/components/form/Checkbox';
 import ButtonGroup from '@/components/ButtonGroup';
 import { mapPref, THEME } from '@/store/prefs';
 import { ucFirst } from '@/utils/string';
@@ -13,6 +14,7 @@ export default {
   layout:     'unauthenticated',
   components: {
     ButtonGroup,
+    Checkbox,
     LabeledInput,
     LabeledSelect,
     UnitInput,
@@ -37,6 +39,7 @@ export default {
       n:       'n',
       m:       'm',
       x:       'x',
+      cb:      false,
     };
   },
 
@@ -173,6 +176,76 @@ export default {
         :mode="mode"
         :tooltip="tooltip"
         :options="['foo','bar']"
+      />
+    </div>
+    <div class="m-20">
+      <Checkbox 
+        v-model="cb"
+        label="Test checkbox (toggle-able)"
+        :mode="mode"
+      />
+      <Checkbox 
+        :value="false"
+        label="Test checkbox (not checked)"
+        :mode="mode"
+      />
+      <Checkbox 
+        :value="true"
+        label="Test checkbox (checked)"
+        :mode="mode"
+      />
+      <Checkbox 
+        :value="false"
+        label="Test checkbox (disabled)"
+        :disabled="true"
+        :mode="mode"
+      />
+      <Checkbox 
+        :value="true"
+        label="Test checkbox (disabled, checked)"
+        :disabled="true"
+        :mode="mode"
+      />
+      <Checkbox 
+        :value="true"
+        label="Test checkbox with tooltip"
+        :disabled="false"
+        :mode="mode"
+        tooltip="Test tooltip for checkbox"
+      />
+    </div>
+    <div class="m-20">
+      <Checkbox 
+        v-model="cb"
+        label="Test checkbox (indeterminate)"
+        :mode="mode"
+        :indeterminate="true"
+      />
+      <Checkbox 
+        :value="false"
+        label="Test checkbox (indeterminate, not checked)"
+        :mode="mode"
+        :indeterminate="true"
+      />
+      <Checkbox 
+        :value="true"
+        label="Test checkbox (indeterminate, checked)"
+        :mode="mode"
+        :indeterminate="true"
+      />
+      <Checkbox 
+        :value="false"
+        label="Test checkbox (indeterminate, not checked, disabled)"
+        :mode="mode"
+        :disabled="true"
+        :indeterminate="true"
+      />
+      <Checkbox 
+        :value="true"
+        label="Test checkbox (indeterminate, checked, disabled)"
+        :mode="mode"
+        :disabled="true"
+        :indeterminate="true"
       />
     </div>
   </div>


### PR DESCRIPTION
This PR improves the presentation of text boxes, particularly in light mode (fixed the color of the tick). It adds a better disable state presentation and improves the alignment of the info icon when the checkbox has a tooltip. Finally, it adds checkboxes to the design system form control page to easily see the changes that have been made.

Validated both light and dark mode

Before:
![Screenshot 2021-01-29 at 14 57 43](https://user-images.githubusercontent.com/1955897/106290602-914c6a80-6242-11eb-8b77-359674370b28.png)

After:
![Screenshot 2021-01-29 at 14 54 47](https://user-images.githubusercontent.com/1955897/106290108-fce20800-6241-11eb-9f5a-6b5cbf5dfe06.png)

