### PR TITLE
Filter ownerReferences to standard kinds

### DIFF
--- a/list/workload.vue
+++ b/list/workload.vue
@@ -71,7 +71,6 @@ export default {
 
     rows() {
       const out = [];
-      const allTypes = this.allTypes;
 
       for ( const typeRows of this.resources ) {
         if ( !typeRows ) {
@@ -79,14 +78,14 @@ export default {
         }
 
         for ( const row of typeRows ) {
-          if ( !allTypes || !row.metadata?.ownerReferences ) {
+          if (row.showAsWorkload) {
             out.push(row);
           }
         }
       }
 
       return out;
-    }
+    },
   },
 
   typeDisplay() {

--- a/models/workload.js
+++ b/models/workload.js
@@ -436,4 +436,16 @@ export default {
       return { toSave, toRemove };
     };
   },
+
+  showAsWorkload() {
+    let kindCount = 0;
+
+    if (this.metadata?.ownerReferences) {
+      for (const owner of this.metadata.ownerReferences) {
+        kindCount += Object.values(WORKLOAD_TYPES).flatMap(type => type.includes(owner.kind.toLowerCase())).length;
+      }
+    }
+
+    return !!kindCount;
+  },
 };


### PR DESCRIPTION
This helps fix part of https://github.com/rancher/rancher/issues/31286

This allows ReplicaSets controlled by Argo rollouts to appear in the Overview section