### PR TITLE
adjusted spacing to bring text back into view

### DIFF
--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -921,7 +921,7 @@ export default {
                 <hr />
               </template>
               <template v-else-if="opt.kind === 'label'">
-                <b style="position: relative; left: -10px;">{{ opt.label }}</b>
+                <b style="position: relative; left: -2.5px;">{{ opt.label }}</b>
               </template>
             </template>
           </LabeledSelect>


### PR DESCRIPTION
Simple fix to bring dropdown label text back into window. 
A more elegant solution probably exists but would affect all dropdown cmps, and is likely out of the scope of this ticket.