### PR TITLE
Remove Cluster Manager

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4676,6 +4676,12 @@ v1ClusterTools:
   logging:
     label: Logging (Legacy)
     description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="https://rancher.com/docs/rancher/v2.x/en/logging/v2.5/migrating/">Learn more</a> about migrating to V2 Logging.'
+  istio:
+    label: Istio (Legacy)
+    description: 'Legacy V1 Istio. Istio v1.5 has been deprecated since Rancher 2.5.0. <a target="blank" href="https://rancher.com/docs/rancher/v2.5/en/istio/#migrate-from-previous-istio-version">Learn more</a> about migrating to the latest version.'
+  cis:
+    label: CIS Scanning (Legacy)
+    description: Leagcy CIS Scanning. CIS Scanning has been deprecated as of Rancher 2.5.0 - use the newer CIS Benchmarking.
 
 legacy:
   alerts: Alerts

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4681,12 +4681,17 @@ legacy:
   alerts: Alerts
   apps: Apps
   catalogs: Catalogs
+  cis-scans: CIS Scans
+  configuration: Configuration
   globalDnsEntries: Global DNS Entries
   globalDnsProviders: Global DNS Providers
+  istio: Istio
   logging: Logging
   notifiers: Notifiers
   monitoring: Monitoring
+  pipelines: Pipelines
   psps: Pod Security Policies
+
   project:
     label: Project
     select: "Use the Project/Namespace filter at the top of the page to select a Project in order to see legacy Project features."

--- a/components/EmberPage.vue
+++ b/components/EmberPage.vue
@@ -46,9 +46,7 @@ const INTERCEPTS = {
   },
   'authenticated.cluster.istio.cluster-setting': {
     name:   'c-cluster-explorer-tools-pages-page',
-    params: {
-      page:    'istio'
-    }
+    params: { page: 'istio' }
   },
 };
 
@@ -309,7 +307,7 @@ export default {
 
         const frameParent = document.getElementById(this.inline);
         const w = frameParent.offsetWidth;
-        
+
         if (w && this.frameWidth !== w) {
           this.frameWidth = w;
           iframeEl.width = w;
@@ -390,6 +388,10 @@ export default {
       } else if (msg.action === 'dashboard') {
         this.iframeEl.setAttribute('data-ready', false);
         this.$router.replace(msg.page);
+      } else if (msg.action === 'reload') {
+        this.loaded = false;
+        this.iframeEl.remove();
+        this.initFrame();
       }
     },
 

--- a/components/EmberPage.vue
+++ b/components/EmberPage.vue
@@ -44,9 +44,7 @@ const INTERCEPTS = {
       page:    'catalogs'
     }
   },
-  'authenticated.cluster.istio.cluster-setting': {
-    name:   'c-cluster-explorer-tools',
-  },
+  'authenticated.cluster.istio.cluster-setting': { name: 'c-cluster-explorer-tools' },
 };
 
 export default {

--- a/components/EmberPage.vue
+++ b/components/EmberPage.vue
@@ -45,9 +45,8 @@ const INTERCEPTS = {
     }
   },
   'authenticated.cluster.istio.cluster-setting': {
-    name:   'c-cluster-legacy-pages-page',
+    name:   'c-cluster-explorer-tools-pages-page',
     params: {
-      cluster: 'local',
       page:    'istio'
     }
   },
@@ -84,6 +83,7 @@ export default {
       error:            false,
       heightSync:       null,
       frameHeight:      -1,
+      frameWidth:       -1,
       showHeaderBanner: false,
       showFooterBanner: false,
     };
@@ -280,22 +280,22 @@ export default {
         iframeEl.classList.remove('ember-iframe');
         iframeEl.classList.add('ember-iframe-inline');
         iframeEl.height = 0;
-        this.syncHeight();
+        this.syncSize();
       }
     },
 
