### PR TITLE
Fix placeholders and labels for lifecycle hooks exec command and readiness probe command

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4500,7 +4500,7 @@ workload:
         add: Add command to execute
         command:
           label: Command
-          placeholder: e.g. sh -c 'sleep 10'
+          placeholder: "e.g. sh -c 'sleep 10'"
       httpGet:
         title: HttpGet
         add: Create HTTP request

--- a/components/form/HookOption.vue
+++ b/components/form/HookOption.vue
@@ -138,7 +138,7 @@ export default {
             v-model="value.exec.command"
             :mode="mode"
             :label="t('workload.container.lifecycleHook.exec.command.label')"
-            :placeholder="t('workload.container.lifecycleHook.exec.command.placeholder')"
+            :placeholder="t('workload.container.lifecycleHook.exec.command.placeholder', null, true)"
             required
           />
         </div>

--- a/components/form/Probe.vue
+++ b/components/form/Probe.vue
@@ -200,8 +200,8 @@ export default {
           <div class="col span-12">
             <ShellInput
               v-model="exec.command"
-              :label="t('probe.httpGet.port.command.label')"
-              :placeholder="t('probe.httpGet.port.command.placeholder')"
+              :label="t('probe.command.label')"
+              :placeholder="t('probe.command.placeholder')"
             />
           </div>
           <div class="spacer-small" />


### PR DESCRIPTION
Reference #4505 

Fix localization input for lifecycle `exec` command input.
![lifecycle](https://user-images.githubusercontent.com/40806497/140781650-4503e6df-998c-4c42-a4d3-f2cc12504068.png)

---
**_Unrelated but found during testing_**
Fixed incorrect `label` and `placeholder` for Health check readiness probe `Command To Run`.
![healthcheck](https://user-images.githubusercontent.com/40806497/140781674-299be1af-c580-4895-b77f-949be831e0aa.png)


