### PR TITLE
Bugfix UnitInput being used for SI units

### DIFF
--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -43,30 +43,37 @@ export default {
       limitsCpu, limitsMemory, requestsCpu, requestsMemory
     } = this.value;
 
-    const parsed = {
-      limitsCpu:      limitsCpu ? parseSi(limitsCpu) : null,
-      limitsMemory:   limitsMemory ? parseSi(limitsMemory) : null,
-      requestsCpu:    requestsCpu ? parseSi(requestsCpu) : null,
-      requestsMemory: requestsMemory ? parseSi(requestsMemory) : null,
-    };
+    // // Convert string inputs w/ increment modifiers to integers eg "1m" CPUS -> .001 CPUS
+    // const parsed = {
+    //   limitsCpu:      limitsCpu ? parseSi(limitsCpu) : null,
+    //   limitsMemory:   limitsMemory ? parseSi(limitsMemory) : null,
+    //   requestsCpu:    requestsCpu ? parseSi(requestsCpu) : null,
+    //   requestsMemory: requestsMemory ? parseSi(requestsMemory) : null,
+    // };
 
-    const formatted = {
-      limitsCpu:  parsed.limitsCpu ? formatSi(parsed.limitsCpu, {
-        minExponent: 1, maxExponent: 1, addSuffix: false, increment: 1 / 1000
-      }) : null,
-      limitsMemory: parsed.limitsMemory ? formatSi(parsed.limitsMemory, {
-        minExponent: 2, maxExponent: 2, addSuffix: false, increment: 1024,
-      }) : null,
-      requestsCpu:  parsed.requestsCpu ? formatSi(parsed.requestsCpu, {
-        minExponent: 1, maxExponent: 1, addSuffix: false, increment: 1 / 1000,
-      }) : null,
-      requestsMemory: parsed.requestsMemory ? formatSi(parsed.requestsMemory, {
-        minExponent: 2, maxExponent: 2, addSuffix: false, increment: 1024,
-      }) : null,
-      viewMode: _VIEW,
-    };
+    // // debugger;
+    // // format cpu integers to milliCPU and Bytes integers to MiB
+    // const formatted = {
+    //   limitsCpu:  parsed.limitsCpu ? formatSi(parsed.limitsCpu, {
+    //     minExponent: 1, maxExponent: 1, addSuffix: true, increment: 1 / 1000
+    //   }) : null,
+    //   limitsMemory: parsed.limitsMemory ? formatSi(parsed.limitsMemory, {
+    //     minExponent: 2, maxExponent: 2, addSuffix: true, increment: 1024,
+    //   }) : null,
+    //   requestsCpu:  parsed.requestsCpu ? formatSi(parsed.requestsCpu, {
+    //     minExponent: 1, maxExponent: 1, addSuffix: true, increment: 1 / 1000,
+    //   }) : null,
+    //   requestsMemory: parsed.requestsMemory ? formatSi(parsed.requestsMemory, {
+    //     minExponent: 2, maxExponent: 2, addSuffix: true, increment: 1024,
+    //   }) : null,
+    //   viewMode: _VIEW,
+    // };
 
