### PR TITLE
Add inputs to Output form for Cloudwatch logging

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2050,6 +2050,8 @@ logging:
     secretKey: Secret Key from Secret
     endpoint: Endpoint
     region: Region
+    logGroupName: Log Group Name
+    logStreamName: Log Stream Name
   datadog:
     apiKey: API Key from Secret
     useSSL: Use SSL
@@ -2119,6 +2121,7 @@ logging:
       access: Access
       certificate: Connection
       labels: Labels
+      configuration: Configuration
   outputProviders:
     elasticsearch: Elasticsearch
     splunkHec: Splunk

--- a/edit/logging.banzaicloud.io.output/providers/cloudwatch.vue
+++ b/edit/logging.banzaicloud.io.output/providers/cloudwatch.vue
@@ -42,7 +42,6 @@ export default {
         <LabeledInput v-model="value.endpoint" :mode="mode" :disabled="disabled" :label="t('logging.cloudwatch.endpoint')" />
       </div>
     </div>
-    <div class="spacer"></div>
     <div class="row">
       <div class="col span-6">
         <h3>{{ t('logging.output.sections.access') }}</h3>
@@ -70,5 +69,24 @@ export default {
         />
       </div>
     </div>
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.configuration') }}</h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <LabeledInput v-model="value.log_group_name" :mode="mode" :disabled="disabled" :label="t('logging.cloudwatch.logGroupName')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.log_stream_name" :mode="mode" :disabled="disabled" :label="t('logging.cloudwatch.logStreamName')" />
+      </div>
+    </div>
   </div>
 </template>
+
+<style>
+h3 {
+  margin-top: 10px;
+}
+</style>


### PR DESCRIPTION



This PR addresses https://github.com/rancher/dashboard/issues/3988 by adding the `log_group_name` and `log_stream_name` fields to the form for creating logging Outputs.

To test the Cloudwatch Output form,

1. I installed the logging operator
2. I went to form to create logging Outputs and created an Output with a `name`, `region`, `log_group_name` and `log_stream_name`

![Screen Shot 2021-09-10 at 5 34 13 PM](https://user-images.githubusercontent.com/20599230/132930775-47560bdd-95ef-47c2-a29e-32435b8d893f.png)

The Output was successfully created and I confirmed that the resulting YAML for the new fields matched the YAML for the Cloudwatch example in the Banzai Cloud documentation. https://banzaicloud.com/docs/one-eye/logging-operator/plugins/outputs/cloudwatch/#example-output-configurations

![Screen Shot 2021-09-10 at 5 38 53 PM](https://user-images.githubusercontent.com/20599230/132930768-1cf854b1-da8f-49c8-bf02-d3c889709f89.png)



Bastian said the `log_group_name` is required, so it looks like the Banzai Cloud docs incorrectly stated that the field is optional. I created a PR in the upstream Banzai Cloud docs to mark the field as required. https://github.com/banzaicloud/logging-operator-docs/pull/89