### PR TITLE
[master] Add custom validation rule for server url in management settings

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4079,6 +4079,9 @@ validation:
         iana: 'Port Rule [{position}] - Target Port must be an IANA Service Name or Integer'
         ianaAt: 'Port Rule [{position}] - Target Port '
         required: 'Port Rule [{position}] - Target Port is required'
+  setting:
+    serverUrl: 
+      https: server-url must be https.
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
     exactly: '"{key}" should be {count, plural, =1 {# character} other {# characters}}'

--- a/models/management.cattle.io.setting.js
+++ b/models/management.cattle.io.setting.js
@@ -25,6 +25,16 @@ export default {
     }
 
     return out;
-  }
+  },
+
+  customValidationRules() {
+    return [
+      {
+        path:           'value',
+        translationKey: 'setting.serverUrl.https',
+        validators:     [`isHttps:${ this.metadata.name }`]
+      },
+    ];
+  },
 
 };

--- a/utils/custom-validators.js
+++ b/utils/custom-validators.js
@@ -8,6 +8,7 @@ import { cronSchedule } from '@/utils/validators/cron-schedule';
 import { podAffinity } from '@/utils/validators/pod-affinity';
 import { roleTemplateRules } from '@/utils/validators/role-template';
 import { clusterName } from '@/utils/validators/cluster-name';
+import { isHttps } from '@/utils/validators/setting';
 
 /**
 * Custom validation functions beyond normal scalr types
@@ -28,5 +29,6 @@ export default {
   containerImages,
   cronSchedule,
   podAffinity,
-  roleTemplateRules
+  roleTemplateRules,
+  isHttps
 };

--- a/utils/validators/setting.js
+++ b/utils/validators/setting.js
@@ -5,7 +5,7 @@ const httpsKeys = [
 export function isHttps(value, getters, errors, validatorArgs, displayKey) {
   const key = validatorArgs[0];
 
-  if (httpsKeys.includes(key) && !value.startsWith('https://')) {
+  if (httpsKeys.includes(key) && !value.toLowerCase().startsWith('https://')) {
     errors.push(getters['i18n/t']('validation.setting.serverUrl.https'));
   }
 

--- a/utils/validators/setting.js
+++ b/utils/validators/setting.js
@@ -1,0 +1,13 @@
+const httpsKeys = [
+  'server-url'
+];
+
+export function isHttps(value, getters, errors, validatorArgs, displayKey) {
+  const key = validatorArgs[0];
+
+  if (httpsKeys.includes(key) && !value.startsWith('https://')) {
+    errors.push(getters['i18n/t']('validation.setting.serverUrl.https'));
+  }
+
+  return errors;
+}


### PR DESCRIPTION
This adds a custom validation rule to management settings to check if `server-url` starts with `https://`.

I took the simple path of checking if the string literally starts with `https://` because I felt that satisfies the conditions in the issue, but we can easily modify this one to use some sort of regex that will check for a fully qualified url if that makes more sense.

#3832 