### PR TITLE
Fix issues when creating clusters as non-admin

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -111,7 +111,8 @@ export default {
 
       const data = { type: resource };
 
-      if ( schema.attributes?.namespaced ) {
+      // TODO: RC API standard user, no clusters - `provisioning.cattle.io.cluster` isn't in v1/schemas (but is reachable by v1/schemas/provisioning.cattle.io.cluster)
+      if ( schema?.attributes?.namespaced ) {
         data.metadata = { namespace };
       }
 

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -165,10 +165,7 @@ export default {
           {{ currentCluster.spec.displayName }}
         </div>
         <div v-else class="simple-title">
-          <img class="side-menu-logo" src="~/assets/images/pl/rancher-logo.svg" width="110" />
-          <div class="title">
-            {{ appName }}
-          </div>
+          <BrandImage class="side-menu-logo-img" file-name="rancher-logo.svg" />
         </div>
       </div>
       <div v-if="currentProduct && !currentProduct.showClusterSwitcher" class="cluster">

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -84,7 +84,7 @@ export default {
 
     nameTooltip() {
       return !this.showTooltip ? {} : {
-        content: this.currentCluster.nameDisplay,
+        content: this.currentCluster?.nameDisplay,
         delay:   400,
       };
     }
@@ -159,8 +159,8 @@ export default {
     <div class="menu-spacer"></div>
     <div v-if="!simple" class="product">
       <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-tooltip="nameTooltip" class="cluster cluster-clipped">
-        <RancherProviderIcon v-if="currentCluster.isLocal" class="mr-10 cluster-local-logo" width="25" />
-        <img v-else-if="currentCluster" class="cluster-os-logo" :src="currentCluster.providerLogo" />
+        <RancherProviderIcon v-if="currentCluster && currentCluster.isLocal" class="mr-10 cluster-local-logo" width="25" />
+        <img v-else-if="currentCluster && currentCluster.providerLogo" class="cluster-os-logo" :src="currentCluster.providerLogo" />
         <div v-if="currentCluster" ref="clusterName" class="cluster-name">
           {{ currentCluster.spec.displayName }}
         </div>
@@ -185,12 +185,12 @@ export default {
 
     <TopLevelMenu></TopLevelMenu>
 
-    <div v-if="!simple" class="top">
+    <div v-if="currentCluster && !simple" class="top">
       <NamespaceFilter v-if="clusterReady && currentProduct && (currentProduct.showNamespaceFilter || isExplorer)" />
       <WorkspaceSwitcher v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher" />
     </div>
 
-    <div v-if="!simple" class="header-buttons">
+    <div v-if="currentCluster && !simple" class="header-buttons">
       <template v-if="currentProduct && currentProduct.showClusterSwitcher">
         <button
           v-tooltip="t('nav.import')"

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -16,6 +16,7 @@ import { CATALOG } from '@/config/labels-annotations';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE } from '@/store/features';
 import { allHash } from '@/utils/promise';
+import { BLANK_CLUSTER } from '@/store';
 import Rke2Config from './rke2';
 import Import from './import';
 
@@ -296,9 +297,9 @@ export default {
 
       if ( parts[0] === 'chart' ) {
         const chart = this.$store.getters['catalog/chart']({ key: parts[1] });
-        const localCluster = this.$store.getters['management/all'](MANAGEMENT.CLUSTER).find(x => x.isLocal);
 
-        chart.goToInstall(FROM_CLUSTER, localCluster.id);
+        // TODO: RC Test
+        chart.goToInstall(FROM_CLUSTER, BLANK_CLUSTER);
 
         return;
       }

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -96,6 +96,7 @@ export default {
   async fetch() {
     if ( !this.allSecrets ) {
       const hash = {
+        // TODO: RC API standard user, no clusters - v1/secret GET 403
         allSecrets:   this.$store.dispatch('management/findAll', { type: SECRET }),
         rke2Versions: this.$store.dispatch('management/request', { url: '/v1-rke2-release/releases' }),
         k3sVersions:  this.$store.dispatch('management/request', { url: '/v1-k3s-release/releases' }),

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -21,6 +21,7 @@ import ConsumptionGauge from '@/components/ConsumptionGauge';
 import { get } from '@/utils/object';
 import { mapFeature, MULTI_CLUSTER } from '@/store/features';
 import { SETTING } from '@/config/settings';
+import { BLANK_CLUSTER } from '@/store';
 
 const SET_LOGIN_ACTION = 'set-as-login';
 const RESET_CARDS_ACTION = 'reset-homepage-cards';
@@ -79,7 +80,7 @@ export default {
         name:   'c-cluster-product-resource-create',
         params: {
           product:  MANAGER,
-          cluster:  this.currentCluster?.id || 'local',
+          cluster:  BLANK_CLUSTER,
           resource: CAPI.RANCHER_CLUSTER
         },
       };
@@ -90,7 +91,7 @@ export default {
         name:   'c-cluster-product-resource-create',
         params: {
           product:  MANAGER,
-          cluster:  this.currentCluster?.id || 'local',
+          cluster:  BLANK_CLUSTER,
           resource: CAPI.RANCHER_CLUSTER
         },
         query: { [MODE]: _IMPORT }

--- a/store/index.js
+++ b/store/index.js
@@ -17,6 +17,8 @@ import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
 // becaues it's more efficient to do that sometimes.
 export const strict = false;
 
+export const BLANK_CLUSTER = '_';
+
 export const plugins = [
   Steve({ namespace: 'management', baseUrl: '/v1' }),
   Steve({ namespace: 'cluster', baseUrl: '' }), // URL dynamically set for the selected cluster
@@ -127,7 +129,7 @@ export const getters = {
       return clusters[0].id;
     }
 
-    return null;
+    return BLANK_CLUSTER;
   },
 
   isAllNamespaces(state, getters) {
@@ -545,6 +547,11 @@ export const actions = {
 
     console.log(`Loading ${ isMultiCluster ? 'ECM ' : '' }cluster...`); // eslint-disable-line no-console
 
+    if (id === BLANK_CLUSTER) {
+      commit('clusterChanged', true);
+
+      return;
+    }
     // See if it really exists
     const cluster = await dispatch('management/find', {
       type: MANAGEMENT.CLUSTER,


### PR DESCRIPTION
- Working on top of changes in #3440
- Still need to 
  - check places where we assume 'local' cluster, including in routes,
  - ~~where we should use the new blank cluster~~
  - ~~pages/components that assume we have a currentCluster~~

Currently tracked issues when creating a cluster as standard user with no clusters (using latest dev build)
- `provisioning.cattle.io.cluster` isn't in the response to `v1/schemas` (but is reachable by `v1/schemas/provisioning.cattle.io.cluster`)
- `v1/provisioning.cattle.io.cluster` GET gives a 403 error. causes issues with our breadcrumbs
- `v1/secret` GET gives a 403 error. causes issues when create a rke2 cluster ('custom' option)
- `catalog.cattle.io.clusterrepos` schema/resources 404, so cannot fetch charts to use when deploying via cluster template. 

Dashboard side issues
- need to confirm install works when the cluster is empty by defaukt
  ```
  //chart.goToInstall(FROM_CLUSTER, localCluster.id);
  chart.goToInstall(FROM_CLUSTER, BLANK_CLUSTER);
  ```