### PR TITLE
[master] fix clusterrolebinding creation for standard user

### DIFF
--- a/components/form/Members/ClusterPermissionsEditor.vue
+++ b/components/form/Members/ClusterPermissionsEditor.vue
@@ -35,6 +35,11 @@ export default {
     useTwoColumnsForCustom: {
       type:    Boolean,
       default: false
+    },
+
+    clusterName: {
+      type:    String,
+      default: null
     }
   },
   async fetch() {
@@ -176,7 +181,7 @@ export default {
     async updateBindings() {
       const bindingPromises = this.roleTemplateIds.map(id => this.$store.dispatch(`management/create`, {
         type:              MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
-        clusterName:       this.$store.getters['currentCluster'].id,
+        clusterName:       this.clusterName,
         roleTemplateName:  id,
         principalName:    this.principalId
       }));

--- a/components/form/Members/MembershipEditor.vue
+++ b/components/form/Members/MembershipEditor.vue
@@ -9,8 +9,8 @@ function normalizeId(id) {
   return id?.replace(':', '/') || id;
 }
 
-export function canViewMembershipEditor(store) {
-  return !!store.getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING) &&
+export function canViewMembershipEditor(store, needsProject = false) {
+  return (!!store.getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING) || !needsProject) &&
     !!store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE) &&
     !!store.getters['rancher/schemaFor'](NORMAN.PRINCIPAL);
 }

--- a/components/form/Members/ProjectMembershipEditor.vue
+++ b/components/form/Members/ProjectMembershipEditor.vue
@@ -5,7 +5,7 @@ import MembershipEditor from '@/components/form/Members/MembershipEditor';
 import { canViewMembershipEditor } from '@/components/form/Members/MembershipEditor.vue';
 
 export function canViewProjectMembershipEditor(store) {
-  return canViewMembershipEditor(store);
+  return canViewMembershipEditor(store, true);
 }
 
 export default {

--- a/edit/management.cattle.io.clusterroletemplatebinding.vue
+++ b/edit/management.cattle.io.clusterroletemplatebinding.vue
@@ -51,6 +51,6 @@ export default {
     @finish="saveOverride"
     @cancel="done"
   >
-    <ClusterPermissionsEditor v-model="bindings" />
+    <ClusterPermissionsEditor v-model="bindings" :cluster-name="$store.getters['currentCluster'].id" />
   </CruResource>
 </template>


### PR DESCRIPTION
#3907 - I found two issues when looking into this:
- The visibility of the member roles tab is dependent on `canViewMembershipEditor` but as far as I can tell a user doesn't need to be able to access project role template bindings to create/edit cluster role template bindings. So a standard user who should see this tab doesn't. This is caused by changes merged yesterday, hence not in the linked ticket. 
- new cluster role template bindings are being defined initially with the current cluster's id; standard users don't necessarily have access to any clusters so `this.$store.getters['currentCluster'].id` was causing an error. 

@codyrancher we both have PRs that touch `MembershipEditor` now. Our actual work doesn't conflict but git may think otherwise. You're welcome to get yours in first; I don't mind dealing with any 'conflicts' that arise.