### PR TITLE
Fix for headless services showing as type ClusterIP in the Service list

### DIFF
--- a/components/formatter/ServiceType.vue
+++ b/components/formatter/ServiceType.vue
@@ -25,7 +25,7 @@ export default {
     }
 
     const match = DEFAULT_SERVICE_TYPES.find(s => s.id.toLowerCase() === cloned);
-    const { translationLabel } = match;
+    const translationLabel = match.label;
     let translated;
 
     if (translationLabel && this.$store.getters['i18n/exists'](translationLabel)) {


### PR DESCRIPTION
See #2201 

This PR is a trivial fix - the code was looking up 'translationLabel' when the field is simply 'label' - se DEFAULT_SERVICE_TYPES in service.js model.