### PR TITLE
Remove duplicate type keys from YAML

### DIFF
--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -124,7 +124,7 @@ export function createYaml(schemas, type, data, processAlwaysAdd = true, depth =
   });
 
   for ( const key in data ) {
-    if ( typeof data[key] !== 'undefined' ) {
+    if (shouldAddKey(key, data, regularFields)) {
       addObject(regularFields, key);
     }
   }
@@ -325,6 +325,14 @@ function indent(lines, depth = 1) {
 
 function serializeSimpleValue(data) {
   return jsyaml.dump(data).trim();
+}
+
+function shouldAddKey(key, data, regularFields) {
+  if (typeof data[key] === 'undefined') {
+    return false;
+  }
+
+  return key !== 'type' || !regularFields.includes('_type');
 }
 
 export function typeRef(type, str) {

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -118,7 +118,7 @@ export function createYaml(schemas, type, data, processAlwaysAdd = true, depth =
   const commentFields = Object.keys(schema.resourceFields || {});
 
   commentFields.forEach((key) => {
-    if ( typeof data[key] !== 'undefined' || key === '_type' ) {
+    if ( typeof data[key] !== 'undefined' || (key === '_type' && !regularFields.includes('type')) ) {
       addObject(regularFields, key);
     }
   });

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -118,13 +118,13 @@ export function createYaml(schemas, type, data, processAlwaysAdd = true, depth =
   const commentFields = Object.keys(schema.resourceFields || {});
 
   commentFields.forEach((key) => {
-    if ( typeof data[key] !== 'undefined' || (key === '_type' && !regularFields.includes('type')) ) {
+    if ( typeof data[key] !== 'undefined' || (depth === 0 && key === '_type') ) {
       addObject(regularFields, key);
     }
   });
 
   for ( const key in data ) {
-    if (shouldAddKey(key, data, regularFields)) {
+    if (( typeof data[key] !== 'undefined' )) {
       addObject(regularFields, key);
     }
   }
@@ -325,14 +325,6 @@ function indent(lines, depth = 1) {
 
 function serializeSimpleValue(data) {
   return jsyaml.dump(data).trim();
-}
-
-function shouldAddKey(key, data, regularFields) {
-  if (typeof data[key] === 'undefined') {
-    return false;
-  }
-
-  return key !== 'type' || !regularFields.includes('_type');
 }
 
 export function typeRef(type, str) {

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -57,6 +57,7 @@ const ACTIVELY_REMOVE = [
   'metadata.managedFields',
   'metadata.relationships',
   'metadata.state',
+  'spec._type',
   'status',
   'links',
   'type',

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -57,7 +57,6 @@ const ACTIVELY_REMOVE = [
   'metadata.managedFields',
   'metadata.relationships',
   'metadata.state',
-  'spec._type',
   'status',
   'links',
   'type',

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -124,7 +124,7 @@ export function createYaml(schemas, type, data, processAlwaysAdd = true, depth =
   });
 
   for ( const key in data ) {
-    if (( typeof data[key] !== 'undefined' )) {
+    if ( typeof data[key] !== 'undefined' ) {
       addObject(regularFields, key);
     }
   }


### PR DESCRIPTION
This removes the duplicated  `type` key that show up when modifying YAML for services by only inserting `_type` at a depth of 0. Both keys `_type` and `type` were present in the schema and `_type` was getting transformed into `type`, generating the duplicate key.

#4042
#4136