### PR TITLE
Fix tooltip positionning on buttons in header

### DIFF
--- a/assets/styles/global/_tooltip.scss
+++ b/assets/styles/global/_tooltip.scss
@@ -61,7 +61,7 @@
         border-top-width: 0;
         border-bottom-color: var(--tooltip-bg);
         top: 1px;
-        left: -20px;
+        left: -$triangle-inner-size;
         background: transparent;
       }
     }

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -25,7 +25,7 @@ export default {
       type:    Boolean
     },
     hoverTooltip: {
-      default: false,
+      default: true,
       type:    Boolean
     },
     localizedLabel: {


### PR DESCRIPTION
Fixes issue where the tooltip is not correctly positioned/aligned for the header buttons (import, shell.

Also fixes the LabeledSelect control so that the tooltip is only shown when hovered by default (you can see the current behaviour on the form-controls page of deisng-system)

@lvuch It looks like your PR that changed buttons etc changed the css that affected the tooltip alignment - I can't see anything broken with the change back in this PR - can you recall why that change was necessary?