### PR TITLE
Fix race condition when showing the registration tab while importing a new cluster

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -35,6 +35,7 @@ export default {
   },
 
   async fetch() {
+    await this.value.waitForProvisioner();
     const hash = {};
 
     const isImportedOrCustom = this.value.isImported || this.value.isCustom;

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -129,6 +129,14 @@ export default {
     return out;
   },
 
+  waitForProvisioner() {
+    return (timeout, interval) => {
+      return this.waitForTestFn(() => {
+        return !!this.provisioner;
+      }, `set provisioner`, timeout, interval);
+    };
+  },
+
   waitForMgmt() {
     return (timeout, interval) => {
       return this.waitForTestFn(() => {


### PR DESCRIPTION
When you import an existing cluster, you are redirected to the cluster detail page in the 2nd step. Due to a race condition, this page often does not show the registration tab with the kubectl apply command.

Debugging showed, that the problem is, that `provisioner` (https://github.com/rancher/dashboard/blob/master/models/provisioning.cattle.io.cluster.js#L142-L157) is not set, because `mgmt` is not set yet.

Because of that `isImported` is set to `false` https://github.com/rancher/dashboard/blob/master/models/provisioning.cattle.io.cluster.js#L92-L94.

Waiting at the beginning of `fetch` for provisioner to be set, fixes the issue for me. If there is a better way to handle this, I'm happy to change it.

Issue: https://github.com/rancher/dashboard/issues/3398