### PR TITLE
Add service create form

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6082,6 +6082,8 @@ epinio:
     tableHeaders:
       api: URL
       explore: Explore
+  services:
+    pairs: Configure data that will be available to a container
   applications:
     tableHeaders:
       route: Route

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -36,7 +36,7 @@ export default {
       type:    Boolean,
     },
 
-    minHeight: {
+    minInputHeight: {
       // Prevent buttons from shifting when error
       // messages appear
       type:    String,
@@ -177,7 +177,7 @@ export default {
 
 <template>
   <div
-    :style="{'min-height': minHeight}"
+    :style="{'min-height': minInputHeight}"
   >
     <div
       :class="{

--- a/plugins/core-store/resource-class.js
+++ b/plugins/core-store/resource-class.js
@@ -705,7 +705,8 @@ export default class Resource {
     if ( !opt.url ) {
       throw new Error(`Unknown link ${ linkName } on ${ this.type } ${ this.id }`);
     }
-
+    const res = this.$dispatch('request', { opt, type: this.type } )
+    debugger;
     return this.$dispatch('request', { opt, type: this.type } );
   }
 

--- a/products/epinio/edit/services.vue
+++ b/products/epinio/edit/services.vue
@@ -68,11 +68,11 @@ export default Vue.extend({
         namespace-key="namespace"
         :namespaces-override="namespaces"
         :description-hidden="true"
-        :value="value.meta"
+        :value="value.metadata"
         :mode="mode"
       />
       <KeyValue
-        v-model="value.data"
+        v-model="value.keyValuePairs"
         :mode="mode"
         :title="t('epinio.services.pairs')"
         :key-label="t('epinio.applications.create.envvar.keyLabel')"

--- a/products/epinio/edit/services.vue
+++ b/products/epinio/edit/services.vue
@@ -73,6 +73,7 @@ export default Vue.extend({
       />
       <KeyValue
         v-model="value.keyValuePairs"
+        :initial-empty-row="true"
         :mode="mode"
         :title="t('epinio.services.pairs')"
         :key-label="t('epinio.applications.create.envvar.keyLabel')"

--- a/products/epinio/edit/services.vue
+++ b/products/epinio/edit/services.vue
@@ -1,13 +1,57 @@
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { PropType } from 'vue';
+import CreateEditView from '@/mixins/create-edit-view';
+import Loading from '@/components/Loading.vue';
+import CruResource from '@/components/CruResource.vue';
+import NameNsDescription from '@/components/form/NameNsDescription.vue';
+import { mapGetters } from 'vuex';
+import ServiceModel from '@/products/epinio/models/services.class';
+import { EPINIO_TYPES } from '@/products/epinio/types';
+import { sortBy } from '@/utils/sort';
+import KeyValue from '@/components/form/KeyValue.vue';
 
-interface Data {
-}
+export default Vue.extend({
+  components: {
+    Loading,
+    CruResource,
+    NameNsDescription,
+    KeyValue
+  },
+  mixins: [CreateEditView],
 
-// Data, Methods, Computed, Props
-export default Vue.extend<Data, any, any, any>({
   data() {
-    return { };
+    return {
+      errors: [],
+      values: {
+        meta: {
+          name:      this.value.meta?.name,
+          namespace: this.value.meta?.namespace
+        },
+        keyValuePairs: this.value.keyValuePairs,
+      },
+      namespaces: []
+    };
+  },
+
+  props: {
+    value: {
+      type:     Object as PropType<ServiceModel>,
+      required: true,
+    },
+    originalValue: {
+      type:     Object as PropType<ServiceModel>,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    },
+  },
+
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
+
+  fetch() {
+    this.namespaces = sortBy(this.$store.getters['epinio/all'](EPINIO_TYPES.NAMESPACE), 'name');
   },
 
 });
@@ -15,6 +59,31 @@ export default Vue.extend<Data, any, any, any>({
 
 <template>
   <div>
-    holder
+    <Loading v-if="!value || namespaces.length === 0" />
+    <CruResource
+      v-if="value && namespaces.length > 0"
+      :can-yaml="false"
+      :mode="mode"
+      :resource="value"
+      :errors="errors"
+      @error="e=>errors = e"
+      @finish="save"
+    >
+      <NameNsDescription
+        name-key="name"
+        namespace-key="namespace"
+        :namespaces-override="namespaces"
+        :description-hidden="true"
+        :value="values.meta"
+        :mode="mode"
+      />
+      <KeyValue
+        v-model="values.keyValuePairs"
+        :mode="mode"
+        :title="t('epinio.services.pairs')"
+        :key-label="t('epinio.applications.create.envvar.keyLabel')"
+        :value-label="t('epinio.applications.create.envvar.valueLabel')"
+      />
+    </CruResource>
   </div>
 </template>

--- a/products/epinio/edit/services.vue
+++ b/products/epinio/edit/services.vue
@@ -21,9 +21,7 @@ export default Vue.extend({
   data() {
     return {
       errors:        [],
-      value:         {} as PropType<ServiceModel>,
-      originalValue: {} as PropType<ServiceModel>,
-      namespaces: []
+      namespaces:    []
     };
   },
 
@@ -32,15 +30,20 @@ export default Vue.extend({
       type:     String,
       required: true
     },
+    value: {
+      type:     Object as PropType<ServiceModel>,
+      required: true
+    },
+    originalValue: {
+      type:     Object as PropType<ServiceModel>,
+      required: true
+    }
   },
 
   computed: { ...mapGetters({ t: 'i18n/t' }) },
 
   async fetch() {
     this.namespaces = await this.$store.dispatch('epinio/findAll', { type: EPINIO_TYPES.NAMESPACE });
-    this.originalValue = await this.$store.dispatch(`epinio/create`, { type: EPINIO_TYPES.SERVICE });
-    // Dissassociate the original model & model. This fixes `Create` after refreshing page with SSR on
-    this.value = await this.$store.dispatch(`epinio/clone`, { resource: this.originalValue });
   },
 });
 </script>
@@ -50,12 +53,15 @@ export default Vue.extend({
     <Loading v-if="!value || namespaces.length === 0" />
     <CruResource
       v-if="value && namespaces.length > 0"
-      :can-yaml="false"
+      :min-height="'7em'"
       :mode="mode"
+      :done-route="doneRoute"
       :resource="value"
+      :can-yaml="false"
       :errors="errors"
-      @error="e=>errors = e"
+      @error="(e) => (errors = e)"
       @finish="save"
+      @cancel="done"
     >
       <NameNsDescription
         name-key="name"
@@ -66,7 +72,7 @@ export default Vue.extend({
         :mode="mode"
       />
       <KeyValue
-        v-model="values.keyValuePairs"
+        v-model="value.data"
         :mode="mode"
         :title="t('epinio.services.pairs')"
         :key-label="t('epinio.applications.create.envvar.keyLabel')"

--- a/products/epinio/list/namespaces.vue
+++ b/products/epinio/list/namespaces.vue
@@ -128,7 +128,7 @@ export default {
         <div slot="body">
           <LabeledInput
             v-model="value.name"
-            :min-height="'90px'"
+            :min-input-height="'90px'"
             :label="t('epinio.namespace.name')"
             :mode="mode"
             :required="true"

--- a/products/epinio/list/services.vue
+++ b/products/epinio/list/services.vue
@@ -22,7 +22,39 @@ export default {
       type:     Object,
       required: true,
     },
+    rows: {
+      type:     Array,
+      required: true,
+    },
   },
+
+  computed: {
+
+    filterRows() {
+      // A custom list component is needed
+      // because the backend gives a null value for
+      // boundapps of a service that is not bound
+      // to any apps.
+      // ResourceTable needs the value to be
+      // an array because boundapps is defined as a list
+      // in the service type.
+      return this.rows.map((row) => {
+        if (!row.boundapps) {
+          row.boundapps = [];
+        }
+
+        // SortableTable also checks for the namespace
+        // name in the metadata, so we put it in meta.
+        row.meta = {
+          name:      row.name,
+          namespace: row.namespace
+        };
+        delete row.namespace;
+
+        return row;
+      });
+    },
+  }
 };
 </script>
 

--- a/products/epinio/models/applications.js
+++ b/products/epinio/models/applications.js
@@ -86,14 +86,6 @@ export default class EpinioApplication extends EpinioResource {
     return { url: this.deployment?.route ? `https://${ this.deployment?.route }` : '' };
   }
 
-  get nsLocation() {
-    return createEpinioRoute(`c-cluster-resource-id`, {
-      cluster:   this.$rootGetters['clusterId'],
-      resource:  EPINIO_TYPES.NAMESPACE,
-      id:       this.meta.namespace
-    });
-  }
-
   get links() {
     return {
       update: this.getUrl(),

--- a/products/epinio/models/services.js
+++ b/products/epinio/models/services.js
@@ -88,9 +88,10 @@ export default class EpinioService extends EpinioResource {
       },
       data: {
         name:          this.meta.name,
-        data:          this.data
+        data:          this.keyValuePairs
       }
     });
+    await this._save(...arguments);
     const services = await this.$dispatch('findAll', { type: this.type, opt: { force: true } });
 
     // Find new namespace

--- a/products/epinio/models/services.js
+++ b/products/epinio/models/services.js
@@ -11,7 +11,7 @@ export default class EpinioService extends EpinioResource {
       update: this.getUrl(),
       self:   this.getUrl(),
       remove: this.getUrl(),
-      create: this.getUrl(this.meta?.namespace, null), // ensure name is null
+      create: this.getUrl(this.meta?.namespace, null),
     };
   }
 
@@ -77,6 +77,25 @@ export default class EpinioService extends EpinioResource {
 
   get _key() {
     return this.name;
+  }
+
+  async save() {
+    await this.followLink('create', {
+      method:  'post',
+      headers: {
+        'content-type': 'application/json',
+        accept:         'application/json'
+      },
+      data: {
+        name:          this.meta.name,
+        data:          this.data
+      }
+    });
+    const services = await this.$dispatch('findAll', { type: this.type, opt: { force: true } });
+
+    // Find new namespace
+    // return new namespace
+    return services.filter(n => n.name === this.name)?.[0];
   }
   // ------------------------------------------------------------------
 }

--- a/products/epinio/models/services.js
+++ b/products/epinio/models/services.js
@@ -71,5 +71,12 @@ export default class EpinioService extends EpinioResource {
     });
   }
 
+  get hasCustomList() {
+    return true;
+  }
+
+  get _key() {
+    return this.name;
+  }
   // ------------------------------------------------------------------
 }

--- a/products/epinio/models/services.js
+++ b/products/epinio/models/services.js
@@ -79,7 +79,7 @@ export default class EpinioService extends EpinioResource {
     return this.name;
   }
 
-  async save() {
+  async create() {
     await this.followLink('create', {
       method:  'post',
       headers: {
@@ -87,16 +87,31 @@ export default class EpinioService extends EpinioResource {
         accept:         'application/json'
       },
       data: {
-        name:          this.meta.name,
-        data:          this.keyValuePairs
+        name: this.meta.name,
+        data: this.keyValuePairs
       }
     });
+  }
+
+  async save() {
     await this._save(...arguments);
     const services = await this.$dispatch('findAll', { type: this.type, opt: { force: true } });
 
     // Find new namespace
     // return new namespace
     return services.filter(n => n.name === this.name)?.[0];
+  }
+
+  get canClone() {
+    return false;
+  }
+
+  get canViewInApi() {
+    return false;
+  }
+
+  get canCustomEdit() {
+    return false;
   }
   // ------------------------------------------------------------------
 }


### PR DESCRIPTION
https://github.com/epinio/ui/issues/6

<img width="1269" alt="Screen Shot 2021-11-03 at 10 05 35 PM" src="https://user-images.githubusercontent.com/20599230/140261058-ca403f3f-29ec-456c-ba49-1ccdcc66a9ea.png">

To do:

- Waiting on backend to allow querying all services from all namespaces at once: If you create a service in a non-default namespace (anything other than 'workspace') it doesn't show in the list view
- The edit form doesn't work yet
- I'm adding two validation rules - one for the name, and one to require at least one key-value pair


----
The required format for the request data to create an epinio service is:
```
{ 
  "name": "test-service",
  "data": {"foo": "bar"}
}
```
And at least one value is required.

Currently my save function has
```
await this.followLink('create', {
      method:  'post',
      headers: {
        'content-type': 'application/json',
        accept:         'application/json'
      },
      data: {
        name:          this.meta.name,
        data:          this.keyValuePairs
      }
    });
```
But the name value isn't getting attached at the top level as is required. Instead the name value getting sent is nested under `meta`:
```
{
  "type":"services",
  "meta":{
    "namespace":"jglkdsjgks",
    "name":"fdaf"
  },
  "data":{"gdas":"dga"}
}
```