### PR TITLE
If a chart has no defined options, the `none` field is clickable, and links to the home page of rancher install

### DIFF
--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -1201,7 +1201,7 @@ export default {
                 :in-store="inStore"
                 :mode="mode"
                 :source="versionInfo"
-                tabbed="multiple"
+                :tabbed="multiple"
                 :target-namespace="targetNamespace"
               />
             </Tabbed>


### PR DESCRIPTION
#4318 

Fix missing vue bind for `Questions` component inside `Tabbed` component



