### PR TITLE
HARVESTER: fix resource loading logic

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -675,7 +675,7 @@ export const actions = {
       return;
     }
 
-    if ( state.clusterId && state.clusterId === id) {
+    if ( state.clusterId && state.clusterId === id && oldProduct === VIRTUAL) {
       // Do nothing, we're already connected/connecting to this cluster
       return;
     }


### PR DESCRIPTION
When switching between Explorer and harvester in the same cluster, the scheme needs to be reloaded, so we also need to use the product to determine

**Related issue:**
https://github.com/rancher/dashboard/issues/3894