### PR TITLE
GitHub Issue automation for PRs

### DIFF
--- a/.github/workflows/pr-zube.yaml
+++ b/.github/workflows/pr-zube.yaml
@@ -1,0 +1,16 @@
+name: zube-integration
+on:
+  pull_request_target:
+    types: [ opened, reopened, edited, closed ]
+
+jobs:
+  rancher_zube:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - name: script
+      run: node .github/workflows/scripts/pr.js "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/scripts/pr.js
+++ b/.github/workflows/scripts/pr.js
@@ -5,6 +5,7 @@ const request = require('./request');
 const IN_REVIEW_LABEL = '[zube]: Review';
 const IN_TEST_LABEL = '[zube]: To Test';
 const DONE_LABEL = '[zube]: Done';
+const BACKEND_BLOCKED_LABEL = '[zube]: Backend Blocked';
 
 // The event object
 const event = require(process.env.GITHUB_EVENT_PATH);
@@ -178,11 +179,15 @@ async function processOpenOrEditAction() {
       console.log('')
       console.log('Processing Issue #' + i + ' - ' + iss.title);
 
-      if (!hasLabel(iss, IN_REVIEW_LABEL)) {
-          // Add the In Review label to the issue as it does not have it
-          await resetZubeLabels(iss, IN_REVIEW_LABEL);
+      if (hasLabel(iss, BACKEND_BLOCKED_LABEL)) {
+        console.log('    Issue will not be moved to In Review (Backend Blocked)');
       } else {
-          console.log('    Issue already has the In Review label');
+        if (!hasLabel(iss, IN_REVIEW_LABEL)) {
+            // Add the In Review label to the issue as it does not have it
+            await resetZubeLabels(iss, IN_REVIEW_LABEL);
+        } else {
+            console.log('    Issue already has the In Review label');
+        }
       }
 
       if (iss.milestone) {
@@ -196,7 +201,7 @@ async function processOpenOrEditAction() {
     } else if (keys.length > 1) {
       console.log('More than one milestone on issues for this PR');
     } else {
-      // There is excatly 1 milestone, so use that for the PR
+      // There is exactly 1 milestone, so use that for the PR
       const milestoneNumber = milestones[keys[0]];
 
       if (event.pull_request.milestone?.number !== milestoneNumber) {

--- a/.github/workflows/scripts/pr.js
+++ b/.github/workflows/scripts/pr.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+const request = require('./request');
+
+const IN_REVIEW_LABEL = '[zube]: Review';
+const IN_TEST_LABEL = '[zube]: To Test';
+const DONE_LABEL = '[zube]: Done';
+
+// The event object
+const event = require(process.env.GITHUB_EVENT_PATH);
+
+function getReferencedIssues(body) {
+    // https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+    const regexp = /[Ff]ix(es|ed)?\s*#([0-9]*)|[Cc]lose(s|d)?\s*#([0-9]*)|[Rr]esolve(s|d)?\s*#([0-9]*)/g;
+    var v;
+    const issues = [];
+    do {
+        v = regexp.exec(body);
+        if (v) {
+            issues.push(parseInt(v[2], 10));
+        }
+    } while (v);
+    return issues;
+}
+
+function hasLabel(issue, label) {
+    return !!(issue.labels.find(l =>l.name.toLowerCase() === label.toLowerCase()));
+}
+
+function removeZubeLabels(labels) {
+    return labels.filter(l => l.name.indexOf('[zube]') === -1);
+}
+
+async function resetZubeLabels(issue, label) {
+    // Remove all zube labels
+    const cleanLabels = removeZubeLabels(issue.labels);
+    console.log(`    Current Labels: ${cleanLabels}`);
+    // Add the 'to test' label
+    cleanLabels.push(label);
+    console.log(`    New Labels    : ${cleanLabels}`);
+
+    // Update the labels
+    const labelsAPI = `${issue.url}/labels`;
+    return request.put(labelsAPI, {labels: cleanLabels});
+}
+
+async function waitForLabel(issue, label) {
+    let tries = 0;
+    while (!hasLabel(issue, label) && tries < 10) {
+        console.log(`  Waiting for issue to have the label ${label} (${tries})`);
+
+        // Wait 10 seconds
+        await new Promise(r => setTimeout(r, 10000));
+
+        // Refetch the issue
+        issue = await request.fetch(issue.url);
+
+        tries++;
+    }
+
+    if (tries > 10) {
+        console.log('WARNING: Timed out waiting for issue to have the Done label');
+    } else {
+        console.log('  Issue has the done label');
+    }
+}
+
+async function processClosedAction() {
+    const pr = event.pull_request;
+    const body = pr.body;
+
+    console.log('======');
+    console.log('Processing Closed PR #' + pr.number + ' : ' + pr.title);
+    console.log('======');
+
+    // Check that the issue was merged and not just closed
+    if (!pr.merged) {
+        console.log( '  PR was closed without merging - ignoring');
+        return;
+    }
+
+    const issues = getReferencedIssues(body);
+    if (issues.length > 0) {
+        console.log('  This PR fixes issues: ' + issues.join(', '));
+    } else {
+        console.log("  This PR does not fix any issues");
+        return;
+    }
+
+    // Need to get all open PRs to see if any other references the same issues that this PR says it fixes
+    const openPRs = event.repository.url + '/pulls?state=open&per_page=100';
+    const r = await request.fetch(openPRs);
+    const issueMap = issues.reduce((prev, issue) => { prev[issue] = true; return prev; }, {})
+
+    // Go through all of the Open PRs and see if they fix any of the same issues that this PR does
+    // If not, then the issue has been completed, so we can process it
+    r.forEach(openPR => {
+        const fixed = getReferencedIssues(openPR.body);
+        fixed.forEach(issue => issueMap[issue] = false);
+    });
+
+    // Filter down the list of issues that should be closed because this PR was merged
+    const fixed = Object.keys(issueMap).filter(key => !!issueMap[key]);
+    console.log('');
+
+    Object.keys(issueMap).forEach(k => {
+        if (!issueMap[k]) {
+            console.log(`  Issue #${k} will be ignored as another open PR also states that it fixes this issue`);
+        }
+    })
+
+    // GitHub will do the closing, so we expect each issue to already be closed
+    // We will fetch each issue in turn, expecting it to be closed
+    // We will re-open the issue and label it as ready to test
+    fixed.forEach(async(i) => {
+        const detail = event.repository.url + '/issues/' + i;
+        const iss = await request.fetch(detail);
+        console.log('')
+        console.log('Processing Issue #' + i + ' - ' + iss.title);
+        console.log('  Updating labels to move issue to Test');
+
+        // console.log(JSON.stringify(iss, null, 2));
+
+        // The Zube Integration will label the issue with the Done label
+        // Since it runs via a webhook, it should have done that well before our GitHub action
+        // is scheduled and has run, but we will check it has the label and wait if not
+
+        await waitForLabel(iss, DONE_LABEL);
+
+        await resetZubeLabels(iss, IN_TEST_LABEL);
+
+        // Re-open the issue if it is closed
+        if (iss.state === 'closed') {
+            console.log('  Re-opening issue');
+            await request.patch(detail, { state: 'open' });
+        } else {
+            console.log('  Expecting issue to be closed, but it is not');
+        }
+        console.log('');
+    });
+}
+
+async function processOpenAction() {
+    const pr = event.pull_request;
+
+    // Check that an assignee has been set
+    if (pr.assignees.length === 0) {
+        console.log('======');
+        console.log('Processing Opened PR #' + pr.number + ' : ' + pr.title);
+        console.log('======');
+
+        console.log(`  Adding assignee to the PR: ${pr.user.login}`);
+
+        // Update the assignees
+        const assigneesAPI = `${event.repository.url}/issues/${pr.number}/assignees`;
+        await request.post(assigneesAPI, {assignees: [pr.user.login]});
+    }
+}
+
+async function processOpenOrEditAction() {
+    console.log('======');
+    console.log('Processing Opened/Edited PR #' + event.pull_request.number + ' : ' + event.pull_request.title);
+    console.log('======');
+
+    const body = event.pull_request.body;
+    const issues = getReferencedIssues(body);
+    if (issues.length > 0) {
+        console.log('+ This PR fixes issues: #' + issues.join(', '));
+    } else {
+        console.log("+ This PR does not fix any issues");
+    }
+
+    const milestones = {};
+
+    for (i of issues) {
+      const detail = `${event.repository.url}/issues/${i}`;
+      const iss = await request.fetch(detail);
+      console.log('')
+      console.log('Processing Issue #' + i + ' - ' + iss.title);
+
+      if (!hasLabel(iss, IN_REVIEW_LABEL)) {
+          // Add the In Review label to the issue as it does not have it
+          await resetZubeLabels(iss, IN_REVIEW_LABEL);
+      } else {
+          console.log('    Issue already has the In Review label');
+      }
+
+      if (iss.milestone) {
+        milestones[iss.milestone.title] = iss.milestone.number;
+      }
+    }
+
+    const keys = Object.keys(milestones);
+    if (keys.length === 0) {
+      console.log('No milestones on issue(s) for this PR');
+    } else if (keys.length > 1) {
+      console.log('More than one milestone on issues for this PR');
+    } else {
+      // There is excatly 1 milestone, so use that for the PR
+      const milestoneNumber = milestones[keys[0]];
+
+      if (event.pull_request.milestone?.number !== milestoneNumber) {
+        console.log('Updating PR with milestone: ' + keys[0]);
+        await request.patch(event.pull_request.issue_url, {milestone: milestoneNumber});
+      } else {
+        console.log('PR is already assigned to milestone ' + keys[0]);
+      }
+    }
+}
+
+// Debugging
+// console.log(JSON.stringify(event, null, 2));
+
+// Look at the action
+if (event.action === 'opened' || event.action === 'reopened') {
+    processOpenAction();
+    processOpenOrEditAction();
+} else if (event.action === 'edited') {
+    processOpenOrEditAction();
+} else if (event.action === 'closed') {
+    processClosedAction();
+}

--- a/.github/workflows/scripts/request.js
+++ b/.github/workflows/scripts/request.js
@@ -1,0 +1,85 @@
+const USER_AGENT = 'PR Action'
+const TOKEN = process.argv.length > 2 ? process.argv[2] : process.env.TOKEN;
+
+const https = require('https');
+
+function fetch (url) {
+    const opts = {
+        headers: {
+            'User-Agent': USER_AGENT,
+            'Authorization': `token ${TOKEN}`
+        }
+    };
+
+    return new Promise((resolve, reject) => {
+        https.get(url, opts, (response) => {
+            let chunks_of_data = [];
+
+            response.on('data', (fragments) => {
+                chunks_of_data.push(fragments);
+            });
+
+            response.on('end', () => {
+                let response_body = Buffer.concat(chunks_of_data);
+                resolve(JSON.parse(response_body.toString()));
+            });
+
+            response.on('error', (error) => {
+                reject(error);
+            });
+        });
+    });
+};
+
+function post(url, data) {
+    return write(url, data, 'POST');
+}
+
+function put(url, data) {
+    return write(url, data, 'PUT');
+}
+
+function patch(url, data) {
+    return write(url, data, 'PATCH');
+}
+
+function write(url, data, method) {
+    const json = JSON.stringify(data);
+    const opts = {
+        method: method || 'POST',
+        headers: {
+            'User-Agent': USER_AGENT,
+            'Authorization': `token ${TOKEN}`,
+            'Content-Type': 'application/json',
+            'Content-Length': json.length            
+        }
+    };
+
+    return new Promise((resolve, reject) => {
+        const req = https.request(url, opts, (response) => {
+            let chunks_of_data = [];
+
+            response.on('data', (fragments) => {
+                chunks_of_data.push(fragments);
+            });
+
+            response.on('end', () => {
+                let response_body = Buffer.concat(chunks_of_data);
+                resolve(JSON.parse(response_body.toString()));
+            });
+
+            response.on('error', (error) => {
+                reject(error);
+            });
+        });
+        req.write(json);
+        req.end();
+    });
+}
+
+module.exports = {
+    fetch,
+    post,
+    put,
+    patch,
+};


### PR DESCRIPTION
This PR adds a GitHub action.

This allows us to use the GH 'fixes' notation in PRs - which will link PRs <> Issues.

Currently, when using this notation, merging a PR will automatically close associated issues. For our workflow, this is not what we want - we want them to stay open but moved to the 'To Test' pipeline in Zube.

The GitHub action introduced by this PR will re-open linked issues and move then to the 'To Test' pipeline automatically.

When a PR is open, it will move any associated issues to the 'Review' pipeline.

It will also:

- Set the assignee to the author if the PR has no assignees
- Set the milestone to the milestone of the linked issues (if no milestone is set). If there are multiple issues associated with multiple milestones, it does nothing.

Note: The GitHub action uses the pull_request_target event - which means it can run on forks. When executed, the code in the master branch is always used, preventing someone from adding malicious code in a PR.