### PR TITLE
Change default HookOption to None in Workload Creation

### DIFF
--- a/components/form/HookOption.vue
+++ b/components/form/HookOption.vue
@@ -5,6 +5,7 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import ShellInput from '@/components/form/ShellInput';
 import debounce from 'lodash/debounce';
 import { _VIEW } from '@/config/query-params';
+import { isEmpty } from '@/utils/object';
 
 export default {
   props: {
@@ -58,6 +59,11 @@ export default {
     if (this.value) {
       this.selectHook = Object.keys(this.value)[0];
     }
+
+    if (isEmpty(this.value)) {
+      this.selectHook = 'none';
+    }
+
     this.queueUpdate = debounce(this.update, 500);
   },
 


### PR DESCRIPTION
This is an update to #4247 which changes the default hook option from `null` to `none`.

To see the change: Workload > Creation > General Tab > Lifecycle Hooks
![defaultHookOption](https://user-images.githubusercontent.com/40806497/135324424-70cb41b9-0a53-452c-ac3f-a57609f4d67c.png)
