### PR TITLE
Pass through errors received from keycloak redirect when configuring auth provider

### DIFF
--- a/pages/auth/verify.vue
+++ b/pages/auth/verify.vue
@@ -73,7 +73,10 @@ export default {
   mounted() {
     if ( this.testing ) {
       try {
-        reply(null, this.$route.query[GITHUB_CODE] );
+        const { error: respError, error_description: respErrorDescription, [GITHUB_CODE]: code } = this.$route.query;
+        const error = respErrorDescription || respError || (!code ? 'No code supplied by auth provider' : null);
+
+        reply(error, code );
       } catch (e) {
         window.close();
       }

--- a/store/auth.js
+++ b/store/auth.js
@@ -10,7 +10,7 @@ export const BASE_SCOPES = {
   github:       ['read:org'],
   googleoauth:  ['openid profile email'],
   azuread:      [],
-  keycloakoidc: ['profile,email']
+  keycloakoidc: ['openid profile email']
 };
 
 const KEY = 'rc_nonce';


### PR DESCRIPTION
Change one - `pages/auth/verify.vue`
- When configuring an auth provider we prompt user for creds
- Once user has successfully authed with keycloak it redirects back to our `veritfy-auth` page
- Here normally we're all good and we extract the `code` and close the popup
- However keycloak can error, with for instance `Invalid scopes: profile,email`, which were previously ignored and sent back an undefined code
- Now we handle errors (these may be in a different format for other providers) and no auth codes
- This was the cause for the generic error in #3406, which hid the actual error

Change two  - `store/auth.js`
- Actual fix for #3406 
- Updated keycloak scopes which were treated differently in newer versions (fix also works with older keycloak versions)
- Note - requires changes from backend also