### PR TITLE
Fixing a grouping and filtering issue for projects/namespaces in downstream clusters

### DIFF
--- a/models/namespace.js
+++ b/models/namespace.js
@@ -5,6 +5,11 @@ import { ISTIO, MANAGEMENT } from '@/config/types';
 import { escapeHtml } from '@/utils/string';
 import { insertAt, isArray } from '@/utils/array';
 
+const OBSCURE_NAMESPACE_PREFIX = [
+  'c-', // cluster namesapce
+  'p-' // project namespace
+];
+
 export default {
 
   _availableActions() {
@@ -74,8 +79,16 @@ export default {
     return false;
   },
 
+  // These are namespaces that are created by rancher to serve purposes in the background but the user shouldn't have
+  // to worry themselves about them.
+  isObscure() {
+    return OBSCURE_NAMESPACE_PREFIX.some(prefix => this.metadata.name.startsWith(prefix)) && this.isSystem;
+  },
+
   projectId() {
-    return this.metadata?.labels?.[PROJECT] || null;
+    const projectAnnotation = this.metadata?.annotations?.[PROJECT] || '';
+
+    return projectAnnotation.split(':')[1] || null;
   },
 
   project() {

--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -6,7 +6,7 @@ import { MANAGEMENT, NAMESPACE } from '@/config/types';
 import Loading from '@/components/Loading';
 import { PROJECT_ID } from '@/config/query-params';
 import Masthead from '@/components/ResourceList/Masthead';
-import { mapPref, GROUP_RESOURCES } from '@/store/prefs';
+import { mapPref, GROUP_RESOURCES, DEV } from '@/store/prefs';
 import MoveModal from '@/components/MoveModal';
 
 export default {
@@ -29,14 +29,14 @@ export default {
       return;
     }
 
-    this.rows = await this.$store.dispatch(`${ inStore }/findAll`, { type: NAMESPACE });
+    this.namespaces = await this.$store.dispatch(`${ inStore }/findAll`, { type: NAMESPACE });
     this.projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });
   },
 
   data() {
     return {
       schema:        null,
-      rows:          [],
+      namespaces:    [],
       projects:      [],
       projectSchema: null,
       MANAGEMENT,
@@ -95,6 +95,13 @@ export default {
     groupPreference: mapPref(GROUP_RESOURCES),
     filteredRows() {
       return this.groupPreference === 'none' ? this.rows : this.rowsWithFakeNamespaces;
+    },
+    rows() {
+      if (this.$store.getters['prefs/get'](DEV)) {
+        return this.namespaces;
+      }
+
+      return this.namespaces.filter(namespace => !namespace.isObscure);
     }
   },
   methods: {


### PR DESCRIPTION
This was being caused because we were failing to retrieve the namespaces's project (projectId) in downstream clusters.

- The projectId only comes back on the annotation in downstream clusters whereas it comes back as both a label
and annotation in the local cluster. This now retrieves the id from the appropriate location and formats it to be
consistent with the existing usage.
- I also noticed that in the local cluster we werent filtering namesapces that are generated by the backend when creating new clusters and projects in downstream clusters. These were prefixed with 'c-' and 'p-' so we filter them as long as they're a system namespace

https://github.com/rancher/dashboard/issues/2500#issuecomment-848267026