### PR TITLE
Parse API list responses as a application/jsonl stream

### DIFF
--- a/list/management.cattle.io.user.vue
+++ b/list/management.cattle.io.user.vue
@@ -56,6 +56,10 @@ export default {
     },
 
     users() {
+      if ( !this.allUsers ) {
+        return [];
+      }
+
       // Update the list of users
       // 1) Only show system users in explorer/users and not in auth/users
       // 2) Supplement user with info to enable/disable the refresh group membership action (this is not persisted on save)

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -199,6 +199,9 @@ export default async function({
             notLoggedIn();
           } else {
             store.commit('setError', e);
+            if ( process.server ) {
+              redirect(302, '/fail-whale');
+            }
           }
 
           return;

--- a/mixins/brand.js
+++ b/mixins/brand.js
@@ -79,35 +79,32 @@ export default {
     }
   },
   head() {
-    let out = {};
     let cssClass = `overflow-hidden dashboard-body`;
-
-    let brandMeta;
+    const out = {
+      bodyAttrs: { class: `theme-${ this.theme } ${ cssClass }` },
+      title:     getVendor(),
+    };
 
     if (getVendor() === 'Harvester') {
       const ico = require(`~/assets/images/pl/harvester.png`);
 
-      out = {
-        title: 'Harvester',
-        link:      [{
-          hid:  'icon',
-          rel:  'icon',
-          type: 'image/x-icon',
-          href: ico
-        }],
-      };
+      out.title = 'Harvester';
+      out.link = [{
+        hid:  'icon',
+        rel:  'icon',
+        type: 'image/x-icon',
+        href: ico
+      }];
     }
 
-    try {
-      brandMeta = require(`~/assets/brand/${ this.brand }/metadata.json`);
-    } catch {
-      out = {
-        bodyAttrs: { class: `theme-${ this.theme } ${ cssClass }` },
-        title:     getVendor(),
-        ...out,
-      };
+    let brandMeta;
 
-      return out;
+    if ( this.brand ) {
+      try {
+        brandMeta = require(`~/assets/brand/${ this.brand }/metadata.json`);
+      } catch {
+        return out;
+      }
     }
 
     if (brandMeta?.hasStylesheet === 'true') {
@@ -117,11 +114,7 @@ export default {
       this.$store.dispatch('prefs/setBrandStyle', this.theme === 'dark');
     }
 
-    out = {
-      bodyAttrs: { class: cssClass },
-      title:     getVendor(),
-      ...out,
-    };
+    out.bodyAttrs.class = cssClass;
 
     return out;
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -14,6 +14,7 @@ const version = process.env.VERSION ||
   require('./package.json').version;
 
 const dev = (process.env.NODE_ENV !== 'production');
+const devPorts = dev || process.env.DEV_PORTS === 'true';
 const pl = process.env.PL || STANDARD;
 const commit = process.env.COMMIT || 'head';
 
@@ -338,11 +339,11 @@ module.exports = {
 
   // Nuxt server
   server: {
-    https: (dev ? {
+    https: (devPorts ? {
       key:  fs.readFileSync(path.resolve(__dirname, 'server/server.key')),
       cert: fs.readFileSync(path.resolve(__dirname, 'server/server.crt'))
     } : null),
-    port:      (dev ? 8005 : 80),
+    port:      (devPorts ? 8005 : 80),
     host:      '0.0.0.0',
   },
 

--- a/pages/auth/logout.vue
+++ b/pages/auth/logout.vue
@@ -6,7 +6,13 @@ export default {
 
   async asyncData({ redirect, store, router }) {
     await store.dispatch('auth/logout', null, { root: true });
-    redirect(302, `/auth/login?${ LOGGED_OUT }`);
+    const url = `/auth/login?${ LOGGED_OUT }`;
+
+    if ( process.server ) {
+      redirect(302, url);
+    } else {
+      window.location.href = url;
+    }
   }
 };
 </script>

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -7,6 +7,7 @@ import { SPOOFED_API_PREFIX, SPOOFED_PREFIX } from '@/store/type-map';
 import { addParam } from '@/utils/url';
 import { isArray } from '@/utils/array';
 import { deferred } from '@/utils/promise';
+import { streamJson } from '@/utils/stream';
 import { normalizeType } from './normalize';
 import { classify } from './classify';
 
@@ -36,9 +37,11 @@ export default {
 
     opt.depaginate = opt.depaginate !== false;
     opt.url = opt.url.replace(/\/*$/g, '');
+    opt.httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
     const method = (opt.method || 'get').toLowerCase();
-    const key = JSON.stringify(opt.headers || {}) + method + opt.url;
+    const headers = (opt.headers || {});
+    const key = JSON.stringify(headers) + method + opt.url;
     let waiting;
 
     if ( (method === 'get') ) {
@@ -59,7 +62,20 @@ export default {
       }
     }
 
-    opt.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+    if ( opt.stream && state.config.supportsStream && typeof TextDecoderStream !== 'undefined') {
+      console.log('Using Streaming for', opt.url);
+
+      return streamJson(opt.url, opt, opt.onData).then(() => {
+        return { finishDeferred: finishDeferred.bind(null, key, 'resolve') };
+      }).catch((err) => {
+        // @TODO look for 401
+        err.finishDeferred = finishDeferred.bind(null, key, 'resolve');
+
+        return Promise.reject(err);
+      });
+    } else {
+      console.log('NOT Using Streaming for', opt.url);
+    }
 
     return this.$axios(opt).then((res) => {
       if ( opt.depaginate ) {
@@ -84,31 +100,12 @@ export default {
         out = responseObject(res);
       }
 
-      finishDeferred(key, out, 'resolve');
+      finishDeferred(key, 'resolve', out);
 
       return out;
-    }).catch((err) => {
-      let out = err;
+    }).catch(onError);
 
-      if ( err?.response ) {
-        const res = err.response;
-
-        // Go to the logout page for 401s, unless redirectUnauthorized specifically disables (for the login page)
-        if ( opt.redirectUnauthorized !== false && process.client && res.status === 401 ) {
-          dispatch('auth/logout', opt.logoutOnError, { root: true });
-        }
-
-        if ( typeof res.data !== 'undefined' ) {
-          out = responseObject(res);
-        }
-      }
-
-      finishDeferred(key, out, 'reject');
-
-      return Promise.reject(out);
-    });
-
-    function finishDeferred(key, res, action = 'resolve') {
+    function finishDeferred(key, action = 'resolve', res) {
       const waiting = state.deferredRequests[key] || [];
 
       // console.log('Resolving deferred for', key, waiting.length);
@@ -146,6 +143,27 @@ export default {
       });
 
       return out;
+    }
+
+    function onError(err) {
+      let out = err;
+
+      if ( err?.response ) {
+        const res = err.response;
+
+        // Go to the logout page for 401s, unless redirectUnauthorized specifically disables (for the login page)
+        if ( opt.redirectUnauthorized !== false && process.client && res.status === 401 ) {
+          dispatch('auth/logout', opt.logoutOnError, { root: true });
+        }
+
+        if ( typeof res.data !== 'undefined' ) {
+          out = responseObject(res);
+        }
+      }
+
+      finishDeferred(key, 'reject', out);
+
+      return Promise.reject(out);
     }
   },
 
@@ -201,12 +219,6 @@ export default {
       return getters.all(type);
     }
 
-    console.log(`Find All: [${ ctx.state.config.namespace }] ${ type }`); // eslint-disable-line no-console
-    opt = opt || {};
-    opt.url = getters.urlFor(type, null, opt);
-
-    const res = await dispatch('request', opt);
-
     let load = (opt.load === undefined ? _ALL : opt.load);
 
     if ( opt.load === false || opt.load === _NONE ) {
@@ -221,8 +233,65 @@ export default {
       }
     }
 
+    console.log(`Find All: [${ ctx.state.config.namespace }] ${ type }`); // eslint-disable-line no-console
+    opt = opt || {};
+    opt.url = getters.urlFor(type, null, opt);
+    opt.stream = load !== _NONE;
+    let streamStarted = false;
+    let out;
+
+    // opt.onData = function(data) {
+    //   if ( streamStarted ) {
+    //     out.data.push(data);
+    //   } else {
+    //     streamStarted = true;
+    //     out = data;
+    //     out.data = [];
+    //   }
+    // };
+
+    let queue = [];
+
+    opt.onData = function(data) {
+      if ( streamStarted ) {
+        queue.push(data);
+        if ( queue.length > 10 ) {
+          const tmp = queue;
+
+          queue = [];
+          commit('loadMulti', { ctx, data: tmp });
+        }
+      } else {
+        commit('forgetAll', { type });
+        streamStarted = true;
+      }
+    };
+
+    try {
+      const res = await dispatch('request', opt);
+
+      if ( streamStarted ) {
+        if ( queue.length ) {
+          commit('loadMulti', { ctx, data: queue });
+          queue = [];
+        }
+        commit('loadedAll', { type });
+        const all = getters.all(type);
+
+        res.finishDeferred(all);
+
+        return all;
+      } else {
+        out = res;
+      }
+    } catch (e) {
+      if ( streamStarted ) {
+        e.finishDeferred(e);
+      }
+    }
+
     if ( load === _NONE ) {
-      return res;
+      return out;
     } else if ( load === _MULTI ) {
       // This has the effect of adding the response to the store,
       // without replacing all the existing content for that type,
@@ -232,20 +301,20 @@ export default {
       // while still knowing we need to load the full list later.
       commit('loadMulti', {
         ctx,
-        data: res.data
+        data: out.data
       });
     } else {
       commit('loadAll', {
         ctx,
         type,
-        data: res.data
+        data: out.data
       });
     }
 
     if ( opt.watch !== false ) {
       dispatch('watch', {
         type,
-        revision:  res.revision,
+        revision:  out.revision,
         namespace: opt.watchNamespace
       });
     }

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -63,18 +63,15 @@ export default {
     }
 
     if ( opt.stream && state.config.supportsStream && typeof TextDecoderStream !== 'undefined') {
-      console.log('Using Streaming for', opt.url);
+      // console.log('Using Streaming for', opt.url);
 
       return streamJson(opt.url, opt, opt.onData).then(() => {
         return { finishDeferred: finishDeferred.bind(null, key, 'resolve') };
       }).catch((err) => {
-        // @TODO look for 401
-        err.finishDeferred = finishDeferred.bind(null, key, 'resolve');
-
-        return Promise.reject(err);
+        return onError(err);
       });
     } else {
-      console.log('NOT Using Streaming for', opt.url);
+      // console.log('NOT Using Streaming for', opt.url);
     }
 
     return this.$axios(opt).then((res) => {
@@ -236,7 +233,7 @@ export default {
     console.log(`Find All: [${ ctx.state.config.namespace }] ${ type }`); // eslint-disable-line no-console
     opt = opt || {};
     opt.url = getters.urlFor(type, null, opt);
-    opt.stream = load !== _NONE;
+    opt.stream = opt.stream !== false && load !== _NONE;
     let streamStarted = false;
     let out;
 
@@ -285,9 +282,7 @@ export default {
         out = res;
       }
     } catch (e) {
-      if ( streamStarted ) {
-        e.finishDeferred(e);
-      }
+      return Promise.reject(e);
     }
 
     if ( load === _NONE ) {

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -168,6 +168,21 @@ export default {
     cache.haveAll = true;
   },
 
+  forgetAll(state, { type }) {
+    const cache = registerType(state, type);
+
+    clear(cache.list);
+    cache.map.clear();
+    cache.generation++;
+  },
+
+  loadedAll(state, { type }) {
+    const cache = registerType(state, type);
+
+    cache.generation++;
+    cache.haveAll = true;
+  },
+
   remove(state, obj) {
     let type = normalizeType(obj.type);
     const keyField = KEY_FIELD_FOR[type] || KEY_FIELD_FOR['default'];

--- a/plugins/steve/rehydrate-all.js
+++ b/plugins/steve/rehydrate-all.js
@@ -1,3 +1,5 @@
+const MAX_DEPTH = 20;
+
 export default function() {
   this.nuxt.hook('vue-renderer:ssr:context', (context) => {
     if ( context.nuxt.data ) {
@@ -8,7 +10,15 @@ export default function() {
       recurse(context.nuxt.fetch);
     }
 
-    function recurse(obj, parent, key) {
+    function recurse(obj, parent, key, depth = 0, path = '') {
+      if ( depth >= MAX_DEPTH ) {
+        return obj;
+      }
+
+      if ( key === '_error' ) {
+        return null;
+      }
+
       if ( Array.isArray(obj) && obj.__rehydrateAll ) {
         parent[`__rehydrateAll__${ key }`] = obj.__rehydrateAll;
       } else if ( obj && typeof obj === 'object' ) {
@@ -18,11 +28,11 @@ export default function() {
         }
 
         for ( const k of Object.keys(obj) ) {
-          if ( k === '__rehydrate' || k === '__clone' ) {
+          if ( k === '__rehydrate' || k === '__clone') {
             continue;
           }
 
-          obj[k] = recurse(obj[k], obj, k);
+          obj[k] = recurse(obj[k], obj, k, depth + 1, (path ? `${ path }.${ k }` : k));
         }
       }
 

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -1165,7 +1165,7 @@ export default class Resource {
 
     if ( !schema ) {
       // eslint-disable-next-line
-      console.warn(this.t('validation.noSchema'), originalType, data);
+      // console.warn(this.t('validation.noSchema'), originalType, data);
 
       return errors;
     }

--- a/store/index.js
+++ b/store/index.js
@@ -26,13 +26,27 @@ export const BLANK_CLUSTER = '_';
 
 export const plugins = [
   Steve({
-    namespace: 'management', baseUrl: '/v1', modelBaseClass: BY_TYPE
+    namespace:      'management',
+    baseUrl:        '/v1',
+    modelBaseClass: BY_TYPE,
+    supportsStream: true,
   }),
-  Steve({ namespace: 'cluster', baseUrl: '' }), // URL dynamically set for the selected cluster
   Steve({
-    namespace: 'rancher', baseUrl: '/v3', modelBaseClass: NORMAN_CLASS
+    namespace:      'cluster',
+    baseUrl:        '', // URL is dynamically set for the selected cluster
+    supportsStream: true,
   }),
-  Steve({ namespace: 'harvester', baseUrl: '' }),
+  Steve({
+    namespace:      'rancher',
+    baseUrl:        '/v3',
+    supportsStream: false,
+    modelBaseClass: NORMAN_CLASS,
+  }),
+  Steve({
+    namespace:      'harvester',
+    baseUrl:        '', // URL is dynamically set for the selected cluster
+    supportsStream: true,
+  }),
 ];
 
 export const state = () => {

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -376,12 +376,15 @@ export const actions = {
           force:                true,
           watch:                false,
           redirectUnauthorized: false,
+          stream:               false,
         }
       }, { root: true });
 
       server = all?.[0];
     } catch (e) {
       console.error('Error loading preferences', e); // eslint-disable-line no-console
+
+      return server;
     }
 
     if ( !server?.data ) {

--- a/utils/error.js
+++ b/utils/error.js
@@ -19,6 +19,16 @@ export class ApiError extends Error {
   toString() {
     return `[${ this.status } ${ this.statusText }]: ${ this.message }`;
   }
+
+  toJSON() {
+    return {
+      type:       'error',
+      status:     this.status,
+      statusText: this.statusText,
+      message:    this.statusMessage,
+      url:        this.url,
+    };
+  }
 }
 
 export function stringify(err) {

--- a/utils/stream.js
+++ b/utils/stream.js
@@ -8,8 +8,20 @@ export function streamJson(url, opt, onData) {
   let buf = '';
 
   return fetch(url, opt)
-    .then(res => res.body.getReader())
-    .then((reader) => {
+    .then((res) => {
+      if ( res.status >= 400 ) {
+        // eslint-disable-next-line no-console
+        console.error('Error Streaming', res);
+
+        const out = { message: 'Error Streaming' };
+
+        out.response = res;
+
+        return Promise.reject(out);
+      } else {
+        return res.body.getReader();
+      }
+    }).then((reader) => {
       return reader.read().then(function process({ value, done }) {
         if (done) {
           onData(JSON.parse(buf));

--- a/utils/stream.js
+++ b/utils/stream.js
@@ -1,0 +1,29 @@
+export function streamJson(url, opt, onData) {
+  opt = opt || {};
+  opt.method = opt.method || 'get';
+  opt.headers = opt.headers || {};
+  opt.headers.accept = 'application/jsonl';
+
+  const decoder = new TextDecoder();
+  let buf = '';
+
+  return fetch(url, opt)
+    .then(res => res.body.getReader())
+    .then((reader) => {
+      return reader.read().then(function process({ value, done }) {
+        if (done) {
+          onData(JSON.parse(buf));
+
+          return;
+        }
+
+        buf += decoder.decode(value, { stream: true });
+        const lines = buf.split(/[\r\n](?=.)/);
+
+        buf = lines.pop();
+        lines.map(JSON.parse).forEach(onData);
+
+        return reader.read().then(process);
+      });
+    });
+}


### PR DESCRIPTION
#4512 

Send `Accept: application/jsonl` for `findAll()` for requests by default.  This causes the response to be sent as many separate JSON documents (separated by newlines, with the first line being the collection object sans `data` field).  The server can then start streaming out response objects as it receives them instead of buffering all in memory to produce one giant `{type: 'collection' data: [...many resources...]}` blob.  Similarly the client can start parsing the individual smaller lines as they come in instead of waiting for the entire blob to be downloaded and parsed.

In practice the total response time is still about the same from the server, but the TTFB (time to first byte) can be much sooner for slow requests.  And by the time the last byte arrives most of the parsing and adding to the store should have already been done in the client. 

This is not as dramatic of an improvement as I'd _like_, mainly because the data is sent from etcd -> steve api -> browser and etcd doesn't also support this streaming.  So there's still a long delay waiting for it before steve can start responding, but there is measurable improvement on slow/large responses anyway.

Also several fixes for handling errors in SSR requests found along the way, and avoiding trying to load a brand file with no brand set.