### PR TITLE
Fix for service detail selector table not having table header

### DIFF
--- a/detail/service.vue
+++ b/detail/service.vue
@@ -95,13 +95,9 @@ export default {
       serviceSelectorInfoHeaders: [
         {
           ...KEY,
-          label: '',
           width: 200,
         },
-        {
-          ...VALUE,
-          label: '',
-        },
+        VALUE,
       ],
     };
   },
@@ -192,7 +188,7 @@ export default {
         :rows="selectorTableRows"
         :row-actions="false"
         :table-actions="false"
-        :show-headers="false"
+        :show-headers="true"
         :search="false"
       />
     </Tab>


### PR DESCRIPTION
This is a trivial fix for the issue #2201 

Turns on the table header and leaves the labels as their defaults.