### PR TITLE
Add dynamic 'Uninstall V1' step to Monitoring V2 wizard

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -513,6 +513,10 @@ asyncButton:
     action: Snapshot Now
     waiting: Snapshotting&hellip;
     success: Snapshot Creating
+  uninstall:
+    action: Uninstall
+    success: Uninstalled
+    waiting: Uninstalling&hellip;
   update:
     action: Update
     success: Updated
@@ -1763,7 +1767,6 @@ monitoring:
         label: Prometheus Targets
     subtitle: 'Powered By: <a href="https://github.com/coreos/prometheus-operator" target="_blank" rel="noopener noreferrer nofollow">Prometheus</a>'
     title: Dashboard
-    v1Warning: 'Monitoring is currently deployed from Cluster Manager. If you are migrating from an older version of {vendor} with monitoring enabled, please disable monitoring in Cluster Manager before attempting to use monitoring in Cluster Explorer.'
   prometheus:
     config:
       adminApi: Admin API
@@ -1822,6 +1825,14 @@ monitoring:
       repeatInterval: Repeat Interval
   routesAndReceivers: Routes and Receivers
   monitors: Monitors
+  installSteps:
+    uninstallV1:
+      stepTitle: Uninstall V1
+      stepSubtext: Uninstall Previous Monitoring
+      warning1: V1 Monitoring is currently deployed. This needs to be uninstalled before V2 monitoring can be installed.
+      warning2: <a target="blank" href="https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/v2.5/migrating/#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about migrating to V2 Monitoring.
+      success1: V1 monitoring successfully uninstalled.
+      success2: Press Next to continue
   tabs:
     alerting: Alerting
     general: General
@@ -4217,6 +4228,7 @@ action:
   hide: Hide
   copy: Copy
   unassign: 'Unassign'
+  uninstall: Uninstall
 
 unit:
   sec: secs

--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -16,8 +16,6 @@ import Tab from '@/components/Tabbed/Tab';
 import { allHash } from '@/utils/promise';
 import { STORAGE_CLASS, PVC, SECRET, WORKLOAD_TYPES } from '@/config/types';
 
