### PR TITLE
Fix issue where root nav group can disappear

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -80,7 +80,7 @@ export default {
     },
 
     showExpanded() {
-      return this.isExpanded || this.isActiveGroup;
+      return this.isExpanded || this.isActiveGroup || this.group.isRoot;
     },
 
     isActiveGroup() {


### PR DESCRIPTION
This PR fixes an issue where items in a root nav group can disappear when another group is expanded.

For example, explore a cluster, then go to Continuous Delivery and then click on 'Advanced'. The two three items will vanish.