### PR TITLE
Addresses #4215 - Mobile UI/UX

### DIFF
--- a/assets/styles/base/_variables.scss
+++ b/assets/styles/base/_variables.scss
@@ -46,3 +46,11 @@ $breakpoints: (
   '--viewport-9':  992px, // Laptop/Desktop
   '--viewport-12': 1281px, // Desktop
 );
+
+
+$screen-sizes: (
+  'xs': '--viewport-4', // Phone
+  'sm': '--viewport-7', // Tablet
+  'med': '--viewport-9', // Laptop/Desktop
+  'lrg': '--viewport-12', // Desktop
+);

--- a/assets/styles/global/_columns.scss
+++ b/assets/styles/global/_columns.scss
@@ -32,7 +32,15 @@ $DEFAULT_COLUMNS: 12;
 /* ROWS */
 .row {
   display: flex;
-  // margin-bottom: 20px;
+  flex-direction: row;
+
+  @each $size, $viewport in $screen-sizes {
+    @media only screen and (max-width: map-get($breakpoints, $viewport)) {
+      &.#{$size}-column {
+        flex-direction: column;
+      }
+    }
+  }
 }
 
 .row:before,
@@ -59,6 +67,18 @@ $DEFAULT_COLUMNS: 12;
 
     // Gutterless column
     .gutless .span-#{$span}#{$suffix} { margin-right: 0; width: decimal-round( math.div($span, $cols) * 100%, 3, 'floor'); }
+    
+    @each $size, $viewport in $screen-sizes {
+      @media only screen and (max-width: map-get($breakpoints, $viewport)) {
+        .#{$size}-span-#{$span}#{$suffix} {
+          width: decimal-round( (((100 - ($column-gutter * ($cols - 1))) / $cols) * $span) + (($span - 1) * $column-gutter) , 3, 'floor') !important; 
+        }
+        .gutless .#{$size}-span-#{$span}#{$suffix} {
+          margin-right: 0;
+          width: decimal-round( $span / $cols * 100%, 3, 'floor') !important;
+        }
+      }
+    }
 
     // Offsets
     .offset-#{$span}#{$suffix} {
@@ -69,6 +89,17 @@ $DEFAULT_COLUMNS: 12;
     .gutless .offset-#{$span}#{$suffix} { margin-left: decimal-round( (math.div($span, $cols)*100%), 3, 'floor' ); }
 
     $span: $span - 1;
+  }
+  
+  // Span should be 0 now, that's short-hand for "Don't show this"
+  .span-#{$span}#{$suffix} { width: 0 !important; }
+
+  @each $size, $viewport in $screen-sizes {
+    @media only screen and (max-width: map-get($breakpoints, $viewport)) {
+      .#{$size}-span-#{$span}#{$suffix} {
+        width: 0 !important;
+      }
+    }
   }
 }
 

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -80,6 +80,7 @@ locale:
   none: (None)
 
 nav:
+  menu: Menu
   backToRancher: Cluster Manager
   clusterTools: Cluster Tools
   kubeconfig: Download KubeConfig

--- a/components/ActionMenu.vue
+++ b/components/ActionMenu.vue
@@ -70,6 +70,7 @@ export default {
           fudgeY:    elem ? 4 : 0,
           positionX: (elem ? AUTO : CENTER),
           positionY: AUTO,
+          fixed:     true
         });
 
         this.style.visibility = 'visible';

