### PR TITLE
Forward port feature to see difference when rolling back a workload

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3547,6 +3547,7 @@ resourceYaml:
     continue: Continue Editing
     edit: Edit YAML
     diff: Show Diff
+    hideDiff: Hide Diff
     unified: Unified
     split: Split
 

--- a/components/PromptModal.vue
+++ b/components/PromptModal.vue
@@ -21,10 +21,18 @@ export default {
       return resources || [];
     },
 
+    modalWidth() {
+      // property set from workload.js to overwrite modal default width of 600px, with fallback value as well
+      return this.modalData?.modalWidth || '600px';
+    },
     component() {
       // Looks for a dialog component by looking up @/components/dialog/${name}.
       return importDialog(this.modalData?.component);
     },
+    cssProps() {
+      // this computed property lets us generate scss vars that we can use in the style
+      return { '--custom-width': `${ this.modalWidth }` };
+    }
   },
 
   watch: {
@@ -56,7 +64,7 @@ export default {
   <modal
     class="promptModal-modal"
     name="promptModal"
-    styles="background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 100vh;"
+    :styles="`background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 95vh; maxWidth: ${modalWidth}` "
     height="auto"
     :scrollable="true"
     @closed="close()"
@@ -72,6 +80,12 @@ export default {
     max-height: 100vh;
     & ::-webkit-scrollbar-corner {
       background: rgba(0,0,0,0);
+    }
+    // using a css var appears to be the only way with our implementation of the vue-js-modal library
+    & .v--modal-box.v--modal {
+      width: var(--custom-width) !important;
+      left: unset !important;
+      margin: auto !important
     }
   }
 </style>

--- a/components/PromptModal.vue
+++ b/components/PromptModal.vue
@@ -30,8 +30,8 @@ export default {
       return importDialog(this.modalData?.component);
     },
     cssProps() {
-      // this computed property lets us generate scss vars that we can use in the style
-      return { '--custom-width': `${ this.modalWidth }` };
+      // this computed property lets us generate a scss var that we can use in the style
+      return `--prompt-modal-width: ${ this.modalWidth }`;
     }
   },
 
@@ -64,7 +64,7 @@ export default {
   <modal
     class="promptModal-modal"
     name="promptModal"
-    :styles="`background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 95vh; maxWidth: ${modalWidth}` "
+    :styles="`background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 95vh; ${cssProps}`"
     height="auto"
     :scrollable="true"
     @closed="close()"
@@ -81,9 +81,8 @@ export default {
     & ::-webkit-scrollbar-corner {
       background: rgba(0,0,0,0);
     }
-    // using a css var appears to be the only way with our implementation of the vue-js-modal library
     & .v--modal-box.v--modal {
-      width: var(--custom-width) !important;
+      width: var(--prompt-modal-width) !important;
       left: unset !important;
       margin: auto !important
     }

--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -158,6 +158,14 @@ export default {
     getOptionLabel(option) {
       return option.label;
     },
+    sizeDialog() {
+      const dialogs = document.getElementsByClassName('v--modal');
+      const width = this.showDiff ? '85%' : '600px';
+
+      if (dialogs.length === 1) {
+        dialogs[0].style.setProperty('--prompt-modal-width', width);
+      }
+    }
   }
 };
 </script>
@@ -199,9 +207,9 @@ export default {
         <button
           :disabled="!selectedRevision"
           class="btn role-secondary diff"
-          @click="showDiff = !showDiff"
+          @click="showDiff = !showDiff; sizeDialog()"
         >
-          {{ t('resourceYaml.buttons.diff') }}
+          {{ showDiff ? t('resourceYaml.buttons.hideDiff') : t('resourceYaml.buttons.diff') }}
         </button>
       </div>
       <div class="right">

--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -28,6 +28,8 @@ export default {
       selectedRevision:   null,
       currentRevision:    null,
       revisions:          [],
+      editorMode:         EDITOR_MODES.DIFF_CODE,
+      showDiff:           false
     };
   },
   computed: {
@@ -163,7 +165,7 @@ export default {
     <h4 slot="title" class="text-default-text">
       {{ t('promptRollback.modalTitle', { workloadName }, true) }}
     </h4>
-    <div slot="body" class="pl-10 pr-10">
+    <div slot="body" class="pl-10 pr-10 ">
       <Banner v-if="revisions.length === 1" color="info" :label="t('promptRollback.singleRevisionBanner')" />
       <form>
         <LabeledSelect
@@ -176,39 +178,73 @@ export default {
         />
       </form>
       <Banner v-for="(error, i) in errors" :key="i" class="" color="error" :label="error" />
-    </div>
-    <div slot="actions" class="buttons right-align">
-      <button class="btn role-secondary mr-10" @click="close">
-        {{ t('generic.cancel') }}
-      </button>
-      <AsyncButton
-        :action-label="t('asyncButton.rollback.action')"
-        :disabled="!selectedRevision"
-        get-option-label="getOptionLabel"
-        :right-align="true"
-        @click="save"
+      <YamlEditor
+        v-if="selectedRevision && showDiff"
+        :key="selectedRevisionId"
+        v-model="selectedRevision"
+        :initial-yaml-values="currentRevision"
+        class="mt-10 "
+        :editor-mode="editorMode"
+        :as-object="true"
+        :hide-preview-buttons="true"
       />
+    </div>
+    <div slot="actions" class="buttons ">
+      <div class="left">
+        <button
+          :disabled="!selectedRevision"
+          class="btn role-secondary diff"
+          @click="showDiff = !showDiff"
+        >
+          {{ t('resourceYaml.buttons.diff') }}
+        </button>
+      </div>
+      <div class="right">
+        <button class="btn role-secondary mr-10" @click="close">
+          {{ t('generic.cancel') }}
+        </button>
+        <AsyncButton
+          :action-label="t('asyncButton.rollback.action')"
+          :disabled="!selectedRevision"
+          get-option-label="getOptionLabel"
+          :right-align="true"
+          @click="save"
+        />
+      </div>
     </div>
   </Card>
 </template>
 <style lang='scss' scoped>
-  .prompt-rollback {
-    margin: 0;
+
+.prompt-rollback {
+  margin: 0;
+
+  & ::v-deep .card-actions {
+    display: grid;
   }
-  .right-align {
-    margin-right: 0;
-    margin-left: auto;
+}
+
+.yaml-editor {
+  max-height: 70vh;
+
+  & ::v-deep.root {
+    max-height: 65vh;
   }
-  .bottom {
-    flex-direction: column;
-    flex: 1;
-    .banner {
-      margin-top: 0
-    }
-    .buttons {
-      display: flex;
-      justify-content: flex-end;
-      width: 100%;
-    }
+}
+
+.diff {
+  &:disabled {
+    border: none;
   }
+  &:focus {
+    background: transparent;
+    box-shadow: none;
+  }
+}
+
+::v-deep .card-body {
+  max-height: calc(95vh - 135px);
+  overflow: hidden;
+}
+
 </style>

--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -5,6 +5,7 @@ import Card from '@/components/Card';
 import { exceptionToErrorsArray } from '@/utils/error';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Banner from '@/components/Banner';
+import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import { WORKLOAD_TYPES } from '@/config/types';
 import { diffFrom } from '@/utils/time';
 import { mapGetters } from 'vuex';
@@ -14,7 +15,8 @@ export default {
     Card,
     AsyncButton,
     LabeledSelect,
-    Banner
+    Banner,
+    YamlEditor,
   },
   props:      {
     resources: {
@@ -74,6 +76,9 @@ export default {
       ];
 
       return body;
+    },
+    selectedRevisionId() {
+      return this.selectedRevision.id;
     }
   },
   fetch() {

--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -199,7 +199,6 @@ export default {
         class="mt-10 "
         :editor-mode="editorMode"
         :as-object="true"
-        :hide-preview-buttons="true"
       />
     </div>
     <div slot="actions" class="buttons ">

--- a/models/workload.js
+++ b/models/workload.js
@@ -87,7 +87,8 @@ export default class Workload extends SteveModel {
   toggleRollbackModal( resources = this ) {
     this.$dispatch('promptModal', {
       resources,
-      component: 'RollbackWorkloadDialog'
+      component:  'RollbackWorkloadDialog',
+      modalWidth: '85%'
     });
   }
 

--- a/models/workload.js
+++ b/models/workload.js
@@ -87,8 +87,7 @@ export default class Workload extends SteveModel {
   toggleRollbackModal( resources = this ) {
     this.$dispatch('promptModal', {
       resources,
-      component:  'RollbackWorkloadDialog',
-      modalWidth: '85%'
+      component: 'RollbackWorkloadDialog'
     });
   }
 


### PR DESCRIPTION
This pr addresses issue #4229 by adding a code diff modal to the workload deployment rollback process.

To test this PR:

1. Create a Deployment under Workloads using a specific nginix Image of your choosing. (eg 1.21.1)
2. Edit Config the newly created deployment and change the nginix Image to another version (eg 1.21.2)
3. Now that you have an multiple revisions you can select the Rollback menu option for the deployment
4. When the modal displays, select your previous revision and click the Show Diff button to display the yaml code diff



![2021-11-23_01-24-57 (1)](https://user-images.githubusercontent.com/13671297/142992034-48d9e2ce-6a6b-4bcf-8657-3b5a3ceb9e70.gif)


