### PR TITLE
show warning if app is installing into project

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -547,6 +547,7 @@ catalog:
             other { seconds }
           }
       wait: Wait
+    namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:
       appReadme: README

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -358,9 +358,8 @@ export default {
       if ( !want ) {
         return false;
       }
-      const found = findBy(all, 'id', want);
 
-      return !found;
+      return !findBy(all, 'id', want);
     },
 
     showProject() {
@@ -530,7 +529,8 @@ export default {
     'value.metadata.namespace'(neu, old) {
       if (neu) {
         const ns = this.$store.getters['cluster/byId'](NAMESPACE, this.value.metadata.namespace);
-        const project = ns.metadata.annotations[PROJECT];
+
+        const project = ns?.metadata.annotations[PROJECT];
 
         if (project) {
           this.project = project.replace(':', '/');


### PR DESCRIPTION
#2222 - currently the project dropdown is hidden entirely if the app's target namespace already exists, because that namespace can't be added to/remade in a different project. This PR makes that limitation clearer by still showing the dropdown (with relevant project), but disabled with a tooltip explaining why.
<img width="1660" alt="Screen Shot 2021-03-16 at 6 58 08 AM" src="https://user-images.githubusercontent.com/42977925/111323424-1939d880-8627-11eb-87ab-11d366709a52.png">
