### PR TITLE
Forward port rollback workload feature

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -534,6 +534,10 @@ asyncButton:
     action: Restore
     waiting: Restoring&hellip;
     success: Restored
+  rollback:
+    action: Roll Back
+    success: Rolled Back
+    waiting: Rolling Back Workload
   rotate:
     action: Rotate
     waiting: Rotating&hellip;
@@ -1414,7 +1418,6 @@ cluster:
   toggle:
     v1: RKE1
     v2: RKE2/K3s
-
 
 clusterIndexPage:
   hardwareResourceGauge:
@@ -3151,6 +3154,17 @@ promptRestore:
   name: Name
   date: Date
   fromS3: Restore from S3
+
+promptRollback:
+  modalTitle: Roll Back {workloadName}
+  dropdownTitle: Roll Back to Revision
+  placeholder: Choose a Revision...
+  attemptingToRollBack: Attempting to roll back workload...
+  differences: Differences
+  revisionOption: "Revision {revisionNumber}, created {revisionAge} {units} ago {currentLabel}"
+  currentLabel: "(Current)"
+  multipleWorkloadError: "Only one workload can be rolled back at a time."
+  singleRevisionBanner: There are no revisions to roll back to.
 
 promptSaveAsRKETemplate:
   title: Convert {cluster} to new RKE Template

--- a/components/PromptModal.vue
+++ b/components/PromptModal.vue
@@ -22,6 +22,7 @@ export default {
     },
 
     component() {
+      // Looks for a dialog component by looking up @/components/dialog/${name}.
       return importDialog(this.modalData?.component);
     },
   },

