### PR TITLE
Separate type vs subtype display for Secrets

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2448,6 +2448,7 @@ tableHeaders:
   status: Status
   storage_class_provisioner: Provisioner
   subject: Subject
+  subType: Kind
   success: Success
   summary: Summary
   target: Target

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -13,7 +13,7 @@ import {
   USER_ID, USERNAME, USER_DISPLAY_NAME, USER_PROVIDER, WORKLOAD_ENDPOINTS, STORAGE_CLASS_DEFAULT,
   STORAGE_CLASS_PROVISIONER, PERSISTENT_VOLUME_SOURCE,
   HPA_REFERENCE, MIN_REPLICA, MAX_REPLICA, CURRENT_REPLICA,
-  ACCESS_KEY, DESCRIPTION, SCOPE, EXPIRES, EXPIRY_STATE,
+  ACCESS_KEY, DESCRIPTION, SCOPE, EXPIRES, EXPIRY_STATE, SUB_TYPE,
 } from '@/config/table-headers';
 
 import { copyResourceValues, SUBTYPES } from '@/models/rbac.authorization.k8s.io.roletemplate';
@@ -138,13 +138,7 @@ export function init(store) {
     STATE,
     NAME_COL,
     NAMESPACE_COL,
-    {
-      name:      'type',
-      label:     'Type',
-      value:     'typeDisplay',
-      sort:      ['typeDisplay', 'nameSort'],
-      width:     120,
-    },
+    SUB_TYPE,
     {
       name:      'data',
       label:     'Data',

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -392,6 +392,14 @@ export const TYPE = {
   width:    100,
 };
 
+export const SUB_TYPE = {
+  name:     'subType',
+  labelKey: 'tableHeaders.subType',
+  value:    'subTypeDisplay',
+  sort:     ['subTypeDisplay'],
+  width:    120,
+};
+
 export const STATUS = {
   name:     'status',
   labelKey: 'tableHeaders.status',

--- a/edit/admin.rio.cattle.io.publicdomain.vue
+++ b/edit/admin.rio.cattle.io.publicdomain.vue
@@ -74,7 +74,7 @@ export default {
     secretOptions() {
       return groupAndFilterOptions(this.allSecrets, {
         'metadata.namespace': RIO.SYSTEM_NAMESPACE,
-        secretType:           TYPES.TLS,
+        _type:                TYPES.TLS,
       }, {
         groupBy:      null,
         itemValueKey: 'metadata.name',

--- a/models/secret.js
+++ b/models/secret.js
@@ -143,7 +143,7 @@ export default {
       return false;
     }
 
-    if ( this.secretType === TYPES.SERVICE_ACCT ) {
+    if ( this._type === TYPES.SERVICE_ACCT ) {
       return false;
     }
 
@@ -229,11 +229,7 @@ export default {
     }
   },
 
-  secretType() {
-    return this._type;
-  },
-
-  typeDisplay() {
+  subTypeDisplay() {
     const type = this._type || '';
     const fallback = type.replace(/^kubernetes.io\//, '');
 


### PR DESCRIPTION
#2379

Avoid overwriting typeDisplay on secrets with the subtype so that the regular type is shown on import.
