### PR TITLE
Fix refresh on node detail and list pages with SSR enabled

### DIFF
--- a/list/node.vue
+++ b/list/node.vue
@@ -1,19 +1,17 @@
 <script>
 import ResourceTable from '@/components/ResourceTable';
 import Loading from '@/components/Loading';
-import Poller from '@/utils/poller';
 import {
   STATE, NAME, ROLES, VERSION, INTERNAL_EXTERNAL_IP, CPU, RAM
 } from '@/config/table-headers';
+import metricPoller from '@/mixins/metric-poller';
 
 import { CAPI, METRIC, NODE } from '@/config/types';
-
-const METRICS_POLL_RATE_MS = 30000;
-const MAX_FAILURES = 2;
 
 export default {
   name:       'ListNode',
   components: { Loading, ResourceTable },
+  mixins:     [metricPoller],
 
   props: {
     schema: {
@@ -34,16 +32,7 @@ export default {
     return {
       rows:         null,
       headers:      [STATE, NAME, ROLES, VERSION, INTERNAL_EXTERNAL_IP, CPU, RAM],
-      metricPoller: new Poller(this.loadMetrics, METRICS_POLL_RATE_MS, MAX_FAILURES),
     };
-  },
-
-  mounted() {
-    this.metricPoller.start();
-  },
-
-  beforeDestroy() {
-    this.metricPoller.stop();
   },
 
   methods: {

--- a/mixins/metric-poller.js
+++ b/mixins/metric-poller.js
@@ -1,0 +1,19 @@
+import Poller from '@/utils/poller';
+
+const METRICS_POLL_RATE_MS = 30000;
+const MAX_FAILURES = 2;
+
+export default {
+  data() {
+    return { metricPoller: null };
+  },
+
+  mounted() {
+    this.metricPoller = new Poller(this.loadMetrics, METRICS_POLL_RATE_MS, MAX_FAILURES);
+    this.metricPoller.start();
+  },
+
+  beforeDestroy() {
+    this.metricPoller.stop();
+  },
+};

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -5,7 +5,6 @@ import { mapGetters } from 'vuex';
 import isEmpty from 'lodash/isEmpty';
 import SortableTable from '@/components/SortableTable';
 import { allHash } from '@/utils/promise';
-import Poller from '@/utils/poller';
 import AlertTable from '@/components/AlertTable';
 import {
   parseSi, formatSi, exponentNeeded, UNITS, createMemoryFormat, MEMORY_PARSE_RULES
@@ -34,11 +33,9 @@ import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
 import { allDashboardsExist } from '@/utils/grafana';
 import EtcdInfoBanner from '@/components/EtcdInfoBanner';
+import metricPoller from '@/mixins/metric-poller';
 import ResourceSummary, { resourceCounts } from './ResourceSummary';
 import HardwareResourceGauge from './HardwareResourceGauge';
-
-const METRICS_POLL_RATE_MS = 30000;
-const MAX_FAILURES = 2;
 
 const RESOURCES = [NAMESPACE, INGRESS, PV, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.DAEMON_SET, SERVICE];
 
@@ -61,6 +58,8 @@ export default {
     Tabbed,
     AlertTable
   },
+
+  mixins: [metricPoller],
 
   async fetch() {
     const hash = {
@@ -126,7 +125,6 @@ export default {
     ];
 
     return {
-      metricPoller:        null,
       eventHeaders,
       nodeHeaders,
       constraints:         [],
@@ -265,11 +263,6 @@ export default {
     }
   },
 
-  mounted() {
-    this.metricPoller = new Poller(this.loadMetrics, METRICS_POLL_RATE_MS, MAX_FAILURES);
-    this.metricPoller.start();
-  },
-
   methods: {
     createMemoryValues(total, useful) {
       const parsedTotal = parseSi((total || '0').toString());
@@ -322,10 +315,6 @@ export default {
     findBy,
   },
 
-  beforeRouteLeave(to, from, next) {
-    this.metricPoller.stop();
-    next();
-  }
 };
 </script>
 


### PR DESCRIPTION
- match fix that had been applied to cluster home page
- move out common Poll code into mixin
- note - in cluster home page poll was being stopped via beforeRouteLeave, whereas others were in beforeDestroy. I've tested this in both modes and it still works ok
- addresses #2984