### PR TITLE
Fix create/edit cluster & project roles

### DIFF
--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -160,7 +160,7 @@ export function createYaml(schemas, type, data, processAlwaysAdd = true, depth =
   // ---------------
 
   function stringifyField(key) {
-    const field = schema.resourceFields[key];
+    const field = schema.resourceFields?.[key];
     let out = `${ key }:`;
 
     // '_type' in steve maps to kubernetes 'type' field; show 'type' field in yaml


### PR DESCRIPTION
- This bug exists for any schema where `resourceFields` is null (like management.cattle.io.roletemplate)
- Before we didn't hit `stringifyField` as `regularFields` was empty for these types, i haven't delved into why it's populated now... but the fix seems safe
- Addresses #2926