### PR TITLE
Remove Edit as Yaml button for blocked-PUT resource methods

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -128,6 +128,13 @@ export default {
       return this.initialYaml !== this.resourceYaml;
     },
 
+    canEditYaml() {
+      const inStore = this.$store.getters['currentStore'](this.resource);
+      const schema = this.$store.getters[`${ inStore }/schemaFor`](this.resource.type);
+
+      return !schema.resourceMethods.find(x => x === 'blocked-PUT');
+    },
+
     isView() {
       return this.mode === _VIEW;
     },
@@ -321,7 +328,7 @@ export default {
               <template #default>
                 <div v-if="!isView">
                   <button
-                    v-if="canYaml && (_selectedSubtype || !subtypes.length)"
+                    v-if="canYaml && (_selectedSubtype || !subtypes.length) && canEditYaml"
                     type="button"
                     class="btn role-secondary"
                     @click="showPreviewYaml"

--- a/components/ResourceList/Masthead.vue
+++ b/components/ResourceList/Masthead.vue
@@ -98,7 +98,7 @@ export default {
         return this.isYamlCreatable;
       }
 
-      return this.schema && this._isCreatable && this.$store.getters['type-map/optionsFor'](this.resource).canYaml;
+      return this.schema && this._isCreatable && this.$store.getters['type-map/optionsFor'](this.resource).canEditYaml;
     },
 
     _isCreatable() {

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -680,7 +680,7 @@ export default class Resource {
   }
 
   get canYaml() {
-    return this.hasLink('view');
+    return this.hasLink('view') && !this.schema?.resourceMethods.find(x => x === 'blocked-PUT'); // 'blocked-PUT' will prevent config from saving when editing as yaml
   }
 
   // ------------------------------------------------------------------

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -603,8 +603,8 @@ export default class Resource {
         enabled:  this.canCustomEdit,
       },
       {
-        action:  this.canUpdate ? 'goToEditYaml' : 'goToViewYaml',
-        label:   this.t(this.canUpdate ? 'action.editYaml' : 'action.viewYaml'),
+        action:  this.canEditYaml ? 'goToEditYaml' : 'goToViewYaml',
+        label:   this.t(this.canEditYaml ? 'action.editYaml' : 'action.viewYaml'),
         icon:    'icon icon-file',
         enabled: this.canYaml,
       },
@@ -680,7 +680,11 @@ export default class Resource {
   }
 
   get canYaml() {
-    return this.hasLink('view') && !this.schema?.resourceMethods.find(x => x === 'blocked-PUT'); // 'blocked-PUT' will prevent config from saving when editing as yaml
+    return this.hasLink('view');
+  }
+
+  get canEditYaml() {
+    return this.schema?.resourceMethods.find(x => x === 'blocked-PUT') ? false : this.canUpdate;
   }
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
Reference #4265 

**Original Issue**
When editing a `Global Role` as Yaml, the save would fail due to `PUT` permissions being `blocked`.

---

After investigating where else this issue was happening, at least 27 different instances had `blocked-PUT` permissions and would cause the `Edit as Yaml` to fail.

This PR removes `Edit Yaml` from a resource's `availableActions`, as well as the `Edit as Yaml` button in the `CruResource` component.

 ---
_List of known areas with `blocked-PUT` permissions:_

`cluster`
  - Project/Namespaces 
    - Edit Project
  - More Resources
    - Cluster Provisioning 
      - Mgmt Cluster
    - Rancher
      - APIServices
      - Auth Providers
      - Catalogs
      - DynamicSchemas
      - GlobalRoleBindings
      - KontainerDrivers
      - Mgmt Clusters
      - NodeDrivers
      - UserAttributes
      - Workspaces
      - CatalogTemplates
      - CatalogTemplateVersions
      - ClusterAlertGroups
      - ClusterAlertRules
      - ClusterRegistrationTokens
      - Nodes
      - NodeTemplates
      - ProjectAlertGroups
      - ProjectAlertRules
      - ProjectMonitorGraphs
      - RkeAddons
      - RkeK8sServiceOptions
      - RkeK8sSystemImages

Continuous Delivery
  - Advanced
    - Workspaces

Users & Authentication
  - Users
  - Roles