### PR TITLE
Faster table filtering

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,17 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Debug in Browser",
+      "request": "launch",
+      "type": "pwa-chrome",
+      "url": "https://localhost:8005",
+      "webRoot": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+    },
+    {
       "type": "node",
       "request": "launch",
-      "name": "Launch Program",
+      "name": "Debug Node.js",
       "program": "${workspaceFolder}/node_modules/.bin/nuxt",
       "outFiles": [
         "${workspaceFolder}/**/*.js"

--- a/components/SortableTable/grouping.js
+++ b/components/SortableTable/grouping.js
@@ -17,8 +17,7 @@ export default {
       const out = [];
       const map = {};
 
-      for ( let i = 0 ; i < this.pagedRows.length ; i++ ) {
-        const obj = this.pagedRows[i];
+      for ( const obj of this.pagedRows ) {
         const key = get(obj, groupKey) || '';
         const ref = get(obj, refKey);
         let entry = map[key];

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -6,6 +6,7 @@ import { removeObject } from '@/utils/array';
 import Checkbox from '@/components/form/Checkbox';
 import $ from 'jquery';
 import throttle from 'lodash/throttle';
+import debounce from 'lodash/debounce';
 import THead from './THead';
 import filtering from './filtering';
 import selection from './selection';
@@ -33,8 +34,8 @@ export const COLUMN_BREAKPOINTS = {
 
 // Data Flow:
 // rows prop
-// -> filteredRows (filtering.js)
 // -> arrangedRows (sorting.js)
+// -> filteredRows (filtering.js)
 // -> pagedRows    (paging.js)
 // -> groupedRows  (grouping.js)
 
@@ -242,7 +243,17 @@ export default {
   },
 
   data() {
-    return { expanded: {} };
+    return {
+      expanded:            {},
+      searchQuery:         '',
+      eventualSearchQuery: '',
+    };
+  },
+
+  watch: {
+    eventualSearchQuery: debounce(function(q) {
+      this.searchQuery = q;
+    }, 100),
   },
 
   computed: {
@@ -525,7 +536,7 @@ export default {
           <input
             v-if="search"
             ref="searchQuery"
-            v-model="searchQuery"
+            v-model="eventualSearchQuery"
             type="search"
             class="input-sm"
             :placeholder="t('sortableTable.search')"

--- a/components/SortableTable/paging.js
+++ b/components/SortableTable/paging.js
@@ -27,11 +27,11 @@ export default {
     },
 
     indexTo() {
-      return Math.min(this.arrangedRows.length, this.indexFrom + this.perPage - 1);
+      return Math.min(this.filteredRows.length, this.indexFrom + this.perPage - 1);
     },
 
     totalPages() {
-      return Math.ceil(this.arrangedRows.length / this.perPage );
+      return Math.ceil(this.filteredRows.length / this.perPage );
     },
 
     showPaging() {
@@ -42,7 +42,7 @@ export default {
       const opt = {
         ...(this.pagingParams || {}),
 
-        count: this.arrangedRows.length,
+        count: this.filteredRows.length,
         pages: this.totalPages,
         from:  this.indexFrom,
         to:    this.indexTo,
@@ -53,9 +53,9 @@ export default {
 
     pagedRows() {
       if ( this.paging ) {
-        return this.arrangedRows.slice(this.indexFrom - 1, this.indexTo);
+        return this.filteredRows.slice(this.indexFrom - 1, this.indexTo);
       } else {
-        return this.arrangedRows;
+        return this.filteredRows;
       }
     }
   },
@@ -69,7 +69,7 @@ export default {
       // Go to the last page if we end up "past" the last page because the table changed
 
       const from = this.indexFrom;
-      const last = this.arrangedRows.length;
+      const last = this.filteredRows.length;
 
       if ( this.page > 1 && from > last ) {
         this.setPage(this.totalPages);

--- a/components/SortableTable/sorting.js
+++ b/components/SortableTable/sorting.js
@@ -34,14 +34,14 @@ export default {
       let key;
 
       if ( this.sortGenerationFn ) {
-        key = `${ this.sortGenerationFn.apply(this) }/${ this.filteredRows.length }/${ this.descending }/${ this.sortFields.join(',') }`;
+        key = `${ this.sortGenerationFn.apply(this) }/${ this.rows.length }/${ this.descending }/${ this.sortFields.join(',') }`;
 
         if ( this.cacheKey === key ) {
           return this.cachedRows;
         }
       }
 
-      const out = sortBy(this.filteredRows, this.sortFields, this.descending);
+      const out = sortBy(this.rows, this.sortFields, this.descending);
 
       if ( key ) {
         this.cacheKey = key;

--- a/components/formatter/ServiceType.vue
+++ b/components/formatter/ServiceType.vue
@@ -18,14 +18,14 @@ export default {
   },
   data() {
     const { row } = this;
-    let cloned = this.value.toLowerCase().slice();
+    let cloned = this.value.toLowerCase();
 
     if (this.value === 'ClusterIP' && row?.spec?.clusterIP === 'None') {
       cloned = 'headless';
     }
 
     const match = DEFAULT_SERVICE_TYPES.find(s => s.id.toLowerCase() === cloned);
-    const translationLabel = match.label;
+    const translationLabel = match?.label;
     let translated;
 
     if (translationLabel && this.$store.getters['i18n/exists'](translationLabel)) {

--- a/utils/object.js
+++ b/utils/object.js
@@ -43,10 +43,6 @@ export function set(obj, path, value) {
 }
 
 export function get(obj, path) {
-  if ( !path.includes('.') ) {
-    return obj?.[path];
-  }
-
   if ( path.startsWith('$') ) {
     try {
       return JSONPath({
@@ -60,6 +56,10 @@ export function get(obj, path) {
 
       return '(JSON Path err)';
     }
+  }
+
+  if ( !path.includes('.') ) {
+    return obj?.[path];
   }
 
   let parts;

--- a/utils/object.js
+++ b/utils/object.js
@@ -8,7 +8,6 @@ import isObject from 'lodash/isObject';
 import isEqual from 'lodash/isEqual';
 import difference from 'lodash/difference';
 
-const quotedKey = /['"]/;
 const quotedMatch = /[^."']+|"([^"]*)"|'([^']*)'/g;
 
 export function set(obj, path, value) {
@@ -19,7 +18,7 @@ export function set(obj, path, value) {
     return;
   }
 
-  if ( path.match(quotedKey) ) {
+  if ( path.includes('"') || path.includes("'") ) {
     // Path with quoted section
     parts = path.match(quotedMatch).map(x => x.replace(/['"]/g, ''));
   } else {
@@ -44,6 +43,10 @@ export function set(obj, path, value) {
 }
 
 export function get(obj, path) {
+  if ( !path.includes('.') ) {
+    return obj?.[path];
+  }
+
   if ( path.startsWith('$') ) {
     try {
       return JSONPath({
@@ -61,9 +64,9 @@ export function get(obj, path) {
 
   let parts;
 
-  if ( path.match(quotedKey) ) {
+  if ( path.includes('"') || path.includes("'") ) {
     // Path with quoted section
-    parts = path.match(/[^."']+|"([^"]*)"|'([^']*)'/g).map(x => x.replace(/['"]/g, ''));
+    parts = path.match(quotedMatch).map(x => x.replace(/['"]/g, ''));
   } else {
     // Regular path
     parts = path.split('.');


### PR DESCRIPTION
- Faster utils/object get()
  - A surprising amount of time everywhere in tables goes into get(), but get(obj, 'simpleField') can bypass most of the code that supports json-path, nested.fields, nested."quoted.fields", etc.
  - Regex is slower than simple string operations

- Faster SortableTable search (#4174)
  - Sort first, then filter, because the sorting doesn't change as you type.
  - As you filter each additional keystroke can only remove more entries, so remember the previous filter+result and start from there when possible instead of searching everything again.
  - Debounce the user input field from the actual filtering operation so that the user's typing shows up normally instead of 'hanging'

Bonus:
- Chrome debugger launch.json
