### PR TITLE
Display both error message and Amazon EC2 machine config form 

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1198,6 +1198,50 @@ cluster:
         label: Custom attributes (legacy)
         description: Custom attributes allow you to attach metadata to objects in the vSphere inventory to make it easier to sort and search for these objects.
         add: Add custom attribute
+    amazonEc2: 
+      region: Region
+      zone: Zone
+      instanceType: Instance Type
+      rootSize:
+        placeholder: 'Default: 16'
+        label: Root Disk Size
+        suffix: GB
+      selectedNetwork:
+        label: 'VPC/Subnet'
+        placeholder: Select a VPC or Subnet
+      iamInstanceProfile:
+        label: IAM Instance Profile Name
+        tooltip: Kubernetes AWS Cloud Provider support requires an appropriate instance profile
+      ami:
+        label: AMI ID
+        placeholder: 'Default: A recent Ubuntu LTS'
+      sshUser: 
+        label: SSH Username for AMI
+        placeholder: 'Default: ubuntu'
+        tooltip: 'The username that exists in the selected AMI; Provisioning will SSH to the node with this.'
+      securityGroup:
+        title: Security Group
+        vpcId: '(select a VPC/Subnet first)'
+        mode: 
+          default: 'Standard: Automatically create and use a "{defaultGroup}"; security group'
+          custom: 'Choose one or more existing security groups:'
+      volumeType:
+        label: EBS Root Volume Type
+        placeholder: 'Default: gp2'
+      encryptEbsVolume: Encrypt EBS Volume
+      kmsKey: 
+        label: KMS Key ARN
+        text: 'You do not have permission to list KMS keys, but may still be able to enter a Key ARN if you know one.'
+      requestSpotInstance: Request Spot Instance
+      spotPrice:
+        label: Spot Price
+        placeholder: 'Default: 0.50'
+        suffix: Dollars per hour
+      privateAddressOnly: Use only private address
+      useEbsOptimizedInstance: EBS-Optimized Instance
+      httpEndpoint: Allow access to EC2 metadata
+      httpTokens: Use tokens for metadata
+      tagTitle: EC2 Tags
 
   machinePool:
     name:

