### PR TITLE
[master] Tidy management node terminology

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3821,8 +3821,8 @@ tableHeaders:
   lastUpdated: Last Updated
   lastSeen: Last Seen
   loggingOutputProviders: Provider
-  machines: Machines/Nodes
-  machineNodeName: K8s Node
+  machines: Machines
+  machineNodeName: Node
   manual: Manual
   matches: Matches
   maxKubernetesVersion: Max Kubernetes Version
@@ -4786,8 +4786,8 @@ typeLabel:
     }
   node: |-
     {count, plural,
-      one { Kube Node }
-      other { Kube Nodes }
+      one { Node }
+      other { Nodes }
     }
   group.principal: |-
     {count, plural,


### PR DESCRIPTION
- The cluster management / cluster detail / tab for nodes/machines is now always labelled as machines. 
- Ensure all references to cluster detail machines tab align
  - cluster management / cluster List `Machines/Nodes` --> `Machines` (these are counts/state of items from that detail machines tab type)
- There's only one concept of nodes now (to the user), so remove any previous attempts to differentiate node / mgmt node 
  - explorer / cluster / `Kube Node` --> `Node`
  - cluster management / cluster List `K8s Nodes` --> `Node`