### PR TITLE
Workload: Fix missing `Remove Container` button & incorrect `general` Tab name

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3522,7 +3522,7 @@ workload:
       name: Name
       protocol: Protocol
       listeningPort: Listening Port
-      removeContainer: Remove Container
+    removeContainer: Remove Container
     security:
       addCapabilities: Add Capabilities
       addGroupIDs: Add Group IDs
@@ -3562,6 +3562,7 @@ workload:
       containers: Containers
       env: Environment Variables
       events: Events
+      general: General
       healthCheck: Health Check
       image: Image
       networking: Networking


### PR DESCRIPTION
- button to remove workload container was missing due to a misplaced translation (not sure why i10n string wasn't shown)
- text for `general` was also missing
- these were both fine at one point
- addresses #2983