### PR TITLE
Remove debug json in side navigation

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -194,12 +194,6 @@ export default {
           @selected="$emit('selected')"
           @click="clicked"
         />
-        <div
-          v-else
-          :key="id+'_' + child.name + '_hmm'"
-        >
-          {{ child }}??
-        </div>
       </template>
     </ul>
   </div>


### PR DESCRIPTION
Removes debug json shown for overview groups:

![image](https://user-images.githubusercontent.com/1955897/119333207-813d1880-bc81-11eb-9fee-3687cd997422.png)
