### PR TITLE
[2.6] Non-admin permissions based errors

### DIFF
--- a/components/IndentedPanel.vue
+++ b/components/IndentedPanel.vue
@@ -10,6 +10,7 @@ export default {};
 
 <style lang="scss">
   .indented-panel {
+    height: 100%;
     width: 90%;
     margin-left: 5%;
   }

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -208,6 +208,7 @@ export default {
       as:              null,
       value:           null,
       model:           null,
+      notFound:        null,
     };
   },
 

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -225,37 +225,40 @@ export default {
               </div>
             </nuxt-link>
           </div>
-          <div class="category">
-            {{ t('nav.categories.explore') }}
-          </div>
-          <div v-if="showClusterSearch" class="search">
-            <input
-              ref="clusterFilter"
-              v-model="clusterFilter"
-              :placeholder="t('nav.search.placeholder')"
-            />
-            <i v-if="clusterFilter.length > 0" class="icon icon-close" @click="clusterFilter=''" />
-          </div>
-          <div ref="clusterList" class="clusters">
-            <div v-for="c in clusters" :key="c.id" @click="hide()">
-              <nuxt-link
-                v-if="c.ready"
-                class="cluster selector option"
-                :to="{ name: 'c-cluster', params: { cluster: c.id } }"
-              >
-                <RancherProviderIcon v-if="c.isLocal" width="24" class="rancher-provider-icon" />
-                <img v-else :src="c.logo" />
-                <div>{{ c.label }}</div>
-              </nuxt-link>
-              <span v-else class="option-disabled cluster selector disabled">
-                <img :src="c.logo" />
-                <div>{{ c.label }}</div>
-              </span>
+          <template v-if="clusters && !!clusters.length">
+            <div class="category">
+              {{ t('nav.categories.explore') }}
             </div>
-            <div v-if="clusters.length === 0" class="none-matching">
-              {{ t('nav.search.noResults') }}
+            <div v-if="showClusterSearch" class="search">
+              <input
+                ref="clusterFilter"
+                v-model="clusterFilter"
+                :placeholder="t('nav.search.placeholder')"
+              />
+              <i v-if="clusterFilter.length > 0" class="icon icon-close" @click="clusterFilter=''" />
             </div>
-          </div>
+            <div ref="clusterList" class="clusters">
+              <div v-for="c in clusters" :key="c.id" @click="hide()">
+                <nuxt-link
+                  v-if="c.ready"
+                  class="cluster selector option"
+                  :to="{ name: 'c-cluster', params: { cluster: c.id } }"
+                >
+                  <RancherProviderIcon v-if="c.isLocal" width="24" class="rancher-provider-icon" />
+                  <img v-else :src="c.logo" />
+                  <div>{{ c.label }}</div>
+                </nuxt-link>
+                <span v-else class="option-disabled cluster selector disabled">
+                  <img :src="c.logo" />
+                  <div>{{ c.label }}</div>
+                </span>
+              </div>
+              <div v-if="clusters.length === 0" class="none-matching">
+                {{ t('nav.search.noResults') }}
+              </div>
+            </div>
+          </template>
+
           <template v-if="multiClusterApps.length">
             <div class="category">
               {{ t('nav.categories.multiCluster') }}

--- a/config/query-params.js
+++ b/config/query-params.js
@@ -60,6 +60,7 @@ export const DEPRECATED = 'deprecated';
 export const HIDDEN = 'hidden';
 export const FROM_TOOLS = 'tools';
 export const FROM_CLUSTER = 'cluster';
+export const HIDE_SIDE_NAV = 'hide-side-nav';
 
 // Cluster provisioning
 export const PROVIDER = 'provider';

--- a/edit/provisioning.cattle.io.cluster/import.vue
+++ b/edit/provisioning.cattle.io.cluster/import.vue
@@ -1,5 +1,6 @@
 <script>
 import CreateEditView from '@/mixins/create-edit-view';
+
 import CruResource from '@/components/CruResource';
 import Loading from '@/components/Loading';
 import NameNsDescription from '@/components/form/NameNsDescription';

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -16,6 +16,7 @@ import { CATALOG } from '@/config/labels-annotations';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE } from '@/store/features';
 import { allHash } from '@/utils/promise';
