### PR TITLE
Fix issues viewing secrets list

### DIFF
--- a/models/secret.js
+++ b/models/secret.js
@@ -286,6 +286,7 @@ export default {
 
         return displaySans;
       }
+
       return this.certInfo?.sans || [];
     }
   },

--- a/models/secret.js
+++ b/models/secret.js
@@ -280,10 +280,13 @@ export default {
   // use for + n more name display
   unrepeatedSans() {
     if (this._type === TYPES.TLS ) {
-      const commonBases = this.certInfo?.sans.filter(name => name.indexOf('*.') === 0 || name.indexOf('www.') === 0).map(name => name.substr(name.indexOf('.')));
-      const displaySans = removeObjects(this.certInfo?.sans, commonBases);
+      if (this.certInfo?.sans?.filter) {
+        const commonBases = this.certInfo?.sans.filter(name => name.indexOf('*.') === 0 || name.indexOf('www.') === 0).map(name => name.substr(name.indexOf('.')));
+        const displaySans = removeObjects(this.certInfo?.sans, commonBases);
 
-      return displaySans;
+        return displaySans;
+      }
+      return this.certInfo?.sans || [];
     }
   },
 


### PR DESCRIPTION
This fixes an issue where going to the Secrets List gave an error - this.certInfo?.sans.filter is not a function.

This may be a mismatch between the backend and frontend versions (?) - but this PR guards against filter being undefined.