### PR TITLE
Remove edit/upgrade action from Apps with no chart

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -697,6 +697,13 @@ catalog:
       requiresMissing: 'This chart requires another chart that provides {name}, but none was was found.'
       insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
       insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
+      legacy:
+        label: This is a {legacyType} App and it cannot be modified here.
+        enableLegacy: You will need to enable <a href="{target}">Legacy Features</a> to edit this App.
+        navigate: Navigate to <a href="{target}">{legacyType} Apps</a>
+        category:
+          legacy: Legacy
+          mcm: Multi-cluster
     header:
       install: 'Install {name}'
       installGeneric: Install Chart
@@ -728,12 +735,6 @@ catalog:
             other { seconds }
           }
       wait: Wait
-    multiCluster:
-      label: This is a Multi-cluster App and it cannot be modified here.
-      legacy:
-        description: 'You will need to enable <a href="{target}">Legacy Features</a>'
-      mcm:
-        description: Navigate to <a href="{target}">Multi-cluster Apps</a>
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -698,9 +698,11 @@ catalog:
       insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
       insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
       legacy:
-        label: This is a {legacyType} App and it cannot be modified here.
-        enableLegacy: You will need to enable <a href="{target}">Legacy Features</a> to edit this App.
-        navigate: Navigate to <a href="{target}">{legacyType} Apps</a>
+        label: This is a {legacyType} App and it cannot be modified here
+        enableLegacy:
+          prompt: You will need to enable Legacy Features to edit this App
+          goto: Go to Feature Flag settings
+        navigate: Navigate to {legacyType} Apps
         category:
           legacy: Legacy
           mcm: Multi-cluster

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -731,11 +731,9 @@ catalog:
     multiCluster:
       label: This is a Multi-cluster App and it cannot be modified here.
       legacy:
-        label: You will need to turn on
-        target: Legacy Features
+        description: 'You will need to enable <a href="{target}">Legacy Features</a>'
       mcm:
-        label: Navigate to
-        target: Multi-cluster Apps
+        description: Navigate to <a href="{target}">Multi-cluster Apps</a>
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -728,6 +728,14 @@ catalog:
             other { seconds }
           }
       wait: Wait
+    multiCluster:
+      label: This is a Multi-cluster App and it cannot be modified here.
+      legacy:
+        label: You will need to turn on
+        target: Legacy Features
+      mcm:
+        label: Navigate to
+        target: Multi-cluster Apps
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:

