### PR TITLE
[master] Fix creation of group cluster and project template bindings

### DIFF
--- a/components/dialog/AddProjectMemberDialog.vue
+++ b/components/dialog/AddProjectMemberDialog.vue
@@ -21,7 +21,7 @@ export default {
       member:       {
         permissionGroup: 'member',
         custom:          {},
-        userPrincipalId: '',
+        principalId:     '',
         projectId:       null,
         roleTemplateIds: []
       }
@@ -48,7 +48,7 @@ export default {
       const promises = this.member.roleTemplateIds.map(roleTemplateId => this.$store.dispatch(`management/create`, {
         type:                  MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING,
         roleTemplateName:      roleTemplateId,
-        userPrincipalName:     this.member.userPrincipalId,
+        principalName:         this.member.principalId,
         projectName:           this.member.projectId,
       }));
 

--- a/components/form/Members/ClusterMembershipEditor.vue
+++ b/components/form/Members/ClusterMembershipEditor.vue
@@ -38,7 +38,7 @@ export default {
       return this.$store.dispatch(`management/create`, {
         type:                  MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
         roleTemplateName:      'cluster-owner',
-        userPrincipalName:     this.$store.getters['auth/principalId'],
+        principalName:         this.$store.getters['auth/principalId'],
       });
     }
   }

--- a/components/form/Members/ClusterPermissionsEditor.vue
+++ b/components/form/Members/ClusterPermissionsEditor.vue
@@ -101,7 +101,7 @@ export default {
       permissionGroup: 'member',
       custom:          {},
       roleTemplates:     [],
-      userPrincipalId: '',
+      principalId:     '',
       bindings:        []
     };
   },
@@ -162,8 +162,8 @@ export default {
     }
   },
   methods: {
-    onAdd(userId) {
-      this.$set(this, 'userPrincipalId', userId);
+    onAdd(principalId) {
+      this.$set(this, 'principalId', principalId);
       this.updateBindings();
     },
 
@@ -172,7 +172,7 @@ export default {
         type:              MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
         clusterName:       this.$store.getters['currentCluster'].id,
         roleTemplateName:  id,
-        userPrincipalName: this.userPrincipalId
+        principalName:    this.principalId
       }));
 
       const bindings = await Promise.all(bindingPromises);

--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -174,7 +174,7 @@ export default {
     <template #columns="{row}">
       <div class="columns row">
         <div class="col span-6">
-          <Principal :key="row.value.userPrincipalName" :value="row.value.userPrincipalName" />
+          <Principal :key="row.value.principalId" :value="row.value.principalId" />
         </div>
         <div class="col span-6 role">
           {{ row.value.roleDisplay }}

--- a/components/form/Members/ProjectMembershipEditor.vue
+++ b/components/form/Members/ProjectMembershipEditor.vue
@@ -39,7 +39,7 @@ export default {
       return this.$store.dispatch(`management/create`, {
         type:                  MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING,
         roleTemplateName:      'project-owner',
-        userPrincipalName:     this.$store.getters['auth/principalId'],
+        principalName:         this.$store.getters['auth/principalId'],
       });
     }
   }

