### PR TITLE
[master]fix service targetport type

### DIFF
--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -182,7 +182,7 @@ export default {
           <span v-if="isView">{{ row.targetPort }}</span>
           <input
             v-else
-            v-model="row.targetPort"
+            v-model.number="row.targetPort"
             :placeholder="t('servicePorts.rules.target.placeholder')"
             @input="queueUpdate"
           />


### PR DESCRIPTION
#3701 - This value _can_ be a string but needs to be an integer if it doesn't contain letters; using the `.number` modifier on an input that otherwise accepts strings enforces this. 