### PR TITLE
re-load user prefs on login

### DIFF
--- a/store/auth.js
+++ b/store/auth.js
@@ -246,8 +246,6 @@ export const actions = {
         ...body
       }, { redirectUnauthorized: false });
 
-      await dispatch('prefs/loadServer', {}, { root: true });
-
       return res;
     } catch (err) {
       if (err._status === 401) {

--- a/store/auth.js
+++ b/store/auth.js
@@ -246,6 +246,8 @@ export const actions = {
         ...body
       }, { redirectUnauthorized: false });
 
+      await dispatch('prefs/loadServer', {}, { root: true });
+
       return res;
     } catch (err) {
       if (err._status === 401) {

--- a/store/index.js
+++ b/store/index.js
@@ -603,6 +603,7 @@ export const actions = {
     await dispatch('management/unsubscribe');
     commit('managementChanged', { ready: false });
     commit('management/reset');
+    commit('prefs/reset');
 
     await dispatch('cluster/unsubscribe');
     commit('clusterChanged', false);

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -225,6 +225,15 @@ export const mutations = {
   cookiesLoaded(state) {
     state.cookiesLoaded = true;
   },
+
+  reset(state) {
+    for (const key in definitions) {
+      if ( definitions[key]?.asCookie ) {
+        continue;
+      }
+      delete state.data[key];
+    }
+  }
 };
 
 export const actions = {


### PR DESCRIPTION
#3282 - This is happening because the `prefs` store data isn't re-loaded when the user changes. Dispatching `prefs/loadServer` on login should ensure the correct user's preferences are available before the index page redirects based off `afterLoginRoute`.