### PR TITLE
[master] Update route comparison when checking for active route

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -143,7 +143,7 @@ export default {
         } else if (item.route) {
           const route = this.$router.resolve(item.route);
 
-          if (this.$route.fullPath === route.href) {
+          if (this.$route.fullPath === route.route.fullPath) {
             return true;
           }
         }


### PR DESCRIPTION
This resolves an issue where navigation trees were automatically collapsing when routing to a cluster's context in production. 

The problem stemmed from a combination of `ROUTER_BASE` containing and the route comparison that is made when checking for active routes in `Group.vue`. In this scenario, with the `ROUTER_BASE` set to `/dashboard`, `$route.fullPath`  returns `/c/local/explorer`, while `route.href` returns `/dashboard/c/local/explorer`. In day to day development. Updating the comparison to `route.route.fullPath` produces `/c/local/explorer`, allowing us to properly determine if a route is active.

I tried testing this change in other pages that have navigation and didn't take note any regressions related to this change.  

#3512