### PR TITLE
clear promptremove store when modal closed

### DIFF
--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -258,6 +258,7 @@ export default {
     :width="350"
     height="auto"
     styles="max-height: 100vh;"
+    @closed="close"
   >
     <Card class="prompt-remove" :show-highlight-border="false">
       <h4 slot="title" class="text-default-text">

--- a/store/action-menu.js
+++ b/store/action-menu.js
@@ -72,9 +72,10 @@ export const mutations = {
     state.elem = null;
   },
 
-  togglePromptRemove(state, resources = []) {
-    if (!resources.length) {
+  togglePromptRemove(state, resources) {
+    if (!resources) {
       state.showPromptRemove = false;
+      resources = [];
     } else {
       state.showPromptRemove = !state.showPromptRemove;
       if (!isArray(resources)) {

--- a/store/action-menu.js
+++ b/store/action-menu.js
@@ -73,9 +73,13 @@ export const mutations = {
   },
 
   togglePromptRemove(state, resources = []) {
-    state.showPromptRemove = !state.showPromptRemove;
-    if (!isArray(resources)) {
-      resources = [resources];
+    if (!resources.length) {
+      state.showPromptRemove = false;
+    } else {
+      state.showPromptRemove = !state.showPromptRemove;
+      if (!isArray(resources)) {
+        resources = [resources];
+      }
     }
     state.toRemove = resources;
   },


### PR DESCRIPTION
#2328 - this PR just implements the changes outlined in the issue; add an event listener to the modal to set `showPromptRemove` to false and empty the `toRemove` array when the modal is closed.