### PR TITLE
Fix setting of page size to 1000

### DIFF
--- a/pages/prefs.vue
+++ b/pages/prefs.vue
@@ -86,7 +86,10 @@ export default {
     perPageOptions() {
       const t = this.$store.getters['i18n/t'];
 
-      return this.$store.getters['prefs/options'](ROWS_PER_PAGE).map(count => t('prefs.perPage.value', { count }));
+      return this.$store.getters['prefs/options'](ROWS_PER_PAGE).map(count => ({
+        label: t('prefs.perPage.value', { count }),
+        value: count
+      }));
     },
 
     hideDescriptions: {
@@ -149,6 +152,8 @@ export default {
           v-model.number="perPage"
           :label="t('prefs.perPage.label')"
           :options="perPageOptions"
+          option-key="value"
+          option-label="label"
           placeholder="Select a row count"
         />
       </div>


### PR DESCRIPTION
- `v-model.number` was converting the option `1,000` to `1`
- Fixed by setting explicit label/value properties in options
- Addresses #2594