### PR TITLE
Multiple Groups Fixes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2194,6 +2194,7 @@ rbac:
         description: Additional roles to define more fine-grain permissions model.
     unknownRole:
         description: No description provided
+    assignOnlyRole: This role is already assigned
     role:
       admin:
         label: Administrator

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3626,6 +3626,7 @@ typeDescription:
   logging.banzaicloud.io.clusteroutput: A cluster output defines which logging providers that logs can be sent to and is only effective when deployed in the namespace that the logging operator is in.
   logging.banzaicloud.io.flow: A flow defines which logs to collect and filter as well as which output to send the logs. The flow is a namespaced resource, which means logs will only be collected from the namepsace that the flow is deployed in.
   logging.banzaicloud.io.output: An output defines which logging providers that logs can be sent to. The output needs to be in the same namespace as the flow that is using it.
+  group.principal: Assigning global roles to a group only works with external auth providers that support groups. Local authorization does not support groups
 
 typeLabel:
   management.cattle.io.token: |-

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -20,6 +20,10 @@ export default {
     showHighlightBorder: {
       type:    Boolean,
       default: true
+    },
+    showActions: {
+      type:    Boolean,
+      default: true
     }
   }
 };
@@ -39,7 +43,7 @@ export default {
           {{ content }}
         </slot>
       </div>
-      <div class="card-actions">
+      <div v-if="showActions" class="card-actions">
         <slot name="actions">
           <button class="btn role-primary" @click="buttonAction">
             {{ buttonText }}

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -6,6 +6,7 @@ import Checkbox from '@/components/form/Checkbox';
 import { _CREATE, _VIEW } from '@/config/query-params';
 import Loading from '@/components/Loading';
 import { addObjects, isArray } from '@/utils/array';
+import Card from '@/components/Card';
 
 /**
  * Display checkboxes for each global role, checked for given user or principal (group). Can save changes.
@@ -14,6 +15,7 @@ export default {
   components: {
     Checkbox,
     Loading,
+    Card
   },
   props:      {
     mode: {
@@ -283,41 +285,58 @@ export default {
   <div v-else>
     <form v-if="selectedRoles">
       <div v-for="(sortedRole, roleType) in sortedRoles" :key="getUnique(roleType)" class="role-group mb-10">
-        <template v-if="Object.keys(sortedRole).length">
-          <h2>{{ t(`rbac.globalRoles.types.${roleType}.label`) }}</h2>
-          <div class="type-description mb-10">
-            {{ t(`rbac.globalRoles.types.${roleType}.description`, { isUser }) }}
-          </div>
-          <div class="checkbox-section" :class="'checkbox-section--' + roleType">
-            <div v-for="role in sortedRoles[roleType]" :key="getUnique(roleType, role.id)" class="checkbox mb-10 mr-10">
-              <Checkbox
-                :key="getUnique(roleType, role.id, 'checkbox')"
-                v-model="selectedRoles"
-                :value-when-true="role.id"
-                :disabled="!!assignOnlyRoles[role.id]"
-                :tooltip-key="!!assignOnlyRoles[role.id] ? 'rbac.globalRoles.assignOnlyRole' : ''"
-                :label="role.nameDisplay"
-                :mode="mode"
-                @input="checkboxChanged"
-              >
-                <template #label>
-                  <span class="checkbox-label">{{ role.nameDisplay }}</span>
-                </template>
-              </Checkbox>
+        <Card v-if="Object.keys(sortedRole).length" :show-highlight-border="false" :show-actions="false">
+          <template v-slot:title>
+            <div class="type-title">
+              <h3>{{ t(`rbac.globalRoles.types.${roleType}.label`) }}</h3>
+              <div class="type-description">
+                {{ t(`rbac.globalRoles.types.${roleType}.description`, { isUser }) }}
+              </div>
             </div>
-          </div>
-        </template>
+          </template>
+          <template v-slot:body>
+            <div class="checkbox-section" :class="'checkbox-section--' + roleType">
+              <div v-for="role in sortedRoles[roleType]" :key="getUnique(roleType, role.id)" class="checkbox mb-10 mr-10">
+                <Checkbox
+                  :key="getUnique(roleType, role.id, 'checkbox')"
+                  v-model="selectedRoles"
+                  :value-when-true="role.id"
+                  :disabled="!!assignOnlyRoles[role.id]"
+                  :tooltip-key="!!assignOnlyRoles[role.id] ? 'rbac.globalRoles.assignOnlyRole' : ''"
+                  :label="role.nameDisplay"
+                  :mode="mode"
+                  @input="checkboxChanged"
+                >
+                  <template #label>
+                    <span class="checkbox-label">{{ role.nameDisplay }}</span>
+                  </template>
+                </Checkbox>
+              </div>
+            </div>
+          </template>
+        </Card>
       </div>
     </form>
   </div>
 </template>
-
+<style lang='scss'>
+.role-group {
+  .card-container {
+    margin: 0;
+  }
+}
+</style>
 <style lang='scss' scoped>
   $detailSize: 11px;
   .role-group {
-    .type-description {
-      font-size: $detailSize;
+    .type-title {
+      display: flex;
+      flex-direction: column;
+      .type-description {
+        font-size: $detailSize;
+      }
     }
+
     .checkbox-section {
       display: grid;
 

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -310,13 +310,16 @@ export default {
                   v-model="selectedRoles"
                   :value-when-true="role.id"
                   :disabled="!!assignOnlyRoles[role.id]"
-                  :tooltip-key="!!assignOnlyRoles[role.id] ? 'rbac.globalRoles.assignOnlyRole' : ''"
                   :label="role.nameDisplay"
+                  :description="role.description"
                   :mode="mode"
                   @input="checkboxChanged"
                 >
                   <template #label>
-                    <span class="checkbox-label">{{ role.nameDisplay }}</span>
+                    <div class="checkbox-label-slot">
+                      <span class="checkbox-label">{{ role.nameDisplay }}</span>
+                      <i v-if="!!assignOnlyRoles[role.id]" v-tooltip="t('rbac.globalRoles.assignOnlyRole')" class="checkbox-info icon icon-info icon-lg" />
+                    </div>
                   </template>
                 </Checkbox>
               </div>
@@ -354,7 +357,11 @@ export default {
         grid-template-columns: 100%;
       }
 
-      .checkbox-label{
+      .checkbox-label {
+        &-slot {
+          display: inline-flex;
+          align-items: center;
+        }
         color: var(--body-text);
         margin: 0;
       }

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -24,6 +24,10 @@ export default {
       type:    String,
       default: _VIEW,
     },
+    assignOnly: {
+      type:    Boolean,
+      default: false,
+    },
     type: {
       type:    String,
       default: 'group',
@@ -83,6 +87,7 @@ export default {
       sortedRoles:           null,
       selectedRoles:         [],
       startingSelectedRoles: [],
+      assignOnlyRoles:       {},
       roleChanges:           {}
     };
   },
@@ -127,6 +132,7 @@ export default {
     update() {
       this.selectedRoles = [];
       this.startingSelectedRoles = [];
+      this.assignOnlyRoles = {};
       if (this.isCreate) {
         // Start with the new user default for each role
         Object.values(this.sortedRoles).forEach((roles) => {
@@ -156,6 +162,8 @@ export default {
                 roleId:    mappedRole.id,
                 bindingId: boundRole.id
               });
+              // Checkboxes should be disabled, besides normal 'mode' ways, if we're only assigning and not removing existing roles
+              this.assignOnlyRoles[mappedRole.id] = this.assignOnly;
             }
           });
         });
@@ -264,6 +272,7 @@ export default {
         return verbsRequiredForLogin.includes(verbs[0]);
       }
     },
+
   }
 };
 </script>
@@ -285,6 +294,8 @@ export default {
                 :key="getUnique(roleType, role.id, 'checkbox')"
                 v-model="selectedRoles"
                 :value-when-true="role.id"
+                :disabled="!!assignOnlyRoles[role.id]"
+                :tooltip-key="!!assignOnlyRoles[role.id] ? 'rbac.globalRoles.assignOnlyRole' : ''"
                 :label="role.nameDisplay"
                 :mode="mode"
                 @input="checkboxChanged"

--- a/components/GlobalRoleBindings.vue
+++ b/components/GlobalRoleBindings.vue
@@ -131,19 +131,22 @@ export default {
     getUnique(...ids) {
       return `${ this.groupPrincipalId || this.userId }-${ ids.join('-') }`;
     },
+    selectDefaults() {
+      Object.values(this.sortedRoles).forEach((roles) => {
+        roles.forEach((mappedRole) => {
+          if (mappedRole.newUserDefault) {
+            this.selectedRoles.push(mappedRole.id);
+          }
+        });
+      });
+    },
     update() {
       this.selectedRoles = [];
       this.startingSelectedRoles = [];
       this.assignOnlyRoles = {};
       if (this.isCreate) {
         // Start with the new user default for each role
-        Object.values(this.sortedRoles).forEach((roles) => {
-          roles.forEach((mappedRole) => {
-            if (mappedRole.newUserDefault) {
-              this.selectedRoles.push(mappedRole.id);
-            }
-          });
-        });
+        this.selectDefaults();
       } else {
         // Start with the principal/user's roles
         if (!this.groupPrincipalId && !this.userId) {
@@ -169,6 +172,11 @@ export default {
             }
           });
         });
+
+        if (this.assignOnly && !this.selectedRoles.length) {
+          // If we're assigning roles to a group that has no existing roles start with the default roles selected
+          this.selectDefaults();
+        }
       }
 
       // Force an update to pump out the initial state

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -165,7 +165,7 @@ export default {
 <style lang="scss" scoped>
   .select-principal {
     &.retain-selection {
-      min-height: 84px;
+      min-height: 86px;
       &.focused {
         .principal {
           display: none;

--- a/components/form/Footer.vue
+++ b/components/form/Footer.vue
@@ -23,6 +23,11 @@ export default {
       type:    Array,
       default: null,
     },
+
+    disableSave: {
+      type:     Boolean,
+      default: false,
+    }
   },
 
   computed: {
@@ -64,6 +69,7 @@ export default {
           <AsyncButton
             v-if="!isView"
             :mode="mode"
+            :disabled="disableSave"
             @click="save"
           />
         </slot>

--- a/models/group.principal.js
+++ b/models/group.principal.js
@@ -28,6 +28,11 @@ export default {
     return detailLocation;
   },
 
+  globalRoleBindings() {
+    return this.$rootGetters['management/all'](RBAC.GLOBAL_ROLE_BINDING)
+      .filter(globalRoleBinding => this.id === globalRoleBinding.groupPrincipalName);
+  },
+
   availableActions() {
     return [
       {
@@ -41,7 +46,7 @@ export default {
         label:      this.t('action.unassign'),
         icon:       'icon icon-trash',
         bulkable:   true,
-        enabled:    true,
+        enabled:    !!this.globalRoleBindings.length,
         bulkAction: 'unassignGroupRoles',
       },
     ];

--- a/pages/c/_cluster/auth/group.principal/assign-edit.vue
+++ b/pages/c/_cluster/auth/group.principal/assign-edit.vue
@@ -83,7 +83,7 @@ export default {
       <form>
         <SelectPrincipal :retain-selection="true" class="mb-20" :show-my-group-types="['group']" :search-group-types="'group'" @add="setPrincipal" />
 
-        <GlobalRoleBindings ref="grb" :group-principal-id="principalId" :mode="mode" />
+        <GlobalRoleBindings ref="grb" :group-principal-id="principalId" :mode="mode" :assign-only="true" />
 
         <FooterComponent
           :mode="mode"

--- a/pages/c/_cluster/auth/group.principal/assign-edit.vue
+++ b/pages/c/_cluster/auth/group.principal/assign-edit.vue
@@ -3,7 +3,7 @@ import FooterComponent from '@/components/form/Footer';
 import SelectPrincipal from '@/components/auth/SelectPrincipal.vue';
 import GlobalRoleBindings from '@/components/GlobalRoleBindings.vue';
 import { NORMAN } from '@/config/types';
-import { _VIEW } from '@/config/query-params';
+import { _VIEW, _EDIT } from '@/config/query-params';
 import { exceptionToErrorsArray } from '@/utils/error';
 import { NAME } from '@/config/product/auth';
 
@@ -17,11 +17,17 @@ export default {
     return {
       errors:       [],
       principalId:  null,
+      canLogIn:     false,
+      rolesChanged: false,
+      editMode:     _EDIT,
     };
   },
   computed: {
     mode() {
       return !this.principalId ? _VIEW : this.$route.query.mode || _VIEW;
+    },
+    canSave() {
+      return this.rolesChanged && this.canLogIn;
     }
   },
   methods: {
@@ -83,11 +89,19 @@ export default {
       <form>
         <SelectPrincipal :retain-selection="true" class="mb-20" :show-my-group-types="['group']" :search-group-types="'group'" @add="setPrincipal" />
 
-        <GlobalRoleBindings ref="grb" :group-principal-id="principalId" :mode="mode" :assign-only="true" />
+        <GlobalRoleBindings
+          ref="grb"
+          :group-principal-id="principalId"
+          :mode="mode"
+          :assign-only="true"
+          @canLogIn="canLogIn = $event"
+          @hasChanges="rolesChanged = $event"
+        />
 
         <FooterComponent
-          :mode="mode"
+          :mode="editMode"
           :errors="errors"
+          :disable-save="!canSave"
           @save="save"
           @done="cancel"
         >


### PR DESCRIPTION
This PR contains fixes to the groups list and assign/edit group page. This involves changing the GlobalRoleBinding component which handles group assign/edit of global roles and new/existing users view/edit/initial global roles 
- #2540 UI Issues
  - Issue 3 - GlobalRoleBinding - Built-in and custom roles are now sorted alphabetically
  - Issue 4 - GlobalRoleBinding - Role types are now encapsulated in cards
- Improvement - Assign Global Roles - Ensure only assign is possible
  - In Ember this was a pure assign page, any existing roles were disregarded (this meant there could be multiple bindings to the same role)
  - In the Dashboard we now take into account the groups existing roles. Previously to this PR these existing roles could be removed via the assign page, this is now not possible. 
  - The UX for existing roles has also been improved 
- #2541 - Groups list - Ensure group is removed from groups table when all roles are unassigned from the group
  - This was caused by the spoofed groups collection not updating after the delete of the non-spoofed global role bindings
- #2542 - GlobalRoleBinding - Ensure a sensible set of starting roles are selected when a group has no bindings
- #2551 - Groups list - Show a warning to user that groups aren't applicable when there's no auth provider
  - This matches ember's behaviour
- #2567, #2570 - Groups list - Added disabled plumbing to Footer save button, wire in disabled state to state of GlobalRoleBinding.
  - Button is disabled if there are no changes OR changes are invalid
  - This already happens when used with user, so just needed the plumbing
  - This change also fixed the issue where cancel/submit was not shown when no group was selected
  