### PR TITLE
remove machine provider detail header for v2 cloud provider

### DIFF
--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -30,6 +30,13 @@ export default {
       },
     ];
 
+    const provisioner = this?.provisioner ?? '';
+    const v2Providers = ['aks', 'gke', 'eks'];
+
+    if (v2Providers.includes(provisioner)) {
+      return out.filter(deet => deet.label !== 'Machine Provider');
+    }
+
     return out;
   },
 

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -30,13 +30,6 @@ export default {
       },
     ];
 
-    const provisioner = this?.provisioner ?? '';
-    const v2Providers = ['aks', 'gke', 'eks'];
-
-    if (v2Providers.includes(provisioner)) {
-      return out.filter(deet => deet.label !== 'Machine Provider');
-    }
-
     return out;
   },
 

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -23,11 +23,10 @@ export default {
       },
     ];
 
-    const provisioner = this?.provisioner ?? '';
-    const v2Providers = ['aks', 'gke', 'eks'];
+    if (!this.machineProvider) {
+      out.splice(1, 1);
 
-    if (v2Providers.includes(provisioner)) {
-      return out.filter(deet => deet.label !== 'Machine Provider');
+      return out;
     }
 
     return out;

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -23,6 +23,13 @@ export default {
       },
     ];
 
+    const provisioner = this?.provisioner ?? '';
+    const v2Providers = ['aks', 'gke', 'eks'];
+
+    if (v2Providers.includes(provisioner)) {
+      return out.filter(deet => deet.label !== 'Machine Provider');
+    }
+
     return out;
   },
 


### PR DESCRIPTION
aks, eks, and gke v2 providers do not have a machine provider so lets drop it from the details.

@vincent99 I was not 100% sure about adding this to the management model. If I understand correctly the management cluster is always going to be the local cluster but I wasn't sure if that could also be one of these clusters? I added the check to the details to be on the safe side, I can remove it if its not needed. 



rancher/dashboard#2985