### PR TITLE
Updating how we check if a cluster/projectRoleTemplateBinding isSystem

### DIFF
--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -52,11 +52,12 @@ export default {
     ];
     const allBindings = this.schema ? await this.$store.dispatch(`management/findAll`, { type: this.type }) : [];
     const bindings = allBindings
+      .filter(b => !b.isSystem)
       .filter(b => !b.user?.isSystem)
       .filter(b => normalizeId(get(b, this.parentKey)) === normalizeId(this.parentId));
 
     // Add the current user as the project owner. This will get created by default
-    if (bindings.length === 0 && this.defaultBindingHandler) {
+    if (this.mode === _CREATE && bindings.length === 0 && this.defaultBindingHandler) {
       bindings.push(await this.defaultBindingHandler());
     }
 

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -10,7 +10,6 @@ export const CATTLE_PUBLIC_ENDPOINTS = 'field.cattle.io/publicEndpoints';
 export const TARGET_WORKLOADS = 'field.cattle.io/targetWorkloadIds';
 export const UI_MANAGED = 'management.cattle.io/ui-managed';
 export const CREATOR_ID = 'field.cattle.io/creatorId';
-export const CREATOR_OWNER_BINDING = 'authz.management.cattle.io/creator-owner-binding';
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',

--- a/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/models/management.cattle.io.clusterroletemplatebinding.js
@@ -1,4 +1,4 @@
-import { CREATOR_ID, CREATOR_OWNER_BINDING } from '@/config/labels-annotations';
+import { CREATOR_ID } from '@/config/labels-annotations';
 import { _CREATE } from '@/config/query-params';
 import { MANAGEMENT, NORMAN } from '@/config/types';
 
@@ -83,7 +83,7 @@ export default {
   },
 
   isSystem() {
-    return !this.metadata.annotations[CREATOR_ID] && this.metadata.annotations[CREATOR_OWNER_BINDING] !== 'true';
+    return !this.metadata.annotations[CREATOR_ID];
   },
 
   norman() {

--- a/models/management.cattle.io.projectroletemplatebinding.js
+++ b/models/management.cattle.io.projectroletemplatebinding.js
@@ -1,3 +1,4 @@
+import { CREATOR_ID } from '@/config/labels-annotations';
 import { MANAGEMENT, NORMAN } from '@/config/types';
 
 export default {
@@ -97,6 +98,10 @@ export default {
 
   listLocation() {
     return { name: 'c-cluster-explorer-project-members' };
+  },
+
+  isSystem() {
+    return !this.metadata.annotations[CREATOR_ID];
   },
 
   norman() {


### PR DESCRIPTION
Turns out `authz.management.cattle.io/creator-owner-binding` is more a reflection on the current state of something rather than the origin of something.

rancher/dashboard#3296
rancher/dashboard#3413 