### PR TITLE
Resolving an issue around claims showing up when creating a pv

### DIFF
--- a/models/persistentvolume.js
+++ b/models/persistentvolume.js
@@ -44,6 +44,10 @@ export default {
     return this.t(VOLUME_PLUGINS.find(plugin => this.spec[plugin.value]).labelKey);
   },
   claim() {
+    if (!this.name) {
+      return null;
+    }
+
     const allClaims = this.$rootGetters['cluster/all'](PVC);
 
     return allClaims.find(claim => claim.spec.volumeName === this.name);


### PR DESCRIPTION
When creating a PV the name is undefined and that allowed it to find PVCs that had
volumeName undefined.

rancher/dashboard#2431