### PR TITLE
Workloads: Fix two minor form issues 

### DIFF
--- a/components/form/Command.vue
+++ b/components/form/Command.vue
@@ -102,10 +102,9 @@ export default {
         args:       this.args,
         workingDir: this.workingDir,
         tty:        this.tty,
-
       };
 
-      this.$emit('input', cleanUp(out) );
+      this.$emit('input', cleanUp(out));
     },
   },
 };

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -249,7 +249,10 @@ export default {
     },
 
     allContainers() {
-      return [...this.podTemplateSpec.containers, ...(this.podTemplateSpec.initContainers || []).map((each) => {
+      const containers = this.podTemplateSpec?.containers || [];
+      const initContainers = this.podTemplateSpec?.initContainers || [];
+
+      return [...containers, ...initContainers.map((each) => {
         each._init = true;
 
         return each;
@@ -744,7 +747,7 @@ export default {
           </button>
         </div>
       </div>
-      <Tabbed :key="allContainers.indexOf(container)" :side-tabs="true">
+      <Tabbed :key="container.name" :side-tabs="true">
         <Tab :label="t('workload.container.titles.general')" name="general">
           <div>
             <div :style="{'align-items':'center'}" class="row mb-20">

--- a/pages/c/_cluster/apps/charts.vue
+++ b/pages/c/_cluster/apps/charts.vue
@@ -327,7 +327,6 @@ export default {
 
       <button v-shortkey.once="['/']" class="hide" @shortkey="focusSearch()" />
       <AsyncButton mode="refresh" size="sm" @click="refresh" />
-      <!-- </div> -->
     </div>
 
     <Banner v-for="err in loadingErrors" :key="err" color="error" :label="err" />


### PR DESCRIPTION
- Fix refresh with SSR switched on
- Fix issue where entering text in the General tab's Command fields loses focus
  - This was interesting to hunt down
  - Revolved around the change to `container` re-rendering the Tab component due to it's key 'changing'
  - This issue isn't helped by the jumble of workload and container fields in the same context (covered by #2683)
  - Now uses containers name, which cannot change and is unique to the namespace
  - Addresses #2723