### PR TITLE
Drop down menu color changes

### DIFF
--- a/assets/styles/themes/_light.scss
+++ b/assets/styles/themes/_light.scss
@@ -114,10 +114,10 @@ $selected: rgba($primary, .5);
   --dropdown-border            : #{$medium};
   --dropdown-divider           : #{$medium};
   --dropdown-text              : #{$link};
-  --dropdown-active-text       : #{darken($link, 1%)};
-  --dropdown-active-bg         : #{$selected};
-  --dropdown-hover-text        : #{lighten($link, 1%)};
-  --dropdown-hover-bg          : #{rgba($link, 0.2)};
+  --dropdown-active-text       : #{$lightest};
+  --dropdown-active-bg         : #{$dark};
+  --dropdown-hover-text        : #{$lightest};
+  --dropdown-hover-bg          : #{$primary};
   --dropdown-disabled-text     : var(--muted);
   --dropdown-disabled-bg       : #{$disabled};
 

--- a/assets/styles/themes/_suse.scss
+++ b/assets/styles/themes/_suse.scss
@@ -22,6 +22,8 @@
   --tooltip-bg                 : #{lighten($primary, 35%)};
   --terminal-selection         : #{$selected};
 
+  --dropdown-hover-bg          : #{$primary};
+
   &.dark-theme{
     --accent-btn: #{rgba($primary, 0.2)};
 

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -216,19 +216,23 @@ export default {
             <div class="category">
               {{ t('nav.categories.multiCluster') }}
             </div>
-            <nuxt-link v-for="a in multiClusterApps" :key="a.label" class="option" :to="a.to">
-              <i class="icon group-icon" :class="a.icon" />
-              <div>{{ a.label }}</div>
-            </nuxt-link>
+            <div v-for="a in multiClusterApps" :key="a.label" @click="hide()">
+              <nuxt-link class="option" :to="a.to">
+                <i class="icon group-icon" :class="a.icon" />
+                <div>{{ a.label }}</div>
+              </nuxt-link>
+            </div>
           </template>
           <template v-if="configurationApps.length">
             <div class="category">
               {{ t('nav.categories.configuration') }}
             </div>
-            <nuxt-link v-for="a in configurationApps" :key="a.label" class="option" :to="a.to">
-              <i class="icon group-icon" :class="a.icon" />
-              <div>{{ a.label }}</div>
-            </nuxt-link>
+            <div v-for="a in configurationApps" :key="a.label" @click="hide()">
+              <nuxt-link class="option" :to="a.to">
+                <i class="icon group-icon" :class="a.icon" />
+                <div>{{ a.label }}</div>
+              </nuxt-link>
+            </div>
           </template>
           <div class="pad"></div>
           <div class="cluster-manager">
@@ -332,6 +336,13 @@ export default {
 
     &:hover {
       text-decoration: none;
+    }
+
+    &:focus {
+      outline: 0;
+      > div {
+        text-decoration: underline;
+      }
     }
 
     > i {


### PR DESCRIPTION
This PR changes back the dropdown colors to what they were before the SUSE theme changes.

It also fixes a bug in the top level menu where it does not close it you select the currently active page for global or configuration apps.