### PR TITLE
Adding support for `unsupported-storage-drivers`

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1605,6 +1605,14 @@ persistentVolume:
     filesystemType:
       label: Filesystem Type
       placeholder: e.g. ext4
+    secretName:
+      label: Secret Name
+      placeholder: e.g. secret
+    secretNamespace:
+      label: Secret Namespace
+      placeholder: e.g. default
+    monitors:
+      add: Add Monitor
   vsphereVolume:
     label: 	VMWare vSphere Volume
     volumePath:
@@ -1616,6 +1624,179 @@ persistentVolume:
     storagePolicyId:
       label: Storage Policy ID
       placeholder: e.g. sp1
+  csi:
+    label: CSI (Unsupported)
+    driver:
+      label: Driver
+      placeholder: e.g. driver.longhorn.io
+    volumeHandle:
+      label: Volume Handle
+      placeholder: e.g. pvc-xxxx
+    volumeAttributes:
+      add: Add Volume Attribute
+    nodePublishSecretName:
+      label: Node Publish Secret Name
+      placeholder: e.g. secret
+    nodePublishSecretNamespace:
+      label: Node Publish Secret Namespace
+      placeholder: e.g. default
+    nodeStageSecretName:
+      label: Node Stage Secret Name
+      placeholder: e.g. secret
+    nodeStageSecretNamespace:
+      label: Node Stage Secret Namespace
+      placeholder: e.g. default
+    controllerExpandSecretName:
+      label: Controller Expand Secret Name
+      placeholder: e.g. secret
+    controllerExpandSecretNamespace:
+      label: Controller Expand Secret Namespace
+      placeholder: e.g. default
+    controllerPublishSecretName:
+      label: Controller Publish Secret Name
+      placeholder: e.g. secret
+    controllerPublishSecretNamespace:
+      label: Controller Publish Secret Namespace
+      placeholder: e.g. default
+  cephfs:
+    label: Ceph Filesystem (Unsupported)
+    path:
+      label: Path
+      placeholder: e.g. /var
+    user:
+      label: User
+      placeholder: e.g. root
+    secretFile:
+      label: Secret File
+      placeholder: e.g. secret
+  rbd:
+    label: Ceph RBD (Unsupported)
+    user:
+      label: User
+      placeholder: e.g. root
+    keyRing:
+      label: Key Ring
+      placeholder: e.g. /etc/ceph/keyring
+    pool:
+      label: Pool
+      placeholder: e.g. rbd
+    image:
+      label: Image
+      placeholder: e.g. image
+  fc:
+    label: Fibre Channel (Unsupported)
+    targetWWNS:
+      add: Add Target WWN
+    wwids:
+      add: Add WWID
+    lun:
+      label: Lun
+      placeholder: e.g. 2
+  flexVolume:
+    label: Flex Volume (Unsupported)
+    driver:
+      label: Driver
+      placeholder: e.g. driver
+    options:
+      add: Add Option
+  flocker:
+    label: Flocker (Unsupported)
+    datasetName:
+      label: Dataset Name
+      placeholder: e.g. dataset
+    datasetUUID: 
+      label: Dataset UUID
+      placeholder: e.g. uuid
+  glusterfs:
+    label: Gluster Volume (Unsupported)
+    endpoints:
+      label: Endpoints
+      placeholder: e.g. glusterfs-cluster
+    path:
+      label: Path
+      placeholder: e.g. kube-vol
+  iscsi:
+    label: iSCSI Target (Unsupported)
+    initiatorName:
+      label: Initiator Name
+      placeholder: iqn.1994-05.com.redhat:1df7a24fcb92
+    iscsiInterface:
+      label: iSCSI Interface
+      placeholder: e.g. interface
+    chapAuthDiscovery:
+      label: Chap Auth Discovery
+    chapAuthSession:
+      label: Chap Auth Session
+    iqn:
+      label: IQN
+      placeholder: iqn.2001-04.com.example:storage.kube.sys1.xyz
+    lun:
+      label: Lun
+      placeholder: e.g. 2
+    targetPortal:
+      label: Target Portal
+      placeholder: e.g. portal
+    portals:
+      add: Add Portal
+  cinder:
+    label: Openstack Cinder Volume (Unsupported)
+    volumeId:
+      label: Volume ID
+      placeholder: e.g. vol
+  quobyte:
+    label: Quobyte Volume (Unsupported)
+    volume:
+      label: Volume
+      placeholder: e.g. vol
+    user:
+      label: User
+      placeholder: e.g. root
+    group:
+      label: Group
+      placeholder: e.g. abc
+    registry:
+      label: Registry
+      placeholder: e.g. abc
+  photonPersistentDisk:
+    label: Photon Volume (Unsupported)
+    pdId:
+      label: PD ID
+      placeholder: e.g. abc
+  portworxVolume:
+    label: Portworx Volume (Unsupported)
+    volumeId:
+      label: Volume ID
+      placeholder: e.g. abc
+  scaleIO:
+    label: ScaleIO Volume (Unsupported)
+    volumeName:
+      label: Volume Name
+      placeholder: e.g. vol-0
+    gateway:
+      label: Gateway
+      placeholder: e.g. https://localhost:443/api
+    protectionDomain:
+      label: Protection Domain
+      placeholder: e.g. pd01
+    storageMode:
+      label: Storage Mode
+      placeholder: e.g. ThinProvisioned
+    storagePool:
+      label: Storage Pool
+      placeholder: e.g. sp01
+    system:
+      label: System
+      placeholder: e.g. scaleio
+    sslEnabled:
+      label: SSL Enabled
+  storageos:
+    label: StorageOS (Unsupported)
+    volumeName: 
+      label: Volume Name
+      placeholder: e.g. vol
+    volumeNamespace: 
+      label: Volume Namespace
+      placeholder: e.g. default
   nfs:
     label: NFS Share
     path:
@@ -1624,7 +1805,7 @@ persistentVolume:
     server:
       label: Server
       placeholder: e.g. 10.244.1.4
-  csi:
+  longhorn:
     label: Longhorn
     volumeHandle:
       label: Volume Handle
@@ -1667,12 +1848,6 @@ persistentVolume:
     shareName:
       label: Share Name
       placeholder: e.g. abc
-    secretName:
-      label: Secret Name
-      placeholder: e.g. secret
-    secretNamespace:
-      label: Secret Namespace
-      placeholder: e.g. default
   azureDisk:
     label: Azure Disk
     diskName:
@@ -1691,12 +1866,6 @@ persistentVolume:
       none: None
       readOnly: Read Only
       readWrite: Read Write
-    filesystemType:
-      label: Filesystem Type
-      placeholder: e.g. ext4
-    readOnly:
-      label: Read Only
-
 
 persistentVolumeClaim:
   accessModes: Access Modes
@@ -2365,6 +2534,175 @@ storageClass:
       placeholder: e.g. ext3
   custom:
     addLabel: Add Parameter
