### PR TITLE
Changes to kube node list

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4292,6 +4292,7 @@ typeDescription:
   monitoring.coreos.com.prometheusrule: A Prometheus Rule resource defines both recording and/or alert rules. A recording rule can pre-compute values and save the results. Alerting rules allow you to define conditions on when to send notifications to AlertManager.
   monitoring.coreos.com.prometheus: A Prometheus server is a Prometheus deployment whose scrape configuration and rules are determined by selected ServiceMonitors, PodMonitors, and PrometheusRules and whose alerts will be sent to all selected Alertmanagers with the custom resource's configuration.
   monitoring.coreos.com.alertmanager: An alert manager is deployment whose configuration will be specified by a secret in the same namespace, which determines which alerts should go to which receiver.
+  node: The base Kubernetes Node resource represents a virtual or physical machine which hosts deployments. To manage the machine lifecyle, if available, go to Cluster Management.   
   catalog.cattle.io.clusterrepo: 'A chart repository is a Helm repository or {vendor} git based application catalog. It provides the list of available charts in the cluster.'
   catalog.cattle.io.operation: An operation is the list of recent Helm operations that have been applied to the cluster.
   catalog.cattle.io.app: An installed application is a Helm 3 chart that was installed either via our charts or through the Helm CLI.
@@ -4463,6 +4464,11 @@ typeLabel:
     {count, plural,
       one { Namespace }
       other { Namespaces }
+    }
+  node: |-
+    {count, plural,
+      one { Kube Node }
+      other { Kube Nodes }
     }
   group.principal: |-
     {count, plural,


### PR DESCRIPTION
- Make type node seen in explorer / node list clearer
  - change resource label
  - add a resource description  (also mention where lifecycle management can be done)
  - Remove node pool groups for rke1, so there are no pools at all in this view
- Also addresses #3355