### PR TITLE
Support HPA Quantity Values with SI suffix

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -90,6 +90,7 @@ product:
 
 
 suffix:
+  percent: "%"
   cpus: CPUs
   ib: iB
   revisions: |-

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -920,7 +920,7 @@ hpa:
     external: In order to use custom metrics with HPA, you need to deploy the custom metrics server such as prometheus adapter.
   metricIdentifier:
     name:
-      label: Metic Name
+      label: Metric Name
       placeholder: e.g. packets-per-second
     selector:
       label: Add Selector

--- a/components/form/UnitInput.vue
+++ b/components/form/UnitInput.vue
@@ -56,6 +56,11 @@ export default {
       type:     String,
       default: null
     },
+
+    required: {
+      type:    Boolean,
+      default: false,
+    }
   },
 
   computed: {
@@ -111,6 +116,7 @@ export default {
     :label-key="labelKey"
     :tooltip="tooltip"
     :tooltip-key="tooltipKey"
+    :required="required"
     @input="update($event)"
   >
     <template #suffix>

--- a/edit/autoscaling.horizontalpodautoscaler/external-metric.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/external-metric.vue
@@ -13,7 +13,7 @@ export const DEFAULT_EXTERNAL_METRIC = {
   },
   target: {
     type:               'AverageValue',
-    averageValue:       50,
+    averageValue:       '80',
   },
 };
 
@@ -42,7 +42,7 @@ export default {
 <template>
   <div>
     <div class="row mb-20">
-      <MetricTarget v-model="value.target" :mode="mode" type="external" />
+      <MetricTarget v-model="value.target" :mode="mode" metric-resource="external" />
     </div>
     <div class="row">
       <MetricIdentifier v-model="value.metric" :mode="mode" />

--- a/edit/autoscaling.horizontalpodautoscaler/object-metric.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/object-metric.vue
@@ -14,7 +14,7 @@ export const DEFAULT_OBJECT_METRIC = {
   },
   target: {
     type:               'AverageValue',
-    averageValue:       50,
+    averageValue:       '80',
   },
   describedObject: {
     apiVersion: '',
@@ -49,7 +49,7 @@ export default {
 <template>
   <div>
     <div class="row mb-20">
-      <MetricTarget v-model="value.target" :mode="mode" type="object" />
+      <MetricTarget v-model="value.target" :mode="mode" metric-resource="object" />
     </div>
     <div class="row mb-20">
       <MetricObjectReference v-model="value.describedObject" :mode="mode" />

--- a/edit/autoscaling.horizontalpodautoscaler/pod-metric.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/pod-metric.vue
@@ -13,7 +13,7 @@ export const DEFAULT_POD_METRIC = {
   },
   target: {
     type:               'AverageValue',
-    averageValue:       50,
+    averageValue:       '80',
   },
 };
 
@@ -42,7 +42,7 @@ export default {
 <template>
   <div>
     <div class="row mb-20">
-      <MetricTarget v-model="value.target" :mode="mode" type="pod" />
+      <MetricTarget v-model="value.target" :mode="mode" metric-resource="pods" />
     </div>
     <div class="row">
       <MetricIdentifier v-model="value.metric" :mode="mode" />

--- a/edit/autoscaling.horizontalpodautoscaler/resource-metric.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/resource-metric.vue
@@ -8,7 +8,7 @@ export const DEFAULT_RESOURCE_METRIC = {
     name:   'cpu',
     target: {
       type:               'Utilization',
-      averageUtilization: 50,
+      averageUtilization: 80,
     },
   },
 };
@@ -56,7 +56,7 @@ export default {
       </div>
     </div>
     <div class="row">
-      <MetricTarget v-model="value.target" :mode="mode" type="resource" />
+      <MetricTarget v-model="value.target" :mode="mode" metric-resource="resource" :resource-name="value.name" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
This PR adds the functionality to support SI values in Resource metrics. Additionally its adds the input addons for the CPU and Memory metric types in a Resource metric. When porting over I missed this. This required a bit of a rework in the logic that updated the values on the various metrics, and changing the input from a two-way binding to a one way with an update event. This also allowed me to reset the values fields when either the metric type or resource name changes. This prevents a user from changing types from something like Average Value (quantity + si suffix - `300m or 300Mib`) to Utilization (int w/o si suffix - `80`) have having an incorrect value type in the input.

Additional changes include a typo in the translations and adding the required flag to the Unit Input component. 


rancher/dashboard#2442
rancher/dashboard#2444 - (translation on this ticket)


![Screen Shot 2021-02-26 at 11 16 13 AM](https://user-images.githubusercontent.com/858614/109338881-17e56f00-7824-11eb-9067-a85bef0755ff.png)
![Screen Shot 2021-02-26 at 11 16 22 AM](https://user-images.githubusercontent.com/858614/109338890-19af3280-7824-11eb-8e25-34f8fe077dae.png)
