### PR TITLE
fix clusterroletemplatebinding nameDisplay

### DIFF
--- a/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/models/management.cattle.io.clusterroletemplatebinding.js
@@ -42,7 +42,7 @@ export default {
   },
 
   nameDisplay() {
-    return this.user?.nameDisplay;
+    return this.user?.nameDisplay || this.userName || this.principalId;
   },
 
   roleDisplay() {


### PR DESCRIPTION
#4263 #4271 - both bugs are happening because the clusterroletemplatebinding model's `nameDisplay` function is returning undefined and breaking resource-instance `nameSort` (used to sort table columns). They have slightly different underlying causes:
#4263 - `this.user` is undefined when a standard user tries to load a clusterroletemplatebinding for another user
#4271 - `this.user` is undefined because `this.userName` doesn't exist for auth group clusterroletemplatebindings