### PR TITLE
Update lifecycle httpget path placeholder

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4424,7 +4424,7 @@ workload:
           placeholder: e.g. 172.17.0.2
         path:
           label: Path
-          placeholder: e.g. /bin/sh
+          placeholder: e.g. app/bin/endpoint?param=value
         port:
           label: Port
           placeholder: e.g. 3000


### PR DESCRIPTION
In reference to rancher/dashboard#4369 

Updated the placeholder for `path` of a lifecycle `httpGet` request.
![httpgetPath](https://user-images.githubusercontent.com/40806497/137320357-e951c57c-72da-40e8-b635-4a79cfee4d14.png)

**To test**
1. Navigate to `cluster` => Workload => Create => General tab
2. Select `Create HTTP request`