### PR TITLE
Fix missing nodes on Cluster detail page for RKE2 custom clusters

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -37,9 +37,7 @@ export default {
   async fetch() {
     const hash = {};
 
-    const isImportedOrCustom = this.value.isImported || this.value.isCustom;
-
-    if (isImportedOrCustom || this.value.isRke1) {
+    if (this.value.isImported || this.value.isRke1) {
       // Cluster isn't compatible with machines/machineDeployments, show nodes/node pools instead
 
       hash.allNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
@@ -50,7 +48,7 @@ export default {
       hash.machines = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE });
     }
 
-    if (isImportedOrCustom) {
+    if (this.value.isImported || this.value.isCustom) {
       hash.clusterToken = this.value.getOrCreateToken();
     } else if (!this.value.isRke2 ) {
       // These are needed to resolve references in the mgmt cluster -> node pool -> node template to figure out what provider the cluster is using


### PR DESCRIPTION
Before:

![Bildschirmfoto 2021-07-06 um 12 28 42](https://user-images.githubusercontent.com/243056/124587570-0c502780-de58-11eb-9af7-6a327e280671.png)

After:

![Bildschirmfoto 2021-07-06 um 12 28 25](https://user-images.githubusercontent.com/243056/124587594-1540f900-de58-11eb-96f8-f42d52ae35f6.png)

Other cluster options also still work correctly with this change.

Imported:

![Bildschirmfoto 2021-07-06 um 12 44 35](https://user-images.githubusercontent.com/243056/124587661-27229c00-de58-11eb-920a-6ee9e879de8d.png)

Custom RKE1:

![Bildschirmfoto 2021-07-06 um 12 44 26](https://user-images.githubusercontent.com/243056/124587684-2db11380-de58-11eb-8872-55770fe0ac3d.png)

RKE2 with node driver:

![Bildschirmfoto 2021-07-06 um 12 45 04](https://user-images.githubusercontent.com/243056/124587698-3570b800-de58-11eb-94c7-82c765a494a2.png)

Issue: https://github.com/rancher/dashboard/issues/3393