### PR TITLE
Show info banner for related resources while app is pending-install

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -642,7 +642,9 @@ catalog:
     section:
       notes: Release Notes
       readme: Chart README
-      resources: Resources
+      resources: 
+        label: Resources
+        busy: The related resources will appear when {app} is fully installed.
       values: Values YAML
   chart:
     header:

--- a/detail/catalog.cattle.io.app.vue
+++ b/detail/catalog.cattle.io.app.vue
@@ -4,6 +4,7 @@ import Loading from '@/components/Loading';
 import Markdown from '@/components/Markdown';
 import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
+import Banner from '@/components/Banner';
 import RelatedResources from '@/components/RelatedResources';
 import jsyaml from 'js-yaml';
 import merge from 'lodash/merge';
@@ -12,7 +13,7 @@ export default {
   name: 'DetailRelease',
 
   components: {
-    Markdown, Tabbed, Tab, Loading, YamlEditor, RelatedResources
+    Markdown, Tabbed, Tab, Loading, YamlEditor, Banner, RelatedResources
   },
 
   props: {
@@ -40,6 +41,14 @@ export default {
 
       return jsyaml.dump(combined);
     },
+
+    isBusy() {
+      if (this.value?.metadata?.state?.transitioning && this.value?.metadata?.state?.name === 'pending-install') {
+        return true;
+      }
+
+      return false;
+    }
   },
 
   methods: {
@@ -64,8 +73,9 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <Tabbed v-else class="mt-20" default-tab="resources" @changed="tabChanged($event)">
-    <Tab name="resources" :label="t('catalog.app.section.resources')" :weight="4">
-      <RelatedResources :value="value" rel="helmresource" />
+    <Tab name="resources" :label="t('catalog.app.section.resources.label')" :weight="4">
+      <Banner v-if="isBusy" color="info" :label="t('catalog.app.section.resources.busy', { app: value.metadata.name })" />
+      <RelatedResources v-else :value="value" rel="helmresource" />
     </Tab>
     <Tab name="values-yaml" :label="t('catalog.app.section.values')" :weight="3">
       <YamlEditor


### PR DESCRIPTION
In reference to #3401 where an app detail page does not show the related resources while the app is installing.
 
While an app is installing the only relationship that is returned by the API is the app that is being installed, the related resources will not exist until the app is fully installed/deployed.

The original message that is shown during the install:

![124621926-f43dcf80-de7a-11eb-860f-b6bef94a852a](https://user-images.githubusercontent.com/40806497/136078485-518641d5-7047-4207-88b2-8f58b47f63a7.png)


The fix here displays a new message while the app's state is `pending-install`:

![appRelatedResources](https://user-images.githubusercontent.com/40806497/136078525-b6ddd51e-b0b0-4f05-8807-0d30938e7372.png)

To recreate:
1. Install an app from Apps & Marketplace
2. Navigate to the app detail page: Cluster > Apps & Marketplace > Installed Apps > `App`
3. View info banner under Resources tab 