### PR TITLE
Port Ember Version Modal & Minor Changes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -166,7 +166,6 @@ about:
     component: Component
     version: Version
     cli: CLI
-    ui: User Interface
     helm: Helm
     machine: Machine
     releaseNotes: 'Release notes can be found <a href="/docs/release-notes">here</a>.'

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -168,7 +168,7 @@ about:
     cli: CLI
     helm: Helm
     machine: Machine
-    releaseNotes: 'Release notes can be found <a href="/docs/release-notes">here</a>.'
+    releaseNotes: 'View release notes'
   imageList:
     title: Image Lists
     linuxImageList: Linux
@@ -1342,7 +1342,7 @@ landing:
     forums: Forums
   commercial:
     title: Commercial Support
-    body: Learn about commercial support <a href="/support">here</a>.
+    body: Learn about commercial support
   landingPrefs:
     title: What do you want to see when you log in?
     options:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -113,7 +113,11 @@ nav:
   header:
     setLoginPage: Set as login page
     restoreCards: Restore hidden cards
- 
+  userMenu:
+    preferences: Preferences
+    accountAndKeys: Account & API Keys
+    logOut: Log Out
+
 product:
   apps: Apps & Marketplace
   auth: Users & Authentication
@@ -155,6 +159,23 @@ suffix:
 ##############################
 # Components & Pages
 ##############################
+about:
+  title: About
+  versions:
+    title: Versions
+    component: Component
+    version: Version
+    cli: CLI
+    ui: User Interface
+    helm: Helm
+    machine: Machine
+    releaseNotes: 'Release notes can be found <a href="/docs/release-notes">here</a>.'
+  imageList:
+    title: Image Lists
+    linuxImageList: Linux
+    windowsImageList: Windows
+
+
 accountAndKeys:
   title: Account and API Keys
   account:
@@ -1322,7 +1343,7 @@ landing:
     forums: Forums
   commercial:
     title: Commercial Support
-    body: Learn about commercial support <a href="https://rancher.com/support-maintenance-terms/" target='_blank' rel='noopener nofollow noreferrer'>here</a>.
+    body: Learn about commercial support <a href="/support">here</a>.
   landingPrefs:
     title: What do you want to see when you log in?
     options:
@@ -4125,6 +4146,7 @@ support:
     addSubscription: Add
     linksTitle: Community Support
     learnMore: Find out more about SUSE Rancher Support
+    pricing: Contact us for pricing
   suse:
     title: "Great News - You're covered"
   promos:

--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -257,7 +257,7 @@ export default {
           position: absolute;
           right: 0;
           top: 0;
-          padding: 9px 7px;
+          padding: 10px 7px 9px 7px;
           user-select: none;
         }
       }

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -270,9 +270,6 @@ export default {
             <nuxt-link v-if="isRancher" tag="li" :to="{name: 'account'}" class="user-menu-item">
               <a>{{ t('nav.userMenu.accountAndKeys', {}, true) }} <i class="icon icon-fw icon-user" /></a>
             </nuxt-link>
-            <nuxt-link tag="li" :to="{name: 'about'}" class="user-menu-item">
-              <a>{{ t('nav.userMenu.about') }} <i class="icon icon-fw icon-info" /></a>
-            </nuxt-link>
             <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'auth-logout'}" class="user-menu-item">
               <a @blur="showMenu(false)">{{ t('nav.userMenu.logOut') }} <i class="icon icon-fw icon-close" /></a>
             </nuxt-link>

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -265,13 +265,16 @@ export default {
               </div>
             </li>
             <nuxt-link tag="li" :to="{name: 'prefs'}" class="user-menu-item">
-              <a>Preferences <i class="icon icon-fw icon-gear" /></a>
+              <a>{{ t('nav.userMenu.preferences') }} <i class="icon icon-fw icon-gear" /></a>
             </nuxt-link>
             <nuxt-link v-if="isRancher" tag="li" :to="{name: 'account'}" class="user-menu-item">
-              <a>Account &amp; API Keys <i class="icon icon-fw icon-user" /></a>
+              <a>{{ t('nav.userMenu.accountAndKeys', {}, true) }} <i class="icon icon-fw icon-user" /></a>
+            </nuxt-link>
+            <nuxt-link tag="li" :to="{name: 'about'}" class="user-menu-item">
+              <a>{{ t('nav.userMenu.about') }} <i class="icon icon-fw icon-info" /></a>
             </nuxt-link>
             <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'auth-logout'}" class="user-menu-item">
