### PR TITLE
Adding support to deselect options in Labeled/Select by clicking on the options in the dropdown

### DIFF
--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -6,6 +6,7 @@ import { get } from '@/utils/object';
 import LabeledTooltip from '@/components/form/LabeledTooltip';
 import VueSelectOverrides from '@/mixins/vue-select-overrides';
 import $ from 'jquery';
+import { onClickOption } from '@/utils/select';
 
 export default {
   components: { LabeledTooltip },
@@ -41,8 +42,8 @@ export default {
       type:    String
     },
     options: {
-      default: null,
-      type:    Array
+      default:   null,
+      type:      Array
     },
     placement: {
       default: null,
@@ -77,7 +78,11 @@ export default {
     value: {
       default: null,
       type:    [String, Object, Number, Array, Boolean]
-    }
+    },
+    closeOnSelect: {
+      type:    Boolean,
+      default: true
+    },
   },
 
   data() {
@@ -108,7 +113,7 @@ export default {
     // resizeHandler = in mixin
     focusSearch() {
       this.$nextTick(() => {
-        const el = this.$refs.input?.searchEl;
+        const el = this.$refs['select-input']?.searchEl;
 
         if (el) {
           el.focus();
@@ -198,6 +203,9 @@ export default {
       return () => popper.destroy();
     },
     get,
+    onClickOption(option, event) {
+      onClickOption.call(this, option, event);
+    }
   },
 };
 </script>
@@ -230,7 +238,7 @@ export default {
       </label>
     </div>
     <v-select
-      ref="input"
+      ref="select-input"
       v-bind="$attrs"
       class="inline"
       :append-to-body="appendToBody"
@@ -254,6 +262,11 @@ export default {
       @search:focus="onFocus"
       @open="resizeHandler"
     >
+      <template #option="option">
+        <div @mousedown="(e) => onClickOption(option, e)">
+          {{ option.label }}
+        </div>
+      </template>
       <!-- Pass down templates provided by the caller -->
       <template v-for="(_, slot) of $scopedSlots" #[slot]="scope">
         <slot :name="slot" v-bind="scope" />

--- a/components/form/Select.vue
+++ b/components/form/Select.vue
@@ -5,6 +5,7 @@ import LabeledFormElement from '@/mixins/labeled-form-element';
 import VueSelectOverrides from '@/mixins/vue-select-overrides';
 import LabeledTooltip from '@/components/form/LabeledTooltip';
 import $ from 'jquery';
+import { onClickOption } from '@/utils/select';
 
 export default {
   components: { LabeledTooltip },
@@ -31,8 +32,8 @@ export default {
       type:    String,
     },
     options: {
-      default: null,
-      type:    Array,
+      default:   null,
+      type:      Array,
     },
     placement: {
       default: null,
@@ -77,6 +78,10 @@ export default {
     value: {
       default: null,
       type:    [String, Object, Number, Array, Boolean],
+    },
+    closeOnSelect: {
+      type:    Boolean,
+      default: true
     },
   },
 
@@ -155,7 +160,11 @@ export default {
     },
 
     get,
-  },
+
+    onClickOption(option, event) {
+      onClickOption.call(this, option, event);
+    }
+  }
 };
 </script>
 
@@ -196,6 +205,11 @@ export default {
       @search:focus="onFocus"
       @open="resizeHandler"
     >
+      <template #option="option">
+        <div @mousedown="(e) => onClickOption(option, e)">
+          {{ option.label }}
+        </div>
+      </template>
       <!-- Pass down templates provided by the caller -->
       <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope">
         <slot :name="slot" v-bind="scope" />

--- a/utils/select.js
+++ b/utils/select.js
@@ -1,0 +1,23 @@
+export function onClickOption(option, e) {
+  if (!this.$attrs.multiple) {
+    return;
+  }
+
+  const getValue = opt => (this.optionKey ? this.get(opt, this.optionKey) : this.getOptionLabel(opt));
+  const optionValue = getValue(option);
+  const optionIndex = this.value.findIndex(option => getValue(option) === optionValue);
+
+  if (optionIndex < 0) {
+    return;
+  }
+
+  this.value.splice(optionIndex, 1);
+
+  this.$emit('input', this.value);
+  e.preventDefault();
+  e.stopPropagation();
+
+  if (this.closeOnSelect) {
+    this.$refs['select-input'].closeSearchOptions();
+  }
+}


### PR DESCRIPTION
This was more involved than initially anticipated because of a few choices made by vue-select.
1. Vue select prevents event bubbling by watching the mouse-down event instead of the click event which preempted any clicks that you added in the #options slot.
2. optionKey and valueNormalization changes the shape of the options and the values so I needed to make sure we retrieved the values and selected options appropriately.
3. When updating the values to remove the selectedOption vue-select kept overriding my value because in it's updateValue would be called if the values were changed. So strangely if I emitted input it would reset the value but if I didn't emit input it wouldn't update the value even though it was going through the same control flow.

rancher/dashboard#2357

Verified these cases
![image](https://user-images.githubusercontent.com/55104481/111006112-67aa5700-8349-11eb-879f-5cc87d21b172.png)

![select](https://user-images.githubusercontent.com/55104481/111006163-87417f80-8349-11eb-9356-ae4e0a2cb3b0.gif)
