### PR TITLE
Reinstate special key mapping for proxies

### DIFF
--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { addObject, addObjects, clear, removeObject } from '@/utils/array';
 import { SCHEMA } from '@/config/types';
 import { normalizeType, KEY_FIELD_FOR } from './normalize';
-import { proxyFor } from './resource-proxy';
+import { proxyFor, remapSpecialKeys } from './resource-proxy';
 import { keyForSubscribe } from './subscribe';
 
 function registerType(state, type) {
@@ -52,6 +52,8 @@ function load(state, { data, ctx, existing }) {
     for ( const k of Object.keys(existing) ) {
       delete existing[k];
     }
+
+    remapSpecialKeys(data);
 
     for ( const k of Object.keys(data) ) {
       Vue.set(existing, k, data[k]);

--- a/plugins/steve/resource-instance.js
+++ b/plugins/steve/resource-instance.js
@@ -297,7 +297,7 @@ export default {
   },
 
   description() {
-    return this.metadata?.annotations?.[DESCRIPTION] || this.spec?.description;
+    return this.metadata?.annotations?.[DESCRIPTION] || this.spec?.description || this._description;
   },
 
   labels() {

--- a/plugins/steve/resource-proxy.js
+++ b/plugins/steve/resource-proxy.js
@@ -25,6 +25,8 @@ export function proxyFor(ctx, obj, isClone = false) {
     return obj;
   }
 
+  remapSpecialKeys(obj);
+
   const mappedType = ctx.rootGetters['type-map/componentFor'](obj.type);
   let customModel = lookup(ctx.state.config.namespace, mappedType, obj?.metadata?.name);
 
@@ -114,4 +116,32 @@ export function proxyFor(ctx, obj, isClone = false) {
   }
 
   return out;
+}
+
+export function remapSpecialKeys(obj) {
+  // Hack for now, the resource-instance name() overwrites the model name.
+  if ( obj.name ) {
+    obj._name = obj.name;
+    delete obj.name;
+  }
+
+  if ( obj.description ) {
+    obj._description = obj.description;
+    delete obj.description;
+  }
+
+  if ( obj.state ) {
+    obj._state = obj.state;
+    delete obj.state;
+  }
+
+  if ( obj.labels ) {
+    obj._labels = obj.labels;
+    delete obj.labels;
+  }
+
+  if ( obj.annotations ) {
+    obj._annotations = obj.annotations;
+    delete obj.annotations;
+  }
 }

--- a/plugins/steve/steve-class.js
+++ b/plugins/steve/steve-class.js
@@ -3,7 +3,7 @@ import HybridModel from './hybrid-class';
 
 export default class SteveModel extends HybridModel {
   get name() {
-    return this.metadata?.name;
+    return this.metadata?.name || this._name;
   }
 
   get namespace() {
@@ -11,6 +11,6 @@ export default class SteveModel extends HybridModel {
   }
 
   get description() {
-    return this.metadata?.annotations?.[DESCRIPTION] || this.spec?.description;
+    return this.metadata?.annotations?.[DESCRIPTION] || this.spec?.description || this._description;
   }
 }

--- a/plugins/steve/subscribe.js
+++ b/plugins/steve/subscribe.js
@@ -1,3 +1,4 @@
+import { remapSpecialKeys } from '@/plugins/steve/resource-proxy';
 import { addObject, removeObject } from '@/utils/array';
 import { get } from '@/utils/object';
 import Socket, {
@@ -40,6 +41,8 @@ export function equivalentWatch(a, b) {
 
 function queueChange({ getters, state }, { data, revision }, load, label) {
   const type = getters.normalizeType(data.type);
+
+  remapSpecialKeys(data);
 
   const entry = getters.typeEntry(type);
 


### PR DESCRIPTION
Should fix issues with some names appearing incorrectly.

_description was also missing in the resource-instance, which meant descriptions did not show for API Keys