### PR TITLE
reload principal when auth provider enabled/disabled

### DIFF
--- a/components/InfoBox.vue
+++ b/components/InfoBox.vue
@@ -37,6 +37,7 @@ export default {
     .step-number {
       border-radius: var(--border-radius);
       background: var(--secondary);
+      color: var(--input-text);
       display: inline-block;
       padding: 5px 10px;
   }

--- a/components/auth/login/ldap.vue
+++ b/components/auth/login/ldap.vue
@@ -8,16 +8,14 @@ export default {
   mixins:     [Login],
 
   props: {
-    onlyOption: {
+    open: {
       type:    Boolean,
       default: false
     }
   },
 
   data() {
-    return {
-      username: '', password: '', showInputs: this.onlyOption
-    };
+    return { username: '', password: '' };
   },
 
   methods: {
@@ -45,7 +43,7 @@ export default {
 
 <template>
   <form>
-    <template v-if="showInputs">
+    <template v-if="open">
       <div class="span-6 offset-3">
         <div class="mb-20">
           <LabeledInput
@@ -80,7 +78,7 @@ export default {
       </div>
     </template>
     <div v-else class="text-center">
-      <button style="font-size: 18px;" type="button" class="btn bg-primary" @click="showInputs = true">
+      <button style="font-size: 18px;" type="button" class="btn bg-primary" @click="$emit('toggle')">
         {{ t('login.loginWithProvider', {provider: displayName}) }}
       </button>
     </div>

--- a/components/auth/login/ldap.vue
+++ b/components/auth/login/ldap.vue
@@ -78,7 +78,7 @@ export default {
       </div>
     </template>
     <div v-else class="text-center">
-      <button style="font-size: 18px;" type="button" class="btn bg-primary" @click="$emit('toggle')">
+      <button style="font-size: 18px;" type="button" class="btn bg-primary" @click="$emit('showInputs')">
         {{ t('login.loginWithProvider', {provider: displayName}) }}
       </button>
     </div>

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -30,6 +30,11 @@ export default {
       opt:  { url: `/v1/{ MANAGEMENT.SETTING }/server-url` }
     });
 
+    this.principals = await this.$store.dispatch('rancher/findAll', {
+      type: NORMAN.PRINCIPAL,
+      opt:  { url: '/v3/principals', force: true }
+    });
+
     if ( serverUrl ) {
       this.serverSetting = serverUrl.value;
     }
@@ -56,16 +61,11 @@ export default {
       serverSetting: null,
       errors:        null,
       originalModel: null,
+      principals:    []
     };
   },
 
   computed: {
-    me() {
-      const out = findBy(this.principals, 'me', true);
-
-      return out;
-    },
-
     doneLocationOverride() {
       return {
         name:   this.$route.name,
@@ -88,7 +88,7 @@ export default {
     },
 
     principal() {
-      return this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.$store.getters['auth/principalId']) || {};
+      return findBy(this.principals, 'me', true) || {};
     },
 
     displayName() {
@@ -203,6 +203,10 @@ export default {
         // Covers case where user disables... then enables in same visit to page
         this.applyDefaults();
 
+        this.principals = await this.$store.dispatch('rancher/findAll', {
+          type: NORMAN.PRINCIPAL,
+          opt:  { url: '/v3/principals', force: true }
+        });
         this.showLdap = false;
         btnCb(true);
       } catch (err) {

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -211,7 +211,7 @@ export default {
             :focus-on-mount="(idx === 0 && !showLocal)"
             :name="name"
             :open="!showLocal"
-            @toggle="showLocal = false"
+            @showInputs="showLocal = false"
           />
         </div>
         <template v-if="hasLocal">

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -210,7 +210,8 @@ export default {
             class="mb-10"
             :focus-on-mount="(idx === 0 && !showLocal)"
             :name="name"
-            :only-option="providers.length === 1 && !showLocal"
+            :open="!showLocal"
+            @toggle="showLocal = false"
           />
         </div>
         <template v-if="hasLocal">


### PR DESCRIPTION
#2654 - refresh principal information when an auth provider is enabled/disabled
#2655 - lighten step number text color
#2949 - hide ldap username/password inputs when local inputs are shown, and vice versa