### PR TITLE
Fix table selection no longer showing

### DIFF
--- a/components/SortableTable/selection.js
+++ b/components/SortableTable/selection.js
@@ -355,7 +355,6 @@ export default {
     },
 
     updateInput(node, on, keyField) {
-
       const id = get(node, keyField);
 
       if ( id ) {

--- a/components/SortableTable/selection.js
+++ b/components/SortableTable/selection.js
@@ -355,16 +355,20 @@ export default {
     },
 
     updateInput(node, on, keyField) {
+
       const id = get(node, keyField);
 
       if ( id ) {
-        const input = $(`label[data-node-id="${ id }"]`);
+        // Note: This is looking for the checkbox control for the row
+        const input = $(`div[data-checkbox-ctrl][data-node-id="${ id }"]`);
 
         if ( input && input.length && !input[0].disabled ) {
-          // can't reuse the input ref here because the table has rerenderd and the ref is no longer good
-          $(`label[data-node-id="${ id }"]`).prop('value', on);
+          const label = $(input[0]).find('label');
 
-          let tr = $(`label[data-node-id="${ id }"]`).closest('tr');
+          if (label) {
+            label.prop('value', on);
+          }
+          let tr = input.closest('tr');
           let first = true;
 
           while ( tr && (first || tr.hasClass('sub-row') ) ) {

--- a/components/form/Checkbox.vue
+++ b/components/form/Checkbox.vue
@@ -102,7 +102,7 @@ export default {
 </script>
 
 <template>
-  <div class="checkbox-outer-container">
+  <div class="checkbox-outer-container" data-checkbox-ctrl>
     <label
       class="checkbox-container"
       :class="{ 'disabled': isDisabled}"


### PR DESCRIPTION
This PR fixes the issue where the table select highlight has disappeared.

The problem was caused by changes to the checkbox control and the fact that the table select relies on the dom structure of the checkbox control, so changing one broke the other.
