### PR TITLE
use option-label-getting func instead of option.label

### DIFF
--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -252,7 +252,7 @@ export default {
     >
       <template #option="option">
         <div @mousedown="(e) => onClickOption(option, e)">
-          {{ option.label }}
+          {{ getOptionLabel(option) }}
         </div>
       </template>
       <!-- Pass down templates provided by the caller -->


### PR DESCRIPTION
Some LabeledSelects that use get-option-label do not populate the LabeledSelect slot correctly and make the dropdown appear empty: 
(workload env vars)
<img width="1137" alt="Screen Shot 2021-03-31 at 4 47 21 PM" src="https://user-images.githubusercontent.com/42977925/113227145-ca0abf00-9246-11eb-8079-8b044974891a.png">
