### PR TITLE
Clear the support key in the add dialog

### DIFF
--- a/pages/support/index.vue
+++ b/pages/support/index.vue
@@ -114,6 +114,7 @@ export default {
 
     showDialog(isAdd) {
       this.isRemoveDialog = isAdd;
+      this.supportKey = '';
       this.$modal.show('toggle-support');
     },
 


### PR DESCRIPTION
Small fix - this PR clears the support key in the add dialog - on the support page, if you add key then remove, then click to add again, you see the pervious key. We now clear the key before showing the add dialog.