### PR TITLE
[2.6] Download KubeConfig fails to download when MCM feature flag is disabled

### DIFF
--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -260,6 +260,7 @@ export default {
   generateKubeConfig() {
     return async() => {
       const res = await this.doAction('generateKubeconfig');
+
       return res.config;
     };
 

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -263,7 +263,6 @@ export default {
 
       return res.config;
     };
-
   },
 
   downloadKubeConfig() {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -259,13 +259,10 @@ export default {
 
   generateKubeConfig() {
     return async() => {
-      const res = await this.$dispatch('request', {
-        method: 'post',
-        url:    `/v3/clusters/${ this.id }?action=generateKubeconfig`
-      });
-
+      const res = await this.doAction('generateKubeconfig');
       return res.config;
     };
+
   },
 
   downloadKubeConfig() {


### PR DESCRIPTION
#3625 
`generateKubeConfig()` passed to `doAction()` to hit correct endpoint as opposed to statically hitting /v3/