### PR TITLE
fix base64 url-safe and add nestedGroup to google auth view

### DIFF
--- a/edit/auth/googleoauth.vue
+++ b/edit/auth/googleoauth.vue
@@ -104,6 +104,8 @@ export default {
           <template slot="rows">
             <tr><td>{{ t(`authConfig.${NAME}.adminEmail`) }}: </td><td>{{ model.adminEmail }}</td></tr>
             <tr><td>{{ t(`authConfig.${NAME}.domain`) }}: </td><td>{{ model.hostname }}</td></tr>
+
+            <tr><td>{{ t('authConfig.ldap.nestedGroupMembership.label') }}: </td><td>{{ model.nestedGroupMembershipEnabled ? t('generic.enabled') : t('generic.disabled') }}</td></tr>
           </template>
         </AuthBanner>
 

--- a/utils/crypto/index.js
+++ b/utils/crypto/index.js
@@ -24,10 +24,9 @@ export function base64Encode(string, alphabet = NORMAL) {
     const m = {
       '+': '-',
       '/': '_',
-      '=': ''
     };
 
-    return buf.toString('base64').replace(/[+/]|=+$/g, char => m[char]);
+    return buf.toString('base64').replace(/[+/]|=+$/g, char => m[char] || '');
   }
 
   return buf.toString('base64');


### PR DESCRIPTION
#2116 - I failed at addressing this bug with the state query param previously and introduced a different issue with url-safe base64 encoding. 

#2667 - adds nestedGroupMembership field to google oauth enabled view:
<img width="1656" alt="Screen Shot 2021-04-14 at 6 52 33 AM" src="https://user-images.githubusercontent.com/42977925/114722728-e6026c00-9cee-11eb-9876-26de8b6bddd3.png">
 related ember pr: https://github.com/rancher/ui/pull/4537