### PR TITLE
Support requests-cpu & memory chart annotations (#1849)

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -471,6 +471,11 @@ catalog:
       goToUpgrade: Edit/Upgrade
     appReadmeGeneric: This chart doesn't have a Rancher-specific README.  Review the Helm README to learn more about the available configuration options and their usage.
     chart: Chart
+    error:
+      requiresFound: '<a href="{url}">${name}</a> must be installed before you can install this chart.'
+      requiresMissing: 'This chart requires another chart that provides {name}, but none was was found.'
+      insufficientCpu: 'This chart requires {need, number} CPU cores, but this cluster only has {have, number} available.'
+      insufficientMemory: 'This chart requires {need} of memory, but this cluster only has {have} available.'
     header:
       install: 'Install {name}'
       installGeneric: Install Chart

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -45,6 +45,8 @@ export const CATALOG = {
   AUTO_INSTALL_GVK: 'catalog.cattle.io/auto-install-gvr',
   AUTO_INSTALL:     'catalog.cattle.io/auto-install',
   HIDDEN:           'catalog.cattle.io/hidden',
+  REQUESTS_CPU:     'catalog.cattle.io/requests-cpu',
+  REQUESTS_MEMORY:  'catalog.cattle.io/requests-memory',
 
   SCOPE:            'catalog.cattle.io/scope',
   _MANAGEMENT:      'management',

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -1,6 +1,7 @@
 import { CATALOG } from '@/config/labels-annotations';
 import { FLEET } from '@/config/types';
 import { insertAt } from '@/utils/array';
+import { parseSi } from '@/utils/units';
 
 export default {
   _availableActions() {
@@ -89,4 +90,26 @@ export default {
       }
     };
   },
+
+  availableCpu() {
+    const reserved = parseSi(this.status.requested?.cpu);
+    const allocatable = parseSi(this.status.allocatable?.cpu);
+
+    if ( allocatable > 0 && reserved >= 0 ) {
+      return Math.max(0, allocatable - reserved);
+    } else {
+      return null;
+    }
+  },
+
+  availableMemory() {
+    const reserved = parseSi(this.status.requested?.memory);
+    const allocatable = parseSi(this.status.allocatable?.memory);
+
+    if ( allocatable > 0 && reserved >= 0 ) {
+      return Math.max(0, allocatable - reserved);
+    } else {
+      return null;
+    }
+  }
 };

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -29,6 +29,7 @@ import { clone, diff, get, set } from '@/utils/object';
 import { findBy, insertAt } from '@/utils/array';
 import ChildHook, { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
 import sortBy from 'lodash/sortBy';
+import { formatSi, parseSi } from '@/utils/units';
 
 export default {
   name: 'Install',
@@ -210,15 +211,36 @@ export default {
         }).href;
 
         if ( provider ) {
-          this.requires.push(`<a href="${ url }">${ provider.name }</a> must be installed before you can install this chart.`);
+          this.requires.push(this.t('catalog.install.error.requiresFound', {
+            url,
+            name: provider.name
+          }, true));
         } else {
-          this.warnings.push(`This chart requires another chart that provides ${ gvr }, but none was was found`);
+          this.requires.push(this.t('catalog.install.error.requiresMissing', { name: gvr }));
         }
       }
     }
 
-    // const updateValues = (this.existing && !this.chartValues) ||
-    // (!this.existing && (!this.loadedVersion || this.loadedVersion !== this.version.key) );
+    const needCpu = parseSi(this.version?.annotations?.[CATALOG_ANNOTATIONS.REQUESTS_CPU] || '0');
+    const needMemory = parseSi(this.version?.annotations?.[CATALOG_ANNOTATIONS.REQUESTS_MEMORY] || '0');
+
+    // Note: These are null if unknown
+    const availableCpu = this.currentCluster.availableCpu;
+    const availableMemory = this.currentCluster.availableMemory;
+
+    if ( availableCpu !== null && availableCpu < needCpu ) {
+      this.warnings.push(this.t('catalog.install.error.insufficientCpu', {
+        need: Math.round(needCpu * 100) / 100,
+        have: Math.round(availableCpu * 100) / 100,
+      }));
+    }
+
+    if ( availableMemory !== null && availableMemory < needMemory ) {
+      this.warnings.push(this.t('catalog.install.error.insufficientCpu', {
+        need: formatSi(needMemory, { increment: 1024, suffix: 'B' }),
+        have: formatSi(availableMemory, { increment: 1024, suffix: 'B' }),
+      }));
+    }
 
     if ( !this.loadedVersion || this.loadedVersion !== this.version.key ) {
       let userValues;


### PR DESCRIPTION
#1849 

Support looking for the `catalog.cattle.io/requests-cpu` and `-memory` annotations on charts and prevent installation if there is less than that much available on the cluster.

![image](https://user-images.githubusercontent.com/753917/108576101-8d5bb780-72d9-11eb-93cc-ee6e06d1fe1d.png)