### PR TITLE
Change getLoginRoute to accept $route parameters

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -293,15 +293,10 @@ export default {
     },
 
     getLoginRoute() {
-      // Cluster Explorer
-      if (this.currentProduct.inStore === 'cluster') {
-        return {
-          name:   'c-cluster-explorer',
-          params: { cluster: this.clusterId }
-        };
-      }
-
-      return this.$route;
+      return {
+        name:   this.$route.name,
+        params: this.$route.params
+      };
     },
 
     collapseAll() {


### PR DESCRIPTION
In reference to #4423 which highlights an issue of setting the login screen only maintaining the `cluster` main page and not the sub-pages within.
This PR changes the `getLoginRoute` to set the path based on the `$route` store parameters rather than the base level `cluster` explorer.

**To Test**
1. Navigate to a page which allows setting the login page
2. Set the login page by the 3 dots in Header Nav
3. Logout and log back in to be redirected to the page that was set.