### PR TITLE
Add initContainers to the collection of pod containers

### DIFF
--- a/detail/pod.vue
+++ b/detail/pod.vue
@@ -54,10 +54,11 @@ export default {
   computed:   {
     ...mapGetters(['currentCluster']),
     containers() {
-      const { containerStatuses = [] } = this.value.status;
+      const containers = this.allContainers;
+      const statuses = this.allStatuses;
 
-      return (this.value.spec.containers || []).map((container) => {
-        container.status = findBy(containerStatuses, 'name', container.name) || {};
+      return (containers || []).map((container) => {
+        container.status = findBy(statuses, 'name', container.name) || {};
         container.stateDisplay = this.value.containerStateDisplay(container);
         container.stateBackground = this.value.containerStateColor(container).replace('text', 'bg');
         container.nameSort = sortableNumericSuffix(container.name).toLowerCase();
@@ -65,6 +66,19 @@ export default {
 
         return container;
       });
+    },
+
+    allContainers() {
+      const containers = this.value.spec.containers || [];
+      const initContainers = this.value.spec.initContainers || [];
+
+      return [...containers, ...initContainers];
+    },
+
+    allStatuses() {
+      const { containerStatuses = [], initContainerStatuses = [] } = this.value.status;
+
+      return [...containerStatuses, ...initContainerStatuses];
     },
 
     containerHeaders() {

--- a/detail/pod.vue
+++ b/detail/pod.vue
@@ -69,8 +69,7 @@ export default {
     },
 
     allContainers() {
-      const containers = this.value.spec.containers || [];
-      const initContainers = this.value.spec.initContainers || [];
+      const { containers = [], initContainers = [] } = this.value.spec;
 
       return [...containers, ...initContainers];
     },


### PR DESCRIPTION
This adds `initContainers` to pod containers by merging `containers` and `initContainers`, as well as associated statuses, into respective collections for each.

An alternative approach might be to create an additional tab that only displays when `initContainers` exist for a pod.  

#3508