### PR TITLE
Request typed confirmation when deleting multiple resources

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1857,6 +1857,14 @@ promptRemove:
     }
   attemptingToRemove: "You are attempting to delete the {type}"
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
+  confirmName: "Enter its name below to confirm:"
+  confirmNameSpecific: "Enter the {pos, plural,
+    =0 {first}
+    =1 {second}
+    =2 {third}
+    =3 {fourth}
+    =4 {fifth}
+    } {resource} below to confirm: "
 
 rbac:
   roleBinding:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1852,19 +1852,12 @@ promptRemove:
   andOthers: |-
     {count, plural,
     =0 {.}
-    =1 {, and one other.}
-    other {, and {count} others.}
+    =1 { and one other.}
+    other { and {count} others.}
     }
   attemptingToRemove: "You are attempting to delete the {type}"
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
-  confirmName: "Enter its name below to confirm:"
-  confirmNameSpecific: "Enter the {pos, plural,
-    =0 {first}
-    =1 {second}
-    =2 {third}
-    =3 {fourth}
-    =4 {fifth}
-    } {resource} below to confirm: "
+  confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
 
 rbac:
   roleBinding:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1852,8 +1852,8 @@ promptRemove:
   andOthers: |-
     {count, plural,
     =0 {.}
-    =1 { and one other.}
-    other { and {count} others.}
+    =1 { and <b>one other</b>.}
+    other { and <b>{count} others</b>.}
     }
   attemptingToRemove: "You are attempting to delete the {type}"
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -252,7 +252,15 @@ export default {
       </h4>
       <div slot="body">
         <div class="mb-10">
-          {{ t('promptRemove.attemptingToRemove', {type}) }} <template v-for="(resource, i) in names"><template v-if="i<5"><b :key="resource+1">{{ toRemove[i].nameDisplay }}</b><template v-if="i===names.length-1">{{ plusMore }}</template><template v-else>{{ i === toRemove.length-2 ? ' and ' : ', ' }}</template></template></template>
+          {{ t('promptRemove.attemptingToRemove', {type}) }} <template v-for="(resource, i) in names">
+            <template v-if="i<5">
+              <b :key="resource+1">{{ toRemove[i].nameDisplay }}</b><template v-if="i===names.length-1">
+                {{ plusMore }}
+              </template><template v-else>
+                {{ i === toRemove.length-2 ? ' and ' : ', ' }}
+              </template>
+            </template>
+          </template>
           <div v-if="needsConfirm" class="mt-10">
             <tempate
               v-html="t('promptRemove.confirmName', {

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -115,7 +115,23 @@ export default {
     },
 
     ...mapState('action-menu', ['showPromptRemove', 'toRemove']),
-    ...mapGetters({ t: 'i18n/t' })
+    ...mapGetters({ t: 'i18n/t' }),
+
+    resourceNames() {
+      return this.names.reduce((res, name, i) => {
+        if (i >= 5) {
+          return res;
+        }
+        res += `<b>${ name }</b>`;
+        if (i === this.names.length - 1) {
+          res += this.plusMore;
+        } else {
+          res += i === this.toRemove.length - 2 ? ' and ' : ', ';
+        }
+
+        return res;
+      }, '');
+    }
   },
 
   watch:    {
@@ -249,21 +265,11 @@ export default {
       </h4>
       <div slot="body">
         <div class="mb-10">
-          {{ t('promptRemove.attemptingToRemove', {type}) }} <template v-for="(resource, i) in names">
-            <template v-if="i<5">
-              <b :key="resource+1">{{ toRemove[i].nameDisplay }}</b><template v-if="i===names.length-1">
-                {{ plusMore }}
-              </template><template v-else>
-                {{ i === toRemove.length-2 ? ' and ' : ', ' }}
-              </template>
-            </template>
-          </template>
+          {{ t('promptRemove.attemptingToRemove', { type }) }} <span v-html="resourceNames"></span>
           <div v-if="needsConfirm" class="mt-10">
-            <tempate
-              v-html="t('promptRemove.confirmName', {
-                nameToMatch
-              }, true)"
-            />
+            <span
+              v-html="t('promptRemove.confirmName', { nameToMatch }, true)"
+            ></span>
           </div>
         </div>
         <input v-if="needsConfirm" id="confirm" v-model="confirmName" type="text" />

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -3,14 +3,11 @@ import { mapState, mapGetters } from 'vuex';
 import { get, isEmpty } from '@/utils/object';
 import Card from '@/components/Card';
 import { alternateLabel } from '@/utils/platform';
