### PR TITLE
Remove tcpSocket option, fix inability to edit config after creation

### DIFF
--- a/components/form/HookOption.vue
+++ b/components/form/HookOption.vue
@@ -1,4 +1,5 @@
 <script>
+import debounce from 'lodash/debounce';
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
@@ -34,7 +35,7 @@ export default {
         path:        '',
         port:        null,
         scheme:      '',
-        httpHeaders: [{ name: '', value: '' }]
+        httpHeaders: null
       }
     };
 
@@ -60,11 +61,17 @@ export default {
     if (isEmpty(this.value)) {
       this.selectHook = 'none';
     }
+
+    this.queueUpdate = debounce(this.update, 500);
   },
 
   methods: {
     addHeader() {
       const header = { name: '', value: '' };
+
+      if (!this.value.httpGet.httpHeaders) {
+        this.$set(this.value.httpGet, 'httpHeaders', []);
+      }
 
       this.value.httpGet.httpHeaders.push(header);
     },
@@ -171,7 +178,7 @@ export default {
       </div>
 
       <h4>{{ t('workload.container.lifecycleHook.httpHeaders.title') }}</h4>
-      <div v-for="(header, index) in value.httpGet.httpHeaders" :key="header.vKey" class="var-row">
+      <div v-for="(header, index) in value.httpGet.httpHeaders" :key="header.id" class="var-row">
         <template @input="update">
           <LabeledInput
             v-model="value.httpGet.httpHeaders[index].name"
@@ -187,17 +194,19 @@ export default {
             class="single-value"
             :mode="mode"
           />
-          <button
-            v-if="!isView"
-            type="button"
-            class="btn role-link"
-            :disabled="mode==='view'"
-            @click.stop="removeHeader(index)"
-          >
-            <t k="generic.remove" />
-          </button>
         </template>
+
+        <button
+          v-if="!isView"
+          type="button"
+          class="btn role-link"
+          :disabled="mode==='view'"
+          @click.stop="removeHeader(index)"
+        >
+          <t k="generic.remove" />
+        </button>
       </div>
+
       <div>
         <button
           v-if="!isView"
@@ -223,6 +232,10 @@ export default {
 
   .single-value {
     grid-column: span 2;
+  }
+
+  .labeled-select {
+    min-height: 61px;
   }
 }
 </style>

--- a/components/form/HookOption.vue
+++ b/components/form/HookOption.vue
@@ -3,7 +3,6 @@ import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import ShellInput from '@/components/form/ShellInput';
-import debounce from 'lodash/debounce';
 import { _VIEW } from '@/config/query-params';
 import { isEmpty } from '@/utils/object';
 
@@ -38,13 +37,11 @@ export default {
         httpHeaders: [{ name: '', value: '' }]
       }
     };
-    const defaultTcpSocket = { tcpSocket: { host: '', port: null } };
 
     return {
       selectHook,
       defaultExec,
       defaultHttpGet,
-      defaultTcpSocket,
       schemeOptions: ['HTTP', 'HTTPS']
     };
   },
@@ -63,8 +60,6 @@ export default {
     if (isEmpty(this.value)) {
       this.selectHook = 'none';
     }
-
-    this.queueUpdate = debounce(this.update, 500);
   },
 
   methods: {
@@ -76,7 +71,6 @@ export default {
 
     removeHeader(index) {
       this.value.httpGet.httpHeaders.splice(index, 1);
-      this.queueUpdate();
     },
 
     update() {
@@ -93,10 +87,6 @@ export default {
       case 'httpGet':
         this.deleteLeftovers(leftovers);
         Object.assign(this.value, this.defaultHttpGet);
-        break;
-      case 'tcpSocket':
-        this.deleteLeftovers(leftovers);
-        Object.assign(this.value, this.defaultTcpSocket);
         break;
       default:
         break;
@@ -117,17 +107,16 @@ export default {
 </script>
 
 <template>
-  <div @input="update">
+  <div>
     <div class="row mb-10">
       <RadioGroup
         v-model="selectHook"
         name="selectHook"
-        :options="['none', 'exec', 'httpGet', 'tcpSocket']"
+        :options="['none', 'exec', 'httpGet']"
         :labels="[
           t('generic.none'),
           t('workload.container.lifecycleHook.exec.add'),
           t('workload.container.lifecycleHook.httpGet.add'),
-          t('workload.container.lifecycleHook.tcpSocket.add')
         ]"
         :mode="mode"
         @input="update"
@@ -149,114 +138,77 @@ export default {
     </template>
 
     <template v-if="selectHook === 'httpGet'">
-      <template>
-        <h4>{{ t('workload.container.lifecycleHook.httpGet.title') }}</h4>
-        <slot name="httpGetOption">
-          <div class="var-row">
-            <template>
-              <LabeledInput
-                v-model="value.httpGet.host"
-                :label="t('workload.container.lifecycleHook.httpGet.host.label')"
-                :placeholder="t('workload.container.lifecycleHook.httpGet.host.placeholder')"
-                :mode="mode"
-              />
-            </template>
-            <template>
-              <LabeledInput
-                v-model="value.httpGet.path"
-                :label="t('workload.container.lifecycleHook.httpGet.path.label')"
-                :placeholder="t('workload.container.lifecycleHook.httpGet.path.placeholder')"
-                :mode="mode"
-              />
-            </template>
-            <template>
-              <LabeledInput
-                v-model.number="value.httpGet.port"
-                type="number"
-                :label="t('workload.container.lifecycleHook.httpGet.port.label')"
-                :placeholder="t('workload.container.lifecycleHook.httpGet.port.placeholder')"
-                :mode="mode"
-              />
-            </template>
-            <template>
-              <LabeledSelect
-                v-model="value.httpGet.scheme"
-                :label="t('workload.container.lifecycleHook.httpGet.scheme.label')"
-                :placeholder="t('workload.container.lifecycleHook.httpGet.scheme.placeholder')"
-                :options="schemeOptions"
-                :mode="mode"
-              />
-            </template>
-          </div>
-        </slot>
-      </template>
-
-      <template>
-        <h4>{{ t('workload.container.lifecycleHook.httpHeaders.title') }}</h4>
-        <template>
-          <div v-for="(header, index) in value.httpGet.httpHeaders" :key="header.vKey" class="var-row">
-            <LabeledInput
-              v-model="value.httpGet.httpHeaders[index].name"
-              :label="t('workload.container.lifecycleHook.httpHeaders.name.label')"
-              :placeholder="t('workload.container.lifecycleHook.httpHeaders.name.placeholder')"
-              class="single-value"
-              :mode="mode"
-            />
-            <LabeledInput
-              v-model="value.httpGet.httpHeaders[index].value"
-              :label="t('workload.container.lifecycleHook.httpHeaders.value.label')"
-              :placeholder="t('workload.container.lifecycleHook.httpHeaders.value.placeholder')"
-              class="single-value"
-              :mode="mode"
-            />
-            <button
-              v-if="!isView"
-              type="button"
-              class="btn role-link"
-              :disabled="mode==='view'"
-              @click.stop="removeHeader(index)"
-            >
-              <t k="generic.remove" />
-            </button>
-          </div>
+      <h4>{{ t('workload.container.lifecycleHook.httpGet.title') }}</h4>
+      <div class="var-row">
+        <template @input="update">
+          <LabeledInput
+            v-model="value.httpGet.host"
+            :label="t('workload.container.lifecycleHook.httpGet.host.label')"
+            :placeholder="t('workload.container.lifecycleHook.httpGet.host.placeholder')"
+            :mode="mode"
+          />
+          <LabeledInput
+            v-model="value.httpGet.path"
+            :label="t('workload.container.lifecycleHook.httpGet.path.label')"
+            :placeholder="t('workload.container.lifecycleHook.httpGet.path.placeholder')"
+            :mode="mode"
+          />
+          <LabeledInput
+            v-model.number="value.httpGet.port"
+            type="number"
+            :label="t('workload.container.lifecycleHook.httpGet.port.label')"
+            :placeholder="t('workload.container.lifecycleHook.httpGet.port.placeholder')"
+            :mode="mode"
+          />
+          <LabeledSelect
+            v-model="value.httpGet.scheme"
+            :label="t('workload.container.lifecycleHook.httpGet.scheme.label')"
+            :placeholder="t('workload.container.lifecycleHook.httpGet.scheme.placeholder')"
+            :options="schemeOptions"
+            :mode="mode"
+          />
         </template>
-        <div>
+      </div>
+
+      <h4>{{ t('workload.container.lifecycleHook.httpHeaders.title') }}</h4>
+      <div v-for="(header, index) in value.httpGet.httpHeaders" :key="header.vKey" class="var-row">
+        <template @input="update">
+          <LabeledInput
+            v-model="value.httpGet.httpHeaders[index].name"
+            :label="t('workload.container.lifecycleHook.httpHeaders.name.label')"
+            :placeholder="t('workload.container.lifecycleHook.httpHeaders.name.placeholder')"
+            class="single-value"
+            :mode="mode"
+          />
+          <LabeledInput
+            v-model="value.httpGet.httpHeaders[index].value"
+            :label="t('workload.container.lifecycleHook.httpHeaders.value.label')"
+            :placeholder="t('workload.container.lifecycleHook.httpHeaders.value.placeholder')"
+            class="single-value"
+            :mode="mode"
+          />
           <button
             v-if="!isView"
             type="button"
-            class="btn role-link mb-20"
-            :disabled="mode === 'view'"
-            @click.stop="addHeader"
+            class="btn role-link"
+            :disabled="mode==='view'"
+            @click.stop="removeHeader(index)"
           >
-            Add Header
+            <t k="generic.remove" />
           </button>
-        </div>
-      </template>
-    </template>
-
-    <template v-if="selectHook === 'tcpSocket'">
-      <h4>{{ t('workload.container.lifecycleHook.tcpSocket.title') }}</h4>
-      <template>
-        <div class="var-row">
-          <template>
-            <LabeledInput
-              v-model="value.tcpSocket.host"
-              :label="t('workload.container.lifecycleHook.tcpSocket.host.label')"
-              :placeholder="t('workload.container.lifecycleHook.tcpSocket.host.placeholder')"
-              :mode="mode"
-            />
-          </template>
-          <template>
-            <LabeledInput
-              v-model.number="value.tcpSocket.port"
-              type="number"
-              :label="t('workload.container.lifecycleHook.tcpSocket.port.label')"
-              :placeholder="t('workload.container.lifecycleHook.tcpSocket.port.label')"
-              :mode="mode"
-            />
-          </template>
-        </div>
-      </template>
+        </template>
+      </div>
+      <div>
+        <button
+          v-if="!isView"
+          type="button"
+          class="btn role-link mb-20"
+          :disabled="mode === 'view'"
+          @click.stop="addHeader"
+        >
+          Add Header
+        </button>
+      </div>
     </template>
   </div>
 </template>

--- a/components/form/LifecycleHooks.vue
+++ b/components/form/LifecycleHooks.vue
@@ -62,20 +62,18 @@ export default {
 
 <template>
   <div>
-    <template>
-      <div class="mb-20">
-        <h3 class="clearfix">
-          {{ t('workload.container.lifecycleHook.postStart.label') }}
-        </h3>
-        <HookOption v-model="postStart" :mode="mode" @input="update" />
-      </div>
+    <div class="mb-20">
+      <h3 class="clearfix">
+        {{ t('workload.container.lifecycleHook.postStart.label') }}
+      </h3>
+      <HookOption v-model="postStart" :mode="mode" @input="update" />
+    </div>
 
-      <div>
-        <h3 class="clearfix">
-          {{ t('workload.container.lifecycleHook.preStop.label') }}
-        </h3>
-        <HookOption v-model="preStop" :mode="mode" @input="update" />
-      </div>
-    </template>
+    <div>
+      <h3 class="clearfix">
+        {{ t('workload.container.lifecycleHook.preStop.label') }}
+      </h3>
+      <HookOption v-model="preStop" :mode="mode" @input="update" />
+    </div>
   </div>
 </template>


### PR DESCRIPTION
This is in relation to #1817 

The tcpSocket option in a lifecycle hook has been removed due to being unsupported https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#handler-v1-core

Fixed bug where the values in a hook option couldn't be edited/updated after the container has been created.

https://user-images.githubusercontent.com/40806497/135865106-b72c322a-8b7f-4508-bcae-05da57716ca4.mp4

To recreate:
1. Cluster > Workload > Deployment > Create
2. Add lifecycle hooks
3. Create deployment
4. Edit config of deployment
5. Update values in lifecycle hooks 