### PR TITLE
do not allow removing sole allowed user/group

### DIFF
--- a/assets/styles/global/_button.scss
+++ b/assets/styles/global/_button.scss
@@ -102,13 +102,12 @@ button,
 .btn.disabled,
 .btn[disabled],
 fieldset[disabled] .btn {
-  &:not(.role-link) {
-    @extend .bg-disabled;
-  }
-  
-  @extend .text-disabled;
   cursor: not-allowed;
-  border: solid thin var(--input-disabled-border);
+  color: var(--disabled-text) !important;
+  &:not(.role-link){
+    border: solid thin var(--input-disabled-border);
+    background-color: var(--disabled-bg) !important;
+  }
 }
 
 .btn-group {

--- a/components/auth/AllowedPrincipals.vue
+++ b/components/auth/AllowedPrincipals.vue
@@ -91,6 +91,12 @@ export default {
             <Principal :key="row.value" :value="row.value" />
           </template>
 
+          <template v-if="authConfig.allowedPrincipalIds.length <= 1" #remove-button>
+            <button type="button" disabled class="btn role-link bg-transparent">
+              {{ t('generic.remove') }}
+            </button>
+          </template>
+
           <template #add>
             <SelectPrincipal :mode="mode" @add="addPrincipal" />
           </template>

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -160,7 +160,7 @@ export default {
       padding: 0 5px;
     }
 
-    ::v-deep > div > .btn {
+    ::v-deep > div > .btn.role-tertiary {
       border: 1px solid var(--header-btn-bg);
       background: rgba(0,0,0,.05);
       color: var(--header-btn-text);


### PR DESCRIPTION
#2374 - the Ember UI disables the 'remove' button for a user/group if it is the only one in the list; this PR updates the dashboard ui to do the same. 

@lvuch  I also made a change to `.role-link` disabled button styling because the alignment is always weird compared to the borderess enabled link/button, before/after:
![Screen Shot 2021-02-23 at 8 32 16 AM](https://user-images.githubusercontent.com/42977925/108866893-df3e5f00-75b1-11eb-9c3d-1314f3ee524d.png)
![Screen Shot 2021-02-23 at 8 31 38 AM](https://user-images.githubusercontent.com/42977925/108866896-dfd6f580-75b1-11eb-9d56-be66148ad5ad.png)

![Screen Shot 2021-02-23 at 8 38 44 AM](https://user-images.githubusercontent.com/42977925/108867551-9044f980-75b2-11eb-9496-00ff99601bfa.png)
