### PR TITLE
[2.6] Add reload button to fail whale

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -80,7 +80,6 @@ nav:
   kubeconfig: Download KubeConfig
   import: Import YAML
   home: Home
-  reload: Reload
   shell: Kubectl Shell
   support: |-
     {hasSupport, select,
@@ -125,6 +124,9 @@ nav:
     preferences: Preferences
     accountAndKeys: Account & API Keys
     logOut: Log Out
+  failWhale: 
+    reload: Reload
+    separator: or
 
 product:
   apps: Apps & Marketplace

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -80,6 +80,7 @@ nav:
   kubeconfig: Download KubeConfig
   import: Import YAML
   home: Home
+  reload: Reload
   shell: Kubectl Shell
   support: |-
     {hasSupport, select,

--- a/pages/fail-whale.vue
+++ b/pages/fail-whale.vue
@@ -50,6 +50,11 @@ export default {
             {{ t('nav.home') }}
           </a>
         </p>
+        <hr>
+        <a class="btn role-secondary" @click="$router.go(-1)">
+          Reload
+        </a>
+        </p>
       </div>
     </main>
   </div>
@@ -73,4 +78,21 @@ export default {
       }
     }
   }
+
+  hr {
+    text-align: center;
+    margin-top: 18px;
+    margin-bottom: 18px;
+    max-width: 450px;
+  }
+
+  hr:after {
+    background: var(--body-bg);
+    color: var(--body-text);
+    content: 'or';
+    padding: 0 12px;
+    position: relative;
+    top: -12px;
+  }
+
 </style>

--- a/pages/fail-whale.vue
+++ b/pages/fail-whale.vue
@@ -51,9 +51,10 @@ export default {
           </a>
         </p>
         <hr>
-        <a class="btn role-secondary" @click="$router.go(-1)">
-          {{ t('nav.reload') }}
-        </a>
+        <p class="mt-20">
+          <a class="btn role-secondary" @click="$router.go(-1)">
+            {{ t('nav.reload') }}
+          </a>
         </p>
       </div>
     </main>

--- a/pages/fail-whale.vue
+++ b/pages/fail-whale.vue
@@ -52,7 +52,7 @@ export default {
         </p>
         <hr>
         <a class="btn role-secondary" @click="$router.go(-1)">
-          Reload
+          {{ t('nav.reload') }}
         </a>
         </p>
       </div>

--- a/pages/fail-whale.vue
+++ b/pages/fail-whale.vue
@@ -17,7 +17,10 @@ export default {
       this.$router.replace('/');
     }
 
-    return { home };
+    return {
+      home,
+      previousRoute: ''
+    };
   },
 
   computed: {
@@ -28,6 +31,11 @@ export default {
     },
   },
 
+  beforeRouteEnter(to, from, next) {
+    next((vm) => {
+      vm.previousRoute = from;
+    });
+  },
 };
 </script>
 
@@ -52,7 +60,7 @@ export default {
         </p>
         <hr>
         <p class="mt-20">
-          <a class="btn role-secondary" @click="$router.go(-1)">
+          <a class="btn role-secondary" @click="$router.push(previousRoute.fullPath)">
             {{ t('nav.reload') }}
           </a>
         </p>

--- a/pages/fail-whale.vue
+++ b/pages/fail-whale.vue
@@ -19,7 +19,8 @@ export default {
 
     return {
       home,
-      previousRoute: ''
+      previousRoute: '',
+      styles:        { '--custom-content': `'${ this.t('nav.failWhale.separator') }'` }
     };
   },
 
@@ -58,10 +59,10 @@ export default {
             {{ t('nav.home') }}
           </a>
         </p>
-        <hr>
+        <hr class="custom-content" :style="styles">
         <p class="mt-20">
           <a class="btn role-secondary" @click="$router.push(previousRoute.fullPath)">
-            {{ t('nav.reload') }}
+            {{ t('nav.failWhale.reload') }}
           </a>
         </p>
       </div>
@@ -88,20 +89,19 @@ export default {
     }
   }
 
-  hr {
+  .custom-content {
     text-align: center;
     margin-top: 18px;
     margin-bottom: 18px;
     max-width: 450px;
-  }
 
-  hr:after {
-    background: var(--body-bg);
-    color: var(--body-text);
-    content: 'or';
-    padding: 0 12px;
-    position: relative;
-    top: -12px;
+    &::after {
+      background: var(--body-bg);
+      color: var(--body-text);
+      content: var(--custom-content);
+      padding: 0 12px;
+      position: relative;
+      top: -12px;
+    }
   }
-
 </style>

--- a/store/index.js
+++ b/store/index.js
@@ -670,7 +670,7 @@ export const actions = {
     commit('setError', err);
     const router = state.$router;
 
-    router.replace('/fail-whale');
+    router.push('/fail-whale');
   },
 
   updateServerVersion({ commit, state }, neu) {

--- a/store/index.js
+++ b/store/index.js
@@ -670,7 +670,7 @@ export const actions = {
     commit('setError', err);
     const router = state.$router;
 
-    router.push('/fail-whale');
+    router.replace('/fail-whale');
   },
 
   updateServerVersion({ commit, state }, neu) {


### PR DESCRIPTION
This adds a button to the fail whale page to allow the user to "refresh" the page on error by attempting to navigate back one step in the router history. 

I attempted another approach to display the fail whale page without modifying the url by introducing a named catch-all route, similar to instructions detailed in [NUXT](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-router#extendroutes) and [Vue Router](https://next.router.vuejs.org/guide/essentials/dynamic-matching.html#catch-all-404-not-found-route), but I think the functionality that I was looking for is only available in Vue Router 4.x. I'm open to other potential solutions to resolve this issue.

#3421 

Backports PR #3926 into release-2.6