### PR TITLE
Tweak the location of the harvester cluster tech preview notice

### DIFF
--- a/list/harvesterhci.io.management.cluster.vue
+++ b/list/harvesterhci.io.management.cluster.vue
@@ -56,6 +56,10 @@ export default {
       :resource="resource"
       :is-creatable="false"
     >
+      <template #typeDescription>
+        <TypeDescription :resource="hResource" />
+      </template>
+
       <template slot="extraActions">
         <n-link
           :to="importLocation"
@@ -65,8 +69,6 @@ export default {
         </n-link>
       </template>
     </Masthead>
-
-    <TypeDescription :resource="hResource" />
 
     <ResourceTable
       :schema="schema"


### PR DESCRIPTION
- uses new slot in Masthead
- moves from underneath `Clusters` title row

![image](https://user-images.githubusercontent.com/18697775/133826763-8167ac56-ad57-4f79-ac25-9ea27d8c443e.png)
