### PR TITLE
add rke windows as monitoring cluster type

### DIFF
--- a/chart/monitoring/ClusterSelector.vue
+++ b/chart/monitoring/ClusterSelector.vue
@@ -78,6 +78,12 @@ const CLUSTER_TYPES = [
       'rke2Etcd',
     ],
   },
+  {
+    group:      'rke',
+    id:         'rke-windows',
+    label:      'cluster.provider.rkeWindows',
+    configKeys: ['rkeControllerManager', 'rkeScheduler', 'rkeProxy', 'rkeEtcd', 'windowsExporter'],
+  },
 ];
 
 export default {


### PR DESCRIPTION
#2537 - adds rke windows cluster type, which sets all the same default config values as rke, plus `windowsExporter`
![Screen Shot 2021-04-06 at 10 25 18 AM](https://user-images.githubusercontent.com/42977925/113752961-678c4580-96c2-11eb-97b8-7f660c0b42d6.png)
