### PR TITLE
Add back in missing feature flag prompt translations

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4531,6 +4531,8 @@ featureFlags:
     Features that are off by defult shoud be considered experimental functionality.
     Some features require a restart of the {vendor} server to change.
     This will result in a short outage of the API and UI, but not affect running clusters or workloads.
+  promptActivate: Please confirm that you want to activate the feature flag "{flag}"
+  promptDeactivate: Please confirm that you want to deactivate the feature flag "{flag}"    
   restartRequired: "Note: Updating this feature flag requires a restart"
   restart:
     title: Waiting for Restart


### PR DESCRIPTION
These strings got lost somehow - adding them back - otherwise the dialog to enable/disable a feature flag does not show a message. 