### PR TITLE
[2.6] monitoring - use global.cattle.windows.enabled instead of windowsExporter.enabled

### DIFF
--- a/chart/monitoring/ClusterSelector.vue
+++ b/chart/monitoring/ClusterSelector.vue
@@ -82,7 +82,7 @@ const CLUSTER_TYPES = [
     group:      'rke',
     id:         'rke-windows',
     label:      'cluster.provider.rkeWindows',
-    configKeys: ['rkeControllerManager', 'rkeScheduler', 'rkeProxy', 'rkeEtcd', 'windowsExporter'],
+    configKeys: ['rkeControllerManager', 'rkeScheduler', 'rkeProxy', 'rkeEtcd'],
   },
 ];
 
@@ -164,6 +164,16 @@ export default {
       if (clusterType.group === 'k3s') {
         this.$set(this.value.prometheus.prometheusSpec.resources.limits, 'memory', '2500Mi');
         this.$set(this.value.prometheus.prometheusSpec.resources.requests, 'memory', '1750Mi');
+      }
+
+      if (clusterType.id === 'rke-windows') {
+        if (!this.value.global.cattle.windows) {
+          this.$set(this.value.global.cattle, 'windows', { enabled: true });
+        } else {
+          this.value.global.cattle.windows.enabled = true;
+        }
+      } else if (oldClusterType && oldClusterType.id === 'rke-windows') {
+        delete this.value.global.cattle.windows;
       }
     },
   },


### PR DESCRIPTION
Related 2.5.8 PR: https://github.com/rancher/dashboard/pull/2742