### PR TITLE
Fix Download YAML list action when multiple resources are selected

### DIFF
--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -1075,7 +1075,7 @@ export default {
         const link = item.hasLink('rioview') ? 'rioview' : 'view';
 
         return item.followLink(link, { headers: { accept: 'application/yaml' } } ).then((data) => {
-          files[`resources/${ names[idx] }`] = data;
+          files[`resources/${ names[idx] }`] = data.data || data;
         });
       });
 


### PR DESCRIPTION
- #2561
- Ensure contents of files is correct
- Accessing `.data` matches, roughly, what happens in download() action
- fallback on previous way just in case
