### PR TITLE
[2.6] Ensure Cluster Tools only shows if user can access required resources

### DIFF
--- a/components/SingleClusterInfo.vue
+++ b/components/SingleClusterInfo.vue
@@ -1,7 +1,9 @@
 <script>
 import RancherProviderIcon from '@/components/RancherProviderIcon';
 import ResourceSummary, { resourceCounts } from '@/pages/c/_cluster/explorer/ResourceSummary';
-import { NAMESPACE, MANAGEMENT, NODE, COUNT } from '@/config/types';
+import {
+  NAMESPACE, MANAGEMENT, NODE, COUNT, CATALOG
+} from '@/config/types';
 import { RESOURCES } from '@/pages/c/_cluster/explorer/index';
 
 export default {
@@ -64,6 +66,11 @@ export default {
 
     canAccessNamespaces() {
       return !!this.clusterCounts?.[0]?.counts?.[NAMESPACE];
+    },
+
+    showClusterTools() {
+      return this.$store.getters['cluster/canList'](CATALOG.CLUSTER_REPO) &&
+             this.$store.getters['cluster/canList'](CATALOG.APP);
     }
   },
 
@@ -111,7 +118,7 @@ export default {
           {{ t('nav.categories.explore') }}
         </nuxt-link>
       </div>
-      <div class="glance-item">
+      <div v-if="showClusterTools" class="glance-item">
         <nuxt-link :to="clusterToolsLink" class="cluster-link">
           {{ t('nav.clusterTools') }}
         </nuxt-link>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,7 +13,9 @@ import Group from '@/components/nav/Group';
 import Header from '@/components/nav/Header';
 import Brand from '@/mixins/brand';
 import FixedBanner from '@/components/FixedBanner';
-import { COUNT, SCHEMA, MANAGEMENT, UI } from '@/config/types';
+import {
+  COUNT, SCHEMA, MANAGEMENT, UI, CATALOG
+} from '@/config/types';
 import { BASIC, FAVORITE, USED } from '@/store/type-map';
 import { addObjects, replaceWith, clear, addObject } from '@/utils/array';
 import { NAME as EXPLORER } from '@/config/product/explorer';
@@ -129,6 +131,12 @@ export default {
 
       return {};
     },
+
+    showClusterTools() {
+      return this.isExplorer &&
+             this.$store.getters['cluster/canList'](CATALOG.CLUSTER_REPO) &&
+             this.$store.getters['cluster/canList'](CATALOG.APP);
+    }
   },
 
   watch: {
@@ -506,7 +514,7 @@ export default {
             </Group>
           </template>
         </div>
-        <n-link v-if="isExplorer" tag="div" class="tools" :to="{name: 'c-cluster-explorer-tools', params: {cluster: clusterId}}">
+        <n-link v-if="showClusterTools" tag="div" class="tools" :to="{name: 'c-cluster-explorer-tools', params: {cluster: clusterId}}">
           <a class="tools-button" @click="collapseAll()">
             <i class="icon icon-gear" />
             <span>{{ t('nav.clusterTools') }}</span>


### PR DESCRIPTION
- cluster member gains visiblity of catalog app when they can see a namespace
- fixed in cluster side nav and single cluster info