### PR TITLE
Fix issue accessing a cluster after logging in again

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -573,8 +573,10 @@ export const actions = {
 
     await dispatch('cluster/unsubscribe');
     commit('clusterChanged', false);
+    commit('setCluster', null);
     commit('cluster/reset');
 
+    await dispatch('rancher/unsubscribe');
     commit('rancher/reset');
     commit('catalog/reset');
 


### PR DESCRIPTION
This PR fixes a bug where you can't access a cluster after logging in again following a logout.

Currently doing so gives an empty screen instead of the cluster navigation and pages.