### PR TITLE
[2.6] Add Helm Chart Detail Page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -537,6 +537,21 @@ catalog:
       readme: Chart README
       resources: Resources
       values: Values YAML
+  chart:
+    header:
+      charts: Charts
+      install: Install
+    info:
+      appVersion: Application Version
+      chartVersions:
+        label: Chart Versions
+        showMore: Show More
+        showLess: Show Less
+      home: Home
+      maintainers: Maintainers
+      related: Related
+      chartUrls: Chart
+      keywords: Keywords
   charts:
     all: All
     categories:
@@ -553,6 +568,7 @@ catalog:
     action:
       goToUpgrade: Edit/Upgrade
       ignoreWarning: Continue Anyways
+    appReadmeMissing: This chart doesn't have a README.
     appReadmeGeneric: This chart doesn't have a Rancher-specific README.  Review the Helm README to learn more about the available configuration options and their usage.
     chart: Chart
     error:

--- a/components/formatter/Date.vue
+++ b/components/formatter/Date.vue
@@ -23,7 +23,18 @@ export default {
     emptyTextKey: {
       type:    String,
       default: ''
-    }
+    },
+
+    showDate: {
+      type:    Boolean,
+      default: true,
+    },
+
+    showTime: {
+      type:    Boolean,
+      default: true,
+    },
+
   },
 
   computed: {
@@ -53,6 +64,11 @@ export default {
 
 <template>
   <component :is="tagName">
-    {{ date }}<br v-if="multiline" /><span v-else>&nbsp;</span>{{ time }}
+    <template v-if="showDate">
+      {{ date }}<br v-if="multiline" /><span v-else>&nbsp;</span>
+    </template>
+    <template v-if="showTime">
+      {{ time }}
+    </template>
   </component>
 </template>

--- a/pages/c/_cluster/apps/chart.vue
+++ b/pages/c/_cluster/apps/chart.vue
@@ -1,0 +1,264 @@
+<script>
+import Loading from '@/components/Loading';
+import ChartMixin from '@/pages/c/_cluster/apps/chart_mixin';
+import { mapGetters } from 'vuex';
+import LazyImage from '@/components/LazyImage';
+import Markdown from '@/components/Markdown';
+import Tab from '@/components/Tabbed/Tab';
+import Tabbed from '@/components/Tabbed';
+import DateFormatter from '@/components/formatter/Date';
+import isEqual from 'lodash/isEqual';
+import { CHART, REPO, REPO_TYPE, VERSION } from '@/config/query-params';
+
+export default {
+  components: {
+    DateFormatter,
+    LazyImage,
+    Loading,
+    Markdown,
+    Tab,
+    Tabbed,
+  },
+
+  mixins: [
+    ChartMixin
+  ],
+
+  async fetch() {
+    await this.baseFetch();
+  },
+
+  data() {
+    return {
+      showLastVersions:  10,
+      showMoreVersions:  false,
+    };
+  },
+
+  computed: {
+    ...mapGetters(['currentCluster']),
+    versions() {
+      return this.showMoreVersions ? this.mappedVersions : this.mappedVersions.slice(0, this.showLastVersions);
+    },
+    hasReadme() {
+      return this.versionInfo?.appReadme || this.versionInfo?.readme;
+    },
+  },
+
+  watch: {
+    '$route.query'(neu, old) {
+      if ( !isEqual(neu, old) ) {
+        this.$fetch();
+      }
+    },
+  },
+
+  methods: {
+    install() {
+      this.$router.push({
+        name:   'c-cluster-apps-install',
+        params: {
+          cluster:  this.$route.params.cluster,
+          product:  this.$store.getters['productId'],
+        },
+        query: {
+          [REPO_TYPE]: this.query.repoType,
+          [REPO]:      this.query.repoName,
+          [CHART]:     this.query.chartName,
+          [VERSION]:   this.query.versionName,
+        }
+      });
+    }
+  },
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <div v-if="chart" class="chart-header">
+      <div class="name-logo-install">
+        <div class="name-logo">
+          <h1>
+            <nuxt-link :to="{ name: 'c-cluster-apps-charts' }">
+              {{ t('catalog.chart.header.charts') }}:
+            </nuxt-link>
+            {{ chart.chartDisplayName }} ({{ version.version }})
+          </h1>
+          <div v-if="chart.icon" class="logo-container">
+            <div class="logo-bg ml-10">
+              <LazyImage :src="chart.icon" class="logo" />
+            </div>
+          </div>
+        </div>
+        <button type="button" class="btn role-primary" @click.prevent="install">
+          {{ t('catalog.chart.header.install') }}
+        </button>
+      </div>
+      <div v-if="version.description" class="description mt-10">
+        <p>
+          {{ version.description }}
+        </p>
+      </div>
+    </div>
+    <div class="spacer"></div>
+    <div class="chart-content">
+      <Tabbed v-if="hasReadme" class="chart-content__tabs">
+        <Tab v-if="versionInfo && versionInfo.appReadme" name="appReadme" :label="t('catalog.install.section.appReadme')" :weight="2">
+          <Markdown v-model="versionInfo.appReadme" class="md md-desc" />
+        </Tab>
+        <Tab v-if="versionInfo && versionInfo.readme" name="readme" :label="t('catalog.install.section.readme')" :weight="1">
+          <Markdown v-model="versionInfo.readme" class="md md-desc" />
+        </Tab>
+      </Tabbed>
+      <div v-else class="chart-content__tabs">
+        {{ t('catalog.install.appReadmeMissing', {}, true) }}
+      </div>
+      <div class="chart-content__right-bar ml-20">
+        <div class="chart-content__right-bar__section">
+          <h3>
+            {{ t('catalog.chart.info.chartVersions.label') }}
+          </h3>
+          <div v-for="vers of versions" :key="vers.id" class="chart-content__right-bar__section--cVersion">
+            <a v-tooltip="vers.label.length > 16 ? vers.label : null" :class="{'selected': vers.label === version.version}" @click.prevent="selectVersion(vers)">
+              {{ vers.shortLabel }}
+            </a>
+            <DateFormatter :value="vers.created" :show-time="false" />
+          </div>
+          <div class="mt-10 chart-content__right-bar__section--cVersion">
+            <button v-if="mappedVersions.length > showLastVersions" type="button" class="btn role-secondary" @click="showMoreVersions = !showMoreVersions">
+              {{ t(`catalog.chart.info.chartVersions.${showMoreVersions ? 'showLess' : 'showMore'}`) }}
+            </button>
+          </div>
+        </div>
+        <div class="chart-content__right-bar__section">
+          <h3 t>
+            {{ t('catalog.chart.info.appVersion') }}
+          </h3>
+          {{ version.appVersion }}
+        </div>
+        <div v-if="version.home" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.home') }}</h3>
+          <a :href="version.home" rel="nofollow noopener noreferrer" target="_blank">{{ version.home }}</a>
+        </div>
+        <div v-if="version.maintainers" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.maintainers') }}</h3>
+          <a v-for="m of maintainers" :key="m.id" :href="m.url" rel="nofollow noopener noreferrer" target="_blank">{{ m.text }}</a>
+        </div>
+        <div v-if="version.sources" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.related') }}</h3>
+          <a v-for="s of version.sources" :key="s" :href="s" rel="nofollow noopener noreferrer" target="_blank">{{ s }}</a>
+        </div>
+        <div v-if="version.urls" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.chartUrls') }}</h3>
+          <a v-for="url of version.urls" :key="url" :href="url" rel="nofollow noopener noreferrer" target="_blank">{{ url }}</a>
+        </div>
+        <div v-if="version.keywords" class="chart-content__right-bar__section chart-content__right-bar__section--keywords">
+          <h3>{{ t('catalog.chart.info.keywords') }}Keywords</h3>
+          {{ version.keywords.join(', ') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  $name-height: 30px;
+  $padding: 5px;
+  .md {
+    overflow: auto;
+    max-width: 100%;
+
+    ::v-deep {
+      * + H1,
+      * + H2,
+      * + H3,
+      * + H4,
+      * + H5,
+      * + H6 {
+        margin-top: 40px;
+      }
+    }
+
+    ::v-deep pre {
+      white-space: break-spaces;
+      word-break: break-word;
+    }
+  }
+
+  ::v-deep .md-desc > h1:first-of-type {
+    display: none;
+  }
+
+  .chart-header {
+
+    .name-logo-install {
+      display: flex;
+      height: $name-height;
+      justify-content: space-between;
+    }
+
+    .name-logo {
+      display: flex;
+    }
+
+    .logo-container {
+      height: $name-height;
+      width: $name-height;
+      text-align: center;
+    }
+
+    .logo-bg {
+      height: $name-height;
+      width: $name-height;
+      background-color: white;
+      border: $padding solid white;
+      border-radius: calc( 3 * var(--border-radius));
+      position: relative;
+    }
+
+    .logo {
+      max-height: $name-height - 2 * $padding;
+      max-width: $name-height - 2 * $padding;
+      position: absolute;
+      width: auto;
+      height: auto;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      margin: auto;
+    }
+  }
+
+  .chart-content {
+    display: flex;
+    &__tabs {
+      flex: 1;
+    }
+    &__right-bar {
+      max-width: 260px;
+      &__section {
+        display: flex;
+        flex-direction: column;
+        padding-bottom: 20px;
+        word-break: break-all;
+        a {
+          cursor: pointer;
+        }
+        &--cVersion{
+          display: flex;
+          justify-content: space-between;
+
+          .selected {
+            font-weight: bold;
+          }
+        }
+        &--keywords{
+         word-break: break-word;
+        }
+
+      }
+    }
+  }
+</style>

--- a/pages/c/_cluster/apps/chart.vue
+++ b/pages/c/_cluster/apps/chart.vue
@@ -125,8 +125,8 @@ export default {
             </a>
             <DateFormatter :value="vers.created" :show-time="false" />
           </div>
-          <div class="mt-10 chart-content__right-bar__section--cVersion">
-            <button v-if="mappedVersions.length > showLastVersions" type="button" class="btn role-secondary" @click="showMoreVersions = !showMoreVersions">
+          <div class="mt-10 chart-content__right-bar__section--showMore">
+            <button v-if="mappedVersions.length > showLastVersions" type="button" class="btn btn-sm role-link" @click="showMoreVersions = !showMoreVersions">
               {{ t(`catalog.chart.info.chartVersions.${showMoreVersions ? 'showLess' : 'showMore'}`) }}
             </button>
           </div>
@@ -151,7 +151,7 @@ export default {
         </div>
         <div v-if="version.urls" class="chart-content__right-bar__section">
           <h3>{{ t('catalog.chart.info.chartUrls') }}</h3>
-          <a v-for="url of version.urls" :key="url" :href="url" rel="nofollow noopener noreferrer" target="_blank">{{ url }}</a>
+          <a v-for="url of version.urls" :key="url" :href="url" rel="nofollow noopener noreferrer" target="_blank">{{ version.urls.length === 1 ? 'Download': url }}</a>
         </div>
         <div v-if="version.keywords" class="chart-content__right-bar__section chart-content__right-bar__section--keywords">
           <h3>{{ t('catalog.chart.info.keywords') }}Keywords</h3>
@@ -176,8 +176,12 @@ export default {
       * + H4,
       * + H5,
       * + H6 {
-        margin-top: 40px;
+        margin-top: 20px;
       }
+    }
+
+    ::v-deep code {
+      padding: 0;
     }
 
     ::v-deep pre {
@@ -253,6 +257,10 @@ export default {
           .selected {
             font-weight: bold;
           }
+        }
+        &--showMore {
+          display: flex;
+          justify-content: center;
         }
         &--keywords{
          word-break: break-word;

--- a/pages/c/_cluster/apps/chart_mixin.js
+++ b/pages/c/_cluster/apps/chart_mixin.js
@@ -1,0 +1,188 @@
+
+import { mapGetters } from 'vuex';
+
+import {
+  REPO_TYPE, REPO, CHART, VERSION, NAMESPACE, NAME, DESCRIPTION as DESCRIPTION_QUERY, FORCE, DEPRECATED, HIDDEN, _FLAGGED
+} from '@/config/query-params';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@/config/labels-annotations';
+import { SHOW_PRE_RELEASE, mapPref } from '@/store/prefs';
+
+const semver = require('semver');
+
+export default {
+  data() {
+    return {
+      version:     null,
+      versionInfo: null,
+
+      catalogOSAnnotation: CATALOG_ANNOTATIONS.SUPPORTED_OS,
+    };
+  },
+
+  computed: {
+    ...mapGetters(['currentCluster', 'isRancher']),
+
+    showPreRelease: mapPref(SHOW_PRE_RELEASE),
+
+    chart() {
+      if ( this.repo && this.query.chartName ) {
+        return this.$store.getters['catalog/chart']({
+          repoType:      this.query.repoType,
+          repoName:      this.query.repoName,
+          chartName:     this.query.chartName,
+          includeHidden: true,
+        });
+      }
+
+      return null;
+    },
+
+    repo() {
+      return this.$store.getters['catalog/repo']({
+        repoType: this.query.repoType,
+        repoName: this.query.repoName,
+      });
+    },
+
+    showReadme() {
+      return !!this.versionInfo?.readme;
+    },
+
+    mappedVersions() {
+      const {
+        currentCluster,
+        catalogOSAnnotation,
+      } = this;
+
+      const versions = this.chart?.versions || [];
+      const selectedVersion = this.version?.version;
+      const isWindows = currentCluster.providerOs === 'windows';
+      const out = [];
+
+      versions.forEach((version) => {
+        const nue = {
+          label:      version.version,
+          shortLabel: version.version.length > 16 ? `${ version.version.slice(0, 15) }...` : version.version,
+          id:         version.version,
+          created:    version.created,
+          disabled:   false,
+          keywords:   version.keywords
+        };
+
+        if ( version?.annotations?.[catalogOSAnnotation] === 'windows' ) {
+          nue.label = this.t('catalog.install.versions.windows', { ver: version.version });
+
+          if ( !isWindows ) {
+            nue.disabled = true;
+          }
+        } else if ( version?.annotations?.[catalogOSAnnotation] === 'linux' ) {
+          nue.label = this.t('catalog.install.versions.linux', { ver: version.version });
+
+          if ( isWindows ) {
+            nue.disabled = true;
+          }
+        }
+        if (!semver.valid(version.version)) {
+          nue.version = semver.clean(version.version, { loose: true });
+        }
+
+        if (!this.showPreRelease && !!semver.prerelease(version.version)) {
+          return;
+        }
+
+        out.push(nue);
+      });
+
+      const selectedMatch = out.find(v => v.id === selectedVersion);
+
+      if (!selectedMatch) {
+        out.push({ value: selectedVersion, label: this.t('catalog.install.versions.current', { ver: selectedVersion }) });
+      }
+
+      return out;
+    },
+
+    filteredVersions() {
+      return this.showPreRelease ? this.mappedVersions : this.mappedVersions.filter(v => !v.isPre);
+    },
+
+    maintainers() {
+      return this.version.maintainers.map((m) => {
+        return {
+          id:   m.name,
+          text: m.name,
+          url:  `mailto:${ m.email }`
+        };
+      });
+    },
+
+    query() {
+      const query = this.$route.query;
+
+      return {
+        repoType:     query[REPO_TYPE],
+        repoName:     query[REPO],
+        chartName:    query[CHART],
+        versionName:  query[VERSION],
+        appNamespace: query[NAMESPACE] || '',
+        appName:      query[NAME] || '',
+        description:  query[DESCRIPTION_QUERY]
+      };
+    },
+
+    showDeprecated() {
+      return this.$route.query[DEPRECATED] === _FLAGGED;
+    },
+
+    showHidden() {
+      return this.$route.query[HIDDEN] === _FLAGGED;
+    },
+
+    forced() {
+      return this.$route.query[FORCE] === _FLAGGED;
+    }
+  },
+
+  methods: {
+    async baseFetch() {
+      await this.$store.dispatch('catalog/load');
+
+      if ( !this.chart ) {
+        return;
+      }
+
+      if ( !this.query.versionName && this.chart.versions?.length ) {
+        this.query.versionName = this.chart.versions[0].version;
+      }
+
+      if ( !this.query.versionName ) {
+        return;
+      }
+
+      this.version = this.$store.getters['catalog/version']({
+        repoType:      this.query.repoType,
+        repoName:      this.query.repoName,
+        chartName:     this.query.chartName,
+        versionName: this.query.versionName
+      });
+
+      try {
+        this.versionInfo = await this.$store.dispatch('catalog/getVersionInfo', {
+          repoType:      this.query.repoType,
+          repoName:      this.query.repoName,
+          chartName:     this.query.chartName,
+          versionName: this.query.versionName
+        });
+      } catch (e) {
+        console.error(e); // eslint-disable-line no-console
+        this.versionInfo = null;
+      }
+    },
+
+    selectVersion({ id: version }) {
+      this.$router.applyQuery({ [VERSION]: version });
+    },
+
+  },
+
+};

--- a/pages/c/_cluster/apps/charts.vue
+++ b/pages/c/_cluster/apps/charts.vue
@@ -242,7 +242,7 @@ export default {
       }
 
       this.$router.push({
-        name:   'c-cluster-apps-install',
+        name:   'c-cluster-apps-chart',
         params: {
           cluster:  this.$route.params.cluster,
           product:  this.$store.getters['productId'],

--- a/utils/install-redirect.js
+++ b/utils/install-redirect.js
@@ -21,7 +21,7 @@ export default function(product, chartName, defaultResourceOrRoute) {
 
       // Otherwise just let the middleware pass through
     } else {
-      // The product is not installed, redirect to the install chart
+      // The product is not installed, redirect to the details chart
 
       await store.dispatch('catalog/load');
 
@@ -29,7 +29,7 @@ export default function(product, chartName, defaultResourceOrRoute) {
 
       if ( chart ) {
         return redirect({
-          name:   'c-cluster-apps-install',
+          name:   'c-cluster-apps-chart',
           query:  {
             [REPO_TYPE]: chart.repoType,
             [REPO]:      chart.repoName,


### PR DESCRIPTION
- As per 2.6 design doc, add a specific chart details page which leads on to the install process
- The PR is clean, however there will be some changes to the flow when the Helm Chart install process is updated
  - User is taken from chart details to legacy install page, which also shows the READMEs
  - `ChartMixin` will be updated once the install page is updated
  - There's a duped way to nav to the chart detail/install page. This will be updated when the install page is updated
    - model / chart.js goToInstall (used in the cluster tools page, currently goes directly to chart install page)
    - pages / charts.vue selectChart (used in charts list, currently goes to chart detail page)
  - READMEs for some charts fail to fetch. This is not effected by this pr... but still investigating further
    - (fails) https://github.com/SUSE/stratos branch `gh-pages`, 'console'
    - (succeeds) http://opensource.suse.com/stratos, 'console'

