### PR TITLE
rancher-logging: UI for GELF output plugin

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2116,6 +2116,17 @@ logging:
       label: Client Key from Secret
       placeholder: Paste in the client key
     clientKeyPass: Client Key Pass from Secret
+  gelf:
+    host: Host
+    port: Port
+    protocol: Protocol
+    tls: Enable TLS
+    tlsOptions:
+      clientCert: Client Cert
+      clientKey: Client Cert Key
+      allCiphers: Allow any ciphers to be used
+      tlsVersion: TLS version
+      noVerify: Skip TLS verification
   kafka:
     brokers: Brokers
     defaultTopic: Default Topic
@@ -2236,6 +2247,7 @@ logging:
     splunkHec: Splunk
     kafka: Kafka
     forward: Fluentd
+    gelf: GELF
     loki: Loki
     awsElasticsearch: Amazon Elasticsearch
     azurestorage: Azure Storage

--- a/edit/logging.banzaicloud.io.output/providers/gelf.vue
+++ b/edit/logging.banzaicloud.io.output/providers/gelf.vue
@@ -1,0 +1,129 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import Checkbox from '@/components/form/Checkbox';
+
+export default {
+  components: {
+    Checkbox, LabeledInput, LabeledSelect
+  },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+    namespace: {
+      type:     String,
+      required: true
+    }
+  },
+  data() {
+    const protocolOptions = ['tcp', 'udp'];
+
+    this.$set(this.value, 'tls_options', this.value.tls_options || {});
+    this.$set(this.value, 'protocol', this.value.protocol || protocolOptions[0]);
+
+    return { protocolOptions };
+  },
+  computed: {
+    port: {
+      get() {
+        return this.value.port;
+      },
+      set(port) {
+        this.$set(this.value, 'port', Number.parseInt(port));
+      }
+    },
+    no_verify: {
+      get() {
+        return this.value.tls_options.no_verify === 'true';
+      },
+      set(noVerify) {
+        this.$set(this.value.tls_options, 'no_verify', noVerify ? 'true' : null);
+      }
+    },
+    all_ciphers: {
+      get() {
+        return this.value.tls_options.all_ciphers === 'true';
+      },
+      set(allCiphers) {
+        this.$set(this.value.tls_options, 'all_ciphers', allCiphers ? 'true' : null);
+      }
+    },
+  }
+};
+</script>
+
+<template>
+  <div class="gelf">
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.target') }}</h3>
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput v-model="value.host" :mode="mode" :disabled="disabled" class="host" :label="t('logging.gelf.host')" />
+      </div>
+      <div class="col span-3">
+        <LabeledInput
+          v-model="port"
+          :mode="mode"
+          :disabled="disabled"
+          class="port"
+          type="number"
+          :label="t('logging.gelf.port')"
+        />
+      </div>
+      <div class="col span-3">
+        <LabeledSelect
+          v-model="value.protocol"
+          :options="protocolOptions"
+          :mode="mode"
+          :disabled="disabled"
+          :label="t('logging.gelf.protocol')"
+        />
+      </div>
+    </div>
+    <div class="spacer"></div>
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.certificate') }}</h3>
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <Checkbox v-model="value.tls" :mode="mode" :disabled="disabled" :label="t('logging.gelf.tls')" />
+      </div>
+      <div class="col span-6">
+        <Checkbox v-model="no_verify" :mode="mode" :disabled="disabled" :label="t('logging.gelf.tlsOptions.noVerify')" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput v-model="value.tls_options.cert" type="multiline" :mode="mode" :disabled="disabled" :label="t('logging.gelf.tlsOptions.clientCert')" />
+      </div>
+      <div class="col span-6">
+        <LabeledInput v-model="value.tls_options.key" type="multiline" :mode="mode" :disabled="disabled" :label="t('logging.gelf.tlsOptions.clientKey')" />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput v-model="value.tls_options.tls_version" :mode="mode" :disabled="disabled" :label="t('logging.gelf.tlsOptions.tlsVersion')" />
+      </div>
+      <div class="col span-6">
+        <Checkbox v-model="all_ciphers" :mode="mode" :disabled="disabled" :label="t('logging.gelf.tlsOptions.allCiphers')" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/models/logging.banzaicloud.io.output.js
+++ b/models/logging.banzaicloud.io.output.js
@@ -35,6 +35,11 @@ export const PROVIDERS = [
     default:  { servers: [{}] },
   },
   {
+    name:     'gelf',
+    labelKey: 'logging.outputProviders.gelf',
+    default:  { },
+  },
+  {
     name:     'gcs',
     labelKey: 'logging.outputProviders.gcs',
     default:  { },


### PR DESCRIPTION
Adds support for the GELF output plugin in rancher-logging. GELF support was added upstream with https://github.com/banzaicloud/logging-operator/pull/705 and is included in the current rancher-logging version (see https://github.com/rancher/charts/blob/dev-v2.6/charts/rancher-logging/rancher-logging-crd/100.0.0%2Bup3.12.0/templates/logging.banzaicloud.io_clusteroutputs.yaml#L1995)

Addresses https://github.com/rancher/rancher/issues/14062

<img width="1744" alt="Bildschirmfoto 2021-10-13 um 18 15 54" src="https://user-images.githubusercontent.com/243056/137173061-b23b927c-a876-4f93-8a15-8f3be4b06021.png">

