### PR TITLE
Optionally supply 'service' account to keycloak auth config

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -397,6 +397,9 @@ authConfig:
     rancherUrl: Rancher URL
     clientId: Client ID
     clientSecret: Client Secret
+    adminAccountUsername: Service Account Username
+    adminAccountPassword: Service Account Password
+    adminAccountInfo: '{vendor} needs a service account that is a member of all the parent groups that will be able to login. This is specifically required to determine if a user is in a child group of that parent. If your groups are not nested the Service Account is not required.'
     customEndpoint:
       label: Endpoints
       custom: Specify

--- a/edit/auth/oidc.vue
+++ b/edit/auth/oidc.vue
@@ -9,6 +9,7 @@ import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
 import FileSelector from '@/components/form/FileSelector';
 import AuthBanner from '@/components/auth/AuthBanner';
 import RadioGroup from '@/components/form/RadioGroup';
+import Password from '@/components/form/Password';
 
 export default {
   components: {
@@ -19,7 +20,8 @@ export default {
     AllowedPrincipals,
     FileSelector,
     AuthBanner,
-    RadioGroup
+    RadioGroup,
+    Password
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -152,6 +154,25 @@ export default {
               :label="t(`authConfig.oidc.clientSecret`)"
               :mode="mode"
               required
+            />
+          </div>
+        </div>
+
+        <Banner color="info" :label="t('authConfig.oidc.adminAccountInfo')" />
+        <div class="row mb-20">
+          <div class="col span-6">
+            <LabeledInput
+              v-model="model.adminAccountUsername"
+              :label="t(`authConfig.oidc.adminAccountUsername`)"
+              :mode="mode"
+            />
+          </div>
+          <div class="col span-6">
+            <Password
+              v-model="model.adminAccountPassword"
+              :label="t(`authConfig.oidc.adminAccountPassword`)"
+              :ignore-password-managers="true"
+              :mode="mode"
             />
           </div>
         </div>


### PR DESCRIPTION
- see #3516
- ensures that when when keycloak log in is restricted to a group, users of child groups of that group can still log in
- does so by using the supplied service account to fetch groups to work out nesting

Note - This change is unverified but will aid backend team to test real-world scenario. The fields aren't required so leaving them blank will result in same auth config as we currently post.
