### PR TITLE
fix cluster permissions editor radio when no principal selected

### DIFF
--- a/components/form/Members/ClusterPermissionsEditor.vue
+++ b/components/form/Members/ClusterPermissionsEditor.vue
@@ -194,17 +194,19 @@ export default {
     },
 
     async updateBindings() {
-      const principalProperty = await this.principalProperty();
-      const bindingPromises = this.roleTemplateIds.map(id => this.$store.dispatch(`rancher/create`, {
-        type:                NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING,
-        clusterId:           this.clusterName,
-        roleTemplateId:      id,
-        [principalProperty]: this.principalId
-      }));
+      if (this.principalId) {
+        const principalProperty = await this.principalProperty();
+        const bindingPromises = this.roleTemplateIds.map(id => this.$store.dispatch(`rancher/create`, {
+          type:                NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING,
+          clusterId:           this.clusterName,
+          roleTemplateId:      id,
+          [principalProperty]: this.principalId
+        }));
 
-      const bindings = await Promise.all(bindingPromises);
+        const bindings = await Promise.all(bindingPromises);
 
-      this.$emit('input', bindings);
+        this.$emit('input', bindings);
+      }
     }
   }
 };


### PR DESCRIPTION
#4248 - this bug is seen if you toggle the radio buttons without having selected a user/group from the dropdown. It happens because principal is undefined on [this](https://github.com/rancher/dashboard/blob/master/components/form/Members/ClusterPermissionsEditor.vue#L188) line but I think the right solution here is to ensure we're not trying to create bindings before a principal has been selected.