### PR TITLE
[master]revert to using norman to delete projects

### DIFF
--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -43,6 +43,15 @@ export default {
     };
   },
 
+  remove() {
+    return async() => {
+      const norman = await this.norman;
+
+      await norman.remove(...arguments);
+      this.$commit('management/remove', this, { root: true });
+    };
+  },
+
   norman() {
     return this.id ? this.normanEditProject : this.normanNewProject;
   },


### PR DESCRIPTION
This PR reverts a change made I here https://github.com/rancher/dashboard/pull/3489 -- deleting projects is no longer allowed through steve. I originally made that change in an effort to fix the same issue described here: #3828 

Previously we were deleting through norman then calling 
`$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });` 
to refresh the project list but #3828 still happens some of the time. Here I've opted to remove the project object from the management/steve store once the norman delete runs so the project is consistently removed from the list view.