### PR TITLE
[2.6] Warn users about adding windows and linux nodes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -915,7 +915,7 @@ cluster:
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
       windowsDetail: Run this command in Powershell on each of the existing Windows machines you want to register.
       windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
-      windowsWarning: Registering Windows and Linux worker nodes will allow workloads to deploy on both Linux and Windows worker nodes.
+      windowsWarning: Workload pods will be scheduled on both Linux and Windows nodes by default;  Use taints & tolerations or node/pod scheduling rules to direct them to be placed onto a compatible node.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:
     aws:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -915,7 +915,7 @@ cluster:
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
       windowsDetail: Run this command in Powershell on each of the existing Windows machines you want to register.
       windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
-      windowsWarning: Workload pods will be scheduled on both Linux and Windows nodes by default;  Use taints & tolerations or node/pod scheduling rules to direct them to be placed onto a compatible node.
+      windowsWarning: Workload pods will be scheduled on both Linux and Windows nodes by default;  Use taints and tolerations or node/pod scheduling rules to direct them to be placed onto a compatible node.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:
     aws:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -915,6 +915,7 @@ cluster:
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
       windowsDetail: Run this command in Powershell on each of the existing Windows machines you want to register.
       windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
+      windowsWarning: Registering Windows and Linux worker nodes will allow workloads to deploy on both Linux and Windows worker nodes.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:
     aws:

--- a/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -181,6 +181,10 @@ function sanitizeValue(v) {
             v-model="insecureWindows"
             label-key="cluster.custom.registrationCommand.insecure"
           />
+          <Banner
+            color="info"
+            :label="t('cluster.custom.registrationCommand.windowsWarning')"
+          />
         </template>
         <Banner
           v-else

--- a/list/node.vue
+++ b/list/node.vue
@@ -60,8 +60,6 @@ export default {
 
     const res = await allHash(hash);
 
-    await this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }, { root: true });
-
     this.kubeNodes = res.kubeNodes;
   },
 
