### PR TITLE
hide disable action for one-way feature flags

### DIFF
--- a/config/features.js
+++ b/config/features.js
@@ -1,0 +1,3 @@
+export const ONE_WAY = [
+  'token-hashing', 'multi-cluster-management'
+];

--- a/models/management.cattle.io.feature.js
+++ b/models/management.cattle.io.feature.js
@@ -1,3 +1,5 @@
+import { ONE_WAY } from '@/config/features';
+
 export default {
 
   state() {
@@ -16,6 +18,10 @@ export default {
     return false;
   },
 
+  canDisable() {
+    return this.canUpdate && !ONE_WAY.includes(this.id);
+  },
+
   _availableActions() {
     const out = this._standardActions;
     const state = this.enabled;
@@ -25,7 +31,7 @@ export default {
       action:  'toggleFeatureFlag',
       label:   state ? 'Deactivate' : 'Activate',
       icon:    'icon icon-edit',
-      enabled: this.canUpdate,
+      enabled: state ? this.canDisable : this.canUpdate,
     };
 
     out.unshift(enableAction);


### PR DESCRIPTION
#3312 - MCM can be enabled from the UI, but can only be set to false during installation. Similarly, token hashing cannot be disabled once enabled. This PR removes the 'deactivate' action for both feature flags.