### PR TITLE
fix rke2 defaults

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -141,7 +141,7 @@ export default {
       if ( this.serverConfig[k] === undefined ) {
         const def = this.serverArgs[k].default;
 
-        set(this.serverConfig, k, (def !== undefined ? undefined : def));
+        set(this.serverConfig, k, (def !== undefined ? def : undefined));
       }
     }
 
@@ -149,7 +149,7 @@ export default {
       if ( this.agentConfig[k] === undefined ) {
         const def = this.agentArgs[k].default;
 
-        set(this.agentConfig, k, (def !== undefined ? undefined : def));
+        set(this.agentConfig, k, (def !== undefined ? def : undefined));
       }
     }
 


### PR DESCRIPTION
As of this pr https://github.com/rancher/dashboard/pull/3658, some default rke2 config values are missing, looks like there was a mix-up in these two turnery statements that's setting config values to `undefined` even if a default is found