### PR TITLE
Project/namespace fixes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2239,6 +2239,13 @@ namespace:
   enableAutoInjection: Enable Istio Auto Injection
   disableAutoInjection: Disable Istio Auto Injection
   move: Move
+  resourceStates:
+      success: 'Active'
+      info: 'Transitioning'
+      warning: 'Warning'
+      error: 'Error'
+      unknown: 'Unknown'
+
 
 namespaceFilter:
   selected:

--- a/components/FleetSummary.vue
+++ b/components/FleetSummary.vue
@@ -23,23 +23,32 @@ export default {
       const out = {
         success: {
           count: 0,
-          color: 'success'
+          color: 'success',
+          label: this.$store.getters['i18n/withFallback'](`${ this.stateKey }.success`, null, 'Success')
         },
         info:    {
           count: 0,
-          color: 'info'
+          color: 'info',
+          label: this.$store.getters['i18n/withFallback'](`${ this.stateKey }.info`, null, 'Info')
+
         },
         warning: {
           count: 0,
-          color: 'warning'
+          color: 'warning',
+          label: this.$store.getters['i18n/withFallback'](`${ this.stateKey }.warning`, null, 'Warning')
+
         },
         error:   {
           count: 0,
-          color: 'error'
+          color: 'error',
+          label: this.$store.getters['i18n/withFallback'](`${ this.stateKey }.error`, null, 'Error')
+
         },
         unknown: {
           count: 0,
-          color: 'warning'
+          color: 'warning',
+          label: this.$store.getters['i18n/withFallback'](`${ this.stateKey }.unknown`, null, 'Unknown')
+
         },
       };
 
@@ -57,6 +66,7 @@ export default {
           out[k] = {
             count: this.value[k] || 0,
             color: mapped.color,
+            label: this.$store.getters['i18n/withFallback'](`${ this.stateKey }.${ k }`, null, capitalize(k))
           };
         }
       }
