### PR TITLE
Add termination grace period input to preStop lifecycle hook

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4415,6 +4415,12 @@ workload:
         command:
           label: Command
           placeholder: e.g. sh -c sleep 10
+        gracePeriod:
+          label: Termination Grace Period Seconds
+          placeholder: e.g. 120
+          options:
+            default: Default (30 seconds)
+            custom: Custom
       httpGet:
         title: HttpGet
         add: Create HTTP request
@@ -4501,6 +4507,7 @@ workload:
       env: Environment Variables
       events: Events
       general: General
+      gracePeriod: Termination Grace Period
       healthCheck: Health Check
       image: Image
       lifecycle: Lifecycle Hooks

--- a/components/form/LifecycleHooks.vue
+++ b/components/form/LifecycleHooks.vue
@@ -14,13 +14,18 @@ export default {
       required: true,
     },
 
-    // container spec
+    // container.lifecycle spec
     value: {
       type:    Object,
       default: () => {
         return {};
       }
     },
+
+    podTemplateSpec: {
+      type:     Object,
+      required: true
+    }
   },
 
   data() {
@@ -66,14 +71,21 @@ export default {
       <h3 class="clearfix">
         {{ t('workload.container.lifecycleHook.postStart.label') }}
       </h3>
-      <HookOption v-model="postStart" :mode="mode" @input="update" />
+      <HookOption v-model="postStart" type="postStart" :mode="mode" @input="update" />
     </div>
 
     <div>
       <h3 class="clearfix">
         {{ t('workload.container.lifecycleHook.preStop.label') }}
       </h3>
-      <HookOption v-model="preStop" :mode="mode" @input="update" />
+      <HookOption
+        v-model="preStop"
+        type="preStop"
+        :mode="mode"
+        :grace-period="podTemplateSpec.terminationGracePeriodSeconds"
+        @input="update"
+        @update:grace-period="podTemplateSpec.terminationGracePeriodSeconds = $event"
+      />
     </div>
   </div>
 </template>

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -838,7 +838,7 @@ export default {
           <div class="spacer"></div>
           <div>
             <h3>{{ t('workload.container.titles.lifecycle') }}</h3>
-            <LifecycleHooks v-model="container.lifecycle" :mode="mode" />
+            <LifecycleHooks v-model="container.lifecycle" :pod-template-spec="podTemplateSpec" :mode="mode" />
           </div>
         </Tab>
         <Tab :label="t('workload.storage.title')" name="storage">


### PR DESCRIPTION
In relation to #4333 

This PR adds the ability to modify the termination grace period of a pod with a preStop lifecycle hook. If a preStop `exec` command is supplied the default grace period of 30 seconds may not be enough to complete the command.

**To **Test:****
1. Navigate to `cluster` => Workload => Create
2. In the General tab choose PreStop => Add Command to Execute
3. Add a command that will take longer than the default grace period (`sleep 60` was used in example)
4. Select Termination Grace Period => Custom
5. Add a time in seconds greater than 30 (`120` used in example)

![createTGP](https://user-images.githubusercontent.com/40806497/136225918-22c27317-7a40-48cd-952b-cefd2fc48a95.png)

6. Create Workload
7. Delete workload after it's been created
8. Navigate to `cluster` => Workload => Pods => `pod` => Recent Events tab
9. Confirm `pod` can complete the supplied command
 
![terminatingPod](https://user-images.githubusercontent.com/40806497/136227487-32605b03-e5e2-449d-9d7c-e358728ea108.png)

