### PR TITLE
Simplified project norman acccess and now refresh management projects when modifying norman projects

### DIFF
--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -80,8 +80,7 @@ export default {
   methods: {
     async save(saveCb) {
       try {
-        const normanProject = this.isCreate ? await this.createProject() : await this.editProject();
-        const savedProject = await normanProject.save();
+        const savedProject = await this.value.save();
 
         await this.saveBindings(savedProject.id);
 
@@ -122,43 +121,6 @@ export default {
           id:                    managementBinding.id?.replace('/', ':')
         });
       };
-    },
-
-    async createProject() {
-      const normanProject = await this.$store.dispatch('rancher/create', {
-        type:                          NORMAN.PROJECT,
-        name:                          this.value.spec.displayName,
-        description:                   this.value.spec.description,
-        annotations:                   this.value.metadata.annotations,
-        labels:                        this.value.metadata.labels,
-        clusterId:                     this.$store.getters['currentCluster'].id,
-        creatorId:                     this.$store.getters['auth/principalId'],
-        containerDefaultResourceLimit: this.value.spec.containerDefaultResourceLimit,
-        namespaceDefaultResourceQuota: this.value.spec.namespaceDefaultResourceQuota,
-        resourceQuota:                 this.value.spec.resourceQuota,
-      });
-
-      // The backend seemingly required both labels/annotation and metadata.labels/annotations or it doesn't save the labels and annotations
-      normanProject.setAnnotations(this.value.metadata.annotations);
-      normanProject.setLabels(this.value.metadata.labels);
-
-      return normanProject;
-    },
-
-    async editProject() {
-      const normanProject = await this.$store.dispatch('rancher/find', {
-        type:       NORMAN.PROJECT,
-        id:   this.value.id.replace('/', ':'),
-      });
-
-      normanProject.setAnnotations(this.value.metadata.annotations);
-      normanProject.setLabels(this.value.metadata.labels);
-      normanProject.description = this.value.spec.description;
-      normanProject.containerDefaultResourceLimit = this.value.spec.containerDefaultResourceLimit;
-      normanProject.namespaceDefaultResourceQuota = this.value.spec.namespaceDefaultResourceQuota;
-      normanProject.resourceQuota = this.value.spec.resourceQuota;
-
-      return normanProject;
     },
 
     saveBindings(projectId) {

--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -30,7 +30,7 @@ export default {
     }
 
     this.namespaces = await this.$store.dispatch(`${ inStore }/findAll`, { type: NAMESPACE });
-    this.projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });
+    this.projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } });
   },
 
   data() {
@@ -66,8 +66,14 @@ export default {
 
       return uniq(ids);
     },
+    clusterProjects() {
+      const clusterId = this.$store.getters['currentCluster'].id;
+
+      return this.projects.filter(project => project.spec.clusterName === clusterId);
+    },
     projectsWithoutNamespaces() {
-      return this.projects.filter(project => !this.projectIdsWithNamespaces.includes(project.name));
+      return this.clusterProjects
+        .filter(project => !this.projectIdsWithNamespaces.includes(project.name));
     },
     // We're using this because we need to show projects as groups even if the project doesn't have any namespaces.
     rowsWithFakeNamespaces() {


### PR DESCRIPTION
The management projects weren't consistently being updated when modifying norman projects. Now when
saving or removing norman projects we refresh the management projects to make sure the list is up to date.

I also moved accessing the norman project into the project model to clean up some of the mess in the project component.

https://github.com/rancher/dashboard/issues/3175