### PR TITLE
Improve display of Auth Provider settings

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -149,6 +149,9 @@ authConfig:
       label: Which version of GitHub do you want to use?
       private: A private installation of GitHub Enterprise
       public: Public GitHub.com
+    table:
+      server: Server
+      clientId: Client ID
   googleoauth:
     adminEmail: Admin Email
     domain: Domain
@@ -232,6 +235,9 @@ authConfig:
       placeholder: 'e.g. ou=users,dc=mycompany,dc=com'
     username: Username
     usernameAttribute: Username Attribute
+    table:
+      server: Server
+      clientId: Client ID
   saml:
     entityID: Entity ID Field
     UID: UID Field

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -254,6 +254,13 @@ authConfig:
     shibboleth: Congiure a Shibboleth account
     showLdap: Configure an OpenLDAP Server
     userName: User Name Field
+  azuread:
+    tenantId: Tenant ID
+    applicationId: Application ID
+    endpoint: Endpoint
+    graphEndpoint: Graph Endpoint
+    tokenEndpoint: Token Endpoint
+    authEndpoint: Auth Endpoint
   stateBanner:
     disabled: '{provider} is currently disabled.'
     enabled: '{provider} is currently enabled.'

--- a/components/auth/AuthBanner.vue
+++ b/components/auth/AuthBanner.vue
@@ -1,0 +1,71 @@
+
+<script>
+import Banner from '@/components/Banner';
+import AsyncButton from '@/components/AsyncButton';
+
+export default {
+  components: {
+    AsyncButton,
+    Banner
+  },
+
+  props: {
+    tArgs: {
+      type:     Object,
+      required: true,
+      default:  () => { },
+    },
+    disable: {
+      type:     Function,
+      required: true,
+      default:  () => { },
+    },
+    edit: {
+      type:     Function,
+      required: true,
+      default:  () => { },
+    }
+  },
+
+  computed: {
+    values() {
+      return Object.entries(this.table);
+    }
+  },
+};
+</script>
+
+<template>
+  <div>
+    <Banner color="success clearfix" class="banner">
+      <div class="text">
+        {{ t('authConfig.stateBanner.enabled', tArgs) }}
+      </div>
+      <button type="button" class="btn-sm role-primary" @click="edit">
+        {{ t('action.edit') }}
+      </button>
+      <AsyncButton class="ml-10" mode="disable" size="sm" action-color="bg-error" @click="disable" />
+    </Banner>
+
+    <table v-if="!!$slots.rows" class="values">
+      <slot name="rows"></slot>
+    </table>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.banner {
+  display: flex;
+    align-items: center;
+  .text {
+    flex: 1;
+  }
+}
+
+.values {
+  tr td:not(:first-of-type) {
+    padding-left: 10px;
+  }
+}
+
+</style>

--- a/edit/auth/azuread.vue
+++ b/edit/auth/azuread.vue
@@ -6,7 +6,7 @@ import InfoBox from '@/components/InfoBox';
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import Banner from '@/components/Banner';
-import AsyncButton from '@/components/AsyncButton';
+import AuthBanner from '@/components/auth/AuthBanner';
 import CopyToClipboardText from '@/components/CopyToClipboardText.vue';
 import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
 import AuthConfig from '@/mixins/auth-config';
