### PR TITLE
[master]add creator annotation to ns, warn before project delete

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2951,6 +2951,11 @@ project:
   containerDefaultResourceLimit: Container Default Resource Limit
   resourceQuotas: Resource Quotas
   haveOneOwner: There must be at least one member with the Owner role.
+  warnDeletion:  |-
+    {count, plural,
+    =1 { Deleting a project will delete all associated namespaces that were created through the Rancher UI. }
+    other { Deleting these projects will delete all associated namespaces that were created through the Rancher UI. }
+    }
 
 projectMembers:
   project:

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -4,7 +4,7 @@ import NameNsDescription from '@/components/form/NameNsDescription';
 import CreateEditView from '@/mixins/create-edit-view';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import { MANAGEMENT } from '@/config/types';
-import { CONTAINER_DEFAULT_RESOURCE_LIMIT, PROJECT } from '@/config/labels-annotations';
+import { CONTAINER_DEFAULT_RESOURCE_LIMIT, CREATOR_ID, PROJECT } from '@/config/labels-annotations';
 import ContainerResourceLimit from '@/components/ContainerResourceLimit';
 import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
@@ -102,10 +102,12 @@ export default {
   methods: {
     willSave() {
       const cluster = this.$store.getters['currentCluster'];
-      const annotation = this.project ? `${ cluster.id }:${ this.project }` : null;
+      const projectAnnotation = this.project ? `${ cluster.id }:${ this.project }` : null;
+      const creatorAnnotation = this.$store.getters['auth/principalId'];
 
       this.value.setLabel(PROJECT, this.project);
-      this.value.setAnnotation(PROJECT, annotation);
+      this.value.setAnnotation(PROJECT, projectAnnotation);
+      this.value.setAnnotation(CREATOR_ID, creatorAnnotation);
     },
 
     getDefaultContainerResourceLimits(projectName) {

--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -23,6 +23,16 @@ export default {
     });
   },
 
+  warnDeletionMessage() {
+    return (toRemove = []) => {
+      return this.$rootGetters['i18n/t']('project.warnDeletion', { count: toRemove.length });
+    };
+  },
+
+  confirmRemove() {
+    return true;
+  },
+
   listLocation() {
     return { name: 'c-cluster-product-projectsnamespaces' };
   },

--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -41,6 +41,15 @@ export default {
     return this.listLocation;
   },
 
+  remove() {
+    return async() => {
+      const norman = await this.norman;
+
+      await norman.remove(...arguments);
+      this.$commit('management/remove', this, { root: true });
+    };
+  },
+
   save() {
     return async() => {
       const norman = await this.norman;

--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -43,6 +43,12 @@ export default {
       VIRTUAL_TYPES
     };
   },
+  // watch: {
+  //   projects(neu) {
+  //     console.log('projects list changed');
+  //     console.dir(neu);
+  //   }
+  // },
 
   computed: {
     headers() {


### PR DESCRIPTION
#3607 - I originally thought this was happening because I updated project deletion to go through steve instead of norman, but the issue is actually with namespace creation; namespaces created in vue aren't deleted when their project is deleted whether the project deletion happens in vue or ember. I found that the deletion is triggered by the presence of a `field.cattle.io/creatorId` annotation on namespaces so I updated the namespace save method to add this annotation. Since deleting a project will also potentially delete a bunch of other stuff now, I updated that process to require confirmation and include a warning about which sort of namespace will be removed.