### PR TITLE
fix node affinity radio

### DIFF
--- a/components/form/NodeScheduling.vue
+++ b/components/form/NodeScheduling.vue
@@ -65,15 +65,27 @@ export default {
     update() {
       const { nodeName, nodeSelector, nodeAffinity } = this;
 
-      if (this.selectNode === 'nodeSelector') {
+      switch (this.selectNode) {
+      case 'nodeSelector':
         Object.assign(this.value, { nodeSelector, nodeName });
-      } else {
+        if (this.value?.affinity?.nodeAffinity) {
+          delete this.value.affinity.nodeAffinity;
+        }
+        break;
+      case 'affinity':
         delete this.value.nodeName;
         delete this.value.nodeSelector;
         if (!this.value.affinity) {
           Object.assign(this.value, { affinity: { nodeAffinity } });
         } else {
           Object.assign(this.value.affinity, { nodeAffinity });
+        }
+        break;
+      default:
+        delete this.value.nodeName;
+        delete this.value.nodeSelector;
+        if (this.value?.affinity?.nodeAffinity) {
+          delete this.value.affinity.nodeAffinity;
         }
       }
     },
@@ -91,6 +103,7 @@ export default {
         :options="[null, 'nodeSelector', 'affinity']"
         :labels="[ t('workload.scheduling.affinity.anyNode'), t('workload.scheduling.affinity.specificNode'), t('workload.scheduling.affinity.schedulingRules') ]"
         :mode="mode"
+        @input="update"
       />
     </div>
     <template v-if="selectNode === 'nodeSelector'">

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -660,6 +660,7 @@ export default {
                 :mode="mode"
                 :label="t('workload.serviceName')"
                 :options="headlessServices"
+                required
               />
             </template>
           </NameNsDescription>


### PR DESCRIPTION
#2577 - actually delete `affinity.nodeAffinity` when 'run pods on any node' is selected
#2553 - this PR marks the service dropdown as required, but no changes to how that dropdown is populated. That actually appears to be the result of a broader dropdown bug which was addressed here: https://github.com/rancher/dashboard/pull/2603