### PR TITLE
delete warning for norman-made workloads

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4487,6 +4487,7 @@ workload:
     subdomain:
       label: Subdomain
       placeholder: e.g. web
+  normanWarning: It looks like this workload was created in the legacy Rancher UI. You may need to manually delete any services that were automatically created for it.
   validation:
     containers: Containers
     containerImage: Container {name} - "Container Image" is required.

--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -313,7 +313,7 @@ export default {
           </template>
         </div>
         <input v-if="needsConfirm" id="confirm" v-model="confirmName" type="text" />
-        <div class="mb-10">
+        <div class="text-warning mb-10">
           {{ warning }}
         </div>
         <div class="text-error mb-10">

--- a/models/workload.class.js
+++ b/models/workload.class.js
@@ -537,4 +537,12 @@ export default class Workload extends Resource {
   get isFromNorman() {
     return (this.metadata.labels || {})['cattle.io/creator'] === 'norman';
   }
+
+  get warnDeletionMessage() {
+    if (this.isFromNorman) {
+      return this.t('workload.normanWarning');
+    } else {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
#4212 - This PR adds a warning to the PromptRemove dialogue for workloads created in ember (workloads with the 'norman' cattlio.io/creator label)
Neil and I discussed this offline and it seemed safer to warn users they'd have to go delete services than attempt to delete them through the UI. 