--- a/components/NavDropdown.vue
+++ b/components/NavDropdown.vue
@@ -1,0 +1,173 @@
+<script>
+export default {
+  methods: {
+    hasSlot(name = 'default') {
+      return !!this.$slots[name] || !!this.$scopedSlots[name];
+    },
+  }
+};
+</script>
+<template>
+  <div class="dropdown-button-group">
+    <div
+      class="dropdown-button bg-primary"
+    >
+      <v-popover
+        v-if="hasSlot('popover-content')"
+        id="navDropdown"
+        placement="bottom-start"
+        :container="false"
+      >
+        <slot name="button-content">
+          <button
+            ref="popoverButton"
+            class="icon-container bg-primary no-left-border-radius full-width"
+            type="button"
+          >
+            Button <i class="icon icon-chevron-down" />
+          </button>
+        </slot>
+
+        <template slot="popover">
+          <slot name="popover-content" />
+        </template>
+      </v-popover>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.dropdown-button-group {
+  margin: 1rem;
+  width: calc(100% - 2rem);
+
+  button {
+    width: 100%;
+  }
+
+  .btn {
+    line-height: normal;
+    border: 0px;
+  }
+
+  // this matches the top/bottom padding of the default button
+  $trigger-padding: 15px 10px 15px 10px;
+
+  .v-popover {
+    width: 100%;
+    .text-right {
+      margin-top: 5px;
+    }
+    .trigger {
+      width: 100%;
+      height: 100%;
+      .icon-container {
+        height: 100%;
+        padding: 10px 10px 10px 10px;
+        i {
+          transform: scale(1);
+        }
+        &:focus {
+          outline-style: none;
+          box-shadow: none;
+          border-color: transparent;
+        }
+      }
+    }
+  }
+
+  .dropdown-button {
+    border-radius: 4px;
+    width: 100%;
+    background: var(--tooltip-bg);
+    color: var(--link-text);
+    padding: 0;
+    display: inline-flex;
+
+    .wrapper-content {
+      button {
+        border-right: 0px;
+      }
+    }
+
+    &>*, .icon-chevron-down {
+      color: var(--primary);
+      background-color: rgba(0,0,0,0);
+    }
+
+    &.bg-primary:hover {
+      background: var(--accent-btn-hover);
+    }
+
+    &.one-action {
+      position: relative;
+      &>.btn {
+        padding: 15px 35px 15px 15px;
+      }
+      .v-popover{
+        width: 100%;
+        .trigger{
+          position: absolute;
+          top: 0px;
+          right: 0px;
+          left: 0px;
+          bottom: 0px;
+          BUTTON {
+            position: absolute;
+            right: 0px;
+          }
+        }
+      }
+    }
+  }
+  .popover {
+    border: none;
+  }
+  .tooltip {
+    margin-top: 0px;
+
+    &[x-placement^="bottom"] {
+      .tooltip-arrow {
+        border-bottom-color: var(--dropdown-border);
+
+        &:after {
+          border-bottom-color: var(--dropdown-bg);
+        }
+      }
+    }
+
+    .tooltip-inner {
+      color: var(--dropdown-text);
+      background-color: var(--dropdown-bg);
+      border: 1px solid var(--dropdown-border);
+      padding: 0px;
+      text-align: left;
+      width: calc(100vw - 2.5rem);
+
+      LI {
+        padding: 0 10px !important;
+
+        &.divider {
+          padding-top: 0px;
+          padding-bottom: 0px;
+
+          > .divider-inner {
+            padding: 0;
+            border-bottom: 1px solid var(--dropdown-divider);
+            width: 125%;
+            margin: 0 auto;
+          }
+        }
+
+        &:not(.divider):hover {
+          background-color: var(--dropdown-hover-bg);
+          color: var(--dropdown-hover-text);
+          cursor: pointer;
+        }
+      }
+
+    }
+  }
+}
+
+</style>

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -532,7 +532,7 @@ export default {
 </script>
 
 <template>
-  <div>
+  <div class="table-wrapper">
     <div :class="{'titled': $slots.title && $slots.title.length}" class="sortable-table-header">
       <slot name="title" />
       <div v-if="showHeaderRow" class="fixed-header-actions">
@@ -774,6 +774,10 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  .table-wrapper {
+    overflow-x: scroll;
+  }
+
   // Remove colors from multi-action buttons in the table
   td {
     .actions.role-multi-action {

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -467,6 +467,9 @@ export default {
     grid-template-areas:  "menu product top buttons header-actions cluster user";
     grid-template-columns: var(--header-height) calc(var(--nav-width) - var(--header-height)) auto min-content min-content min-content var(--header-height);
     grid-template-rows:    var(--header-height);
+    overflow-x: scroll;
+    overflow-y: clip;
+    width: 100vw;
 
     &.simple {
       grid-template-columns: var(--header-height) min-content auto min-content min-content min-content var(--header-height);

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -487,6 +487,10 @@ export default {
     flex-direction: column;
     padding: 0;
 
+    @media only screen and (max-width: 640px) {
+      width: 100% !important;
+    }
+
     &:focus {
       outline: 0;
     }
@@ -653,10 +657,16 @@ export default {
 
   .fade-leave-to {
     left: -300px;
+    @media only screen and (max-width: 640px) {
+      left: -100% !important;
+    }
   }
 
   .fade-enter {
     left: -300px;
+    @media only screen and (max-width: 640px) {
+      left: -100% !important;
+    }
 
     .side-menu-logo {
       opacity: 0;

--- a/components/nav/Type.vue
+++ b/components/nav/Type.vue
@@ -1,6 +1,7 @@
 <script>
 import Favorite from '@/components/nav/Favorite';
 import { FAVORITE, USED } from '@/store/type-map';
+import $ from 'jquery';
 
 const showFavoritesFor = [FAVORITE, USED];
 
@@ -56,6 +57,11 @@ export default {
     },
 
     selectType() {
+      const navDropdown = $('#navDropdown:visible');
+
+      if (navDropdown.hasClass('open')) {
+        navDropdown.find('button.btn').click();
+      }
       const typePath = this.$router.resolve(this.type.route)?.route?.fullPath;
 
       if (typePath !== this.$route.fullPath) {

--- a/detail/workload/index.vue
+++ b/detail/workload/index.vue
@@ -324,9 +324,15 @@ export default {
   .gauges {
     display: flex;
     justify-content: space-around;
+    @media only screen and (max-width: map-get($breakpoints, '--viewport-7')) {
+      flex-direction: column;
+    }
     &>*{
-    flex: 1;
-    margin-right: $column-gutter;
+      flex: 1;
+      margin-right: $column-gutter;
+      @media only screen and (max-width: map-get($breakpoints, '--viewport-7')) {
+        margin-top: 1rem;
+      }
+    }
   }
-}
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,6 +13,7 @@ import Group from '@/components/nav/Group';
 import Header from '@/components/nav/Header';
 import Brand from '@/mixins/brand';
 import FixedBanner from '@/components/FixedBanner';
+import NavDropdown from '@/components/NavDropdown';
 import {
   COUNT, SCHEMA, MANAGEMENT, UI, CATALOG, HCI
 } from '@/config/types';
@@ -41,7 +42,8 @@ export default {
     Group,
     GrowlManager,
     WindowManager,
-    FixedBanner
+    FixedBanner,
+    NavDropdown
   },
 
   mixins: [PageHeaderActions, Brand],
@@ -322,6 +324,7 @@ export default {
       const clusterId = this.$store.getters['clusterId'];
       const currentProduct = this.$store.getters['productId'];
       const currentType = this.$route.params.resource || '';
+
       let namespaces = null;
 
       if ( !this.$store.getters['isAllNamespaces'] ) {
@@ -527,7 +530,6 @@ export default {
 <template>
   <div class="dashboard-root">
     <FixedBanner />
-
     <div v-if="managementReady" class="dashboard-content">
       <Header />
       <nav v-if="clusterReady" class="side-nav">
@@ -597,6 +599,53 @@ export default {
         </div>
       </nav>
       <main v-if="clusterReady">
+        <NavDropdown class="dropdown-nav">
+          <template #button-content>
+            <button class="btn bg-primary">
+              <span>{{ t('nav.menu') }}</span>
+              <i class="ml-10 icon icon-chevron-down" />
+            </button>
+          </template>
+          <template #popover-content>
+            <nav v-if="clusterReady" class="modal-nav">
+              <div class="nav">
+                <template v-for="(g, idx) in groups">
+                  <Group
+                    ref="groups"
+                    :key="idx"
+                    id-prefix=""
+                    class="package"
+                    :group="g"
+                    :can-collapse="!g.isRoot"
+                    :show-header="!g.isRoot"
+                    @selected="groupSelected($event)"
+                    @expand="groupSelected($event)"
+                  >
+                    <template #header>
+                      <h6>{{ g.label }}</h6>
+                    </template>
+                  </Group>
+                </template>
+              </div>
+              <n-link v-if="showClusterTools" tag="div" class="tools" :to="{name: 'c-cluster-explorer-tools', params: {cluster: clusterId}}">
+                <a class="tools-button" @click="collapseAll()">
+                  <i class="icon icon-gear" />
+                  <span>{{ t('nav.clusterTools') }}</span>
+                </a>
+              </n-link>
+              <div class="version text-muted">
+                {{ displayVersion }}
+                <nuxt-link
+                  v-if="showProductSupport"
+                  :to="supportLink"
+                  class="pull-right"
+                >
+                  {{ t('nav.support', {hasSupport: true}) }}
+                </nuxt-link>
+              </div>
+            </nav>
+          </template>
+        </NavDropdown>
         <nuxt class="outlet" />
         <ActionMenu />
         <PromptRemove />
@@ -617,7 +666,62 @@ export default {
   </div>
 </template>
 <style lang="scss" scoped>
+  .dropdown-nav {
+    @media only screen and (min-width: map-get($breakpoints, '--viewport-4')) {
+      display: none !important;
+    }
+    display:inline-block;
+
+    .dropdown-button {
+      background-color: var(--primary);
+
+      &:hover {
+        background-color: var(--primary-hover-bg);
+        color: var(--primary-hover-text);
+      }
+
+      > *, .icon-chevron-down {
+        color: var(--primary-text);
+      }
+
+      .button-divider {
+        border-color: var(--primary-text);
+      }
+
+      &.disabled {
+        border-color: var(--disabled-bg);
+
+        .icon-chevron-down {
+          color: var(--disabled-text) !important;
+        }
+
+        .button-divider {
+          border-color: var(--disabled-text);
+        }
+      }
+    }
+  }
+  .navModal {
+    border-radius: var(--border-radius);
+    overflow: scroll;
+    max-height: 100vh;
+    width: 100vw;
+    & ::-webkit-scrollbar-corner {
+      background: rgba(0,0,0,0);
+    }
+  }
   .side-nav {
+    display: flex;
+    @media only screen and (max-width: map-get($breakpoints, '--viewport-4')) {
+      display: none !important;
+    }
+    flex-direction: column;
+    .nav {
+      flex: 1;
+      overflow-y: auto;
+    }
+  }
+  .modal-nav {
     display: flex;
     flex-direction: column;
     .nav {
@@ -648,6 +752,15 @@ export default {
 
     grid-template-columns: var(--nav-width)     auto;
     grid-template-rows:    var(--header-height) auto  var(--wm-height, 0px);
+
+    @media only screen and (max-width: map-get($breakpoints, '--viewport-4')) {
+      flex: 1 auto;
+      grid-template-areas:
+        "header"
+        "main"
+        "wm";
+      grid-template-columns: calc(100vw - 50px);
+    }
 
     > HEADER {
       grid-area: header;
@@ -742,6 +855,10 @@ export default {
   MAIN {
     grid-area: main;
     overflow: auto;
+    @media only screen and (max-width: map-get($breakpoints, '--viewport-4')) {
+      width: calc(100% + 50px);
+    }
+    width: calc(100%);
 
     .outlet {
       display: flex;

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -253,7 +253,7 @@ export default {
 <template>
   <main class="login">
     <div class="row gutless mb-20">
-      <div class="col span-6 p-20">
+      <div class="col sm-span-12 span-6 p-20">
         <p class="text-center">
           {{ t('login.howdy') }}
         </p>
@@ -360,7 +360,7 @@ export default {
         </template>
       </div>
 
-      <BrandImage class="col span-6 landscape" file-name="login-landscape.svg" />
+      <BrandImage class="col span-6 sm-span-0 landscape brand-image" file-name="login-landscape.svg" />
     </div>
   </main>
 </template>

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -455,6 +455,7 @@ export default {
   border-bottom: 1px solid var(--border);
   padding: 20px 0px;
   display: flex;
+  flex-wrap: wrap;
 
   &>*:not(:last-child) {
     margin-right: 40px;

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -237,7 +237,7 @@ export default {
   <div v-if="managementReady" class="home-page">
     <BannerGraphic :small="true" :title="t('landing.welcomeToRancher', {vendor})" :pref="HIDE_HOME_PAGE_CARDS" pref-key="welcomeBanner" />
     <IndentedPanel class="mt-20 mb-20">
-      <div v-if="!readWhatsNewAlready" class="row">
+      <div v-if="!readWhatsNewAlready" class="row sm-column">
         <div class="col span-12">
           <Banner color="info whats-new">
             <div>{{ t('landing.seeWhatsNew') }}</div>
@@ -246,8 +246,8 @@ export default {
         </div>
       </div>
 
-      <div class="row">
-        <div :class="{'span-9': showSidePanel, 'span-12': !showSidePanel }" class="col">
+      <div class="row sm-column">
+        <div :class="{'span-9': showSidePanel, 'span-12': !showSidePanel , 'sm-span-12': true}" class="col">
           <SimpleBox
             id="migration"
             class="panel"
@@ -267,7 +267,7 @@ export default {
           <SimpleBox :title="t('landing.landingPrefs.title')" :pref="HIDE_HOME_PAGE_CARDS" pref-key="setLoginPage" class="panel">
             <LandingPagePreference />
           </SimpleBox>
-          <div class="row panel">
+          <div class="row sm-column panel">
             <div v-if="mcm" class="col span-12">
               <SortableTable :table-actions="false" :row-actions="false" key-field="id" :rows="kubeClusters" :headers="clusterHeaders">
                 <template #header-left>
@@ -341,7 +341,7 @@ export default {
             </div>
           </div>
         </div>
-        <div v-if="showSidePanel" class="col span-3">
+        <div v-if="showSidePanel" class="col span-3 sm-span-12">
           <CommunityLinks v-if="showCommunityLinks" :pref="HIDE_HOME_PAGE_CARDS" pref-key="communitySupportTip" class="mb-20" />
           <SimpleBox v-if="showCommercialSupport" :pref="HIDE_HOME_PAGE_CARDS" pref-key="commercialSupportTip" :title="t('landing.commercial.title')">
             <nuxt-link :to="{ path: 'support'}">

--- a/utils/position.js
+++ b/utils/position.js
@@ -59,6 +59,8 @@ export function fitOnScreen(contentElem, triggerElemOrEvent, opt) {
     positionY = AUTO, // Preferred vertical position
   } = opt || {};
 
+  const { fixed = false } = opt || {};
+
   // console.log(positionX, positionY);
 
   const {
@@ -83,7 +85,7 @@ export function fitOnScreen(contentElem, triggerElemOrEvent, opt) {
   // console.log('trigger', trigger);
   // console.log('content', content);
 
-  const style = { position: 'absolute' };
+  const style = { position: fixed ? 'fixed' : 'absolute' };
 
   const originFor = {
     left:   (overlapX ? trigger.left : trigger.right ),


### PR DESCRIPTION
* Adds screensizes to be used as shorthand in class-names
* Smaller screens will shift from row to column flex directions
![image](https://user-images.githubusercontent.com/37550899/135647885-d9743984-4193-47e2-8828-3f5c281c92b3.png)
![image](https://user-images.githubusercontent.com/37550899/135647942-1a1935c6-f1a2-4c63-9d3c-bce2573e481b.png)
* Size-specific span classes for explicit responsive columns
![image](https://user-images.githubusercontent.com/37550899/135648180-58842354-27f0-497c-abba-b39a4358f7b5.png)
![image](https://user-images.githubusercontent.com/37550899/135648223-07977657-3ea4-4cb4-b09b-9a1513990df8.png)
* Action menu on tables now works regardless of scroll position
![image](https://user-images.githubusercontent.com/37550899/135648500-ac160c5f-7575-4ceb-95dd-f99a16604167.png)
* Dashboard header scrolls horizontally rather than growing the width of the whole page
![image](https://user-images.githubusercontent.com/37550899/135648696-71b1b53a-d580-4f2a-865e-644339205587.png)
* TopLevelMenu spans full width of viewport on mobile now
* Secondary side-bar is now a dropdown on mobile
![image](https://user-images.githubusercontent.com/37550899/135648864-a887ad68-c6d5-4e32-848f-0c1db5dd409b.png)
* Tables scroll internally so that they don't break the page layout
![image](https://user-images.githubusercontent.com/37550899/135649001-15183c22-2d7b-4e71-9ec6-dd90df350ec8.png)
* Login page is now a single column with no image
![image](https://user-images.githubusercontent.com/37550899/135648312-c492ae92-4ff1-419d-bd4c-51eef9ee8bd4.png)

