### PR TITLE
check for auth verification errors sooner in page load

### DIFF
--- a/pages/auth/verify.vue
+++ b/pages/auth/verify.vue
@@ -20,22 +20,7 @@ export default {
 
   async fetch({ store, route, redirect }) {
     const code = route.query[GITHUB_CODE];
-    const stateStr = route.query[GITHUB_NONCE] || '';
-
-    let parsed;
-
-    try {
-      parsed = JSON.parse(base64Decode((stateStr)));
-    } catch {
-      return;
-    }
-
-    const { test, provider, nonce } = parsed;
-
-    if (test) {
-      return;
-    }
-
+    const stateStr = route.query[GITHUB_NONCE];
     const {
       error, error_description: errorDescription, errorCode, errorMsg
     } = route.query;
@@ -49,6 +34,19 @@ export default {
 
       redirect(`/auth/login?err=${ escape(out) }`);
 
+      return;
+    }
+    let parsed;
+
+    try {
+      parsed = JSON.parse(base64Decode((stateStr)));
+    } catch (err) {
+      return;
+    }
+
+    const { test, provider, nonce } = parsed;
+
+    if (test) {
       return;
     }
 


### PR DESCRIPTION
#3841 - my previous PR for this (#4144) wasn't checking for errors early enough (ie before looking for a github nonce code) in the `/auth/verify` page load and consequently missing some errors for some providers.