-const CATTLE_MONITORING_NAMESPACE = 'cattle-monitoring-system';
-
 export default {
   components: {
     Alerting,
@@ -53,32 +51,6 @@ export default {
 
   async fetch() {
     const { $store } = this;
-
-    await Promise.all(
-      Object.values(WORKLOAD_TYPES).map(type => this.$store.dispatch('cluster/findAll', { type })
-      )
-    );
-
-    this.workloads.forEach((workload) => {
-      if (
-        !isEmpty(workload?.spec?.template?.spec?.containers) &&
-        workload.spec.template.spec.containers.find(
-          c => c.image.includes('quay.io/coreos/prometheus-operator') ||
-            c.image.includes('rancher/coreos-prometheus-operator')
-        ) &&
-        workload?.metadata?.namespace !== CATTLE_MONITORING_NAMESPACE
-      ) {
-        if (!this.v1Installed) {
-          this.v1Installed = true;
-        }
-      }
-    });
-
-    if (this.v1Installed) {
-      this.$emit('warn', this.t('monitoring.v1Warning', {}, true));
-
-      return;
-    }
 
     const hash = await allHash({
       namespaces:     $store.getters['namespaces'](),
@@ -130,7 +102,6 @@ export default {
       secrets:               [],
       storageClasses:        [],
       targetNamespace:       null,
-      v1Installed:           false,
     };
   },
 

--- a/chart/monitoring/steps/uninstall-v1.vue
+++ b/chart/monitoring/steps/uninstall-v1.vue
@@ -1,0 +1,126 @@
+
+<script>
+import { haveV1Monitoring, haveV1MonitoringWorkloads } from '@/utils/monitoring';
+import AsyncButton from '@/components/AsyncButton';
+import IconMessage from '@/components/IconMessage';
+
+function delay(t, v) {
+  return new Promise((resolve) => {
+    setTimeout(resolve.bind(null, v), t);
+  });
+}
+
+export default {
+
+  label:   'monitoring.installSteps.uninstallV1.stepTitle',
+  subtext: 'monitoring.installSteps.uninstallV1.stepSubtext',
+  weight:  100,
+
+  components: {
+    AsyncButton,
+    IconMessage
+  },
+
+  data() {
+    return {
+      uninstalled: false,
+      error:       null,
+    };
+  },
+
+  mounted() {
+    this.$emit('update', {
+      loading: false,
+      ready:   false,
+      hidden:  !haveV1Monitoring(this.$store.getters),
+    });
+  },
+
+  methods: {
+    uninstall(buttonCb) {
+      Promise.resolve()
+        .then(async() => {
+          await this.$store.getters['currentCluster'].doAction('disableMonitoring');
+
+          for (let index = 0; index < 30; index++) {
+            // Wait 30 seconds for the containers to go
+            const hasV1Monitoring = haveV1Monitoring(this.$store.getters);
+            const hasV1MonitoringWorkloads = await haveV1MonitoringWorkloads(this.$store);
+
+            if ((!hasV1Monitoring && !hasV1MonitoringWorkloads)) {
+              this.$emit('update', { ready: true });
+              buttonCb(true);
+              this.uninstalled = true;
+
+              return;
+            }
+            await delay(1000);
+          }
+          this.$emit('errors', [`Failed to uninstall: timed out`]);
+          buttonCb(false);
+        })
+        .catch((e) => {
+          this.$emit('errors', [`Failed to uninstall: ${ e }`]);
+          buttonCb(false);
+        });
+    },
+  }
+};
+
+</script>
+<template>
+  <div class="v1-monitoring">
+    <IconMessage
+      v-if="uninstalled"
+      class="mt-40"
+      icon="icon-checkmark"
+      :vertical="true"
+      icon-state="success"
+    >
+      <template #message>
+        <p class="">
+          {{ t('monitoring.installSteps.uninstallV1.success1') }}
+        </p>
+        <p class="mt-10" v-html="t('monitoring.installSteps.uninstallV1.success2')">
+        </p>
+      </template>
+    </IconMessage>
+    <template v-else>
+      <IconMessage
+        class="mt-40 mb-20"
+        icon="icon-warning"
+        :vertical="true"
+        icon-state="warning"
+      >
+        <template #message>
+          <p>
+            {{ t('monitoring.installSteps.uninstallV1.warning1') }}
+          </p>
+          <p class="mt-10" v-html="t('monitoring.installSteps.uninstallV1.warning2', {}, true)">
+          </p>
+        </template>
+      </IconMessage>
+      <AsyncButton
+        mode="uninstall"
+        :delay="2000"
+        :disabled="uninstalled"
+        @click="uninstall"
+      />
+    </template>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.v1-monitoring {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  p {
+    max-width: 900px;
+  }
+  .btn {
+    min-width: 200px;
+  }
+}
+</style>

--- a/chart/monitoring/steps/uninstall-v1.vue
+++ b/chart/monitoring/steps/uninstall-v1.vue
@@ -23,16 +23,17 @@ export default {
 
   data() {
     return {
-      uninstalled: false,
-      error:       null,
+      haveV1Monitoring: false,
+      error:            null,
     };
   },
 
   mounted() {
+    this.haveV1Monitoring = haveV1Monitoring(this.$store.getters);
     this.$emit('update', {
       loading: false,
       ready:   false,
-      hidden:  !haveV1Monitoring(this.$store.getters),
+      hidden:  !this.haveV1Monitoring,
     });
   },
 
@@ -48,9 +49,9 @@ export default {
             const hasV1MonitoringWorkloads = await haveV1MonitoringWorkloads(this.$store);
 
             if ((!hasV1Monitoring && !hasV1MonitoringWorkloads)) {
-              this.$emit('update', { ready: true });
+              this.$emit('update', { ready: true, hidden: true });
               buttonCb(true);
-              this.uninstalled = true;
+              this.haveV1Monitoring = false;
 
               return;
             }
@@ -70,22 +71,7 @@ export default {
 </script>
 <template>
   <div class="v1-monitoring">
-    <IconMessage
-      v-if="uninstalled"
-      class="mt-40"
-      icon="icon-checkmark"
-      :vertical="true"
-      icon-state="success"
-    >
-      <template #message>
-        <p class="">
-          {{ t('monitoring.installSteps.uninstallV1.success1') }}
-        </p>
-        <p class="mt-10" v-html="t('monitoring.installSteps.uninstallV1.success2')">
-        </p>
-      </template>
-    </IconMessage>
-    <template v-else>
+    <template v-if="haveV1Monitoring">
       <IconMessage
         class="mt-40 mb-20"
         icon="icon-warning"
@@ -103,10 +89,24 @@ export default {
       <AsyncButton
         mode="uninstall"
         :delay="2000"
-        :disabled="uninstalled"
         @click="uninstall"
       />
     </template>
+    <IconMessage
+      v-else
+      class="mt-40"
+      icon="icon-checkmark"
+      :vertical="true"
+      icon-state="success"
+    >
+      <template #message>
+        <p class="">
+          {{ t('monitoring.installSteps.uninstallV1.success1') }}
+        </p>
+        <p class="mt-10" v-html="t('monitoring.installSteps.uninstallV1.success2')">
+        </p>
+      </template>
+    </IconMessage>
   </div>
 </template>
 

--- a/components/IconMessage.vue
+++ b/components/IconMessage.vue
@@ -1,9 +1,17 @@
 <script>
 export default {
   props:      {
+    vertical: {
+      type:     Boolean,
+      default: false,
+    },
     icon: {
       type:     String,
       required: true,
+    },
+    iconState: {
+      type:     String,
+      default: null
     },
     message: {
       type:    String,
@@ -18,28 +26,52 @@ export default {
 </script>
 
 <template>
-  <div class="icon-message">
-    <i class="icon" :class="icon" />
+  <div class="icon-message" :class="{'vertical': vertical}">
+    <i class="icon" :class="{ [icon]: true, [iconState]: !!iconState}" />
     <div class="message">
-      <template v-if="messageKey">
-        {{ t(messageKey) }}
-      </template>
-      <template v-else>
-        {{ message }}
-      </template>
+      <slot name="message">
+        <template v-if="messageKey">
+          {{ t(messageKey) }}
+        </template>
+        <template v-else>
+          {{ message }}
+        </template>
+      </slot>
     </div>
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
+  .vertical {
+    flex-direction: column;
+    width: 100%;
+  }
+
   .icon-message {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex: 1;
 
     > I {
       font-size: 64px;
       margin-bottom: 20px;
+
+      &.info {
+      color: var(--primary);
+      }
+
+      &.error {
+        color: var(--error);
+      }
+
+      &.warning {
+        color: var(--warning);
+      }
+
+      &.success {
+        color: var(--success);
+      }
     }
 
     > .message {
@@ -49,5 +81,6 @@ export default {
       text-align: center;
       line-height: 30px;
     }
+
   }
 </style>

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -236,6 +236,31 @@ export const getters = {
       return importChart(name);
     };
   },
+
+  chartSteps(state, getters) {
+    return (name) => {
+      const steps = [];
+
+      const stepsPath = `./${ name }/steps/`;
+      // require.context only takes literals, so find all candidate step files and filter out
+      const allPaths = require.context('@/chart', true, /\.vue$/).keys();
+
+      allPaths
+        .filter(path => path.startsWith(stepsPath))
+        .forEach((path) => {
+          try {
+            steps.push({
+              name:      path.replace(stepsPath, ''),
+              component: importChart(path.substr(2, path.length)),
+            });
+          } catch (e) {
+            console.warn(`Failed to load step component ${ path } for chart ${ name }`, e); // eslint-disable-line no-console
+          }
+        });
+
+      return steps;
+    };
+  }
 };
 
 export const mutations = {

--- a/utils/dynamic-importer.js
+++ b/utils/dynamic-importer.js
@@ -3,7 +3,7 @@
 // an import with a variable in the path.
 
 export function importCloudCredential(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
@@ -11,7 +11,7 @@ export function importCloudCredential(name) {
 }
 
 export function importMachineConfig(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
@@ -19,7 +19,7 @@ export function importMachineConfig(name) {
 }
 
 export function importLogin(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
@@ -27,7 +27,7 @@ export function importLogin(name) {
 }
 
 export function importChart(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
@@ -35,7 +35,7 @@ export function importChart(name) {
 }
 
 export function importList(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
@@ -43,7 +43,7 @@ export function importList(name) {
 }
 
 export function importDetail(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
@@ -51,7 +51,7 @@ export function importDetail(name) {
 }
 
 export function importEdit(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
@@ -59,10 +59,10 @@ export function importEdit(name) {
 }
 
 export function loadProduct(name) {
-  if ( !name ) {
+  if (!name) {
     throw new Error('Name required');
   }
 
   // Note: directly returns the import, not a function
-  return import(/* webpackChunkName: "product" */ `@/config/product/${ name }`);
+  return import(/* webpackChunkName: "product" */ `@/config/product/${name}`);
 }

--- a/utils/monitoring.js
+++ b/utils/monitoring.js
@@ -1,7 +1,9 @@
 // Helpers for determining if V2 or v1 Monitoring are installed
-import { MONITORING, SCHEMA } from '@/config/types';
+
+import { SCHEMA, MONITORING, WORKLOAD_TYPES } from '@/config/types';
 import { normalizeType } from '@/plugins/steve/normalize';
 import { findBy } from '@/utils/array';
+import { isEmpty } from '@/utils/object';
 
 // Can be used inside a components' computed property
 export function monitoringStatus() {
@@ -37,6 +39,29 @@ export function haveV1Monitoring(getters) {
   const cluster = getters['currentCluster'];
 
   return !!cluster?.status?.monitoringStatus;
+}
+
+const CATTLE_MONITORING_NAMESPACE = 'cattle-monitoring-system';
+
+export async function haveV1MonitoringWorkloads(store) {
+  const workloadsByType = await Promise.all(
+    Object.values(WORKLOAD_TYPES).map(type => store.dispatch('cluster/findAll', { type })
+    )
+  );
+  const workloads = workloadsByType.flat();
+
+  for (let i = 0; i < workloads.length; i++) {
+    const workload = workloads[i];
+
+    if (!isEmpty(workload?.spec?.template?.spec?.containers) &&
+        workload.spec.template.spec.containers.find(c => c.image?.includes('quay.io/coreos/prometheus-operator') ||
+          c.image?.includes('rancher/coreos-prometheus-operator')) &&
+        workload?.metadata?.namespace !== CATTLE_MONITORING_NAMESPACE) {
+      return Promise.resolve(true);
+    }
+
+    return Promise.resolve(false);
+  }
 }
 
 // Other ways we check for monitoring:


### PR DESCRIPTION
- Add ability to dynamically include additional steps when installing charts
  - Works in a similar way to custom values components (discoverable via component files)
  - Step component will report if it's loaded and if it's hidden
- Add dynamic step to v2 monitoring that is shown if v1 monitoring is installed
  - User is able to uninstall v1 from step
  - step blocks wizard until uninstall occurs