@@ -73,6 +71,9 @@ export default {
   },
 
   computed: {
+    hasWindowsNodes() {
+      return this.kubeNodes.some(node => node.status.nodeInfo.operatingSystem === 'windows');
+    },
     currentCluster() {
       return this.$store.getters['currentCluster'];
     },
@@ -128,7 +129,7 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <div v-else>
     <Banner
-      v-if="clusterSupportsWindows"
+      v-if="hasWindowsNodes"
       color="info"
       :label="t('cluster.custom.registrationCommand.windowsWarning')"
     />

--- a/list/node.vue
+++ b/list/node.vue
@@ -74,12 +74,6 @@ export default {
     hasWindowsNodes() {
       return this.kubeNodes.some(node => node.status.nodeInfo.operatingSystem === 'windows');
     },
-    currentCluster() {
-      return this.$store.getters['currentCluster'];
-    },
-    clusterSupportsWindows() {
-      return this.currentCluster.provisioningCluster.supportsWindows;
-    },
     tableGroup: mapPref(GROUP_RESOURCES),
 
     headers() {

--- a/list/node.vue
+++ b/list/node.vue
@@ -2,6 +2,7 @@
 import ResourceTable from '@/components/ResourceTable';
 import Loading from '@/components/Loading';
 import Tag from '@/components/Tag';
+import Banner from '@/components/Banner';
 import {
   STATE, NAME, ROLES, VERSION, INTERNAL_EXTERNAL_IP, CPU, RAM, PODS, AGE
 } from '@/config/table-headers';
@@ -19,7 +20,10 @@ import { COLUMN_BREAKPOINTS } from '@/components/SortableTable/index.vue';
 export default {
   name:       'ListNode',
   components: {
-    Loading, ResourceTable, Tag
+    Loading,
+    ResourceTable,
+    Tag,
+    Banner
   },
   mixins: [metricPoller],
 
@@ -56,17 +60,25 @@ export default {
 
     const res = await allHash(hash);
 
+    await this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }, { root: true });
+
     this.kubeNodes = res.kubeNodes;
   },
 
   data() {
     return {
-      kubeNodes:     null,
+      kubeNodes:   null,
       canViewPods: false,
     };
   },
 
   computed: {
+    currentCluster() {
+      return this.$store.getters['currentCluster'];
+    },
+    clusterSupportsWindows() {
+      return this.currentCluster.provisioningCluster.supportsWindows;
+    },
     tableGroup: mapPref(GROUP_RESOURCES),
 
     headers() {
@@ -114,33 +126,39 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <ResourceTable
-    v-else
-    v-bind="$attrs"
-    :schema="schema"
-    :headers="headers"
-    :rows="kubeNodes"
-    :sub-rows="true"
-    v-on="$listeners"
-  >
-    <template #sub-row="{fullColspan, row}">
-      <tr class="taints sub-row" :class="{'empty-taints': !row.spec.taints || !row.spec.taints.length}">
-        <template v-if="row.spec.taints && row.spec.taints.length">
-          <td>&nbsp;</td>
-          <td>&nbsp;</td>
-          <td :colspan="fullColspan-2">
-            {{ t('node.list.nodeTaint') }}:
-            <Tag v-for="taint in row.spec.taints" :key="taint.key + taint.value + taint.effect" class="mr-5">
-              {{ taint.key }}={{ taint.value }}:{{ taint.effect }}
-            </Tag>
-          </td>
-        </template>
-        <td v-else :colspan="fullColspan">
+  <div v-else>
+    <Banner
+      v-if="clusterSupportsWindows"
+      color="info"
+      :label="t('cluster.custom.registrationCommand.windowsWarning')"
+    />
+    <ResourceTable
+      v-bind="$attrs"
+      :schema="schema"
+      :headers="headers"
+      :rows="kubeNodes"
+      :sub-rows="true"
+      v-on="$listeners"
+    >
+      <template #sub-row="{fullColspan, row}">
+        <tr class="taints sub-row" :class="{'empty-taints': !row.spec.taints || !row.spec.taints.length}">
+          <template v-if="row.spec.taints && row.spec.taints.length">
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+            <td :colspan="fullColspan-2">
+              {{ t('node.list.nodeTaint') }}:
+              <Tag v-for="taint in row.spec.taints" :key="taint.key + taint.value + taint.effect" class="mr-5">
+                {{ taint.key }}={{ taint.value }}:{{ taint.effect }}
+              </Tag>
+            </td>
+          </template>
+          <td v-else :colspan="fullColspan">
 &nbsp;
-        </td>
-      </tr>
-    </template>
-  </ResourceTable>
+          </td>
+        </tr>
+      </template>
+    </ResourceTable>
+  </div>
 </template>
 
 <style lang='scss' scoped>

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -1,5 +1,5 @@
 import { CATALOG } from '@/config/labels-annotations';
-import { CAPI, FLEET, MANAGEMENT, NODE } from '@/config/types';
+import { FLEET, MANAGEMENT, NODE } from '@/config/types';
 import { insertAt } from '@/utils/array';
 import { downloadFile } from '@/utils/download';
 import { parseSi } from '@/utils/units';
@@ -292,10 +292,6 @@ export default {
 
       downloadFile('kubeconfig.yaml', out, 'application/yaml');
     };
-  },
-
-  provisioningCluster() {
-    return this.$getters['all'](CAPI.RANCHER_CLUSTER).find(c => c.name === this.id);
   },
 
   fetchNodeMetrics() {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -1,5 +1,5 @@
 import { CATALOG } from '@/config/labels-annotations';
-import { FLEET, MANAGEMENT, NODE } from '@/config/types';
+import { CAPI, FLEET, MANAGEMENT, NODE } from '@/config/types';
 import { insertAt } from '@/utils/array';
 import { downloadFile } from '@/utils/download';
 import { parseSi } from '@/utils/units';
@@ -292,6 +292,10 @@ export default {
 
       downloadFile('kubeconfig.yaml', out, 'application/yaml');
     };
+  },
+
+  provisioningCluster() {
+    return this.$getters['all'](CAPI.RANCHER_CLUSTER).find(c => c.name === this.id);
   },
 
   fetchNodeMetrics() {


### PR DESCRIPTION
This displays warning to the user, notifying them that workloads will deploy to both windows and linux nodes. This warning is displayed while registering windows nodes or viewing a collection of nodes for a cluster that contains windows nodes. 

#3921 

Backports PR #3946 into release-2.6