### PR TITLE
Fix cluster dashboard for users with restricted access

### DIFF
--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -356,8 +356,8 @@ export default {
 
     <div class="resource-gauges">
       <ResourceSummary :spoofed-counts="totalCountGaugeInput" />
-      <ResourceSummary resource="node" />
-      <ResourceSummary resource="apps.deployment" />
+      <ResourceSummary v-if="clusterCounts['node']" resource="node" />
+      <ResourceSummary v-if="clusterCounts['apps.deployment']" resource="apps.deployment" />
     </div>
 
     <h3 class="mt-40">


### PR DESCRIPTION
Currently, the cluster dash breaks if the user viewing it doesn't have permission to count info for nodes or deployments.