### PR TITLE
Login: Tweak the switch between a provider and local user login

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1769,6 +1769,7 @@ login:
   loggedIn: Logged in
   loginWithLocal: Log in with Local User
   useProvider: Use a {provider} user
+  useNonLocal: Use a non-local user
 
 members:
   clusterMembers: Cluster Members


### PR DESCRIPTION
Addresses #2949 

Updates the login screen when a provider has been configured to make the choice between local and provider login similar to what we did in the Ember UI.