### PR TITLE
[Master] Kubelet args, reorganize options

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1274,6 +1274,10 @@ cluster:
     services: Services
     allServices: Rotate all service certificates
     selectService: Rotate an individual service
+  toggle:
+    v1: RKE1
+    v2: RKE2/K3s
+
 
 clusterIndexPage:
   hardwareResourceGauge:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1223,12 +1223,12 @@ cluster:
     zstack: ZStack
   providerGroup:
     create-custom1: Use existing nodes and create a cluster using RKE
-    create-custom2: Use existing nodes and create a cluster using RKE2
+    create-custom2: Use existing nodes and create a cluster using RKE2 (Tech Preview)
     create-kontainer: Create a cluster in a hosted Kubernetes provider
     register-kontainer: Register an existing cluster in a hosted Kubernetes provider
     create-rke1: Provision new nodes and create a cluster using RKE
-    create-rke2: Provision new nodes and create a cluster using RKE2
-    create-template: Use a Catalog Template to create a cluster
+    create-rke2: Provision new nodes and create a cluster using RKE2 (Tech Preview)
+    create-template: Use a Catalog Template to create a cluster (Tech Preview)
     register-custom: Import any Kubernetes cluster
   rke2:
     systemService:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -888,6 +888,9 @@ cluster:
     label: Agent Environment
     detail: Add additional environment variables to the agent container.  This is most commonly useful for configuring a HTTP proxy.
     keyLabel: Variable Name
+  cloudProvider:
+    vsphere:
+      note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-On Config tab.'
   custom:
     nodeRole:
       label: Node Role
@@ -1257,6 +1260,7 @@ cluster:
       }
   tabs:
     ace: Authorized Endpoint
+    addons: Add-On Config
     advanced: Advanced
     agentEnv: Agent Environment Vars
     basic: Basics
@@ -1266,7 +1270,7 @@ cluster:
     machinePools: Machine Pools
     machines: Machines
     memberRoles: Member Roles
-    registry: Private Registry
+    registry: Registries
     upgrade: Upgrade Strategy
   rotateCertificates:
     label: Rotate Certificates

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3421,13 +3421,11 @@ setup:
   currentPassword: Bootstrap Password
   confirmPassword: Confirm New Password
   defaultPassword:
-    intro: It looks like this is your first time visiting {vendor}; if you pre-set your own bootstrap password, enter it here.  Otherwise a random one has been generated for you.<br/><br/>
+    intro: It looks like this is your first time visiting {vendor}; if you pre-set your own bootstrap password, enter it here.  Otherwise a random one has been generated for you.  To find it:<br/><br/>
     dockerPrefix: 'For a "docker run" installation:'
-    dockerCmd: 'docker logs <i>container-id</i> 2&gt;&amp;1 | grep "Bootstrap Password:"'
     dockerPs: 'Find your container ID with <code>docker ps</code>, then run:'
     dockerSuffix: ""
     helmPrefix: 'For a Helm installation, run:'
-    helmCmd: "kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{.data.bootstrapPassword|base64decode}}{{\"\\n\"}}'"
     helmSuffix: ""
   eula: I agree to the <a href="https://rancher.com/eula" target="_blank" rel="noopener noreferrer nofollow">terms and conditions</a> for using Rancher.
   newPassword: New Password

