### PR TITLE
Update CloudCredential to prevent disappearing fields on input

### DIFF
--- a/edit/cloudcredential.vue
+++ b/edit/cloudcredential.vue
@@ -262,15 +262,16 @@ export default {
       @error="e=>errors = e"
     >
       <NameNsDescription v-model="value" name-key="_name" :mode="mode" :namespaced="false" />
-
-      <component
-        :is="cloudComponent"
-        ref="cloudComponent"
-        :driver-name="driverName"
-        :value="value"
-        :mode="mode"
-        :hide-sensitive-data="hideSensitiveData"
-      />
+      <keep-alive>
+        <component
+          :is="cloudComponent"
+          ref="cloudComponent"
+          :driver-name="driverName"
+          :value="value"
+          :mode="mode"
+          :hide-sensitive-data="hideSensitiveData"
+        />
+      </keep-alive>
     </CruResource>
   </form>
 </template>


### PR DESCRIPTION
rancher/dashboard#3866 

Make use of vue's `keep-alive` to maintain state while `aws.vue` or `s3.vue` perform `async fetch()`

![2021-10-15_03-07-10 (1)](https://user-images.githubusercontent.com/13671297/137471132-062f8f83-4f80-42be-9419-c7d60f269857.gif)

