### PR TITLE
Fix issues when creating clusters as non-admin

### DIFF
--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -114,6 +114,7 @@ export default {
 
       const data = { type: resource };
 
+      // TODO: RC API standard user, no clusters - `provisioning.cattle.io.cluster` isn't in v1/schemas (but is reachable by v1/schemas/provisioning.cattle.io.cluster)
       if ( schema?.attributes?.namespaced ) {
         data.metadata = { namespace };
       }

--- a/config/product/manager.js
+++ b/config/product/manager.js
@@ -1,5 +1,5 @@
 import { AGE, NAME as NAME_COL, STATE } from '@/config/table-headers';
-import { CAPI } from '@/config/types';
+import { CAPI, SECRET } from '@/config/types';
 import { MULTI_CLUSTER } from '@/store/features';
 import { DSL } from '@/store/type-map';
 
@@ -85,6 +85,7 @@ export function init(store) {
     name:        'secret',
     weight:      99,
     route:       { name: 'c-cluster-manager-secret' },
+    ifHaveType: SECRET
   });
 
   basicType([

--- a/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -42,7 +42,7 @@ export default {
   async fetch() {
     const secretSchema = this.$store.getters['management/schemaFor'](SECRET);
 
-    if (secretSchema?.collectionMethods.find(x => x.toLowerCase() === 'get')) {
+    if (secretSchema?.canGetCollection) {
       this.allSecrets = await this.$store.dispatch('management/findAll', { type: SECRET });
     }
 

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -16,6 +16,7 @@ import { CATALOG } from '@/config/labels-annotations';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE } from '@/store/features';
 import { allHash } from '@/utils/promise';
+import { BLANK_CLUSTER } from '@/store';
 import Rke2Config from './rke2';
 import Import from './import';
 
@@ -296,9 +297,9 @@ export default {
 
       if ( parts[0] === 'chart' ) {
         const chart = this.$store.getters['catalog/chart']({ key: parts[1] });
-        const localCluster = this.$store.getters['management/all'](MANAGEMENT.CLUSTER).find(x => x.isLocal);
 
-        chart.goToInstall(FROM_CLUSTER, localCluster.id);
+        // TODO: RC Test
+        chart.goToInstall(FROM_CLUSTER, BLANK_CLUSTER);
 
         return;
       }

--- a/models/schema.js
+++ b/models/schema.js
@@ -2,4 +2,9 @@ export default {
   groupName() {
     return this.attributes.namespaced ? 'ns' : 'cluster';
   },
+
+  canGetCollection() {
+    return !!this?.collectionMethods.find(x => x.toLowerCase() === 'get') && !!this.links?.collection;
+  },
+
 };

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -769,7 +769,7 @@ export default {
   followLink() {
     return (linkName, opt = {}) => {
       if ( !opt.url ) {
-        opt.url = (this.links || {})[linkName];
+        opt.url = this.linkFor(linkName);
       }
 
       if ( opt.urlSuffix ) {

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -111,7 +111,7 @@ import { AGE, NAME, NAMESPACE, STATE } from '@/config/table-headers';
 import { COUNT, SCHEMA, MANAGEMENT } from '@/config/types';
 import { DEV, EXPANDED_GROUPS, FAVORITE_TYPES } from '@/store/prefs';
 import {
-  addObject, findBy, insertAt, isArray, removeObject
+  addObject, filterBy, findBy, insertAt, isArray, removeObject
 } from '@/utils/array';
 import { clone, get } from '@/utils/object';
 import {
@@ -783,8 +783,14 @@ export const getters = {
           if ( item.ifHaveType ) {
             const targetedSchemas = typeof item.ifHaveType === 'string' ? schemas : rootGetters[`${ item.ifHaveType.store }/all`](SCHEMA);
             const type = typeof item.ifHaveType === 'string' ? item.ifHaveType : item.ifHaveType?.type;
+            const foundSchemas = filterBy(targetedSchemas, 'id', normalizeType(type));
 
-            if (!findBy(targetedSchemas, 'id', normalizeType(type))) {
+            if (!foundSchemas.find(s => s.canGetCollection)) {
+              if (out[id]) {
+                // Some scenarios have virtual types spoofing genuine types, so avoid showing underlying genuine type as well
+                // (secrets in cluster manage for non-admins)
+                delete out[id];
+              }
               continue;
             }
           }


### PR DESCRIPTION
- Working on top of changes in #3440
- Still need to 
  - check places where we assume 'local' cluster, including in routes,
  - ~~where we should use the new blank cluster~~
  - ~~pages/components that assume we have a currentCluster~~

Currently tracked issues when creating a cluster as standard user with no clusters (using latest dev build)
- `v1/provisioning.cattle.io.cluster` GET gives a 403 error. causes issues with our breadcrumbs
- `v1/secret` POST fails as schema is missing `links.collection`
- Fixed
  - ~~`provisioning.cattle.io.cluster` isn't in the response to `v1/schemas` (but is reachable by `v1/schemas/provisioning.cattle.io.cluster`)~~ fixed via https://github.com/rancher/rancher/pull/33663
  - ~~`v1/secret` GET gives a 403 error. causes issues when create an rke2 cluster ('custom' option)~~ fixed via https://github.com/rancher/rancher/pull/33663
  - ~~`catalog.cattle.io.clusterrepos` schema/resources 404, so cannot fetch charts to use when deploying via cluster template.~~ fixed via https://github.com/rancher/rancher/pull/33663

Dashboard side issues
- need to confirm install works when the cluster is empty by default
  ```
  //chart.goToInstall(FROM_CLUSTER, localCluster.id);
  chart.goToInstall(FROM_CLUSTER, BLANK_CLUSTER);
  ```
- If users won't have access to clusters list until a cluster is created...
  - need to update all effected mastheads to not show link to clusters list
  - need a safe way to handle routing to clusters list if clusters list is unavailable (user cancels create flow, user completes create flow - avoid race condition). couldn't possible check if user has no clusters and route to create every time?