### PR TITLE
Fix mighty confused routing

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -89,8 +89,8 @@ export default {
     },
 
     groupSelected() {
-      // Don't do anything if we're in the fixed mode and this is an overview, or the group is the root (so this isn't a true visual group)
-      if (this.fixedOpen || this.group.isRoot) {
+      // Don't auto-select first group entry if we're already expanded
+      if (this.isExpanded) {
         return;
       }
 

--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -89,8 +89,8 @@ export default {
     },
 
     groupSelected() {
-      // Don't do anything if we're in the fixed mode and this is an overview
-      if (this.fixedOpen) {
+      // Don't do anything if we're in the fixed mode and this is an overview, or the group is the root (so this isn't a true visual group)
+      if (this.fixedOpen || this.group.isRoot) {
         return;
       }
 


### PR DESCRIPTION
- Core Problem
  - Type component selects an item in the side menu... which then fires off groupSelected in Groups component
  - Group component groupSelected then replaces route with first item in group, regardless of the route Type that was just selected
  - Page however still stays on the Type's route and not what the $route now thinks is the current one
  - This leads to all sorts of errors when clicking around types in a group
- Problem from Issue #3989
  - There is a guard in Type that normally prevents the groupSelected from firing if you're on the same page
  - However for the auth provider, where we change the route to a configured provider on click, this compares '/c/local/auth/config' to '/c/local/auth/config/github'
  - This means we try to change the page and GlobalLoading somehow gets stuck (we never receive the `finish` call, or even `failure` - https://nuxtjs.org/docs/2.x/features/loading#using-a-custom-loading-component)
- Fix
  - see second commit, basically don't autoselect if it's already expanded
  - ~Fixed for this specific issue by avoiding groupSelected when the group is the root (which means it's not a true group where the first should be selected)~
  - ~This fixes the error, but also the error logs for the auth and setting products~
  - ~This does not fix the error logs in groups where it's not root~
- Future Fix?
  - Break the link between Type select and Group groupSelected. I have a feeling this is very situational and to do with automatic selection rather than user clicking on a specific type