### PR TITLE
Fix navigation error promise not being rejected

### DIFF
--- a/plugins/extend-router.js
+++ b/plugins/extend-router.js
@@ -11,14 +11,14 @@ VueRouter.prototype.push = function push(location, onResolve, onReject) {
     return originalPush.call(this, location, onResolve, onReject);
   }
 
-  return originalPush.call(this, location).catch((err) => {
+  return originalPush?.call(this, location)?.catch((err) => {
     if (VueRouter.isNavigationFailure(err)) {
-      // resolve err
-      return err;
+      // If there really is an error, throw it
+      return Promise.reject(err);
     }
 
-    // rethrow error
-    return Promise.reject(err);
+    // Otherwise resolve to false to indicate the original push call didn't go to its original destination.
+    return Promise.resolve(false);
   });
 };
 


### PR DESCRIPTION
Reference #4475 

The error ` TypeError: Cannot read properties of undefined (reading 'catch')` is caused by not properly rejecting the `Promise` Navigation Error created by VueRouter. This would cause other issues in the dashboard where `Navigation Failures` would not be consumed correctly.

For VueRouter reference: 
 - https://router.vuejs.org/guide/advanced/navigation-failures.html
 - https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378