### PR TITLE
only show remediation for fail/warn cis scan results

### DIFF
--- a/detail/cis.cattle.io.clusterscan.vue
+++ b/detail/cis.cattle.io.clusterscan.vue
@@ -293,7 +293,7 @@ export default {
         <template #sub-row="{row, fullColspan}">
           <tr>
             <td :colspan="fullColspan">
-              <Banner v-if="row.remediation" class="sub-banner" :label="remediationDisplay(row)" color="warning" />
+              <Banner v-if="(row.state==='fail' || row.state==='warn')&& row.remediation" class="sub-banner" :label="remediationDisplay(row)" color="warning" />
               <SortableTable
                 class="sub-table"
                 :rows="row.nodeRows"


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/2207#issuecomment-773494686
- per slack convo with Rajashree, the remediation field should only be shown if scan results are fail or warn