### PR TITLE
Add polyfill for String.replaceAll

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+
 import { STANDARD } from './config/private-label';
 import { directiveSsr as t } from './plugins/i18n';
 import { trimWhitespaceSsr as trimWhitespace } from './plugins/trim-whitespace';
@@ -288,6 +289,7 @@ module.exports = {
     { src: '~/plugins/extend-router' },
     { src: '~/plugins/lookup', ssr: false },
     { src: '~/plugins/nuxt-client-init', ssr: false },
+    '~/plugins/replaceall',
   ],
 
   // Proxy: https://github.com/nuxt-community/proxy-module#options

--- a/plugins/replaceall.js
+++ b/plugins/replaceall.js
@@ -1,0 +1,19 @@
+/**
+ * String.prototype.replaceAll() polyfill
+ * https://gomakethings.com/how-to-replace-a-section-of-a-string-with-another-one-with-vanilla-js/
+ * @author Chris Ferdinandi
+ * @license MIT
+ */
+/* eslint-disable no-extend-native */
+if (!String.prototype.replaceAll) {
+  String.prototype.replaceAll = function(str, newStr) {
+    // If a regex pattern
+    if (Object.prototype.toString.call(str).toLowerCase() === '[object regexp]') {
+      return this.replace(str, newStr);
+    }
+
+    // If a string
+    return this.replace(new RegExp(str, 'g'), newStr);
+  };
+}
+/* eslint-enable no-extend-native */


### PR DESCRIPTION
#2326 

This PR fixes the issue creating certain logging resource types - this code uses String.replaceAll, which was only added to Chrome in version 85 (Aug 2020).

I've brought in a polyfill for String.replaceAll to use for older browsers which don't support this natively.