### PR TITLE
Fixing the type for partitions in two persistent volume providers

### DIFF
--- a/edit/persistentvolume/plugins/awsElasticBlockStore.vue
+++ b/edit/persistentvolume/plugins/awsElasticBlockStore.vue
@@ -32,6 +32,16 @@ export default {
 
     return { readOnlyOptions };
   },
+  computed: {
+    parition: {
+      get() {
+        return this.value.spec.awsElasticBlockStore.partition;
+      },
+      set(value) {
+        this.$set(this.value.spec.awsElasticBlockStore, 'partition', Number.parseInt(value, 10));
+      }
+    }
+  }
 };
 </script>
 
@@ -42,7 +52,7 @@ export default {
         <LabeledInput v-model="value.spec.awsElasticBlockStore.volumeID" :mode="mode" :label="t('persistentVolume.awsElasticBlockStore.volumeId.label')" :placeholder="t('persistentVolume.awsElasticBlockStore.volumeId.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.awsElasticBlockStore.partition" :mode="mode" :label="t('persistentVolume.shared.partition.label')" :placeholder="t('persistentVolume.shared.partition.placeholder')" type="number" />
+        <LabeledInput v-model="parition" :mode="mode" :label="t('persistentVolume.shared.partition.label')" :placeholder="t('persistentVolume.shared.partition.placeholder')" type="number" />
       </div>
     </div>
     <div class="row mb-20">

--- a/edit/persistentvolume/plugins/gcePersistentDisk.vue
+++ b/edit/persistentvolume/plugins/gcePersistentDisk.vue
@@ -32,6 +32,16 @@ export default {
 
     return { readOnlyOptions };
   },
+  computed: {
+    parition: {
+      get() {
+        return this.value.spec.gcePersistentDisk.partition;
+      },
+      set(value) {
+        this.$set(this.value.spec.gcePersistentDisk, 'partition', Number.parseInt(value, 10));
+      }
+    }
+  }
 };
 </script>
 
@@ -42,7 +52,7 @@ export default {
         <LabeledInput v-model="value.spec.gcePersistentDisk.pdName" :mode="mode" :label="t('persistentVolume.gcePersistentDisk.persistentDiskName.label')" :placeholder="t('persistentVolume.gcePersistentDisk.persistentDiskName.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.gcePersistentDisk.partition" :mode="mode" :label="t('persistentVolume.shared.partition.label')" :placeholder="t('persistentVolume.azureFile.secretName.placeholder')" type="number" />
+        <LabeledInput v-model="parition" :mode="mode" :label="t('persistentVolume.shared.partition.label')" :placeholder="t('persistentVolume.azureFile.secretName.placeholder')" type="number" />
       </div>
     </div>
     <div class="row mb-20">


### PR DESCRIPTION
While trying to reproduce another issue I noticed that partitions were of the wrong type when saving. This now converts partition to a number before setting the value.