### PR TITLE
github style, detailed authz message

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -228,7 +228,7 @@ authConfig:
     unrestricted: Allow any valid user
   allowedPrincipalIds:
     title: Authorized Users & Groups
-  associatedWarning: 'Note: The {provider} user you authenticate as will be associated as an alternate way to login to the {vendor} user you are currently logged in as (<code>{username}</code>).'
+  associatedWarning: 'Note: The {provider} user you authenticate as will be associated as an alternate way to login to the {vendor} user you are currently logged in as (<code>{username}</code>); all the global permissions, project, and cluster role bindings of this {vendor} user will also apply to the {provider} user.'
   github:
     clientId:
       label: Client ID
@@ -381,6 +381,8 @@ authConfig:
     enabled: 'The {provider} authentication provider is currently enabled.'
   testAndEnable: Test and Enable Authentication
   noneEnabled: Local Authentication is always enabled, but you may select another additional authentication provider from those shown below.
+  localEnabled: '{vendor} is configured to allow access to accounts in its local database.'
+  manageLocal: Manage Accounts
 
 authGroups:
   actions:

--- a/edit/auth/github.vue
+++ b/edit/auth/github.vue
@@ -7,7 +7,7 @@ import LabeledInput from '@/components/form/LabeledInput';
 import Banner from '@/components/Banner';
 import CopyToClipboard from '@/components/CopyToClipboard';
 import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
-import { NORMAN, MANAGEMENT } from '@/config/types';
+import { MANAGEMENT } from '@/config/types';
 import { findBy } from '@/utils/array';
 import AuthConfig from '@/mixins/auth-config';
 import AuthBanner from '@/components/auth/AuthBanner';
@@ -67,10 +67,6 @@ export default {
 
     baseUrl() {
       return `${ this.model.tls ? 'https://' : 'http://' }${ this.model.hostname }`;
-    },
-
-    principal() {
-      return this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.$store.getters['auth/principalId']) || {};
     },
 
     displayName() {
@@ -170,7 +166,7 @@ export default {
           :labels="[ t(`authConfig.${NAME}.target.public`), t(`authConfig.${NAME}.target.private`)]"
         />
 
-        <div class="row">
+        <div class="row mb-20">
           <div class="col span-6">
             <LabeledInput
               v-if="!isPublic"

--- a/pages/c/_cluster/auth/config/index.vue
+++ b/pages/c/_cluster/auth/config/index.vue
@@ -45,7 +45,16 @@ export default {
 
     displayName() {
       return this.$store.getters['type-map/labelFor'](this.schema, 2);
-    }
+    },
+
+    localUsersRoute() {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          cluster: this.$route.params.cluster, product: 'auth', resource: MANAGEMENT.USER
+        }
+      };
+    },
   },
 
   methods: {
@@ -67,7 +76,7 @@ export default {
         params: { id },
         query:  { [MODE]: _EDIT }
       });
-    }
+    },
   }
 };
 </script>
@@ -77,7 +86,14 @@ export default {
     <h1 class="m-0">
       {{ displayName }}
     </h1>
-    <Banner v-if="!enabled.length" :label="t('authConfig.noneEnabled')" color="info" />
+    <Banner v-if="!enabled.length" :label="t('authConfig.noneEnabled')" color="info">
+      {{ t('authConfig.localEnabled') }}
+      <nuxt-link :to="localUsersRoute">
+        {{ t('authConfig.manageLocal') }}
+      </nuxt-link>
+      <br />
+      {{ t('authConfig.noneEnabled') }}
+    </Banner>
     <SelectIconGrid
       :rows="rows"
       :color-for="colorFor"


### PR DESCRIPTION
#2655 
#2654 - This PR includes changes for the first and third issue described in the comment here; neither Anupama nor I were able to reproduce the second issue:

> While we enable the auth provider, the following note is displayed for the users with "currently logged in as" empty which should be user ID of the admin.