### PR TITLE
Login/Logout catch navigation rejection error

### DIFF
--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -239,7 +239,7 @@ export default {
           this.$store.dispatch('auth/setInitialPass', this.password);
           this.$router.push({ name: 'auth-setup' });
         } else {
-          this.$router.replace('/');
+          this.$router.replace('/').catch(() => {});
         }
       } catch (err) {
         this.err = err;

--- a/store/index.js
+++ b/store/index.js
@@ -829,7 +829,7 @@ export const actions = {
     } else {
       const QUERY = (LOGGED_OUT in route.query) ? LOGGED_OUT : TIMED_OUT;
 
-      router.replace(`/auth/login?${ QUERY }`);
+      router.replace(`/auth/login?${ QUERY }`).catch(() => {});
     }
   },
 


### PR DESCRIPTION
This is in reference to #4290 where vue-router is throwing an `Uncaught (in promise) Error` when logging in or out.

According to https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378 - the error is part of a new promise api; 

> if the navigation failure (anything that cancels a navigation like a next(false) or next('/other') also counts) is not caught, you will see an error in the console because that promise rejection is not caught. However, the failure was always there because trying to navigate to same location as the current one fails. It's now visible because of the promise being rejected but not caught.

The fix is to add a `.catch(() => {})` to the `$router.replace` method which will consume the error.

The original errors:

https://user-images.githubusercontent.com/40806497/136030894-e5623a6b-e461-4f3f-a47c-174be3b03378.mp4


To reproduce:
1. Login > check console for errors
2. Logout > check console for errors
