### PR TITLE
account for undefined pod initContainers in view logs

### DIFF
--- a/components/nav/WindowManager/ContainerLogs.vue
+++ b/components/nav/WindowManager/ContainerLogs.vue
@@ -87,8 +87,8 @@ export default {
 
   computed: {
     containerChoices() {
-      const containers = this.pod?.spec?.containers?.map(x => x.name) || [];
-      const initContainers = this.pod?.spec?.initContainers.map(x => x.name) || [];
+      const containers = (this.pod?.spec?.containers || []).map(x => x.name);
+      const initContainers = (this.pod?.spec?.initContainers || []).map(x => x.name);
 
       return [...containers, ...initContainers];
     },


### PR DESCRIPTION
#4220 - `pod.spec.initContainers` is not necessarily defined so this `.map()` was throwing an error for some pods.