### PR TITLE
Change colours for dropdown select on light theme

### DIFF
--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -113,10 +113,10 @@ $selected: rgba($primary, .5);
   --dropdown-border            : #{$medium};
   --dropdown-divider           : #{$medium};
   --dropdown-text              : #{$link};
-  --dropdown-active-text       : #{darken($link, 1%)};
-  --dropdown-active-bg         : #{$selected};
-  --dropdown-hover-text        : #{lighten($link, 1%)};
-  --dropdown-hover-bg          : #{rgba($primary, 0.2)};
+  --dropdown-active-text       : #{$lightest};
+  --dropdown-active-bg         : #{$dark};
+  --dropdown-hover-text        : #{$lightest};
+  --dropdown-hover-bg          : #{$primary};
   --dropdown-disabled-text     : var(--muted);
   --dropdown-disabled-bg       : #{$disabled};
 

--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -351,6 +351,14 @@ export default {
   display: inline-block;
 }
 
+.filter {
+  ::v-deep .vs__dropdown-menu {
+    li.vs__dropdown-option {
+      padding: 4px 5px;
+    }
+  }
+}
+
 .filter.show-masked ::v-deep .unlabeled-select:not(.masked-dropdown) {
   position: absolute;
   left: 0;


### PR DESCRIPTION
For light mode, use the same primary colour for hover

Also, for the Cluster Selection control, add small padding to the menu items