### PR TITLE
Cluster Dashboard page tweaks

### DIFF
--- a/components/ConsumptionGauge.vue
+++ b/components/ConsumptionGauge.vue
@@ -51,7 +51,12 @@ export default {
     colorStops: {
       type:    Object,
       default: null
-    }
+    },
+
+    showDetail: {
+      type:     Boolean,
+      required: true,
+    }    
   },
   computed: {
     displayUnits() {
@@ -87,7 +92,7 @@ export default {
     <h3>
       {{ resourceName }}
     </h3>
-    <div class="numbers text-muted">
+    <div class="numbers">
       <slot name="title">
         <span>{{ t('node.detail.glance.consumptionGauge.used') }}</span> <span>{{ t('node.detail.glance.consumptionGauge.amount', amountTemplateValues) }} <span class="ml-10 percentage">/&nbsp;{{ formattedPercentage }}</span></span>
       </slot>

--- a/components/ConsumptionGauge.vue
+++ b/components/ConsumptionGauge.vue
@@ -52,11 +52,6 @@ export default {
       type:    Object,
       default: null
     },
-
-    showDetail: {
-      type:     Boolean,
-      required: true,
-    }    
   },
   computed: {
     displayUnits() {

--- a/pages/c/_cluster/explorer/HardwareResourceGauge.vue
+++ b/pages/c/_cluster/explorer/HardwareResourceGauge.vue
@@ -64,7 +64,7 @@ export default {
 <template>
   <SimpleBox class="hardware-resource-gauge">
     <div class="chart">
-      <h3 class="text-muted">
+      <h3>
         {{ name }}
       </h3>
       <div v-if=" reserved && (reserved.total || reserved.useful)" class="">
@@ -75,7 +75,7 @@ export default {
         >
           <template #title>
             <span>
-              {{ t('clusterIndexPage.hardwareResourceGauge.reserved') }}
+              {{ t('clusterIndexPage.hardwareResourceGauge.reserved') }} <span class="values text-muted">{{ reserved.useful }} / {{ reserved.total }} {{ reserved.units }}</span>
             </span>
             <span>
               {{ percentage(reserved) }}
@@ -83,7 +83,7 @@ export default {
           </template>
         </ConsumptionGauge>
       </div>
-      <div v-if=" used && used.useful" class="">
+      <div v-if=" used && used.useful">
         <ConsumptionGauge
           :capacity="used.total"
           :used="used.useful"
@@ -91,7 +91,7 @@ export default {
         >
           <template #title>
             <span>
-              {{ t('clusterIndexPage.hardwareResourceGauge.used') }}
+              {{ t('clusterIndexPage.hardwareResourceGauge.used') }} <span class="values text-muted">{{ used.useful }} / {{ used.total }} {{ used.units }}</span>
             </span>
             <span>
               {{ percentage(used) }}
@@ -103,14 +103,18 @@ export default {
   </SimpleBox>
 </template>
 
-<style lang="scss">
-    .hardware-resource-gauge {
-        $spacing: 10px;
-        $large-spacing: $spacing * 1.5;
+<style lang="scss" scoped>
+  .hardware-resource-gauge {
+    $spacing: 10px;
+    $large-spacing: $spacing * 1.5;
 
-        position: relative;
-        display: flex;
-        flex-direction: column;
+    position: relative;
+    display: flex;
+    flex-direction: column;
 
+    .values {
+      font-size: 12px;
+      padding-left: 10px;
     }
+  }
 </style>

--- a/pages/c/_cluster/explorer/ResourceSummary.vue
+++ b/pages/c/_cluster/explorer/ResourceSummary.vue
@@ -98,16 +98,16 @@ export default {
 
 <template>
   <div>
-    <SimpleBox class="container" @click="goToResource">
+    <SimpleBox class="container" :class="{'has-link': !!location}" @click="goToResource">
       <h1>{{ resourceCounts.useful }}</h1>
-      <h3 class="text-muted">
+      <h3>
         {{ name }}
       </h3>
       <div class="warnings">
-        <div :class="{'invisible':!resourceCounts.warningCount }" class="warn-count mb-10 chip">
+        <div v-if="resourceCounts.warningCount" class="warn-count mb-10 chip">
           {{ resourceCounts.warningCount }}
         </div>
-        <div :class="{'invisible':!resourceCounts.errorCount}" class="error-count chip">
+        <div v-if="resourceCounts.errorCount" class="error-count chip">
           {{ resourceCounts.errorCount }}
         </div>
       </div>
@@ -116,7 +116,15 @@ export default {
 </template>
 
 <style lang='scss' scoped>
-::v-deep .content{
+  .has-link {
+    cursor: pointer;
+
+    &:hover {
+      border-color: var(--link-text);
+    }
+  }
+
+  ::v-deep .content{
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -125,18 +133,17 @@ export default {
     }
 
     & .chip{
-        border-radius: 2em;
-        color: var(--body-bg);
-        padding: 0px 1em;
+      border-radius: 2em;
+      color: var(--body-bg);
+      padding: 0px 1em;
 
-        &.warn-count {
-            background: var(--warning)
-        }
+      &.warn-count {
+          background: var(--warning)
+      }
 
-        &.error-count {
-            background: var(--error)
-        }
+      &.error-count {
+          background: var(--error)
+      }
     }
 }
-
 </style>

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -124,9 +124,6 @@ export default {
       ROLES,
     ];
 
-    console.log('>>>>>>>>>>>>>>>>>>>');
-    console.log(clusterCounts);
-
     return {
       metricPoller:        null,
       eventHeaders,

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -26,7 +26,8 @@ import {
   SERVICE,
   PV,
   WORKLOAD_TYPES,
-  COUNT
+  COUNT,
+  CATALOG,
 } from '@/config/types';
 import { findBy } from '@/utils/array';
 import Tabbed from '@/components/Tabbed';

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -248,15 +248,15 @@ export default {
     },
 
     hasMonitoring() {
-      return !!this.clusterCounts?.[0]?.counts?.['catalog.cattle.io.app']?.namespaces?.['cattle-monitoring-system'];
+      return !!this.clusterCounts?.[0]?.counts?.[CATALOG.APP]?.namespaces?.['cattle-monitoring-system'];
     },
 
     canAccessNodes() {
-      return !!this.clusterCounts?.[0]?.counts?.['node'];
+      return !!this.clusterCounts?.[0]?.counts?.[NODE];
     },
 
     canAccessDeployments() {
-      return !!this.clusterCounts?.[0]?.counts?.['apps.deployment'];
+      return !!this.clusterCounts?.[0]?.counts?.[WORKLOAD_TYPES.DEPLOYMENT];
     },
   },
 

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -124,6 +124,9 @@ export default {
       ROLES,
     ];
 
+    console.log('>>>>>>>>>>>>>>>>>>>');
+    console.log(clusterCounts);
+
     return {
       metricPoller:        null,
       eventHeaders,
@@ -249,7 +252,15 @@ export default {
 
     hasMonitoring() {
       return !!this.clusterCounts?.[0]?.counts?.['catalog.cattle.io.app']?.namespaces?.['cattle-monitoring-system'];
-    }
+    },
+
+    canAccessNodes() {
+      return !!this.clusterCounts?.[0]?.counts?.['node'];
+    },
+
+    canAccessDeployments() {
+      return !!this.clusterCounts?.[0]?.counts?.['apps.deployment'];
+    },
   },
 
   mounted() {
@@ -347,17 +358,17 @@ export default {
         <span><LiveDate :value="currentCluster.metadata.creationTimestamp" :add-suffix="true" :show-tooltip="true" /></span>
       </div>
       <div :style="{'flex':1}" />
-      <div v-if="hasMonitoring">
+      <div v-if="hasMonitoring && false">
         <n-link :to="{name: 'c-cluster-monitoring'}">
-          {{ t('glance.monitoringDashboard') }} <i class="icon icon-external-link" />
+          {{ t('glance.monitoringDashboard') }}
         </n-link>
       </div>
     </div>
 
     <div class="resource-gauges">
       <ResourceSummary :spoofed-counts="totalCountGaugeInput" />
-      <ResourceSummary v-if="clusterCounts['node']" resource="node" />
-      <ResourceSummary v-if="clusterCounts['apps.deployment']" resource="apps.deployment" />
+      <ResourceSummary v-if="canAccessNodes" resource="node" />
+      <ResourceSummary v-if="canAccessDeployments" resource="apps.deployment" />
     </div>
 
     <h3 class="mt-40">
@@ -441,7 +452,6 @@ export default {
 
   &>*{
     margin-right: 40px;
-    color: var(--muted);
 
     & SPAN {
        font-weight: bold


### PR DESCRIPTION
This PR:

- Removes text-muted to make text easier to read
- Fixes alignment of error/warnings on card when there is only one shown
- Fixes Nodes and Deployment boxes not showing
- Adds back the usage for pods, cpu and memory (in addition to percentage)
- Sets cursor and hover for cards that can navigate you to nodes or deployments