--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -1,0 +1,214 @@
+<script>
+import AsyncButton from '@/components/AsyncButton';
+import day from 'dayjs';
+import Card from '@/components/Card';
+import { exceptionToErrorsArray } from '@/utils/error';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import Banner from '@/components/Banner';
+import { WORKLOAD_TYPES } from '@/config/types';
+import { diffFrom } from '@/utils/time';
+import { mapGetters } from 'vuex';
+
+export default {
+  components: {
+    Card,
+    AsyncButton,
+    LabeledSelect,
+    Banner
+  },
+  props:      {
+    resources: {
+      type:     Array,
+      required: true
+    }
+  },
+  data() {
+    return {
+      errors:             [],
+      selectedRevision:   null,
+      currentRevision:    null,
+      revisions:          [],
+    };
+  },
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+    workload() {
+      return this.resources[0];
+    },
+    workloadName() {
+      return this.workload.metadata.name;
+    },
+    workloadNamespace() {
+      return this.workload.metadata.namespace;
+    },
+    currentRevisionNumber() {
+      return this.workload.metadata.annotations['deployment.kubernetes.io/revision'];
+    },
+    rollbackRequestBody() {
+      if (!this.selectedRevision) {
+        return null;
+      }
+
+      // Build the request body in the same format that kubectl
+      // uses to call the Kubernetes API to roll back a workload.
+      // To see an example request body, run:
+      // kubectl rollout undo deployment/[deployment name] --to-revision=[revision number] -v=8
+      const body = [
+        {
+          op:      'replace',
+          path:  '/spec/template',
+          value: {
+            metadata: {
+              creationTimestamp: null,
+              labels:            { 'workload.user.cattle.io/workloadselector': this.selectedRevision.spec.template.metadata.labels['workload.user.cattle.io/workloadselector'] }
+            },
+            spec: this.selectedRevision.spec.template.spec
+          }
+        }, {
+          op:    'replace',
+          path:  '/metadata/annotations',
+          value: { 'deployment.kubernetes.io/revision': this.selectedRevision.metadata.annotations['deployment.kubernetes.io/revision'] }
+        }
+      ];
+
+      return body;
+    }
+  },
+  fetch() {
+    // Fetch revisions of the current workload
+    this.$store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.REPLICA_SET })
+      .then(( response ) => {
+        const allReplicaSets = response;
+
+        const hasRelationshipWithCurrentWorkload = ( replicaSet ) => {
+          const relationshipsOfReplicaSet = replicaSet.metadata.relationships;
+
+          const revisionsOfCurrentWorkload = relationshipsOfReplicaSet.filter(( relationship ) => {
+            const isRevisionOfCurrentWorkload = relationship.fromId && relationship.fromId === `${ this.workloadNamespace }/${ this.workloadName }`;
+
+            return isRevisionOfCurrentWorkload;
+          });
+
+          return revisionsOfCurrentWorkload.length > 0;
+        };
+
+        const workloadRevisions = allReplicaSets.filter(( replicaSet ) => {
+          return hasRelationshipWithCurrentWorkload( replicaSet );
+        });
+
+        const revisionOptions = workloadRevisions.map( (revision ) => {
+          const isCurrentRevision = this.getRevisionNumber(revision) === this.currentRevisionNumber;
+
+          if (isCurrentRevision) {
+            this.currentRevision = revision;
+          }
+
+          return this.buildRevisionOption( revision );
+        });
+
+        this.revisions = revisionOptions;
+      })
+      .catch(( err ) => {
+        this.errors = exceptionToErrorsArray(err);
+      });
+  },
+  methods: {
+    close() {
+      this.$emit('close');
+    },
+    async save() {
+      try {
+        await this.workload.rollBackWorkload(this.workload, this.rollbackRequestBody);
+        this.close();
+      } catch (err) {
+        this.errors = exceptionToErrorsArray(err);
+      }
+    },
+    getRevisionNumber( revision ) {
+      return revision.metadata.annotations['deployment.kubernetes.io/revision'];
+    },
+    buildRevisionOption( revision ) {
+      const revisionNumber = this.getRevisionNumber(revision);
+      const isCurrentRevision = revisionNumber === this.currentRevisionNumber;
+      const now = day();
+      const createdDate = day(revision.metadata.creationTimestamp);
+      const revisionAge = diffFrom(createdDate, now, this.t);
+      const units = this.t(revisionAge.unitsKey, { count: revisionAge.label });
+      const currentLabel = this.t('promptRollback.currentLabel');
+      const optionLabel = this.t('promptRollback.revisionOption', {
+        revisionNumber,
+        revisionAge:    revisionAge.label,
+        units,
+        currentLabel:   isCurrentRevision ? currentLabel : ''
+      });
+
+      return {
+        label:    optionLabel,
+        value:    revision,
+        disabled: isCurrentRevision
+      };
+    },
+    getOptionLabel(option) {
+      return option.label;
+    },
+  }
+};
+</script>
+
+<template>
+  <Card
+    class="prompt-rollback"
+    :show-highlight-border="false"
+  >
+    <h4 slot="title" class="text-default-text">
+      {{ t('promptRollback.modalTitle', { workloadName }, true) }}
+    </h4>
+    <div slot="body" class="pl-10 pr-10">
+      <Banner v-if="revisions.length === 1" color="info" :label="t('promptRollback.singleRevisionBanner')" />
+      <form>
+        <LabeledSelect
+          v-model="selectedRevision"
+          class="provider"
+          :label="t('promptRollback.dropdownTitle')"
+          :placeholder="t('promptRollback.placeholder')"
+          :options="revisions"
+          :get-option-label="getOptionLabel"
+        />
+      </form>
+      <Banner v-for="(error, i) in errors" :key="i" class="" color="error" :label="error" />
+    </div>
+    <div slot="actions" class="buttons right-align">
+      <button class="btn role-secondary mr-10" @click="close">
+        {{ t('generic.cancel') }}
+      </button>
+      <AsyncButton
+        :action-label="t('asyncButton.rollback.action')"
+        :disabled="!selectedRevision"
+        get-option-label="getOptionLabel"
+        :right-align="true"
+        @click="save"
+      />
+    </div>
+  </Card>
+</template>
+<style lang='scss' scoped>
+  .prompt-rollback {
+    margin: 0;
+  }
+  .right-align {
+    margin-right: 0;
+    margin-left: auto;
+  }
+  .bottom {
+    flex-direction: column;
+    flex: 1;
+    .banner {
+      margin-top: 0
+    }
+    .buttons {
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+    }
+  }
+</style>

--- a/components/formatter/PodImages.vue
+++ b/components/formatter/PodImages.vue
@@ -17,20 +17,16 @@ export default {
       }
     }
   },
-
-  data() {
-    let images = [];
-
-    if ( this.row?.imageNames ) {
-      images = this.row.imageNames;
-    } else {
-      images = this.value;
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+    images() {
+      if ( this.row?.imageNames ) {
+        return this.row.imageNames;
+      } else {
+        return this.value;
+      }
     }
-
-    return { images };
-  },
-
-  computed: { ...mapGetters({ t: 'i18n/t' }) }
+  }
 
 };
 </script>

--- a/models/workload.class.js
+++ b/models/workload.class.js
@@ -25,6 +25,13 @@ export default class Workload extends SteveModel {
         enabled:    !!this.links.update,
         bulkable:   true,
       });
+
+      insertAt(out, 0, {
+        action:  'toggleRollbackModal',
+        label:   'Rollback',
+        icon:    'icon icon-history',
+        enabled: !!this.links.update,
+      });
     }
 
     const toFilter = ['cloneYaml'];
@@ -70,6 +77,25 @@ export default class Workload extends SteveModel {
       }
     }
     vm.$set(this, 'spec', spec);
