### PR TITLE
[master] Download KubeConfig fails to download when MCM feature flag is disabled

### DIFF
--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -259,10 +259,7 @@ export default {
 
   generateKubeConfig() {
     return async() => {
-      const res = await this.$dispatch('request', {
-        method: 'post',
-        url:    `/v3/clusters/${ this.id }?action=generateKubeconfig`
-      });
+      const res = await this.doAction('generateKubeconfig');
 
       return res.config;
     };


### PR DESCRIPTION
#3625
`generateKubeConfig()` passed to `doAction()` to hit correct endpoint as opposed to statically hitting /v3/