### PR TITLE
Ensure we fetch `server-url` in auth-config correctly

### DIFF
--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -27,7 +27,7 @@ export default {
     const serverUrl = await this.$store.dispatch('management/find', {
       type: MANAGEMENT.SETTING,
       id:   'server-url',
-      opt:  { url: `/v1/{ MANAGEMENT.SETTING }/server-url` }
+      opt:  { url: `/v1/${ MANAGEMENT.SETTING }/server-url` }
     });
 
     this.principals = await this.$store.dispatch('rancher/findAll', {


### PR DESCRIPTION
- url part of `management/find` was incorrect
- url was never used as we normally have the resource, however there's some kind of log in bug #3160 where settings are missing, including server-url
- so server-url was never fetched... dodgy url threw exception... model was never fetched
- we don't have a pattern for $fetchState.error anywhere, which we could use here when fetch failed instead of continuing
- addresses #3137