### PR TITLE
Support streaming repsonses in Firefox

### DIFF
--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -7,7 +7,7 @@ import { SPOOFED_API_PREFIX, SPOOFED_PREFIX } from '@/store/type-map';
 import { addParam } from '@/utils/url';
 import { isArray } from '@/utils/array';
 import { deferred } from '@/utils/promise';
-import { streamJson } from '@/utils/stream';
+import { streamingSupported, streamJson } from '@/utils/stream';
 import { normalizeType } from './normalize';
 import { classify } from './classify';
 
@@ -62,7 +62,7 @@ export default {
       }
     }
 
-    if ( opt.stream && state.config.supportsStream && typeof TextDecoderStream !== 'undefined') {
+    if ( opt.stream && state.allowStreaming && state.config.supportsStream && streamingSupported() ) {
       // console.log('Using Streaming for', opt.url);
 
       return streamJson(opt.url, opt, opt.onData).then(() => {

--- a/plugins/steve/index.js
+++ b/plugins/steve/index.js
@@ -28,6 +28,7 @@ function SteveFactory(namespace, baseUrl) {
         queue:            [], // For change event coalescing
         wantSocket:       false,
         debugSocket:      false,
+        allowStreaming:   true,
         pendingFrames:    [],
         deferredRequests: {},
         started:          [],

--- a/utils/stream.js
+++ b/utils/stream.js
@@ -39,3 +39,11 @@ export function streamJson(url, opt, onData) {
       });
     });
 }
+
+export function streamingSupported() {
+  const supported = typeof TextDecoder !== 'undefined';
+
+  // console.log('Streaming Supported: ', supported);
+
+  return supported;
+}


### PR DESCRIPTION
Look for TextDecoder instead of TextDecoderStream.  Also adds a `[store].state.allowStreaming` flag to disable at runtime for debugging/performance testing.