### PR TITLE
Fix issue where external IP address is not shown

### DIFF
--- a/components/PercentageBar.vue
+++ b/components/PercentageBar.vue
@@ -65,7 +65,7 @@ export default {
 <template>
   <span class="percentage-bar">
     <Bar :percentage="value" :primary-color="primaryColor" />
-    <span v-if="showPercentage" class="ml-5">{{ formattedPercentage }}</span>
+    <span v-if="showPercentage" class="ml-5 percentage-label">{{ formattedPercentage }}</span>
   </span>
 </template>
 
@@ -73,5 +73,8 @@ export default {
 .percentage-bar {
   display: flex;
   flex-direction: row;
+}
+.percentage-label {
+  word-break: keep-all;
 }
 </style>

--- a/components/formatter/InternalExternalIP.vue
+++ b/components/formatter/InternalExternalIP.vue
@@ -10,13 +10,8 @@ export default {
       required: true
     },
   },
-  computed: {
-    showBoth() {
-      return this.row.internalIp !== this.row.externalIp;
-    },
-    ...mapGetters({ t: 'i18n/t' })
-  },
-  methods: {
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
+  methods:  {
     isIp(ip) {
       return ip && (isV4Format(ip) || isV6Format(ip));
     }
@@ -33,7 +28,7 @@ export default {
       {{ t('generic.none') }}
     </template>
 
-    <template v-if="showBoth">
+    <template>
       <template v-if="isIp(row.internalIp)">
         / {{ row.internalIp }} <CopyToClipboard label-as="tooltip" :text="row.internalIp" class="icon-btn" action-color="bg-transparent" />
       </template>


### PR DESCRIPTION
#795 

This PR addresses the issue above - we are currently hiding the Internal IP if it is the same as the External IP - for consistency and clarity it is probably best to always show it in this case - this PR makes this change.

I also tweaked the formatting of the percentage formatter, so that the label shown after the bar does not work wrap.