### PR TITLE
[2.6] Update wording for registering Windows nodes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -901,8 +901,8 @@ cluster:
     registrationCommand:
       label: Registration Command
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
-      windowsDetail: Run this command on each of the existing Windows machines you want to register.  Windows nodes can only be workers.
-      windowsNotReady: The cluster must be up and running with Linux etcd and Control Plane nodes before you can add Windows workers.
+      windowsDetail: Run this command in Powershell on each of the existing Windows machines you want to register.
+      windowsNotReady: The cluster must be up and running with Linux etcd and Control Plane nodes before the registration command for adding Windows workers will display.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:
     aws:


### PR DESCRIPTION
This updates some wording regarding registration of Windows nodes in a custom cluster. 

Backport PR #3621 to release-2.6

#3580 