### PR TITLE
[2.6] Handle Mgmt AuthConfig & User Remove

### DIFF
--- a/models/management.cattle.io.authconfig.js
+++ b/models/management.cattle.io.authconfig.js
@@ -62,11 +62,4 @@ export default {
     return 'inactive';
   },
 
-  disable() {
-    return async() => {
-      this.enabled = false;
-      await this.save();
-      this.currentRouter().push({ name: 'c-cluster-auth-config' });
-    };
-  },
 };

--- a/models/management.cattle.io.user.js
+++ b/models/management.cattle.io.user.js
@@ -201,4 +201,12 @@ export default {
   confirmRemove() {
     return true;
   },
+
+  remove() {
+    return async() => {
+      const norman = await this.$dispatch(`rancher/find`, { id: this.id, type: NORMAN.USER }, { root: true });
+
+      await norman.remove();
+    };
+  }
 };


### PR DESCRIPTION
- Removed auth config `disable` (not used and is now misleading)
- Added mgmt user 'remove' (create/edit by-passes mgmt user type entirely)

#3865