### PR TITLE
Users & Auth: Roles Fixes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2848,6 +2848,10 @@ tableHeaders:
   address: Address
   age: Age
   apiGroup: API Groups
+  authRoles:
+    globalDefault: New User Default
+    clusterDefault: Cluster Creator Default
+    projectDefault: Project Creator Default
   branch: Branch
   builtIn: Built In
   bundlesReady: Bundles

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2192,8 +2192,8 @@ rbac:
         yes: "Yes: Default role for new cluster creation"
         defaultLabel: Cluster Creator Default
       NAMESPACE:
-        createButton: Create Project/Namespace Role
-        label: Project/Namespace
+        createButton: Create Project/Namespaces Role
+        label: Project/Namespaces
         yes: "Yes: Default role for new project creation"
         defaultLabel: Project Creator Default
       RBAC_ROLE:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2177,7 +2177,7 @@ rbac:
         label: Grant Resources
         tableHeaders:
           verbs: Verbs
-          resources: Resources
+          resources: Resource
           nonResourceUrls: Non-Resource URLs
           apiGroups: API Groups
     subtypes:

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -61,7 +61,7 @@ export default {
     },
 
     doneOverride: {
-      type:    Function,
+      type:    [Function, Object],
       default: null
     },
 
@@ -288,7 +288,7 @@ export default {
 
     done() {
       if (this.doneOverride) {
-        return this.doneOverride();
+        return typeof (this.doneOverride) === 'function' ? this.doneOverride() : this.$router.replace(this.doneOverride);
       }
       if ( !this.doneRoute ) {
         return;

--- a/components/auth/RoleDetailEdit.vue
+++ b/components/auth/RoleDetailEdit.vue
@@ -245,6 +245,18 @@ export default {
     cancel() {
       this.done();
     },
+    async actuallySave(url) {
+      if ( this.isCreate ) {
+        url = url || this.schema.linkFor('collection');
+        const res = await this.value.save({ url, redirectUnauthorized: false });
+
+        if (res) {
+          Object.assign(this.value, res);
+        }
+      } else {
+        await this.value.save({ redirectUnauthorized: false });
+      }
+    },
     // Detail View
     verbKey(verb) {
       return `has${ ucFirst(verb) }`;

--- a/components/auth/RoleDetailEdit.vue
+++ b/components/auth/RoleDetailEdit.vue
@@ -153,10 +153,7 @@ export default {
       return this.as === _DETAIL;
     },
     doneLocationOverride() {
-      return this.isRancherType ? {
-        name:   'c-cluster-auth-roles',
-        hash:   `#${ this.value.subtype }`
-      } : this.value.listLocation;
+      return this.value.listLocation;
     },
     // Detail View
     rules() {
@@ -245,7 +242,7 @@ export default {
       this.$set(row, key, value);
     },
     cancel() {
-      this.$router.replace(this.doneLocationOverride);
+      this.done();
     },
     // Detail View
     verbKey(verb) {
@@ -290,7 +287,7 @@ export default {
         });
 
       return res;
-    }
+    },
   }
 };
 </script>

--- a/components/auth/RoleDetailEdit.vue
+++ b/components/auth/RoleDetailEdit.vue
@@ -62,16 +62,6 @@ export default {
 
   data() {
     this.$set(this.value, 'rules', this.value.rules || []);
-    switch (this.value.subtype) {
-    case GLOBAL:
-      this.$set(this.value, 'newUserDefault', !!this.value.newUserDefault);
-      break;
-    case CLUSTER:
-    case NAMESPACE:
-      this.$set(this.value, 'roleTemplateNames', this.value.roleTemplateNames || []);
-      this.$set(this.value, 'locked', !!this.value.locked);
-      break;
-    }
 
     this.value.rules.forEach((rule) => {
       if (rule.verbs[0] === '*') {
@@ -84,6 +74,17 @@ export default {
 
     if (roleContext && this.value.updateSubtype) {
       this.value.updateSubtype(roleContext);
+    }
+
+    switch (this.value.subtype) {
+    case GLOBAL:
+      this.$set(this.value, 'newUserDefault', !!this.value.newUserDefault);
+      break;
+    case CLUSTER:
+    case NAMESPACE:
+      this.$set(this.value, 'roleTemplateNames', this.value.roleTemplateNames || []);
+      this.$set(this.value, 'locked', !!this.value.locked);
+      break;
     }
 
     this.$nextTick(() => {

--- a/components/auth/RoleDetailEdit.vue
+++ b/components/auth/RoleDetailEdit.vue
@@ -382,10 +382,7 @@ export default {
             <template #column-headers>
               <div class="column-headers row">
                 <div class="col span-3">
-                  <label class="text-label">
-                    {{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.verbs') }}
-                    <span class="required">*</span>
-                  </label>
+                  <label class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.verbs') }}</label>
                 </div>
                 <div class="col span-3">
                   <label class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.resources') }}</label>
@@ -477,10 +474,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .required {
-    color: var(--error);
-  }
-
   ::v-deep {
     .column-headers {
       margin-right: 75px;

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -47,7 +47,7 @@ export default {
     },
 
     muteLabel() {
-      // Don't mute the label if the mode if view and the button is checked
+      // Don't mute the label if the mode is view and the button is checked
       return this.disabled && !(this.mode === _VIEW && this.isChecked);
     }
   },
@@ -79,7 +79,7 @@ export default {
 
 <template>
   <label
-    class="radio-container"
+    :class="[ isDisabled ? 'disabled' : '', 'radio-container']"
     @keydown.enter="clicked($event)"
     @keydown.space="clicked($event)"
     @click.stop="clicked($event)"
@@ -138,6 +138,10 @@ export default {
   border-radius: var(--border-radius);
   padding-bottom: 5px;
 
+  &.disabled {
+    cursor: default
+  }
+
   .radio-label {
     margin: 3px 10px 0px 5px;
   }
@@ -171,10 +175,9 @@ export default {
       opacity:1;
       border: 1.5px solid var(--dropdown-text);
 
-      // Ensure that checked radio buttons are greyed out when not enabled
+      // Ensure that checked radio buttons are muted but still visibly selected when muted
       &.text-muted {
-        background-color: var(--disabled-bg);
-        border-color: var(--disabled-bg);
+        opacity: .25;
       }
     }
   }

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -79,7 +79,7 @@ export default {
 
 <template>
   <label
-    :class="[ isDisabled ? 'disabled' : '', 'radio-container']"
+    :class="{'disabled': isDisabled, 'radio-container': true}"
     @keydown.enter="clicked($event)"
     @keydown.space="clicked($event)"
     @click.stop="clicked($event)"
@@ -139,7 +139,7 @@ export default {
   padding-bottom: 5px;
 
   &.disabled {
-    cursor: default
+    cursor: not-allowed
   }
 
   .radio-label {

--- a/config/product/auth.js
+++ b/config/product/auth.js
@@ -193,7 +193,10 @@ export function init(store) {
     DISPLAY_NAME,
     SIMPLE_NAME,
     RBAC_BUILTIN,
-    RBAC_DEFAULT,
+    {
+      ...RBAC_DEFAULT,
+      labelKey: 'tableHeaders.authRoles.globalDefault',
+    },
     AGE
   ]);
 

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -225,4 +225,8 @@ export function init(store) {
 
   // Ignore these types as they are managed through the auth product
   ignoreType(MANAGEMENT.USER);
+
+  // Ignore these types as they are managed through the auth product
+  ignoreType(MANAGEMENT.GLOBAL_ROLE);
+  ignoreType(MANAGEMENT.ROLE_TEMPLATE);
 }

--- a/models/management.cattle.io.globalrole.js
+++ b/models/management.cattle.io.globalrole.js
@@ -80,4 +80,8 @@ export default {
     };
   },
 
+  doneOverride() {
+    return this.listLocation;
+  }
+
 };

--- a/models/management.cattle.io.roletemplate.js
+++ b/models/management.cattle.io.roletemplate.js
@@ -155,4 +155,8 @@ export default {
     };
   },
 
+  doneOverride() {
+    return this.listLocation;
+  }
+
 };

--- a/pages/c/_cluster/auth/roles/index.vue
+++ b/pages/c/_cluster/auth/roles/index.vue
@@ -47,6 +47,9 @@ export default {
     const globalRoleSchema = this.$store.getters[`management/schemaFor`](MANAGEMENT.GLOBAL_ROLE);
     const roleTemplatesSchema = this.$store.getters[`management/schemaFor`](MANAGEMENT.ROLE_TEMPLATE);
 
+    const roleTemplateHeaders = this.$store.getters['type-map/headersFor'](roleTemplatesSchema);
+    const defaultHeaderIndex = roleTemplateHeaders.findIndex(header => header.name === 'default');
+
     return {
       tabs: {
         [GLOBAL]: {
@@ -66,6 +69,7 @@ export default {
           labelKey:       SUBTYPE_MAPPING.CLUSTER.labelKey,
           weight:         2,
           schema:         roleTemplatesSchema,
+          headers:        this.applyDefaultHeaderLabel(roleTemplateHeaders, defaultHeaderIndex, 'tableHeaders.authRoles.clusterDefault'),
           createLocation: {
             ...createRoleTemplate,
             query: { roleContext: CLUSTER }
@@ -77,6 +81,7 @@ export default {
           labelKey:       SUBTYPE_MAPPING.NAMESPACE.labelKey,
           weight:         1,
           schema:         roleTemplatesSchema,
+          headers:        this.applyDefaultHeaderLabel(roleTemplateHeaders, defaultHeaderIndex, 'tableHeaders.authRoles.projectDefault'),
           createLocation: {
             ...createRoleTemplate,
             query: { roleContext: PROJECT }
@@ -131,6 +136,19 @@ export default {
 
   },
 
+  methods: {
+    applyDefaultHeaderLabel(roleTemplateHeaders, defaultHeaderIndex, labelKey) {
+      const headers = [...roleTemplateHeaders];
+
+      headers[defaultHeaderIndex] = {
+        ...roleTemplateHeaders[defaultHeaderIndex],
+        labelKey,
+      };
+
+      return headers;
+    }
+  }
+
 };
 </script>
 
@@ -161,11 +179,11 @@ export default {
       </Tab>
 
       <Tab v-if="tabs[CLUSTER].canFetch" :name="CLUSTER" :weight="tabs[CLUSTER].weight" :label-key="tabs[CLUSTER].labelKey">
-        <ResourceTable :schema="tabs[CLUSTER].schema" :rows="clusterResources" />
+        <ResourceTable :schema="tabs[CLUSTER].schema" :headers="tabs[CLUSTER].headers" :rows="clusterResources" />
       </Tab>
 
       <Tab v-if="tabs[PROJECT].canFetch" :name="PROJECT" :weight="tabs[PROJECT].weight" :label-key="tabs[PROJECT].labelKey">
-        <ResourceTable :schema="tabs[PROJECT].schema" :rows="namespaceResources" />
+        <ResourceTable :schema="tabs[PROJECT].schema" :headers="tabs[PROJECT].headers" :rows="namespaceResources" />
       </Tab>
     </Tabbed>
   </div>

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -931,10 +931,6 @@ export default {
   },
 
   listLocation() {
-    return this._listLocation;
-  },
-
-  _listLocation() {
     return {
       name:   `c-cluster-product-resource`,
       params: {

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -931,6 +931,10 @@ export default {
   },
 
   listLocation() {
+    return this._listLocation;
+  },
+
+  _listLocation() {
     return {
       name:   `c-cluster-product-resource`,
       params: {


### PR DESCRIPTION
- Address majority of points from #2675
- Ensure form/yaml cancel/done return to auth roles page
  - Previously yaml version returned to cluster explorer
  - This also removes the management global role and role template resource types from the cluster explorer (as per other types served by the auth section)
- Roles Tables: Apply better labels to 'default' role table column
 - Previously these were all labelled as 'Default'
 - Now they're New User Default, Cluster Creator Default and Project Creator Default
- Grant Resources Tab: Remove required indicator for role rules
  - These aren't required by the API and were causing confusion
- Fixed Visual bugs
  - Grant Resources Tab: Change Rule 'Resources' label to 'Resource`
  - Radio Button Disabled State: Don't show standard grey colour for radio blob, use the usual with opacity
    - Seen in View Config page
- Create Cluster / Project Role: Ensure default locked value is applied
