### PR TITLE
Tweak function to determine if a cluster is a Harvester cluster

### DIFF
--- a/utils/cluster.js
+++ b/utils/cluster.js
@@ -1,5 +1,5 @@
-import { VIRTUAL_HARVESTER_PROVIDER } from '@/config/types';
 import { HCI } from '@/config/labels-annotations';
+import { VIRTUAL_HARVESTER_PROVIDER } from '@/config/types';
 
 // Filter out any clusters that are not Kubernetes Clusters
 // Currently this removes Harvester clusters
@@ -10,5 +10,13 @@ export function filterOnlyKubernetesClusters(mgmtClusters) {
 }
 
 export function isHarvesterCluster(mgmtCluster) {
-  return mgmtCluster?.metadata?.labels?.[HCI.HARVESTER_CLUSTER] === 'true' || mgmtCluster?.status?.provider === VIRTUAL_HARVESTER_PROVIDER;
+  // Use the provider if it is set
+  const provider = mgmtCluster?.status?.provider;
+
+  if (provider) {
+    return provider === VIRTUAL_HARVESTER_PROVIDER;
+  }
+
+  // Otherwise use the label
+  return mgmtCluster?.metadata?.labels?.[HCI.HARVESTER_CLUSTER] === 'true';
 }


### PR DESCRIPTION
As requested by the Harvester team - only look at the label if the provider is not set.