### PR TITLE
Improve validation for Roles, Fix empty Rule property bug

### DIFF
--- a/components/auth/RoleDetailEdit.vue
+++ b/components/auth/RoleDetailEdit.vue
@@ -205,34 +205,14 @@ export default {
   },
 
   methods: {
-
-    getVerb(verb, rule) {
-      const verbs = rule.verbs || [];
-
-      return verbs.includes(verb);
-    },
-
-    setVerb(verb, value, rule) {
-      this.$set(rule.verbs, rule.verbs || []);
-
-      if (value) {
-        const index = rule.verbs.indexOf(verb);
-
-        if (index === -1) {
-          rule.verbs.push(verb);
-        }
-      } else {
-        const index = rule.verbs.indexOf(verb);
-
-        if (index !== -1) {
-          rule.verbs.splice(index, 1);
-        }
-      }
-    },
     setRule(key, rule, event) {
       const value = event.label ? event.label : event;
 
-      this.$set(rule, key, [value]);
+      if (value) {
+        this.$set(rule, key, [value]);
+      } else {
+        this.$set(rule, key, []);
+      }
     },
     getRule(key, rule) {
       return rule[key]?.[0] || null;
@@ -443,7 +423,6 @@ export default {
                   <LabeledInput
                     :value="getRule('apiGroups', props.row.value)"
                     :mode="mode"
-                    :required="!isRancherType"
                     @input="setRule('apiGroups', props.row.value, $event)"
                   />
                 </div>

--- a/models/rbac.authorization.k8s.io.role.js
+++ b/models/rbac.authorization.k8s.io.role.js
@@ -3,6 +3,17 @@ import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@/models/management.cattle.io
 import { uniq } from '@/utils/array';
 
 export default {
+  customValidationRules() {
+    return [
+      {
+        path:           'rules',
+        validators:     ['roleTemplateRules'],
+        nullable:       false,
+        type:           'array',
+      },
+    ];
+  },
+
   nameWithinProduct() {
     return this.$rootGetters['i18n/withFallback'](`rbac.displayRole.${ this.name }`, this.name);
   },


### PR DESCRIPTION
- Addresses #2693
- Removed unused code (setVerb/getVerb)
- Improve handling of empty strings when setting arrays in a rule
- Remove required field for api groups for non-rancher types (rbac role/cluster role)
  - There's a lot of validation for these types in the backend that would be tricky to do with the current mechanism up front
    - Namespaced roles cannot use non-resource urls
    - Rules with resources must have api groups (and vice versa)
    - Roles with no rules are ok (guessing this is because there's no validation of the inherit role side)
  - So let the api validation do it's thing for the complex cases on submit
- Apply basic rule validation to non-rancher role types