--- a/chart/monitoring/prometheus/index.vue
+++ b/chart/monitoring/prometheus/index.vue
@@ -359,7 +359,6 @@ export default {
             <MatchExpressions
               :initial-empty-row="false"
               :mode="mode"
-              type=""
               :value="matchExpressions"
               :show-remove="false"
               @input="matchChanged($event)"

--- a/components/CopyCode.vue
+++ b/components/CopyCode.vue
@@ -2,12 +2,16 @@
 import { isArray } from '@/utils/array';
 
 function flatten(node) {
-  if ( isArray(node) ) {
+  if ( node.text ) {
+    return node.text;
+  } else if ( isArray(node) ) {
     return node.map(flatten).join(' ');
   } else if ( node.children ) {
     return node.children.map(flatten).join(' ');
-  } else if ( node.text ) {
-    return node.text;
+  } else if ( node.child ) {
+    return flatten(node.child);
+  } else {
+    return '';
   }
 }
 

--- a/components/InfoBox.vue
+++ b/components/InfoBox.vue
@@ -12,7 +12,7 @@ export default {
 <template>
   <div :class="{'stepped': !!step}" class="info-box">
     <div v-if="step" class="step-number mb-10">
-      Step {{ step }}
+      <h2>Step {{ step }}</h2>
     </div>
     <slot />
   </div>

--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -269,7 +269,7 @@ export default {
           </div>
         </slot>
         <div v-if="showRemove" class="remove">
-          <slot name="remove-button" :remove="() => remove(idx)" :i="idx">
+          <slot name="remove-button" :remove="() => remove(idx)" :i="idx" :row="row">
             <button type="button" :disabled="isView" class="btn role-link" @click="remove(idx)">
               {{ removeLabel }}
             </button>

--- a/components/form/ArrayListGrouped.vue
+++ b/components/form/ArrayListGrouped.vue
@@ -5,9 +5,30 @@ import { _VIEW } from '@/config/query-params';
 
 export default {
   components: { ArrayList, InfoBox },
+  props:      {
+    canRemove: {
+      type:    [Boolean, Function],
+      default: true,
+    }
+  },
+
   computed:   {
     isDisabled() {
       return this.$attrs.mode === _VIEW;
+    }
+  },
+
+  methods: {
+    canRemoveRow(row, idx) {
+      if ( this.isDisabled ) {
+        return false;
+      }
+
+      if ( typeof this.canRemove === 'function' ) {
+        return this.canRemove(row, idx);
+      }
+
+      return this.canRemove;
     }
   }
 };
@@ -16,12 +37,12 @@ export default {
 <template>
   <ArrayList class="array-list-grouped" v-bind="$attrs" @input="$emit('input', $event)" @add="$emit('add')">
     <template v-slot:columns="scope">
-      <InfoBox :class="{'pt-40': !isDisabled}">
-        <slot v-bind="scope"></slot>
+      <InfoBox>
+        <slot v-bind="scope" />
       </InfoBox>
     </template>
     <template v-slot:remove-button="scope">
-      <button v-if="!isDisabled" type="button" class="btn role-link close btn-sm" @click="scope.remove">
+      <button v-if="canRemoveRow(scope.row, scope.i)" type="button" class="btn role-link close btn-sm" @click="scope.remove">
         <i class="icon icon-2x icon-x" />
       </button>
       <span v-else></span>

--- a/components/form/FileSelector.vue
+++ b/components/form/FileSelector.vue
@@ -1,5 +1,5 @@
 <script>
-import { _EDIT } from '@/config/query-params';
+import { _EDIT, _VIEW } from '@/config/query-params';
 import { set } from '@/utils/object';
 
 export function createOnSelected(field) {
@@ -52,8 +52,8 @@ export default {
   },
 
   computed: {
-    isEditing() {
-      return this.mode === _EDIT;
+    isView() {
+      return this.mode === _VIEW;
     }
   },
 
@@ -118,7 +118,7 @@ export default {
 </script>
 
 <template>
-  <button v-if="isEditing" :disabled="disabled" type="button" class="file-selector btn" @click="selectFile">
+  <button v-if="!isView" :disabled="disabled" type="button" class="file-selector btn" @click="selectFile">
     <span>{{ label }}</span>
     <input
       ref="uploader"

--- a/components/form/NodeAffinity.vue
+++ b/components/form/NodeAffinity.vue
@@ -131,7 +131,6 @@ export default {
           </div>
           <MatchExpressions
             v-model="props.row.value.matchExpressions"
-            :initial-empty-row="!isView"
             :mode="mode"
             class="col span-12 mt-20"
             :type="node"

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -74,6 +74,7 @@ export const CATALOG = {
   TYPE:             'catalog.cattle.io/type',
   _APP:             'app',
   _CLUSTER_TPL:     'cluster-template',
+  _CLUSTER_TOOL:    'cluster-tool',
 
   COMPONENT:        'catalog.cattle.io/ui-component',
   SOURCE_REPO_TYPE: 'catalog.cattle.io/ui-source-repo-type',

--- a/edit/autoscaling.horizontalpodautoscaler/metric-identifier.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/metric-identifier.vue
@@ -68,7 +68,6 @@ export default {
         <h3>Metric Selector</h3>
         <MatchExpressions
           :mode="mode"
-          type=""
           :value="matchExpressions"
           :label="t('hpa.metricIdentifier.selector.label')"
           :show-remove="false"

--- a/edit/fleet.cattle.io.clustergroup.vue
+++ b/edit/fleet.cattle.io.clustergroup.vue
@@ -135,9 +135,7 @@ export default {
 
     <h2 v-t="'fleet.clusterGroup.selector.label'" />
     <MatchExpressions
-      :initial-empty-row="!isView"
       :mode="mode"
-      type=""
       :value="expressions"
       :show-remove="false"
       @input="matchChanged($event)"

--- a/edit/persistentvolume/index.vue
+++ b/edit/persistentvolume/index.vue
@@ -287,7 +287,6 @@ export default {
                 <MatchExpressions
                   v-model="props.row.value.matchExpressions"
                   :mode="modeOverride"
-                  :initial-empty-row="!isView"
                   class="col span-12"
                   :type="NODE"
                   :show-remove="false"

--- a/edit/provisioning.cattle.io.cluster/ACE.vue
+++ b/edit/provisioning.cattle.io.cluster/ACE.vue
@@ -1,13 +1,12 @@
 <script>
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
-import Tab from '@/components/Tabbed/Tab';
 import FileSelector, { createOnSelected } from '@/components/form/FileSelector';
 import { set } from '@/utils/object';
 
 export default {
   components: {
-    RadioGroup, LabeledInput, Tab, FileSelector
+    RadioGroup, LabeledInput, FileSelector
   },
 
   props: {
@@ -45,7 +44,9 @@ export default {
 </script>
 
 <template>
-  <Tab name="ace" label-key="cluster.tabs.ace">
+  <div>
+    <h3 v-t="'cluster.tabs.ace'" />
+
     <RadioGroup
       v-model="config.enabled"
       name="enabled"
@@ -55,25 +56,26 @@ export default {
     />
 
     <template v-if="config.enabled">
-      <div class="spacer" />
-
-      <LabeledInput
-        v-model="config.fqdn"
-        :mode="mode"
-        label="FQDN"
-        tooltip="A FQDN which will resolve to the healthy control plane nodes of the cluster."
-      />
-
-      <div class="spacer" />
-
-      <LabeledInput
-        v-model="config.caCerts"
-        :mode="mode"
-        label="CA Certificates"
-        type="multiline"
-        tooltip="Certificates required for the client to successfully verify the validity of the certificate returned by the endpoint."
-      />
-      <FileSelector :mode="mode" class="btn btn-sm bg-primary mt-10" :label="t('generic.readFromFile')" @selected="onCertSelected" />
+      <div class="row mb-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="config.fqdn"
+            :mode="mode"
+            label="FQDN"
+            tooltip="A FQDN which will resolve to the healthy control plane nodes of the cluster."
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-model="config.caCerts"
+            :mode="mode"
+            label="CA Certificates"
+            type="multiline"
+            tooltip="Certificates required for the client to successfully verify the validity of the certificate returned by the endpoint."
+          />
+          <FileSelector :mode="mode" class="btn btn-sm bg-primary mt-10" :label="t('generic.readFromFile')" @selected="onCertSelected" />
+        </div>
+      </div>
     </template>
-  </Tab>
+  </div>
 </template>

--- a/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -58,7 +58,7 @@ export default {
     key-name="hostname"
     key-placeholder="e.g. docker.io or *"
     value-label="Mirror Endpoints"
-    value-placeholder="e.g. a.my-registry.com:5000, b.my-registry.com:5000"
+    value-placeholder="e.g. a.registry.com:5000, b.registry.com:5000"
     value-name="endpoints"
     add-label="Add Mirror"
     :mode="mode"

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -354,9 +354,9 @@ export default {
               v-model="provisioner"
               class="rke-switch"
               off-value="rke1"
-              off-label="RKE1"
+              :off-label="t('cluster.toggle.v1')"
               on-value="rke2"
-              on-label="RKE2/K3s"
+              :on-label="t('cluster.toggle.v2')"
             />
           </div>
           {{ obj.label }}

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -169,6 +169,10 @@ export default {
     },
 
     templateOptions() {
+      if ( !this.rke2Enabled ) {
+        return [];
+      }
+
       const out = filterAndArrangeCharts(this.allCharts, { showTypes: CATALOG._CLUSTER_TPL });
 
       return out;

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -393,6 +393,10 @@ export default {
       return this.selectedVersion?.charts || {};
     },
 
+    showCisProfile() {
+      return this.provider !== 'custom' && ( this.serverArgs.profile || this.agentArgs.profile );
+    },
+
     needCredential() {
       if ( this.provider === 'custom' || this.provider === 'import' ) {
         return false;
@@ -1167,7 +1171,7 @@ export default {
         </Tab>
 
         <Tab name="advanced" label-key="cluster.tabs.advanced" :weight="-1" @active="refreshYamls">
-          <template v-if="serverArgs.profile || agentArgs.profile">
+          <template v-if="showCisProfile">
             <h3>CIS Profile Validation</h3>
             <div class="row">
               <div v-if="serverArgs.profile" class="col span-6">

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -394,7 +394,7 @@ export default {
     },
 
     showCisProfile() {
-      return this.provider !== 'custom' && ( this.serverArgs.profile || this.agentArgs.profile );
+      return this.provider === 'custom' && ( this.serverArgs.profile || this.agentArgs.profile );
     },
 
     needCredential() {
@@ -515,8 +515,19 @@ export default {
       switch ( name ) {
       case 'none': return false;
       case 'aws': return false;
+      case 'vsphere': return false;
       default: return true;
       }
+    },
+
+    showVsphereNote() {
+      if ( !this.agentArgs['cloud-provider-name'] ) {
+        return false;
+      }
+
+      const name = this.agentConfig['cloud-provider-name'];
+
+      return name === 'vsphere';
     },
 
     showCni() {
@@ -978,7 +989,10 @@ export default {
             </div>
           </div>
 
-          <template v-if="showCloudConfigYaml">
+          <template v-if="showVsphereNote">
+            <Banner color="warning" label-key="cluster.cloudProvider.vsphere.note" />
+          </template>
+          <template v-else-if="showCloudConfigYaml">
             <div class="spacer" />
 
             <div class="col span-12">
@@ -1005,17 +1019,29 @@ export default {
                 label="Default Pod Security Policy"
               />
             </div>
-            <div class="col span-6 mt-5">
-              <div v-if="serverArgs['secrets-encryption']">
-                <Checkbox v-model="serverConfig['secrets-encryption']" :mode="mode" label="Encrypt Secrets" />
-              </div>
-              <div><Checkbox v-model="value.spec.enableNetworkPolicy" :mode="mode" label="Project Network Isolation" /></div>
-              <div v-if="agentArgs.selinux">
-                <Checkbox v-model="agentConfig.selinux" :mode="mode" label="SELinux" />
-              </div>
+            <div v-if="showCisProfile" class="col span-6">
+              <LabeledSelect
+                v-if="serverArgs.profile"
+                v-model="serverConfig.profile"
+                :mode="mode"
+                :options="profileOptions"
+                label="Server CIS Profile"
+              />
+              <LabeledSelect
+                v-else-if="agentArgs.profile"
+                v-model="agentConfig.profile"
+                :mode="mode"
+                :options="profileOptions"
+                label="Worker CIS Profile"
+              />
             </div>
           </div>
           <div class="row">
+            <div class="col span-12 mt-20">
+              <Checkbox v-if="serverArgs['secrets-encryption']" v-model="serverConfig['secrets-encryption']" :mode="mode" label="Encrypt Secrets" />
+              <Checkbox v-model="value.spec.enableNetworkPolicy" :mode="mode" label="Project Network Isolation" />
+              <Checkbox v-if="agentArgs.selinux" v-model="agentConfig.selinux" :mode="mode" label="SELinux" />
+            </div>
           </div>
 
           <div class="spacer" />
@@ -1042,7 +1068,7 @@ export default {
           <ClusterMembershipEditor :mode="mode" :parent-id="value.mgmt ? value.mgmt.id : null" @membership-update="onMembershipUpdate" @has-owner-changed="onHasOwnerChanged" />
         </Tab>
 
-        <Tab name="etcd" label-key="cluster.tabs.etcd" :weight="9">
+        <Tab name="etcd" label-key="cluster.tabs.etcd">
           <div class="row">
             <div class="col span-6">
               <RadioGroup
@@ -1107,13 +1133,8 @@ export default {
           </div>
         </Tab>
 
-        <Tab v-if="haveArgInfo" name="networking" label-key="cluster.tabs.networking" :weight="8">
-          <div v-if="serverArgs['service-node-port-range']" class="row mb-20">
-            <div class="col span-6">
-              <LabeledInput v-model="serverConfig['service-node-port-range']" :mode="mode" label="NodePort Service Port Range" />
-            </div>
-          </div>
-
+        <Tab v-if="haveArgInfo" name="networking" label-key="cluster.tabs.networking">
+          <h3>Addressing</h3>
           <div class="row mb-20">
             <div v-if="serverArgs['cluster-cidr']" class="col span-6">
               <LabeledInput v-model="serverConfig['cluster-cidr']" :mode="mode" label="Cluster CIDR" />
@@ -1132,14 +1153,22 @@ export default {
             </div>
           </div>
 
-          <div v-if="serverArgs['tls-san']" class="row mb-20">
+          <div v-if="serverArgs['service-node-port-range']" class="row mb-20">
             <div class="col span-6">
-              <ArrayList :mode="mode" :value="serverConfig['tls-san']" title="TLS Alternate Names" />
+              <LabeledInput v-model="serverConfig['service-node-port-range']" :mode="mode" label="NodePort Service Port Range" />
             </div>
           </div>
+
+          <div v-if="serverArgs['tls-san']" class="row mb-20">
+            <div class="col span-6">
+              <ArrayList :protip="false" :mode="mode" :value="serverConfig['tls-san']" title="TLS Alternate Names" />
+            </div>
+          </div>
+
+          <ACE v-model="value" :mode="mode" />
         </Tab>
 
-        <Tab name="upgrade" label-key="cluster.tabs.upgrade" :weight="7">
+        <Tab name="upgrade" label-key="cluster.tabs.upgrade">
           <div class="row">
             <div class="col span-6">
               <h3>Control Plane</h3>
@@ -1156,7 +1185,7 @@ export default {
           </div>
         </Tab>
 
-        <Tab name="registry" label-key="cluster.tabs.registry" :weight="6">
+        <Tab name="registry" label-key="cluster.tabs.registry">
           <RegistryMirrors
             v-model="value"
             :mode="mode"
@@ -1170,73 +1199,9 @@ export default {
           />
         </Tab>
 
-        <Tab name="advanced" label-key="cluster.tabs.advanced" :weight="-1" @active="refreshYamls">
-          <template v-if="showCisProfile">
-            <h3>CIS Profile Validation</h3>
-            <div class="row">
-              <div v-if="serverArgs.profile" class="col span-6">
-                <LabeledSelect
-                  v-model="serverConfig.profile"
-                  :mode="mode"
-                  :options="profileOptions"
-                  label="Server CIS Profile"
-                />
-              </div>
-              <div v-if="agentArgs.profile" class="col span-6">
-                <LabeledSelect
-                  v-model="agentConfig.profile"
-                  :mode="mode"
-                  :options="profileOptions"
-                  label="Worker CIS Profile"
-                />
-              </div>
-            </div>
-
-            <div class="spacer" />
-          </template>
-
-          <template v-if="agentArgs['protect-kernel-defaults']">
-            <div class="row">
-              <div class="col span-12">
-                <Checkbox v-model="agentConfig['protect-kernel-defaults']" :mode="mode" label="Raise error if kernel parameters are different than the expected kubelet defaults." />
-              </div>
-            </div>
-
-            <div class="spacer" />
-          </template>
-
-          <template v-if="haveArgInfo">
-            <div class="row">
-              <div class="col span-6">
-                <ArrayList v-if="agentArgs['kubelet-arg']" :mode="mode" :value="agentConfig['kubelet-arg']" title="Additional Kubelet Args" class="mb-20" />
-                <ArrayList v-if="serverArgs['kube-controller-manager-arg']" :mode="mode" :value="serverConfig['kube-controller-manager-arg']" title="Additional Controller Manager Args" class="mb-20" />
-              </div>
-              <div class="col span-6">
-                <ArrayList v-if="serverArgs['kube-apiserver-arg']" :mode="mode" :value="serverConfig['kube-apiserver-arg']" title="Additional API Server Args" class="mb-20" />
-                <ArrayList v-if="serverArgs['kube-scheduler-arg']" :mode="mode" :value="serverConfig['kube-scheduler-arg']" title="Additional Scheduler Args" />
-              </div>
-            </div>
-
-            <div class="spacer" />
-          </template>
-
-          <div>
-            <h3>
-              Additional Manifest
-              <i v-tooltip="'Additional Kubernetes Manifet YAML to be applied to the cluster on startup.'" class="icon icon-info" />
-            </h3>
-            <YamlEditor
-              ref="yaml-additional"
-              v-model="rkeConfig.additionalManifest"
-              :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
-              initial-yaml-values="# Additional Manifest YAML"
-              class="yaml-editor"
-            />
-          </div>
-
+        <Tab name="addons" label-key="cluster.tabs.addons" @active="refreshYamls">
           <div v-if="addonVersions.length">
             <div v-for="v in addonVersions" :key="v._key">
-              <div class="spacer" />
               <h3>{{ labelForAddon(v.name) }}</h3>
               <Questions
                 v-if="versionInfo[v.name].questions"
@@ -1257,11 +1222,50 @@ export default {
                 :hide-preview-buttons="true"
                 @input="data => updateValues(v.name, data)"
               />
+              <div class="spacer" />
             </div>
+          </div>
+
+          <div>
+            <h3>
+              Additional Manifest
+              <i v-tooltip="'Additional Kubernetes Manifet YAML to be applied to the cluster on startup.'" class="icon icon-info" />
+            </h3>
+            <YamlEditor
+              ref="yaml-additional"
+              v-model="rkeConfig.additionalManifest"
+              :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
+              initial-yaml-values="# Additional Manifest YAML"
+              class="yaml-editor"
+            />
           </div>
         </Tab>
 
-        <ACE v-model="value" :mode="mode" />
+        <Tab name="advanced" label-key="cluster.tabs.advanced" :weight="-1" @active="refreshYamls">
+          <template v-if="agentArgs['protect-kernel-defaults']">
+            <div class="row">
+              <div class="col span-12">
+                <Checkbox v-model="agentConfig['protect-kernel-defaults']" :mode="mode" label="Raise error if kernel parameters are different than the expected kubelet defaults" />
+              </div>
+            </div>
+
+            <div class="spacer" />
+          </template>
+
+          <template v-if="haveArgInfo">
+            <div class="row">
+              <div class="col span-6">
+                <ArrayList v-if="agentArgs['kubelet-arg']" :mode="mode" :value="agentConfig['kubelet-arg']" title="Additional Kubelet Args" class="mb-20" />
+                <ArrayList v-if="serverArgs['kube-controller-manager-arg']" :mode="mode" :value="serverConfig['kube-controller-manager-arg']" title="Additional Controller Manager Args" class="mb-20" />
+              </div>
+              <div class="col span-6">
+                <ArrayList v-if="serverArgs['kube-apiserver-arg']" :mode="mode" :value="serverConfig['kube-apiserver-arg']" title="Additional API Server Args" class="mb-20" />
+                <ArrayList v-if="serverArgs['kube-scheduler-arg']" :mode="mode" :value="serverConfig['kube-scheduler-arg']" title="Additional Scheduler Args" />
+              </div>
+            </div>
+          </template>
+        </Tab>
+
         <AgentEnv v-model="value" :mode="mode" />
         <Labels v-model="value" :mode="mode" />
       </Tabbed>

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -330,7 +330,7 @@ export default {
     },
 
     pspOptions() {
-      const out = [{ label: '(None)', value: null }];
+      const out = [{ label: 'RKE2 Default', value: null }];
 
       if ( this.allPSPs ) {
         for ( const pspt of this.allPSPs ) {

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -130,6 +130,10 @@ export default {
 
       return this.err;
     },
+
+    kubectlCmd() {
+      return "kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{.data.bootstrapPassword|base64decode}}{{\"\\n\"}}'";
+    }
   },
 
   created() {
@@ -261,7 +265,7 @@ export default {
               </li>
               <li>
                 <CopyCode>
-                  <t k="setup.defaultPassword.dockerCmd" :raw="true" />
+                  docker logs <u>container-id</u> 2&gt;&amp;1 | grep "Bootstrap Password:"
                 </CopyCode>
               </li>
             </ul>
@@ -271,7 +275,7 @@ export default {
             <div><t k="setup.defaultPassword.helmPrefix" :raw="true" /></div>
             <br />
             <CopyCode>
-              <t k="setup.defaultPassword.helmCmd" :raw="true" />
+              {{ kubectlCmd }}
             </CopyCode>
             <br />
             <div><t k="setup.defaultPassword.helmSuffix" :raw="true" /></div>

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -157,7 +157,7 @@ export default {
         showDeprecated: this.showDeprecated,
         showHidden:     this.showHidden,
         hideRepos:      this.hideRepos,
-        showTypes:      [CATALOG._APP],
+        hideTypes:      [CATALOG._CLUSTER_TPL],
         showPrerelease: this.$store.getters['prefs/get'](SHOW_PRE_RELEASE),
       });
     },

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -4,6 +4,7 @@ import Loading from '@/components/Loading';
 import { _FLAGGED, DEPRECATED, HIDDEN, FROM_TOOLS } from '@/config/query-params';
 import { filterAndArrangeCharts } from '@/store/catalog';
 import { CATALOG, MANAGEMENT } from '@/config/types';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@/config/labels-annotations';
 import LazyImage from '@/components/LazyImage';
 import AppSummaryGraph from '@/components/formatter/AppSummaryGraph';
 import { sortBy } from '@/utils/sort';
@@ -92,6 +93,7 @@ export default {
         showDeprecated: this.showDeprecated,
         showHidden:     this.showHidden,
         showRepos:      [this.rancherCatalog._key],
+        showTypes:      [CATALOG_ANNOTATIONS._CLUSTER_TOOL],
       });
 
       //  If legacy support is enabled, show V1 charts for some V1 Cluster tools


### PR DESCRIPTION
- Only show charts with catalog.cattle.io/type=cluster-tool as tools (rancher/rancher#33841)
- Mark RKE2 as tech preview
- Call null PSP the RKE2 Default
- Templates available only if feature flag is enabled
- Show CIS Profile only for Custom
- Reorganize tabs and options
- Additional Kubelet Args
