### PR TITLE
e2e nav tests

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -69,7 +69,7 @@ export default {
         if (overviewRoute && grp.overview) {
           const route = this.$router.resolve(overviewRoute || {});
 
-          return this.$route.fullPath === route.href;
+          return this.$route.fullPath === route?.route?.fullPath;
         }
       }
 

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -202,7 +202,7 @@ export default {
 </script>
 <template>
   <div>
-    <div class="menu" :class="{'raised': shown}" @click="toggle()">
+    <div class="menu" :class="{'raised': shown, 'unraised':!shown}" @click="toggle()">
       <svg class="menu-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none" /><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" /></svg>
     </div>
     <div v-if="shown" class="side-menu-glass" @click="hide()"></div>

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -7,7 +7,6 @@ describe('Home Page', () => {
   });
 
   it('Renders', () => {
-    // cy.visit('/home');
     cy.get('.title').contains('Welcome');
   });
 

--- a/cypress/integration/inappmenu.spec.ts
+++ b/cypress/integration/inappmenu.spec.ts
@@ -1,0 +1,63 @@
+import { DefaultNav } from './util/defaultnav';
+import { TopLevelMenu } from '~/cypress/integration/util/toplevelmenu';
+Cypress.config();
+describe('Default Layout Side Nav', () => {
+  const topLevelMenu = new TopLevelMenu();
+  const defaultnav = new DefaultNav();
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/home');
+    topLevelMenu.openIfClosed();
+    topLevelMenu.clusters().eq(0).click();
+  });
+
+  it('navigates to menu item on click', () => {
+    defaultnav.visibleNavTypes().eq(0).as('firstLink');
+    cy.get('@firstLink').click();
+    cy.get('@firstLink').then((linkEl) => {
+      cy.location('href').should('equal', linkEl.prop('href'));
+    });
+  });
+
+  it('opens menu groups on click', () => {
+    defaultnav.groups().not('.expanded').eq(0)
+      .as('closedGroup');
+    cy.get('@closedGroup').click();
+    cy.get('@closedGroup').find('ul').should('have.length.gt', 0);
+  });
+
+  it('closes menu groups on click', () => {
+    defaultnav.groups().get('.expanded').as('openGroup');
+    defaultnav.groups().not('.expanded').eq(0).click();
+    cy.get('@openGroup').find('ul').should('have.length', 0);
+  });
+
+  it('navigates to group item when group is expanded', () => {
+    defaultnav.groups().not('.expanded').eq(0)
+      .as('closedGroup');
+    cy.get('@closedGroup').click();
+    cy.get('@closedGroup').find('.header.active').then((activeHeader) => {
+      if (!activeHeader) {
+        cy.get('@closedGroup').find('.nuxt-link-active').should('have.lenght.gt', 0);
+      }
+    });
+  });
+
+  it('contains only valid links', () => {
+    defaultnav.groups().each((group, index) => {
+      defaultnav.groups().eq(index).click();
+      defaultnav.groups().eq(index).then((group) => {
+        if (group.find('.accordion').length) {
+          cy.wrap(group).get('.accordion .accordion').click({ multiple: true });
+        }
+      });
+      defaultnav.visibleNavTypes().each((link, idx) => {
+        defaultnav.visibleNavTypes().eq(idx).click();
+        defaultnav.visibleNavTypes().eq(idx).then((linkEl) => {
+          cy.location('href').should('equal', linkEl.prop('href'));
+        });
+      });
+    });
+  });
+});

--- a/cypress/integration/inappmenu.spec.ts
+++ b/cypress/integration/inappmenu.spec.ts
@@ -33,27 +33,29 @@ describe('Default Layout Side Nav', () => {
     cy.get('@openGroup').find('ul').should('have.length', 0);
   });
 
