### PR TITLE
Fix line break in % value on percentage bar component

### DIFF
--- a/components/PercentageBar.vue
+++ b/components/PercentageBar.vue
@@ -65,7 +65,7 @@ export default {
 <template>
   <span class="percentage-bar">
     <Bar :percentage="value" :primary-color="primaryColor" />
-    <span v-if="showPercentage" class="ml-5">{{ formattedPercentage }}</span>
+    <span v-if="showPercentage" class="ml-5 percentage-value">{{ formattedPercentage }}</span>
   </span>
 </template>
 
@@ -73,5 +73,9 @@ export default {
 .percentage-bar {
   display: flex;
   flex-direction: row;
+
+  .percentage-value {
+    word-break: keep-all;
+  }
 }
 </style>


### PR DESCRIPTION
#2592 

This PR ensures that the text value in the percentage bar component does not word wrap - fixes issue where the value and the % units would be split on different lines