### PR TITLE
Add Version step when installing a cluster from a template

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -711,6 +711,14 @@ catalog:
           }. Start by setting some basic information used by {vendor} to manage the App.
         nsCreationDescription: "To install the app into a new namespace enter it's name and select it in the Namespace field."
         createNamespace: "Namespace <code>{namespace}</code> will be created."
+      clusterTplVersion:
+        label: Version
+        subtext: Select a version of the template
+        description: Select a version of the Cluster Template
+      clusterTplValues:
+        label: Values
+        subtext: Change how the Cluster is defined
+        description: Configure Values used by Helm that help define the Cluster.
       helmValues:
         label: Values
         subtext: Change how the App works

--- a/components/Wizard.vue
+++ b/components/Wizard.vue
@@ -106,7 +106,7 @@ export default {
     },
 
     activeStepIndex() {
-      return this.visibleSteps.indexOf(this.activeStep);
+      return this.visibleSteps.findIndex(s => s.name === this.activeStep.name);
     },
 
     canNext() {
@@ -188,7 +188,7 @@ export default {
         return false;
       }
 
-      const idx = this.visibleSteps.indexOf(step);
+      const idx = this.visibleSteps.findIndex(s => s.name === step.name);
 
       if (idx === 0 && !this.editFirstStep) {
         return false;
@@ -251,17 +251,17 @@ export default {
 
                 :id="step.name"
                 :key="step.name+'li'"
-                :class="{step: true, active: step === activeStep, disabled: !isAvailable(step)}"
+                :class="{step: true, active: step.name === activeStep.name, disabled: !isAvailable(step)}"
                 role="presentation"
               >
                 <span
                   :aria-controls="'step' + idx+1"
-                  :aria-selected="step === activeStep"
+                  :aria-selected="step.name === activeStep.name"
                   role="tab"
                   class="controls"
                   @click.prevent="goToStep(idx+1, true)"
                 >
-                  <span class="icon icon-lg" :class="{'icon-dot': step === activeStep, 'icon-dot-open':step !== activeStep}" />
+                  <span class="icon icon-lg" :class="{'icon-dot': step.name === activeStep.name, 'icon-dot-open':step.name !== activeStep.name}" />
                   <span>
                     {{ step.label }}
                   </span>
@@ -275,7 +275,7 @@ export default {
 
       <div class="step-container">
         <template v-for="step in steps">
-          <div v-if="step === activeStep || step.hidden" :key="step.name" class="step-container__step" :class="{'hide': step !== activeStep && step.hidden}">
+          <div v-if="step.name === activeStep.name || step.hidden" :key="step.name" class="step-container__step" :class="{'hide': step.name !== activeStep.name && step.hidden}">
             <slot :step="step" :name="step.name" />
           </div>
         </template>


### PR DESCRIPTION
- Only show if there are multiple versions associated with the chart
- #3285

Also
- Improved generic step 2 text to be more fitting for clusters (instead of apps)

For whoever reviews steps to reproduce ..
1. Nav to Local cluster --> Apps & Marketplace --> Chart Repo and add a repo of type `git` `https://github.com/slickwarren/cluster-template-examples` branch `v2charts-template`
2. Nav to Cluster Manager --> Create
3. Select `qa-v2charts-template` for a chart with multiple versions, any other for single version