### PR TITLE
Update Cluster Manager Node/Machine Lists

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3,6 +3,7 @@
 ##############################
 generic:
   add: Add
+  all: All
   back: Back
   cancel: Cancel
   close: Close
@@ -2138,7 +2139,7 @@ namespaceList:
 node:
   list:
     pool: Pool
-    noNodes: There are no Nodes in this Pool
+    noNodes: This pool is empty
     nodeTaint: Taints
     scaleDown: Scale Pool Down
     scaleUp: Scale Pool Up
@@ -2918,7 +2919,7 @@ resourceTable:
     cluster: "<span>Cluster:</span> {name}"
     namespace: "<span>Namespace:</span> {name}"
     notInAMachinePool: "Not In A Deployment"
-    machinePool: "<span>Pools:</span> {name}"
+    machinePool: "<span>Pool:</span> {name}"
     notInANamespace: Not Namespaced
     notInAProject: Not in a Project
     project: "<span>Project:</span> {name}"

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1150,9 +1150,6 @@ cluster:
     services: Services
     allServices: Rotate all service certificates
     selectService: Rotate an individual service
-  nodePool:
-    scaleDown: Scale Pool Down
-    scaleUp: Scale Pool Up
 
 clusterIndexPage:
   hardwareResourceGauge:
@@ -2141,7 +2138,10 @@ namespaceList:
 node:
   list:
     pool: Pool
+    noNodes: There are no Nodes in this Pool
     nodeTaint: Taints
+    scaleDown: Scale Pool Down
+    scaleUp: Scale Pool Up
     poolDescription:
       noSize: No Size
       noLocation: No Location
@@ -2917,14 +2917,15 @@ resourceTable:
   groupLabel:
     cluster: "<span>Cluster:</span> {name}"
     namespace: "<span>Namespace:</span> {name}"
-    machinePool: "<span>Machine Pool:</span> {name}"
+    notInAMachinePool: "Not In A Deployment"
+    machinePool: "<span>Pools:</span> {name}"
     notInANamespace: Not Namespaced
     notInAProject: Not in a Project
     project: "<span>Project:</span> {name}"
     notInAWorkspace: Not in a Workspace
     workspace: "<span>Workspace:</span> {name}"
     notInANodePool: "Not in a Pool"
-    nodePool: "<span>Node Pool:</span> {name} ({count})"
+    nodePool: "<span>Pool:</span> {name} ({count})"
 
 resourceTabs:
   conditions:
@@ -4286,6 +4287,9 @@ typeDescription:
   cis.cattle.io.clusterscan: A scan is created to trigger a CIS scan on the cluster based on the defined profile. A report is created after the scan is completed.
   cis.cattle.io.clusterscanreport: A report is the result of a CIS scan of the cluster.
   management.cattle.io.feature: Feature Flags allow certain {vendor} features to be toggled on and off.  Features that are off by default shoud be considered experimental functionality.
+  cluster.x-k8s.io.machine: A Machine encapsulates the configuration of a Kubernetes Node. Use this view to see what happens after updating a cluster.
+  cluster.x-k8s.io.machinedeployment: A Machine Deployment orchestrates deployments via templates over a collection of Machine Sets (similar to a Deployment). Use this view to see what happens after updating a cluster.
+  cluster.x-k8s.io.machineset: A Machine Set ensures the desired number of Machine resources are up and running at all times (similar to a ReplicaSet). Use this view to see what happens after updating a cluster.
   resources.cattle.io.backup: A backup is created to perform one-time backups or schedule recurring backups based on a ResourceSet.
   resources.cattle.io.restore: A restore is created to trigger a restore to the cluster based on a backup file.
   resources.cattle.io.resourceset: A resource set defines which CRDs and resources to store in the backup.

--- a/components/ResourceTable.vue
+++ b/components/ResourceTable.vue
@@ -62,10 +62,6 @@ export default {
       default: 'resourceTable.groupBy.namespace',
     },
 
