### PR TITLE
Disable prism theme brought in via Nuxt Content

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -101,6 +101,8 @@ module.exports = {
     // debug:   true
   },
 
+  content: { markdown: { prism: { theme: false } } },
+
   router: {
     base:       routerBasePath,
     middleware: ['i18n'],


### PR DESCRIPTION
- prism theme borks our code block styles
- see https://content.nuxtjs.org/configuration/#markdownprismtheme
- the docs pages look fine without, but we may need to investigate when those use cases grow
- addresses #2867