### PR TITLE
Settings: Change text color of heading so as not to confuse with a link

### DIFF
--- a/list/management.cattle.io.setting.vue
+++ b/list/management.cattle.io.setting.vue
@@ -119,12 +119,12 @@ export default {
   border: 1px solid var(--border);
 
   h1 {
-    color: var(--link-text);
     font-size: 14px;
   }
   h2 {
     font-size: 12px;
     margin-bottom: 0;
+    opacity: 0.8;
   }
 }
 


### PR DESCRIPTION
#2471 

Small fix to change the color of the settings titles so that they are not confused with links.