### PR TITLE
Including rke2 for the isRKE check when displaying the etcd metrics

### DIFF
--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -177,7 +177,7 @@ export default {
     },
 
     isRKE() {
-      return ['rke', 'rke.windows'].includes(this.currentCluster.status.provider);
+      return ['rke', 'rke2', 'rke.windows'].includes(this.currentCluster.status.provider);
     },
 
     accessibleResources() {


### PR DESCRIPTION
This was just changed as part of a merge to not search for the rke prefix. This corrects the behavior.

rancher/dashboard#2759