### PR TITLE
Create mock local cluster to handle users who aren't members of any clusters

### DIFF
--- a/pages/home.vue
+++ b/pages/home.vue
@@ -43,7 +43,7 @@ export default {
   mixins: [PageHeaderActions],
 
   async fetch() {
-    this.clusters = await this.$store.dispatch('management/findAll', {
+    this.baseClusters = await this.$store.dispatch('management/findAll', {
       type: MANAGEMENT.CLUSTER,
       opt:  { url: MANAGEMENT.CLUSTER }
     });
@@ -66,7 +66,7 @@ export default {
 
     return {
 
-      HIDE_HOME_PAGE_CARDS, clusters: [], fullVersion, pageActions, vendor: getVendor(), clusterDetail: null,
+      HIDE_HOME_PAGE_CARDS, baseClusters: [], fullVersion, pageActions, vendor: getVendor(), clusterDetail: null,
     };
   },
 
@@ -83,6 +83,10 @@ export default {
           resource: CAPI.RANCHER_CLUSTER
         },
       };
+    },
+
+    clusters() {
+      return this.baseClusters.filter(c => !c.spec.mock);
     },
 
     importLocation() {


### PR DESCRIPTION
- Normally the user is a member of at least one cluster, which becomes the default and used in places like cluster management, settings, etc
- For cases where the user is not a member of any cluster 'local' is defaulted to (there is also some places where this is hardcoded into the route)
- The dashboard will go out and fetch the local cluster, and there's a lot of generic components that require the cluster references in the route
- To work around this, add a mock local cluster to appease routing and components

Note
- The main driving cause for this is reaching the create cluster screens (which is currently blocked as user doesn't have any permissions on the provisioning cluster resource)
