### PR TITLE
Resolving a number of issues around pv/pvc/storageclass regarding longhorn

### DIFF
--- a/edit/persistentvolume/plugins/csi.vue
+++ b/edit/persistentvolume/plugins/csi.vue
@@ -2,6 +2,7 @@
 import KeyValue from '@/components/form/KeyValue';
 import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';
+import { _CREATE } from '@/config/query-params';
 
 export default {
   components: {
@@ -25,9 +26,12 @@ export default {
       fromBackup:          ''
     };
 
-    this.$set(this.value.spec, 'csi', this.value.spec.csi || {});
-    this.$set(this.value.spec.csi, 'readOnly', this.value.spec.csi.readOnly || false);
-    this.$set(this.value.spec.csi, 'volumeAttributes', this.value.spec.csi.volumeAttributes || defaultVolumeAttributes);
+    if (this.mode === _CREATE) {
+      this.$set(this.value.spec, 'csi', this.value.spec.csi || {});
+      this.$set(this.value.spec.csi, 'driver', 'driver.longhorn.io');
+      this.$set(this.value.spec.csi, 'readOnly', this.value.spec.csi.readOnly || false);
+      this.$set(this.value.spec.csi, 'volumeAttributes', this.value.spec.csi.volumeAttributes || defaultVolumeAttributes);
+    }
 
     const readOnlyOptions = [
       {
@@ -52,7 +56,7 @@ export default {
         <LabeledInput v-model="value.spec.csi.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.csi.volumeHandle" :mode="mode" :label="t('persistentVolume.csi.volumeHandle.label')" :placeholder="t('persistentVolume.csi.volumeHandle.placeholder')" />
+        <LabeledInput v-model="value.spec.csi.volumeHandle" :mode="mode" :label="t('persistentVolume.csi.volumeHandle.label')" :placeholder="t('persistentVolume.csi.volumeHandle.placeholder')" :required="true" />
       </div>
     </div>
     <div class="row mb-20">

--- a/edit/persistentvolumeclaim.vue
+++ b/edit/persistentvolumeclaim.vue
@@ -118,10 +118,8 @@ export default {
         return this.value.spec.volumeName;
       },
       set(value) {
-        const persistentVolume = this.persistentVolumes.find(pv => pv.name === value);
-
         this.$set(this.value.spec, 'volumeName', value);
-        this.$set(this.value.spec, 'storageClassName', persistentVolume.spec.storageClassName);
+        this.$set(this.value.spec, 'storageClassName', '');
       }
     }
   },

--- a/edit/storage.k8s.io.storageclass/index.vue
+++ b/edit/storage.k8s.io.storageclass/index.vue
@@ -88,6 +88,10 @@ export default {
     }
   },
 
+  created() {
+    this.registerBeforeHook(this.willSave, 'willSave');
+  },
+
   methods: {
     getComponent(name) {
       const isCustom = !PROVISIONER_OPTIONS.find(o => o.value === name);
@@ -100,7 +104,15 @@ export default {
       const provisioner = event.labelKey ? event.labelKey : event;
 
       this.$set(this.value, 'provisioner', provisioner);
-    }
+      this.$set(this.value, 'allowVolumeExpansion', provisioner === 'driver.longhorn.io');
+    },
+    willSave() {
+      Object.keys(this.value.parameters).forEach((key) => {
+        if (this.value.parameters[key] === null) {
+          delete this.value.parameters[key];
+        }
+      });
+    },
   }
 };
 </script>
@@ -112,7 +124,7 @@ export default {
     :resource="value"
     :subtypes="[]"
     :validation-passed="true"
-    :errors="[]"
+    :errors="errors"
     @error="e=>errors = e"
     @finish="save"
     @cancel="done"
@@ -159,7 +171,7 @@ export default {
                   v-model="value.allowVolumeExpansion"
                   name="allowVolumeExpansion"
                   :label="t('storageClass.customize.allowVolumeExpansion.label')"
-                  :mode="modeOverride"
+                  :mode="mode"
                   :options="allowVolumeExpansionOptions"
                 />
               </div>
@@ -169,7 +181,7 @@ export default {
             <h3>Mount Options</h3>
             <ArrayList
               v-model="value.mountOptions"
-              :mode="modeOverride"
+              :mode="mode"
               :label="t('storageClass.customize.mountOptions.label')"
               add-label="Add Option"
             />

--- a/edit/storage.k8s.io.storageclass/provisioners/driver.longhorn.io.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/driver.longhorn.io.vue
@@ -19,10 +19,10 @@ export default {
       this.$set(this.value, 'parameters', {
         numberOfReplicas:    '3',
         staleReplicaTimeout: '2880',
-        fromBackup:          '',
-        diskSelector:        '',
-        nodeSelector:        '',
-        recurringJobs:       '',
+        fromBackup:          null,
+        diskSelector:        null,
+        nodeSelector:        null,
+        recurringJobs:       null,
       });
     }
 


### PR DESCRIPTION
  - There was a problem with the longhorn driver not being set so this is
  now set
  - In some versions of the rancher backend a pvc couldn't be bound to a
  pv because the storageClassName was expected to be empty
  - The wrong storage class name was being shown when a persistent volume
  was bound also caused by storageClassName not being empty
  - A field should've been marked as required
  - Change default values for longhorn
  - Clear unset parameters for storage classes

  rancher/dashboard#2415
  rancher/dashboard#2416
  rancher/dashboard#2380
  rancher/dashboard#2420
  rancher/dashboard#2429