### PR TITLE
Hide More Info links on CRU Resource

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -88,6 +88,12 @@ export default {
       showAsForm:    this.$route.query[AS] !== _YAML,
       resourceYaml:  yaml,
       initialYaml:   yaml,
+      abbrSizes:     {
+        3: '24px',
+        4: '18px',
+        5: '16px',
+        6: '14px'
+      }
     };
   },
 
@@ -233,7 +239,7 @@ export default {
                         class="banner-abbrv"
                       >
                         <span v-if="$store.getters['i18n/exists'](subtype.bannerAbbrv)">{{ t(subtype.bannerAbbrv) }}</span>
-                        <span v-else>{{ subtype.bannerAbbrv }}</span>
+                        <span v-bind:style="{fontSize: abbrSizes[subtype.bannerAbbrv.length]}" v-else>{{ subtype.bannerAbbrv }}</span>
                       </div>
                       <div v-else>
                         {{ subtype.id.slice(0, 1).toUpperCase() }}
@@ -249,7 +255,7 @@ export default {
                   </h5>
                   <a v-if="subtype.docLink" :href="subtype.docLink" target="_blank" rel="noopener nofollow" class="flex-right">More Info <i class="icon icon-external-link" /></a>
                 </div>
-                <hr />
+                <hr v-if="subtype.description" />
                 <div v-if="subtype.description" class="description">
                   <span
                     v-if="$store.getters['i18n/exists'](subtype.description)"

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -247,7 +247,7 @@ export default {
                     ></span>
                     <span v-else>{{ subtype.label }}</span>
                   </h5>
-                  <a href="" target="_blank" rel="noopener nofollow" class="flex-right">More Info <i class="icon icon-external-link" /></a>
+                  <a v-if="subtype.docLink" :href="subtype.docLink" target="_blank" rel="noopener nofollow" class="flex-right">More Info <i class="icon icon-external-link" /></a>
                 </div>
                 <hr />
                 <div v-if="subtype.description" class="description">


### PR DESCRIPTION
#2595 

The more info link on the CruResource component is not wired up - we show the link, but the link is always empty.

I have hidden the links for now - I see no evidence that there was ever any docs for these. They are gated on a docLink property that is not currently set, so they never show.

We should revisit - I assume the intent was that these linked to the k9s docs