### PR TITLE
fix monitoring route/receiver and pod/service monitor routing 

### DIFF
--- a/config/product/monitoring.js
+++ b/config/product/monitoring.js
@@ -174,6 +174,7 @@ export function init(store) {
     group:         'monitoring',
     name:     'route-receiver',
     icon:     'globe',
+    route: { name: 'c-cluster-monitoring-route-receiver' }
   });
 
   virtualType({
@@ -181,12 +182,11 @@ export function init(store) {
     group:         'monitoring',
     name:     'monitor',
     icon:     'globe',
+    route: { name: 'c-cluster-monitoring-monitor' }
   });
 
   configureType('route-receiver', { showListMasthead: false });
   configureType('monitor', { showListMasthead: false });
-  configureType(ROUTE, { showState: false, showAge: false });
-  configureType(RECEIVER, { showState: false, showAge: false });
 
   basicType([
     'monitoring-overview',

--- a/edit/monitoring.coreos.com.receiver/index.vue
+++ b/edit/monitoring.coreos.com.receiver/index.vue
@@ -59,12 +59,17 @@ export default {
 
     return {
       expectedFields,
-      receiverTypes:    RECEIVERS_TYPES,
-      fileFound:        false,
-      receiver:         {},
+      receiverTypes:        RECEIVERS_TYPES,
+      fileFound:            false,
+      receiver:             {},
       suffixYaml,
       EDITOR_MODES,
-      yamlError:        ''
+      yamlError:            '',
+      doneLocationOverride:      {
+        name:   'c-cluster-monitoring-route-receiver',
+        params: { cluster: this.$store.getters['clusterId'] },
+        query:  { resource: MONITORING.SPOOFED.RECEIVER }
+      }
     };
   },
 
@@ -153,6 +158,7 @@ export default {
     :subtypes="[]"
     :can-yaml="false"
     :errors="errors"
+    :cancel-event="true"
     @error="e=>errors = e"
     @finish="saveOverride"
     @cancel="done"

--- a/edit/monitoring.coreos.com.route.vue
+++ b/edit/monitoring.coreos.com.route.vue
@@ -43,7 +43,14 @@ export default {
   data() {
     this.$set(this.value.spec, 'group_by', this.value.spec.group_by || []);
 
-    return { receiverOptions: [] };
+    return {
+      receiverOptions:      [],
+      doneLocationOverride:      {
+        name:   'c-cluster-monitoring-route-receiver',
+        params: { cluster: this.$store.getters['clusterId'] },
+        query:  { resource: MONITORING.SPOOFED.ROUTE }
+      }
+    };
   },
 };
 </script>
@@ -58,6 +65,7 @@ export default {
     :mode="mode"
     :resource="value"
     :subtypes="[]"
+    :cancel-event="true"
     @error="e=>errors = e"
     @finish="save"
     @cancel="done"

--- a/mixins/create-edit-view/impl.js
+++ b/mixins/create-edit-view/impl.js
@@ -89,7 +89,6 @@ export default {
       if ( this.onDone ) {
         return this.onDone();
       }
-
       if ( this.doneLocationOverride) {
         return this.$router.replace(this.doneLocationOverride);
       }

--- a/models/monitoring.coreos.com.podmonitor.js
+++ b/models/monitoring.coreos.com.podmonitor.js
@@ -1,0 +1,21 @@
+export default {
+  _detailLocation() {
+    const id = this.id?.replace(/.*\//, '');
+
+    return {
+      name:   'c-cluster-monitoring-monitor-namespace-id',
+      params: {
+        cluster: this.$rootGetters['clusterId'], id, namespace: this.metadata.namespace
+      },
+      query: { resource: this.type }
+    };
+  },
+
+  doneOverride() {
+    return {
+      name:   'c-cluster-monitoring-monitor',
+      params: { cluster: this.$rootGetters['clusterId'] },
+      query:  { resource: this.type }
+    };
+  },
+};

--- a/models/monitoring.coreos.com.receiver.js
+++ b/models/monitoring.coreos.com.receiver.js
@@ -114,6 +114,14 @@ export default {
     return true;
   },
 
+  _detailLocation() {
+    return {
+      name:   'c-cluster-monitoring-route-receiver-id',
+      params: { cluster: this.$rootGetters['clusterId'], id: this.id },
+      query:  { resource: this.type }
+    };
+  },
+
   receiverTypes() {
     const types = RECEIVERS_TYPES
       .filter(type => type.name !== 'custom' && this.spec[type.key]?.length > 0)

--- a/models/monitoring.coreos.com.route.js
+++ b/models/monitoring.coreos.com.route.js
@@ -86,6 +86,14 @@ export default {
     return areRoutesSupportedFormat(this.secret);
   },
 
+  _detailLocation() {
+    return {
+      name:   'c-cluster-monitoring-route-receiver-id',
+      params: { cluster: this.$rootGetters['clusterId'], id: this.id },
+      query:  { resource: this.type }
+    };
+  },
+
   customValidationRules() {
     const rules = [
       {

--- a/models/monitoring.coreos.com.servicemonitor.js
+++ b/models/monitoring.coreos.com.servicemonitor.js
@@ -1,0 +1,21 @@
+export default {
+  _detailLocation() {
+    const id = this.id?.replace(/.*\//, '');
+
+    return {
+      name:   'c-cluster-monitoring-monitor-namespace-id',
+      params: {
+        cluster: this.$rootGetters['clusterId'], id, namespace: this.metadata.namespace
+      },
+      query: { resource: this.type }
+    };
+  },
+
+  doneOverride() {
+    return {
+      name:   'c-cluster-monitoring-monitor',
+      params: { cluster: this.$rootGetters['clusterId'] },
+      query:  { resource: this.type }
+    };
+  },
+};

--- a/pages/c/_cluster/monitoring/monitor/_id.vue
+++ b/pages/c/_cluster/monitoring/monitor/_id.vue
@@ -1,0 +1,19 @@
+<script>
+import ResourceDetail from '@/components/ResourceDetail';
+
+export default {
+  name: 'RouteReceiverCreate',
+
+  components: { ResourceDetail },
+
+  data() {
+    const { query:{ resource } } = this.$route;
+
+    return { resource };
+  }
+};
+</script>
+
+<template>
+  <ResourceDetail :resource-override="resource" />
+</template>

--- a/pages/c/_cluster/monitoring/monitor/create.vue
+++ b/pages/c/_cluster/monitoring/monitor/create.vue
@@ -1,0 +1,19 @@
+<script>
+import ResourceDetail from '@/components/ResourceDetail';
+
+export default {
+  name: 'RouteReceiverCreate',
+
+  components: { ResourceDetail },
+
+  data() {
+    const { query:{ resource } } = this.$route;
+
+    return { resource };
+  }
+};
+</script>
+
+<template>
+  <ResourceDetail :resource-override="resource" />
+</template>

--- a/pages/c/_cluster/monitoring/monitor/index.vue
+++ b/pages/c/_cluster/monitoring/monitor/index.vue
@@ -26,20 +26,21 @@ export default {
   },
 
   data() {
+    const initTab = this.$route.query.resource || MONITORING.SPOOFED.PODMONITOR;
+
     return {
-      podMonitors: [], serviceMonitors: [], podMonitorSchema: null, serviceMonitorSchema: null
+      podMonitors: [], serviceMonitors: [], podMonitorSchema: null, serviceMonitorSchema: null, initTab
     };
   },
 
   computed: {
     createRoute() {
-      const activeResource = this.$refs?.tabs?.activeTabName;
+      const activeResource = this.$refs?.tabs?.activeTabName || this.routeSchema.id;
 
       return {
-        name:   'c-cluster-product-resource-create',
-        params: {
-          resource: activeResource, cluster: this.$route.params.cluster, product: 'monitoring'
-        }
+        name:   'c-cluster-monitoring-monitor-create',
+        params: { cluster: this.$route.params.cluster },
+        query:  { resource: activeResource }
       };
     },
   }
@@ -57,7 +58,7 @@ export default {
         </button>
       </div>
     </div>
-    <Tabbed ref="tabs">
+    <Tabbed ref="tabs" :default-tab="initTab">
       <Tab :name="podMonitorSchema.id" :label="$store.getters['type-map/labelFor'](podMonitorSchema, 2)">
         <TypeDescription :resource="podMonitorSchema.id" />
         <ResourceTable :schema="podMonitorSchema" :rows="podMonitors" />

--- a/pages/c/_cluster/monitoring/route-receiver/_id.vue
+++ b/pages/c/_cluster/monitoring/route-receiver/_id.vue
@@ -1,0 +1,19 @@
+<script>
+import ResourceDetail from '@/components/ResourceDetail';
+
+export default {
+  name: 'RouteReceiverDetail',
+
+  components: { ResourceDetail },
+
+  data() {
+    const { query:{ resource } } = this.$route;
+
+    return { resource };
+  }
+};
+</script>
+
+<template>
+  <ResourceDetail :resource-override="resource" />
+</template>

--- a/pages/c/_cluster/monitoring/route-receiver/create.vue
+++ b/pages/c/_cluster/monitoring/route-receiver/create.vue
@@ -1,0 +1,19 @@
+<script>
+import ResourceDetail from '@/components/ResourceDetail';
+
+export default {
+  name: 'RouteReceiverCreate',
+
+  components: { ResourceDetail },
+
+  data() {
+    const { query:{ resource } } = this.$route;
+
+    return { resource };
+  }
+};
+</script>
+
+<template>
+  <ResourceDetail :resource-override="resource" />
+</template>

--- a/pages/c/_cluster/monitoring/route-receiver/index.vue
+++ b/pages/c/_cluster/monitoring/route-receiver/index.vue
@@ -16,13 +16,6 @@ export default {
     Tab,
   },
 
-  props: {
-    schema: {
-      type:     Object,
-      required: true,
-    },
-  },
-
   async fetch() {
     this.routeSchema = this.$store.getters['cluster/schemaFor'](MONITORING.SPOOFED.ROUTE);
     this.receiverSchema = this.$store.getters['cluster/schemaFor'](MONITORING.SPOOFED.RECEIVER);
@@ -45,8 +38,10 @@ export default {
   },
 
   data() {
+    const initTab = this.$route.query.resource || MONITORING.SPOOFED.RECEIVER;
+
     return {
-      routes: [], receivers: [], secretTo: null, routeSchema: null, receiverSchema: null
+      routes: [], receivers: [], secretTo: null, routeSchema: null, receiverSchema: null, initTab
     };
   },
   computed: {
@@ -55,10 +50,9 @@ export default {
       const activeResource = this.$refs?.tabs?.activeTabName || this.routeSchema.id;
 
       return {
-        name:   'c-cluster-product-resource-create',
-        params: {
-          resource: activeResource, cluster: this.$route.params.cluster, product: 'monitoring'
-        }
+        name:   'c-cluster-monitoring-route-receiver-create',
+        params: { cluster: this.$route.params.cluster },
+        query:  { resource: activeResource }
       };
     },
   },
@@ -77,7 +71,7 @@ export default {
         </button>
       </div>
     </div>
-    <Tabbed ref="tabs">
+    <Tabbed ref="tabs" :default-tab="initTab">
       <Tab :name="routeSchema.id" :label="$store.getters['type-map/labelFor'](routeSchema, 2)">
         <div v-if="secretTo">
           We don't support the current route format stored in alertmanager.yaml. Click


### PR DESCRIPTION
#2510 - I didn't implement this very completely previously; I added list views but didn't fix the create/detail pages to properly exist on that route and navigate back to it after save or cancel. This pr moves route, receiver, pod monitor, and service monitor creation/viewing under their list view route.