-    alwaysGroup: {
-      type:    Boolean,
-      default: false
-    }
   },
 
   computed: {
@@ -242,7 +238,7 @@ export default {
     key-field="_key"
     v-on="$listeners"
   >
-    <template v-if="showGrouping && !alwaysGroup" #header-middle>
+    <template v-if="showGrouping" #header-middle>
       <slot name="more-header-middle" />
       <ButtonGroup v-model="group" :options="groupOptions" />
     </template>

--- a/components/ResourceTable.vue
+++ b/components/ResourceTable.vue
@@ -61,6 +61,11 @@ export default {
       type:    String,
       default: 'resourceTable.groupBy.namespace',
     },
+
+    alwaysGroup: {
+      type:    Boolean,
+      default: false
+    }
   },
 
   computed: {
@@ -237,7 +242,7 @@ export default {
     key-field="_key"
     v-on="$listeners"
   >
-    <template v-if="showGrouping" #header-middle>
+    <template v-if="showGrouping && !alwaysGroup" #header-middle>
       <slot name="more-header-middle" />
       <ButtonGroup v-model="group" :options="groupOptions" />
     </template>

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -589,7 +589,7 @@ export default {
         </slot>
         <template v-for="(row, i) in group.rows">
           <slot name="main-row" :row="row">
-            <slot :name="'main-row:' + (row.mainRowKey || i)">
+            <slot :name="'main-row:' + (row.mainRowKey || i)" :full-colspan="fullColspan">
               <!-- The data-cant-run-bulk-action-of-interest attribute is being used instead of :class because
               because our selection.js invokes toggleClass and :class clobbers what was added by toggleClass if
               the value of :class changes. -->

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -29,6 +29,8 @@ export const STORAGE = {
   BETA_DEFAULT_STORAGE_CLASS: 'storageclass.beta.kubernetes.io/is-default-class'
 };
 
+export const MANAGEMENT_NODE = { NODE_NAME: 'management.cattle.io/nodename' };
+
 export const NODE_ROLES = {
   CONTROL_PLANE_OLD: 'node-role.kubernetes.io/controlplane',
   CONTROL_PLANE:     'node-role.kubernetes.io/control-plane',

--- a/list/node.vue
+++ b/list/node.vue
@@ -45,7 +45,7 @@ export default {
     }
 
     if (canViewNodePools && canViewNodeTemplates) {
-      // Managemnet Node's required for kube role and some reousrce states
+      // Managemnet Node's required for kube role and some resource states
       hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
       hash.nodePools = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL });
       hash.nodeTemplates = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE });

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -1,5 +1,6 @@
-import { CAPI } from '@/config/types';
+import { CAPI, NODE } from '@/config/types';
 import { CAPI as CAPI_LABELS, MACHINE_ROLES } from '@/config/labels-annotations';
+import { NAME as EXPLORER } from '@/config/product/explorer';
 import { escapeHtml } from '@/utils/string';
 import { insertAt } from '@/utils/array';
 import { downloadUrl } from '@/utils/download';
@@ -70,6 +71,20 @@ export default {
 
   pool() {
     return this.$rootGetters['management/byId'](CAPI.MACHINE_DEPLOYMENT, this.poolId);
+  },
+
+  kubeNodeDetailLocation() {
+    const kubeId = this.status?.nodeRef?.name;
+
+    return kubeId ? {
+      name:   'c-cluster-product-resource-id',
+      params: {
+        cluster:  this.cluster.status.clusterName,
+        product:  EXPLORER,
+        resource: NODE,
+        id:       kubeId
+      }
+    } : kubeId;
   },
 
   groupByLabel() {

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -1,6 +1,7 @@
 import { CAPI, NODE } from '@/config/types';
 import { CAPI as CAPI_LABELS, MACHINE_ROLES } from '@/config/labels-annotations';
 import { NAME as EXPLORER } from '@/config/product/explorer';
+import { listNodeRoles } from '@/models/cluster/node';
 import { escapeHtml } from '@/utils/string';
 import { insertAt } from '@/utils/array';
 import { downloadUrl } from '@/utils/download';
@@ -112,35 +113,6 @@ export default {
   roles() {
     const { isControlPlane, isWorker, isEtcd } = this;
 
-    if (( isControlPlane && isWorker && isEtcd ) ||
-        ( !isControlPlane && !isWorker && !isEtcd )) {
-      // !isControlPlane && !isWorker && !isEtcd === RKE?
-      return 'All';
-    }
-    // worker+cp, worker+etcd, cp+etcd
-
-    if (isControlPlane && isWorker) {
-      return 'Control Plane, Worker';
-    }
-
-    if (isControlPlane && isEtcd) {
-      return 'Control Plane, Etcd';
-    }
-
-    if (isEtcd && isWorker) {
-      return 'Etcd, Worker';
-    }
-
-    if (isControlPlane) {
-      return 'Control Plane';
-    }
-
-    if (isEtcd) {
-      return 'Etcd';
-    }
-
-    if (isWorker) {
-      return 'Worker';
-    }
+    return listNodeRoles(isControlPlane, isWorker, isEtcd, this.t('generic.all'));
   },
 };

--- a/models/cluster/node.js
+++ b/models/cluster/node.js
@@ -7,6 +7,25 @@ import { parseSi } from '@/utils/units';
 import { PRIVATE } from '@/plugins/steve/resource-proxy';
 import findLast from 'lodash/findLast';
 
+export const listNodeRoles = (isControlPlane, isWorker, isEtcd, allString) => {
+  const res = [];
+
+  if (isControlPlane) {
+    res.push('Control Plane');
+  }
+  if (isWorker) {
+    res.push('Worker');
+  }
+  if (isEtcd) {
+    res.push('Etcd');
+  }
+  if (res.length === 3 || res.length === 0) {
+    return allString;
+  }
+
+  return res.join(', ');
+};
+
 export default {
   _availableActions() {
     const normanAction = this.normanNode?.actions || {};
@@ -147,36 +166,7 @@ export default {
   roles() {
     const { isControlPlane, isWorker, isEtcd } = this;
 
-    if (( isControlPlane && isWorker && isEtcd ) ||
-        ( !isControlPlane && !isWorker && !isEtcd )) {
-      // !isControlPlane && !isWorker && !isEtcd === RKE?
-      return 'All';
-    }
-    // worker+cp, worker+etcd, cp+etcd
-
-    if (isControlPlane && isWorker) {
-      return 'Control Plane, Worker';
-    }
-
-    if (isControlPlane && isEtcd) {
-      return 'Control Plane, Etcd';
-    }
-
-    if (isEtcd && isWorker) {
-      return 'Etcd, Worker';
-    }
-
-    if (isControlPlane) {
-      return 'Control Plane';
-    }
-
-    if (isEtcd) {
-      return 'Etcd';
-    }
-
-    if (isWorker) {
-      return 'Worker';
-    }
+    return listNodeRoles(isControlPlane, isWorker, isEtcd, this.t('generic.all'));
   },
 
   version() {

--- a/models/management.cattle.io.node.js
+++ b/models/management.cattle.io.node.js
@@ -1,6 +1,7 @@
 import { MANAGEMENT_NODE } from '@/config/labels-annotations';
 import { CAPI, MANAGEMENT, NODE } from '@/config/types';
 import { NAME as EXPLORER } from '@/config/product/explorer';
+import { listNodeRoles } from '@/models/cluster/node';
 
 export default {
 
@@ -8,7 +9,7 @@ export default {
     return this.metadata.labels[MANAGEMENT_NODE.NODE_NAME];
   },
 
-  clusterId() {
+  mgmtClusterId() {
     return this.id.substring(0, this.id.indexOf('/'));
   },
 
@@ -16,7 +17,7 @@ export default {
     return this.kubeNodeName ? {
       name:   'c-cluster-product-resource-id',
       params: {
-        cluster:  this.clusterId,
+        cluster:  this.mgmtClusterId,
         product:  EXPLORER,
         resource: NODE,
         id:       this.kubeNodeName
@@ -39,36 +40,7 @@ export default {
   roles() {
     const { isControlPlane, isWorker, isEtcd } = this;
 
-    if (( isControlPlane && isWorker && isEtcd ) ||
-        ( !isControlPlane && !isWorker && !isEtcd )) {
-      // !isControlPlane && !isWorker && !isEtcd === RKE?
-      return 'All';
-    }
-    // worker+cp, worker+etcd, cp+etcd
-
-    if (isControlPlane && isWorker) {
-      return 'Control Plane, Worker';
-    }
-
-    if (isControlPlane && isEtcd) {
-      return 'Control Plane, Etcd';
-    }
-
-    if (isEtcd && isWorker) {
-      return 'Etcd, Worker';
-    }
-
-    if (isControlPlane) {
-      return 'Control Plane';
-    }
-
-    if (isEtcd) {
-      return 'Etcd';
-    }
-
-    if (isWorker) {
-      return 'Worker';
-    }
+    return listNodeRoles(isControlPlane, isWorker, isEtcd, this.t('generic.all'));
   },
 
   pool() {

--- a/models/management.cattle.io.node.js
+++ b/models/management.cattle.io.node.js
@@ -1,5 +1,29 @@
+import { MANAGEMENT_NODE } from '@/config/labels-annotations';
+import { CAPI, MANAGEMENT, NODE } from '@/config/types';
+import { NAME as EXPLORER } from '@/config/product/explorer';
 
 export default {
+
+  kubeNodeName() {
+    return this.metadata.labels[MANAGEMENT_NODE.NODE_NAME];
+  },
+
+  clusterId() {
+    return this.id.substring(0, this.id.indexOf('/'));
+  },
+
+  kubeNodeDetailLocation() {
+    return this.kubeNodeName ? {
+      name:   'c-cluster-product-resource-id',
+      params: {
+        cluster:  this.clusterId,
+        product:  EXPLORER,
+        resource: NODE,
+        id:       this.kubeNodeName
+      }
+    } : null;
+  },
+
   isWorker() {
     return this.spec.worker;
   },
@@ -11,4 +35,61 @@ export default {
   isEtcd() {
     return this.spec.etcd;
   },
+
+  roles() {
+    const { isControlPlane, isWorker, isEtcd } = this;
+
+    if (( isControlPlane && isWorker && isEtcd ) ||
+        ( !isControlPlane && !isWorker && !isEtcd )) {
+      // !isControlPlane && !isWorker && !isEtcd === RKE?
+      return 'All';
+    }
+    // worker+cp, worker+etcd, cp+etcd
+
+    if (isControlPlane && isWorker) {
+      return 'Control Plane, Worker';
+    }
+
+    if (isControlPlane && isEtcd) {
+      return 'Control Plane, Etcd';
+    }
+
+    if (isEtcd && isWorker) {
+      return 'Etcd, Worker';
+    }
+
+    if (isControlPlane) {
+      return 'Control Plane';
+    }
+
+    if (isEtcd) {
+      return 'Etcd';
+    }
+
+    if (isWorker) {
+      return 'Worker';
+    }
+  },
+
+  pool() {
+    const nodePoolID = this.spec.nodePoolName.replace(':', '/');
+
+    return this.$rootGetters['management/byId'](MANAGEMENT.NODE_POOL, nodePoolID);
+  },
+
+  provisioningCluster() {
+    return this.$getters['all'](CAPI.RANCHER_CLUSTER).find(c => c.name === this.namespace);
+  },
+
+  doneOverride() {
+    return {
+      name:   'c-cluster-product-resource-namespace-id',
+      params: {
+        resource:  CAPI.RANCHER_CLUSTER,
+        namespace: this.provisioningCluster?.namespace,
+        id:        this.namespace
+      }
+    };
+  }
+
 };

--- a/models/management.cattle.io.nodepool.js
+++ b/models/management.cattle.io.nodepool.js
@@ -44,9 +44,11 @@ export default {
     };
   },
 
-  scalePool(delta) {
-    this.spec.quantity += delta;
-    this.save();
+  scalePool() {
+    return (delta) => {
+      this.spec.quantity += delta;
+      this.save();
+    };
   }
 
 };

--- a/models/management.cattle.io.nodepool.js
+++ b/models/management.cattle.io.nodepool.js
@@ -1,6 +1,7 @@
-import { MANAGEMENT } from '@/config/types';
+import { CAPI, MANAGEMENT } from '@/config/types';
 
 export default {
+
   nodeTemplate() {
     const id = (this.spec?.nodeTemplateName || '').replace(/:/, '/');
     const template = this.$getters['byId'](MANAGEMENT.NODE_TEMPLATE, id);
@@ -27,5 +28,25 @@ export default {
   providerSize() {
     return this.nodeTemplate?.providerSize;
   },
+
+  provisioningCluster() {
+    return this.$getters['all'](CAPI.RANCHER_CLUSTER).find(c => c.name === this.spec.clusterName);
+  },
+
+  doneOverride() {
+    return {
+      name:   'c-cluster-product-resource-namespace-id',
+      params: {
+        resource:  CAPI.RANCHER_CLUSTER,
+        namespace: this.provisioningCluster?.namespace,
+        id:        this.spec.clusterName
+      }
+    };
+  },
+
+  scalePool(delta) {
+    this.spec.quantity += delta;
+    this.save();
+  }
 
 };

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -107,6 +107,10 @@ export default {
     return !!this.mgmt?.spec?.rancherKubernetesEngineConfig;
   },
 
+  clusterId() {
+    return this.mgmt?.id || this.id.replace(`${ this.metadata.namespace }/`, '');
+  },
+
   mgmt() {
     const name = this.status?.clusterName;
 

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -107,7 +107,7 @@ export default {
     return !!this.mgmt?.spec?.rancherKubernetesEngineConfig;
   },
 
-  clusterId() {
+  mgmtClusterId() {
     return this.mgmt?.id || this.id.replace(`${ this.metadata.namespace }/`, '');
   },
 

--- a/models/rke-machine.cattle.io.amazonec2machinetemplate.js
+++ b/models/rke-machine.cattle.io.amazonec2machinetemplate.js
@@ -1,0 +1,18 @@
+export default {
+
+  nameDisplay() {
+    return this.name.replace(`${ this.metadata.annotations['objectset.rio.cattle.io/owner-name'] }-`, '');
+  },
+
+  provider() {
+    return 'amazonec2';
+  },
+
+  providerLocation() {
+    return `${ this.spec.template.spec.region }${ this.spec.template.spec.zone }`;
+  },
+
+  providerSize() {
+    return this.spec.template.spec.instanceType;
+  }
+};

--- a/models/rke-machine.cattle.io.azuremachinetemplate.js
+++ b/models/rke-machine.cattle.io.azuremachinetemplate.js
@@ -1,0 +1,18 @@
+export default {
+
+  nameDisplay() {
+    return this.name.replace(`${ this.metadata.annotations['objectset.rio.cattle.io/owner-name'] }-`, '');
+  },
+
+  provider() {
+    return 'azure';
+  },
+
+  providerLocation() {
+    return this.spec.template.spec.location ;
+  },
+
+  providerSize() {
+    return this.spec.template.spec.size;
+  }
+};

--- a/models/rke-machine.cattle.io.digitaloceanmachinetemplate.js
+++ b/models/rke-machine.cattle.io.digitaloceanmachinetemplate.js
@@ -1,0 +1,18 @@
+export default {
+
+  nameDisplay() {
+    return this.name.replace(`${ this.metadata.annotations['objectset.rio.cattle.io/owner-name'] }-`, '');
+  },
+
+  provider() {
+    return 'digitalocean';
+  },
+
+  providerLocation() {
+    return this.spec.template.spec.region ;
+  },
+
+  providerSize() {
+    return this.spec.template.spec.size;
+  }
+};

--- a/models/rke-machine.cattle.io.linodemachinetemplate.js
+++ b/models/rke-machine.cattle.io.linodemachinetemplate.js
@@ -1,0 +1,18 @@
+export default {
+
+  nameDisplay() {
+    return this.name.replace(`${ this.metadata.annotations['objectset.rio.cattle.io/owner-name'] }-`, '');
+  },
+
+  provider() {
+    return 'linode';
+  },
+
+  providerLocation() {
+    return this.spec.template.spec.region ;
+  },
+
+  providerSize() {
+    return this.spec.template.spec.instanceType;
+  }
+};

--- a/models/rke-machine.cattle.io.vmwarevspheremachinetemplate.js
+++ b/models/rke-machine.cattle.io.vmwarevspheremachinetemplate.js
@@ -1,0 +1,18 @@
+import { formatSi } from '@/utils/units';
+
+export default {
+
+  nameDisplay() {
+    return this.name.replace(`${ this.metadata.annotations['objectset.rio.cattle.io/owner-name'] }-`, '');
+  },
+
+  provider() {
+    return 'vmwarevsphere';
+  },
+
+  providerSize() {
+    const size = formatSi(this.spec.template.spec.size.memorySize * 1048576, 1024, 'iB');
+
+    return `${ size }, ${ this.spec.template.spec.size.cpuCount } Core`;
+  }
+};


### PR DESCRIPTION
- Add a Node list grouped by Node Pools
  - Both Node/Node Pools are of type 'management'
  - For pools...
    - Show node count next to pool label
    - Show description of pool underneath pool label
    - Show convenience scale down/up buttons (normally scale by cluster config)
    - Show node pool action menu
  - For nodes
    - Link to kube node
    - Show node role/s
- Update Machine/Machine Pool List
  - For pools
    - Like Node Pools add a description of machine pool underneath label
    - Like Node Pools Show convenience scale down/up buttons (normally scale by cluster config)
  - For machines
    - Like Nodes link to kube node
    - Like Nodes show node machine role/s
- Add resource descriptions (shown on lists) for machine, machine deployment and machine set
- Addresses #3291
  - Includes #3016, #493