### PR TITLE
do not force mcapps under local cluster

### DIFF
--- a/pages/c/_cluster/mcapps/index.vue
+++ b/pages/c/_cluster/mcapps/index.vue
@@ -7,7 +7,6 @@ export default {
       name:   'c-cluster-mcapps-pages-page',
       params: {
         ...route.params,
-        cluster: 'local',
         product:  NAME,
         page:    'apps'
       }


### PR DESCRIPTION
https://github.com/rancherlabs/rancher-security/issues/828 - restricted admins don't have access to the local cluster and thus can't access routes nested beneath it. 