### PR TITLE
[2.6] Ensure we don't generically `management/findAll` settings type before logging in

### DIFF
--- a/components/BrandImage.vue
+++ b/components/BrandImage.vue
@@ -15,7 +15,7 @@ export default {
     }
   },
   async fetch() {
-    this.managementSettings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.SETTING });
+    this.managementSettings = await this.$store.getters['management/all'](MANAGEMENT.SETTING);
   },
   data() {
     return { managementSettings: [] };

--- a/mixins/brand.js
+++ b/mixins/brand.js
@@ -6,7 +6,7 @@ import { createCssVars } from '@/utils/color';
 
 export default {
   async fetch() {
-    this.globalSettings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.SETTING, opt: { url: `/v1/${ MANAGEMENT.SETTING }` } });
+    this.globalSettings = await this.$store.getters['management/all'](MANAGEMENT.SETTING);
   },
 
   data() {


### PR DESCRIPTION
- Partial settings are loaded before logging in via the `_ALL_IF_AUTHED` flag
- Any other attempt to findAll without flag will result in list marked as `haveAll` with the set of results
- Any attempt afterward that to findAll would just return the partial list and not refetch
- There were a couple of places this happened pre-log in, resulting in partial list of settings after log in
- This was needed to show version info (and to populate settings page)
- #3596