### PR TITLE
fix workload config->yaml edit breaking

### DIFF
--- a/components/form/WorkloadPorts.vue
+++ b/components/form/WorkloadPorts.vue
@@ -143,7 +143,6 @@ export default {
       if ( this.isView ) {
         return;
       }
-
       const out = [];
 
       for ( const row of this.rows ) {
@@ -201,7 +200,7 @@ export default {
       :class="{'show-host':row._showHost}"
     >
       <div class="service-type">
-        <LabeledSelect v-model="row._serviceType" :mode="mode" :label="t('workload.container.ports.createService')" :options="serviceTypes" />
+        <LabeledSelect v-model="row._serviceType" :mode="mode" :label="t('workload.container.ports.createService')" :options="serviceTypes" @input="update" />
       </div>
 
       <div class="portName">

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -440,7 +440,12 @@ export default {
     },
 
     async saveService() {
-      const { toSave = [], toRemove = [] } = await this.value.servicesFromContainerPorts(this.mode);
+      const svcs = await this.value.servicesFromContainerPorts(this.mode);
+
+      if (!svcs) {
+        return;
+      }
+      const { toSave = [], toRemove = [] } = svcs;
 
       this.servicesOwned = toSave;
       this.servicesToRemove = toRemove;

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -121,7 +121,8 @@ export default {
       spec,
       type,
       servicesOwned:     [],
-      servicesToRemove:    []
+      servicesToRemove:    [],
+      portsForServices:  []
     };
   },
 
@@ -415,9 +416,7 @@ export default {
 
   created() {
     this.registerBeforeHook(this.saveWorkload, 'willSaveWorkload');
-    this.registerBeforeHook(this.saveService, 'saveService');
-    this.registerAfterHook(this.setOwnerRef, 'setOwnerRef');
-    this.registerAfterHook(this.removeService, 'removeService');
+    this.registerAfterHook(this.saveService, 'saveService');
   },
 
   methods: {
@@ -440,66 +439,22 @@ export default {
     },
 
     async saveService() {
-      const svcs = await this.value.servicesFromContainerPorts(this.mode);
-
-      if (!svcs) {
-        return;
-      }
-      const { toSave = [], toRemove = [] } = svcs;
+      const { toSave = [], toRemove = [] } = await this.value.servicesFromContainerPorts(this.mode, this.portsForServices) || {};
 
       this.servicesOwned = toSave;
       this.servicesToRemove = toRemove;
 
-      if (!toSave.length) {
+      if (!toSave.length && !toRemove.length) {
         return;
       }
 
-      return Promise.all(toSave.map(svc => svc.save()));
-    },
-
-    removeService() {
-      if (!this.servicesToRemove) {
-        return;
-      }
-
-      return Promise.all(this.servicesToRemove.map((svc) => {
+      return Promise.all([...toSave.map(svc => svc.save()), ...toRemove.map((svc) => {
         const ui = svc?.metadata?.annotations[UI_MANAGED];
 
         if (ui) {
           svc.remove();
         }
-      }));
-    },
-
-    setOwnerRef() {
-      if (!this.servicesOwned.length ) {
-        return;
-      }
-
-      const ownerRef = {
-        apiVersion: this.value.apiVersion,
-        controller: true,
-        kind:       this.value.kind,
-        name:       this.value.metadata.name,
-        uid:        this.value.metadata.uid
-      };
-
-      this.servicesOwned.forEach((svc) => {
-        const id = `${ svc.metadata.namespace }/${ svc.metadata.name }`;
-
-        try {
-          this.$store.dispatch('cluster/find', {
-            type:     SERVICE,
-            id,
-            opt:  { force: true }
-          }).then((svc) => {
-            if (!svc.metadata.ownerReferences) {
-              svc.metadata.ownerReferences = [ownerRef];
-            }
-            svc.save();
-          });
-        } catch {}
-      });
+      })]);
     },
 
     saveWorkload() {
@@ -536,6 +491,11 @@ export default {
       if (!this.container.name || this.mode === _CREATE) {
         this.$set(this.container, 'name', this.value.metadata.name);
       }
+
+      const { ports = [] } = this.value.container;
+
+      // ports contain info used to create services after saving
+      this.portsForServices = ports.filter(port => port._serviceType && port._serviceType !== '');
 
       Object.assign(this.value, { spec: this.spec });
     },

--- a/models/workload.js
+++ b/models/workload.js
@@ -254,14 +254,18 @@ export default {
 
   // create clusterip, nodeport, loadbalancer services from container port spec
   servicesFromContainerPorts() {
-    return async(mode) => {
-      const workloadErrors = await this.validationErrors(this);
-
-      if (workloadErrors.length ) {
+    return async(mode, ports) => {
+      if (!ports || !ports.length) {
         return;
       }
 
-      const { ports = [] } = this.container;
+      const ownerRef = {
+        apiVersion: this.apiVersion,
+        controller: true,
+        kind:       this.kind,
+        name:       this.metadata.name,
+        uid:        this.metadata.uid
+      };
 
       let clusterIP = {
         type: SERVICE,
@@ -271,9 +275,10 @@ export default {
           type:     'ClusterIP'
         },
         metadata: {
-          name:        this.metadata.name,
-          namespace:   this.metadata.namespace,
-          annotations:    { [TARGET_WORKLOADS]: `['${ this.metadata.namespace }/${ this.metadata.name }']`, [UI_MANAGED]: 'true' },
+          name:            this.metadata.name,
+          namespace:       this.metadata.namespace,
+          annotations:     { [TARGET_WORKLOADS]: `['${ this.metadata.namespace }/${ this.metadata.name }']`, [UI_MANAGED]: 'true' },
+          ownerReferences: [ownerRef]
         },
       };
 
@@ -285,10 +290,10 @@ export default {
           type:     'NodePort'
         },
         metadata: {
-          name:        `${ this.metadata.name }-nodeport`,
-          namespace:   this.metadata.namespace,
-          annotations:    { [TARGET_WORKLOADS]: `['${ this.metadata.namespace }/${ this.metadata.name }']`, [UI_MANAGED]: 'true' },
-
+          name:            `${ this.metadata.name }-nodeport`,
+          namespace:       this.metadata.namespace,
+          annotations:     { [TARGET_WORKLOADS]: `['${ this.metadata.namespace }/${ this.metadata.name }']`, [UI_MANAGED]: 'true' },
+          ownerReferences: [ownerRef]
         },
       };
 
@@ -301,10 +306,10 @@ export default {
           externalTrafficPolicy: 'Cluster'
         },
         metadata: {
-          name:        `${ this.metadata.name }-loadbalancer`,
-          namespace:   this.metadata.namespace,
-          annotations:    { [TARGET_WORKLOADS]: `['${ this.metadata.namespace }/${ this.metadata.name }']`, [UI_MANAGED]: 'true' },
-
+          name:            `${ this.metadata.name }-loadbalancer`,
+          namespace:       this.metadata.namespace,
+          annotations:     { [TARGET_WORKLOADS]: `['${ this.metadata.namespace }/${ this.metadata.name }']`, [UI_MANAGED]: 'true' },
+          ownerReferences: [ownerRef]
         },
       };
 

--- a/models/workload.js
+++ b/models/workload.js
@@ -258,7 +258,7 @@ export default {
       const workloadErrors = await this.validationErrors(this);
 
       if (workloadErrors.length ) {
-        throw workloadErrors;
+        return;
       }
 
       const { ports = [] } = this.container;


### PR DESCRIPTION
Switching from editing workloads via form to editing via yaml breaks the page if the workload doesn't pass validation because `BEFORE_SAVE_HOOKS` are applied when 'Edit as YAML' is clicked, and the service-creation logic in workloads' `BEFORE_SAVE_HOOKS` runs workload validation. It's necessary for another workload `BEFORE_SAVE_HOOK` to run prior to yamlizing the workload, but I think it's pretty undesirable to create services upon switching from form to yaml view; it really shouldn't happen until the user is really done defining the workload. 

In light of that, I moved service creation to after the workload is made. This has the added benefit of simplifying the process of attaching ownerRefs to the services.