### PR TITLE
k8s version update when a GKEv2 cluster is provisioning

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -49,6 +49,7 @@ generic:
   hideAdvanced: Hide Advanced
   type: Type
   unknown: Unknown
+  provisioning: '—'
   key: Key
   value: Value
   yes: Yes

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -143,7 +143,6 @@ export default {
 
   kubernetesVersion() {
     return this.kubernetesVersionRaw || this.$rootGetters['i18n/t']('generic.provisioning');
-    // return this.kubernetesVersionRaw || this.$rootGetters['i18n/t']('generic.provisioning');
   },
 
   kubernetesVersionBase() {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -142,7 +142,8 @@ export default {
   },
 
   kubernetesVersion() {
-    return this.kubernetesVersionRaw || this.$rootGetters['i18n/t']('generic.unknown');
+    return this.kubernetesVersionRaw || this.$rootGetters['i18n/t']('generic.provisioning');
+    // return this.kubernetesVersionRaw || this.$rootGetters['i18n/t']('generic.provisioning');
   },
 
   kubernetesVersionBase() {


### PR DESCRIPTION
#3997  Update to yaml translation to be consistent with other fields
<img width="810" alt="Screen Shot 2021-08-31 at 7 44 32 PM" src="https://user-images.githubusercontent.com/13671297/131603631-9539c5af-e73c-48c8-9ade-8e034d84d9f6.png">
