### PR TITLE
Cluster create: Fix issue with refresh always going to RKE2 create

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -85,8 +85,14 @@ export default {
       set(this.value, 'spec', {});
     }
 
+    // Explicitly asked from query string?
     if ( this.subType ) {
-      // Explicitly asked from query string
+      // For RKE1 Cluster, set the ember link so that we load the page rather than using RKE2 create
+      if (this.isRke1) {
+        const selected = this.subTypes.find(s => s.id === this.subType);
+
+        this.emberLink = selected?.link;
+      }
       await this.selectType(this.subType, false);
     } else if ( this.value.isImported ) {
       // Edit exiting import


### PR DESCRIPTION
When on the cluster creation page and with the toggle set to RKE1, selecting a cluster type will load the embedded IFRAME for that type. Hitting refresh will always load the RKE2 create view, not the RKE1 view.

This PR fixes this bug.