### PR TITLE
Auth fixes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -208,24 +208,20 @@ authConfig:
     steps:
       1:
         title: 'Step One: For standard Google, click <a href="https://console.developers.google.com/apis/credentials" target="_blank" rel="noopener noreferrer nofollow">here</a> to go applications settings in a new window'
-        body: |-
-          <ul class="mt-0">
-          <li>Login to your account. Navigate to "APIs & Services" and then select "OAuth consent screen". </li>
-          <li>Authorized domains: Top private domain of {hostname} </li>
-          <li>Application homepage link: {serverUrl}</li>
-          <li>Under Scopes for Google APIs, enable "email", "profile", and "openid". </li>
-          <li>Click on "Save". </li>
-          </ul>
+        body:
+         1: Login to your account. Navigate to "APIs & Services" and then select "OAuth consent screen".
+         2: 'Authorized domains: Top private domain of: '
+         3: 'Application homepage link: '
+         4: 'Under Scopes for Google APIs, enable "email", "profile", and "openid".'
+         5: 'Click on "Save".'
       2:
         title: 'Step Two: Navigate to the "Credentials" tab to create your OAuth client ID'
-        body: |-
-          <ul class="mt-0">
-          <li>Select the "Create Credentials" dropdown, and select "OAuth clientID", then select "Web application".</li>
-          <li>Authorized Javascript origins: {serverUrl}</li>
-          <li>Authorized redirect URIs: {serverUrl}/verify-auth </li>
-          <li>Click "Create", and then click on the "Download JSON" button.</li>
-          <li>Upload the downloaded JSON file in the OAuth credentials box.</li>
-          </ul>
+        body: 
+          1: 'Select the "Create Credentials" dropdown, and select "OAuth clientID", then select "Web application".'
+          2: 'Authorized Javascript origins:'
+          3: 'Authorized redirect URIs:'
+          4: 'Click "Create", and then click on the "Download JSON" button.'
+          5: 'Upload the downloaded JSON file in the OAuth credentials box.'
       3:
         title: 'Step Three: Create Service Account credentials'
         body: |-

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -239,7 +239,10 @@ authConfig:
     freeipa: Configure a FreeIPA server
     activedirectory: Configure an Active Directory account
     openldap: Configure an OpenLDAP server
-    defaultLoginDomain: Default Login Domain
+    defaultLoginDomain:
+      label: Default Login Domain
+      placeholder: eg mycompany
+      hint: This domain will be used if a user logs in without specifying one.
     cert: Certificate
     disabledStatusBitmask: Disabled Status Bitmask
     groupDNAttribute: Group DN Attribute

--- a/edit/auth/googleoauth.vue
+++ b/edit/auth/googleoauth.vue
@@ -11,6 +11,7 @@ import Banner from '@/components/Banner';
 import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
 import FileSelector from '@/components/form/FileSelector';
 import AuthBanner from '@/components/auth/AuthBanner';
+import CopyToClipboardText from '@/components/CopyToClipboardText';
 
 const NAME = 'googleoauth';
 
@@ -24,7 +25,8 @@ export default {
     Checkbox,
     AllowedPrincipals,
     FileSelector,
-    AuthBanner
+    AuthBanner,
+    CopyToClipboardText
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -135,14 +137,35 @@ export default {
         </div>
         <InfoBox class=" mt-20 mb-20 p-10">
           <h3 v-html="t('authConfig.googleoauth.steps.1.title', tArgs, true)" />
-          <div v-html="t('authConfig.googleoauth.steps.1.body', tArgs, true)" />
+          <!-- <div v-html="t('authConfig.googleoauth.steps.1.body', tArgs, true)" /> -->
+          <ul class="mt-0">
+            <li>{{ t('authConfig.googleoauth.steps.1.body.1', {}, true) }} </li>
+            <li>{{ t('authConfig.googleoauth.steps.1.body.2', {}, true) }} <CopyToClipboardText :text="tArgs.hostname" /> </li>
+
+            <li>{{ t('authConfig.googleoauth.steps.1.body.3', {}, true) }} <CopyToClipboardText :text="serverUrl" /> </li>
+
+            <li>{{ t('authConfig.googleoauth.steps.1.body.4', {}, true) }} </li>
+
+            <li>{{ t('authConfig.googleoauth.steps.1.body.5', {}, true) }} </li>
+          </ul>
         </InfoBox>
         <InfoBox class="mb-20 p-10">
           <div class="row">
             <h3 v-html="t('authConfig.googleoauth.steps.2.title', tArgs, true)" />
           </div>
           <div class="row">
-            <div class="col span-6" v-html="t('authConfig.googleoauth.steps.2.body', tArgs, true)" />
+            <div class="col span-6">
+              <ul class="mt-0">
+                <li>{{ t('authConfig.googleoauth.steps.2.body.1', {}, true) }} </li>
+                <li>{{ t('authConfig.googleoauth.steps.2.body.2', {}, true) }} <CopyToClipboardText :text="serverUrl" /> </li>
+
+                <li>{{ t('authConfig.googleoauth.steps.2.body.3', {}, true) }} <CopyToClipboardText :text="serverUrl+'/verify-auth'" /> </li>
+
+                <li>{{ t('authConfig.googleoauth.steps.2.body.4', {}, true) }} </li>
+
+                <li>{{ t('authConfig.googleoauth.steps.2.body.5', {}, true) }} </li>
+              </ul>
+            </div>
             <div class="col span-6">
               <LabeledInput
                 v-model="model.oauthCredential"

--- a/edit/auth/ldap/config.vue
+++ b/edit/auth/ldap/config.vue
@@ -132,7 +132,14 @@ export default {
       </div>
       <div v-if="type==='activedirectory'" class="row mb-20">
         <div class="col span-6">
-          <LabeledInput v-model="model.defaultLoginDomain" required :mode="mode" :label="t('authConfig.ldap.defaultLoginDomain')" />
+          <LabeledInput
+            v-model="model.defaultLoginDomain"
+            :hoover-tooltip="true"
+            :tooltip="t('authConfig.ldap.defaultLoginDomain.hint')"
+            :placeholder="t('authConfig.ldap.defaultLoginDomain.placeholder')"
+            :mode="mode"
+            :label="t('authConfig.ldap.defaultLoginDomain.label')"
+          />
         </div>
       </div>
       <div class="row mb-20">

--- a/utils/crypto/index.js
+++ b/utils/crypto/index.js
@@ -27,7 +27,7 @@ export function base64Encode(string, alphabet = NORMAL) {
       '=': ''
     };
 
-    return buf.toString('base64').replace(/[+/]|=$/g, char => m[char]);
+    return buf.toString('base64').replace(/[+/]|=+$/g, char => m[char]);
   }
 
   return buf.toString('base64');


### PR DESCRIPTION
#2116 - This is happening because the `state` query param (used to determine which ui to route to) is malformed. The url-safe base64 encoding in dashboard is only removing at most 1 padding `=` when there can be up to 2. eg
` {"nonce":"OqO3ozOqPsnPeQKJ","to":"vue","test":true,"provider":"googleoauth"}` 
becomes 
`eyJub25jZSI6Ik9xTzNvek9xUHNuUGVRS0oiLCJ0byI6InZ1ZSIsInRlc3QiOnRydWUsInByb3ZpZGVyIjoiZ29vZ2xlb2F1dGgifQ==`

#2627 #2628  also in this pr