### PR TITLE
Add pod affinity weight input to pod scheduling tab

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4461,6 +4461,9 @@ workload:
         label: Topology Key
         placeholder: e.g. failure-domain.beta.kubernetes.io/zone
       type: Type
+      weight:
+        label: Weight
+        placeholder: Must be a weight between 1 and 100
     priority:
       className: Priority Class Name
       priority: Priority

--- a/components/form/PodAffinity.vue
+++ b/components/form/PodAffinity.vue
@@ -106,14 +106,14 @@ export default {
       this.allSelectorTerms.forEach((term) => {
         if (term._anti) {
           if (term.weight) {
-            const neu = { podAffinityTerm: term, weight: 1 };
+            const neu = { podAffinityTerm: term, weight: term.weight || this.defaultWeight };
 
             podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.push(neu);
           } else {
             podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.push(term);
           }
         } else if (term.weight) {
-          const neu = { podAffinityTerm: term, weight: 1 };
+          const neu = { podAffinityTerm: term, weight: term.weight || this.defaultWeight };
 
           podAffinity.preferredDuringSchedulingIgnoredDuringExecution.push(neu);
         } else {
@@ -139,7 +139,7 @@ export default {
       if (term.weight) {
         delete term.weight;
       } else {
-        term.weight = 1;
+        term.weight = this.defaultWeight;
       }
 
       this.$set(this.allSelectorTerms, idx, clone(term));
@@ -235,6 +235,21 @@ export default {
                 required
                 :label="t('workload.scheduling.affinity.topologyKey.label')"
                 :placeholder="t('workload.scheduling.affinity.topologyKey.placeholder')"
+              />
+            </div>
+          </div>
+
+          <div class="spacer"></div>
+          <div class="row">
+            <div class="col span-6">
+              <LabeledInput
+                v-model.number="props.row.value.weight"
+                :mode="mode"
+                type="number"
+                min="1"
+                max="100"
+                :label="t('workload.scheduling.affinity.weight.label')"
+                :placeholder="t('workload.scheduling.affinity.weight.placeholder')"
               />
             </div>
           </div>


### PR DESCRIPTION
#1815 
Added an input to select the weight for a pod when configuring preferred affinities.
![pod-weight](https://user-images.githubusercontent.com/40806497/133100360-7b710fd2-1858-4f46-be9a-49268710b54c.png)
 