+  glusterfs:
+    title: Gluster Volume (Unsupported)
+    restUrl:
+      label: REST URL
+      placeholder: e.g. http://127.0.0.1:8081
+    restUser:
+      label: REST User
+      placeholder: e.g. admin
+    restUserKey:
+      label: REST User Key
+      placeholder: e.g. password
+    secretNamespace:
+      label: Secret Namespace
+      placeholder: e.g. default
+    secretName:
+      label: Secret Name
+      placeholder: e.g. heketi-secret
+    clusterId:
+      label: Cluster ID
+      placeholder: e.g. 630372ccdc720a92c681fb928f27b53f
+    gidMin:
+      label: GID MIN
+      placeholder: e.g. 40000
+    gidMax:
+      label: GID MAX
+      placeholder: e.g. 50000
+    volumeType:
+      label: Volume Type
+      placeholder: "e.g. replicate:3"
+  cinder:
+    title: Openstack Cinder Volume (Unsupported)
+    volumeType:
+      label: Volume Type
+      placeholder: e.g. fast
+    availabilityZone:
+      label: Availability Zone
+      automatic: "Automatic: Zones the cluster has a node in"
+      manual: 
+        label: "Manual: Choose specific zones"
+        placeholder: e.g. nova
+  rbd:
+    title: Ceph RBD (Unsupported)
+    monitors:
+      label: Monitors
+      placeholder: e.g. 10.16.153.105:6789
+    adminId:
+      label: Admin ID
+      placeholder: e.g. kube
+    adminSecretNamespace:
+      label: Admin Secret Namespace
+      placeholder: e.g. kube-system
+    adminSecret:
+      label: Admin Secret
+      placeholder: e.g. Secret
+    pool:
+      label: Pool
+      placeholder: e.g. kube
+    userId:
+      label: User ID
+      placeholder: e.g. kube
+    userSecretNamespace:
+      label: User Secret Namespace
+      placeholder: e.g. default
+    userSecretName:
+      label: User Secret Name
+      placeholder: e.g. ceph-secret-user
+    filesystemType:
+      label: Filesystem Type
+      placeholder: e.g. ext4
+    imageFormat:
+      label: Image Format
+      placeholder: e.g. 2
+    imageFeatures:
+      label: Image Features
+      placeholder: e.g. layering
+  quobyte:
+    title: Quobyte Volume (Unsupported)
+    quobyteApiServer:
+      label: Quobyte API Server
+      placeholder: "e.g. http://138.68.74.142:7860"
+    registry: 
+      label: Registry
+      placeholder: e.g. 138.68.74.142:7861
+    adminSecretNamespace:
+      label: Admin Secret Namespace
+      placeholder: e.g. kube-system
+    adminSecretName:
+      label: Admin Secret Name
+      placeholder: e.g. quobyte-admin-secret
+    user:
+      label: User
+      placeholder: e.g. root
+    group:
+      label: Group
+      placeholder: e.g. root
+    quobyteConfig:
+      label: Quobyte Config
+      placeholder: e.g. BASE
+    quobyteTenant:
+      label: Quobyte Tenant
+      placeholder: e.g. DEFAULT
+  portworx-volume:
+    title: Portworx Volume (Unsupported)
+    filesystem:
+      label: Filesystem
+      placeholder: e.g. ext4
+    blockSize:
+      label: Block Size
+      placeholder: e.g. 32
+    repl:
+      label: Repl
+      placeholder: e.g.1; 0 for entire device
+    ioPriority:
+      label: I/O Priority
+      placeholder: e.g. low
+    snapshotsInterval:
+      label: Snapshots Interval
+      placeholder: e.g. 70
+    aggregationLevel:
+      label: Aggregation Level
+      placeholder: e.g. 0
+    ephemeral:
+      label: Ephemeral
+      placeholder: e.g. true
+  scaleio:
+    title: ScaleIO Volume (Unsupported)
+    gateway:
+      label: Gateway
+      placeholder: e.g. https://192.168.99.200:443/api
+    system:
+      label: System
+      placeholder: e.g. scaleio
+    protectionDomain:
+      label: Protection Domain
+      placeholder: e.g. pd0
+    storagePool:
+      label: Storage Pool
+      placeholder: e.g. sp1
+    storageMode:
+      label: StorageMode
+      thin: Thin Provisioned
+      thick: Thick Provisioned
+    secretRef:
+      label: Secret Ref
+      placeholder: e.g. sio-secret
+    readOnly:
+      label: Read Only
+    filesystemType:
+      label: Filesystem Type
+      placeholder: e.g. xfs
+  storageos:
+    title: StorageOS (Unsupported)
+    pool:
+      label: Pool
+      placeholder: e.g. default
+    description:
+      label: Description
+      placeholder: e.g. Kubernetes volume
+    filesystemType:
+      label: Filesystem Type
+      placeholder: e.g. ext4
+    adminSecretNamespace:
+      label: Admin Secret Namespace
+      placeholder: e.g. default
+    adminSecretName:
+      label: Admin Secret Name
+      placeholder: e.g. storageos-secret
+  no-provisioner:
+    title: Local Storage (Unsupported)
 
 tableHeaders:
   accessKey: Access Key

--- a/edit/persistentvolume/index.vue
+++ b/edit/persistentvolume/index.vue
@@ -14,10 +14,11 @@ import uniq from 'lodash/uniq';
 import UnitInput from '@/components/form/UnitInput';
 import { NODE, PVC, STORAGE_CLASS } from '@/config/types';
 import Loading from '@/components/Loading';
-import { VOLUME_PLUGINS } from '@/models/persistentvolume';
+import { LONGHORN_PLUGIN, VOLUME_PLUGINS } from '@/models/persistentvolume';
 import { _CREATE, _VIEW } from '@/config/query-params';
 import { clone } from '@/utils/object';
 import { parseSi } from '@/utils/units';
