### PR TITLE
Fix two OIDC issues - second princpal search and better handle failed verify auth

### DIFF
--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -117,6 +117,16 @@ export default {
       }
 
       return this.t('login.useNonLocal');
+    },
+
+    errorMessage() {
+      if (this.err === LOGIN_ERRORS.CLIENT_UNAUTHORIZED) {
+        return this.t('login.clientError');
+      } else if (this.err === LOGIN_ERRORS.CLIENT || this.err === LOGIN_ERRORS.SERVER) {
+        return this.t('login.error');
+      }
+
+      return this.err;
     }
   },
 
@@ -197,13 +207,7 @@ export default {
           this.$router.replace('/');
         }
       } catch (err) {
-        if (err === LOGIN_ERRORS.CLIENT_UNAUTHORIZED) {
-          this.err = this.t('login.clientError');
-        } else if (err === LOGIN_ERRORS.CLIENT || err === LOGIN_ERRORS.SERVER) {
-          this.err = this.t('login.error');
-        } else {
-          this.err = err;
-        }
+        this.err = err;
         buttonCb(false);
       }
     },
@@ -222,8 +226,8 @@ export default {
           {{ t('login.welcome', {vendor}) }}
         </h1>
         <div class="login-messages">
-          <h4 v-if="err" class="text-error text-center">
-            {{ err }}
+          <h4 v-if="errorMessage" class="text-error text-center">
+            {{ errorMessage }}
           </h4>
           <h4 v-else-if="loggedOut" class="text-success text-center">
             {{ t('login.loggedOut') }}

--- a/pages/auth/verify.vue
+++ b/pages/auth/verify.vue
@@ -36,18 +36,22 @@ export default {
       return;
     }
 
-    const res = await store.dispatch('auth/verifyOAuth', {
-      code,
-      nonce,
-      provider
-    });
+    try {
+      const res = await store.dispatch('auth/verifyOAuth', {
+        code,
+        nonce,
+        provider
+      });
 
-    if ( res._status === 200) {
-      const backTo = route.query[BACK_TO] || '/';
+      if ( res._status === 200) {
+        const backTo = route.query[BACK_TO] || '/';
 
-      redirect(backTo);
-    } else {
-      redirect(`/auth/login?err=${ escape(res) }`);
+        redirect(backTo);
+      } else {
+        redirect(`/auth/login?err=${ escape(res) }`);
+      }
+    } catch (err) {
+      redirect(`/auth/login?err=${ escape(err) }`);
     }
   },
 

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { addObject, addObjects, clear, removeObject } from '@/utils/array';
 import { SCHEMA } from '@/config/types';
 import { normalizeType, KEY_FIELD_FOR } from './normalize';
-import { proxyFor } from './resource-proxy';
+import { proxyFor, remapSpecialKeys } from './resource-proxy';
 
 function registerType(state, type) {
   let cache = state.types[type];
@@ -47,6 +47,8 @@ function load(state, { data, ctx, existing }) {
     for ( const k of Object.keys(existing) ) {
       delete existing[k];
     }
+
+    remapSpecialKeys(data);
 
     for ( const k of Object.keys(data) ) {
       Vue.set(existing, k, data[k]);


### PR DESCRIPTION
- ~~Blocked on #3221~~
- Fix issue where searching the second time for principals resulted in missing principal resource names
  - 1st call to v3/principals?action=search --> rancher/loadMulti - new principals for store, new proxy objects
  - 2nd call to v3/principals?action=search --> rancher/loadMulti - existing principals in store, load updates object by deleting all existing props (like _name) and applying new (that didn't contain _name)
-  Handle errors when verifying auth
   - seen as part of #3234 (does not solve entirely, backend changes needed)
