### PR TITLE
Add ability to configure a container lifecycle

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4331,6 +4331,51 @@ workload:
     imagePullPolicy: Pull Policy
     imagePullSecrets: Pull Secrets
     init: Init Container
+    lifecycleHook:
+      postStart: 
+        label: PostStart
+        add: Add PostStart Hook
+      preStop: 
+        label: PreStop
+        add: Add PreStop Hook
+      exec:
+        title: Exec
+        add: Add command to execute
+        command:
+          label: Command
+          placeholder: e.g. sh -c sleep 10
+      httpGet:
+        title: HttpGet
+        add: Create HTTP request
+        host:
+          label: Host IP
+          placeholder: e.g. 172.17.0.2
+        path:
+          label: Path
+          placeholder: e.g. /bin/sh
+        port:
+          label: Port
+          placeholder: e.g. 3000
+        scheme:
+          label: Scheme
+          placeholder: e.g. HTTP
+      httpHeaders:
+        title: HTTP Headers
+        name:
+          label: Name
+          placeholder: e.g. accept-ranges
+        value:
+          label: Value
+          placeholder: e.g. bytes
+      tcpSocket:
+        title: TCPSocket
+        add: Open a TCP socket
+        host:
+          label: Host
+          placeholder: e.g. 192.168.0.1
+        port:
+          label: Port
+          placeholder: e.g. 80
     name: Container Name
     noResourceLimits: There are no resource requirements configured.
     noPorts: There are no ports configured.
@@ -4387,6 +4432,7 @@ workload:
       general: General
       healthCheck: Health Check
       image: Image
+      lifecycle: Lifecycle Hooks
       networking: Networking
       networkSettings: Network Settings
       podAnnotations: Pod Annotations

