### PR TITLE
Login Page Tweaks

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1770,6 +1770,7 @@ login:
   loggedOut: You have been logged out.
   loginAgain: Log in again to continue.
   error: An error occured logging in. Please try again.
+  clientError: Invalid username or password. Please try again.
   useLocal: Use a local user
   loginWithProvider: Log in with {provider}
   username: Username

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -12,6 +12,7 @@ import { importLogin } from '@/utils/dynamic-importer';
 import { _ALL_IF_AUTHED } from '@/plugins/steve/actions';
 import { MANAGEMENT } from '@/config/types';
 import { SETTING } from '@/config/settings';
+import { LOGIN_ERRORS } from '@/store/auth';
 import { getVendor, getProduct, setVendor } from '../../config/private-label';
 
 export default {
@@ -169,6 +170,8 @@ export default {
     async loginLocal(buttonCb) {
       try {
         this.err = null;
+        this.timedOut = null;
+        this.loggedOut = null;
         await this.$store.dispatch('auth/login', {
           provider: 'local',
           body:     {
@@ -186,7 +189,6 @@ export default {
         } else {
           this.$cookies.remove(USERNAME);
         }
-        buttonCb(true);
 
         if (this.needsSetup) {
           this.$router.push({ name: 'auth-setup', query: { setup: this.password } });
@@ -194,7 +196,13 @@ export default {
           this.$router.replace('/');
         }
       } catch (err) {
-        this.err = err;
+        if (err === LOGIN_ERRORS.CLIENT_UNAUTHORIZED) {
+          this.err = this.t('login.clientError');
+        } else if (err === LOGIN_ERRORS.CLIENT || err === LOGIN_ERRORS.SERVER) {
+          this.err = this.t('login.error');
+        } else {
+          this.err = err;
+        }
         buttonCb(false);
       }
     },
@@ -212,17 +220,18 @@ export default {
         <h1 class="text-center">
           {{ t('login.welcome', {vendor}) }}
         </h1>
-        <h4 v-if="err" class="text-error text-center">
-          {{ err }}
-        </h4>
-        <h4 v-else-if="loggedOut" class="text-success text-center">
-          {{ t('login.loggedOut') }}
-        </h4>
-        <h4 v-else-if="timedOut" class="text-error text-center">
-          {{ t('login.loginAgain') }}
-        </h4>
-
-        <div v-if="(!hasLocal || (hasLocal && !showLocal)) && providers.length" class="mt-50">
+        <div class="login-messages">
+          <h4 v-if="err" class="text-error text-center">
+            {{ err }}
+          </h4>
+          <h4 v-else-if="loggedOut" class="text-success text-center">
+            {{ t('login.loggedOut') }}
+          </h4>
+          <h4 v-else-if="timedOut" class="text-error text-center">
+            {{ t('login.loginAgain') }}
+          </h4>
+        </div>
+        <div v-if="(!hasLocal || (hasLocal && !showLocal)) && providers.length" class="mt-30">
           <component
             :is="providerComponents[idx]"
             v-for="(name, idx) in providers"
@@ -303,6 +312,10 @@ export default {
       background-size: cover;
       background-position: center center;
       height: 100vh;
+    }
+
+    .login-messages {
+      height: 20px
     }
   }
 </style>

--- a/store/auth.js
+++ b/store/auth.js
@@ -15,8 +15,12 @@ export const BASE_SCOPES = {
 const KEY = 'rc_nonce';
 
 const ERR_NONCE = 'nonce';
-const ERR_CLIENT = 'client';
-const ERR_SERVER = 'server';
+
+export const LOGIN_ERRORS = {
+  CLIENT:              'client',
+  CLIENT_UNAUTHORIZED: 'client_unauthorized',
+  SERVER:              'server'
+};
 
 export const state = function() {
   return {
@@ -244,11 +248,13 @@ export const actions = {
 
       return res;
     } catch (err) {
-      if ( err._status >= 400 && err._status <= 499 ) {
-        return Promise.reject(ERR_CLIENT);
+      if (err._status === 401) {
+        return Promise.reject(LOGIN_ERRORS.CLIENT_UNAUTHORIZED);
+      } else if ( err._status >= 400 && err._status <= 499 ) {
+        return Promise.reject(LOGIN_ERRORS.CLIENT);
       }
 
-      return Promise.reject(ERR_SERVER);
+      return Promise.reject(LOGIN_ERRORS.SERVER);
     }
   },
 


### PR DESCRIPTION
- Beef up error message
  - Previosuly just showed 'client' or 'server', now show existing error message and one specificaly for 401's
  - Clear out loggedOut & timedOut messages on log in attempt (so text doesn't flash up when attempting to log in after a failed attempt)
- Avoid vertical bobble of content when error message is shown/hidden
- Ensure 'log in' button doesn't report success to avoid confusing 'Logged In' and, if login takes a while, 'Log in with Local User' button text (on login success we're changing page with a page 'loading' overlay)