### PR TITLE
Charts Page Tweaks/Fixes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -638,7 +638,7 @@ catalog:
       other: Other
       partner: Partner
       rancher: '{vendor}'
-    header: Deploy Chart
+    header: Charts
     noCharts: 'There are no charts available, have you added any repos?'
     noWindows: Your catalogs do not contain any charts capable of being deployed on a Windows cluster.
     search: Filter

--- a/components/form/Select.vue
+++ b/components/form/Select.vue
@@ -224,6 +224,7 @@ export default {
     />
   </div>
 </template>
+
 <style lang="scss" scoped>
   .unlabeled-select {
     position: relative;

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -68,6 +68,8 @@ export default {
 
     repoOptions() {
       let nextColor = 1;
+      // Colors 3 and 4 match `rancher` and `partner` colors, so just avoid them
+      const colors = [0, 1, 2, 5, 6, 7, 8];
 
       let out = this.$store.getters['catalog/repos'].map((r) => {
         return {
@@ -83,8 +85,8 @@ export default {
 
       for ( const entry of out ) {
         if ( !entry.color ) {
-          entry.color = `color${ nextColor }`;
-          if ( nextColor < 8 ) {
+          entry.color = `color${ colors[nextColor] }`;
+          if ( nextColor < 6 ) {
             nextColor++;
           }
         }
@@ -100,6 +102,12 @@ export default {
     },
 
     flattenedRepoNames() {
+      const allChecked = this.repoOptionsForDropdown.find(repo => repo.all && repo.enabled);
+
+      if (allChecked) {
+        return allChecked.label;
+      }
+
       const shownRepos = this.repoOptions.filter(repo => !this.hideRepos.includes(repo._key));
       const reducedRepos = shownRepos.reduce((acc, c, i) => {
         acc += c.label;
@@ -315,30 +323,31 @@ export default {
     </header>
 
     <div class="left-right-split">
-      <div>
-        <Select
-          :searchable="false"
-          :options="repoOptionsForDropdown"
-          :value="flattenedRepoNames"
-          class="checkbox-select"
-          :close-on-select="false"
-          @option:selecting="$event.all ? toggleAll(!$event.enabled) : toggleRepo($event, !$event.enabled) "
-        >
-          <template #option="repo">
-            <Checkbox
-              :value="repo.enabled"
-              :label="repo.label"
-              class="pull-left repo in-select"
-              :class="{ [repo.color]: true}"
-              :color="repo.color"
-            >
-              <template #label>
-                <span>{{ repo.label }}</span><i v-if="!repo.all" class=" pl-5 icon icon-dot icon-sm" :class="{[repo.color]: true}" />
-              </template>
-            </Checkbox>
-          </template>
-        </Select>
-      </div>
+      <Select
+        :searchable="false"
+        :options="repoOptionsForDropdown"
+        :value="flattenedRepoNames"
+        class="checkbox-select"
+        :close-on-select="false"
+        @option:selecting="$event.all ? toggleAll(!$event.enabled) : toggleRepo($event, !$event.enabled) "
+      >
+        <template #selected-option="selected">
+          {{ selected.label }}
+        </template>
+        <template #option="repo">
+          <Checkbox
+            :value="repo.enabled"
+            :label="repo.label"
+            class="pull-left repo in-select"
+            :class="{ [repo.color]: true}"
+            :color="repo.color"
+          >
+            <template #label>
+              <span>{{ repo.label }}</span><i v-if="!repo.all" class=" pl-5 icon icon-dot icon-sm" :class="{[repo.color]: true}" />
+            </template>
+          </Checkbox>
+        </template>
+      </Select>
 
       <Select
         v-model="category"
@@ -489,7 +498,7 @@ export default {
     &:hover ::v-deep.checkbox-label {
       color: var(--app-color3-accent-text);
     }
-        & i {
+    & i {
       color: var(--app-color3-accent)
     }
   }
@@ -500,7 +509,7 @@ export default {
     &:hover ::v-deep.checkbox-label {
       color: var(--app-color4-accent-text);
     }
-        & i {
+    & i {
       color: var(--app-color4-accent)
     }
   }
@@ -511,8 +520,8 @@ export default {
     &:hover ::v-deep.checkbox-label {
       color: var(--app-color5-accent-text);
     }
-        & i {
-      color: var(--app-color4-accent)
+    & i {
+      color: var(--app-color5-accent)
     }
   }
   &.color6 {
@@ -522,7 +531,7 @@ export default {
     &:hover ::v-deep.checkbox-label {
       color: var(--app-color6-accent-text);
     }
-        & i {
+    & i {
       color: var(--app-color6-accent)
     }
   }
@@ -533,7 +542,7 @@ export default {
     &:hover ::v-deep.checkbox-label {
       color: var(--app-color7-accent-text);
     }
-        & i {
+    & i {
       color: var(--app-color7-accent)
     }
   }
@@ -544,7 +553,7 @@ export default {
     &:hover ::v-deep.checkbox-label {
       color: var(--app-color8-accent-text);
     }
-        & i {
+    & i {
       color: var(--app-color8-accent)
     }
   }

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -67,9 +67,9 @@ export default {
     },
 
     repoOptions() {
-      let nextColor = 1;
+      let nextColor = 0;
       // Colors 3 and 4 match `rancher` and `partner` colors, so just avoid them
-      const colors = [0, 1, 2, 5, 6, 7, 8];
+      const colors = [1, 2, 5, 6, 7, 8];
 
       let out = this.$store.getters['catalog/repos'].map((r) => {
         return {
@@ -86,8 +86,9 @@ export default {
       for ( const entry of out ) {
         if ( !entry.color ) {
           entry.color = `color${ colors[nextColor] }`;
-          if ( nextColor < 6 ) {
-            nextColor++;
+          nextColor++;
+          if ( nextColor >= colors.length ) {
+            nextColor = 0;
           }
         }
       }
@@ -106,6 +107,11 @@ export default {
 
       if (allChecked) {
         return allChecked.label;
+      }
+
+      // None checked
+      if (!this.repoOptionsForDropdown.find(repo => repo.enabled)) {
+        return this.t('generic.none');
       }
 
       const shownRepos = this.repoOptions.filter(repo => !this.hideRepos.includes(repo._key));

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -611,7 +611,7 @@ export function filterAndArrangeCharts(charts, {
       const searchTokens = searchQuery.split(/\s*[, ]\s*/).map(x => ensureRegex(x, false));
 
       for ( const token of searchTokens ) {
-        if ( !c.chartName.match(token) && (c.chartDescription && !c.chartDescription.match(token)) ) {
+        if ( !c.chartNameDisplay.match(token) && (c.chartDescription && !c.chartDescription.match(token)) ) {
           return false;
         }
       }


### PR DESCRIPTION
- Change title from `Deploy Chart` to `Charts`
- Avoid using rancher and partner repo colours for non rancher/partner repos (visible on 4th and 5th repos)
- Repeat colours when number of repo's exceed 6
- Fix issue where repo colour 5 had the wrong dot colour
- When all repos are selected, show 'All'. When none are selected show 'None'
- Fix height of repo drop down
- When searching charts search by chart display name rather than chart id-ish name
- addresses some of the points raised in #2668

![image](https://user-images.githubusercontent.com/18697775/121901127-0ade8400-cd1e-11eb-9f48-c32cab67bd6f.png)


Note - For test repos see those listed in https://artifacthub.io/packages/search?kind=0&page=1 (click on a chart and the repo is normally listed in the `helm repo add` command)
