### PR TITLE
Add tech preview noticed for rke1 harvester node driver

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1387,6 +1387,9 @@ cluster:
     upcloud: UpCloud
     vmwarevsphere: VMware vSphere
     zstack: ZStack
+  providerDescription:
+    rke1:
+      harvester: Tech Preview
   providerGroup:
     create-custom1: Use existing nodes and create a cluster using RKE
     create-custom2: Use existing nodes and create a cluster using RKE2/K3s (Tech Preview)

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -47,6 +47,7 @@ generic:
   save: Save
   showAdvanced: Show Advanced
   hideAdvanced: Hide Advanced
+  techPreview: Tech Preview
   type: Type
   unknown: Unknown
   provisioning: '—'
@@ -1387,17 +1388,16 @@ cluster:
     upcloud: UpCloud
     vmwarevsphere: VMware vSphere
     zstack: ZStack
-  providerDescription:
-    rke1:
-      harvester: Tech Preview
+  providerTag:
+    harvester: '{techPreview}'
   providerGroup:
     create-custom1: Use existing nodes and create a cluster using RKE
-    create-custom2: Use existing nodes and create a cluster using RKE2/K3s (Tech Preview)
+    create-custom2: Use existing nodes and create a cluster using RKE2/K3s
     create-kontainer: Create a cluster in a hosted Kubernetes provider
     register-kontainer: Register an existing cluster in a hosted Kubernetes provider
     create-rke1: Provision new nodes and create a cluster using RKE
-    create-rke2: Provision new nodes and create a cluster using RKE2/K3s (Tech Preview)
-    create-template: Use a Catalog Template to create a cluster (Tech Preview)
+    create-rke2: Provision new nodes and create a cluster using RKE2/K3s
+    create-template: Use a Catalog Template to create a cluster
     register-custom: Import any Kubernetes cluster
   rke2:
     snapshots:

--- a/components/SelectIconGrid.vue
+++ b/components/SelectIconGrid.vue
@@ -92,7 +92,7 @@ export default {
       :target="get(r, targetField)"
       :rel="rel"
       class="item"
-      :class="{'has-description': !!get(r, descriptionField), [colorFor(r, idx)]: true, disabled: get(r, disabledField) === true}"
+      :class="{'has-description': !!get(r, descriptionField), 'has-side-label': !!get(r, sideLabelField), [colorFor(r, idx)]: true, disabled: get(r, disabledField) === true}"
       @click="select(r, idx)"
     >
       <div class="side-label" :class="{'indicator': true }" />
@@ -151,6 +151,8 @@ export default {
       }
     }
 
+    $color: var(--body-text) !important;
+
     .item {
       height: $height;
       margin: $margin;
@@ -159,7 +161,7 @@ export default {
       //border-radius: calc( 1.5 * var(--border-radius));
       border: 1px solid var(--border);
       text-decoration: none !important;
-      color: var(--body-text) !important;
+      color: $color;
 
       &:hover:not(.disabled) {
         box-shadow: 0 0 30px var(--shadow);
@@ -172,7 +174,7 @@ export default {
         position: absolute;
         top: 10px;
         right: 10px;
-        padding: 2px 10px;
+        padding: 2px 5px;
 
         &.indicator {
           top: 0;
@@ -187,6 +189,9 @@ export default {
           display: block;
           white-space: no-wrap;
           text-overflow: ellipsis;
+          // Override default form label properties
+          color: $color;
+          margin: 0;
         }
 
       }
@@ -287,9 +292,17 @@ export default {
         margin-left: $side+$logo+$margin;
       }
 
-      &.has-description .name {
-        margin-top: $margin;
-        line-height: initial;
+      &.has-description {
+        .name {
+          margin-top: $margin;
+          line-height: initial;
+        }
+
+        &.has-side-label {
+          .name {
+            margin-top: $margin + 5px;
+          }
+        }
       }
 
       .description {

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -222,6 +222,7 @@ export default {
             description: chart.chartDescription,
             icon:        chart.icon || require('~/assets/images/generic-catalog.svg'),
             group:       'template',
+            tag:         getters['i18n/t']('generic.techPreview')
           });
         });
 
@@ -244,7 +245,10 @@ export default {
 
       function addType(id, group, disabled = false, link = null) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
-        const description = getters['i18n/withFallback'](`cluster.providerDescription.${ group }."${ id }"`, null, '');
+        const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
+        const techPreview = getters['i18n/t']('generic.techPreview');
+        const isTechPreview = group === 'rke2' || group === 'custom2';
+        const tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
         let icon = require('~/assets/images/generic-driver.svg');
 
         try {
@@ -258,7 +262,8 @@ export default {
           icon,
           group,
           disabled,
-          link
+          link,
+          tag
         };
 
         out.push(subtype);
@@ -389,6 +394,7 @@ export default {
           :rows="obj.types"
           key-field="id"
           name-field="label"
+          side-label-field="tag"
           :color-for="colorFor"
           @clicked="clickedType"
         />

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -244,7 +244,7 @@ export default {
 
       function addType(id, group, disabled = false, link = null) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
-        const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
+        const description = getters['i18n/withFallback'](`cluster.providerDescription.${ group }."${ id }"`, null, '');
         let icon = require('~/assets/images/generic-driver.svg');
 
         try {
@@ -414,6 +414,7 @@ export default {
     </template>
   </CruResource>
 </template>
+
 <style lang='scss'>
   .grouped-type {
     position: relative;


### PR DESCRIPTION
- #4249
- Use card side labels to denote tech preview, removes confusion from previous solution (see bottom two screenshots), can easily switch off global handling and apply on a per provider basis

![image](https://user-images.githubusercontent.com/18697775/134659076-ad129dd7-d9b1-4440-9c48-86d2f8a36e98.png)

![image](https://user-images.githubusercontent.com/18697775/134659118-4a7d13a2-6967-4627-8061-bd6e09e70319.png)


------
**Previous solution**

![image](https://user-images.githubusercontent.com/18697775/134498734-c1c886a9-37ac-4f21-9e35-ba70fe54438a.png)

![image](https://user-images.githubusercontent.com/18697775/134498788-16dccf83-16cd-4ce5-bb4e-97af7ff40ba0.png)
