### PR TITLE
[2.6] Add more width to protocols dropdown

### DIFF
--- a/components/form/WorkloadPorts.vue
+++ b/components/form/WorkloadPorts.vue
@@ -308,7 +308,7 @@ $checkbox: 75;
 }
 .ports-headers, .ports-row{
   display: grid;
-  grid-template-columns: 20% 32% 145px 80px .5fr .5fr;
+  grid-template-columns: 20% 32% 145px 90px .5fr .5fr;
   grid-column-gap: $column-gutter;
   margin-bottom: 10px;
   align-items: center;
@@ -318,7 +318,7 @@ $checkbox: 75;
   }
 
   &.show-host{
-    grid-template-columns: 20% 20% 145px 80px 140px .5fr .5fr;
+    grid-template-columns: 20% 20% 145px 90px 140px .5fr .5fr;
   }
 
 }

--- a/components/form/WorkloadPorts.vue
+++ b/components/form/WorkloadPorts.vue
@@ -199,8 +199,14 @@ export default {
       class="ports-row"
       :class="{'show-host':row._showHost}"
     >
-      <div class="service-type">
-        <LabeledSelect v-model="row._serviceType" :mode="mode" :label="t('workload.container.ports.createService')" :options="serviceTypes" @input="queueUpdate" />
+      <div class="service-type col">
+        <LabeledSelect
+          v-model="row._serviceType"
+          :mode="mode"
+          :label="t('workload.container.ports.createService')"
+          :options="serviceTypes"
+          @input="queueUpdate"
+        />
       </div>
 
       <div class="portName">
@@ -226,7 +232,7 @@ export default {
         />
       </div>
 
-      <div class="protocol">
+      <div class="protocol col">
         <LabeledSelect
           v-model="row.protocol"
           :mode="mode"


### PR DESCRIPTION
This adds a little more spacing to the protocol column by increasing the width to 90px. This also adds the `col` class to the labeled selects in order to satisfy the requirements for the style that defines minimum height. 

#3662

Backports PR #3897 into release-2.6