### PR TITLE
[master]fix custom brand when subscription enabled

### DIFF
--- a/mixins/brand.js
+++ b/mixins/brand.js
@@ -85,7 +85,7 @@ export default {
 
     return {
       bodyAttrs: { class: cssClass },
-      title:     this.$store.getters['i18n/t']('nav.title'),
+      title:     getVendor(),
     };
   },
 


### PR DESCRIPTION
#3861 - the `head` function setting the title wasn't using `getVendor` with the SUSE brand enabled so I rectified that here. I thought that `getVendor` returned 'SUSE Rancher' or something similar with the subscription key provided, but I don't see any code for that hanging around... @nwmac do you know if that was intentionally removed?