### PR TITLE
Focus on Select Member when adding a cluster member

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1231,7 +1231,8 @@ cluster:
     addClusterMember:
       labelSelect: Select Member
       labelAdd: Add Member
-      placeholder: Start typing to search for principals
+      placeholder: Search for a member to provide cluster access
+      searchPlaceholder: Start typing to search for principals
   privateRegistry:
     systemDefaultRegistry:
       label: Registry hostname for {vendor} images

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1228,6 +1228,10 @@ cluster:
           }
   memberRoles:
     removeMessage: 'Note: Removing a user will not remove their project permissions'
+    addClusterMember:
+      labelSelect: Select Member
+      labelAdd: Add Member
+      placeholder: Start typing to search for principals
   privateRegistry:
     systemDefaultRegistry:
       label: Registry hostname for {vendor} images

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1232,7 +1232,8 @@ cluster:
       labelSelect: Select Member
       labelAdd: Add Member
       placeholder: Search for a member to provide cluster access
-      searchPlaceholder: Start typing to search for principals
+      searchPlaceholder: Start typing to search
+      noResults: No results found
   privateRegistry:
     systemDefaultRegistry:
       label: Registry hostname for {vendor} images

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -138,8 +138,8 @@ export default {
 
 <template>
   <LabeledSelect
+    ref="labeled-select"
     v-model="newValue"
-    v-focus
     :mode="mode"
     :label="label"
     :placeholder="t('cluster.memberRoles.addClusterMember.placeholder')"

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -151,10 +151,10 @@ export default {
     @input="add"
     @search="onSearch"
   >
-    <template v-slot:no-options="{ search: searchVal , searching }">
+    <template v-slot:no-options="{ searching }">
       <template v-if="searching">
         <span class="search-slot">
-          No results found for <em>{{ searchVal }}</em>
+          {{ t('cluster.memberRoles.addClusterMember.noResults') }}
         </span>
       </template>
       <div v-else>

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -72,6 +72,10 @@ export default {
 
       return out;
     },
+
+    label() {
+      return this.retainSelection ? this.t('cluster.memberRoles.addClusterMember.labelSelect') : this.t('cluster.memberRoles.addClusterMember.labelAdd');
+    }
   },
 
   created() {
@@ -137,8 +141,8 @@ export default {
     v-model="newValue"
     v-focus
     :mode="mode"
-    :label="retainSelection ? `Select Member` : `Add Member`"
-    placeholder="Start typing to search for principals"
+    :label="label"
+    :placeholder="t('cluster.memberRoles.addClusterMember.placeholder')"
     :options="options"
     :searchable="true"
     :filterable="false"

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -151,6 +151,19 @@ export default {
     @input="add"
     @search="onSearch"
   >
+    <template v-slot:no-options="{ search: searchVal , searching }">
+      <template v-if="searching">
+        <span class="search-slot">
+          No results found for <em>{{ searchVal }}</em>
+        </span>
+      </template>
+      <div v-else>
+        <em class="search-slot">
+          {{ t('cluster.memberRoles.addClusterMember.searchPlaceholder') }}
+        </em>
+      </div>
+    </template>
+
     <template v-if="!searchStr && options.length" #list-header>
       <li class="pl-10 text-muted">
         Your Groups:
@@ -168,6 +181,10 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  .search-slot{
+    color: var(--body-text);
+  }
+
   .select-principal {
     &.retain-selection {
       min-height: 86px;

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -187,7 +187,7 @@ export default {
 
   .select-principal {
     &.retain-selection {
-      min-height: 86px;
+      min-height: 91px;
       &.focused {
         .principal {
           display: none;

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -135,6 +135,7 @@ export default {
 <template>
   <LabeledSelect
     v-model="newValue"
+    v-focus
     :mode="mode"
     :label="retainSelection ? `Select Member` : `Add Member`"
     placeholder="Start typing to search for principals"

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -214,6 +214,17 @@ export default {
     get,
     onClickOption(option, event) {
       onClickOption.call(this, option, event);
+    },
+    dropdownShouldOpen(instance) {
+      const { noDrop, open, mutableLoading } = instance;
+      const shouldOpen = this.shouldOpen;
+
+      if (shouldOpen === false) {
+        this.shouldOpen = true;
+        instance.open = false;
+      }
+
+      return noDrop ? false : open && shouldOpen && !mutableLoading;
     }
   },
 };
@@ -266,6 +277,7 @@ export default {
       :searchable="isSearchable"
       :selectable="selectable"
       :value="value != null && !loading ? value : ''"
+      :dropdown-should-open="dropdownShouldOpen"
       v-on="$listeners"
       @search:blur="onBlur"
       @search:focus="onFocus"

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -94,7 +94,10 @@ export default {
   },
 
   data() {
-    return { selectedVisibility: 'visible' };
+    return {
+      selectedVisibility: 'visible',
+      shouldOpen:         true
+    };
   },
 
   computed: {

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -215,9 +215,16 @@ export default {
     onClickOption(option, event) {
       onClickOption.call(this, option, event);
     },
-    dropdownShouldOpen(instance) {
-      const { noDrop, open, mutableLoading } = instance;
+    dropdownShouldOpen(instance, forceOpen = false) {
+      const { noDrop, mutableLoading } = instance;
+      const { open } = instance;
       const shouldOpen = this.shouldOpen;
+
+      if (forceOpen) {
+        instance.open = true;
+
+        return true;
+      }
 
       if (shouldOpen === false) {
         this.shouldOpen = true;
@@ -225,6 +232,9 @@ export default {
       }
 
       return noDrop ? false : open && shouldOpen && !mutableLoading;
+    },
+    onSearch(newSearchString, toggleLoading) {
+      this.dropdownShouldOpen(this.$refs['select-input'], true);
     }
   },
 };
@@ -281,6 +291,7 @@ export default {
       v-on="$listeners"
       @search:blur="onBlur"
       @search:focus="onFocus"
+      @search="onSearch"
       @open="resizeHandler"
     >
       <template #option="option">

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -228,14 +228,16 @@ export default {
 
       if (shouldOpen === false) {
         this.shouldOpen = true;
-        instance.open = false;
+        instance.closeSearchOptions();
       }
 
       return noDrop ? false : open && shouldOpen && !mutableLoading;
     },
-    onSearch(newSearchString, toggleLoading) {
-      this.dropdownShouldOpen(this.$refs['select-input'], true);
-    }
+    onSearch(newSearchString) {
+      if (newSearchString) {
+        this.dropdownShouldOpen(this.$refs['select-input'], true);
+      }
+    },
   },
 };
 </script>

--- a/components/form/Members/ClusterPermissionsEditor.vue
+++ b/components/form/Members/ClusterPermissionsEditor.vue
@@ -214,7 +214,13 @@ export default {
   <div v-else class="cluster-permissions-editor">
     <div class="row mt-10">
       <div class="col span-12">
-        <SelectPrincipal class="mb-20" :mode="mode" :retain-selection="true" @add="onAdd" />
+        <SelectPrincipal
+          v-focus
+          class="mb-20"
+          :mode="mode"
+          :retain-selection="true"
+          @add="onAdd"
+        />
       </div>
     </div>
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -293,6 +293,7 @@ module.exports = {
     '~/plugins/tooltip',
     '~/plugins/vue-clipboard2',
     '~/plugins/v-select',
+    '~/plugins/directives',
     '~/plugins/transitions',
     { src: '~plugins/vue-js-modal' },
     { src: '~/plugins/js-yaml', ssr: false },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "vue-codemirror": "^4.0.6",
     "vue-js-modal": "^1.3.31",
     "vue-resize": "^0.4.5",
-    "vue-select": "^3.11.2",
+    "vue-select": "^3.13.0",
     "vue-shortkey": "^3.1.7",
     "vue2-transitions": "^0.3.0",
     "xterm": "^4.9.0",

--- a/plugins/directives.js
+++ b/plugins/directives.js
@@ -1,0 +1,21 @@
+import Vue from 'vue';
+
+Vue.directive('focus', {
+  inserted(_el, _binding, vnode) {
+    const element = getElement(vnode);
+
+    if (element) {
+      element.focus();
+    }
+  }
+});
+
+const getElement = (vnode) => {
+  switch (vnode.componentOptions.tag) {
+  case 'LabeledInput':
+    return vnode.componentInstance.$refs.value;
+
+  case 'LabeledSelect':
+    return vnode.componentInstance.$refs['select-input'].$refs.search;
+  }
+};

--- a/plugins/directives.js
+++ b/plugins/directives.js
@@ -11,13 +11,23 @@ Vue.directive('focus', {
 });
 
 const getElement = (vnode) => {
-  switch (vnode.componentOptions.tag) {
-  case 'LabeledInput':
-    return vnode.componentInstance.$refs.value;
+  const { componentInstance, componentOptions: { tag } } = vnode;
 
-  case 'LabeledSelect':
-    vnode.componentInstance.shouldOpen = false;
+  if (tag === 'LabeledInput') {
+    return componentInstance.$refs.value;
+  }
 
-    return vnode.componentInstance.$refs['select-input'].$refs.search;
+  if (tag === 'LabeledSelect') {
+    componentInstance.shouldOpen = false;
+
+    return componentInstance.$refs['select-input'].$refs.search;
+  }
+
+  if (tag === 'SelectPrincipal') {
+    const labeledSelect = componentInstance.$refs['labeled-select'];
+
+    labeledSelect.shouldOpen = false;
+
+    return labeledSelect.$refs['select-input'].$refs.search;
   }
 };

--- a/plugins/directives.js
+++ b/plugins/directives.js
@@ -16,6 +16,8 @@ const getElement = (vnode) => {
     return vnode.componentInstance.$refs.value;
 
   case 'LabeledSelect':
+    vnode.componentInstance.shouldOpen = false;
+
     return vnode.componentInstance.$refs['select-input'].$refs.search;
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14070,9 +14070,10 @@ vue-router@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.3.tgz#fa93768616ee338aa174f160ac965167fa572ffa"
 
-vue-select@^3.11.2:
-  version "3.11.2"
-  resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-3.11.2.tgz#3ef93e3f2707e133c2df0b2920a05eea78764d18"
+vue-select@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-3.13.0.tgz#78d519984139156adcbf56af260fb6c2a69093a6"
+  integrity sha512-+PcWtfA1i3WVtkVwBPQknnOZL6QWSD2XiAVbSn0xAQvjOrmGAg7z+o9HkezXhtGdEstloJOdM8SujrUVyphKqg==
 
 vue-server-renderer@^2.6.12:
   version "2.6.12"


### PR DESCRIPTION
This adds focus to the member select when the component loads by creating a new `v-focus` directive. This directive provides focus to a `LabeledInput` or `LabeledSelect` by attempting to locate the focus-able element in the component instance. If the correct component can't be located, `v-focus` won't attempt to provide focus to any component.

Ideally, more focus-able components can be added to the directive as we identify components throughout Rancher that need support for this directive.

This also adds translations to the labeled select when adding cluster members.

#4026

