### PR TITLE
Only check app resource requirements on install, not upgrade

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -515,8 +515,8 @@ catalog:
     error:
       requiresFound: '<a href="{url}">${name}</a> must be installed before you can install this chart.'
       requiresMissing: 'This chart requires another chart that provides {name}, but none was was found.'
-      insufficientCpu: 'This chart requires {need, number} CPU cores, but this cluster only has {have, number} available.'
-      insufficientMemory: 'This chart requires {need} of memory, but this cluster only has {have} available.'
+      insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
+      insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
     header:
       install: 'Install {name}'
       installGeneric: Install Chart

--- a/config/query-params.js
+++ b/config/query-params.js
@@ -60,6 +60,9 @@ export const NAME = 'name';
 export const NAMESPACE = 'namespace';
 export const DESCRIPTION = 'description';
 export const CATEGORY = 'category';
+export const DEPRECATED = 'deprecated';
+export const HIDDEN = 'hidden';
+export const FORCE = 'force';
 
 // Cluster provisioning
 export const PROVIDER = 'provider';

--- a/pages/c/_cluster/apps/charts.vue
+++ b/pages/c/_cluster/apps/charts.vue
@@ -4,7 +4,7 @@ import Loading from '@/components/Loading';
 import Banner from '@/components/Banner';
 import SelectIconGrid from '@/components/SelectIconGrid';
 import {
-  REPO_TYPE, REPO, CHART, VERSION, SEARCH_QUERY, _FLAGGED, CATEGORY
+  REPO_TYPE, REPO, CHART, VERSION, SEARCH_QUERY, _FLAGGED, CATEGORY, DEPRECATED, HIDDEN
 } from '@/config/query-params';
 import { ensureRegex, lcFirst } from '@/utils/string';
 import { sortBy } from '@/utils/sort';
@@ -33,8 +33,8 @@ export default {
     const query = this.$route.query;
 
     this.searchQuery = query[SEARCH_QUERY] || '';
-    this.showDeprecated = query['deprecated'] === _FLAGGED;
-    this.showHidden = query['hidden'] === _FLAGGED;
+    this.showDeprecated = query[DEPRECATED] === _FLAGGED;
+    this.showHidden = query[HIDDEN] === _FLAGGED;
     this.category = query[CATEGORY] || '';
     this.allRepos = this.areAllEnabled();
   },


### PR DESCRIPTION
#1849

Ignore the chart's cpu/memory requirements on upgrade.  Also added a `force` query param you can add to bypass the check for install.