+import { fetchFeatureFlag, UNSUPPORTED_STORAGE_DRIVERS } from '@/utils/feature-flag';
 import InfoBox from '@/components/InfoBox';
 
 export default {
@@ -44,6 +45,7 @@ export default {
   async fetch() {
     const storageClasses = await this.$store.dispatch('cluster/findAll', { type: STORAGE_CLASS });
     const pvcPromise = this.$store.dispatch('cluster/findAll', { type: PVC });
+    const featureFlagPromise = fetchFeatureFlag(this.$store, UNSUPPORTED_STORAGE_DRIVERS);
 
     this.storageClassOptions = storageClasses.map(s => ({
       label: s.name,
@@ -51,6 +53,7 @@ export default {
     }));
     this.storageClassOptions.unshift(this.NONE_OPTION);
     await pvcPromise;
+    this.showUnsupportedStorage = await featureFlagPromise;
   },
 
   data() {
@@ -66,10 +69,11 @@ export default {
     this.$set(this.value.spec.capacity, 'storage', this.value.spec.capacity.storage || '10Gi');
     this.$set(this.value.spec, 'storageClassName', this.value.spec.storageClassName || NONE_OPTION.value);
 
-    const plugin = VOLUME_PLUGINS.find(plugin => this.value.spec[plugin.value])?.value || VOLUME_PLUGINS[0].value;
+    const foundPlugin = this.value.isLonghorn ? LONGHORN_PLUGIN : VOLUME_PLUGINS.find(plugin => this.value.spec[plugin.value]);
+    const plugin = (foundPlugin || VOLUME_PLUGINS[0]).value;
 
     return {
-      storageClassOptions: [], VOLUME_PLUGINS, plugin, NONE_OPTION, NODE, initialNodeAffinity: clone(this.value.spec.nodeAffinity)
+      storageClassOptions: [], plugin, NONE_OPTION, NODE, initialNodeAffinity: clone(this.value.spec.nodeAffinity), showUnsupportedStorage: false
     };
   },
 
@@ -133,6 +137,9 @@ export default {
     },
     areNodeSelectorsRequired() {
       return this.plugin === 'local';
+    },
+    plugins() {
+      return VOLUME_PLUGINS.filter(plugin => this.showUnsupportedStorage || plugin.supported);
     }
   },
 
@@ -166,7 +173,9 @@ export default {
       }
     },
     updatePlugin(value) {
-      delete this.value.spec[this.plugin];
+      const plugin = this.plugin === LONGHORN_PLUGIN.value ? 'csi' : this.plugin;
+
+      delete this.value.spec[plugin];
       this.$set(this, 'plugin', value);
     }
   }
@@ -216,7 +225,7 @@ export default {
           :label="'Volume Plugin'"
           :localized-label="true"
           option-label="labelKey"
-          :options="VOLUME_PLUGINS"
+          :options="plugins"
           :mode="modeOverride"
           :required="true"
           @input="updatePlugin($event)"
@@ -232,7 +241,6 @@ export default {
         />
       </div>
     </div>
-
     <Tabbed :side-tabs="true">
       <Tab name="plugin-configuration" :label="'Plugin Configuration'" :weight="1">
         <component :is="getComponent(plugin)" :key="plugin" :value="value" :mode="modeOverride" />

--- a/edit/persistentvolume/plugins/azureDisk.vue
+++ b/edit/persistentvolume/plugins/azureDisk.vue
@@ -59,7 +59,7 @@ export default {
     this.$set(this.value.spec, 'azureDisk', this.value.spec.azureDisk || {});
     this.$set(this.value.spec.azureDisk, 'readOnly', this.value.spec.azureDisk.readOnly || false);
     this.$set(this.value.spec.azureDisk, 'cachingMode', this.value.spec.azureDisk.cachingMode || cachingModeOptions[0].value);
-    this.$set(this.value.spec.azureDisk, 'kind', this.value.spec.azureDisk.kindOptions || kindOptions[2].value);
+    this.$set(this.value.spec.azureDisk, 'kind', this.value.spec.azureDisk.kind || kindOptions[2].value);
 
     return {
       kindOptions, readOnlyOptions, cachingModeOptions

--- a/edit/persistentvolume/plugins/cephfs.vue
+++ b/edit/persistentvolume/plugins/cephfs.vue
@@ -1,0 +1,80 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import ArrayList from '@/components/form/ArrayList';
+
+export default {
+  components: {
+    ArrayList, LabeledInput, RadioGroup
+  },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const readOnlyOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'cephfs', this.value.spec.cephfs || {});
+    this.$set(this.value.spec.cephfs, 'readOnly', this.value.spec.cephfs.readOnly || false);
+    this.$set(this.value.spec.cephfs, 'secretRef', this.value.spec.cephfs.secretRef || {});
+
+    return { readOnlyOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cephfs.path" :mode="mode" :label="t('persistentVolume.cephfs.path.label')" :placeholder="t('persistentVolume.cephfs.path.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cephfs.user" :mode="mode" :label="t('persistentVolume.cephfs.user.label')" :placeholder="t('persistentVolume.cephfs.user.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cephfs.secretFile" :mode="mode" :label="t('persistentVolume.cephfs.secretFile.label')" :placeholder="t('persistentVolume.cephfs.secretFile.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cephfs.secretRef.name" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cephfs.secretRef.namespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.cephfs.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="readOnlyOptions"
+          :row="true"
+        />
+      </div>
+      <div class="col span-6">
+        <ArrayList v-model="value.spec.cephfs.monitors" :add-label="t('persistentVolume.shared.monitors.add')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/cinder.vue
+++ b/edit/persistentvolume/plugins/cinder.vue
@@ -1,0 +1,69 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+
+export default {
+  components: { LabeledInput, RadioGroup },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const readOnlyOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'cinder', this.value.spec.cinder || {});
+    this.$set(this.value.spec.cinder, 'readOnly', this.value.spec.cinder.readOnly || false);
+    this.$set(this.value.spec.cinder, 'secretRef', this.value.spec.cinder.secretRef || {});
+
+    return { readOnlyOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cinder.volumeID" :mode="mode" :label="t('persistentVolume.cinder.volumeId.label')" :placeholder="t('persistentVolume.cinder.volumeId.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cinder.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cinder.secretRef.name" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.cinder.secretRef.namespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.cinder.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="readOnlyOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/csi.vue
+++ b/edit/persistentvolume/plugins/csi.vue
@@ -1,12 +1,11 @@
 <script>
-import KeyValue from '@/components/form/KeyValue';
 import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';
-import { _CREATE } from '@/config/query-params';
+import KeyValue from '@/components/form/KeyValue';
 
 export default {
   components: {
-    LabeledInput, KeyValue, RadioGroup
+    KeyValue, LabeledInput, RadioGroup
   },
   props:      {
     value:      {
@@ -19,20 +18,6 @@ export default {
     },
   },
   data() {
-    const defaultVolumeAttributes = {
-      size:                '2Gi',
-      numberOfReplicas:    '3',
-      staleReplicaTimeout: '20',
-      fromBackup:          ''
-    };
-
-    if (this.mode === _CREATE) {
-      this.$set(this.value.spec, 'csi', this.value.spec.csi || {});
-      this.$set(this.value.spec.csi, 'driver', 'driver.longhorn.io');
-      this.$set(this.value.spec.csi, 'readOnly', this.value.spec.csi.readOnly || false);
-      this.$set(this.value.spec.csi, 'volumeAttributes', this.value.spec.csi.volumeAttributes || defaultVolumeAttributes);
-    }
-
     const readOnlyOptions = [
       {
         label: this.t('generic.yes'),
@@ -44,6 +29,13 @@ export default {
       }
     ];
 
+    this.$set(this.value.spec, 'csi', this.value.spec.csi || {});
+    this.$set(this.value.spec.csi, 'readOnly', this.value.spec.csi.readOnly || false);
+    this.$set(this.value.spec.csi, 'nodePublishSecretRef', this.value.spec.csi.nodePublishSecretRef || {});
+    this.$set(this.value.spec.csi, 'nodeStageSecretRef', this.value.spec.csi.nodeStageSecretRef || {});
+    this.$set(this.value.spec.csi, 'controllerExpandSecretRef', this.value.spec.csi.controllerExpandSecretRef || {});
+    this.$set(this.value.spec.csi, 'controllerPublishSecretRef', this.value.spec.csi.controllerPublishSecretRef || {});
+
     return { readOnlyOptions };
   },
 };
@@ -53,13 +45,16 @@ export default {
   <div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.csi.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+        <LabeledInput v-model="value.spec.csi.driver" :mode="mode" :label="t('persistentVolume.csi.driver.label')" :placeholder="t('persistentVolume.csi.driver.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.csi.volumeHandle" :mode="mode" :label="t('persistentVolume.csi.volumeHandle.label')" :placeholder="t('persistentVolume.csi.volumeHandle.placeholder')" :required="true" />
+        <LabeledInput v-model="value.spec.csi.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
       </div>
     </div>
     <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.volumeHandle" :mode="mode" :label="t('persistentVolume.csi.volumeHandle.label')" :placeholder="t('persistentVolume.csi.volumeHandle.placeholder')" />
+      </div>
       <div class="col span-6">
         <RadioGroup
           v-model="value.spec.csi.readOnly"
@@ -73,14 +68,39 @@ export default {
     </div>
     <div class="row mb-20">
       <div class="col span-12">
-        <KeyValue
-          v-model="value.spec.csi.volumeAttributes"
-          :required="true"
-          :mode="mode"
-          :title="t('persistentVolume.csi.options.label')"
-          :add-label="t('persistentVolume.csi.options.addLabel')"
-          :read-allowed="false"
-        />
+        <KeyValue v-model="value.spec.csi.volumeAttributes" :add-label="t('persistentVolume.csi.volumeAttributes.add')" :mode="mode" :read-allowed="false" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.nodePublishSecretRef.name" :mode="mode" :label="t('persistentVolume.csi.nodePublishSecretName.label')" :placeholder="t('persistentVolume.csi.nodePublishSecretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.nodePublishSecretRef.namespace" :mode="mode" :label="t('persistentVolume.csi.nodePublishSecretNamespace.label')" :placeholder="t('persistentVolume.csi.nodePublishSecretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.nodeStageSecretRef.name" :mode="mode" :label="t('persistentVolume.csi.nodeStageSecretName.label')" :placeholder="t('persistentVolume.csi.nodeStageSecretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.nodeStageSecretRef.namespace" :mode="mode" :label="t('persistentVolume.csi.nodeStageSecretNamespace.label')" :placeholder="t('persistentVolume.csi.nodeStageSecretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.controllerExpandSecretRef.name" :mode="mode" :label="t('persistentVolume.csi.controllerExpandSecretName.label')" :placeholder="t('persistentVolume.csi.controllerExpandSecretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.controllerExpandSecretRef.namespace" :mode="mode" :label="t('persistentVolume.csi.controllerExpandSecretNamespace.label')" :placeholder="t('persistentVolume.csi.controllerExpandSecretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.controllerPublishSecretRef.name" :mode="mode" :label="t('persistentVolume.csi.controllerPublishSecretName.label')" :placeholder="t('persistentVolume.csi.controllerPublishSecretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.controllerPublishSecretRef.namespace" :mode="mode" :label="t('persistentVolume.csi.controllerPublishSecretNamespace.label')" :placeholder="t('persistentVolume.csi.controllerPublishSecretNamespace.placeholder')" />
       </div>
     </div>
   </div>

--- a/edit/persistentvolume/plugins/fc.vue
+++ b/edit/persistentvolume/plugins/fc.vue
@@ -1,0 +1,82 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import ArrayList from '@/components/form/ArrayList';
+
+export default {
+  components: {
+    ArrayList, LabeledInput, RadioGroup
+  },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const readOnlyOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'fc', this.value.spec.fc || {});
+    this.$set(this.value.spec.fc, 'readOnly', this.value.spec.fc.readOnly || false);
+    this.$set(this.value.spec.fc, 'secretRef', this.value.spec.fc.secretRef || {});
+
+    return { readOnlyOptions };
+  },
+  computed: {
+    lun: {
+      get() {
+        return this.value.spec.fc.lun;
+      },
+      set(value) {
+        this.$set(this.value.spec.fc, 'lun', Number.parseInt(value, 10));
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <ArrayList v-model="value.spec.fc.targetWWNs" :add-label="t('persistentVolume.fc.targetWWNS.add')" :mode="mode" />
+      </div>
+      <div class="col span-6">
+        <ArrayList v-model="value.spec.fc.wwids" :add-label="t('persistentVolume.fc.wwids.add')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="lun" :mode="mode" :label="t('persistentVolume.fc.lun.label')" :placeholder="t('persistentVolume.fc.lun.placeholder')" type="number" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.fc.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.fc.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="readOnlyOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/flexVolume.vue
+++ b/edit/persistentvolume/plugins/flexVolume.vue
@@ -1,0 +1,77 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import KeyValue from '@/components/form/KeyValue';
+
+export default {
+  components: {
+    KeyValue, LabeledInput, RadioGroup
+  },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const readOnlyOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'flexVolume', this.value.spec.flexVolume || {});
+    this.$set(this.value.spec.flexVolume, 'readOnly', this.value.spec.flexVolume.readOnly || false);
+    this.$set(this.value.spec.flexVolume, 'secretRef', this.value.spec.flexVolume.secretRef || {});
+
+    return { readOnlyOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.flexVolume.driver" :mode="mode" :label="t('persistentVolume.flexVolume.driver.label')" :placeholder="t('persistentVolume.flexVolume.driver.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.flexVolume.secretRef.name" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.flexVolume.secretRef.namespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.flexVolume.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.flexVolume.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="readOnlyOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <KeyValue v-model="value.spec.flexVolume.options" :add-label="t('persistentVolume.flexVolume.options.add')" :mode="mode" :read-allowed="false" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/flocker.vue
+++ b/edit/persistentvolume/plugins/flocker.vue
@@ -1,0 +1,35 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    this.$set(this.value.spec, 'flocker', this.value.spec.flocker || {});
+
+    return {};
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.flocker.datasetName" :mode="mode" :label="t('persistentVolume.flocker.datasetName.label')" :placeholder="t('persistentVolume.flocker.datasetName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.flocker.datasetUUID" :mode="mode" :label="t('persistentVolume.flocker.datasetUUID.label')" :placeholder="t('persistentVolume.flocker.datasetUUID.placeholder')" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/glusterfs.vue
+++ b/edit/persistentvolume/plugins/glusterfs.vue
@@ -3,7 +3,7 @@ import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';
 
 export default {
-  components: { LabeledInput, RadioGroup },
+  components: { RadioGroup, LabeledInput },
   props:      {
     value:      {
       type:    Object,
@@ -15,9 +15,6 @@ export default {
     },
   },
   data() {
-    this.$set(this.value.spec, 'azureFile', this.value.spec.azureFile || {});
-    this.$set(this.value.spec.azureFile, 'readOnly', this.value.spec.azureFile.readOnly || false);
-
     const readOnlyOptions = [
       {
         label: this.t('generic.yes'),
@@ -29,6 +26,9 @@ export default {
       }
     ];
 
+    this.$set(this.value.spec, 'glusterfs', this.value.spec.glusterfs || {});
+    this.$set(this.value.spec.glusterfs, 'readOnly', this.value.spec.glusterfs.readOnly || false);
+
     return { readOnlyOptions };
   },
 };
@@ -38,19 +38,16 @@ export default {
   <div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.shareName" :mode="mode" :label="t('persistentVolume.azureFile.shareName.label')" :placeholder="t('persistentVolume.azureFile.shareName.placeholder')" />
+        <LabeledInput v-model="value.spec.glusterfs.endpoints" :mode="mode" :label="t('persistentVolume.glusterfs.endpoints.label')" :placeholder="t('persistentVolume.glusterfs.endpoints.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.secretName" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+        <LabeledInput v-model="value.spec.glusterfs.path" :mode="mode" :label="t('persistentVolume.glusterfs.path.label')" :placeholder="t('persistentVolume.glusterfs.path.placeholder')" />
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.secretNamespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
-      </div>
-      <div class="col span-6">
         <RadioGroup
-          v-model="value.spec.azureFile.readOnly"
+          v-model="value.spec.glusterfs.readOnly"
           name="readOnly"
           :mode="mode"
           :label="t('persistentVolume.shared.readOnly.label')"

--- a/edit/persistentvolume/plugins/iscsi.vue
+++ b/edit/persistentvolume/plugins/iscsi.vue
@@ -1,0 +1,125 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import ArrayList from '@/components/form/ArrayList';
+
+export default {
+  components: {
+    ArrayList, LabeledInput, RadioGroup
+  },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const yesNoOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'iscsi', this.value.spec.iscsi || {});
+    this.$set(this.value.spec.iscsi, 'readOnly', this.value.spec.iscsi.readOnly || false);
+    this.$set(this.value.spec.iscsi, 'secretRef', this.value.spec.iscsi.secretRef || {});
+    this.$set(this.value.spec.iscsi, 'chapAuthDiscovery', this.value.spec.iscsi.chapAuthDiscovery || false);
+    this.$set(this.value.spec.iscsi, 'chapAuthSession', this.value.spec.iscsi.chapAuthSession || false);
+
+    return { yesNoOptions };
+  },
+  computed: {
+    lun: {
+      get() {
+        return this.value.spec.iscsi.lun;
+      },
+      set(value) {
+        this.$set(this.value.spec.iscsi, 'lun', Number.parseInt(value, 10));
+      }
+    },
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.iscsi.initiatorName" :mode="mode" :label="t('persistentVolume.iscsi.initiatorName.label')" :placeholder="t('persistentVolume.iscsi.initiatorName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.iscsi.iscsiInterface" :mode="mode" :label="t('persistentVolume.iscsi.iscsiInterface.label')" :placeholder="t('persistentVolume.iscsi.iscsiInterface.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.iscsi.chapAuthDiscovery"
+          name="chap-auth-discovery"
+          :mode="mode"
+          :label="t('persistentVolume.iscsi.chapAuthDiscovery.label')"
+          :options="yesNoOptions"
+          :row="true"
+        />
+      </div>
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.iscsi.chapAuthSession"
+          name="chap-auth-session"
+          :mode="mode"
+          :label="t('persistentVolume.iscsi.chapAuthSession.label')"
+          :options="yesNoOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.iscsi.iqn" :mode="mode" :label="t('persistentVolume.iscsi.iqn.label')" :placeholder="t('persistentVolume.iscsi.iqn.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="lun" :mode="mode" :label="t('persistentVolume.iscsi.lun.label')" :placeholder="t('persistentVolume.iscsi.lun.placeholder')" type="number" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.iscsi.targetPortal" :mode="mode" :label="t('persistentVolume.iscsi.targetPortal.label')" :placeholder="t('persistentVolume.iscsi.targetPortal.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <ArrayList v-model="value.spec.iscsi.portals" :mode="mode" :add-label="t('persistentVolume.iscsi.portals.add')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.iscsi.secretRef.name" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.iscsi.secretRef.namespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.iscsi.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.iscsi.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="yesNoOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/longhorn.vue
+++ b/edit/persistentvolume/plugins/longhorn.vue
@@ -1,0 +1,88 @@
+<script>
+import KeyValue from '@/components/form/KeyValue';
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import { _CREATE } from '@/config/query-params';
+import { LONGHORN_DRIVER } from '@/models/persistentvolume';
+
+export default {
+  components: {
+    LabeledInput, KeyValue, RadioGroup
+  },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const defaultVolumeAttributes = {
+      size:                '2Gi',
+      numberOfReplicas:    '3',
+      staleReplicaTimeout: '20',
+      fromBackup:          ''
+    };
+
+    if (this.mode === _CREATE) {
+      this.$set(this.value.spec, 'csi', this.value.spec.csi || {});
+      this.$set(this.value.spec.csi, 'driver', LONGHORN_DRIVER);
+      this.$set(this.value.spec.csi, 'readOnly', this.value.spec.csi.readOnly || false);
+      this.$set(this.value.spec.csi, 'volumeAttributes', this.value.spec.csi.volumeAttributes || defaultVolumeAttributes);
+    }
+
+    const readOnlyOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    return { readOnlyOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.csi.volumeHandle" :mode="mode" :label="t('persistentVolume.longhorn.volumeHandle.label')" :placeholder="t('persistentVolume.longhorn.volumeHandle.placeholder')" :required="true" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.csi.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="readOnlyOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-12">
+        <KeyValue
+          v-model="value.spec.csi.volumeAttributes"
+          :required="true"
+          :mode="mode"
+          :title="t('persistentVolume.longhorn.options.label')"
+          :add-label="t('persistentVolume.longhorn.options.addLabel')"
+          :read-allowed="false"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/photonPersistentDisk.vue
+++ b/edit/persistentvolume/plugins/photonPersistentDisk.vue
@@ -1,0 +1,48 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const readOnlyOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'photonPersistentDisk', this.value.spec.photonPersistentDisk || {});
+    this.$set(this.value.spec.photonPersistentDisk, 'readOnly', this.value.spec.photonPersistentDisk.readOnly || false);
+    this.$set(this.value.spec.photonPersistentDisk, 'secretRef', this.value.spec.photonPersistentDisk.secretRef || {});
+
+    return { readOnlyOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.photonPersistentDisk.pdID" :mode="mode" :label="t('persistentVolume.photonPersistentDisk.pdId.label')" :placeholder="t('persistentVolume.photonPersistentDisk.pdId.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.photonPersistentDisk.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/portworxVolume.vue
+++ b/edit/persistentvolume/plugins/portworxVolume.vue
@@ -15,9 +15,6 @@ export default {
     },
   },
   data() {
-    this.$set(this.value.spec, 'azureFile', this.value.spec.azureFile || {});
-    this.$set(this.value.spec.azureFile, 'readOnly', this.value.spec.azureFile.readOnly || false);
-
     const readOnlyOptions = [
       {
         label: this.t('generic.yes'),
@@ -29,6 +26,10 @@ export default {
       }
     ];
 
+    this.$set(this.value.spec, 'portworxVolume', this.value.spec.portworxVolume || {});
+    this.$set(this.value.spec.portworxVolume, 'readOnly', this.value.spec.portworxVolume.readOnly || false);
+    this.$set(this.value.spec.portworxVolume, 'secretRef', this.value.spec.portworxVolume.secretRef || {});
+
     return { readOnlyOptions };
   },
 };
@@ -38,19 +39,16 @@ export default {
   <div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.shareName" :mode="mode" :label="t('persistentVolume.azureFile.shareName.label')" :placeholder="t('persistentVolume.azureFile.shareName.placeholder')" />
+        <LabeledInput v-model="value.spec.portworxVolume.volumeID" :mode="mode" :label="t('persistentVolume.portworxVolume.volumeId.label')" :placeholder="t('persistentVolume.portworxVolume.volumeId.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.secretName" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+        <LabeledInput v-model="value.spec.portworxVolume.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.secretNamespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
-      </div>
-      <div class="col span-6">
         <RadioGroup
-          v-model="value.spec.azureFile.readOnly"
+          v-model="value.spec.portworxVolume.readOnly"
           name="readOnly"
           :mode="mode"
           :label="t('persistentVolume.shared.readOnly.label')"

--- a/edit/persistentvolume/plugins/quobyte.vue
+++ b/edit/persistentvolume/plugins/quobyte.vue
@@ -15,9 +15,6 @@ export default {
     },
   },
   data() {
-    this.$set(this.value.spec, 'azureFile', this.value.spec.azureFile || {});
-    this.$set(this.value.spec.azureFile, 'readOnly', this.value.spec.azureFile.readOnly || false);
-
     const readOnlyOptions = [
       {
         label: this.t('generic.yes'),
@@ -29,6 +26,9 @@ export default {
       }
     ];
 
+    this.$set(this.value.spec, 'quobyte', this.value.spec.quobyte || {});
+    this.$set(this.value.spec.quobyte, 'readOnly', this.value.spec.quobyte.readOnly || false);
+
     return { readOnlyOptions };
   },
 };
@@ -38,19 +38,24 @@ export default {
   <div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.shareName" :mode="mode" :label="t('persistentVolume.azureFile.shareName.label')" :placeholder="t('persistentVolume.azureFile.shareName.placeholder')" />
+        <LabeledInput v-model="value.spec.quobyte.volume" :mode="mode" :label="t('persistentVolume.quobyte.volume.label')" :placeholder="t('persistentVolume.quobyte.volume.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.secretName" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+        <LabeledInput v-model="value.spec.quobyte.user" :mode="mode" :label="t('persistentVolume.quobyte.user.label')" :placeholder="t('persistentVolume.quobyte.user.placeholder')" />
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.spec.azureFile.secretNamespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+        <LabeledInput v-model="value.spec.quobyte.group" :mode="mode" :label="t('persistentVolume.quobyte.group.label')" :placeholder="t('persistentVolume.quobyte.group.placeholder')" />
       </div>
       <div class="col span-6">
+        <LabeledInput v-model="value.spec.quobyte.registry" :mode="mode" :label="t('persistentVolume.quobyte.registry.label')" :placeholder="t('persistentVolume.quobyte.registry.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
         <RadioGroup
-          v-model="value.spec.azureFile.readOnly"
+          v-model="value.spec.quobyte.readOnly"
           name="readOnly"
           :mode="mode"
           :label="t('persistentVolume.shared.readOnly.label')"

--- a/edit/persistentvolume/plugins/rbd.vue
+++ b/edit/persistentvolume/plugins/rbd.vue
@@ -1,0 +1,88 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import ArrayList from '@/components/form/ArrayList';
+
+export default {
+  components: {
+    ArrayList, LabeledInput, RadioGroup
+  },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const readOnlyOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'rbd', this.value.spec.rbd || {});
+    this.$set(this.value.spec.rbd, 'readOnly', this.value.spec.rbd.readOnly || false);
+    this.$set(this.value.spec.rbd, 'secretRef', this.value.spec.rbd.secretRef || {});
+
+    return { readOnlyOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.rbd.user" :mode="mode" :label="t('persistentVolume.rbd.user.label')" :placeholder="t('persistentVolume.rbd.user.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.rbd.keyring" :mode="mode" :label="t('persistentVolume.rbd.keyRing.label')" :placeholder="t('persistentVolume.rbd.keyRing.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.rbd.pool" :mode="mode" :label="t('persistentVolume.rbd.pool.label')" :placeholder="t('persistentVolume.rbd.pool.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.rbd.image" :mode="mode" :label="t('persistentVolume.rbd.image.label')" :placeholder="t('persistentVolume.rbd.image.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.rbd.secretRef.name" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.rbd.secretRef.namespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.rbd.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.rbd.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="readOnlyOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <ArrayList v-model="value.spec.rbd.monitors" :add-label="t('persistentVolume.shared.monitors.add')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/scaleIO.vue
+++ b/edit/persistentvolume/plugins/scaleIO.vue
@@ -1,0 +1,101 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+
+export default {
+  components: { LabeledInput, RadioGroup },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const yesNoOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'scaleIO', this.value.spec.scaleIO || {});
+    this.$set(this.value.spec.scaleIO, 'readOnly', this.value.spec.scaleIO.readOnly || false);
+    this.$set(this.value.spec.scaleIO, 'secretRef', this.value.spec.scaleIO.secretRef || {});
+    this.$set(this.value.spec.scaleIO, 'sslEnabled', this.value.spec.scaleIO.sslEnabled || false);
+
+    return { yesNoOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.volumeName" :mode="mode" :label="t('persistentVolume.scaleIO.volumeName.label')" :placeholder="t('persistentVolume.scaleIO.volumeName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.gateway" :mode="mode" :label="t('persistentVolume.scaleIO.gateway.label')" :placeholder="t('persistentVolume.scaleIO.gateway.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.protectionDomain" :mode="mode" :label="t('persistentVolume.scaleIO.protectionDomain.label')" :placeholder="t('persistentVolume.scaleIO.protectionDomain.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.storageMode" :mode="mode" :label="t('persistentVolume.scaleIO.storageMode.label')" :placeholder="t('persistentVolume.scaleIO.storageMode.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.storagePool" :mode="mode" :label="t('persistentVolume.scaleIO.storagePool.label')" :placeholder="t('persistentVolume.scaleIO.storagePool.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.system" :mode="mode" :label="t('persistentVolume.scaleIO.system.label')" :placeholder="t('persistentVolume.scaleIO.system.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.scaleIO.sslEnabled"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.scaleIO.sslEnabled.label')"
+          :options="yesNoOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.secretRef.name" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.secretRef.namespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.scaleIO.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.scaleIO.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="yesNoOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/persistentvolume/plugins/storageos.vue
+++ b/edit/persistentvolume/plugins/storageos.vue
@@ -1,0 +1,73 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+
+export default {
+  components: { LabeledInput, RadioGroup },
+  props:      {
+    value:      {
+      type:    Object,
+      default: () => ({})
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  data() {
+    const yesNoOptions = [
+      {
+        label: this.t('generic.yes'),
+        value: true
+      },
+      {
+        label: this.t('generic.no'),
+        value: false
+      }
+    ];
+
+    this.$set(this.value.spec, 'storageos', this.value.spec.storageos || {});
+    this.$set(this.value.spec.storageos, 'readOnly', this.value.spec.storageos.readOnly || false);
+    this.$set(this.value.spec.storageos, 'secretRef', this.value.spec.storageos.secretRef || {});
+
+    return { yesNoOptions };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.storageos.volumeName" :mode="mode" :label="t('persistentVolume.storageos.volumeName.label')" :placeholder="t('persistentVolume.storageos.volumeName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.storageos.volumeNamespace" :mode="mode" :label="t('persistentVolume.storageos.volumeNamespace.label')" :placeholder="t('persistentVolume.storageos.volumeNamespace.placeholder')" />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.storageos.secretRef.name" :mode="mode" :label="t('persistentVolume.shared.secretName.label')" :placeholder="t('persistentVolume.shared.secretName.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.storageos.secretRef.namespace" :mode="mode" :label="t('persistentVolume.shared.secretNamespace.label')" :placeholder="t('persistentVolume.shared.secretNamespace.placeholder')" />
+      </div>
+    </div>
+
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput v-model="value.spec.storageos.fsType" :mode="mode" :label="t('persistentVolume.shared.filesystemType.label')" :placeholder="t('persistentVolume.shared.filesystemType.placeholder')" />
+      </div>
+      <div class="col span-6">
+        <RadioGroup
+          v-model="value.spec.storageos.readOnly"
+          name="readOnly"
+          :mode="mode"
+          :label="t('persistentVolume.shared.readOnly.label')"
+          :options="yesNoOptions"
+          :row="true"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/cinder.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/cinder.vue
@@ -1,0 +1,58 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+
+export default {
+  components: { LabeledInput, RadioGroup },
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      availabilityZoneOptions: [
+        {
+          label: this.t('storageClass.cinder.availabilityZone.automatic'),
+          value: 'automatic'
+        },
+        {
+          label: this.t('storageClass.cinder.availabilityZone.manual.label'),
+          value: 'manual'
+        }
+      ],
+      availabilityZone: this.value.parameters.availability ? 'manual' : 'automatic'
+    };
+  },
+  watch: {
+    availabilityZone() {
+      this.$set(this.value.parameters, 'availability', '');
+    }
+  }
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput v-model="value.parameters.type" :placeholder="t('storageClass.cinder.volumeType.placeholder')" :label="t('storageClass.cinder.volumeType.label')" :mode="mode" />
+      </div>
+      <div class="col span-6">
+        <RadioGroup v-model="availabilityZone" name="availability-zone" :options="availabilityZoneOptions" :label="t('storageClass.cinder.availabilityZone.label')" :mode="mode" />
+        <LabeledInput
+          v-if="availabilityZone === 'manual'"
+          v-model="value.parameters.availability"
+          class="mt-10"
+          :placeholder="t('storageClass.cinder.availabilityZone.manual.placeholder')"
+          :label="t('storageClass.cinder.availabilityZone.manual.label')"
+          :mode="mode"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/glusterfs.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/glusterfs.vue
@@ -1,0 +1,54 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  }
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.resturl" :placeholder="t('storageClass.glusterfs.restUrl.placeholder')" :label="t('storageClass.glusterfs.restUrl.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.restuser" :placeholder="t('storageClass.glusterfs.restUser.placeholder')" :label="t('storageClass.glusterfs.restUser.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.restuserkey" :placeholder="t('storageClass.glusterfs.restUserKey.placeholder')" :label="t('storageClass.glusterfs.restUserKey.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.secretNamespace" :placeholder="t('storageClass.glusterfs.secretNamespace.placeholder')" :label="t('storageClass.glusterfs.secretNamespace.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.secretName" :placeholder="t('storageClass.glusterfs.secretName.placeholder')" :label="t('storageClass.glusterfs.secretName.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.clusterid" :placeholder="t('storageClass.glusterfs.clusterId.placeholder')" :label="t('storageClass.glusterfs.clusterId.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.gidMin" :placeholder="t('storageClass.glusterfs.gidMin.placeholder')" :label="t('storageClass.glusterfs.gidMin.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.gidMax" :placeholder="t('storageClass.glusterfs.gidMax.placeholder')" :label="t('storageClass.glusterfs.gidMax.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.volumetype" :placeholder="t('storageClass.glusterfs.volumeType.placeholder')" :label="t('storageClass.glusterfs.volumeType.label')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/no-provisioner.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/no-provisioner.vue
@@ -1,0 +1,21 @@
+<script>
+export default {
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  }
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      {{ t('generic.na') }}
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/portworx-volume.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/portworx-volume.vue
@@ -1,0 +1,48 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  }
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.fs" :placeholder="t('storageClass.portworx-volume.filesystem.placeholder')" :label="t('storageClass.portworx-volume.filesystem.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.block_size" :placeholder="t('storageClass.portworx-volume.blockSize.placeholder')" :label="t('storageClass.portworx-volume.blockSize.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.repl" :placeholder="t('storageClass.portworx-volume.repl.placeholder')" :label="t('storageClass.portworx-volume.repl.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.io_priority" :placeholder="t('storageClass.portworx-volume.ioPriority.placeholder')" :label="t('storageClass.portworx-volume.ioPriority.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.snap_interval" :placeholder="t('storageClass.portworx-volume.snapshotsInterval.placeholder')" :label="t('storageClass.portworx-volume.snapshotsInterval.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.aggregation_level" :placeholder="t('storageClass.portworx-volume.aggregationLevel.placeholder')" :label="t('storageClass.portworx-volume.aggregationLevel.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.ephemeral" :placeholder="t('storageClass.portworx-volume.ephemeral.placeholder')" :label="t('storageClass.portworx-volume.ephemeral.label')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/quobyte.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/quobyte.vue
@@ -1,0 +1,51 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  }
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.quobyteAPIServer" :placeholder="t('storageClass.quobyte.quobyteApiServer.placeholder')" :label="t('storageClass.quobyte.quobyteApiServer.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.registry" :placeholder="t('storageClass.quobyte.registry.placeholder')" :label="t('storageClass.quobyte.registry.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.adminSecretNamespace" :placeholder="t('storageClass.quobyte.adminSecretNamespace.placeholder')" :label="t('storageClass.quobyte.adminSecretNamespace.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.adminSecretName" :placeholder="t('storageClass.quobyte.adminSecretName.placeholder')" :label="t('storageClass.quobyte.adminSecretName.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.user" :placeholder="t('storageClass.quobyte.user.placeholder')" :label="t('storageClass.quobyte.user.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.group" :placeholder="t('storageClass.quobyte.group.placeholder')" :label="t('storageClass.quobyte.group.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.quobyteConfig" :placeholder="t('storageClass.quobyte.quobyteConfig.placeholder')" :label="t('storageClass.quobyte.quobyteConfig.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.quobyteTenant" :placeholder="t('storageClass.quobyte.quobyteTenant.placeholder')" :label="t('storageClass.quobyte.quobyteTenant.label')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/rbd.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/rbd.vue
@@ -1,0 +1,62 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  }
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.monitors" :placeholder="t('storageClass.rbd.monitors.placeholder')" :label="t('storageClass.rbd.monitors.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.adminId" :placeholder="t('storageClass.rbd.adminId.placeholder')" :label="t('storageClass.rbd.adminId.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.adminSecretNamespace" :placeholder="t('storageClass.rbd.adminSecretNamespace.placeholder')" :label="t('storageClass.rbd.adminSecretNamespace.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.adminSecretName" :placeholder="t('storageClass.rbd.adminSecret.placeholder')" :label="t('storageClass.rbd.adminSecret.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.pool" :placeholder="t('storageClass.rbd.pool.placeholder')" :label="t('storageClass.rbd.pool.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.userId" :placeholder="t('storageClass.rbd.userId.placeholder')" :label="t('storageClass.rbd.userId.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.userSecretNamespace" :placeholder="t('storageClass.rbd.userSecretNamespace.placeholder')" :label="t('storageClass.rbd.userSecretNamespace.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.userSecretName" :placeholder="t('storageClass.rbd.userSecretName.placeholder')" :label="t('storageClass.rbd.userSecretName.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.fsType" :placeholder="t('storageClass.rbd.filesystemType.placeholder')" :label="t('storageClass.rbd.filesystemType.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.imageFormat" :placeholder="t('storageClass.rbd.imageFormat.placeholder')" :label="t('storageClass.rbd.imageFormat.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.imageFeatures" :placeholder="t('storageClass.rbd.imageFeatures.placeholder')" :label="t('storageClass.rbd.imageFeatures.label')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/scaleio.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/scaleio.vue
@@ -1,0 +1,76 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+
+export default {
+  components: { LabeledInput, LabeledSelect },
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      storageModeOptions: [
+        {
+          label: this.t('storageClass.scaleio.storageMode.thin'),
+          value: 'ThinProvisioned'
+        },
+        {
+          label: this.t('storageClass.scaleio.storageMode.thick'),
+          value: 'ThickProvisioned'
+        }
+      ],
+      readOnlyOptions: [
+        {
+          label: this.t('generic.yes'),
+          value: 'true'
+        },
+        {
+          label: this.t('generic.no'),
+          value: 'false'
+        }
+      ]
+    };
+  },
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.gateway" :placeholder="t('storageClass.scaleio.gateway.placeholder')" :label="t('storageClass.scaleio.gateway.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.system" :placeholder="t('storageClass.scaleio.system.placeholder')" :label="t('storageClass.scaleio.system.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.protectionDomain" :placeholder="t('storageClass.scaleio.protectionDomain.placeholder')" :label="t('storageClass.scaleio.protectionDomain.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.storagePool" :placeholder="t('storageClass.scaleio.storagePool.placeholder')" :label="t('storageClass.scaleio.storagePool.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledSelect v-model="value.parameters.storageMode" :options="storageModeOptions" :label="t('storageClass.scaleio.storageMode.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.secretRef" :placeholder="t('storageClass.scaleio.secretRef.placeholder')" :label="t('storageClass.scaleio.secretRef.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledSelect v-model="value.parameters.readOnly" :options="readOnlyOptions" :label="t('storageClass.scaleio.readOnly.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.fsType" :placeholder="t('storageClass.scaleio.filesystemType.placeholder')" :label="t('storageClass.scaleio.filesystemType.label')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/storageos.vue
+++ b/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/storageos.vue
@@ -1,0 +1,40 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  props:      {
+    value: {
+      type:     Object,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    }
+  }
+};
+</script>
+<template>
+  <div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.pool" :placeholder="t('storageClass.storageos.pool.placeholder')" :label="t('storageClass.storageos.pool.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.description" :placeholder="t('storageClass.storageos.description.placeholder')" :label="t('storageClass.storageos.description.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.fsType" :placeholder="t('storageClass.storageos.filesystemType.placeholder')" :label="t('storageClass.storageos.filesystemType.label')" :mode="mode" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.adminSecretNamespace" :placeholder="t('storageClass.storageos.adminSecretNamespace.placeholder')" :label="t('storageClass.storageos.adminSecretNamespace.label')" :mode="mode" />
+      </div>
+      <div class="col span-4">
+        <LabeledInput v-model="value.parameters.adminSecretName" :placeholder="t('storageClass.storageos.adminSecretName.placeholder')" :label="t('storageClass.storageos.adminSecretName.label')" :mode="mode" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/models/persistentvolume.js
+++ b/models/persistentvolume.js
@@ -2,47 +2,125 @@ import { PVC } from '@/config/types';
 
 export const VOLUME_PLUGINS = [
   {
-    labelKey: 'persistentVolume.awsElasticBlockStore.label',
-    value:    'awsElasticBlockStore',
+    labelKey:  'persistentVolume.awsElasticBlockStore.label',
+    value:     'awsElasticBlockStore',
+    supported: true
   },
   {
-    labelKey: 'persistentVolume.azureDisk.label',
-    value:    'azureDisk',
+    labelKey:  'persistentVolume.azureDisk.label',
+    value:     'azureDisk',
+    supported: true
   },
   {
-    labelKey: 'persistentVolume.azureFile.label',
-    value:    'azureFile',
+    labelKey:  'persistentVolume.azureFile.label',
+    value:     'azureFile',
+    supported: true
   },
   {
-    labelKey: 'persistentVolume.gcePersistentDisk.label',
-    value:    'gcePersistentDisk',
+    labelKey: 'persistentVolume.cephfs.label',
+    value:    'cephfs',
   },
   {
-    labelKey: 'persistentVolume.hostPath.label',
-    value:    'hostPath',
-  },
-  {
-    labelKey: 'persistentVolume.local.label',
-    value:    'local',
+    labelKey: 'persistentVolume.rbd.label',
+    value:    'rbd',
   },
   {
     labelKey: 'persistentVolume.csi.label',
     value:    'csi',
   },
   {
-    labelKey: 'persistentVolume.nfs.label',
-    value:    'nfs',
+    labelKey: 'persistentVolume.fc.label',
+    value:    'fc',
   },
   {
-    labelKey: 'persistentVolume.vsphereVolume.label',
-    value:    'vsphereVolume',
+    labelKey: 'persistentVolume.flexVolume.label',
+    value:    'flexVolume',
+  },
+  {
+    labelKey: 'persistentVolume.flocker.label',
+    value:    'flocker',
+  },
+  {
+    labelKey: 'persistentVolume.glusterfs.label',
+    value:    'glusterfs',
+  },
+  {
+    labelKey:  'persistentVolume.gcePersistentDisk.label',
+    value:     'gcePersistentDisk',
+    supported: true
+  },
+  {
+    labelKey:  'persistentVolume.hostPath.label',
+    value:     'hostPath',
+    supported: true
+  },
+  {
+    labelKey: 'persistentVolume.iscsi.label',
+    value:    'iscsi',
+  },
+  {
+    labelKey:  'persistentVolume.local.label',
+    value:     'local',
+    supported: true
+  },
+  {
+    labelKey:  'persistentVolume.longhorn.label',
+    value:     'longhorn',
+    supported: true
+  },
+  {
+    labelKey:  'persistentVolume.nfs.label',
+    value:     'nfs',
+    supported: true
+  },
+  {
+    labelKey: 'persistentVolume.cinder.label',
+    value:    'cinder',
+  },
+  {
+    labelKey: 'persistentVolume.photonPersistentDisk.label',
+    value:    'photonPersistentDisk',
+  },
+  {
+    labelKey: 'persistentVolume.portworxVolume.label',
+    value:    'portworxVolume',
+  },
+
+  {
+    labelKey: 'persistentVolume.quobyte.label',
+    value:    'quobyte',
+  },
+
+  {
+    labelKey: 'persistentVolume.scaleIO.label',
+    value:    'scaleIO',
+  },
+  {
+    labelKey: 'persistentVolume.storageos.label',
+    value:    'storageos',
+  },
+  {
+    labelKey:  'persistentVolume.vsphereVolume.label',
+    value:     'vsphereVolume',
+    supported: true
   },
 ];
 
+export const LONGHORN_DRIVER = 'driver.longhorn.io';
+
+export const LONGHORN_PLUGIN = VOLUME_PLUGINS.find(plugin => plugin.value === 'longhorn');
+
 export default {
   source() {
-    return this.t(VOLUME_PLUGINS.find(plugin => this.spec[plugin.value]).labelKey);
+    const plugin = this.isLonghorn ? LONGHORN_PLUGIN : VOLUME_PLUGINS.find(plugin => this.spec[plugin.value]);
+
+    return this.t(plugin.labelKey);
   },
+
+  isLonghorn() {
+    return this.spec.csi && this.spec.csi.driver === LONGHORN_DRIVER;
+  },
+
   claim() {
     if (!this.name) {
       return null;

--- a/models/storage.k8s.io.storageclass.js
+++ b/models/storage.k8s.io.storageclass.js
@@ -3,28 +3,66 @@ import { STORAGE_CLASS } from '@/config/types';
 
 export const PROVISIONER_OPTIONS = [
   {
-    labelKey: 'storageClass.aws-ebs.title',
-    value:    'kubernetes.io/aws-ebs'
+    labelKey:  'storageClass.aws-ebs.title',
+    value:     'kubernetes.io/aws-ebs',
+    supported: true
   },
   {
-    labelKey: 'storageClass.azure-disk.title',
-    value:    'kubernetes.io/azure-disk'
+    labelKey:  'storageClass.azure-disk.title',
+    value:     'kubernetes.io/azure-disk',
+    supported: true
   },
   {
-    labelKey: 'storageClass.azure-file.title',
-    value:    'kubernetes.io/azure-file'
+    labelKey:  'storageClass.azure-file.title',
+    value:     'kubernetes.io/azure-file',
+    supported: true
   },
   {
-    labelKey: 'storageClass.gce-pd.title',
-    value:    'kubernetes.io/gce-pd'
+    labelKey: 'storageClass.rbd.title',
+    value:    'kubernetes.io/rbd',
   },
   {
-    labelKey: 'storageClass.longhorn.title',
-    value:    'driver.longhorn.io'
+    labelKey: 'storageClass.glusterfs.title',
+    value:    'kubernetes.io/glusterfs',
   },
   {
-    labelKey: 'storageClass.vsphere-volume.title',
-    value:    'kubernetes.io/vsphere-volume'
+    labelKey:  'storageClass.gce-pd.title',
+    value:     'kubernetes.io/gce-pd',
+    supported: true
+  },
+  {
+    labelKey: 'storageClass.no-provisioner.title',
+    value:    'kubernetes.io/no-provisioner',
+  },
+  {
+    labelKey:  'storageClass.longhorn.title',
+    value:     'driver.longhorn.io',
+    supported: true
+  },
+  {
+    labelKey: 'storageClass.cinder.title',
+    value:    'kubernetes.io/cinder',
+  },
+  {
+    labelKey: 'storageClass.portworx-volume.title',
+    value:    'kubernetes.io/portworx-volume',
+  },
+  {
+    labelKey: 'storageClass.quobyte.title',
+    value:    'kubernetes.io/quobyte',
+  },
+  {
+    labelKey: 'storageClass.scaleio.title',
+    value:    'kubernetes.io/scaleio',
+  },
+  {
+    labelKey: 'storageClass.storageos.title',
+    value:    'kubernetes.io/storageos',
+  },
+  {
+    labelKey:  'storageClass.vsphere-volume.title',
+    value:     'kubernetes.io/vsphere-volume',
+    supported: true
   }
 ];
 

--- a/utils/feature-flag.js
+++ b/utils/feature-flag.js
@@ -1,0 +1,21 @@
+import { MANAGEMENT } from '@/config/types';
+
+export const EMBEDDED_CLUSTER_API = 'embedded-cluster-api';
+export const FLEET = 'fleet';
+export const ISTIO_VIRTUAL_SERVICE_UI = 'istio-virtual-service-ui';
+export const RKE2 = 'rke2';
+export const UNSUPPORTED_STORAGE_DRIVERS = 'unsupported-storage-drivers';
+
+export async function fetchFeatureFlag(store, key) {
+  if (!store.getters['isRancher']) {
+    return false;
+  }
+
+  try {
+    const featureFlag = await store.dispatch('management/find', { type: MANAGEMENT.FEATURE, id: key });
+
+    return featureFlag.enabled;
+  } catch (ex) {
+    return false;
+  }
+}


### PR DESCRIPTION
- Adding unsupported storageclasses
- Adding unsupported persistent

rancher/dashboard#2284

Adding the persistent volume plugins that are gated by the `unsupported-storage-drivers` feature flag.