### PR TITLE
Bugfix release/3547 snapshot action

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -286,6 +286,10 @@ export default {
 
       return false;
     },
+
+    isClusterActive() {
+      return this.$attrs['original-value'].metadata.state.name === 'active';
+    }
   },
 
   mounted() {
@@ -444,7 +448,12 @@ export default {
         :search="false"
       >
         <template #header-right>
-          <AsyncButton mode="snapshot" class="btn role-primary" @click="takeSnapshot" />
+          <AsyncButton
+            mode="snapshot"
+            class="btn role-primary"
+            :disabled="!isClusterActive"
+            @click="takeSnapshot"
+          />
         </template>
       </SortableTable>
     </Tab>

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -288,7 +288,7 @@ export default {
     },
 
     isClusterActive() {
-      return this.$attrs['original-value'].metadata.state.name === 'active';
+      return this.value.state === 'active';
     }
   },
 


### PR DESCRIPTION
This disables the snapshot button when the cluster state is not equal to "active". 

Backport PR #3597 to release-2.6

#3547 