--- a/components/form/HookOption.vue
+++ b/components/form/HookOption.vue
@@ -1,0 +1,270 @@
+<script>
+import RadioGroup from '@/components/form/RadioGroup';
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import ShellInput from '@/components/form/ShellInput';
+import debounce from 'lodash/debounce';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  props: {
+    mode: {
+      type:     String,
+      required: true,
+    },
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    }
+  },
+
+  components: {
+    RadioGroup, LabeledInput, LabeledSelect, ShellInput
+  },
+
+  data() {
+    const selectHook = null;
+
+    const defaultExec = { exec: { command: [] } };
+    const defaultHttpGet = {
+      httpGet: {
+        host:        '',
+        path:        '',
+        port:        null,
+        scheme:      '',
+        httpHeaders: [{ name: '', value: '' }]
+      }
+    };
+    const defaultTcpSocket = { tcpSocket: { host: '', port: null } };
+
+    return {
+      selectHook,
+      defaultExec,
+      defaultHttpGet,
+      defaultTcpSocket,
+      schemeOptions: ['HTTP', 'HTTPS']
+    };
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+  },
+
+  created() {
+    if (this.value) {
+      this.selectHook = Object.keys(this.value)[0];
+    }
+    this.queueUpdate = debounce(this.update, 500);
+  },
+
+  methods: {
+    addHeader() {
+      const header = { name: '', value: '' };
+
+      this.value.httpGet.httpHeaders.push(header);
+    },
+
+    removeHeader(index) {
+      this.value.httpGet.httpHeaders.splice(index, 1);
+      this.queueUpdate();
+    },
+
+    update() {
+      const { ...leftovers } = this.value;
+
+      switch (this.selectHook) {
+      case 'none':
+        this.deleteLeftovers(leftovers);
+        break;
+      case 'exec':
+        this.deleteLeftovers(leftovers);
+        Object.assign(this.value, this.defaultExec);
+        break;
+      case 'httpGet':
+        this.deleteLeftovers(leftovers);
+        Object.assign(this.value, this.defaultHttpGet);
+        break;
+      case 'tcpSocket':
+        this.deleteLeftovers(leftovers);
+        Object.assign(this.value, this.defaultTcpSocket);
+        break;
+      default:
+        break;
+      }
+
+      this.$emit('input', this.value);
+    },
+
+    deleteLeftovers(leftovers) {
+      if (leftovers) {
+        for (const obj in leftovers) {
+          delete this.value[obj];
+        }
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div @input="update">
+    <div class="row mb-10">
+      <RadioGroup
+        v-model="selectHook"
+        name="selectHook"
+        :options="['none', 'exec', 'httpGet', 'tcpSocket']"
+        :labels="[
+          t('generic.none'),
+          t('workload.container.lifecycleHook.exec.add'),
+          t('workload.container.lifecycleHook.httpGet.add'),
+          t('workload.container.lifecycleHook.tcpSocket.add')
+        ]"
+        :mode="mode"
+        @input="update"
+      />
+    </div>
+
+    <template v-if="selectHook === 'exec'">
+      <div class="mb-20 single-value">
+        <h4>{{ t('workload.container.lifecycleHook.exec.title') }}</h4>
+        <div>
+          <ShellInput
+            v-model="value.exec.command"
+            :mode="mode"
+            :label="t('workload.container.lifecycleHook.exec.command.label')"
+            :placeholder="t('workload.container.lifecycleHook.exec.command.placeholder')"
+          />
+        </div>
+      </div>
+    </template>
+
+    <template v-if="selectHook === 'httpGet'">
+      <template>
+        <h4>{{ t('workload.container.lifecycleHook.httpGet.title') }}</h4>
+        <slot name="httpGetOption">
+          <div class="var-row">
+            <template>
+              <LabeledInput
+                v-model="value.httpGet.host"
+                :label="t('workload.container.lifecycleHook.httpGet.host.label')"
+                :placeholder="t('workload.container.lifecycleHook.httpGet.host.placeholder')"
+                :mode="mode"
+              />
+            </template>
+            <template>
+              <LabeledInput
+                v-model="value.httpGet.path"
+                :label="t('workload.container.lifecycleHook.httpGet.path.label')"
+                :placeholder="t('workload.container.lifecycleHook.httpGet.path.placeholder')"
+                :mode="mode"
+              />
+            </template>
+            <template>
+              <LabeledInput
+                v-model.number="value.httpGet.port"
+                type="number"
+                :label="t('workload.container.lifecycleHook.httpGet.port.label')"
+                :placeholder="t('workload.container.lifecycleHook.httpGet.port.placeholder')"
+                :mode="mode"
+              />
+            </template>
+            <template>
+              <LabeledSelect
+                v-model="value.httpGet.scheme"
+                :label="t('workload.container.lifecycleHook.httpGet.scheme.label')"
+                :placeholder="t('workload.container.lifecycleHook.httpGet.scheme.placeholder')"
+                :options="schemeOptions"
+                :mode="mode"
+              />
+            </template>
+          </div>
+        </slot>
+      </template>
+
+      <template>
+        <h4>{{ t('workload.container.lifecycleHook.httpHeaders.title') }}</h4>
+        <template>
+          <div v-for="(header, index) in value.httpGet.httpHeaders" :key="header.vKey" class="var-row">
+            <LabeledInput
+              v-model="value.httpGet.httpHeaders[index].name"
+              :label="t('workload.container.lifecycleHook.httpHeaders.name.label')"
+              :placeholder="t('workload.container.lifecycleHook.httpHeaders.name.placeholder')"
+              class="single-value"
+              :mode="mode"
+            />
+            <LabeledInput
+              v-model="value.httpGet.httpHeaders[index].value"
+              :label="t('workload.container.lifecycleHook.httpHeaders.value.label')"
+              :placeholder="t('workload.container.lifecycleHook.httpHeaders.value.placeholder')"
+              class="single-value"
+              :mode="mode"
+            />
+            <button
+              v-if="!isView"
+              type="button"
+              class="btn role-link"
+              :disabled="mode==='view'"
+              @click.stop="removeHeader(index)"
+            >
+              <t k="generic.remove" />
+            </button>
+          </div>
+        </template>
+        <div>
+          <button
+            v-if="!isView"
+            type="button"
+            class="btn role-link mb-20"
+            :disabled="mode === 'view'"
+            @click.stop="addHeader"
+          >
+            Add Header
+          </button>
+        </div>
+      </template>
+    </template>
+
+    <template v-if="selectHook === 'tcpSocket'">
+      <h4>{{ t('workload.container.lifecycleHook.tcpSocket.title') }}</h4>
+      <template>
+        <div class="var-row">
+          <template>
+            <LabeledInput
+              v-model="value.tcpSocket.host"
+              :label="t('workload.container.lifecycleHook.tcpSocket.host.label')"
+              :placeholder="t('workload.container.lifecycleHook.tcpSocket.host.placeholder')"
+              :mode="mode"
+            />
+          </template>
+          <template>
+            <LabeledInput
+              v-model.number="value.tcpSocket.port"
+              type="number"
+              :label="t('workload.container.lifecycleHook.tcpSocket.port.label')"
+              :placeholder="t('workload.container.lifecycleHook.tcpSocket.port.label')"
+              :mode="mode"
+            />
+          </template>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.var-row{
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 100px;
+  grid-column-gap: 20px;
+  margin-bottom: 20px;
+  align-items: center;
+
+  .single-value {
+    grid-column: span 2;
+  }
+}
+</style>

--- a/components/form/LifecycleHooks.vue
+++ b/components/form/LifecycleHooks.vue
@@ -1,0 +1,80 @@
+<script>
+import Vue from 'vue';
+
+import HookOption from '@/components/form/HookOption';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  components: { HookOption },
+
+  props: {
+    mode: {
+      type:     String,
+      required: true,
+    },
+
+    // container spec
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+  },
+
+  data() {
+    const { postStart, preStop } = this.value;
+
+    return {
+      postStart, preStop, hookOptions: ['postStart', 'preStop']
+    };
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+  },
+
+  methods: {
+    update() {
+      const out = {
+        postStart: this.postStart,
+        preStop:   this.preStop
+      };
+
+      for (const prop in out) {
+        const val = out[prop];
+
+        if (val === '' || typeof val === 'undefined' || val === null || val === {}) {
+          Vue.delete(this.value, prop);
+        } else {
+          Vue.set(this.value, prop, val);
+        }
+      }
+
+      this.$emit('input', this.value);
+    },
+  }
+};
+</script>
+
+<template>
+  <div @input="update">
+    <template>
+      <div class="mb-20">
+        <h3 class="clearfix">
+          {{ t('workload.container.lifecycleHook.postStart.label') }}
+        </h3>
+        <HookOption v-model="postStart" :mode="mode" />
+      </div>
+
+      <div>
+        <h3 class="clearfix">
+          {{ t('workload.container.lifecycleHook.preStop.label') }}
+        </h3>
+        <HookOption v-model="preStop" :mode="mode" />
+      </div>
+    </template>
+  </div>
+</template>

--- a/components/form/LifecycleHooks.vue
+++ b/components/form/LifecycleHooks.vue
@@ -3,6 +3,7 @@ import Vue from 'vue';
 
 import HookOption from '@/components/form/HookOption';
 import { _VIEW } from '@/config/query-params';
+import { isEmpty } from '@/utils/object';
 
 export default {
   components: { HookOption },
@@ -46,7 +47,7 @@ export default {
       for (const prop in out) {
         const val = out[prop];
 
-        if (val === '' || typeof val === 'undefined' || val === null || val === {}) {
+        if (val === '' || typeof val === 'undefined' || val === null || isEmpty(val)) {
           Vue.delete(this.value, prop);
         } else {
           Vue.set(this.value, prop, val);
@@ -60,20 +61,20 @@ export default {
 </script>
 
 <template>
-  <div @input="update">
+  <div>
     <template>
       <div class="mb-20">
         <h3 class="clearfix">
           {{ t('workload.container.lifecycleHook.postStart.label') }}
         </h3>
-        <HookOption v-model="postStart" :mode="mode" />
+        <HookOption v-model="postStart" :mode="mode" @input="update" />
       </div>
 
       <div>
         <h3 class="clearfix">
           {{ t('workload.container.lifecycleHook.preStop.label') }}
         </h3>
-        <HookOption v-model="preStop" :mode="mode" />
+        <HookOption v-model="preStop" :mode="mode" @input="update" />
       </div>
     </template>
   </div>

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -28,6 +28,7 @@ import PodAffinity from '@/components/form/PodAffinity';
 import Tolerations from '@/components/form/Tolerations';
 import CruResource from '@/components/CruResource';
 import Command from '@/components/form/Command';
+import LifecycleHooks from '@/components/form/LifecycleHooks';
 import Storage from '@/edit/workload/storage';
 import Labels from '@/components/form/Labels';
 import RadioGroup from '@/components/form/RadioGroup';
@@ -56,6 +57,7 @@ export default {
     Tolerations,
     CruResource,
     Command,
+    LifecycleHooks,
     Storage,
     VolumeClaimTemplate,
     Labels,
@@ -831,6 +833,12 @@ export default {
           <div>
             <h3>{{ t('workload.container.titles.command') }}</h3>
             <Command v-model="container" :secrets="namespacedSecrets" :config-maps="namespacedConfigMaps" :mode="mode" />
+          </div>
+
+          <div class="spacer"></div>
+          <div>
+            <h3>{{ t('workload.container.titles.lifecycle') }}</h3>
+            <LifecycleHooks v-model="container.lifecycle" :mode="mode" />
           </div>
         </Tab>
         <Tab :label="t('workload.storage.title')" name="storage">


### PR DESCRIPTION
This PR is in reference to #1817 which gives the ability to configure lifecycle hooks when creating containers.
There are two lifecycle hooks `postStart` and `preStop` that can be added. Each can only have 1 handler at a time.

Process: workload >  create > general tab > lifecycle hooks
![lifecycleHook](https://user-images.githubusercontent.com/40806497/134364350-36968fdb-baf0-4ea8-ad76-db49e93f18f3.png)

