### PR TITLE
[2.6] Fix create cluster by template for admins

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -301,8 +301,13 @@ export default {
 
       if ( parts[0] === 'chart' ) {
         const chart = this.$store.getters['catalog/chart']({ key: parts[1] });
+        let localCluster;
 
-        chart.goToInstall(FROM_CLUSTER, BLANK_CLUSTER, true);
+        if (!!this.$store.getters[`management/schemaFor`](MANAGEMENT.CLUSTER)) {
+          localCluster = this.$store.getters['management/all'](MANAGEMENT.CLUSTER).find(x => x.isLocal);
+        }
+
+        chart.goToInstall(FROM_CLUSTER, localCluster?.id || BLANK_CLUSTER, true);
 
         return;
       }

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -263,7 +263,7 @@ export default {
       return deployments;
     }
 
-    return this.$getters['all'](MANAGEMENT.NODE_POOL).filter(pool => pool.spec.clusterName === this.status.clusterName);
+    return this.$getters['all'](MANAGEMENT.NODE_POOL).filter(pool => pool.spec.clusterName === this.status?.clusterName);
   },
 
   desired() {


### PR DESCRIPTION
- This will unblock some QA use cases when creating as admin (non-admins will still be in same broken state)
- Ensure that if we have access to the local cluster use it
- For non-admins they're still in a broken state, this is tracked in another issue

Also fixed issue where returning to the provisioning cluster too early would fail

master PR #3782