### PR TITLE
filter local auth when searching for enabled provider

### DIFF
--- a/models/management.cattle.io.authconfig.js
+++ b/models/management.cattle.io.authconfig.js
@@ -1,5 +1,5 @@
 import { insertAt } from '@/utils/array';
-import HybridModel from '@/plugins/steve/hybrid-class';
+import SteveModel from '@/plugins/steve/steve-class';
 
 export const configType = {
   activedirectory: 'ldap',
@@ -19,7 +19,7 @@ export const configType = {
 
 const imageOverrides = { keycloakoidc: 'keycloak' };
 
-export default class AuthConfig extends HybridModel {
+export default class AuthConfig extends SteveModel {
   get _availableActions() {
     const out = this._standardActions;
 

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -62,7 +62,7 @@ export function returnTo(opt, vm) {
  */
 export const authProvidersInfo = async(store) => {
   const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
-  const nonLocal = rows.filter(x => x.id !== 'local');
+  const nonLocal = rows.filter(x => x.name !== 'local');
   // Generic OIDC is returned via API but not supported (and will be removed or fixed in future)
   const supportedNonLocal = nonLocal.filter(x => x.id !== 'oidc');
   const enabled = nonLocal.filter(x => x.enabled === true );

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -62,7 +62,7 @@ export function returnTo(opt, vm) {
  */
 export const authProvidersInfo = async(store) => {
   const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
-  const nonLocal = rows.filter(x => x.name !== 'local');
+  const nonLocal = rows.filter(x => x.id !== 'local');
   // Generic OIDC is returned via API but not supported (and will be removed or fixed in future)
   const supportedNonLocal = nonLocal.filter(x => x.id !== 'oidc');
   const enabled = nonLocal.filter(x => x.enabled === true );


### PR DESCRIPTION
#4453 - this PR hides the local auth config so users can configure third party auth. A separate (security) ticket is tracking ui changes needed once it is possible to disable/re-enable local auth.