### PR TITLE
[2.6] Apply inventive wait for standard-users and creating a cluster

### DIFF
--- a/components/EmberPage.vue
+++ b/components/EmberPage.vue
@@ -5,6 +5,8 @@ import { NAME as MANAGER } from '@/config/product/manager';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { SETTING } from '@/config/settings';
 
+import DynamicRBAC from '@/mixins/dyanmic-rbac/dyammic-rbac';
+
 const EMBER_FRAME = 'ember-iframe';
 const EMBER_FRAME_HIDE_CLASS = 'ember-iframe-hidden';
 const PAGE_CHECK_TIMEOUT = 30000;
@@ -51,6 +53,10 @@ const INTERCEPTS = {
 export default {
   components: { Loading },
 
+  mixins: [
+    DynamicRBAC
+  ],
+
   props: {
     src: {
       type:     String,
@@ -68,6 +74,10 @@ export default {
       type:    Boolean,
       default: false
     }
+  },
+
+  async fetch() {
+    await this.dynamicRbacFetch();
   },
 
   data() {
@@ -400,7 +410,16 @@ export default {
           }
 
           this.setLoaded(false);
-          this.$router.replace(this.fillRoute(dest));
+
+          if (msg.target === 'global-admin.clusters.index') {
+            this.setDynamicRBACState(true)
+              .then(() => {
+                this.$router.replace(this.fillRoute(dest));
+              })
+              .catch((e) => {
+                console.error(e); // eslint-disable-line no-console
+              });
+          }
         }
       } else if (msg.action === 'loading') {
         this.setLoaded(!msg.state);

--- a/components/IndentedPanel.vue
+++ b/components/IndentedPanel.vue
@@ -10,6 +10,7 @@ export default {};
 
 <style lang="scss">
   .indented-panel {
+    height: 100%;
     width: 90%;
     margin-left: 5%;
   }

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -208,6 +208,7 @@ export default {
       as:              null,
       value:           null,
       model:           null,
+      notFound:        null,
     };
   },
 

--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -105,7 +105,8 @@ export default {
         save:            (parentId) => {
           const savedPromises = newBindings.map((binding) => {
             set(binding, this.parentKey, parentId);
-            binding.save();
+
+            return binding.save();
           });
 
           const removedPromises = removedBindings.map(binding => binding.remove());

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -225,37 +225,40 @@ export default {
               </div>
             </nuxt-link>
           </div>
-          <div class="category">
-            {{ t('nav.categories.explore') }}
-          </div>
-          <div v-if="showClusterSearch" class="search">
-            <input
-              ref="clusterFilter"
-              v-model="clusterFilter"
-              :placeholder="t('nav.search.placeholder')"
-            />
-            <i v-if="clusterFilter.length > 0" class="icon icon-close" @click="clusterFilter=''" />
-          </div>
-          <div ref="clusterList" class="clusters">
-            <div v-for="c in clusters" :key="c.id" @click="hide()">
-              <nuxt-link
-                v-if="c.ready"
-                class="cluster selector option"
-                :to="{ name: 'c-cluster', params: { cluster: c.id } }"
-              >
-                <RancherProviderIcon v-if="c.isLocal" width="24" class="rancher-provider-icon" />
-                <img v-else :src="c.logo" />
-                <div>{{ c.label }}</div>
-              </nuxt-link>
-              <span v-else class="option-disabled cluster selector disabled">
-                <img :src="c.logo" />
-                <div>{{ c.label }}</div>
-              </span>
+          <template v-if="clusters && !!clusters.length">
+            <div class="category">
+              {{ t('nav.categories.explore') }}
             </div>
-            <div v-if="clusters.length === 0" class="none-matching">
-              {{ t('nav.search.noResults') }}
+            <div v-if="showClusterSearch" class="search">
+              <input
+                ref="clusterFilter"
+                v-model="clusterFilter"
+                :placeholder="t('nav.search.placeholder')"
+              />
+              <i v-if="clusterFilter.length > 0" class="icon icon-close" @click="clusterFilter=''" />
             </div>
-          </div>
+            <div ref="clusterList" class="clusters">
+              <div v-for="c in clusters" :key="c.id" @click="hide()">
+                <nuxt-link
+                  v-if="c.ready"
+                  class="cluster selector option"
+                  :to="{ name: 'c-cluster', params: { cluster: c.id } }"
+                >
+                  <RancherProviderIcon v-if="c.isLocal" width="24" class="rancher-provider-icon" />
+                  <img v-else :src="c.logo" />
+                  <div>{{ c.label }}</div>
+                </nuxt-link>
+                <span v-else class="option-disabled cluster selector disabled">
+                  <img :src="c.logo" />
+                  <div>{{ c.label }}</div>
+                </span>
+              </div>
+              <div v-if="clusters.length === 0" class="none-matching">
+                {{ t('nav.search.noResults') }}
+              </div>
+            </div>
+          </template>
+
           <template v-if="multiClusterApps.length">
             <div class="category">
               {{ t('nav.categories.multiCluster') }}

--- a/config/query-params.js
+++ b/config/query-params.js
@@ -60,6 +60,7 @@ export const DEPRECATED = 'deprecated';
 export const HIDDEN = 'hidden';
 export const FROM_TOOLS = 'tools';
 export const FROM_CLUSTER = 'cluster';
+export const HIDE_SIDE_NAV = 'hide-side-nav';
 
 // Cluster provisioning
 export const PROVIDER = 'provider';

--- a/edit/provisioning.cattle.io.cluster/import.vue
+++ b/edit/provisioning.cattle.io.cluster/import.vue
@@ -1,5 +1,6 @@
 <script>
 import CreateEditView from '@/mixins/create-edit-view';
+
 import CruResource from '@/components/CruResource';
 import Loading from '@/components/Loading';
 import NameNsDescription from '@/components/form/NameNsDescription';
@@ -10,7 +11,6 @@ import ClusterMembershipEditor from '@/components/form/Members/ClusterMembership
 import Banner from '@/components/Banner';
 import Labels from './Labels';
 import AgentEnv from './AgentEnv';
-// import { set } from '@/utils/object';
 
 export default {
   components: {
@@ -55,6 +55,7 @@ export default {
   },
 
   computed: {},
+
   watch:    {
     hasOwner() {
       if (this.hasOwner) {
@@ -64,6 +65,11 @@ export default {
       }
     }
   },
+
+  created() {
+    this.registerAfterHook(this.saveRoleBindings, 'save-role-bindings');
+  },
+
   methods: {
     done() {
       return this.$router.replace({
@@ -75,18 +81,23 @@ export default {
         },
       });
     },
-    async saveOverride() {
-      await this.save(...arguments);
 
-      this.value.waitForMgmt().then(() => {
-        if (this.membershipUpdate.save) {
-          this.membershipUpdate.save(this.value.mgmt.id);
-        }
-      });
+    async saveRoleBindings() {
+      await this.value.waitForMgmt();
+
+      if (this.membershipUpdate.save) {
+        await this.membershipUpdate.save(this.value.mgmt.id);
+      }
     },
+
+    async saveOverride(btnCb) {
+      await this.save(btnCb);
+    },
+
     onMembershipUpdate(update) {
       this.$set(this, 'membershipUpdate', update);
     },
+
     onHasOwnerChanged(hasOwner) {
       this.$set(this, 'hasOwner', hasOwner);
     },

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -16,6 +16,7 @@ import { CATALOG } from '@/config/labels-annotations';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE } from '@/store/features';
 import { allHash } from '@/utils/promise';
+import { BLANK_CLUSTER } from '@/store';
 import Rke2Config from './rke2';
 import Import from './import';
 
@@ -300,9 +301,8 @@ export default {
 
       if ( parts[0] === 'chart' ) {
         const chart = this.$store.getters['catalog/chart']({ key: parts[1] });
-        const localCluster = this.$store.getters['management/all'](MANAGEMENT.CLUSTER).find(x => x.isLocal);
 
-        chart.goToInstall(FROM_CLUSTER, localCluster.id);
+        chart.goToInstall(FROM_CLUSTER, BLANK_CLUSTER, true);
 
         return;
       }

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -6,6 +6,7 @@ import merge from 'lodash/merge';
 import { mapGetters } from 'vuex';
 
 import CreateEditView from '@/mixins/create-edit-view';
+
 import { CAPI, MANAGEMENT, NORMAN } from '@/config/types';
 import { _CREATE, _EDIT } from '@/config/query-params';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
@@ -684,6 +685,7 @@ export default {
   created() {
     this.registerBeforeHook(this.saveMachinePools, 'save-machine-pools');
     this.registerAfterHook(this.cleanupMachinePools, 'cleanup-machine-pools');
+    this.registerAfterHook(this.saveRoleBindings, 'save-role-bindings');
   },
 
   methods: {
@@ -821,6 +823,14 @@ export default {
       }
     },
 
+    async saveRoleBindings() {
+      await this.value.waitForMgmt();
+
+      if (this.membershipUpdate.save) {
+        await this.membershipUpdate.save(this.value.mgmt.id);
+      }
+    },
+
     validationPassed() {
       return (this.provider === 'custom' || !!this.credentialId) && this.hasOwner;
     },
@@ -876,18 +886,7 @@ export default {
         return;
       }
 
-      try {
-        await this.save();
-        await this.value.waitForMgmt();
-
-        if (this.membershipUpdate.save) {
-          await this.membershipUpdate.save(this.value.mgmt.id);
-        }
-
-        btnCb(true);
-      } catch (e) {
-        btnCb(false);
-      }
+      await this.save(btnCb);
     },
 
     cancel() {
@@ -969,6 +968,7 @@ export default {
     canRemoveKubeletRow(row, idx) {
       return idx !== 0;
     },
+
   },
 };
 </script>

--- a/layouts/plain.vue
+++ b/layouts/plain.vue
@@ -28,9 +28,6 @@ export default {
       name: this.$route.name,
     };
   },
-  mounted() {
-    this.$store.dispatch('prefs/setBrand');
-  },
 
 };
 </script>

--- a/list/management.cattle.io.setting.vue
+++ b/list/management.cattle.io.setting.vue
@@ -46,7 +46,7 @@ export default {
       }
       // There are only 2 actions that can be enabled - Edit Setting or View in API
       // If neither is available for this setting then we hide the action menu button
-      s.hasActions = !s.readOnly || isDev;
+      s.hasActions = (!s.readOnly || isDev) && settingsMap[setting].availableActions?.length;
       settings.push(s);
     });
     this.settings = settings;

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -9,18 +9,31 @@ export default {
   components: { ResourceTable, Masthead },
 
   async fetch() {
-    const hash = await allHash({
+    const hash = {
       mgmtClusters:       this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
-      // Used to determine non-rke2 node counts
-      mgmtNodes:          this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE }),
-      mgmtPools:          this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL }),
-      mgmtTemplates:      this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE }),
       rancherClusters:    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
-      machineDeployments: this.$store.dispatch('management/findAll', { type: CAPI.MACHINE_DEPLOYMENT })
-    });
+    };
 
-    this.mgmtClusters = hash.mgmtClusters;
-    this.rancherClusters = hash.rancherClusters;
+    if ( this.$store.getters['management/schemaFor'](MANAGEMENT.NODE) ) {
+      hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
+    }
+
+    if ( this.$store.getters['management/schemaFor'](MANAGEMENT.NODE_POOL) ) {
+      hash.mgmtPools = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL });
+    }
+
+    if ( this.$store.getters['management/schemaFor'](MANAGEMENT.NODE_TEMPLATE) ) {
+      hash.mgmtTemplates = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE });
+    }
+
+    if ( this.$store.getters['management/schemaFor'](CAPI.MACHINE_DEPLOYMENT) ) {
+      hash.machineDeployments = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE_DEPLOYMENT });
+    }
+
+    const res = await allHash(hash);
+
+    this.mgmtClusters = res.mgmtClusters;
+    this.rancherClusters = res.rancherClusters;
   },
 
   data() {

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -1,4 +1,6 @@
 <script>
+import DynamicRBAC from '@/mixins/dyanmic-rbac/dyammic-rbac';
+
 import ResourceTable from '@/components/ResourceTable';
 import Masthead from '@/components/ResourceList/Masthead';
 import { allHash } from '@/utils/promise';
@@ -8,7 +10,11 @@ import { MODE, _IMPORT } from '@/config/query-params';
 export default {
   components: { ResourceTable, Masthead },
 
+  mixins: [DynamicRBAC],
+
   async fetch() {
+    await this.processDynamicRBAC();
+
     const hash = {
       mgmtClusters:       this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
       rancherClusters:    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),

--- a/mixins/chart.js
+++ b/mixins/chart.js
@@ -67,7 +67,7 @@ export default {
 
       const versions = this.chart?.versions || [];
       const selectedVersion = this.targetVersion;
-      const isWindows = currentCluster.providerOs === 'windows';
+      const isWindows = currentCluster?.providerOs === 'windows';
       const out = [];
 
       versions.forEach((version) => {
@@ -162,8 +162,8 @@ export default {
         const needMemory = parseSi(this.version?.annotations?.[CATALOG_ANNOTATIONS.REQUESTS_MEMORY] || '0');
 
         // Note: These are null if unknown
-        const availableCpu = this.currentCluster.availableCpu;
-        const availableMemory = this.currentCluster.availableMemory;
+        const availableCpu = this.currentCluster?.availableCpu;
+        const availableMemory = this.currentCluster?.availableMemory;
 
         if ( availableCpu !== null && availableCpu < needCpu ) {
           warnings.push(this.t('catalog.install.error.insufficientCpu', {

--- a/mixins/create-edit-view/impl.js
+++ b/mixins/create-edit-view/impl.js
@@ -111,7 +111,7 @@ export default {
       });
     },
 
-    async save(buttonDone, url) {
+    async save(buttonDone, url, callDone = true) {
       if ( this.errors ) {
         clear(this.errors);
       }
@@ -148,7 +148,7 @@ export default {
         await this.applyHooks(AFTER_SAVE_HOOKS);
         buttonDone && buttonDone(true);
 
-        this.done();
+        callDone && this.done();
       } catch (err) {
         this.errors = exceptionToErrorsArray(err);
         buttonDone && buttonDone(false);

--- a/mixins/dyanmic-rbac/dyammic-rbac-hook.js
+++ b/mixins/dyanmic-rbac/dyammic-rbac-hook.js
@@ -1,0 +1,111 @@
+
+import Vue from 'vue';
+
+import { CAPI, MANAGEMENT } from '@/config/types';
+
+import DynamicRBAC from '@/mixins/dyanmic-rbac/dyammic-rbac';
+
+export default {
+
+  mixins: [
+    DynamicRBAC
+  ],
+
+  computed: {
+    clusterId() {
+      return this.value?.id;
+    },
+
+  },
+
+  methods: {
+    async dynamicRbacHookFetch() {
+      await this.dynamicRbacFetch();
+    },
+
+    // Wait until all dynamic resources are available, cluster specific
+    async waitForDynamicResources(doneAction) {
+      // Wait for sockets to be reset (if needed, see comment in handleDynamicRBAC) and for the required resources to be available
+      try {
+        // Given we're about to rip out a lot of resources from underneath components ensure we hide them first to avoid undefined.x errors
+        Vue.set(this, 'waitingForResource', true);
+
+        if (!this.hasDynamicSchema && this.initialClusterCount === 0) {
+          await this.handleDynamicRBAC();
+        }
+
+        await this.waitForProvisioningCluster();
+
+        await this.waitForMgmtName();
+
+        await this.waitForMgmt();
+
+        // Do anything additional in the same context before returning
+        // This avoids setting waitingForResource to true here (to show any errors) and the blip of screen components whilst anything extra
+        // happens afterwards
+        doneAction && doneAction(this.mgmtClusterId);
+      } catch (e) {
+        Vue.set(this, 'waitingForResource', false);
+        throw e;
+      }
+    },
+
+    async waitForProvisioningCluster() {
+      if (this.value) {
+        return this.value.id;
+      }
+
+      await this.waitFor(
+        () => this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER),
+        (clusters) => {
+          if (!!clusters?.[0]) {
+            return clusters[0].id;
+          }
+        },
+        () => this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER, opt: { force: true } }),
+        'Provisioning Cluster',
+        'Failed to find provisioning cluster'
+      );
+    },
+
+    async waitForMgmtName() {
+      await this.waitFor(
+        () => this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, this.clusterId),
+        (provisioningCluster) => {
+          if (!!provisioningCluster?.status?.clusterName) {
+            return true;
+          }
+        },
+        () => this.$store.dispatch('management/find', {
+          type: CAPI.RANCHER_CLUSTER,
+          id:   this.clusterId,
+          opt:  { force: true }
+        }),
+        'Mgmt Name',
+        'Failed to fetch mgmt cluster name from provisioning cluster'
+      );
+    },
+
+    async waitForMgmt() {
+      const provisioningCluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, this.clusterId);
+      const mgmtId = provisioningCluster.status.clusterName; // This should be populated by now
+
+      await this.waitFor(
+        () => this.$store.getters['management/byId'](MANAGEMENT.CLUSTER, mgmtId),
+        (mgmt) => {
+          if (!!mgmt) {
+            return true;
+          }
+        },
+        () => this.$store.dispatch('management/find', {
+          type: MANAGEMENT.CLUSTER,
+          id:   mgmtId,
+          opt:  { force: true }
+        }),
+        'Mgmt Cluster',
+        'Failed to fetch mgmt cluster name from provisioning cluster'
+      );
+    },
+  }
+
+};

--- a/mixins/dyanmic-rbac/dyammic-rbac.js
+++ b/mixins/dyanmic-rbac/dyammic-rbac.js
@@ -1,0 +1,112 @@
+
+import { mapGetters } from 'vuex';
+
+import { CAPI, MANAGEMENT, SCHEMA } from '@/config/types';
+
+import waitFor from '@/utils/waitFor';
+
+export default {
+  data() {
+    return {
+      initialClusterCount: 0,
+
+      waitingForResource: false,
+      dynamicSchema:      MANAGEMENT.NODE
+    };
+  },
+
+  computed: {
+    ...mapGetters(['dynamicRBAC']),
+
+    mgmtClusterId() {
+      const pCluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, this.clusterId);
+
+      return this.value?.status?.clusterName || pCluster?.status?.clusterName;
+    },
+
+    // Determine if the dashboard has all of the dynamic resources following a cluster create. Ideally this would be as simple as seeing if the user is an admin
+    hasDynamicSchema() {
+      const hasDynamicSchema = this.$store.getters['management/schemaFor'](this.dynamicSchema);
+
+      // console.warn('cluster-rbac: ', 2, hasDynamicSchema, this.initialClusterCount)
+      return !!hasDynamicSchema;
+    },
+  },
+
+  methods: {
+    async dynamicRbacFetch() {
+      // Fetch number of clusters before attempt to create one, also register our interest in this resource type (in case we start on this page)
+      const clusters = await this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
+
+      this.initialClusterCount = clusters?.length; // Needs to be stored before clusters updates
+    },
+
+    async handleDynamicRBAC() {
+      // An admin has access to all resource schemas and can exercise all(?) actions against individual resources and resource collections
+      // Non-admins however begin with a very small set of schemas and some only with POST rights. After they have access to a single cluster
+      // they gain the rights required to continue.
+      // These rights are not pushed to the client, so behold....
+
+      // Before refreshing schemas / resource types via resetting the subscription ensure that the backend has caught up with the RBAC
+      // changes following the cluster creation
+      await this.waitForNewSchemaAccess();
+
+      // Refresh that schema/resource instance states
+      await this.$store.dispatch('loadManagement', true);
+
+      // loadManagement re-fetches everything else.... but not `provisioning.cattle.io.clusters`, so request / wait again
+      await this.waitForProvisioningClusters();
+    },
+
+    async setDynamicRBACState(wait) {
+      await this.$store.dispatch('setDynamicRBACState', wait);
+    },
+
+    // ---
+
+    // Used to handle refreshing sockets in the ember world where we don't wait after cluster creation
+    async processDynamicRBAC() {
+      if (this.dynamicRBAC && !this.hasDynamicSchema) {
+        await this.handleDynamicRBAC();
+      }
+      await this.setDynamicRBACState(false);
+    },
+
+    // ----
+
+    async waitFor() {
+      await waitFor.waitFor(...arguments);
+    },
+
+    async waitForNewSchemaAccess() {
+      // We use the management node as a schema that a non-admin doesn't have access to before their first cluster... but will eventually
+      // Once we have this we know the backend will provide the correct responses for when we reset
+
+      await this.waitFor(
+        () => this.$store.getters['management/byId'](SCHEMA, this.dynamicSchema),
+        (nodeSchema) => {
+          if (!!nodeSchema) {
+            return true;
+          }
+        },
+        () => this.$store.dispatch('management/find', { type: SCHEMA, id: this.dynamicSchema }),
+        'Mgmt Node Schema',
+        'Failed to fetch new schemas'
+      );
+    },
+
+    async waitForProvisioningClusters() {
+      await this.waitFor(
+        () => this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER),
+        (clusters) => {
+          return !!clusters?.[0];
+        },
+        () => this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER, opt: { force: true } }),
+        'Provisioning Cluster',
+        'Failed to find provisioning cluster'
+      );
+    },
+
+  }
+
+};

--- a/models/chart.js
+++ b/models/chart.js
@@ -1,16 +1,17 @@
 import { compatibleVersionsFor } from '@/store/catalog';
 import {
-  REPO_TYPE, REPO, CHART, VERSION, _FLAGGED,
+  REPO_TYPE, REPO, CHART, VERSION, _FLAGGED, HIDE_SIDE_NAV
 } from '@/config/query-params';
+import { BLANK_CLUSTER } from '@/store';
 
 export default {
   queryParams() {
-    return (from) => {
+    return (from, hideSideNav) => {
       let version;
       const chartVersions = this.versions;
       const currentCluster = this.$rootGetters['currentCluster'];
 
-      const clusterProvider = currentCluster.status.provider || 'other';
+      const clusterProvider = currentCluster?.status.provider || 'other';
       const windowsVersions = (chartVersions, 'windows');
       const linuxVersions = compatibleVersionsFor(chartVersions, 'linux');
 
@@ -33,18 +34,22 @@ export default {
         out[from] = _FLAGGED;
       }
 
+      if (hideSideNav) {
+        out[HIDE_SIDE_NAV] = _FLAGGED;
+      }
+
       return out;
     };
   },
 
   goToInstall() {
-    return (from, clusterId) => {
-      const query = this.queryParams(from);
+    return (from, clusterId, hideSideNav) => {
+      const query = this.queryParams(from, hideSideNav);
       const currentCluster = this.$rootGetters['currentCluster'];
 
       this.currentRouter().push({
         name:   'c-cluster-apps-charts-install',
-        params: { cluster: clusterId || currentCluster.id },
+        params: { cluster: clusterId || currentCluster?.id || BLANK_CLUSTER },
         query,
       });
     };

--- a/models/management.cattle.io.user.js
+++ b/models/management.cattle.io.user.js
@@ -1,4 +1,4 @@
-import { NORMAN } from '@/config/types';
+import { MANAGEMENT, NORMAN } from '@/config/types';
 
 export default {
   isSystem() {
@@ -15,6 +15,27 @@ export default {
     const currentPrincipal = this.$rootGetters['auth/principalId'];
 
     return !!(this.principalIds || []).find(p => p === currentPrincipal);
+  },
+
+  async isAdmin() {
+    const canSeeSchemas = !!this.$store.getters[`management/schemaFor`](MANAGEMENT.GLOBAL_ROLE) && !!this.$store.getters[`management/schemaFor`](MANAGEMENT.GLOBAL_ROLE);
+
+    if (canSeeSchemas) {
+      // Cannot determine so can't be
+      return false;
+    }
+    const roles = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.GLOBAL_ROLE });
+    const globalRoleBindings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.GLOBAL_ROLE_BINDING });
+
+    return !!globalRoleBindings
+      .find((binding) => {
+        if (binding.userName !== this.id) {
+          return false;
+        }
+        const globalRole = roles.find(r => r.id === binding.globalRoleName);
+
+        return globalRole.id === 'admin';
+      });
   },
 
   principals() {

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -159,7 +159,10 @@ export default {
   waitForMgmt() {
     return (timeout, interval) => {
       return this.waitForTestFn(() => {
-        const name = this.status?.clusterName;
+        // `this` instance isn't getting updated with `status.clusterName`
+        // Workaround - Get fresh copy from the store
+        const pCluster = this.$getters['byId'](CAPI.RANCHER_CLUSTER, this.id);
+        const name = this.status?.clusterName || pCluster?.status?.clusterName;
 
         return name && !!this.$getters['byId'](MANAGEMENT.CLUSTER, name);
       }, `mgmt cluster create`, timeout, interval);

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -23,7 +23,7 @@ import ChartMixin from '@/mixins/chart';
 import ChildHook, { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
 import { CATALOG, MANAGEMENT } from '@/config/types';
 import {
-  CHART, FROM_CLUSTER, FROM_TOOLS, NAMESPACE, REPO, REPO_TYPE, VERSION, _FLAGGED
+  CHART, FROM_CLUSTER, FROM_TOOLS, HIDE_SIDE_NAV, NAMESPACE, REPO, REPO_TYPE, VERSION, _FLAGGED
 } from '@/config/query-params';
 import { CATALOG as CATALOG_ANNOTATIONS, PROJECT } from '@/config/labels-annotations';
 
@@ -40,8 +40,16 @@ const VALUES_STATE = {
   DIFF: 'DIFF'
 };
 
+function isPlainLayout(query) {
+  return Object.keys(query).includes(HIDE_SIDE_NAV);
+}
+
 export default {
   name: 'Install',
+
+  layout(context) {
+    return isPlainLayout(context.query) ? 'plain' : '';
+  },
 
   components: {
     Banner,
@@ -260,7 +268,9 @@ export default {
 
       customSteps: [
 
-      ]
+      ],
+
+      isPlainLayout: isPlainLayout(this.$route.query)
     };
   },
 
@@ -728,12 +738,12 @@ export default {
       const cluster = this.currentCluster;
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
-      const isWindows = cluster.providerOs === 'windows';
-      const pathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
-      const windowsPathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
+      const isWindows = cluster?.providerOs === 'windows';
+      const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
+      const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
 
-      setIfNotSet(cattle, 'clusterId', cluster.id);
-      setIfNotSet(cattle, 'clusterName', cluster.nameDisplay);
+      setIfNotSet(cattle, 'clusterId', cluster?.id);
+      setIfNotSet(cattle, 'clusterName', cluster?.nameDisplay);
       setIfNotSet(cattle, 'systemDefaultRegistry', defaultRegistry);
       setIfNotSet(global, 'systemDefaultRegistry', defaultRegistry);
       setIfNotSet(cattle, 'url', serverUrl);
@@ -761,13 +771,13 @@ export default {
       const cluster = this.$store.getters['currentCluster'];
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
-      const isWindows = cluster.providerOs === 'windows';
-      const pathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
-      const windowsPathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
+      const isWindows = cluster?.providerOs === 'windows';
+      const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
+      const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
 
       if ( values.global?.cattle ) {
-        deleteIfEqual(values.global.cattle, 'clusterId', cluster.id);
-        deleteIfEqual(values.global.cattle, 'clusterName', cluster.nameDisplay);
+        deleteIfEqual(values.global.cattle, 'clusterId', cluster?.id);
+        deleteIfEqual(values.global.cattle, 'clusterName', cluster?.nameDisplay);
         deleteIfEqual(values.global.cattle, 'systemDefaultRegistry', defaultRegistry);
         deleteIfEqual(values.global.cattle, 'url', serverUrl);
         deleteIfEqual(values.global.cattle, 'rkePathPrefix', pathPrefix);
@@ -959,7 +969,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <div v-else class="install-steps">
+  <div v-else class="install-steps" :class="{ 'isPlainLayout': isPlainLayout}">
     <Wizard
       v-if="value"
       :steps="steps"
@@ -1264,6 +1274,10 @@ export default {
   .install-steps {
     position: relative;
     overflow: hidden;
+
+    &.isPlainLayout {
+      padding: 20px;
+    }
 
     .description {
       display: flex;

--- a/pages/c/_cluster/settings/brand.vue
+++ b/pages/c/_cluster/settings/brand.vue
@@ -14,6 +14,8 @@ import { getVendor, setVendor } from '@/config/private-label';
 import { SETTING, fetchOrCreateSetting } from '@/config/settings';
 import isEmpty from 'lodash/isEmpty';
 import { clone } from '@/utils/object';
+import { _EDIT, _VIEW } from '@/config/query-params';
+
 const Color = require('color');
 const parse = require('url-parse');
 
@@ -95,6 +97,14 @@ export default {
 
       errors: []
     };
+  },
+
+  computed: {
+    mode() {
+      const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
+
+      return schema?.resourceMethods?.includes('PUT') ? _EDIT : _VIEW;
+    }
   },
 
   watch: {
@@ -223,7 +233,7 @@ export default {
     <div>
       <div class="row mb-20">
         <div class="col span-6">
-          <LabeledInput v-model="uiPLSetting.value" :label="t('branding.uiPL.label')" />
+          <LabeledInput v-model="uiPLSetting.value" :label="t('branding.uiPL.label')" :mode="mode" />
         </div>
       </div>
 
@@ -235,10 +245,10 @@ export default {
       </label>
       <div :style="{'align-items':'center'}" class="row mt-10">
         <div class="col span-6 pb-5">
-          <LabeledInput v-model="uiIssuesSetting.value" :label="t('branding.uiIssues.issuesUrl')" />
+          <LabeledInput v-model="uiIssuesSetting.value" :label="t('branding.uiIssues.issuesUrl')" :mode="mode" />
         </div>
         <div class="col span-6">
-          <Checkbox :value="uiCommunitySetting.value === 'true'" :label="t('branding.uiIssues.communityLinks')" @input="e=>$set(uiCommunitySetting, 'value', e.toString())" />
+          <Checkbox :value="uiCommunitySetting.value === 'true'" :label="t('branding.uiIssues.communityLinks')" :mode="mode" @input="e=>$set(uiCommunitySetting, 'value', e.toString())" />
         </div>
       </div>
 
@@ -250,7 +260,7 @@ export default {
       </label>
 
       <div class="row mt-10 mb-20">
-        <Checkbox v-model="customizeLogo" :label="t('branding.logos.useCustom')" />
+        <Checkbox v-model="customizeLogo" :label="t('branding.logos.useCustom')" :mode="mode" />
       </div>
 
       <div v-if="customizeLogo" class="row mb-20">
@@ -261,6 +271,7 @@ export default {
               :read-as-data-url="true"
               class="role-secondary"
               :label="t('branding.logos.uploadLight')"
+              :mode="mode"
               @error="setError"
               @selected="updateLogo($event, 'uiLogoLight')"
             />
@@ -277,6 +288,7 @@ export default {
               :read-as-data-url="true"
               class="role-secondary"
               :label="t('branding.logos.uploadDark')"
+              :mode="mode"
               @error="setError"
               @selected="updateLogo($event, 'uiLogoDark')"
             />
@@ -295,7 +307,7 @@ export default {
         {{ t('branding.color.tip', {}, true) }}
       </label>
       <div class="row mt-20">
-        <Checkbox v-model="customizeColor" :label="t('branding.color.useCustom')" />
+        <Checkbox v-model="customizeColor" :label="t('branding.color.useCustom')" :mode="mode" />
       </div>
       <div v-if="customizeColor" class="row mt-20 mb-20">
         <ColorInput v-model="uiColor" />
@@ -311,7 +323,7 @@ export default {
       <template>
         <div class="row mt-20 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showHeader==='true'" :label="t('branding.uiBanner.showHeader')" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
+            <Checkbox :value="bannerVal.showHeader==='true'" :label="t('branding.uiBanner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
           </div>
         </div>
         <div v-if="bannerVal.showHeader==='true'" class="row mb-20">
@@ -333,7 +345,7 @@ export default {
         </div>
         <div class="row">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showFooter==='true'" :label="t('branding.uiBanner.showFooter')" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
+            <Checkbox :value="bannerVal.showFooter==='true'" :label="t('branding.uiBanner.showFooter')" :mode="mode" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
           </div>
         </div>
         <div v-if="bannerVal.showFooter==='true'" class="row">

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -29,6 +29,7 @@ import {
   validateLength,
   validateBoolean
 } from '@/utils/validators';
+import waitFor from '@/utils/waitFor';
 
 import { ANNOTATIONS_TO_IGNORE_REGEX, DESCRIPTION, LABELS_TO_IGNORE_REGEX, NORMAN_NAME } from '@/config/labels-annotations';
 import {
@@ -66,9 +67,6 @@ const REMAP_STATE = {
 
 const DEFAULT_COLOR = 'warning';
 const DEFAULT_ICON = 'x';
-
-const DEFAULT_WAIT_INTERVAL = 1000;
-const DEFAULT_WAIT_TMIMEOUT = 30000;
 
 export const STATES = {
   'in-progress':      { color: 'info', icon: 'tag' },
@@ -512,43 +510,7 @@ export default {
   // ------------------------------------------------------------------
 
   waitForTestFn() {
-    return (fn, msg, timeoutMs, intervalMs) => {
-      console.log('Starting wait for', msg); // eslint-disable-line no-console
-
-      if ( !timeoutMs ) {
-        timeoutMs = DEFAULT_WAIT_TMIMEOUT;
-      }
-
-      if ( !intervalMs ) {
-        intervalMs = DEFAULT_WAIT_INTERVAL;
-      }
-
-      return new Promise((resolve, reject) => {
-        // Do a first check immediately
-        if ( fn.apply(this) ) {
-          console.log('Wait for', msg, 'done immediately'); // eslint-disable-line no-console
-          resolve(this);
-        }
-
-        const timeout = setTimeout(() => {
-          console.log('Wait for', msg, 'timed out'); // eslint-disable-line no-console
-          clearInterval(interval);
-          clearTimeout(timeout);
-          reject(new Error(`Failed while: ${ msg }`));
-        }, timeoutMs);
-
-        const interval = setInterval(() => {
-          if ( fn.apply(this) ) {
-            console.log('Wait for', msg, 'done'); // eslint-disable-line no-console
-            clearInterval(interval);
-            clearTimeout(timeout);
-            resolve(this);
-          } else {
-            console.log('Wait for', msg, 'not done yet'); // eslint-disable-line no-console
-          }
-        }, intervalMs);
-      });
-    };
+    return waitFor.testFn;
   },
 
   waitForState() {
@@ -610,10 +572,10 @@ export default {
   },
 
   waitForCondition() {
-    return (name, withStatus = 'True', timeoutMs = DEFAULT_WAIT_TMIMEOUT, intervalMs = DEFAULT_WAIT_INTERVAL) => {
+    return (name, withStatus = 'True') => {
       return this.waitForTestFn(() => {
         return this.isCondition(name, withStatus);
-      }, `condition ${ name }=${ withStatus }`, timeoutMs, intervalMs);
+      }, `condition ${ name }=${ withStatus }`);
     };
   },
 

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -67,7 +67,7 @@ export const getters = {
     const repoKeys = getters.repos.map(x => x._key);
     let cluster = rootGetters['currentCluster'];
 
-    if ( rootGetters['currentProduct'].inStore === 'management' ) {
+    if ( rootGetters['currentProduct']?.inStore === 'management' ) {
       cluster = null;
     }
 
@@ -319,7 +319,10 @@ export const actions = {
     } = ctx;
 
     let promises = {};
-    const inStore = rootGetters['currentProduct'].inStore;
+    // Installing an app? This is fine (in cluster store)
+    // Fetching list of cluster templates? This is fine (in management store)
+    // Installing a cluster template? This isn't fine (in cluster store as per insalling app, but if there is no cluster we need to default to management)
+    const inStore = rootGetters['currentCluster'] ? rootGetters['currentProduct'].inStore : 'management';
 
     if ( rootGetters[`${ inStore }/schemaFor`](CATALOG.CLUSTER_REPO) ) {
       promises.cluster = dispatch(`${ inStore }/findAll`, { type: CATALOG.CLUSTER_REPO }, { root: true });

--- a/store/index.js
+++ b/store/index.js
@@ -40,6 +40,7 @@ export const state = () => {
     error:            null,
     cameFromError:    false,
     pageActions:      [],
+    dynamicRBAC:      false,
   };
 };
 
@@ -355,6 +356,10 @@ export const getters = {
 
     return '/';
   },
+
+  dynamicRBAC(state) {
+    return state.dynamicRBAC;
+  },
 };
 
 export const mutations = {
@@ -417,15 +422,28 @@ export const mutations = {
   cameFromError(state) {
     state.cameFromError = true;
   },
+
+  dynamicRBACStare(state, neu) {
+    state.dynamicRBAC = neu;
+  }
 };
 
 export const actions = {
   async loadManagement({
     getters, state, commit, dispatch
-  }) {
-    if ( state.managementReady) {
+  }, force = false) {
+    if ( state.managementReady && !force) {
       // Do nothing, it's already loaded
       return;
+    }
+
+    if (state.managementReady) {
+      await dispatch('management/unsubscribe');
+      // commit('managementChanged', { ready: false });
+      commit('management/reset');
+
+      await dispatch('rancher/unsubscribe');
+      commit('rancher/reset');
     }
 
     console.log('Loading management...'); // eslint-disable-line no-console
@@ -666,4 +684,7 @@ export const actions = {
     router.replace('/fail-whale');
   },
 
+  setDynamicRBACState({ commit }, neu) {
+    commit('dynamicRBACStare', neu);
+  }
 };

--- a/store/index.js
+++ b/store/index.js
@@ -416,14 +416,14 @@ export const mutations = {
 
   cameFromError(state) {
     state.cameFromError = true;
-  }
+  },
 };
 
 export const actions = {
   async loadManagement({
     getters, state, commit, dispatch
   }) {
-    if ( state.managementReady ) {
+    if ( state.managementReady) {
       // Do nothing, it's already loaded
       return;
     }
@@ -664,5 +664,6 @@ export const actions = {
     const router = state.$router;
 
     router.replace('/fail-whale');
-  }
+  },
+
 };

--- a/utils/waitFor.js
+++ b/utils/waitFor.js
@@ -1,0 +1,56 @@
+const DEFAULT_WAIT_INTERVAL = 1000;
+const DEFAULT_WAIT_TIMEOUT = 30000;
+
+export default {
+  testFn(fn, msg, timeoutMs, intervalMs) {
+    console.log('Starting wait for', msg); // eslint-disable-line no-console
+
+    if ( !timeoutMs ) {
+      timeoutMs = DEFAULT_WAIT_TIMEOUT;
+    }
+
+    if ( !intervalMs ) {
+      intervalMs = DEFAULT_WAIT_INTERVAL;
+    }
+
+    return new Promise((resolve, reject) => {
+      // Do a first check immediately
+      if ( fn.apply(this) ) {
+        console.log('Wait for', msg, 'done immediately'); // eslint-disable-line no-console
+        resolve(this);
+      }
+
+      const timeout = setTimeout(() => {
+        console.log('Wait for', msg, 'timed out'); // eslint-disable-line no-console
+        clearInterval(interval);
+        clearTimeout(timeout);
+        reject(new Error(`Failed while: ${ msg }`));
+      }, timeoutMs);
+
+      const interval = setInterval(() => {
+        if ( fn.apply(this) ) {
+          console.log('Wait for', msg, 'done'); // eslint-disable-line no-console
+          clearInterval(interval);
+          clearTimeout(timeout);
+          resolve(this);
+        } else {
+          console.log('Wait for', msg, 'not done yet'); // eslint-disable-line no-console
+        }
+      }, intervalMs);
+    });
+  },
+
+  async waitFor(getterFn, testFn, fetchFn, msg, errorMsg) {
+    try {
+      await this.testFn(() => {
+        if (testFn(getterFn())) {
+          return true;
+        }
+        fetchFn();
+      }, msg, undefined, 2000);
+    } catch (e) {
+      console.warn(errorMsg, e); // eslint-disable-line no-console
+      throw new Error(errorMsg);
+    }
+  },
+};


### PR DESCRIPTION
See second commit for changes (branch based on #3554

This is an attempt to resolve #3719 which has become incredibly convoluted with multiple bugs regarding the socket reset.

**Approach**
- Clusters creating within the dashboard (import, create RKE2)
  - Don't block transition (avoids showing embeded cluster list), instead handle in cluster list / detail
  - Do so by setting flag in store before EmberPage navigates away. Cluster list/detail will then use this to determine if we should reset sockets
- Clusters creating within ember (create RKE2, create custom)
  - Block transition away from create screen in order to determine management cluster id and apply roles

**Problems with this PR**
- There's a lot of hooks we have to cater for regarding the different types of ways a user can go from 0 to 1 clusters (see below)
- We never know when the permissions have been updated following creation, so have to poll for a random schema we didn't have access to before
- Resetting the sockets sometimes doesn't result in updates coming through for the provisioning type (see below)
- It only solves the problem of going from the situation where a user has no clusters --> gains rights --> loses rights. It does not cover the reverse. 

**Other issues**
- Haven't touched restricted-admin yet

**Specific Cluster Info**

After all of the following types, where a cluster can be created, we need to handle the change in roles

Import Hosted (embedded)
- Haven't touched, but should be similar to create RKE1

Import Generic
- Navigation to cluster list works and can see new cluster
- If the new cluster is deleted the list _does not_ react and can still see cluster
- if the new cluster is deleted by another browser the list _does not_ react and can still see cluster

Create By Template (helm install)
- Haven't touched, this could be handled with a small hook just like create RKE1

Create Hosted Cluster (embedded)
- Haven't touched, but should be similar to create RKE1

Create RKE1 (embedded)
- This eventually works, but presented with empty list to start with
- if the new cluster is deleted the list _does_ react and the cluster is removed
- if the new cluster is deleted by another browser the list _does not_ react and can still see cluster

Create RKE2
- This eventually works, but process is very slow
- if the new cluster is deleted a 'page not found' error is shown (dev). In console `[vue-router] Route with name 'c-cluster-product-resour' does not exist`. 
- if the new cluster is deleted by another browser the list _does not_ react and can still see cluster

Create Custom  (embedded)
- The redirect to cluster detail page for some reason does not work in branch (the EmberPage receiveMessage never fires after create, fires in other scenarios)


 