### PR TITLE
hide azuread

### DIFF
--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -113,7 +113,7 @@ export function init(store) {
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/keycloak`, 'auth/saml');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/adfs`, 'auth/saml');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/googleoauth`, 'auth/googleoauth');
-  componentForType(`${ MANAGEMENT.AUTH_CONFIG }/azuread`, 'auth/azuread');
+  // componentForType(`${ MANAGEMENT.AUTH_CONFIG }/azuread`, 'auth/azuread');
 
   basicType([
     'config',

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -62,7 +62,7 @@ export function returnTo(opt, vm) {
  */
 export const authProvidersInfo = async(store) => {
   const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
-  const nonLocal = rows.filter(x => x.name !== 'local');
+  const nonLocal = rows.filter(x => x.name !== 'local' && x.name !== 'azuread');
   const enabled = nonLocal.filter(x => x.enabled === true );
 
   const enabledLocation = enabled.length === 1 ? {


### PR DESCRIPTION
Per slack convo with @vincent99 and @codyrancher it is currently not possible to enable azure AD auth through one UI and login through the other. Given the potential for azureAD as it is now to possibly direct users to misconfigure their auth setup, and the time constraints we are currently under, this PR is to hide azure AD config from the UI for this release. 
- hide the custom edit component
- hide the azureAD option from the auth provider select screen