### PR TITLE
Improve dashboard performance

### DIFF
--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -238,11 +238,6 @@ export default async function({
     const oldProduct = from?.params?.product;
 
     if (product === VIRTUAL || route.name === `c-cluster-${ VIRTUAL }` || route.name.startsWith(`c-cluster-${ VIRTUAL }-`)) {
-      await store.dispatch('resetStore', {
-        id:    clusterId,
-        store: 'cluster',
-      });
-
       const res = [
         store.dispatch('loadManagement'),
         store.dispatch('loadVirtual', {
@@ -253,11 +248,6 @@ export default async function({
 
       await Promise.all(res);
     } else if ( clusterId ) {
-      await store.dispatch('resetStore', {
-        id:    clusterId,
-        store: VIRTUAL,
-      });
-
       // Run them in parallel
       const res = [
         store.dispatch('loadManagement'),

--- a/store/index.js
+++ b/store/index.js
@@ -554,9 +554,14 @@ export const actions = {
     const isMultiCluster = getters['isMultiCluster'];
     const isRancher = getters['isRancher'];
 
-    if ( state.clusterId && state.clusterId === id && oldProduct !== VIRTUAL) {
+    if ( state.clusterId && state.clusterId === id) {
       // Do nothing, we're already connected/connecting to this cluster
       return;
+    }
+
+    if (oldProduct === VIRTUAL) {
+      await dispatch('harvester/unsubscribe');
+      commit('harvester/reset');
     }
 
     if ( state.clusterId && id ) {
@@ -670,9 +675,14 @@ export const actions = {
       return;
     }
 
-    if ( state.clusterId && state.clusterId === id && oldProduct === VIRTUAL) {
+    if ( state.clusterId && state.clusterId === id) {
       // Do nothing, we're already connected/connecting to this cluster
       return;
+    }
+
+    if (oldProduct !== VIRTUAL) {
+      await dispatch('cluster/unsubscribe');
+      commit('cluster/reset');
     }
 
     if ( state.clusterId && id ) {
@@ -725,15 +735,6 @@ export const actions = {
     commit('clusterChanged', true);
 
     console.log('Done loading virtual cluster.'); // eslint-disable-line no-console
-  },
-
-  async resetStore({
-    state, commit, dispatch, getters
-  }, { id, store }) {
-    if ( state.clusterId && id && store) {
-      await dispatch(`${ store }/unsubscribe`);
-      commit(`${ store }/reset`);
-    }
   },
 
   async cleanNamespaces({ getters, dispatch }) {


### PR DESCRIPTION
- On every route transition either the `cluster` or `harvester` store was reset (`unsubscribe` + `reset`)
  - Cause of lots of the following in log
    ```
    Reset Harvester
    All of schema is not loaded yet
    ```
- Now conditionally reset stores - `cluster` in `loadVirtual`, `harvester` in `loadCluster`
- Also removed odd check gating check for no-op route changes
