### PR TITLE
Fix login catching errors from missing settings

### DIFF
--- a/pages/auth/logout.vue
+++ b/pages/auth/logout.vue
@@ -6,13 +6,7 @@ export default {
 
   async asyncData({ redirect, store, router }) {
     await store.dispatch('auth/logout', null, { root: true });
-    const url = `/auth/login?${ LOGGED_OUT }`;
-
-    if ( process.server ) {
-      redirect(302, url);
-    } else {
-      window.location.href = url;
-    }
+    redirect(302, `/auth/login?${ LOGGED_OUT }`);
   }
 };
 </script>

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -282,23 +282,25 @@ export default {
 
     if ( load === _NONE ) {
       return out;
-    } else if ( load === _MULTI ) {
-      // This has the effect of adding the response to the store,
-      // without replacing all the existing content for that type,
-      // and without marking that type as having 'all 'loaded.
-      //
-      // This is used e.g. to load a partial list of settings before login
-      // while still knowing we need to load the full list later.
-      commit('loadMulti', {
-        ctx,
-        data: out.data
-      });
-    } else {
-      commit('loadAll', {
-        ctx,
-        type,
-        data: out.data
-      });
+    } else if ( out.data ) {
+      if ( load === _MULTI ) {
+        // This has the effect of adding the response to the store,
+        // without replacing all the existing content for that type,
+        // and without marking that type as having 'all 'loaded.
+        //
+        // This is used e.g. to load a partial list of settings before login
+        // while still knowing we need to load the full list later.
+        commit('loadMulti', {
+          ctx,
+          data: out.data
+        });
+      } else {
+        commit('loadAll', {
+          ctx,
+          type,
+          data: out.data
+        });
+      }
     }
 
     if ( opt.watch !== false ) {

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -128,7 +128,7 @@ export default {
   },
 
   loadMulti(state, { data, ctx }) {
-    // console.log('### Mutation loadMulti', data.length);
+    // console.log('### Mutation loadMulti', data?.length);
     for ( const entry of data ) {
       load(state, { data: entry, ctx });
     }

--- a/plugins/steve/subscribe.js
+++ b/plugins/steve/subscribe.js
@@ -13,8 +13,8 @@ export const NO_WATCH = 'NO_WATCH';
 export const NO_SCHEMA = 'NO_SCHEMA';
 
 export function keyForSubscribe({
-  resourceType, type, namespace, id, selector, reason
-}) {
+  resourceType, type, namespace, id, selector
+} = {}) {
   return `${ resourceType || type || '' }/${ namespace || '' }/${ id || '' }/${ selector || '' }`;
 }
 

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -258,6 +258,7 @@ export const actions = {
 
       this.$cookies.set(`${ cookiePrefix }${ key }`.toUpperCase(), value, opt);
     }
+
     if ( definition.asUserPreference ) {
       try {
         server = await dispatch('loadServer', key); // There's no watch on prefs, so get before set...
@@ -384,7 +385,7 @@ export const actions = {
     } catch (e) {
       console.error('Error loading preferences', e); // eslint-disable-line no-console
 
-      return server;
+      return;
     }
 
     if ( !server?.data ) {


### PR DESCRIPTION
#4519 #4521

Hosted for dev vs production builds behave differently, and the UI tries to get the ui-brand setting but it's not marked as available for unauthenticated requests.