### PR TITLE
Improve product menu drop down behaviour

### DIFF
--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -349,16 +349,6 @@ header .vs-select .vs__dropdown-toggle {
   background: red !important;
 }
 
-header {
-  .unlabeled-select {
-    padding: 0;
-
-    &.focused {
-      border: 0;
-    }
-  }
-}
-
 .vs__no-options {
   padding: 3px 20px;
 }

--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -349,6 +349,16 @@ header .vs-select .vs__dropdown-toggle {
   background: red !important;
 }
 
+header {
+  .unlabeled-select {
+    padding: 0;
+
+    &.focused {
+      border: 0;
+    }
+  }
+}
+
 .vs__no-options {
   padding: 3px 20px;
 }

--- a/components/form/Select.vue
+++ b/components/form/Select.vue
@@ -171,7 +171,6 @@ export default {
       taggable: $attrs.taggable,
       taggable: $attrs.multiple,
     }"
-    @click="focusSearch"
     @focus="focusSearch"
   >
     <v-select
@@ -214,6 +213,14 @@ export default {
 <style lang="scss" scoped>
   .unlabeled-select {
     position: relative;
+
+    ::v-deep .vs__selected-options {
+      display: flex;
+
+      .vs__selected {
+          width: 100%;
+      }
+    }
 
     @include input-status-color;
   }

--- a/components/nav/ProductSwitcher.vue
+++ b/components/nav/ProductSwitcher.vue
@@ -246,6 +246,10 @@ export default {
   min-height: 50px;
   border: 0;
 
+  &.focused {
+    box-shadow: none;
+  }
+
   .v-select {
     &.vs--disabled .vs__actions {
       display: none;
@@ -268,7 +272,7 @@ export default {
 
     .vs__selected {
       user-select: none;
-      cursor: default;
+      cursor: pointer;
       color: white;
       line-height: calc(var(--header-height) - 7px);
       position: relative;


### PR DESCRIPTION
This PR tweaks the product menu:

- Removes the drop-shadow which currently causes a misaligned grey border when the dropdown is open:
![ProductMenu](https://user-images.githubusercontent.com/1955897/108197826-cac21880-7112-11eb-9e46-cac908982c47.png)
- Updates the behaviour, so that clicking on the select, correctly toggles the display of the dropdown - currently when the dropdown is visible, clicking on the select again, causes the menu to hide then show again - this PR changes that so it will hide when clicked subsequently.