### PR TITLE
yaml apostrophe change

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1598,7 +1598,7 @@ monitoringRoute:
   interval:
     label: Group Interval
   matching:
-    info: The root route has to match everything so matching can't be configured.
+    info: The root route has to match everything so matching cannot be configured.
     label: Match
   receiver:
     label: Receiver


### PR DESCRIPTION
#2914 
Git was unable to find a difference between existing character and new character.
Changed wording instead to circumvent issue