### PR TITLE
ui-banners enhancements

### DIFF
--- a/components/FixedBanner.vue
+++ b/components/FixedBanner.vue
@@ -1,6 +1,8 @@
 <script>
 import { MANAGEMENT } from '@/config/types';
 import { SETTING } from '@/config/settings';
+import isEmpty from 'lodash/isEmpty';
+
 export default {
   props: {
     footer: {
@@ -44,10 +46,24 @@ export default {
       if (neu?.value && neu.value !== '') {
         try {
           const parsed = JSON.parse(neu.value);
+          const {
+            bannerHeader, bannerFooter, banner, showHeader, showFooter
+          } = parsed;
+          let bannerContent = parsed?.banner || {};
 
-          this.showHeader = parsed.showHeader === 'true';
-          this.showFooter = parsed.showFooter === 'true';
-          this.banner = parsed.banner || {};
+          if (isEmpty(banner)) {
+            if (showFooter && this.footer) {
+              bannerContent = bannerFooter || {};
+            } else if (showHeader) {
+              bannerContent = bannerHeader || {};
+            } else {
+              bannerContent = {};
+            }
+          }
+
+          this.showHeader = showHeader === 'true';
+          this.showFooter = showFooter === 'true';
+          this.banner = bannerContent;
         } catch {}
       }
     }

--- a/pages/c/_cluster/settings/brand.vue
+++ b/pages/c/_cluster/settings/brand.vue
@@ -12,6 +12,7 @@ import { allHash } from '@/utils/promise';
 import { MANAGEMENT } from '@/config/types';
 import { getVendor, setVendor } from '@/config/private-label';
 import { SETTING, fetchOrCreateSetting } from '@/config/settings';
+import isEmpty from 'lodash/isEmpty';
 const Color = require('color');
 const parse = require('url-parse');
 
@@ -36,7 +37,9 @@ export default {
     Object.assign(this, hash);
 
     try {
-      this.bannerVal = JSON.parse(hash.uiBannerSetting.value);
+      const parsedBanner = JSON.parse(hash.uiBannerSetting.value);
+
+      this.bannerVal = this.checkOrUpdateLegacyUIBannerSetting(parsedBanner);
     } catch {
       this.bannerVal = {};
     }
@@ -103,6 +106,22 @@ export default {
   },
 
   methods: {
+    checkOrUpdateLegacyUIBannerSetting(parsedBanner) {
+      const { bannerHeader, bannerFooter, banner } = parsedBanner;
+
+      if (isEmpty(bannerHeader) && isEmpty(bannerFooter) && !isEmpty(banner?.text)) {
+        const neu = {
+          bannerHeader: { ...parsedBanner.banner },
+          bannerFooter: { ...parsedBanner.banner },
+          showHeader:   parsedBanner?.showHeader ? parsedBanner?.showHeader.toString() : false.toString(),
+          showFooter:   parsedBanner?.showFooter ? parsedBanner?.showFooter.toString() : false.toString(),
+        };
+
+        return neu;
+      }
+
+      return parsedBanner;
+    },
     updateLogo(img, key) {
       this[key] = img;
     },
@@ -263,21 +282,44 @@ export default {
       </label>
 
       <div class="row mt-20 mb-20">
-        <Checkbox :value="bannerVal.showHeader==='true'" :label="t('branding.uiBanner.showHeader')" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
-        <Checkbox :value="bannerVal.showFooter==='true'" :label="t('branding.uiBanner.showFooter')" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
-      </div>
-      <template v-if="bannerVal.showHeader==='true' || bannerVal.showFooter==='true'">
-        <div class="row">
-          <div class="col span-12">
-            <LabeledInput v-model="bannerVal.banner.text" :label="t('branding.uiBanner.text')" />
-          </div>
+        <div class="col span-6">
+          <Checkbox :value="bannerVal.showHeader==='true'" :label="t('branding.uiBanner.showHeader')" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
         </div>
-        <div class="row mt-10">
-          <div class="col span-3">
-            <ColorInput v-model="bannerVal.banner.color" :label="t('branding.uiBanner.textColor')" />
+        <div class="col span-6">
+          <Checkbox :value="bannerVal.showFooter==='true'" :label="t('branding.uiBanner.showFooter')" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
+        </div>
+      </div>
+      <template>
+        <div class="row">
+          <div v-if="bannerVal.showHeader==='true'" class="col span-6">
+            <div class="row">
+              <div class="col span-12">
+                <LabeledInput v-model="bannerVal.bannerHeader.text" :label="t('branding.uiBanner.text')" />
+              </div>
+            </div>
+            <div class="row mt-10">
+              <div class="col span-6">
+                <ColorInput v-model="bannerVal.bannerHeader.color" :label="t('branding.uiBanner.textColor')" />
+              </div>
+              <div class="col span-6">
+                <ColorInput v-model="bannerVal.bannerHeader.background" :label="t('branding.uiBanner.background')" />
+              </div>
+            </div>
           </div>
-          <div class="col span-3">
-            <ColorInput v-model="bannerVal.banner.background" :label="t('branding.uiBanner.background')" />
+          <div v-if="bannerVal.showFooter==='true'" class="col span-6">
+            <div class="row">
+              <div class="col span-12">
+                <LabeledInput v-model="bannerVal.bannerFooter.text" :label="t('branding.uiBanner.text')" />
+              </div>
+            </div>
+            <div class="row mt-10">
+              <div class="col span-6">
+                <ColorInput v-model="bannerVal.bannerFooter.color" :label="t('branding.uiBanner.textColor')" />
+              </div>
+              <div class="col span-6">
+                <ColorInput v-model="bannerVal.bannerFooter.background" :label="t('branding.uiBanner.background')" />
+              </div>
+            </div>
           </div>
         </div>
       </template>


### PR DESCRIPTION
Updates the banner parsers to handle a new `ui-banners` data structure to enable setting header and footer banners separately. The old structure used a single banner param to hold the text, text-color, and background-color for both header and footer banners. Updated the logic to handle a new blob with separate `bannerHeader` and `bannerFooter` params. If the user has an existing, and now legacy, `ui-banners` settings, I migrate it to the new structure when they land on the brand settings page populating the header and footer objects with the content of the current `banner` object. I know we typically do not like to change a users setting without notifying them but in this case it feels okay since I am migrating the old content to a new structure the end result for the user is the same if they do not change anything in the banners section. They would see the same header content in the header and footer banners as before.

rancher/dashboard#3241

![Screenshot 2021-06-21 at 16-21-41 Rancher](https://user-images.githubusercontent.com/858614/122839491-f87bc180-d2ac-11eb-9005-518be0334a9e.png)
