### PR TITLE
Add dev target with increased memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "./node_modules/.bin/nyc ava --serial --verbose",
     "nuxt": "./node_modules/.bin/nuxt",
     "dev": "./node_modules/.bin/nuxt dev",
+    "mem-dev": "node --max-old-space-size=8192 ./node_modules/.bin/nuxt dev",
     "docker-dev": "docker run --rm --name dashboard-dev -p 8005:8005 -e API=$API -v $(pwd):/src -v dashboard_node:/src/node_modules rancher/dashboard:dev",
     "build": "./node_modules/.bin/nuxt build --devtools",
     "analyze": "./node_modules/.bin/nuxt build --analyze",


### PR DESCRIPTION
- Seeing some heap crashes after running the app for a while
- Added a target to increase the available mem to work around this
- Ideally need to find the underlying issue
- I had a quick look, but requires more time to investigate (we already have some fixes for common causes like missing `require('dotenv').config()`)