### PR TITLE
[2.6] Provide styles for disabled labeled selects

### DIFF
--- a/assets/styles/global/_select.scss
+++ b/assets/styles/global/_select.scss
@@ -94,12 +94,8 @@
   }
 }
 
+.labeled-select,
 .unlabeled-select {
-  background-color: var(--input-bg);
-  border-radius: var(--border-radius);
-  color: var(--input-text);
-  padding: 3px 0;
-
   &.disabled {
     border: solid var(--border-width) var(--input-disabled-border);
 
@@ -107,6 +103,28 @@
       cursor: not-allowed;
     }
   }
+
+  &:not(.view) {
+    &.disabled .v-select {
+      background-color: var(--input-disabled-bg);
+      border-color: var(--input-disabled-border);
+      cursor: not-allowed;
+
+      .vs__dropdown-toggle, input {
+        cursor: not-allowed;
+      }
+      .vs__selected {
+        color: var(--input-disabled-text);
+      }
+    }
+  }
+}
+
+.unlabeled-select {
+  background-color: var(--input-bg);
+  border-radius: var(--border-radius);
+  color: var(--input-text);
+  padding: 3px 0;
 
   .vs--single .vs__selected-options {
     flex-wrap: nowrap;
@@ -134,19 +152,6 @@
       &,
       .vs__dropdown-menu {
         background: var(--input-hover-bg);
-      }
-    }
-
-    &.disabled .v-select {
-      background-color: var(--input-disabled-bg);
-      border-color: var(--input-disabled-border);
-      cursor: not-allowed;
-
-      .vs__dropdown-toggle, input {
-        cursor: not-allowed;
-      }
-      .vs__selected {
-        color: var(--input-disabled-text);
       }
     }
   }

--- a/assets/styles/global/_select.scss
+++ b/assets/styles/global/_select.scss
@@ -92,29 +92,25 @@
       }
     }
   }
-}
 
-.labeled-select,
-.unlabeled-select {
   &.disabled {
     border: solid var(--border-width) var(--input-disabled-border);
 
     .vs__dropdown-toggle, input {
       cursor: not-allowed;
     }
-  }
 
-  &:not(.view) {
-    &.disabled .v-select {
+    .v-select {
       background-color: var(--input-disabled-bg);
       border-color: var(--input-disabled-border);
       cursor: not-allowed;
 
       .vs__dropdown-toggle, input {
         cursor: not-allowed;
-      }
-      .vs__selected {
-        color: var(--input-disabled-text);
+
+        .vs__selected {
+          color: var(--input-disabled-text);
+        }
       }
     }
   }


### PR DESCRIPTION
This defines some disabled styles for labeled selects by creating a new selector list that handles disabled styles for both `.labeled-select` and `.unlabeled-select`.

#3553

Backports PR #3775 to release-2.6