### PR TITLE
[master]remove references to /v1/users in membershipeditor

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2166,7 +2166,6 @@ membershipEditor:
   label: Members
   user: User
   role: Role
-  onlyUser: You are the only active registered user.
 
 monitoring:
   accessModes:

--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -49,7 +49,6 @@ export default {
 
   async fetch() {
     const userHydration = [
-      this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.USER }),
       this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }),
       this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL }),
     ];
@@ -68,10 +67,9 @@ export default {
       bindings.push(defaultBinding);
     }
 
-    const [users] = await Promise.all(userHydration);
+    await Promise.all(userHydration);
 
     this.$set(this, 'bindings', bindings);
-    this.$set(this, 'users', users);
   },
 
   data() {
@@ -79,7 +77,6 @@ export default {
       schema:            this.$store.getters[`management/schemaFor`](this.type),
       bindings:                  [],
       lastSavedBindings:         [],
-      users:                     [],
     };
   },
 
@@ -123,10 +120,6 @@ export default {
     isView() {
       return this.mode === _VIEW;
     },
-
-    isOnlyRegisteredUser() {
-      return this.users.filter(u => !u.isSystem).length === 1;
-    }
   },
   watch: {
     hasOwnerBinding() {
@@ -186,13 +179,9 @@ export default {
       <button
         type="button"
         class="btn role-primary mt-10"
-        :disabled="isOnlyRegisteredUser"
         @click="addMember"
       >
         {{ t('generic.add') }}
-      </button>
-      <button v-if="isOnlyRegisteredUser" class="btn role-primary mt-10" :disabled="true">
-        {{ t('membershipEditor.onlyUser') }}
       </button>
     </template>
     <template #remove-button="{remove, i}">


### PR DESCRIPTION
#3790 - this bug is happening because standard users with the cluster owner role can't list users other than themselves. Initially I thought this was a permission issue, but on closer inspection there's no real need for a user to access that resource to edit project membership: the MembershipEditor component was using the list of users to disable the 'add' button when there are no potential members to add. Since we can't assume the user editing the project has access to `/v1/users` (other than themselves), and we can't just list all `/v3/principals`, I don't see a good alternative of calculating `isOnlyRegisteredUser` and ended up removing that functionality entirely.