@@ -74,7 +84,7 @@ export default {
     <div v-for="(v, k) in counts" :key="k" class="col span-2-of-10">
       <CountBox
         :count="v['count']"
-        :name="t(`${stateKey}.${k}`) || capitalize(k)"
+        :name="v.label"
         :primary-color-var="'--sizzle-' + v.color"
       />
     </div>

--- a/components/FleetSummary.vue
+++ b/components/FleetSummary.vue
@@ -11,6 +11,11 @@ export default {
       type:     Object,
       required: true,
     },
+
+    stateKey: {
+      type:    String,
+      default: 'fleet.fleetSummary.state'
+    }
   },
 
   computed: {
@@ -69,7 +74,7 @@ export default {
     <div v-for="(v, k) in counts" :key="k" class="col span-2-of-10">
       <CountBox
         :count="v['count']"
-        :name="capitalize(k)"
+        :name="t(`${stateKey}.${k}`) || capitalize(k)"
         :primary-color-var="'--sizzle-' + v.color"
       />
     </div>

--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -56,6 +56,8 @@ export default {
       .filter(b => !b.user?.isSystem)
       .filter(b => normalizeId(get(b, this.parentKey)) === normalizeId(this.parentId));
 
+    this.$set(this, 'lastSavedBindings', [...bindings]);
+
     // Add the current user as the project owner. This will get created by default
     if (this.mode === _CREATE && bindings.length === 0 && this.defaultBindingHandler) {
       bindings.push(await this.defaultBindingHandler());
@@ -64,7 +66,6 @@ export default {
     const [users] = await Promise.all(userHydration);
 
     this.$set(this, 'bindings', bindings);
-    this.$set(this, 'lastSavedBindings', bindings);
     this.$set(this, 'users', users);
   },
 

--- a/detail/namespace.vue
+++ b/detail/namespace.vue
@@ -9,11 +9,13 @@ import ResourceTabs from '@/components/form/ResourceTabs';
 
 import { COUNT } from '@/config/types';
 import { getStatesByType } from '@/plugins/steve/resource-instance';
+import MoveModal from '@/components/MoveModal';
 
 export default {
   components: {
     FleetSummary,
     ResourceTabs,
+    MoveModal
   },
 
   mixins: [CreateEditView],
@@ -93,8 +95,9 @@ export default {
   <div>
     <div class="mb-20">
       <h3>{{ t('namespace.resources') }}</h3>
-      <FleetSummary :value="namespacedCounts" />
+      <FleetSummary state-key="namespace.resourceStates" :value="namespacedCounts" />
     </div>
     <ResourceTabs v-model="value" :mode="mode" />
+    <MoveModal />
   </div>
 </template>

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -44,13 +44,11 @@ export default {
       projectName = null;
     }
 
-    if (this.mode === 'edit') {
-      return {
-        originalQuotaId,
-        project:                 projectName,
-        containerResourceLimits: this.value.annotations[CONTAINER_DEFAULT_RESOURCE_LIMIT] || this.getDefaultContainerResourceLimits(projectName)
-      };
-    }
+    return {
+      originalQuotaId,
+      project:                 projectName,
+      containerResourceLimits: this.value.annotations[CONTAINER_DEFAULT_RESOURCE_LIMIT] || this.getDefaultContainerResourceLimits(projectName)
+    };
   },
 
   computed: {

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -11,6 +11,7 @@ import Tab from '@/components/Tabbed/Tab';
 import CruResource from '@/components/CruResource';
 import Labels from '@/components/form/Labels';
 import { PROJECT_ID } from '@/config/query-params';
+import MoveModal from '@/components/MoveModal';
 
 export default {
   components: {
@@ -20,7 +21,8 @@ export default {
     Labels,
     NameNsDescription,
     Tab,
-    Tabbed
+    Tabbed,
+    MoveModal
   },
 
   mixins: [CreateEditView],
@@ -31,14 +33,24 @@ export default {
     if ( this.originalValue?.metadata?.name ) {
       originalQuotaId = `${ this.originalValue.metadata.name }/default-quota`;
     }
+    let projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID];
+    const projects = this.$store.getters['management/all'](MANAGEMENT.PROJECT);
 
-    const project = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID];
+    const project = projects.find(p => p.id.includes(projectName));
 
-    return {
-      originalQuotaId,
-      project,
-      containerResourceLimits: this.value.annotations[CONTAINER_DEFAULT_RESOURCE_LIMIT] || this.getDefaultContainerResourceLimits(project)
-    };
+    // namespaces' project label remains when a project has been deleted: verify this project still exists
+    if (!project && this.value?.metadata?.labels?.[PROJECT]) {
+      delete this.value.metadata.labels[PROJECT];
+      projectName = null;
+    }
+
+    if (this.mode === 'edit') {
+      return {
+        originalQuotaId,
+        project:                 projectName,
+        containerResourceLimits: this.value.annotations[CONTAINER_DEFAULT_RESOURCE_LIMIT] || this.getDefaultContainerResourceLimits(projectName)
+      };
+    }
   },
 
   computed: {
@@ -98,13 +110,14 @@ export default {
       this.value.setAnnotation(PROJECT, annotation);
     },
 
-    getDefaultContainerResourceLimits(projectId) {
-      if (!projectId) {
+    getDefaultContainerResourceLimits(projectName) {
+      if (!projectName) {
         return;
       }
 
       const projects = this.$store.getters['management/all'](MANAGEMENT.PROJECT);
-      const project = projects.find(p => p.id.includes(projectId));
+
+      const project = projects.find(p => p.id.includes(projectName));
 
       return project.spec.containerDefaultResourceLimit || {};
     }
@@ -162,5 +175,6 @@ export default {
         />
       </Tab>
     </Tabbed>
+    <MoveModal />
   </CruResource>
 </template>

--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -39,15 +39,6 @@ export default {
     };
   },
 
-  remove() {
-    return async() => {
-      const norman = await this.norman;
-
-      await norman.remove(...arguments);
-      await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
-    };
-  },
-
   norman() {
     return this.id ? this.normanEditProject : this.normanNewProject;
   },

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -163,5 +163,9 @@ export default {
 
   parentLocationOverride() {
     return this.listLocation;
+  },
+
+  doneOverride() {
+    return this.listLocation;
   }
 };

--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -1,6 +1,6 @@
 <script>
 import ResourceTable from '@/components/ResourceTable';
-import { STATE, AGE, SIMPLE_NAME } from '@/config/table-headers';
+import { STATE, AGE, NAME } from '@/config/table-headers';
 import { uniq } from '@/utils/array';
 import { MANAGEMENT, NAMESPACE, VIRTUAL_TYPES } from '@/config/types';
 import Loading from '@/components/Loading';
@@ -55,7 +55,7 @@ export default {
 
       return [
         STATE,
-        SIMPLE_NAME,
+        NAME,
         this.groupPreference === 'none' ? project : null,
         AGE
       ].filter(h => h);


### PR DESCRIPTION
#3175  - per discussion w/ Darren, removing projects through Steve is acceptable. This avoids issues with the project list not refreshing correctly when deleting a project in a downstream cluster
 
#3422 - this ticket says remove the 'Move' action from namespace detail but I don't see why users shouldn't be allowed to change the project from this view, so I just made it work correctly there instead.


Other things noticed and addressed here:
- projects were being created without saving `defaultBinding` (aka the current user) as owner
- namespace edit page exploded for namespaces formerly in projects. The project label on each namespace sticks around after the project is deleted (whether it's done through Steve or Norman). In such instances the detail page correctly shows no project for the namespace; I've updated the edit page to account for this possibility as well.