### PR TITLE
[2.6] Update machine pools when editing RKE2 cluster

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -644,6 +644,7 @@ export default {
             id,
             remove: false,
             create:  false,
+            update: true,
             pool:    clone(pool),
             config:  await this.$store.dispatch('management/clone', { resource: config }),
           });
@@ -674,6 +675,7 @@ export default {
         config,
         remove: false,
         create:  true,
+        update: false,
         pool:    {
           name,
           etcdRole:         numCurrentPools === 0,
@@ -731,7 +733,7 @@ export default {
           entry.config = neu;
           entry.pool.machineConfigRef.name = neu.metadata.name;
           entry.create = false;
-        } else {
+        } else if (entry.update) {
           const response = await entry.config.save();
 
           entry.config = response;

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -731,6 +731,10 @@ export default {
           entry.config = neu;
           entry.pool.machineConfigRef.name = neu.metadata.name;
           entry.create = false;
+        } else {
+          const response = await entry.config.save();
+
+          entry.config = response;
         }
 
         if ( !entry.pool.hostnamePrefix ) {


### PR DESCRIPTION
This adds update functionality for machine pools configuration. 

It should be safe to invoke `entry.config.save()` because our HTTP action will be set to PUT when when an id exists on a resource. 

This also adds  an update property to `machinePools`, which can be used this in the future to to conditionally update any given pool only when configuration has changed. For now, this property is always set to `true` when machine pools are initialized and `false` when adding a new machine pool. Checking for the existence of an machine pool id could also work in place of the update property. 

Backport of PR #3629 into release-2.6

#3553 