### PR TITLE
Harvester: Add banner to cluster page when viewed from cluster explorer

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1040,6 +1040,11 @@ cluster:
     warning:
       label: This is a Harvester Cluster - enable the Harvester feature flag to manage it
       state: Warning
+    clusterWarning: |-
+      There {count, plural,
+      =1 {is 1 Harvester cluster that is not shown}
+      other {are # Harvester clusters that are not shown}
+      }  
   haveOneOwner: There must be at least one member with the Owner role.
   import:
     commandInstructions: 'Run the <code>kubectl</code> command below on an existing Kubernetes cluster running a supported Kubernetes version to import it into {vendor}:'

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -1,4 +1,5 @@
 <script>
+import Banner from '@/components/Banner';
 import ResourceTable from '@/components/ResourceTable';
 import Masthead from '@/components/ResourceList/Masthead';
 import { allHash } from '@/utils/promise';
@@ -6,9 +7,12 @@ import { CAPI, MANAGEMENT } from '@/config/types';
 import { MODE, _IMPORT } from '@/config/query-params';
 import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 import { mapFeature, HARVESTER as HARVESTER_FEATURE } from '@/store/features';
+import { NAME as EXPLORER } from '@/config/product/explorer';
 
 export default {
-  components: { ResourceTable, Masthead },
+  components: {
+    Banner, ResourceTable, Masthead
+  },
 
   async fetch() {
     const hash = {
@@ -58,6 +62,18 @@ export default {
       return this.rancherClusters;
     },
 
+    hiddenHarvesterCount() {
+      const product = this.$store.getters['currentProduct'];
+      const isExplorer = product?.name === EXPLORER;
+
+      // Don't show Harveser banner message on the cluster management page or if Harvester if not enabled
+      if (!isExplorer || !this.harvesterEnabled) {
+        return 0;
+      }
+
+      return this.rancherClusters.length - filterOnlyKubernetesClusters(this.rancherClusters).length;
+    },
+
     createLocation() {
       return {
         name:   'c-cluster-product-resource-create',
@@ -96,6 +112,8 @@ export default {
 
 <template>
   <div>
+    <Banner v-if="hiddenHarvesterCount" color="info" :label="t('cluster.harvester.clusterWarning', {count: hiddenHarvesterCount} )" />
+
     <Masthead
       :schema="schema"
       :resource="resource"


### PR DESCRIPTION
Addresses #4251 

This PR:

- Adds a banner when that are Harvester clusters that are being filtered out - it only does this for the cluster page when viewed in explorer, not when viewed in Cluster Management.