### PR TITLE
fix log in provider buttons

### DIFF
--- a/components/auth/login/ldap.vue
+++ b/components/auth/login/ldap.vue
@@ -7,8 +7,17 @@ export default {
   components: { LabeledInput, AsyncButton },
   mixins:     [Login],
 
+  props: {
+    onlyOption: {
+      type:    Boolean,
+      default: false
+    }
+  },
+
   data() {
-    return { username: '', password: '' };
+    return {
+      username: '', password: '', showInputs: this.onlyOption
+    };
   },
 
   methods: {
@@ -36,37 +45,44 @@ export default {
 
 <template>
   <form>
-    <div class="span-6 offset-3">
-      <div class="mb-20">
-        <LabeledInput
-          v-model="username"
-          :label="t('login.username')"
-          autocomplete="username"
-        />
+    <template v-if="showInputs">
+      <div class="span-6 offset-3">
+        <div class="mb-20">
+          <LabeledInput
+            v-model="username"
+            :label="t('login.username')"
+            autocomplete="username"
+          />
+        </div>
+        <div class="mb-20">
+          <LabeledInput
+            v-model="password"
+            type="password"
+            :label="t('login.password')"
+            autocomplete="password"
+          />
+        </div>
       </div>
-      <div class="mb-20">
-        <LabeledInput
-          v-model="password"
-          type="password"
-          :label="t('login.password')"
-          autocomplete="password"
-        />
+      <div class="row">
+        <div class="col span-12 text-center">
+          <AsyncButton
+            ref="btn"
+            type="submit"
+            :action-label="t('login.loginWithProvider', {provider: displayName})"
+            :waiting-label="t('login.loggingIn')"
+            :success-label="t('login.loggedIn')"
+            :error-label="t('asyncButton.default.error')"
+            class="btn bg-primary"
+            style="font-size: 18px;"
+            @click="login"
+          />
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <div class="col span-12 text-center">
-        <AsyncButton
-          ref="btn"
-          type="submit"
-          :action-label="t('login.loginWithProvider', {provider: displayName})"
-          :waiting-label="t('login.loggingIn')"
-          :success-label="t('login.loggedIn')"
-          :error-label="t('asyncButton.default.error')"
-          class="btn bg-primary"
-          style="font-size: 18px;"
-          @click="login"
-        />
-      </div>
+    </template>
+    <div v-else class="text-center">
+      <button style="font-size: 18px;" type="button" class="btn bg-primary" @click="showInputs = true">
+        {{ t('login.loginWithProvider', {provider: displayName}) }}
+      </button>
     </div>
   </form>
 </template>

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -167,7 +167,7 @@ export default {
           {{ t('login.loginAgain') }}
         </h4>
 
-        <div v-if="providers.length" class="mt-50 mb-50">
+        <div v-if="providers.length" class="mt-50">
           <component
             :is="providerComponents[idx]"
             v-for="(name, idx) in providers"
@@ -175,6 +175,7 @@ export default {
             class="mb-10"
             :focus-on-mount="(idx === 0 && !showLocal)"
             :name="name"
+            :only-option="providers.length === 1 && !showLocal"
           />
         </div>
         <template v-if="hasLocal">
@@ -206,6 +207,7 @@ export default {
                   :waiting-label="t('login.loggingIn')"
                   :success-label="t('login.loggedIn')"
                   :error-label="t('asyncButton.default.error')"
+                  style="font-size: 18px;"
                   @click="loginLocal"
                 />
                 <div class="mt-20">
@@ -214,7 +216,7 @@ export default {
               </div>
             </div>
           </form>
-          <div v-if="hasLocal" class="mt-20 text-center">
+          <div v-if="hasLocal && !showLocal" class="mt-20 text-center">
             <button type="button" class="btn bg-link" @click="toggleLocal">
               {{ t('login.useLocal') }}
             </button>


### PR DESCRIPTION
#2596 - in addition to addressing the problem outlined here, I made a minor change to the ldap component so its inputs aren't shown if there are multiple providers present. I don't think that scenario is particularly common and the UI is structured to discourage it anyway, but this change makes it clearer which provider the inputs are for. If I didn't know the other two providers opened a popup I would find this somewhat ambiguous (and it's a bit ugly):
<img width="971" alt="Screen Shot 2021-04-02 at 3 33 59 PM" src="https://user-images.githubusercontent.com/42977925/113458934-e0d91f00-93c8-11eb-8ba1-7c033748e32b.png">

changes in this pr:

no third party provider:
<img width="971" alt="Screen Shot 2021-04-02 at 3 17 39 PM" src="https://user-images.githubusercontent.com/42977925/113458279-aff7ea80-93c6-11eb-9988-cf1e9b14ffd8.png">
one ldap provider:
<img width="976" alt="Screen Shot 2021-04-02 at 3 17 08 PM" src="https://user-images.githubusercontent.com/42977925/113458281-b1291780-93c6-11eb-91d4-02bc0b866235.png">
multiple providers:
<img width="976" alt="Screen Shot 2021-04-02 at 3 16 14 PM" src="https://user-images.githubusercontent.com/42977925/113458284-b25a4480-93c6-11eb-9715-8e8a1a3fc937.png">

ldap/local input toggle behavior:

https://user-images.githubusercontent.com/42977925/113458599-aa4ed480-93c7-11eb-904f-9a9213b1add3.mov




