### PR TITLE
[2.5.8] workload sidecar fixes

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -62,7 +62,7 @@ export default {
     keyPlaceholder: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('keyValue.valuePlaceholder');
+        return this.$store.getters['i18n/t']('keyValue.keyPlaceholder');
       },
     },
 
@@ -276,7 +276,7 @@ export default {
           }
 
           return {
-            [this.keyName]:   row.key,
+            [this.keyName]:   row[this.keyName],
             [this.valueName]: value,
           };
         }));

--- a/components/form/Security.vue
+++ b/components/form/Security.vue
@@ -116,6 +116,7 @@ export default {
             :options="[false,true]"
             :labels="[t('workload.container.security.privileged.false'), t('workload.container.security.privileged.true')]"
             :mode="mode"
+            @input="update"
           />
         </div>
         <div v-if="!privileged" class="col span-6">
@@ -127,6 +128,7 @@ export default {
             :options="[false,true]"
             :labels="[t('workload.container.security.allowPrivilegeEscalation.false'), t('workload.container.security.allowPrivilegeEscalation.true')]"
             :mode="mode"
+            @input="update"
           />
         </div>
       </div>
@@ -143,7 +145,7 @@ export default {
             :options="[false, true]"
             :labels="[t('workload.container.security.runAsNonRoot.false'), t('workload.container.security.runAsNonRoot.true')]"
             :mode="mode"
-            @input="e=>runAsRoot = !e"
+            @input="e=>{runAsRoot = !e; update()}"
           />
         </div>
         <div class="col span-6">
@@ -154,6 +156,7 @@ export default {
             :options="[false, true]"
             :labels="[t('workload.container.security.readOnlyRootFilesystem.false'), t('workload.container.security.readOnlyRootFilesystem.true')]"
             :mode="mode"
+            @input="update"
           />
         </div>
       </div>


### PR DESCRIPTION
#2804  - This is happening because of [this](https://github.com/rancher/dashboard/pull/2740/files#diff-d9e05a5df9a8de1f810e516fb295a3217ccf413a0a8fa868c36ff881dc58cc2cL528-L538) change; I thought with the sidecar-picker-in-form change this code was unnecessary and edits to the `container` data prop were being properly reflected in the `podTemplate` but that isn't the case for every container sub-component. Adding that code back to `saveWorkload` is insufficient because it'd only ensure the current container's spec is reflected in the `podTemplate` correctly so I added a watcher instead. 

#2807 - updated `saveWorkload` to not attempt to set a pod selector on edit/clone. In the process I noticed creation via Ember doesn't set one for cron jobs so I replicated that behavior here.

I found a few other issues while verifying the above changes:
* container naming issue:
    * add a container
    * delete the first container
    * add another container
    * observe that there are now two "container-1"
* security context radio selection is not saved
* `KeyValue` using `asMap=false` with a `keyName` defined always returns `undefined` for the key's value (I noticed this with health check http headers)
* wrong default placeholder in key/value (bar: bar)\


2.6 PR: https://github.com/rancher/dashboard/pull/2818