### PR TITLE
Fix azuread auth route

### DIFF
--- a/edit/auth/azuread.vue
+++ b/edit/auth/azuread.vue
@@ -72,7 +72,7 @@ export default {
     },
 
     replyUrl() {
-      return `${ window.location.origin }/verify-auth`;
+      return `${ window.location.origin }/verify-auth-azure`;
     },
 
     tenantId() {

--- a/store/auth.js
+++ b/store/auth.js
@@ -126,7 +126,7 @@ export const actions = {
       const params = { response_type: 'code', response_mode: 'query' };
 
       redirectUrl = addParams(redirectUrl, params );
-      returnToUrl = `${ window.location.origin }/verify-auth`;
+      returnToUrl = `${ window.location.origin }/verify-auth-azure`;
     }
 
     const nonce = await dispatch('setNonce', opt);
@@ -143,6 +143,7 @@ export const actions = {
     }
 
     let url = removeParam(redirectUrl, GITHUB_SCOPE);
+
     const params = {
       [GITHUB_SCOPE]:    scopes.join(','),
       [GITHUB_NONCE]:   base64Encode(nonce, 'url')


### PR DESCRIPTION
As part of this https://github.com/rancher/rancher/issues/31562 I changed azure auth to use the same redirect url as other auth types, `/verify-auth`. This works as expected for new setups, but while looking at a different azuread issue I realized it was a poor decision, and will break preexisting  azuread configs that use `/verify-auth-azure`. Both ui's should use `/verify-auth-azure` for azuread, which leverages the same redirect logic as` /verify-auth`. Related UI PR: https://github.com/rancher/ui/pull/4507