### PR TITLE
Filter out Harvester clusters from the various cluster lists

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1027,6 +1027,10 @@ cluster:
         label: KubeconfigContent
       placeholder: 'Namespace/Name'
   description:
+  harvester:
+    warning:
+      label: This is a Harvester Cluster - enable the Harvester feature flag to manage it
+      state: Warning
     label: Cluster Description
     placeholder: Any text you want that better describes this cluster
   haveOneOwner: There must be at least one member with the Owner role.

--- a/components/LandingPagePreference.vue
+++ b/components/LandingPagePreference.vue
@@ -5,6 +5,7 @@ import RadioGroup from '@/components/form/RadioGroup';
 import RadioButton from '@/components/form/RadioButton';
 import Select from '@/components/form/Select';
 import { MANAGEMENT } from '@/config/types';
+import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 export default {
   components: {
@@ -71,8 +72,9 @@ export default {
     routeDropdownOptions() {
       // Drop-down shows list of clusters that can ber set as login landing page
       const out = [];
+      const kubeClusters = filterOnlyKubernetesClusters(this.clusters);
 
-      this.clusters.forEach((c) => {
+      kubeClusters.forEach((c) => {
         if (c.isReady) {
           out.push({
             label: c.nameDisplay,

--- a/components/ResourceTable.vue
+++ b/components/ResourceTable.vue
@@ -123,6 +123,11 @@ export default {
 
       const includedNamespaces = this.$store.getters['namespaces']();
 
+      // Shouldn't happen, but does for resources like management.cattle.io.preference
+      if (!this.rows) {
+        return [];
+      }
+
       return this.rows.filter((row) => {
         return !!includedNamespaces[row.metadata.namespace];
       });

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -11,6 +11,7 @@ import { KEY } from '@/utils/platform';
 import { getVersionInfo } from '@/utils/version';
 import { LEGACY } from '@/store/features';
 import { SETTING } from '@/config/settings';
+import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 const UNKNOWN = 'unknown';
 const UI_VERSION = process.env.VERSION || UNKNOWN;
@@ -52,12 +53,17 @@ export default {
 
     showClusterSearch() {
       return this.clusters.length > this.maxClustersToShow;
+      const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
+      const kubeClusters = filterOnlyKubernetesClusters(all);
+
+      return kubeClusters.length > this.maxClustersToShow;
     },
 
     clusters() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
+      const kubeClusters = filterOnlyKubernetesClusters(all);
 
-      return all.map((x) => {
+      let out = kubeClusters.map((x) => {
         return {
           id:      x.id,
           label:   x.nameDisplay,

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -53,17 +53,13 @@ export default {
 
     showClusterSearch() {
       return this.clusters.length > this.maxClustersToShow;
-      const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-      const kubeClusters = filterOnlyKubernetesClusters(all);
-
-      return kubeClusters.length > this.maxClustersToShow;
     },
 
     clusters() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
       const kubeClusters = filterOnlyKubernetesClusters(all);
 
-      let out = kubeClusters.map((x) => {
+      return kubeClusters.map((x) => {
         return {
           id:      x.id,
           label:   x.nameDisplay,

--- a/config/product/harvester-manager.js
+++ b/config/product/harvester-manager.js
@@ -1,9 +1,9 @@
-import { HCI, MANAGEMENT, VIRTUAL_HARVESTER_PROVIDER, CAPI } from '@/config/types';
+import { HCI, MANAGEMENT, CAPI } from '@/config/types';
 import { HARVESTER, MULTI_CLUSTER } from '@/store/features';
 import { DSL } from '@/store/type-map';
 import { STATE, NAME as NAME_COL, AGE, VERSION } from '@/config/table-headers';
 import { allHash } from '@/utils/promise';
-import { HCI as HCI_LABEL } from '@/config/labels-annotations';
+import { isHarvesterCluster } from '@/utils/cluster';
 
 export const NAME = 'harvesterManager';
 
@@ -98,7 +98,7 @@ export function init(store) {
           type:     HCI.CLUSTER,
           provider: cluster?.status?.provider,
         };
-      }).filter(c => c?.metadata?.labels?.[HCI_LABEL.HARVESTER_CLUSTER] === 'true' || c.provider === VIRTUAL_HARVESTER_PROVIDER);
+      }).filter(c => isHarvesterCluster(c));
     },
   });
 }

--- a/edit/token.vue
+++ b/edit/token.vue
@@ -12,6 +12,7 @@ import RadioGroup from '@/components/form/RadioGroup';
 import Select from '@/components/form/Select';
 import CreateEditView from '@/mixins/create-edit-view';
 import { diffFrom } from '@/utils/time';
+import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 export default {
   components: {
@@ -56,7 +57,8 @@ export default {
     ...mapGetters({ t: 'i18n/t' }),
     scopes() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-      let out = all.map(opt => ({ value: opt.id, label: opt.nameDisplay }));
+      const kubeClusters = filterOnlyKubernetesClusters(all);
+      let out = kubeClusters.map(opt => ({ value: opt.id, label: opt.nameDisplay }));
 
       out = sortBy(out, ['label']);
       out.unshift( { value: '', label: this.t('accountAndKeys.apiKeys.add.noScope') } );

--- a/list/fleet.cattle.io.cluster.vue
+++ b/list/fleet.cattle.io.cluster.vue
@@ -2,7 +2,7 @@
 import FleetClusters from '@/components/FleetClusters';
 import { FLEET, MANAGEMENT } from '@/config/types';
 import Loading from '@/components/Loading';
-import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+import { isHarvesterCluster } from '@/utils/cluster';
 
 export default {
   name:       'ListCluster',
@@ -29,9 +29,6 @@ export default {
   },
 
   computed: {
-    kubeMgmtClusters() {
-      return filterOnlyKubernetesClusters(this.allMgmt);
-    },
     rows() {
       const out = this.allFleet.slice();
 
@@ -41,13 +38,13 @@ export default {
         known[c.metadata.name] = true;
       }
 
-      for ( const c of this.kubeMgmtClusters ) {
+      for ( const c of this.allMgmt ) {
         if ( !known[c.metadata.name] ) {
           out.push(c);
         }
       }
 
-      return out;
+      return out.filter(c => !isHarvesterCluster(c));
     },
   },
 };

--- a/list/fleet.cattle.io.cluster.vue
+++ b/list/fleet.cattle.io.cluster.vue
@@ -2,6 +2,7 @@
 import FleetClusters from '@/components/FleetClusters';
 import { FLEET, MANAGEMENT } from '@/config/types';
 import Loading from '@/components/Loading';
+import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 export default {
   name:       'ListCluster',
@@ -28,6 +29,9 @@ export default {
   },
 
   computed: {
+    kubeMgmtClusters() {
+      return filterOnlyKubernetesClusters(this.allMgmt);
+    },
     rows() {
       const out = this.allFleet.slice();
 
@@ -37,7 +41,7 @@ export default {
         known[c.metadata.name] = true;
       }
 
-      for ( const c of this.allMgmt ) {
+      for ( const c of this.kubeMgmtClusters ) {
         if ( !known[c.metadata.name] ) {
           out.push(c);
         }

--- a/list/management.cattle.io.cluster.vue
+++ b/list/management.cattle.io.cluster.vue
@@ -1,0 +1,28 @@
+<script>
+import ResourceTable from '@/components/ResourceTable';
+import Loading from '@/components/Loading';
+import { MANAGEMENT } from '@/config/types';
+import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+
+export default {
+  name:       'ListMgmtClusters',
+  components: { Loading, ResourceTable },
+  // fetch nodes before loading this page, as they may be referenced in the Target table column
+  async fetch() {
+    await this.$store.dispatch(`management/findAll`, { type: this.$attrs.resource });
+  },
+
+  computed: {
+    rows() {
+      const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
+
+      return filterOnlyKubernetesClusters(all);
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <ResourceTable v-else :schema="$attrs.schema" :rows="rows" :headers="$attrs.headers" :group-by="$attrs.groupBy" />
+</template>

--- a/list/management.cattle.io.cluster.vue
+++ b/list/management.cattle.io.cluster.vue
@@ -7,7 +7,7 @@ import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 export default {
   name:       'ListMgmtClusters',
   components: { Loading, ResourceTable },
-  // fetch nodes before loading this page, as they may be referenced in the Target table column
+
   async fetch() {
     await this.$store.dispatch(`management/findAll`, { type: this.$attrs.resource });
   },

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -4,6 +4,7 @@ import Masthead from '@/components/ResourceList/Masthead';
 import { allHash } from '@/utils/promise';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { MODE, _IMPORT } from '@/config/query-params';
+import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 export default {
   components: { ResourceTable, Masthead },
@@ -47,7 +48,7 @@ export default {
 
   computed: {
     rows() {
-      return this.rancherClusters;
+      return filterOnlyKubernetesClusters(this.rancherClusters);
     },
 
     createLocation() {

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -5,6 +5,7 @@ import { allHash } from '@/utils/promise';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { MODE, _IMPORT } from '@/config/query-params';
 import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+import { mapFeature, HARVESTER as HARVESTER_FEATURE } from '@/store/features';
 
 export default {
   components: { ResourceTable, Masthead },
@@ -48,7 +49,13 @@ export default {
 
   computed: {
     rows() {
-      return filterOnlyKubernetesClusters(this.rancherClusters);
+      // If Harvester feature is enabled, hide Harvester Clusters
+      if (this.harvesterEnabled) {
+        return filterOnlyKubernetesClusters(this.rancherClusters);
+      }
+
+      // Otherwise, show Harvester clusters - these will be shown with a warning
+      return this.rancherClusters;
     },
 
     createLocation() {
@@ -77,6 +84,8 @@ export default {
 
       return !!schema?.collectionMethods.find(x => x.toLowerCase() === 'post');
     },
+
+    harvesterEnabled: mapFeature(HARVESTER_FEATURE),
   },
 
   mounted() {
@@ -118,7 +127,8 @@ export default {
         <span v-if="!row.stateParts.length">{{ row.nodes.length }}</span>
       </template>
       <template #cell:explorer="{row}">
-        <n-link v-if="row.mgmt && row.mgmt.isReady" class="btn btn-sm role-primary" :to="{name: 'c-cluster', params: {cluster: row.mgmt.id}}">
+        <span v-if="row.mgmt && row.mgmt.isHarvester"></span>
+        <n-link v-else-if="row.mgmt && row.mgmt.isReady" class="btn btn-sm role-primary" :to="{name: 'c-cluster', params: {cluster: row.mgmt.id}}">
           Explore
         </n-link>
         <button v-else :disabled="true" class="btn btn-sm role-primary">

--- a/models/harvesterhci.io.management.cluster.js
+++ b/models/harvesterhci.io.management.cluster.js
@@ -4,6 +4,10 @@ import cluster, { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.clus
 export default {
   ...cluster,
 
+  availableActions() {
+    return this._availableActions;
+  },
+
   stateObj() {
     return this._stateObj;
   },

--- a/models/harvesterhci.io.management.cluster.js
+++ b/models/harvesterhci.io.management.cluster.js
@@ -4,6 +4,10 @@ import cluster, { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.clus
 export default {
   ...cluster,
 
+  stateObj() {
+    return this._stateObj;
+  },
+
   applyDefaults() {
     return () => {
       if ( !this.spec ) {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -14,6 +14,8 @@ import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 // If the logo is not named with the provider name, add an override here
 const PROVIDER_LOGO_OVERRIDE = {};
 
+const HARVESTER_LABEL = 'cluster.harvesterhci.io';
+
 export default {
   details() {
     const out = [
@@ -172,6 +174,10 @@ export default {
 
   isLocal() {
     return this.spec?.internal === true;
+  },
+
+  isHarvester() {
+    return this.metadata?.labels?.[HARVESTER_LABEL] === 'true';
   },
 
   providerLogo() {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -8,13 +8,12 @@ import { eachLimit } from '@/utils/promise';
 import { addParams } from '@/utils/url';
 import { isEmpty } from '@/utils/object';
 import { NAME as HARVESTER } from '@/config/product/harvester';
+import { isHarvesterCluster } from '@/utils/cluster';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 
 // See translation file cluster.providers for list of providers
 // If the logo is not named with the provider name, add an override here
 const PROVIDER_LOGO_OVERRIDE = {};
-
-const HARVESTER_LABEL = 'cluster.harvesterhci.io';
 
 export default {
   details() {
@@ -177,7 +176,7 @@ export default {
   },
 
   isHarvester() {
-    return this.metadata?.labels?.[HARVESTER_LABEL] === 'true';
+    return isHarvesterCluster(this);
   },
 
   providerLogo() {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -9,8 +9,6 @@ import { addParams } from '@/utils/url';
 import { isEmpty } from '@/utils/object';
 import { NAME as HARVESTER } from '@/config/product/harvester';
 import { isHarvesterCluster } from '@/utils/cluster';
-import { NAME as HARVESTER } from '@/config/product/harvester';
-import { isHarvesterCluster } from '@/utils/cluster';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 
 // See translation file cluster.providers for list of providers

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -16,6 +16,8 @@ import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 // If the logo is not named with the provider name, add an override here
 const PROVIDER_LOGO_OVERRIDE = {};
 
+const HARVESTER_LABEL = 'cluster.harvesterhci.io';
+
 export default {
   details() {
     const out = [

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -10,13 +10,12 @@ import { isEmpty } from '@/utils/object';
 import { NAME as HARVESTER } from '@/config/product/harvester';
 import { isHarvesterCluster } from '@/utils/cluster';
 import { NAME as HARVESTER } from '@/config/product/harvester';
+import { isHarvesterCluster } from '@/utils/cluster';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 
 // See translation file cluster.providers for list of providers
 // If the logo is not named with the provider name, add an override here
 const PROVIDER_LOGO_OVERRIDE = {};
-
-const HARVESTER_LABEL = 'cluster.harvesterhci.io';
 
 export default {
   details() {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -9,6 +9,7 @@ import { addParams } from '@/utils/url';
 import { isEmpty } from '@/utils/object';
 import { NAME as HARVESTER } from '@/config/product/harvester';
 import { isHarvesterCluster } from '@/utils/cluster';
+import { NAME as HARVESTER } from '@/config/product/harvester';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 
 // See translation file cluster.providers for list of providers

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -511,7 +511,7 @@ export default {
   },
 
   stateObj() {
-    if (this.isHarvester) {
+    if ( this.isHarvester) {
       return {
         error:         true,
         message:       this.$rootGetters['i18n/t']('cluster.harvester.warning.label'),
@@ -520,6 +520,10 @@ export default {
       };
     }
 
+    return this._stateObj;
+  },
+
+  _stateObj() {
     if (!this.isRke2) {
       return this.mgmt?.stateObj || this.metadata?.state;
     }

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -49,6 +49,11 @@ export default {
       }
     }
 
+    // No actions for Harvester clusters
+    if (this.isHarvester) {
+      return [];
+    }
+
     insertAt(out, idx++, {
       action:     'openShell',
       label:      'Kubectl Shell',
@@ -153,6 +158,10 @@ export default {
 
   isRke1() {
     return !!this.mgmt?.spec?.rancherKubernetesEngineConfig;
+  },
+
+  isHarvester() {
+    return !!this.mgmt?.isHarvester;
   },
 
   mgmtClusterId() {
@@ -502,6 +511,15 @@ export default {
   },
 
   stateObj() {
+    if (this.isHarvester) {
+      return {
+        error:         true,
+        message:       this.$rootGetters['i18n/t']('cluster.harvester.warning.label'),
+        name:          this.$rootGetters['i18n/t']('cluster.harvester.warning.state'),
+        transitioning: false
+      };
+    }
+
     if (!this.isRke2) {
       return this.mgmt?.stateObj || this.metadata?.state;
     }

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -35,6 +35,15 @@ export default {
     return out;
   },
 
+  availableActions() {
+    // No actions for Harvester clusters
+    if (this.isHarvester) {
+      return [];
+    }
+
+    return this._availableActions;
+  },
+
   _availableActions() {
     const out = this._standardActions;
     let idx = 0;
@@ -47,11 +56,6 @@ export default {
       if (remove > -1) {
         out.splice(remove, 1);
       }
-    }
-
-    // No actions for Harvester clusters
-    if (this.isHarvester) {
-      return [];
     }
 
     insertAt(out, idx++, {

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -21,6 +21,7 @@ import { getVendor } from '@/config/private-label';
 import { mapFeature, MULTI_CLUSTER } from '@/store/features';
 import { SETTING } from '@/config/settings';
 import { BLANK_CLUSTER } from '@/store';
+import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 const SET_LOGIN_ACTION = 'set-as-login';
 const RESET_CARDS_ACTION = 'reset-homepage-cards';
@@ -174,7 +175,11 @@ export default {
       return hasSomethingToShow && !hiddenByPreference;
     },
 
-    ...mapGetters(['currentCluster', 'defaultClusterId'])
+    ...mapGetters(['currentCluster', 'defaultClusterId']),
+
+    kubeClusters() {
+      return filterOnlyKubernetesClusters(this.clusters);
+    }
   },
 
   async created() {
@@ -264,7 +269,7 @@ export default {
           </SimpleBox>
           <div class="row panel">
             <div v-if="mcm" class="col span-12">
-              <SortableTable :table-actions="false" :row-actions="false" key-field="id" :rows="clusters" :headers="clusterHeaders">
+              <SortableTable :table-actions="false" :row-actions="false" key-field="id" :rows="kubeClusters" :headers="clusterHeaders">
                 <template #header-left>
                   <div class="row table-heading">
                     <h2 class="mb-0">

--- a/utils/cluster.js
+++ b/utils/cluster.js
@@ -1,14 +1,14 @@
-const HARVESTER_LABEL = 'cluster.harvesterhci.io';
-const VIRTUAL_HARVESTER_PROVIDER = 'harvester';
+import { VIRTUAL_HARVESTER_PROVIDER } from '@/config/types';
+import { HCI } from '@/config/labels-annotations';
 
 // Filter out any clusters that are not Kubernetes Clusters
 // Currently this removes Harvester clusters
-export function filterOnlyKubernetesClusters(clusters) {
-  return clusters.filter((c) => {
+export function filterOnlyKubernetesClusters(mgmtClusters) {
+  return mgmtClusters.filter((c) => {
     return !c.isHarvester;
   });
 }
 
-export function isHarvesterCluster(cluster) {
-  return cluster.metadata?.labels?.[HARVESTER_LABEL] === 'true' || cluster.provider === VIRTUAL_HARVESTER_PROVIDER;
+export function isHarvesterCluster(mgmtCluster) {
+  return mgmtCluster.metadata?.labels?.[HCI.HARVESTER_CLUSTER] === 'true' || mgmtCluster.provider === VIRTUAL_HARVESTER_PROVIDER;
 }

--- a/utils/cluster.js
+++ b/utils/cluster.js
@@ -1,12 +1,7 @@
-const HARVESTER_LABEL = 'cluster.harvesterhci.io';
-
 // Filter out any clusters that are not Kubernetes Clusters
-// Currently this removed Harvester clusters
+// Currently this removes Harvester clusters
 export function filterOnlyKubernetesClusters(clusters) {
   return clusters.filter((c) => {
-    const labels = c.metadata?.labels || {};
-    const isHarvester = labels[HARVESTER_LABEL] === 'true';
-
-    return !isHarvester;
+    return !c.isHarvester;
   });
 }

--- a/utils/cluster.js
+++ b/utils/cluster.js
@@ -1,0 +1,12 @@
+const HARVESTER_LABEL = 'cluster.harvesterhci.io';
+
+// Filter out any clusters that are not Kubernetes Clusters
+// Currently this removed Harvester clusters
+export function filterOnlyKubernetesClusters(clusters) {
+  return clusters.filter((c) => {
+    const labels = c.metadata?.labels || {};
+    const isHarvester = labels[HARVESTER_LABEL] === 'true';
+
+    return !isHarvester;
+  });
+}

--- a/utils/cluster.js
+++ b/utils/cluster.js
@@ -1,7 +1,14 @@
+const HARVESTER_LABEL = 'cluster.harvesterhci.io';
+const VIRTUAL_HARVESTER_PROVIDER = 'harvester';
+
 // Filter out any clusters that are not Kubernetes Clusters
 // Currently this removes Harvester clusters
 export function filterOnlyKubernetesClusters(clusters) {
   return clusters.filter((c) => {
     return !c.isHarvester;
   });
+}
+
+export function isHarvesterCluster(cluster) {
+  return cluster.metadata?.labels?.[HARVESTER_LABEL] === 'true' || cluster.provider === VIRTUAL_HARVESTER_PROVIDER;
 }


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/3467

Also contains bug fix for ResouceTable if you go to view a list for user preferences - the object returned is null, not an empty array, so this is now handled.