### PR TITLE
[2.6] Fix 'plus more' text

### DIFF
--- a/assets/styles/base/_helpers.scss
+++ b/assets/styles/base/_helpers.scss
@@ -249,3 +249,8 @@ $spacing-property-map: (
   margin-bottom: 20px;
   border-radius: var(--border-radius);
 }
+
+.plus-more {
+  color: var(  --input-placeholder );
+  font-size: 0.8em;
+}

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -26,6 +26,7 @@ generic:
   none: None
   number: '{prefix}{value, number}{suffix}'
   overview: Overview
+  plusMore: "+ {n} more"
   readFromFile: Read from File
   register: Register
   remove: Remove

--- a/components/formatter/RouterDestination.vue
+++ b/components/formatter/RouterDestination.vue
@@ -97,7 +97,7 @@ export default {
       {{ route }}
     </a>
     <br />
-    <span v-if="remaining > 0" class="plus-more">+{{ remaining }} more</span>
+    <span v-if="remaining > 0" class="plus-more">{{ t('generic.plusMore', {n:remaining}) }}</span>
   </span>
 </template>
 

--- a/components/formatter/RouterMatch.vue
+++ b/components/formatter/RouterMatch.vue
@@ -73,7 +73,7 @@ export default {
       {{ methodToShow }} = {{ valueToShow }}
     </span>
     <br />
-    <span v-if="remaining>0" class="plus-more">+{{ remaining }} more</span>
+    <span v-if="remaining>0" class="plus-more">{{ t('generic.plusMore', {n:remaining}) }}</span>
   </span>
   <span v-else class="text-muted">
     &mdash;
@@ -83,9 +83,5 @@ export default {
 <style lang='scss'>
 .col-router-match {
   color: var(--input-label);
-}
-.plus-more{
-  color: var(  --input-placeholder );
-  font-size: 0.8em;
 }
 </style>


### PR DESCRIPTION
- Seen in Deployment list Images column (`components/formatter/PodImages.vue`), translation was missing, so only ever showed a single image
- Also
  - Moved global scoped `plus-more` to a more fitting place
  - Ensure + more translation is used in other places

![image](https://user-images.githubusercontent.com/18697775/114701181-5d99c080-9d1a-11eb-91dd-84097c6a80f1.png)
