### PR TITLE
Cluster Edit Redirect Bug

### DIFF
--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -99,6 +99,8 @@ export default {
       }
     } else if ( this.driver && this.provisioner ) {
       provider = this.driver;
+    } else if ( !this.driver && provisioner.endsWith('v2') ) {
+      provider = provisioner;
     } else {
       provider = 'import';
     }


### PR DESCRIPTION
@nwmac The root cause of the referenced issue is that the `management.cattle.io.cluster` resource doesn't have `driver` on it so we are hitting the edit route for the import provider on the ember side. In dashboard I tested a few different clusters and found none of the resources had a `driver` property so I am not sure we'd ever actually fall into the branch on line 100? I tested editing a new v2 cluster, rke2 clusters, and rke1 clusters and did not find any issues with the redirect after this change. Let me know if you'd like me to remove the lines above my change. 

rancher/dashboard#3006