### PR TITLE
[2.6] Fix issue where drop down re-opens when clicking on collapse button

### DIFF
--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -112,6 +112,12 @@ export default {
   methods: {
     // resizeHandler = in mixin
     focusSearch() {
+      const blurredAgo = Date.now() - this.blurred;
+
+      if (!this.focused && blurredAgo < 250) {
+        return;
+      }
+
       this.$nextTick(() => {
         const el = this.$refs['select-input']?.searchEl;
 

--- a/mixins/labeled-form-element.js
+++ b/mixins/labeled-form-element.js
@@ -65,6 +65,7 @@ export default {
     return {
       raised:  this.mode === _VIEW || !!`${ this.value }`,
       focused: false,
+      blurred: null,
     };
   },
 
@@ -129,6 +130,8 @@ export default {
       if ( !this.value ) {
         this.raised = false;
       }
+
+      this.blurred = Date.now();
     }
   }
 };


### PR DESCRIPTION
- This also fixes the blip when drop down is open and the selected value is clicked on again
- Investigated other fixes...
  - slot'ing a new open indicator in (doesn't handle clickes)
  - using document.activeElement (already set away from drop down)
  - this.raised (not applicable in some cases)

Issue: #3961
Master: #3965