### PR TITLE
Limit Secret options for Ingress to same namespace as Ingress

### DIFF
--- a/edit/networking.k8s.io.ingress/index.vue
+++ b/edit/networking.k8s.io.ingress/index.vue
@@ -63,7 +63,7 @@ export default {
       return this.isView ? this.t('ingress.rulesAndCertificates.title') : this.t('ingress.rules.title');
     },
     certificates() {
-      return this.filterByNamespace(this.allSecrets.filter(secret => secret._type === TYPES.TLS)).map((secret) => {
+      return this.filterByCurrentResourceNamespace(this.allSecrets.filter(secret => secret._type === TYPES.TLS)).map((secret) => {
         const { id } = secret;
 
         return id.slice(id.indexOf('/') + 1);
@@ -83,6 +83,8 @@ export default {
   },
   methods: {
     filterByCurrentResourceNamespace(resources) {
+      // When configuring an Ingress, the options for Secrets and
+      // default backend Services are limited to the namespace of the Ingress.
       return resources.filter((resource) => {
         return resource.metadata.namespace === this.value.metadata.namespace;
       });
@@ -97,13 +99,6 @@ export default {
 
         set(this.value.spec, path, null);
       }
-    },
-    filterByNamespace(list) {
-      const namespaces = this.$store.getters['namespaces']();
-
-      return list.filter((resource) => {
-        return !!namespaces[resource.metadata.namespace];
-      });
     },
   }
 };


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4125 by limiting the Secret options for Ingress configuration to only the Secrets that are in the same namespace as the Ingress.

The problem was that the secret options was based on what was selected in the top nav instead of the namespace selected in the Ingress creation form. So if you selected two namespaces in the top nav, you would see secrets from both namespaces as options when configuring the Ingress, even if the Ingress has a single namespace already configured.

To test this PR,

1. I created a namespace for the Ingress - `ingress-namespace`.
2. I created two Secrets of type Certificate - one in `ingress-namespace` named `correct-secret` and one in `default` named `incorrect-secret`:
  ```
apiVersion: v1
data:
  tls.crt: [test certificate]
  tls.key: [test key]
kind: Secret
metadata:
  name: correct-secret
  namespace: ingress-namespace
type: kubernetes.io/tls
---
apiVersion: v1
data:
  tls.crt: [test certificate]
  tls.key: [test key]
kind: Secret
metadata:
  name: incorrect-secret
  namespace: default
type: kubernetes.io/tls
  ```
3. In the top nav, I selected All Namespaces, or both `ingress-namespace` and `default`. I went to create an Ingress in `ingress-namespace`. Only `correct-secret` was available as a certificate option.

![Screen Shot 2021-09-13 at 4 59 55 PM](https://user-images.githubusercontent.com/20599230/133176873-6b519633-6b9e-4198-be1e-ae42f2017c45.png)


In the PR, I didn't have to write a new method to filter resources by the selected namespace because there was already an available method that did that. So I deleted the method that was filtering resources by the namespaces in the top nav because it wasn't used anywhere else in Ingress configuration.