### PR TITLE
[master] Fix issue with provider display displaying wrong value

### DIFF
--- a/models/management.cattle.io.nodetemplate.js
+++ b/models/management.cattle.io.nodetemplate.js
@@ -76,7 +76,10 @@ const CONFIG_KEYS = [
 export default {
   provider() {
     const allKeys = Object.keys(this);
-    const configKey = allKeys.find( k => k.endsWith('Config'));
+
+    const configKey = allKeys
+      .filter(k => this[k] !== null)
+      .find(k => k.endsWith('Config'));
 
     if ( configKey ) {
       return configKey.replace(/config$/i, '');


### PR DESCRIPTION
This fixes an issue where incorrect providers could be displayed by filtering out any node template keys that contain a `null` value. 

There were some cases (observed when creating an EC1 cluster for Digital Ocean and vSphere) where the node template contained config keys for both `amazonec2` and `vmwarevsphere`. The `amazonec2` config was always `null`, but simply finding the first config could generate the wrong provider for display. 

#3731