### PR TITLE
Only join in List formatter if value is array

### DIFF
--- a/components/formatter/List.vue
+++ b/components/formatter/List.vue
@@ -2,14 +2,18 @@
 export default {
   props: {
     value: {
-      type:     Array,
+      type:     [Array, String],
       default: () => []
     }
   },
 
   computed: {
     string() {
-      return this.value.join(', ');
+      if (Array.isArray(this.value)) {
+        return this.value.join(', ');
+      }
+
+      return this.value;
     }
   },
 };


### PR DESCRIPTION
This resolves an issue where a list of Logging resources with a Logging Output Provider would sometimes print an error to the console (in prod) or throw a Nuxt error (in dev).

Sometimes Providers associated with Logging Flows and Outputs could return a string instead of an array. I opted to fix this issue in the List formatter by accepting a type of `Array` or `String` in the `value` prop and only attempting to join if value is an array. 

I was contemplating if the formatter prop for `LOGGING_OUTPUT_PROVIDERS` in `config/table-headers.js` could accept multiple values, but that didn't appear to be the case.