### PR TITLE
[master] Remove "Powershell" from windows detail

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -913,7 +913,7 @@ cluster:
     registrationCommand:
       label: Registration Command
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
-      windowsDetail: Run this command in Powershell on each of the existing Windows machines you want to register.
+      windowsDetail: Run this command on each of the existing Windows machines you want to register.
       windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:


### PR DESCRIPTION
This change works in conjunction with rancher/rancher#34369 by removing "Powershell" from the windows detail message in order to reduce redundancy in messaging.

#3952