+import { BLANK_CLUSTER } from '@/store';
 import Rke2Config from './rke2';
 import Import from './import';
 
@@ -300,9 +301,8 @@ export default {
 
       if ( parts[0] === 'chart' ) {
         const chart = this.$store.getters['catalog/chart']({ key: parts[1] });
-        const localCluster = this.$store.getters['management/all'](MANAGEMENT.CLUSTER).find(x => x.isLocal);
 
-        chart.goToInstall(FROM_CLUSTER, localCluster.id);
+        chart.goToInstall(FROM_CLUSTER, BLANK_CLUSTER, true);
 
         return;
       }

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -6,6 +6,7 @@ import merge from 'lodash/merge';
 import { mapGetters } from 'vuex';
 
 import CreateEditView from '@/mixins/create-edit-view';
+
 import { CAPI, MANAGEMENT, NORMAN } from '@/config/types';
 import { _CREATE, _EDIT } from '@/config/query-params';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
@@ -967,6 +968,7 @@ export default {
     canRemoveKubeletRow(row, idx) {
       return idx !== 0;
     },
+
   },
 };
 </script>

--- a/layouts/plain.vue
+++ b/layouts/plain.vue
@@ -28,9 +28,6 @@ export default {
       name: this.$route.name,
     };
   },
-  mounted() {
-    this.$store.dispatch('prefs/setBrand');
-  },
 
 };
 </script>

--- a/list/management.cattle.io.setting.vue
+++ b/list/management.cattle.io.setting.vue
@@ -46,7 +46,7 @@ export default {
       }
       // There are only 2 actions that can be enabled - Edit Setting or View in API
       // If neither is available for this setting then we hide the action menu button
-      s.hasActions = !s.readOnly || isDev;
+      s.hasActions = (!s.readOnly || isDev) && settingsMap[setting].availableActions?.length;
       settings.push(s);
     });
     this.settings = settings;

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -9,18 +9,31 @@ export default {
   components: { ResourceTable, Masthead },
 
   async fetch() {
-    const hash = await allHash({
+    const hash = {
       mgmtClusters:       this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
-      // Used to determine non-rke2 node counts
-      mgmtNodes:          this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE }),
-      mgmtPools:          this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL }),
-      mgmtTemplates:      this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE }),
       rancherClusters:    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
-      machineDeployments: this.$store.dispatch('management/findAll', { type: CAPI.MACHINE_DEPLOYMENT })
-    });
+    };
 
