### PR TITLE
rancher-logging: Always create ClusterFlows in cattle-logging-system

### DIFF
--- a/edit/logging-flow/index.vue
+++ b/edit/logging-flow/index.vue
@@ -223,6 +223,10 @@ export default {
   },
 
   created() {
+    if (this.isCreate && this.value.type === LOGGING.CLUSTER_FLOW) {
+      this.value.metadata.namespace = 'cattle-logging-system';
+    }
+
     this.registerBeforeHook(this.willSave, 'willSave');
   },
 


### PR DESCRIPTION
If they are created somewhere else, they won't be picked up by rancher-logging

Addresses https://github.com/rancher/dashboard/issues/4413
