### PR TITLE
pass external auth errors from auth/verify redirects back to main window

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2176,6 +2176,12 @@ login:
   welcome: Welcome to {vendor}
   loggedOut: You have been logged out.
   loginAgain: Log in again to continue.
+  serverError:  
+    authFailedCreds: "Logging in failed: Check credentials, or your account may not be authorized to log in."
+    authFailed: "Logging in failed: Your account may not be authorized to log in."
+    unknown: "An unknown error occured while attempting to login. Please contact your system administrator."
+    invalidSamlAttrs: "Invalid saml attributes"
+    noResponse: "No response received"
   error: An error occured logging in. Please try again.
   clientError: Invalid username or password. Please try again.
   useLocal: Use a local user

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -261,9 +261,7 @@ export default {
           {{ t('login.welcome', {vendor}) }}
         </h1>
         <div class="login-messages">
-          <h4 v-if="errorMessage" class="text-error text-center">
-            {{ errorMessage }}
-          </h4>
+          <Banner v-if="errorMessage" :label="errorMessage" color="error" />
           <h4 v-else-if="loggedOut" class="text-success text-center">
             {{ t('login.loggedOut') }}
           </h4>
@@ -387,10 +385,6 @@ export default {
       .text-error, .banner {
         max-width: 80%;
       }
-    }
-
-    .login-messages {
-      height: 20px;
     }
 
     .first-login-message {

--- a/pages/auth/verify.vue
+++ b/pages/auth/verify.vue
@@ -36,6 +36,22 @@ export default {
       return;
     }
 
+    const {
+      error, error_description: errorDescription, errorCode, errorMsg
+    } = route.query;
+
+    if (error || errorDescription || errorCode || errorMsg) {
+      let out = errorDescription || error || errorCode;
+
+      if (errorMsg) {
+        out = store.getters['i18n/withFallback'](`login.serverError.${ errorMsg }`, null, errorMsg);
+      }
+
+      redirect(`/auth/login?err=${ escape(out) }`);
+
+      return;
+    }
+
     try {
       const res = await store.dispatch('auth/verifyOAuth', {
         code,
@@ -73,8 +89,15 @@ export default {
   mounted() {
     if ( this.testing ) {
       try {
-        const { error: respError, error_description: respErrorDescription, [GITHUB_CODE]: code } = this.$route.query;
-        const error = respErrorDescription || respError || (!code ? 'No code supplied by auth provider' : null);
+        const {
+          error: respError, error_description: respErrorDescription, [GITHUB_CODE]: code, errorMsg
+        } = this.$route.query;
+
+        let error = respErrorDescription || respError || (!code ? 'No code supplied by auth provider' : null);
+
+        if (errorMsg) {
+          error = this.$store.getters['i18n/withFallback'](`login.serverError.${ errorMsg }`, null, errorMsg);
+        }
 
         reply(error, code );
       } catch (e) {
@@ -95,7 +118,7 @@ export default {
         }
       }
     }
-  },
+  }
 };
 </script>
 


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/3841

This issue arose from https://github.com/rancher/rancher/issues/13666 and it's specifically about errors the backend is returning on the redirect to `/auth/verify ` .  Some auth types return an `error_description` query param and some an `errorMsg`; the Ember code equivalent is [here](https://github.com/rancher/ui/blob/8e07c492673171731f3b26af14c978bc103d1828/app/verify/route.js#L54) and [here](https://github.com/rancher/ui/blob/8e07c492673171731f3b26af14c978bc103d1828/app/verify/route.js#L121) for saml and oauth respectively.