### PR TITLE
Add a temporary fix for positioning issue in Change Password prompt

### DIFF
--- a/components/form/ChangePassword.vue
+++ b/components/form/ChangePassword.vue
@@ -251,7 +251,7 @@ export default {
       display: flex;
       flex-direction: column;
       .fields{
-        height: 215px;
+        height: 225px;
         #username, #password {
           height: 0;
           width: 0;


### PR DESCRIPTION
- This is a fix for a very minor visual bug (checkbox position is too high)
  ![image](https://user-images.githubusercontent.com/18697775/106441513-0a7dd480-6472-11eb-83be-2da60815fa23.png)
- Think this came in after the styles update
- I'll be updated this area in the create/edit user pr, will be sure to make it less brittle