### PR TITLE
Settings: Fix issue with default value when editing

### DIFF
--- a/edit/management.cattle.io.setting.vue
+++ b/edit/management.cattle.io.setting.vue
@@ -35,7 +35,7 @@ export default {
     }
 
     const canReset = this.value.default !== null;
-    const isDefault = canReset && !this.value.value;
+    const isDefault = canReset && this.value.value === this.value.default;
 
     this.value.value = this.value.value || this.value.default;
 


### PR DESCRIPTION
#2417 

Ensures that if the current value is the same as the default, when editing, on load, the 'Use default value' is set, not the use custom value.