### PR TITLE
Store ns/project filter per cluster

### DIFF
--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -180,7 +180,10 @@ export default {
 
     value: {
       get() {
-        const values = this.$store.getters['prefs/get'](NAMESPACE_FILTERS);
+        const prefs = this.$store.getters['prefs/get'](NAMESPACE_FILTERS);
+        const clusterId = this.$store.getters['clusterId'];
+        const values = prefs[clusterId];
+
         const options = this.options;
 
         if (!values) {

--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -182,13 +182,8 @@ export default {
       get() {
         const prefs = this.$store.getters['prefs/get'](NAMESPACE_FILTERS);
         const clusterId = this.$store.getters['clusterId'];
-        const values = prefs[clusterId];
-
+        const values = prefs[clusterId] || ['all://user'];
         const options = this.options;
-
-        if (!values) {
-          return [];
-        }
 
         // Remove values that are not valid options
         const out = values

--- a/edit/constraints.gatekeeper.sh.constraint/NamespaceList.vue
+++ b/edit/constraints.gatekeeper.sh.constraint/NamespaceList.vue
@@ -4,7 +4,7 @@ import { _EDIT } from '@/config/query-params';
 import { NAMESPACE } from '@/config/types';
 import LabeledSelect from '@/components/form/LabeledSelect';
 
-export const NAMESPACE_FILTERS = {
+export const NAMESPACE_FILTERS_HELPER = {
   nonSystem(namespace) {
     return !namespace.isSystem;
   }

--- a/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -15,7 +15,7 @@ import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import CruResource from '@/components/CruResource';
 import { ENFORCEMENT_ACTION_VALUES } from '@/models/constraints.gatekeeper.sh.constraint';
 import { saferDump } from '@/utils/create-yaml';
-import NamespaceList, { NAMESPACE_FILTERS } from './NamespaceList';
+import NamespaceList, { NAMESPACE_FILTERS_HELPER } from './NamespaceList';
 import MatchKinds from './MatchKinds';
 import Scope, { SCOPE_OPTIONS } from './Scope';
 
@@ -98,7 +98,7 @@ export default {
         }
       ],
       enforcementActionLabels: Object.values(ENFORCEMENT_ACTION_VALUES).map(ucFirst),
-      NAMESPACE_FILTERS,
+      NAMESPACE_FILTERS_HELPER,
     };
   },
 
@@ -273,7 +273,7 @@ export default {
                   :label="t('gatekeeperConstraint.tab.namespaces.sub.namespaces')"
                   tooltip="If defined, a constraint will only apply to resources in a listed namespace."
                   :mode="mode"
-                  :namespace-filter="NAMESPACE_FILTERS.nonSystem"
+                  :namespace-filter="NAMESPACE_FILTERS_HELPER.nonSystem"
                   add-label="Add Namespace"
                 />
               </div>

--- a/store/index.js
+++ b/store/index.js
@@ -633,12 +633,12 @@ export const actions = {
     commit('updateNamespaces', { filters: value });
   },
 
-  async cleanNamespaces({ commit, getters, dispatch }) {
+  async cleanNamespaces({ getters, dispatch }) {
+    // Initialise / Remove any filters that the user no-longer has access to
     const clusters = await dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
     const filters = getters['prefs/get'](NAMESPACE_FILTERS);
 
-    // Convert pre 2.6.1 setting to new format
-    if (Array.isArray(filters)) {
+    if (!filters || !filters.length) {
       dispatch('prefs/set', {
         key:   NAMESPACE_FILTERS,
         value: { }

--- a/store/index.js
+++ b/store/index.js
@@ -636,6 +636,17 @@ export const actions = {
   async cleanNamespaces({ commit, getters, dispatch }) {
     const clusters = await dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
     const filters = getters['prefs/get'](NAMESPACE_FILTERS);
+
+    // Convert pre 2.6.1 setting to new format
+    if (Array.isArray(filters)) {
+      dispatch('prefs/set', {
+        key:   NAMESPACE_FILTERS,
+        value: { }
+      });
+
+      return;
+    }
+
     const cleanFilters = {};
 
     Object.entries(filters).forEach(([clusterId, pref]) => {

--- a/store/index.js
+++ b/store/index.js
@@ -607,8 +607,10 @@ export const actions = {
       navLinks:   !!getters['cluster/schemaFor'](UI.NAV_LINK) && dispatch('cluster/findAll', { type: UI.NAV_LINK }),
     });
 
+    await dispatch('cleanNamespaces');
+
     commit('updateNamespaces', {
-      filters: getters['prefs/get'](NAMESPACE_FILTERS),
+      filters: getters['prefs/get'](NAMESPACE_FILTERS)?.[id] || [],
       all:     res.namespaces
     });
 
@@ -617,9 +619,38 @@ export const actions = {
     console.log('Done loading cluster.'); // eslint-disable-line no-console
   },
 
-  switchNamespaces({ commit, dispatch }, value) {
-    dispatch('prefs/set', { key: NAMESPACE_FILTERS, value });
+  switchNamespaces({ commit, dispatch, getters }, value) {
+    const filters = getters['prefs/get'](NAMESPACE_FILTERS);
+    const clusterId = getters['clusterId'];
+
+    dispatch('prefs/set', {
+      key:   NAMESPACE_FILTERS,
+      value: {
+        ...filters,
+        [clusterId]: value
+      }
+    });
     commit('updateNamespaces', { filters: value });
+  },
+
+  async cleanNamespaces({ commit, getters, dispatch }) {
+    const clusters = await dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
+    const filters = getters['prefs/get'](NAMESPACE_FILTERS);
+    const cleanFilters = {};
+
+    Object.entries(filters).forEach(([clusterId, pref]) => {
+      if (clusters.find(c => c.id === clusterId)) {
+        cleanFilters[clusterId] = pref;
+      }
+    });
+
+    if (Object.keys(filters).length !== Object.keys(cleanFilters).length) {
+      console.debug('Unknown clusters have been removed from namespace filters list (before/after)', filters, cleanFilters); // eslint-disable-line no-console
+      dispatch('prefs/set', {
+        key:   NAMESPACE_FILTERS,
+        value: cleanFilters
+      });
+    }
   },
 
   async onLogout({ dispatch, commit, state }) {

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -43,7 +43,8 @@ const asCookie = true; // Store as a cookie so that it's available before auth +
 // Keys must be lowercase and valid dns label (a-z 0-9 -)
 export const CLUSTER = create('cluster', '');
 export const LAST_NAMESPACE = create('last-namespace', '');
-export const NAMESPACE_FILTERS = create('ns', ['all://user'], { parseJSON });
+export const NAMESPACE_FILTERS_LEGACY = create('ns', ['all://user'], { parseJSON });
+export const NAMESPACE_FILTERS = create('ns-by-cluster', {}, { parseJSON });
 export const WORKSPACE = create('workspace', '');
 export const EXPANDED_GROUPS = create('open-groups', ['cluster', 'rbac', 'serviceDiscovery', 'storage', 'workload'], { parseJSON });
 export const FAVORITE_TYPES = create('fav-type', [], { parseJSON });

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -43,7 +43,8 @@ const asCookie = true; // Store as a cookie so that it's available before auth +
 // Keys must be lowercase and valid dns label (a-z 0-9 -)
 export const CLUSTER = create('cluster', '');
 export const LAST_NAMESPACE = create('last-namespace', '');
-export const NAMESPACE_FILTERS_LEGACY = create('ns', ['all://user'], { parseJSON });
+// Pre-2.6.1 value which may exist when switching between version
+// export const NAMESPACE_FILTERS_LEGACY = create('ns', ['all://user'], { parseJSON });
 export const NAMESPACE_FILTERS = create('ns-by-cluster', {}, { parseJSON });
 export const WORKSPACE = create('workspace', '');
 export const EXPANDED_GROUPS = create('open-groups', ['cluster', 'rbac', 'serviceDiscovery', 'storage', 'workload'], { parseJSON });


### PR DESCRIPTION
- Previously there was one value for all clusters
- Now
  - prefs NAMESPACE_FILTERS stores values keyed by cluster
  - when accessing prefs NS the specific cluster is extracted and everything behaves as before
  - On switch of cluster any pref for an unknown cluster is removed
- addresses #3858

Also changed name of clashing NAMESPACE_FILTERS object