### PR TITLE
Single-Cluster home page tweak

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1444,6 +1444,8 @@ landing:
       {count, plural,
       =1 {core}
       other {cores}}
+    cpuUsed: CPU Used
+    memoryUsed: Memory Used
   seeWhatsNew: Learn more about the improvements and new capabilities in this version.
   whatsNewLink: "What's new in 2.5"
   learnMore: Learn More

--- a/components/ConsumptionGauge.vue
+++ b/components/ConsumptionGauge.vue
@@ -84,7 +84,7 @@ export default {
 
 <template>
   <div class="consumption-gauge">
-    <h3>
+    <h3 v-if="resourceName">
       {{ resourceName }}
     </h3>
     <div class="numbers">

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -1,5 +1,5 @@
 import { CATALOG } from '@/config/labels-annotations';
-import { FLEET, MANAGEMENT } from '@/config/types';
+import { FLEET, MANAGEMENT, NODE } from '@/config/types';
 import { insertAt } from '@/utils/array';
 import { downloadFile } from '@/utils/download';
 import { parseSi } from '@/utils/units';
@@ -295,4 +295,35 @@ export default {
       downloadFile('kubeconfig.yaml', out, 'application/yaml');
     };
   },
+
+  fetchNodeMetrics() {
+    return async() => {
+      const nodes = await this.$dispatch('cluster/findAll', { type: NODE }, { root: true });
+      const nodeMetrics = await this.$dispatch('cluster/findAll', { type: NODE }, { root: true });
+
+      const someNonWorkerRoles = nodes.some(node => node.hasARole && !node.isWorker);
+
+      const metrics = nodeMetrics.filter((metric) => {
+        const node = nodes.find(nd => nd.id === metric.id);
+
+        return node && (!someNonWorkerRoles || node.isWorker);
+      });
+      const initialAggregation = {
+        cpu:    0,
+        memory: 0
+      };
+
+      if (isEmpty(metrics)) {
+        return null;
+      }
+
+      return metrics.reduce((agg, metric) => {
+        agg.cpu += parseSi(metric?.usage?.cpu);
+        agg.memory += parseSi(metric?.usage?.memory);
+
+        return agg;
+      }, initialAggregation);
+    };
+  },
+
 };

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -13,10 +13,12 @@ import { MANAGEMENT, CAPI } from '@/config/types';
 import { NAME as MANAGER } from '@/config/product/manager';
 import { STATE } from '@/config/table-headers';
 import { MODE, _IMPORT } from '@/config/query-params';
-import { createMemoryFormat, formatSi, parseSi } from '@/utils/units';
+import { createMemoryFormat, createMemoryValues, formatSi, parseSi } from '@/utils/units';
 import { getVersionInfo, readReleaseNotes, markReadReleaseNotes, markSeenReleaseNotes } from '@/utils/version';
 import PageHeaderActions from '@/mixins/page-actions';
 import { getVendor } from '@/config/private-label';
+import ConsumptionGauge from '@/components/ConsumptionGauge';
+import { get } from '@/utils/object';
 import { mapFeature, MULTI_CLUSTER } from '@/store/features';
 
 const SET_LOGIN_ACTION = 'set-as-login';
@@ -34,6 +36,7 @@ export default {
     CommunityLinks,
     SimpleBox,
     LandingPagePreference,
+    ConsumptionGauge
   },
 
   mixins: [PageHeaderActions],
