### PR TITLE
Fix `Labels &amp Annotations` tab label

### DIFF
--- a/edit/configmap.vue
+++ b/edit/configmap.vue
@@ -92,7 +92,7 @@ export default {
       </Tab>
       <Tab
         name="labels-and-annotations"
-        :label="t('generic.labelsAndAnnotations')"
+        label-key="generic.labelsAndAnnotations"
         :weight="-1"
       >
         <Labels

--- a/edit/logging.banzaicloud.io.output/index.vue
+++ b/edit/logging.banzaicloud.io.output/index.vue
@@ -131,7 +131,7 @@ export default {
         <Tab
           v-if="!isView"
           name="labels-and-annotations"
-          :label="t('generic.labelsAndAnnotations')"
+          label-key="generic.labelsAndAnnotations"
           :weight="0"
         >
           <Labels

--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -48,7 +48,7 @@ export default {
       </Tab>
       <Tab
         name="labels-and-annotations"
-        :label="t('generic.labelsAndAnnotations')"
+        label-key="generic.labelsAndAnnotations"
         :weight="7"
       >
         <Labels

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -123,7 +123,7 @@ export default {
       <Tab
         v-if="!isView"
         name="labels-and-annotations"
-        :label="t('generic.labelsAndAnnotations')"
+        label-key="generic.labelsAndAnnotations"
         :weight="-1"
       >
         <Labels

--- a/edit/networking.k8s.io.ingress/index.vue
+++ b/edit/networking.k8s.io.ingress/index.vue
@@ -140,7 +140,7 @@ export default {
       <Tab
         v-if="!isView"
         name="labels-and-annotations"
-        :label="t('generic.labelsAndAnnotations')"
+        label-key="generic.labelsAndAnnotations"
         :weight="0"
       >
         <Labels

--- a/edit/secret/index.vue
+++ b/edit/secret/index.vue
@@ -247,7 +247,7 @@ export default {
             :hide-sensitive-data="hideSensitiveData"
           />
         </Tab>
-        <Tab name="labels" :label="t('generic.labelsAndAnnotations')">
+        <Tab name="labels" label-key="generic.labelsAndAnnotations">
           <Labels v-model="value" :mode="mode" />
         </Tab>
       </Tabbed>

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -880,7 +880,7 @@ export default {
         <Tab v-if="isStatefulSet" :label="t('workload.container.titles.volumeClaimTemplates')" name="volumeClaimTemplates">
           <VolumeClaimTemplate v-model="spec" :mode="mode" />
         </Tab>
-        <Tab name="labels" :label="t('generic.labelsAndAnnotations')">
+        <Tab name="labels" label-key="generic.labelsAndAnnotations">
           <Labels v-model="value" :mode="mode" />
           <div class="spacer"></div>
 


### PR DESCRIPTION
- Use simpler :label-key instead of :label
- Actual issue was that..
  - some components used Vue.prototype.t ... which did the escaping of some characters like `&`
  - others used `...mapGetters({ t: 'i18n/t' })` ... which didn't do the escaping and looked fine
- Guessing this might have been caused by a change in CreateEditView
- Addresses #2943