### PR TITLE
Describe secrets and link to Kubernetes docs

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3376,6 +3376,22 @@ secret:
     'provisioning.cattle.io/cloud-credential': 'CC'
     's3': 'S3'
   relatedWorkloads: Related Workloads
+  typeDescriptions:
+    'kubernetes.io/basic-auth':
+      description: 'Authentication with a username and password'
+      docLink: https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+    'Opaque': 
+      description: Default type of Secret using key-value pairs
+      docLink: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
+    'kubernetes.io/dockerconfigjson':
+      description: Authenticated registry for pulling container images
+      docLink: https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+    'kubernetes.io/ssh-auth':
+      description: Public key and private key for SSH authentication
+      docLink: https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+    'kubernetes.io/tls':
+      description: Store a certificate and key for TLS
+      docLink: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
 
 selectOrCreateAuthSecret:
   label: Authentication

--- a/edit/secret/index.vue
+++ b/edit/secret/index.vue
@@ -143,7 +143,9 @@ export default {
           out.push({
             id,
             label:       this.typeDisplay(id),
-            bannerAbbrv: this.initialDisplayFor(id)
+            bannerAbbrv: this.initialDisplayFor(id),
+            description: this.t(`secret.typeDescriptions.'${ id }'.description`),
+            docLink:     this.t(`secret.typeDescriptions.'${ id }'.docLink`)
           });
         }
       }


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/2644

This PR adds descriptions and Kubernetes docs links to each type of secret you can create on this page:
<img width="1056" alt="Screen Shot 2021-09-02 at 10 15 53 AM" src="https://user-images.githubusercontent.com/20599230/131890728-a8cdc4fa-d220-4318-a3c3-f89287073914.png">

The part about adding similar descriptions for role types isn't applicable because the page was removed.