@@ -47,7 +50,6 @@ export default {
 
   data() {
     const fullVersion = getVersionInfo(this.$store).fullVersion;
-
     // Page actions don't change on the Home Page
     const pageActions = [
       {
@@ -62,7 +64,8 @@ export default {
     ];
 
     return {
-      HIDE_HOME_PAGE_CARDS, clusters: [], fullVersion, pageActions, vendor: getVendor(),
+
+      HIDE_HOME_PAGE_CARDS, clusters: [], fullVersion, pageActions, vendor: getVendor(), clusterDetail: null,
     };
   },
 
@@ -155,6 +158,23 @@ export default {
     ...mapGetters(['currentCluster', 'defaultClusterId'])
   },
 
+  watch: {
+    async clusters(neu) {
+      if (!this.mcm) {
+        this.clusterDetail = neu[1];
+        const nodeMetrics = await this.clusterDetail.fetchNodeMetrics();
+
+        this.$set(this.clusterDetail, 'metrics', {
+          cpu:    {
+            total: parseInt(get(this.clusterDetail, 'status.capacity.cpu')),
+            used:  nodeMetrics?.cpu || 0
+          },
+          memory: createMemoryValues(get(this.clusterDetail, 'status.capacity.memory'), nodeMetrics?.memory || 0 )
+        });
+      }
+    }
+  },
+
   async created() {
     // Update last visited on load
     await this.$store.dispatch('prefs/setLastVisited', { name: 'home' });
@@ -201,7 +221,9 @@ export default {
     async resetCards() {
       await this.$store.dispatch('prefs/set', { key: HIDE_HOME_PAGE_CARDS, value: {} });
       await this.$store.dispatch('prefs/set', { key: READ_WHATS_NEW, value: '' });
-    }
+    },
+    get,
+    parseSi
   }
 };
 
@@ -218,6 +240,58 @@ export default {
           </Banner>
         </div>
       </div>
+
+      <div
+        v-if="!mcm && clusterDetail"
+        class="cluster-dashboard-glance"
+      >
+        <div>
+          <label>{{ t('glance.provider') }}: </label>
+          <span>
+            {{ t(`cluster.provider.${ clusterDetail.status.provider || 'other' }`) }}</span>
+        </div>
+        <div>
+          <label>{{ t('glance.version') }}: </label>
+          <span v-if="clusterDetail.kubernetesVersionExtension" style="font-size: 0.5em">{{ clusterDetail.kubernetesVersionExtension }}</span>
+          <span>{{ clusterDetail.kubernetesVersionBase }}</span>
+        </div>
+        <div>
+          <label>{{ t('glance.created') }}: </label>
+          <span><LiveDate :value="clusterDetail.metadata.creationTimestamp" :add-suffix="true" :show-tooltip="true" /></span>
+        </div>
+
+        <div class="glance-gauge">
+          <span>{{ t('landing.clusters.cpuUsed') }}:</span>
+
+          <ConsumptionGauge
+
+            :capacity="get(clusterDetail, 'metrics.cpu.total')"
+            :used="get(clusterDetail, 'metrics.cpu.used')"
+          >
+            <template #title>
+              <span class="text-muted">
+                {{ get(clusterDetail, 'metrics.cpu.used') || 0 }} / {{ get(clusterDetail, 'metrics.cpu.total') }}
+              </span>
+            </template>
+          </ConsumptionGauge>
+        </div>
+        <div class="glance-gauge">
+          <span>{{ t('landing.clusters.memoryUsed') }}:</span>
+          <ConsumptionGauge
+            :units="get(clusterDetail, 'metrics.memory.units')"
+            :capacity="get(clusterDetail, 'metrics.memory.total')"
+            :used="get(clusterDetail, 'metrics.memory.used')"
+          >
+            <template #title>
+              <span class="text-muted">
+                {{ get(clusterDetail, 'metrics.memory.used') || 0 }} / {{ get(clusterDetail, 'metrics.memory.total') }}{{ get(clusterDetail, 'metrics.memory.units') }}
+              </span>
+            </template>
+          </ConsumptionGauge>
+        </div>
+        <div :style="{'flex':1}" />
+      </div>
+
       <div class="row">
         <div :class="{'span-9': showSidePanel, 'span-12': !showSidePanel }" class="col">
           <SimpleBox
@@ -240,7 +314,7 @@ export default {
             <LandingPagePreference />
           </SimpleBox>
           <div class="row panel">
-            <div class="col span-12">
+            <div v-if="mcm" class="col span-12">
               <SortableTable :table-actions="false" :row-actions="false" key-field="id" :rows="clusters" :headers="clusterHeaders">
                 <template #header-left>
                   <div class="row table-heading">
@@ -250,7 +324,7 @@ export default {
                     <BadgeState :label="clusters.length.toString()" color="role-tertiary ml-20 mr-20" />
                   </div>
                 </template>
-                <template v-if="mcm" #header-middle>
+                <template #header-middle>
                   <n-link
                     :to="importLocation"
                     class="btn btn-sm role-primary"
@@ -323,6 +397,46 @@ export default {
   </div>
 </template>
 <style lang='scss' scoped>
+.cluster-dashboard-glance {
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 20px;
+  margin-bottom: 40px;
+  display: flex;
+
+  &>*:not(:last-child) {
+    margin-right: 40px;
+
+    & SPAN {
+       font-weight: bold
+    }
+  }
+
+  .glance-gauge{
+    display:flex;
+    flex:1;
+    &>span {
+      padding-right: 5px;
+    }
+
+    & .consumption-gauge {
+      flex-grow: 1;
+      max-width: 100px;
+      position:relative;
+
+      & >:first-child {
+        font-size: 12px;
+        position: absolute;
+        bottom: calc(-1em - 3px);
+        right:  0;
+      }
+      & >:last-child{
+        margin-top: 0 !important;
+        flex:1;
+      }
+    }
+  }
+}
   .banner.info.whats-new {
     border: 0;
     margin-top: 10px;

--- a/utils/units.js
+++ b/utils/units.js
@@ -127,6 +127,26 @@ export function createMemoryFormat(n) {
   };
 }
 
+function createMemoryUnits(n) {
+  const exponent = exponentNeeded(n, MEMORY_PARSE_RULES.memory.format.increment);
+
+  return `${ UNITS[exponent] }${ MEMORY_PARSE_RULES.memory.format.suffix }`;
+}
+
+export function createMemoryValues(total, useful) {
+  const parsedTotal = parseSi((total || '0').toString());
+  const parsedUseful = parseSi((useful || '0').toString());
+  const format = createMemoryFormat(parsedTotal);
+  const formattedTotal = formatSi(parsedTotal, format);
+  const formattedUseful = formatSi(parsedUseful, format);
+
+  return {
+    total:  Number.parseFloat(formattedTotal),
+    useful: Number.parseFloat(formattedUseful),
+    units:  createMemoryUnits(parsedTotal)
+  };
+}
+
 export default {
   exponentNeeded,
   formatSi,


### PR DESCRIPTION
#2795 - this PR updates the home page so that when multi-cluster management is disabled, rather than a table of clusters (with 1 row) the page shows a brief cluster summary similar to the cluster dashboard view: 
<img width="1449" alt="Screen Shot 2021-06-07 at 9 24 21 AM" src="https://user-images.githubusercontent.com/42977925/121055822-75b61b00-c772-11eb-88d2-5c9c26132f26.png">
