### PR TITLE
workload details pod list update

### DIFF
--- a/plugins/steve/subscribe.js
+++ b/plugins/steve/subscribe.js
@@ -360,7 +360,7 @@ export const actions = {
       return;
     }
 
-    // console.debug(`Create Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
+    // console.log(`Create Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
 
     state.queue.push({
       action: 'dispatch',
@@ -374,7 +374,7 @@ export const actions = {
       return;
     }
 
-    // console.debug(`Change Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
+    // console.log(`Change Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
 
     state.queue.push({
       action: 'dispatch',
@@ -390,7 +390,7 @@ export const actions = {
       return;
     }
 
-    // console.debug(`Remove Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
+    // console.log(`Remove Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
 
     const obj = getters.byId(data.type, data.id);
 


### PR DESCRIPTION
#1940 - updating the logic around cron job details to get jobs from `metadata.relationships` rather than `status` + fetching jobs on initial page load seems to address this 
#2218 - Switching to a 'matching' getter in computed prop instead of 'findMatching' action in a resource instance method returns a live list of pods here

This PR also addresses a couple issues around editing/cloning cron jobs I encountered in the process.