### PR TITLE
Existing AlertManager Secret

### DIFF
--- a/chart/monitoring/alerting/index.vue
+++ b/chart/monitoring/alerting/index.vue
@@ -135,6 +135,14 @@ export default {
       }
     },
   },
+
+  beforeMount() {
+    const amSecrets = this.value?.alertmanager?.alertmanagerSpec?.secrets ?? [];
+
+    if (this.existingSecret && amSecrets.length <= 0) {
+      this.$set(this.value.alertmanager.alertmanagerSpec, 'useExistingSecret', true);
+    }
+  },
 };
 </script>
 


### PR DESCRIPTION
If we have the existing alertmanager secret, regardless of upgrade status, we should at least default to using that secret. 

rancher/rancher#2225