### PR TITLE
Multiple fixes to Users

### DIFF
--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -73,7 +73,7 @@
 
   --checkbox-tick              : #{$lightest};
   --checkbox-border            : #{$medium};
-  --checkbox-tick-disabled     : #{lighten($disabled, 20%)};
+  --checkbox-tick-disabled     : #{lighten($disabled, 50%)};
   --checkbox-disabled-bg       : #{$disabled};
   --checkbox-ticked-bg         : #{$link};
 

--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -93,7 +93,7 @@ $selected: rgba($primary, .5);
 
   --checkbox-tick              : #{$lightest};
   --checkbox-border            : #{$medium};
-  --checkbox-tick-disabled     : #{darken($disabled, 20%)};
+  --checkbox-tick-disabled     : #{darken($disabled, 40%)};
   --checkbox-disabled-bg       : #{$disabled};
   --checkbox-ticked-bg         : #{$link};
 

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3773,6 +3773,11 @@ typeLabel:
       one { Cluster }
       other { Clusters }
     }
+  'management.cattle.io.user': |-
+    {count, plural,
+      one { User }
+      other { Users }
+    }
   group.principal: |-
     {count, plural,
       one { Group }

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -281,13 +281,14 @@ export default {
                 :key="getUnique(roleType, roleId, 'checkbox')"
                 v-model="selectedRoles"
                 :value-when-true="roleId"
-                :label="role.nameDisplay"
+                :description="role.description"
                 :mode="mode"
                 @input="checkboxChanged"
-              />
-              <div class="description">
-                {{ role.description }}
-              </div>
+              >
+                <template #label>
+                  <span class="checkbox-label">{{ role.nameDisplay }}</span>
+                </template>
+              </Checkbox>
             </div>
           </div>
         </template>
@@ -311,15 +312,9 @@ export default {
         grid-template-columns: 100%;
       }
 
-      .checkbox {
-        display: flex;
-        flex-direction: column;
-
-        .description {
-          font-size: $detailSize;
-          margin-left: 20px;
-          margin-top: 5px;
-        }
+      .checkbox-label{
+        color: var(--body-text);
+        margin: 0;
       }
     }
   }

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -49,6 +49,16 @@ export default {
       type:    null,
       default: true
     },
+
+    descriptionKey: {
+      type:    String,
+      default: null
+    },
+
+    description: {
+      type:    String,
+      default: null
+    },
   },
 
   computed: {
@@ -92,43 +102,64 @@ export default {
 </script>
 
 <template>
-  <label
-    class="checkbox-container"
-    :class="{ 'disabled': isDisabled}"
-    @keydown.enter.prevent="clicked($event)"
-    @keydown.space.prevent="clicked($event)"
-    @click.stop.prevent="clicked($event)"
-  >
-    <input
-      v-model="value"
-      :checked="isChecked"
-      :value="valueWhenTrue"
-      type="checkbox"
-      :tabindex="-1"
-      @click.stop.prevent
-    />
-    <span
-      class="checkbox-custom"
-      :class="{indeterminate: indeterminate}"
-      :tabindex="isDisabled ? -1 : 0"
-      :aria-label="label"
-      :aria-checked="!!value"
-      role="checkbox"
-    />
-    <span
-      class="checkbox-label"
+  <div class="checkbox-outer-container">
+    <label
+      class="checkbox-container"
+      :class="{ 'disabled': isDisabled}"
+      @keydown.enter.prevent="clicked($event)"
+      @keydown.space.prevent="clicked($event)"
+      @click.stop.prevent="clicked($event)"
     >
-      <slot name="label">
-        <t v-if="labelKey" :k="labelKey" />
-        <template v-else-if="label">{{ label }}</template>
-        <i v-if="tooltipKey" v-tooltip="t(tooltipKey)" class="checkbox-info icon icon-info icon-lg" />
-        <i v-else-if="tooltip" v-tooltip="tooltip" class="checkbox-info icon icon-info icon-lg" />
-      </slot>
-    </span>
-  </label>
+      <input
+        v-model="value"
+        :checked="isChecked"
+        :value="valueWhenTrue"
+        type="checkbox"
+        :tabindex="-1"
+        @click.stop.prevent
+      />
+      <span
+        class="checkbox-custom"
+        :class="{indeterminate: indeterminate}"
+        :tabindex="isDisabled ? -1 : 0"
+        :aria-label="label"
+        :aria-checked="!!value"
+        role="checkbox"
+      />
+      <span
+        class="checkbox-label"
+      >
+        <slot name="label">
+          <t v-if="labelKey" :k="labelKey" />
+          <template v-else-if="label">{{ label }}</template>
+          <i v-if="tooltipKey" v-tooltip="t(tooltipKey)" class="checkbox-info icon icon-info icon-lg" />
+          <i v-else-if="tooltip" v-tooltip="tooltip" class="checkbox-info icon icon-info icon-lg" />
+        </slot>
+      </span>
+    </label>
+    <div v-if="descriptionKey || description" class="checkbox-outer-container-description">
+      <t v-if="descriptionKey" :k="descriptionKey" />
+      <template v-else-if="description">
+        {{ description }}
+      </template>
+    </div>
+  </div>
 </template>
 
 <style lang='scss'>
+$fontColor: var(--input-label);
+
+.checkbox-outer-container {
+  display: inline-flex;
+  flex-direction: column;
+  &-description {
+    color: $fontColor;
+    font-size: 11px;
+    margin-left: 20px;
+    margin-top: 5px;
+  }
+}
+
 // NOTE: SortableTable depends on the names of this class, do not arbitrarily change.
 .checkbox-container {
   position: relative;
@@ -242,7 +273,7 @@ export default {
     display: flex;
     flex-direction: column;
     LABEL {
-      color: var(--input-label)
+      color: $fontColor;
     }
   }
 }

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -5,6 +5,8 @@ import { GROUP_NAME, GROUP_ROLE_NAME } from '@/config/table-headers';
 
 export const NAME = 'auth';
 
+const usersVirtualType = 'users';
+
 export function init(store) {
   const {
     product,
@@ -33,10 +35,26 @@ export function init(store) {
     icon:        'lock',
     namespaced:  false,
     name:        'config',
-    weight:      100,
+    weight:      -1,
     route:       { name: 'c-cluster-auth-config' },
     ifHaveType: MANAGEMENT.AUTH_CONFIG
   });
+
+  virtualType({
+    label:       store.getters['type-map/labelFor']({ id: MANAGEMENT.USER }, 2),
+    name:           usersVirtualType,
+    namespaced:     false,
+    weight:         102,
+    icon:           'user',
+    route:          {
+      name:   'c-cluster-product-resource',
+      params: {
+        product:  NAME,
+        resource: MANAGEMENT.USER,
+      }
+    }
+  });
+  configureType(MANAGEMENT.USER, { showListMasthead: false });
 
   spoofedType({
     label:             store.getters['type-map/labelFor']({ id: NORMAN.SPOOFED.GROUP_PRINCIPAL }, 2),
@@ -90,13 +108,9 @@ export function init(store) {
     isRemovable:      false,
     showListMasthead: false,
   });
-
   // Use labelFor... so lookup succeeds with .'s in path.... and end result is 'trimmed' as per other entries
   mapType(NORMAN.SPOOFED.GROUP_PRINCIPAL, store.getters['type-map/labelFor']({ id: NORMAN.SPOOFED.GROUP_PRINCIPAL }, 2));
-
-  weightType(NORMAN.SPOOFED.GROUP_PRINCIPAL, -1, true);
-  weightType(MANAGEMENT.USER, 100);
-  configureType(MANAGEMENT.USER, { showListMasthead: false });
+  weightType(NORMAN.SPOOFED.GROUP_PRINCIPAL, 101, true);
 
   configureType(MANAGEMENT.AUTH_CONFIG, {
     isCreatable: false,
@@ -119,7 +133,7 @@ export function init(store) {
 
   basicType([
     'config',
-    MANAGEMENT.USER,
+    usersVirtualType,
     NORMAN.SPOOFED.GROUP_PRINCIPAL
   ]);
 

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -228,6 +228,9 @@ export function init(store) {
   ignoreType(MANAGEMENT.TOKEN);
   ignoreType(NORMAN.TOKEN);
 
+  // Ignore these types as they are managed through the auth product
+  ignoreType(MANAGEMENT.USER);
+
   spoofedType({
     label:             'Role Template',
     type:              RBAC.SPOOFED.ROLE_TEMPLATE,

--- a/edit/management.cattle.io.user.vue
+++ b/edit/management.cattle.io.user.vue
@@ -110,28 +110,19 @@ export default {
         throw new Error(this.t('user.edit.credentials.username.exists'));
       }
 
-      const user = await this.$store.dispatch('management/create', {
-        type:               MANAGEMENT.USER,
-        metadata:           { generateName: `user-` },
+      const user = await this.$store.dispatch('rancher/create', {
+        type:               NORMAN.USER,
         description:        this.form.description,
-        displayName:        this.form.displayName,
         enabled:            true,
         mustChangePassword: this.form.password.userChangeOnLogin,
-        // password:           this.form.password.password,
-        username:           this.form.username,
+        name:               this.form.displayName,
+        password:           this.form.password.password,
+        username:           this.form.username
       });
 
-      const newSteveUser = await user.save();
+      const newNormanUser = await user.save();
 
-      // Change the password in a separate step... sent via create request just means storeing it in plane text
-      const newNormanUser = await this.$store.dispatch('rancher/find', {
-        type:       NORMAN.USER,
-        id:   newSteveUser.id,
-      });
-
-      this.$refs.changePassword.setPassword(newNormanUser);
-
-      return newSteveUser;
+      return this.$store.dispatch('management/find', { type: MANAGEMENT.USER, id: newNormanUser.id });
     },
     async editUser() {
       if (!this.credentialsChanged) {

--- a/models/management.cattle.io.user.js
+++ b/models/management.cattle.io.user.js
@@ -184,8 +184,9 @@ export default {
   details() {
     return [
       {
-        label:   this.t('user.detail.username'),
-        content: this.username
+        label:     this.t('user.detail.username'),
+        formatter: 'CopyToClipboard',
+        content:   this.username
       },
       ...this._details
     ];

--- a/plugins/steve/resource-proxy.js
+++ b/plugins/steve/resource-proxy.js
@@ -39,7 +39,8 @@ export function proxyFor(ctx, obj, isClone = false) {
   }
 
   const mappedType = ctx.rootGetters['type-map/componentFor'](obj.type);
-  const model = lookup(mappedType, obj?.metadata?.name) || ResourceInstance;
+  const customModel = lookup(mappedType, obj?.metadata?.name);
+  const model = customModel || ResourceInstance;
 
   // Hack for now, the resource-instance name() overwrites the model name.
   if ( obj.name ) {
@@ -72,7 +73,7 @@ export function proxyFor(ctx, obj, isClone = false) {
 
       let fn;
 
-      if ( model && Object.prototype.hasOwnProperty.call(model, name) ) {
+      if ( customModel && Object.prototype.hasOwnProperty.call(customModel, name) ) {
         fn = model[name];
       } else if (nativeProperties.includes(name) && obj[name] !== undefined) {
         // If there's not a model specific override for this property check if it exists natively in the object... otherwise fall back on


### PR DESCRIPTION
- #2524
  - Create user via norman rather than steve
- Code changes for #2525
  - Updates checkbox label and description colour (move description into checkbox component, make label stand out more via slot)
  - Make tick in disabled checkboxes clearer
  - Add copy button to user details username field (at top)
  - ~~Fix download of yaml for multiple resources (bug covers batch yaml download).~~ Split out in to #2562
 - #2526
   - Remove confusion between Auth products Users list and Cluster Explorers Users list by removing the latter. This is the same approach used by some of the other resources in product views
 - Also fixed a bug where resources with a description that didn't have a custom model failed to report the correct description value