-    this.mgmtClusters = hash.mgmtClusters;
-    this.rancherClusters = hash.rancherClusters;
+    if ( this.$store.getters['management/schemaFor'](MANAGEMENT.NODE) ) {
+      hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
+    }
+
+    if ( this.$store.getters['management/schemaFor'](MANAGEMENT.NODE_POOL) ) {
+      hash.mgmtPools = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL });
+    }
+
+    if ( this.$store.getters['management/schemaFor'](MANAGEMENT.NODE_TEMPLATE) ) {
+      hash.mgmtTemplates = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE });
+    }
+
+    if ( this.$store.getters['management/schemaFor'](CAPI.MACHINE_DEPLOYMENT) ) {
+      hash.machineDeployments = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE_DEPLOYMENT });
+    }
+
+    const res = await allHash(hash);
+
+    this.mgmtClusters = res.mgmtClusters;
+    this.rancherClusters = res.rancherClusters;
   },
 
   data() {

--- a/mixins/chart.js
+++ b/mixins/chart.js
@@ -67,7 +67,7 @@ export default {
 
       const versions = this.chart?.versions || [];
       const selectedVersion = this.targetVersion;
-      const isWindows = currentCluster.providerOs === 'windows';
+      const isWindows = currentCluster?.providerOs === 'windows';
       const out = [];
 
       versions.forEach((version) => {
@@ -162,8 +162,8 @@ export default {
         const needMemory = parseSi(this.version?.annotations?.[CATALOG_ANNOTATIONS.REQUESTS_MEMORY] || '0');
 
         // Note: These are null if unknown
-        const availableCpu = this.currentCluster.availableCpu;
-        const availableMemory = this.currentCluster.availableMemory;
+        const availableCpu = this.currentCluster?.availableCpu;
+        const availableMemory = this.currentCluster?.availableMemory;
 
         if ( availableCpu !== null && availableCpu < needCpu ) {
           warnings.push(this.t('catalog.install.error.insufficientCpu', {

--- a/models/chart.js
+++ b/models/chart.js
@@ -1,16 +1,17 @@
 import { compatibleVersionsFor } from '@/store/catalog';
 import {
-  REPO_TYPE, REPO, CHART, VERSION, _FLAGGED,
+  REPO_TYPE, REPO, CHART, VERSION, _FLAGGED, HIDE_SIDE_NAV
 } from '@/config/query-params';
+import { BLANK_CLUSTER } from '@/store';
 
 export default {
   queryParams() {
-    return (from) => {
+    return (from, hideSideNav) => {
       let version;
       const chartVersions = this.versions;
       const currentCluster = this.$rootGetters['currentCluster'];
 
-      const clusterProvider = currentCluster.status.provider || 'other';
+      const clusterProvider = currentCluster?.status.provider || 'other';
       const windowsVersions = (chartVersions, 'windows');
       const linuxVersions = compatibleVersionsFor(chartVersions, 'linux');
 
@@ -33,18 +34,22 @@ export default {
         out[from] = _FLAGGED;
       }
 
+      if (hideSideNav) {
+        out[HIDE_SIDE_NAV] = _FLAGGED;
+      }
+
       return out;
     };
   },
 
   goToInstall() {
-    return (from, clusterId) => {
-      const query = this.queryParams(from);
+    return (from, clusterId, hideSideNav) => {
+      const query = this.queryParams(from, hideSideNav);
       const currentCluster = this.$rootGetters['currentCluster'];
 
       this.currentRouter().push({
         name:   'c-cluster-apps-charts-install',
-        params: { cluster: clusterId || currentCluster.id },
+        params: { cluster: clusterId || currentCluster?.id || BLANK_CLUSTER },
         query,
       });
     };

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -162,7 +162,7 @@ export default {
         // `this` instance isn't getting updated with `status.clusterName`
         // Workaround - Get fresh copy from the store
         const pCluster = this.$getters['byId'](CAPI.RANCHER_CLUSTER, this.id);
-        const name = this.status?.clusterName || pCluster.status?.clusterName;
+        const name = this.status?.clusterName || pCluster?.status?.clusterName;
 
         return name && !!this.$getters['byId'](MANAGEMENT.CLUSTER, name);
       }, `mgmt cluster create`, timeout, interval);

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -23,7 +23,7 @@ import ChartMixin from '@/mixins/chart';
 import ChildHook, { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
 import { CATALOG, MANAGEMENT } from '@/config/types';
 import {
-  CHART, FROM_CLUSTER, FROM_TOOLS, NAMESPACE, REPO, REPO_TYPE, VERSION, _FLAGGED
+  CHART, FROM_CLUSTER, FROM_TOOLS, HIDE_SIDE_NAV, NAMESPACE, REPO, REPO_TYPE, VERSION, _FLAGGED
 } from '@/config/query-params';
 import { CATALOG as CATALOG_ANNOTATIONS, PROJECT } from '@/config/labels-annotations';
 
@@ -40,8 +40,16 @@ const VALUES_STATE = {
   DIFF: 'DIFF'
 };
 
+function isPlainLayout(query) {
+  return Object.keys(query).includes(HIDE_SIDE_NAV);
+}
+
 export default {
   name: 'Install',
+
+  layout(context) {
+    return isPlainLayout(context.query) ? 'plain' : '';
+  },
 
   components: {
     Banner,
@@ -260,7 +268,9 @@ export default {
 
       customSteps: [
 
-      ]
+      ],
+
+      isPlainLayout: isPlainLayout(this.$route.query)
     };
   },
 
@@ -728,12 +738,12 @@ export default {
       const cluster = this.currentCluster;
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
-      const isWindows = cluster.providerOs === 'windows';
-      const pathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
-      const windowsPathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
+      const isWindows = cluster?.providerOs === 'windows';
+      const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
+      const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
 
-      setIfNotSet(cattle, 'clusterId', cluster.id);
-      setIfNotSet(cattle, 'clusterName', cluster.nameDisplay);
+      setIfNotSet(cattle, 'clusterId', cluster?.id);
+      setIfNotSet(cattle, 'clusterName', cluster?.nameDisplay);
       setIfNotSet(cattle, 'systemDefaultRegistry', defaultRegistry);
       setIfNotSet(global, 'systemDefaultRegistry', defaultRegistry);
       setIfNotSet(cattle, 'url', serverUrl);
@@ -761,13 +771,13 @@ export default {
       const cluster = this.$store.getters['currentCluster'];
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
-      const isWindows = cluster.providerOs === 'windows';
-      const pathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
-      const windowsPathPrefix = cluster.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
+      const isWindows = cluster?.providerOs === 'windows';
+      const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
+      const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
 
       if ( values.global?.cattle ) {
-        deleteIfEqual(values.global.cattle, 'clusterId', cluster.id);
-        deleteIfEqual(values.global.cattle, 'clusterName', cluster.nameDisplay);
+        deleteIfEqual(values.global.cattle, 'clusterId', cluster?.id);
+        deleteIfEqual(values.global.cattle, 'clusterName', cluster?.nameDisplay);
         deleteIfEqual(values.global.cattle, 'systemDefaultRegistry', defaultRegistry);
         deleteIfEqual(values.global.cattle, 'url', serverUrl);
         deleteIfEqual(values.global.cattle, 'rkePathPrefix', pathPrefix);
@@ -959,7 +969,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <div v-else class="install-steps">
+  <div v-else class="install-steps" :class="{ 'isPlainLayout': isPlainLayout}">
     <Wizard
       v-if="value"
       :steps="steps"
@@ -1264,6 +1274,10 @@ export default {
   .install-steps {
     position: relative;
     overflow: hidden;
+
+    &.isPlainLayout {
+      padding: 20px;
+    }
 
     .description {
       display: flex;

--- a/pages/c/_cluster/settings/brand.vue
+++ b/pages/c/_cluster/settings/brand.vue
@@ -14,6 +14,8 @@ import { getVendor, setVendor } from '@/config/private-label';
 import { SETTING, fetchOrCreateSetting } from '@/config/settings';
 import isEmpty from 'lodash/isEmpty';
 import { clone } from '@/utils/object';
+import { _EDIT, _VIEW } from '@/config/query-params';
+
 const Color = require('color');
 const parse = require('url-parse');
 
@@ -95,6 +97,14 @@ export default {
 
       errors: []
     };
+  },
+
+  computed: {
+    mode() {
+      const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
+
+      return schema?.resourceMethods?.includes('PUT') ? _EDIT : _VIEW;
+    }
   },
 
   watch: {
@@ -223,7 +233,7 @@ export default {
     <div>
       <div class="row mb-20">
         <div class="col span-6">
-          <LabeledInput v-model="uiPLSetting.value" :label="t('branding.uiPL.label')" />
+          <LabeledInput v-model="uiPLSetting.value" :label="t('branding.uiPL.label')" :mode="mode" />
         </div>
       </div>
 
@@ -235,10 +245,10 @@ export default {
       </label>
       <div :style="{'align-items':'center'}" class="row mt-10">
         <div class="col span-6 pb-5">
-          <LabeledInput v-model="uiIssuesSetting.value" :label="t('branding.uiIssues.issuesUrl')" />
+          <LabeledInput v-model="uiIssuesSetting.value" :label="t('branding.uiIssues.issuesUrl')" :mode="mode" />
         </div>
         <div class="col span-6">
-          <Checkbox :value="uiCommunitySetting.value === 'true'" :label="t('branding.uiIssues.communityLinks')" @input="e=>$set(uiCommunitySetting, 'value', e.toString())" />
+          <Checkbox :value="uiCommunitySetting.value === 'true'" :label="t('branding.uiIssues.communityLinks')" :mode="mode" @input="e=>$set(uiCommunitySetting, 'value', e.toString())" />
         </div>
       </div>
 
@@ -250,7 +260,7 @@ export default {
       </label>
 
       <div class="row mt-10 mb-20">
-        <Checkbox v-model="customizeLogo" :label="t('branding.logos.useCustom')" />
+        <Checkbox v-model="customizeLogo" :label="t('branding.logos.useCustom')" :mode="mode" />
       </div>
 
       <div v-if="customizeLogo" class="row mb-20">
@@ -261,6 +271,7 @@ export default {
               :read-as-data-url="true"
               class="role-secondary"
               :label="t('branding.logos.uploadLight')"
+              :mode="mode"
               @error="setError"
               @selected="updateLogo($event, 'uiLogoLight')"
             />
@@ -277,6 +288,7 @@ export default {
               :read-as-data-url="true"
               class="role-secondary"
               :label="t('branding.logos.uploadDark')"
+              :mode="mode"
               @error="setError"
               @selected="updateLogo($event, 'uiLogoDark')"
             />
@@ -295,7 +307,7 @@ export default {
         {{ t('branding.color.tip', {}, true) }}
       </label>
       <div class="row mt-20">
-        <Checkbox v-model="customizeColor" :label="t('branding.color.useCustom')" />
+        <Checkbox v-model="customizeColor" :label="t('branding.color.useCustom')" :mode="mode" />
       </div>
       <div v-if="customizeColor" class="row mt-20 mb-20">
         <ColorInput v-model="uiColor" />
@@ -311,7 +323,7 @@ export default {
       <template>
         <div class="row mt-20 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showHeader==='true'" :label="t('branding.uiBanner.showHeader')" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
+            <Checkbox :value="bannerVal.showHeader==='true'" :label="t('branding.uiBanner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
           </div>
         </div>
         <div v-if="bannerVal.showHeader==='true'" class="row mb-20">
@@ -333,7 +345,7 @@ export default {
         </div>
         <div class="row">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showFooter==='true'" :label="t('branding.uiBanner.showFooter')" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
+            <Checkbox :value="bannerVal.showFooter==='true'" :label="t('branding.uiBanner.showFooter')" :mode="mode" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
           </div>
         </div>
         <div v-if="bannerVal.showFooter==='true'" class="row">

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -67,7 +67,7 @@ export const getters = {
     const repoKeys = getters.repos.map(x => x._key);
     let cluster = rootGetters['currentCluster'];
 
-    if ( rootGetters['currentProduct'].inStore === 'management' ) {
+    if ( rootGetters['currentProduct']?.inStore === 'management' ) {
       cluster = null;
     }
 
@@ -319,7 +319,10 @@ export const actions = {
     } = ctx;
 
     let promises = {};
-    const inStore = rootGetters['currentProduct'].inStore;
+    // Installing an app? This is fine (in cluster store)
+    // Fetching list of cluster templates? This is fine (in management store)
+    // Installing a cluster template? This isn't fine (in cluster store as per insalling app, but if there is no cluster we need to default to management)
+    const inStore = rootGetters['currentCluster'] ? rootGetters['currentProduct'].inStore : 'management';
 
     if ( rootGetters[`${ inStore }/schemaFor`](CATALOG.CLUSTER_REPO) ) {
       promises.cluster = dispatch(`${ inStore }/findAll`, { type: CATALOG.CLUSTER_REPO }, { root: true });

--- a/store/index.js
+++ b/store/index.js
@@ -416,14 +416,14 @@ export const mutations = {
 
   cameFromError(state) {
     state.cameFromError = true;
-  }
+  },
 };
 
 export const actions = {
   async loadManagement({
     getters, state, commit, dispatch
   }) {
-    if ( state.managementReady ) {
+    if ( state.managementReady) {
       // Do nothing, it's already loaded
       return;
     }
@@ -664,5 +664,6 @@ export const actions = {
     const router = state.$router;
 
     router.replace('/fail-whale');
-  }
+  },
+
 };


### PR DESCRIPTION
_This is a fix of #3554 (managed to push master changes to 2.6 branch). Comments have been lost on that PR, but all have either had their code fixed as per first comments or moved to another PR._

Along with recent updates to the backend (https://github.com/rancher/rancher/pull/33791) this fixes all but a few issues in #3416. Remaining...
  - Standard User, member of a single non-local cluster - Feature Flags - Action buttons shown with 'no actions available' text

Other RBAC Fixes
- Standard User, member of no clusters
  - Fixed multiple bugs when installing a cluster from a template (missing currentCluster, display of helm install stepper, catalog requests `inStore` fixed when there's no cluster)

Other Fixes
- Add error handling to cluster save fn
- Fixed error in console due dispatching old removed action in plain layout
- Ensure we wait for cluster roles to be applied (MembershipEditor)

Contains #3711
