### PR TITLE
[master] Markdown: Don't render relative links as anchors

### DIFF
--- a/components/Markdown.vue
+++ b/components/Markdown.vue
@@ -44,6 +44,11 @@ export default {
     renderer.link = function(href, title, text) {
       let external = true;
 
+      // Relative links don't work, since they aren't relative to the dashboard page
+      if (href.startsWith('./')) {
+        return text;
+      }
+
       if ( href.startsWith('#') ) {
         href = `${ base }${ href }`;
         external = false;


### PR DESCRIPTION
Addresses #3763 

We don't have the base URL where the chart came from, so we can't render relative links.