### PR TITLE
Fix resource detail's detail values spacing

### DIFF
--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -132,7 +132,7 @@ export default {
 
 <style lang="scss">
   .detail-top {
-    $spacing: 5px;
+    $spacing: 4px;
 
     &:not(.empty) {
       // Flip of .masthead padding/margin

--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -90,7 +90,7 @@ export default {
       <span class="content">{{ description }}</span>
     </div>
 
-    <div class="details">
+    <div v-if="hasDetails" class="details">
       <div v-for="detail in details" :key="detail.label || detail.slotName" class="detail">
         <span class="label">
           {{ detail.label }}:
@@ -135,7 +135,8 @@ export default {
     $spacing: 5px;
 
     &:not(.empty) {
-      padding-top: 5px;
+      // Flip of .masthead padding/margin
+      padding-top: 10px;
       border-top: 1px solid var(--border);
       margin-top: 10px;
     }
@@ -153,7 +154,7 @@ export default {
       }
 
       .tag {
-        margin: $spacing/2 $spacing $spacing $spacing/2;
+        margin: $spacing/2 $spacing 0 $spacing/2;
         font-size: 12px;
       }
     }
@@ -171,10 +172,15 @@ export default {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      margin-bottom: 5px;
 
       .detail {
         margin-right: 20px;
+      }
+    }
+
+    & > div {
+      &:not(:last-of-type) {
+        margin-bottom: $spacing;
       }
     }
   }


### PR DESCRIPTION
- Fixed places like namespace (only shows 'detail' sections) and cluster  (only shows 'tags' section) detail pages 
- Still looks ok in places like node detail page (show's different types of sections)

Example
Old
![image](https://user-images.githubusercontent.com/18697775/132194626-2b9b1b8d-37b3-481d-b245-b8c88fbfa75d.png)
vs

New
![image](https://user-images.githubusercontent.com/18697775/132194749-24db0f38-3292-41c2-a456-a02ba9430e05.png)


