### PR TITLE
css fixes for header input fields

### DIFF
--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -68,6 +68,7 @@ $selected: rgba($primary, .5);
   --header-logo                : #{$lightest};
   --header-btn-bg              : #317DB0;
   --header-btn-text            : #{$lightest};
+  --header-input-text          : #{$lightest};
   --header-height              : 55px;
   --nav-width                  : 250px;
   --nav-bg                     : #{$lighter};

--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -345,6 +345,10 @@ $transition-duration: 150ms;
   color: var(--input-text);
 }
 
+header .vs__selected-options input {
+  color: var(--header-input-text);
+}
+
 header .vs-select .vs__dropdown-toggle {
   background: var(--error) !important;
 }

--- a/components/nav/ClusterSwitcher.vue
+++ b/components/nav/ClusterSwitcher.vue
@@ -256,9 +256,6 @@ export default {
     color: white !important;
   }
 
-  .vs__selected-options input {
-    color: var(--header-btn-text);
-  }
   .vs__dropdown-toggle {
     background: rgba(0, 0, 0, 0.05);
     border-radius: var(--border-radius);

--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -344,7 +344,7 @@ export default {
   </div>
 </template>
 
-<style type="scss" scoped>
+<style lang="scss" scoped>
 .filter {
   min-width: 220px;
   max-width: 100%;

--- a/components/nav/WorkspaceSwitcher.vue
+++ b/components/nav/WorkspaceSwitcher.vue
@@ -55,7 +55,7 @@ export default {
   </div>
 </template>
 
-<style type="scss" scoped>
+<style lang="scss" scoped>
 .filter {
   min-width: 220px;
   max-width: 100%;


### PR DESCRIPTION
- Overwrote 2520 and elevated from component level to global dropdown styling
- Added css var for future ease in themes
- Fixed typo, `<style type="scss" scoped>` should be `<style lang="scss" scoped>`
