### PR TITLE
Ember Embedding: Fix issue with page not showing

### DIFF
--- a/components/EmberPage.vue
+++ b/components/EmberPage.vue
@@ -173,7 +173,7 @@ export default {
       // If the iframe already exists, check if it is ready for us to reuse
       // by navigating within the app that is already loaded
       if (iframeEl !== null) {
-        const ready = iframeEl.getAttribute('data-ready');
+        const ready = iframeEl.getAttribute('data-ready') !== 'false';
         const lastDidLoad = iframeEl.getAttribute('data-loaded') !== 'false';
 
         if (!ready || this.inline || !lastDidLoad) {
@@ -359,6 +359,7 @@ export default {
           this.doSyncHeight();
         }
       } else if (msg.action === 'dashboard') {
+        this.iframeEl.setAttribute('data-ready', false);
         this.$router.replace(msg.page);
       }
     },


### PR DESCRIPTION
This PR fixes a minor bug where navigating in an embedded page to the dashboard via a link and then going back to the same embedded page results in the page being stuck on loading.