### PR TITLE
Fix for missing Internal and External IPs on node detail page

### DIFF
--- a/components/formatter/CopyToClipboard.vue
+++ b/components/formatter/CopyToClipboard.vue
@@ -1,0 +1,18 @@
+<script>
+import CopyToClipboardText from '@/components/CopyToClipboardText';
+
+export default {
+  components: { CopyToClipboardText },
+
+  props: {
+    value: {
+      type:    String,
+      default: ''
+    },
+  }
+};
+</script>
+
+<template>
+  <CopyToClipboardText :text="value" />
+</template>

--- a/models/node.js
+++ b/models/node.js
@@ -238,7 +238,7 @@ export default {
     if (this.internalIp) {
       details.unshift({
         label:         this.t('node.detail.detailTop.internalIP'),
-        formatter:     'CopyToClipboardText',
+        formatter:     'CopyToClipboard',
         content:       this.internalIp
       });
     }
@@ -246,7 +246,7 @@ export default {
     if (this.externalIp) {
       details.unshift({
         label:         this.t('node.detail.detailTop.externalIP'),
-        formatter:     'CopyToClipboardText',
+        formatter:     'CopyToClipboard',
         content:       this.externalIp
       });
     }


### PR DESCRIPTION
#2352 

We have a formatter 'CopyToClipboardText' that does not exist, leading to the console error message and also to the missing internal and external IPs from the node detail view.

This PR adds a formatter that wraps the CopyToClipboardText component and fixes this issue.