### PR TITLE
Fix isRancher getter

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -421,7 +421,7 @@ export const actions = {
       }),
     };
 
-    const isRancher = res.rancherSchemas.status === 'fulfilled' && getters['management/schemaFor'](MANAGEMENT.PROJECT);
+    const isRancher = res.rancherSchemas.status === 'fulfilled' && !!getters['management/schemaFor'](MANAGEMENT.PROJECT);
 
     if ( isRancher ) {
       promises['prefs'] = dispatch('prefs/loadServer');


### PR DESCRIPTION
- getter is `isRancher === true`
- value of isRancher was a truthy (a schema obj) rather than boolean, so getter was always false
- this was the cause of the missing `Accounts & API Keys` menu item in the user avatar menu