### PR TITLE
Ensure top-level navigation is expanded if a child is active

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -213,7 +213,7 @@ export default {
     font-size: 14px;
     position: relative;
     cursor: pointer;
-    color: var(--input-label);
+    color: var(--body-text);
 
     > H6 {
       color: var(--body-text);

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -397,6 +397,14 @@ export default {
     expanded(name) {
       const currentType = this.$route.params.resource || '';
 
+      if (!currentType) {
+        const grp = this.groups.find(item => item.name === name);
+
+        if (grp?.children) {
+          return this.hasRoute(grp.children);
+        }
+      }
+
       return name === currentType;
     },
 
@@ -416,6 +424,20 @@ export default {
           }
         });
       }
+    },
+
+    hasRoute(grp) {
+      return !!grp.find((item) => {
+        if (item.children) {
+          return this.hasRoute(item.children);
+        } else if (item.route) {
+          const route = this.$router.resolve(item.route);
+
+          return this.$route.fullPath === route.href;
+        }
+
+        return false;
+      });
     },
 
     wheresMyDebugger() {


### PR DESCRIPTION
This PR fixes an issue where the side-nav does not auto expand the top-level item when a child's child is active - this is most notable on a page reload.

A good example if the Legacy nav item - go to the project item within it, choose a project and you will be on Project Apps - refresh the window and the nav will not auto-expand to show you the active nav item.

This PR also fixes the color of the 2nd level nav headers, so that they are the same as the rest of the nav rather tyhan --input-label