### PR TITLE
Fix: Clicking on a PVC results in page error

### DIFF
--- a/components/RelatedWorkloadsTable.vue
+++ b/components/RelatedWorkloadsTable.vue
@@ -2,7 +2,7 @@
 import {
   STATE, NAME, WORKLOAD_IMAGES, WORKLOAD_ENDPOINTS, TYPE, AGE
 } from '@/config/table-headers';
-import { WORKLOAD_TYPES, WORKLOAD } from '@/config/types';
+import { WORKLOAD_TYPES } from '@/config/types';
 import ResourceTable from '@/components/ResourceTable';
 
 export default {
@@ -33,7 +33,7 @@ export default {
     return {
       relatedWorkloadRows: [],
       relatedWorkloadHeaders,
-      schema:              this.$store.getters['cluster/schemaFor'](WORKLOAD.DEPLOYMENT)
+      schema:              this.$store.getters['cluster/schemaFor'](WORKLOAD_TYPES.DEPLOYMENT)
     };
   },
 };

--- a/components/ResourceTable.vue
+++ b/components/ResourceTable.vue
@@ -79,11 +79,13 @@ export default {
     _showBulkActions() {
       if (this.tableActions !== null) {
         return this.tableActions;
-      } else {
+      } else if (this.schema) {
         const hideTableActions = this.$store.getters['type-map/hideBulkActionsFor'](this.schema);
 
         return !hideTableActions;
       }
+
+      return false;
     },
 
     _headers() {


### PR DESCRIPTION
- nav to pvc list, click on a pvc, white page error shown
- caused by new code in ResourceTable requiring the schema & pvc supplies a junk one