### PR TITLE
'Show' button in password boxes removed from tab order

### DIFF
--- a/components/form/Password.vue
+++ b/components/form/Password.vue
@@ -80,6 +80,9 @@ export default {
     },
     show(reveal) {
       this.reveal = reveal;
+    },
+    focus() {
+      this.$refs.input.$refs.value.focus();
     }
   }
 };

--- a/components/form/Password.vue
+++ b/components/form/Password.vue
@@ -88,6 +88,7 @@ export default {
 <template>
   <div class="password">
     <LabeledInput
+      ref="input"
       v-model="password"
       v-bind="attributes"
       :type="isRandom || reveal ? 'text' : 'password'"
@@ -103,8 +104,8 @@ export default {
           <a href="#" @click.prevent.stop="$copyText(password)">{{ t('action.copy') }}</a>
         </div>
         <div v-else class="addon">
-          <a v-if="reveal" href="#" @click.prevent.stop="reveal = false">{{ t('action.hide') }}</a>
-          <a v-else href="#" @click.prevent.stop="reveal=true">{{ t('action.show') }}</a>
+          <a v-if="reveal" tabindex="-1" href="#" @click.prevent.stop="reveal = false">{{ t('action.hide') }}</a>
+          <a v-else tabindex="-1" href="#" @click.prevent.stop="reveal=true">{{ t('action.show') }}</a>
         </div>
       </template>
     </LabeledInput>

--- a/edit/auth/ldap/index.vue
+++ b/edit/auth/ldap/index.vue
@@ -8,6 +8,7 @@ import AllowedPrincipals from '@/components/auth/AllowedPrincipals';
 import config from '@/edit/auth/ldap/config';
 import AuthConfig from '@/mixins/auth-config';
 import AuthBanner from '@/components/auth/AuthBanner';
+import Password from '@/components/form/Password';
 
 const AUTH_TYPE = 'ldap';
 
@@ -19,7 +20,8 @@ export default {
     Banner,
     AllowedPrincipals,
     config,
-    AuthBanner
+    AuthBanner,
+    Password
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -115,9 +117,8 @@ export default {
             />
           </div>
           <div class="col span-6">
-            <LabeledInput
+            <Password
               v-model="password"
-              type="password"
               :label="t(`authConfig.${AUTH_TYPE}.password`)"
               :mode="mode"
               required

--- a/pages/auth/setup.vue
+++ b/pages/auth/setup.vue
@@ -13,6 +13,7 @@ import { setSetting, SETTING } from '@/config/settings';
 import { _ALL_IF_AUTHED } from '@/plugins/steve/actions';
 import { isDevBuild } from '@/utils/version';
 import { exceptionToErrorsArray } from '@/utils/error';
+import Password from '@/components/form/Password';
 
 const calcIsFirstLogin = (store) => {
   const firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);
@@ -65,7 +66,7 @@ export default {
   },
 
   components: {
-    AsyncButton, LabeledInput, CopyToClipboard, Checkbox, RadioGroup
+    AsyncButton, LabeledInput, CopyToClipboard, Checkbox, RadioGroup, Password
   },
 
   async asyncData({ route, req, store }) {
@@ -192,8 +193,8 @@ export default {
       } else {
         this.password = '';
         this.$nextTick(() => {
-          this.$refs.password.focus();
-          this.$refs.password.select();
+          this.$refs.password.$refs.input.focus();
+          this.$refs.password.$refs.input.select();
         });
       }
     }
@@ -279,13 +280,14 @@ export default {
               v-html="t(isFirstLogin ? 'setup.setPassword' : 'setup.newUserSetPassword', { username }, true)"
             ></p>
 
-            <LabeledInput
+            <Password
               v-if="!haveCurrent"
               v-model.trim="current"
               autocomplete="current-password"
               type="password"
-              label-key="setup.currentPassword"
+              :label="t('setup.currentPassword')"
               class="mb-20"
+              :required="true"
             />
 
             <!-- For password managers... -->
@@ -295,6 +297,7 @@ export default {
             </div>
             <div class="mb-20">
               <LabeledInput
+                v-if="useRandom"
                 ref="password"
                 v-model.trim="password"
                 :type="useRandom ? 'text' : 'password'"
@@ -307,13 +310,20 @@ export default {
                   </div>
                 </template>
               </LabeledInput>
+              <Password
+                v-else
+                ref="password"
+                v-model.trim="password"
+                :label="t('setup.newPassword')"
+                :required="true"
+              />
             </div>
-            <LabeledInput
+            <Password
               v-show="!useRandom"
               v-model.trim="confirm"
               autocomplete="new-password"
-              type="password"
-              label-key="setup.confirmPassword"
+              :label="t('setup.confirmPassword')"
+              :required="true"
             />
           </template>
 

--- a/pages/auth/setup.vue
+++ b/pages/auth/setup.vue
@@ -193,19 +193,9 @@ export default {
       } else {
         this.password = '';
         this.$nextTick(() => {
-          this.$refs.password.$refs.input.focus();
-          this.$refs.password.$refs.input.select();
+          this.$refs.password.focus();
         });
       }
-    }
-  },
-
-  mounted() {
-    const el = this.$refs.password;
-
-    if ( el ) {
-      el.focus();
-      el.select();
     }
   },
 

--- a/plugins/directives.js
+++ b/plugins/directives.js
@@ -34,4 +34,8 @@ const getElement = (vnode) => {
   if (tag === 'TextAreaAutoGrow') {
     return componentInstance.$refs.ta;
   }
+
+  if (tag === 'Password') {
+    return componentInstance.$refs.input.$refs.value;
+  }
 };


### PR DESCRIPTION
Updated `tabindex` in Password component to remove 'show' tag from tab order
Used password component in place of labeledinput in other `edit/auth/ldap/index.vue` and `pages/auth/setup.vue`

#4200 

![2021-09-21_12-41-48 (1)](https://user-images.githubusercontent.com/13671297/134237245-276ef93b-5e50-457a-a405-0ac1bda94976.gif)
s 