### PR TITLE
Add menu to open shell and logs for each container

### DIFF
--- a/detail/pod.vue
+++ b/detail/pod.vue
@@ -63,6 +63,18 @@ export default {
         container.stateBackground = this.value.containerStateColor(container).replace('text', 'bg');
         container.nameSort = sortableNumericSuffix(container.name).toLowerCase();
         container.readyIcon = container?.status?.ready ? 'icon-checkmark icon-2x text-success ml-5' : 'icon-x icon-2x text-error ml-5';
+        container.availableActions = this.value.containerActions;
+
+        container.openShell = () => {
+          // Call openShell here so that opening the shell
+          // at the container level still has 'this' in scope.
+          this.value.openShell(container.name);
+        };
+        container.openLogs = () => {
+          // Call openLogs here so that opening the logs
+          // at the container level still has 'this' in scope.
+          this.value.openLogs(container.name);
+        };
 
         return container;
       });
@@ -166,7 +178,7 @@ export default {
         :mode="mode"
         key-field="name"
         :search="false"
-        :row-actions="false"
+        :row-actions="true"
         :table-actions="false"
       />
     </Tab>

--- a/models/pod.class.js
+++ b/models/pod.class.js
@@ -17,25 +17,39 @@ export default class Pod extends SteveModel {
   get _availableActions() {
     const out = this._standardActions;
 
-    const openShell = {
+    // Add backwards, each one to the top
+    insertAt(out, 0, { divider: true });
+    insertAt(out, 0, this.openLogsMenuItem);
+    insertAt(out, 0, this.openShellMenuItem);
+
+    return out;
+  }
+
+  get openShellMenuItem() {
+    return {
       action:     'openShell',
       enabled:    !!this.links.view && this.isRunning,
       icon:       'icon icon-fw icon-chevron-right',
       label:      'Execute Shell',
       total:      1,
     };
-    const openLogs = {
+  }
+
+  get openLogsMenuItem() {
+    return {
       action:     'openLogs',
       enabled:    !!this.links.view,
       icon:       'icon icon-fw icon-chevron-right',
       label:      'View Logs',
       total:      1,
     };
+  }
 
-    // Add backwards, each one to the top
-    insertAt(out, 0, { divider: true });
-    insertAt(out, 0, openLogs);
-    insertAt(out, 0, openShell);
+  get containerActions() {
+    const out = [];
+
+    insertAt(out, 0, this.openLogsMenuItem);
+    insertAt(out, 0, this.openShellMenuItem);
 
     return out;
   }
@@ -51,28 +65,28 @@ export default class Pod extends SteveModel {
     return containers[0]?.name;
   }
 
-  openShell() {
+  openShell(containerName = this.defaultContainerName) {
     this.$dispatch('wm/open', {
       id:        `${ this.id }-shell`,
       label:     this.nameDisplay,
       icon:      'terminal',
       component: 'ContainerShell',
       attrs:     {
-        pod:       this,
-        container: this.defaultContainerName
+        pod:              this,
+        initialContainer: containerName
       }
     }, { root: true });
   }
 
-  openLogs() {
+  openLogs(containerName = this.defaultContainerName) {
     this.$dispatch('wm/open', {
       id:        `${ this.id }-logs`,
       label:     this.nameDisplay,
       icon:      'file',
       component: 'ContainerLogs',
       attrs:     {
-        pod:       this,
-        container: this.defaultContainerName
+        pod:              this,
+        initialContainer: containerName
       }
     }, { root: true });
   }


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/3100 by making it so that for each container listed on the Pod detail page, you have a menu that lets you directly open the shell and logs for each container. (Previously, to open logs or shell for a non-default container, you had to open the menu at the Pod level and then switch containers from there.)

<img width="1046" alt="Screen Shot 2021-09-22 at 3 16 24 PM" src="https://user-images.githubusercontent.com/20599230/134429322-5ee63b3c-5d79-416a-844a-79290dcedfba.png">
To test this PR,

1. I created a Deployment named `test` with two containers (`nginx` and `debian`) to allow testing the action menu for both default and non-default containers:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test
  annotations:
    {}
  labels:
    {}
  namespace: default
spec:
  selector:
    matchLabels:
      workload.user.cattle.io/workloadselector: apps.deployment-default-undefined
  template:
    metadata:
      labels:
        workload.user.cattle.io/workloadselector: apps.deployment-default-undefined
    spec:
      volumes:
      - name: html
        emptyDir: {}
      containers:
      - name: 1st
        image: nginx
        volumeMounts:
        - name: html
          mountPath: /usr/share/nginx/html
      - name: 2nd
        image: debian
        volumeMounts:
        - name: html
          mountPath: /html
        command: ["/bin/sh", "-c"]
        args:
          - while true; do
              date >> /html/index.html;
              sleep 1;
            done
  replicas: 1
__clone: true
```

2. From the cluster explorer, I went to **Workload > Deployments.**
3. I clicked the `test` Deployment and clicked a Pod name.
4. In the `1st` container,
    - I clicked **⋮ > Execute Shell.** The shell window opened with the `1st` container as the default.
    - I clicked **⋮ > View Logs.** The logs window opened with the `1st` container as the default.
5. In the `2nd` container,
    - I clicked **⋮ > Execute Shell.** The shell window opened with the `2nd` container as the default.
    - I clicked **⋮ > View Logs.** The logs window opened with the `2nd` container as the default.
 6. Confirmed that the action menu for the Pod works the same as before.

Note: There is a known issue that on mobile, the action menus don't look right, as shown below. The work to fix the action menus is being tracked in https://github.com/rancher/dashboard/issues/4215
![image](https://user-images.githubusercontent.com/20599230/134435692-8947adf7-09f3-4b05-86fc-55e5dc21ffe9.png)
.
