### PR TITLE
Add required values to lifecycle hook inputs

### DIFF
--- a/components/form/HookOption.vue
+++ b/components/form/HookOption.vue
@@ -139,6 +139,7 @@ export default {
             :mode="mode"
             :label="t('workload.container.lifecycleHook.exec.command.label')"
             :placeholder="t('workload.container.lifecycleHook.exec.command.placeholder')"
+            required
           />
         </div>
       </div>
@@ -166,6 +167,7 @@ export default {
             :label="t('workload.container.lifecycleHook.httpGet.port.label')"
             :placeholder="t('workload.container.lifecycleHook.httpGet.port.placeholder')"
             :mode="mode"
+            required
           />
           <LabeledSelect
             v-model="value.httpGet.scheme"
@@ -186,6 +188,7 @@ export default {
             :placeholder="t('workload.container.lifecycleHook.httpHeaders.name.placeholder')"
             class="single-value"
             :mode="mode"
+            required
           />
           <LabeledInput
             v-model="value.httpGet.httpHeaders[index].value"


### PR DESCRIPTION
Reference rancher/dashboard#4367 

Added `required` values to lifecycle hook inputs:
_Exec_: `command`
_HTTP Get_: `port`
_HTTP Header_: `name`

Form will no longer submit when those fields are empty and will return error messages for each.
_Empty Command_
![emptyCommand](https://user-images.githubusercontent.com/40806497/137326980-24aaff2d-0663-44d0-a086-297ffebda9c9.png)
 
_Empty Port_
![emptyPort](https://user-images.githubusercontent.com/40806497/137327090-c91af2db-28d0-426d-a889-4f986aef4987.png)

_Empty Header Name_
![emptyHeader](https://user-images.githubusercontent.com/40806497/137327106-15c4f31c-53d5-4bbf-a34c-cf65e9598b90.png)

**To Test**
1. Navigate to `cluster` => workload => create => general tab
2. Add both lifecycle hooks and attempt to create container with input fields empty 