### PR TITLE
Update grammar and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn build
 yarn start
 
 # Develop via Docker instead of a local nodejs
-docker build -f Dockerfile.dev -t dashboard:dev
+docker build -f Dockerfile.dev -t dashboard:dev .
 docker run -v $(pwd):/src \
   -v dashboard_node:/src/node_modules \
   -p 8005:8005 \
@@ -168,7 +168,7 @@ wm | "Window manager" at the bottom of the screen for things like container shel
 
 ## Synching state
 
-The high-level way the entire UI works is that API calls are made to load data from the server, and then a "watch" is started to notify us of changes so that information can be kept up to date at all times without polling or refreshing.  You can load a single resource by ID, an entire collection of all those resources, or something in between, and they should still stay up to date.  This works by having an array of a single authorititive copy of all the "known" models saved in the API stores (`management` & `cluster`) and updating the data when an event is received from the "subscribe" websocket.  The update is done on the _existing_ copy, so that anything that refers to it finds out that it changed through Vue's reactivity.  When manipulating models or collections of results from the API, some care is needed to make sure you are keeping that single copy and not making extras or turning a "live" array of models into a "dead" clone of it.
+The high-level way the entire UI works is that API calls are made to load data from the server, and then a "watch" is started to notify us of changes so that information can be kept up to date at all times without polling or refreshing.  You can load a single resource by ID, an entire collection of all those resources, or something in between, and they should still stay up to date.  This works by having an array of a single authoritative copy of all the "known" models saved in the API stores (`management` & `cluster`) and updating the data when an event is received from the "subscribe" websocket.  The update is done on the _existing_ copy, so that anything that refers to it finds out that it changed through Vue's reactivity.  When manipulating models or collections of results from the API, some care is needed to make sure you are keeping that single copy and not making extras or turning a "live" array of models into a "dead" clone of it.
 
   The most basic operations are `find({type, id})` to load a single resource by ID, `findAll({type})` load all of them.  These (anything starting with `find`) are async calls to the API.  Getters like `all(type)` and `byId(type, id)` are synchronous and return only info that has already been previously loaded.  See `plugins/steve/` for all the available actions and getters.
 

--- a/content/docs/en-us/getting-started.md
+++ b/content/docs/en-us/getting-started.md
@@ -11,7 +11,7 @@ If you have previously been using the Cluster Manager UI, check out the guide be
 
 ## Home
 
-When you first login to Rancher you'll be taken to the new Home page. There are a numebr of information cards presented. You can close these using the <i class="icon icon-close doc-icon"></i> icon. If you wish to bring back the hidden cards, open the page menu using the <i class="icon icon-actions doc-icon"></i>  icon in the top-right and choose 'Restore hidden cards'.
+When you first login to Rancher you'll be taken to the new Home page. There are a number of information cards presented. You can close these using the <i class="icon icon-close doc-icon"></i> icon. If you wish to bring back the hidden cards, open the page menu using the <i class="icon icon-actions doc-icon"></i>  icon in the top-right and choose 'Restore hidden cards'.
 
 You can change where you land when you login from the Home page and also from the Preferences page. To access User Preferences, click on the user avatar icon in the top right and choose 'Preferences' from the menu.
 ### Top-level Menu
@@ -22,7 +22,7 @@ The new slide-in menu provides quick access to your clusters and apps. It is acc
 
 ## Migrating from Cluster Manager
 
-As of version 2.6, Cluster Manager is no longer provided as a separate UI. The dashboard UI has been enhanced to provide the functionality from Cluster Manager. As a result, functionality you might be familar with from Cluster Manager can be found in slightly different locations within the new UI - this guide helps you find what you're looking for.
+As of version 2.6, Cluster Manager is no longer provided as a separate UI. The dashboard UI has been enhanced to provide the functionality from Cluster Manager. As a result, functionality you might be familiar with from Cluster Manager can be found in slightly different locations within the new UI - this guide helps you find what you're looking for.
 
 > Note that the legacy feature flag needs to be enabled for legacy functionality to be available. You can enable this from the slide-in menu → Global Settings → Feature Flags.
 
@@ -245,5 +245,5 @@ As of version 2.6, Cluster Manager is no longer provided as a separate UI. The d
       <td>User Avatar → Preferences</td>
       <td>User Avatar → Preferences</td>
     </tr>    
-  </tbdoy>
+  </tbody>
 </table>

--- a/docs/developer/getting-started/development.md
+++ b/docs/developer/getting-started/development.md
@@ -7,7 +7,7 @@ See [APIs](../../../README.md#apis).
 
 The older Norman API is served on `/v3`. The newer Steve API (see [here](https://github.com/rancher/api-spec/blob/master/specification.md) for spec) is served on `/v1` .
 
-In both cases the schema's returned dictate 
+In both cases the schemas returned dictate 
 - Which resources are shown
 - What operations (create, update, delete, etc) can be made against resource/s
 - What actions (archive, change password, etc) can be made against resource/s
@@ -237,15 +237,15 @@ This customisation should also support the `as=config` param, where the form is 
 
 ## Styling
 
-SCSS Styles can be found in `assets/styles/`. It's recommended to browse through some of the common styles in `_helpers.scss` and `_mixings.scss`.
+SCSS Styles can be found in `assets/styles/`. It's recommended to browse through some of the common styles in `_helpers.scss` and `_mixins.scss`.
 
 ### Examples
 
 The following pages contain example components and their styling
 
 - Buttons - `<dashboard url>/design-system`
-- Form Controls - `<dashvoard url>/design-system/form-controls`
-- Provider Images - `<dashvoard url>/design-system/provider-images`
+- Form Controls - `<dashboard url>/design-system/form-controls`
+- Provider Images - `<dashboard url>/design-system/provider-images`
 
 
 ## Internationalisation i18n / Localisation i10n
@@ -259,7 +259,7 @@ In HTML
 
 ```
 <t k="<path to localisation>" />
-{{ t("<path to localisation>1") }}
+{{ t("<path to localisation>") }}
 ```
 
 Many components will also accept a localisation path via a `value-key` property, instead of the translated text in `value`.
@@ -267,7 +267,7 @@ Many components will also accept a localisation path via a `value-key` property,
 In JS
 
 ```
-this.t('<path to localisation')
+this.t('<path to localisation>')
 ```
 
 A localisation can be checked with

--- a/docs/developer/getting-started/development_environment.md
+++ b/docs/developer/getting-started/development_environment.md
@@ -83,7 +83,7 @@ Due to the way Dashboard resources are constructed examining the contents of one
 > A These are part of the common underlying `resource-instance.js` or, if the resource type has it, the type's own `model`.
 
 ### Exploring the API
-The API serves up an interface to [browse both Norman and Steve API's](https://github.com/rancher/api-ui). Both will list supported schema's and allow the user to fetch individual or collections of resources. The schema's will describe the actions executable against individual or collections of resource. For Norman it will also show fields that can be filtered on.
+The API serves up an interface to [browse both Norman and Steve APIs](https://github.com/rancher/api-ui). Both will list supported schemas and allow the user to fetch individual or collections of resources. The schemas will describe the actions executable against individual or collections of resource. For Norman it will also show fields that can be filtered on.
 
 The dashboard will proxy requests to the API, so the interfaces are available via `<Dashboard URL>/v3` (Norman) and `<Dashboard URL>/v1` (Steve)
 


### PR DESCRIPTION
This corrects a few typos that I encountered while reviewing the docs. This also updates grammar in a few places where possessive nouns were in use when it looked like they were meant to be plural. 