### PR TITLE
Address minor issues in side menu

### DIFF
--- a/assets/styles/global/_button.scss
+++ b/assets/styles/global/_button.scss
@@ -85,7 +85,6 @@ button,
   background: var(--accent-btn);
   border: solid 1px var(--primary);
   color: var(--primary);
-  line-height: $btn-height - 2px;
 }
 
 .role-link {

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2322,7 +2322,7 @@ prefs:
     ember: Cluster Manager
   formatting: Formatting
   clusterToShow:
-    label: Number of clusters to show in top menu
+    label: Number of clusters to show in side menu
     value: |-
       {count, number}    
   dateFormat:

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -180,7 +180,7 @@ export default {
 
       if (el) {
         const $el = $(el);
-        const h = 34 * max;
+        const h = 32 * max;
 
         $el.css('height', `${ h }px`);
       }
@@ -396,7 +396,7 @@ export default {
 <style lang="scss" scoped>
   $clear-search-size: 20px;
   $icon-size: 24px;
-  $option-padding: 5px;
+  $option-padding: 4px;
   $option-height: $icon-size + $option-padding + $option-padding;
 
   .option {
@@ -532,9 +532,9 @@ export default {
       }
 
       .cluster {
-        padding: $option-padding 0 $option-padding 10px;
         align-items: center;
         display: flex;
+        height: $option-height;
         &:focus {
           outline: 0;
         }


### PR DESCRIPTION
Fixes height of cluster options to be consistent with other options - they are all 32px high - this fixes issue with extra spacing at bottom of cluster list.

Changes text for pref for cluster size to say 'side menu' rather than 'top menu'.

Reverted change to role-tertiary which caused issues on the home page

