### PR TITLE
[2.6] Fix groups list refresh on enter

### DIFF
--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -38,12 +38,18 @@ export default {
       assignLocation:   {
         path:   `/c/local/${ NAME }/${ NORMAN.SPOOFED.GROUP_PRINCIPAL }/assign-edit`,
         query: { [MODE]: _EDIT }
-      }
+      },
+      initialLoad: true,
     };
   },
   computed: { ...mapState('action-menu', ['showPromptRemove', 'toRemove']) },
   watch:    {
     async toRemove(resources) {
+      if (this.initialLoad) {
+        this.initialLoad = false;
+
+        return;
+      }
       if (resources?.length === 0) {
         await this.refreshGroupMemberships(() => {});
         // spoofed collections normally get updated when promptRemove has completed (given the resources are of a spoofed type)..


### PR DESCRIPTION
- #3496
- The group list component fires off a couple of things when a group is removed (all at top level, not per group)
- This used to work fine piggybacking on `showPromptRemove` but was updated to supported the alt action where no prompt was shown
- So whenever a group is unassigned it updates the list by watching `toRemove`
- This was always triggered on initial load, now we work around this
- Was searching for a better way, but the newVal/oldVal reported same array for both initial load and after removing groups (need to ignore first and work thereafter)