### PR TITLE
Adding helper info to the SSL portions of the email and webhook monitoring receivers

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1437,6 +1437,19 @@ monitoring:
   receiver:
     fields:
       name: Name
+    tls:
+      label: SSL
+      caFilePath:
+        label: CA File Path
+        placeholder: e.g. ./ca-file.csr
+      certFilePath:
+        label: Cert File Path
+        placeholder: e.g. ./cert-file.crt
+      keyFilePath:
+        label: Key File Path
+        placeholder: e.g. ./key-file.pfx
+      secretsBanner: The file paths below must be referenced in <pre class="inline-block m-0 p-0 vertical-middle">alertmanager.alertmanagerSpec.secrets</pre> when deploying the Monitoring chart
+
   route:
     fields:
       groupBy: Group By

--- a/edit/monitoring.coreos.com.receiver/tls.vue
+++ b/edit/monitoring.coreos.com.receiver/tls.vue
@@ -1,8 +1,9 @@
 <script>
 import LabeledInput from '@/components/form/LabeledInput';
+import Banner from '@/components/Banner';
 
 export default {
-  components: { LabeledInput },
+  components: { Banner, LabeledInput },
   props:      {
     mode: {
       type:     String,
@@ -24,21 +25,22 @@ export default {
 <template>
   <div>
     <div class="row">
-      <div class="col span-6">
-        <h3>SSL</h3>
+      <div class="col span-12">
+        <h3>{{ t('monitoring.receiver.tls.label') }}</h3>
+        <Banner color="info" v-html="t('monitoring.receiver.tls.secretsBanner', {}, true)" />
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.tls_config.ca_file" :mode="mode" label="CA File Path" placeholder="e.g. ./ca-file.csr" />
+        <LabeledInput v-model="value.tls_config.ca_file" :mode="mode" :label="t('monitoring.receiver.tls.caFilePath.label')" :placeholder="t('monitoring.receiver.tls.caFilePath.placeholder')" />
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.tls_config.cert_file" :mode="mode" label="Cert File Path" placeholder="e.g. ./cert-file.crt" />
+        <LabeledInput v-model="value.tls_config.cert_file" :mode="mode" :label="t('monitoring.receiver.tls.certFilePath.label')" :placeholder="t('monitoring.receiver.tls.certFilePath.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.tls_config.key_file" :mode="mode" label="Key File Path" placeholder="e.g. ./key-file.pfx" />
+        <LabeledInput v-model="value.tls_config.key_file" :mode="mode" :label="t('monitoring.receiver.tls.keyFilePath.label')" :placeholder="t('monitoring.receiver.tls.keyFilePath.placeholder')" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
rancher/dashboard#2400

![image](https://user-images.githubusercontent.com/55104481/111111937-7bf27d80-851c-11eb-9ff5-1fb46b071757.png)
