### PR TITLE
fix azureAD login action

### DIFF
--- a/pages/auth/verify.vue
+++ b/pages/auth/verify.vue
@@ -20,18 +20,23 @@ export default {
   async fetch({ store, route, redirect }) {
     const code = route.query[GITHUB_CODE];
     const state = route.query[GITHUB_NONCE] || '';
-    const isGoogle = state.includes('-googleoauth');
     const isTesting = state.includes('-test');
 
     if (isTesting) {
       return;
     }
+    let provider = 'github';
 
     if (code) {
+      if (state.includes('-googleoauth')) {
+        provider = 'googleoauth';
+      } else if (state.includes('-azuread')) {
+        provider = 'azuread';
+      }
       const res = await store.dispatch('auth/verifyOAuth', {
         code,
-        nonce:    route.query[GITHUB_NONCE],
-        provider: isGoogle ? 'googleoauth' : 'github'
+        nonce: route.query[GITHUB_NONCE],
+        provider
       });
 
       if ( res._status === 200) {

--- a/store/auth.js
+++ b/store/auth.js
@@ -117,6 +117,12 @@ export const actions = {
       redirectUrl = driver.redirectUrl;
     }
 
+    if (provider === 'azuread') {
+      const params = { response_type: 'code', response_mode: 'query' };
+
+      redirectUrl = addParams(redirectUrl, params );
+    }
+
     const nonce = await dispatch('setNonce', opt);
 
     const returnToUrl = returnTo(opt, this);
@@ -180,13 +186,8 @@ export const actions = {
       } else {
       // github, google, azuread
         const res = await driver.doAction('configureTest', body);
-        let { redirectUrl } = res;
+        const { redirectUrl } = res;
 
-        if (provider === 'azuread') {
-          const params = { response_type: 'code', response_mode: 'query' };
-
-          redirectUrl = addParams(redirectUrl, params );
-        }
         const url = await dispatch('redirectTo', {
           provider,
           redirectUrl,


### PR DESCRIPTION
#2340 - This ended up being pretty small, moving the addition of azureAD's redirect url query params response_type and response_mode to `auth/redictTo` (called on enable and login) instead of `auth/test`(only called on enable) + specifying the correct provider in `auth/verifyOAuth` fixes the problem. 