### PR TITLE
Add banners to Fleet for Harvester clusters that are filtered out

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1551,6 +1551,18 @@ fleet:
   cluster:
     summary: Resource Summary
     nonReady: Non-Ready Bundles
+  clusters:
+    harvester: |-
+      There {count, plural,
+      =1 {is 1 Harvester cluster that is hidden as this can not be used with Continuous Delivery}
+      other {are # Harvester clusters that are hidden as they can not be used with Continuous Delivery}
+      }  
+  tokens:
+    harvester: |-
+      {count, plural,
+      =1 {1 token is hidden as it belongs to a Harvester cluster that can not be used with Continuous Delivery}
+      other {# tokens are hidden as they belong to Harvester clusters that can not be used with Continuous Delivery}
+      }  
   fleetSummary:
     state:
       success: 'Ready'

--- a/list/fleet.cattle.io.cluster.vue
+++ b/list/fleet.cattle.io.cluster.vue
@@ -51,7 +51,7 @@ export default {
     },
 
     rows() {
-      return this.allClusters.filter(c => !isHarvesterCluster(c));
+      return this.fleetClusters.filter(c => !isHarvesterCluster(c));
     },
 
     fleetClusters() {

--- a/list/fleet.cattle.io.cluster.vue
+++ b/list/fleet.cattle.io.cluster.vue
@@ -3,10 +3,13 @@ import FleetClusters from '@/components/FleetClusters';
 import { FLEET, MANAGEMENT } from '@/config/types';
 import Loading from '@/components/Loading';
 import { isHarvesterCluster } from '@/utils/cluster';
+import Banner from '@/components/Banner';
 
 export default {
   name:       'ListCluster',
-  components: { FleetClusters, Loading },
+  components: {
+    Banner, FleetClusters, Loading
+  },
 
   props: {
     schema: {
@@ -29,7 +32,7 @@ export default {
   },
 
   computed: {
-    rows() {
+    allClusters() {
       const out = this.allFleet.slice();
 
       const known = {};
@@ -44,17 +47,33 @@ export default {
         }
       }
 
-      return out.filter(c => !isHarvesterCluster(c));
+      return out;
+    },
+
+    rows() {
+      return this.allClusters.filter(c => !isHarvesterCluster(c));
+    },
+
+    fleetClusters() {
+      return this.allClusters.filter(c => c.type === FLEET.CLUSTER);
+    },
+
+    hiddenHarvesterCount() {
+      return this.fleetClusters.length - this.rows.length;
     },
   },
 };
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
-  <FleetClusters
-    v-else
-    :rows="rows"
-    :schema="schema"
-  />
+  <div>
+    <Loading v-if="$fetchState.pending" />
+    <div v-else>
+      <Banner v-if="hiddenHarvesterCount" color="info" :label="t('fleet.clusters.harvester', {count: hiddenHarvesterCount} )" />
+      <FleetClusters
+        :rows="rows"
+        :schema="schema"
+      />
+    </div>
+  </div>
 </template>

--- a/list/fleet.cattle.io.clusterregistrationtoken.vue
+++ b/list/fleet.cattle.io.clusterregistrationtoken.vue
@@ -1,0 +1,81 @@
+<script>
+import { FLEET } from '@/config/types';
+import Banner from '@/components/Banner';
+import Loading from '@/components/Loading';
+import ResourceTable from '@/components/ResourceTable';
+import { isHarvesterCluster } from '@/utils/cluster';
+
+export default {
+  name:       'ListClusterGroup',
+  components: {
+    Banner, Loading, ResourceTable
+  },
+
+  props: {
+    schema: {
+      type:     Object,
+      required: true,
+    },
+  },
+
+  async fetch() {
+    this.allTokens = await this.$store.dispatch('management/findAll', { type: FLEET.TOKEN });
+    this.allFleet = await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER });
+  },
+
+  data() {
+    return {
+      allFleet:  null,
+      allTokens: null,
+    };
+  },
+
+  computed: {
+    harvesterClusters() {
+      const harvester = {};
+
+      this.allFleet.forEach((c) => {
+        if (isHarvesterCluster(c)) {
+          harvester[c.metadata.uid] = c;
+        }
+      });
+
+      return harvester;
+    },
+    tokens() {
+      const harvester = this.harvesterClusters;
+
+      return this.allTokens.filter((token) => {
+        const refs = token.metadata?.ownerReferences || [];
+
+        for (const owner of refs) {
+          if (harvester[owner.uid]) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+    },
+
+    hidden() {
+      return this.allTokens.length - this.tokens.length;
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <Loading v-if="$fetchState.pending" />
+    <div v-else>
+      <Banner v-if="hidden" color="info" :label="t('fleet.tokens.harvester', {count: hidden} )" />
+      <ResourceTable
+        v-bind="$attrs"
+        :schema="schema"
+        :rows="tokens"
+      >
+      </ResourceTable>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Addresses #4250 

This PR:

- Adds a banner to the Fleet clusters page when there are Harvester clusters that have been hidden - this helps the user understand why the count in the nav differs from the items in the list
- Updates the Fleet tokens page to filter out tokens that belong to Harvester Clusters
- Adds a banner to the Fleet tokens page when there are tokens that have been hidden because they belong to Harvester clusters - this helps the user understand why the count in the nav differs from the items in the list