### PR TITLE
ldap defaults for shibboleth

### DIFF
--- a/edit/auth/ldap/config.vue
+++ b/edit/auth/ldap/config.vue
@@ -215,7 +215,7 @@ export default {
         <div class="col span-6">
           <LabeledInput v-model="model.disabledStatusBitmask" :mode="mode" :label="t('authConfig.ldap.disabledStatusBitmask')" />
         </div>
-        <div class=" col span-6">
+        <div v-if="type!=='shibboleth'" class=" col span-6">
           <RadioGroup
             v-model="model.nestedGroupMembershipEnabled"
             :mode="mode"

--- a/edit/auth/saml.vue
+++ b/edit/auth/saml.vue
@@ -43,6 +43,36 @@ export default {
     },
 
   },
+  watch: {
+    showLdap(neu, old) {
+      if (neu) {
+        if (!this.model.openLdapConfig) {
+          const config = {
+            connectionTimeout:            5000,
+            groupDNAttribute:             'entryDN',
+            groupMemberMappingAttribute:  'member',
+            groupMemberUserAttribute:     'entryDN',
+            groupNameAttribute:           'cn',
+            groupObjectClass:             'groupOfNames',
+            groupSearchAttribute:         'cn',
+            nestedGroupMembershipEnabled: false,
+            port:                         389,
+            servers:                      [],
+            starttls:                     false,
+            tls:                          false,
+            userDisabledBitMask:          0,
+            userLoginAttribute:           'uid',
+            userMemberAttribute:          'memberOf',
+            userNameAttribute:            'cn',
+            userObjectClass:              'inetOrgPerson',
+            userSearchAttribute:          'uid|sn|givenName'
+          };
+
+          this.$set(this.model, 'openLdapConfig', config);
+        }
+      }
+    }
+  }
 };
 </script>
 

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -133,6 +133,9 @@ export default {
             if (!this.model.accessMode) {
               this.model.accessMode = 'unrestricted';
             }
+            if (this.model.openLdapConfig && !this.showLdap) {
+              delete this.model.openLdapConfig;
+            }
             await this.model.save();
             await this.$store.dispatch('auth/test', { provider: this.model.id, body: this.model });
             this.model.enabled = true;
@@ -221,10 +224,6 @@ export default {
       switch (this.value.configType) {
       case 'saml':
         set(this.model, 'accessMode', 'unrestricted');
-
-        if (this.model.id === 'shibboleth' && !this.model.openLdapConfig) {
-          set(this.model, 'openLdapConfig', {});
-        }
         break;
       case 'ldap':
         set(this.model, 'servers', []);


### PR DESCRIPTION
#2545 #2548 #2547 - these are resolved by ensuring that `model.openLdapConfig` is defined and has defaults set any time the ldap section is shown.
#2546 - also in this PR