### PR TITLE
Add key up handler to cluster ClusterSwitcher

### DIFF
--- a/components/nav/ClusterSwitcher.vue
+++ b/components/nav/ClusterSwitcher.vue
@@ -56,6 +56,16 @@ export default {
   },
 
   methods: {
+    handleDelete() {
+      // because v-select handles the backspace key on the keydown a bunch of weird stuff happens when using META+A -> Delete/Backspace
+      // but the crux of this issue is that by the time the dd recomputes a new size the dropdown width is the same because the search value is still the same
+      // by key up we have an empty value and can trigger the update manually
+      if (this.$refs?.search?.value === '' && this.popperInstance?.update) {
+        this.popperInstance.update();
+      }
+
+      return true;
+    },
     filterBy(option, label, search) {
       return (label || '').toLowerCase().includes(search.toLowerCase());
     },
@@ -79,7 +89,7 @@ export default {
     focus() {
       this.$refs.select.focusSearch();
     },
-    withPopper(dropdownList, component, { width }) {
+    withPopper(dropdownList, component) {
       const componentWidth = $(component.$parent.$el).width();
 
       dropdownList.style['min-width'] = `${ componentWidth }px`;
@@ -135,6 +145,14 @@ export default {
       :options="options"
       :filter="filter"
     >
+      <template #search="{ attributes, events }">
+        <input
+          class="vs__search"
+          v-bind="attributes"
+          v-on="events"
+          @keyup.delete="handleDelete"
+        >
+      </template>
       <template #selected-option="opt">
         <span class="cluster-label-container">
           <img


### PR DESCRIPTION
Cluster switcher handles its own positioning because the default positioning would flow the dd off the right side of the window with how our styles are setup. 

A unique edge case presented itself: 
User has at least one cluster with a very long name (I used a 62 char string)
User searches for something that returns no results
User executes a `CMD+A` (or your os equiv) and `backspace/delete` key press

The dropdown would not recompute the size as one would expect and the dropdown would overflow off the screen until the user typed another character or left the dd and came back.

This was a tricky solve that I tracked down to the dropdown repositioning not firing because of the way that v-select handles the keydown event. I tried overriding the backspace key in `vue-select-overrides` but because the event is keydown the search value is not empty and triggering the recompute at that point doesn't resolve the issue. Because the search isn't empty the size of the dd isn't computed correctly. So we need to trigger the recompute after the search value is actually empty. 

I did not add this fix to the root Select and LabeledSelect components because this will only affect dds that would overflow the left side of the screen (cluster switcher is the only one I can find that is close enough to actually do this). This is because the items in the dd fit there content.

rancher/dashboard#2544