### PR TITLE
[master] Add insecure command to Windows cluster registration

### DIFF
--- a/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -172,15 +172,21 @@ function sanitizeValue(v) {
       <template v-if="cluster.supportsWindows">
         <hr class="mt-20 mb-20" />
         <h4 v-t="'cluster.custom.registrationCommand.windowsDetail'" />
-        <CopyCode v-if="isClusterReady" class="m-10 p-10">
-          {{ windowsCommand }}
-        </CopyCode>
-        <Checkbox
-          v-if="isClusterReady && clusterToken.insecureWindowsNodeCommand"
-          v-model="insecureWindows"
-          label-key="cluster.custom.registrationCommand.insecure"
+        <template v-if="isClusterReady">
+          <CopyCode class="m-10 p-10">
+            {{ windowsCommand }}
+          </CopyCode>
+          <Checkbox
+            v-if="clusterToken.insecureWindowsNodeCommand"
+            v-model="insecureWindows"
+            label-key="cluster.custom.registrationCommand.insecure"
+          />
+        </template>
+        <Banner
+          v-else
+          color="info"
+          :label="t('cluster.custom.registrationCommand.windowsNotReady')"
         />
-        <Banner color="info" :label="t('cluster.custom.registrationCommand.windowsNotReady')" />
       </template>
     </InfoBox>
   </div>

--- a/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -102,6 +102,10 @@ export default {
       return out.join(' ');
     },
 
+    isClusterReady() {
+      return this.cluster.mgmt && this.cluster.mgmt.isReady;
+    }
+
   },
 
   methods: {
@@ -168,11 +172,11 @@ function sanitizeValue(v) {
       <template v-if="cluster.supportsWindows">
         <hr class="mt-20 mb-20" />
         <h4 v-t="'cluster.custom.registrationCommand.windowsDetail'" />
-        <CopyCode v-if="cluster.mgmt && cluster.mgmt.isReady" class="m-10 p-10">
+        <CopyCode v-if="isClusterReady" class="m-10 p-10">
           {{ windowsCommand }}
         </CopyCode>
         <Checkbox
-          v-if="clusterToken.insecureWindowsNodeCommand"
+          v-if="isClusterReady && clusterToken.insecureWindowsNodeCommand"
           v-model="insecureWindows"
           label-key="cluster.custom.registrationCommand.insecure"
         />

--- a/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -31,6 +31,7 @@ export default {
       controlPlane:    true,
       worker:          true,
       insecure:        false,
+      insecureWindows: true,
       address:         '',
       internalAddress: '',
       nodeName:        '',
@@ -73,7 +74,7 @@ export default {
     },
 
     windowsCommand() {
-      const out = [this.clusterToken.windowsNodeCommand];
+      const out = this.insecureWindows ? [this.clusterToken.insecureWindowsNodeCommand] : [this.clusterToken.windowsNodeCommand];
 
       this.address && out.push(`-Address "${ sanitizeValue(this.address) }"`);
       this.internalAddress && out.push(`-InternalAddress "${ sanitizeValue(this.internalAddress) }"`);
@@ -170,6 +171,11 @@ function sanitizeValue(v) {
         <CopyCode v-if="cluster.mgmt && cluster.mgmt.isReady" class="m-10 p-10">
           {{ windowsCommand }}
         </CopyCode>
+        <Checkbox
+          v-if="clusterToken.insecureWindowsNodeCommand"
+          v-model="insecureWindows"
+          label-key="cluster.custom.registrationCommand.insecure"
+        />
         <Banner color="info" :label="t('cluster.custom.registrationCommand.windowsNotReady')" />
       </template>
     </InfoBox>

--- a/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -31,7 +31,7 @@ export default {
       controlPlane:    true,
       worker:          true,
       insecure:        false,
-      insecureWindows: true,
+      insecureWindows: false,
       address:         '',
       internalAddress: '',
       nodeName:        '',


### PR DESCRIPTION
This adds an insecure command to Windows cluster registration by adding a checkbox that updates the code snippet when checked. This is made possible by recent changes on the backend that introduces an insecure Windows command by updating from `iwr` to `curl.exe`.

#3580 