### PR TITLE
use listening port field for nodeport

### DIFF
--- a/models/workload.js
+++ b/models/workload.js
@@ -365,7 +365,7 @@ export default {
       }
 
       ports.forEach((port) => {
-        const name = port.name ? `${ port.name }` : `${ port.containerPort }${ port.protocol.toLowerCase() }${ port.hostPort || port._lbPort || '' }`;
+        const name = port.name ? `${ port.name }` : `${ port.containerPort }${ port.protocol.toLowerCase() }${ port.hostPort || port._listeningPort || '' }`;
 
         port.name = name;
         const portSpec = {
@@ -374,15 +374,21 @@ export default {
 
         if (port._serviceType && port._serviceType !== '') {
           clusterIP.spec.ports.push(portSpec);
-
           switch (port._serviceType) {
-          case 'NodePort':
-            nodePort.spec.ports.push(portSpec);
-            break;
+          case 'NodePort': {
+            const npPort = clone(portSpec);
+
+            if (port._listeningPort) {
+              npPort.nodePort = port._listeningPort;
+            }
+            nodePort.spec.ports.push(npPort);
+            break; }
           case 'LoadBalancer': {
             const lbPort = clone(portSpec);
 
-            lbPort.port = port._lbPort;
+            if (port._listeningPort) {
+              lbPort.port = port._listeningPort;
+            }
             loadBalancer.spec.ports.push(lbPort);
             break; }
           default:


### PR DESCRIPTION
[1728](https://github.com/rancher/dashboard/issues/1728#issuecomment-777921220) - updated workload container port NodePort type rows to be more consistent with the Ember UI, where nodeport rows have a 'listening port' input which corresponds to the services ports' nodePort field:
![Screen Shot 2021-02-16 at 9 26 03 AM](https://user-images.githubusercontent.com/42977925/108091562-11434480-7039-11eb-866e-30449dea7a23.png)

![Screen Shot 2021-02-16 at 9 26 25 AM](https://user-images.githubusercontent.com/42977925/108091556-10aaae00-7039-11eb-802f-881f889ac5fa.png)

![Screen Shot 2021-02-16 at 10 48 12 AM](https://user-images.githubusercontent.com/42977925/108101631-b9123f80-7044-11eb-998d-48863e2680e9.png)
![Screen Shot 2021-02-16 at 10 49 45 AM](https://user-images.githubusercontent.com/42977925/108101635-bb749980-7044-11eb-8671-717ab7630144.png)