### PR TITLE
Fix `Create` on custom create resource pages after page refresh

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -105,7 +105,8 @@ export default {
       }
 
       originalModel = await store.dispatch(`${ inStore }/create`, data);
-      model = originalModel;
+      // Dissassociate the original model & model. This fixes `Create` after refreshing page with SSR on
+      model = await store.dispatch(`${ inStore }/clone`, { resource: originalModel });
 
       if ( as === _YAML ) {
         yaml = createYaml(schemas, resource, data);


### PR DESCRIPTION
- On pressing `Create` on, for example, a new HPA, get 'not a function' error
- Only an issue for create (not edit), with SSR and on refresh (nav to create page works fine, think this bypasses ssr)
- Caused by ResourceDetail `value` object not being a proxy
- Looks like `__rehydrate` was stripped from both `originalModel` and `value` by delete obj.__rehydrate in `plugins/steve/index.js`
- These were previously the same instance, the fix is to help break this (as per edit mode) with a `clone`
- Not sure how this reference is carried across server/client boundary. Possibly a case of cached with the same key
- Addresses rancher/dashboard#2369

> Note for QA - SSR is not enabled in production and therefore this would not be reproducible. Would suggest testing that the change has not broken existing functionality by running through issue as described in #2369