### PR TITLE
Fix incorrect scaleTargetRef in HPAs

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -893,6 +893,7 @@ hpa:
     labels: Labels
     metrics: Metrics
     workload: Workload
+    target: Target
   types:
     cpu: CPU
     memory: Memory
@@ -901,7 +902,7 @@ hpa:
     last: Last Scale Time
     max: Maximum Replicas
     min: Minimum Replicas
-    target: Target Workload
+    targetReference: Target Reference
 
 import:
   title: Import YAML
@@ -1575,13 +1576,13 @@ persistentVolume:
       placeholder: e.g. volume1
   azureFile:
     label: Azure Filesystem
-    shareName: 
+    shareName:
       label: Share Name
       placeholder: e.g. abc
     secretName:
       label: Secret Name
       placeholder: e.g. secret
-    secretNamespace: 
+    secretNamespace:
       label: Secret Namespace
       placeholder: e.g. default
   azureDisk:
@@ -1607,7 +1608,7 @@ persistentVolume:
       placeholder: e.g. ext4
     readOnly:
       label: Read Only
-  
+
 
 persistentVolumeClaim:
   accessModes: Access Modes
@@ -1822,17 +1823,17 @@ rbac:
     tabs:
       resources: Grant Resources
     subtypes:
-      GLOBAL: 
+      GLOBAL:
         label: Global
         abbreviation: G
         yes: "Yes: Default role for new users"
         defaultLabel: New User Default
-      CLUSTER: 
+      CLUSTER:
         label: Cluster
         abbreviation: C
         yes: "Yes: Default role for new cluster creation"
         defaultLabel: Cluster Creator Default
-      NAMESPACE: 
+      NAMESPACE:
         label: Project/Namespace
         abbreviation: PN
         yes: "Yes: Default role for new project creation"
@@ -2288,10 +2289,10 @@ storageClass:
     storagePolicyName:
       label: Storage Policy Name
       placeholder: e.g. gold
-    datastore: 
+    datastore:
       label: Datastore
       placeholder: e.g. VSANDatastore
-    hostFailuresToTolerate: 
+    hostFailuresToTolerate:
       label: Host Failures To Tolerate
       placeholder: e.g. 2
     cacheReservation:

--- a/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -19,8 +19,6 @@ import find from 'lodash/find';
 import endsWith from 'lodash/endsWith';
 
 const RESOURCE_METRICS_API_GROUP = 'metrics.k8s.io';
-const OBJECT_REFERENCE =
-  'io.k8s.api.autoscaling.v1.crossversionobjectreference';
 
 export default {
   name: 'CruHPA',
@@ -98,15 +96,22 @@ export default {
   },
 
   methods: {
+    setTarget(target) {
+      const { apiVersion, kind, name } = target;
+
+      this.value.spec.scaleTargetRef.name = name;
+      this.value.spec.scaleTargetRef.kind = kind;
+      this.value.spec.scaleTargetRef.apiVersion = apiVersion;
+    },
     initSpec() {
       this.$set(this.value, 'spec', {
         type:           'io.k8s.api.autoscaling.v1.horizontalpodautoscalerspec',
         minReplicas:    1,
         maxReplicas:    10,
         scaleTargetRef: {
-          type: OBJECT_REFERENCE,
-          kind: 'workload',
-          name: '',
+          apiVersion: '',
+          kind:       '',
+          name:       '',
         },
         metrics: [{ ...this.defaultResourceMetric }],
       });
@@ -140,16 +145,16 @@ export default {
       <NameNsDescription v-if="!isView" :value="value" :mode="mode" />
 
       <Tabbed :side-tabs="true">
-        <Tab name="workload" :label="t('hpa.tabs.workload')" :weight="10">
+        <Tab name="target" :label="t('hpa.tabs.target')" :weight="10">
           <div class="row mb-20">
             <div class="col span-6">
               <LabeledSelect
-                v-model="value.spec.scaleTargetRef.name"
+                :value="value.spec.scaleTargetRef.name"
                 option-label="metadata.name"
-                :reduce="(workload) => workload.metadata.name"
                 :mode="mode"
-                :label="t('hpa.workloadTab.target')"
+                :label="t('hpa.workloadTab.targetReference')"
                 :options="allWorkloadsFiltered"
+                @input="setTarget"
               />
             </div>
           </div>

--- a/edit/autoscaling.horizontalpodautoscaler/resource-metric.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/resource-metric.vue
@@ -5,7 +5,7 @@ import MetricTarget from '@/edit/autoscaling.horizontalpodautoscaler/metric-targ
 export const DEFAULT_RESOURCE_METRIC = {
   type:     'Resource',
   resource: {
-    name:   'CPU',
+    name:   'cpu',
     target: {
       type:               'Utilization',
       averageUtilization: 50,


### PR DESCRIPTION
The scaleTargetRef object on the HPA was incorrect. I didn't understand that the `apiVersion` is the actual api version of the referent object and that `kind` had to match the referent kind. The Ember UI only sets it statically I believe and this goofed me up.  
Also changed the default value for resource.name in `DEFAULT_RESOURCE_METRIC` to lower cased as is expected by the API. I doubled checked the other types of metric types and those defaults all seem to be okay based on my understanding of the docs. 
Made a minor change to the translation so it doesn't reference `Target Workload` as we can have multiple types of targets. Trimmed some spaces on translations. 


rancher/dashboard#2187

Easy way to test is to run the `rancher/hello-world` app as deployment. When that is up, create an HPA with `hello-world` as the target. The default values should fine as this includes a CPU utilization metric. 