### PR TITLE
Making node selector operators more consistent with ember

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3741,15 +3741,15 @@ workload:
       antiAffinityOption: Anti-Affinity
       matchExpressions:
         addRule: Add Rule
-        doesNotExist: Does Not Exist
-        exists: Exists
+        doesNotExist: is not set
+        exists: is set
         greaterThan: ">"
-        in: =
+        in: in list
         inNamespaces: "Pods in these namespaces:"
         key: Key
         lessThan: <
         namespaces: Namespaces
-        notIn: ≠
+        notIn: not in list
         operator: Operator
         value: Value
         weight: Weight

--- a/components/form/MatchExpressions.vue
+++ b/components/form/MatchExpressions.vue
@@ -69,10 +69,10 @@ export default {
     const nodeOptions = [
       { label: t('workload.scheduling.affinity.matchExpressions.in'), value: 'In' },
       { label: t('workload.scheduling.affinity.matchExpressions.notIn'), value: 'NotIn' },
-      { label: t('workload.scheduling.affinity.matchExpressions.lessThan'), value: 'Lt' },
-      { label: t('workload.scheduling.affinity.matchExpressions.greaterThan'), value: 'Gt' },
       { label: t('workload.scheduling.affinity.matchExpressions.exists'), value: 'Exists' },
       { label: t('workload.scheduling.affinity.matchExpressions.doesNotExist'), value: 'DoesNotExist' },
+      { label: t('workload.scheduling.affinity.matchExpressions.lessThan'), value: 'Lt' },
+      { label: t('workload.scheduling.affinity.matchExpressions.greaterThan'), value: 'Gt' },
     ];
 
     const ops = this.type === NODE ? nodeOptions : podOptions;


### PR DESCRIPTION
Switched to:

- is set
- is not set
- in list
- not in list

rancher/dashboard#2449

![image](https://user-images.githubusercontent.com/55104481/119735746-a3759880-be31-11eb-97b5-ea10b15cbae0.png)
