### PR TITLE
Update lifecycle hook placeholder for exec command

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4500,7 +4500,7 @@ workload:
         add: Add command to execute
         command:
           label: Command
-          placeholder: e.g. sh -c sleep 10
+          placeholder: e.g. sh -c 'sleep 10'
       httpGet:
         title: HttpGet
         add: Create HTTP request


### PR DESCRIPTION
#4505 
Updates lifecycle hook placeholder for Exec command from `sh -c sleep 10` to `sh -c 'sleep 10'`