### PR TITLE
make apps marketplace product account for ns filter in header

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -141,7 +141,7 @@ export const getters = {
       return false;
     }
 
-    if ( !product.showNamespaceFilter ) {
+    if ( !product.showNamespaceFilter && !getters['isExplorer'] ) {
       return true;
     }
 


### PR DESCRIPTION
#3352 The [namespace filtering performed in getTree](https://github.com/rancher/dashboard/blob/master/store/type-map.js#L508) was using all namespaces when Apps & Marketplace was selected because [isAllNamespaces](https://github.com/rancher/dashboard/blob/master/store/index.js#L145) returns true when `showNamespaceFilter` is false for the current product (the default)