### PR TITLE
table sort/active tab conflict

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -4,14 +4,13 @@ import Loading from '@/components/Loading';
 import ResourceYaml from '@/components/ResourceYaml';
 import {
   _VIEW, _EDIT, _CLONE, _STAGE, _CREATE,
-  AS, _YAML, _DETAIL, _CONFIG, PREVIEW,
+  AS, _YAML, _DETAIL, _CONFIG, PREVIEW, MODE,
 } from '@/config/query-params';
 import { SCHEMA } from '@/config/types';
 import { createYaml } from '@/utils/create-yaml';
 import Masthead from '@/components/ResourceDetail/Masthead';
 import DetailTop from '@/components/DetailTop';
-import isEqual from 'lodash/isEqual';
-import { clone, set } from '@/utils/object';
+import { clone, set, diff } from '@/utils/object';
 
 function modeFor(route) {
   if ( route.params.id ) {
@@ -248,7 +247,9 @@ export default {
         delete old[AS];
       }
 
-      if ( !isEqual(neu, old) ) {
+      const queryDiff = Object.keys(diff(neu, old));
+
+      if ( queryDiff.includes(MODE) || queryDiff.includes(AS)) {
         this.$fetch();
       }
     },

--- a/components/SortableTable/THead.vue
+++ b/components/SortableTable/THead.vue
@@ -1,4 +1,6 @@
 <script>
+import { queryParamsFor } from '@/plugins/extend-router';
+import { SORT_BY, DESCENDING } from '@/config/query-params';
 import Checkbox from '@/components/form/Checkbox';
 import { SOME, NONE } from './selection';
 
@@ -90,6 +92,17 @@ export default {
       return col.name === this.sortBy;
     },
 
+    queryFor(col) {
+      const query = queryParamsFor(this.$route.query, {
+        [SORT_BY]:    col.name,
+        [DESCENDING]: this.isCurrent(col) && !this.descending,
+      }, {
+        [SORT_BY]:    this.defaultSortBy,
+        [DESCENDING]: false,
+      });
+
+      return query;
+    },
   }
 };
 </script>
@@ -113,7 +126,7 @@ export default {
         :class="{ sortable: col.sort }"
         @click.prevent="changeSort($event, col)"
       >
-        <span v-if="col.sort">
+        <span v-if="col.sort" @click="$router.applyQuery(queryFor(col))">
           <span v-html="labelFor(col)" />
           <span class="icon-stack">
             <i class="icon icon-sort icon-stack-1x faded" />
@@ -130,7 +143,7 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .sortable > SPAN {
+   .sortable > SPAN {
     display: inline-block;
     white-space: nowrap;
     &:hover,

--- a/components/SortableTable/THead.vue
+++ b/components/SortableTable/THead.vue
@@ -1,6 +1,4 @@
 <script>
-import { queryParamsFor } from '@/plugins/extend-router';
-import { SORT_BY, DESCENDING } from '@/config/query-params';
 import Checkbox from '@/components/form/Checkbox';
 import { SOME, NONE } from './selection';
 
@@ -92,17 +90,6 @@ export default {
       return col.name === this.sortBy;
     },
 
-    queryFor(col) {
-      const query = queryParamsFor(this.$route.query, {
-        [SORT_BY]:    col.name,
-        [DESCENDING]: this.isCurrent(col) && !this.descending,
-      }, {
-        [SORT_BY]:    this.defaultSortBy,
-        [DESCENDING]: false,
-      });
-
-      return query;
-    },
   }
 };
 </script>
@@ -126,14 +113,14 @@ export default {
         :class="{ sortable: col.sort }"
         @click.prevent="changeSort($event, col)"
       >
-        <nuxt-link v-if="col.sort" :to="{query: queryFor(col)}">
+        <span v-if="col.sort">
           <span v-html="labelFor(col)" />
           <span class="icon-stack">
             <i class="icon icon-sort icon-stack-1x faded" />
             <i v-if="isCurrent(col) && !descending" class="icon icon-sort-down icon-stack-1x" />
             <i v-if="isCurrent(col) && descending" class="icon icon-sort-up icon-stack-1x" />
           </span>
-        </nuxt-link>
+        </span>
         <span v-else>{{ labelFor(col) }}</span>
       </th>
       <th v-if="rowActions" :width="rowActionsWidth">
@@ -143,9 +130,14 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .sortable > A {
+  .sortable > SPAN {
     display: inline-block;
     white-space: nowrap;
+    &:hover,
+    &:active {
+      text-decoration: underline;
+      color: var(--body-text);
+    }
   }
 
   thead {

--- a/components/SortableTable/paging.js
+++ b/components/SortableTable/paging.js
@@ -90,12 +90,6 @@ export default {
   methods: {
     setPage(num) {
       this.page = num;
-
-      if ( num === 1 ) {
-        this.$router.applyQuery({ [PAGE]: undefined });
-      } else {
-        this.$router.applyQuery({ [PAGE]: num });
-      }
     },
 
     goToPage(which) {

--- a/components/SortableTable/paging.js
+++ b/components/SortableTable/paging.js
@@ -79,7 +79,7 @@ export default {
     sortFields(old, neu) {
       if ( old.join(',') === neu.join(',') ) {
         // Nothing really changed
-        return;
+
       }
 
       // Go back to the first page when sort changes
@@ -89,7 +89,16 @@ export default {
 
   methods: {
     setPage(num) {
+      if (this.page === num) {
+        return;
+      }
       this.page = num;
+
+      if ( num === 1 ) {
+        this.$router.applyQuery({ [PAGE]: undefined });
+      } else {
+        this.$router.applyQuery({ [PAGE]: num });
+      }
     },
 
     goToPage(which) {

--- a/components/SortableTable/sorting.js
+++ b/components/SortableTable/sorting.js
@@ -1,4 +1,3 @@
-import { SORT_BY, DESCENDING, PAGE } from '@/config/query-params';
 import { sortBy } from '@/utils/sort';
 import { addObject } from '@/utils/array';
 
@@ -84,16 +83,6 @@ export default {
       this.sortBy = sort;
       this.descending = desc;
       this.currentPage = 1;
-
-      this.$router.applyQuery({
-        [SORT_BY]:    this.sortBy,
-        [DESCENDING]: this.descending,
-        [PAGE]:       this.currentPage,
-      }, {
-        [SORT_BY]:    this._defaultSortBy,
-        [DESCENDING]: false,
-        [PAGE]:       1,
-      });
     },
   },
 };

--- a/components/SortableTable/sorting.js
+++ b/components/SortableTable/sorting.js
@@ -1,3 +1,4 @@
+import { SORT_BY, DESCENDING, PAGE } from '@/config/query-params';
 import { sortBy } from '@/utils/sort';
 import { addObject } from '@/utils/array';
 
@@ -83,6 +84,16 @@ export default {
       this.sortBy = sort;
       this.descending = desc;
       this.currentPage = 1;
+
+      this.$router.applyQuery({
+        [SORT_BY]:    this.sortBy,
+        [DESCENDING]: this.descending,
+        [PAGE]:       this.currentPage,
+      }, {
+        [SORT_BY]:    this._defaultSortBy,
+        [DESCENDING]: false,
+        [PAGE]:       1,
+      });
     },
   },
 };


### PR DESCRIPTION
#2327 - This issue was happening because both Tabs and SortableTable were using route query params to track their state state (active tab, table sort order and page). Updating SortableTable to track column sorting and page number only in local state (`this.sortBy this.descending; this.currentPage`) instead of query params avoids the problem. 