### PR TITLE
Fix: don't show modified tag for ca certs

### DIFF
--- a/list/management.cattle.io.setting.vue
+++ b/list/management.cattle.io.setting.vue
@@ -24,12 +24,13 @@ export default {
 
     // Combine the allowed settings with the data from the API
     Object.keys(ALLOWED_SETTINGS).forEach((setting) => {
+      const readonly = !!ALLOWED_SETTINGS[setting].readOnly;
       const s = {
         ...ALLOWED_SETTINGS[setting],
         id:          setting,
         description: t(`advancedSettings.descriptions.${ setting }`),
         data:        settingsMap[setting],
-        customized:  settingsMap[setting].value && settingsMap[setting].value !== settingsMap[setting].default
+        customized:  !readonly && settingsMap[setting].value && settingsMap[setting].value !== settingsMap[setting].default
       };
 
       s.hide = s.canHide = (s.kind === 'json' || s.kind === 'multiline');


### PR DESCRIPTION
#2418 

This PR fixes the above issue. CACerts is a readonly setting, so we should not show the modified tag.