### PR TITLE
Fixing the grafana link for etcd metrics

### DIFF
--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -447,6 +447,7 @@ export default {
         <template #default="props">
           <DashboardMetrics
             v-if="props.active"
+            class="etcd-metrics"
             :detail-url="ETCD_METRICS_DETAIL_URL"
             :summary-url="ETCD_METRICS_SUMMARY_URL"
             graph-height="550px"
@@ -506,5 +507,9 @@ export default {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+}
+
+.etcd-metrics ::v-deep .external-link {
+  top: -102px;
 }
 </style>


### PR DESCRIPTION
etcd metrics had an info box that needed to be accounted for.

https://github.com/rancher/dashboard/issues/2704#issuecomment-822707996

![image](https://user-images.githubusercontent.com/55104481/115298335-32481480-a112-11eb-8f76-334e9f51d75b.png)
