### PR TITLE
Show Node counts in Cluster Management's cluster list

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3516,7 +3516,7 @@ tableHeaders:
   lastUpdated: Last Updated
   lastSeen: Last Seen
   loggingOutputProviders: Provider
-  machines: Machines
+  machines: Machines/Nodes
   machineNodeName: K8s Node
   manual: Manual
   matches: Matches

--- a/config/product/manager.js
+++ b/config/product/manager.js
@@ -114,7 +114,6 @@ export function init(store) {
   const MACHINE_SUMMARY = {
     name:      'summary',
     labelKey:  'tableHeaders.machines',
-    value:     'status',
     sort:      false,
     search:    false,
     formatter: 'MachineSummaryGraph',

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -11,6 +11,8 @@ export default {
   async fetch() {
     const hash = await allHash({
       mgmtClusters:       this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
+      // Used to determine non-rke2 node counts
+      mgmtNodes:          this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE }),
       mgmtPools:          this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL }),
       mgmtTemplates:      this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE }),
       rancherClusters:    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
@@ -93,7 +95,7 @@ export default {
         </template>
       </template>
       <template #cell:summary="{row}">
-        <span v-if="!row.isRke2 || row.isCustom" class="text-muted">&mdash;</span>
+        <span v-if="!row.stateParts.length">{{ row.nodes.length }}</span>
       </template>
       <template #cell:explorer="{row}">
         <n-link v-if="row.mgmt && row.mgmt.isReady" class="btn btn-sm role-primary" :to="{name: 'c-cluster', params: {cluster: row.mgmt.id}}">

--- a/models/management.cattle.io.nodepool.js
+++ b/models/management.cattle.io.nodepool.js
@@ -1,4 +1,5 @@
 import { CAPI, MANAGEMENT } from '@/config/types';
+import { sortBy } from '@/utils/sort';
 
 export default {
 
@@ -49,6 +50,45 @@ export default {
       this.spec.quantity += delta;
       this.save();
     };
-  }
+  },
+
+  nodes() {
+    const nodePoolName = this.id.replace('/', ':');
+
+    return this.$getters['all'](MANAGEMENT.NODE).filter(node => node.spec.nodePoolName === nodePoolName);
+  },
+
+  desired() {
+    return this.spec?.quantity || 0;
+  },
+
+  pending() {
+    return Math.max(0, this.desired - (this.nodes?.length || 0));
+  },
+
+  ready() {
+    return Math.max(0, (this.nodes?.length || 0) - (this.pending || 0));
+  },
+
+  stateParts() {
+    const out = [
+      {
+        label:     'Pending',
+        color:     'bg-info',
+        textColor: 'text-info',
+        value:     this.pending,
+        sort:      1,
+      },
+      {
+        label:     'Ready',
+        color:     'bg-success',
+        textColor: 'text-success',
+        value:     this.ready,
+        sort:      4,
+      },
+    ].filter(x => x.value > 0);
+
+    return sortBy(out, 'sort:desc');
+  },
 
 };

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -210,6 +210,10 @@ export default {
     }
   },
 
+  nodes() {
+    return this.$getters['all'](MANAGEMENT.NODE).filter(node => node.id.startsWith(this.mgmtClusterId));
+  },
+
   displayName() {
     if ( this.mgmt && !this.isRke2 ) {
       return this.mgmt.spec.displayName;
@@ -217,7 +221,13 @@ export default {
   },
 
   pools() {
-    return this.$getters['all'](CAPI.MACHINE_DEPLOYMENT).filter(pool => pool.spec?.clusterName === this.metadata.name);
+    const deployments = this.$getters['all'](CAPI.MACHINE_DEPLOYMENT).filter(pool => pool.spec?.clusterName === this.metadata.name);
+
+    if (!!deployments.length) {
+      return deployments;
+    }
+
+    return this.$getters['all'](MANAGEMENT.NODE_POOL).filter(pool => pool.spec.clusterName === this.status.clusterName);
   },
 
   desired() {


### PR DESCRIPTION
- counts are shown (ready, pending,etc) are already shown for RKE2 machines
- show restricted set of counts for RKE1 nodes
- show basic total node count for non-RKE clusters
- #3028
- ![image](https://user-images.githubusercontent.com/18697775/123821820-a281cc00-d8f3-11eb-8bce-b5289ba2b2c8.png)
