### PR TITLE
Improve drone build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,6 +39,12 @@ platform:
   arch: amd64
 
 steps:
+- name: build
+  pull: default
+  image: node:12
+  commands:
+  - ./scripts/build-upload-gate
+
 - name: docker-image
   image: plugins/docker
   settings:
@@ -100,6 +106,12 @@ steps:
   image: node:12
   commands:
   - ./scripts/build-hosted
+
+- name: build
+  pull: default
+  image: node:12
+  commands:
+  - ./scripts/build-upload-gate
 
 - name: upload
   pull: default
@@ -207,6 +219,12 @@ steps:
   image: node:12
   commands:
   - ./scripts/build-embedded
+
+- name: build
+  pull: default
+  image: node:12
+  commands:
+  - ./scripts/build-upload-gate
 
 - name: upload
   pull: default

--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ platform:
   arch: amd64
 
 steps:
-- name: build
+- name: gate
   pull: default
   image: node:12
   commands:
@@ -107,7 +107,7 @@ steps:
   commands:
   - ./scripts/build-hosted
 
-- name: build
+- name: upload-gate
   pull: default
   image: node:12
   commands:
@@ -220,7 +220,7 @@ steps:
   commands:
   - ./scripts/build-embedded
 
-- name: build
+- name: upload-gate
   pull: default
   image: node:12
   commands:

--- a/scripts/build-upload-gate
+++ b/scripts/build-upload-gate
@@ -1,6 +1,5 @@
-!/bin/bash
+#!/bin/bash
 set -e
-set -x
 
 BUILD_DEBUG="${BUILD_DEBUG:-}"
 if [[ -n "${BUILD_DEBUG}" ]]; then
@@ -33,7 +32,7 @@ echo "Branch: $DRONE_BRANCH"
 echo "Build Commit: $DRONE_COMMIT"
 
 tmp=$(mktemp -u)
-STATUS_CODE=$(curl -w "%{http_code}" -s -o tmp https://api.github.com/repos/$DRONE_REPO/branches/$DRONE_BRANCH)
+STATUS_CODE=$(curl -w "%{http_code}" -s -o $tmp https://api.github.com/repos/$DRONE_REPO/branches/$DRONE_BRANCH)
 
 if [ "$STATUS_CODE" == "403" ]; then
     RATE_LIMIT_REMAINING=$(curl -s https://api.github.com/rate_limit | jq -r .rate.remaining)
@@ -46,8 +45,8 @@ if [ "$STATUS_CODE" == "403" ]; then
     # Fall through to the normal path like any other failed status code
 fi
 
-LATEST_BRANCH_COMMIT=$(cat tmp | jq -r .commit.sha)
-rm tmp
+LATEST_BRANCH_COMMIT=$(cat $tmp | jq -r .commit.sha)
+rm $tmp
 echo "Latest Branch Commit: $LATEST_BRANCH_COMMIT"
 if [ -z "$LATEST_BRANCH_COMMIT" ]; then
     echo "Unable to determine latest commit, failing gate"

--- a/scripts/build-upload-gate
+++ b/scripts/build-upload-gate
@@ -32,12 +32,31 @@ echo "Repo: $DRONE_REPO"
 echo "Branch: $DRONE_BRANCH"
 echo "Build Commit: $DRONE_COMMIT"
 
-LATEST_BRANCH_COMMIT=$(curl -s https://api.github.com/repos/$DRONE_REPO/branches/$DRONE_BRANCH | jq -r .commit.sha)
+tmp=$(mktemp -u)
+STATUS_CODE=$(curl -w "%{http_code}" -s -o tmp https://api.github.com/repos/$DRONE_REPO/branches/$DRONE_BRANCH)
+
+if [ "$STATUS_CODE" == "403" ]; then
+    RATE_LIMIT_REMAINING=$(curl -s https://api.github.com/rate_limit | jq -r .rate.remaining)
+    echo "Remaining GITHUB requests available: $RATE_LIMIT_REMAINING"
+    RATE_LIMIT_REMAINING=${RATE_LIMIT_REMAINING:-0}
+    if ((RATE_LIMIT_REMAINING < 1)); then
+        echo "Github Rate Limit has been hit, skipping gate"
+        exit 0
+    fi
+    # Fall through to the normal path like any other failed status code
+fi
+
+LATEST_BRANCH_COMMIT=$(cat tmp | jq -r .commit.sha)
+rm tmp
 echo "Latest Branch Commit: $LATEST_BRANCH_COMMIT"
+if [ -z "$LATEST_BRANCH_COMMIT" ]; then
+    echo "Unable to determine latest commit, failing gate"
+    exit 1
+fi
 
 if [ "$LATEST_BRANCH_COMMIT" == "$DRONE_COMMIT" ]; then
     echo "Build was created from latest commit, passed upload gate"
 else
-    echo "Build was not created from latest commit, aborting upload"
+    echo "Build was not created from latest commit, failing gate"
     exit 1
 fi

--- a/scripts/build-upload-gate
+++ b/scripts/build-upload-gate
@@ -1,0 +1,43 @@
+!/bin/bash
+set -e
+set -x
+
+BUILD_DEBUG="${BUILD_DEBUG:-}"
+if [[ -n "${BUILD_DEBUG}" ]]; then
+    set -x
+    env
+fi
+
+if [[ -n "$DRONE_TAG" ]]; then
+    echo "Build has been triggered by a tag. Skipping gate"
+    exit 0
+fi 
+
+if [[ -z "$DRONE_BRANCH" ]]; then 
+    echo "No branch detected. Skipping gate"
+    exit 0
+fi
+
+if [[ -z "$DRONE_REPO" ]]; then 
+    echo "No repository detected. Unable to gate"
+    exit 1
+fi
+
+if [[ -z "$DRONE_COMMIT" ]]; then 
+    echo "No commit detected. Unable to gate"
+    exit 1
+fi
+
+echo "Repo: $DRONE_REPO"
+echo "Branch: $DRONE_BRANCH"
+echo "Build Commit: $DRONE_COMMIT"
+
+LATEST_BRANCH_COMMIT=$(curl -s https://api.github.com/repos/$DRONE_REPO/branches/$DRONE_BRANCH | jq -r .commit.sha)
+echo "Latest Branch Commit: $LATEST_BRANCH_COMMIT"
+
+if [ "$LATEST_BRANCH_COMMIT" == "$DRONE_COMMIT" ]; then
+    echo "Build was created from latest commit, passed upload gate"
+else
+    echo "Build was not created from latest commit, aborting upload"
+    exit 1
+fi


### PR DESCRIPTION
- Reduce the impact of concurrent drone builds, specifically avoid overwritting newer builds that were quicker by older builds that were slower.
- hosted and embedded builds will only get uploaded if they're built from the same commit as head of their branch
- docker builds however still might get uploaded, there's no intermediate step between build and upload to docker. Not quite sure how this doesn't fail as the drone plugin `force_tag` uses default false (doesn't overwrite - http://plugins.drone.io/drone-plugins/drone-docker/)