### PR TITLE
Ensure current user cannot deactivate or delete themselves

### DIFF
--- a/models/management.cattle.io.user.js
+++ b/models/management.cattle.io.user.js
@@ -11,6 +11,12 @@ export default {
     return false;
   },
 
+  isCurrentUser() {
+    const currentPrincipal = this.$rootGetters['auth/principalId'];
+
+    return !!this.principalIds.find(p => p === currentPrincipal);
+  },
+
   nameDisplay() {
     return this.displayName || this.username || this.id;
   },
@@ -136,8 +142,12 @@ export default {
       const stateOk = state ? this.state === 'inactive' : this.state === 'active';
       const permissionOk = this.hasLink('update'); // Not canUpdate, only gate on api not whether editable pages should be visible
 
-      return stateOk && permissionOk;
+      return stateOk && permissionOk && !this.isCurrentUser;
     };
+  },
+
+  canDelete() {
+    return this._canDelete && !this.isCurrentUser;
   },
 
   _availableActions() {

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -702,6 +702,10 @@ export default {
   // ------------------------------------------------------------------
 
   canDelete() {
+    return this._canDelete;
+  },
+
+  _canDelete() {
     return this.hasLink('remove') && this.$rootGetters['type-map/optionsFor'](this.type).isRemovable;
   },
 


### PR DESCRIPTION
- #2527
- the api does not allow the signed in user to deactivate/delete themselves
- ensure that we don't show these options by checking user isn't the signed in one
- ideally this should be done via the api by removing the 'remove' link for the signed in user