### PR TITLE
Fix navigation issue with Fleet from home page

### DIFF
--- a/utils/install-redirect.js
+++ b/utils/install-redirect.js
@@ -2,6 +2,8 @@ import { REPO_TYPE, REPO, CHART, VERSION } from '@/config/query-params';
 
 export default function(product, chartName, defaultResourceOrRoute) {
   return async function middleware({ redirect, store } ) {
+    const cluster = store.getters['currentCluster']?.id || 'local';
+
     if ( store.getters['type-map/isProductActive'](product) ) {
       // If the product is installed and there's a default resource, redirect there
 
@@ -13,6 +15,7 @@ export default function(product, chartName, defaultResourceOrRoute) {
         return redirect({
           name:   'c-cluster-product-resource',
           params: {
+            cluster,
             product,
             resource: defaultResourceOrRoute
           },
@@ -30,6 +33,7 @@ export default function(product, chartName, defaultResourceOrRoute) {
       if ( chart ) {
         return redirect({
           name:   'c-cluster-apps-install',
+          params: { cluster },
           query:  {
             [REPO_TYPE]: chart.repoType,
             [REPO]:      chart.repoName,


### PR DESCRIPTION
This PR fixes a bug where navigating from the home page to Fleet, without first going via a cluster, fails.