### PR TITLE
Add hideTypeDescription method on close of banner for clusterrepo list

### DIFF
--- a/list/catalog.cattle.io.clusterrepo.vue
+++ b/list/catalog.cattle.io.clusterrepo.vue
@@ -4,6 +4,7 @@ import ResourceTable from '@/components/ResourceTable';
 import Masthead from '@/components/ResourceList/Masthead';
 import Banner from '@/components/Banner';
 import { HIDE_DESC, mapPref } from '@/store/prefs';
+import { addObject } from '@/utils/array';
 
 export default {
   name:       'ListClusterReposApps',
@@ -37,8 +38,28 @@ export default {
     typeDescriptionKey() {
       // Show a different message to cover support for RKE templates in the local cluster
       // (no current cluster means catalog requests default to local)
-      return !this.currentCluster || this.currentCluster.isLocal ? 'typeDescription."catalog.cattle.io.clusterrepo.local"' : 'typeDescription."catalog.cattle.io.clusterrepo"';
+      const key = !this.currentCluster || this.currentCluster.isLocal ? 'typeDescription."catalog.cattle.io.clusterrepo.local"' : 'typeDescription."catalog.cattle.io.clusterrepo"';
+
+      if ( this.hideDescriptions.includes(this.resource) || this.hideDescriptions.includes('ALL') ) {
+        return false;
+      }
+
+      if ( this.$store.getters['i18n/exists'](key) ) {
+        return key;
+      }
+
+      return false;
     }
+  },
+
+  methods: {
+    hideTypeDescription() {
+      const neu = this.hideDescriptions.slice();
+
+      addObject(neu, this.resource);
+
+      this.hideDescriptions = neu;
+    },
   }
 };
 </script>
@@ -51,6 +72,7 @@ export default {
     >
       <template #typeDescription>
         <Banner
+          v-if="typeDescriptionKey"
           class="type-banner mb-20 mt-0"
           color="info"
           :closable="true"


### PR DESCRIPTION
This is in reference to #4359 where the info banner on the cluster repo list page would not close.

Added the `hideTypeDescription` method to update the `typeDescriptionKey` property which will allow the banner to be closed properly. This also removes the errors in the console.

To test:
1. Navigate to _cluster_ => Apps & Marketplace => Repositories
2. Close the info banner above the list