### PR TITLE
Fix monitoring side navigation

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -186,6 +186,7 @@ export default {
           :key="id+'_' + child.name + '_type'"
           :is-root="depth == 0 && !showHeader"
           :type="child"
+          :depth="depth"
           @selected="$emit('selected')"
           @click="clicked"
         />
@@ -220,13 +221,24 @@ export default {
   }
 
   .accordion {
+    .header {
+      &:hover:not(.noHover) {
+        background-color: var(--nav-hover);
+      }
+
+      > I {
+        &:hover {
+          background-color: var(--nav-expander-hover);
+        }
+      }
+    }
+  }
+
+  .accordion {
     &.depth-0 {
       > .header {
         padding: 8px 0;
 
-        &:hover:not(.noHover) {
-          background-color: var(--nav-hover);
-        }
         &.noHover {
           cursor: default;
         }
@@ -243,10 +255,6 @@ export default {
           top: 0;
           padding: 9px 7px;
           user-select: none;
-
-          &:hover {
-            background-color: var(--nav-expander-hover);
-          }
         }
       }
 
@@ -257,6 +265,7 @@ export default {
 
     &:not(.depth-0) {
       > .header {
+        padding-left: 10px;
         > SPAN {
           // Child groups that aren't linked themselves
           display: inline-block;
@@ -267,7 +276,7 @@ export default {
           position: absolute;
           right: 0;
           top: 0;
-          padding: 6px 8px 6px 0;
+          padding: 6px 8px 6px 8px;
         }
       }
     }
@@ -275,10 +284,10 @@ export default {
 
  .body ::v-deep > .child.nuxt-link-active,
  .header ::v-deep > .child.nuxt-link-exact-active {
-    background-color: var(--nav-active);
     padding: 0;
 
     A, A I {
+      background-color: var(--nav-active);
       color: var(--body-text);
     }
   }

--- a/components/nav/Type.vue
+++ b/components/nav/Type.vue
@@ -17,7 +17,12 @@ export default {
     isRoot: {
       type:    Boolean,
       default: false,
-    }
+    },
+
+    depth: {
+      type:    Number,
+      default: 0,
+    },    
   },
 
   data() {
@@ -58,8 +63,8 @@ export default {
     :key="type.name"
     :to="type.route"
     tag="li"
-    class="child"
-    :class="{'root': isRoot}"
+    class="child nav-type"
+    :class="{'root': isRoot, [`depth-${depth}`]: true}"
     :exact="type.exact"
   >
     <a
@@ -137,5 +142,13 @@ export default {
       justify-items: center;
       padding-right: 4px;
     }
+
+    &.nav-type:not(.depth-0) {
+      A {
+        font-size: 13px;
+        padding: 5.5px 7px 5.5px 10px;
+      }
+    }
   }
+
 </style>

--- a/config/product/monitoring.js
+++ b/config/product/monitoring.js
@@ -10,10 +10,10 @@ export const CHART_NAME = 'rancher-monitoring';
 
 export function init(store) {
   const {
-    product,
     basicType,
     headers,
     mapType,
+    product,
     spoofedType,
     virtualType,
     weightType,
@@ -38,7 +38,6 @@ export function init(store) {
 
   virtualType({
     label:      'Monitoring',
-    group:      'monitoring',
     namespaced: false,
     name:       'monitoring-overview',
     weight:     105,
@@ -178,23 +177,13 @@ export function init(store) {
     ROUTE,
     SERVICEMONITOR,
     PODMONITOR,
-  ], 'monitoring');
+  ]);
 
-  // virtualType({
-  //   label:      'Advanced',
-  //   group:      'monitoring-overview',
-  //   namespaced: false,
-  //   name:       'monitoring-advanced',
-  //   weight:     105,
-  //   route:      { name: 'c-cluster-monitoring' },
-  //   exact:      true
-  // });
-
-  // basicType([
-  //   PROMETHEUSRULE,
-  //   ALERTMANAGER,
-  //   PROMETHEUS
-  // ], 'monitoring-advanced');
+  basicType([
+    PROMETHEUSRULE,
+    ALERTMANAGER,
+    PROMETHEUS
+  ], 'Advanced');
 
   mapType(SERVICEMONITOR, store.getters['i18n/t'](`typeLabel.${ SERVICEMONITOR }`, { count: 2 }));
   mapType(PODMONITOR, store.getters['i18n/t'](`typeLabel.${ PODMONITOR }`, { count: 2 }));


### PR DESCRIPTION
Monitoring doesn't appear correctly in the side nav - the Advanced section is lost and the Monitoring items appear under the Monitoring header in a 2nd-level Monitoring group rather than at the top level.

This PR fixes this.