### PR TITLE
[2.5.8] fix sidecar indexing, container image validation, workload storage pvc namespacing

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3421,7 +3421,9 @@ workload:
     subdomain:
       label: Subdomain
       placeholder: e.g. web
-
+  validation:
+    containers: Containers
+    containerImage: Container {name} - "Container Image" is required.
   replicas: Replicas
   showTabs: 'Show Advanced Options'
   scheduling:

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -525,17 +525,6 @@ export default {
       if (this.container && !this.container.name) {
         this.$set(this.container, 'name', this.value.metadata.name);
       }
-      if (this.container) {
-        let existing;
-
-        if (this.isInitContainer) {
-          existing = this.podTemplateSpec.initContainers.find(container => container._active);
-        } else {
-          existing = this.podTemplateSpec.containers.find(container => container._active);
-        }
-
-        Object.assign(existing, this.container);
-      }
 
       const ports = this.value.containers.reduce((total, each) => {
         const containerPorts = each.ports || [];

--- a/edit/workload/storage/index.vue
+++ b/edit/workload/storage/index.vue
@@ -57,10 +57,7 @@ export default {
   },
 
   async fetch() {
-    const pvcs = await this.$store.dispatch('cluster/findAll', { type: PVC });
-    const namespace = this.namespace || this.$store.getters['defaultNamespace'];
-
-    this.pvcs = pvcs.filter(pvc => pvc.metadata.namespace === namespace);
+    this.pvcs = await this.$store.dispatch('cluster/findAll', { type: PVC });
   },
 
   data() {
@@ -70,6 +67,12 @@ export default {
   computed: {
     isView() {
       return this.mode === _VIEW;
+    },
+
+    namespacedPVCs() {
+      const namespace = this.namespace || this.$store.getters['defaultNamespace'];
+
+      return this.pvcs.filter(pvc => pvc.metadata.namespace === namespace);
     },
 
     volumeTypeOpts() {
@@ -99,7 +102,7 @@ export default {
     },
 
     pvcNames() {
-      return this.pvcs.map(pvc => pvc.metadata.name);
+      return this.namespacedPVCs.map(pvc => pvc.metadata.name);
     },
     // only show volumes mounted in current container
     containerVolumes: {

--- a/utils/validators/container-images.js
+++ b/utils/validators/container-images.js
@@ -11,7 +11,7 @@ export function containerImages(spec, getters, errors) {
   }
 
   if (!podSpec.containers || !podSpec.containers.length) {
-    errors.push(getters['i18n/t']('validation.required', { key: getters['i18n/t']('workload.container.containers') }));
+    errors.push(getters['i18n/t']('validation.required', { key: getters['i18n/t']('workload.container.titles.containers') }));
 
     return;
   }

--- a/utils/validators/container-images.js
+++ b/utils/validators/container-images.js
@@ -1,18 +1,23 @@
+import { get } from '@/utils/object';
+
 export function containerImages(spec, getters, errors) {
-  let container;
+  let podSpec;
 
   if (spec.jobTemplate) {
     // cronjob pod template is nested slightly different than other types
-    const { jobTemplate: { spec: { template: { spec: { containers = [] } } } } } = spec;
-
-    container = containers[0] || {};
+    podSpec = get(spec, 'jobTemplate.spec.template.spec');
   } else {
-    const { template:{ spec:{ containers = [] } } } = spec;
+    podSpec = get(spec, 'template.spec');
+  }
+  if (!podSpec.containers) {
+    errors.push(getters['i18n/t']('validation.required', { key: getters['i18n/t']('workload.container.containers') }));
 
-    container = containers[0] || {};
+    return;
   }
 
-  if (!container.image) {
-    errors.push(getters['i18n/t']('validation.required', { key: getters['i18n/t']('workload.container.image') }));
-  }
+  podSpec.containers.forEach((container) => {
+    if (container && !container.image) {
+      errors.push(getters['i18n/t']('workload.validation.containerImage', { name: container.name }));
+    }
+  });
 }

--- a/utils/validators/container-images.js
+++ b/utils/validators/container-images.js
@@ -9,7 +9,8 @@ export function containerImages(spec, getters, errors) {
   } else {
     podSpec = get(spec, 'template.spec');
   }
-  if (!podSpec.containers) {
+
+  if (!podSpec.containers || !podSpec.containers.length) {
     errors.push(getters['i18n/t']('validation.required', { key: getters['i18n/t']('workload.container.containers') }));
 
     return;


### PR DESCRIPTION
#2722 - this isn't called out in the issue, but I noticed the container image validator wasn't updated to account for multiple containers so I went ahead and added that functionality as well

#2709 #2722 - both of these are related to some lingering code in the workload save function no longer relevant with the switch to sidecars-in-config-page

#2716 - moved PVC filtering (by namespace) to a computed prop to make it reactive


This should go in 2.6 as well. Related PR: https://github.com/rancher/dashboard/pull/2740