### PR TITLE
Create/Edit Workloads | remove white-spaces in the "Container Image" field

### DIFF
--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -816,7 +816,7 @@ export default {
             <div class="row mb-20">
               <div class="col span-6">
                 <LabeledInput
-                  v-model="container.image"
+                  v-model.trim="container.image"
                   :mode="mode"
                   :label="t('workload.container.image')"
                   placeholder="e.g. nginx:latest"


### PR DESCRIPTION
This pr addresses issue #4317 by using vue's trim modifier on the input field.