### PR TITLE
Navigation: Allow default child for a group to be configured

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -143,7 +143,16 @@ export default {
 
           // Navigate to the first item in the group
           if (items && items.length > 0) {
-            const route = items[0].route;
+            let index = 0;
+
+            // If there is a default type, use it
+            if (this.group.defaultType) {
+              const found = items.findIndex(i => i.name === this.group.defaultType);
+
+              index = (found === -1) ? 0 : found;
+            }
+
+            const route = items[index].route;
 
             this.$router.replace(route);
           }

--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -141,7 +141,7 @@ export default {
         if (this.isExpanded && !skipAutoClose) {
           const items = this.group[this.childrenKey];
 
-          // Navigate to the first item in the group
+          // Navigate to one of the child items (by default the first child)
           if (items && items.length > 0) {
             let index = 0;
 

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -35,6 +35,7 @@ export function init(store) {
     virtualType,
     componentForType,
     configureType,
+    setGroupDefaultType,
   } = DSL(store, NAME);
 
   product({
@@ -133,6 +134,8 @@ export function init(store) {
   configureType(WORKLOAD_TYPES.JOB, { isEditable: false, match: WORKLOAD_TYPES.JOB });
   configureType(PVC, { isEditable: false });
   configureType(MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, { isEditable: false });
+
+  setGroupDefaultType('serviceDiscovery', 'service');
 
   configureType('workload', {
     displayName: 'Workload',

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -135,7 +135,7 @@ export function init(store) {
   configureType(PVC, { isEditable: false });
   configureType(MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, { isEditable: false });
 
-  setGroupDefaultType('serviceDiscovery', 'service');
+  setGroupDefaultType('serviceDiscovery', SERVICE);
 
   configureType('workload', {
     displayName: 'Workload',

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -97,6 +97,10 @@
 //   groupOrArrayOfGroups,    -- see weightType...
 //   weight
 // )
+// setGroupDefaultType(       Set the default child type to show when the group is expanded
+//   groupOrArrayOfGroups,    -- see setGroupDefaultType...
+//   defaultType
+// )
 // mapGroup(                  Remap a group name to a display name
 //   matchRegexOrString,      -- see mapType...
 //   replacementString,

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -222,6 +222,14 @@ export function DSL(store, product, module = 'type-map') {
       }
     },
 
+    setGroupDefaultType(input, defaultType) {
+      if ( isArray(input) ) {
+        store.commit(`${ module }/setGroupDefaultType`, { groups: input, defaultType });
+      } else {
+        store.commit(`${ module }/setGroupDefaultType`, { group: input, defaultType });
+      }
+    },
+
     weightType(input, weight, forBasic) {
       if ( isArray(input) ) {
         store.commit(`${ module }/weightType`, {
@@ -291,6 +299,7 @@ export const state = function() {
     basicTypes:              {},
     groupIgnore:             [],
     groupWeights:            {},
+    groupDefaultTypes:       {},
     basicGroupWeights:       { [ROOT]: 1000 },
     groupMappings:           [],
     typeIgnore:              [],
@@ -446,6 +455,14 @@ export const getters = {
     };
   },
 
+  groupDefaultTypeFor(state) {
+    return (group) => {
+      group = group.toLowerCase();
+
+      return state.groupDefaultTypes[group];
+    };
+  },
+
   getTree(state, getters, rootState, rootGetters) {
     return (productId, mode, allTypes, clusterId, namespaceMode, namespaces, currentType, search) => {
       // modes: basic, used, all, favorite
@@ -594,7 +611,8 @@ export const getters = {
           group = {
             name,
             label,
-            weight: getters.groupWeightFor(name, forBasic),
+            weight:      getters.groupWeightFor(name, forBasic),
+            defaultType: getters.groupDefaultTypeFor(name),
           };
 
           tree.children.push(group);
@@ -1243,6 +1261,24 @@ export const mutations = {
 
     for ( const g of groups ) {
       map[g.toLowerCase()] = weight;
+    }
+  },
+
+  // setGroupDefaultType({group: 'core', defaultType: 'name'});
+  // By default ehwn e agroup is clicked, the first item is selected - this allows
+  // this behvaiour to be changed and a named child type can be chosen
+  // These operate on group names *after* mapping but *before* translation
+  setGroupDefaultType(state, { group, groups, defaultType }) {
+    if ( !groups ) {
+      groups = [];
+    }
+
+    if ( group ) {
+      groups.push(group);
+    }
+
+    for ( const g of groups ) {
+      state.groupDefaultTypes[g.toLowerCase()] = defaultType;
     }
   },
 


### PR DESCRIPTION
Addresses #3191 

This PR provides a mechanism to change the default type that is selected when you expand a group that does not have an overview. The default is to select the first child type - you can now configure which child should be selected.

'Service Discovery' is updated to select 'Services' rather than the first child 'Horizontal Pod Autoscalers'