### PR TITLE
fix up cluster switcher text color

### DIFF
--- a/components/nav/ClusterSwitcher.vue
+++ b/components/nav/ClusterSwitcher.vue
@@ -238,6 +238,9 @@ export default {
     color: white !important;
   }
 
+  .vs__selected-options input {
+    color: var(--header-btn-text);
+  }
   .vs__dropdown-toggle {
     background: rgba(0, 0, 0, 0.05);
     border-radius: var(--border-radius);


### PR DESCRIPTION
Changes the text color from var input-color to header-btn-text (black -> white)


![Screen Shot 2021-03-11 at 11 27 56 AM](https://user-images.githubusercontent.com/858614/110836818-bbd80d00-825d-11eb-876b-388c868dabd8.png)


rancher/dashboard#2329