### PR TITLE
[2.5.8] Google Ouath edit

### DIFF
--- a/edit/auth/googleoauth.vue
+++ b/edit/auth/googleoauth.vue
@@ -59,25 +59,6 @@ export default {
       };
     }
   },
-
-  created() {
-    this.registerBeforeHook(this.addCreds, 'willsave');
-  },
-  methods: {
-    // re-add credentials when adding allowed users/groups to model
-    addCreds() {
-      if (this.model.enabled) {
-        const { oauthCredential, serviceAccountCredential } = this.originalValue;
-
-        if (!this.model.oauthCredential) {
-          this.model.oauthCredential = oauthCredential;
-        }
-        if (!this.model.serviceAccountCredential) {
-          this.model.serviceAccountCredential = serviceAccountCredential;
-        }
-      }
-    }
-  }
 };
 </script>
 

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -157,7 +157,11 @@ export default {
             addObject(this.model.allowedPrincipalIds, this.me.id);
           }
         }
-        await this.model.save();
+        if (wasEnabled && configType === 'oauth') {
+          await this.model.save({ ignoreFields: ['oauthCredential', 'serviceAccountCredential'] });
+        } else {
+          await this.model.save();
+        }
         await this.reloadModel();
         this.isEnabling = false;
         this.editConfig = false;
@@ -233,18 +237,6 @@ export default {
           set(this.model, 'disabledStatusBitmask', 2);
         } else {
           set(this.model, 'disabledStatusBitmask', 0);
-        }
-        break;
-      case 'oauth':
-        if (this.model.id === 'googleoauth') {
-          const { oauthCredential, serviceAccountCredential } = this.originalValue;
-
-          if (!this.model.oauthCredential) {
-            set(this.model, 'oauthCredential', oauthCredential);
-          }
-          if (!this.model.serviceAccountCredential) {
-            set(this.model, 'serviceAccountCredential', serviceAccountCredential);
-          }
         }
         break;
       default:

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -816,7 +816,7 @@ export default {
       delete this.__rehydrate;
       const forNew = !this.id;
 
-      const errors = await this.validationErrors(this);
+      const errors = await this.validationErrors(this, opt.ignoreFields);
 
       if (!isEmpty(errors)) {
         return Promise.reject(errors);


### PR DESCRIPTION
#2824  Per Dan's comment [here](https://github.com/rancher/dashboard/issues/2824#issuecomment-825999391), the dashboard shouldn't set `oauthCredential` or `serviceAccountCredential` fields before saving the config; omitting these results in a UI validation error so I added exceptions for those two fields when saving the model to edit allowed users/groups

2.6 PR: https://github.com/rancher/dashboard/pull/2833