### PR TITLE
Fix alignment of cluster count in cluster explorer

### DIFF
--- a/assets/styles/base/_typography.scss
+++ b/assets/styles/base/_typography.scss
@@ -6,7 +6,6 @@ H1, H2, H3, H4, H5, H6 {
   color: var(--body-text);
   font-style: normal;
   font-weight: 400;
-  letter-spacing: 0em;
   margin: 0 0 10px 0;
 }
 
@@ -32,14 +31,12 @@ H5 {
 
 H6 {
   font-size: 12px;
-  letter-spacing: .25em;
   text-transform: uppercase;
 }
 
 P {
   font-weight: 400;
   font-style: normal;
-  letter-spacing: 0em;
   margin: 0;
 }
 

--- a/components/nav/Type.vue
+++ b/components/nav/Type.vue
@@ -133,7 +133,6 @@ export default {
       font-size: 12px;
       text-align: right;
       justify-items: center;
-      line-height: 20px;
     }
   }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -312,7 +312,6 @@ export default {
       H6, .root.child .label {
         margin: 0;
         letter-spacing: 0.1em;
-        line-height: initial;
 
         A { padding-left: 0; }
       }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -311,7 +311,6 @@ export default {
 
       H6, .root.child .label {
         margin: 0;
-        letter-spacing: 0.1em;
 
         A { padding-left: 0; }
       }


### PR DESCRIPTION
- Rely on inheriting parent's (`.child A`) line-height for both label and count
- This removes the different line-height approach between root (user & auth / users) and resource type (cluster explorer / any) side nav items
- This also fixes the `jump to..` list