### PR TITLE
Fleet: Fix missing count boxes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1561,6 +1561,8 @@ fleet:
       warning: 'Warning'
       error: 'Error'
       unknown: 'Unknown'
+      notReady: Not Ready
+      waitApplied: Wait Applied
   gitRepo:
     tabs:
       resources: Resources

--- a/components/CountBox.vue
+++ b/components/CountBox.vue
@@ -14,6 +14,10 @@ export default {
       type:     String,
       required: true
     },
+    compact: {
+      type:    Boolean,
+      default: false
+    }
   },
   computed: {
     sideStyle() {
@@ -36,7 +40,7 @@ export default {
 <template>
   <div class="count-container" :style="sideStyle">
     <div class="count" :primary-color-var="primaryColorVar" :style="mainStyle">
-      <div class="data">
+      <div class="data" :class="{ 'compact': compact }">
         <h1>{{ count }}</h1>
         <label>{{ name }}</label>
       </div>
@@ -64,6 +68,20 @@ export default {
 
         label {
           opacity: 0.7;
+        }
+
+        &.compact {
+          align-items: center;
+          flex-direction: row;
+
+          h1 {
+            margin-bottom: 0;
+            padding-bottom: 0;
+          }
+
+          label {
+            margin-left: 5px;
+          }
         }
       }
 

--- a/components/FleetSummary.vue
+++ b/components/FleetSummary.vue
@@ -21,7 +21,7 @@ export default {
   computed: {
     counts() {
       const out = {
-        success: {
+        ready: {
           count: 0,
           color: 'success',
           label: this.$store.getters['i18n/withFallback'](`${ this.stateKey }.success`, null, 'Success')
@@ -80,9 +80,10 @@ export default {
 </script>
 
 <template>
-  <div class="row">
-    <div v-for="(v, k) in counts" :key="k" class="col span-2-of-10">
+  <div class="row flexwrap">
+    <div v-for="(v, k) in counts" :key="k" class="col countbox">
       <CountBox
+        :compact="true"
         :count="v['count']"
         :name="v.label"
         :primary-color-var="'--sizzle-' + v.color"
@@ -90,3 +91,13 @@ export default {
     </div>
   </div>
 </template>
+<style lang="scss" scoped>
+  .flexwrap {
+    flex-wrap: wrap;
+  }
+  .countbox {
+    min-width: 150px;
+    width: 12.5%;
+    margin-bottom: 10px;
+  }
+</style>


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/3504

Now looks like this:

![image](https://user-images.githubusercontent.com/1955897/137325189-7c4d2131-1ac9-4dd5-8153-08d05faf734e.png)

The count boxes wrap rather than vanishing off screen