### PR TITLE
Remove border on disabled buttons to prevent wobble

### DIFF
--- a/assets/styles/global/_button.scss
+++ b/assets/styles/global/_button.scss
@@ -110,7 +110,6 @@ fieldset[disabled] .btn {
   cursor: not-allowed;
   color: var(--disabled-text) !important;
   &:not(.role-link){
-    border: solid thin var(--input-disabled-border);
     background-color: var(--disabled-bg) !important;
   }
 }


### PR DESCRIPTION
Disabled state shows a 1px border, which changes the height of the button, leading to wobble on the setup page