### PR TITLE
Init Service Selector Matching Pods

### DIFF
--- a/edit/service.vue
+++ b/edit/service.vue
@@ -205,7 +205,7 @@ export default {
         const inStore = this.$store.getters['currentProduct'].inStore;
 
         this.allPods = await this.$store.dispatch(`${ inStore }/findAll`, { type: POD });
-        this.matchingPods.total = this.allPods.length;
+        this.updateMatchingPods();
       } catch (e) { }
     },
 


### PR DESCRIPTION
On service edit, after we fetch all the pods we should have been calling the update function to initialize the matching pods correctly rather than rely on the observer. 

rancher/dashboard#717