### PR TITLE
[2.6] Adding a prometheusOperator hostNetwork option to chart installation

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1610,6 +1610,9 @@ monitoring:
       volumeMode: Volume Mode
       volumeName: Volume Name
     title: Configure Grafana
+  hostNetwork:
+    label: Use Host Network For Prometheus Operator
+    tip: If you are using a managed Kubernetes cluster with custom CNI (e.g. Calico), you must enable this option to allow a managed control plane to contact the admission webhook exposed by Prometheus Operator to mutate or validate incoming PrometheusRules.
   overview:
     alertsList:
       ends:

--- a/chart/monitoring/ClusterSelector.vue
+++ b/chart/monitoring/ClusterSelector.vue
@@ -134,8 +134,6 @@ export default {
             this.$set(this.value.coreDns, 'enabled', true);
             this.$set(this.value.kubeDns, 'enabled', false);
           }
-
-          this.$set(this.value.prometheusOperator, 'hostNetwork', false);
         } else if (oldClusterType.group !== 'other') { // old cluster type only sets some values to false, if they need to be reset true it will happen below
           this.setClusterTypeEnabledValues([oldConfigKeys, false]);
         }
@@ -151,7 +149,6 @@ export default {
         this.setClusterTypeEnabledValues([configKeys, false]);
       } else if (clusterType.group === 'managed') {
         this.setClusterTypeEnabledValues([configKeys, false]);
-        this.$set(this.value.prometheusOperator, 'hostNetwork', true);
 
         if (clusterType.id === 'gke') {
           this.$set(this.value.coreDns, 'enabled', false);
@@ -175,6 +172,7 @@ export default {
       } else if (oldClusterType && oldClusterType.id === 'rke.windows') {
         delete this.value.global.cattle.windows;
       }
+      this.$emit('onClusterTypeChanged', clusterType);
     },
   },
 

--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -123,6 +123,7 @@ export default {
           label: 'monitoring.accessModes.many',
         },
       ],
+      clusterType:           {},
       disableAggregateRoles: false,
       prometheusResources:   [],
       pvcs:                  [],
@@ -217,7 +218,14 @@ export default {
     <Tab name="general" :label="t('monitoring.tabs.general')" :weight="99">
       <div>
         <div class="row mb-20">
-          <ClusterSelector :value="value" :mode="mode" />
+          <ClusterSelector :value="value" :mode="mode" @onClusterTypeChanged="clusterType = $event" />
+        </div>
+        <div v-if="clusterType.group === 'managed'" class="row mb-20">
+          <Checkbox
+            v-model="value.prometheusOperator.hostNetwork"
+            label-key="monitoring.hostNetwork.label"
+            :tooltip="t('monitoring.hostNetwork.tip', {}, true)"
+          />
         </div>
         <div class="row">
           <div class="col span-6">


### PR DESCRIPTION
rancher/dashboard#2573

![image](https://user-images.githubusercontent.com/55104481/115303888-1300b580-a119-11eb-9a9e-efc359fcf9df.png)
![image](https://user-images.githubusercontent.com/55104481/115303912-1b58f080-a119-11eb-81fc-de832f9e4d84.png)
![image](https://user-images.githubusercontent.com/55104481/115303928-1f850e00-a119-11eb-8a33-f30dba82736b.png)
