### PR TITLE
ui branding issues

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -79,7 +79,11 @@ nav:
   import: Import YAML
   home: Home
   shell: Kubectl Shell
-  support: Get Support
+  support: |-
+    {hasSupport, select,
+      true {Support}
+      other {Get Support}
+    }
   group:
     cluster: Cluster
     inUse: More Resources

--- a/components/CommunityLinks.vue
+++ b/components/CommunityLinks.vue
@@ -16,7 +16,7 @@ export default {
   },
 
   data() {
-    return { uiIssuesSetting: null, hideCommunitySetting: null };
+    return { uiIssuesSetting: null, communitySetting: null };
   },
   computed: {
 

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -138,23 +138,13 @@ export default {
       return entries;
     },
 
-    showSupportLink() {
-      const hasSupport = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.SUPPORTED )?.value;
+    canEditSettings() {
+      return (this.$store.getters['management/schemaFor'](MANAGEMENT.SETTING)?.resourceMethods || []).includes('PATCH');
+    },
 
-      if (hasSupport === 'true') {
-        const canEditSettings = (this.$store.getters['management/schemaFor'](MANAGEMENT.SETTING)?.resourceMethods || []).includes('PATCH');
-
-        if (canEditSettings) {
-          return { name: 'support' };
-        } else {
-          const uiIssues = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_ISSUES )?.value;
-
-          return uiIssues || null;
-        }
-      }
-
-      return { name: 'support' };
-    }
+    hasSupport() {
+      return this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.SUPPORTED )?.value === 'true';
+    },
   },
 
   watch: {
@@ -300,9 +290,9 @@ export default {
           <div class="pad"></div>
         </div>
         <div class="footer">
-          <div v-if="showSupportLink" @click="hide()">
-            <nuxt-link :to="showSupportLink">
-              {{ t('nav.support') }}
+          <div v-if="canEditSettings" @click="hide()">
+            <nuxt-link :to="{name: 'support'}">
+              {{ t('nav.support', {hasSupport}) }}
             </nuxt-link>
           </div>
           <div @click="hide()">

--- a/config/footer.js
+++ b/config/footer.js
@@ -1,9 +1,10 @@
 export function options(issues, hideRancher) {
   if (!issues) {
+    if (hideRancher) {
+      return { };
+    }
     issues = 'https://github.com/rancher/dashboard/issues/new';
-  }
-
-  if (hideRancher) {
+  } else if (hideRancher) {
     return { 'footer.issue': issues };
   }
 

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -105,7 +105,7 @@ export default {
     },
 
     showSidePanel() {
-      return this.showCommercialSupport || !this.homePageCards.communitySupportTip;
+      return this.showCommercialSupport || this.showCommunityLinks;
     },
 
     clusterHeaders() {
@@ -157,9 +157,21 @@ export default {
     },
 
     showCommercialSupport() {
+      const canEditSettings = (this.$store.getters['management/schemaFor'](MANAGEMENT.SETTING)?.resourceMethods || []).includes('PATCH');
+
       const hasSupport = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.SUPPORTED) || {};
 
-      return !this.homePageCards.commercialSupportTip && hasSupport.value !== 'true';
+      return !this.homePageCards.commercialSupportTip && hasSupport.value !== 'true' && canEditSettings;
+    },
+
+    showCommunityLinks() {
+      const uiIssuesSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_ISSUES) || {};
+      const communityLinksSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.COMMUNITY_LINKS) || {};
+
+      const hasSomethingToShow = communityLinksSetting?.value !== 'false' || !!( uiIssuesSetting.value && uiIssuesSetting.value !== '');
+      const hiddenByPreference = this.homePageCards.communitySupportTip === true;
+
+      return hasSomethingToShow && !hiddenByPreference;
     },
 
     ...mapGetters(['currentCluster', 'defaultClusterId'])
@@ -392,7 +404,7 @@ export default {
           </div>
         </div>
         <div v-if="showSidePanel" class="col span-3">
-          <CommunityLinks :pref="HIDE_HOME_PAGE_CARDS" pref-key="communitySupportTip" class="mb-20" />
+          <CommunityLinks v-if="showCommunityLinks" :pref="HIDE_HOME_PAGE_CARDS" pref-key="communitySupportTip" class="mb-20" />
           <SimpleBox v-if="showCommercialSupport" :pref="HIDE_HOME_PAGE_CARDS" pref-key="commercialSupportTip" :title="t('landing.commercial.title')">
             <nuxt-link :to="{ path: 'support'}">
               {{ t('landing.commercial.body') }}

--- a/pages/support/index.vue
+++ b/pages/support/index.vue
@@ -4,7 +4,7 @@ import BannerGraphic from '@/components/BannerGraphic';
 import AsyncButton from '@/components/AsyncButton';
 import IndentedPanel from '@/components/IndentedPanel';
 import Card from '@/components/Card';
-
+import CommunityLinks from '@/components/CommunityLinks';
 import { MANAGEMENT } from '@/config/types';
 import { getVendor } from '@/config/private-label';
 import { SETTING } from '@/config/settings';
@@ -18,7 +18,8 @@ export default {
     BannerGraphic,
     IndentedPanel,
     AsyncButton,
-    Card
+    Card,
+    CommunityLinks
   },
 
   async fetch() {
@@ -83,7 +84,7 @@ export default {
 
     validSupportKey() {
       return !!this.supportKey.match(KEY_REGX);
-    }
+    },
   },
 
   methods: {
@@ -173,10 +174,7 @@ export default {
           </div>
         </div>
         <div class="community">
-          <h2>{{ t('support.community.linksTitle') }}</h2>
-          <div v-for="(value, name) in options" :key="name" class="support-link">
-            <a v-t="name" :href="value" target="_blank" rel="noopener noreferrer nofollow" />
-          </div>
+          <CommunityLinks />
         </div>
       </div>
     </IndentedPanel>


### PR DESCRIPTION
This pr addresses remaining issues in #3029 with the exception of the 'Get Support' link visibility; there are conflicting requirements in https://github.com/rancher/dashboard/issues/2895. As per discussion with @nwmac this PR hides the support link for non-admins regardless of subscription status, and changes the label from 'Get Support' to 'Support' when a subscription key has been added. We've opted not to hide the link entirely in supported mode because the page still has utility. Other issues from #3029 :

> The Community Support Box in the Dashboard Home is visible always even if we uncheck the Show Rancher community support links in Branding (See screenshot)

This should work correctly now, *but* if a custom issue-reporting url has been provided, it will be shown in the box regardless of whether `show rancher community support links` is checked or not.

>Should we force hiding that Support Box if a Subscription ID exists and it was never removed from home? ℹ️

We've opted not to hide the Community Support box when a subscription id is present because those resources are still helpful; eg a user may choose to read docs or peruse open issues before contacting support.