### PR TITLE
[master] Ensure we use the correct store when checking for catalog operation

### DIFF
--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -696,13 +696,16 @@ export default {
 
           return;
         }
+
         const res = await this.repo.doAction((isUpgrade ? 'upgrade' : 'install'), input);
         const operationId = `${ res.operationNamespace }/${ res.operationName }`;
 
         // Non-admins without a cluster won't be able to fetch operations immediately
         await this.repo.waitForOperation(operationId);
+        // Dynamically use store decided when loading catalog (covers standard user case when there's not cluster)
+        const inStore = this.$store.getters['catalog/inStore'];
 
-        this.operation = await this.$store.dispatch('cluster/find', {
+        this.operation = await this.$store.dispatch(`${ inStore }/find`, {
           type: CATALOG.OPERATION,
           id:   operationId
         });

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -37,7 +37,8 @@ export const state = function() {
     namespacedRepos: [],
     charts:          {},
     versionInfos:    {},
-    config:          { namespace: 'catalog' }
+    config:          { namespace: 'catalog' },
+    inStore:         undefined,
   };
 };
 
@@ -283,6 +284,10 @@ export const getters = {
 
       return steps;
     };
+  },
+
+  inStore(state) {
+    return state.inStore;
   }
 };
 
@@ -291,6 +296,10 @@ export const mutations = {
     const newState = state();
 
     Object.assign(currentState, newState);
+  },
+
+  setInStore(state, inStore) {
+    state.inStore = inStore;
   },
 
   setRepos(state, { cluster, namespaced }) {
@@ -321,7 +330,7 @@ export const actions = {
     let promises = {};
     // Installing an app? This is fine (in cluster store)
     // Fetching list of cluster templates? This is fine (in management store)
-    // Installing a cluster template? This isn't fine (in cluster store as per insalling app, but if there is no cluster we need to default to management)
+    // Installing a cluster template? This isn't fine (in cluster store as per installing app, but if there is no cluster we need to default to management)
     const inStore = rootGetters['currentCluster'] ? rootGetters['currentProduct'].inStore : 'management';
 
     if ( rootGetters[`${ inStore }/schemaFor`](CATALOG.CLUSTER_REPO) ) {
@@ -333,6 +342,9 @@ export const actions = {
     }
 
     const hash = await allHash(promises);
+
+    // As per comment above, when there are no clusters this will be management. Store it such that it can be used for those cases
+    commit('setInStore', inStore);
 
     commit('setRepos', hash);
 


### PR DESCRIPTION
- for standard users creating their first cluster (by template) there's no `cluster` available
- so for those scenarios the catalog entities are stored in the management store
- ensure then when we fetch the catalog operation after installing we respect the original store

Issue: #3721
2.6 PR: #3985