### PR TITLE
[2.6] Update windows not ready warning

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -911,7 +911,7 @@ cluster:
       label: Registration Command
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
       windowsDetail: Run this command in Powershell on each of the existing Windows machines you want to register.
-      windowsNotReady: The cluster must be up and running with Linux etcd and Control Plane nodes before the registration command for adding Windows workers will display.
+      windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:
     aws:


### PR DESCRIPTION
This updates the custom cluster registration windows not ready message to mention linux worker nodes.

#3580

Backports PR #3928 into release-2.6