### PR TITLE
Add Github Issue Template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,29 @@
+<!--------- For bugs and general issues --------->
+**Setup**
+- Rancher version:
+- Browser type & version:
+
+**Describe the bug**
+<!--A clear and concise description of what the bug is.-->
+
+**To Reproduce**
+<!--Steps to reproduce the behavior-->
+
+**Result**
+
+**Expected Result**
+<!--A clear and concise description of what you expected to happen.-->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem and/or errors in the browser's dev console -->
+
+**Additional context**
+<!--Add any other context about the problem here.—>
+
+<!--------- For feature requests --------->
+**Detailed Description**
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+**Context**
+<!--- Why is this change important to you? How would you use it? -->
+<!--- How can it benefit other users? -->


### PR DESCRIPTION
- Balanced asking too little info with wall of text that would probably be ignored
- Kept this simple, so clicking new issue takes user directly to template
  - Alternative is to have specific bug and feature request templates that user has to choose from first (see rancher/rancher)
- Could consider making this into a github form