### PR TITLE
fix volume re-name

### DIFF
--- a/edit/workload/storage/Mount.vue
+++ b/edit/workload/storage/Mount.vue
@@ -11,12 +11,6 @@ export default {
       default: 'create'
     },
 
-    // container volume mounts
-    value: {
-      type:    Array,
-      default: () => []
-    },
-
     // volume name
     name: {
       type:     String,
@@ -42,13 +36,7 @@ export default {
     return { volumeMounts };
   },
 
-  computed: {
-    type() {
-      return Object.keys(this.value).filter(key => key !== 'name')[0];
-    },
-
-    ...mapGetters({ t: 'i18n/t' })
-  },
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
 
   watch: {
     volumeMounts(neu) {

--- a/edit/workload/storage/hostPath.vue
+++ b/edit/workload/storage/hostPath.vue
@@ -84,7 +84,7 @@ export default {
     <div>
       <div class="row mb-10">
         <div class="col span-6">
-          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" @input="e=>updateMountNames(e)" />
+          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" />
         </div>
       </div>
       <div class="row mb-10">

--- a/edit/workload/storage/nfs.vue
+++ b/edit/workload/storage/nfs.vue
@@ -40,7 +40,7 @@ export default {
     <div>
       <div class="row mb-10">
         <div class="col span-6">
-          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" @input="e=>updateMountNames(e)" />
+          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" />
         </div>
         <div class="col span-6">
           <Checkbox v-model="value.nfs.readOnly" :mode="mode" :label="t('workload.storage.readOnly')" />

--- a/edit/workload/storage/persistentVolumeClaim/index.vue
+++ b/edit/workload/storage/persistentVolumeClaim/index.vue
@@ -97,7 +97,7 @@ export default {
       </div>
       <div class="row mb-10">
         <div class="col span-6">
-          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" @input="e=>updateMountNames(e)" />
+          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" />
         </div>
         <div class="col span-6">
           <LabeledSelect v-if="!createNew" v-model="value.persistentVolumeClaim.claimName" :mode="mode" :label="t('workload.storage.subtypes.persistentVolumeClaim')" :options="pvcs" />

--- a/edit/workload/storage/secret.vue
+++ b/edit/workload/storage/secret.vue
@@ -129,7 +129,7 @@ export default {
     <div>
       <div class="row mb-10">
         <div class="col span-6">
-          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" @input="e=>updateMountNames(e)" />
+          <LabeledInput v-model="value.name" :required="true" :mode="mode" :label="t('workload.storage.volumeName')" />
         </div>
 
         <div class="col span-6">


### PR DESCRIPTION
#3313 In addition to the two problems outlined in this ticket, I noticed the Mount components weren't updating correctly when multiple volumes are defined and one is removed. Addressed by these changes:
- track subset of volumes mounted in current container in data + watcher instead of a computed prop
- remove outdated call to `updateMountNames` when a volume name changes (this is handled within the Mount component)
- add a key to Mount components to force updating when a volume is removed