### PR TITLE
auth nonce as json

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -221,7 +221,7 @@ authConfig:
           <ul class="mt-0">
           <li>Select the "Create Credentials" dropdown, and select "OAuth clientID", then select "Web application".</li>
           <li>Authorized Javascript origins: {serverUrl}</li>
-          <li>Authorized redirect URIs: {serverUrl}/auth/verify </li>
+          <li>Authorized redirect URIs: {serverUrl}/verify-auth </li>
           <li>Click "Create", and then click on the "Download JSON" button.</li>
           <li>Upload the downloaded JSON file in the OAuth credentials box.</li>
           </ul>

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -115,7 +115,7 @@ export function init(store) {
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/keycloak`, 'auth/saml');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/adfs`, 'auth/saml');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/googleoauth`, 'auth/googleoauth');
-  // componentForType(`${ MANAGEMENT.AUTH_CONFIG }/azuread`, 'auth/azuread');
+  componentForType(`${ MANAGEMENT.AUTH_CONFIG }/azuread`, 'auth/azuread');
 
   basicType([
     'config',

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -24,7 +24,7 @@ export function init(store) {
     icon:                'user',
     removable:           false,
     weight:              50,
-    public:              false, // Hide from regular view during development
+    public:              true, // Hide from regular view during development
     showClusterSwitcher: false,
   });
 

--- a/edit/auth/azuread.vue
+++ b/edit/auth/azuread.vue
@@ -72,7 +72,7 @@ export default {
     },
 
     replyUrl() {
-      return `${ window.location.origin }/verify-auth-azure/dashboard/auth/verify`;
+      return `${ window.location.origin }/verify-auth`;
     },
 
     tenantId() {

--- a/edit/auth/saml.vue
+++ b/edit/auth/saml.vue
@@ -123,7 +123,7 @@ export default {
           </div>
         </div>
         <div class="row mb-20">
-          <div v-if="NAME !== 'okta'" class="col span-6">
+          <div v-if="NAME === 'keycloak' || NAME === 'ping'" class="col span-6">
             <LabeledInput
               v-model="model.entityID"
               :label="t(`authConfig.saml.entityID`)"

--- a/server/server-middleware.js
+++ b/server/server-middleware.js
@@ -8,10 +8,10 @@ export default function(req, res, next) {
     console.log('SPA mode enabled'); // eslint-disable-line no-console
   }
 
-  // We do this redirect so that /verify-auth-azure/dashboard/auth/verify can work with both standalone and
+  // We do this redirect so that /verify-auth can work with both standalone and
   // while dashboard is nested under ember.
-  if (req.url.includes('/verify-auth-azure/dashboard/auth/verify')) {
-    res.writeHead(301, { Location: req.url.replace('/verify-auth-azure/dashboard', '') });
+  if (req.url.includes('/verify-auth') || req.url.includes('/verify-auth-azure')) {
+    res.writeHead(301, { Location: req.url.replace(/verify-auth(-azure)?/, 'auth/verify') });
     res.end();
   }
 

--- a/store/auth.js
+++ b/store/auth.js
@@ -3,6 +3,7 @@ import { parse as parseUrl, removeParam, addParams } from '@/utils/url';
 import { findBy, addObjects } from '@/utils/array';
 import { openAuthPopup, returnTo } from '@/utils/auth';
 import { GITHUB_SCOPE, GITHUB_NONCE, GITHUB_REDIRECT } from '@/config/query-params';
+import { base64Encode } from '@/utils/crypto';
 
 export const BASE_SCOPES = {
   github: ['read:org'], googleoauth: ['openid profile email'], azuread: []
@@ -89,22 +90,25 @@ export const actions = {
   },
 
   setNonce({ dispatch }, opt) {
-    let nonce = randomStr(16);
+    const out = { nonce: randomStr(16), to: 'vue' };
 
     if ( opt.test ) {
-      nonce += '-test';
+      out.test = true;
     }
 
     if (opt.provider) {
-      nonce += `-${ opt.provider }`;
+      out.provider = opt.provider;
     }
-    this.$cookies.set(KEY, nonce, {
+
+    const strung = JSON.stringify(out);
+
+    this.$cookies.set(KEY, strung, {
       path:     '/',
       sameSite: false,
       secure:   true,
     });
 
-    return nonce;
+    return strung;
   },
 
   async redirectTo({ state, commit, dispatch }, opt = {}) {
@@ -116,16 +120,16 @@ export const actions = {
 
       redirectUrl = driver.redirectUrl;
     }
+    let returnToUrl = `${ window.location.origin }/verify-auth`;
 
     if (provider === 'azuread') {
       const params = { response_type: 'code', response_mode: 'query' };
 
       redirectUrl = addParams(redirectUrl, params );
+      returnToUrl = `${ window.location.origin }/verify-auth`;
     }
 
     const nonce = await dispatch('setNonce', opt);
-
-    const returnToUrl = returnTo(opt, this);
 
     const fromQuery = unescape(parseUrl(redirectUrl).query?.[GITHUB_SCOPE] || '');
     const scopes = fromQuery.split(/[, ]+/).filter(x => !!x);
@@ -141,7 +145,7 @@ export const actions = {
     let url = removeParam(redirectUrl, GITHUB_SCOPE);
     const params = {
       [GITHUB_SCOPE]:    scopes.join(','),
-      [GITHUB_NONCE]:    nonce
+      [GITHUB_NONCE]:   base64Encode(nonce, 'url')
     };
 
     if (!url.includes(GITHUB_REDIRECT)) {
@@ -158,7 +162,16 @@ export const actions = {
   },
 
   verifyOAuth({ dispatch }, { nonce, code, provider }) {
-    const expect = this.$cookies.get(KEY, { parseJSON: false });
+    const expectJSON = this.$cookies.get(KEY, { parseJSON: false });
+    let parsed;
+
+    try {
+      parsed = JSON.parse(expectJSON);
+    } catch {
+      return ERR_NONCE;
+    }
+
+    const expect = parsed.nonce;
 
     if ( !expect || expect !== nonce ) {
       return ERR_NONCE;

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -62,7 +62,7 @@ export function returnTo(opt, vm) {
  */
 export const authProvidersInfo = async(store) => {
   const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
-  const nonLocal = rows.filter(x => x.name !== 'local' && x.name !== 'azuread');
+  const nonLocal = rows.filter(x => x.name !== 'local');
   const enabled = nonLocal.filter(x => x.enabled === true );
 
   const enabledLocation = enabled.length === 1 ? {

--- a/utils/crypto/index.js
+++ b/utils/crypto/index.js
@@ -5,7 +5,10 @@ import Sha256 from './browserSha256';
 import Sha1 from './browserSha1';
 
 // lib/util.js
-export function base64Encode(string) {
+const NORMAL = 'normal';
+const URL = 'url';
+
+export function base64Encode(string, alphabet = NORMAL) {
   let buf;
 
   if (string === null || typeof string === 'undefined') {
@@ -16,6 +19,15 @@ export function base64Encode(string) {
     buf = Buffer.from(string);
   } else {
     buf = new Buffer(string);
+  }
+  if (alphabet === URL) {
+    const m = {
+      '+': '-',
+      '/': '_',
+      '=': ''
+    };
+
+    return buf.toString('base64').replace(/[+/]|=$/, char => m[char]);
   }
 
   return buf.toString('base64');
@@ -34,7 +46,7 @@ export function base64DecodeToBuffer(string) {
 }
 
 export function base64Decode(string) {
-  return base64DecodeToBuffer(string || '').toString();
+  return base64DecodeToBuffer(string || '').toString().replace(/[-_]/, char => char === '-' ? '+' : '/');
 }
 
 export function md5(data, digest, callback) {


### PR DESCRIPTION
1. change redirect_uri for googleoauth and azureAD to match Ember UI instructions: `<window.location.origin>/verify-auth` and `<window.location.origin>/verify-auth-azure` respectively
2. Use a JSON object for `rc_nonce` cookie, with keys: nonce, provider, to, test

included #2422 - entityID field should only be visible for keycloak and ping