### PR TITLE
Enable models to override their cleanForNew method

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -1,5 +1,4 @@
 <script>
-import { cleanForNew } from '@/plugins/steve/normalize';
 import CreateEditView from '@/mixins/create-edit-view/impl';
 import Loading from '@/components/Loading';
 import ResourceYaml from '@/components/ResourceYaml';
@@ -136,7 +135,7 @@ export default {
       }
 
       if ( realMode === _CLONE || realMode === _STAGE ) {
-        cleanForNew(model);
+        model.cleanForNew();
         yaml = model.cleanYaml(yaml, realMode);
       }
     }

--- a/models/constraints.gatekeeper.sh.constraint.js
+++ b/models/constraints.gatekeeper.sh.constraint.js
@@ -1,4 +1,5 @@
 import jsyaml from 'js-yaml';
+import { cleanForNew } from '@/plugins/steve/normalize';
 
 export const ENFORCEMENT_ACTION_VALUES = {
   DENY:   'deny',
@@ -20,6 +21,15 @@ export default {
       constraint.metadata = this.metadata;
 
       await constraint.save();
+    };
+  },
+
+  cleanForNew() {
+    return () => {
+      cleanForNew(this);
+      if (this.constraint) {
+        delete this.constraint;
+      }
     };
   },
 

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -1137,6 +1137,12 @@ export default {
     };
   },
 
+  cleanForNew() {
+    return () => {
+      cleanForNew(this);
+    };
+  },
+
   yamlForSave() {
     return (yaml) => {
       try {


### PR DESCRIPTION
Constraints were failing to clone because cleanForNew didn't remove `this.constraint` which casued the save method to attempt to save the existing constraint instead of creating a new constraint.

This enables models to be able to create their own cleanForNew method to remove custom props if necessary.

rancher/dashboard#2341