### PR TITLE
Fix a few auth presentation issues

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -174,7 +174,7 @@ authConfig:
       calllback:
         label: Authorization callback URL
       description:
-        label: Description
+        label: Application description
         value: 'Optional, can be left blank'
       homepage:
         label: Homepage URL

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -210,10 +210,11 @@ authConfig:
         title: 'Step One: For standard Google, click <a href="https://console.developers.google.com/apis/credentials" target="_blank" rel="noopener noreferrer nofollow">here</a> to go applications settings in a new window'
         body:
          1: Login to your account. Navigate to "APIs & Services" and then select "OAuth consent screen".
-         2: 'Authorized domains: Top private domain of: '
+         2: 'Authorized domains:'
          3: 'Application homepage link: '
          4: 'Under Scopes for Google APIs, enable "email", "profile", and "openid".'
          5: 'Click on "Save".'
+        topPrivateDomain: 'Top private domain of:'
       2:
         title: 'Step Two: Navigate to the "Credentials" tab to create your OAuth client ID'
         body: 
@@ -224,13 +225,11 @@ authConfig:
           5: 'Upload the downloaded JSON file in the OAuth credentials box.'
       3:
         title: 'Step Three: Create Service Account credentials'
-        body: |-
-          Follow <a href="https://rancher.com/docs/rancher/v2.x/en/admin-settings/authentication/google/#creating-service-account-credentials" target="_blank" rel="noopener noreferrer nofollow">this</a> guide to:<br/>
-          <ul class="mt-0">
-          <li> Create a service account.</li>
-          <li> Generate a key for the service account.</li>
-          <li> Add the service account as an OAuth client in your google domain.</li>
-          </ul>
+        introduction: 'Follow <a href="https://rancher.com/docs/rancher/v2.x/en/admin-settings/authentication/google/#creating-service-account-credentials" target="_blank" rel="noopener noreferrer nofollow">this</a> guide to:'
+        body:
+          1: Create a service account.
+          2: Generate a key for the service account.
+          3: Add the service account as an OAuth client in your google domain.
   ldap:
     freeipa: Configure a FreeIPA server
     activedirectory: Configure an Active Directory account
@@ -300,7 +299,7 @@ authConfig:
       placeholder: Paste in the IDP Metadata XML
     okta: Configure an Okta account
     ping: Configure a Ping account
-    shibboleth: Congiure a Shibboleth account
+    shibboleth: Configure a Shibboleth account
     showLdap: Configure an OpenLDAP Server
     userName: User Name Field
   azuread:

--- a/components/CopyToClipboardText.vue
+++ b/components/CopyToClipboardText.vue
@@ -5,6 +5,11 @@ export default {
       type:     String,
       required: true,
     },