-import LinkDetail from '@/components/formatter/LinkDetail';
 import { uniq } from '@/utils/array';
 import AsyncButton from '@/components/AsyncButton';
 
 export default {
-  components: {
-    Card, LinkDetail, AsyncButton
-  },
+  components: { Card, AsyncButton },
   data() {
     return {
       randomPosition: Math.random(), confirmName: '', error: '', warning: '', preventDelete: false

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -252,25 +252,13 @@ export default {
       </h4>
       <div slot="body">
         <div class="mb-10">
-          {{ t('promptRemove.attemptingToRemove', {type}) }} <template v-for="(resource, i) in names">
-            <template v-if="i<5">
-              <LinkDetail :key="resource" :value="resource" :row="toRemove[i]" @click.native="close" />
-              <span v-if="i===names.length-1" :key="resource+2">{{ plusMore }}</span><span v-else :key="resource+1">{{ i === toRemove.length-2 ? ', and ' : ', ' }}</span>
-            </template>
-          </template>
+          {{ t('promptRemove.attemptingToRemove', {type}) }} <template v-for="(resource, i) in names"><template v-if="i<5"><b :key="resource+1">{{ toRemove[i].nameDisplay }}</b><template v-if="i===names.length-1">{{ plusMore }}</template><template v-else>{{ i === toRemove.length-2 ? ' and ' : ', ' }}</template></template></template>
           <div v-if="needsConfirm" class="mt-10">
-            <template v-if="toRemove.length === 1">
-              {{ t('promptRemove.confirmName') }}
-            </template>
-            <template v-else>
-              {{
-                t('promptRemove.confirmNameSpecific',
-                  {
-                    pos: nameToMatchPosition,
-                    resource: t('generic.resource', { count: 1 })
-                  })
-              }}
-            </template>
+            <tempate
+              v-html="t('promptRemove.confirmName', {
+                nameToMatch
+              }, true)"
+            />
           </div>
         </div>
         <input v-if="needsConfirm" id="confirm" v-model="confirmName" type="text" />

--- a/models/management.cattle.io.user.js
+++ b/models/management.cattle.io.user.js
@@ -170,5 +170,9 @@ export default {
       },
       ...this._details
     ];
-  }
+  },
+
+  confirmRemove() {
+    return true;
+  },
 };

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -119,4 +119,8 @@ export default {
       this.enableAutoInjection(namespaces, false);
     };
   },
+
+  confirmRemove() {
+    return true;
+  },
 };

--- a/models/node.js
+++ b/models/node.js
@@ -262,7 +262,11 @@ export default {
 
   runningPods() {
     return this.pods.filter(pod => pod.isRunning);
-  }
+  },
+
+  confirmRemove() {
+    return true;
+  },
 };
 
 function calculatePercentage(allocatable, capacity) {

--- a/models/rio.cattle.io.stack.js
+++ b/models/rio.cattle.io.stack.js
@@ -20,4 +20,8 @@ export default {
 
     return branch || 'master';
   },
+
+  confirmRemove() {
+    return true;
+  },
 };

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -1097,6 +1097,10 @@ export default {
     };
   },
 
+  confirmRemove() {
+    return false;
+  },
+
   applyDefaults() {
     return () => {
     };


### PR DESCRIPTION
- when deleting multiple resources, and confirm is enabled, prompt for a random resource name for confirmation
- the random resource name will always be visible in the list shown to the user (given that this list is sometimes truncated)
- Improved process to declare which resource requires confirmation
- i10n'd some text
- addresses #2175

~~Q - The wording when deleting the random resource doesn't quite sit right given the resource to enter is from the list above and the box it has to go in is below. Open to suggestions on rewording~~