### PR TITLE
Ensure table row hover and 'select all' rows respect empty table scenarios

### DIFF
--- a/components/SortableTable/THead.vue
+++ b/components/SortableTable/THead.vue
@@ -55,6 +55,14 @@ export default {
       type:     Function,
       required: true,
     },
+    noRows: {
+      type:    Boolean,
+      default: true,
+    },
+    noResults: {
+      type:    Boolean,
+      default: true,
+    }
   },
 
   computed: {
@@ -115,6 +123,7 @@ export default {
           v-model="isAll"
           class="check"
           :indeterminate="isIndeterminate"
+          :disabled="noRows || noResults"
         />
       </th>
       <th v-if="subExpandColumn" :width="expandWidth"></th>

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -514,14 +514,16 @@ export default {
         :sort-by="sortBy"
         :default-sort-by="_defaultSortBy"
         :descending="descending"
+        :no-rows="noRows"
+        :no-results="noResults"
         @on-toggle-all="onToggleAll"
         @on-sort-change="changeSort"
       />
 
       <tbody v-if="noRows">
         <slot name="no-rows">
-          <tr>
-            <td :colspan="fullColspan" class="no-rows">
+          <tr class="no-rows">
+            <td :colspan="fullColspan">
               <t v-if="showNoRows" :k="noRowsKey" />
             </td>
           </tr>
@@ -529,8 +531,8 @@ export default {
       </tbody>
       <tbody v-else-if="noResults">
         <slot name="no-results">
-          <tr>
-            <td :colspan="fullColspan" class="no-results text-center">
+          <tr class="no-results">
+            <td :colspan="fullColspan" class="text-center">
               <t :k="noDataKey" />
             </td>
           </tr>
@@ -749,8 +751,16 @@ $spacing: 10px;
     }
 
     .no-rows {
-      padding: 30px 0;
-      text-align: center;
+      td {
+        padding: 30px 0;
+        text-align: center;
+      }
+    }
+
+    .no-rows, .no-results {
+      &:hover {
+        background-color: var(--body-bg);
+      }
     }
 
     &.group {


### PR DESCRIPTION
- Hover state is overridden
- Select all checkbox in header is disabled
- Applies to tables where there are no rows at all or when they're all filtered out
- addresses #2946