### PR TITLE
Only check for ember availability in dev

### DIFF
--- a/components/EmberPage.vue
+++ b/components/EmberPage.vue
@@ -116,7 +116,7 @@ export default {
         }
       }
 
-      if (iframeEl === null) {
+      if (iframeEl === null && process.env.dev) {
         // Fetch a page to check that the Ember UI is available
         try {
           this.error = false;


### PR DESCRIPTION
Local UI development (running dashboard and ui on your laptop) is the only time the two UIs are served up by a different process and one might be down while the other is up.

So changing this check to only happen in dashboard dev mode (`yarn run dev`).

For the backend people's local dev they have no copy of the assets, so this currently always fails.

Non-releases (*-head and *-rcX) load the UIs from CDN instead of from the server, so asking the server doesn't tell you much (a version of the assets is available from the server, but not an up-to-date one)..
