### PR TITLE
Resolving an issue where endpoints werent editable in azure ad auth config

### DIFF
--- a/edit/auth/azuread.vue
+++ b/edit/auth/azuread.vue
@@ -99,7 +99,9 @@ export default {
     },
 
     tenantId() {
-      this.setEndpoints(this.endpoint);
+      if (this.endpoint !== 'custom') {
+        this.setEndpoints(this.endpoint);
+      }
     },
 
     model: {
@@ -107,7 +109,9 @@ export default {
       handler() {
         this.model.accessMode = this.model.accessMode || 'unrestricted';
         this.model.rancherUrl = this.model.rancherUrl || this.replyUrl;
-        this.setEndpoints(this.endpoint);
+        if (this.endpoint !== 'custom') {
+          this.setEndpoints(this.endpoint);
+        }
 
         if (this.model.applicationSecret) {
           this.$set(this, 'applicationSecret', this.model.applicationSecret);
@@ -119,7 +123,7 @@ export default {
   methods: {
     setEndpoints(endpoint) {
       Object.keys(ENDPOINT_MAPPING[endpoint]).forEach((key) => {
-        this.model[key] = ENDPOINT_MAPPING[endpoint][key].replace(TENANT_ID_TOKEN, this.model.tenantId);
+        this.$set(this.model, key, ENDPOINT_MAPPING[endpoint][key].replace(TENANT_ID_TOKEN, this.model.tenantId));
       });
     },
   },


### PR DESCRIPTION
setEndpoints() was getting called for every keystroke which effectively overwrote what was entered.

rancher/dashboard#2349

![image](https://user-images.githubusercontent.com/55104481/108824803-61616000-757f-11eb-8a0e-958c7dd2f34f.png)
