### PR TITLE
Moving the fluentbit mountpath to global.dockerRootDirectory

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -953,7 +953,7 @@ logging:
   install:
     k3sContainerEngine: K3S Container Engine
     enableAdditionalLoggingSources: Enable enhanced cloud provider logging
-    fluentbitMountPath: Fluentbit Mount Path
+    dockerRootDirectory: Docker Root Directory
   elasticsearch:
     host: Host
     scheme: Scheme

--- a/chart/logging/index.vue
+++ b/chart/logging/index.vue
@@ -25,8 +25,7 @@ export default {
     this.$set(this.value, 'additionalLoggingSources', this.value.additionalLoggingSources || {});
     this.$set(this.value.additionalLoggingSources, this.provider, this.value.additionalLoggingSources[this.provider] || {});
     this.$set(this.value.additionalLoggingSources[this.provider], 'enabled', true);
-    this.$set(this.value.additionalLoggingSources[this.provider], 'fluentbit', this.value.additionalLoggingSources[this.provider].fluentbit || {});
-    this.$set(this.value.additionalLoggingSources[this.provider].fluentbit, 'mountPath', this.value.additionalLoggingSources[this.provider].fluentbit.mountPath || '');
+    this.$set(this.value, 'global', this.value.global || {});
   },
 };
 </script>
@@ -40,7 +39,7 @@ export default {
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.additionalLoggingSources[provider].fluentbit.mountPath" :label="t('logging.install.fluentbitMountPath')" />
+        <LabeledInput v-model="value.global.dockerRootDirectory" :label="t('logging.install.dockerRootDirectory')" />
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
This is to support a backend interface change.

rancher/dashboard#2199

switching from:
```
additionalLoggingSources:
   k3s:
      fluentbit:
         mountPath: path
```
To:
```
global:
  dockerRootDirectory: path
```

![image](https://user-images.githubusercontent.com/55104481/107559081-d5236600-6b98-11eb-8650-bfcfb639830f.png)
