### PR TITLE
Can see logs from init containers

### DIFF
--- a/components/nav/WindowManager/ContainerLogs.vue
+++ b/components/nav/WindowManager/ContainerLogs.vue
@@ -87,7 +87,10 @@ export default {
 
   computed: {
     containerChoices() {
-      return this.pod?.spec?.containers?.map(x => x.name) || [];
+      const containers = this.pod?.spec?.containers?.map(x => x.name) || [];
+      const initContainers = this.pod?.spec?.initContainers.map(x => x.name) || [];
+
+      return [...containers, ...initContainers];
     },
 
     rangeOptions() {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4032

To test this PR, I deployed a Pod on the `local` cluster from YAML. I used this YAML, taken mainly from the upstream [Kubernetes docs about initContainers](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-initialization/#create-a-pod-that-has-an-init-container). I created two initContainers named `install` and `install2` so show that you can switch between viewing logs for both of them.

```
apiVersion: v1
kind: Pod
metadata:
  name: init-demo
  namespace: default
spec:
  containers:
  - name: nginx
    image: nginx
    ports:
    - containerPort: 80
    volumeMounts:
    - name: workdir
      mountPath: /usr/share/nginx/html
  # These containers are run during pod initialization
  initContainers:
  - name: install
    image: busybox
    command:
    - wget
    - "-O"
    - "/work-dir/index.html"
    - http://info.cern.ch
    volumeMounts:
    - name: workdir
      mountPath: "/work-dir"
  - name: install2
    image: busybox
    command:
    - wget
    - "-O"
    - "/work-dir/index.html"
    - http://info.cern.ch
    volumeMounts:
    - name: workdir
      mountPath: "/work-dir"
  dnsPolicy: Default
  volumes:
  - name: workdir
    emptyDir: {}
```

Then I went to the new Pod's detail page and clicked **⋮ > View Logs.** Then I could see that the dropdown menu for containers now includes initContainers `install` and `install2`:

![Screen Shot 2021-09-09 at 9 34 33 PM](https://user-images.githubusercontent.com/20599230/132801123-80e623c7-b88a-4422-a78f-2c7b218fecd0.png)

