### PR TITLE
Support standalone steve

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,24 @@ docker run -v $(pwd):/src \
   dashboard:dev
 # The first time will take *forever* installing node_modules into the volume; it will be faster next time.
 # Goto https://localhost:8005
+
+# Developing against a standalone "Steve" API on a Mac
+git clone https://github.com/rancher/steve.git
+cd steve
+make run-host
+
+cd dashboard
+docker build -f Dockerfile.dev -t rancher/dashboard:dev .
+docker run -v $(pwd):/src \
+  -v dashboard_node:/src/node_modules \
+  -p 8005:8005 \
+  -e API=http://172.17.0.1:8989 \
+  rancher/dashboard:dev
+# The first time will take *forever* installing node_modules into the volume; it will be faster next time.
+# Goto https://localhost:8005
 ```
 
-## What is it?
+# What is it?
 
 Dashboard is "stateless" client for the Rancher APIs built with [Vue.js](https://vuejs.org/) and [NuxtJS](https://nuxtjs.org/).  It is normally build and packaged as a folder of static HTML/CSS/JS files which are bundled into a Rancher release, with the index.html returned by the API server as the "fallback" case for any request that looks like it came from a browser and does not match an API URL.
 
@@ -200,7 +215,7 @@ data:
 
 License
 =======
-Copyright (c) 2014-2020 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2014-2021 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -18,7 +18,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['clusterReady', 'isMultiCluster', 'currentCluster',
+    ...mapGetters(['clusterReady', 'isMultiCluster', 'isRancher', 'currentCluster',
       'currentProduct', 'backToRancherLink', 'backToRancherGlobalLink']),
 
     authEnabled() {
@@ -75,13 +75,13 @@ export default {
     </div>
 
     <div class="back">
-      <a v-if="currentProduct && isMultiCluster" class="btn role-tertiary" :href="(currentProduct.inStore === 'management' ? backToRancherGlobalLink : backToRancherLink)">
+      <a v-if="currentProduct && isRancher" class="btn role-tertiary" :href="(currentProduct.inStore === 'management' ? backToRancherGlobalLink : backToRancherLink)">
         {{ t('nav.backToRancher') }}
       </a>
     </div>
 
     <div class="import">
-      <button v-if="currentProduct && currentProduct.showClusterSwitcher" :disabled="!showImport" type="button" class="btn role-tertiary" @click="openImport()">
+      <button v-if="currentProduct && currentProduct.showClusterSwitcher && showImport" type="button" class="btn role-tertiary" @click="openImport()">
         <i v-tooltip="t('nav.import')" class="icon icon-upload icon-lg" />
       </button>
       <modal
@@ -96,7 +96,7 @@ export default {
     </div>
 
     <div class="kubectl">
-      <button v-if="currentProduct && currentProduct.showClusterSwitcher" :disabled="!showShell" type="button" class="btn role-tertiary" @click="currentCluster.openShell()">
+      <button v-if="currentProduct && currentProduct.showClusterSwitcher && showShell" type="button" class="btn role-tertiary" @click="currentCluster.openShell()">
         <i v-tooltip="t('nav.shell')" class="icon icon-terminal icon-lg" />
       </button>
     </div>
@@ -132,7 +132,7 @@ export default {
             <nuxt-link tag="li" :to="{name: 'prefs'}" class="user-menu-item">
               <a>Preferences <i class="icon icon-fw icon-gear" /></a>
             </nuxt-link>
-            <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'account'}" class="user-menu-item">
+            <nuxt-link v-if="isRancher" tag="li" :to="{name: 'account'}" class="user-menu-item">
               <a>Account &amp; API Keys <i class="icon icon-fw icon-user" /></a>
             </nuxt-link>
             <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'auth-logout'}" class="user-menu-item">

--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -73,7 +73,7 @@ export default {
         ['nameDisplay']
       );
 
-      if (this.$store.getters['isMultiCluster']) {
+      if (this.$store.getters['isRancher']) {
         const cluster = this.$store.getters['currentCluster'];
         let projects = this.$store.getters['management/all'](
           MANAGEMENT.PROJECT

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -39,7 +39,7 @@ export default {
 
   computed: {
     extraColumns() {
-      if ( this.$store.getters['isMultiCluster'] ) {
+      if ( this.$store.getters['isRancher'] ) {
         return ['project-col'];
       }
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -203,7 +203,7 @@ export default {
     async toggleShell() {
       const clusterId = this.$route.params.cluster;
 
-      if ( !clusterId || !this.$store.getters['isMultiCluster'] ) {
+      if ( !clusterId ) {
         return;
       }
 

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -92,9 +92,9 @@ export default async function({
           store.commit('setError', e);
           console.log(JSON.stringify(e)); // eslint-disable-line no-console
         }
-      }
 
-      return;
+        return;
+      }
     }
   }
 

--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -8,7 +8,7 @@ export default {
 
   namespaces() {
     // I don't know how you'd end up with a project outside of rancher, but just in case...
-    if ( !this.$rootGetters['isMultiCluster'] ) {
+    if ( !this.$rootGetters['isRancher'] ) {
       return [];
     }
 

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -61,7 +61,7 @@ export default {
   },
 
   project() {
-    if ( !this.projectId || !this.$rootGetters['isMultiCluster'] ) {
+    if ( !this.projectId || !this.$rootGetters['isRancher'] ) {
       return null;
     }
 

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -2,7 +2,7 @@
 import isEqual from 'lodash/isEqual';
 import jsyaml from 'js-yaml';
 import merge from 'lodash/merge';
-import { mapState, mapGetters } from 'vuex';
+import { mapGetters } from 'vuex';
 
 import AsyncButton from '@/components/AsyncButton';
 import Banner from '@/components/Banner';
@@ -336,8 +336,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentCluster']),
-    ...mapState(['isMultiCluster']),
+    ...mapGetters(['currentCluster', 'isRancher']),
 
     namespaceIsNew() {
       const all = this.$store.getters['cluster/all'](NAMESPACE);
@@ -351,7 +350,7 @@ export default {
     },
 
     showProject() {
-      return this.isMultiCluster && !this.existing && this.namespaceIsNew;
+      return this.isRancher && !this.existing && this.namespaceIsNew;
     },
 
     projectOpts() {


### PR DESCRIPTION
- Separate out isMultiCluster from isRancher on various features, because Steve supports multiple clusters without other Rancher CRDs being present
- Avoid loading rancher store stuff when running in standalone steve
- Hide import & shell buttons if link isn't present instead of disabling, because the only time they should be missing now is if unsupported.
