### PR TITLE
[2.6] Ensure we wait for required resources before leaving cluster import / create rke2

### DIFF
--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -105,7 +105,8 @@ export default {
         save:            (parentId) => {
           const savedPromises = newBindings.map((binding) => {
             set(binding, this.parentKey, parentId);
-            binding.save();
+
+            return binding.save();
           });
 
           const removedPromises = removedBindings.map(binding => binding.remove());

--- a/edit/provisioning.cattle.io.cluster/import.vue
+++ b/edit/provisioning.cattle.io.cluster/import.vue
@@ -10,7 +10,6 @@ import ClusterMembershipEditor from '@/components/form/Members/ClusterMembership
 import Banner from '@/components/Banner';
 import Labels from './Labels';
 import AgentEnv from './AgentEnv';
-// import { set } from '@/utils/object';
 
 export default {
   components: {
@@ -55,6 +54,7 @@ export default {
   },
 
   computed: {},
+
   watch:    {
     hasOwner() {
       if (this.hasOwner) {
@@ -64,6 +64,11 @@ export default {
       }
     }
   },
+
+  created() {
+    this.registerAfterHook(this.saveRoleBindings, 'save-role-bindings');
+  },
+
   methods: {
     done() {
       return this.$router.replace({
@@ -75,18 +80,23 @@ export default {
         },
       });
     },
-    async saveOverride() {
-      await this.save(...arguments);
 
-      this.value.waitForMgmt().then(() => {
-        if (this.membershipUpdate.save) {
-          this.membershipUpdate.save(this.value.mgmt.id);
-        }
-      });
+    async saveRoleBindings() {
+      await this.value.waitForMgmt();
+
+      if (this.membershipUpdate.save) {
+        await this.membershipUpdate.save(this.value.mgmt.id);
+      }
     },
+
+    async saveOverride(btnCb) {
+      await this.save(btnCb);
+    },
+
     onMembershipUpdate(update) {
       this.$set(this, 'membershipUpdate', update);
     },
+
     onHasOwnerChanged(hasOwner) {
       this.$set(this, 'hasOwner', hasOwner);
     },

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -684,6 +684,7 @@ export default {
   created() {
     this.registerBeforeHook(this.saveMachinePools, 'save-machine-pools');
     this.registerAfterHook(this.cleanupMachinePools, 'cleanup-machine-pools');
+    this.registerAfterHook(this.saveRoleBindings, 'save-role-bindings');
   },
 
   methods: {
@@ -821,6 +822,14 @@ export default {
       }
     },
 
+    async saveRoleBindings() {
+      await this.value.waitForMgmt();
+
+      if (this.membershipUpdate.save) {
+        await this.membershipUpdate.save(this.value.mgmt.id);
+      }
+    },
+
     validationPassed() {
       return (this.provider === 'custom' || !!this.credentialId) && this.hasOwner;
     },
@@ -876,18 +885,7 @@ export default {
         return;
       }
 
-      try {
-        await this.save();
-        await this.value.waitForMgmt();
-
-        if (this.membershipUpdate.save) {
-          await this.membershipUpdate.save(this.value.mgmt.id);
-        }
-
-        btnCb(true);
-      } catch (e) {
-        btnCb(false);
-      }
+      await this.save(btnCb);
     },
 
     cancel() {

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -159,7 +159,10 @@ export default {
   waitForMgmt() {
     return (timeout, interval) => {
       return this.waitForTestFn(() => {
-        const name = this.status?.clusterName;
+        // `this` instance isn't getting updated with `status.clusterName`
+        // Workaround - Get fresh copy from the store
+        const pCluster = this.$getters['byId'](CAPI.RANCHER_CLUSTER, this.id);
+        const name = this.status?.clusterName || pCluster.status?.clusterName;
 
         return name && !!this.$getters['byId'](MANAGEMENT.CLUSTER, name);
       }, `mgmt cluster create`, timeout, interval);


### PR DESCRIPTION
- Previously nav away was occurring inside `this.save` before we could wait for the mgmt cluster
- This meant some info was missing when we arrived at the next page
- So move wait and role change into after hook and rely on native nav in this.save again

This should resolve #3396 and most of #3677