### PR TITLE
rancher-logging: Add UI for output buffers

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2223,6 +2223,8 @@ logging:
     path: Path
     overwriteExistingPath: Overwrite Existing Path
   output:
+    buffer:
+      label: Output Buffer
     selectOutputs: Select Outputs
     selectBanner: Select to configure an output
     sections:


### PR DESCRIPTION
Since there are a lot of different possible values, I added a YAML editor similar to the flow filters.

<img width="925" alt="Bildschirmfoto 2021-10-19 um 16 56 32" src="https://user-images.githubusercontent.com/243056/137936621-eb99ad97-8b4e-4451-a654-da7ce450ad66.png">
<img width="917" alt="Bildschirmfoto 2021-10-19 um 16 56 43" src="https://user-images.githubusercontent.com/243056/137936626-17a87915-654a-4a29-aa42-bd6a37c0a56e.png">

Addresses https://github.com/rancher/dashboard/issues/4421

