### PR TITLE
[2.6] Disable editing RKE2 machine pool configs after creation

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -999,6 +999,8 @@ cluster:
     label: Cluster Name
     placeholder: A unique name for the cluster
   machineConfig:
+    banner:
+      updateInfo: Create a new pool to update machine configs
     aws:
       sizeLabel: |-
         {apiName}: {cpu}, {memory, number} GiB Memory, {storageSize, plural,

--- a/components/Questions/Array.vue
+++ b/components/Questions/Array.vue
@@ -23,6 +23,7 @@ export default {
         :title="question.label"
         :mode="mode"
         :protip="false"
+        :disabled="disabled"
         @input="update"
       />
     </div>

--- a/components/Questions/Boolean.vue
+++ b/components/Questions/Boolean.vue
@@ -15,6 +15,7 @@ export default {
         :mode="mode"
         :label="displayLabel"
         :value="value"
+        :disabled="disabled"
         @input="$emit('input', $event)"
       />
     </div>

--- a/components/Questions/CloudCredential.vue
+++ b/components/Questions/CloudCredential.vue
@@ -34,7 +34,7 @@ export default {
       <LabeledSelect
         :mode="mode"
         :options="options"
-        :disabled="$fetchState.pending"
+        :disabled="$fetchState.pending || disabled"
         :label="displayLabel"
         :placeholder="question.description"
         :required="question.required"

--- a/components/Questions/Enum.vue
+++ b/components/Questions/Enum.vue
@@ -18,6 +18,7 @@ export default {
         :placeholder="question.description"
         :required="question.required"
         :value="value"
+        :disabled="disabled"
         @input="$emit('input', $event)"
       />
     </div>

--- a/components/Questions/Float.vue
+++ b/components/Questions/Float.vue
@@ -20,6 +20,7 @@ export default {
         :placeholder="question.default"
         :required="question.required"
         :value="value"
+        :disabled="disabled"
         @input="val = parseFloat($event); if ( !isNaN(val) ) { $emit('input', val) }"
       />
     </div>

--- a/components/Questions/Int.vue
+++ b/components/Questions/Int.vue
@@ -20,6 +20,7 @@ export default {
         :placeholder="question.default"
         :required="question.required"
         :value="value"
+        :disabled="disabled"
         @input="val = parseInt($event, 10); if ( !isNaN(val) ) { $emit('input', val) }"
       />
     </div>

--- a/components/Questions/Map.vue
+++ b/components/Questions/Map.vue
@@ -29,6 +29,7 @@ export default {
           :title="question.label"
           :mode="mode"
           :protip="false"
+          :disabled="disabled"
           @input="update"
         />
       </div>

--- a/components/Questions/Question.js
+++ b/components/Questions/Question.js
@@ -21,6 +21,11 @@ export default {
       type:     null,
       required: true,
     },
+
+    disabled: {
+      type:    Boolean,
+      default: false,
+    }
   },
 
   computed: {

--- a/components/Questions/Reference.vue
+++ b/components/Questions/Reference.vue
@@ -82,7 +82,7 @@ export default {
       <LabeledSelect
         :mode="mode"
         :options="options"
-        :disabled="$fetchState.pending"
+        :disabled="$fetchState.pending || disabled"
         :label="displayLabel"
         :placeholder="question.description"
         :required="question.required"

--- a/components/Questions/String.vue
+++ b/components/Questions/String.vue
@@ -30,6 +30,7 @@ export default {
         :placeholder="question.default"
         :required="question.required"
         :value="value"
+        :disabled="disabled"
         @input="$emit('input', $event)"
       />
     </div>

--- a/components/Questions/index.vue
+++ b/components/Questions/index.vue
@@ -197,6 +197,11 @@ export default {
       type:    Array,
       default: () => [],
     },
+
+    disabled: {
+      type:    Boolean,
+      default: false,
+    }
   },
 
   data() {
@@ -327,6 +332,7 @@ export default {
             :question="q"
             :target-namespace="targetNamespace"
             :value="get(value, q.variable)"
+            :disabled="disabled"
             @input="set(value, q.variable, $event)"
           />
         </div>
@@ -349,6 +355,7 @@ export default {
             :target-namespace="targetNamespace"
             :mode="mode"
             :value="get(value, q.variable)"
+            :disabled="disabled"
             @input="set(value, q.variable, $event)"
           />
         </div>

--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -80,6 +80,11 @@ export default {
     loading: {
       type:    Boolean,
       default: false
+    },
+
+    disabled: {
+      type:    Boolean,
+      default: false,
     }
   },
 
@@ -261,7 +266,7 @@ export default {
                 ref="value"
                 v-model="row.value"
                 :placeholder="valuePlaceholder"
-                :disabled="isView"
+                :disabled="isView || disabled"
                 @paste="onPaste(idx, $event)"
                 @input="queueUpdate"
               />

--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -258,6 +258,7 @@ export default {
                 v-model="row.value"
                 :placeholder="valuePlaceholder"
                 :mode="mode"
+                :disabled="disabled"
                 @paste="onPaste(idx, $event)"
                 @input="queueUpdate"
               />

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -7,6 +7,7 @@ import { importMachineConfig } from '@/utils/dynamic-importer';
 import Taints from '@/components/form/Taints.vue';
 import KeyValue from '@/components/form/KeyValue.vue';
 import AdvancedSection from '@/components/AdvancedSection.vue';
+import Banner from '@/components/Banner';
 import { randomStr } from '@/utils/string';
 
 export default {
@@ -17,6 +18,7 @@ export default {
     Taints,
     KeyValue,
     AdvancedSection,
+    Banner,
   },
 
   props: {
@@ -124,6 +126,11 @@ export default {
     </div>
 
     <hr class="mt-10" />
+
+    <Banner
+      color="info"
+      :label="t('cluster.machineConfig.banner.updateInfo')"
+    />
 
     <component
       :is="configComponent"

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -101,7 +101,6 @@ export default {
           type="number"
           min="0"
           :required="true"
-          :disabled="!!value.config.id"
         />
       </div>
       <div class="col span-6 pt-5">
@@ -109,19 +108,16 @@ export default {
         <Checkbox
           v-model="value.pool.etcdRole"
           :mode="mode"
-          :disabled="!!value.config.id"
           label="etcd"
         />
         <Checkbox
           v-model="value.pool.controlPlaneRole"
           :mode="mode"
-          :disabled="!!value.config.id"
           label="Control Plane"
         />
         <Checkbox
           v-model="value.pool.workerRole"
           :mode="mode"
-          :disabled="!!value.config.id"
           label="Worker"
         />
       </div>

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -41,6 +41,11 @@ export default {
       type:     String,
       required: true,
     },
+
+    showWarning: {
+      type:    Boolean,
+      default: false
+    }
   },
 
   data() {
@@ -128,6 +133,7 @@ export default {
     <hr class="mt-10" />
 
     <Banner
+      v-if="showWarning"
       color="info"
       :label="t('cluster.machineConfig.banner.updateInfo')"
     />

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -85,7 +85,13 @@ export default {
   <div>
     <div class="row">
       <div class="col span-4">
-        <LabeledInput v-model="value.pool.name" :mode="mode" label="Pool Name" :required="true" :disabled="!!value.config.id" />
+        <LabeledInput
+          v-model="value.pool.name"
+          :mode="mode"
+          label="Pool Name"
+          :required="true"
+          :disabled="!!value.config.id"
+        />
       </div>
       <div class="col span-2">
         <LabeledInput
@@ -95,13 +101,29 @@ export default {
           type="number"
           min="0"
           :required="true"
+          :disabled="!!value.config.id"
         />
       </div>
       <div class="col span-6 pt-5">
         <h3>Roles</h3>
-        <Checkbox v-model="value.pool.etcdRole" :mode="mode" label="etcd" />
-        <Checkbox v-model="value.pool.controlPlaneRole" :mode="mode" label="Control Plane" />
-        <Checkbox v-model="value.pool.workerRole" :mode="mode" label="Worker" />
+        <Checkbox
+          v-model="value.pool.etcdRole"
+          :mode="mode"
+          :disabled="!!value.config.id"
+          label="etcd"
+        />
+        <Checkbox
+          v-model="value.pool.controlPlaneRole"
+          :mode="mode"
+          :disabled="!!value.config.id"
+          label="Control Plane"
+        />
+        <Checkbox
+          v-model="value.pool.workerRole"
+          :mode="mode"
+          :disabled="!!value.config.id"
+          label="Worker"
+        />
       </div>
     </div>
 
@@ -115,6 +137,7 @@ export default {
       :value="value.config"
       :provider="provider"
       :credential-id="credentialId"
+      :disabled="!!value.config.id"
       @error="e=>errors = e"
     />
 

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -798,10 +798,6 @@ export default {
           entry.config = neu;
           entry.pool.machineConfigRef.name = neu.metadata.name;
           entry.create = false;
-        } else if (entry.update) {
-          const response = await entry.config.save();
-
-          entry.config = response;
         }
 
         if ( !entry.pool.hostnamePrefix ) {

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -798,6 +798,7 @@ export default {
           entry.config = neu;
           entry.pool.machineConfigRef.name = neu.metadata.name;
           entry.create = false;
+          entry.update = true;
         }
 
         if ( !entry.pool.hostnamePrefix ) {
@@ -1047,6 +1048,7 @@ export default {
               :mode="mode"
               :provider="provider"
               :credential-id="credentialId"
+              :show-warning="obj.update"
               @error="e=>errors = e"
             />
           </Tab>

--- a/machine-config/amazonec2.vue
+++ b/machine-config/amazonec2.vue
@@ -33,6 +33,11 @@ export default {
       type:     String,
       required: true,
     },
+
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   async fetch() {
@@ -382,6 +387,7 @@ export default {
             :options="regionOptions"
             :required="true"
             :searchable="true"
+            :disabled="disabled"
             label="Region"
           />
         </div>
@@ -391,6 +397,7 @@ export default {
             :mode="mode"
             :options="zoneOptions"
             :required="true"
+            :disabled="disabled"
             label="Zone"
           />
         </div>
@@ -404,6 +411,7 @@ export default {
             :required="true"
             :selectable="option => !option.disabled"
             :searchable="true"
+            :disabled="disabled"
             label="Instance Type"
           >
             <template v-slot:option="opt">
@@ -421,6 +429,7 @@ export default {
             v-model="value.rootSize"
             output-as="string"
             :mode="mode"
+            :disabled="disabled"
             placeholder="Default: 16"
             label="Root Disk Size"
             suffix="GB"
@@ -435,6 +444,7 @@ export default {
             :options="networkOptions"
             :searchable="true"
             :required="true"
+            :disabled="disabled"
             label="VPC/Subnet"
             placeholder="Select a VPC or Subnet"
             @input="updateNetwork($event)"
@@ -453,6 +463,7 @@ export default {
           <LabeledInput
             v-model="value.iamInstanceProfile"
             :mode="mode"
+            :disabled="disabled"
             label="IAM Instance Profile Name"
             tooltip="Kubernetes AWS Cloud Provider support requires an appropriate instance profile"
           />
@@ -465,6 +476,7 @@ export default {
             <LabeledInput
               v-model="value.ami"
               :mode="mode"
+              :disabled="disabled"
               label="AMI ID"
               placeholder="Default: A recent Ubuntu LTS"
             />
@@ -474,7 +486,7 @@ export default {
               v-model="value.sshUser"
               :mode="mode"
               label="SSH Username for AMI"
-              :disabled="!value.ami"
+              :disabled="!value.ami || disabled"
               placeholder="Default: ubuntu"
               tooltip="The username that exists in the selected AMI; Provisioning will SSH to the node with this."
             />
@@ -493,7 +505,7 @@ export default {
               v-model="securityGroupMode"
               name="securityGroupMode"
               :mode="mode"
-              :disabled="!value.vpcId"
+              :disabled="!value.vpcId || disabled"
               :labels="[`Standard: Automatically create and use a &quot;${DEFAULT_GROUP}&quot; security group`, 'Choose one or more existing security groups:']"
               :options="['default','custom']"
             />
@@ -501,7 +513,7 @@ export default {
               v-if="value.vpcId && securityGroupMode === 'custom'"
               v-model="value.securityGroup"
               :mode="mode"
-              :disabled="!value.vpcId"
+              :disabled="!value.vpcId || disabled"
               :options="securityGroupOptions"
               :searchable="true"
               :multiple="true"
@@ -515,6 +527,7 @@ export default {
             <LabeledInput
               v-model="value.volumeType"
               :mode="mode"
+              :disabled="disabled"
               label="EBS Root Volume Type"
               placeholder="Default: gp2"
             />
@@ -530,12 +543,14 @@ export default {
                 v-model="value.kmsKey"
                 :mode="mode"
                 :options="kmsOptions"
+                :disabled="disabled"
                 label="KMS Key ARN"
               />
               <template v-else>
                 <LabeledInput
                   v-model="value.kmsKey"
                   :mode="mode"
+                  :disabled="disabled"
                   label="KMS Key ARN"
                 />
                 <p class="text-muted">
@@ -553,6 +568,7 @@ export default {
                 v-model="value.spotPrice"
                 output-as="string"
                 :mode="mode"
+                :disabled="disabled"
                 placeholder="Default: 0.50"
                 label="Spot Price"
                 suffix="Dollars per hour"
@@ -563,10 +579,38 @@ export default {
 
         <div class="row mt-20">
           <div class="col span-12">
-            <div><Checkbox v-model="value.privateAddressOnly" :mode="mode" label="Use only private addresses" /></div>
-            <div><Checkbox v-model="value.useEbsOptimizedInstance" :mode="mode" label="EBS-Optimized Instance" /></div>
-            <div><Checkbox v-model="value.httpEndpoint" :mode="mode" label="Allow access to EC2 metadata" /></div>
-            <div><Checkbox v-model="value.httpTokens" :mode="mode" :disabled="!value.httpEndpoint" label="Use tokens for metadata" /></div>
+            <div>
+              <Checkbox
+                v-model="value.privateAddressOnly"
+                :mode="mode"
+                :disabled="disabled"
+                label="Use only private addresses"
+              />
+            </div>
+            <div>
+              <Checkbox
+                v-model="value.useEbsOptimizedInstance"
+                :mode="mode"
+                :disabled="disabled"
+                label="EBS-Optimized Instance"
+              />
+            </div>
+            <div>
+              <Checkbox
+                v-model="value.httpEndpoint"
+                :mode="mode"
+                :disabled="disabled"
+                label="Allow access to EC2 metadata"
+              />
+            </div>
+            <div>
+              <Checkbox
+                v-model="value.httpTokens"
+                :mode="mode"
+                :disabled="!value.httpEndpoint || disabled"
+                label="Use tokens for metadata"
+              />
+            </div>
           </div>
         </div>
 
@@ -578,6 +622,7 @@ export default {
               :read-allowed="false"
               title="EC2 Tags"
               :add-label="t('labels.addTag')"
+              :disabled="disabled"
               @input="updateTags"
             />
           </div>

--- a/machine-config/azure.vue
+++ b/machine-config/azure.vue
@@ -108,6 +108,10 @@ export default {
       type:     String,
       required: true,
     },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   async fetch() {
@@ -222,6 +226,7 @@ export default {
           :searchable="false"
           :required="true"
           :label="t('cluster.machineConfig.azure.environment.label')"
+          :disabled="disabled"
         />
       </div>
       <div class="col span-6">
@@ -234,6 +239,7 @@ export default {
           :searchable="true"
           :required="true"
           :label="t('cluster.machineConfig.azure.location.label')"
+          :disabled="disabled"
           @input="setLocation"
         />
       </div>
@@ -244,6 +250,7 @@ export default {
           v-model="value.resourceGroup"
           :mode="mode"
           :label="t('cluster.machineConfig.azure.resourceGroup.label')"
+          :disabled="disabled"
         />
       </div>
       <div class="col span-6">
@@ -251,6 +258,7 @@ export default {
           v-model="value.availabilitySet"
           :mode="mode"
           :label="t('cluster.machineConfig.azure.availabilitySet.label')"
+          :disabled="disabled"
         />
       </div>
     </div>
@@ -262,6 +270,7 @@ export default {
           :mode="mode"
           :label="t('cluster.machineConfig.azure.image.label')"
           :tooltip="t('cluster.machineConfig.azure.image.help')"
+          :disabled="disabled"
         />
       </div>
       <div class="col span-6">
@@ -272,6 +281,7 @@ export default {
           :searchable="true"
           :required="true"
           :label="t('cluster.machineConfig.azure.size.label')"
+          :disabled="disabled"
         />
       </div>
     </div>
@@ -284,6 +294,7 @@ export default {
             :mode="mode"
             :label="t('cluster.machineConfig.azure.faultDomainCount.label')"
             :tooltip="t('cluster.machineConfig.azure.faultDomainCount.help')"
+            :disabled="disabled"
           />
         </div>
         <div class="col span-6">
@@ -292,19 +303,26 @@ export default {
             :mode="mode"
             :label="t('cluster.machineConfig.azure.updateDomainCount.label')"
             :tooltip="t('cluster.machineConfig.azure.updateDomainCount.help')"
+            :disabled="disabled"
           />
         </div>
       </div>
       <hr class="mt-20" />
       <div class="row mt-20">
         <div class="col span-6">
-          <LabeledInput v-model="value.subnet" :mode="mode" :label="t('cluster.machineConfig.azure.subnet.label')" />
+          <LabeledInput
+            v-model="value.subnet"
+            :mode="mode"
+            :label="t('cluster.machineConfig.azure.subnet.label')"
+            :disabled="disabled"
+          />
         </div>
         <div class="col span-6">
           <LabeledInput
             v-model="value.subnetPrefix"
             :mode="mode"
             :label="t('cluster.machineConfig.azure.subnetPrefix.label')"
+            :disabled="disabled"
           />
         </div>
       </div>
@@ -315,6 +333,7 @@ export default {
             :mode="mode"
             :label="t('cluster.machineConfig.azure.vnet.label')"
             :placeholder="t('cluster.machineConfig.azure.vnet.placeholder')"
+            :disabled="disabled"
           />
         </div>
         <div class="col span-6">
@@ -355,6 +374,7 @@ export default {
             class="mt-10"
             :label="t('cluster.machineConfig.azure.nsg.label')"
             :tooltip="t('cluster.machineConfig.azure.nsg.help')"
+            :disabled="disabled"
           />
         </div>
         <div class="col span-6">
@@ -364,6 +384,7 @@ export default {
             class="mt-10"
             :label="t('cluster.machineConfig.azure.dns.label')"
             :tooltip="t('cluster.machineConfig.azure.dns.help')"
+            :disabled="disabled"
           />
         </div>
       </div>
@@ -377,6 +398,7 @@ export default {
             :searchable="false"
             :required="true"
             :label="t('cluster.machineConfig.azure.storageType.label')"
+            :disabled="disabled"
             option-key="value"
             option-label="name"
           />
@@ -388,12 +410,14 @@ export default {
             v-model="value.managedDisks"
             :mode="mode"
             :label="t('cluster.machineConfig.azure.managedDisks.label')"
+            :disabled="disabled"
           />
           <LabeledInput
             v-model="value.diskSize"
             :mode="mode"
             class="mt-10"
             :label="t('cluster.machineConfig.azure.managedDisksSize.label')"
+            :disabled="disabled"
           />
         </div>
       </div>
@@ -403,6 +427,7 @@ export default {
             v-model="value.sshUser"
             :mode="mode"
             :label="t('cluster.machineConfig.azure.sshUser.label')"
+            :disabled="disabled"
           />
         </div>
       </div>
@@ -416,6 +441,7 @@ export default {
             :add-label="t('cluster.machineConfig.azure.openPort.add')"
             :show-protip="true"
             :protip="t('cluster.machineConfig.azure.openPort.help')"
+            :disabled="disabled"
           />
         </div>
       </div>

--- a/machine-config/digitalocean.vue
+++ b/machine-config/digitalocean.vue
@@ -19,6 +19,11 @@ export default {
       type:     String,
       required: true,
     },
+
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   async fetch() {
@@ -127,6 +132,7 @@ export default {
           :options="regionOptions"
           :searchable="true"
           :required="true"
+          :disabled="disabled"
           label="Region"
         />
       </div>
@@ -137,6 +143,7 @@ export default {
           :options="instanceOptions"
           :searchable="true"
           :required="true"
+          :disabled="disabled"
           label="Size"
         />
       </div>
@@ -150,14 +157,30 @@ export default {
           :options="imageOptions"
           :searchable="true"
           :required="true"
+          :disabled="disabled"
           label="OS Image"
         />
       </div>
       <div class="col span-6 pt-5">
         <h3>Additional DigitalOcean Options</h3>
-        <Checkbox v-model="value.monitoring" :mode="mode" label="Monitoring" />
-        <Checkbox v-model="value.ipv6" :mode="mode" label="IPv6" />
-        <Checkbox v-model="value.privateNetworking" :mode="mode" label="Private Networking" />
+        <Checkbox
+          v-model="value.monitoring"
+          :mode="mode"
+          :disabled="disabled"
+          label="Monitoring"
+        />
+        <Checkbox
+          v-model="value.ipv6"
+          :mode="mode"
+          :disabled="disabled"
+          label="IPv6"
+        />
+        <Checkbox
+          v-model="value.privateNetworking"
+          :mode="mode"
+          :disabled="disabled"
+          label="Private Networking"
+        />
       </div>
     </div>
   </div>

--- a/machine-config/generic.vue
+++ b/machine-config/generic.vue
@@ -24,7 +24,12 @@ export default {
     provider: {
       type:     String,
       required: true,
-    }
+    },
+
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   async fetch() {
@@ -98,6 +103,7 @@ export default {
       :source="fields"
       :ignore-variables="cloudCredentialKeys"
       :target-namespace="value.metadata.namespace"
+      :disabled="disabled"
     />
   </div>
 </template>

--- a/machine-config/harvester.vue
+++ b/machine-config/harvester.vue
@@ -35,6 +35,11 @@ export default {
       type:     String,
       required: true,
     },
+
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   async fetch() {
@@ -297,6 +302,7 @@ export default {
           output-as="string"
           required
           :mode="mode"
+          :disabled="disabled"
         />
       </div>
 
@@ -308,6 +314,7 @@ export default {
           output-as="string"
           suffix="GiB"
           :mode="mode"
+          :disabled="disabled"
           required
         />
       </div>
@@ -322,6 +329,7 @@ export default {
           output-as="string"
           suffix="GiB"
           :mode="mode"
+          :disabled="disabled"
           required
         />
       </div>
@@ -334,6 +342,7 @@ export default {
           :options="namespaceOptions"
           :searchable="true"
           :required="true"
+          :disabled="disabled"
           label-key="cluster.credential.harvester.namespace"
         />
 
@@ -343,6 +352,7 @@ export default {
           label-key="cluster.credential.harvester.namespace"
           :required="true"
           :mode="mode"
+          :disabled="disabled"
         />
       </div>
     </div>
@@ -354,6 +364,7 @@ export default {
           :mode="mode"
           :options="imageOptions"
           :required="true"
+          :disabled="disabled"
           label-key="cluster.credential.harvester.image"
         />
       </div>
@@ -364,6 +375,7 @@ export default {
           :mode="mode"
           :options="networkOptions"
           :required="true"
+          :disabled="disabled"
           label-key="cluster.credential.harvester.network"
         />
       </div>
@@ -376,6 +388,7 @@ export default {
           :mode="mode"
           :required="true"
           :placeholder="t('cluster.credential.harvester.placeholder')"
+          :disabled="disabled"
           label-key="cluster.credential.harvester.image"
         />
       </div>
@@ -386,6 +399,7 @@ export default {
           :mode="mode"
           :required="true"
           :placeholder="t('cluster.credential.harvester.placeholder')"
+          :disabled="disabled"
           label-key="cluster.credential.harvester.network"
         />
       </div>
@@ -398,6 +412,7 @@ export default {
           label-key="cluster.credential.harvester.sshUser"
           :required="true"
           :mode="mode"
+          :disabled="disabled"
         />
       </div>
     </div>
@@ -412,6 +427,7 @@ export default {
           :options="userDataOptions"
           label-key="cluster.credential.harvester.userData.label"
           :mode="mode"
+          :disabled="disabled"
         />
 
         <YamlEditor
@@ -420,6 +436,7 @@ export default {
           class="yaml-editor mb-20"
           :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
           :value="userData"
+          :disabled="disabled"
           @onInput="valuesChanged($event, 'userData')"
         />
       </div>
@@ -433,6 +450,7 @@ export default {
           :options="networkDataOptions"
           label-key="cluster.credential.harvester.networkData.label"
           :mode="mode"
+          :disabled="disabled"
         />
 
         <YamlEditor
@@ -441,6 +459,7 @@ export default {
           class="yaml-editor mb-10"
           :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
           :value="networkData"
+          :disabled="disabled"
           @onInput="valuesChanged($event, 'networkData')"
         />
       </div>

--- a/machine-config/vmwarevsphere.vue
+++ b/machine-config/vmwarevsphere.vue
@@ -145,6 +145,10 @@ export default {
       type:     String,
       required: true,
     },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   async fetch() {
@@ -620,6 +624,7 @@ export default {
               :mode="mode"
               :options="dataCenters"
               :label="t('cluster.machineConfig.vsphere.scheduling.dataCenter')"
+              :disabled="disabled"
             />
           </div>
           <div class="col span-6">
@@ -629,6 +634,7 @@ export default {
               :mode="mode"
               :options="resourcePools"
               :label="t('cluster.machineConfig.vsphere.scheduling.resourcePool')"
+              :disabled="disabled"
             />
           </div>
         </div>
@@ -640,6 +646,7 @@ export default {
               :mode="mode"
               :options="dataStores"
               :label="t('cluster.machineConfig.vsphere.scheduling.dataStore')"
+              :disabled="disabled"
             />
           </div>
           <div class="col span-6">
@@ -649,6 +656,7 @@ export default {
               :mode="mode"
               :options="folders"
               :label="t('cluster.machineConfig.vsphere.scheduling.folder')"
+              :disabled="disabled"
             />
           </div>
         </div>
@@ -660,6 +668,7 @@ export default {
               :mode="mode"
               :options="hosts"
               :label="t('cluster.machineConfig.vsphere.scheduling.host.label')"
+              :disabled="disabled"
             />
             <p class="text-muted mt-5">
               {{ t('cluster.machineConfig.vsphere.scheduling.host.note') }}
@@ -683,6 +692,7 @@ export default {
               :mode="mode"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.cpus')"
               :suffix="t('suffix.cores')"
+              :disabled="disabled"
             />
           </div>
           <div class="col span-6">
@@ -691,6 +701,7 @@ export default {
               :mode="mode"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.memory')"
               :suffix="t('suffix.mib')"
+              :disabled="disabled"
             />
           </div>
         </div>
@@ -701,6 +712,7 @@ export default {
               :mode="mode"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.disk')"
               :suffix="t('suffix.mib')"
+              :disabled="disabled"
             />
           </div>
         </div>
@@ -711,6 +723,7 @@ export default {
               :mode="mode"
               :options="creationMethods"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.creationMethod')"
+              :disabled="disabled"
             />
           </div>
           <div v-if="showTemplate" class="col span-6">
@@ -720,6 +733,7 @@ export default {
               :mode="mode"
               :options="templates"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.template')"
+              :disabled="disabled"
             />
           </div>
           <div v-if="showContentLibrary" class="col span-4">
@@ -729,6 +743,7 @@ export default {
               :mode="mode"
               :options="contentLibraries"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.contentLibrary')"
+              :disabled="disabled"
             />
           </div>
           <div v-if="showContentLibrary" class="col span-4">
@@ -739,6 +754,7 @@ export default {
               :options="libraryTemplates"
               :searchable="true"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.libraryTemplate')"
+              :disabled="disabled"
             />
           </div>
           <div v-if="showVirtualMachines" class="col span-6">
@@ -748,6 +764,7 @@ export default {
               :mode="mode"
               :options="virtualMachines"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.virtualMachine')"
+              :disabled="disabled"
             />
           </div>
           <div v-if="showIso" class="col span-6">
@@ -756,6 +773,7 @@ export default {
               :mode="mode"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.osIsoUrl.label')"
               :placeholder="t('cluster.machineConfig.vsphere.instanceOptions.osIsoUrl.placeholder')"
+              :disabled="disabled"
             />
           </div>
         </div>
@@ -766,6 +784,7 @@ export default {
               :mode="mode"
               :label="t('cluster.machineConfig.vsphere.instanceOptions.cloudInit.label')"
               :placeholder="t('cluster.machineConfig.vsphere.instanceOptions.cloudInit.placeholder')"
+              :disabled="disabled"
             />
             <p class="text-muted mt-5">
               {{ t('cluster.machineConfig.vsphere.instanceOptions.cloudInit.note') }}
@@ -779,6 +798,7 @@ export default {
               ref="yaml-additional"
               v-model="value.cloudConfig"
               :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
+              :disabled="disabled"
               initial-yaml-values="# Additional Manifest YAML"
               class="yaml-editor"
             />
@@ -789,7 +809,13 @@ export default {
             <label class="text-label mt-0">
               {{ t('cluster.machineConfig.vsphere.networks.label') }}
             </label>
-            <ArrayListSelect v-model="value.network" :options="networks" :array-list-props="{ addLabel: t('cluster.machineConfig.vsphere.networks.add') }" :loading="networksLoading" />
+            <ArrayListSelect
+              v-model="value.network"
+              :options="networks"
+              :array-list-props="{ addLabel: t('cluster.machineConfig.vsphere.networks.add') }"
+              :loading="networksLoading"
+              :disabled="disabled"
+            />
           </div>
         </div>
         <div class="row mt-10">
@@ -797,7 +823,14 @@ export default {
             <label class="text-label mt-0">
               {{ t('cluster.machineConfig.vsphere.guestinfo.label') }}
             </label>
-            <KeyValue v-model="cfgparam" :add-label="t('cluster.machineConfig.vsphere.guestinfo.add')" :key-placeholder="t('cluster.machineConfig.vsphere.guestinfo.keyPlaceholder')" :value-placeholder="t('cluster.machineConfig.vsphere.guestinfo.valuePlaceholder')" :read-allowed="false" />
+            <KeyValue
+              v-model="cfgparam"
+              :add-label="t('cluster.machineConfig.vsphere.guestinfo.add')"
+              :key-placeholder="t('cluster.machineConfig.vsphere.guestinfo.keyPlaceholder')"
+              :value-placeholder="t('cluster.machineConfig.vsphere.guestinfo.valuePlaceholder')"
+              :read-allowed="false"
+              :disabled="disabled"
+            />
           </div>
         </div>
       </div>
@@ -810,7 +843,13 @@ export default {
         </p>
       </h4>
       <div slot="body">
-        <ArrayListSelect v-model="value.tag" :options="tags" :array-list-props="{ addLabel: t('cluster.machineConfig.vsphere.tags.addTag') }" :loading="tagsLoading" />
+        <ArrayListSelect
+          v-model="value.tag"
+          :options="tags"
+          :array-list-props="{ addLabel: t('cluster.machineConfig.vsphere.tags.addTag') }"
+          :loading="tagsLoading"
+          :disabled="disabled"
+        />
       </div>
     </Card>
     <Card v-if="haveAttributes" class="m-0 mt-20" :show-highlight-border="false" :show-actions="false">
@@ -830,6 +869,7 @@ export default {
           :loading="attributeKeysLoading"
           :key-taggable="false"
           :key-option-unique="true"
+          :disabled="disabled"
         />
       </div>
     </Card>
@@ -848,6 +888,7 @@ export default {
               name="restoreMode"
               :label="t('cluster.machineConfig.vsphere.vAppOptions.restoreType')"
               :options="vAppOptions"
+              :disabled="disabled"
             />
           </div>
         </div>
@@ -859,6 +900,7 @@ export default {
               :label="t('cluster.machineConfig.vsphere.vAppOptions.transport.label')"
               :tooltip="t('cluster.machineConfig.vsphere.vAppOptions.transport.tooltip')"
               :placeholder="t('cluster.machineConfig.vsphere.vAppOptions.transport.placeholder')"
+              :disabled="disabled"
             />
           </div>
           <div class="col span-4">
@@ -868,6 +910,7 @@ export default {
               :label="t('cluster.machineConfig.vsphere.vAppOptions.protocol.label')"
               :tooltip="t('cluster.machineConfig.vsphere.vAppOptions.protocol.tooltip')"
               :placeholder="t('cluster.machineConfig.vsphere.vAppOptions.protocol.placeholder')"
+              :disabled="disabled"
             />
           </div>
           <div class="col span-4">
@@ -877,6 +920,7 @@ export default {
               :label="t('cluster.machineConfig.vsphere.vAppOptions.allocation.label')"
               :tooltip="t('cluster.machineConfig.vsphere.vAppOptions.allocation.tooltip')"
               :placeholder="t('cluster.machineConfig.vsphere.vAppOptions.allocation.placeholder')"
+              :disabled="disabled"
             />
           </div>
         </div>
@@ -889,6 +933,7 @@ export default {
               :value-placeholder="t('cluster.machineConfig.vsphere.vAppOptions.properties.valuePlaceholder')"
               :add-label="t('cluster.machineConfig.vsphere.vAppOptions.properties.add')"
               :read-allowed="false"
+              :disabled="disabled"
             />
           </div>
         </div>


### PR DESCRIPTION
This disables editing for all RKE2 machine pool configs by adding a disabled prop to each machine pool config component and any children fields. A new banner has been added to notify the user that they will need to create a new pool if they wish to edit any config values. 

This also reverts changes introduced by PR #3629, but we keep the update prop as an easy way to determine if any machine configs should be in a disabled state.

#3553

Backports PR #3735 into release-2.6