### PR TITLE
Add Helm Chart Install Stepper

### DIFF
--- a/assets/styles/global/_button.scss
+++ b/assets/styles/global/_button.scss
@@ -67,6 +67,11 @@ button,
     background-color: var(--primary-hover-bg);
     color: var(--primary-text);
   }
+
+  &:focus {
+    background-color: var(--primary-hover-bg);
+    color: var(--primary-text);
+  }
 }
 
 .role-secondary {

--- a/assets/styles/global/_button.scss
+++ b/assets/styles/global/_button.scss
@@ -147,4 +147,9 @@ fieldset[disabled] .btn {
       border-bottom-right-radius: var(--border-radius);
     }
   }
+
+  .btn[disabled] {
+    // Ensure disabled button's border remains as-is, otherwise button appears vertically shorter than others in group
+    border: inherit;
+  }
 }

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -647,17 +647,25 @@ catalog:
       basics:
         label: Metadata
         subtext: Set App metadata
-        description: This process will help you {action} your chosen chart.
+        description: This process will help {action, select,
+            install { create }
+            upgrade { upgrade }
+            update { update }
+          } the {existing, select,
+            true { app }
+            false { chart }
+          }. Start by setting some basic information used by {vendor} to manage the App.
       helmValues:
         label: Values
-        subtext: Change how the App runs
+        subtext: Change how the App works
+        description: Configure Values used by Helm to define the App.
         chartInfo:
           button: View Chart Info
           label: Chart Info
       helmCli:
         label: Command
-        subtext: Change how the Helm command runs
-        description: "{appName} will {action} your chart using a CLI tool. Here's the settings you can apply for its command."
+        subtext: Change how the Values are applied
+        description: Configure Options used by {vendor} to {action} the App.
     version: Version
     versions:
       current: '{ver} (Current)'

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -477,6 +477,10 @@ asyncButton:
     action: Remove
     success: Removed
     waiting: Removing&hellip;
+  update:
+    action: Update
+    success: Updated
+    waiting: Updating&hellip;
   upgrade:
     action: Upgrade
     success: Upgrading
@@ -566,6 +570,22 @@ catalog:
       readme: Chart README
       resources: Resources
       values: Values YAML
+  chart:
+    header:
+      charts: Charts
+    info:
+      appVersion: Application Version
+      chartVersions:
+        label: Chart Versions
+        showMore: Show More
+        showLess: Show Less
+      home: Home
+      maintainers: Maintainers
+      related: Related
+      chartUrls: Chart
+      keywords: Keywords
+    errors:
+      clusterToolExists: The application for this Cluster Tool already exists. To edit or update go to the <a href="{url}">App</a>
   charts:
     all: All
     categories:
@@ -581,11 +601,12 @@ catalog:
   install:
     action:
       goToUpgrade: Edit/Upgrade
-      ignoreWarning: Continue Anyways
-    appReadmeGeneric: "This chart doesn't have a {vendor}-specific README.  Review the Helm README to learn more about the available configuration options and their usage."
+      ignoreWarning: Ignore Warning/s
+    appReadmeMissing: This chart doesn't have any additional chart information.
+    appReadmeTitle: Chart Information (Helm README)
     chart: Chart
     error:
-      requiresFound: '<a href="{url}">${name}</a> must be installed before you can install this chart.'
+      requiresFound: '<a href="{url}">{name}</a> must be installed before you can install this chart.'
       requiresMissing: 'This chart requires another chart that provides {name}, but none was was found.'
       insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
       insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
@@ -620,14 +641,26 @@ catalog:
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:
-      appReadme: README
       chartOptions: Chart Options
-      helm: Helm Deploy Options
-      readme: Helm README
       valuesYaml: Values YAML
+    steps:
+      basics:
+        label: Metadata
+        subtext: Set App metadata
+        description: This process will help you {action} your chosen chart.
+      helmValues:
+        label: Values
+        subtext: Change how the App runs
+        chartInfo:
+          button: View Chart Info
+          label: Chart Info
+      helmCli:
+        label: Command
+        subtext: Change how the Helm command runs
+        description: Rancher will {action} your chart using a CLI tool. Here's the settings you can apply for it's command.
     version: Version
     versions:
-      current: '{ver} (current)'
+      current: '{ver} (Current)'
       linux: '{ver} (Linux-only)'
       windows: '{ver} (Windows-only)'
   operation:
@@ -2563,7 +2596,10 @@ resourceYaml:
     namespaceRequired: This resource is namespaced, so a namespace must be provided.
   buttons:
     continue: Continue Editing
+    edit: Edit YAML
     diff: Show Diff
+    unified: Unified
+    split: Split
 
 rioConfig:
   configure:
@@ -3366,7 +3402,7 @@ wizard:
   back: Back
   finish: Finish
   next: Next
-  step: "Step {number}:"
+  step: "Step {number}"
 
 wm:
   connection:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -601,7 +601,6 @@ catalog:
   install:
     action:
       goToUpgrade: Edit/Upgrade
-      ignoreWarning: Ignore {count, plural, =1 { warning } other { warnings }}
     appReadmeMissing: This chart doesn't have any additional chart information.
     appReadmeTitle: Chart Information (Helm README)
     chart: Chart

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -585,7 +585,7 @@ catalog:
       chartUrls: Chart
       keywords: Keywords
     errors:
-      clusterToolExists: The application for this Cluster Tool already exists. To edit or update go to the <a href="{url}">App</a>
+      clusterToolExists: This chart has a fixed namespace and name. A matching <a href="{url}">application</a> has been found and any changes will be made to it. 
   charts:
     all: All
     categories:
@@ -601,7 +601,7 @@ catalog:
   install:
     action:
       goToUpgrade: Edit/Upgrade
-      ignoreWarning: Ignore Warning/s
+      ignoreWarning: Ignore {count, plural, =1 { warning } other { warnings }}
     appReadmeMissing: This chart doesn't have any additional chart information.
     appReadmeTitle: Chart Information (Helm README)
     chart: Chart
@@ -657,7 +657,7 @@ catalog:
       helmCli:
         label: Command
         subtext: Change how the Helm command runs
-        description: Rancher will {action} your chart using a CLI tool. Here's the settings you can apply for it's command.
+        description: "{appName} will {action} your chart using a CLI tool. Here's the settings you can apply for its command."
     version: Version
     versions:
       current: '{ver} (Current)'
@@ -3399,7 +3399,7 @@ validation:
       interval: '"{key}" must be of a format with digits followed by a unit i.e. 1h, 2m, 30s'
 
 wizard:
-  back: Back
+  previous: Previous
   finish: Finish
   next: Next
   step: "Step {number}"

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -641,8 +641,9 @@ catalog:
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:
-      chartOptions: Chart Options
-      valuesYaml: Values YAML
+      chartOptions: Edit Options
+      valuesYaml: Edit YAML
+      diff: Compare Changes
     steps:
       basics:
         label: Metadata

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -663,6 +663,7 @@ catalog:
           button: View Chart Info
           label: Chart Info
       helmCli:
+        checkbox: Supply additional settings used by {vendor} to {action} the App.
         label: Command
         subtext: Change how the Values are applied
         description: Configure Options used by {vendor} to {action} the App.

--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -158,22 +158,24 @@ export default {
 
   created() {
     if (this.mode === 'create') {
+      // merge here doesn't work (existing values are lost when going from form to yaml and back again) so instead supply some better default values
+      // any changes here need to respect the order of properties (reflected in the yaml diff)
       const extendedDefaults = {
         global: {
           rbac: {
             userRoles: {
-              create:                  true,
-              aggregateToDefaultRoles: true,
+              create:                  this.mergeValue(this.value?.global?.rbac?.userRoles?.create, true),
+              aggregateToDefaultRoles:  this.mergeValue(this.value?.global?.rbac?.userRoles?.aggregateToDefaultRoles, true),
             },
           },
         },
         prometheus: {
           prometheusSpec: {
-            scrapeInterval:     '1m',
-            evaluationInterval: '1m',
-            retention:          '10d',
-            retentionSize:      '50GiB',
-            enableAdminAPI:     false,
+            scrapeInterval:     this.mergeValue(this.value?.prometheus?.prometheusSpec?.scrapeInterval, '1m'),
+            evaluationInterval: this.mergeValue(this.value?.prometheus?.prometheusSpec?.evaluationInterval, '1m'),
+            retention:          this.mergeValue(this.value?.prometheus?.prometheusSpec?.retention, '10d'),
+            retentionSize:      this.mergeValue(this.value?.prometheus?.prometheusSpec?.retentionSize, '50GiB'),
+            enableAdminAPI:     this.mergeValue(this.value?.prometheus?.prometheusSpec?.enableAdminAPI, false),
           },
         },
       };
@@ -208,6 +210,10 @@ export default {
           .volumeClaimTemplate.spec.selector;
       }
     },
+
+    mergeValue(value, defaultValue) {
+      return value === undefined || (typeof value === 'string' && !value.length) ? defaultValue : value;
+    }
   },
 };
 </script>