-    syncHeight() {
+    syncSize() {
       if (this.heightSync) {
         clearTimeout(this.heightSync);
       }
 
       this.heightSync = setTimeout(() => {
-        this.doSyncHeight();
-        this.syncHeight();
+        this.dosyncSize();
+        this.syncSize();
       }, 500);
     },
 
-    doSyncHeight() {
+    dosyncSize() {
       if (this.inline) {
         const iframeEl = document.getElementById(EMBER_FRAME);
         const doc = iframeEl.contentWindow.document;
@@ -305,6 +305,14 @@ export default {
         if (h && this.frameHeight !== h) {
           this.frameHeight = h;
           iframeEl.height = h;
+        }
+
+        const frameParent = document.getElementById(this.inline);
+        const w = frameParent.offsetWidth;
+        
+        if (w && this.frameWidth !== w) {
+          this.frameWidth = w;
+          iframeEl.width = w;
         }
       }
     },
@@ -377,7 +385,7 @@ export default {
         if (!this.loadRequired) {
           this.setLoaded(true);
           this.updateFrameVisibility();
-          this.doSyncHeight();
+          this.dosyncSize();
         }
       } else if (msg.action === 'dashboard') {
         this.iframeEl.setAttribute('data-ready', false);
@@ -538,7 +546,6 @@ export default {
 
   .ember-iframe-inline {
     border: 0;
-    width: 100%;
     overflow: hidden;
   }
 

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -33,6 +33,11 @@ export default {
     useHash: {
       type:    Boolean,
       default: true,
+    },
+
+    noContent: {
+      type:    Boolean,
+      default: false,
     }
   },
 
@@ -236,7 +241,7 @@ export default {
         </li>
       </ul>
     </ul>
-    <div :class="{ 'tab-container': !!tabs.length }">
+    <div :class="{ 'tab-container': !!tabs.length, 'no-content': noContent }">
       <slot />
     </div>
   </div>
@@ -289,6 +294,10 @@ export default {
     padding: 20px;
     background-color: var(--tabbed-container-bg);
     // box-shadow: 0 0 20px var(--shadow);
+
+    &.no-content {
+      padding: 0 0 3px 0;
+    }
   }
 
   .side-tabs{

--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -276,6 +276,19 @@ export default {
       }
     }
 
+    &.depth-1 {
+      > .header {
+        > SPAN {
+          font-size: 13px;
+          line-height: 16px;
+          padding: 8px 0 7px 5px !important;
+        }
+        > I {
+          padding: 9px 7px 8px 7px !important;
+        }
+      }
+    }
+
     &:not(.depth-0) {
       > .header {
         padding-left: 10px;

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -35,8 +35,7 @@ export default {
 
   computed: {
     ...mapGetters(['clusterId']),
-    ...mapGetters(['clusterReady', 'isRancher', 'currentCluster',
-      'currentProduct', 'backToRancherLink', 'backToRancherGlobalLink']),
+    ...mapGetters(['clusterReady', 'isRancher', 'currentCluster', 'currentProduct']),
     ...mapGetters('type-map', ['activeProducts']),
     ...mapGetters('i18n', ['selectedLocaleLabel', 'availableLocales']),
     ...mapGetters({ features: 'features/get' }),
@@ -279,12 +278,6 @@ export default {
           <template v-if="legacyEnabled">
             <div class="category">
               {{ t('nav.categories.legacy') }}
-            </div>
-            <div v-if="currentProduct && isRancher" @click="hide()">
-              <a :href="(currentProduct.inStore === 'management' ? backToRancherGlobalLink : backToRancherLink)" class="option">
-                <i class="icon icon-cluster" />
-                {{ t('nav.backToRancher') }}
-              </a>
             </div>
             <div v-for="a in legacyApps" :key="a.label" @click="hide()">
               <nuxt-link class="option" :to="a.to">

--- a/components/nav/Type.vue
+++ b/components/nav/Type.vue
@@ -74,7 +74,7 @@ export default {
       @mouseleave="setNear(false)"
     >
       <span v-if="type.labelKey" class="label"><t :k="type.labelKey" /></span>
-      <span v-else class="label" v-html="type.labelDisplay || type.label" />
+      <span v-else class="label" :class="{'no-icon': !type.icon}" v-html="type.labelDisplay || type.label" />
       <span v-if="showFavorite || showCount" class="count">
         <Favorite v-if="showFavorite" :resource="type.name" />
         {{ type.count }}
@@ -111,6 +111,10 @@ export default {
       display: flex;
       overflow: hidden;
       text-overflow: ellipsis;
+
+      &.no-icon {
+        padding-left: 3px;
+      }
 
       ::v-deep .highlight {
         background: var(--diff-ins-bg);

--- a/config/product/legacy.js
+++ b/config/product/legacy.js
@@ -47,16 +47,6 @@ export function init(store) {
   });
 
   virtualType({
-    labelKey:       'legacy.istio',
-    name:           'v1-istio',
-    group:          'Root',
-    namespaced:     true,
-    weight:         111,
-    route:          { name: 'c-cluster-legacy-pages-page', params: { page: 'istio' } },
-    exact:          true
-  });
-
-  virtualType({
     labelKey:       'legacy.cis-scans',
     name:           'v1-cis-scans',
     group:          'Root',
@@ -93,7 +83,6 @@ export function init(store) {
     'v1-catalogs',
     'v1-notifiers',
     'v1-cis-scans',
-    'v1-istio',
     'v1-project-overview'
   ]);
 

--- a/config/product/legacy.js
+++ b/config/product/legacy.js
@@ -22,7 +22,6 @@ export function init(store) {
     group:          'Root',
     namespaced:     true,
     weight:         111,
-    icon:           'folder',
     route:          { name: 'c-cluster-legacy-pages-page', params: { page: 'alerts' } },
     exact:          true
   });
@@ -33,7 +32,6 @@ export function init(store) {
     group:          'Root',
     namespaced:     true,
     weight:         111,
-    icon:           'folder',
     route:          { name: 'c-cluster-legacy-pages-page', params: { page: 'catalogs' } },
     exact:          true
   });
@@ -44,8 +42,27 @@ export function init(store) {
     group:          'Root',
     namespaced:     true,
     weight:         111,
-    icon:           'folder',
     route:          { name: 'c-cluster-legacy-pages-page', params: { page: 'notifiers' } },
+    exact:          true
+  });
+
+  virtualType({
+    labelKey:       'legacy.istio',
+    name:           'v1-istio',
+    group:          'Root',
+    namespaced:     true,
+    weight:         111,
+    route:          { name: 'c-cluster-legacy-pages-page', params: { page: 'istio' } },
+    exact:          true
+  });
+
+  virtualType({
+    labelKey:       'legacy.cis-scans',
+    name:           'v1-cis-scans',
+    group:          'Root',
+    namespaced:     true,
+    weight:         111,
+    route:          { name: 'c-cluster-legacy-pages-page', params: { page: 'cis' } },
     exact:          true
   });
 
@@ -55,7 +72,6 @@ export function init(store) {
     namespaced: true,
     name:       'v1-project',
     weight:     105,
-    icon:       'folder',
     route:      { name: 'c-cluster-project-apps' },
     exact:      true,
     overview:   false,
@@ -67,7 +83,6 @@ export function init(store) {
     namespaced: true,
     name:       'v1-project-overview',
     weight:     105,
-    icon:       'folder',
     route:      { name: 'c-cluster-legacy-project' },
     exact:      true,
     overview:   false,
@@ -77,6 +92,8 @@ export function init(store) {
     'v1-alerts',
     'v1-catalogs',
     'v1-notifiers',
+    'v1-cis-scans',
+    'v1-istio',
     'v1-project-overview'
   ]);
 
@@ -137,11 +154,35 @@ export function init(store) {
     overview:   false,
   });
 
+  virtualType({
+    ifHave:     IF_HAVE.PROJECT,
+    labelKey:   'legacy.istio',
+    namespaced: true,
+    name:       'project-istio',
+    weight:     105,
+    route:      { name: 'c-cluster-legacy-project-page', params: { page: 'istio' } },
+    exact:      true,
+    overview:   false,
+  });
+
+  virtualType({
+    ifHave:     IF_HAVE.PROJECT,
+    labelKey:   'legacy.pipelines',
+    namespaced: true,
+    name:       'project-pipelines',
+    weight:     104,
+    route:      { name: 'c-cluster-legacy-pipelines' },
+    exact:      true,
+    overview:   false,
+  });
+
   basicType([
     'project-apps',
     'project-alerts',
     'project-catalogs',
     'project-logging',
+    'project-istio',
     'project-monitoring',
+    'project-pipelines',
   ], 'Project');
 }

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -100,6 +100,8 @@ export default {
       if (this.legacyEnabled) {
         this.moveAppWhenLegacy(chartsWithApps, 'v1-monitoring', 'rancher-monitoring');
         this.moveAppWhenLegacy(chartsWithApps, 'v1-logging', 'rancher-logging');
+        this.moveAppWhenLegacy(chartsWithApps, 'v1-istio', 'rancher-istio');
+        this.moveAppWhenLegacy(chartsWithApps, 'v1-cis', 'rancher-cis');
       }
 
       return chartsWithApps;
@@ -110,6 +112,8 @@ export default {
       return [
         this._legacyChart('monitoring'),
         this._legacyChart('logging'),
+        this._legacyChart('istio'),
+        this._legacyChart('cis'),
       ];
     }
   },
@@ -176,6 +180,9 @@ export default {
     moveAppWhenLegacy(chartsWithApps, v1ChartName, v2ChartName) {
       const v1 = chartsWithApps.find(a => a.chart.chartName === v1ChartName);
       const v2 = chartsWithApps.find(a => a.chart.chartName === v2ChartName);
+
+      console.log('************************');
+      console.log(JSON.parse(JSON.stringify(chartsWithApps)));
 
       // Check app on v2
       if (v1 && v2 && v2.app) {

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -3,7 +3,7 @@ import { mapGetters } from 'vuex';
 import Loading from '@/components/Loading';
 import { _FLAGGED, DEPRECATED, HIDDEN, FROM_TOOLS } from '@/config/query-params';
 import { filterAndArrangeCharts } from '@/store/catalog';
-import { CATALOG } from '@/config/types';
+import { CATALOG, MANAGEMENT } from '@/config/types';
 import LazyImage from '@/components/LazyImage';
 import AppSummaryGraph from '@/components/formatter/AppSummaryGraph';
 import { sortBy } from '@/utils/sort';
@@ -27,7 +27,7 @@ export default {
     // If legacy feature flag enabled
     if (this.legacyEnabled) {
       const res = await this.$store.dispatch('management/findMatching', {
-        type: 'management.cattle.io.catalogtemplate',
+        type:     MANAGEMENT.CATALOG_TEMPLATE,
         selector: 'catalog.cattle.io/name=system-library'
       });
 

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -26,10 +26,17 @@ export default {
 
     // If legacy feature flag enabled
     if (this.legacyEnabled) {
-      this.v1SystemCatalog = await this.$store.dispatch('cluster/find', {
-        type: 'management.cattle.io.catalog',
-        id:   'system-library',
-      });
+      const res = await this.$store.dispatch('cluster/request', { url: '/v3/templates?catalogId=system-library' });
+
+      if (res && res.data) {
+        this.v1SystemCatalog = res.data.reduce((map, template) => {
+          map[template.name] = template;
+
+          return map;
+        }, {});
+      } else {
+        this.v1SystemCatalog = {};
+      }
     }
   },
 
@@ -167,11 +174,10 @@ export default {
 
     getLegacyVersions(id) {
       const versions = [];
-      const hvcs = this.v1SystemCatalog?.status?.helmVersionCommits;
-      const c = hvcs ? hvcs[id]?.Value : null;
+      const c = this.v1SystemCatalog?.[id];
 
       if (c) {
-        Object.keys(c).forEach(v => versions.unshift({ version: v }));
+        Object.keys(c.versionLinks).forEach(v => versions.unshift({ version: v }));
       }
 
       return versions;
@@ -180,9 +186,6 @@ export default {
     moveAppWhenLegacy(chartsWithApps, v1ChartName, v2ChartName) {
       const v1 = chartsWithApps.find(a => a.chart.chartName === v1ChartName);
       const v2 = chartsWithApps.find(a => a.chart.chartName === v2ChartName);
-
-      console.log('************************');
-      console.log(JSON.parse(JSON.stringify(chartsWithApps)));
 
       // Check app on v2
       if (v1 && v2 && v2.app) {

--- a/pages/c/_cluster/legacy/pipelines.vue
+++ b/pages/c/_cluster/legacy/pipelines.vue
@@ -1,0 +1,74 @@
+<script>
+import EmberPage from '@/components/EmberPage';
+import Tabbed from '@/components/Tabbed';
+import Tab from '@/components/Tabbed/Tab';
+import { project } from '@/store/type-map';
+
+const PAGES = {
+  pipelines:     'pipeline/pipelines',
+  configuration: 'pipeline',
+};
+
+export default {
+  components: {
+    EmberPage,
+    Tabbed,
+    Tab
+  },
+
+  data() {
+    return { activeTab: null };
+  },
+
+  computed: {
+    pipelinesPage() {
+      const prj = project(this.$store.getters);
+
+      if (!!prj && this.activeTab) {
+        const id = prj.id.replace('/', ':');
+        const suffix = PAGES[this.activeTab];
+
+        return `/p/${ id }/${ suffix }`;
+      }
+
+      return '';
+    }
+  },
+
+  methods: {
+    tabChanged(tab) {
+      this.activeTab = tab.tab.name;
+    },
+
+    intercept(target) {
+      if (target === 'authenticated.project.pipeline.settings') {
+        // User went to the config page from the pipelines page, so change the active tab
+        this.$refs.tabs.select('configuration');
+      }
+    }
+  }
+
+};
+</script>
+
+<template>
+  <div class="pipelines">
+    <Tabbed ref="tabs" :no-content="true" @changed="tabChanged">
+      <Tab name="pipelines" label-key="legacy.pipelines" :weight="3" />
+      <Tab name="configuration" label-key="legacy.configuration" :weight="2" />
+    </Tabbed>
+    <div id="legacy-pipelines" class="embed-pipelines">
+      <EmberPage v-if="pipelinesPage" inline="legacy-pipelines" :src="pipelinesPage" :force-reuse="true" @before-nav="intercept" />
+    </div>
+  </div>
+</template>
+
+<style scoped lang='scss'>
+  .pipelines {
+    display: flex;
+
+    .embed-pipelines {
+      flex: 1;
+    }
+  }
+</style>

--- a/pages/c/_cluster/legacy/project/_page.vue
+++ b/pages/c/_cluster/legacy/project/_page.vue
@@ -2,7 +2,12 @@
 import EmberPage from '@/components/EmberPage';
 import { project } from '@/store/type-map';
 
-const PAGES = { monitoring: 'monitoring/project-setting' };
+const PAGES = {
+  istio:          'istio/project-istio/metrics',
+  monitoring:     'monitoring/project-setting',
+  pipelineConfig: 'pipeline',
+  pipelines:      'pipeline/pipelines'
+};
 
 export default {
   components: { EmberPage },


### PR DESCRIPTION
This PR:

- Embeds the remaining pages that we originally planned to leave in Cluster Manager
   - CIS Scans, Istio, Pipelines and Pipeline configuration are now available under Legacy
- Removes the link to Cluster Manager in the slide-in menu
- Fixes some styling issues with the 2nd-level navigation