### PR TITLE
PVC Request Storage UnitInput: Handle falsy values, set min value

### DIFF
--- a/components/form/UnitInput.vue
+++ b/components/form/UnitInput.vue
@@ -60,6 +60,11 @@ export default {
     required: {
       type:    Boolean,
       default: false,
+    },
+
+    min: {
+      type:    Number,
+      default: 0
     }
   },
 
@@ -110,7 +115,7 @@ export default {
     :value="userValue"
     v-bind="$attrs"
     type="number"
-    min="0"
+    :min="min"
     :mode="mode"
     :label="label"
     :label-key="labelKey"

--- a/edit/persistentvolumeclaim.vue
+++ b/edit/persistentvolumeclaim.vue
@@ -109,7 +109,7 @@ export default {
         return this.value.spec.resources.requests.storage;
       },
       set(value) {
-        this.$set(this.value.spec.resources.requests, 'storage', `${ value }Gi`);
+        this.$set(this.value.spec.resources.requests, 'storage', `${ value || 1 }Gi`);
       }
     },
     persistentVolume: {
@@ -210,6 +210,7 @@ export default {
                   :label="t('persistentVolumeClaim.volumeClaim.requestStorage')"
                   :suffix="'GiB'"
                   :mode="mode"
+                  :min="1"
                 />
               </div>
             </div>


### PR DESCRIPTION
- Fix exception thrown when UnitInput converts duff (`nullGi`) value into correct format (before min handler kicks in)
- Also wire in a min prop to UnitInput & set Request Storage min to 1 (min supported by API)
- Addresses #2591