### PR TITLE
Fix monitoring navigation

### DIFF
--- a/config/product/monitoring.js
+++ b/config/product/monitoring.js
@@ -192,17 +192,7 @@ export function init(store) {
     'monitoring-overview',
     'monitor',
     'route-receiver',
-  ], 'monitoring');
-
-  // virtualType({
-  //   label:      'Advanced',
-  //   group:      'monitoring-overview',
-  //   namespaced: false,
-  //   name:       'monitoring-advanced',
-  //   weight:     105,
-  //   route:      { name: 'c-cluster-monitoring' },
-  //   exact:      true
-  // });
+  ]);
 
   basicType([
     PROMETHEUSRULE,


### PR DESCRIPTION
There is an extra sub-nav 'monitoring' - these items should be under the main 'Monitoring" header.