@@ -44,7 +44,7 @@ export default {
     Banner,
     CopyToClipboardText,
     AllowedPrincipals,
-    AsyncButton
+    AuthBanner
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -145,21 +145,16 @@ export default {
       @cancel="cancel"
     >
       <template v-if="model.enabled && !isEnabling && !editConfig">
-        <Banner color="success clearfix">
-          <div class="pull-left mt-10">
-            {{ t('authConfig.stateBanner.enabled', tArgs) }}
-          </div>
-          <div class="pull-right">
-            <AsyncButton mode="disable" size="sm" action-color="bg-error" @click="disable" />
-          </div>
-        </Banner>
-
-        <div>Tenant ID: {{ model.tenantId }}</div>
-        <div>Application ID: {{ model.applicationId }}</div>
-        <div>Endpoint: {{ model.endpoint }}</div>
-        <div>Graph Endpoint: {{ model.graphEndpoint }}</div>
-        <div>Token Endpoint: {{ model.tokenEndpoint }}</div>
-        <div>Auth Endpoint: {{ model.authEndpoint }}</div>
+        <AuthBanner :t-args="tArgs" :disable="disable" :edit="goToEdit">
+          <template slot="rows">
+            <tr><td>{{ t(`authConfig.azuread.tenantId`) }}: </td><td>{{ model.tenantId }}</td></tr>
+            <tr><td>{{ t(`authConfig.azuread.applicationId`) }}: </td><td>{{ model.applicationId }}</td></tr>
+            <tr><td>{{ t(`authConfig.azuread.endpoint`) }}: </td><td>{{ model.endpoint }}</td></tr>
+            <tr><td>{{ t(`authConfig.azuread.graphEndpoint`) }}: </td><td>{{ model.graphEndpoint }}</td></tr>
+            <tr><td>{{ t(`authConfig.azuread.tokenEndpoint`) }}: </td><td>{{ model.tokenEndpoint }}</td></tr>
+            <tr><td>{{ t(`authConfig.azuread.authEndpoint`) }}: </td><td>{{ model.authEndpoint }}</td></tr>
+          </template>
+        </AuthBanner>
 
         <hr />
 

--- a/edit/auth/github.vue
+++ b/edit/auth/github.vue
@@ -6,12 +6,12 @@ import InfoBox from '@/components/InfoBox';
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import Banner from '@/components/Banner';
-import AsyncButton from '@/components/AsyncButton';
 import CopyToClipboard from '@/components/CopyToClipboard';
 import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
 import { NORMAN, MANAGEMENT } from '@/config/types';
 import { findBy } from '@/utils/array';
 import AuthConfig from '@/mixins/auth-config';
+import AuthBanner from '@/components/auth/AuthBanner';
 
 const NAME = 'github';
 
@@ -25,7 +25,7 @@ export default {
     Banner,
     CopyToClipboard,
     AllowedPrincipals,
-    AsyncButton
+    AuthBanner
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -111,6 +111,7 @@ export default {
         description:  'Enable GitHub',
       };
     }
+
   },
 
   watch: {
@@ -155,20 +156,12 @@ export default {
       @cancel="cancel"
     >
       <template v-if="model.enabled && !isEnabling && !editConfig">
-        <Banner color="success clearfix">
-          <div class="pull-left mt-10">
-            {{ t('authConfig.stateBanner.enabled', tArgs) }}
-          </div>
-          <div class="pull-right">
-            <button type="button" class="btn-sm role-primary" @click="goToEdit">
-              {{ t('action.edit') }}
-            </button>
-            <AsyncButton mode="disable" size="sm" action-color="bg-error" @click="disable" />
-          </div>
-        </Banner>
-
-        <div>Server: {{ baseUrl }}</div>
-        <div>Client ID: {{ value.clientId }}</div>
+        <AuthBanner :t-args="tArgs" :disable="disable" :edit="goToEdit">
+          <template slot="rows">
+            <tr><td>{{ t(`authConfig.${ NAME }.table.server`) }}: </td><td>{{ baseUrl }}</td></tr>
+            <tr><td>{{ t(`authConfig.${ NAME }.table.clientId`) }}: </td><td>{{ value.clientId }}</td></tr>
+          </template>
+        </AuthBanner>
 
         <hr />
 

--- a/edit/auth/googleoauth.vue
+++ b/edit/auth/googleoauth.vue
@@ -8,9 +8,9 @@ import InfoBox from '@/components/InfoBox';
 import Checkbox from '@/components/form/Checkbox';
 import LabeledInput from '@/components/form/LabeledInput';
 import Banner from '@/components/Banner';
-import AsyncButton from '@/components/AsyncButton';
 import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
 import FileSelector from '@/components/form/FileSelector';
+import AuthBanner from '@/components/auth/AuthBanner';
 
 const NAME = 'googleoauth';
 
@@ -23,8 +23,8 @@ export default {
     Banner,
     Checkbox,
     AllowedPrincipals,
-    AsyncButton,
-    FileSelector
+    FileSelector,
+    AuthBanner
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -79,20 +79,12 @@ export default {
       @cancel="cancel"
     >
       <template v-if="model.enabled && !isEnabling && !editConfig">
-        <Banner color="success clearfix">
-          <div class="pull-left mt-10">
-            {{ t('authConfig.stateBanner.enabled', tArgs) }}
-          </div>
-          <div class="pull-right">
-            <button type="button" class="btn-sm role-primary" @click="goToEdit">
-              {{ t('action.edit') }}
-            </button>
-            <AsyncButton mode="disable" size="sm" action-color="bg-error" @click="disable" />
-          </div>
-        </Banner>
-
-        <div>{{ t(`authConfig.${NAME}.adminEmail`) }}: {{ model.adminEmail }}</div>
-        <div>{{ t(`authConfig.${NAME}.domain`) }}: {{ model.hostname }}</div>
+        <AuthBanner :t-args="tArgs" :disable="disable" :edit="goToEdit">
+          <template slot="rows">
+            <tr><td>{{ t(`authConfig.${NAME}.adminEmail`) }}: </td><td>{{ model.adminEmail }}</td></tr>
+            <tr><td>{{ t(`authConfig.${NAME}.domain`) }}: </td><td>{{ model.hostname }}</td></tr>
+          </template>
+        </AuthBanner>
 
         <hr />
 

--- a/edit/auth/ldap/index.vue
+++ b/edit/auth/ldap/index.vue
@@ -5,9 +5,9 @@ import CruResource from '@/components/CruResource';
 import LabeledInput from '@/components/form/LabeledInput';
 import Banner from '@/components/Banner';
 import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
-import AsyncButton from '@/components/AsyncButton';
 import config from '@/edit/auth/ldap/config';
 import AuthConfig from '@/mixins/auth-config';
+import AuthBanner from '@/components/auth/AuthBanner';
 
 const AUTH_TYPE = 'ldap';
 
@@ -18,8 +18,8 @@ export default {
     LabeledInput,
     Banner,
     AllowedPrincipals,
-    AsyncButton,
-    config
+    config,
+    AuthBanner
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -61,7 +61,7 @@ export default {
       }
 
       return out;
-    }
+    },
   },
 
 };
@@ -86,19 +86,12 @@ export default {
       @cancel="cancel"
     >
       <template v-if="model.enabled && !isEnabling && !editConfig">
-        <Banner color="success clearfix">
-          <div class="pull-left mt-10">
-            {{ t('authConfig.stateBanner.enabled', tArgs) }}
-          </div>
-          <div class="pull-right">
-            <button type="button" class="btn-sm role-primary" @click="goToEdit">
-              {{ t('action.edit') }}
-            </button>
-            <AsyncButton mode="disable" size="sm" action-color="bg-error" @click="disable" />
-          </div>
-        </Banner>
-        <div>Server: {{ serverUrl }}</div>
-        <div>Client ID: {{ model.serviceAccountDistinguishedName || model.serviceAccountUsername }}</div>
+        <AuthBanner :t-args="tArgs" :disable="disable" :edit="goToEdit">
+          <template slot="rows">
+            <tr><td>{{ t(`authConfig.ldap.table.server`) }}: </td><td>{{ serverUrl }}</td></tr>
+            <tr><td>{{ t(`authConfig.ldap.table.clientId`) }}: </td><td>{{ model.serviceAccountDistinguishedName || model.serviceAccountUsername }}</td></tr>
+          </template>
+        </AuthBanner>
 
         <hr />
 

--- a/edit/auth/saml.vue
+++ b/edit/auth/saml.vue
@@ -7,8 +7,8 @@ import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import Banner from '@/components/Banner';
 import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
-import AsyncButton from '@/components/AsyncButton';
 import FileSelector from '@/components/form/FileSelector';
+import AuthBanner from '@/components/auth/AuthBanner';
 import config from '@/edit/auth/ldap/config';
 
 export default {
@@ -20,8 +20,8 @@ export default {
     AllowedPrincipals,
     Checkbox,
     FileSelector,
-    AsyncButton,
-    config
+    config,
+    AuthBanner
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -40,7 +40,8 @@ export default {
 
     toSave() {
       return { enabled: true, ...this.model };
-    }
+    },
+
   },
 };
 </script>
@@ -64,24 +65,16 @@ export default {
       @cancel="cancel"
     >
       <template v-if="model.enabled && !isEnabling && !editConfig">
-        <Banner color="success clearfix">
-          <div class="pull-left mt-10">
-            {{ t('authConfig.stateBanner.enabled', tArgs) }}
-          </div>
-          <div class="pull-right">
-            <button type="button" class="btn-sm role-primary" @click="goToEdit">
-              {{ t('action.edit') }}
-            </button>
-            <AsyncButton mode="disable" size="sm" action-color="bg-error" @click="disable" />
-          </div>
-        </Banner>
-
-        <div>{{ t(`authConfig.saml.displayName`) }}: {{ model.displayNameField }}</div>
-        <div>{{ t(`authConfig.saml.userName`) }}:{{ model.userNameField }}</div>
-        <div>{{ t(`authConfig.saml.UID`) }}: {{ model.uidField }}</div>
-        <div>{{ t(`authConfig.saml.entityID`) }}: {{ model.entityID }}</div>
-        <div>{{ t(`authConfig.saml.api`) }}: {{ model.rancherApiHost }}</div>
-        <div>{{ t(`authConfig.saml.groups`) }}: {{ model.groupsField }}</div>
+        <AuthBanner :t-args="tArgs" :disable="disable" :edit="goToEdit">
+          <template slot="rows">
+            <tr><td>{{ t(`authConfig.saml.displayName`) }}: </td><td>{{ model.displayNameField }}</td></tr>
+            <tr><td>{{ t(`authConfig.saml.userName`) }}: </td><td>{{ model.userNameField }}</td></tr>
+            <tr><td>{{ t(`authConfig.saml.UID`) }}: </td><td>{{ model.uidField }}</td></tr>
+            <tr><td>{{ t(`authConfig.saml.entityID`) }}: </td><td>{{ model.entityID }}</td></tr>
+            <tr><td>{{ t(`authConfig.saml.api`) }}: </td><td>{{ model.rancherApiHost }}</td></tr>
+            <tr><td>{{ t(`authConfig.saml.groups`) }}: </td><td>{{ model.groupsField }}</td></tr>
+          </template>
+        </AuthBanner>
 
         <hr />
 


### PR DESCRIPTION
- Make a common component used by all auth providers
- Component contains
  - enabled/disabled banner
  - settings which are now aligned in a table

Addresses #2274

~~Blocked on #2309~~

Notes for QA
- This effects all five types of provider (Github, SAML based, Google Auth, LDAP based and AzureAD)
