### PR TITLE
Fix create/edit of resources that use ContainerResourceLimit

### DIFF
--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -108,6 +108,12 @@ export default {
       this.$emit('input', cleanUp(out));
     },
 
+    applyUnits(out, key, value, unit) {
+      if (value) {
+        out[key] = typeof value === 'string' ? value : `${ value }${ unit }`;
+      }
+    },
+
     updateBeforeSave(value) {
       const {
         limitsCpu,
@@ -119,18 +125,10 @@ export default {
 
       const out = {};
 
-      if (limitsCpu) {
-        out.limitsCpu = `${ limitsCpu }m`;
-      }
-      if (limitsMemory) {
-        out.limitsMemory = `${ limitsMemory }Mi`;
-      }
-      if (requestsCpu) {
-        out.requestsCpu = `${ requestsCpu }Mi`;
-      }
-      if (requestsMemory) {
-        out.requestsMemory = `${ requestsMemory }Mi`;
-      }
+      this.applyUnits(out, 'limitsCpu', limitsCpu, 'm');
+      this.applyUnits(out, 'limitsMemory', limitsMemory, 'Mi');
+      this.applyUnits(out, 'requestsCpu', requestsCpu, 'Mi');
+      this.applyUnits(out, 'requestsMemory', requestsMemory, 'Mi');
 
       if (namespace) {
         namespace.setAnnotation(CONTAINER_DEFAULT_RESOURCE_LIMIT, JSON.stringify(out));

--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -116,12 +116,21 @@ export default {
         requestsMemory,
       } = this;
       const namespace = this.namespace; // no deep copy in destructure proxy yet
-      const out = {
-        limitsCpu:      `${ limitsCpu }m`,
-        limitsMemory:   `${ limitsMemory }Mi`,
-        requestsCpu:    `${ requestsCpu }m`,
-        requestsMemory: `${ requestsMemory }Mi`,
-      };
+
+      const out = {};
+
+      if (limitsCpu) {
+        out.limitsCpu = `${ limitsCpu }m`;
+      }
+      if (limitsMemory) {
+        out.limitsMemory = `${ limitsMemory }Mi`;
+      }
+      if (requestsCpu) {
+        out.requestsCpu = `${ requestsCpu }Mi`;
+      }
+      if (requestsMemory) {
+        out.requestsMemory = `${ requestsMemory }Mi`;
+      }
 
       if (namespace) {
         namespace.setAnnotation(CONTAINER_DEFAULT_RESOURCE_LIMIT, JSON.stringify(out));


### PR DESCRIPTION
- Think this covers workloads, container and namespaces
- when no limits were set we were still appending the unit, leading to values like `nullMi`
- we now overwrite all limits every time, keeping only those with new values
- Addresses #2878