### PR TITLE
[2.6] Ensure we pre-fetch machines to show node ssh & download key actions

### DIFF
--- a/components/PromptRestore.vue
+++ b/components/PromptRestore.vue
@@ -37,12 +37,6 @@ export default {
     };
   },
 
-  mounted() {
-    const cluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, this.snapshot?.clusterId);
-
-    this.cloudCredentialName = cluster?.spec?.rkeConfig?.etcd?.s3?.cloudCredentialName;
-  },
-
   computed:   {
     ...mapState('action-menu', ['showPromptRestore', 'toRestore']),
     ...mapGetters({ t: 'i18n/t' }),
@@ -67,6 +61,12 @@ export default {
         this.$modal.hide('promptRestore');
       }
     }
+  },
+
+  mounted() {
+    const cluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, this.snapshot?.clusterId);
+
+    this.cloudCredentialName = cluster?.spec?.rkeConfig?.etcd?.s3?.cloudCredentialName;
   },
 
   methods: {

--- a/list/node.vue
+++ b/list/node.vue
@@ -8,6 +8,7 @@ import {
 import metricPoller from '@/mixins/metric-poller';
 
 import {
+  CAPI,
   MANAGEMENT, METRIC, NODE, NORMAN, POD
 } from '@/config/types';
 import { allHash } from '@/utils/promise';
@@ -32,18 +33,20 @@ export default {
   async fetch() {
     const hash = { kubeNodes: this.$store.dispatch('cluster/findAll', { type: NODE }) };
 
-    const canViewMgmtNodes = this.$store.getters[`management/schemaFor`](MANAGEMENT.NODE);
-    const canViewNormanNodes = this.$store.getters[`rancher/schemaFor`](NORMAN.NODE);
-
     this.canViewPods = this.$store.getters[`cluster/schemaFor`](POD);
 
-    if (canViewNormanNodes) {
+    if (this.$store.getters[`management/schemaFor`](MANAGEMENT.NODE)) {
       // Required for Drain/Cordon action
       hash.normanNodes = this.$store.dispatch('rancher/findAll', { type: NORMAN.NODE });
     }
 
-    if (canViewMgmtNodes) {
+    if (this.$store.getters[`rancher/schemaFor`](NORMAN.NODE)) {
       hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
+    }
+
+    if (this.$store.getters[`management/schemaFor`](CAPI.MACHINE)) {
+      // Required for ssh / download key actions
+      hash.machines = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE });
     }
 
     if (this.canViewPods) {


### PR DESCRIPTION
- Both actions require `provisionedMachine` in `/models/cluster/node.js`
- #3699