### PR TITLE
Minor visual tweaks to top menu/header

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -458,6 +458,7 @@ export default {
       display: flex;
       margin-right: 8px;
       height: 55px;
+      margin-left: 5px;
       max-width: 200px;
       padding: 12px 0;
     }

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -404,7 +404,7 @@ export default {
     }
     svg {
       margin-right: 8px;
-      fill: var(--topmenu-text);
+      fill: var(--link);
     }
 
     > div {
@@ -502,6 +502,10 @@ export default {
         text-transform: uppercase;
         opacity: 0.8;
         margin-top: 10px;
+      }
+
+      .home {
+        color: var(--link);
       }
 
       .home:focus {


### PR DESCRIPTION
This PR:

- Changes the color of the home icon in the slide-in to match the link color used elsewhere
- Changes the position of the logo in the header to match the position of the logo in the slide-in menu