### PR TITLE
Fix User type and Settings Product when user is non-admin in non-local cluster

### DIFF
--- a/config/product/settings.js
+++ b/config/product/settings.js
@@ -19,7 +19,7 @@ export function init(store) {
   } = DSL(store, NAME);
 
   product({
-    ifHaveType:          MANAGEMENT.SETTING,
+    ifHaveType:          new RegExp(`${ MANAGEMENT.SETTING }|${ MANAGEMENT.FEATURE }`, 'i'),
     inStore:             'management',
     icon:                'globe',
     weight:              -10,
@@ -28,6 +28,7 @@ export function init(store) {
   });
 
   virtualType({
+    ifHaveType:          MANAGEMENT.SETTING,
     labelKey:       'advancedSettings.label',
     name:           'settings',
     namespaced:     false,
@@ -43,6 +44,7 @@ export function init(store) {
   });
 
   virtualType({
+    ifHaveType:          MANAGEMENT.FEATURE,
     labelKey:       'featureFlags.label',
     name:           'features',
     namespaced:     false,

--- a/config/product/settings.js
+++ b/config/product/settings.js
@@ -28,7 +28,7 @@ export function init(store) {
   });
 
   virtualType({
-    ifHaveType:          MANAGEMENT.SETTING,
+    ifHaveType:     MANAGEMENT.SETTING,
     labelKey:       'advancedSettings.label',
     name:           'settings',
     namespaced:     false,
@@ -44,7 +44,7 @@ export function init(store) {
   });
 
   virtualType({
-    ifHaveType:          MANAGEMENT.FEATURE,
+    ifHaveType:     MANAGEMENT.FEATURE,
     labelKey:       'featureFlags.label',
     name:           'features',
     namespaced:     false,

--- a/list/management.cattle.io.user.vue
+++ b/list/management.cattle.io.user.vue
@@ -17,9 +17,7 @@ export default {
     const store = this.$store;
     const resource = this.resource;
 
-    const inStore = store.getters['currentProduct'].inStore;
-
-    this.allUsers = await store.dispatch(`${ inStore }/findAll`, { type: resource });
+    this.allUsers = await store.dispatch(`management/findAll`, { type: resource });
 
     this.canRefreshAccess = await this.$store.dispatch('rancher/request', { url: '/v3/users?limit=0' })
       .then(res => !!res?.actions?.refreshauthprovideraccess);
@@ -31,8 +29,7 @@ export default {
 
     const resource = params.resource;
 
-    const inStore = getters['currentProduct'].inStore;
-    const schema = getters[`${ inStore }/schemaFor`](resource);
+    const schema = getters[`management/schemaFor`](resource);
 
     return {
       schema,

--- a/models/management.cattle.io.user.js
+++ b/models/management.cattle.io.user.js
@@ -131,6 +131,15 @@ export default {
     };
   },
 
+  canActivate() {
+    return (state) => {
+      const stateOk = state ? this.state === 'inactive' : this.state === 'active';
+      const schemaOk = !!this.schema?.resourceMethods.find(x => x.toLowerCase() === 'put');
+
+      return stateOk && schemaOk;
+    };
+  },
+
   _availableActions() {
     return [
       {
@@ -139,7 +148,7 @@ export default {
         icon:       'icon icon-play',
         bulkable:   true,
         bulkAction: 'activateBulk',
-        enabled:    this.state === 'inactive',
+        enabled:    this.canActivate(true),
         weight:     2
       },
       {
@@ -148,7 +157,7 @@ export default {
         icon:       'icon icon-pause',
         bulkable:   true,
         bulkAction: 'deactivateBulk',
-        enabled:    this.state === 'active',
+        enabled:    this.canActivate(false),
         weight:     1
       },
       {

--- a/models/management.cattle.io.user.js
+++ b/models/management.cattle.io.user.js
@@ -134,9 +134,9 @@ export default {
   canActivate() {
     return (state) => {
       const stateOk = state ? this.state === 'inactive' : this.state === 'active';
-      const schemaOk = !!this.schema?.resourceMethods.find(x => x.toLowerCase() === 'put');
+      const permissionOk = this.hasLink('update'); // Not canUpdate, only gate on api not whether editable pages should be visible
 
-      return stateOk && schemaOk;
+      return stateOk && permissionOk;
     };
   },
 

--- a/pages/c/_cluster/settings/index.vue
+++ b/pages/c/_cluster/settings/index.vue
@@ -5,13 +5,16 @@ import { MANAGEMENT } from '@/config/types';
 export default {
   layout: 'plain',
 
-  middleware({ redirect, route } ) {
+  middleware({ redirect, route, store } ) {
+    const hasSettings = !!store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
+
     return redirect({
       name:   'c-cluster-product-resource',
       params: {
         ...route.params,
         product:  SETTINGS,
-        resource: MANAGEMENT.SETTING,
+        // Will have one or t'other
+        resource: hasSettings ? MANAGEMENT.SETTING : MANAGEMENT.FEATURE,
       }
     });
   }


### PR DESCRIPTION
- Users
  - users list does not fail, only signed in user visible (returned via api)
  - user 'activate/deactive' now respects api put flag (previously could attempt to deactivate self)
  - user details page (of signed in user) better handles case when role schemas are inaccessible
- Settings
  - Only show settings/feature flag when settings/feature flag schemas are avaiable
  - Only show setting product when either settings or feature flags are available