### PR TITLE
do not allow multiple auth providers

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -313,6 +313,7 @@ authConfig:
   stateBanner:
     disabled: '{provider} is currently disabled.'
     enabled: '{provider} is currently enabled.'
+  thereCanOnlyBeOne: '{otherProvider} authentication is already enabled. You must disable it before enabling authentication with {provider}.'
   testAndEnable: Test and Enable Authentication
 
 authGroups:

--- a/edit/auth/azuread.vue
+++ b/edit/auth/azuread.vue
@@ -49,10 +49,6 @@ export default {
 
   mixins: [CreateEditView, AuthConfig],
 
-  async fetch() {
-    await this.reloadModel();
-  },
-
   data() {
     return {
       endpoint:          'standard',
@@ -132,6 +128,8 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
+  <Banner v-else-if="!!otherProviderEnabled" :label="t('authConfig.thereCanOnlyBeOne', {otherProvider: t(`model.authConfig.provider.${ otherProviderEnabled.id }`), provider: displayName})" color="error" />
+
   <div v-else>
     <CruResource
       :done-route="doneRoute"

--- a/edit/auth/github.vue
+++ b/edit/auth/github.vue
@@ -30,23 +30,6 @@ export default {
 
   mixins: [CreateEditView, AuthConfig],
 
-  async fetch() {
-    await this.reloadModel();
-
-    const serverUrl = await this.$store.dispatch('management/find', {
-      type: MANAGEMENT.SETTING,
-      id:   'server-url',
-      opt:  { url: `/v1/{ MANAGEMENT.SETTING }/server-url` }
-    });
-
-    if ( serverUrl ) {
-      this.serverSetting = serverUrl.value;
-    }
-
-    this.targetType = (!this.model.hostname || this.model.hostname === 'github.com' ? 'public' : 'private');
-    this.targetUrl = (this.model.tls ? 'https://' : 'http://') + (this.model.hostname || 'github.com');
-  },
-
   data() {
     return {
       targetType:    'public',
@@ -117,6 +100,12 @@ export default {
   watch: {
     targetType: 'updateHost',
     targetUrl:  'updateHost',
+    model(neu, old) {
+      if (!old) {
+        this.targetType = (!this.model.hostname || this.model.hostname === 'github.com' ? 'public' : 'private');
+        this.targetUrl = (this.model.tls ? 'https://' : 'http://') + (this.model.hostname || 'github.com');
+      }
+    }
   },
 
   methods: {
@@ -139,6 +128,8 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
+  <Banner v-else-if="!!otherProviderEnabled" :label="t('authConfig.thereCanOnlyBeOne', {otherProvider: t(`model.authConfig.provider.${ otherProviderEnabled.id }`), provider: displayName})" color="error" />
+
   <div v-else>
     <CruResource
       :cancel-event="true"

--- a/edit/auth/googleoauth.vue
+++ b/edit/auth/googleoauth.vue
@@ -83,6 +83,8 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
+  <Banner v-else-if="!!otherProviderEnabled" :label="t('authConfig.thereCanOnlyBeOne', {otherProvider: t(`model.authConfig.provider.${ otherProviderEnabled.id }`), provider: displayName})" color="error" />
+
   <div v-else>
     <CruResource
       :cancel-event="true"

--- a/edit/auth/ldap/index.vue
+++ b/edit/auth/ldap/index.vue
@@ -69,6 +69,8 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
+  <Banner v-else-if="!!otherProviderEnabled" :label="t('authConfig.thereCanOnlyBeOne', {otherProvider: t(`model.authConfig.provider.${ otherProviderEnabled.id }`), provider: displayName})" color="error" />
+
   <div v-else>
     <CruResource
       :cancel-event="true"

--- a/edit/auth/saml.vue
+++ b/edit/auth/saml.vue
@@ -76,6 +76,8 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
+  <Banner v-else-if="!!otherProviderEnabled" :label="t('authConfig.thereCanOnlyBeOne', {otherProvider: t(`model.authConfig.provider.${ otherProviderEnabled.id }`), provider: displayName})" color="error" />
+
   <div v-else>
     <CruResource
       :cancel-event="true"

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -14,13 +14,9 @@ export default {
   },
 
   async fetch() {
-    const drivers = await this.$store.dispatch('auth/getAuthProviders');
+    this.drivers = await this.$store.dispatch('auth/getAuthProviders');
 
     const NAME = this.$route.params.id;
-
-    this.otherProviderEnabled = drivers.filter((driver) => {
-      return driver.id !== NAME && driver.id !== 'local';
-    })[0];
 
     this.originalModel = await this.$store.dispatch('rancher/find', {
       type: NORMAN.AUTH_CONFIG,
@@ -38,6 +34,7 @@ export default {
       this.serverSetting = serverUrl.value;
     }
     this.model = await this.$store.dispatch(`rancher/clone`, { resource: this.originalModel });
+
     if (this.model.openLdapConfig) {
       this.showLdap = true;
     }
@@ -53,13 +50,13 @@ export default {
 
   data() {
     return {
+      drivers:              [],
       isEnabling:           false,
       editConfig:           false,
       model:                null,
       serverSetting:        null,
       errors:               null,
       originalModel:        null,
-      otherProviderEnabled: false
     };
   },
 
@@ -109,7 +106,13 @@ export default {
 
     showCancel() {
       return this.editConfig || !this.model.enabled;
-    }
+    },
+
+    otherProviderEnabled() {
+      return this.drivers.filter((driver) => {
+        return driver.id !== this.model?.id && driver.id !== 'local';
+      })[0];
+    },
   },
 
   methods: {
@@ -191,6 +194,7 @@ export default {
         }
         await this.reloadModel();
         this.showLdap = false;
+        this.drivers = await this.$store.dispatch('auth/getAuthProviders');
         btnCb(true);
       } catch (err) {
         this.errors = [err];
@@ -259,4 +263,5 @@ export default {
       }
     }
   },
+
 };

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -14,7 +14,13 @@ export default {
   },
 
   async fetch() {
+    const drivers = await this.$store.dispatch('auth/getAuthProviders');
+
     const NAME = this.$route.params.id;
+
+    this.otherProviderEnabled = drivers.filter((driver) => {
+      return driver.id !== NAME && driver.id !== 'local';
+    })[0];
 
     this.originalModel = await this.$store.dispatch('rancher/find', {
       type: NORMAN.AUTH_CONFIG,
@@ -47,12 +53,13 @@ export default {
 
   data() {
     return {
-      isEnabling:    false,
-      editConfig:    false,
-      model:         null,
-      serverSetting: null,
-      errors:        null,
-      originalModel: null,
+      isEnabling:           false,
+      editConfig:           false,
+      model:                null,
+      serverSetting:        null,
+      errors:               null,
+      originalModel:        null,
+      otherProviderEnabled: false
     };
   },
 

--- a/store/auth.js
+++ b/store/auth.js
@@ -66,7 +66,9 @@ export const actions = {
   getAuthProviders({ dispatch }) {
     return dispatch('rancher/findAll', {
       type: 'authProvider',
-      opt:  { url: `/v3-public/authProviders`, watch: false }
+      opt:  {
+        url: `/v3-public/authProviders`, watch: false, force: true
+      }
     }, { root: true });
   },
 


### PR DESCRIPTION
Per discussion from this morning's 2.6 UI/UX meeting, this PR disallows enabling multiple auth providers (for now).

In the process of doing this I noticed that the azuread and github components are each using `fetch`. Unlike vue lifecycle hooks, when `fetch` is defined in a component and mixin, the mixin `fetch` isn't run. Pulling `fetch` out of these two components didn't take much, but any PR reviewer may want to verify azuread/github in addition to the new restriction on multiple providers (I also checked them myself of course). 