### PR TITLE
Handle situations in create cluster flow where user cannot fetch `secrets`

### DIFF
--- a/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -40,7 +40,11 @@ export default {
   },
 
   async fetch() {
-    this.allSecrets = await this.$store.dispatch('management/findAll', { type: SECRET });
+    const secretSchema = this.$store.getters['management/schemaFor'](SECRET);
+
+    if (secretSchema?.collectionMethods.find(x => x.toLowerCase() === 'get')) {
+      this.allSecrets = await this.$store.dispatch('management/findAll', { type: SECRET });
+    }
 
     this.newCredential = await this.$store.dispatch('management/create', {
       type:     SECRET,
@@ -62,7 +66,7 @@ export default {
 
   data() {
     return {
-      allSecrets:             null,
+      allSecrets:             [],
       nodeComponent:          null,
       credentialId:           this.value || _NONE,
       newCredential:          null,

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -94,9 +94,8 @@ export default {
   },
 
   async fetch() {
-    if ( !this.allSecrets ) {
+    if ( !this.rke2Versions ) {
       const hash = {
-        allSecrets:   this.$store.dispatch('management/findAll', { type: SECRET }),
         rke2Versions: this.$store.dispatch('management/request', { url: '/v1-rke2-release/releases' }),
         k3sVersions:  this.$store.dispatch('management/request', { url: '/v1-k3s-release/releases' }),
       };
@@ -107,7 +106,6 @@ export default {
 
       const res = await allHash(hash);
 
-      this.allSecrets = res.allSecrets;
       this.rke2Versions = res.rke2Versions.data;
       this.k3sVersions = res.k3sVersions.data;
     }
@@ -211,7 +209,6 @@ export default {
 
     return {
       lastIdx:          0,
-      allSecrets:       null,
       allPSPs:          null,
       nodeComponent:    null,
       credentialId:     null,


### PR DESCRIPTION
- This will help the backend team to continue permissions work in the create cluster flow
- For some resources, like secrets and clusters, users may not end up having access to the schema or collection `get` if they haven't yet created a resource of that type
  - Applies to users and restricted-admins who aren't a member of any cluster
- These changes safeguard against these scenarios and match how things worked in ember (ish)
  - Safeguard fetch of secrets in SelectCredential component
  - Remove unused fetch of secrets in RKE2 create cluster flow
