### PR TITLE
Fix issue where logging out shows the red text for session timeout

### DIFF
--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -199,7 +199,6 @@ export default {
                   :waiting-label="t('login.loggingIn')"
                   :success-label="t('login.loggedIn')"
                   :error-label="t('asyncButton.default.error')"
-                  style="font-size: 18px;"
                   @click="loginLocal"
                 />
                 <div class="mt-20">

--- a/store/index.js
+++ b/store/index.js
@@ -584,7 +584,7 @@ export const actions = {
     if ( route.name === 'index' ) {
       router.replace('/auth/login');
     } else {
-      const QUERY = (LOGGED_OUT in route.query) ? LOGGED_OUT : TIMED_OUT
+      const QUERY = (LOGGED_OUT in route.query) ? LOGGED_OUT : TIMED_OUT;
 
       router.replace(`/auth/login?${ QUERY }`);
     }

--- a/store/index.js
+++ b/store/index.js
@@ -9,7 +9,7 @@ import { sortBy } from '@/utils/sort';
 import { filterBy, findBy } from '@/utils/array';
 import { BOTH, CLUSTER_LEVEL, NAMESPACED } from '@/store/type-map';
 import { NAME as EXPLORER } from '@/config/product/explorer';
-import { TIMED_OUT } from '@/config/query-params';
+import { TIMED_OUT, LOGGED_OUT } from '@/config/query-params';
 
 // Disables strict mode for all store instances to prevent warning about changing state outside of mutations
 // becaues it's more efficient to do that sometimes.
@@ -584,7 +584,9 @@ export const actions = {
     if ( route.name === 'index' ) {
       router.replace('/auth/login');
     } else {
-      router.replace(`/auth/login?${ TIMED_OUT }`);
+      const QUERY = (LOGGED_OUT in route.query) ? LOGGED_OUT : TIMED_OUT
+
+      router.replace(`/auth/login?${ QUERY }`);
     }
   },
 


### PR DESCRIPTION
This PR fixes an issue where the query param can get changed from logged-out to timed-out, leading to the red text on the login page after a successful logout.

I also changed the font size of the button text back to the default button text size.