### PR TITLE
Enabling ingressNginx by default when installing a monitoring chart

### DIFF
--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -178,6 +178,10 @@ export default {
       };
 
       merge(this.value, extendedDefaults);
+      if (this.provider.startsWith('rke')) {
+        this.$set(this.value, 'ingressNginx', this.value.ingressNginx || {});
+        this.$set(this.value.ingressNginx, 'enabled', true);
+      }
     }
 
     this.$emit('register-before-hook', this.willSave, 'willSave');


### PR DESCRIPTION
only sets the default if the provider is rke or rke2.

rancher/dashboard#2485