### PR TITLE
Fix for bug where node with no images shows error page

### DIFF
--- a/detail/node.vue
+++ b/detail/node.vue
@@ -106,7 +106,8 @@ export default {
     },
 
     imageTableRows() {
-      return this.value.status.images.map(image => ({
+      const images = this.value.status.images || [];
+      return images.map(image => ({
         // image.names[1] typically has the user friendly name but on occasion there's only one name and we should use that
         name:      image.names[1] || image.names[0],
         sizeBytes: image.sizeBytes

--- a/detail/node.vue
+++ b/detail/node.vue
@@ -107,6 +107,7 @@ export default {
 
     imageTableRows() {
       const images = this.value.status.images || [];
+
       return images.map(image => ({
         // image.names[1] typically has the user friendly name but on occasion there's only one name and we should use that
         name:      image.names[1] || image.names[0],


### PR DESCRIPTION
#2350 

It looks like a node with no images (e.g. the local node on fresh install) causes the node detail page not to load - we try and map an undefined - this PR is a trivial fix for this case.