### PR TITLE
[forwardport] Changing the source of the cluster provisioner

### DIFF
--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -66,14 +66,7 @@ export default {
   },
 
   provisioner() {
-    const allKeys = Object.keys(this.spec);
-    const configKey = allKeys.find( k => k.endsWith('Config'));
-
-    if ( configKey ) {
-      return configKey.replace(/Config$/, '');
-    } else {
-      return 'imported';
-    }
+    return this.status.driver ? this.status.driver : 'imported';
   },
 
   machineProvider() {


### PR DESCRIPTION
Searching the specs keys for a config wasn't as reliable as checking the status.driver field.

https://github.com/rancher/dashboard/issues/3714

forwardport of https://github.com/rancher/dashboard/pull/3771