### PR TITLE
More faster

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -49,6 +49,7 @@ export default {
   data() {
     return {
       groups:         [],
+      gettingGroups:  false,
       wantNavSync:    false
     };
   },
@@ -310,8 +311,15 @@ export default {
     },
 
     getGroups() {
+      if ( this.gettingGroups ) {
+        return;
+      }
+
+      this.gettingGroups = true;
+
       if ( !this.clusterReady ) {
         clear(this.groups);
+        this.gettingGroups = false;
 
         return;
       }
@@ -445,6 +453,7 @@ export default {
       }
 
       replaceWith(this.groups, ...sortBy(out, ['weight:desc', 'label']));
+      this.gettingGroups = false;
     },
 
     toggleNoneLocale() {

--- a/models/schema.class.js
+++ b/models/schema.class.js
@@ -1,0 +1,17 @@
+import { Resource } from '~/plugins/steve/resource-class';
+
+export default class Schema extends Resource {
+  get groupName() {
+    return this.attributes.namespaced ? 'ns' : 'cluster';
+  }
+}
+
+export function parseType(str) {
+  if ( str.startsWith('array[') ) {
+    return ['array', ...parseType(str.slice(6, -1))];
+  } else if ( str.startsWith('map[') ) {
+    return ['map', ...parseType(str.slice(4, -1))];
+  } else {
+    return [str];
+  }
+}

--- a/models/schema.js
+++ b/models/schema.js
@@ -1,5 +1,0 @@
-export default {
-  groupName() {
-    return this.attributes.namespaced ? 'ns' : 'cluster';
-  },
-};

--- a/plugins/steve/getters.js
+++ b/plugins/steve/getters.js
@@ -1,8 +1,9 @@
 import { SCHEMA } from '@/config/types';
-import { COLLECTION_TYPES, PRIMITIVE_TYPES } from '@/config/schema';
 import { matches } from '@/utils/selector';
 import { typeMunge, typeRef, SIMPLE_TYPES } from '@/utils/create-yaml';
-import { normalizeType, keyFieldFor, KEY_FIELD_FOR } from './normalize';
+import { splitObjectPath } from '@/utils/string';
+import { parseType } from '@/models/schema.class';
+import { normalizeType, KEY_FIELD_FOR } from './normalize';
 import urlOptions from './urloptions';
 import mutations from './mutations';
 
@@ -37,85 +38,27 @@ export default {
     }
   },
 
-  expandedArraySchema: (state, getters) => (type) => {
-    const unwrappedType = type.match(new RegExp(`^${ COLLECTION_TYPES.array }\\[(.*)\\]$`))[1];
-
-    return {
-      type:            COLLECTION_TYPES.array,
-      subType:         unwrappedType,
-      expandedSubType: getters.expandedSchema(unwrappedType)
-    };
-  },
-
-  expandedMapSchema: (state, getters) => (type) => {
-    const unwrappedType = type.match(new RegExp(`^${ COLLECTION_TYPES.map }\\[(.*)\\]$`))[1];
-
-    return {
-      type:            COLLECTION_TYPES.map,
-      subType:         unwrappedType,
-      expandedSubType: getters.expandedSchema(unwrappedType)
-    };
-  },
-
-  expandedResourceFields: (state, getters) => (schema) => {
-    return Object.keys(schema.resourceFields || {}).reduce((agg, key) => {
-      const field = schema.resourceFields[key];
-
-      return {
-        ...agg,
-        [key]: getters.expandedSchema(field)
-      };
-    }, {});
-  },
-
-  expandedSchema: (state, getters) => (typeInput) => {
-    const type = (typeof typeInput === 'string') ? typeInput : (typeInput.type || typeInput.id);
-
-    if (Object.values(PRIMITIVE_TYPES).includes(type)) {
-      return { type, isPrimitive: true };
-    }
-
-    const schema = getters.schema(type) || { type: typeInput };
-
-    if (type.startsWith(COLLECTION_TYPES.array)) {
-      return getters.expandedArraySchema(type);
-    }
-
-    if (type.startsWith(COLLECTION_TYPES.map)) {
-      return getters.expandedMapSchema(type);
-    }
-
-    if (!schema.resourceFields) {
-      return schema;
-    }
-
-    const keyField = keyFieldFor(type);
-
-    return {
-      ...schema,
-      type:                   schema[keyField],
-      expandedResourceFields: getters.expandedResourceFields(schema)
-    };
-  },
-
   pathExistsInSchema: (state, getters) => (type, path) => {
-    let schema = getters.expandedSchema(type);
-    const splitPath = path.split('.');
+    let schema = getters.schemaFor(type);
+    const parts = splitObjectPath(path);
 
-    while (splitPath.length > 0) {
-      const pathPart = splitPath.shift();
+    while ( parts.length ) {
+      const key = parts.shift();
 
-      if (schema?.expandedResourceFields?.[pathPart]) {
-        schema = schema.expandedResourceFields[pathPart];
-        continue;
+      type = schema.resourceFields?.[key]?.type;
+
+      if ( !type ) {
+        return false;
       }
 
-      if (schema.expandedSubType?.expandedResourceFields?.[pathPart]) {
-        schema = schema.expandedSubType.expandedResourceFields[pathPart];
-        continue;
-      }
+      if ( parts.length ) {
+        type = parseType(type).pop(); // Get the main part of array[map[something]] => something
+        schema = getters.schemaFor(type);
 
-      return false;
+        if ( !schema ) {
+          return false;
+        }
+      }
     }
 
     return true;

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { addObject, addObjects, clear, removeObject } from '@/utils/array';
 import { SCHEMA } from '@/config/types';
+import { Resource } from '@/plugins/steve/resource-class';
 import { normalizeType, KEY_FIELD_FOR } from './normalize';
 import { proxyFor, remapSpecialKeys } from './resource-proxy';
 import { keyForSubscribe } from './subscribe';
@@ -53,7 +54,9 @@ function load(state, { data, ctx, existing }) {
       delete existing[k];
     }
 
-    remapSpecialKeys(data);
+    if ( !(existing instanceof Resource) ) {
+      remapSpecialKeys(data);
+    }
 
     for ( const k of Object.keys(data) ) {
       Vue.set(existing, k, data[k]);

--- a/plugins/steve/resource-proxy.js
+++ b/plugins/steve/resource-proxy.js
@@ -25,8 +25,6 @@ export function proxyFor(ctx, obj, isClone = false) {
     return obj;
   }
 
-  remapSpecialKeys(obj);
-
   const mappedType = ctx.rootGetters['type-map/componentFor'](obj.type);
   let customModel = lookup(ctx.state.config.namespace, mappedType, obj?.metadata?.name);
 
@@ -55,6 +53,8 @@ export function proxyFor(ctx, obj, isClone = false) {
   } else {
     // Old Proxy-based models that will eventually go away
     const model = customModel || ResourceInstance;
+
+    remapSpecialKeys(obj);
 
     out = new Proxy(obj, {
       get(target, name) {

--- a/utils/object.js
+++ b/utils/object.js
@@ -7,24 +7,16 @@ import transform from 'lodash/transform';
 import isObject from 'lodash/isObject';
 import isEqual from 'lodash/isEqual';
 import difference from 'lodash/difference';
-
-const quotedMatch = /[^."']+|"([^"]*)"|'([^']*)'/g;
+import { splitObjectPath } from '@/utils/string';
 
 export function set(obj, path, value) {
   let ptr = obj;
-  let parts;
 
   if (!ptr) {
     return;
   }
 
-  if ( path.includes('"') || path.includes("'") ) {
-    // Path with quoted section
-    parts = path.match(quotedMatch).map(x => x.replace(/['"]/g, ''));
-  } else {
-    // Regular path
-    parts = path.split('.');
-  }
+  const parts = splitObjectPath(path);
 
   for (let i = 0; i < parts.length; i++) {
     const key = parts[i];
@@ -62,15 +54,7 @@ export function get(obj, path) {
     return obj?.[path];
   }
 
-  let parts;
-
-  if ( path.includes('"') || path.includes("'") ) {
-    // Path with quoted section
-    parts = path.match(quotedMatch).map(x => x.replace(/['"]/g, ''));
-  } else {
-    // Regular path
-    parts = path.split('.');
-  }
+  const parts = splitObjectPath(path);
 
   for (let i = 0; i < parts.length; i++) {
     if (!obj) {

--- a/utils/string.js
+++ b/utils/string.js
@@ -241,3 +241,15 @@ export function ensureRegex(strOrRegex, exact = true) {
 export function nlToBr(value) {
   return escapeHtml(value || '').replace(/(\r\n|\r|\n)/g, '<br/>\n');
 }
+
+const quotedMatch = /[^."']+|"([^"]*)"|'([^']*)'/g;
+
+export function splitObjectPath(path) {
+  if ( path.includes('"') || path.includes("'") ) {
+    // Path with quoted section
+    return path.match(quotedMatch).map(x => x.replace(/['"]/g, ''));
+  }
+
+  // Regular path
+  return path.split('.');
+}


### PR DESCRIPTION
- Faster getters.pathExistsInSchema
- Don't overlap getGroups calls
- Only remapSpecialKeys for old Proxies
