### PR TITLE
Worker CIS Profile - Default is blank instead of (None) #3805

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -378,7 +378,7 @@ export default {
         return { label: x, value: x };
       });
 
-      out.unshift({ label: '(None)', value: null });
+      out.unshift({ label: '(None)', value: '' });
 
       return out;
     },


### PR DESCRIPTION
#3805 
Updated `profileOptions` computed function  `null` value to `''` to avoid Select component truthiness override


![Screen Shot 2021-08-13 at 2 04 02 AM](https://user-images.githubusercontent.com/13671297/129333153-78ca406d-7f60-47cd-9cf9-e0b9abbd4233.png)
