### PR TITLE
Fix disparity between admin and standard user global settings actions

### DIFF
--- a/models/management.cattle.io.setting.js
+++ b/models/management.cattle.io.setting.js
@@ -3,7 +3,7 @@ import { ALLOWED_SETTINGS } from '@/config/settings';
 export default {
 
   _availableActions() {
-    const toFilter = ['cloneYaml', 'download', 'goToEditYaml'];
+    const toFilter = ['cloneYaml', 'download', 'goToEditYaml', 'goToViewYaml', 'goToViewConfig'];
     const settingMetadata = ALLOWED_SETTINGS[this.id];
 
     let out = this._standardActions;


### PR DESCRIPTION
- previously admin showed `edit` and standard user showed `view config` & `view yaml`
- neither 'view' action should be visible
- this makes use of empty action menu feature in #2440