### PR TITLE
[2.6] Fix issue with provider display displaying wrong value

### DIFF
--- a/components/PromptRestore.vue
+++ b/components/PromptRestore.vue
@@ -37,12 +37,6 @@ export default {
     };
   },
 
-  mounted() {
-    const cluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, this.snapshot?.clusterId);
-
-    this.cloudCredentialName = cluster?.spec?.rkeConfig?.etcd?.s3?.cloudCredentialName;
-  },
-
   computed:   {
     ...mapState('action-menu', ['showPromptRestore', 'toRestore']),
     ...mapGetters({ t: 'i18n/t' }),
@@ -67,6 +61,12 @@ export default {
         this.$modal.hide('promptRestore');
       }
     }
+  },
+
+  mounted() {
+    const cluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, this.snapshot?.clusterId);
+
+    this.cloudCredentialName = cluster?.spec?.rkeConfig?.etcd?.s3?.cloudCredentialName;
   },
 
   methods: {

--- a/models/management.cattle.io.nodetemplate.js
+++ b/models/management.cattle.io.nodetemplate.js
@@ -76,7 +76,10 @@ const CONFIG_KEYS = [
 export default {
   provider() {
     const allKeys = Object.keys(this);
-    const configKey = allKeys.find( k => k.endsWith('Config'));
+
+    const configKey = allKeys
+      .filter(k => this[k] !== null)
+      .find(k => k.endsWith('Config'));
 
     if ( configKey ) {
       return configKey.replace(/config$/i, '');


### PR DESCRIPTION
This fixes an issue where incorrect providers could be displayed by filtering out any node template keys that contain a `null` value. 

There were some cases (observed when creating an EC1 cluster for Digital Ocean and vSphere) where the node template contained config keys for both `amazonec2` and `vmwarevsphere`. The `amazonec2` config was always `null`, but simply finding the first config could generate the wrong provider for display. 

#3731

Backports PR #3830 into release-2.6