### PR TITLE
LDAP Auth: Change the port number when the user changes the TLS setting

### DIFF
--- a/edit/auth/ldap/config.vue
+++ b/edit/auth/ldap/config.vue
@@ -6,6 +6,9 @@ import UnitInput from '@/components/form/UnitInput';
 import Banner from '@/components/Banner';
 import FileSelector from '@/components/form/FileSelector';
 
+const DEFAULT_NON_TLS_PORT = 389;
+const DEFAULT_TLS_PORT = 636;
+
 export default {
   components: {
     RadioGroup,
@@ -58,6 +61,17 @@ export default {
     'model.tls'(neu) {
       if (neu) {
         this.model.starttls = false;
+      }
+
+      const expectedCurrentDefault = neu ? DEFAULT_NON_TLS_PORT : DEFAULT_TLS_PORT;
+      const newDefault = neu ? DEFAULT_TLS_PORT : DEFAULT_NON_TLS_PORT;
+
+      // Note: The defualt port value is a number
+      // If the user edits this value, the type will be a string
+      // Thus, we will only change the value when the user toggles the TLS flag if they have
+      // NOT edited the port value in any way
+      if (this.model.port === expectedCurrentDefault) {
+        this.value.port = newDefault;
       }
     }
   }


### PR DESCRIPTION
Addresses #2251 

This is a simple fix for the issue above. When the user changes the TLS checkbox, the port field will be updated with the correct default depending on the TLS setting. It will ONLY do this if the user has not edited the contents of the port field.