### PR TITLE
[2.6] Cluster Template Install: Wait for operations to become available

### DIFF
--- a/models/catalog.cattle.io.clusterrepo.js
+++ b/models/catalog.cattle.io.clusterrepo.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import { parse } from '@/utils/url';
 import { CATALOG } from '@/config/labels-annotations';
 import { insertAt } from '@/utils/array';
+import { CATALOG as CATALOG_TYPE } from '@/config/types';
 
 export default {
   applyDefaults() {
@@ -140,4 +141,21 @@ export default {
       },
     ];
   },
+
+  waitForOperation() {
+    return (operationId, timeout, interval = 2000) => {
+      return this.waitForTestFn(() => {
+        if (!this.$getters['schemaFor'](CATALOG_TYPE.OPERATION)) {
+          return false;
+        }
+        if (this.$getters['byId'](CATALOG_TYPE.OPERATION, operationId)) {
+          return true;
+        }
+        this.$dispatch('find', {
+          type: CATALOG_TYPE.OPERATION,
+          id:   operationId
+        });
+      }, `catalog operation fetch`, timeout, interval);
+    };
+  }
 };

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -697,10 +697,14 @@ export default {
           return;
         }
         const res = await this.repo.doAction((isUpgrade ? 'upgrade' : 'install'), input);
+        const operationId = `${ res.operationNamespace }/${ res.operationName }`;
+
+        // Non-admins without a cluster won't be able to fetch operations immediately
+        await this.repo.waitForOperation(operationId);
 
         this.operation = await this.$store.dispatch('cluster/find', {
           type: CATALOG.OPERATION,
-          id:   `${ res.operationNamespace }/${ res.operationName }`
+          id:   operationId
         });
 
         try {


### PR DESCRIPTION
- Non-admins without a cluster won't be able to fetch operations immediately

Addresses (front end of) #3721
Master PR: #3893

Issues
- Operation type only becomes available when provisioning cluster is created. If the install fails before this the user can never get the operation (and thus logs) to see why (see comment - https://github.com/rancher/dashboard/issues/3721#issuecomment-898592109, have also pinged Dan on slack)