### PR TITLE
[2.6.2] fix group overview selection

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -53,8 +53,12 @@ export default {
       return this.group.children?.length > 0;
     },
 
+    hasOverview() {
+      return this.group.children?.[0]?.overview;
+    },
+
     onlyHasOverview() {
-      return this.group.children && this.group.children.length === 1 && this.group.children[0].overview;
+      return this.group.children && this.group.children.length === 1 && this.hasOverview;
     },
 
     isOverview() {
@@ -180,9 +184,12 @@ export default {
 
 <template>
   <div class="accordion" :class="{[`depth-${depth}`]: true, 'expanded': isExpanded, 'has-children': hasChildren}">
-    <div v-if="showHeader" class="header" :class="{'active': isOverview, 'noHover': !canCollapse}" @click="groupSelected($event)">
+    <div v-if="showHeader" class="header" :class="{'active': isOverview, 'noHover': !canCollapse}" @click="groupSelected()">
       <slot name="header">
-        <span v-html="group.labelDisplay || group.label" />
+        <n-link v-if="hasOverview" :to="group.children[0].route" :exact="group.children[0].exact">
+          <h6 v-html="group.labelDisplay || group.label" />
+        </n-link>
+        <h6 v-else v-html="group.labelDisplay || group.label" />
       </slot>
       <i v-if="!onlyHasOverview && canCollapse" class="icon toggle" :class="{'icon-chevron-down': !isExpanded, 'icon-chevron-up': isExpanded}" @click="peek($event, true)" />
     </div>
@@ -224,7 +231,6 @@ export default {
 
 <style lang="scss" scoped>
   .header {
-    font-size: 14px;
     position: relative;
     cursor: pointer;
     color: var(--body-text);
@@ -232,10 +238,23 @@ export default {
     > H6 {
       color: var(--body-text);
       user-select: none;
+      text-transform: none;
+      font-size: 14px;
     }
 
     > A {
       display: block;
+      padding-left: 10px;
+      &:hover{
+          text-decoration: none;
+        }
+      &:focus{
+        outline:none;
+      }
+      > H6 {
+        font-size: 14px;
+        text-transform: none;
+      }
     }
 
     &.active {
@@ -292,7 +311,7 @@ export default {
 
     &.depth-1 {
       > .header {
-        > SPAN {
+        > H6 {
           font-size: 13px;
           line-height: 16px;
           padding: 8px 0 7px 5px !important;
@@ -306,7 +325,7 @@ export default {
     &:not(.depth-0) {
       > .header {
         padding-left: 10px;
-        > SPAN {
+        > H6 {
           // Child groups that aren't linked themselves
           display: inline-block;
           padding: 5px 0 5px 5px;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -544,11 +544,7 @@ export default {
               :show-header="!g.isRoot"
               @selected="groupSelected($event)"
               @expand="groupSelected($event)"
-            >
-              <template #header>
-                <h6>{{ g.label }}</h6>
-              </template>
-            </Group>
+            />
           </template>
         </div>
         <n-link v-if="showClusterTools" tag="div" class="tools" :to="{name: 'c-cluster-explorer-tools', params: {cluster: clusterId}}">


### PR DESCRIPTION
rancher/dashboard#4358 - this is caused by this change https://github.com/rancher/dashboard/pull/3992
The Group component's `groupSelected` method is intended to fire when a closed group is clicked. It should expand a group and select the first nav item in it. It is _also_ being relied upon to open the overview page. Prior to the above PR, when a user clicked the overview header (in this case 'Cluster') `groupSelected` fired and picked the first nav item, which was the overview page. 

I think Richard's fix to prevent `groupSelected` from firing when the group is already selected is rational and should stay as-is. This PR addresses the problem with selecting overviews by making them actual links instead of relying on `groupSelected`. This has the added benefit of making them more screen-reader-friendly.

Backports rancher/dashboard#4365 into release-2.6.2