### PR TITLE
update default admin password message for initial setup

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3134,7 +3134,7 @@ servicesPage:
 
 setup:
   confirmPassword: Confirm New Password
-  defaultPasswordError: It looks like this is your first time visting the Rancher UI, but the local admin account password is already set to something unique. Log in with that account below to continue the setup process.
+  defaultPasswordError: It looks like this is your first time visting the Rancher UI; you will need to log in to the local admin account to continue to the setup process. If the admin password wasn't preset with an environment variable during installation, one has been randomly generated for you and may be found in your logs, or reset by following the instructions <a rel="noopener noreferrer nofollow" target="_blank" href="https://rancher.com/docs/rancher/v2.x/en/faq/technical/">here</a>.
   eula: I agree to the <a href="https://rancher.com/eula" target="_blank" rel="noopener noreferrer nofollow">terms and conditions</a> for using Rancher.
   newPassword: New Password
   newUserSetPassword: The first order of business is to set a strong password. We suggest using this random one generated just for you, but enter your own if you like.

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3134,7 +3134,7 @@ servicesPage:
 
 setup:
   confirmPassword: Confirm New Password
-  defaultPasswordError: It looks like this is your first time visting the Rancher UI; you will need to log in to the local admin account to continue to the setup process. If the admin password wasn't preset with an environment variable during installation, one has been randomly generated for you and may be found in your logs, or reset by following the instructions <a rel="noopener noreferrer nofollow" target="_blank" href="https://rancher.com/docs/rancher/v2.x/en/faq/technical/">here</a>.
+  defaultPasswordError: It looks like this is your first time visiting the Rancher UI; you will need to log in to the local <code>admin</code> account to continue to the setup process.<br><br>If the admin password wasn't preset with an environment variable during installation, one has been randomly generated for you and may be found in your install logs. Alternatively follow the instructions <a rel="noopener noreferrer nofollow" target="_blank" href="https://rancher.com/docs/rancher/v2.5/en/faq/technical/">here</a> to reset the admin password.
   eula: I agree to the <a href="https://rancher.com/eula" target="_blank" rel="noopener noreferrer nofollow">terms and conditions</a> for using Rancher.
   newPassword: New Password
   newUserSetPassword: The first order of business is to set a strong password. We suggest using this random one generated just for you, but enter your own if you like.

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -98,9 +98,7 @@ export default async function({
 
       return redirect({ name: 'auth-setup' });
     } else {
-      const t = store.getters['i18n/t'];
-
-      return redirect({ name: 'auth-login', query: { err: t('setup.defaultPasswordError') } });
+      return redirect({ name: 'auth-login' });
     }
   }
 

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -137,6 +137,7 @@ export default {
   },
 
   mounted() {
+    this.username = this.firstLogin ? 'admin' : this.username;
     this.$nextTick(() => {
       this.focusSomething();
     });
@@ -247,9 +248,12 @@ export default {
             {{ t('login.loginAgain') }}
           </h4>
         </div>
-        <Banner v-if="firstLogin" color="info">
-          <t k="setup.defaultPasswordError" :raw="true" />
-        </Banner>
+        <div v-if="firstLogin" class="first-login-message">
+          <Banner color="info">
+            <t k="setup.defaultPasswordError" :raw="true" />
+          </Banner>
+        </div>
+
         <div v-if="(!hasLocal || (hasLocal && !showLocal)) && providers.length" class="mt-30">
           <component
             :is="providerComponents[idx]"
@@ -263,10 +267,11 @@ export default {
           />
         </div>
         <template v-if="hasLocal">
-          <form v-if="showLocal" class="mt-50">
+          <form v-if="showLocal" class="mt-40">
             <div class="span-6 offset-3">
               <div class="mb-20">
                 <LabeledInput
+                  v-if="!firstLogin"
                   ref="username"
                   v-model="username"
                   :label="t('login.username')"
@@ -293,7 +298,7 @@ export default {
                   :error-label="t('asyncButton.default.error')"
                   @click="loginLocal"
                 />
-                <div class="mt-20">
+                <div v-if="!firstLogin" class="mt-20">
                   <Checkbox v-model="remember" label="Remember Username" type="checkbox" />
                 </div>
               </div>
@@ -331,12 +336,27 @@ export default {
       object-fit: cover;
     }
 
-    .login-messages {
-      height: 20px;
+    .login-messages, .first-login-message {
       display: flex;
       justify-content: center;
-      .text-error {
+      .text-error, .banner {
         max-width: 80%;
+      }
+    }
+
+    .login-messages {
+      height: 20px;
+    }
+
+    .first-login-message {
+      .banner {
+        margin-bottom: 0;
+        border-left: 0;
+
+        ::v-deep code {
+          font-size: 12px;
+          padding: 0;
+        }
       }
     }
   }

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -4,6 +4,7 @@ import { USERNAME } from '@/config/cookies';
 import LabeledInput from '@/components/form/LabeledInput';
 import AsyncButton from '@/components/AsyncButton';
 import BrandImage from '@/components/BrandImage';
+import Banner from '@/components/Banner';
 import { LOCAL, LOGGED_OUT, TIMED_OUT, _FLAGGED } from '@/config/query-params';
 import Checkbox from '@/components/form/Checkbox';
 import { sortBy } from '@/utils/sort';
@@ -20,7 +21,7 @@ export default {
   name:       'Login',
   layout:     'unauthenticated',
   components: {
-    LabeledInput, AsyncButton, Checkbox, BrandImage,
+    LabeledInput, AsyncButton, Checkbox, BrandImage, Banner
   },
 
   async asyncData({ route, redirect, store }) {
@@ -68,7 +69,6 @@ export default {
     if (plSetting.value?.length && plSetting.value !== getVendor()) {
       setVendor(plSetting.value);
     }
-    const needsSetup = firstLoginSetting?.value === 'true';
 
     let singleProvider;
 
@@ -77,12 +77,12 @@ export default {
     }
 
     return {
-      vendor:    getVendor(),
+      vendor:     getVendor(),
       providers,
       hasOthers,
       hasLocal,
-      showLocal: !hasOthers || (route.query[LOCAL] === _FLAGGED),
-      needsSetup,
+      showLocal:  !hasOthers || (route.query[LOCAL] === _FLAGGED),
+      firstLogin: firstLoginSetting?.value === 'true',
       singleProvider
     };
   },
@@ -127,7 +127,7 @@ export default {
       }
 
       return this.err;
-    }
+    },
   },
 
   created() {
@@ -198,8 +198,6 @@ export default {
 
         if (!!user?.[0]) {
           this.$store.dispatch('auth/gotUser', user[0]);
-
-          this.needsSetup = this.needsSetup || user[0].mustChangePassword;
         }
 
         if ( this.remember ) {
@@ -213,7 +211,7 @@ export default {
           this.$cookies.remove(USERNAME);
         }
 
-        if (this.needsSetup) {
+        if (this.firstLogin || user[0]?.mustChangePassword) {
           this.$store.dispatch('auth/setInitialPass', this.password);
           this.$router.push({ name: 'auth-setup' });
         } else {
@@ -249,6 +247,9 @@ export default {
             {{ t('login.loginAgain') }}
           </h4>
         </div>
+        <Banner v-if="firstLogin" color="info">
+          <t k="setup.defaultPasswordError" :raw="true" />
+        </Banner>
         <div v-if="(!hasLocal || (hasLocal && !showLocal)) && providers.length" class="mt-30">
           <component
             :is="providerComponents[idx]"

--- a/store/auth.js
+++ b/store/auth.js
@@ -110,12 +110,14 @@ export const actions = {
       return;
     }
 
-    const user = await dispatch('rancher/findAll', {
-      type: NORMAN.USER,
-      opt:  { url: '/v3/users', filter: { me: true } }
-    }, { root: true });
+    try {
+      const user = await dispatch('rancher/findAll', {
+        type: NORMAN.USER,
+        opt:  { url: '/v3/users', filter: { me: true } }
+      }, { root: true });
 
-    commit('gotUser', user?.[0]);
+      commit('gotUser', user?.[0]);
+    } catch { }
   },
 
   gotUser({ commit }, user) {


### PR DESCRIPTION
#3408 - this pr clarifies the message shown when the UI can't login on initial setup using `admin/admin`. I also tweaked the logic around that message so it isn't dependent on a query string; the message is relevant any time a user is on this page and `first-login` is true, and I don't think presenting it as an error is accurate if this (random passwords) is expected behavior going forward.

![image](https://user-images.githubusercontent.com/18697775/124802349-c5ddf400-df4f-11eb-9bc9-96a91dcc8a13.png)

