### PR TITLE
Minor fixes to the support page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4389,8 +4389,9 @@ support:
     addSubscription: Add a Subscription ID
     removeSubscription: Remove your Subscription ID
     addTitle: Add your SUSE Subscription ID
+    addLabel: "Please enter a valid Subscription ID:"
     removeTitle: Remove your ID?
-    removeBody: "Note: This will not effect your subscription."
+    removeBody: "Note: This will not affect your subscription."
   suse:
     title: "Great News - You're covered"
     editBrand: Customize UI Theme

--- a/pages/support/index.vue
+++ b/pages/support/index.vue
@@ -115,6 +115,14 @@ export default {
     showDialog(isAdd) {
       this.isRemoveDialog = isAdd;
       this.$modal.show('toggle-support');
+    },
+
+    dialogOpened() {
+      const input = this.$refs.subscriptionIDInput;
+
+      if (input) {
+        input.focus();
+      }
     }
   }
 };
@@ -172,6 +180,7 @@ export default {
       name="toggle-support"
       height="auto"
       :width="340"
+      @opened="dialogOpened"
     >
       <Card :show-highlight-border="false" class="toogle-support">
         <template #title>
@@ -182,7 +191,10 @@ export default {
             {{ t('support.subscription.removeBody') }}
           </div>
           <div v-else class="mt-20">
-            <input v-model="supportKey" />
+            <p class="pb-10">
+              {{ t('support.subscription.addLabel') }}
+            </p>
+            <input ref="subscriptionIDInput" v-model="supportKey" />
           </div>
         </template>
         <template #actions>


### PR DESCRIPTION
A couple of minor fixes to the support page:

- Fix type 'effects' -> 'affects'
- Add label to the subscription ID dialog
- Auto-focus the input box in the modal