### PR TITLE
Azure cloud credentials and RKE2 Cluster Provisioning

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -886,6 +886,8 @@ cluster:
         label: Client ID
       clientSecret:
         label: Client Secret
+      environment:
+        label: Environment
       subscriptionId:
         label: Subscription ID
       tenantId:
@@ -933,6 +935,61 @@ cluster:
           =0 {EBS-Only}
           other {{storageSize, number} GiB {storageType}}
         }
+    azure:
+      availabilitySet:
+        label: Availability Set (unmanaged)
+      dns:
+        help: A unique DNS label for the public IP adddress.
+        label: DNS Label
+      environment:
+        label: Environment
+      faultDomainCount:
+        help: If the availability set has already been created, the fault domain count will be ignored.
+        label: Fault Domain Count
+      image:
+        help: Providing an ARM resource identifier requires using managed disk.
+        label: Image
+      location:
+        label: Location
+      managedDisks:
+        label: Use Managed Disks
+      managedDisksSize:
+        label: Managed Disk Size
+      nsg:
+        help: When using a Rancher managed or providing an existing NSG, all nodes using this template will use the supplied NSG. If no NSG is provided, a new NSG will be created for each node.
+        label: Network Security Group
+      openPort:
+        add: Add Port
+        help: When using an existing NSG, Open Ports are ignored.
+        label: Open Port
+      privateIp:
+        label: Private IP Address
+      publicIpOptions:
+        header: Public IP Options
+        noPublic:
+          label: No Public IP
+        staticPublicIp:
+          label: Static Public IP
+      resourceGroup:
+        label: Resource Group
+      size:
+        label: VM Size
+      sshUser:
+        label: SSH Username
+      storageType:
+        label: Storage Type
+      subnet:
+        label: Subnet
+      subnetPrefix:
+        label: Subnet Prefix
+      updateDomainCount:
+        help: If the availability set has already been created, the update domain count will be ignored.
+        label: Update Domain Count
+      usePrivateIp:
+        label: Use Private IP
+      vnet:
+        label: Virtual Network
+        placeholder: '[resourcegroup:]name'
     digitalocean:
       sizeLabel: |-
         {plan, select,

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -248,11 +248,11 @@ authConfig:
       homepage:
         label: Homepage URL
       instruction: 'Fill in the form with these values:'
-      prefix: 
+      prefix:
         1: <li><a href="{baseUrl}/settings/developers" target="_blank" rel="noopener noreferrer nofollow">Click here</a> to go to GitHub application settings in a new window.</li>
         2: <li>Click on the "OAuth Apps" tab.</li>
         3: <li>Click the "New OAuth App" button.</li>
-      suffix: 
+      suffix:
         1: <li>Click "Register application"</li>
         2: <li>Copy and paste the Client ID and Client Secret of your newly created OAuth app into the fields below</li>
     host:
@@ -286,7 +286,7 @@ authConfig:
         topPrivateDomain: 'Top private domain of:'
       2:
         title: 'Navigate to the "Credentials" tab to create your OAuth client ID'
-        body: 
+        body:
           1: 'Select the "Create Credentials" dropdown, and select "OAuth clientID", then select "Web application".'
           2: 'Authorized Javascript origins:'
           3: 'Authorized redirect URIs:'
@@ -354,16 +354,16 @@ authConfig:
     UID: UID Field
     adfs: Configure an AD FS account
     api: '{vendor} API Host'
-    cert: 
+    cert:
       label: Certificate
       placeholder: Paste in the certificate, starting with -----BEGIN CERTIFICATE-----
     displayName: Display Name Field
     groups: Groups Field
-    key: 
+    key:
       label: Private Key
       placeholder: Paste in the private key, typically starting with -----BEGIN RSA PRIVATE KEY-----
     keycloak: Configure a Keycloak account
-    metadata: 
+    metadata:
       label: Metadata XML
       placeholder: Paste in the IDP Metadata XML
     okta: Configure an Okta account
@@ -629,7 +629,7 @@ catalog:
       chartUrls: Chart
       keywords: Keywords
     errors:
-      clusterToolExists: This chart has a fixed namespace and name. A matching <a href="{url}">application</a> has been found and any changes will be made to it. 
+      clusterToolExists: This chart has a fixed namespace and name. A matching <a href="{url}">application</a> has been found and any changes will be made to it.
   charts:
     all: All
     categories:
@@ -881,6 +881,15 @@ cluster:
       secretKey:
         label: SecretKey
         placeholder: Your AWS Secret Key
+    azure:
+      clientId:
+        label: Client ID
+      clientSecret:
+        label: Client Secret
+      subscriptionId:
+        label: Subscription ID
+      tenantId:
+        label: Tenant ID
     digitalocean:
       accessToken:
         help: Paste in a Personal Access Token from the DigitalOcean <a href="https://cloud.digitalocean.com/settings/api/tokens" target="_blank" rel="noopener noreferrer nofollow">Applications & API</a> screen.
@@ -1272,7 +1281,7 @@ grafanaDashboard:
   reload: Reload
   grafana: Grafana
 
-graphOptions: 
+graphOptions:
   detail: Detail
   summary: Summary
   refresh: Refresh
@@ -1451,7 +1460,7 @@ labels:
     title: Annotations
 
 landing:
-  clusters: 
+  clusters:
     title: Clusters
     provider: Provider
     kubernetesVersion: Kubernetes Version
@@ -1951,7 +1960,7 @@ monitoringReceiver:
       placeholder: e.g. http://my-proxy/
     sendResolved:
       label: Enable send resolved alerts
-    
+
 monitoringRoute:
   groups:
     label: Group By
@@ -2171,7 +2180,7 @@ persistentVolume:
     datasetName:
       label: Dataset Name
       placeholder: e.g. dataset
-    datasetUUID: 
+    datasetUUID:
       label: Dataset UUID
       placeholder: e.g. uuid
   glusterfs:
@@ -2258,10 +2267,10 @@ persistentVolume:
       label: SSL Enabled
   storageos:
     label: StorageOS (Unsupported)
-    volumeName: 
+    volumeName:
       label: Volume Name
       placeholder: e.g. vol
-    volumeNamespace: 
+    volumeNamespace:
       label: Volume Namespace
       placeholder: e.g. default
   nfs:
@@ -2380,7 +2389,7 @@ prefs:
   clusterToShow:
     label: Number of clusters to show in side menu
     value: |-
-      {count, number}    
+      {count, number}
   dateFormat:
     label: Date Format
   timeFormat:
@@ -2563,7 +2572,7 @@ rbac:
       yes: 'Yes: New bindings are not allowed to use this role'
       no: No
     tabs:
-      grantResources: 
+      grantResources:
         label: Grant Resources
         tableHeaders:
           verbs: Verbs
@@ -2952,7 +2961,7 @@ servicesPage:
 
 setup:
   welcome: Welcome to {vendor}!
-  setPassword: The first order of business is to set a strong password for the default <code>admin</code> user. We suggest using this random one generated just for you, but enter your own if you like. 
+  setPassword: The first order of business is to set a strong password for the default <code>admin</code> user. We suggest using this random one generated just for you, but enter your own if you like.
   newPassword: New Password
   confirmPassword: Confirm New Password
   useRandom: Use a randomly generated password
@@ -2967,7 +2976,7 @@ setup:
           Once enabled you can view exactly what data will be sent at <code>/v1-telemetry</code>.
           <a href="https://rancher.com/docs/rancher/v2.x/en/faq/telemetry/" target="_blank" rel="noopener noreferrer nofollow">More Info</a>'
   eula: I agree to the <a href="https://rancher.com/eula" target="_blank" rel="noopener noreferrer nofollow">terms and conditions</a> for using Rancher.
-  serverUrl: 
+  serverUrl:
     label: Server URL
     tip:  What URL should be used for this Rancher installation? All the nodes in your clusters will need to be able to reach this. You can skip setting this for now, and update it later in General Settings>Advanced Settings.
     skip: Skip
@@ -3145,7 +3154,7 @@ storageClass:
     availabilityZone:
       label: Availability Zone
       automatic: "Automatic: Zones the cluster has a node in"
-      manual: 
+      manual:
         label: "Manual: Choose specific zones"
         placeholder: e.g. nova
   rbd:
@@ -3188,7 +3197,7 @@ storageClass:
     quobyteApiServer:
       label: Quobyte API Server
       placeholder: "e.g. http://138.68.74.142:7860"
-    registry: 
+    registry:
       label: Registry
       placeholder: e.g. 138.68.74.142:7861
     adminSecretNamespace:
@@ -3534,7 +3543,7 @@ validation:
   required: '"{key}" is required'
   requiredOrOverride: '"{key}" is required or must allow override'
   roleTemplate:
-    roleTemplateRules: 
+    roleTemplateRules:
       missingVerb: You must specify at least one verb for each resource grant
       missingResource: You must specify a Resource for each resource grant
       missingApiGroup: You must specify an API Group for each resource grant
@@ -4482,7 +4491,7 @@ support:
     learnMore: Find out more about SUSE Rancher Support
     pricing: Contact us for pricing
   subscription:
-    haveSupport: Already have support? 
+    haveSupport: Already have support?
     addSubscription: Add a Subscription ID
     removeSubscription: Remove your Subscription ID
     addTitle: Add your SUSE Subscription ID
@@ -4535,4 +4544,4 @@ legacy:
   project:
     label: Project
     select: "Use the Project/Namespace filter at the top of the page to select a Project in order to see legacy Project features."
-  
+

--- a/cloud-credential/azure.vue
+++ b/cloud-credential/azure.vue
@@ -1,0 +1,93 @@
+<script>
+import CreateEditView from '@/mixins/create-edit-view';
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  mixins:     [CreateEditView],
+
+  watch: {
+    'value.decodedData.clientId'(neu) {
+      this.$emit('validationChanged', !!neu);
+    },
+    'value.decodedData.clientSecret'(neu) {
+      this.$emit('validationChanged', !!neu);
+    },
+    'value.decodedData.subscriptionId'(neu) {
+      this.$emit('validationChanged', !!neu);
+    },
+    'value.decodedData.tenantId'(neu) {
+      this.$emit('validationChanged', !!neu);
+    },
+  },
+
+  methods: {
+    async test() {
+      const {
+        clientId,
+        clientSecret,
+        subscriptionId,
+        tenantId,
+      } = this.value.decodedData;
+
+      try {
+        await this.$store.dispatch('management/request', {
+          url:    '/meta/aksLocations',
+          method: 'POST',
+          data:   {
+            clientId,
+            clientSecret,
+            subscriptionId,
+            tenantId,
+          },
+        });
+
+        return true;
+      } catch (e) {
+        return false;
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <section>
+    <div class="mb-10">
+      <LabeledInput
+        :value="value.decodedData.tenantId"
+        label-key="cluster.credential.azure.tenantId.label"
+        type="text"
+        :mode="mode"
+        @input="value.setData('tenantId', $event)"
+      />
+    </div>
+    <div class="mb-10">
+      <LabeledInput
+        :value="value.decodedData.subscriptionId"
+        label-key="cluster.credential.azure.subscriptionId.label"
+        type="text"
+        :mode="mode"
+        @input="value.setData('subscriptionId', $event)"
+      />
+    </div>
+    <div class="mb-10">
+      <LabeledInput
+        :value="value.decodedData.clientId"
+        label-key="cluster.credential.azure.clientId.label"
+        type="text"
+        :mode="mode"
+        @input="value.setData('clientId', $event)"
+      />
+    </div>
+    <div>
+      <LabeledInput
+        :value="value.decodedData.clientSecret"
+        label-key="cluster.credential.azure.clientSecret.label"
+        type="password"
+        :mode="mode"
+        @input="value.setData('clientSecret', $event)"
+      />
+    </div>
+  </section>
+</template>

--- a/cloud-credential/azure.vue
+++ b/cloud-credential/azure.vue
@@ -62,54 +62,60 @@ export default {
 
 <template>
   <section>
-    <div class="mb-10">
-      <LabeledInput
-        :value="value.decodedData.tenantId"
-        label-key="cluster.credential.azure.tenantId.label"
-        type="text"
-        :mode="mode"
-        @input="value.setData('tenantId', $event)"
-      />
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput
+          :value="value.decodedData.tenantId"
+          label-key="cluster.credential.azure.tenantId.label"
+          type="text"
+          :mode="mode"
+          @input="value.setData('tenantId', $event)"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          :value="value.decodedData.subscriptionId"
+          label-key="cluster.credential.azure.subscriptionId.label"
+          type="text"
+          :mode="mode"
+          @input="value.setData('subscriptionId', $event)"
+        />
+      </div>
     </div>
-    <div class="mb-10">
-      <LabeledInput
-        :value="value.decodedData.subscriptionId"
-        label-key="cluster.credential.azure.subscriptionId.label"
-        type="text"
-        :mode="mode"
-        @input="value.setData('subscriptionId', $event)"
-      />
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput
+          :value="value.decodedData.clientId"
+          label-key="cluster.credential.azure.clientId.label"
+          type="text"
+          :mode="mode"
+          @input="value.setData('clientId', $event)"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          :value="value.decodedData.clientSecret"
+          label-key="cluster.credential.azure.clientSecret.label"
+          type="password"
+          :mode="mode"
+          @input="value.setData('clientSecret', $event)"
+        />
+      </div>
     </div>
-    <div class="mb-10">
-      <LabeledInput
-        :value="value.decodedData.clientId"
-        label-key="cluster.credential.azure.clientId.label"
-        type="text"
-        :mode="mode"
-        @input="value.setData('clientId', $event)"
-      />
-    </div>
-    <div class="mb-10">
-      <LabeledInput
-        :value="value.decodedData.clientSecret"
-        label-key="cluster.credential.azure.clientSecret.label"
-        type="password"
-        :mode="mode"
-        @input="value.setData('clientSecret', $event)"
-      />
-    </div>
-    <div class="mb-10">
-      <LabeledSelect
-        :value="value.decodedData.environment"
-        :mode="mode"
-        :options="azureEnvironments"
-        option-key="value"
-        option-label="value"
-        :searchable="false"
-        :required="true"
-        :label="t('cluster.credential.azure.environment.label')"
-        @input="value.setData('environment', $event);"
-      />
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledSelect
+          :value="value.decodedData.environment"
+          :mode="mode"
+          :options="azureEnvironments"
+          option-key="value"
+          option-label="value"
+          :searchable="false"
+          :required="true"
+          :label="t('cluster.credential.azure.environment.label')"
+          @input="value.setData('environment', $event)"
+        />
+      </div>
     </div>
   </section>
 </template>

--- a/cloud-credential/azure.vue
+++ b/cloud-credential/azure.vue
@@ -1,10 +1,16 @@
 <script>
 import CreateEditView from '@/mixins/create-edit-view';
 import LabeledInput from '@/components/form/LabeledInput';
+import { azureEnvironments } from '@/machine-config/azure';
+import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
-  components: { LabeledInput },
+  components: { LabeledInput, LabeledSelect },
   mixins:     [CreateEditView],
+
+  data() {
+    return { azureEnvironments };
+  },
 
   watch: {
     'value.decodedData.clientId'(neu) {
@@ -17,6 +23,9 @@ export default {
       this.$emit('validationChanged', !!neu);
     },
     'value.decodedData.tenantId'(neu) {
+      this.$emit('validationChanged', !!neu);
+    },
+    'value.decodedData.environment'(neu) {
       this.$emit('validationChanged', !!neu);
     },
   },
@@ -80,13 +89,26 @@ export default {
         @input="value.setData('clientId', $event)"
       />
     </div>
-    <div>
+    <div class="mb-10">
       <LabeledInput
         :value="value.decodedData.clientSecret"
         label-key="cluster.credential.azure.clientSecret.label"
         type="password"
         :mode="mode"
         @input="value.setData('clientSecret', $event)"
+      />
+    </div>
+    <div class="mb-10">
+      <LabeledSelect
+        :value="value.decodedData.environment"
+        :mode="mode"
+        :options="azureEnvironments"
+        option-key="value"
+        option-label="value"
+        :searchable="false"
+        :required="true"
+        :label="t('cluster.credential.azure.environment.label')"
+        @input="value.setData('environment', $event);"
       />
     </div>
   </section>

--- a/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -85,10 +85,15 @@ export default {
 
     driverName() {
       let driver = this.provider;
+      const azureDrivers = ['azure', 'aks'];
 
       // Map providers that share a common credential to one driver
       if ( driver === 'amazonec2' || driver === 'amazoneks' ) {
         driver = 'aws';
+      }
+
+      if ( azureDrivers.includes(driver) ) {
+        driver = 'azure';
       }
 
       return driver;

--- a/machine-config/azure.vue
+++ b/machine-config/azure.vue
@@ -1,0 +1,427 @@
+<script>
+import Loading from '@/components/Loading';
+import CreateEditView from '@/mixins/create-edit-view';
+import { SECRET } from '@/config/types';
+import { stringify, exceptionToErrorsArray } from '@/utils/error';
+import Banner from '@/components/Banner';
+import merge from 'lodash/merge';
+import isEmpty from 'lodash/isEmpty';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import LabeledInput from '@/components/form/LabeledInput';
+import Checkbox from '@/components/form/Checkbox';
+import ArrayList from '@/components/form/ArrayList';
+import { randomStr } from '@/utils/string';
+
+export const azureEnvironments = [
+  { value: 'AzurePublicCloud' },
+  { value: 'AzureGermanCloud' },
+  { value: 'AzureChinaCloud' },
+  { value: 'AzureUSGovernmentCloud' },
+];
+
+const defaultConfig = {
+  availabilitySet:   'docker-machine',
+  clientId:          '',
+  clientSecret:      '',
+  customData:        '',
+  diskSize:          '30',
+  dns:               '',
+  environment:       'AzurePublicCloud',
+  faultDomainCount:  '3',
+  image:             'canonical:UbuntuServer:18.04-LTS:latest',
+  location:          'westus',
+  managedDisks:      false,
+  noPublicIp:        false,
+  nsg:               null,
+  privateIpAddress:  null,
+  resourceGroup:     'docker-machine',
+  size:              'Standard_D2_v2',
+  sshUser:           'docker-user',
+  staticPublicIp:    false,
+  storageType:       'Standard_LRS',
+  subnet:            'docker-machine',
+  subnetPrefix:      '192.168.0.0/16',
+  subscriptionId:    '',
+  tenantId:          '',
+  updateDomainCount: '5',
+  usePrivateIp:      false,
+  vnet:              'docker-machine-vnet',
+  openPort:          [
+    '6443/tcp',
+    '2379/tcp',
+    '2380/tcp',
+    '8472/udp',
+    '4789/udp',
+    '9796/tcp',
+    '10256/tcp',
+    '10250/tcp',
+    '10251/tcp',
+    '10252/tcp',
+  ],
+};
+
+const storageTypes = [
+  {
+    name:  'Standard LRS',
+    value: 'Standard_LRS',
+  },
+  {
+    name:  'Standard ZRS',
+    value: 'Standard_ZRS',
+  },
+  {
+    name:  'Standard GRS',
+    value: 'Standard_GRS',
+  },
+  {
+    name:  'Standard RAGRS',
+    value: 'Standard_RAGRS',
+  },
+  {
+    name:  'Premium LRS',
+    value: 'Premium_LRS',
+  },
+];
+
+export default {
+  components: {
+    ArrayList,
+    Banner,
+    Checkbox,
+    LabeledInput,
+    LabeledSelect,
+    Loading,
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    credentialId: {
+      type:     String,
+      required: true,
+    },
+    mode: {
+      type:    String,
+      default: 'create',
+    },
+    uuid: {
+      type:     String,
+      required: true,
+    },
+  },
+
+  async fetch() {
+    this.errors = [];
+
+    try {
+      this.credential = await this.$store.dispatch('management/find', {
+        type: SECRET,
+        id:   this.credentialId,
+      });
+
+      const {
+        clientId,
+        clientSecret,
+        environment,
+        subscriptionId,
+        tenantId,
+      } = this.credential.decodedData;
+
+      if (!isEmpty(clientId)) {
+        this.value.clientId = clientId;
+      }
+      if (!isEmpty(clientSecret)) {
+        this.value.clientSecret = clientSecret;
+      }
+      if (!isEmpty(environment)) {
+        this.value.environment = environment;
+      }
+      if (!isEmpty(subscriptionId)) {
+        this.value.subscriptionId = subscriptionId;
+      }
+      if (!isEmpty(tenantId)) {
+        this.value.tenantId = tenantId;
+      }
+
+      this.locationOptions = await this.$store.dispatch('management/request', {
+        url:    '/meta/aksLocations',
+        method: 'POST',
+        data:   {
+          clientId,
+          clientSecret,
+          subscriptionId,
+          tenantId,
+        },
+      });
+
+      const defaultLocation = 'westus';
+
+      this.vmSizes = await this.$store.dispatch('management/request', {
+        url:    '/meta/aksVMSizes',
+        method: 'POST',
+        data:   {
+          clientId,
+          clientSecret,
+          subscriptionId,
+          tenantId,
+          region: defaultLocation,
+        },
+      });
+    } catch (e) {
+      this.errors = exceptionToErrorsArray(e);
+    }
+  },
+
+  data() {
+    return {
+      azureEnvironments,
+      defaultConfig,
+      storageTypes,
+      credential:      null,
+      locationOptions: null,
+      vmSizes:         null,
+    };
+  },
+
+  watch: {
+    credentialId() {
+      this.$fetch();
+    },
+  },
+
+  created() {
+    if (this.mode === 'create') {
+      merge(this.value, this.defaultConfig);
+
+      this.value.nsg = `rancher-managed-${ randomStr(8) }`;
+    }
+  },
+
+  methods: {
+    stringify,
+    setLocation(location) {
+      this.value.location = location?.name;
+    },
+  },
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" :delayed="true" />
+  <div v-else-if="errors.length">
+    <div v-for="(err, idx) in errors" :key="idx">
+      <Banner color="error" :label="stringify(err)" />
+    </div>
+  </div>
+  <div v-else>
+    <div class="row mt-20">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.environment"
+          :mode="mode"
+          :options="azureEnvironments"
+          option-key="value"
+          option-label="value"
+          :searchable="false"
+          :required="true"
+          :label="t('cluster.machineConfig.azure.environment.label')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledSelect
+          :value="value.location"
+          :mode="mode"
+          :options="locationOptions"
+          option-key="name"
+          option-label="displayName"
+          :searchable="true"
+          :required="true"
+          :label="t('cluster.machineConfig.azure.location.label')"
+          @input="setLocation"
+        />
+      </div>
+    </div>
+    <div class="row mt-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.resourceGroup"
+          :mode="mode"
+          :label="t('cluster.machineConfig.azure.resourceGroup.label')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.availabilitySet"
+          :mode="mode"
+          :label="t('cluster.machineConfig.azure.availabilitySet.label')"
+        />
+      </div>
+    </div>
+    <hr class="mt-20" />
+    <div class="row mt-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.image"
+          :mode="mode"
+          :label="t('cluster.machineConfig.azure.image.label')"
+          :tooltip="t('cluster.machineConfig.azure.image.help')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.size"
+          :mode="mode"
+          :options="vmSizes"
+          :searchable="true"
+          :required="true"
+          :label="t('cluster.machineConfig.azure.size.label')"
+        />
+      </div>
+    </div>
+
+    <portal :to="'advanced-' + uuid">
+      <div class="row mt-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.faultDomainCount"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.faultDomainCount.label')"
+            :tooltip="t('cluster.machineConfig.azure.faultDomainCount.help')"
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.updateDomainCount"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.updateDomainCount.label')"
+            :tooltip="t('cluster.machineConfig.azure.updateDomainCount.help')"
+          />
+        </div>
+      </div>
+      <hr class="mt-20" />
+      <div class="row mt-20">
+        <div class="col span-6">
+          <LabeledInput v-model="value.subnet" :mode="mode" :label="t('cluster.machineConfig.azure.subnet.label')" />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.subnetPrefix"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.subnetPrefix.label')"
+          />
+        </div>
+      </div>
+      <div class="row mt-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.vnet"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.vnet.label')"
+            :placeholder="t('cluster.machineConfig.azure.vnet.placeholder')"
+          />
+        </div>
+        <div class="col span-6">
+          <h3><t k="cluster.machineConfig.azure.publicIpOptions.header" /></h3>
+          <Checkbox
+            v-model="value.noPublicIp"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.publicIpOptions.noPublic.label')"
+          />
+          <Checkbox
+            v-model="value.staticPublicIp"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.publicIpOptions.staticPublicIp.label')"
+          />
+        </div>
+      </div>
+      <div class="row mt-20">
+        <div class="col span-6">
+          <Checkbox
+            v-model="value.usePrivateIp"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.usePrivateIp.label')"
+          />
+          <LabeledInput
+            v-model="value.privateIpAddress"
+            :mode="mode"
+            class="mt-10"
+            :label="t('cluster.machineConfig.azure.privateIp.label')"
+            :disabled="!value.usePrivateIp"
+          />
+        </div>
+      </div>
+      <div class="row mt-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.nsg"
+            :mode="mode"
+            class="mt-10"
+            :label="t('cluster.machineConfig.azure.nsg.label')"
+            :tooltip="t('cluster.machineConfig.azure.nsg.help')"
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.dns"
+            :mode="mode"
+            class="mt-10"
+            :label="t('cluster.machineConfig.azure.dns.label')"
+            :tooltip="t('cluster.machineConfig.azure.dns.help')"
+          />
+        </div>
+      </div>
+      <hr class="mt-20" />
+      <div class="row mt-20">
+        <div class="col span-6">
+          <LabeledSelect
+            v-model="value.storageType"
+            :mode="mode"
+            :options="storageTypes"
+            :searchable="false"
+            :required="true"
+            :label="t('cluster.machineConfig.azure.storageType.label')"
+            option-key="value"
+            option-label="name"
+          />
+        </div>
+      </div>
+      <div class="row mt-20">
+        <div class="col span-6">
+          <Checkbox
+            v-model="value.managedDisks"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.managedDisks.label')"
+          />
+          <LabeledInput
+            v-model="value.diskSize"
+            :mode="mode"
+            class="mt-10"
+            :label="t('cluster.machineConfig.azure.managedDisksSize.label')"
+          />
+        </div>
+      </div>
+      <div class="row mt-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.sshUser"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.sshUser.label')"
+          />
+        </div>
+      </div>
+      <div class="row mt-20">
+        <div class="col span-6">
+          <ArrayList
+            v-model="value.openPort"
+            table-class="fixed"
+            :mode="mode"
+            :title="t('cluster.machineConfig.azure.openPort.label')"
+            :add-label="t('cluster.machineConfig.azure.openPort.add')"
+            :show-protip="true"
+            :protip="t('cluster.machineConfig.azure.openPort.help')"
+          />
+        </div>
+      </div>
+    </portal>
+  </div>
+</template>

--- a/store/plugins.js
+++ b/store/plugins.js
@@ -1,6 +1,7 @@
 const credentialOptions = {
   aws:          { publicKey: 'accessKey', publicMode: 'full' },
   digitalocean: { publicKey: 'accessToken', publicMode: 'prefix' },
+  azure:        { publicKey: 'clientId', publicMode: 'full' },
 };
 
 // Dynamically loaded drivers can call this eventually to register thier options


### PR DESCRIPTION
The PR adds the Azure provider cloud credential and RKE2 Cluster/Node Provisioning using the cloud credentials.

For node provisioning I've left out a few things from the Ember UI that I think go against the more hands off approach the new UI takes. 
Public IP options is no longer a dropdown with 3 arbitrary dropdown options that don't translate into what the actual fields on the resource, instead we expose the public IP options.
Environments is a static list because there is no API available to fetch this data. In the Ember UI we kept a static list of locations available in each Environment. Here rather than try to maintain a static list of Environs/Locations we're fetching the locations dynamically (probably more likely to change then new environs) and keeping a static list of environs. The onus is on the user to understand the environment where there selected location resides. Ideally we would have an API that returns this data in some nested obj/list fashion but this doesn't exist as of yet. 

https://github.com/rancher/dashboard/issues/2163
https://github.com/rancher/dashboard/issues/2166


Azure CC:
![Screen Shot 2021-06-02 at 4 42 36 PM](https://user-images.githubusercontent.com/858614/120565280-915fa100-c3c1-11eb-8921-ddcca96207c0.png)

Azure RKE 2 Machine Config:
Default:
![Screen Shot 2021-06-02 at 4 24 49 PM](https://user-images.githubusercontent.com/858614/120565316-a1778080-c3c1-11eb-98be-b34041c8514a.png)
Advanced:
![Screen Shot 2021-06-02 at 4 29 07 PM](https://user-images.githubusercontent.com/858614/120565326-a6d4cb00-c3c1-11eb-9f8b-1685db02ba86.png)
