### PR TITLE
Making several fixes to spoofed types

### DIFF
--- a/store/type-map.js
+++ b/store/type-map.js
@@ -470,7 +470,7 @@ export const getters = {
         const virtual = !!typeObj.virtual;
         let icon = typeObj.icon;
 
-        if ( !virtual && !icon ) {
+        if ( (!virtual || typeObj.isSpoofed ) && !icon ) {
           if ( namespaced ) {
             icon = 'folder';
           } else {
@@ -695,14 +695,16 @@ export const getters = {
         };
       }
 
-      // Add virtual types and spoofed types
+      // Add virtual and spoofed types
       if ( mode !== USED ) {
         const virtualTypes = state.virtualTypes[product] || [];
+        const spoofedTypes = state.spoofedTypes[product] || [];
+        const allTypes = [...virtualTypes, ...spoofedTypes];
 
-        for ( const vt of virtualTypes ) {
-          const item = clone(vt);
+        for ( const type of allTypes ) {
+          const item = clone(type);
           const id = item.name;
-          const weight = vt.weight || getters.typeWeightFor(item.label, isBasic);
+          const weight = type.weight || getters.typeWeightFor(item.label, isBasic);
 
           if ( item['public'] === false && !isDev ) {
             continue;
@@ -734,11 +736,6 @@ export const getters = {
           out[id] = item;
         }
       }
-
-      const spoofedTypes = state.spoofedTypes[product] || [];
-      spoofedTypes.forEach(type => {
-        out[type.name] = type;
-      });
 
       return out;
     };
@@ -1103,6 +1100,7 @@ export const mutations = {
     instanceMethods[product][copy.type] = copy.getInstances;
     delete copy.getInstances;
 
+    copy.name = copy.type;
     copy.isSpoofed = true;
     copy.virtual = true;
     copy.schemas.forEach(schema => {


### PR DESCRIPTION
- Made it so we add spoofed types as a part of the virtual type loop.
Previously we were adding the types to all modes without appropriate filtering
- Made it so spoofed types can have the nav icons
- There was also a problem where the virtual/spoofed types were expected to have a name so I copied the type over to the name of spoofed types.