### PR TITLE
Add OS column to Machine Pools tab

### DIFF
--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -839,3 +839,11 @@ export const KUBE_NODE_OS = {
   sort:      ['status.nodeInfo.operatingSystem'],
   formatter: 'Capitalize'
 };
+
+export const MACHINE_NODE_OS = {
+  name:      'operating-system',
+  labelKey:  'tableHeaders.operatingSystem',
+  value:     'operatingSystem',
+  sort:      ['operatingSystem'],
+  formatter: 'Capitalize'
+};

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -847,3 +847,11 @@ export const MACHINE_NODE_OS = {
   sort:      ['operatingSystem'],
   formatter: 'Capitalize'
 };
+
+export const MANAGEMENT_NODE_OS = {
+  name:      'operating-system',
+  labelKey:  'tableHeaders.operatingSystem',
+  value:     'status.internalNodeStatus.nodeInfo.operatingSystem',
+  sort:      ['status.internalNodeStatus.nodeInfo.operatingSystem'],
+  formatter: 'Capitalize'
+};

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -9,7 +9,7 @@ import Tab from '@/components/Tabbed/Tab';
 import { allHash } from '@/utils/promise';
 import { CAPI, MANAGEMENT, NORMAN } from '@/config/types';
 import {
-  STATE, NAME as NAME_COL, AGE, AGE_NORMAN, STATE_NORMAN, ROLES,
+  STATE, NAME as NAME_COL, AGE, AGE_NORMAN, STATE_NORMAN, ROLES, MACHINE_NODE_OS, MANAGEMENT_NODE_OS
 } from '@/config/table-headers';
 import CustomCommand from '@/edit/provisioning.cattle.io.cluster/CustomCommand';
 import AsyncButton from '@/components/AsyncButton.vue';
@@ -204,6 +204,7 @@ export default {
           formatter:     'LinkDetail',
           formatterOpts: { reference: 'kubeNodeDetailLocation' }
         },
+        MACHINE_NODE_OS,
         ROLES,
         AGE,
       ];
@@ -220,6 +221,7 @@ export default {
           formatter:     'LinkDetail',
           formatterOpts: { reference: 'kubeNodeDetailLocation' }
         },
+        MANAGEMENT_NODE_OS,
         ROLES,
         AGE
       ];

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -78,6 +78,10 @@ export default {
     return this.$rootGetters['management/byId'](CAPI.MACHINE_DEPLOYMENT, this.poolId);
   },
 
+  operatingSystem() {
+    return this.metadata?.labels['cattle.io/os'] || 'linux';
+  },
+
   kubeNodeDetailLocation() {
     const kubeId = this.status?.nodeRef?.name;
     const cluster = this.cluster?.status?.clusterName;


### PR DESCRIPTION
This add an OS column to Machine Pools tab by lookup up `metadata?.labels['cattle.io/os']` (RKE2, Custom Cluster), or `status.internalNodeStatus.nodeInfo.operatingSystem` (non RKE2).

Since the OS can only be Windows or Linux and we only support Windows nodes in custom clusters, we check for the presence of a `cattle.io/os` label to display the OS; Linux is assumed if the label does not exist. 

#4240
#3222 