### PR TITLE
[2.6] Cluster Tools & inline cluster product nav

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -34,6 +34,11 @@ generic:
     one  {resource}
     other {resources}
     }
+  resourceCount: |-
+    {count, plural,
+    one  {1 resource}
+    other {# resources}
+    }
   save: Save
   type: Type
   unknown: Unknown
@@ -65,6 +70,7 @@ locale:
 nav:
   title: Dashboard
   backToRancher: Cluster Manager
+  clusterTools: Cluster Tools
   shell: Kubectl Shell
   import: Import YAML
   group:
@@ -606,6 +612,13 @@ catalog:
     url:
       label: Index URL
       placeholder: 'e.g. https://charts.rancher.io'
+  tools:
+    header: Cluster Tools
+    action:
+      install: Install
+      upgrade: Upgrade/Edit
+      edit: Edit
+      remove: Remove
 
 changePassword:
   title: Change Password

--- a/components/TypeDescription.vue
+++ b/components/TypeDescription.vue
@@ -1,6 +1,5 @@
 <script>
 import Banner from '@/components/Banner';
-import { mapGetters } from 'vuex';
 import { HIDE_DESC, mapPref } from '@/store/prefs';
 import { addObject } from '@/utils/array';
 
@@ -15,8 +14,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['isExplorer']),
-
     hideDescriptions: mapPref(HIDE_DESC),
 
     typeDescriptionKey() {

--- a/components/formatter/AppSummaryGraph.vue
+++ b/components/formatter/AppSummaryGraph.vue
@@ -11,6 +11,16 @@ export default {
       type:     Object,
       required: true
     },
+
+    labelKey: {
+      type:    String,
+      default: null
+    },
+
+    linkTo: {
+      type:    Object,
+      default: null
+    }
   },
 
   computed: {
@@ -59,6 +69,16 @@ export default {
       }
 
       return sortBy(Object.values(out), 'sort:desc');
+    },
+
+    displayLabel() {
+      const count = this.row?.deployedResources?.length || 0;
+
+      if ( this.labelKey ) {
+        return this.t(this.labelKey, { count });
+      }
+
+      return `${ count }`;
     }
   },
 };
