### PR TITLE
[master] Disable snapshot button when cluster is not active

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -286,6 +286,10 @@ export default {
 
       return false;
     },
+
+    isClusterActive() {
+      return this.$attrs['original-value'].metadata.state.name === 'active';
+    }
   },
 
   mounted() {
@@ -444,7 +448,12 @@ export default {
         :search="false"
       >
         <template #header-right>
-          <AsyncButton mode="snapshot" class="btn role-primary" @click="takeSnapshot" />
+          <AsyncButton
+            mode="snapshot"
+            class="btn role-primary"
+            :disabled="!isClusterActive"
+            @click="takeSnapshot"
+          />
         </template>
       </SortableTable>
     </Tab>

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -287,8 +287,8 @@ export default {
       return false;
     },
 
-    isClusterActive() {
-      return this.value.state === 'active';
+    isClusterReady() {
+      return this.value.mgmt?.isReady;
     }
   },
 
@@ -451,7 +451,7 @@ export default {
           <AsyncButton
             mode="snapshot"
             class="btn role-primary"
-            :disabled="!isClusterActive"
+            :disabled="!isClusterReady"
             @click="takeSnapshot"
           />
         </template>

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -288,7 +288,7 @@ export default {
     },
 
     isClusterActive() {
-      return this.$attrs['original-value'].metadata.state.name === 'active';
+      return this.value.state === 'active';
     }
   },
 


### PR DESCRIPTION
This disables the snapshot button when the cluster state is not equal to "active". 

#3547 