### PR TITLE
Add pause orchestration button for workloads

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -520,6 +520,11 @@ asyncButton:
     action: Install
     success: Installing
     waiting: Starting&hellip;
+  pause:
+    action: Pause Orchestration
+    success: Paused Orchestration
+    waiting: Pausing Orchestration
+    description: New revisions will not be deployed because orchestration is temporarily paused. To deploy new revisions, resume orchestration.
   refresh:
     action: ''
     actionIcon: refresh
@@ -537,6 +542,10 @@ asyncButton:
     action: Restore
     waiting: Restoring&hellip;
     success: Restored
+  resume:
+    action: Resume Orchestration
+    success: Resumed Orchestration
+    waiting: Resuming Orchestration
   rollback:
     action: Roll Back
     success: Rolled Back
@@ -2700,6 +2709,10 @@ namespace:
       warning: 'Warning'
       error: 'Error'
       unknown: 'Unknown'
+      paused:
+        stateName: 'Inactive'
+        shortDescription: Deployment is paused
+        longDescription: Deployment is paused. Pausing stops the controller from deploying revisions.
 
 
 namespaceFilter:
@@ -4940,7 +4953,7 @@ harvester:
     restart: Restart
     stop: Stop
     pause: Pause
-    unpause: unpasue
+    unpause: Unpause
     ejectCDROM: Eject CDROM
     launchFormTemplate: Launch instance from template
     modifyTemplate: Modify template (Create new version)

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -153,6 +153,13 @@ export default {
         };
       }
 
+      if (this.value?.spec?.paused) {
+        return {
+          color:   'info',
+          message: this.t('asyncButton.pause.description')
+        };
+      }
+
       if (this.value?.stateObj?.transitioning) {
         const defaultTransitioningMessage = this.t('resourceDetail.masthead.defaultBannerMessage.transitioning', undefined, true);
 

--- a/models/workload.js
+++ b/models/workload.js
@@ -37,6 +37,20 @@ export default class Workload extends SteveModel {
         enabled:    !!this.links.update,
         bulkable:   true,
       });
+
+      insertAt(out, 0, {
+        action:  'pause',
+        label:   this.t('asyncButton.pause.action'),
+        icon:    'icon icon-pause',
+        enabled: !!this.links.update && !this.spec?.paused
+      });
+
+      insertAt(out, 0, {
+        action:  'resume',
+        label:   this.t('asyncButton.resume.action'),
+        icon:    'icon icon-play',
+        enabled: !!this.links.update && this.spec?.paused === true
+      });
     }
 
     const toFilter = ['cloneYaml'];
@@ -101,6 +115,24 @@ export default class Workload extends SteveModel {
     const workloadName = workload.metadata.name;
 
     await this.patch(rollbackRequestBody, { url: `/apis/apps/v1/namespaces/${ namespace }/deployments/${ workloadName }` });
+  }
+
+  pause() {
+    set(this.spec, 'paused', true);
+    this.save();
+  }
+
+  resume() {
+    set(this.spec, 'paused', false);
+    this.save();
+  }
+
+  get state() {
+    if ( this.spec?.paused === true ) {
+      return 'paused';
+    }
+
+    return super.state;
   }
 
   addSidecar() {


### PR DESCRIPTION
This WIP addresses https://github.com/rancher/dashboard/issues/4331

When a workload is running normally, the pause orchestration button is available from the actions:
<img width="895" alt="Screen Shot 2021-10-29 at 1 27 45 AM" src="https://user-images.githubusercontent.com/20599230/139405043-930469d7-8870-4080-880a-3f277bb0a938.png">

When orchestration is paused, an info message appears on the detail page that lets you know what happened and how to undo it:
<img width="1053" alt="Screen Shot 2021-10-29 at 1 43 10 AM" src="https://user-images.githubusercontent.com/20599230/139404937-0fef98e4-9c65-4543-8517-f842f51c49ed.png">

When orchestration is paused, the pause orchestration button is no longer available, and it has been replaced by the resume orchestration button:
<img width="437" alt="Screen Shot 2021-10-29 at 1 43 19 AM" src="https://user-images.githubusercontent.com/20599230/139404853-858a59ec-d73e-4535-a14d-f0408fb1b3ba.png">

I made it so the list view shows the workload's status as "paused" instead of "inactive," as it used to be in Ember. I believe the 'paused' is the expected behavior because this way it is consistent with what happens when you pause and unpause a Fleet cluster.
<img width="459" alt="Screen Shot 2021-10-29 at 2 11 25 AM" src="https://user-images.githubusercontent.com/20599230/139409319-1c30184c-8fb2-4c99-9d9b-d02fd952f28a.png">

# Testing
To test this PR, 

1. I created an nginx deployment in the default namespace of the local cluster and toggled it back and forth a few times. It seems to pause and unpause normally. The expected behavior is that the pod continues running, and it does continue. 
2. After pausing the workload, I went into the YAML and changed the image from nginx:latest to nginx. This would normally count as a revision. Note: Normally scaling the workload won't count as a revision.
3. I clicked ⋮ > Rollback to roll back the workload and it confirmed that there were still no revisions to roll back to. This is the desired behavior for troubleshooting https://forums.rancher.com/t/pausing-orchestration-does-not-stop-pods/11751
4. I unpaused the workload, clicked ⋮ > Rollback again, and THEN there was a revision to roll back to.
-------
Here is the Ember equivalent for reference:

![Screen Shot 2021-10-11 at 8 18 30 PM](https://user-images.githubusercontent.com/20599230/136897698-355fe6bb-b609-4f1c-b7c2-7f8331ff6348.png)

![Screen Shot 2021-10-11 at 8 18 43 PM](https://user-images.githubusercontent.com/20599230/136897693-79378136-f65f-47a3-a4ec-14276f60a7fb.png)

![Screen Shot 2021-10-11 at 8 31 46 PM](https://user-images.githubusercontent.com/20599230/136897675-83bce894-5082-4caf-807c-4266aa93fa3c.png)

![Screen Shot 2021-10-11 at 8 19 20 PM](https://user-images.githubusercontent.com/20599230/136897683-b2f7b89c-c90d-4272-9a9b-28a4356b069a.png)
