### PR TITLE
More info links are shown in top right corner

### DIFF
--- a/assets/styles/global/_resource.scss
+++ b/assets/styles/global/_resource.scss
@@ -61,7 +61,7 @@
 
     &:not(.top) {
       align-items: top;
-      flex-direction: row;
+      flex-direction: column;
       justify-content: start;
       &:hover {
         cursor: pointer;


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4108

When you create a new Secret, the subresource types now display the More Info links with proper alignment:

![Screen Shot 2021-09-09 at 10 23 21 PM](https://user-images.githubusercontent.com/20599230/132804156-28dbf0c8-5b12-4767-93c5-b42bb8a4fd4f.png)
