### PR TITLE
Improve presentation of locale menu

### DIFF
--- a/components/nav/Footer.vue
+++ b/components/nav/Footer.vue
@@ -83,22 +83,24 @@ export default {
 
     <div class="space" />
 
-    <div v-if="showLocale">
+    <div v-if="showLocale" class="locale-selector">
       <v-popover
         placement="top"
         trigger="click"
+        :container="false"
       >
-        <a>
+        <a class="hand">
           {{ selectedLocaleLabel }}
         </a>
 
         <template slot="popover">
           <ul class="list-unstyled dropdown" style="margin: -1px;">
-            <li v-if="showNone" v-t="'locale.none'" class="p-10 hand" @click="switchLocale('none')" />
+            <li v-if="showNone" v-close-popover="true" v-t="'locale.none'" class="hand" @click="switchLocale('none')" />
             <li
               v-for="(value, name) in availableLocales"
               :key="name"
-              class="p-10 hand"
+              v-close-popover="true"
+              class="hand"
               @click="switchLocale(name)"
             >
               {{ value }}
@@ -123,6 +125,31 @@ export default {
 
       &.space {
         flex-grow: 1;
+      }
+    }
+
+    .locale-selector {
+
+      ::v-deep .popover-inner {
+        padding: 10px 0;
+      }
+
+      ::v-deep .popover-arrow {
+        display: none;
+      }
+
+      ::v-deep .popover:focus {
+        outline: 0;
+      }
+
+      li {
+        padding: 0 20px;
+
+        &:hover {
+          background-color: var(--dropdown-hover-bg);
+          color: var(--dropdown-hover-text);
+          text-decoration: none;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR improves the presentation of the locale selector menu, making it more consistent with the UI, specifically:

- Add pointer cursor when hovering over the locale in the right of the footer
- Remove the arrow in the dropdown (which was the wrong colour)
- Apply a hover state to menu items that is consistent with other menus
- Close the menu when an option is selected

![Locale_Menu](https://user-images.githubusercontent.com/1955897/108179937-17e7bf80-70fe-11eb-9f93-051c4d923327.png)
