### PR TITLE
Classification banners show on login screen

### DIFF
--- a/layouts/unauthenticated.vue
+++ b/layouts/unauthenticated.vue
@@ -1,12 +1,20 @@
 <script>
 import Brand from '@/mixins/brand';
+import FixedBanner from '@/components/FixedBanner';
 
-export default { mixins: [Brand] };
+export default {
+  mixins:     [Brand],
+  components: { FixedBanner }
+};
 </script>
 
 <template>
   <main>
-    <nuxt />
+    <div class="dashboard-root">
+      <FixedBanner />
+      <nuxt />
+      <FixedBanner :footer="true" />
+    </div>
   </main>
 </template>
 


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/4091

After enabling a custom header and footer, they both now show when you log in and log out.
![Screen Shot 2021-09-01 at 8 44 14 PM](https://user-images.githubusercontent.com/20599230/131779267-4f89988e-3c43-47db-9d2f-4ed0cc60eeaa.png)
![Screen Shot 2021-09-01 at 8 39 39 PM](https://user-images.githubusercontent.com/20599230/131779270-9bdf07db-92d3-4b22-aabf-509ebbf93e1b.png)
