### PR TITLE
Update helm chart install step 1

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -697,7 +697,8 @@ catalog:
             true { app}
             false { chart}
           }. Start by setting some basic information used by {vendor} to manage the App.
-        createNamespace: Namespace will be created
+        nsCreationDescription: "To install the app into a new namespace enter it's name and select it in the Namespace field."
+        createNamespace: "Namespace <code>{namespace}</code> will be created."
       helmValues:
         label: Values
         subtext: Change how the App works

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -375,9 +375,9 @@ export default {
 
 <style lang='scss' scoped>
   .masthead {
-    padding-bottom: 5px;
+    padding-bottom: 10px;
     border-bottom: 1px solid var(--border);
-    margin-bottom: 5px;
+    margin-bottom: 10px;
   }
 
   HEADER {

--- a/components/Wizard.vue
+++ b/components/Wizard.vue
@@ -469,7 +469,7 @@ $spacer: 10px;
   flex: 1 1 auto;
   height: 0;
   overflow-y: auto;
-  padding: 20px $spacer 2px 2px; // Handle borders flush against edge
+  padding: 20px 2px 2px 2px; // Handle borders flush against edge
 
   display: flex;
   flex-direction: column;

--- a/components/form/NameNsDescription.vue
+++ b/components/form/NameNsDescription.vue
@@ -106,6 +106,10 @@ export default {
     showSpacer: {
       type:    Boolean,
       default: true
+    },
+    horizontal: {
+      type:    Boolean,
+      default: true,
     }
   },
 
@@ -191,6 +195,10 @@ export default {
     },
 
     colSpan() {
+      if (!this.horizontal) {
+        return `span-8`;
+      }
+
       let cols = (this.nameNsHidden ? 0 : 1) + (this.descriptionHidden ? 0 : 1) + this.extraColumns.length;
 
       cols = Math.max(2, cols); // If there's only one column, make it render half-width as if there were two
@@ -263,7 +271,7 @@ export default {
 
 <template>
   <div>
-    <div class="row name-ns-description">
+    <div class="name-ns-description" :class="{'flip-direction': !horizontal, row: true}">
       <div v-show="!nameNsHidden" :class="{ col: true, [colSpan]: true }">
         <slot :namespaces="namespaces" name="namespace">
           <InputWithSelect
@@ -334,6 +342,18 @@ export default {
           padding-bottom: 2px;
         }
       }
+    }
+  }
+
+  &.flip-direction {
+    flex-direction: column;
+
+    &.name-ns-description {
+      max-height: initial;
+    }
+
+    & > div > * {
+      margin-bottom: 20px;
     }
   }
 }

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -438,6 +438,10 @@ export default {
 
     cmdOptions() {
       return this.showCommandStep ? this.customCmdOpts : this.defaultCmdOpts;
+    },
+
+    namespaceNewAllowed() {
+      return !this.existing && !this.forceNamespace;
     }
   },
 
@@ -940,9 +944,12 @@ export default {
       </template>
       <template #basics>
         <div class="step__basic">
-          <p v-if="step1Description" class="row mb-10">
-            {{ step1Description }}
-          </p>
+          <Banner v-if="step1Description" color="info" class="description">
+            <span>{{ step1Description }}</span>
+            <span v-if="namespaceNewAllowed" class="mt-10">
+              {{ t('catalog.install.steps.basics.nsCreationDescription', {}, true) }}
+            </span>
+          </Banner>
           <div v-if="requires.length || warnings.length" class="mb-30">
             <Banner v-for="msg in requires" :key="msg" color="error">
               <span v-html="msg" />
@@ -953,7 +960,7 @@ export default {
             </Banner>
           </div>
           <div v-if="existing" class="row mb-10">
-            <div class="col span-6">
+            <div class="col span-4">
               <!-- We have a chart, select a new version -->
               <LabeledSelect
                 v-if="chart"
@@ -994,9 +1001,10 @@ export default {
             :name-required="false"
             :name-ns-hidden="!showNameEditor"
             :force-namespace="forceNamespace"
-            :namespace-new-allowed="!existing && !forceNamespace"
+            :namespace-new-allowed="namespaceNewAllowed"
             :extra-columns="showProject ? ['project'] : []"
             :show-spacer="false"
+            :horizontal="false"
             @isNamespaceNew="isNamespaceNew = $event"
           >
             <template v-if="showProject" #project>
@@ -1012,20 +1020,19 @@ export default {
               />
             </template>
           </NameNsDescription>
-          <div class="mt-10 mb-40">
-            {{ isNamespaceNew ? t('catalog.install.steps.basics.createNamespace') : '&nbsp;' }}
-          </div>
           <div class="step__values__controls--spacer" style="flex:1">
 &nbsp;
           </div>
+          <Banner v-if="isNamespaceNew" color="info" v-html="t('catalog.install.steps.basics.createNamespace', {namespace: value.metadata.namespace}, true) ">
+          </Banner>
 
-          <Checkbox v-model="showCommandStep" :label="t('catalog.install.steps.helmCli.checkbox', { action, existing: !!existing })" />
+          <Checkbox v-model="showCommandStep" class="mb-20" :label="t('catalog.install.steps.helmCli.checkbox', { action, existing: !!existing })" />
         </div>
       </template>
       <template #helmValues>
-        <p v-if="step2Description" class="row mb-10">
+        <Banner v-if="step2Description" color="info" class="description">
           {{ step2Description }}
-        </p>
+        </Banner>
         <div class="step__values__controls">
           <ButtonGroup
             v-model="preFormYamlOption"
@@ -1130,9 +1137,9 @@ export default {
         <ResourceCancelModal ref="cancelModal" :is-cancel-modal="false" :is-form="true" @cancel-cancel="preFormYamlOption=formYamlOption" @confirm-cancel="formYamlOption = preFormYamlOption;"></ResourceCancelModal>
       </template>
       <template #helmCli>
-        <p v-if="step3Description" class="row mb-10">
+        <Banner v-if="step3Description" color="info" class="description">
           {{ step3Description }}
-        </p>
+        </Banner>
         <div><Checkbox v-if="existing" v-model="customCmdOpts.cleanupOnFail" :label="t('catalog.install.helm.cleanupOnFail')" /></div>
         <div><Checkbox v-if="!existing" v-model="customCmdOpts.crds" :label="t('catalog.install.helm.crds')" /></div>
         <div><Checkbox v-model="customCmdOpts.hooks" :label="t('catalog.install.helm.hooks')" /></div>
@@ -1180,7 +1187,14 @@ export default {
   $slideout-width: 35%;
 
   .install-steps {
-    position: relative; overflow: hidden;
+    position: relative;
+    overflow: hidden;
+
+    .description {
+      display: flex;
+      flex-direction: column;
+      margin-top: 0;
+    }
   }
 
   .wizard {
@@ -1209,6 +1223,10 @@ export default {
 
   .step {
     &__basic {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+
       .spacer {
         line-height: 2;
       }

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -443,7 +443,7 @@ export const actions = {
 };
 
 function getLoginRoute(route) {
-  let parts = route.name.split('-');
+  let parts = route.name?.split('-') || [];
   const params = {};
   const routeParams = route.params || {};
 


### PR DESCRIPTION
- Step descriptions are now info banners
- Added guide to creating new ns in description
- Added and used vertical layout to NameNSDescription component
- Changed 'new ns' message to banner and moved to bottom (to discuss)
- addresses #3060

Also
- Brought back margin/padding bottom sizing. This was important for pages with no detailtop or banner
- Fixed an issue where getLoginRoute would fail where there was no recognised route