### PR TITLE
Fix for typo in auth config and add header label for users/groups

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -113,7 +113,7 @@ suffix:
 authConfig:
   accessMode:
     label: 'Configure who should be able to login and use {vendor}'
-    required: Restrict access to only the auhorized users & groups
+    required: Restrict access to only the authorized users & groups
     restricted: 'Allow members of clusters and projects, plus authorized users & groups'
     unrestricted: Allow any valid user
   allowedPrincipalIds:

--- a/components/auth/AllowedPrincipals.vue
+++ b/components/auth/AllowedPrincipals.vue
@@ -76,7 +76,7 @@ export default {
         />
       </div>
       <div class="col span-6">
-        <h4 v-if="accessMode!=='unrestricted'" class="mb-20"><t k="authConfig.allowedPrincipalIds.title" :raw="true" /></h4>
+        <h4 v-if="accessMode!=='unrestricted'"><t k="authConfig.allowedPrincipalIds.title" :raw="true" /></h4>
         <ArrayList
           v-if="accessMode!=='unrestricted'"
           key="allowedPrincipalIds"

--- a/components/auth/AllowedPrincipals.vue
+++ b/components/auth/AllowedPrincipals.vue
@@ -76,7 +76,7 @@ export default {
         />
       </div>
       <div class="col span-6">
-        <h4 v-if="accessMode!=='unrestricted'" class="mb-20"><t k="authConfig.allowedPrincipalIds.title'" :raw="true" /></h4>
+        <h4 v-if="accessMode!=='unrestricted'" class="mb-20"><t k="authConfig.allowedPrincipalIds.title" :raw="true" /></h4>
         <ArrayList
           v-if="accessMode!=='unrestricted'"
           key="allowedPrincipalIds"

--- a/components/auth/AllowedPrincipals.vue
+++ b/components/auth/AllowedPrincipals.vue
@@ -77,7 +77,7 @@ export default {
       </div>
       <div class="col span-6">
         <h4 v-if="accessMode!=='unrestricted'">
-           <t k="authConfig.allowedPrincipalIds.title" :raw="true" />
+          <t k="authConfig.allowedPrincipalIds.title" :raw="true" />
         </h4>
         <ArrayList
           v-if="accessMode!=='unrestricted'"

--- a/components/auth/AllowedPrincipals.vue
+++ b/components/auth/AllowedPrincipals.vue
@@ -76,7 +76,9 @@ export default {
         />
       </div>
       <div class="col span-6">
-        <h4 v-if="accessMode!=='unrestricted'"><t k="authConfig.allowedPrincipalIds.title" :raw="true" /></h4>
+        <h4 v-if="accessMode!=='unrestricted'">
+           <t k="authConfig.allowedPrincipalIds.title" :raw="true" />
+        </h4>
         <ArrayList
           v-if="accessMode!=='unrestricted'"
           key="allowedPrincipalIds"

--- a/components/auth/AllowedPrincipals.vue
+++ b/components/auth/AllowedPrincipals.vue
@@ -76,6 +76,7 @@ export default {
         />
       </div>
       <div class="col span-6">
+        <h4 v-if="accessMode!=='unrestricted'" class="mb-20"><t k="authConfig.allowedPrincipalIds.title'" :raw="true" /></h4>
         <ArrayList
           v-if="accessMode!=='unrestricted'"
           key="allowedPrincipalIds"


### PR DESCRIPTION
#2384 

This PR fixes the typo 'auhorized' and adds a title about the chooser for user & groups.

![Fix](https://user-images.githubusercontent.com/1955897/108837467-318b7a00-75ca-11eb-8ecd-c8a4ddff1e2d.png)
