### PR TITLE
Fixing two issues that showed up in pod scheduling

### DIFF
--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -249,7 +249,6 @@ export default {
       :searchable="isSearchable"
       :selectable="selectable"
       :value="value != null ? value : ''"
-      @input="(e) => $emit('input', e)"
       v-on="$listeners"
       @search:blur="onBlur"
       @search:focus="onFocus"

--- a/components/form/PodAffinity.vue
+++ b/components/form/PodAffinity.vue
@@ -1,6 +1,6 @@
 <script>
 import { _VIEW } from '@/config/query-params';
-import { get, isEmpty, clone } from '@/utils/object';
+import { get, set, isEmpty, clone } from '@/utils/object';
 import { POD, NODE, NAMESPACE } from '@/config/types';
 import MatchExpressions from '@/components/form/MatchExpressions';
 import LabeledSelect from '@/components/form/LabeledSelect';
@@ -141,7 +141,8 @@ export default {
       } else {
         term.weight = 1;
       }
-      this.$set(this.allSelectorTerms, idx, term);
+
+      this.$set(this.allSelectorTerms, idx, clone(term));
       this.queueUpdate();
     },
 
@@ -164,6 +165,7 @@ export default {
 
     isEmpty,
     get,
+    set
   }
 
 };
@@ -186,11 +188,12 @@ export default {
             </div>
             <div class="col span-6">
               <LabeledSelect
+                :key="priorityDisplay(props.row.value)"
                 :mode="mode"
                 :options="[t('workload.scheduling.affinity.preferred'),t('workload.scheduling.affinity.required')]"
                 :value="priorityDisplay(props.row.value)"
                 :label="t('workload.scheduling.affinity.priority')"
-                @input="changePriority(props.row.value, idx)"
+                @input="changePriority(props.row.value, props.i)"
               />
             </div>
           </div>
@@ -201,7 +204,7 @@ export default {
               :name="`namespaces-${props.row.value._id}`"
               :mode="mode"
               :value="!!props.row.value.namespaces"
-              @input="changeNamespaceMode(props.row.value, idx)"
+              @input="changeNamespaceMode(props.row.value, props.i)"
             />
           </div>
           <div class="spacer"></div>
@@ -221,7 +224,7 @@ export default {
             :type="pod"
             :value="get(props.row.value, 'labelSelector.matchExpressions')"
             :show-remove="false"
-            @input="e=>$set(props.row.value.labelSelector, 'matchExpressions', e)"
+            @input="e=>set(props.row.value, 'labelSelector.matchExpressions', e)"
           />
           <div class="spacer"></div>
           <div class="row">


### PR DESCRIPTION
- The first issue was caused by the introductions of ArrayListGrouped and not updating all references appropriately
- The other was caused by LabeledSelect calling the @input handler twice for every selection. The handler was toggling which caused the value to always reset. It looks like the reason LabeledSelect was calling the handler twice was because of having both v-bind="$attrs" and @input="...". So i removed @input and verified that LabeledSelect still works for both v-model and value/@input.

rancher/dashboard#2211

![image](https://user-images.githubusercontent.com/55104481/107578015-6ce07e80-6bb0-11eb-8e63-8968e483d55d.png)
