### PR TITLE
Fix issue where default scan profile not set for rke cluster

### DIFF
--- a/edit/cis.cattle.io.clusterscan.vue
+++ b/edit/cis.cattle.io.clusterscan.vue
@@ -119,7 +119,7 @@ export default {
 
         if (name.includes(':')) {
           const pairs = name.split('\n');
-          const clusterVersion = this.currentCluster.kubernetesVersionDisplay;
+          const clusterVersion = this.currentCluster.kubernetesVersion;
 
           pairs.forEach((pair) => {
             const version = (pair.match(/[<>=]+[-._a-zA-Z0-9]+/) || [])[0];


### PR DESCRIPTION
#2348 

This PR is a simple fix for this issue - the Kubernetes version for the cluster was not using the correct property name.

I've validated using a local RKE cluster that this is an issue and that this PR fixes it.