### PR TITLE
Tweak the loading indicator so its less jarring when changing views

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -17,6 +17,7 @@ generic:
   ignored: Ignored
   invalidCron: Invalid cron schedule
   labelsAndAnnotations: Labels and Annotations
+  loading: Loading&hellip;
   members: Members
   na: n/a
   name: Name
@@ -1660,7 +1661,7 @@ changePassword:
     failedDeleteKeys: Failed to delete keys
 
 principal:
-  loading: 'Loading...'
+  loading: Loading&hellip;
   error: Unable to fetch principal info
 
 probe:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1660,7 +1660,7 @@ changePassword:
     failedDeleteKeys: Failed to delete keys
 
 principal:
-  loading: Loading&hellip;
+  loading: 'Loading...'
   error: Unable to fetch principal info
 
 probe:

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -22,7 +22,7 @@ export default {
   <div v-if="loading">
     <div class="overlay"></div>
     <div class="content" :class="{ 'content-content-mode' : mode === 'content', 'content-main-mode' : mode === 'main' }">
-      Loading...
+      <t k="principal.loading" />
     </div>
   </div>
   <div v-else>

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -20,7 +20,9 @@ export default {
   },
 
   mounted() {
-    this.timer = setTimeout(() => { this.showMessage = true; }, 250);
+    this.timer = setTimeout(() => {
+      this.showMessage = true;
+    }, 250);
   },
 
   beforeDestroy() {

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -20,7 +20,7 @@ export default {
   },
 
   mounted() {
-    this.timer = setTimeout(() => { this.showMessage = true; console.log('ok'); }, 250);
+    this.timer = setTimeout(() => { this.showMessage = true; }, 250);
   },
 
   beforeDestroy() {

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -15,14 +15,24 @@ export default {
     }
   },
 
+  data() {
+    return { timer: null, showMessage: false };
+  },
+
+  mounted() {
+    this.timer = setTimeout(() => { this.showMessage = true; console.log('ok'); }, 250);
+  },
+
+  beforeDestroy() {
+    clearTimeout(this.timer);
+  }
 };
 </script>
 
 <template>
   <div v-if="loading">
-    <div class="overlay"></div>
-    <div class="content" :class="{ 'content-content-mode' : mode === 'content', 'content-main-mode' : mode === 'main' }">
-      <t k="principal.loading" />
+    <div v-if="showMessage" class="overlay" :class="{ 'overlay-content-mode' : mode === 'content', 'overlay-main-mode' : mode === 'main' }">
+      <t k="generic.loading" :raw="true" />
     </div>
   </div>
   <div v-else>
@@ -32,15 +42,6 @@ export default {
 
 <style lang="scss" scoped>
   .overlay {
-    z-index: z-index('loadingOverlay');
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-  }
-
-  .content {
     align-items: center;
     background-color: var(--overlay-bg);
     display: flex;

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -4,6 +4,14 @@ export default {
     loading: {
       type:    Boolean,
       default: true,
+    },
+    // How to size and position the loading indicator - supports three modes:
+    // 'content' - the content area only (not side nav or header)
+    // 'main' - entire main view excluding the header, but including the side nav
+    // 'full' - entire view including the header and the side nav
+    mode: {
+      type:    String,
+      default: 'content',
     }
   },
 };
@@ -12,7 +20,7 @@ export default {
 <template>
   <div v-if="loading">
     <div class="overlay"></div>
-    <div class="content">
+    <div class="content" v-bind:class="{ 'content-content-mode' : mode === 'content', 'content-main-mode' : mode === 'main' }">
       Loading...
     </div>
   </div>
@@ -24,7 +32,6 @@ export default {
 <style lang="scss" scoped>
   .overlay {
     z-index: z-index('loadingOverlay');
-    background-color: var(--overlay-bg);
     position: fixed;
     top: 0;
     left: 0;
@@ -33,11 +40,25 @@ export default {
   }
 
   .content {
+    align-items: center;
+    background-color: var(--overlay-bg);
+    display: flex;
+    justify-content: center;
     position: absolute;
-    top: 50vh;
+    bottom: 0;
+    top: 0;
     left: 0;
     right: 0;
     text-align: center;
     z-index: z-index('loadingContent');
+
+    &-main-mode {
+      top: var(--header-height);
+    }
+
+    &-content-mode {
+      left: var(--nav-width);
+      top: var(--header-height);
+    }
   }
 </style>

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -14,13 +14,14 @@ export default {
       default: 'content',
     }
   },
+
 };
 </script>
 
 <template>
   <div v-if="loading">
     <div class="overlay"></div>
-    <div class="content" v-bind:class="{ 'content-content-mode' : mode === 'content', 'content-main-mode' : mode === 'main' }">
+    <div class="content" :class="{ 'content-content-mode' : mode === 'content', 'content-main-mode' : mode === 'main' }">
       Loading...
     </div>
   </div>

--- a/components/nav/GlobalLoading.vue
+++ b/components/nav/GlobalLoading.vue
@@ -18,5 +18,5 @@ export default {
 
 </script>
 <template>
-  <Loading v-if="loading" />
+  <Loading v-if="loading" mode="full" />
 </template>


### PR DESCRIPTION
Most of the time when you navigate around the UI, a loading indicator is shown on page changes as data is fetched - this currently overlays the entire browser view, which is quite jarring.

This PR changes this behaviour - page views will now only show the loading indicator over the content area (not the side nav or header).

I've added a mode to the Loading component to allow configurability of what portion of the window should be covered for the indicator.

The Global Loading component uses the 'full' mode - so when you log in, the Loading indicator still appears over the entire browser view.

I think this overall gives a better user experience. 