@@ -74,7 +94,10 @@ export default {
     offset="1"
   >
     <ProgressBarMulti :values="colorParts" class="mb-5" />
-    <span>{{ row.deployedResources.length }}</span>
+    <n-link v-if="linkTo" :to="linkTo">
+      {{ displayLabel }}
+    </n-link>
+    <span v-else>{{ displayLabel }}</span>
 
     <template #popover>
       <table v-if="show" class="fixed">

--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -221,7 +221,7 @@ export default {
         padding: 8px 0;
 
         > H6 {
-          font-size: 14px;
+          font-size: 17px;
           text-transform: none;
           padding-left: 10px;
         }

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -29,7 +29,6 @@ export function init(store) {
     inStore:             'management',
     icon:                'user',
     removable:           false,
-    weight:              50,
     public:              true, // Hide from regular view during development
     showClusterSwitcher: false,
     category:            'configuration',

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -42,7 +42,7 @@ export function init(store) {
     icon:                'compass'
   });
 
-  basicType(['cluster-dashboard']);
+  basicType(['cluster-dashboard', 'cluster-tools']);
   basicType([
     'cluster-dashboard',
     NAMESPACE,

--- a/config/product/fleet.js
+++ b/config/product/fleet.js
@@ -21,7 +21,6 @@ export function init(store) {
     icon:                  'fleet',
     inStore:               'management',
     removable:             false,
-    weight:                -1,
     showClusterSwitcher:   false,
     showWorkspaceSwitcher: true,
   });

--- a/config/product/manager.js
+++ b/config/product/manager.js
@@ -18,7 +18,6 @@ export function init(store) {
     ifHaveType:          CAPI.CAPI_CLUSTER,
     inStore:             'management',
     icon:                'globe',
-    weight:              -1,
     removable:           false,
     public:              false, // Hide from regular view during development
     showClusterSwitcher: false,

--- a/config/product/settings.js
+++ b/config/product/settings.js
@@ -22,7 +22,6 @@ export function init(store) {
     ifHaveType:          new RegExp(`${ MANAGEMENT.SETTING }|${ MANAGEMENT.FEATURE }`, 'i'),
     inStore:             'management',
     icon:                'globe',
-    weight:              -10,
     removable:           false,
     showClusterSwitcher: false,
     category:            'configuration',

--- a/config/query-params.js
+++ b/config/query-params.js
@@ -63,6 +63,7 @@ export const CATEGORY = 'category';
 export const DEPRECATED = 'deprecated';
 export const HIDDEN = 'hidden';
 export const FORCE = 'force';
+export const FROM_TOOLS = 'tools';
 
 // Cluster provisioning
 export const PROVIDER = 'provider';

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -264,6 +264,10 @@ export default {
       </template>
     </nav>
 
+    <n-link tag="div" class="tools" :to="{name: 'c-cluster-explorer-tools'}">
+      <a><i class="icon icon-marketplace" /> {{ t('nav.clusterTools') }}</a>
+    </n-link>
+
     <main v-if="clusterReady">
       <nuxt class="outlet" />
 
@@ -290,10 +294,11 @@ export default {
     grid-template-areas:
       "header  header"
       "nav      main"
+      "tools    main"
       "wm       wm";
 
     grid-template-columns: var(--nav-width)     auto;
-    grid-template-rows:    var(--header-height) auto var(--wm-height, 0px);
+    grid-template-rows:    var(--header-height) auto calc( var(--footer-height) + 1px ) var(--wm-height, 0px);
 
     > HEADER {
       grid-area: header;
@@ -321,6 +326,41 @@ export default {
         line-height: initial;
 
         A { padding-left: 0; }
+      }
+    }
+
+    > .tools {
+      grid-area: tools;
+      border-top: solid thin var(--border);
+      font-size: 1.25em;
+      position: relative;
+
+      A {
+        padding: 15px 10px;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+
+        &:hover {
+          background: var(--dropdown-hover-bg);
+          text-decoration: none;
+
+          ::v-deep .icon {
+            color: var(--body-text);
+          }
+        }
+      }
+
+      &.nuxt-link-active {
+        background-color: var(--nav-active);
+        border-left: solid 5px var(--primary);
+
+        A {
+          padding: 15px 5px;
+          color: var(--body-text);
+        }
       }
     }
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,9 +10,10 @@ import Group from '@/components/nav/Group';
 import Header from '@/components/nav/Header';
 import { COUNT, SCHEMA, MANAGEMENT } from '@/config/types';
 import { BASIC, FAVORITE, USED } from '@/store/type-map';
-import { addObjects, replaceWith, clear } from '@/utils/array';
+import { addObjects, replaceWith, clear, addObject } from '@/utils/array';
 import { NAME as EXPLORER } from '@/config/product/explorer';
 import isEqual from 'lodash/isEqual';
+import { ucFirst } from '@/utils/string';
 
 export default {
 
@@ -33,7 +34,7 @@ export default {
 
   computed: {
     ...mapState(['managementReady', 'clusterReady']),
-    ...mapGetters(['productId', 'namespaceMode']),
+    ...mapGetters(['productId', 'namespaceMode', 'isExplorer']),
     ...mapGetters({ locale: 'i18n/selectedLocaleLabel' }),
     ...mapGetters('type-map', ['activeProducts']),
 
@@ -74,10 +75,6 @@ export default {
       }
 
       return {};
-    },
-
-    showJump() {
-      return this.productId === EXPLORER;
     },
   },
 
@@ -151,7 +148,7 @@ export default {
       }
 
       const clusterId = this.$store.getters['clusterId'];
-      const productId = this.$store.getters['productId'];
+      const currentProduct = this.$store.getters['productId'];
       const currentType = this.$route.params.resource || '';
       let namespaces = null;
 
@@ -161,18 +158,46 @@ export default {
 
       const namespaceMode = this.$store.getters['namespaceMode'];
       const out = [];
-      const modes = [BASIC];
+      const loadProducts = this.isExplorer ? [EXPLORER] : [];
 
-      if ( productId === EXPLORER ) {
-        modes.push(FAVORITE);
-        modes.push(USED);
+      if ( this.isExplorer ) {
+        for ( const product of this.activeProducts ) {
+          if ( product.inStore === 'cluster' ) {
+            addObject(loadProducts, product.name);
+          }
+        }
       }
 
-      for ( const mode of modes ) {
-        const types = this.$store.getters['type-map/allTypes'](productId, mode) || {};
-        const more = this.$store.getters['type-map/getTree'](productId, mode, types, clusterId, namespaceMode, namespaces, currentType);
+      // This should already have come into the list from above, but in case it hasn't...
+      addObject(loadProducts, currentProduct);
 
-        addObjects(out, more);
+      for ( const productId of loadProducts ) {
+        const modes = [BASIC];
+
+        if ( productId === EXPLORER ) {
+          modes.push(FAVORITE);
+          modes.push(USED);
+        }
+
+        for ( const mode of modes ) {
+          const types = this.$store.getters['type-map/allTypes'](productId, mode) || {};
+          const more = this.$store.getters['type-map/getTree'](productId, mode, types, clusterId, namespaceMode, namespaces, currentType);
+
+          if ( productId === EXPLORER || !this.isExplorer ) {
+            addObjects(out, more);
+          } else {
+            const root = more.find(x => x.name === 'root');
+            const other = more.filter(x => x.name !== 'root');
+
+            const group = {
+              name:     productId,
+              label:    this.$store.getters['i18n/withFallback'](`product.${ productId }`, null, ucFirst(productId)),
+              children: [...(root.children), ...other],
+            };
+
+            addObject(out, group);
+          }
+        }
       }
 
       replaceWith(this.groups, ...out);
@@ -245,6 +270,9 @@ export default {
     <Header />
 
     <nav v-if="clusterReady">
+      <Jump v-if="isExplorer" class="m-10" />
+      <div v-else class="mb-20" />
+
       <template v-for="(g, idx) in groups">
         <Group
           ref="groups"
@@ -298,7 +326,7 @@ export default {
       "wm       wm";
 
     grid-template-columns: var(--nav-width)     auto;
-    grid-template-rows:    var(--header-height) auto calc( var(--footer-height) + 1px ) var(--wm-height, 0px);
+    grid-template-rows:    var(--header-height) auto 50px var(--wm-height, 0px);
 
     > HEADER {
       grid-area: header;
@@ -310,6 +338,20 @@ export default {
       background-color: var(--nav-bg);
       border-right: var(--nav-border-size) solid var(--nav-border);
       overflow-y: auto;
+
+      .package {
+        border-top: 1px solid var(--border);
+
+        &:last-child {
+          border-bottom: 1px solid var(--border);
+        }
+      }
+
+      .package.depth-0 {
+        &.expanded > .body {
+          margin-bottom: 5px;
+        }
+      }
 
       .header {
         background: transparent;

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -62,6 +62,10 @@ export default {
     };
   },
 
+  currentVersion() {
+    return this.spec?.chart?.metadata?.version;
+  },
+
   upgradeAvailable() {
     // false = does not apply (managed by fleet)
     // null = no upgrade found

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import {
-  NAMESPACE, NAME, REPO, REPO_TYPE, CHART, VERSION, _VIEW
+  NAMESPACE, NAME, REPO, REPO_TYPE, CHART, VERSION, _VIEW, FROM_TOOLS, _FLAGGED
 } from '@/config/query-params';
 import { CATALOG as CATALOG_ANNOTATIONS, FLEET } from '@/config/labels-annotations';
 import { compare, isPrerelease, sortable } from '@/utils/version';
@@ -123,7 +123,7 @@ export default {
   },
 
   goToUpgrade() {
-    return (forceVersion) => {
+    return (forceVersion, fromTools) => {
       const match = this.matchingChart(true);
       const versionName = this.spec?.chart?.metadata?.version;
       const query = {
@@ -136,6 +136,10 @@ export default {
         query[REPO] = match.repoName;
         query[REPO_TYPE] = match.repoType;
         query[CHART] = match.chartName;
+      }
+
+      if ( fromTools ) {
+        query[FROM_TOOLS] = _FLAGGED;
       }
 
       this.currentRouter().push({

--- a/models/chart.js
+++ b/models/chart.js
@@ -1,0 +1,37 @@
+import { compatibleVersionsFor } from '@/store/catalog';
+import { REPO_TYPE, REPO, CHART, VERSION } from '@/config/query-params';
+import { NAME as APPS } from '@/config/product/apps';
+
+export default {
+  goToInstall() {
+    let version;
+    const chartVersions = this.versions;
+    const currentCluster = this.$rootGetters['currentCluster'];
+
+    const clusterProvider = currentCluster.status.provider || 'other';
+    const windowsVersions = (chartVersions, 'windows');
+    const linuxVersions = compatibleVersionsFor(chartVersions, 'linux');
+
+    if (clusterProvider === 'rke.windows' && windowsVersions.length > 0) {
+      version = windowsVersions[0].version;
+    } else if (clusterProvider !== 'rke.windows' && linuxVersions.length > 0) {
+      version = linuxVersions[0].version;
+    } else {
+      version = chartVersions[0].version;
+    }
+
+    this.currentRouter().push({
+      name:   'c-cluster-apps-install',
+      params: {
+        cluster:  currentCluster.id,
+        product:  APPS,
+      },
+      query: {
+        [REPO_TYPE]: this.repoType,
+        [REPO]:      this.repoName,
+        [CHART]:     this.chartName,
+        [VERSION]:   version,
+      }
+    });
+  },
+};

--- a/models/chart.js
+++ b/models/chart.js
@@ -1,37 +1,42 @@
 import { compatibleVersionsFor } from '@/store/catalog';
-import { REPO_TYPE, REPO, CHART, VERSION } from '@/config/query-params';
+import {
+  REPO_TYPE, REPO, CHART, VERSION, FROM_TOOLS, _FLAGGED, _UNFLAG
+} from '@/config/query-params';
 import { NAME as APPS } from '@/config/product/apps';
 
 export default {
   goToInstall() {
-    let version;
-    const chartVersions = this.versions;
-    const currentCluster = this.$rootGetters['currentCluster'];
+    return (fromTools) => {
+      let version;
+      const chartVersions = this.versions;
+      const currentCluster = this.$rootGetters['currentCluster'];
 
-    const clusterProvider = currentCluster.status.provider || 'other';
-    const windowsVersions = (chartVersions, 'windows');
-    const linuxVersions = compatibleVersionsFor(chartVersions, 'linux');
+      const clusterProvider = currentCluster.status.provider || 'other';
+      const windowsVersions = (chartVersions, 'windows');
+      const linuxVersions = compatibleVersionsFor(chartVersions, 'linux');
 
-    if (clusterProvider === 'rke.windows' && windowsVersions.length > 0) {
-      version = windowsVersions[0].version;
-    } else if (clusterProvider !== 'rke.windows' && linuxVersions.length > 0) {
-      version = linuxVersions[0].version;
-    } else {
-      version = chartVersions[0].version;
-    }
-
-    this.currentRouter().push({
-      name:   'c-cluster-apps-install',
-      params: {
-        cluster:  currentCluster.id,
-        product:  APPS,
-      },
-      query: {
-        [REPO_TYPE]: this.repoType,
-        [REPO]:      this.repoName,
-        [CHART]:     this.chartName,
-        [VERSION]:   version,
+      if (clusterProvider === 'rke.windows' && windowsVersions.length > 0) {
+        version = windowsVersions[0].version;
+      } else if (clusterProvider !== 'rke.windows' && linuxVersions.length > 0) {
+        version = linuxVersions[0].version;
+      } else {
+        version = chartVersions[0].version;
       }
-    });
+
+      this.currentRouter().push({
+        name:   'c-cluster-apps-install',
+        params: {
+          cluster:  currentCluster.id,
+          product:  APPS,
+        },
+        query: {
+          [REPO_TYPE]:  this.repoType,
+          [REPO]:       this.repoName,
+          [CHART]:      this.chartName,
+          [VERSION]:    version,
+          [FROM_TOOLS]: fromTools ? _FLAGGED : _UNFLAG
+        }
+      });
+    };
   },
 };

--- a/pages/c/_cluster/explorer/tools.vue
+++ b/pages/c/_cluster/explorer/tools.vue
@@ -77,7 +77,7 @@ export default {
 
   methods: {
     edit(app) {
-      app.goToUpgrade();
+      app.goToUpgrade(null, true);
     },
 
     remove(app) {
@@ -85,7 +85,7 @@ export default {
     },
 
     install(chart) {
-      chart.goToInstall();
+      chart.goToInstall(true);
     },
   },
 };

--- a/pages/c/_cluster/explorer/tools.vue
+++ b/pages/c/_cluster/explorer/tools.vue
@@ -1,0 +1,263 @@
+<script>
+import { mapGetters } from 'vuex';
+import Loading from '@/components/Loading';
+import { _FLAGGED, DEPRECATED, HIDDEN } from '@/config/query-params';
+import { filterAndArrangeCharts } from '@/store/catalog';
+import { CATALOG } from '@/config/types';
+import LazyImage from '@/components/LazyImage';
+import AppSummaryGraph from '@/components/formatter/AppSummaryGraph';
+
+export default {
+  components: {
+    AppSummaryGraph, LazyImage, Loading
+  },
+
+  async fetch() {
+    await this.$store.dispatch('catalog/load');
+
+    const query = this.$route.query;
+
+    this.showDeprecated = query[DEPRECATED] === _FLAGGED;
+    this.showHidden = query[HIDDEN] === _FLAGGED;
+
+    this.allInstalled = await this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
+  },
+
+  data() {
+    return { allInstalled: null };
+  },
+
+  computed: {
+    ...mapGetters(['currentCluster']),
+    ...mapGetters({ allCharts: 'catalog/charts', loadingErrors: 'catalog/errors' }),
+
+    rancherCatalog() {
+      return this.$store.getters['catalog/repos'].find(x => x.isRancher);
+    },
+
+    installedAppForChart() {
+      const out = {};
+
+      for ( const app of this.allInstalled ) {
+        const matching = app.matchingChart();
+
+        if ( !matching ) {
+          continue;
+        }
+
+        out[matching.id] = app;
+      }
+
+      return out;
+    },
+
+    options() {
+      const clusterProvider = this.currentCluster.status.provider || 'other';
+      const enabledCharts = (this.allCharts || []);
+
+      const charts = filterAndArrangeCharts(enabledCharts, {
+        clusterProvider,
+        showDeprecated: this.showDeprecated,
+        showHidden:     this.showHidden,
+        showRepos:      [this.rancherCatalog._key],
+      });
+
+      return charts.map((chart) => {
+        return {
+          chart,
+          app: this.installedAppForChart[chart.id],
+        };
+      });
+    },
+  },
+
+  mounted() {
+    window.c = this;
+  },
+
+  methods: {
+    edit(app) {
+      app.goToUpgrade();
+    },
+
+    remove(app) {
+      app.promptRemove();
+    },
+
+    install(chart) {
+      chart.goToInstall();
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  $margin: 10px;
+  $logo: 50px;
+
+  .grid {
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    margin: 0 -1*$margin;
+
+    @media only screen and (min-width: map-get($breakpoints, '--viewport-4')) {
+      .item {
+        width: 100%;
+      }
+    }
+    @media only screen and (min-width: map-get($breakpoints, '--viewport-7')) {
+      .item {
+        width: 100%;
+      }
+    }
+    @media only screen and (min-width: map-get($breakpoints, '--viewport-9')) {
+      .item {
+        width: calc(50% - 2 * #{$margin});
+      }
+    }
+    @media only screen and (min-width: map-get($breakpoints, '--viewport-12')) {
+      .item {
+        width: calc(33.33333% - 2 * #{$margin});
+      }
+    }
+
+    .item {
+      display: grid;
+      grid-template-areas:  "logo name-version name-version"
+                            "description description description"
+                            "state state action";
+      grid-template-columns: $logo auto min-content;
+      grid-template-rows: 50px 55px 35px;
+      row-gap: $margin;
+      column-gap: $margin;
+
+      margin: $margin;
+      padding: $margin;
+      position: relative;
+      border: 1px solid var(--border);
+      border-radius: calc( 1.5 * var(--border-radius));
+
+      .logo {
+        grid-area: logo;
+        text-align: center;
+        width: $logo;
+        height: $logo;
+        border-radius: calc(2 * var(--border-radius));
+        overflow: hidden;
+        background-color: white;
+
+        img {
+          width: $logo - 4px;
+          height: $logo - 4px;
+          object-fit: contain;
+          position: relative;
+          top: 2px;
+        }
+      }
+
+      .name-version {
+        grid-area: name-version;
+        padding: 10px 0 0 0;
+      }
+
+      .name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin: 0;
+      }
+
+      .version {
+        color: var(--muted);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.9em
+      }
+
+      .description {
+        grid-area: description;
+      }
+
+      .description-content {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        line-clamp: 3;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: var(--text-muted);
+      }
+
+      .state {
+        grid-area: state;
+      }
+
+      .action {
+        grid-area: action;
+        white-space: nowrap;
+      }
+    }
+  }
+</style>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <h1 v-html="t('catalog.tools.header')" />
+
+    <div v-if="options.length" class="grid">
+      <div
+        v-for="opt in options"
+        :key="opt.chart.id"
+        class="item"
+      >
+        <div class="logo">
+          <LazyImage :src="opt.chart.icon" />
+        </div>
+        <div class="name-version">
+          <h3 class="name">
+            {{ opt.chart.chartDisplayName }}
+          </h3>
+          <div class="version">
+            <template v-if="opt.app && opt.app.upgradeAvailable">
+              v{{ opt.app.currentVersion }} <b><i class="icon icon-chevron-right" /> v{{ opt.app.upgradeAvailable }}</b>
+            </template>
+            <template v-else-if="opt.app">
+              v{{ opt.app.currentVersion }}
+            </template>
+            <template v-else>
+              v{{ opt.chart.versions[0].version }}
+            </template>
+          </div>
+        </div>
+        <div class="description">
+          <div class="description-content">
+            {{ opt.chart.chartDescription }}
+          </div>
+        </div>
+        <div v-if="opt.app" class="state">
+          <AppSummaryGraph :row="opt.app" label-key="generic.resourceCount" :link-to="opt.app.detailLocation" />
+        </div>
+        <div class="action">
+          <template v-if="opt.app && opt.app.upgradeAvailable">
+            <button class="btn btn-sm role-secondary" @click="remove(opt.app)">
+              <i class="icon icon-delete icon-lg" />
+            </button>
+            <button class="btn btn-sm role-secondary" @click="edit(opt.app)" v-html="t('catalog.tools.action.upgrade')" />
+          </template>
+          <template v-else-if="opt.app">
+            <button class="btn btn-sm role-secondary" @click="remove(opt.app)">
+              <i class="icon icon-delete icon-lg" />
+            </button>
+            <button class="btn btn-sm role-secondary" @click="edit(opt.app)" v-html="t('catalog.tools.action.edit')" />
+          </template>
+          <template v-else>
+            <button class="btn btn-sm role-primary" @click="install(opt.chart)" v-html="t('catalog.tools.action.install')" />
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/store/index.js
+++ b/store/index.js
@@ -84,7 +84,13 @@ export const getters = {
   },
 
   isExplorer(state, getters) {
-    return getters.currentProduct?.name === EXPLORER;
+    const product = getters.currentProduct;
+
+    if ( !product ) {
+      return false;
+    }
+
+    return product.name === EXPLORER || product.inStore === 'cluster';
   },
 
   defaultClusterId(state, getters) {

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -437,7 +437,7 @@ export const getters = {
   },
 
   getTree(state, getters, rootState, rootGetters) {
-    return (product, mode, allTypes, clusterId, namespaceMode, namespaces, currentType, search) => {
+    return (productId, mode, allTypes, clusterId, namespaceMode, namespaces, currentType, search) => {
       // modes: basic, used, all, favorite
       // namespaceMode: 'namespaced', 'cluster', or 'both'
       // namespaces: null means all, otherwise it will be an array of specific namespaces to include
@@ -471,7 +471,7 @@ export const getters = {
         }
 
         const count = _matchingCounts(typeObj, namespaces);
-        const groupForBasicType = getters.groupForBasicType(product, typeObj.name);
+        const groupForBasicType = getters.groupForBasicType(productId, typeObj.name);
 
         if ( typeObj.id === currentType ) {
           // If this is the type currently being shown, always show it
@@ -522,7 +522,7 @@ export const getters = {
           route = {
             name:   'c-cluster-product-resource',
             params: {
-              product,
+              product:  productId,
               cluster:  clusterId,
               resource: typeObj.name,
             }
@@ -535,7 +535,7 @@ export const getters = {
         if ( route && typeof route === 'object' ) {
           route.params = route.params || {};
           route.params.cluster = clusterId;
-          route.params.product = product;
+          route.params.product = productId;
         }
 
         group.children.push({

--- a/utils/dynamic-importer.js
+++ b/utils/dynamic-importer.js
@@ -64,5 +64,5 @@ export function loadProduct(name) {
   }
 
   // Note: directly returns the import, not a function
-  return import(/* webpackChunkNAme: "product" */ `@/config/product/${ name }`);
+  return import(/* webpackChunkName: "product" */ `@/config/product/${ name }`);
 }


### PR DESCRIPTION
#2509 - Cluster tools at the bottom listing only the Rancher charts and showing the installed status
#2578 - Show cluster-level products inline in the Explorer left nav instead of as separte options in the Product dropdown
