### PR TITLE
Resolving several minor bugs around persistent volumes

### DIFF
--- a/edit/persistentvolume/index.vue
+++ b/edit/persistentvolume/index.vue
@@ -148,8 +148,8 @@ export default {
       } else {
         const indexOf = this.value.spec.accessModes.indexOf(key);
 
-        if (indexOf) {
-          this.value.spec.accessModes.splice(indexOf);
+        if (indexOf >= 0) {
+          this.value.spec.accessModes.splice(indexOf, 1);
         }
       }
     },
@@ -245,9 +245,9 @@ export default {
         <div class="row mb-20">
           <div class="col span-6">
             <h3>{{ t('persistentVolume.customize.accessModes.label') }}</h3>
-            <div><Checkbox v-model="readWriteOnce" :label="t('persistentVolume.customize.accessModes.readWriteOnce')" /></div>
-            <div><Checkbox v-model="readOnlyMany" :label="t('persistentVolume.customize.accessModes.readOnlyMany')" /></div>
-            <div><Checkbox v-model="readWriteMany" :label="t('persistentVolume.customize.accessModes.readWriteMany')" /></div>
+            <div><Checkbox v-model="readWriteOnce" :label="t('persistentVolume.customize.accessModes.readWriteOnce')" :mode="mode" /></div>
+            <div><Checkbox v-model="readOnlyMany" :label="t('persistentVolume.customize.accessModes.readOnlyMany')" :mode="mode" /></div>
+            <div><Checkbox v-model="readWriteMany" :label="t('persistentVolume.customize.accessModes.readWriteMany')" :mode="mode" /></div>
           </div>
           <div class="col span-6">
             <ArrayList

--- a/models/persistentvolume.js
+++ b/models/persistentvolume.js
@@ -47,5 +47,8 @@ export default {
     const allClaims = this.$rootGetters['cluster/all'](PVC);
 
     return allClaims.find(claim => claim.spec.volumeName === this.name);
-  }
+  },
+  canDelete() {
+    return this.state !== 'bound';
+  },
 };


### PR DESCRIPTION
- The checkboxSetter for access mode was just wrong and didn't handle the index properly
- Passed mode to checkboxes so they're disabled in view
- Made deletion action dependent on not being in a 'bound' state

rancher/dashboard#2409