### PR TITLE
Improve modal dialog border and box shadow

### DIFF
--- a/assets/styles/themes/_dark.scss
+++ b/assets/styles/themes/_dark.scss
@@ -82,6 +82,7 @@
   --accent-btn: #{rgba($primary, 0.2)};
   --accent-btn-hover: #{rgba($primary, 0.5)};
   --modal-bg                   :#{$dark};
+  --modal-border: #{$medium};
   --overlay-bg: #{rgba($darkest, 0.75)};
   --shadow: #{rgba($darkest, 0.9)};
 

--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -99,7 +99,8 @@ $selected: rgba($primary, .5);
 
   --accent-btn                 : #{rgba($primary, 0.2)};
   --accent-btn-hover           : #{rgba($primary, 0.5)};
-  --modal-bg                   :#{$light};
+  --modal-bg                   : #{$lightest};
+  --modal-border               : #{$dark};
   --overlay-bg                 : #{rgba($lighter, 0.75)};
   --shadow                     : #{rgba($medium, 0.85)};
 

--- a/assets/styles/vendor/vue-js-modal.scss
+++ b/assets/styles/vendor/vue-js-modal.scss
@@ -6,5 +6,7 @@
 }
 
 .v--modal {
-background-color: var(--modal-bg)!important;
+  background-color: var(--modal-bg)!important;
+  box-shadow: none;
+  border: 2px solid var(--modal-border);
 }


### PR DESCRIPTION
Improved mainly for light mode, but slightly tweaked for dark mode to make it look less washed out around the modal dialogs.

Was:

![Screenshot 2021-05-14 at 08 10 25](https://user-images.githubusercontent.com/1955897/118234894-e2980700-b48b-11eb-9c19-af83388a6506.png)

Now:

![Screenshot 2021-05-14 at 08 08 49](https://user-images.githubusercontent.com/1955897/118234747-b2e8ff00-b48b-11eb-9602-45522abe2cec.png)

