### PR TITLE
Side navigation updates

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -107,6 +107,7 @@ nav:
     noResults: No matching clusters
   resourceSearch:
     label: Resource Search
+    toolTip: Resource Search {key}
     placeholder: Type to search for a resource...
 
 product:
@@ -474,7 +475,7 @@ backupRestoreOperator:
         label: Persistent Volume
       storageClass:
         label: Storage Class
-      tip: 'Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.'
+      tip: 'Configure a storage location where all backups are saved by default. You will have the option to override this witresourceSearchh each backup, but will be limited to using an S3-compatible object store.'
       warning: 'This {type} does not have its reclaim policy set to "Retain".  Your backups may be lost if the volume is changed or becomes unbound.'
   encryption: Encryption
   encryptionConfigName:

--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -64,6 +64,10 @@ export default {
       return this.group.children?.length > 0;
     },
 
+    onlyHasOverview() {
+      return this.group.children && this.group.children.length === 1 && this.group.children[0].overview;
+    },
+
     isOverview() {
       if (this.group.children && this.group.children.length > 0) {
         const grp = this.group.children[0];
@@ -162,7 +166,7 @@ export default {
       <slot name="header">
         <span v-html="group.labelDisplay || group.label" />
       </slot>
-      <i v-if="canCollapse && !isActiveGroup" class="icon toggle" :class="{'icon-chevron-down': !isExpanded, 'icon-chevron-up': isExpanded}" @click="toggle($event, true)" />
+      <i v-if="!onlyHasOverview && canCollapse && !isActiveGroup" class="icon toggle" :class="{'icon-chevron-down': !isExpanded, 'icon-chevron-up': isExpanded}" @click="toggle($event, true)" />
     </div>
     <ul v-if="showExpanded" class="list-unstyled body" v-bind="$attrs">
       <template v-for="(child, idx) in group[childrenKey]">

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 import { NORMAN } from '@/config/types';
 import { ucFirst } from '@/utils/string';
+import { isMac } from '@/utils/platform';
 import Import from '@/components/Import';
 import NamespaceFilter from './NamespaceFilter';
 import WorkspaceSwitcher from './WorkspaceSwitcher';
@@ -26,7 +27,9 @@ export default {
   },
 
   data() {
-    return { show: false };
+    const searchShortcut = isMac ? '(\u2318-K)' : '(Ctrl+K)';
+
+    return { show: false, searchShortcut };
   },
 
   computed: {
@@ -161,7 +164,7 @@ export default {
 
       <button
         v-if="showSearch"
-        v-tooltip="t('nav.resourceSearch.label')"
+        v-tooltip="t('nav.resourceSearch.toolTip', {key: searchShortcut})"
         v-shortkey="{windows: ['ctrl', 'k'], mac: ['meta', 'k']}"
         type="button"
         class="btn header-btn role-tertiary"

--- a/config/product/apps.js
+++ b/config/product/apps.js
@@ -25,7 +25,7 @@ export function init(store) {
 
   product({
     removable:   false,
-    weight:      2,
+    weight:      97,
     ifHaveGroup: 'catalog.cattle.io',
     icon:        'marketplace',
   });

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -79,9 +79,9 @@ export function init(store) {
 
   weightGroup('cluster', 99, true);
   weightGroup('workload', 98, true);
-  weightGroup('serviceDiscovery', 97, true);
-  weightGroup('storage', 96, true);
-  weightGroup('rbac', 95, true);
+  weightGroup('serviceDiscovery', 96, true);
+  weightGroup('storage', 95, true);
+  weightGroup('rbac', 94, true);
   weightType(POD, -1, true);
 
   for (const key in WORKLOAD_TYPES) {

--- a/config/product/gatekeeper.js
+++ b/config/product/gatekeeper.js
@@ -80,7 +80,8 @@ export function init(store) {
     name:       'gatekeeper-overview',
     route:      { name: 'c-cluster-gatekeeper' },
     exact:      true,
-    weight:     3
+    weight:     3,
+    overview:   true,
   });
 
   headers(GATEKEEPER.CONSTRAINT_TEMPLATE, [

--- a/config/product/istio.js
+++ b/config/product/istio.js
@@ -26,6 +26,7 @@ export function init(store) {
     weight:      100,
     route:       { name: 'c-cluster-istio' },
     exact:       true,
+    overview:    true,
   });
 
   basicType('istio-overview');

--- a/config/product/logging.js
+++ b/config/product/logging.js
@@ -19,6 +19,7 @@ export function init(store) {
   product({
     ifHaveGroup: /^(.*\.)?logging\.banzaicloud\.io$/,
     icon:        'logging',
+    weight:      89,
   });
 
   basicType([
@@ -36,6 +37,7 @@ export function init(store) {
     name:       'logging-overview',
     route:      { name: 'c-cluster-logging' },
     exact:       true,
+    overview:    true,
   });
 
   spoofedType({

--- a/config/product/longhorn.js
+++ b/config/product/longhorn.js
@@ -30,7 +30,8 @@ export function init(store) {
     name:       'longhorn-overview',
     weight:     105,
     route:      { name: 'c-cluster-longhorn' },
-    exact:      true
+    exact:      true,
+    overview:   true,
   });
 
   basicType('longhorn-overview');

--- a/config/product/monitoring.js
+++ b/config/product/monitoring.js
@@ -33,7 +33,8 @@ export function init(store) {
 
   product({
     ifHaveType: PODMONITOR, // possible RBAC issue here if mon turned on but user doesn't have view/read roles on pod monitors
-    icon:       'monitoring'
+    icon:       'monitoring',
+    weight:     90,
   });
 
   virtualType({

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,6 +15,7 @@ import { NAME as EXPLORER } from '@/config/product/explorer';
 import isEqual from 'lodash/isEqual';
 import { ucFirst } from '@/utils/string';
 import { getVersionInfo } from '@/utils/version';
+import { sortBy } from '@/utils/sort';
 
 export default {
 
@@ -213,10 +214,7 @@ export default {
         }
       }
 
-      out.sort((a, b) => {
-        return b.weight - a.weight;
-      });
-      replaceWith(this.groups, ...out);
+      replaceWith(this.groups, ...sortBy(out, ['weight:desc', 'label']));
     },
 
     expanded(name) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -168,6 +168,9 @@ export default {
       const namespaceMode = this.$store.getters['namespaceMode'];
       const out = [];
       const loadProducts = this.isExplorer ? [EXPLORER] : [];
+      const productMap = this.activeProducts.reduce((acc, p) => {
+        return {...acc, [p.name]: p};
+      }, {});
 
       if ( this.isExplorer ) {
         for ( const product of this.activeProducts ) {
@@ -202,6 +205,7 @@ export default {
               name:     productId,
               label:    this.$store.getters['i18n/withFallback'](`product.${ productId }`, null, ucFirst(productId)),
               children: [...(root?.children || []), ...other],
+              weight:   productMap[productId]?.weight || 0,
             };
 
             addObject(out, group);
@@ -209,6 +213,7 @@ export default {
         }
       }
 
+      out.sort((a, b) => { return b.weight - a.weight; });
       replaceWith(this.groups, ...out);
     },
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -169,7 +169,7 @@ export default {
       const out = [];
       const loadProducts = this.isExplorer ? [EXPLORER] : [];
       const productMap = this.activeProducts.reduce((acc, p) => {
-        return {...acc, [p.name]: p};
+        return { ...acc, [p.name]: p };
       }, {});
 
       if ( this.isExplorer ) {
@@ -213,7 +213,9 @@ export default {
         }
       }
 
-      out.sort((a, b) => { return b.weight - a.weight; });
+      out.sort((a, b) => {
+        return b.weight - a.weight;
+      });
       replaceWith(this.groups, ...out);
     },
 


### PR DESCRIPTION
#2847 

This PR makes a number of improvements to the side navigation:

- Ensures the weight of products is used to sort the side items in explorer
- Updates the weights, so Apps & Marketplace is under Workloads
- Adds weights top Monitoring and Logging to move them up
- Fixes issues with Longhorn - where an item with only a single overview child still shows the expander icon
- Converts first-child Overview pages to overviews that are accessed from the top-level nav item for the appropriate products
- Updates the tooltip for the Resource Search icon to include the keyboard shortcut