### PR TITLE
Change focus presentation for tabs

### DIFF
--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -252,9 +252,11 @@ export default {
      outline:none;
 
       & .tab.active {
-        outline-color: var(--outline);
-        outline-style: solid;
-        outline-width: var(--outline-width);
+        text-decoration: underline;
+
+        > A {
+          color: var(--outline);
+        }
       }
     }
 


### PR DESCRIPTION
This PR makes a minor change to the presentation to the focus state for vertical and horizontal tabs.

Instead of the blue border, we use underline text decoration - this still gives us a focus indicator, but does look as jarring as the border.

Now:

![image](https://user-images.githubusercontent.com/1955897/121145530-f8081300-c836-11eb-9b74-657ccd7bd360.png)

Was:

![image](https://user-images.githubusercontent.com/1955897/121146091-811f4a00-c837-11eb-9069-50f8ed01080c.png)
