### PR TITLE
Filter Apps & Marketplace when a namespace filter is active

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -222,8 +222,10 @@ export default {
     <div>
       <TopLevelMenu v-if="isMultiCluster || !isSingleVirtualCluster"></TopLevelMenu>
     </div>
-
-    <div v-if="currentCluster && !simple" class="top">
+    <div
+      v-if="currentCluster && !simple && (currentProduct.showNamespaceFilter || currentProduct.showWorkspaceSwitcher)"
+      class="top"
+    >
       <NamespaceFilter v-if="clusterReady && currentProduct && (currentProduct.showNamespaceFilter || isExplorer)" />
       <WorkspaceSwitcher v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher" />
     </div>

--- a/config/product/apps.js
+++ b/config/product/apps.js
@@ -24,10 +24,11 @@ export function init(store) {
   } = DSL(store, NAME);
 
   product({
-    removable:   false,
-    weight:      97,
-    ifHaveGroup: 'catalog.cattle.io',
-    icon:        'marketplace',
+    removable:           false,
+    weight:              97,
+    ifHaveGroup:         'catalog.cattle.io',
+    icon:                'marketplace',
+    showNamespaceFilter: true
   });
 
   virtualType({

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -528,10 +528,10 @@ export default {
       <Header />
       <nav v-if="clusterReady" class="side-nav">
         <div class="nav">
-          <template v-for="(g, idx) in groups">
+          <template v-for="(g) in groups">
             <Group
               ref="groups"
-              :key="idx"
+              :key="g.name"
               id-prefix=""
               class="package"
               :group="g"

--- a/store/index.js
+++ b/store/index.js
@@ -7,7 +7,7 @@ import { allHash, allHashSettled } from '@/utils/promise';
 import { ClusterNotFoundError, ApiError } from '@/utils/error';
 import { sortBy } from '@/utils/sort';
 import { filterBy, findBy } from '@/utils/array';
-import { BOTH, CLUSTER_LEVEL, NAMESPACED } from '@/store/type-map';
+import { BOTH, CLUSTER_LEVEL } from '@/store/type-map';
 import { NAME as EXPLORER } from '@/config/product/explorer';
 import { TIMED_OUT, LOGGED_OUT, _FLAGGED, UPGRADED } from '@/config/query-params';
 import { setBrand, setVendor } from '@/config/private-label';

--- a/store/index.js
+++ b/store/index.js
@@ -7,7 +7,7 @@ import { allHash, allHashSettled } from '@/utils/promise';
 import { ClusterNotFoundError, ApiError } from '@/utils/error';
 import { sortBy } from '@/utils/sort';
 import { filterBy, findBy } from '@/utils/array';
-import { BOTH, CLUSTER_LEVEL } from '@/store/type-map';
+import { BOTH, CLUSTER_LEVEL, NAMESPACED } from '@/store/type-map';
 import { NAME as EXPLORER } from '@/config/product/explorer';
 import { TIMED_OUT, LOGGED_OUT, _FLAGGED, UPGRADED } from '@/config/query-params';
 import { setBrand, setVendor } from '@/config/private-label';
@@ -207,7 +207,7 @@ export const getters = {
 
     // Explicitly asking
     if ( filters.includes('namespaced://true') ) {
-      return BOTH;
+      return NAMESPACED;
     } else if ( filters.includes('namespaced://false') ) {
       return CLUSTER_LEVEL;
     }
@@ -221,7 +221,7 @@ export const getters = {
     }
 
     if ( byKind['project'] > 0 || byKind['ns'] > 0 ) {
-      return BOTH;
+      return NAMESPACED;
     }
 
     return BOTH;

--- a/store/index.js
+++ b/store/index.js
@@ -207,7 +207,7 @@ export const getters = {
 
     // Explicitly asking
     if ( filters.includes('namespaced://true') ) {
-      return NAMESPACED;
+      return BOTH;
     } else if ( filters.includes('namespaced://false') ) {
       return CLUSTER_LEVEL;
     }
@@ -221,7 +221,7 @@ export const getters = {
     }
 
     if ( byKind['project'] > 0 || byKind['ns'] > 0 ) {
-      return NAMESPACED;
+      return BOTH;
     }
 
     return BOTH;


### PR DESCRIPTION
This resolves the navigation behavior described in #4428 by returning `BOTH` where we would normally return `NAMESPACED`. I don't necessarily think that this is the optimal approach, but it does look to be the most straightforward for right now. To better understand why I'm proposing this change, here's a quick rundown of the issue as I see it:

* We make a decision on which menu items should be displayed based on multiple factors, the two most relevant ones for this issue are Product ID and Namespace
* Product ID is able to override namespace when defining top-level menu structure, causing items like `Cluster` to conditionally render based on route (Apps & Marketplace shows `Cluster` while Workload does not)
* Navigating to Workload after setting a namespace filter while Apps & Marketplace is active causes the following to take place
   * Selected Product is updated
   * `default.vue` has a watch on `productId` that triggers a rebuild of the menus, which removes `Cluster` from the list
   * Later, `groupSelected()` is invoked; this attempts to navigate based on the selected index. Since index 1 is no longer Workload we navigate to Apps & Marketplace instead (Workload = 0, Apps & Marketplace = 1)

Making this change to show `BOTH` prevents us from mutating our menu structure by displaying our menu options as they are regardless of namespace filters or selected product. 

I think this change is relatively safe to make because the `namespaceModule` getter is only used by our default layout for displaying the menu.

#4428