### PR TITLE
Improve styling of radio buttons in view mode

### DIFF
--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -39,7 +39,7 @@ $selected: rgba($primary, .5);
   // value can also be map of default, default-text, hover-text, hover-bg, active-text,  active-bg)
   @include color-variables((
     default:    $light,
-    muted:      $disabled,
+    muted:      $dark,
     link:       (
       default-text: $link,
       hover-text:   lighten($link, 30%),
@@ -283,10 +283,5 @@ $selected: rgba($primary, .5);
 
   --product-icon: #{$darker};
   --product-icon-active: #{$darkest};
-
-  // Make text muted slightly darker so it is readable
-  .text-muted {
-    color: $dark !important;
-  }
 }
 

--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -283,5 +283,10 @@ $selected: rgba($primary, .5);
 
   --product-icon: #{$darker};
   --product-icon-active: #{$darkest};
+
+  // Make text muted slightly darker so it is readable
+  .text-muted {
+    color: $dark !important;
+  }
 }
 

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -45,6 +45,10 @@ export default {
     isDisabled() {
       return this.mode === _VIEW || this.disabled;
     },
+
+    isViewChecked() {
+      return this.mode === _VIEW && this.isChecked;
+    }
   },
 
   watch: {
@@ -99,7 +103,7 @@ export default {
     />
     <label
       v-if="label"
-      :class="[ isDisabled ? 'text-muted' : '', 'radio-label']"
+      :class="[ !isViewChecked ? 'text-muted' : '', 'radio-label']"
       v-html="label"
     >
       <slot name="label">{{ label }}</slot>

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -46,8 +46,9 @@ export default {
       return this.mode === _VIEW || this.disabled;
     },
 
-    isViewChecked() {
-      return this.mode === _VIEW && this.isChecked;
+    muteLabel() {
+      // Don't mute the label if the mode if view and the button is checked
+      return this.disabled && !(this.mode === _VIEW && this.isChecked);
     }
   },
 
@@ -103,7 +104,7 @@ export default {
     />
     <label
       v-if="label"
-      :class="[ !isViewChecked ? 'text-muted' : '', 'radio-label']"
+      :class="[ muteLabel ? 'text-muted' : '', 'radio-label']"
       v-html="label"
     >
       <slot name="label">{{ label }}</slot>


### PR DESCRIPTION
#2410 

In light mode, the `text-muted` style is too light and hard to read against the background - this PR uses a darker color. I added a style override, as I couldn't find an easy way to do this with the way the colors are generated, without affecting more colors used elsewhere.

For Radio Buttons, this PR also changes the style so that the label for a checked radio button in view mode uses the normal color and does not use the disable color - this helps make it much clearer to see which radio button is checked:

![RB](https://user-images.githubusercontent.com/1955897/108984002-5db90080-7687-11eb-950e-bea784ea2c2b.png)


