### PR TITLE
[2.6] Trim leading and trailing spaces when entering cluster url

### DIFF
--- a/edit/catalog.cattle.io.clusterrepo.vue
+++ b/edit/catalog.cattle.io.clusterrepo.vue
@@ -39,6 +39,12 @@ export default {
       return this.$store.getters['cluster/all'](NAMESPACE)[0]?.id;
     },
   },
+
+  methods: {
+    trimInput(val) {
+      this.value.spec.url = val.trim();
+    }
+  }
 };
 </script>
 
@@ -82,11 +88,12 @@ export default {
 
     <LabeledInput
       v-else
-      v-model="value.spec.url"
+      :value="value.spec.url"
       :required="true"
       :label="t('catalog.repo.url.label')"
       :placeholder="t('catalog.repo.url.placeholder', null, true)"
       :mode="mode"
+      @input="trimInput"
     />
 
     <SelectOrCreateAuthSecret

--- a/edit/catalog.cattle.io.clusterrepo.vue
+++ b/edit/catalog.cattle.io.clusterrepo.vue
@@ -39,12 +39,6 @@ export default {
       return this.$store.getters['cluster/all'](NAMESPACE)[0]?.id;
     },
   },
-
-  methods: {
-    trimInput(val) {
-      this.value.spec.url = val.trim();
-    }
-  }
 };
 </script>
 
@@ -88,12 +82,11 @@ export default {
 
     <LabeledInput
       v-else
-      :value="value.spec.url"
+      v-model.trim="value.spec.url"
       :required="true"
       :label="t('catalog.repo.url.label')"
       :placeholder="t('catalog.repo.url.placeholder', null, true)"
       :mode="mode"
-      @input="trimInput"
     />
 
     <SelectOrCreateAuthSecret


### PR DESCRIPTION
This trims leading and trailing spaces for the index url when creating a new chart repository. The presence of leading/trailing spaces has lead to hard to understand errors where the user might not be able to easily see the offending space in an error message.

#3794

Backports PR #3878 into release-2.6