### PR TITLE
[master] Multiple fixes to User Detail page

### DIFF
--- a/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/models/management.cattle.io.clusterroletemplatebinding.js
@@ -27,7 +27,13 @@ export default {
   },
 
   principal() {
-    return this.$rootGetters['rancher/byId'](NORMAN.PRINCIPAL, this.principalId);
+    const principalId = this.principalId.replace(/\//g, '%2F');
+
+    return this.$dispatch('rancher/find', {
+      type: NORMAN.PRINCIPAL,
+      id:   this.principalId,
+      opt:  { url: `/v3/principals/${ principalId }` }
+    }, { root: true });
   },
 
   principalId() {
@@ -95,13 +101,14 @@ export default {
     return !this.metadata.annotations[CREATOR_ID];
   },
 
-  norman() {
-    const principalProperty = this.principal.principalType === 'group' ? 'groupPrincipalId' : 'userPrincipalId';
+  async norman() {
+    const principal = await this.principal;
+    const principalProperty = principal.principalType === 'group' ? 'groupPrincipalId' : 'userPrincipalId';
 
     return this.$dispatch(`rancher/create`, {
       type:                  NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING,
       roleTemplateId:        this.roleTemplateName,
-      [principalProperty]:   this.principal.id,
+      [principalProperty]:   principal.id,
       clusterId:             this.clusterName,
       id:                    this.id?.replace('/', ':')
     }, { root: true });

--- a/models/management.cattle.io.projectroletemplatebinding.js
+++ b/models/management.cattle.io.projectroletemplatebinding.js
@@ -19,7 +19,13 @@ export default {
   },
 
   principal() {
-    return this.$rootGetters['rancher/byId'](NORMAN.PRINCIPAL, this.principalId);
+    const principalId = this.principalId.replace(/\//g, '%2F');
+
+    return this.$dispatch('rancher/find', {
+      type: NORMAN.PRINCIPAL,
+      id:   this.principalId,
+      opt:  { url: `/v3/principals/${ principalId }` }
+    }, { root: true });
   },
 
   principalId() {
@@ -113,13 +119,14 @@ export default {
     return !this.metadata.annotations[CREATOR_ID];
   },
 
-  norman() {
-    const principalProperty = this.principal.principalType === 'group' ? 'groupPrincipalId' : 'userPrincipalId';
+  async norman() {
+    const principal = await this.principal;
+    const principalProperty = principal.principalType === 'group' ? 'groupPrincipalId' : 'userPrincipalId';
 
     return this.$dispatch(`rancher/create`, {
       type:                  NORMAN.PROJECT_ROLE_TEMPLATE_BINDING,
       roleTemplateId:        this.roleTemplateName,
-      [principalProperty]:   this.principal.id,
+      [principalProperty]:   principal.id,
       projectId:             this.projectName,
       projectRoleTemplateId: '',
       id:                    this.id?.replace('/', ':')


### PR DESCRIPTION
- Ensure `Cluster Roles` and `Project Roles` tables update on change (specifically delete of a role binding)
- Better error handling
- A `Global Permission` is ticked if the user is of a certain type (admin, standard user, etc) that has a role that contains all the rules in the permission. If the role contains no rules then previously the permission was ticked. This is slightly confusing, so flipped the logic and now empty roles are not ticked by default.
- When saving/remove a cluster/project binding we check the principal to determine if it's a user or group. The principals may not have been fetched when listing (fetch all principals does not guarantee all are fetched), so reach out directly to get the required one.

Addresses #3840

2.6 PR #3869