### PR TITLE
Catch error when failing to load YAML in Logging Flow

### DIFF
--- a/edit/logging-flow/index.vue
+++ b/edit/logging-flow/index.vue
@@ -17,6 +17,7 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import { clone, set } from '@/utils/object';
 import isEmpty from 'lodash/isEmpty';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
+import { exceptionToErrorsArray } from '@/utils/error';
 import Match from './Match';
 
 function emptyMatch(include = true) {
@@ -199,12 +200,16 @@ export default {
     filtersYaml: {
       deep: true,
       handler() {
-        const filterJson = jsyaml.load(this.filtersYaml);
+        try {
+          const filterJson = jsyaml.load(this.filtersYaml);
 
-        if ( isArray(filterJson) ) {
-          set(this.value.spec, 'filters', filterJson);
-        } else {
-          set(this.value.spec, 'filters', undefined);
+          if ( isArray(filterJson) ) {
+            set(this.value.spec, 'filters', filterJson);
+          } else {
+            set(this.value.spec, 'filters', undefined);
+          }
+        } catch (e) {
+          this.errors = exceptionToErrorsArray(e);
         }
       }
     },


### PR DESCRIPTION
This resolves a an issue where typing invalid YAML for Logging Cluster Flow filters would fail unexpectedly in dev. 

To resolve the issue, we wrap `jsyaml.load` in a `try...catch` block and display any errors that might arise.