--- a/config/types.js
+++ b/config/types.js
@@ -144,6 +144,7 @@ export const MANAGEMENT = {
   FEATURE:                       'management.cattle.io.feature',
   // GROUP:                         'management.cattle.io.group',
   KONTANIER_DRIVER:              'management.cattle.io.kontainerdriver',
+  MULTI_CLUSTER_APP:             'management.cattle.io.multiclusterapp',
   NODE:                          'management.cattle.io.node',
   NODE_DRIVER:                   'management.cattle.io.nodedriver',
   NODE_POOL:                     'management.cattle.io.nodepool',

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -215,13 +215,7 @@ export default class CatalogApp extends SteveModel {
       const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
 
       if (mcapps) {
-        for (let i = 0 ; i < mcapps.length ; i++) {
-          const res = mcapps[i].spec?.targets?.find(target => target.appName === this.metadata?.name);
-
-          if (res) {
-            return res;
-          }
-        }
+        return mcapps.find(mcapp => mcapp.spec.targets.find(target => target.appName === this.metadata?.name));
       }
 
       return null;

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -4,7 +4,7 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, FLEET } from '@/config/labels-annotations';
 import { compare, isPrerelease, sortable } from '@/utils/version';
 import { filterBy } from '@/utils/array';
-import { CATALOG, MANAGEMENT } from '@/config/types';
+import { CATALOG, MANAGEMENT, NORMAN } from '@/config/types';
 import { SHOW_PRE_RELEASE } from '@/store/prefs';
 import { set } from '@/utils/object';
 
@@ -225,6 +225,26 @@ export default class CatalogApp extends SteveModel {
       }
 
       return null;
+    };
+  }
+
+  get deployedAsLegacy() {
+    return async() => {
+      if (this.spec.values) {
+        const { clusterName, projectName } = this.spec?.values?.global;
+
+        if (clusterName && projectName) {
+          const legacyApp = await this.$dispatch('rancher/find', {
+            type: NORMAN.APP,
+            id:   `${ projectName }:${ this.metadata?.name }`,
+            opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
+          }, { root: true });
+
+          if (legacyApp) {
+            return legacyApp;
+          }
+        }
+      }
     };
   }
 }

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -28,7 +28,7 @@ export default class CatalogApp extends SteveModel {
 
     const upgrade = {
       action:     'goToUpgrade',
-      enabled:    true,
+      enabled:    !this.currentVersionHasNoChart,
       icon:       'icon icon-fw icon-edit',
       label:      this.t('catalog.install.action.goToUpgrade'),
     };

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -215,7 +215,7 @@ export default class CatalogApp extends SteveModel {
       const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
 
       if (mcapps) {
-        return mcapps.find(mcapp => mcapp.spec.targets.find(target => target.appName === this.metadata?.name));
+        return mcapps.find(mcapp => mcapp.spec?.targets?.find(target => target.appName === this.metadata?.name));
       }
 
       return null;

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -4,7 +4,7 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, FLEET } from '@/config/labels-annotations';
 import { compare, isPrerelease, sortable } from '@/utils/version';
 import { filterBy } from '@/utils/array';
-import { CATALOG } from '@/config/types';
+import { CATALOG, MANAGEMENT } from '@/config/types';
 import { SHOW_PRE_RELEASE } from '@/store/prefs';
 import { set } from '@/utils/object';
 
@@ -28,7 +28,7 @@ export default class CatalogApp extends SteveModel {
 
     const upgrade = {
       action:     'goToUpgrade',
-      enabled:    !this.currentVersionHasNoChart,
+      enabled:    true,
       icon:       'icon icon-fw icon-edit',
       label:      this.t('catalog.install.action.goToUpgrade'),
     };
@@ -208,6 +208,24 @@ export default class CatalogApp extends SteveModel {
 
   get deployedResources() {
     return filterBy(this.metadata?.relationships || [], 'rel', 'helmresource');
+  }
+
+  get deployedAsMultiCluster() {
+    return async() => {
+      const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
+
+      if (mcapps) {
+        for (let i = 0 ; i < mcapps.length ; i++) {
+          const res = mcapps[i].spec?.targets?.find(target => target.appName === this.metadata?.name);
+
+          if (res) {
+            return res;
+          }
+        }
+      }
+
+      return null;
+    };
   }
 }
 

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -104,8 +104,8 @@ export default {
       this.forceNamespace = null;
     }
 
-    this.legacyApp = await this.existing.deployedAsLegacy();
-    this.mcapp = await this.existing.deployedAsMultiCluster();
+    this.legacyApp = this.existing ? await this.existing.deployedAsLegacy() : false;
+    this.mcapp = this.existing ? await this.existing.deployedAsMultiCluster() : false;
 
     this.value = await this.$store.dispatch('cluster/create', {
       type:     'chartInstallAction',
@@ -512,25 +512,19 @@ export default {
       return this.features(LEGACY);
     },
 
-    legacyFeaturePath() {
-      const path = {
+    legacyFeatureRoute() {
+      return {
         name:   'c-cluster-product-resource',
         params: { product: 'settings', resource: 'management.cattle.io.feature' }
       };
-
-      return this.$router.resolve(path).href;
     },
 
-    legacyAppPath() {
-      const path = { name: 'c-cluster-legacy-project' };
-
-      return this.$router.resolve(path).href;
+    legacyAppRoute() {
+      return { name: 'c-cluster-legacy-project' };
     },
 
-    mcmPath() {
-      const path = { name: 'c-cluster-mcapps' };
-
-      return this.$router.resolve(path).href;
+    mcmRoute() {
+      return { name: 'c-cluster-mcapps' };
     }
   },
 
@@ -1345,13 +1339,18 @@ export default {
 
       <Banner color="warning" class="description">
         <span>
-          {{ t('catalog.install.error.legacy.label', { legacyType: legacyApp ? legacyDefs.legacy : legacyDefs.mcm }, true) }}
+          {{ t('catalog.install.error.legacy.label', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true) }}
         </span>
         <template v-if="!legacyEnabled">
-          <span v-html="t('catalog.install.error.legacy.enableLegacy', { target: legacyFeaturePath }, true)" />
+          <span v-html="t('catalog.install.error.legacy.enableLegacy.prompt', true)" />
+          <nuxt-link :to="legacyFeatureRoute">
+            {{ t('catalog.install.error.legacy.enableLegacy.goto') }}
+          </nuxt-link>
         </template>
         <template v-else>
-          <span v-html="t('catalog.install.error.legacy.navigate', { target: legacyApp ? legacyAppPath : mcmPath, legacyType: legacyApp ? legacyDefs.legacy : legacyDefs.mcm }, true)" />
+          <nuxt-link :to="mcapp ? mcmRoute : legacyAppRoute">
+            <span v-html="t('catalog.install.error.legacy.navigate', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true)" />
+          </nuxt-link>
         </template>
       </Banner>
     </div>

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -104,11 +104,7 @@ export default {
       this.forceNamespace = null;
     }
 
-    const isMultiClusterApp = await this.existing.deployedAsMultiCluster();
-
-    if ( isMultiClusterApp ) {
-      this.mcapp = true;
-    }
+    this.mcapp = await this.existing.deployedAsMultiCluster();
 
     this.value = await this.$store.dispatch('cluster/create', {
       type:     'chartInstallAction',
@@ -284,12 +280,6 @@ export default {
       ],
 
       isPlainLayout: isPlainLayout(this.$route.query),
-
-      legacyPath: {
-        name:   'c-cluster-product-resource',
-        params: { product: 'settings', resource: 'management.cattle.io.feature' }
-      },
-      mcmPath: { name: 'c-cluster-mcapps' }
     };
   },
 
@@ -514,6 +504,21 @@ export default {
     legacyEnabled() {
       return this.features(LEGACY);
     },
+
+    legacyPath() {
+      const path = {
+        name:   'c-cluster-product-resource',
+        params: { product: 'settings', resource: 'management.cattle.io.feature' }
+      };
+
+      return this.$router.resolve(path).href;
+    },
+
+    mcmPath() {
+      const path = { name: 'c-cluster-mcapps' };
+
+      return this.$router.resolve(path).href;
+    }
   },
 
   watch: {
@@ -1330,20 +1335,10 @@ export default {
           {{ t('catalog.install.multiCluster.label') }}
         </span>
         <template v-if="!legacyEnabled">
-          <span>
-            {{ t('catalog.install.multiCluster.legacy.label') }}
-            <nuxt-link :to="legacyPath">
-              {{ t('catalog.install.multiCluster.legacy.target') }}
-            </nuxt-link>
-          </span>
+          <span v-html="t('catalog.install.multiCluster.legacy.description', { target: legacyPath }, true)" />
         </template>
         <template v-else-if="legacyEnabled && mcm">
-          <span>
-            {{ t('catalog.install.multiCluster.mcm.label') }}
-            <nuxt-link :to="mcmPath">
-              {{ t('catalog.install.multiCluster.mcm.target') }}
-            </nuxt-link>
-          </span>
+          <span v-html="t('catalog.install.multiCluster.mcm.description', { target: mcmPath }, true)" />
         </template>
       </Banner>
     </div>


### PR DESCRIPTION
This is in reference to rancher/dashboard#4120 where an App created with the old UI would send an error when trying to edit/update: `Cannot read property 'annotations' of undefined`.

According to https://rancher.com/docs/rancher/v2.6/en/helm-charts/ , any App that has been managed by the Cluster Manager (old UI) should continue to be managed only by the Cluster Manager. 

The actual error in this case with OpenEBS was caused by the App utilizing a chart (`2.5.1`) that no longer exists in the default repositories. This PR will check if an App has a chart that is not within the repositories and will disable the `Edit/Upgrade` option from the action menu.

### ** Update: https://github.com/rancher/dashboard/pull/4332#issuecomment-941436439

To reproduce:
1. Navigate to `localhost/g/apps` and launch OpenEBS.
 
![oldAppLaunch](https://user-images.githubusercontent.com/40806497/135671687-ff57be40-78f9-478a-beef-3f3b50f8b6a2.png)

2. Navigate to Cluster > Apps & Marketplace > Installed Apps

![installedApps](https://user-images.githubusercontent.com/40806497/135672003-7189eaac-59a9-4e4e-ba17-880540d64a76.png)

3. Then select the OpenEBS App and try to edit. 

![oldAppNoEditAction](https://user-images.githubusercontent.com/40806497/135672039-fd95dd31-a6e5-4923-9578-636ab0a20898.png)


