### PR TITLE
Show registration tab by default during cluster creation as long as n…

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -100,6 +100,9 @@ export default {
 
   computed: {
     defaultTab() {
+      if (this.showRegistration && !this.machines?.length) {
+        return 'registration';
+      }
       if (this.showMachines) {
         return 'machine-pools';
       }


### PR DESCRIPTION
Show registration tab by default during cluster creation as long as no machines are present.

Issue: https://github.com/rancher/dashboard/issues/3396