### PR TITLE
Warn before uninstall v1 monitoring when installing v2 monitoring

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2022,7 +2022,8 @@ monitoring:
       stepTitle: Uninstall V1
       stepSubtext: Uninstall Previous Monitoring
       warning1: V1 Monitoring is currently deployed. This needs to be uninstalled before V2 monitoring can be installed.
-      warning2: <a target="blank" href="https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/v2.5/migrating/#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about migrating to V2 Monitoring.
+      warning2: <a target="blank" href="https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/v2.5/migrating/#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
+      promptDescription: <div class="mt-20 mb-20">You are attempting to uninstall V1 Monitoring. Please ensure you have read the migration steps.</div>
       success1: V1 monitoring successfully uninstalled.
       success2: Press Next to continue
   tabs:
@@ -2699,6 +2700,7 @@ prometheusRule:
     removeRecord: Remove Record
 
 promptRemove:
+  title: Are you sure?
   andOthers: |-
     {count, plural,
     =0 {.}
@@ -4708,7 +4710,7 @@ embedding:
 v1ClusterTools:
   monitoring:
     label: Monitoring (Legacy)
-    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/v2.5/migrating/#migrating-from-monitoring-v1-to-monitoring-v2">Learn more</a> about migrating to V2 Monitoring.'
+    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/v2.5/migrating/#migrating-from-monitoring-v1-to-monitoring-v2">Learn more</a> about the migration steps to V2 Monitoring.'
   logging:
     label: Logging (Legacy)
     description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="https://rancher.com/docs/rancher/v2.x/en/logging/v2.5/migrating/">Learn more</a> about migrating to V2 Logging.'

--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -224,7 +224,7 @@ export default {
             />
           </div>
         </div>
-        <div v-if="provider === 'rke'" class="row mt-20">
+        <div v-if="provider === 'rke' && value.rkeEtcd" class="row mt-20">
           <div class="col span-6">
             <LabeledInput
               v-model="value.rkeEtcd.clients.https.certDir"

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -261,7 +261,7 @@ export default {
   >
     <Card class="prompt-remove" :show-highlight-border="false">
       <h4 slot="title" class="text-default-text">
-        Are you sure?
+        {{ t('promptRemove.title') }}
       </h4>
       <div slot="body">
         <div class="mb-10">
@@ -285,7 +285,7 @@ export default {
       </div>
       <template #actions>
         <button class="btn role-secondary" @click="close">
-          Cancel
+          {{ t('generic.cancel') }}
         </button>
         <AsyncButton mode="delete" class="btn bg-error ml-10" :disabled="deleteDisabled" @click="remove" />
       </template>

--- a/components/Wizard.vue
+++ b/components/Wizard.vue
@@ -109,6 +109,26 @@ export default {
       return this.visibleSteps.findIndex(s => s.name === this.activeStep.name);
     },
 
+    showPrevious() {
+      // If on first step...
+      if (this.activeStepIndex === 0) {
+        return false;
+      }
+      // .. or any previous step isn't hidden
+      for (let stepIndex = 0; stepIndex < this.activeStepIndex; stepIndex++) {
+        const step = this.visibleSteps[stepIndex];
+
+        if (!step) {
+          break;
+        }
+        if (!step.hidden) {
+          return true;
+        }
+      }
+
+      return false;
+    },
+
     canNext() {
       return (this.activeStepIndex < this.visibleSteps.length - 1) && this.activeStep.ready;
     },
@@ -293,7 +313,7 @@ export default {
           </slot>
 
           <div class="controls-steps">
-            <slot v-if="activeStepIndex!==0" name="back" :back="back">
+            <slot v-if="showPrevious" name="back" :back="back">
               <button :disabled="!editFirstStep && activeStepIndex===1" type="button" class="btn role-secondary" @click="back()">
                 <t k="wizard.previous" />
               </button>

--- a/components/dialog/GenericPrompt.vue
+++ b/components/dialog/GenericPrompt.vue
@@ -1,0 +1,98 @@
+<script>
+import AsyncButton from '@/components/AsyncButton';
+import Card from '@/components/Card';
+import Banner from '@/components/Banner';
+import { exceptionToErrorsArray } from '@/utils/error';
+
+export default {
+  components: {
+    Card,
+    AsyncButton,
+    Banner,
+  },
+  props:      {
+    resources: {
+      type:     Array,
+      required: true
+    }
+  },
+  data() {
+    return { errors: [] };
+  },
+  computed: {
+    config() {
+      return this.resources[0];
+    },
+    applyAction() {
+      return this.config.applyAction;
+    },
+    applyMode() {
+      return this.config.applyMode || 'create';
+    },
+    title() {
+      return this.config.title;
+    },
+    body() {
+      return this.config.body;
+    },
+
+  },
+  methods: {
+    close() {
+      this.$emit('close');
+    },
+
+    async apply(buttonDone) {
+      try {
+        await this.applyAction(buttonDone);
+        this.close();
+      } catch (err) {
+        this.errors = exceptionToErrorsArray(err);
+        buttonDone(false);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <Card class="prompt-restore" :show-highlight-border="false">
+    <h4 slot="title" class="text-default-text" v-html="title" />
+
+    <div slot="body" class="pl-10 pr-10" style="min-height: 50px; display: flex;" v-html="body">
+    </div>
+
+    <div slot="actions" class="bottom">
+      <Banner v-for="(err, i) in errors" :key="i" color="error" :label="err" />
+      <div class="buttons">
+        <button class="btn role-secondary mr-10" @click="close">
+          {{ t('generic.cancel') }}
+        </button>
+
+        <AsyncButton
+          :mode="applyMode"
+          @click="apply"
+        />
+      </div>
+    </div>
+  </Card>
+</template>
+<style lang='scss' scoped>
+  .prompt-restore {
+    margin: 0;
+  }
+  .bottom {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    .banner {
+      margin-top: 0
+    }
+    .buttons {
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+    }
+  }
+
+</style>


### PR DESCRIPTION
- Use a new generic prompt (displays customisable text and provides action to execute)
- Also fixed an issue where previous button was shown after uninstalling v1
- ~blocked on #3364 (heavily tested with those changes)~
- Addresses blocking issues in #2967