### PR TITLE
Fix issue where editing resource yaml resulted in un-expandable sections

### DIFF
--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -76,11 +76,12 @@ export default {
     this.$router.applyQuery({ [PREVIEW]: _UNFLAG });
 
     return {
-      initialYaml: this.initialYamlForDiff || this.yaml,
+      initialYaml:  this.initialYamlForDiff || this.yaml,
       currentYaml:  this.yaml,
       showPreview:  false,
       errors:       null,
-      cm:          null,
+      cm:           null,
+      initialReady: true
     };
   },
 
@@ -141,6 +142,11 @@ export default {
     },
 
     onReady(cm) {
+      if (!this.initialReady) {
+        return;
+      }
+      this.initialReady = false;
+
       this.cm = cm;
 
       if ( this.isEdit ) {


### PR DESCRIPTION
Address #3196

To reproduce
1) Nav to a DaemonSet's `Edit Yaml` page (ensure that the `annotations` section is initially collapsed)
2) Edit any of the yaml (for instance add a new property at the top)
3) Try to expand the `annotations` section, which fails and section remains collapsed


Under the hood
- ResourceYaml component automatically (ish) collapsed status, annotations, managedFields resource sections when codemirror emits 'onReady'
- the 'onReady' event emits in many different scenarios, like edit
- repeatedly handling the onReady event meant codemirror's `foldCode` called often on the same lines
- this somehow broke how folded lines are tracked. as far as i can tell it's something to do with tracking gutter state and marked lines
  - if no edits are made collapsing and uncollapsing annotations is perfectly fine
  - if we don't automatically collapse sections then collapsing and uncollapsing sections after editing works fine