--- a/components/form/ProjectMemberEditor.vue
+++ b/components/form/ProjectMemberEditor.vue
@@ -203,8 +203,8 @@ export default {
     }
   },
   methods: {
-    onAdd(userId) {
-      this.$set(this.value, 'userPrincipalId', userId);
+    onAdd(principalId) {
+      this.$set(this.value, 'principalId', principalId);
     },
 
     setRoleTemplateIds(permissionGroup) {

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -190,7 +190,7 @@ export const PRINCIPAL = {
   name:      'principal',
   labelKey:  'tableHeaders.name',
   sort:      'principal.loginName',
-  value:     'userPrincipalName',
+  value:     'principalId',
   formatter: 'Principal',
 };
 

--- a/edit/management.cattle.io.projectroletemplatebinding.vue
+++ b/edit/management.cattle.io.projectroletemplatebinding.vue
@@ -1,7 +1,7 @@
 <script>
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
-import { MANAGEMENT, NORMAN } from '@/config/types';
+import { MANAGEMENT } from '@/config/types';
 import { PROJECT_ID } from '@/config/query-params';
 import ProjectMemberEditor from '@/components/form/ProjectMemberEditor';
 
@@ -22,7 +22,7 @@ export default {
       binding:         {
         permissionGroup: 'member',
         custom:          {},
-        userPrincipalId: '',
+        principalId:     '',
         projectId:       this.$route.query[PROJECT_ID],
       },
     };
@@ -43,18 +43,15 @@ export default {
     },
   },
   methods: {
-    onAdd(userId) {
-      this.$set(this, 'userPrincipalId', userId);
+    onAdd(principalId) {
+      this.$set(this, 'principalId', principalId);
     },
     async saveOverride() {
-      const asyncBindings = this.binding.roleTemplateIds.map(roleTemplateId => this.$store.dispatch(`rancher/create`, {
-        type:                  NORMAN.PROJECT_ROLE_TEMPLATE_BINDING,
-        roleTemplateId,
-        userPrincipalId:       this.binding.userPrincipalId,
-        projectId:             this.binding.projectId,
-        projectRoleTemplateId: '',
-        subjectKind:           'User',
-        userId:                ''
+      const asyncBindings = this.binding.roleTemplateIds.map(roleTemplateId => this.$store.dispatch(`management/create`, {
+        type:                  MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING,
+        roleTemplateName:      roleTemplateId,
+        principalName:         this.member.principalId,
+        projectName:           this.member.projectId,
       }));
 
       const bindings = await Promise.all(asyncBindings);
@@ -78,7 +75,7 @@ export default {
     :subtypes="[]"
     :can-yaml="false"
     :cancel-event="true"
-    :validation-passed="!!binding.userPrincipalId && !!binding.projectId"
+    :validation-passed="!!binding.principalId && !!binding.projectId"
     @error="e=>errors = e"
     @finish="saveOverride"
     @cancel="done"

--- a/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/models/management.cattle.io.clusterroletemplatebinding.js
@@ -26,6 +26,15 @@ export default {
     return this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userName);
   },
 
+  principal() {
+    return this.$rootGetters['rancher/byId'](NORMAN.PRINCIPAL, this.principalId);
+  },
+
+  principalId() {
+    // We've either set it ourselves or it's comes from native properties
+    return this.principalName || this.userPrincipalName || this.groupPrincipalName;
+  },
+
   nameDisplay() {
     return this.user?.nameDisplay;
   },
@@ -87,12 +96,13 @@ export default {
   },
 
   norman() {
+    const principalProperty = this.principal.principalType === 'group' ? 'groupPrincipalId' : 'userPrincipalId';
+
     return this.$dispatch(`rancher/create`, {
       type:                  NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING,
       roleTemplateId:        this.roleTemplateName,
-      userPrincipalId:       this.userPrincipalName,
+      [principalProperty]:   this.principal.id,
       clusterId:             this.clusterName,
-      subjectKind:           'User',
       id:                    this.id?.replace('/', ':')
     }, { root: true });
   },

--- a/models/management.cattle.io.projectroletemplatebinding.js
+++ b/models/management.cattle.io.projectroletemplatebinding.js
@@ -18,6 +18,15 @@ export default {
     return this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userName);
   },
 
+  principal() {
+    return this.$rootGetters['rancher/byId'](NORMAN.PRINCIPAL, this.principalId);
+  },
+
+  principalId() {
+    // We've either set it ourselves or it's comes from native properties
+    return this.principalName || this.userPrincipalName || this.groupPrincipalName;
+  },
+
   nameDisplay() {
     return this.user?.nameDisplay;
   },
@@ -105,14 +114,14 @@ export default {
   },
 
   norman() {
+    const principalProperty = this.principal.principalType === 'group' ? 'groupPrincipalId' : 'userPrincipalId';
+
     return this.$dispatch(`rancher/create`, {
       type:                  NORMAN.PROJECT_ROLE_TEMPLATE_BINDING,
       roleTemplateId:        this.roleTemplateName,
-      userPrincipalId:       this.userPrincipalName,
+      [principalProperty]:   this.principal.id,
       projectId:             this.projectName,
       projectRoleTemplateId: '',
-      subjectKind:           'User',
-      userId:                '',
       id:                    this.id?.replace('/', ':')
     }, { root: true });
   },


### PR DESCRIPTION
- make userPrincipal id/name properties generic in mgnt binding types
  - userPrincipalName becomes principalName
  - principalId comes from this.principalName || this.userPrincipalName || this.groupPrincipalName
- use principal to determine user/group and properties in norman to save
- removed properties in norman save bindings that weren't needed
- #3643, #3672