### PR TITLE
[master] Check for template before attempting to assign metadata

### DIFF
--- a/models/workload.js
+++ b/models/workload.js
@@ -274,6 +274,10 @@ export default {
   redeploy() {
     const now = (new Date()).toISOString().replace(/\.\d+Z$/, 'Z');
 
+    if (!this.spec.template) {
+      set(this.spec, 'template', {});
+    }
+
     if ( !this.spec.template.metadata ) {
       set(this.spec.template, 'metadata', {});
     }

--- a/models/workload.js
+++ b/models/workload.js
@@ -274,10 +274,6 @@ export default {
   redeploy() {
     const now = (new Date()).toISOString().replace(/\.\d+Z$/, 'Z');
 
-    if (!this.spec.template) {
-      set(this.spec, 'template', {});
-    }
-
     if ( !this.spec.template.metadata ) {
       set(this.spec.template, 'metadata', {});
     }

--- a/models/workload.js
+++ b/models/workload.js
@@ -16,7 +16,7 @@ export default {
       icon:   'icon icon-plus'
     });
 
-    if (type !== WORKLOAD_TYPES.JOB) {
+    if (type !== WORKLOAD_TYPES.JOB && type !== WORKLOAD_TYPES.CRON_JOB) {
       insertAt(out, 0, {
         action:     'redeploy',
         label:      'Redeploy',


### PR DESCRIPTION
This sets template, if it doesn't exist, to the spec for a workload before attempting to set metadata.

This seems like a straightforward solution to resolve the error, but I wonder if there's some underlying problem that needs to be addressed that might explain why template is undefined at this point. 

#3835