--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -213,7 +213,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
+  <Loading v-if="$fetchState.pending" mode="relative" />
   <div v-else class="config-monitoring-container">
     <Tab name="general" :label="t('monitoring.tabs.general')" :weight="99">
       <div>

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -48,6 +48,9 @@ export default {
     }
 
     .closer {
+      display: flex;
+      align-items: center;
+
       cursor: pointer;
       position: absolute;
       top: 0;

--- a/components/ButtonGroup.vue
+++ b/components/ButtonGroup.vue
@@ -75,7 +75,7 @@ export default {
       v-tooltip="opt.tooltipKey ? t(opt.tooltipKey) : opt.tooltip"
       type="button"
       :class="opt.class"
-      :disabled="disabled"
+      :disabled="disabled || opt.disabled"
       @click="change(opt.value)"
     >
       <slot name="option" :label="opt.label" :value="opt.value">

--- a/components/ButtonGroup.vue
+++ b/components/ButtonGroup.vue
@@ -24,7 +24,13 @@ export default {
     iconSize: {
       type:    String,
       default: null,
+    },
+
+    disabled: {
+      type:     Boolean,
+      default: false,
     }
+
   },
 
   computed: {
@@ -69,6 +75,7 @@ export default {
       v-tooltip="opt.tooltipKey ? t(opt.tooltipKey) : opt.tooltip"
       type="button"
       :class="opt.class"
+      :disabled="disabled"
       @click="change(opt.value)"
     >
       <slot name="option" :label="opt.label" :value="opt.value">

--- a/components/ChartReadme.vue
+++ b/components/ChartReadme.vue
@@ -1,0 +1,78 @@
+<script>
+import Markdown from '@/components/Markdown';
+
+export default {
+  components: { Markdown },
+  props:      {
+    versionInfo: {
+      type:     Object,
+      required: true
+    },
+  },
+  data() {
+    return {
+      appReadmeLoaded: false,
+      readmeLoaded:    false,
+    };
+  },
+  computed: {
+    appReadme() {
+      return this.versionInfo?.appReadme || '';
+    },
+    readme() {
+      return this.versionInfo?.readme || '';
+    }
+  },
+};
+</script>
+
+<template>
+  <div class="wrapper">
+    <div class="chart-readmes">
+      <Markdown v-if="appReadme" v-model="appReadme" class="md md-desc mb-20" @loaded="appReadmeLoaded = true" />
+      <h1 v-if="appReadme && readme && appReadmeLoaded && readmeLoaded" class="pt-10">
+        {{ t('catalog.install.appReadmeTitle') }}
+      </h1>
+      <Markdown v-if="readme" v-model="readme" class="md md-desc" @loaded="readmeLoaded = true" />
+    </div>
+    <div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .chart-readmes {
+    & > h1 {
+       border-top: var(--header-border-size) solid var(--header-border);
+    }
+  }
+  .md {
+    overflow: auto;
+    max-width: 100%;
+
+    ::v-deep {
+      * + H1,
+      * + H2,
+      * + H3,
+      * + H4,
+      * + H5,
+      * + H6 {
+        margin-top: 20px;
+      }
+    }
+
+    ::v-deep code {
+      padding: 0;
+    }
+
+    ::v-deep pre {
+      white-space: break-spaces;
+      word-break: break-word;
+    }
+
+    ::v-deep  > h1:first-of-type {
+      display: none;
+    }
+  }
+
+</style>

--- a/components/ChartReadme.vue
+++ b/components/ChartReadme.vue
@@ -63,6 +63,8 @@ export default {
 
     ::v-deep code {
       padding: 0;
+      white-space: break-spaces;
+      word-break: break-word;
     }
 
     ::v-deep pre {

--- a/components/CruResourceFooter.vue
+++ b/components/CruResourceFooter.vue
@@ -2,10 +2,11 @@
 import { mapGetters } from 'vuex';
 
 import AsyncButton from '@/components/AsyncButton';
+import ResourceCancelModal from '@/components/ResourceCancelModal';
 import { _VIEW } from '@/config/query-params';
 
 export default {
-  components: { AsyncButton },
+  components: { AsyncButton, ResourceCancelModal },
   props:      {
     mode: {
       type:    String,
@@ -58,13 +59,10 @@ export default {
       } else {
         this.isCancelModal = false;
       }
-
-      this.$modal.show('cancel-modal');
+      this.$refs.cancelModal.show();
     },
 
     confirmCancel(isCancel) {
-      this.$modal.hide('cancel-modal');
-
       this.$emit('cancel-confirmed', isCancel);
     },
   },
@@ -91,36 +89,7 @@ export default {
         @click="$emit('finish', $event)"
       />
     </slot>
-
-    <modal class="confirm-modal" name="cancel-modal" :width="440" height="auto">
-      <div class="header">
-        <h4 class="text-default-text">
-          <t v-if="isCancelModal" k="generic.cancel" />
-          <span v-else>{{ t("cruResource.backToForm") }}</span>
-        </h4>
-      </div>
-      <div class="body">
-        <p v-if="isCancelModal">
-          <t k="cruResource.cancelBody" />
-        </p>
-        <p v-else>
-          <t k="cruResource.backBody" />
-        </p>
-      </div>
-      <div class="footer">
-        <button
-          type="button"
-          class="btn role-secondary"
-          @click="$modal.hide('cancel-modal')"
-        >
-          {{ isForm ? t("cruResource.reviewForm") : t("cruResource.reviewYaml") }}
-        </button>
-        <button type="button" class="btn role-primary" @click="confirmCancel(isCancelModal)">
-          <span v-if="isCancelModal">{{ t("cruResource.confirmCancel") }}</span>
-          <span v-else>{{ t("cruResource.confirmBack") }}</span>
-        </button>
-      </div>
-    </modal>
+    <ResourceCancelModal ref="cancelModal" :is-cancel-modal="isCancelModal" :is-form="isForm" @confirm-cancel="confirmCancel($event)"></ResourceCancelModal>
   </div>
 </template>
 
@@ -134,39 +103,5 @@ export default {
     margin-left: 20px;
   }
 }
-.confirm-modal {
-  .btn {
-    margin: 0 10px;
-  }
 
-  .v--modal-box {
-    background-color: var(--default);
-    box-shadow: none;
-    min-height: 200px;
-    .body {
-      min-height: 75px;
-      padding: 10px 0 0 15px;
-      p {
-        margin-top: 10px;
-      }
-    }
-    .header {
-      background-color: var(--error);
-      padding: 15px 0 0 15px;
-
-      h4 {
-        color: white;
-      }
-    }
-    .header,
-    .footer {
-      height: 50px;
-    }
-    .footer {
-      border-top: 1px solid var(--border);
-      text-align: center;
-      padding: 10px 0 0 15px;
-    }
-  }
-}
 </style>

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -8,7 +8,7 @@ export default {
     // How to size and position the loading indicator - supports three modes:
     // 'content' - the content area only (not side nav or header)
     // 'main' - entire main view excluding the header, but including the side nav
-    // 'full' - entire view including the header and the side nav
+    // 'relative' - content up to the nearest relatively positioned element
     mode: {
       type:    String,
       default: 'content',

--- a/components/Markdown.vue
+++ b/components/Markdown.vue
@@ -64,6 +64,7 @@ export default {
     this.markedRenderer = renderer;
     this.dompurify = dompurify;
     this.loaded = true;
+    this.$emit('loaded', true);
   }
 };
 </script>

--- a/components/ResourceCancelModal.vue
+++ b/components/ResourceCancelModal.vue
@@ -1,0 +1,108 @@
+<script>
+export default {
+  props:      {
+    isCancelModal: {
+      type:     Boolean,
+      default: false
+    },
+    isForm: {
+      type:     Boolean,
+      default: false
+    },
+  },
+
+  watch: {},
+
+  methods: {
+    show() {
+      this.$modal.show('cancel-modal');
+    },
+
+    /**
+     * Close the modal, no op
+     */
+    cancelCancel() {
+      this.$modal.hide('cancel-modal');
+
+      this.$emit('cancel-cancel');
+    },
+
+    /**
+     * Close the modal, cancel has been confirmed
+     */
+    confirmCancel() {
+      this.$modal.hide('cancel-modal');
+
+      this.$emit('confirm-cancel', this.isCancelModal);
+    },
+  }
+};
+</script>
+
+<template>
+  <modal class="confirm-modal" name="cancel-modal" :width="440" height="auto">
+    <div class="header">
+      <h4 class="text-default-text">
+        <t v-if="isCancelModal" k="generic.cancel" />
+        <span v-else>{{ t("cruResource.backToForm") }}</span>
+      </h4>
+    </div>
+    <div class="body">
+      <p v-if="isCancelModal">
+        <t k="cruResource.cancelBody" />
+      </p>
+      <p v-else>
+        <t k="cruResource.backBody" />
+      </p>
+    </div>
+    <div class="footer">
+      <button
+        type="button"
+        class="btn role-secondary"
+        @click="cancelCancel"
+      >
+        {{ isForm ? t("cruResource.reviewForm") : t("cruResource.reviewYaml") }}
+      </button>
+      <button type="button" class="btn role-primary" @click="confirmCancel">
+        <span v-if="isCancelModal">{{ t("cruResource.confirmCancel") }}</span>
+        <span v-else>{{ t("cruResource.confirmBack") }}</span>
+      </button>
+    </div>
+  </modal>
+</template>
+
+<style lang='scss' scoped>
+ .confirm-modal {
+  .btn {
+    margin: 0 10px;
+  }
+
+  .v--modal-box {
+    background-color: var(--default);
+    box-shadow: none;
+    min-height: 200px;
+    .body {
+      min-height: 75px;
+      padding: 10px 0 0 15px;
+      p {
+        margin-top: 10px;
+      }
+    }
+    .header {
+      background-color: var(--error);
+      padding: 15px 0 0 15px;
+      height: 50px;
+
+      h4 {
+        color: white;
+      }
+    }
+    .footer {
+      border-top: 1px solid var(--border);
+      text-align: center;
+      padding: 10px 0 0 15px;
+      height: 60px;
+    }
+  }
+}
+</style>

--- a/components/SimpleBox.vue
+++ b/components/SimpleBox.vue
@@ -59,7 +59,7 @@ export default {
     opacity: 0.5;
   }
   &:hover {
-    background-color: #eee;
+    background-color: var(--wm-closer-hover-bg);
   }
 }
 </style>

--- a/components/Wizard.vue
+++ b/components/Wizard.vue
@@ -193,7 +193,8 @@ export default {
             <!-- Logo -->
             <slot name="bannerTitleImage">
               <div v-if="bannerImage" class="round-image">
-                <img :src="bannerImage" />
+                <LazyImage :src="bannerImage" class="logo" />
+                <!-- <img :src="bannerImage" /> -->
               </div>
             </slot>
             <!-- Title with subtext -->
@@ -270,7 +271,7 @@ export default {
         <div class="controls-steps">
           <slot v-if="activeStepIndex!==0" name="back" :back="back">
             <button :disabled="!editFirstStep && activeStepIndex===1" type="button" class="btn role-secondary" @click="back()">
-              <t k="wizard.back" />
+              <t k="wizard.previous" />
             </button>
           </slot>
           <slot v-if="activeStepIndex === steps.length-1" name="finish" :finish="finish">
@@ -430,7 +431,7 @@ $spacer: 10px;
       margin: 10px 10px 10px 0;
       border-radius: 50%;
       overflow: hidden;
-      img {
+      .logo {
         min-width: 50px;
         height: 50px;
       }

--- a/components/Wizard.vue
+++ b/components/Wizard.vue
@@ -1,5 +1,5 @@
 <script>
-import { STEP } from '@/config/query-params';
+
 import AsyncButton from '@/components/AsyncButton';
 import Banner from '@/components/Banner';
 import { stringify } from '@/utils/error';
@@ -24,11 +24,6 @@ export default {
   },
 
   props:      {
-    mode: {
-      type:    String,
-      default: 'create'
-    },
-
     /*
   steps need: {
     name: String - this will be the slot name
@@ -39,11 +34,11 @@ export default {
   }
   */
     steps: {
-      type:    Array,
-      default: () => []
+      type:     Array,
+      required: true
     },
 
-    // Initial step to show when Wizard loads. This is overruled by the 'step' query param, if available
+    // Initial step to show when Wizard loads.
     initStepIndex: {
       type:    Number,
       default: 0
@@ -79,6 +74,11 @@ export default {
       default: null
     },
 
+    bannerTitleSubtext: {
+      type:    String,
+      default: null
+    },
+
     // The set of labels to display for the finish AsyncButton
     finishMode: {
       type:    String,
@@ -91,12 +91,9 @@ export default {
       default: null,
     }
   },
+
   data() {
-    const queryStep = this.$route.query[STEP];
-
-    const activeStep = queryStep ? this.steps[queryStep - 1] : this.steps[this.initStepIndex];
-
-    return { activeStep };
+    return { activeStep: this.steps[this.initStepIndex] };
   },
 
   computed: {
@@ -121,14 +118,6 @@ export default {
     }
   },
 
-  watch: {
-    '$route.query'(neu = {}, old) {
-      if (neu.step !== old.step) {
-        this.goToStep(neu[STEP]);
-      }
-    },
-  },
-
   created() {
     this.goToStep(this.activeStepIndex + 1);
   },
@@ -144,26 +133,10 @@ export default {
         return;
       }
 
-      const {
-        steps,
-        $route: { query:{ step: queryStep } },
-      } = this;
-
-      const selected = steps[number - 1];
+      const selected = this.steps[number - 1];
 
       if ( !selected || (!this.isAvailable(selected) && number !== 1)) {
         return;
-      }
-
-      if (queryStep !== number) {
-        this.$router.replace({ query: { ...this.$route.query, [STEP]: number } }).catch((e) => {
-          if (e?.name === 'NavigationDuplicated') {
-            // ignore this
-          } else if (e.message.includes('with a new navigation')) {
-            // route changed by tabs; retry
-            this.$router.applyQuery({ ...this.$route.query, [STEP]: number });
-          }
-        });
       }
 
       this.activeStep = selected;
@@ -172,7 +145,6 @@ export default {
     },
 
     cancel() {
-      this.$router.applyQuery({ [STEP]: 1 });
       this.$emit('cancel');
     },
 
@@ -213,232 +185,291 @@ export default {
 </script>
 
 <template>
-  <div>
-    <ul
-      v-if="showSteps"
-      class="steps"
-      tabindex="0"
-      @keyup.right.stop="selectNext(1)"
-      @keyup.left.stop="selectNext(-1)"
-    >
-      <template v-for="(step, idx ) in steps">
-        <li
-
-          :id="step.name"
-          :key="step.name+'li'"
-          :class="{step: true, active: step === activeStep, disabled: !isAvailable(step)}"
-          role="presentation"
-        >
-          <span
-            :aria-controls="'step' + idx+1"
-            :aria-selected="step === activeStep"
-            role="tab"
-            class="controls"
-            @click.prevent="goToStep(idx+1, true)"
-          >
-            <span class="icon icon-lg" :class="{'icon-dot': step !== activeStep, 'icon-dot-open':step === activeStep}" />
-            <span>
-              {{ step.label }}
-            </span>
-          </span>
-        </li>
-        <div v-if="idx!==steps.length-1" :key="step.name" class="divider" />
-      </template>
-    </ul>
-
-    <div v-if="showSteps" class="spacer" />
-
-    <div v-if="showBanner" class="top choice-banner">
-      <div v-show="initialTitle || activeStepIndex > 0" class="title">
-        <div class="round-image">
-          <slot name="bannerTitleImage">
-            <img :src="bannerImage" />
-          </slot>
+  <div class="container">
+    <div class="header">
+      <div class="title">
+        <div v-if="showBanner" class="top choice-banner">
+          <div v-show="initialTitle || activeStepIndex > 0" class="title">
+            <!-- Logo -->
+            <slot name="bannerTitleImage">
+              <div v-if="bannerImage" class="round-image">
+                <img :src="bannerImage" />
+              </div>
+            </slot>
+            <!-- Title with subtext -->
+            <div class="subtitle">
+              <h2 v-if="bannerTitle">
+                {{ bannerTitle }}
+              </h2>
+              <span v-if="bannerTitleSubtext" class="subtext">{{ bannerTitleSubtext }}</span>
+            </div>
+          </div>
+          <!-- Step number with subtext -->
+          <div class="subtitle">
+            <h2>{{ t(`asyncButton.${finishMode}.action`) }}: {{ t('wizard.step', {number:activeStepIndex+1}) }}</h2>
+            <slot name="bannerSubtext">
+              <span class="subtext">{{ activeStep.subtext || activeStep.label }}</span>
+            </slot>
+          </div>
         </div>
-        <h2 v-if="bannerTitle">
-          {{ bannerTitle }}
-        </h2>
       </div>
-      <div class="subtitle">
-        <h2> {{ t('wizard.step', {number:activeStepIndex+1}) }}</h2>
-        <slot name="bannerSubtext">
-          <span class="subtext">{{ activeStep.subtext || activeStep.label }}</span>
-        </slot>
+      <div class="step-sequence">
+        <ul
+          v-if="showSteps"
+          class="steps"
+          tabindex="0"
+          @keyup.right.stop="selectNext(1)"
+          @keyup.left.stop="selectNext(-1)"
+        >
+          <template v-for="(step, idx ) in steps">
+            <li
+
+              :id="step.name"
+              :key="step.name+'li'"
+              :class="{step: true, active: step === activeStep, disabled: !isAvailable(step)}"
+              role="presentation"
+            >
+              <span
+                :aria-controls="'step' + idx+1"
+                :aria-selected="step === activeStep"
+                role="tab"
+                class="controls"
+                @click.prevent="goToStep(idx+1, true)"
+              >
+                <span class="icon icon-lg" :class="{'icon-dot': step === activeStep, 'icon-dot-open':step !== activeStep}" />
+                <span>
+                  {{ step.label }}
+                </span>
+              </span>
+            </li>
+            <div v-if="idx!==steps.length-1" :key="step.name" class="divider" />
+          </template>
+        </ul>
       </div>
     </div>
-
-    <div v-if="showBanner" class="spacer" />
 
     <div class="step-container">
-      <div v-for="step in steps" :key="step.name">
-        <template v-if="step === activeStep">
+      <template v-for="step in steps">
+        <div v-if="step === activeStep" :key="step.name" class="step-container__step">
           <slot :step="step" :name="step.name" />
-        </template>
+        </div>
+      </template>
+    </div>
+
+    <div class="controls-container">
+      <div v-for="(err,idx) in errorStrings" :key="idx">
+        <Banner color="error" :label="err" :closable="true" @close="errors.splice(idx, 1)" />
       </div>
-    </div>
-
-    <div v-for="(err,idx) in errorStrings" :key="idx">
-      <Banner color="error" :label="err" />
-    </div>
-
-    <div class="spacer" />
-
-    <div class="controls-row">
-      <slot name="cancel" :cancel="cancel">
-        <button type="button" class="btn role-secondary" @click="cancel">
-          <t k="generic.cancel" />
-        </button>
-      </slot>
-
-      <div>
-        <slot v-if="activeStepIndex!==0" name="back" :back="back">
-          <button :disabled="!editFirstStep && activeStepIndex===1" type="button" class="btn role-secondary" @click="back()">
-            <t k="wizard.back" />
+      <div class="controls-row pt-20">
+        <slot name="cancel" :cancel="cancel">
+          <button type="button" class="btn role-secondary" @click="cancel">
+            <t k="generic.cancel" />
           </button>
         </slot>
-        <slot v-if="activeStepIndex === steps.length-1" name="finish" :finish="finish">
-          <AsyncButton
-            :disabled="!activeStep.ready"
-            :mode="finishMode"
-            @click="finish"
-          />
-        </slot>
-        <slot v-else name="next" :next="next">
-          <button :disabled="!canNext" type="button" class="btn role-primary" @click="next()">
-            <t k="wizard.next" />
-          </button>
-        </slot>
+
+        <div class="controls-steps">
+          <slot v-if="activeStepIndex!==0" name="back" :back="back">
+            <button :disabled="!editFirstStep && activeStepIndex===1" type="button" class="btn role-secondary" @click="back()">
+              <t k="wizard.back" />
+            </button>
+          </slot>
+          <slot v-if="activeStepIndex === steps.length-1" name="finish" :finish="finish">
+            <AsyncButton
+              :disabled="!activeStep.ready"
+              :mode="finishMode"
+              @click="finish"
+            />
+          </slot>
+          <slot v-else name="next" :next="next">
+            <button :disabled="!canNext" type="button" class="btn role-primary" @click="next()">
+              <t k="wizard.next" />
+            </button>
+          </slot>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
-<style lang='scss'>
+<style lang='scss' scoped>
+$spacer: 10px;
 
-.choice-banner {
-  padding: 10px;
-  margin: 10px;
-  min-height: 100px;
-  flex-basis: 40%;
-  border-radius: var(--border-radius);
-  border-left: 5px solid var(--primary);
+.container {
   display: flex;
-
-  &.selected{
-    background-color: var(--accent-btn);
-  }
-
-  &.top {
-    background-image: linear-gradient(-90deg, var(--body-bg) , var(--accent-btn));
-
-    H2 {
-      margin: 0px;
-    }
-
-    .title{
-      flex-basis: 10%;
-      border-right: 1px solid var(--primary);
-      margin-right: 20px;
-      padding-right: 20px;
-      display: flex;
-      align-items: center;
-      justify-content: space-evenly;
-    }
-
-    .subtitle{
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      & .subtext {
-        color: var(--input-label);
-      }
-    }
-
-  }
-
-  &:not(.top){
-    box-shadow: 0px 0px 12px 3px var(--box-bg);
-    flex-direction: row;
-    align-items: center;
-    justify-content: start;
-    &:hover{
-      outline: var(--outline-width) solid var(--outline);
-      cursor: pointer;
-    }
-  }
-
-  & .round-image {
-    min-width: 50px;
-    height: 50px;
-    margin: 10px;
-    border-radius: 50%;
-    overflow: hidden;
-  }
+  flex-direction: column;
+  flex: 1;
+  padding: 0;
 }
 
-.steps {
-    margin: 0 20% 0 20%;;
-    display:flex;
-    justify-content: space-between;
-    list-style-type:none;
-    padding: 0;
+.header {
+  display: flex;
+  align-content: space-between;
+  align-items: center;
 
-    &:focus{
-        outline:none;
-        box-shadow: none;
-    }
+  border-bottom: var(--header-border-size) solid var(--header-border);
 
-    & li.step{
-      display: flex;
-      flex-direction: row;
-      flex-grow: 1;
-      align-items: center;
+  & > .title {
+    flex: 1;
+    min-height: 75px;
+  }
+  .step-sequence {
+    flex:1;
 
-      &:last-of-type{
-        flex-grow: 0;
+    .steps {
+      margin: 0 30px;
+      display:flex;
+      justify-content: space-between;
+      list-style-type:none;
+      padding: 0;
+
+      &:focus{
+          outline:none;
+          box-shadow: none;
       }
 
-      & .controls {
+      & li.step{
+        display: flex;
+        flex-direction: row;
+        flex-grow: 1;
+        align-items: center;
+
+        &:last-of-type{
+          flex-grow: 0;
+        }
+
+        & .controls {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          width: 40px;
+          overflow: visible;
+          & > span {
+            padding-bottom: 10px;
+            white-space: nowrap;
+          }
+        }
+
+        &.active .controls{
+          color: var(--primary);
+        }
+
+        &:not(.disabled){
+          & .controls:hover>*{
+              color: var(--primary) !important;
+              cursor: pointer;
+          }
+        }
+
+        &:not(.active) {
+          & .controls>*{
+            color: var(--input-disabled-text);
+            text-decoration: none;
+          }
+        }
+      }
+
+      & .divider {
+        flex-basis: 100%;
+        border-top: 1px solid var(--border);
+        position: relative;
+        top: 5px;
+      }
+    }
+  }
+
+  .choice-banner {
+
+    flex-basis: 40%;
+    display: flex;
+    align-items: center;
+
+    &.selected{
+      background-color: var(--accent-btn);
+    }
+
+    &.top {
+
+      H2 {
+        margin: 0px;
+      }
+
+      .title{
+        display: flex;
+        align-items: center;
+        justify-content: space-evenly;
+
+        & > .subtitle {
+          margin: 0 20px;
+        }
+      }
+
+      .subtitle{
         display: flex;
         flex-direction: column;
-        align-items: center;
-        width: 40px;
-        overflow: visible;
-        & > span {
-          padding-bottom: 10px;
-          white-space: nowrap;
+        & .subtext {
+          color: var(--input-label);
         }
       }
 
-      &.active .controls{
-        color: var(--primary);
-      }
+    }
 
-      &:not(.disabled){
-        & .controls:hover>*{
-            color: var(--primary) !important;
-            cursor: pointer;
-        }
-      }
-
-      &:not(.active) {
-        & .controls>*{
-          color: var(--input-disabled-text);
-          text-decoration: none;
-        }
+    &:not(.top){
+      box-shadow: 0px 0px 12px 3px var(--box-bg);
+      flex-direction: row;
+      align-items: center;
+      justify-content: start;
+      &:hover{
+        outline: var(--outline-width) solid var(--outline);
+        cursor: pointer;
       }
     }
 
-    & .divider {
-      flex-basis: 100%;
-      border-top: 1px solid var(--border);
-      position: relative;
-      top: 5px;
+    & .round-image {
+      min-width: 50px;
+      height: 50px;
+      margin: 10px 10px 10px 0;
+      border-radius: 50%;
+      overflow: hidden;
+      img {
+        min-width: 50px;
+        height: 50px;
+      }
     }
+  }
 }
 
-.controls-row {
+.step-container {
+  position: relative; // Important for loading indicator in chart's with custom form components
+  flex: 1 1 auto;
+  height: 0;
+  overflow-y: auto;
+  padding: 20px $spacer 2px 2px; // Handle borders flush against edge
+
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+
+  &__step {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
 }
+
+.controls-container {
+  .controls-row {
+    display: flex;
+    justify-content: space-between;
+    padding-top: $spacer;
+
+    border-top: var(--header-border-size) solid var(--header-border);
+
+    .controls-steps {
+
+      .btn {
+        margin-left: $spacer;
+      }
+    }
+  }
+}
+
 </style>

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -39,6 +39,11 @@ export default {
       type:     String,
       default:  '',
     },
+
+    hidePreviewButtons: {
+      type:     Boolean,
+      default:  false,
+    }
   },
 
   data() {
@@ -152,6 +157,7 @@ export default {
     updateValue(value) {
       this.value = value;
     }
+
   }
 };
 </script>
@@ -159,7 +165,7 @@ export default {
 <template>
   <div class="yaml-editor">
     <div class="text-right">
-      <span v-if="isPreview" v-trim-whitespace class="btn-group btn-sm diff-mode">
+      <span v-if="isPreview && !hidePreviewButtons" v-trim-whitespace class="btn-group btn-sm diff-mode">
         <button
           type="button"
           class="btn btn-sm bg-default"

--- a/components/formatter/Date.vue
+++ b/components/formatter/Date.vue
@@ -23,7 +23,18 @@ export default {
     emptyTextKey: {
       type:    String,
       default: ''
-    }
+    },
+
+    showDate: {
+      type:    Boolean,
+      default: true,
+    },
+
+    showTime: {
+      type:    Boolean,
+      default: true,
+    },
+
   },
 
   computed: {
@@ -53,6 +64,11 @@ export default {
 
 <template>
   <component :is="tagName">
-    {{ date }}<br v-if="multiline" /><span v-else>&nbsp;</span>{{ time }}
+    <template v-if="showDate">
+      {{ date }}<br v-if="multiline" /><span v-else>&nbsp;</span>
+    </template>
+    <template v-if="showTime">
+      {{ time }}
+    </template>
   </component>
 </template>

--- a/components/nav/GlobalLoading.vue
+++ b/components/nav/GlobalLoading.vue
@@ -18,5 +18,5 @@ export default {
 
 </script>
 <template>
-  <Loading v-if="loading" mode="full" />
+  <Loading v-if="loading" mode="relative" />
 </template>

--- a/components/nav/WindowManager/ChartReadme.vue
+++ b/components/nav/WindowManager/ChartReadme.vue
@@ -1,5 +1,5 @@
 <script>
-import ChartReadme from '@/components/ChartReadme'; // TODO: RC location
+import ChartReadme from '@/components/ChartReadme';
 import Window from './Window';
 
 export default {

--- a/components/nav/WindowManager/ChartReadme.vue
+++ b/components/nav/WindowManager/ChartReadme.vue
@@ -1,0 +1,45 @@
+<script>
+import ChartReadme from '@/components/ChartReadme'; // TODO: RC location
+import Window from './Window';
+
+export default {
+  components: { Window, ChartReadme },
+
+  props:      {
+    // The definition of the tab itself
+    tab: {
+      type:     Object,
+      required: true,
+    },
+
+    // Is this tab currently displayed
+    active: {
+      type:     Boolean,
+      required: true,
+    },
+
+    versionInfo: {
+      type:     Object,
+      required: true,
+    }
+  },
+
+};
+</script>
+
+<template>
+  <Window :active="active">
+    <template #body>
+      <ChartReadme :version-info="versionInfo" class="chart-container" />
+    </template>
+  </Window>
+</template>
+
+<style lang="scss" scoped>
+  .chart-container {
+    height: 100%;
+    overflow: auto;
+    padding: 15px;
+  }
+
+</style>

--- a/components/nav/WindowManager/Window.vue
+++ b/components/nav/WindowManager/Window.vue
@@ -54,8 +54,8 @@ export default {
 </script>
 
 <template>
-  <div class="window">
-    <div class="title clearfix">
+  <div class="window" :class="{'show-grid': $slots.title && $slots.body}">
+    <div v-if="$slots.title" class="title clearfix">
       <slot name="title" />
     </div>
     <div class="body clearfix">
@@ -68,12 +68,15 @@ export default {
   $title-height: 50px;
 
   .window {
-    display: grid;
-    grid-template-areas:
-      "body"
-      "title";
-    grid-template-rows: auto $title-height;
     height: 100%;
+
+    &.show-grid {
+      display: grid;
+      grid-template-areas:
+        "body"
+        "title";
+      grid-template-rows: auto $title-height;
+    }
   }
 
   .title {

--- a/config/query-params.js
+++ b/config/query-params.js
@@ -63,7 +63,6 @@ export const DESCRIPTION = 'description';
 export const CATEGORY = 'category';
 export const DEPRECATED = 'deprecated';
 export const HIDDEN = 'hidden';
-export const FORCE = 'force';
 export const FROM_TOOLS = 'tools';
 
 // Cluster provisioning

--- a/models/chart.js
+++ b/models/chart.js
@@ -2,7 +2,6 @@ import { compatibleVersionsFor } from '@/store/catalog';
 import {
   REPO_TYPE, REPO, CHART, VERSION, FROM_TOOLS, _FLAGGED, _UNFLAG
 } from '@/config/query-params';
-import { NAME as APPS } from '@/config/product/apps';
 
 export default {
   goToInstall() {
@@ -25,11 +24,8 @@ export default {
 
       this.currentRouter().push({
         name:   'c-cluster-apps-install',
-        params: {
-          cluster:  currentCluster.id,
-          product:  APPS,
-        },
-        query: {
+        params: { cluster: currentCluster.id },
+        query:  {
           [REPO_TYPE]:  this.repoType,
           [REPO]:       this.repoName,
           [CHART]:      this.chartName,

--- a/pages/c/_cluster/apps/chart.vue
+++ b/pages/c/_cluster/apps/chart.vue
@@ -1,0 +1,264 @@
+<script>
+import Loading from '@/components/Loading';
+import ChartMixin from '@/pages/c/_cluster/apps/chart_mixin';
+import Banner from '@/components/Banner';
+import ChartReadme from '@/components/ChartReadme';
+import LazyImage from '@/components/LazyImage';
+import DateFormatter from '@/components/formatter/Date';
+import isEqual from 'lodash/isEqual';
+import { CHART, REPO, REPO_TYPE, VERSION } from '@/config/query-params';
+
+export default {
+  components: {
+    Banner,
+    ChartReadme,
+    DateFormatter,
+    LazyImage,
+    Loading,
+  },
+
+  mixins: [
+    ChartMixin
+  ],
+
+  async fetch() {
+    await this.baseFetch();
+  },
+
+  data() {
+    return {
+      showLastVersions:  10,
+      showMoreVersions:  false,
+    };
+  },
+
+  computed: {
+    versions() {
+      return this.showMoreVersions ? this.mappedVersions : this.mappedVersions.slice(0, this.showLastVersions);
+    },
+
+    clusterToolWarning() {
+      if (!this.existing) {
+        return;
+      }
+      const url = this.$router.resolve(this.appLocation()).href;
+
+      return this.isClusterTool ? this.t('catalog.chart.errors.clusterToolExists', { url }, true) : '';
+    },
+
+    maintainers() {
+      return this.version.maintainers.map((m) => {
+        return {
+          id:   m.name,
+          text: m.name,
+          url:  `mailto:${ m.email }`
+        };
+      });
+    },
+
+  },
+
+  watch: {
+    '$route.query'(neu, old) {
+      if ( !isEqual(neu, old) ) {
+        this.$fetch();
+      }
+    },
+  },
+
+  methods: {
+    install() {
+      this.$router.push({
+        name:   'c-cluster-apps-install',
+        params: {
+          cluster:  this.$route.params.cluster,
+          product:  this.$store.getters['productId'],
+        },
+        query: {
+          [REPO_TYPE]: this.query.repoType,
+          [REPO]:      this.query.repoName,
+          [CHART]:     this.query.chartName,
+          [VERSION]:   this.query.versionName,
+        }
+      });
+    },
+
+  },
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <div v-if="chart" class="chart-header">
+      <div class="name-logo-install">
+        <div class="name-logo">
+          <h1>
+            <nuxt-link :to="{ name: 'c-cluster-apps-charts' }">
+              {{ t('catalog.chart.header.charts') }}:
+            </nuxt-link>
+            {{ chart.chartDisplayName }} ({{ targetVersion }})
+          </h1>
+          <div v-if="chart.icon" class="logo-container">
+            <div class="logo-bg ml-10">
+              <LazyImage :src="chart.icon" class="logo" />
+            </div>
+          </div>
+        </div>
+        <button v-if="!requires.length && (!clusterToolWarning)" type="button" class="btn role-primary" @click.prevent="install">
+          {{ t(`asyncButton.${action}.action` ) }}
+        </button>
+      </div>
+      <div v-if="requires.length || warnings.length || clusterToolWarning" class="mt-20">
+        <Banner v-for="msg in requires" :key="msg" color="error">
+          <span v-html="msg" />
+        </Banner>
+
+        <Banner v-for="msg in warnings" :key="msg" color="warning">
+          <span v-html="msg" />
+        </Banner>
+
+        <Banner v-if="clusterToolWarning" color="warning">
+          <span v-html="clusterToolWarning" />
+        </Banner>
+      </div>
+      <div v-else-if="version && version.description" class="description mt-10">
+        <p>
+          {{ version.description }}
+        </p>
+      </div>
+    </div>
+
+    <div class="spacer"></div>
+
+    <div class="chart-content">
+      <ChartReadme v-if="hasReadme" :version-info="versionInfo" class="chart-content__tabs" />
+      <div v-else class="chart-content__tabs">
+        {{ t('catalog.install.appReadmeMissing', {}, true) }}
+      </div>
+      <div v-if="version" class="chart-content__right-bar ml-20">
+        <div class="chart-content__right-bar__section">
+          <h3>
+            {{ t('catalog.chart.info.chartVersions.label') }}
+          </h3>
+          <div v-for="vers of versions" :key="vers.id" class="chart-content__right-bar__section--cVersion">
+            <b v-if="vers.originalVersion === version.version">{{ vers.shortLabel }}</b>
+            <a v-else v-tooltip="vers.label.length > 16 ? vers.label : null" @click.prevent="selectVersion(vers)">
+              {{ vers.shortLabel }}
+            </a>
+            <DateFormatter :value="vers.created" :show-time="false" />
+          </div>
+          <div class="mt-10 chart-content__right-bar__section--showMore">
+            <button v-if="mappedVersions.length > showLastVersions" type="button" class="btn btn-sm role-link" @click="showMoreVersions = !showMoreVersions">
+              {{ t(`catalog.chart.info.chartVersions.${showMoreVersions ? 'showLess' : 'showMore'}`) }}
+            </button>
+          </div>
+        </div>
+        <div class="chart-content__right-bar__section">
+          <h3 t>
+            {{ t('catalog.chart.info.appVersion') }}
+          </h3>
+          {{ version.appVersion }}
+        </div>
+        <div v-if="version.home" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.home') }}</h3>
+          <a :href="version.home" rel="nofollow noopener noreferrer" target="_blank">{{ version.home }}</a>
+        </div>
+        <div v-if="version.maintainers" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.maintainers') }}</h3>
+          <a v-for="m of maintainers" :key="m.id" :href="m.url" rel="nofollow noopener noreferrer" target="_blank">{{ m.text }}</a>
+        </div>
+        <div v-if="version.sources" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.related') }}</h3>
+          <a v-for="s of version.sources" :key="s" :href="s" rel="nofollow noopener noreferrer" target="_blank">{{ s }}</a>
+        </div>
+        <div v-if="version.urls" class="chart-content__right-bar__section">
+          <h3>{{ t('catalog.chart.info.chartUrls') }}</h3>
+          <a v-for="url of version.urls" :key="url" :href="url" rel="nofollow noopener noreferrer" target="_blank">{{ version.urls.length === 1 ? 'Download': url }}</a>
+        </div>
+        <div v-if="version.keywords" class="chart-content__right-bar__section chart-content__right-bar__section--keywords">
+          <h3>{{ t('catalog.chart.info.keywords') }}</h3>
+          {{ version.keywords.join(', ') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  $name-height: 30px;
+  $padding: 5px;
+
+  .chart-header {
+
+    .name-logo-install {
+      display: flex;
+      height: $name-height;
+      justify-content: space-between;
+    }
+
+    .name-logo {
+      display: flex;
+    }
+
+    .logo-container {
+      height: $name-height;
+      width: $name-height;
+      text-align: center;
+    }
+
+    .logo-bg {
+      height: $name-height;
+      width: $name-height;
+      background-color: white;
+      border: $padding solid white;
+      border-radius: calc( 3 * var(--border-radius));
+      position: relative;
+    }
+
+    .logo {
+      max-height: $name-height - 2 * $padding;
+      max-width: $name-height - 2 * $padding;
+      position: absolute;
+      width: auto;
+      height: auto;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      margin: auto;
+    }
+
+    .description {
+      margin-right: 80px;
+    }
+  }
+
+  .chart-content {
+    display: flex;
+    &__tabs {
+      flex: 1;
+    }
+    &__right-bar {
+      max-width: 260px;
+      &__section {
+        display: flex;
+        flex-direction: column;
+        padding-bottom: 20px;
+        word-break: break-all;
+        a {
+          cursor: pointer;
+        }
+        &--cVersion{
+          display: flex;
+          justify-content: space-between;
+        }
+
+        &--keywords{
+         word-break: break-word;
+        }
+
+      }
+    }
+  }
+</style>

--- a/pages/c/_cluster/apps/chart_mixin.js
+++ b/pages/c/_cluster/apps/chart_mixin.js
@@ -1,0 +1,375 @@
+
+import { mapGetters } from 'vuex';
+
+import {
+  REPO_TYPE, REPO, CHART, VERSION, NAMESPACE, NAME, DESCRIPTION as DESCRIPTION_QUERY, DEPRECATED, HIDDEN, _FLAGGED, _CREATE, _EDIT
+} from '@/config/query-params';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@/config/labels-annotations';
+import { SHOW_PRE_RELEASE, mapPref } from '@/store/prefs';
+import { NAME as EXPLORER } from '@/config/product/explorer';
+
+import { formatSi, parseSi } from '@/utils/units';
+import { CATALOG } from '@/config/types';
+import { isPrerelease } from '@/utils/version';
+
+export default {
+  data() {
+    return {
+      version:     null,
+      versionInfo: null,
+      existing:    null,
+
+      ignoreWarning: false,
+
+      catalogOSAnnotation: CATALOG_ANNOTATIONS.SUPPORTED_OS,
+    };
+  },
+
+  computed: {
+    ...mapGetters(['currentCluster', 'isRancher']),
+
+    showPreRelease: mapPref(SHOW_PRE_RELEASE),
+
+    chart() {
+      if ( this.repo && this.query.chartName ) {
+        return this.$store.getters['catalog/chart']({
+          repoType:      this.query.repoType,
+          repoName:      this.query.repoName,
+          chartName:     this.query.chartName,
+          includeHidden: true,
+        });
+      }
+
+      return null;
+    },
+
+    repo() {
+      return this.$store.getters['catalog/repo']({
+        repoType: this.query.repoType,
+        repoName: this.query.repoName,
+      });
+    },
+
+    showReadme() {
+      return !!this.versionInfo?.readme;
+    },
+
+    hasReadme() {
+      return !!this.versionInfo?.appReadme || !!this.versionInfo?.readme;
+    },
+
+    mappedVersions() {
+      const {
+        currentCluster,
+        catalogOSAnnotation,
+      } = this;
+
+      const versions = this.chart?.versions || [];
+      const selectedVersion = this.targetVersion;
+      const isWindows = currentCluster.providerOs === 'windows';
+      const out = [];
+
+      versions.forEach((version) => {
+        const nue = {
+          label:           version.version,
+          version:         version.version,
+          originalVersion: version.version,
+          shortLabel:      version.version.length > 16 ? `${ version.version.slice(0, 15) }...` : version.version,
+          id:              version.version,
+          created:         version.created,
+          disabled:        false,
+          keywords:        version.keywords
+        };
+
+        if ( version?.annotations?.[catalogOSAnnotation] === 'windows' ) {
+          nue.label = this.t('catalog.install.versions.windows', { ver: version.version });
+
+          if ( !isWindows ) {
+            nue.disabled = true;
+          }
+        } else if ( version?.annotations?.[catalogOSAnnotation] === 'linux' ) {
+          nue.label = this.t('catalog.install.versions.linux', { ver: version.version });
+
+          if ( isWindows ) {
+            nue.disabled = true;
+          }
+        }
+
+        if (!this.showPreRelease && isPrerelease(version.version)) {
+          return;
+        }
+
+        out.push(nue);
+      });
+
+      const selectedMatch = out.find(v => v.id === selectedVersion);
+
+      if (!selectedMatch) {
+        out.unshift({
+          label:           selectedVersion,
+          originalVersion: selectedVersion,
+          shortLabel:      selectedVersion.length > 16 ? `${ selectedVersion.slice(0, 15) }...` : selectedVersion,
+          id:              selectedVersion,
+          created:         null,
+          disabled:        false,
+          keywords:        []
+        });
+      }
+
+      const currentVersion = out.find(v => v.originalVersion === this.currentVersion);
+
+      if (currentVersion) {
+        currentVersion.label = this.t('catalog.install.versions.current', { ver: this.currentVersion });
+      }
+
+      return out;
+    },
+
+    filteredVersions() {
+      return this.showPreRelease ? this.mappedVersions : this.mappedVersions.filter(v => !v.isPre);
+    },
+
+    query() {
+      const query = this.$route.query;
+
+      return {
+        repoType:     query[REPO_TYPE],
+        repoName:     query[REPO],
+        chartName:    query[CHART],
+        versionName:  query[VERSION],
+        appNamespace: query[NAMESPACE] || '',
+        appName:      query[NAME] || '',
+        description:  query[DESCRIPTION_QUERY]
+      };
+    },
+
+    showDeprecated() {
+      return this.$route.query[DEPRECATED] === _FLAGGED;
+    },
+
+    showHidden() {
+      return this.$route.query[HIDDEN] === _FLAGGED;
+    },
+
+    warnings() {
+      const warnings = [];
+
+      if ( this.existing ) {
+        // Ignore the limits on upgrade (or if asked by query) and don't show any warnings
+      } else {
+        const needCpu = parseSi(this.version?.annotations?.[CATALOG_ANNOTATIONS.REQUESTS_CPU] || '0');
+        const needMemory = parseSi(this.version?.annotations?.[CATALOG_ANNOTATIONS.REQUESTS_MEMORY] || '0');
+
+        // Note: These are null if unknown
+        const availableCpu = this.currentCluster.availableCpu;
+        const availableMemory = this.currentCluster.availableMemory;
+
+        if ( availableCpu !== null && availableCpu < needCpu ) {
+          warnings.push(this.t('catalog.install.error.insufficientCpu', {
+            need: Math.round(needCpu * 100) / 100,
+            have: Math.round(availableCpu * 100) / 100,
+          }));
+        }
+
+        if ( availableMemory !== null && availableMemory < needMemory ) {
+          warnings.push(this.t('catalog.install.error.insufficientMemory', {
+            need: formatSi(needMemory, {
+              increment: 1024, suffix: 'iB', firstSuffix: 'B'
+            }),
+            have: formatSi(availableMemory, {
+              increment: 1024, suffix: 'iB', firstSuffix: 'B'
+            }),
+          }));
+        }
+      }
+
+      return warnings;
+    },
+
+    requires() {
+      const requires = [];
+
+      const required = (this.version?.annotations?.[CATALOG_ANNOTATIONS.REQUIRES_GVK] || '').split(/\s*,\s*/).filter(x => !!x).reverse();
+
+      if ( required.length ) {
+        for ( const gvr of required ) {
+          if ( this.$store.getters['catalog/isInstalled']({ gvr }) ) {
+            continue;
+          }
+
+          const provider = this.provider(gvr);
+
+          const url = this.$router.resolve(this.chartLocation(true, gvr)).href;
+
+          if ( provider ) {
+            requires.push(this.t('catalog.install.error.requiresFound', {
+              url,
+              name: provider.name
+            }, true));
+          } else {
+            requires.push(this.t('catalog.install.error.requiresMissing', { name: gvr }));
+          }
+        }
+      }
+
+      return requires;
+    },
+
+    currentVersion() {
+      return this.existing?.spec.chart.metadata.version;
+    },
+
+    targetVersion() {
+      return this.version ? this.version.version : this.query.versionName;
+    },
+
+    action() {
+      return this.existing ? this.currentVersion === this.targetVersion ? 'update' : 'upgrade' : 'install';
+    },
+
+    isClusterTool() {
+      // Note - this copies how cluster tools options are created
+      const rancherCatalogKey = this.$store.getters['catalog/repos'].find(x => x.isRancher)._key;
+
+      return this.chart?.repoKey === rancherCatalogKey;
+    }
+  },
+
+  methods: {
+    async baseFetch() {
+      await this.$store.dispatch('catalog/load');
+
+      if ( this.query.appNamespace && this.query.appName ) {
+        // Explicitly asking for edit
+
+        try {
+          this.existing = await this.$store.dispatch('cluster/find', {
+            type: CATALOG.APP,
+            id:   `${ this.query.appNamespace }/${ this.query.appName }`,
+          });
+
+          this.mode = _EDIT;
+        } catch (e) {
+          this.mode = _CREATE;
+          this.existing = null;
+        }
+      } else if ( this.chart?.targetNamespace && this.chart?.targetName ) {
+        // Asking to install a special chart with fixed namespace/name
+        // so edit it if there's an existing install
+
+        try {
+          this.existing = await this.$store.dispatch('cluster/find', {
+            type: CATALOG.APP,
+            id:   `${ this.chart.targetNamespace }/${ this.chart.targetName }`,
+          });
+          this.mode = _EDIT;
+        } catch (e) {
+          this.mode = _CREATE;
+          this.existing = null;
+        }
+      } else {
+        // Regular create
+
+        this.mode = _CREATE;
+      }
+
+      if ( !this.chart ) {
+        return;
+      }
+
+      if ( !this.query.versionName && this.chart.versions?.length ) {
+        this.query.versionName = this.chart.versions[0].version;
+      }
+
+      if ( !this.query.versionName ) {
+        return;
+      }
+
+      try {
+        this.version = this.$store.getters['catalog/version']({
+          repoType:      this.query.repoType,
+          repoName:      this.query.repoName,
+          chartName:     this.query.chartName,
+          versionName: this.query.versionName
+        });
+      } catch (e) {
+        console.error('Unable to fetch Version: ', e); // eslint-disable-line no-console
+      }
+      if (!this.version) {
+        console.warn('No version found: ', this.query.repoType, this.query.repoName, this.query.chartName, this.query.versionName);// eslint-disable-line no-console
+      }
+
+      try {
+        this.versionInfo = await this.$store.dispatch('catalog/getVersionInfo', {
+          repoType:      this.query.repoType,
+          repoName:      this.query.repoName,
+          chartName:     this.query.chartName,
+          versionName: this.query.versionName
+        });
+      } catch (e) {
+        console.error('Unable to fetch VersionInfo: ', e); // eslint-disable-line no-console
+      }
+    },
+
+    selectVersion({ id: version }) {
+      this.$router.applyQuery({ [VERSION]: version });
+    },
+
+    provider(gvr) {
+      return this.$store.getters['catalog/versionProviding']({
+        gvr,
+        repoName: this.chart.repoName,
+        repoType: this.chart.repoType
+      });
+    },
+
+    /**
+     * Location of chart install or details page for either the current chart or from gvr
+     */
+    chartLocation(install = false, gvr) {
+      const provider = gvr ? this.provider(gvr) : {
+        repoType: this.chart.repoType,
+        repoName: this.chart.repoName,
+        name:     this.chart.chartName,
+        version:  this.chart.versionName,
+      };
+
+      return {
+        name:   install ? 'c-cluster-apps-install' : 'c-cluster-apps-chart',
+        params: {
+          cluster:  this.$route.params.cluster,
+          product:  this.$store.getters['productId'],
+        },
+        query: {
+          [REPO_TYPE]: provider.repoType,
+          [REPO]:      provider.repoName,
+          [CHART]:     provider.name,
+          [VERSION]:   provider.version,
+        }
+      };
+    },
+
+    appLocation() {
+      return this.existing?.detailLocation || {
+        name:   `c-cluster-product-resource`,
+        params: {
+          product:   this.$store.getters['productId'],
+          cluster:   this.$store.getters['clusterId'],
+          resource:  CATALOG.APP,
+        }
+      };
+    },
+
+    clusterToolsLocation() {
+      return {
+        name:   `c-cluster-explorer-tools`,
+        params: {
+          product:   EXPLORER,
+          cluster:   this.$store.getters['clusterId'],
+          resource:  CATALOG.APP,
+        }
+      };
+    }
+  },
+
+};

--- a/pages/c/_cluster/apps/chart_mixin.js
+++ b/pages/c/_cluster/apps/chart_mixin.js
@@ -224,14 +224,15 @@ export default {
     },
 
     action() {
-      return this.existing ? this.currentVersion === this.targetVersion ? 'update' : 'upgrade' : 'install';
+      if (this.existing) {
+        return this.currentVersion === this.targetVersion ? 'update' : 'upgrade';
+      }
+
+      return 'install';
     },
 
-    isClusterTool() {
-      // Note - this copies how cluster tools options are created
-      const rancherCatalogKey = this.$store.getters['catalog/repos'].find(x => x.isRancher)._key;
-
-      return this.chart?.repoKey === rancherCatalogKey;
+    isChartTargeted() {
+      return this.chart?.targetNamespace && this.chart?.targetName;
     }
   },
 

--- a/pages/c/_cluster/apps/charts.vue
+++ b/pages/c/_cluster/apps/charts.vue
@@ -240,11 +240,13 @@ export default {
       }
 
       if ( !version ) {
+        console.warn(`Cannot select chart '${ chart.chartName }' (no compatible version available for '${ this.currentCluster.providerOs }')`); // eslint-disable-line no-console
+
         return;
       }
 
       this.$router.push({
-        name:   'c-cluster-apps-install',
+        name:   'c-cluster-apps-chart',
         params: {
           cluster:  this.$route.params.cluster,
           product:  this.$store.getters['productId'],

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -816,7 +816,7 @@ export default {
               <span v-html="msg" />
             </Banner>
 
-            <Checkbox v-if="warnings.length" v-model="ignoreWarning" label-key="catalog.install.action.ignoreWarning" />
+            <Checkbox v-if="warnings.length" v-model="ignoreWarning" :label="t('catalog.install.action.ignoreWarning', { count: warnings.length })" />
           </div>
           <div v-if="existing" class="row mb-10">
             <div class="col span-6">

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -368,6 +368,14 @@ export default {
       return this.existing && this.currentVersion !== this.targetVersion ? `${ this.currentVersion } > ${ this.targetVersion }` : this.targetVersion;
     },
 
+    reademeWindowName() {
+      return `${ this.stepperName }-${ this.version.version }`;
+    },
+
+    showingReadmeWindow() {
+      return !!this.$store.getters['wm/byId'](this.reademeWindowName);
+    },
+
     diffMode: mapPref(DIFF),
 
     step1Description() {
@@ -453,6 +461,10 @@ export default {
       window.v = this.value;
       window.c = this;
     }
+  },
+
+  beforeDestroy() {
+    this.$store.dispatch('wm/close', this.reademeWindowName, { root: true });
   },
 
   methods: {
@@ -778,6 +790,15 @@ export default {
       return opt?.chartDisplayName;
     },
 
+    showReadmeWindow() {
+      this.$store.dispatch('wm/open', {
+        id:        this.reademeWindowName,
+        label:     this.reademeWindowName,
+        icon:      'file',
+        component: 'ChartReadme',
+        attrs:     { versionInfo: this.versionInfo }
+      }, { root: true });
+    }
   },
 };
 </script>
@@ -910,7 +931,7 @@ export default {
             inactive-class="bg-disabled btn-sm"
             active-class="bg-primary btn-sm"
           ></ButtonGroup>
-          <div v-if="hasReadme" class="btn-group">
+          <div v-if="hasReadme && !showingReadmeWindow" class="btn-group">
             <button type="button" class="btn bg-primary btn-sm" @click="showSlideIn = !showSlideIn">
               {{ t('catalog.install.steps.helmValues.chartInfo.button') }}
             </button>
@@ -1026,8 +1047,13 @@ export default {
     <div class="slideIn" :class="{'hide': false, 'slideIn__show': showSlideIn}">
       <h2 class="slideIn__header">
         {{ t('catalog.install.steps.helmValues.chartInfo.label') }}
-        <div class="slideIn__close-button" @click="showSlideIn = false">
-          <i class="icon icon-close" />
+        <div class="slideIn__header__buttons">
+          <div v-tooltip="'Dock in window'" class="slideIn__header__button" @click="showSlideIn = false; showReadmeWindow()">
+            <i class="icon icon-terminal" />
+          </div>
+          <div class="slideIn__header__button" @click="showSlideIn = false">
+            <i class="icon icon-close" />
+          </div>
         </div>
       </h2>
       <ChartReadme v-if="hasReadme" :version-info="versionInfo" class="chart-content__tabs" />
@@ -1114,20 +1140,24 @@ export default {
       display: flex;
       align-items: center;
       justify-content: space-between;
-    }
 
-    &__close-button {
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 2px;
-      > i {
-        font-size: 20px;
-        opacity: 0.5;
+      &__buttons {
+        display: flex;
       }
-      &:hover {
-        background-color: var(--wm-closer-hover-bg);
+
+      &__button {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2px;
+        > i {
+          font-size: 20px;
+          opacity: 0.5;
+        }
+        &:hover {
+          background-color: var(--wm-closer-hover-bg);
+        }
       }
     }
 

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -475,10 +475,6 @@ export default {
       this.updateStepOneReady();
     },
 
-    ignoreWarning() {
-      this.updateStepOneReady();
-    },
-
   },
 
   async mounted() {
@@ -811,10 +807,9 @@ export default {
 
     updateStepOneReady() {
       const okRequires = !this.requires.length;
-      const okWarnings = !this.warnings.length || this.ignoreWarning;
       const okChart = !!this.chart;
 
-      this.steps[0].ready = okRequires && okWarnings && okChart;
+      this.steps[0].ready = okRequires && okChart;
     },
 
     getOptionLabel(opt) {
@@ -867,8 +862,6 @@ export default {
             <Banner v-for="msg in warnings" :key="msg" color="warning">
               <span v-html="msg" />
             </Banner>
-
-            <Checkbox v-if="warnings.length" v-model="ignoreWarning" :label="t('catalog.install.action.ignoreWarning', { count: warnings.length })" />
           </div>
           <div v-if="existing" class="row mb-10">
             <div class="col span-6">

--- a/pages/c/_cluster/apps/install.vue
+++ b/pages/c/_cluster/apps/install.vue
@@ -389,15 +389,15 @@ export default {
     diffMode: mapPref(DIFF),
 
     step1Description() {
-      return this.$store.getters['i18n/exists']('catalog.install.steps.basics.description') ? this.t('catalog.install.steps.basics.description', { action: this.action }, true) : '';
+      return this.$store.getters['i18n/withFallback']('catalog.install.steps.basics.description', { action: this.action, existing: !!this.existing }, '');
     },
 
     step2Description() {
-      return this.$store.getters['i18n/exists']('catalog.install.steps.helmValues.description') ? this.t('catalog.install.steps.helmValues.description', { action: this.action }, true) : '';
+      return this.$store.getters['i18n/withFallback']('catalog.install.steps.helmValues.description', { action: this.action, existing: !!this.existing }, '');
     },
 
     step3Description() {
-      return this.$store.getters['i18n/exists']('catalog.install.steps.helmCli.description') ? this.t('catalog.install.steps.helmCli.description', { action: this.action }, true) : '';
+      return this.$store.getters['i18n/withFallback']('catalog.install.steps.helmCli.description', { action: this.action, existing: !!this.existing }, '');
     },
 
   },

--- a/pages/c/_cluster/explorer/tools.vue
+++ b/pages/c/_cluster/explorer/tools.vue
@@ -76,8 +76,8 @@ export default {
   },
 
   methods: {
-    edit(app) {
-      app.goToUpgrade(null, true);
+    edit(app, version) {
+      app.goToUpgrade(version, true);
     },
 
     remove(app) {
@@ -246,7 +246,7 @@ export default {
             <button class="btn btn-sm role-secondary" @click="remove(opt.app)">
               <i class="icon icon-delete icon-lg" />
             </button>
-            <button class="btn btn-sm role-secondary" @click="edit(opt.app)" v-html="t('catalog.tools.action.upgrade')" />
+            <button class="btn btn-sm role-secondary" @click="edit(opt.app, opt.app.upgradeAvailable)" v-html="t('catalog.tools.action.upgrade')" />
           </template>
           <template v-else-if="opt.app">
             <button class="btn btn-sm role-secondary" @click="remove(opt.app)">

--- a/utils/install-redirect.js
+++ b/utils/install-redirect.js
@@ -24,7 +24,7 @@ export default function(product, chartName, defaultResourceOrRoute) {
 
       // Otherwise just let the middleware pass through
     } else {
-      // The product is not installed, redirect to the install chart
+      // The product is not installed, redirect to the details chart
 
       await store.dispatch('catalog/load');
 
@@ -32,7 +32,7 @@ export default function(product, chartName, defaultResourceOrRoute) {
 
       if ( chart ) {
         return redirect({
-          name:   'c-cluster-apps-install',
+          name:   'c-cluster-apps-chart',
           params: { cluster },
           query:  {
             [REPO_TYPE]: chart.repoType,


### PR DESCRIPTION
- Replaces old edit/install page, which is split out in to Chart Details page and Chart Install page
- Two pages share common mixin
- Updated existing Wizard component for stepper
  - Wizard header greatly updated
  - Step indicator no longer uses query param
- To Review
  - ~~Still not sure i've got the step names and descriptions correct~~
  - ~~The side stepper slide isn't quite right~~

Addresses both of #2669 and #2670 (contains https://github.com/rancher/dashboard/pull/2710)

Other bits
- Cancel modal used when cancelling editing yaml tab in a CruResource has been broken out into it's own component and used in stepper
- ~~Tweaked loading component to (conceptually) handle living in a relative element (by not applying offset)~~
- Updated Date component to optionally show just date and no time
- Also fixed an issue where a cluster tool cart upgrade button didn't link to version it should upgrade to
- I've added some notes for QA in the issue

Observations
- We need to wait for helm to validate values before leaving the page (existing behaviour)
- If a chart install fails or gets stuck in pending for a long time there's no obvious way to debug. 
- The 'Description' is applied to helm (`--description`) but is then lost. When user edits app it's gone (probably existing behaviour, need to check)

