### PR TITLE
Groups List: Ensure all groups are shown

### DIFF
--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -2,6 +2,7 @@ import { DSL } from '@/store/type-map';
 // import { STATE, NAME as NAME_COL, AGE } from '@/config/table-headers';
 import { MANAGEMENT, NORMAN, RBAC } from '@/config/types';
 import { GROUP_NAME, GROUP_ROLE_NAME } from '@/config/table-headers';
+import { uniq } from '@/utils/array';
 
 export const NAME = 'auth';
 
@@ -77,28 +78,34 @@ export function init(store) {
         return [];
       }
 
-      // Groups are a list of principals filtered via those that have group roles bound to them
-      const principals = await store.dispatch('rancher/findAll', {
+      // Ensure we upfront load principals (saves making individual requests later)
+      await store.dispatch('rancher/findAll', {
         type: NORMAN.PRINCIPAL,
         opt:  { url: '/v3/principals' }
       });
+
+      // getInstances should return a list of principals that have global bindings.
+      // It would be easier to just filter principals from above by those with bindings...
+      // .. however the principals list from above is NOT complete and misses some that have bindings (seen when using AD)
+      // So flip the logic and fetch any principal that's missing from the principal list
 
       const globalRoleBindings = await store.dispatch('management/findAll', {
         type: RBAC.GLOBAL_ROLE_BINDING,
         opt:  { force: true }
       });
 
-      // Up front fetch all global roles, instead of individually when needed (results in many duplicated requests)
-      await store.dispatch('management/findAll', { type: RBAC.GLOBAL_ROLE });
+      const uniquePrincipalIds = uniq(globalRoleBindings
+        .filter(grb => !!grb.groupPrincipalName)
+        .map(grb => grb.groupPrincipalName)
+      );
 
-      return principals
-        .filter(principal => principal.principalType === 'group' &&
-          !!globalRoleBindings.find(globalRoleBinding => globalRoleBinding.groupPrincipalName === principal.id)
-        )
-        .map(principal => ({
-          ...principal,
-          type: NORMAN.SPOOFED.GROUP_PRINCIPAL
-        }));
+      const allPrincipals = uniquePrincipalIds.map(pId => store.dispatch('rancher/find', {
+        type: NORMAN.PRINCIPAL,
+        opt:  { url: `/v3/principals/${ encodeURIComponent(pId) }` },
+        id:   pId
+      }));
+
+      return Promise.all(allPrincipals);
     }
   });
   configureType(NORMAN.SPOOFED.GROUP_PRINCIPAL, {

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -2,7 +2,7 @@
 import ResourceTable from '@/components/ResourceTable';
 import Loading from '@/components/Loading';
 import Masthead from '@/components/ResourceList/Masthead';
-import { NORMAN } from '@/config/types';
+import { NORMAN, RBAC } from '@/config/types';
 import AsyncButton from '@/components/AsyncButton';
 import { applyProducts } from '@/store/type-map';
 import { NAME } from '@/config/product/auth';
@@ -58,8 +58,12 @@ export default {
         opt:  { force }
       }, { root: true }); // See PromptRemove.vue
 
+      // Upfront load all global roles, this makes it easier to sync fetch them later on
+      await this.$store.dispatch('management/findAll', { type: RBAC.GLOBAL_ROLE });
+
       const principals = await this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL, opt: { url: '/v3/principals' } });
 
+      // Are there principals that are groups? (don't use rows, it's filtered by those with roles)
       this.hasGroups = principals.filter(principal => principal.principalType === 'group')?.length;
     },
     async refreshGroupMemberships(buttonDone) {


### PR DESCRIPTION
- Groups list shows principals that have global role bindings
- Some global role bindings pointed to principals that weren't returned when fetching all principals
- This meant they were skipped from the list
- Solution is to flip the logic from principals that have grbs... to unique grbs principals
- Seen on a QA system with a AD auth provider
- Address #2568