### PR TITLE
Add `ui-dashboard-index` and `ui-offline-preferred` settings

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4250,7 +4250,9 @@ advancedSettings:
     'ingress-ip-domain': 'Wildcard DNS domain to use for automatically generated Ingress hostnames. <ingress-name>.<namespace-name>.<ip address of ingress controller> will be added to the domain.'
     'server-url': 'Default {appName} install url. Must be HTTPS. All nodes in your cluster must be able to reach this.'
     'system-default-registry': 'Private registry to be used for all system Docker images.'
-    'ui-index': 'HTML index location for the UI.'
+    'ui-index': 'HTML index location for the Cluster Manager UI.'
+    'ui-dashboard-index': 'HTML index location for the {appName} UI.'
+    'ui-offline-preferred': 'Controls whether UI assets are served locally by the server container or from the remote URL defined in the ui-index and ui-dashboard-index settings. The `Dynamic` option will use local assets in production builds of {appName}.'
     'ui-pl': 'Private-Label company name.'
     'ui-issues': "Use a url address to send new 'File an Issue' reports instead of sending users to the Github issues page."
     'telemetry-opt': 'Telemetry reporting opt-in.'
@@ -4273,6 +4275,10 @@ advancedSettings:
       prompt: Prompt
       in: Opt-in to Telemetry
       out: Opt-out of Telemetry
+    'ui-offline-preferred':
+      dynamic: Dynamic
+      true: Local
+      false: Remote
 
 featureFlags:
   label: Feature Flags

--- a/config/settings.js
+++ b/config/settings.js
@@ -32,8 +32,10 @@ export const SETTING = {
   AUTH_USER_INFO_RESYNC_CRON:       'auth-user-info-resync-cron',
   AUTH_LOCAL_VALIDATE_DESC:         'auth-password-requirements-description',
   CLUSTER_TEMPLATE_ENFORCEMENT:     'cluster-template-enforcement',
-  UI_INDEX:                       'ui-index',
-  SYSTEM_DEFAULT_REGISTRY:        'system-default-registry',
+  UI_INDEX:                         'ui-index',
+  UI_DASHBOARD_INDEX:               'ui-dashboard-index',
+  UI_OFFLINE_PREFERRED:             'ui-offline-preferred',
+  SYSTEM_DEFAULT_REGISTRY:          'system-default-registry',
   PL:                               'ui-pl',
   PL_RANCHER_VALUE:                 'rancher',
   SUPPORTED:                        'has-support',
@@ -63,6 +65,11 @@ export const ALLOWED_SETTINGS = {
   // [SETTING.BANNERS]:                        { kind: 'json' },
   [SETTING.SYSTEM_DEFAULT_REGISTRY]:        {},
   [SETTING.UI_INDEX]:                       {},
+  [SETTING.UI_DASHBOARD_INDEX]:             {},
+  [SETTING.UI_OFFLINE_PREFERRED]:           {
+    kind:    'enum',
+    options: ['dynamic', 'true', 'false']
+  },
   [SETTING.BRAND]:                          {},
   [SETTING.CLUSTER_TEMPLATE_ENFORCEMENT]:   { kind: 'boolean' },
 


### PR DESCRIPTION
- For `ui-offline-preferred` usage see
  - https://github.com/rancher/rancher/blob/692a9507ebeec70118aa8496999e89d0dfa1cc18/pkg/ui/handler.go#L34
  - https://github.com/rancher/steve/blob/0a9ab631701fef3d3d7a839253902d896fe018ff/pkg/ui/handler.go#L118
- From what I can determine `ui-offline-preferred` settings are
  - 'dynamic'
    - If server version is not head use LOCAL
    - else if remote available use REMOTE <-- doesn't seem to fail over if assets aren't available
    - otherwise LOCAL
  - 'true'
    - LOCAL
  - 'false'
    - REMOTE