-  it('navigates to group item when group is expanded', () => {
+  it('navigates to a group item when group is expanded', () => {
     defaultnav.groups().not('.expanded').eq(0)
       .as('closedGroup');
     cy.get('@closedGroup').click();
-    cy.get('@closedGroup').find('.header.active').then((activeHeader) => {
-      if (!activeHeader) {
-        cy.get('@closedGroup').find('.nuxt-link-active').should('have.lenght.gt', 0);
-      }
-    });
+    cy.get('@closedGroup').find('.nuxt-link-active').should('have.length.gt', 0);
   });
 
   it('contains only valid links', () => {
+    // iterate through top-level groups
     defaultnav.groups().each((group, index) => {
+      // expand current top-level group
       defaultnav.groups().eq(index).click();
+      // check if it has sub-groups and expand them
       defaultnav.groups().eq(index).then((group) => {
         if (group.find('.accordion').length) {
           cy.wrap(group).get('.accordion .accordion').click({ multiple: true });
         }
       });
+      // iterate through links
       defaultnav.visibleNavTypes().each((link, idx) => {
+        // visit each link
         defaultnav.visibleNavTypes().eq(idx).click();
+        // confirm the app has navigated to that location
         defaultnav.visibleNavTypes().eq(idx).then((linkEl) => {
           cy.location('href').should('equal', linkEl.prop('href'));
         });

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -1,25 +1,24 @@
-describe('Local authentication', () => {
-  it('Log in with valid creds', () => {
-    cy.visit('/auth/login');
-    cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
+// describe('Local authentication', () => {
+//   it('Log in with valid creds', () => {
+//     cy.visit('/auth/login');
+//     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
 
-    cy.login(Cypress.env('username'), Cypress.env('password'), false);
+//     cy.login(Cypress.env('username'), Cypress.env('password'));
 
-    cy.wait('@loginReq').then((login) => {
-      expect(login.response?.statusCode).to.equal(200);
-      cy.url().should('not.equal', `${ Cypress.config().baseUrl }/auth/login`);
-    });
-  });
+//     cy.wait('@loginReq').then((login) => {
+//       expect(login.response?.statusCode).to.equal(200);
+//       cy.url().should('not.equal', `${ Cypress.config().baseUrl }/auth/login`);
+//     });
+//   });
 
-  it('Cannot login with invalid creds', () => {
-    cy.visit('/auth/login');
-    cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
+//   it('Cannot login with invalid creds', () => {
+//     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
 
-    cy.login(Cypress.env('username'), `${ Cypress.env('password') }abc`, false);
+//     cy.login(Cypress.env('username'), `${ Cypress.env('password') }abc`);
 
-    cy.wait('@loginReq').then((login) => {
-      expect(login.response?.statusCode).to.not.equal(200);
-      cy.url().should('equal', `${ Cypress.config().baseUrl }/auth/login`);
-    });
-  });
-});
+//     cy.wait('@loginReq').then((login) => {
+//       expect(login.response?.statusCode).to.not.equal(200);
+//       cy.url().should('equal', `${ Cypress.config().baseUrl }/auth/login`);
+//     });
+//   });
+// });

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -1,24 +1,26 @@
-// describe('Local authentication', () => {
-//   it('Log in with valid creds', () => {
-//     cy.visit('/auth/login');
-//     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
+describe('Local authentication', () => {
+  it('Log in with valid creds', () => {
+    cy.visit('/auth/login');
+    cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
 
-//     cy.login(Cypress.env('username'), Cypress.env('password'));
+    cy.login(Cypress.env('username'), Cypress.env('password'), false);
 
-//     cy.wait('@loginReq').then((login) => {
-//       expect(login.response?.statusCode).to.equal(200);
-//       cy.url().should('not.equal', `${ Cypress.config().baseUrl }/auth/login`);
-//     });
-//   });
+    cy.wait('@loginReq').then((login) => {
+      expect(login.response?.statusCode).to.equal(200);
+      cy.url().should('not.equal', `${ Cypress.config().baseUrl }/auth/login`);
+    });
+  });
 
-//   it('Cannot login with invalid creds', () => {
-//     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
+  it('Cannot login with invalid creds', () => {
+    cy.visit('/auth/login');
 
-//     cy.login(Cypress.env('username'), `${ Cypress.env('password') }abc`);
+    cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
 
-//     cy.wait('@loginReq').then((login) => {
-//       expect(login.response?.statusCode).to.not.equal(200);
-//       cy.url().should('equal', `${ Cypress.config().baseUrl }/auth/login`);
-//     });
-//   });
-// });
+    cy.login(Cypress.env('username'), `${ Cypress.env('password') }abc`, false);
+
+    cy.wait('@loginReq').then((login) => {
+      expect(login.response?.statusCode).to.not.equal(200);
+      cy.url().should('equal', `${ Cypress.config().baseUrl }/auth/login`);
+    });
+  });
+});

--- a/cypress/integration/toplevelmenu.spec.ts
+++ b/cypress/integration/toplevelmenu.spec.ts
@@ -1,34 +1,37 @@
 import { TopLevelMenu } from '~/cypress/integration/util/toplevelmenu';
 
-describe('Cluster Dashboard', () => {
+Cypress.config();
+describe('TopLevelMenu', () => {
+  const topLevelMenu = new TopLevelMenu();
+
   beforeEach(() => {
     cy.login();
     cy.visit('/home');
+    topLevelMenu.openIfClosed();
   });
 
-  const topLevelMenu = new TopLevelMenu();
-
   it('Opens and closes on menu icon click', () => {
-    topLevelMenu.toggle();
     cy.get('.side-menu-glass').should('exist');
     topLevelMenu.toggle();
     cy.get('.side-menu-glass').should('not.exist');
   });
 
   it('Has clusters', () => {
-    topLevelMenu.toggle();
-
     topLevelMenu.clusters().should('exist');
   });
 
   it('Has a localization link', () => {
-    topLevelMenu.toggle();
-
     topLevelMenu.localization().should('exist');
   });
 
   it('Has at least one menu category', () => {
-    topLevelMenu.toggle();
     topLevelMenu.categories().should('have.length.greaterThan', 0);
+  });
+
+  it('Contains valid links', () => {
+    topLevelMenu.links().each((link, idx) => {
+      topLevelMenu.openIfClosed();
+      topLevelMenu.links().eq(idx).click();
+    });
   });
 });

--- a/cypress/integration/toplevelmenu.spec.ts
+++ b/cypress/integration/toplevelmenu.spec.ts
@@ -32,6 +32,16 @@ describe('TopLevelMenu', () => {
     topLevelMenu.links().each((link, idx) => {
       topLevelMenu.openIfClosed();
       topLevelMenu.links().eq(idx).click();
+
+      return topLevelMenu.links().eq(idx).then((linkEl) => {
+        return cy.location('href').then((url) => {
+          if (url.includes('explorer')) {
+            cy.intercept(/.+\/v1\/nodes$/).as('nodeRequest');
+            cy.wait(['@nodeRequest']);
+          }
+          cy.location('href').should('include', linkEl.prop('href'));
+        });
+      });
     });
   });
 });

--- a/cypress/integration/util/defaultnav.ts
+++ b/cypress/integration/util/defaultnav.ts
@@ -1,0 +1,13 @@
+export class DefaultNav {
+  groups() {
+    return cy.get('.accordion.has-children');
+  }
+
+  expandedGroup() {
+    return cy.get('.accordion.expanded');
+  }
+
+  visibleNavTypes() {
+    return cy.get('.side-nav .accordion.expanded li.nav-type>a');
+  }
+}

--- a/cypress/integration/util/toplevelmenu.ts
+++ b/cypress/integration/util/toplevelmenu.ts
@@ -3,8 +3,20 @@ export class TopLevelMenu {
     cy.get('.menu-icon').click();
   }
 
+  openIfClosed() {
+    cy.get('body').then((body) => {
+      if (body.find('.menu.raised').length === 0) {
+        this.toggle();
+      }
+    });
+  }
+
   categories() {
     return cy.get('.side-menu .body .category');
+  }
+
+  links() {
+    return cy.get('.side-menu .option');
   }
 
   clusters() {

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -8,7 +8,6 @@ require('dotenv').config();
 module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-
   const url = process.env.DEV_UI || 'https://localhost:8005';
 
   config.baseUrl = url.replace(/\/$/, '');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,5 @@
-Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password')) => {
-  cy.session([username, password], () => {
+Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password'), cacheSession = true) => {
+  const login = () => {
     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
     cy.visit('/auth/login');
 
@@ -13,7 +13,13 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
 
     cy.get('button').click();
     cy.wait('@loginReq');
-  });
+  };
+
+  if (cacheSession) {
+    cy.session([username, password], login);
+  } else {
+    login();
+  }
 });
 
 Cypress.Commands.add('byLabel', (label) => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,5 @@
-Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password'), cacheSession = true) => {
-  const login = () => {
+Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password')) => {
+  cy.session([username, password], () => {
     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
     cy.visit('/auth/login');
 
@@ -13,13 +13,7 @@ Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cy
 
     cy.get('button').click();
     cy.wait('@loginReq');
-  };
-
-  if (cacheSession) {
-    cy.session([username, password], login);
-  } else {
-    login();
-  }
+  });
 });
 
 Cypress.Commands.add('byLabel', (label) => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "start": "./node_modules/.bin/nuxt start",
     "generate": "./node_modules/.bin/nuxt generate",
     "dev-debug": "node --inspect ./node_modules/.bin/nuxt",
-    "cy:run": "cypress run",
     "cy:open": "cypress open",
     "e2e:dev": "NODE_ENV=dev START_SERVER_AND_TEST_INSECURE=1 start-server-and-test dev https://localhost:8005 cy:open"
   },


### PR DESCRIPTION
#4182 - this pr adds tests to both side navs, and updates the login command to use the new(ish) Cypress [sessions](https://docs.cypress.io/api/commands/session) functionality. I also found/addressed a small bug with overview pages not being highlighted in the nav while active, caused by the `/dashboard` prefix making this always false: `this.$route.fullPath === route.href`
![Screen Shot 2021-10-07 at 8 43 37 AM](https://user-images.githubusercontent.com/42977925/136418588-da6018e6-827d-45a9-a7d4-fd2bf6d4cd65.png)
![Screen Shot 2021-10-07 at 8 44 39 AM](https://user-images.githubusercontent.com/42977925/136418736-a369a324-92d1-4dec-b0ff-24c4cac2cff9.png)