+  }
+
+  toggleRollbackModal( resources = this ) {
+    this.$dispatch('promptModal', {
+      resources,
+      component: 'RollbackWorkloadDialog'
+    });
+  }
+
+  async rollBackWorkload( workload, rollbackRequestData ) {
+    const rollbackRequestBody = JSON.stringify(rollbackRequestData)
+
+    if ( Array.isArray( workload ) ) {
+      throw new TypeError(this.t('promptRollback.multipleWorkloadError'));
+    }
+    const namespace = workload.metadata.namespace;
+    const workloadName = workload.metadata.name;
+
+    await this.patch(rollbackRequestBody, { url: `/apis/apps/v1/namespaces/${ namespace }/deployments/${ workloadName }` });
   }
 
   addSidecar() {

--- a/models/workload.class.js
+++ b/models/workload.class.js
@@ -87,7 +87,7 @@ export default class Workload extends SteveModel {
   }
 
   async rollBackWorkload( workload, rollbackRequestData ) {
-    const rollbackRequestBody = JSON.stringify(rollbackRequestData)
+    const rollbackRequestBody = JSON.stringify(rollbackRequestData);
 
     if ( Array.isArray( workload ) ) {
       throw new TypeError(this.t('promptRollback.multipleWorkloadError'));

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -733,18 +733,18 @@ export class Resource {
 
   // ------------------------------------------------------------------
 
-  // patch(data, opt = {}) {
-  //     if ( !opt.url ) {
-  //       opt.url = this.linkFor('self');
-  //     }
+  patch(data, opt = {}) {
+    if ( !opt.url ) {
+      opt.url = this.linkFor('self');
+    }
 
-  //     opt.method = 'patch';
-  //     opt.headers = opt.headers || {};
-  //     opt.headers['content-type'] = 'application/json-patch+json';
-  //     opt.data = data;
+    opt.method = 'patch';
+    opt.headers = opt.headers || {};
+    opt.headers['content-type'] = 'application/json-patch+json';
+    opt.data = data;
 
-  //     return this.$dispatch('request', opt);
-  // }
+    return this.$dispatch('request', opt);
+  }
 
   save() {
     return this._save(...arguments);

--- a/utils/time.js
+++ b/utils/time.js
@@ -4,7 +4,7 @@ const FACTORS = [60, 60, 24];
 const LABELS = ['sec', 'min', 'hour', 'day'];
 
 // Diff two dates and return an object with values for presentation
-// If 't' is also passed, 'string' property is set on the return object with the diff formated as a string
+// If 't' is also passed, 'string' property is set on the return object with the diff formatted as a string
 // e.g. formats a date difference to return '1 day', '20 hours' etc
 export function diffFrom(value, from, t) {
   const now = day();


### PR DESCRIPTION
This PR addresses this issue https://github.com/rancher/dashboard/issues/4149#issue-995320370 by forward porting the rollback button for each workload so that a user can easily roll back a workload to a previous revision.

To test this PR,

1. In the `local` cluster, I created a Deployment named `test` in the `default`namespace with the `nginx:1.21` image.
2. I created a new version by editing the Deployment to make its image `nginx:1.21.3`.
2. In the cluster explorer I clicked **Workload > Deployments**, then went to `test` and clicked **⋮ Rollback.**
3. I clicked the new revision and clicked **Roll Back**.
4. Confirmed that the image name in the list view reverted to `nginx:1.21`. (Nancy explained that to make the image update in the list view, the `images` in `components/formatter/podImages.vue` needed to be moved from `data` to `computed` so that it would be updated when the row prop changed. Will make doc update in separate PR.)
5. Confirmed on the Deployment detail page that the image was reverted to `nginx:1.21`.
6. Confirmed that for images without any previous revisions, the modal shows a banner saying "There are no revisions to roll back to."

Note: If you switch back and forth between two revisions, the earlier revision numbers are rewritten, so you could end up with only two revisions called 8 and 9. I believe this is normal Kubernetes behavior and kubectl works the same way.

Not in this PR:

- Didn't use typescript because I haven't learned how to convert to typescript yet and didn't have time
- Didn't show the diff between the selected version and the current version, as is shown in the Ember UI when you rollback a workload. Per conversation with Gary I have opened a separate issue to track the diff view. https://github.com/rancher/dashboard/issues/4229

Screenshots:

![Screen Shot 2021-09-15 at 10 15 39 PM](https://user-images.githubusercontent.com/20599230/133553621-6be8f7b9-fb17-43c9-afc9-dcaa23000609.png)
![Screen Shot 2021-09-20 at 7 29 26 PM](https://user-images.githubusercontent.com/20599230/134102752-78a9b097-9cdb-49d9-bcd6-953080e40c9e.png)

Workload with only one revision:
![Screen Shot 2021-09-21 at 6 44 47 PM](https://user-images.githubusercontent.com/20599230/134270723-01b4bcf5-0f1b-43b8-9933-081d64de6a25.png)


Ember equivalent:

![Screen Shot 2021-09-17 at 2 27 36 AM](https://user-images.githubusercontent.com/20599230/133762781-2842b3a6-25e6-4195-9fdf-36af4673463d.png)