--- a/machine-config/amazonec2.vue
+++ b/machine-config/amazonec2.vue
@@ -142,6 +142,13 @@ export default {
   },
 
   computed: {
+    securityGroupLabels() {
+      return [
+        this.t('cluster.machineConfig.amazonEc2.securityGroup.mode.default', { defaultGroup: DEFAULT_GROUP }),
+        this.t('cluster.machineConfig.amazonEc2.securityGroup.mode.custom')
+      ];
+    },
+
     instanceOptions() {
       let lastGroup;
 
@@ -393,7 +400,7 @@ export default {
               :required="true"
               :searchable="true"
               :disabled="disabled"
-              label="Region"
+              :label="t('cluster.machineConfig.amazonEc2.region')"
             />
           </div>
           <div class="col span-6">
@@ -403,7 +410,7 @@ export default {
               :options="zoneOptions"
               :required="true"
               :disabled="disabled"
-              label="Zone"
+              :label="t('cluster.machineConfig.amazonEc2.zone')"
             />
           </div>
         </div>
@@ -417,7 +424,7 @@ export default {
               :selectable="option => !option.disabled"
               :searchable="true"
               :disabled="disabled"
-              label="Instance Type"
+              :label="t('cluster.machineConfig.amazonEc2.instanceType')"
             >
               <template v-slot:option="opt">
                 <template v-if="opt.kind === 'group'">
@@ -435,9 +442,9 @@ export default {
               output-as="string"
               :mode="mode"
               :disabled="disabled"
-              placeholder="Default: 16"
-              label="Root Disk Size"
-              suffix="GB"
+              :placeholder="t('cluster.machineConfig.amazonEc2.rootSize.placeholder')"
+              :label="t('cluster.machineConfig.amazonEc2.rootSize.label')"
+              :suffix="t('cluster.machineConfig.amazonEc2.rootSize.suffix')"
             />
           </div>
         </div>
@@ -450,8 +457,8 @@ export default {
               :searchable="true"
               :required="true"
               :disabled="disabled"
-              label="VPC/Subnet"
-              placeholder="Select a VPC or Subnet"
+              :placeholder="t('cluster.machineConfig.amazonEc2.selectedNetwork.placeholder')"
+              :label="t('cluster.machineConfig.amazonEc2.selectedNetwork.label')"
               @input="updateNetwork($event)"
             >
               <template v-slot:option="opt">
@@ -469,8 +476,8 @@ export default {
               v-model="value.iamInstanceProfile"
               :mode="mode"
               :disabled="disabled"
-              label="IAM Instance Profile Name"
-              tooltip="Kubernetes AWS Cloud Provider support requires an appropriate instance profile"
+              :tooltip="t('cluster.machineConfig.amazonEc2.iamInstanceProfile.tooltip')"
+              :label="t('cluster.machineConfig.amazonEc2.iamInstanceProfile.label')"
             />
           </div>
         </div>
@@ -482,18 +489,18 @@ export default {
                 v-model="value.ami"
                 :mode="mode"
                 :disabled="disabled"
-                label="AMI ID"
-                placeholder="Default: A recent Ubuntu LTS"
+                :placeholder="t('cluster.machineConfig.amazonEc2.ami.placeholder')"
+                :label="t('cluster.machineConfig.amazonEc2.ami.label')"
               />
             </div>
             <div class="col span-6">
               <LabeledInput
                 v-model="value.sshUser"
                 :mode="mode"
-                label="SSH Username for AMI"
+                :label="t('cluster.machineConfig.amazonEc2.sshUser.label')"
                 :disabled="!value.ami || disabled"
-                placeholder="Default: ubuntu"
-                tooltip="The username that exists in the selected AMI; Provisioning will SSH to the node with this."
+                :tooltip="t('cluster.machineConfig.amazonEc2.sshUser.tooltip')"
+                :placeholder="t('cluster.machineConfig.amazonEc2.sshUser.placeholder')"
               />
             </div>
           </div>
@@ -501,9 +508,9 @@ export default {
           <div class="row mt-20">
             <div class="col span-12">
               <h3>
-                Security Group
+                {{ t('cluster.machineConfig.amazonEc2.securityGroup.title') }}
                 <span v-if="!value.vpcId" class="text-muted text-small">
-                  (select a VPC/Subnet first)
+                  {{ t('cluster.machineConfig.amazonEc2.securityGroup.vpcId') }}
                 </span>
               </h3>
               <RadioGroup
@@ -511,7 +518,7 @@ export default {
                 name="securityGroupMode"
                 :mode="mode"
                 :disabled="!value.vpcId || disabled"
-                :labels="[`Standard: Automatically create and use a &quot;${DEFAULT_GROUP}&quot; security group`, 'Choose one or more existing security groups:']"
+                :labels="securityGroupLabels"
                 :options="['default','custom']"
               />
               <LabeledSelect
@@ -533,15 +540,19 @@ export default {
                 v-model="value.volumeType"
                 :mode="mode"
                 :disabled="disabled"
-                label="EBS Root Volume Type"
-                placeholder="Default: gp2"
+                :label="t('cluster.machineConfig.amazonEc2.volumeType.label')"
+                :placeholder="t('cluster.machineConfig.amazonEc2.volumeType.placeholder')"
               />
             </div>
           </div>
 
           <div class="row mt-20">
             <div class="col span-12">
-              <Checkbox v-model="value.encryptEbsVolume" :mode="mode" label="Encrypt EBS Volume" />
+              <Checkbox
+                v-model="value.encryptEbsVolume"
+                :mode="mode"
+                :label="t('cluster.machineConfig.amazonEc2.encryptEbsVolume')"
+              />
               <div v-if="value.encryptEbsVolume" class="mt-10">
                 <LabeledSelect
                   v-if="canReadKms"
@@ -549,17 +560,17 @@ export default {
                   :mode="mode"
                   :options="kmsOptions"
                   :disabled="disabled"
-                  label="KMS Key ARN"
+                  :label="t('cluster.machineConfig.amazonEc2.kmsKey.label')"
                 />
                 <template v-else>
                   <LabeledInput
                     v-model="value.kmsKey"
                     :mode="mode"
                     :disabled="disabled"
-                    label="KMS Key ARN"
+                    :label="t('cluster.machineConfig.amazonEc2.kmsKey.label')"
                   />
                   <p class="text-muted">
-                    You do not have permission to list KMS keys, but may still be able to enter a Key ARN if you know one.
+                    {{ t('cluster.machineConfig.amazonEc2.kmsKey.text') }}
                   </p>
                 </template>
               </div>
@@ -567,16 +578,20 @@ export default {
           </div>
           <div class="row mt-20">
             <div class="col span-6">
-              <Checkbox v-model="value.requestSpotInstance" :mode="mode" label="Request Spot Instance" />
+              <Checkbox
+                v-model="value.requestSpotInstance"
+                :mode="mode"
+                :label="t('cluster.machineConfig.amazonEc2.requestSpotInstance')"
+              />
               <div v-if="value.requestSpotInstance" class="mt-10">
                 <UnitInput
                   v-model="value.spotPrice"
                   output-as="string"
                   :mode="mode"
                   :disabled="disabled"
-                  placeholder="Default: 0.50"
-                  label="Spot Price"
-                  suffix="Dollars per hour"
+                  :placeholder="t('cluster.machineConfig.amazonEc2.spotPrice.placeholder')"
+                  :label="t('cluster.machineConfig.amazonEc2.spotPrice.label')"
+                  :suffix="t('cluster.machineConfig.amazonEc2.spotPrice.suffix')"
                 />
               </div>
             </div>
@@ -589,7 +604,7 @@ export default {
                   v-model="value.privateAddressOnly"
                   :mode="mode"
                   :disabled="disabled"
-                  label="Use only private addresses"
+                  :label="t('cluster.machineConfig.amazonEc2.privateAddressOnly')"
                 />
               </div>
               <div>
@@ -597,7 +612,7 @@ export default {
                   v-model="value.useEbsOptimizedInstance"
                   :mode="mode"
                   :disabled="disabled"
-                  label="EBS-Optimized Instance"
+                  :label="t('cluster.machineConfig.amazonEc2.useEbsOptimizedInstance')"
                 />
               </div>
               <div>
@@ -605,7 +620,7 @@ export default {
                   v-model="value.httpEndpoint"
                   :mode="mode"
                   :disabled="disabled"
-                  label="Allow access to EC2 metadata"
+                  :label="t('cluster.machineConfig.amazonEc2.httpEndpoint')"
                 />
               </div>
               <div>
@@ -613,7 +628,7 @@ export default {
                   v-model="value.httpTokens"
                   :mode="mode"
                   :disabled="!value.httpEndpoint || disabled"
-                  label="Use tokens for metadata"
+                  :label="t('cluster.machineConfig.amazonEc2.httpTokens')"
                 />
               </div>
             </div>
@@ -625,7 +640,7 @@ export default {
                 :value="tags"
                 :mode="mode"
                 :read-allowed="false"
-                title="EC2 Tags"
+                :label="t('cluster.machineConfig.amazonEc2.tagTitle')"
                 :add-label="t('labels.addTag')"
                 :disabled="disabled"
                 @input="updateTags"

--- a/machine-config/amazonec2.vue
+++ b/machine-config/amazonec2.vue
@@ -370,267 +370,270 @@ export default {
 <template>
   <div>
     <Loading v-if="$fetchState.pending" />
-    <div v-else-if="errors.length">
-      <div
-        v-for="(err, idx) in errors"
-        :key="idx"
-      >
-        <Banner
-          color="error"
-          :label="stringify(err)"
-        />
-      </div>
-    </div>
-    <div v-else-if="loadedRegionalFor">
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledSelect
-            v-model="value.region"
-            :mode="mode"
-            :options="regionOptions"
-            :required="true"
-            :searchable="true"
-            :disabled="disabled"
-            label="Region"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledSelect
-            v-model="value.zone"
-            :mode="mode"
-            :options="zoneOptions"
-            :required="true"
-            :disabled="disabled"
-            label="Zone"
-          />
-        </div>
-      </div>
-      <div class="row mb-20">
-        <div class="col span-9">
-          <LabeledSelect
-            v-model="value.instanceType"
-            :mode="mode"
-            :options="instanceOptions"
-            :required="true"
-            :selectable="option => !option.disabled"
-            :searchable="true"
-            :disabled="disabled"
-            label="Instance Type"
-          >
-            <template v-slot:option="opt">
-              <template v-if="opt.kind === 'group'">
-                <b>{{ opt.label }}</b>
-              </template>
-              <template v-else>
-                <span class="pl-10">{{ opt.label }}</span>
-              </template>
-            </template>
-          </LabeledSelect>
-        </div>
-        <div class="col span-3">
-          <UnitInput
-            v-model="value.rootSize"
-            output-as="string"
-            :mode="mode"
-            :disabled="disabled"
-            placeholder="Default: 16"
-            label="Root Disk Size"
-            suffix="GB"
-          />
-        </div>
-      </div>
-      <div class="row mt-20 mb-20">
-        <div class="col span-6">
-          <LabeledSelect
-            :mode="mode"
-            :value="selectedNetwork"
-            :options="networkOptions"
-            :searchable="true"
-            :required="true"
-            :disabled="disabled"
-            label="VPC/Subnet"
-            placeholder="Select a VPC or Subnet"
-            @input="updateNetwork($event)"
-          >
-            <template v-slot:option="opt">
-              <template v-if="opt.kind === 'vpc'">
-                <b>{{ opt.label }}</b>
-              </template>
-              <template v-else>
-                <span class="pl-10">{{ opt.label }}</span>
-              </template>
-            </template>
-          </LabeledSelect>
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model="value.iamInstanceProfile"
-            :mode="mode"
-            :disabled="disabled"
-            label="IAM Instance Profile Name"
-            tooltip="Kubernetes AWS Cloud Provider support requires an appropriate instance profile"
+    <template v-else>
+      <div v-if="errors.length">
+        <div
+          v-for="(err, idx) in errors"
+          :key="idx"
+        >
+          <Banner
+            color="error"
+            :label="stringify(err)"
           />
         </div>
       </div>
 
-      <portal :to="'advanced-'+uuid">
-        <div class="row mt-20">
+      <div v-if="loadedRegionalFor">
+        <div class="row mb-20">
           <div class="col span-6">
-            <LabeledInput
-              v-model="value.ami"
-              :mode="mode"
-              :disabled="disabled"
-              label="AMI ID"
-              placeholder="Default: A recent Ubuntu LTS"
-            />
-          </div>
-          <div class="col span-6">
-            <LabeledInput
-              v-model="value.sshUser"
-              :mode="mode"
-              label="SSH Username for AMI"
-              :disabled="!value.ami || disabled"
-              placeholder="Default: ubuntu"
-              tooltip="The username that exists in the selected AMI; Provisioning will SSH to the node with this."
-            />
-          </div>
-        </div>
-
-        <div class="row mt-20">
-          <div class="col span-12">
-            <h3>
-              Security Group
-              <span v-if="!value.vpcId" class="text-muted text-small">
-                (select a VPC/Subnet first)
-              </span>
-            </h3>
-            <RadioGroup
-              v-model="securityGroupMode"
-              name="securityGroupMode"
-              :mode="mode"
-              :disabled="!value.vpcId || disabled"
-              :labels="[`Standard: Automatically create and use a &quot;${DEFAULT_GROUP}&quot; security group`, 'Choose one or more existing security groups:']"
-              :options="['default','custom']"
-            />
             <LabeledSelect
-              v-if="value.vpcId && securityGroupMode === 'custom'"
-              v-model="value.securityGroup"
+              v-model="value.region"
               :mode="mode"
-              :disabled="!value.vpcId || disabled"
-              :options="securityGroupOptions"
+              :options="regionOptions"
+              :required="true"
               :searchable="true"
-              :multiple="true"
-              :taggable="true"
+              :disabled="disabled"
+              label="Region"
+            />
+          </div>
+          <div class="col span-6">
+            <LabeledSelect
+              v-model="value.zone"
+              :mode="mode"
+              :options="zoneOptions"
+              :required="true"
+              :disabled="disabled"
+              label="Zone"
             />
           </div>
         </div>
-
-        <div class="row mt-20">
-          <div class="col span-6">
-            <LabeledInput
-              v-model="value.volumeType"
+        <div class="row mb-20">
+          <div class="col span-9">
+            <LabeledSelect
+              v-model="value.instanceType"
+              :mode="mode"
+              :options="instanceOptions"
+              :required="true"
+              :selectable="option => !option.disabled"
+              :searchable="true"
+              :disabled="disabled"
+              label="Instance Type"
+            >
+              <template v-slot:option="opt">
+                <template v-if="opt.kind === 'group'">
+                  <b>{{ opt.label }}</b>
+                </template>
+                <template v-else>
+                  <span class="pl-10">{{ opt.label }}</span>
+                </template>
+              </template>
+            </LabeledSelect>
+          </div>
+          <div class="col span-3">
+            <UnitInput
+              v-model="value.rootSize"
+              output-as="string"
               :mode="mode"
               :disabled="disabled"
-              label="EBS Root Volume Type"
-              placeholder="Default: gp2"
+              placeholder="Default: 16"
+              label="Root Disk Size"
+              suffix="GB"
+            />
+          </div>
+        </div>
+        <div class="row mt-20 mb-20">
+          <div class="col span-6">
+            <LabeledSelect
+              :mode="mode"
+              :value="selectedNetwork"
+              :options="networkOptions"
+              :searchable="true"
+              :required="true"
+              :disabled="disabled"
+              label="VPC/Subnet"
+              placeholder="Select a VPC or Subnet"
+              @input="updateNetwork($event)"
+            >
+              <template v-slot:option="opt">
+                <template v-if="opt.kind === 'vpc'">
+                  <b>{{ opt.label }}</b>
+                </template>
+                <template v-else>
+                  <span class="pl-10">{{ opt.label }}</span>
+                </template>
+              </template>
+            </LabeledSelect>
+          </div>
+          <div class="col span-6">
+            <LabeledInput
+              v-model="value.iamInstanceProfile"
+              :mode="mode"
+              :disabled="disabled"
+              label="IAM Instance Profile Name"
+              tooltip="Kubernetes AWS Cloud Provider support requires an appropriate instance profile"
             />
           </div>
         </div>
 
-        <div class="row mt-20">
-          <div class="col span-12">
-            <Checkbox v-model="value.encryptEbsVolume" :mode="mode" label="Encrypt EBS Volume" />
-            <div v-if="value.encryptEbsVolume" class="mt-10">
-              <LabeledSelect
-                v-if="canReadKms"
-                v-model="value.kmsKey"
+        <portal :to="'advanced-'+uuid">
+          <div class="row mt-20">
+            <div class="col span-6">
+              <LabeledInput
+                v-model="value.ami"
                 :mode="mode"
-                :options="kmsOptions"
                 :disabled="disabled"
-                label="KMS Key ARN"
+                label="AMI ID"
+                placeholder="Default: A recent Ubuntu LTS"
               />
-              <template v-else>
-                <LabeledInput
+            </div>
+            <div class="col span-6">
+              <LabeledInput
+                v-model="value.sshUser"
+                :mode="mode"
+                label="SSH Username for AMI"
+                :disabled="!value.ami || disabled"
+                placeholder="Default: ubuntu"
+                tooltip="The username that exists in the selected AMI; Provisioning will SSH to the node with this."
+              />
+            </div>
+          </div>
+
+          <div class="row mt-20">
+            <div class="col span-12">
+              <h3>
+                Security Group
+                <span v-if="!value.vpcId" class="text-muted text-small">
+                  (select a VPC/Subnet first)
+                </span>
+              </h3>
+              <RadioGroup
+                v-model="securityGroupMode"
+                name="securityGroupMode"
+                :mode="mode"
+                :disabled="!value.vpcId || disabled"
+                :labels="[`Standard: Automatically create and use a &quot;${DEFAULT_GROUP}&quot; security group`, 'Choose one or more existing security groups:']"
+                :options="['default','custom']"
+              />
+              <LabeledSelect
+                v-if="value.vpcId && securityGroupMode === 'custom'"
+                v-model="value.securityGroup"
+                :mode="mode"
+                :disabled="!value.vpcId || disabled"
+                :options="securityGroupOptions"
+                :searchable="true"
+                :multiple="true"
+                :taggable="true"
+              />
+            </div>
+          </div>
+
+          <div class="row mt-20">
+            <div class="col span-6">
+              <LabeledInput
+                v-model="value.volumeType"
+                :mode="mode"
+                :disabled="disabled"
+                label="EBS Root Volume Type"
+                placeholder="Default: gp2"
+              />
+            </div>
+          </div>
+
+          <div class="row mt-20">
+            <div class="col span-12">
+              <Checkbox v-model="value.encryptEbsVolume" :mode="mode" label="Encrypt EBS Volume" />
+              <div v-if="value.encryptEbsVolume" class="mt-10">
+                <LabeledSelect
+                  v-if="canReadKms"
                   v-model="value.kmsKey"
                   :mode="mode"
+                  :options="kmsOptions"
                   :disabled="disabled"
                   label="KMS Key ARN"
                 />
-                <p class="text-muted">
-                  You do not have permission to list KMS keys, but may still be able to enter a Key ARN if you know one.
-                </p>
-              </template>
+                <template v-else>
+                  <LabeledInput
+                    v-model="value.kmsKey"
+                    :mode="mode"
+                    :disabled="disabled"
+                    label="KMS Key ARN"
+                  />
+                  <p class="text-muted">
+                    You do not have permission to list KMS keys, but may still be able to enter a Key ARN if you know one.
+                  </p>
+                </template>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="row mt-20">
-          <div class="col span-6">
-            <Checkbox v-model="value.requestSpotInstance" :mode="mode" label="Request Spot Instance" />
-            <div v-if="value.requestSpotInstance" class="mt-10">
-              <UnitInput
-                v-model="value.spotPrice"
-                output-as="string"
-                :mode="mode"
-                :disabled="disabled"
-                placeholder="Default: 0.50"
-                label="Spot Price"
-                suffix="Dollars per hour"
-              />
+          <div class="row mt-20">
+            <div class="col span-6">
+              <Checkbox v-model="value.requestSpotInstance" :mode="mode" label="Request Spot Instance" />
+              <div v-if="value.requestSpotInstance" class="mt-10">
+                <UnitInput
+                  v-model="value.spotPrice"
+                  output-as="string"
+                  :mode="mode"
+                  :disabled="disabled"
+                  placeholder="Default: 0.50"
+                  label="Spot Price"
+                  suffix="Dollars per hour"
+                />
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="row mt-20">
-          <div class="col span-12">
-            <div>
-              <Checkbox
-                v-model="value.privateAddressOnly"
-                :mode="mode"
-                :disabled="disabled"
-                label="Use only private addresses"
-              />
-            </div>
-            <div>
-              <Checkbox
-                v-model="value.useEbsOptimizedInstance"
-                :mode="mode"
-                :disabled="disabled"
-                label="EBS-Optimized Instance"
-              />
-            </div>
-            <div>
-              <Checkbox
-                v-model="value.httpEndpoint"
-                :mode="mode"
-                :disabled="disabled"
-                label="Allow access to EC2 metadata"
-              />
-            </div>
-            <div>
-              <Checkbox
-                v-model="value.httpTokens"
-                :mode="mode"
-                :disabled="!value.httpEndpoint || disabled"
-                label="Use tokens for metadata"
-              />
+          <div class="row mt-20">
+            <div class="col span-12">
+              <div>
+                <Checkbox
+                  v-model="value.privateAddressOnly"
+                  :mode="mode"
+                  :disabled="disabled"
+                  label="Use only private addresses"
+                />
+              </div>
+              <div>
+                <Checkbox
+                  v-model="value.useEbsOptimizedInstance"
+                  :mode="mode"
+                  :disabled="disabled"
+                  label="EBS-Optimized Instance"
+                />
+              </div>
+              <div>
+                <Checkbox
+                  v-model="value.httpEndpoint"
+                  :mode="mode"
+                  :disabled="disabled"
+                  label="Allow access to EC2 metadata"
+                />
+              </div>
+              <div>
+                <Checkbox
+                  v-model="value.httpTokens"
+                  :mode="mode"
+                  :disabled="!value.httpEndpoint || disabled"
+                  label="Use tokens for metadata"
+                />
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="row mt-20">
-          <div class="col span-12">
-            <KeyValue
-              :value="tags"
-              :mode="mode"
-              :read-allowed="false"
-              title="EC2 Tags"
-              :add-label="t('labels.addTag')"
-              :disabled="disabled"
-              @input="updateTags"
-            />
+          <div class="row mt-20">
+            <div class="col span-12">
+              <KeyValue
+                :value="tags"
+                :mode="mode"
+                :read-allowed="false"
+                title="EC2 Tags"
+                :add-label="t('labels.addTag')"
+                :disabled="disabled"
+                @input="updateTags"
+              />
+            </div>
           </div>
-        </div>
-      </portal>
-    </div>
+        </portal>
+      </div>
+    </template>
   </div>
 </template>


### PR DESCRIPTION
This resolves an issue where a pool for Amazon EC2 could go into an unrecoverable error state by performing a simple action like selecting a region that a user might not have authorization to access. We resolve this issue by opting to display both the error message and form at the same time. 

An alternative approach might be to introduce a button that will reset the machine config state and clear the error if we want to keep to current behavior or only displaying either the machine config or error.

This also fills in some gaps in translations that I encountered throughout the component.

#4071