### PR TITLE
[2/6] Allow non-admins to create projects without supplying members

### DIFF
--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -196,7 +196,7 @@ export default {
       </button>
     </template>
     <template #remove-button="{remove, i}">
-      <span v-if="(isCreate && i === 0) || isView" />
+      <span v-if="(isCreate && i === 0) || isView || isOnlyRegisteredUser" />
       <button v-else type="button" :disabled="isView" class="btn role-link" @click="remove">
         {{ t('generic.remove') }}
       </button>

--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -30,15 +30,19 @@ export default {
         },
         query: { [PROJECT_ID]: this.project?.id?.replace('/', ':') }
       },
-      resource:         MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING,
-      saveBindings:     null,
-      hasOwner:         false,
-      membershipUpdate: {}
+      resource:           MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING,
+      saveBindings:       null,
+      membershipHasOwner:         false,
+      membershipUpdate:   {}
     };
   },
   computed: {
     hasMemberAccess() {
       return !!this.projectRoleTemplateBindingSchema;
+    },
+    hasOwner() {
+      // Users who cannot access binding schema cannot see membership component, though will gain owner binding automatically on project create
+      return !this.hasMemberAccess || this.membershipHasOwner;
     },
     isValid() {
       return this.value.isDefault || this.value.isSystem || this.hasOwner;
@@ -72,7 +76,7 @@ export default {
     },
 
     onHasOwnerChanged(hasOwner) {
-      this.$set(this, 'hasOwner', hasOwner);
+      this.$set(this, 'membershipHasOwner', hasOwner);
     },
 
     onMembershipUpdate(update) {


### PR DESCRIPTION
- Non-admin create was blocked (create button disabled) given their lack of rights to the binding type
- When non-admins create their project they get this binding automatically, so count case as valid

Also
- Disable remove of a member binding if there is only one user
  - covers case where a non-admin can remove themselves when editing their project and not re-add

#3756