### PR TITLE
Add harvester cloud provider and Fix credential lack of clusterId

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -907,6 +907,8 @@ cluster:
     rancher-vsphere:
       label: vSphere
       note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-On Config tab.'
+    harvester:
+      label: Harvester
   custom:
     nodeRole:
       label: Node Role
@@ -1026,6 +1028,7 @@ cluster:
       kubeconfigContent:
         label: KubeconfigContent
       placeholder: 'Namespace/Name'
+      cluster: Cluster
   description:
     label: Cluster Description
     placeholder: Any text you want that better describes this cluster

--- a/cloud-credential/harvester.vue
+++ b/cloud-credential/harvester.vue
@@ -4,9 +4,10 @@ import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import RadioGroup from '@/components/form/RadioGroup';
 
-import { get } from '@/utils/object';
+import { get, set } from '@/utils/object';
 import { MANAGEMENT, VIRTUAL_HARVESTER_PROVIDER } from '@/config/types';
-import { HCI } from '@/config/labels-annotations';
+
+const IMPORTED = 'imported';
 
 export default {
   components: {
@@ -22,14 +23,15 @@ export default {
     this.$emit('validationChanged', true);
 
     if (!this.value.decodedData.clusterType) {
-      this.value.setData('clusterType', 'import');
+      this.value.setData('clusterType', IMPORTED);
     }
 
-    const cluster = get(this.value, `metadata.annotations."${ HCI.CLUSTER_ID }"`) || '';
+    const cluster = get(this.value, 'harvestercredentialConfig.clusterId') || '';
 
     return {
       clusters: [],
       cluster,
+      IMPORTED,
     };
   },
 
@@ -44,7 +46,7 @@ export default {
     },
 
     isImportCluster() {
-      return this.value.decodedData.clusterType === 'import';
+      return this.value.decodedData.clusterType === IMPORTED;
     }
   },
 
@@ -64,7 +66,7 @@ export default {
       }
 
       if (this.isCreate) {
-        this.value.setAnnotation(HCI.CLUSTER_ID, neu);
+        set(this.value, 'harvestercredentialConfig.clusterId', neu);
       }
 
       const currentCluster = this.$store.getters['management/all'](MANAGEMENT.CLUSTER).find(x => x.id === neu);
@@ -113,7 +115,7 @@ export default {
         :disabled="isEdit"
         name="clusterType"
         :labels="[t('cluster.credential.harvester.import'),t('cluster.credential.harvester.external')]"
-        :options="['import', 'external']"
+        :options="[IMPORTED, 'external']"
         @input="value.setData('clusterType', $event);"
       />
     </div>
@@ -126,7 +128,7 @@ export default {
           :disabled="isEdit"
           :options="clusterOptions"
           :required="true"
-          label="Cluster"
+          :label="t('cluster.credential.harvester.cluster')"
         />
       </div>
 

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -963,9 +963,10 @@ export default {
         return;
       }
 
-      if (this.agentConfig['cloud-provider-name'] === HARVESTER) {
+      const clusterId = get(this.credential, 'decodedData.clusterId') || '';
+
+      if (this.agentConfig['cloud-provider-name'] === HARVESTER && clusterId) {
         const namespace = this.machinePools?.[0]?.config?.vmNamespace;
-        const clusterId = get(this.credential, 'decodedData.clusterId') || '';
 
         const res = await this.$store.dispatch('management/request', {
           url:                  `/k8s/clusters/${ clusterId }/v1/harvester/kubeconfig`,

--- a/machine-config/harvester.vue
+++ b/machine-config/harvester.vue
@@ -47,10 +47,10 @@ export default {
 
     try {
       this.credential = await this.$store.dispatch('rancher/find', { type: NORMAN.CLOUD_CREDENTIAL, id: this.credentialId });
-      const clusterId = get(this.credential, `metadata.annotations."${ HCI_ANNOTATIONS.CLUSTER_ID }"`);
+      const clusterId = get(this.credential, 'decodedData.clusterId');
 
       const url = `/k8s/clusters/${ clusterId }/v1`;
-      const isImportCluster = this.credential.decodedData.clusterType === 'import';
+      const isImportCluster = this.credential.decodedData.clusterType === 'imported';
 
       this.isImportCluster = isImportCluster;
 

--- a/machine-config/harvester.vue
+++ b/machine-config/harvester.vue
@@ -50,6 +50,7 @@ export default {
       const clusterId = get(this.credential, 'decodedData.clusterId');
 
       const url = `/k8s/clusters/${ clusterId }/v1`;
+
       const isImportCluster = this.credential.decodedData.clusterType === 'imported';
 
       this.isImportCluster = isImportCluster;
@@ -191,16 +192,24 @@ export default {
     };
   },
 
-  computed: { ...mapGetters({ t: 'i18n/t' }) },
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+
+    disabledEdit() {
+      return this.disabled || !!(this.isEdit && this.value.id);
+    }
+  },
 
   watch: {
     'credentialId'() {
-      this.imageOptions = [];
-      this.networkOptions = [];
-      this.namespaceOptions = [];
-      this.value.imageName = '';
-      this.value.networkName = '';
-      this.value.vmNamespace = '';
+      if (!this.isEdit) {
+        this.imageOptions = [];
+        this.networkOptions = [];
+        this.namespaceOptions = [];
+        this.value.imageName = '';
+        this.value.networkName = '';
+        this.value.vmNamespace = '';
+      }
 
       this.$fetch();
     },
@@ -342,7 +351,7 @@ export default {
           :options="namespaceOptions"
           :searchable="true"
           :required="true"
-          :disabled="disabled"
+          :disabled="disabledEdit"
           label-key="cluster.credential.harvester.namespace"
         />
 
@@ -352,7 +361,7 @@ export default {
           label-key="cluster.credential.harvester.namespace"
           :required="true"
           :mode="mode"
-          :disabled="disabled"
+          :disabled="disabledEdit"
         />
       </div>
     </div>
@@ -364,7 +373,7 @@ export default {
           :mode="mode"
           :options="imageOptions"
           :required="true"
-          :disabled="disabled"
+          :disabled="disabledEdit"
           label-key="cluster.credential.harvester.image"
         />
       </div>
@@ -375,7 +384,7 @@ export default {
           :mode="mode"
           :options="networkOptions"
           :required="true"
-          :disabled="disabled"
+          :disabled="disabledEdit"
           label-key="cluster.credential.harvester.network"
         />
       </div>
@@ -388,7 +397,7 @@ export default {
           :mode="mode"
           :required="true"
           :placeholder="t('cluster.credential.harvester.placeholder')"
-          :disabled="disabled"
+          :disabled="disabledEdit"
           label-key="cluster.credential.harvester.image"
         />
       </div>
@@ -399,7 +408,7 @@ export default {
           :mode="mode"
           :required="true"
           :placeholder="t('cluster.credential.harvester.placeholder')"
-          :disabled="disabled"
+          :disabled="disabledEdit"
           label-key="cluster.credential.harvester.network"
         />
       </div>

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -98,7 +98,7 @@ export default {
       return null;
     }
 
-    const clusterId = this.$rootGetters['currentCluster'].id;
+    const clusterId = this.$rootGetters['currentCluster']?.id;
     const project = this.$rootGetters['management/byId'](MANAGEMENT.PROJECT, `${ clusterId }/${ this.projectId }`);
 
     return project;

--- a/models/rke-machine-config.cattle.io.harvesterconfig.js
+++ b/models/rke-machine-config.cattle.io.harvesterconfig.js
@@ -9,6 +9,10 @@ export default {
       if (_machinePools[idx]) {
         const copyConfig = _machinePools[idx]?.config;
 
+        delete copyConfig.id;
+        delete copyConfig.links;
+        delete copyConfig.metadata;
+        delete copyConfig.apiVersion;
         merge(this, copyConfig);
       }
     };

--- a/plugins/steve/subscribe.js
+++ b/plugins/steve/subscribe.js
@@ -489,7 +489,7 @@ export const actions = {
       const alias = typeOption?.alias || [];
 
       alias.map((type) => {
-        const obj = getters.byId(type, data.id);
+        const obj = ctx.getters.byId(type, data.id);
 
         ctx.state.queue.push({
           action: 'commit',

--- a/store/plugins.js
+++ b/store/plugins.js
@@ -97,7 +97,8 @@ export const suffixFields = [
 const driverToCloudProviderMap = {
   amazonec2:     'aws',
   azure:         'azure',
-  vmwarevsphere: 'rancher-vsphere'
+  vmwarevsphere: 'rancher-vsphere',
+  harvester:     'harvester',
 };
 
 // Dynamically loaded drivers can call this eventually to register thier options


### PR DESCRIPTION
Related issues:
- https://github.com/harvester/harvester/issues/1019
- https://github.com/harvester/harvester/issues/1105
- https://github.com/rancher/dashboard/issues/3905

 Desciption:
- Add harvester cloud provider, we will get kubeconfig and set it to `cloud-provider-config` before creating a cluster.
- Use `harvestercredentialConfig.clusterId` insteadof annotation to fix clusterId is undefined.

Validation Steps:
- Import a harvester cluster
- Go to the cluster management, Click create and select harvester cluster.
- Create a new credential by imported harvester cluster
- Click continue
- Select namespace: default, image: ubuntu, and network: 'vlan'
- Select cloud provider to `harvester`
- Click create
- Wait for the new cluster ready