### PR TITLE
Edit workload config ports - delete name upon type selection

### DIFF
--- a/components/form/WorkloadPorts.vue
+++ b/components/form/WorkloadPorts.vue
@@ -154,6 +154,14 @@ export default {
       this.$emit('input', out);
     },
 
+    selectServiceType(row) {
+      delete row.name;
+      if (row._listeningPort) {
+        delete row._listeningPort;
+      }
+      this.queueUpdate();
+    },
+
     setServiceType(row) {
       const { _name } = row;
 
@@ -205,7 +213,7 @@ export default {
           :mode="mode"
           :label="t('workload.container.ports.createService')"
           :options="serviceTypes"
-          @input="queueUpdate"
+          @input="selectServiceType(row)"
         />
       </div>
 


### PR DESCRIPTION
Reference #4398 

**Issue**
When editing container ports for an existing workload, new `serviceTypes` would not be saved to the config unless the name was updated.

**Fix**
After selecting a `Service Type` the name and `Listening Port` (if listed) will be deleted which allows the creation of a new `serviceType`.

https://user-images.githubusercontent.com/40806497/139285160-cf050afe-2db5-4b6e-8cb8-39a05fb9f06b.mp4

**To Test**
1. Create a new workload: `cluster` =>  Workload => Create => General Tab
2. Add a container `Port`, then Create the workload
3. Edit the workload config container `Port`
4. Select a new `Service Type` and add the necessary ports while omitting the `Name` input
5. Save config and verify new conditions are present.
