### PR TITLE
upgrade cypress and use login sessions

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,1 @@
-{}
+{"experimentalSessionSupport": true}

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -3,6 +3,7 @@ import { TopLevelMenu } from '~/cypress/integration/util/toplevelmenu';
 describe('Home Page', () => {
   beforeEach(() => {
     cy.login();
+    cy.visit('/home');
   });
 
   it('Renders', () => {

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -1,8 +1,9 @@
 describe('Local authentication', () => {
   it('Log in with valid creds', () => {
+    cy.visit('/auth/login');
     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
 
-    cy.login(Cypress.env('username'), Cypress.env('password'));
+    cy.login(Cypress.env('username'), Cypress.env('password'), false);
 
     cy.wait('@loginReq').then((login) => {
       expect(login.response?.statusCode).to.equal(200);
@@ -11,9 +12,10 @@ describe('Local authentication', () => {
   });
 
   it('Cannot login with invalid creds', () => {
+    cy.visit('/auth/login');
     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
 
-    cy.login(Cypress.env('username'), `${ Cypress.env('password') }abc`);
+    cy.login(Cypress.env('username'), `${ Cypress.env('password') }abc`, false);
 
     cy.wait('@loginReq').then((login) => {
       expect(login.response?.statusCode).to.not.equal(200);

--- a/cypress/integration/toplevelmenu.spec.ts
+++ b/cypress/integration/toplevelmenu.spec.ts
@@ -3,6 +3,7 @@ import { TopLevelMenu } from '~/cypress/integration/util/toplevelmenu';
 describe('Cluster Dashboard', () => {
   beforeEach(() => {
     cy.login();
+    cy.visit('/home');
   });
 
   const topLevelMenu = new TopLevelMenu();

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -8,7 +8,11 @@ require('dotenv').config();
 module.exports = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-  config.baseUrl = process.env.DEV_UI || 'https://localhost:8005';
+
+  const url = process.env.DEV_UI || 'https://localhost:8005';
+
+  config.baseUrl = url.replace(/\/$/, '');
+
   config.env.username = process.env.TEST_USERNAME;
   config.env.password = process.env.TEST_PASSWORD;
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,17 +1,25 @@
-Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password')) => {
-  cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
-  cy.visit('/auth/login');
+Cypress.Commands.add('login', (username = Cypress.env('username'), password = Cypress.env('password'), cacheSession = true) => {
+  const login = () => {
+    cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
+    cy.visit('/auth/login');
 
-  cy.byLabel('Username')
-    .focus()
-    .type(username);
+    cy.byLabel('Username')
+      .focus()
+      .type(username);
 
-  cy.byLabel('Password')
-    .focus()
-    .type(password);
+    cy.byLabel('Password')
+      .focus()
+      .type(password);
 
-  cy.get('button').click();
-  cy.wait('@loginReq');
+    cy.get('button').click();
+    cy.wait('@loginReq');
+  };
+
+  if (cacheSession) {
+    cy.session([username, password], login);
+  } else {
+    login();
+  }
 });
 
 Cypress.Commands.add('byLabel', (label) => {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -5,7 +5,7 @@ declare global {
   // eslint-disable-next-line no-unused-vars
   namespace Cypress {
     interface Chainable {
-      login(username?: string, password?: string): Chainable<Element>;
+      login(username?: string, password?: string, cacheSession?: boolean): Chainable<Element>;
 
       byLabel(label: string,): Chainable<Element>;
 

--- a/docs/developer/getting-started/development.md
+++ b/docs/developer/getting-started/development.md
@@ -495,6 +495,11 @@ The forms for creating and editing resources are in the `edit` directory. Common
 
 If a form element was repeated for every row in a table, it would make the UI slower. To increase performance, components such as `ActionMenu` and `PromptModal` are not repeated for every row in a table, and they don't directly interact with the data from a table row. Instead, they communicate with each row indirectly through the store. All the information about the actions that should be available for a certain resource is contained in a model, and the `ActionMenu` or `PromptModal` components take that information about the selected resource from the store. Modals and menus are opened by telling the store that they should be opened. For example, this call to the store  `this.$store.commit('action-menu/togglePromptModal');` is used to open the action menu. Then each component uses the `dispatch` method to get all the information it needs from the store.
 
+## Testing
+### E2E Tests
+This repo is configured for end-to-end testing with [Cypress](https://docs.cypress.io/api/table-of-contents). 
+#### Initial Setup
+For the cypress test runner to consume the UI, you must specify two environment variables, `TEST_USERNAME` and `TEST_PASSWORD`. By default the test runner will attempt to visit a locally running dashboard at `https://localhost:8005`. This may be overwritten with the `DEV_UI` environment variable. Run `yarn e2e:dev` to start the dashboard in SSR mode and open the cypress test runner. Run tests through the cypress GUI once the UI is built. Cypress tests will automatically re-run if they are altered (hot reloading). Alternatively the dashboard ui and cypress may be run separately with `yarn dev` and `yarn cypress open`. 
 
 ## Other UI Features
 ### Icons 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "dev-debug": "node --inspect ./node_modules/.bin/nuxt",
     "cy:run": "cypress run",
     "cy:open": "cypress open",
-    "e2e:pre": "NODE_ENV=dev yarn build",
-    "e2e:run": "NODE_ENV=dev START_SERVER_AND_TEST_INSECURE=1 start-server-and-test start  https://localhost:8005/ cy:run",
-    "e2e:dev": "start-server-and-test dev https://localhost:8005 cy:open"
+    "e2e:dev": "NODE_ENV=dev START_SERVER_AND_TEST_INSECURE=1 start-server-and-test dev https://localhost:8005 cy:open"
   },
   "dependencies": {
     "@aws-sdk/client-ec2": "^3.1.0",
@@ -120,7 +118,7 @@
     "core-js": "3",
     "css-loader": "^3.4.2",
     "csv-loader": "^3.0.3",
-    "cypress": "^7.7.0",
+    "cypress": "8.4.1",
     "eslint": "^7.32.0",
     "eslint-config-standard": ">=12.0.0",
     "eslint-plugin-ava": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@
   resolved "https://registry.yarnpkg.com/@cypress/mount-utils/-/mount-utils-1.0.2.tgz#afbc4f8c350b7cd86edc5ad0db0cbe1e0181edc8"
   integrity sha512-Fn3fdTiyayHoy8Ol0RSu4MlBH2maQ2ZEXeEVKl/zHHXEQpld5HX3vdNLhK5YLij8cLynA4DxOT/nO9iEnIiOXw==
 
-"@cypress/request@^2.88.5":
-  version "2.88.5"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.5.tgz#8d7ecd17b53a849cfd5ab06d5abe7d84976375d7"
-  integrity sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==
+"@cypress/request@^2.88.6":
+  version "2.88.6"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.6.tgz#a970dd675befc6bdf8a8921576c01f51cc5798e9"
+  integrity sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -2616,13 +2616,12 @@
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
     performance-now "^2.1.0"
     qs "~6.5.2"
     safe-buffer "^5.1.2"
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
+    uuid "^8.3.2"
 
 "@cypress/vue@^2.2.3":
   version "2.2.3"
@@ -6063,12 +6062,12 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
 
-cypress@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.7.0.tgz#0839ae28e5520536f9667d6c9ae81496b3836e64"
-  integrity sha512-uYBYXNoI5ym0UxROwhQXWTi8JbUEjpC6l/bzoGZNxoKGsLrC1SDPgIDJMgLX/MeEdPL0UInXLDUWN/rSyZUCjQ==
+cypress@8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.4.1.tgz#8b5898bf49359cadc28f02ba05d51f63b8e3a717"
+  integrity sha512-itJXq0Vx3sXCUrDyBi2IUrkxVu/gTTp1VhjB5tzGgkeCR8Ae+/T8WV63rsZ7fS8Tpq7LPPXiyoM/sEdOX7cR6A==
   dependencies:
-    "@cypress/request" "^2.88.5"
+    "@cypress/request" "^2.88.6"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^14.14.31"
     "@types/sinonjs__fake-timers" "^6.0.2"
@@ -14203,6 +14202,11 @@ utils-merge@1.0.1:
 uuid@^3.0.0, uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v-tooltip@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
This PR upgrades cypress to enable us to leverage the new-ish sessions API, and adds some minimal documentation to help others get started.