### PR TITLE
[2.5.8] fix init container updating, command args formatting

### DIFF
--- a/components/form/ShellInput.vue
+++ b/components/form/ShellInput.vue
@@ -10,12 +10,28 @@ export default {
       default: null,
     }
   },
+  /*
+      userValue is a string respresentation of args array, with spaces between each array item and single quotes around any items with whitespace
+      value input of ["-c", "sleep 600"]
+      is displayed as: "-c 'sleep 600'"
 
+      user input of "-c "sleep 600"" or "-c 'sleep 600'"
+      causes $emit 'input' of ["-c", "sleep 600"]
+  */
   data() {
     let userValue = '';
 
     if ( this.value ) {
-      userValue = this.value.join(' ');
+      userValue = this.value.reduce((str, each) => {
+        if (each.includes(' ')) {
+          str += `'${ each }'`;
+        } else {
+          str += each;
+        }
+        str += ' ';
+
+        return str;
+      }, '').trim();
     }
 
     return { userValue };

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -669,6 +669,7 @@ export default {
 
         removeObject(containers, this.container);
       } else {
+        delete this.container._init;
         const initContainers = this.podTemplateSpec.initContainers;
 
         removeObject(initContainers, this.container);

--- a/models/workload.js
+++ b/models/workload.js
@@ -42,7 +42,15 @@ export default {
 
       if (this.type === WORKLOAD_TYPES.CRON_JOB) {
         if (!spec.jobTemplate) {
-          spec.jobTemplate = { spec: { template: { spec: { restartPolicy: 'Never', containers: [{ imagePullPolicy: 'Always', name: 'container-0' }] } } } };
+          spec.jobTemplate = {
+            spec: {
+              template: {
+                spec: {
+                  restartPolicy: 'Never', containers: [{ imagePullPolicy: 'Always', name: 'container-0' }], initContainers: []
+                }
+              }
+            }
+          };
         }
       } else {
         if (!spec.replicas && spec.replicas !== 0) {
@@ -50,7 +58,11 @@ export default {
         }
 
         if (!spec.template) {
-          spec.template = { spec: { restartPolicy: this.type === WORKLOAD_TYPES.JOB ? 'Never' : 'Always', containers: [{ imagePullPolicy: 'Always', name: 'container-0' }] } };
+          spec.template = {
+            spec: {
+              restartPolicy: this.type === WORKLOAD_TYPES.JOB ? 'Never' : 'Always', containers: [{ imagePullPolicy: 'Always', name: 'container-0' }], initContainers: []
+            }
+          };
         }
         if (!spec.selector) {
           spec.selector = {};


### PR DESCRIPTION
 #2860 - defining `initContainers` in the pod spec during `applyDefaults` ensures the UI updates when the list changes (eg when removing an init container)
#2708 - remove `_init` property on container when init/standard radio group is toggled to standard

#2857 - ensure arrays of arguments passed to ShellInput get quotes around space-containing elements so they can be correctly parsed back into an array

related 2.6 PR: https://github.com/rancher/dashboard/pull/2862