### PR TITLE
Show error/transition description in resource lists and resource detail

### DIFF
--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -144,21 +144,21 @@ export default {
     },
 
     banner() {
-      if (this.value?.metadata?.state?.error) {
+      if (this.value?.stateObj?.error) {
         const defaultErrorMessage = this.t('resourceDetail.masthead.defaultBannerMessage.error', undefined, true);
 
         return {
           color:   'error',
-          message: this.value.metadata.state.message || defaultErrorMessage
+          message: this.value.stateObj.message || defaultErrorMessage
         };
       }
 
-      if (this.value?.metadata?.state?.transitioning) {
+      if (this.value?.stateObj?.transitioning) {
         const defaultTransitioningMessage = this.t('resourceDetail.masthead.defaultBannerMessage.transitioning', undefined, true);
 
         return {
           color:   'info',
-          message: this.value.metadata.state.message || defaultTransitioningMessage
+          message: this.value.stateObj.message || defaultTransitioningMessage
         };
       }
 

--- a/components/SortableTable/selection.js
+++ b/components/SortableTable/selection.js
@@ -23,10 +23,14 @@ export default {
     this._onRowClickBound = this.onRowClick.bind(this);
     this._onRowMousedownBound = this.onRowMousedown.bind(this);
     this._onRowContextBound = this.onRowContext.bind(this);
+    this._onRowMouseEnterBound = this.onRowMouseEnter.bind(this);
+    this._onRowMouseLeaveBound = this.onRowMouseLeave.bind(this);
 
     $table.on('click', '> TBODY > TR', this._onRowClickBound);
     $table.on('mousedown', '> TBODY > TR', this._onRowMousedownBound);
     $table.on('contextmenu', '> TBODY > TR', this._onRowContextBound);
+    $table.on('mouseenter', '> TBODY > TR', this._onRowMouseEnterBound);
+    $table.on('mouseleave', '> TBODY > TR', this._onRowMouseLeaveBound);
   },
 
   beforeDestroy() {
@@ -35,6 +39,8 @@ export default {
     $table.off('click', '> TBODY > TR', this._onRowClickBound);
     $table.off('mousedown', '> TBODY > TR', this._onRowMousedownBound);
     $table.off('contextmenu', '> TBODY > TR', this._onRowContextBound);
+    $table.off('mouseenter', '> TBODY > TR', this._onRowMouseEnterBound);
+    $table.off('mouseleave', '> TBODY > TR', this._onRowMouseLeaveBound);
 
     // get rid of the selection Vuex module when the table is destroyed
     this.$store.unregisterModule(this.storeName);
@@ -99,6 +105,26 @@ export default {
     onRowMousedown(e) {
       if ( isRange(e) || this.isSelectionCheckbox(e.target) ) {
         e.preventDefault();
+      }
+    },
+
+    onRowMouseEnter(e) {
+      const tr = $(e.target).closest('TR');
+
+      if (tr.hasClass('state-description')) {
+        const trMainRow = tr.prev('TR');
+
+        trMainRow.toggleClass('sub-row-hovered', true);
+      }
+    },
+
+    onRowMouseLeave(e) {
+      const tr = $(e.target).closest('TR');
+
+      if (tr.hasClass('state-description')) {
+        const trMainRow = tr.prev('TR');
+
+        trMainRow.toggleClass('sub-row-hovered', false);
       }
     },
 
@@ -423,6 +449,7 @@ export default {
 
     clearSelection() {
       this.update([], this.selectedNodes);
-    }
+    },
+
   }
 };

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -256,7 +256,7 @@ export default {
                 <img v-else :src="c.logo" />
                 <div>{{ c.label }}</div>
               </nuxt-link>
-              <span v-else class="cluster selector disabled">
+              <span v-else class="option-disabled cluster selector disabled">
                 <img :src="c.logo" />
                 <div>{{ c.label }}</div>
               </span>
@@ -403,7 +403,6 @@ export default {
     align-items: center;
     cursor: pointer;
     display: flex;
-    padding: $option-padding 0 $option-padding 10px;
     color: var(--link);
 
     &:hover {
@@ -444,6 +443,10 @@ export default {
         color: var(--primary-hover-text);
       }
     }
+  }
+
+  .option, .option-disabled {
+    padding: $option-padding 0 $option-padding 10px;
   }
 
   .menu {

--- a/detail/cis.cattle.io.clusterscan.vue
+++ b/detail/cis.cattle.io.clusterscan.vue
@@ -291,7 +291,7 @@ export default {
         key-field="id"
       >
         <template #sub-row="{row, fullColspan}">
-          <tr>
+          <tr class="sub-row">
             <td :colspan="fullColspan">
               <Banner v-if="(row.state==='fail' || row.state==='warn')&& row.remediation" class="sub-banner" :label="remediationDisplay(row)" color="warning" />
               <SortableTable

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -331,6 +331,14 @@ export default {
         component: 'RotateEncryptionKeyDialog'
       });
     };
-  }
+  },
+
+  stateObj() {
+    if (!this.isRke2) {
+      return this.mgmt?.stateObj || this.metadata?.state;
+    }
+
+    return this.metadata?.state;
+  },
 
 };

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -439,7 +439,7 @@ export default {
 
   // You can override the state by providing your own state (and possibly reading metadata.state)
   state() {
-    return this.metadata?.state?.name || this._state || 'unknown';
+    return this.stateObj?.name || this._state || 'unknown';
   },
 
   // You can override the displayed by providing your own stateDisplay (and possibly using the function exported above)
@@ -451,8 +451,8 @@ export default {
     return colorForState.call(
       this,
       this.state,
-      this.metadata?.state?.error,
-      this.metadata?.state?.transitioning
+      this.stateObj?.error,
+      this.stateObj?.transitioning
     );
   },
 
@@ -495,12 +495,16 @@ export default {
     return stateSort(this.stateColor, this.stateDisplay);
   },
 
-  showMessage() {
-    const trans = this.metadata?.state?.transitioning || false;
-    const error = this.metadata?.state?.error || false;
-    const message = this.metadata?.state?.message;
+  stateDescription() {
+    const trans = this.stateObj?.transitioning || false;
+    const error = this.stateObj?.error || false;
+    const message = this.stateObj?.message;
 
-    return (trans || error) && message && message.toLowerCase() !== this.stateDisplay.toLowerCase();
+    return trans || error ? ucFirst(message) : '';
+  },
+
+  stateObj() {
+    return this.metadata?.state;
   },
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
- for resources in error or transitioning states show the associated message
- message is shown in resource detail masthead (in place of current messages)
- message is also shown in lists as text under affected row

Used predominantly in cluster lists where a cluster is transitioning (provisioning cluster uses management cluster message). I've tested with single use of sub-row feature used in CIS scans.

Also fixed indentation of unconnected clusters in side nav

addresses #3111