### PR TITLE
Cluster Tools: Don't allow v1 to be installed when v2 is already installed

### DIFF
--- a/assets/styles/global/_button.scss
+++ b/assets/styles/global/_button.scss
@@ -79,6 +79,10 @@ button,
   color: var(--primary) !important;
   border: solid 1px var(--primary);
   line-height: $btn-height - 2px;
+
+  &.btn-sm {
+    line-height: $btn-sm-height;
+  }
 }
 
 .role-tertiary {

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -187,7 +187,10 @@ export default {
             // Move the app data to the v1 chart
             v1.app = v2.app;
             v2.app = undefined;
-            v2.blockedV1 = true;
+            v2.blocked = true;
+          } else {
+            // V2 is installed, so block V1
+            v1.blocked = true;
           }
         }
       }
@@ -358,7 +361,7 @@ export default {
           <AppSummaryGraph :row="opt.app" label-key="generic.resourceCount" :link-to="opt.app.detailLocation" />
         </div>
         <div class="action">
-          <template v-if="opt.blockedV1">
+          <template v-if="opt.blocked">
             <button disabled="true" class="btn btn-sm role-primary" v-html="t('catalog.tools.action.install')" />
           </template>
           <template v-else-if="opt.app && opt.chart.legacy">


### PR DESCRIPTION
Prevents installation of V1 tools when v2 installed

Also fixes sizing of the smaller buttons on the cards