### PR TITLE
Fix issues with import yaml

### DIFF
--- a/components/CodeMirror.vue
+++ b/components/CodeMirror.vue
@@ -81,6 +81,12 @@ export default {
     onChanges(cm, changes) {
       this.$emit('onChanges', cm, changes);
     },
+
+    updateValue(value) {
+      if ( this.$refs.cm ) {
+        this.$refs.cm.codemirror.doc.setValue(value);
+      }
+    }
   }
 };
 </script>

--- a/components/CodeMirror.vue
+++ b/components/CodeMirror.vue
@@ -54,6 +54,10 @@ export default {
   },
 
   methods: {
+    updateValue(value) {
+      this.$refs.cm.codemirror.doc.setValue(value);
+    },
+
     focus() {
       if ( this.$refs.cm ) {
         this.$refs.cm.codemirror.focus();

--- a/components/CodeMirror.vue
+++ b/components/CodeMirror.vue
@@ -54,9 +54,6 @@ export default {
   },
 
   methods: {
-    updateValue(value) {
-      this.$refs.cm.codemirror.doc.setValue(value);
-    },
 
     focus() {
       if ( this.$refs.cm ) {

--- a/components/Import.vue
+++ b/components/Import.vue
@@ -73,13 +73,12 @@ export default {
     },
 
     onFileSelected(value) {
-      // const component = this.$refs.yamleditor;
+      const component = this.$refs.yamleditor;
 
-      // if (component) {
-      // component.updateValue(value);
-      // }
-
-      this.currentYaml = value;
+      if (component) {
+        this.errors = null;
+        component.updateValue(value);
+      }
     },
 
     async importYaml(btnCb) {
@@ -173,7 +172,7 @@ export default {
         </button>
       </div>
       <div v-else class="text-center" style="width: 100%">
-        <button type="button" class="btn role-secondary" @click="close">
+        <button type="button" class="btn role-secondary mr-10" @click="close">
           {{ t('generic.cancel') }}
         </button>
         <AsyncButton v-if="!done" mode="import" :disabled="!currentYaml.length" @click="importYaml" />

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -185,7 +185,7 @@ export default {
     },
 
     updateValue(value) {
-      this.curValue = value;
+      this.$refs.cm.updateValue(value);
     }
   }
 };

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -185,7 +185,7 @@ export default {
     },
 
     updateValue(value) {
-      this.$refs.cm.updateValue(value);
+      this.curValue = value;
     }
   }
 };

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -186,6 +186,7 @@ export default {
 
     updateValue(value) {
       this.curValue = value;
+      this.$refs.cm.updateValue(value);
     }
   }
 };

--- a/components/form/FileSelector.vue
+++ b/components/form/FileSelector.vue
@@ -59,6 +59,8 @@ export default {
 
   methods: {
     selectFile() {
+      // Clear the value so the user can reselect the same file again
+      this.$refs.uploader.value = null;
       this.$refs.uploader.click();
     },
 


### PR DESCRIPTION
Addresses #3307 

This PR addresses the issue above and a couple of others with the import yaml dialog:

- You can now reselect a file (we clear the previous file name before opening)
- Added margin between the cancel and import buttons
- Fixes issue where YAML is now shown when a file is selected
- Clear errors when a new file is selected