### PR TITLE
Make Cluster Tools button more prominent

### DIFF
--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -5,6 +5,7 @@ import { mapPref, DEV } from '@/store/prefs';
 import { sortBy } from '@/utils/sort';
 import { ucFirst } from '@/utils/string';
 import { KEY } from '@/utils/platform';
+import { getVersionInfo } from '@/utils/version';
 
 const UNKNOWN = 'unknown';
 const UI_VERSION = process.env.VERSION || UNKNOWN;
@@ -16,15 +17,7 @@ export default {
   components: {},
 
   data() {
-    const setting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, 'server-version');
-    const fullVersion = setting?.value || 'unknown';
-    let displayVersion = fullVersion;
-
-    const match = fullVersion.match(/^(.*)-([0-9a-f]{40})-(.*)$/);
-
-    if ( match ) {
-      displayVersion = match[2].substr(0, 7);
-    }
+    const { displayVersion, fullVersion } = getVersionInfo(this.$store);
 
     return {
       shown:          false,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -29,6 +29,7 @@ export default {
 
   data() {
     const { displayVersion } = getVersionInfo(this.$store);
+
     return { groups: [], displayVersion };
   },
 
@@ -298,7 +299,7 @@ export default {
         </template>
       </div>
       <n-link tag="div" class="tools" :to="{name: 'c-cluster-explorer-tools'}">
-        <a @click="collapseAll()" class="tools-button">
+        <a class="tools-button" @click="collapseAll()">
           <i class="icon icon-gear" />
           <span>{{ t('nav.clusterTools') }}</span>
         </a>
@@ -404,7 +405,7 @@ export default {
     NAV .version {
       cursor: default;
       margin: 0 10px 10px 10px;
-    }      
+    }
   }
 
   MAIN {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -14,6 +14,7 @@ import { addObjects, replaceWith, clear, addObject } from '@/utils/array';
 import { NAME as EXPLORER } from '@/config/product/explorer';
 import isEqual from 'lodash/isEqual';
 import { ucFirst } from '@/utils/string';
+import { getVersionInfo } from '@/utils/version';
 
 export default {
 
@@ -27,7 +28,8 @@ export default {
   },
 
   data() {
-    return { groups: [] };
+    const { displayVersion } = getVersionInfo(this.$store);
+    return { groups: [], displayVersion };
   },
 
   middleware: ['authenticated'],
@@ -296,8 +298,14 @@ export default {
         </template>
       </div>
       <n-link tag="div" class="tools" :to="{name: 'c-cluster-explorer-tools'}">
-        <a @click="collapseAll()">{{ t('nav.clusterTools') }}</a>
+        <a @click="collapseAll()" class="tools-button">
+          <i class="icon icon-gear" />
+          <span>{{ t('nav.clusterTools') }}</span>
+        </a>
       </n-link>
+      <div class="version text-muted">
+        {{ displayVersion }}
+      </div>
     </nav>
 
     <main v-if="clusterReady">
@@ -362,9 +370,16 @@ export default {
 
     NAV .tools {
       display: flex;
-      margin-bottom: 10px;
+      margin: 10px;
+      text-align: center;
+
       A {
+        align-items: center;
+        border: 1px solid var(--border);
+        border-radius: 5px;
         color: var(--body-text);
+        display: flex;
+        justify-content: center;
         outline: 0;
         flex: 1;
         padding: 10px;
@@ -373,12 +388,23 @@ export default {
           background: var(--nav-hover);
           text-decoration: none;
         }
+
+        > I {
+          margin-right: 4px;
+        }
       }
 
-      &.nuxt-link-active {
-        background-color: var(--nav-active);
+      &.nuxt-link-active:not(:hover) {
+        A {
+          background-color: var(--nav-active);
+        }
       }
     }
+
+    NAV .version {
+      cursor: default;
+      margin: 0 10px 10px 10px;
+    }      
   }
 
   MAIN {

--- a/pages/c/_cluster/explorer/tools.vue
+++ b/pages/c/_cluster/explorer/tools.vue
@@ -173,7 +173,8 @@ export default {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        font-size: 0.9em
+        font-size: 0.9em;
+        margin-top: 4px;
       }
 
       .description {

--- a/utils/version.js
+++ b/utils/version.js
@@ -1,5 +1,6 @@
 import { sortableNumericSuffix } from '@/utils/sort';
 import semver from 'semver';
+import { MANAGEMENT } from '@/config/types';
 
 export function parse(str) {
   str = `${ str }`;
@@ -77,4 +78,21 @@ export function isDevBuild(version) {
   }
 
   return false;
+}
+
+export function getVersionInfo(store) {
+  const setting = store.getters['management/byId'](MANAGEMENT.SETTING, 'server-version');
+  const fullVersion = setting?.value || 'unknown';
+  let displayVersion = fullVersion;
+
+  const match = fullVersion.match(/^(.*)-([0-9a-f]{40})-(.*)$/);
+
+  if ( match ) {
+    displayVersion = match[2].substr(0, 7);
+  }
+
+  return {
+    displayVersion,
+    fullVersion
+  };
 }


### PR DESCRIPTION
Following feedback:

- Make the Cluster Tools button more prominent
- Add icon
- Add version number at bottom - (a) so it is there, (b) raise the Cluster Tools button up