+    // Show as plain - don't show in link style
+    plain: {
+      type:    Boolean,
+      default: false
+    }
   },
 
   methods: {
@@ -17,7 +22,18 @@ export default {
 </script>
 
 <template>
-  <a href="#" @click="clicked">
+  <a class="copy-to-cliboard-text" :class="{'plain': plain}" href="#" @click="clicked">
     {{ text }} <i class="icon icon-copy" />
   </a>
 </template>
+<style lang="scss" scoped>
+  .copy-to-cliboard-text {
+    &.plain {
+      color: var(--body-text);
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+</style>

--- a/edit/auth/azuread.vue
+++ b/edit/auth/azuread.vue
@@ -72,7 +72,7 @@ export default {
     },
 
     replyUrl() {
-      return `${ window.location.origin }/verify-auth-azure`;
+      return `${ this.serverUrl }/verify-auth-azure`;
     },
 
     tenantId() {
@@ -171,7 +171,7 @@ export default {
         <InfoBox v-if="!model.enabled" class="mt-20 mb-20 p-10">
           Azure AD requires a whitelisted URL for your Rancher server before beginning this setup. Please ensure that the following URL is set in the Reply URL section of your Azure Portal. Please note that is may take up to 5 minutes for the whitelisted URL to propagate.
           <br />
-          <label>Reply URL: </label> <CopyToClipboardText :text="replyUrl" />
+          <label>Reply URL: </label> <CopyToClipboardText :plain="true" :text="replyUrl" />
         </InfoBox>
 
         <div class="row mb-20">

--- a/edit/auth/github.vue
+++ b/edit/auth/github.vue
@@ -69,16 +69,6 @@ export default {
       return `${ this.model.tls ? 'https://' : 'http://' }${ this.model.hostname }`;
     },
 
-    serverUrl() {
-      if ( this.serverSetting ) {
-        return this.serverSetting;
-      } else if ( process.client ) {
-        return window.location.origin;
-      }
-
-      return '';
-    },
-
     principal() {
       return this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.$store.getters['auth/principalId']) || {};
     },

--- a/edit/auth/github.vue
+++ b/edit/auth/github.vue
@@ -189,11 +189,11 @@ export default {
           <ul>
             <li>
               {{ t(`authConfig.${NAME}.form.instruction`, tArgs, true) }}
-              <ul>
+              <ul class="mt-10">
                 <li><b>{{ t(`authConfig.${NAME}.form.app.label`) }}</b>: <span v-html="t(`authConfig.${NAME}.form.app.value`, tArgs, true)" /></li>
                 <li><b>{{ t(`authConfig.${NAME}.form.homepage.label`) }}</b>: {{ serverUrl }} <CopyToClipboard label-as="tooltip" :text="serverUrl" class="icon-btn" action-color="bg-transparent" /></li>
                 <li><b>{{ t(`authConfig.${NAME}.form.description.label`) }}</b>: <span v-html="t(`authConfig.${NAME}.form.description.value`, tArgs, true)" /></li>
-                <li><b>{{ t(`authConfig.${NAME}.form.app.label`) }}</b>: {{ serverUrl }} <CopyToClipboard :text="serverUrl" label-as="tooltip" class="icon-btn" action-color="bg-transparent" /></li>
+                <li><b>{{ t(`authConfig.${NAME}.form.calllback.label`) }}</b>: {{ serverUrl }} <CopyToClipboard :text="serverUrl" label-as="tooltip" class="icon-btn" action-color="bg-transparent" /></li>
               </ul>
             </li>
           </ul>

--- a/edit/auth/googleoauth.vue
+++ b/edit/auth/googleoauth.vue
@@ -137,15 +137,11 @@ export default {
         </div>
         <InfoBox class=" mt-20 mb-20 p-10">
           <h3 v-html="t('authConfig.googleoauth.steps.1.title', tArgs, true)" />
-          <!-- <div v-html="t('authConfig.googleoauth.steps.1.body', tArgs, true)" /> -->
-          <ul class="mt-0">
+          <ul class="mt-0 step-list">
             <li>{{ t('authConfig.googleoauth.steps.1.body.1', {}, true) }} </li>
-            <li>{{ t('authConfig.googleoauth.steps.1.body.2', {}, true) }} <CopyToClipboardText :text="tArgs.hostname" /> </li>
-
-            <li>{{ t('authConfig.googleoauth.steps.1.body.3', {}, true) }} <CopyToClipboardText :text="serverUrl" /> </li>
-
+            <li><b>{{ t('authConfig.googleoauth.steps.1.body.2', {}, true) }}</b> {{ t('authConfig.googleoauth.steps.1.topPrivateDomain', {}, true) }} <CopyToClipboardText :plain="true" :text="tArgs.hostname" /> </li>
+            <li><b>{{ t('authConfig.googleoauth.steps.1.body.3', {}, true) }}</b> <CopyToClipboardText :plain="true" :text="serverUrl" /> </li>
             <li>{{ t('authConfig.googleoauth.steps.1.body.4', {}, true) }} </li>
-
             <li>{{ t('authConfig.googleoauth.steps.1.body.5', {}, true) }} </li>
           </ul>
         </InfoBox>
@@ -155,14 +151,11 @@ export default {
           </div>
           <div class="row">
             <div class="col span-6">
-              <ul class="mt-0">
+              <ul class="mt-0 step-list">
                 <li>{{ t('authConfig.googleoauth.steps.2.body.1', {}, true) }} </li>
-                <li>{{ t('authConfig.googleoauth.steps.2.body.2', {}, true) }} <CopyToClipboardText :text="serverUrl" /> </li>
-
-                <li>{{ t('authConfig.googleoauth.steps.2.body.3', {}, true) }} <CopyToClipboardText :text="serverUrl+'/verify-auth'" /> </li>
-
+                <li><b>{{ t('authConfig.googleoauth.steps.2.body.2', {}, true) }}</b> <CopyToClipboardText :plain="true" :text="serverUrl" /> </li>
+                <li><b>{{ t('authConfig.googleoauth.steps.2.body.3', {}, true) }}</b> <CopyToClipboardText :plain="true" :text="serverUrl+'/verify-auth'" /> </li>
                 <li>{{ t('authConfig.googleoauth.steps.2.body.4', {}, true) }} </li>
-
                 <li>{{ t('authConfig.googleoauth.steps.2.body.5', {}, true) }} </li>
               </ul>
             </div>
@@ -185,7 +178,14 @@ export default {
             <h3 v-html="t('authConfig.googleoauth.steps.3.title', tArgs, true)" />
           </div>
           <div class="row">
-            <div class="col span-6" v-html="t('authConfig.googleoauth.steps.3.body', tArgs, true)" />
+            <div class="col span-6">
+              <div v-html="t('authConfig.googleoauth.steps.3.introduction', tArgs, true)" />
+              <ul class="mt-10 step-list">
+                <li>{{ t('authConfig.googleoauth.steps.3.body.1', {}, true) }} </li>
+                <li>{{ t('authConfig.googleoauth.steps.3.body.2', {}, true) }} </li>
+                <li>{{ t('authConfig.googleoauth.steps.3.body.3', {}, true) }} </li>
+              </ul>
+            </div>
             <div class="col span-6">
               <LabeledInput
                 v-model="model.serviceAccountCredential"
@@ -210,3 +210,8 @@ export default {
     </CruResource>
   </div>
 </template>
+<style lang="scss" scoped>
+  .step-list li:not(:last-child) {
+    margin-bottom: 8px;
+  }
+</style>

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -71,13 +71,13 @@ export default {
     },
 
     serverUrl() {
-      if ( this.serverSetting ) {
-        return this.serverSetting;
-      } else if ( process.client ) {
+      if (process.client) {
+        // Client-side rendered: use the current window loction
         return window.location.origin;
       }
 
-      return '';
+      // Server-side rendered
+      return this.serverSetting || '';
     },
 
     baseUrl() {


### PR DESCRIPTION
This PR fixes a few auth presentation issues:

- Ensures URLs that the user should use when configuring are not shown as links
- Fixes the serverURL so it correctly uses the window origin when rendering client-side (this is consistent with the Ember UI)
- Improved the spacing of the list item steps in a couple of places
- Fixed a typo in 'Congiure'
- Uses bold text in the same way the Ember UI does for labels for URLs that the user is expected to copy and use for configuration
- Fixed issue with labels on GitHub auth 

This addresses #2628, #2116 and #2690