### PR TITLE
Add ability to copy kubeConfig of current cluster and projects/namespaces to clipboard

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2743,6 +2743,7 @@ namespace:
   enableAutoInjection: Enable Istio Auto Injection
   disableAutoInjection: Disable Istio Auto Injection
   move: Move
+  copy: Copy Config to Clipboard
   resourceStates:
       success: 'Active'
       info: 'Transitioning'

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -82,9 +82,10 @@ locale:
 nav:
   backToRancher: Cluster Manager
   clusterTools: Cluster Tools
-  kubeconfigDownload: Download KubeConfig
-  kubeconfigCopy: Copy KubeConfig to Clipboard
-  kubeconfigOptions: KubeConfig Options
+  kubeconfig:
+    download: Download KubeConfig
+    copy: Copy KubeConfig to Clipboard
+    options: KubeConfig Options
   import: Import YAML
   home: Home
   shell: Kubectl Shell
@@ -930,6 +931,7 @@ cluster:
       note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-On Config tab.'
     harvester:
       label: Harvester
+  copyConfig: Copy Config to Clipboard
   custom:
     nodeRole:
       label: Node Role
@@ -2745,7 +2747,6 @@ namespace:
   enableAutoInjection: Enable Istio Auto Injection
   disableAutoInjection: Disable Istio Auto Injection
   move: Move
-  copy: Copy Config to Clipboard
   resourceStates:
       success: 'Active'
       info: 'Transitioning'

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -82,7 +82,9 @@ locale:
 nav:
   backToRancher: Cluster Manager
   clusterTools: Cluster Tools
