### PR TITLE
Fix two rancher backup form bugs

### DIFF
--- a/chart/rancher-backup/index.vue
+++ b/chart/rancher-backup/index.vue
@@ -48,11 +48,7 @@ export default {
     this.storageClasses = hash.storageClasses;
     this.persistentVolumes = hash.persistentVolumes;
 
-    if (this.mode === 'create') {
-      this.storageSource = 'none';
-    } else {
-      this.storageSource = this.getStorageSource(this.value);
-    }
+    this.storageSource = this.getStorageSource(this.value) || 'none';
   },
 
   data() {
@@ -98,8 +94,8 @@ export default {
       case 'pickSC':
         this.value.persistence.enabled = true;
         this.value.s3.enabled = false;
-        if (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' ) {
-          this.value.persistence.storageClass = this.defaultStorageClass?.id;
+        if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
+          this.value.persistence.storageClass = this.defaultStorageClass.id;
           this.storageClass = this.defaultStorageClass;
         }
         if (this.storageClass?.reclaimPolicy === 'Delete') {


### PR DESCRIPTION
- Ensure that when we load the form component the storage class type from existing value is respected
  - This fixes the situation when switching between form and yaml and the selection is lost
- Don't attempt to use the default storage class if we don't have it
  - This fixes a issue where the yaml became invalid after selecting storage class as the type
 
Addresses #3215