### PR TITLE
Changing the namespace configuration for rke2 monitoring installs

### DIFF
--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -181,6 +181,11 @@ export default {
       if (this.provider.startsWith('rke')) {
         this.$set(this.value, 'ingressNginx', this.value.ingressNginx || {});
         this.$set(this.value.ingressNginx, 'enabled', true);
+
+        // For RKE2 ingress-nginx is installed in the kube-system namespace so we have to modify this configuration to support that.
+        if (this.provider === 'rke2') {
+          this.$set(this.value.ingressNginx, 'namespace', 'kube-system');
+        }
       }
     }
 


### PR DESCRIPTION
rke2 has the nginx-ingress installed in kube-system so we're modifying the default namespace in the monitoring configuration.

https://github.com/rancher/dashboard/issues/2728