### PR TITLE
hide google oauth component

### DIFF
--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -112,7 +112,7 @@ export function init(store) {
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/okta`, 'auth/saml');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/keycloak`, 'auth/saml');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/adfs`, 'auth/saml');
-  componentForType(`${ MANAGEMENT.AUTH_CONFIG }/googleoauth`, 'auth/googleoauth');
+  // componentForType(`${ MANAGEMENT.AUTH_CONFIG }/googleoauth`, 'auth/googleoauth');
   // componentForType(`${ MANAGEMENT.AUTH_CONFIG }/azuread`, 'auth/azuread');
 
   basicType([

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -61,8 +61,9 @@ export function returnTo(opt, vm) {
  * Determines common auth provider info as those that are available (non-local) and the location of the enabled provider
  */
 export const authProvidersInfo = async(store) => {
+  const toExclude = ['local', 'azuread', 'googleoauth'];
   const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
-  const nonLocal = rows.filter(x => x.name !== 'local' && x.name !== 'azuread');
+  const nonLocal = rows.filter(x => !toExclude.includes(x.name));
   const enabled = nonLocal.filter(x => x.enabled === true );
 
   const enabledLocation = enabled.length === 1 ? {


### PR DESCRIPTION
For essentially the same reasons as Azure AD, google oauth will need some api changes to work in vue and allow login from ember. This PR hides the google oauth edit component and removes it from the auth provider picker page. 