### PR TITLE
2.5.8 Bugs

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -512,6 +512,7 @@ catalog:
   install:
     action:
       goToUpgrade: Edit/Upgrade
+      ignoreWarning: Continue Anyways
     appReadmeGeneric: This chart doesn't have a Rancher-specific README.  Review the Helm README to learn more about the available configuration options and their usage.
     chart: Chart
     error:

--- a/components/form/SelectOrCreateAuthSecret.vue
+++ b/components/form/SelectOrCreateAuthSecret.vue
@@ -82,10 +82,16 @@ export default {
 
     let selected = _NONE;
 
-    if ( this.value && typeof this.value === 'object' ) {
-      selected = `${ this.value.namespace }/${ this.value.name }`;
-    } else if ( this.value ) {
-      selected = this.value;
+    if ( this.value ) {
+      if ( typeof this.value === 'object' ) {
+        selected = `${ this.value.namespace }/${ this.value.name }`;
+      } else if ( this.value.includes('/') ) {
+        selected = this.value;
+      } else if ( this.namespace ) {
+        selected = `${ this.namespace }/${ this.value }`;
+      } else {
+        selected = this.value;
+      }
     }
 
     this.selected = selected;

--- a/config/cookies.js
+++ b/config/cookies.js
@@ -1,2 +1,3 @@
+export const CSRF = 'CSRF';
 export const USERNAME = 'R_USERNAME';
 export const LOCALE = 'R_LOCALE';

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -77,7 +77,7 @@ export default {
       return null;
     }
 
-    const clusterProvider = this.$rootGetters['currentCluster'].status.provider || 'other';
+    const isWindows = this.$rootGetters['currentCluster'].providerOs === 'windows';
     const thisVersion = this.spec?.chart?.metadata?.version;
     const newestChart = chart.versions?.[0];
     const newestVersion = newestChart?.version;
@@ -86,9 +86,9 @@ export default {
       return null;
     }
 
-    if (clusterProvider === 'rke.windows' && newestChart?.annotations?.['catalog.cattle.io/os'] === 'linux') {
+    if (isWindows && newestChart?.annotations?.['catalog.cattle.io/os'] === 'linux') {
       return null;
-    } else if (clusterProvider !== 'rke.windows' && newestChart?.annotations?.['catalog.cattle.io/os'] === 'windows') {
+    } else if (!isWindows && newestChart?.annotations?.['catalog.cattle.io/os'] === 'windows') {
       return null;
     }
 

--- a/pages/c/_cluster/apps/charts.vue
+++ b/pages/c/_cluster/apps/charts.vue
@@ -57,11 +57,11 @@ export default {
     hideRepos: mapPref(HIDE_REPOS),
 
     showWindowsClusterNoAppsSplash() {
-      const clusterProvider = this.currentCluster.status.provider || 'other';
+      const isWindows = this.currentCluster.providerOs === 'windows';
       const { filteredCharts } = this;
       let showSplash = false;
 
-      if (clusterProvider === 'rke.windows' && filteredCharts.length === 0) {
+      if ( isWindows && filteredCharts.length === 0 ) {
         showSplash = true;
       }
 
@@ -114,16 +114,16 @@ export default {
     },
 
     filteredCharts() {
-      const clusterProvider = this.currentCluster.status.provider || 'other';
+      const isWindows = this.currentCluster.providerOs === 'windows';
       const enabledCharts = (this.enabledCharts || []); // .slice();
 
       return enabledCharts.filter((c) => {
         const { versions: chartVersions = [] } = c;
 
-        if (clusterProvider === 'rke.windows' && this.getCompatibleVersions(chartVersions, 'windows').length <= 0) {
+        if ( isWindows && this.getCompatibleVersions(chartVersions, 'windows').length <= 0) {
           // if we have at least one windows
           return false;
-        } else if (clusterProvider !== 'rke.windows' && this.getCompatibleVersions(chartVersions, 'linux').length <= 0) { // linux
+        } else if ( !isWindows && this.getCompatibleVersions(chartVersions, 'linux').length <= 0) { // linux
           // if we have at least one linux
           return false;
         }
@@ -270,13 +270,13 @@ export default {
     selectChart(chart) {
       let version;
       const chartVersions = chart.versions;
-      const clusterProvider = this.currentCluster.status.provider || 'other';
+      const isWindows = this.currentCluster.providerOs === 'windows';
       const windowsVersions = this.getCompatibleVersions(chartVersions, 'windows');
       const linuxVersions = this.getCompatibleVersions(chartVersions, 'linux');
 
-      if (clusterProvider === 'rke.windows' && windowsVersions.length > 0) {
+      if ( isWindows && windowsVersions.length > 0) {
         version = windowsVersions[0].version;
-      } else if (clusterProvider !== 'rke.windows' && linuxVersions.length > 0) {
+      } else if ( !isWindows && linuxVersions.length > 0) {
         version = linuxVersions[0].version;
       } else {
         version = chartVersions[0].version;

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -70,6 +70,11 @@ export default {
       id:   'system-default-registry'
     });
 
+    this.serverUrlSetting = await this.$store.dispatch('management/find', {
+      type: MANAGEMENT.SETTING,
+      id:   'server-url'
+    });
+
     const repoType = query[REPO_TYPE];
     const repoName = query[REPO];
     const chartName = query[CHART];
@@ -294,6 +299,7 @@ export default {
       showHidden:             false,
       showDeprecated:         false,
       defaultRegistrySetting: null,
+      serverUrlSetting:       null,
       chart:                  null,
       chartValues:            null,
       originalYamlValues:     null,
@@ -469,7 +475,7 @@ export default {
       } = this;
       const versions = this.chart?.versions || [];
       const selectedVersion = this.version?.version;
-      const clusterProvider = currentCluster.status.provider || 'other';
+      const isWindows = currentCluster.providerOs === 'windows';
       const out = [];
 
       versions.forEach((version) => {
@@ -482,13 +488,13 @@ export default {
         if ( version?.annotations?.[catalogOSAnnotation] === 'windows' ) {
           nue.label = this.t('catalog.install.versions.windows', { ver: version.version });
 
-          if (clusterProvider !== 'rke.windows') {
+          if ( !isWindows ) {
             nue.disabled = true;
           }
         } else if ( version?.annotations?.[catalogOSAnnotation] === 'linux' ) {
           nue.label = this.t('catalog.install.versions.linux', { ver: version.version });
 
-          if (clusterProvider === 'rke.windows') {
+          if ( isWindows ) {
             nue.disabled = true;
           }
         }
@@ -683,11 +689,18 @@ export default {
 
       const cluster = this.$store.getters['currentCluster'];
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
+      const serverUrl = this.serverUrlSetting?.value || '';
+      const isWindows = cluster.providerOs === 'windows';
 
       setIfNotSet(cattle, 'clusterId', cluster.id);
       setIfNotSet(cattle, 'clusterName', cluster.nameDisplay);
       setIfNotSet(cattle, 'systemDefaultRegistry', defaultRegistry);
       setIfNotSet(global, 'systemDefaultRegistry', defaultRegistry);
+      setIfNotSet(cattle, 'url', serverUrl);
+
+      if ( isWindows ) {
+        setIfNotSet(cattle, 'windows.enabled', true);
+      }
 
       return values;
 
@@ -705,17 +718,30 @@ export default {
 
       const cluster = this.$store.getters['currentCluster'];
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
-
-      deleteIfEqual(values, 'systemDefaultRegistry', defaultRegistry);
+      const serverUrl = this.serverUrlSetting?.value || '';
+      const isWindows = cluster.providerOs === 'windows';
 
       if ( values.global?.cattle ) {
         deleteIfEqual(values.global.cattle, 'clusterId', cluster.id);
         deleteIfEqual(values.global.cattle, 'clusterName', cluster.nameDisplay);
         deleteIfEqual(values.global.cattle, 'systemDefaultRegistry', defaultRegistry);
+        deleteIfEqual(values.global.cattle, 'url', serverUrl);
+
+        if ( isWindows ) {
+          deleteIfEqual(values.global.cattle.windows, 'enabled', true);
+        }
+      }
+
+      if ( values.global?.cattle.windows && !Object.keys(values.global.cattle.windows).length ) {
+        delete values.global.cattle.windows;
       }
 
       if ( values.global?.cattle && !Object.keys(values.global.cattle).length ) {
         delete values.global.cattle;
+      }
+
+      if ( values.global ) {
+        deleteIfEqual(values.global, 'systemDefaultRegistry', defaultRegistry);
       }
 
       if ( !Object.keys(values.global || {}).length ) {

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -226,6 +226,8 @@ export default {
       }
     }
 
+    this.warnings = [];
+
     if ( this.existing || query[FORCE] === _FLAGGED ) {
       // Ignore the limits on upgrade (or if asked by query) and don't show any warnings
     } else {
@@ -603,6 +605,10 @@ export default {
       this.showDiff = false;
     },
 
+    ignoreWarning() {
+      this.$router.applyQuery({ [FORCE]: _FLAGGED });
+    },
+
     cancel(reallyCancel) {
       if (!reallyCancel && this.showPreview) {
         return this.resetFromBack();
@@ -924,6 +930,9 @@ export default {
       </Banner>
 
       <div class="mt-20 text-center">
+        <button v-if="warnings.length" type="button" class="btn bg-error" @click="ignoreWarning">
+          <t k="catalog.install.action.ignoreWarning" />
+        </button>
         <button type="button" class="btn role-primary" @click="cancel">
           <t k="generic.cancel" />
         </button>

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,4 +1,5 @@
 import https from 'https';
+import { CSRF } from '@/config/cookies';
 import { parse as setCookieParser } from 'set-cookie-parser';
 import pkg from '../package.json';
 
@@ -9,7 +10,7 @@ export default function({
   $axios.defaults.withCredentials = true;
 
   $axios.onRequest((config) => {
-    const csrf = $cookies.get('CSRF');
+    const csrf = $cookies.get(CSRF, { parseJSON: false });
 
     if ( csrf ) {
       config.headers['x-api-csrf'] = csrf;


### PR DESCRIPTION
- Fix rare CSRF mismatch caused by parsing as scientific notation JSON (Fixes #2432)
- Add windows.enabled and server url global chart defaults (Fixes #2613, Fixes #2626)
- Add button to ignore chart cpu/memory warning (Fixes #2565)
- Load existing gitrepo secrets correctly (Fixes #2503)