-  kubeconfig: Download KubeConfig
+  kubeconfigDownload: Download KubeConfig
+  kubeconfigCopy: Copy KubeConfig to Clipboard
+  kubeconfigOptions: KubeConfig Options
   import: Import YAML
   home: Home
   shell: Kubectl Shell

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -269,7 +269,7 @@ export default {
 
         <button
           v-if="showKubeConfig"
-          v-tooltip="t('nav.kubeconfig')"
+          v-tooltip="t('nav.kubeconfig.download')"
           :disabled="!kubeConfigEnabled"
           type="button"
           class="btn header-btn role-tertiary"

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -156,16 +156,6 @@ export default {
       this.$modal.hide('searchModal');
     },
 
-    showKubeConfigActions(show) {
-      if (this.$refs.kubeConfigActions) {
-        if (show) {
-          this.$refs.kubeConfigActions.show();
-        } else {
-          this.$refs.kubeConfigActions.hide();
-        }
-      }
-    },
-
     showPageActionsMenu(show) {
       if (this.$refs.pageActions) {
         if (show) {
@@ -281,49 +271,22 @@ export default {
           v-if="showKubeConfig"
           v-tooltip="t('nav.kubeconfig')"
           :disabled="!kubeConfigEnabled"
-          class="btn header-btn role-tertiary"
           type="button"
-          @blur="showKubeConfigActions(false)"
-          @click="showKubeConfigActions(true)"
-          @focus.capture="showKubeConfigActions(true)"
+          class="btn header-btn role-tertiary"
+          @click="currentCluster.downloadKubeConfig()"
         >
-          <i class="icon icon-chevron-down icon-lg" />
+          <i class="icon icon-file" />
         </button>
-        <v-popover
-          ref="kubeConfigActions"
-          placement="bottom-end"
-          offset="0"
-          trigger="manual"
-          :delay="{show: 0, hide: 0}"
-          :popper-options="{modifiers: { flip: { enabled: false } } }"
-          :container="false"
+
+        <button
+          v-tooltip="t('nav.kubeconfig.copy')"
+          :disabled="!kubeConfigEnabled"
+          type="button"
+          class="btn header-btn role-tertiary"
+          @click="currentCluster.copyKubeConfig()"
         >
-          <template slot="popover" class="user-menu">
-            <ul class="list-unstyled dropdown config-actions" @click.stop="showKubeConfigActions(false)">
-              <li
-                class="user-menu-item"
-              >
-                <a @click="currentCluster.downloadKubeConfig()">
-                  <i class="icon icon-file" />
-                  {{ t('nav.kubeconfigDownload') }}
-                </a>
-              </li>
-
-              <div class="menu-seperator">
-                <div class="menu-seperator-line" />
-              </div>
-
-              <li
-                class="user-menu-item"
-              >
-                <a @click="currentCluster.copyKubeConfig()">
-                  <i class="icon icon-copy" />
-                  {{ t('nav.kubeconfigCopy') }}
-                </a>
-              </li>
-            </ul>
-          </template>
-        </v-popover>
+          <i class="icon icon-copy" />
+        </button>
       </template>
 
       <button

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -277,6 +277,16 @@ export default {
         >
           <i class="icon icon-file icon-lg" />
         </button>
+
+        <button
+          v-tooltip="t('nav.kubeconfig')"
+          :disabled="!kubeConfigEnabled"
+          type="button"
+          class="btn header-btn role-tertiary"
+          @click="currentCluster.copyKubeConfig()"
+        >
+          <i class="icon icon-copy icon-lg" />
+        </button>
       </template>
 
       <button

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -24,7 +24,7 @@ export default {
     TopLevelMenu,
     Jump,
     BrandImage,
-    RancherProviderIcon,
+    RancherProviderIcon
   },
 
   props: {
@@ -156,6 +156,16 @@ export default {
       this.$modal.hide('searchModal');
     },
 
+    showKubeConfigActions(show) {
+      if (this.$refs.kubeConfigActions) {
+        if (show) {
+          this.$refs.kubeConfigActions.show();
+        } else {
+          this.$refs.kubeConfigActions.hide();
+        }
+      }
+    },
+
     showPageActionsMenu(show) {
       if (this.$refs.pageActions) {
         if (show) {
@@ -271,22 +281,49 @@ export default {
           v-if="showKubeConfig"
           v-tooltip="t('nav.kubeconfig')"
           :disabled="!kubeConfigEnabled"
-          type="button"
           class="btn header-btn role-tertiary"
-          @click="currentCluster.downloadKubeConfig()"
+          type="button"
+          @blur="showKubeConfigActions(false)"
+          @click="showKubeConfigActions(true)"
+          @focus.capture="showKubeConfigActions(true)"
         >
-          <i class="icon icon-file icon-lg" />
+          <i class="icon icon-chevron-down icon-lg" />
         </button>
+        <v-popover
+          ref="kubeConfigActions"
+          placement="bottom-end"
+          offset="0"
+          trigger="manual"
+          :delay="{show: 0, hide: 0}"
+          :popper-options="{modifiers: { flip: { enabled: false } } }"
+          :container="false"
+        >
+          <template slot="popover" class="user-menu">
+            <ul class="list-unstyled dropdown config-actions" @click.stop="showKubeConfigActions(false)">
+              <li
+                class="user-menu-item"
+              >
+                <a @click="currentCluster.downloadKubeConfig()">
+                  <i class="icon icon-file" />
+                  {{ t('nav.kubeconfigDownload') }}
+                </a>
+              </li>
 
-        <button
-          v-tooltip="t('nav.kubeconfig')"
-          :disabled="!kubeConfigEnabled"
-          type="button"
-          class="btn header-btn role-tertiary"
-          @click="currentCluster.copyKubeConfig()"
-        >
-          <i class="icon icon-copy icon-lg" />
-        </button>
+              <div class="menu-seperator">
+                <div class="menu-seperator-line" />
+              </div>
+
+              <li
+                class="user-menu-item"
+              >
+                <a @click="currentCluster.copyKubeConfig()">
+                  <i class="icon icon-copy" />
+                  {{ t('nav.kubeconfigCopy') }}
+                </a>
+              </li>
+            </ul>
+          </template>
+        </v-popover>
       </template>
 
       <button
@@ -670,6 +707,23 @@ export default {
         padding: 10px 20px;
         border-bottom: solid 1px var(--border);
         min-width: 200px;
+      }
+    }
+  }
+
+  .config-actions {
+    li {
+      a {
+        justify-content: start;
+        align-items: center;
+
+        & .icon {
+          margin: 0 4px;
+        }
+
+        &:hover {
+          cursor: pointer;
+        }
       }
     }
   }

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -58,7 +58,7 @@ export default class MgmtCluster extends HybridModel {
 
     insertAt(out, 2, {
       action:     'copyKubeConfig',
-      label:      this.t('namespace.copy'),
+      label:      this.t('cluster.copyConfig'),
       bulkable:   false,
       enabled:    true,
       icon:       'icon icon-copy',

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import { CATALOG } from '@/config/labels-annotations';
 import { NODE, FLEET, MANAGEMENT } from '@/config/types';
 import { insertAt } from '@/utils/array';
@@ -53,6 +54,14 @@ export default class MgmtCluster extends HybridModel {
       icon:       'icon icon-download',
       bulkable:   true,
       enabled:    this.$rootGetters['isRancher'],
+    });
+
+    insertAt(out, 2, {
+      action:     'copyKubeConfig',
+      label:      this.t('namespace.copy'),
+      bulkable:   false,
+      enabled:    true,
+      icon:       'icon icon-copy',
     });
 
     return out;
@@ -307,7 +316,16 @@ export default class MgmtCluster extends HybridModel {
     const out = jsyaml.dump(obj);
 
     downloadFile('kubeconfig.yaml', out, 'application/yaml');
-  }
+    };
+  },
+
+  copyKubeConfig() {
+    return async() => {
+      const config = await this.generateKubeConfig();
+
+      Vue.prototype.$copyText(config);
+    };
+  },
 
   async fetchNodeMetrics() {
     const nodes = await this.$dispatch('cluster/findAll', { type: NODE }, { root: true });

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -316,16 +316,13 @@ export default class MgmtCluster extends HybridModel {
     const out = jsyaml.dump(obj);
 
     downloadFile('kubeconfig.yaml', out, 'application/yaml');
-    };
-  },
+  }
 
-  copyKubeConfig() {
-    return async() => {
-      const config = await this.generateKubeConfig();
+  async copyKubeConfig() {
+    const config = await this.generateKubeConfig();
 
-      Vue.prototype.$copyText(config);
-    };
-  },
+    Vue.prototype.$copyText(config);
+  }
 
   async fetchNodeMetrics() {
     const nodes = await this.$dispatch('cluster/findAll', { type: NODE }, { root: true });

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -68,14 +68,11 @@ export default class Namespace extends SteveModel {
 
   move(resources = this) {
     this.$dispatch('promptMove', resources);
-    };
-  },
+  }
 
-  copy() {
-    return (resource = this) => {
-      Vue.prototype.$copyText(JSON.stringify(resource));
-    };
-  },
+  copy(resource = this) {
+    Vue.prototype.$copyText(JSON.stringify(resource));
+  }
 
   get isSystem() {
     if ( this.metadata?.annotations?.[SYSTEM_NAMESPACE] === 'true' ) {

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import SYSTEM_NAMESPACES from '@/config/system-namespaces';
 import { PROJECT, SYSTEM_NAMESPACE, ISTIO as ISTIO_LABELS, FLEET } from '@/config/labels-annotations';
 import { ISTIO, MANAGEMENT } from '@/config/types';
@@ -53,12 +54,28 @@ export default class Namespace extends SteveModel {
       });
     }
 
+    insertAt(out, 5, {
+      action:     'copy',
+      label:      this.t('namespace.copy'),
+      bulkable:   false,
+      enabled:    true,
+      icon:       'icon icon-copy',
+      weight:     3,
+    });
+
     return out;
   }
 
   move(resources = this) {
     this.$dispatch('promptMove', resources);
-  }
+    };
+  },
+
+  copy() {
+    return (resource = this) => {
+      Vue.prototype.$copyText(JSON.stringify(resource));
+    };
+  },
 
   get isSystem() {
     if ( this.metadata?.annotations?.[SYSTEM_NAMESPACE] === 'true' ) {

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import SYSTEM_NAMESPACES from '@/config/system-namespaces';
 import { PROJECT, SYSTEM_NAMESPACE, ISTIO as ISTIO_LABELS, FLEET } from '@/config/labels-annotations';
 import { ISTIO, MANAGEMENT } from '@/config/types';
@@ -54,24 +53,11 @@ export default class Namespace extends SteveModel {
       });
     }
 
-    insertAt(out, 5, {
-      action:     'copy',
-      label:      this.t('namespace.copy'),
-      bulkable:   false,
-      enabled:    true,
-      icon:       'icon icon-copy',
-      weight:     3,
-    });
-
     return out;
   }
 
   move(resources = this) {
     this.$dispatch('promptMove', resources);
-  }
-
-  copy(resource = this) {
-    Vue.prototype.$copyText(JSON.stringify(resource));
   }
 
   get isSystem() {


### PR DESCRIPTION
This PR is in reference to #4270 to bring back the ability to copy the kubeconfig for clusters.

Converted the button in the navigation header for downloading the kubeconfig yaml of the current cluster into a dropdown which consists of two options: `Download KubeConfig` and `Copy KubeConfig to Clipboard`

Also added an option in the action-menu of each project/namespace to copy the config to the clipboard.

https://user-images.githubusercontent.com/40806497/135504487-4a71ee75-b92d-4bcf-8c4c-734c870ca754.mp4
