### PR TITLE
Replace incorrect translation of 'Encryption'

### DIFF
--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -474,7 +474,7 @@ backupRestoreOperator:
           label: 存储类
         tip: '配置一个默认保存所有备份的存储位置。您可以选择对每个备份进行覆盖，但仅限于使用与 S3 兼容的对象存储。'
         warning: '此 {type} 没有将其回收策略设置为 "保留"。 如果卷被更改或未绑定，您的备份可能会丢失。'
-  encryption: '这个{type}没有将其回收策略设置为 "保留"。 如果该卷被改变或变得不受约束，你的备份可能会丢失。' 
+  encryption: '加密' 
   encryptionConfigName:
     backuptip: '<code>cattle-resource-system</code>命名空间中具有<code>encryption-provider-config.yaml</code>密钥的任何秘密。<br/>此文件的内容是从此备份中执行还原所必需的，Rancher Backup 不会存储这些内容。'
     label: 加密配置密钥 


### PR DESCRIPTION
This issue addresses https://github.com/rancher/dashboard/issues/4102. It removes the variable that wasn't supposed to be there and replaces it with the equivalent of the English translation string `backupRestoreOperator.encryption`, which is just "Encryption."

To test this fix, 

1. I installed the backup application on the local cluster.
2. I switched the language to Chinese.
3. I went to the page for the Backup custom resource and clicked the create button.

Those steps resulted in a normal form without any errors.