### PR TITLE
Disable tooltip for multiple values when only one value is allowed

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -483,7 +483,7 @@ export default {
       <template v-if="rows.length || isView">
         <label class="text-label">
           {{ keyLabel }}
-          <i v-if="protip && !isView" v-tooltip="protip" class="icon icon-info" />
+          <i v-if="protip && !isView && addAllowed" v-tooltip="protip" class="icon icon-info" />
         </label>
         <label class="text-label">
           {{ valueLabel }}


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/3724. The tooltip suggesting hints for entering multiple values no longer shows when only one key-value pair is allowed:
![Screen Shot 2021-09-03 at 1 09 39 AM](https://user-images.githubusercontent.com/20599230/131973426-16fb7dff-959e-45b0-96e2-a606d457db9e.png)


