### PR TITLE
Cluster Switcher Bugs

### DIFF
--- a/assets/styles/global/_select.scss
+++ b/assets/styles/global/_select.scss
@@ -20,7 +20,7 @@
 .unlabeled-select {
   min-width: 75px;
   // line-height: $input-line-height;
-  
+
   .v-select {
     &.inline {
 
@@ -112,10 +112,6 @@
 
     &.inline {
       height: 100%;
-
-      &.vs--unsearchable {
-
-      }
 
       .vs__dropdown-toggle {
         height: 100%;

--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -350,6 +350,7 @@ header .vs-select .vs__dropdown-toggle {
 }
 
 .vs__no-options {
+  color: var(--dropdown-text);
   padding: 3px 20px;
 }
 

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -744,6 +744,10 @@ clusterIndexPage:
       label: Unhealthy Nodes
       noRows: There are no unhealthy nodes to show.
 
+clusterSwitcher:
+  noResults: No Clusters found.
+  search: Start typing to search for a cluster.
+
 configmap:
   tabs:
     data:

--- a/components/nav/ClusterSwitcher.vue
+++ b/components/nav/ClusterSwitcher.vue
@@ -68,6 +68,7 @@ export default {
       :selectable="(option) => option.ready"
       :clearable="false"
       :options="options"
+      :close-on-select="false"
     >
       <template #selected-option="opt">
         <span class="cluster-label-container">
@@ -78,9 +79,9 @@ export default {
         </span>
       </template>
 
-      <template #no-options="{ search, searching }">
+      <template #no-options="{ searching }">
         <template v-if="searching">
-          No clusters found for <em>{{ search }}</em>.
+          No clusters found.
         </template>
         <em v-else class="text-muted">Start typing to search for a cluster.</em>
       </template>

--- a/components/nav/ClusterSwitcher.vue
+++ b/components/nav/ClusterSwitcher.vue
@@ -1,14 +1,16 @@
 <script>
+import { createPopper } from '@popperjs/core';
 import { MANAGEMENT } from '@/config/types';
 import { sortBy } from '@/utils/sort';
 import { findBy } from '@/utils/array';
 import { mapGetters, mapState } from 'vuex';
 import Select from '@/components/form/Select';
+import $ from 'jquery';
 
 export default {
   components: { Select },
 
-  computed:   {
+  computed: {
     ...mapState(['isMultiCluster']),
     ...mapGetters(['currentCluster']),
 
@@ -53,6 +55,51 @@ export default {
     focus() {
       this.$refs.select.focusSearch();
     },
+    withPopper(dropdownList, component, { width }) {
+      /**
+       * We need to explicitly define the dropdown width since
+       * it is usually inherited from the parent with CSS.
+       */
+      const componentWidth = $(component.$parent.$el).width();
+
+      dropdownList.style['min-width'] = `${ componentWidth }px`;
+      dropdownList.style.width = 'min-content';
+      dropdownList.className += ' cluster-switcher-container';
+
+      /**
+       * Here we position the dropdownList relative to the $refs.toggle Element.
+       *
+       * The 'offset' modifier aligns the dropdown so that the $refs.toggle and
+       * the dropdownList overlap by 1 pixel.
+       *
+       * The 'toggleClass' modifier adds a 'drop-up' class to the Vue Select
+       * wrapper so that we can set some styles for when the dropdown is placed
+       * above.
+       */
+      const popper = createPopper(component.$refs.toggle, dropdownList, {
+        placement: 'bottom-end',
+        modifiers: [
+          {
+            name:    'offset',
+            options: { offset: [0, 2] },
+          },
+          {
+            name:    'toggleClass',
+            enabled: true,
+            phase:   'write',
+            fn({ state }) {
+              component.$el.setAttribute('x-placement', state.placement);
+            },
+          },
+        ],
+      });
+
+      /**
+       * To prevent memory leaks Popper needs to be destroyed.
+       * If you return function, it will be called just before dropdown is removed from DOM.
+       */
+      return () => popper.destroy();
+    },
   },
 };
 </script>
@@ -63,16 +110,21 @@ export default {
       ref="select"
       key="cluster"
       v-model="value"
-      :append-to-body="false"
+      :append-to-body="true"
+      :popper-override="withPopper"
+      placement="bottom"
       :searchable="true"
       :selectable="(option) => option.ready"
       :clearable="false"
       :options="options"
-      :close-on-select="false"
     >
       <template #selected-option="opt">
         <span class="cluster-label-container">
-          <img v-if="currentCluster" class="cluster-switcher-os-logo" :src="currentCluster.providerOsLogo" />
+          <img
+            v-if="currentCluster"
+            class="cluster-switcher-os-logo"
+            :src="currentCluster.providerOsLogo"
+          />
           <span class="cluster-label">
             {{ opt.label }}
           </span>
@@ -89,7 +141,11 @@ export default {
       <template #option="opt">
         <span class="dropdown-option">
           <span class="logo">
-            <img v-if="opt.osLogo" class="cluster-switcher-os-logo" :src="opt.osLogo" />
+            <img
+              v-if="opt.osLogo"
+              class="cluster-switcher-os-logo"
+              :src="opt.osLogo"
+            />
           </span>
           <span class="content">
             <b v-if="opt === value">{{ opt.label }}</b>
@@ -109,8 +165,24 @@ export default {
   </div>
 </template>
 
+<style lang="scss">
+// should be outside scoped css, class is dynamic and added by withPopper so scoped + ::v-deep doesn't work
+.cluster-switcher-container {
+  &.vs__dropdown-menu {
+    .vs__dropdown-option {
+      padding: 3px 20px 3px 8px;
+    }
+  }
+}
+</style>
+
 <style lang="scss" scoped>
-.filter {
+.cluster-switcher-os-logo {
+  height: 16px;
+  display: inline-block;
+  vertical-align: middle;
+}
+.cluster-switcher-container {
   .cluster-label-container {
     width: 100%;
     display: grid;
@@ -119,8 +191,13 @@ export default {
     align-content: center;
   }
 
-  .cluster-switcher-os-logo {
-    height: 16px;
+  // matches the padding a layout of the option (and logo/content) to the selected option so it doesn't look off
+  .dropdown-option {
+    display: grid;
+    width: 100%;
+    grid-template-columns: 25px fit-content(100%);
+    align-items: center;
+    align-content: center;
   }
 }
 
@@ -133,18 +210,6 @@ export default {
 
   .vs__selected {
     width: 100%;
-  }
-
-  // matches the padding a layout of the option (and logo/content) to the selected option so it doesn't look off
-  .vs__dropdown-option  {
-    padding: 3px 20px 3px 8px;
-    .dropdown-option {
-      display: grid;
-      width: 100%;
-      grid-template-columns: 25px fit-content(100%);
-      align-items: center;
-      align-content: center;
-    }
   }
 
   &.vs--disabled .vs__actions {


### PR DESCRIPTION
Fixes a light theme issue with the cluster switcher drop down and the no results option where the text color was white on white.
Fixes an issue where a cluster with an extra long name (helps if on a small screen as well) would cause the content of the dropdown to flow off screen. 
Fixes some bare strings in cluster switcher.
Formatted the file. 



rancher/dashboard#2329

![Screen Shot 2021-02-24 at 1 32 48 PM](https://user-images.githubusercontent.com/858614/109062192-dbd7d000-76a4-11eb-80a9-74f03d8702c4.png)
![Screen Shot 2021-02-24 at 1 33 03 PM](https://user-images.githubusercontent.com/858614/109062199-de3a2a00-76a4-11eb-97b8-14f1d42cba0f.png)
