### PR TITLE
Cluster Logging list of containers overflows off visible screen

### DIFF
--- a/edit/logging-flow/Match.vue
+++ b/edit/logging-flow/Match.vue
@@ -88,6 +88,7 @@ export default {
           :taggable="true"
           :clearable="true"
           :close-on-select="false"
+          placement="top"
         />
       </div>
     </div>


### PR DESCRIPTION
#3447 
Simple fix to prevent dropdown from displaying off screen. Change default direction from 'bottom' to 'top'
<img width="1322" alt="Screen Shot 2021-07-21 at 1 42 16 AM" src="https://user-images.githubusercontent.com/13671297/126459201-7c9566af-ae5e-4461-b425-92403bfdbe38.png">