-              <a @blur="showMenu(false)">Log Out <i class="icon icon-fw icon-close" /></a>
+              <a @blur="showMenu(false)">{{ t('nav.userMenu.logOut') }} <i class="icon icon-fw icon-close" /></a>
             </nuxt-link>
           </ul>
         </template>

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -245,7 +245,7 @@ export default {
           <div @click="hide()">
             <nuxt-link
               v-tooltip="{ content: fullVersion, classes: 'footer-tooltip' }"
-              :to="{ name: 'docs-doc', params: { doc: 'release-notes' } }"
+              :to="{ name: 'about' }"
               class="version"
               v-html="displayVersion"
             />

--- a/config/settings.js
+++ b/config/settings.js
@@ -3,7 +3,7 @@
 // Adapted from: https://github.com/rancher/ui/blob/08c379a9529f740666a704b52522a468986c3520/lib/shared/addon/utils/constants.js#L564
 
 // Setting IDs
-const SETTING = {
+export const SETTING = {
   IMAGE_RANCHER:                    'server-image',
   VERSION_RANCHER:                  'server-version',
   VERSION_COMPOSE:                  'compose-version',

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -2,7 +2,7 @@
 import Loading from '@/components/Loading';
 import { MANAGEMENT } from '@/config/types';
 import { SETTING } from '@/config/settings';
-import { getProduct } from '@/config/private-label';
+import { getVendor } from '@/config/private-label';
 import { downloadFile } from '@/utils/download';
 
 export default {
@@ -21,10 +21,7 @@ export default {
       return this.settings.find(s => s.id === SETTING.VERSION_RANCHER);
     },
     appName() {
-      return getProduct();
-    },
-    uiVersion() {
-      return `${ process.env.version }${ process.env.commit ? `-${ process.env.commit }` : '' }`;
+      return getVendor();
     },
     cliVersion() {
       return this.settings.find(s => s.id === SETTING.VERSION_CLI);
@@ -79,13 +76,6 @@ export default {
           </a>
         </td><td>{{ rancherVersion.value }}</td>
       </tr>
-      <tr v-if="uiVersion">
-        <td>
-          <a href="https://github.com/rancher/dashboard" target="_blank" rel="nofollow noopener noreferrer">
-            {{ t("about.versions.ui") }}
-          </a>
-        </td><td>{{ uiVersion }}</td>
-      </tr>
       <tr v-if="cliVersion">
         <td>
           <a href="https://github.com/rancher/cli" target="_blank" rel="nofollow noopener noreferrer">
@@ -134,36 +124,32 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .about {
-    td {
-      min-width: 150px;
-      padding: 8px 5px;
-    }
-    a {
-      cursor: pointer;
-    }
-  }
-
+.about {
   table {
     border-collapse: collapse;
     overflow: hidden;
     border-radius: var(--border-radius);
 
-    > thead > tr > th {
-      padding: 8px 5px;
-      background-color: var(--sortable-table-body-divider);
+    tr > td:first-of-type {
+      width: 20%;
     }
-  }
 
-  th, td {
-    border: 1px solid var(--border);
-    text-align: left;
+    th, td {
+      border: 1px solid var(--border);
+      padding: 8px 5px;
+      min-width: 150px;
+      text-align: left;
     }
-  th {
+
+    th {
+      background-color: var(--sortable-table-top-divider);
       border-bottom: 1px solid var(--sortable-table-top-divider);
-      background-color: var(--body-bg);
+    }
+
+    a {
+      cursor: pointer;
+    }
   }
-  tr:nth-child(odd) {
-      background-color: var(--sortable-table-accent-bg);
-  }
+}
+
 </style>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,0 +1,140 @@
+<script>
+import Loading from '@/components/Loading';
+import { MANAGEMENT } from '@/config/types';
+import { SETTING } from '@/config/settings';
+import { getProduct } from '@/config/private-label';
+import { downloadFile } from '@/utils/download';
+
+export default {
+  components: { Loading },
+  async fetch() {
+    this.settings = await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.SETTING });
+  },
+  data() {
+    return {
+      settings: null,
+      SETTING
+    };
+  },
+  computed:   {
+    rancherVersion() {
+      return this.settings.find(s => s.id === SETTING.VERSION_RANCHER);
+    },
+    appName() {
+      return getProduct();
+    },
+    uiVersion() {
+      return `${ process.env.version }${ process.env.commit ? `-${ process.env.commit }` : '' }`;
+    },
+    cliVersion() {
+      return this.settings.find(s => s.id === SETTING.VERSION_CLI);
+    },
+    helmVersion() {
+      return this.settings.find(s => s.id === SETTING.VERSION_HELM);
+    },
+    dockerMachineVersion() {
+      return this.settings.find(s => s.id === SETTING.VERSION_MACHINE);
+    },
+  },
+  methods: {
+    async downloadLinuxImages() {
+      const res = await this.$store.dispatch('management/request', { url: '/v3/kontainerdrivers/rancher-images' });
+
+      try {
+        await downloadFile(`.rancher-linux-images.txt`, res.data);
+      } catch (error) {
+        this.$store.dispatch('growl/fromError', { title: 'Error downloading Linux image list', err: error }, { root: true });
+      }
+    },
+
+    async downloadWindowsImages() {
+      const res = await this.$store.dispatch('management/request', { url: '/v3/kontainerdrivers/rancher-windows-images' });
+
+      try {
+        await downloadFile(`.rancher-windows-images.txt`, res.data);
+      } catch (error) {
+        this.$store.dispatch('growl/fromError', { title: 'Error downloading Windows image list', err: error }, { root: true });
+      }
+    },
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="!settings" />
+  <div v-else class="row about">
+    <h1 v-t="'about.title'" />
+    <table class="col span-6">
+      <tr><td><h3>{{ t('about.versions.title') }}</h3></td></tr>
+      <tr><td><h6>{{ t('about.versions.component') }}</h6></td><td><h6>{{ t('about.versions.version') }}</h6></td></tr>
+      <tr v-if="rancherVersion">
+        <td>
+          <a href="https://github.com/rancher/rancher" target="_blank" rel="nofollow noopener noreferrer">
+            {{ appName }}
+          </a>
+        </td><td>{{ rancherVersion.value }}</td>
+      </tr>
+      <tr v-if="uiVersion">
+        <td>
+          <a href="https://github.com/rancher/dashboard" target="_blank" rel="nofollow noopener noreferrer">
+            {{ t("about.versions.ui") }}
+          </a>
+        </td><td>{{ uiVersion }}</td>
+      </tr>
+      <tr v-if="cliVersion">
+        <td>
+          <a href="https://github.com/rancher/cli" target="_blank" rel="nofollow noopener noreferrer">
+            {{ appName }} {{ t("about.versions.cli") }}
+          </a>
+        </td><td>{{ cliVersion.value }}</td>
+      </tr>
+      <tr v-if="helmVersion">
+        <td>
+          <a href="https://github.com/rancher/helm" target="_blank" rel="nofollow noopener noreferrer">
+            {{ t("about.versions.helm") }}
+          </a>
+        </td><td>{{ helmVersion.value }}</td>
+      </tr>
+      <tr v-if="dockerMachineVersion">
+        <td>
+          <a href="https://github.com/rancher/machine" target="_blank" rel="nofollow noopener noreferrer">
+            {{ t("about.versions.machine") }}
+          </a>
+        </td><td>{{ dockerMachineVersion.value }}</td>
+      </tr>
+      <tr><td>&nbsp;</td></tr>
+      <tr><td>&nbsp;</td><td><span v-html="t('about.versions.releaseNotes', {}, true)" /></td></tr>
+      <tr><td>&nbsp;</td></tr>
+      <tr><td><h3>{{ t('about.imageList.title') }}</h3></td></tr>
+      <tr>
+        <td>
+          {{ t("about.imageList.linuxImageList") }}
+        </td><td>
+          <a @click="downloadLinuxImages">
+            {{ t('asyncButton.download.action') }}
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          {{ t("about.imageList.windowsImageList") }}
+        </td><td>
+          <a @click="downloadWindowsImages">
+            {{ t('asyncButton.download.action') }}
+          </a>
+        </td>
+      </tr>
+    </table>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .about {
+    td {
+      min-width: 150px;
+    }
+    a {
+      cursor: pointer;
+    }
+  }
+</style>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -98,7 +98,11 @@ export default {
         </td><td>{{ dockerMachineVersion.value }}</td>
       </tr>
     </table>
-    <p class="pt-20 pb-40" v-html="t('about.versions.releaseNotes', {}, true)" />
+    <p class="pt-20 pb-40">
+      <nuxt-link :to="{ path: 'docs/release-notes'}">
+        {{ t('about.versions.releaseNotes') }}
+      </nuxt-link>
+    </p>
     <h3>{{ t('about.imageList.title') }}</h3>
     <table>
       <tr>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -62,11 +62,16 @@ export default {
 
 <template>
   <Loading v-if="!settings" />
-  <div v-else class="row about">
+  <div v-else class="about">
     <h1 v-t="'about.title'" />
-    <table class="col span-6">
-      <tr><td><h3>{{ t('about.versions.title') }}</h3></td></tr>
-      <tr><td><h6>{{ t('about.versions.component') }}</h6></td><td><h6>{{ t('about.versions.version') }}</h6></td></tr>
+    <h3>{{ t('about.versions.title') }}</h3>
+    <table class="">
+      <thead>
+        <tr>
+          <th>{{ t('about.versions.component') }}</th>
+          <th>{{ t('about.versions.version') }}</th>
+        </tr>
+      </thead>
       <tr v-if="rancherVersion">
         <td>
           <a href="https://github.com/rancher/rancher" target="_blank" rel="nofollow noopener noreferrer">
@@ -102,10 +107,10 @@ export default {
           </a>
         </td><td>{{ dockerMachineVersion.value }}</td>
       </tr>
-      <tr><td>&nbsp;</td></tr>
-      <tr><td>&nbsp;</td><td><span v-html="t('about.versions.releaseNotes', {}, true)" /></td></tr>
-      <tr><td>&nbsp;</td></tr>
-      <tr><td><h3>{{ t('about.imageList.title') }}</h3></td></tr>
+    </table>
+    <p class="pt-20 pb-40" v-html="t('about.versions.releaseNotes', {}, true)" />
+    <h3>{{ t('about.imageList.title') }}</h3>
+    <table>
       <tr>
         <td>
           {{ t("about.imageList.linuxImageList") }}
@@ -132,9 +137,33 @@ export default {
   .about {
     td {
       min-width: 150px;
+      padding: 8px 5px;
     }
     a {
       cursor: pointer;
     }
+  }
+
+  table {
+    border-collapse: collapse;
+    overflow: hidden;
+    border-radius: var(--border-radius);
+
+    > thead > tr > th {
+      padding: 8px 5px;
+      background-color: var(--sortable-table-body-divider);
+    }
+  }
+
+  th, td {
+    border: 1px solid var(--border);
+    text-align: left;
+    }
+  th {
+      border-bottom: 1px solid var(--sortable-table-top-divider);
+      background-color: var(--body-bg);
+  }
+  tr:nth-child(odd) {
+      background-color: var(--sortable-table-accent-bg);
   }
 </style>

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -259,6 +259,10 @@ export default {
     canAccessDeployments() {
       return !!this.clusterCounts?.[0]?.counts?.[WORKLOAD_TYPES.DEPLOYMENT];
     },
+
+    hasMetricsTabs() {
+      return this.showClusterMetrics || this.showK8sMetrics || this.showEtcdMetrics;
+    }
   },
 
   mounted() {
@@ -403,7 +407,7 @@ export default {
         </template>
       </SortableTable>
     </div>
-    <Tabbed class="mt-30">
+    <Tabbed v-if="hasMetricsTabs" class="mt-30">
       <Tab v-if="showClusterMetrics" name="cluster-metrics" :label="t('clusterIndexPage.sections.clusterMetrics.label')" :weight="2">
         <template #default="props">
           <DashboardMetrics

--- a/pages/home/index.vue
+++ b/pages/home/index.vue
@@ -338,7 +338,9 @@ export default {
         <div v-if="showSidePanel" class="col span-3">
           <CommunityLinks :pref="HIDE_HOME_PAGE_CARDS" pref-key="communitySupportTip" class="mb-20" />
           <SimpleBox :pref="HIDE_HOME_PAGE_CARDS" pref-key="commercialSupportTip" :title="t('landing.commercial.title')">
-            <span v-html="t('landing.commercial.body', {}, true)" />
+            <nuxt-link :to="{ path: 'support'}">
+              {{ t('landing.commercial.body') }}
+            </nuxt-link>
           </SimpleBox>
         </div>
       </div>

--- a/pages/support/index.vue
+++ b/pages/support/index.vue
@@ -48,7 +48,6 @@ export default {
 <template>
   <div>
     <BannerGraphic :title="t(title)" />
-
     <IndentedPanel v-if="!hasSupport">
       <div class="content mt-20">
         <div class="promo">
@@ -65,7 +64,9 @@ export default {
             </div>
           </div>
           <div class="external">
-            <a href="https://rancher.com/pricing" target="_blank" rel="noopener noreferrer nofollow">{{ t('support.community.learnMore') }} <i class="icon icon-external-link" /></a>
+            <a href="https://rancher.com/support-maintenance-terms" target="_blank" rel="noopener noreferrer nofollow">{{ t('support.community.learnMore') }} <i class="icon icon-external-link" /></a>
+            or
+            <a href="https://rancher.com/pricing" target="_blank" rel="noopener noreferrer nofollow">{{ t('support.community.pricing') }} <i class="icon icon-external-link" /></a>
           </div>
         </div>
         <div class="community">


### PR DESCRIPTION
Port the Ember Version Modal
- Previously this was reached via clicking on the version text in the footer, now it's reached via the user menu top right
- This also previously was a modal whereas now it's a page as per other user menu items
- At the moment it looks pretty stark. As it's a page it lacks the modal header with the snazzy logo 
- There's still the same list of versions, the ui one might be handy for QA
- Addresses #2903


Minor Changes
- i10n - User menu text
- Fix - Vertical size of side menu's group menu down arrow now fills menu hover area (no more thin hover colour below down arrow when in dark mode) 
  ![image](https://user-images.githubusercontent.com/18697775/117314518-c0482d00-ae7e-11eb-8f3a-a405722d85f9.png)
  vs 
  ![image](https://user-images.githubusercontent.com/18697775/117314376-9abb2380-ae7e-11eb-9193-a6383e383a2b.png)

- Fix - Cluster Dashboard - Hide metrics Tabbed element if there are no Tabs (no more empty faded square at bottom when no metrics)
- Update support links
  - Home Page - Commercial Support - Link now goes to support page
  - Support Page - Contains links to both rancher support info and contact pages