-    return { ...formatted };
+    return {
+      ...{
+        limitsCpu, limitsMemory, requestsCpu, requestsMemory
+      }
+    };
   },
 
   computed: {
@@ -98,20 +105,13 @@ export default {
         requestsCpu,
         requestsMemory,
       } = this;
-      const out = {
-        limitsCpu:      limitsCpu ? `${ limitsCpu }m` : null,
-        limitsMemory:   limitsMemory ? `${ limitsMemory }Mi` : null,
-        requestsCpu:    requestsCpu ? `${ requestsCpu }m` : null,
-        requestsMemory: requestsMemory ? `${ requestsMemory }Mi` : null,
-      };
 
-      this.$emit('input', cleanUp(out));
-    },
-
-    applyUnits(out, key, value, unit) {
-      if (value) {
-        out[key] = typeof value === 'string' && value.includes(unit) ? value : `${ value }${ unit }`;
-      }
+      this.$emit('input', cleanUp({
+        limitsCpu,
+        limitsMemory,
+        requestsCpu,
+        requestsMemory
+      }));
     },
 
     updateBeforeSave(value) {
@@ -123,12 +123,12 @@ export default {
       } = this;
       const namespace = this.namespace; // no deep copy in destructure proxy yet
 
-      const out = {};
-
-      this.applyUnits(out, 'limitsCpu', limitsCpu, 'm');
-      this.applyUnits(out, 'limitsMemory', limitsMemory, 'Mi');
-      this.applyUnits(out, 'requestsCpu', requestsCpu, 'm');
-      this.applyUnits(out, 'requestsMemory', requestsMemory, 'Mi');
+      const out = cleanUp({
+        limitsCpu,
+        limitsMemory,
+        requestsCpu,
+        requestsMemory
+      });
 
       if (namespace) {
         namespace.setAnnotation(CONTAINER_DEFAULT_RESOURCE_LIMIT, JSON.stringify(out));
@@ -178,6 +178,7 @@ export default {
           :label="t('containerResourceLimit.requestsCpu')"
           :input-exponent="-1"
           :mode="mode"
+          output-suffix-text="m"
           @input="updateLimits"
         />
       </span>
@@ -188,7 +189,9 @@ export default {
           :placeholder="t('containerResourceLimit.memPlaceholder')"
           :label="t('containerResourceLimit.requestsMemory')"
           :input-exponent="2"
+          :increment="1024"
           :mode="mode"
+          output-suffix-text="Mi"
           @input="updateLimits"
         />
       </span>
@@ -203,6 +206,7 @@ export default {
           :label="t('containerResourceLimit.limitsCpu')"
           :input-exponent="-1"
           :mode="mode"
+          output-suffix-text="m"
           @input="updateLimits"
         />
       </span>
@@ -213,7 +217,9 @@ export default {
           :placeholder="t('containerResourceLimit.memPlaceholder')"
           :label="t('containerResourceLimit.limitsMemory')"
           :input-exponent="2"
+          :increment="1024"
           :mode="mode"
+          output-suffix-text="Mi"
           @input="updateLimits"
         />
       </span>

--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -3,6 +3,7 @@ import isEmpty from 'lodash/isEmpty';
 import UnitInput from '@/components/form/UnitInput';
 import { CONTAINER_DEFAULT_RESOURCE_LIMIT } from '@/config/labels-annotations';
 import { cleanUp } from '@/utils/object';
+import { _VIEW } from '@/config/query-params';
 
 export default {
   components: { UnitInput },
@@ -42,7 +43,7 @@ export default {
     } = this.value;
 
     return {
-      limitsCpu, limitsMemory, requestsCpu, requestsMemory
+      limitsCpu, limitsMemory, requestsCpu, requestsMemory, viewMode: _VIEW
     };
   },
 

--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -2,8 +2,6 @@
 import isEmpty from 'lodash/isEmpty';
 import UnitInput from '@/components/form/UnitInput';
 import { CONTAINER_DEFAULT_RESOURCE_LIMIT } from '@/config/labels-annotations';
-import { _VIEW } from '@/config/query-params';
-import { parseSi, formatSi } from '@/utils/units';
 import { cleanUp } from '@/utils/object';
 
 export default {
@@ -43,36 +41,8 @@ export default {
       limitsCpu, limitsMemory, requestsCpu, requestsMemory
     } = this.value;
 
-    // // Convert string inputs w/ increment modifiers to integers eg "1m" CPUS -> .001 CPUS
-    // const parsed = {
-    //   limitsCpu:      limitsCpu ? parseSi(limitsCpu) : null,
-    //   limitsMemory:   limitsMemory ? parseSi(limitsMemory) : null,
-    //   requestsCpu:    requestsCpu ? parseSi(requestsCpu) : null,
-    //   requestsMemory: requestsMemory ? parseSi(requestsMemory) : null,
-    // };
-
-    // // debugger;
-    // // format cpu integers to milliCPU and Bytes integers to MiB
-    // const formatted = {
-    //   limitsCpu:  parsed.limitsCpu ? formatSi(parsed.limitsCpu, {
-    //     minExponent: 1, maxExponent: 1, addSuffix: true, increment: 1 / 1000
-    //   }) : null,
-    //   limitsMemory: parsed.limitsMemory ? formatSi(parsed.limitsMemory, {
-    //     minExponent: 2, maxExponent: 2, addSuffix: true, increment: 1024,
-    //   }) : null,
-    //   requestsCpu:  parsed.requestsCpu ? formatSi(parsed.requestsCpu, {
-    //     minExponent: 1, maxExponent: 1, addSuffix: true, increment: 1 / 1000,
-    //   }) : null,
-    //   requestsMemory: parsed.requestsMemory ? formatSi(parsed.requestsMemory, {
-    //     minExponent: 2, maxExponent: 2, addSuffix: true, increment: 1024,
-    //   }) : null,
-    //   viewMode: _VIEW,
-    // };
-
     return {
-      ...{
-        limitsCpu, limitsMemory, requestsCpu, requestsMemory
-      }
+      limitsCpu, limitsMemory, requestsCpu, requestsMemory
     };
   },
 
@@ -173,24 +143,23 @@ export default {
       <span class="col span-6">
         <UnitInput
           v-model="requestsCpu"
-          :suffix="t('suffix.cpus')"
           :placeholder="t('containerResourceLimit.cpuPlaceholder')"
           :label="t('containerResourceLimit.requestsCpu')"
-          :input-exponent="-1"
           :mode="mode"
+          :input-exponent="-1"
           :output-modifier="true"
+          :base-unit="t('suffix.cpus')"
           @input="updateLimits"
         />
       </span>
       <span class="col span-6">
         <UnitInput
           v-model="requestsMemory"
-          :suffix="t('suffix.ib')"
           :placeholder="t('containerResourceLimit.memPlaceholder')"
           :label="t('containerResourceLimit.requestsMemory')"
+          :mode="mode"
           :input-exponent="2"
           :increment="1024"
-          :mode="mode"
           :output-modifier="true"
           @input="updateLimits"
         />
@@ -201,24 +170,23 @@ export default {
       <span class="col span-6">
         <UnitInput
           v-model="limitsCpu"
-          :suffix="t('suffix.cpus')"
           :placeholder="t('containerResourceLimit.cpuPlaceholder')"
           :label="t('containerResourceLimit.limitsCpu')"
-          :input-exponent="-1"
           :mode="mode"
+          :input-exponent="-1"
           :output-modifier="true"
+          :base-unit="t('suffix.cpus')"
           @input="updateLimits"
         />
       </span>
       <span class="col span-6">
         <UnitInput
           v-model="limitsMemory"
-          :suffix="t('suffix.ib')"
           :placeholder="t('containerResourceLimit.memPlaceholder')"
           :label="t('containerResourceLimit.limitsMemory')"
+          :mode="mode"
           :input-exponent="2"
           :increment="1024"
-          :mode="mode"
           :output-modifier="true"
           @input="updateLimits"
         />

--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -178,7 +178,7 @@ export default {
           :label="t('containerResourceLimit.requestsCpu')"
           :input-exponent="-1"
           :mode="mode"
-          output-suffix-text="m"
+          :output-modifier="true"
           @input="updateLimits"
         />
       </span>
@@ -191,7 +191,7 @@ export default {
           :input-exponent="2"
           :increment="1024"
           :mode="mode"
-          output-suffix-text="Mi"
+          :output-modifier="true"
           @input="updateLimits"
         />
       </span>
@@ -206,7 +206,7 @@ export default {
           :label="t('containerResourceLimit.limitsCpu')"
           :input-exponent="-1"
           :mode="mode"
-          output-suffix-text="m"
+          :output-modifier="true"
           @input="updateLimits"
         />
       </span>
@@ -219,7 +219,7 @@ export default {
           :input-exponent="2"
           :increment="1024"
           :mode="mode"
-          output-suffix-text="Mi"
+          :output-modifier="true"
           @input="updateLimits"
         />
       </span>

--- a/components/form/ResourceQuota/Row.vue
+++ b/components/form/ResourceQuota/Row.vue
@@ -100,70 +100,66 @@ export default {
       v-if="isCpu"
       v-model="value.spec.resourceQuota.limit[type]"
       class="mr-10"
-      :suffix="t('suffix.cpus')"
       :mode="mode"
       :label="t('resourceQuota.projectLimit.label')"
       :placeholder="t('resourceQuota.projectLimit.cpuPlaceholder')"
-      output-suffix-text="m"
       :input-exponent="-1"
+      :base-unit="t('suffix.cpus')"
+      :output-modifier="true"
     />
     <UnitInput
       v-if="isCpu"
       v-model="value.spec.namespaceDefaultResourceQuota.limit[type]"
-      :suffix="t('suffix.cpus')"
       :mode="mode"
       :label="t('resourceQuota.namespaceDefaultLimit.label')"
       :placeholder="t('resourceQuota.namespaceDefaultLimit.cpuPlaceholder')"
-      output-suffix-text="m"
       :input-exponent="-1"
+      :base-unit="t('suffix.cpus')"
+      :output-modifier="true"
     />
 
     <UnitInput
       v-if="isMemory"
       v-model="value.spec.resourceQuota.limit[type]"
       class="mr-10"
-      :suffix="t('suffix.ib')"
       :mode="mode"
       :label="t('resourceQuota.projectLimit.label')"
       :placeholder="t('resourceQuota.projectLimit.memoryPlaceholder')"
-      output-suffix-text="Mi"
       :input-exponent="2"
       :increment="1024"
+      :output-modifier="true"
     />
     <UnitInput
       v-if="isMemory"
       v-model="value.spec.namespaceDefaultResourceQuota.limit[type]"
-      :suffix="t('suffix.ib')"
       :mode="mode"
       :label="t('resourceQuota.namespaceDefaultLimit.label')"
       :placeholder="t('resourceQuota.namespaceDefaultLimit.memoryPlaceholder')"
-      output-suffix-text="Mi"
       :input-exponent="2"
       :increment="1024"
+      :output-modifier="true"
     />
 
     <UnitInput
       v-if="isStorage"
       v-model="value.spec.resourceQuota.limit[type]"
       class="mr-10"
-      :suffix="t('suffix.ib')"
       :mode="mode"
       :placeholder="t('resourceQuota.projectLimit.storagePlaceholder')"
       :label="t('resourceQuota.projectLimit.label')"
-      output-suffix-text="Gi"
       :input-exponent="3"
       :increment="1024"
+      :output-modifier="true"
     />
     <UnitInput
       v-if="isStorage"
       v-model="value.spec.namespaceDefaultResourceQuota.limit[type]"
-      :suffix="t('suffix.ib')"
       :mode="mode"
       :label="t('resourceQuota.namespaceDefaultLimit.label')"
       :placeholder="t('resourceQuota.namespaceDefaultLimit.storagePlaceholder')"
-      output-suffix-text="Gi"
       :input-exponent="3"
       :increment="1024"
+      :output-modifier="true"
     />
   </div>
 </template>

--- a/components/form/ResourceQuota/Row.vue
+++ b/components/form/ResourceQuota/Row.vue
@@ -2,9 +2,12 @@
 import { _VIEW } from '@/config/query-params';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import UnitInput from '@/components/form/UnitInput';
+import LabeledInput from '@/components/form/LabeledInput';
 
 export default {
-  components: { LabeledSelect, UnitInput },
+  components: {
+    LabeledSelect, UnitInput, LabeledInput
+  },
 
   props: {
     mode: {
@@ -75,76 +78,92 @@ export default {
   <div class="row">
     <LabeledSelect class="mr-10" :value="type" :options="types" :label="t('resourceQuota.resourceType.label')" @input="updateType($event)" />
 
-    <UnitInput
+    <LabeledInput
       v-if="isUnitless"
-      v-model="value.spec.resourceQuota.limit[type]"
+      v-model.number="value.spec.resourceQuota.limit[type]"
       class="mr-10"
       :mode="mode"
-      :suffix="false"
       :label="t('resourceQuota.projectLimit.label')"
       :placeholder="t('resourceQuota.projectLimit.unitlessPlaceholder')"
+      type="number"
     />
-    <UnitInput
+    <LabeledInput
       v-if="isUnitless"
-      v-model="value.spec.namespaceDefaultResourceQuota.limit[type]"
+      v-model.number="value.spec.namespaceDefaultResourceQuota.limit[type]"
       :mode="mode"
-      :suffix="false"
       :label="t('resourceQuota.namespaceDefaultLimit.label')"
       :placeholder="t('resourceQuota.namespaceDefaultLimit.unitlessPlaceholder')"
+      type="number"
     />
 
     <UnitInput
       v-if="isCpu"
       v-model="value.spec.resourceQuota.limit[type]"
       class="mr-10"
-      :suffix="t('suffix.milliCpus')"
+      :suffix="t('suffix.cpus')"
       :mode="mode"
       :label="t('resourceQuota.projectLimit.label')"
       :placeholder="t('resourceQuota.projectLimit.cpuPlaceholder')"
+      output-suffix-text="m"
+      :input-exponent="-1"
     />
     <UnitInput
       v-if="isCpu"
       v-model="value.spec.namespaceDefaultResourceQuota.limit[type]"
-      :suffix="t('suffix.milliCpus')"
+      :suffix="t('suffix.cpus')"
       :mode="mode"
       :label="t('resourceQuota.namespaceDefaultLimit.label')"
       :placeholder="t('resourceQuota.namespaceDefaultLimit.cpuPlaceholder')"
+      output-suffix-text="m"
+      :input-exponent="-1"
     />
 
     <UnitInput
       v-if="isMemory"
       v-model="value.spec.resourceQuota.limit[type]"
       class="mr-10"
-      :suffix="t('suffix.mib')"
+      :suffix="t('suffix.ib')"
       :mode="mode"
       :label="t('resourceQuota.projectLimit.label')"
       :placeholder="t('resourceQuota.projectLimit.memoryPlaceholder')"
+      output-suffix-text="Mi"
+      :input-exponent="2"
+      :increment="1024"
     />
     <UnitInput
       v-if="isMemory"
       v-model="value.spec.namespaceDefaultResourceQuota.limit[type]"
-      :suffix="t('suffix.mib')"
+      :suffix="t('suffix.ib')"
       :mode="mode"
       :label="t('resourceQuota.namespaceDefaultLimit.label')"
       :placeholder="t('resourceQuota.namespaceDefaultLimit.memoryPlaceholder')"
+      output-suffix-text="Mi"
+      :input-exponent="2"
+      :increment="1024"
     />
 
     <UnitInput
       v-if="isStorage"
       v-model="value.spec.resourceQuota.limit[type]"
       class="mr-10"
-      :suffix="t('suffix.gb')"
+      :suffix="t('suffix.ib')"
       :mode="mode"
       :placeholder="t('resourceQuota.projectLimit.storagePlaceholder')"
       :label="t('resourceQuota.projectLimit.label')"
+      output-suffix-text="Gi"
+      :input-exponent="3"
+      :increment="1024"
     />
     <UnitInput
       v-if="isStorage"
       v-model="value.spec.namespaceDefaultResourceQuota.limit[type]"
-      :suffix="t('suffix.gb')"
+      :suffix="t('suffix.ib')"
       :mode="mode"
       :label="t('resourceQuota.namespaceDefaultLimit.label')"
       :placeholder="t('resourceQuota.namespaceDefaultLimit.storagePlaceholder')"
+      output-suffix-text="Gi"
+      :input-exponent="3"
+      :increment="1024"
     />
   </div>
 </template>

--- a/components/form/UnitInput.vue
+++ b/components/form/UnitInput.vue
@@ -8,14 +8,10 @@ export default {
 
   props: {
     // Convert output to string
+    // Output will also be a string regardless of this prop if outputModifer = true
     outputAs: {
       type:    String,
       default: 'number',
-    },
-    // Set suffix text on output
-    outputSuffixText: {
-      type:    String,
-      default: null
     },
 
     /* Append exponential modifier in output, eg "123Mi"
@@ -29,13 +25,18 @@ export default {
 
     /* Set modifier on base unit - positive vals map to UNITS array, negative to FRACTIONAL
       String input values with si notation will be converted to this measurement unit,
-      eg "1Gi" will become "1024Mi" if this is set to 2 */
+      eg "1Gi" will become "1024Mi" if this is set to 2
+      UNITS = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+      FRACTIONAL = ['', 'm', 'u', 'n', 'p', 'f', 'a', 'z', 'y'];
+    */
     inputExponent: {
       type:    Number,
       default: 0,
     },
 
-    // Combines with inputExponent to make displayed unit. Use 'suffix' if the input's units are strictly for display
+    /* Combines with inputExponent to make displayed unit.
+      Use 'suffix' if the input's units are strictly for display
+    */
     baseUnit: {
       type:    String,
       default: 'B',
@@ -47,13 +48,15 @@ export default {
       default: 1000,
     },
 
-    // Ignore baseUnit and inputExponent in favor of a display-only suffix; display/emit integers without SI conversion
+    /* Ignore baseUnit and inputExponent in favor of a display-only suffix
+        display/emit integers without SI conversion
+    */
     suffix: {
       type:    String,
       default: null,
     },
 
-    // LabeledInput Props
+    // LabeledInput props vv
     mode: {
       type:    String,
       default: _EDIT
@@ -133,6 +136,7 @@ export default {
           increment:        this.increment,
           addSuffix:        false,
           maxExponent:      this.inputExponent,
+          minExponent:      this.inputExponent,
         });
       }
 
@@ -156,6 +160,8 @@ export default {
         out = out === null ? null : `${ inputValue }${ this.unit }`;
       } else if ( this.outputAs === 'string' ) {
         out = out === null ? '' : `${ inputValue }`;
+      } else if (out) {
+        out = this.unit ? parseSi(`out${ this.unit }`) : parseInt(out);
       }
 
       this.$emit('input', out);

--- a/components/form/UnitInput.vue
+++ b/components/form/UnitInput.vue
@@ -56,7 +56,7 @@ export default {
       default: null,
     },
 
-    // LabeledInput props vv
+    // LabeledInput props
     mode: {
       type:    String,
       default: _EDIT

--- a/edit/autoscaling.horizontalpodautoscaler/metric-target.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/metric-target.vue
@@ -40,7 +40,6 @@ export default {
         value:      'AverageValue',
         specKey:    'averageValue',
         validTypes: ['resource', 'pod', 'object', 'external'],
-        default:    '80',
       },
       {
         label:      this.t('hpa.metricTarget.utilization.label'),
@@ -54,7 +53,6 @@ export default {
         value:      'Value',
         specKey:    'value',
         validTypes: ['object', 'external'],
-        default:    '80',
       },
     ];
 
@@ -74,6 +72,7 @@ export default {
 
   watch: {
     resourceName(newRn, _oldRn) {
+      // debugger;
       const {
         value: { type: metricType },
         targetTypes,
@@ -90,10 +89,11 @@ export default {
       }
 
       this.$set(this.value, match?.specKey, nueDefault);
-      this.quantity = match?.default ?? null;
+      this.quantity = nueDefault;
     },
 
     'value.type'(targetType, oldType) {
+      // debugger;
       const { targetTypes, resourceName } = this;
       const toDelete = findBy(targetTypes, { value: oldType });
       const nue = findBy(targetTypes, { value: targetType });
@@ -110,7 +110,7 @@ export default {
       delete this.value[toDelete.specKey];
 
       this.$set(this.value, nue?.specKey, nueDefault);
-      this.quantity = nue?.default ?? null;
+      this.quantity = nueDefault;
     },
   },
 
@@ -138,20 +138,10 @@ export default {
       return quantity;
     },
     updateQuantityValue(val) {
-      switch (this.value.type) {
-      case 'Value':
+      if (this.value?.type === 'Value') {
         this.$set(this.value, 'value', val);
-        break;
-      case 'AverageValue':
-      default:
-        if (this.resourceName === 'cpu') {
-          this.$set(this.value, 'averageValue', `${ val }m`);
-        } else if (this.resourceName === 'memory') {
-          this.$set(this.value, 'averageValue', `${ val }Mi`);
-        } else {
-          this.$set(this.value, 'averageValue', val);
-        }
-        break;
+      } else {
+        this.$set(this.value, 'averageValue', val);
       }
     },
   },

--- a/edit/autoscaling.horizontalpodautoscaler/metric-target.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/metric-target.vue
@@ -187,7 +187,8 @@ export default {
           :mode="mode"
           :placeholder="t('containerResourceLimit.cpuPlaceholder')"
           :required="true"
-          :suffix="t('suffix.cpus')"
+          :base-unit="t('suffix.cpus')"
+          :output-modifier="true"
           @input="updateQuantityValue"
         />
         <UnitInput
@@ -198,7 +199,8 @@ export default {
           :mode="mode"
           :placeholder="t('containerResourceLimit.memPlaceholder')"
           :required="true"
-          :suffix="t('suffix.ib')"
+          :output-modifier="true"
+          :increment="1024"
           @input="updateQuantityValue"
         />
       </div>

--- a/edit/harvesterhci.io.volume.vue
+++ b/edit/harvesterhci.io.volume.vue
@@ -11,7 +11,6 @@ import { HCI } from '@/config/types';
 import { sortBy } from '@/utils/sort';
 import { InterfaceOption } from '@/config/harvester-map';
 import { _CREATE } from '@/config/query-params';
-import { formatSi, parseSi } from '@/utils/units';
 import CreateEditView from '@/mixins/create-edit-view';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 
@@ -39,7 +38,7 @@ export default {
       this.value.spec.accessModes = ['ReadWriteMany'];
     }
 
-    const storage = this.getSize(this.value.spec.resources.requests.storage);
+    const storage = this.value?.spec?.resources?.requests?.storage || null;
     const imageId = get(this.value, `metadata.annotations."${ HCI_ANNOTATIONS.IMAGE_ID }"`);
     const source = !imageId ? 'blank' : 'url';
 
@@ -107,7 +106,7 @@ export default {
 
       const spec = {
         ...this.value.spec,
-        resources: { requests: { storage: `${ this.storage }Gi` } },
+        resources: { requests: { storage: this.storage } },
         storageClassName
       };
 
@@ -116,20 +115,6 @@ export default {
       this.$set(this.value, 'spec', spec);
     },
 
-    getSize(storage, addSuffix = false) {
-      if (!storage) {
-        return null;
-      }
-
-      const kibUnitSize = parseSi(storage);
-
-      return formatSi(kibUnitSize, {
-        addSuffix,
-        increment:   1024,
-        minExponent: 3,
-        maxExponent: 3
-      });
-    }
   }
 };
 </script>
@@ -174,7 +159,9 @@ export default {
           <UnitInput
             v-model="storage"
             :label="t('harvester.volume.size')"
-            suffix="MiB"
+            :input-exponent="3"
+            :output-modifier="true"
+            :increment="1024"
             :mode="mode"
             required
             class="mb-20"

--- a/edit/harvesterhci.io.volume.vue
+++ b/edit/harvesterhci.io.volume.vue
@@ -174,8 +174,7 @@ export default {
           <UnitInput
             v-model="storage"
             :label="t('harvester.volume.size')"
-            suffix="iB"
-            :input-exponent="3"
+            suffix="MiB"
             :mode="mode"
             required
             class="mb-20"

--- a/edit/harvesterhci.io.volume.vue
+++ b/edit/harvesterhci.io.volume.vue
@@ -176,7 +176,6 @@ export default {
             :label="t('harvester.volume.size')"
             suffix="iB"
             :input-exponent="3"
-            :output-exponent="3"
             :mode="mode"
             required
             class="mb-20"

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
@@ -1,5 +1,4 @@
 <script>
-import { formatSi, parseSi } from '@/utils/units';
 import UnitInput from '@/components/form/UnitInput';
 import InputOrDisplay from '@/components/InputOrDisplay';
 
@@ -29,7 +28,7 @@ export default {
   data() {
     return {
       localCpu:    this.cpu,
-      localMemory: this.getSize(this.memory)
+      localMemory: this.memory
     };
   },
 
@@ -49,7 +48,7 @@ export default {
     },
     memory(neu) {
       if (neu && !neu.includes('null')) {
-        this.localMemory = this.getSize(neu);
+        this.localMemory = neu;
       }
     }
   },
@@ -69,20 +68,6 @@ export default {
       this.$emit('updateCpuMemory', this.localCpu, memory);
     },
 
-    getSize(storage) {
-      if (!storage) {
-        return null;
-      }
-
-      const kibUnitSize = parseSi(storage);
-
-      return formatSi(kibUnitSize, {
-        addSuffix:   false,
-        increment:   1024,
-        minExponent: 3,
-        maxExponent: 3
-      });
-    },
   }
 };
 </script>
@@ -96,8 +81,6 @@ export default {
           v-int-number
           label="CPU"
           suffix="C"
-          :increment="1"
-          :input-exponent="0"
           required
           :disabled="disabled"
           :mode="mode"
@@ -112,9 +95,10 @@ export default {
           v-model="localMemory"
           v-int-number
           :label="t('harvester.virtualMachine.input.memory')"
-          suffix="iB"
           :mode="mode"
           :input-exponent="3"
+          :increment="1024"
+          :output-modifier="true"
           :disabled="disabled"
           required
           class="mb-20"

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue
@@ -115,7 +115,6 @@ export default {
           suffix="iB"
           :mode="mode"
           :input-exponent="3"
-          :output-exponent="3"
           :disabled="disabled"
           required
           class="mb-20"

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
@@ -230,7 +230,7 @@ export default {
         <InputOrDisplay :name="t('harvester.fields.size')" :value="value.size" :mode="mode">
           <UnitInput
             v-model="value.size"
-            output-suffic-text="Gi"
+            output-suffix-text="Gi"
             output-as="string"
             :label="t('harvester.fields.size')"
             suffix="GiB"

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/existing.vue
@@ -230,10 +230,10 @@ export default {
         <InputOrDisplay :name="t('harvester.fields.size')" :value="value.size" :mode="mode">
           <UnitInput
             v-model="value.size"
-            output-suffix-text="Gi"
-            output-as="string"
+            :output-modifier="true"
+            :increment="1024"
+            :input-exponent="3"
             :label="t('harvester.fields.size')"
-            suffix="GiB"
             :mode="mode"
             :disabled="true"
           />

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -191,8 +191,9 @@ export default {
         <InputOrDisplay :name="t('harvester.fields.size')" :value="value.size" :mode="mode">
           <UnitInput
             v-model="value.size"
-            output-suffix-text="Gi"
-            output-as="string"
+            :output-modifier="true"
+            :increment="1024"
+            :input-exponent="3"
             :label="t('harvester.fields.size')"
             :mode="mode"
             :required="validateRequired"

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/vmImage.vue
@@ -191,7 +191,7 @@ export default {
         <InputOrDisplay :name="t('harvester.fields.size')" :value="value.size" :mode="mode">
           <UnitInput
             v-model="value.size"
-            output-suffic-text="Gi"
+            output-suffix-text="Gi"
             output-as="string"
             :label="t('harvester.fields.size')"
             :mode="mode"

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -132,12 +132,12 @@ export default {
         <InputOrDisplay :name="t('harvester.fields.size')" :value="value.size" :mode="mode">
           <UnitInput
             v-model="value.size"
-            output-suffix-text="Gi"
-            output-as="string"
+            :output-modifier="true"
+            :increment="1024"
+            :input-exponent="3"
             :mode="mode"
             :required="validateRequired"
             :label="t('harvester.fields.size')"
-            suffix="GiB"
             :disabled="isDisabled"
           />
         </InputOrDisplay>

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineVolume/type/volume.vue
@@ -132,7 +132,7 @@ export default {
         <InputOrDisplay :name="t('harvester.fields.size')" :value="value.size" :mode="mode">
           <UnitInput
             v-model="value.size"
-            output-suffic-text="Gi"
+            output-suffix-text="Gi"
             output-as="string"
             :mode="mode"
             :required="validateRequired"

--- a/utils/units.js
+++ b/utils/units.js
@@ -16,14 +16,13 @@ export function formatSi(inValue, {
   const divide = maxExponent >= 0;
 
   // TODO More to think about re: min > max
-
   if (divide) {
     while ( ( val >= increment && exp + 1 < UNITS.length && exp < maxExponent ) || exp < minExponent ) {
       val = val / increment;
       exp++;
     }
   } else {
-    while ( ( val < increment && exp + 1 < FRACTIONAL.length && exp < (maxExponent * -1) ) || exp < minExponent ) {
+    while ( ( val < increment && exp + 1 < FRACTIONAL.length && exp < (maxExponent * -1) ) || exp < (minExponent * -1) ) {
       val = val * increment;
       exp++;
     }

--- a/utils/units.js
+++ b/utils/units.js
@@ -13,11 +13,20 @@ export function formatSi(inValue, {
 } = {}) {
   let val = inValue;
   let exp = startingExponent;
+  const divide = maxExponent >= 0;
 
   // TODO More to think about re: min > max
-  while ( ( val >= increment && exp + 1 < UNITS.length && exp < maxExponent ) || exp < minExponent ) {
-    val = val / increment;
-    exp++;
+
+  if (divide) {
+    while ( ( val >= increment && exp + 1 < UNITS.length && exp < maxExponent ) || exp < minExponent ) {
+      val = val / increment;
+      exp++;
+    }
+  } else {
+    while ( ( val < increment && exp + 1 < FRACTIONAL.length && exp < (maxExponent * -1) ) || exp < minExponent ) {
+      val = val * increment;
+      exp++;
+    }
   }
 
   let out = '';
@@ -32,7 +41,7 @@ export function formatSi(inValue, {
     if ( exp === 0 && firstSuffix !== null) {
       out += ` ${ firstSuffix }`;
     } else {
-      out += ` ${ UNITS[exp] }${ suffix }` || '';
+      out += ` ${ divide ? UNITS[exp] : FRACTIONAL[exp] }${ suffix }` || '';
     }
   }
 


### PR DESCRIPTION
#4417 - this PR fixes/simplifies/clarifies UnitInput's ability to parse and format SI values. There are some kubernetes resources with fields that accept either an integer base unit or a string with an exponential modifier; eg ResourceQuota memory reservation can be specified as an integer 524288 (Bytes) or string "0.5Mi" (Bytes) or "512Ki". UnitInput had some code that looked intended to deal with these type of values but it wasn't quite working, and was hard to follow...

 Namespace/workload resource limits used a different component to parse SI values, Projects used the vanilla UnitInput (simply doesn't work right in that case, hence the bug report), and the Harvester team added two more props to UnitInput to deal with it in a different way. All that now works in the same way with this PR.
 
This updated UnitInput accepts either a plain integer or a string with SI modifier, parses the string into a base unit integer, displays it with whatever exponential modifier is specified by `inputExponent` and outputs either a string with exponential modifier, or an integer the equivalent value converted to base units.
 
 UnitInput is also used in a ton of places as a simple integer input with a unit label displayed next to it. Those uses should be unchanged by this PR.