### PR TITLE
Add Create/Edit/View/Detail Pages for RBAC Role and ClusterRole

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2196,6 +2196,10 @@ rbac:
         label: Project/Namespace
         yes: "Yes: Default role for new project creation"
         defaultLabel: Project Creator Default
+      RBAC_ROLE:
+        label: Role
+      RBAC_CLUSTER_ROLE:
+        label: Cluster Role
       noContext:
         label: No Context
   globalRoles:

--- a/detail/rbac.authorization.k8s.io.clusterrole.vue
+++ b/detail/rbac.authorization.k8s.io.clusterrole.vue
@@ -1,0 +1,8 @@
+<script>
+import RoleDetailEdit from '@/components/auth/RoleDetailEdit';
+
+export default { components: { RoleDetailEdit } };
+</script>
+<template>
+  <RoleDetailEdit v-bind="$attrs" />
+</template>

--- a/detail/rbac.authorization.k8s.io.role.vue
+++ b/detail/rbac.authorization.k8s.io.role.vue
@@ -1,0 +1,8 @@
+<script>
+import RoleDetailEdit from '@/components/auth/RoleDetailEdit';
+
+export default { components: { RoleDetailEdit } };
+</script>
+<template>
+  <RoleDetailEdit v-bind="$attrs" />
+</template>

--- a/edit/rbac.authorization.k8s.io.clusterrole.vue
+++ b/edit/rbac.authorization.k8s.io.clusterrole.vue
@@ -1,0 +1,8 @@
+<script>
+import RoleDetailEdit from '@/components/auth/RoleDetailEdit';
+
+export default { components: { RoleDetailEdit } };
+</script>
+<template>
+  <RoleDetailEdit v-bind="$attrs" />
+</template>

--- a/edit/rbac.authorization.k8s.io.role.vue
+++ b/edit/rbac.authorization.k8s.io.role.vue
@@ -1,0 +1,8 @@
+<script>
+import RoleDetailEdit from '@/components/auth/RoleDetailEdit';
+
+export default { components: { RoleDetailEdit } };
+</script>
+<template>
+  <RoleDetailEdit v-bind="$attrs" />
+</template>

--- a/models/management.cattle.io.globalrole.js
+++ b/models/management.cattle.io.globalrole.js
@@ -51,10 +51,6 @@ export default {
     return GLOBAL;
   },
 
-  updateSubtype() {
-    return () => { };
-  },
-
   default() {
     return !!this.newUserDefault;
   },

--- a/models/management.cattle.io.roletemplate.js
+++ b/models/management.cattle.io.roletemplate.js
@@ -29,6 +29,18 @@ export const SUBTYPE_MAPPING = {
     defaultKey:     'projectCreatorDefault',
     id:             'NAMESPACE',
     labelKey:          'rbac.roletemplate.subtypes.NAMESPACE.label',
+  },
+  RBAC_ROLE: {
+    key:            'RBAC_ROLE',
+    type:           'rbac.authorization.k8s.io.role',
+    id:             'RBAC_ROLE',
+    labelKey:          'rbac.roletemplate.subtypes.RBAC_ROLE.label',
+  },
+  RBAC_CLUSTER_ROLE: {
+    key:            'RBAC_CLUSTER_ROLE',
+    type:           'rbac.authorization.k8s.io.clusterrole',
+    id:             'RBAC_CLUSTER_ROLE',
+    labelKey:          'rbac.roletemplate.subtypes.RBAC_CLUSTER_ROLE.label',
   }
 };
 

--- a/models/rbac.authorization.k8s.io.clusterrole.js
+++ b/models/rbac.authorization.k8s.io.clusterrole.js
@@ -1,3 +1,19 @@
+import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@/models/management.cattle.io.roletemplate';
+import { uniq } from '@/utils/array';
 import Role from './rbac.authorization.k8s.io.role';
 
-export default { ...Role };
+export default {
+  ...Role,
+
+  subtype() {
+    return SUBTYPE_MAPPING.RBAC_CLUSTER_ROLE.key;
+  },
+
+  namespaceResources() {
+    return this.allResources.filter(r => r.attributes.namespaced && !r.attributes.group.includes(CATTLE_API_GROUP));
+  },
+
+  resources() {
+    return uniq(this.namespaceResources.map(r => r.attributes?.kind)).sort();
+  },
+};

--- a/models/rbac.authorization.k8s.io.role.js
+++ b/models/rbac.authorization.k8s.io.role.js
@@ -1,5 +1,25 @@
+import { SCHEMA } from '@/config/types';
+import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@/models/management.cattle.io.roletemplate';
+import { uniq } from '@/utils/array';
+
 export default {
   nameWithinProduct() {
     return this.$rootGetters['i18n/withFallback'](`rbac.displayRole.${ this.name }`, this.name);
+  },
+
+  subtype() {
+    return SUBTYPE_MAPPING.RBAC_ROLE.key;
+  },
+
+  allResources() {
+    return this.$getters['all'](SCHEMA).filter(r => r.attributes?.kind);
+  },
+
+  clusterResources() {
+    return this.allResources.filter(r => !r.attributes.namespaced && !r.attributes.group.includes(CATTLE_API_GROUP));
+  },
+
+  resources() {
+    return uniq(this.clusterResources.map(r => r.attributes?.kind)).sort();
   },
 };


### PR DESCRIPTION
- Uses same generic way to handle roles as Management Global Roles and Role Templates
- Applies to `rbac.authorization.k8s.io.role` and `rbac.authorization.k8s.io.clusterrole`
- Addresses #2663