### PR TITLE
Add custom warning when deleting Epinio namespace

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6122,5 +6122,6 @@ epinio:
       deploy:
         label: Deploy
         description: Deploy and start the Application
-  namespaceName:
+  namespace:
     name: Name
+    deleteWarning: All applications and services in a namespace will be deleted.

--- a/docs/developer/getting-started/development.md
+++ b/docs/developer/getting-started/development.md
@@ -493,6 +493,28 @@ The forms for creating and editing resources are in the `edit` directory. Common
 
 If a form element was repeated for every row in a table, it would make the UI slower. To increase performance, components such as `ActionMenu` and `PromptModal` are not repeated for every row in a table, and they don't directly interact with the data from a table row. Instead, they communicate with each row indirectly through the store. All the information about the actions that should be available for a certain resource is contained in a model, and the `ActionMenu` or `PromptModal` components take that information about the selected resource from the store. Modals and menus are opened by telling the store that they should be opened. For example, this call to the store  `this.$store.commit('action-menu/togglePromptModal');` is used to open the action menu. Then each component uses the `dispatch` method to get all the information it needs from the store.
 
+### Customize Deletion Warnings
+
+To warn users about deleting a certain resource, you can customize the message that is shown to the user when they attempt to delete a resource.
+
+If the resource model is a class model, you can add the error message to the model in this format:
+
+```
+get warnDeletionMessage() {
+  return this.t('epinio.namespace.deleteWarning');
+}
+```
+
+If the resource model is a proxy model, you can add the error message in this format:
+
+```
+warnDeletionMessage() {
+  return (toRemove = []) => {
+    return this.$rootGetters['i18n/t']('cis.deleteProfileWarning', { count: toRemove.length });
+  };
+},
+```
+
 
 ## Other UI Features
 ### Icons 

--- a/products/epinio/edit/namespaces.vue
+++ b/products/epinio/edit/namespaces.vue
@@ -38,7 +38,7 @@ export default {
 
   methods: {
     meetsNameRequirements( name = '') {
-      const nameErrors = validateKubernetesName(name, this.t('epinio.namespaceName.name'), this.$store.getters, undefined, []);
+      const nameErrors = validateKubernetesName(name, this.t('epinio.namespace.name'), this.$store.getters, undefined, []);
 
       if (nameErrors.length > 0) {
         return {
@@ -77,7 +77,7 @@ export default {
     >
       <LabeledInput
         v-model="value.name"
-        :label="t('epinio.namespaceName.name')"
+        :label="t('epinio.namespace.name')"
         :mode="mode"
         :required="true"
         :validators="[ meetsNameRequirements ]"

--- a/products/epinio/models/namespaces.class.js
+++ b/products/epinio/models/namespaces.class.js
@@ -59,4 +59,8 @@ export default class EpinioNamespaces extends EpinioResource {
   confirmRemove() {
     return true;
   }
+
+  get warnDeletionMessage() {
+    return this.t('epinio.namespace.deleteWarning');
+  }
 }


### PR DESCRIPTION
https://github.com/epinio/ui/issues/20

I found out that if you need a custom deletion warning, you don't need to create a new component. You just need to add a property to the model class called `warnDeletionMessage`.

Other models that use this kind of custom deletion warning are `cis.cattle.io.clusterscanbenchmark.js`, `cis.cattle.io.clusterscanprofile`, and `workload.class.js`.

<img width="629" alt="Screen Shot 2021-10-26 at 1 02 37 PM" src="https://user-images.githubusercontent.com/20599230/138952402-805dbf8f-0a97-4b11-aec8-993c5d4c03aa.png">

