### PR TITLE
Automatically handle conflicts on resource edit

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4311,6 +4311,10 @@ validation:
   chars: '"{key}" contains {count, plural, =1 {an invalid character} other {# invalid characters}}: {chars}'
   cluster:
     name: Cluster name cannot be 'local' or take the form 'c-xxxxx'
+  conflict: |-
+    This resource has been modified since you started editing it, and some of those modifications conflict with your changes.
+    This screen has been updated to reflect the current values on the cluster. Review and reapply the changes you wanted to make, then Save again.
+    Conflicting {fieldCount, plural, =1 {field} other {fields}}: {fields}
   custom:
     missing: 'No validtor exists for { validatorName }! Does the validtor exist in custom-validtors? Is the name spelled correctly?'
   dns:

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -1,4 +1,7 @@
 <script lang="ts">
+
+import { nlToBr } from '@/utils/string';
+
 export default {
   props: {
     color: {
@@ -17,16 +20,16 @@ export default {
       type:    Boolean,
       default: false,
     }
-  }
+  },
+
+  methods: { nlToBr },
 };
 </script>
 <template>
   <div class="banner" :class="{[color]: true, closable}">
     <slot>
       <t v-if="labelKey" :k="labelKey" :raw="true" />
-      <template v-else>
-        {{ label }}
-      </template>
+      <span v-else v-html="nlToBr(label)" />
     </slot>
     <div v-if="closable" class="closer" @click="$emit('close')">
       <i class="icon icon-2x icon-close closer-icon" />

--- a/edit/fleet.cattle.io.gitrepo.vue
+++ b/edit/fleet.cattle.io.gitrepo.vue
@@ -319,8 +319,8 @@ export default {
           spec.insecureSkipTLSVerify = false;
         }
 
-        if ( this.originalValue.caBundle ) {
-          spec.caBundle = this.originalValue.caBundle;
+        if ( this.liveValue.caBundle ) {
+          spec.caBundle = this.liveValue.caBundle;
         } else {
           delete spec.caBundle;
         }

--- a/edit/management.cattle.io.user.vue
+++ b/edit/management.cattle.io.user.vue
@@ -235,7 +235,7 @@ export default {
       <div v-if="showGlobalRoles" class="global-permissions">
         <GlobalRoleBindings
           ref="grb"
-          :user-id="value.id || originalValue.id"
+          :user-id="value.id || liveValue.id"
           :mode="mode"
           :real-mode="realMode"
           type="user"

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -30,8 +30,8 @@ export default {
   data() {
     let originalQuotaId = null;
 
-    if ( this.originalValue?.metadata?.name ) {
-      originalQuotaId = `${ this.originalValue.metadata.name }/default-quota`;
+    if ( this.liveValue?.metadata?.name ) {
+      originalQuotaId = `${ this.liveValue.metadata.name }/default-quota`;
     }
     let projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID];
     const projects = this.$store.getters['management/all'](MANAGEMENT.PROJECT);

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -410,7 +410,8 @@ export default {
     <Rke2Config
       v-else-if="subType"
       v-model="value"
-      :original-value="originalValue"
+      :initial-value="initialValue"
+      :live-value="liveValue"
       :mode="mode"
       :provider="subType"
     />

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -376,7 +376,7 @@ export default {
         });
       }
 
-      const cur = this.originalValue?.spec?.kubernetesVersion || '';
+      const cur = this.liveValue?.spec?.kubernetesVersion || '';
       const existingRke2 = this.mode === _EDIT && cur.includes('rke2');
       const existingK3s = this.mode === _EDIT && cur.includes('k3s');
       const rke2 = filterAndMap(this.rke2Versions, (existingRke2 ? cur : null), cur);

--- a/edit/resources.cattle.io.restore.vue
+++ b/edit/resources.cattle.io.restore.vue
@@ -79,7 +79,7 @@ export default {
 
   computed: {
     isClone() {
-      return this.mode === _CREATE && !!this.originalValue.id;
+      return this.mode === _CREATE && !!this.liveValue.id;
     },
 
     availableBackups() {

--- a/edit/secret/index.vue
+++ b/edit/secret/index.vue
@@ -53,7 +53,7 @@ export default {
   data() {
     const newCloudCred = this.$route.query[CLOUD_CREDENTIAL] === _FLAGGED;
     const editCloudCred = this.mode === _EDIT && this.value._type === TYPES.CLOUD_CREDENTIAL;
-    const cloneCloudCred = this.realMode === _CLONE && this.originalValue._type === TYPES.CLOUD_CREDENTIAL;
+    const cloneCloudCred = this.realMode === _CLONE && this.liveValue._type === TYPES.CLOUD_CREDENTIAL;
     const isCloud = newCloudCred || editCloudCred || cloneCloudCred;
 
     if ( newCloudCred ) {

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -419,7 +419,7 @@ export default {
       const out = [...this.allContainers];
 
       if (!this.isView) {
-        out.push({ name: 'Add Container', _add: true });
+        out.push({ name: 'Add Container', __add: true });
       }
 
       return out;
@@ -467,7 +467,7 @@ export default {
 
     container(neu) {
       const containers = this.isInitContainer ? this.podTemplateSpec.initContainers : this.podTemplateSpec.containers;
-      const existing = containers.filter(container => container._active)[0];
+      const existing = containers.filter(container => container.__active)[0];
 
       Object.assign(existing, neu);
     }
@@ -654,17 +654,17 @@ export default {
     },
 
     selectContainer(container) {
-      if (container._add) {
+      if (container.__add) {
         this.addContainer();
 
         return;
       }
       (this.allContainers || []).forEach((container) => {
-        if (container._active) {
-          delete container._active;
+        if (container.__active) {
+          delete container.__active;
         }
       });
-      container._active = true;
+      container.__active = true;
       this.container = container;
       this.isInitContainer = !!container._init;
       this.containerChange++;

--- a/edit/workload/storage/persistentVolumeClaim/index.vue
+++ b/edit/workload/storage/persistentVolumeClaim/index.vue
@@ -57,7 +57,7 @@ export default {
 
   async fetch() {
     // Create the new PVC form state if it doesn't exist
-    if (this.value._newPvc) {
+    if (this.value.__newPvc) {
       return;
     }
     const namespace = this.namespace || this.$store.getters['defaultNamespace'];
@@ -69,7 +69,7 @@ export default {
     const pvc = await this.$store.dispatch('cluster/create', data);
 
     pvc.applyDefaults();
-    this.$set(this.value, '_newPvc', pvc);
+    this.$set(this.value, '__newPvc', pvc);
   },
 
   computed: {
@@ -83,10 +83,10 @@ export default {
 
   watch: {
     namespace(neu) {
-      this._newPvc.metadata.namespace = neu;
+      this.__newPvc.metadata.namespace = neu;
     },
 
-    'value._newPvc.metadata.name'(neu) {
+    'value.__newPvc.metadata.name'(neu) {
       this.value.persistentVolumeClaim.claimName = neu;
     }
   },
@@ -104,8 +104,8 @@ export default {
     <div>
       <div v-if="createNew" class="bordered-section">
         <PersistentVolumeClaim
-          v-if="value._newPvc"
-          v-model="value._newPvc"
+          v-if="value.__newPvc"
+          v-model="value.__newPvc"
           :mode="mode"
           :register-before-hook="registerBeforeHook"
           :save-pvc-hook-name="savePvcHookName"

--- a/mixins/create-edit-view/index.js
+++ b/mixins/create-edit-view/index.js
@@ -20,12 +20,20 @@ export default {
       default: _YAML,
     },
 
+    // The model to be manipulated by the form
     value: {
       type:     Object,
       required: true,
     },
 
-    originalValue: {
+    // A clone of the model before it's been changed, for conflict resolution
+    initialValue: {
+      type:     Object,
+      default: null,
+    },
+
+    // The 'live' equivalent of this model in the store
+    liveValue: {
       type:     Object,
       default: null,
     },

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -1,5 +1,4 @@
 import https from 'https';
-import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
 import { SCHEMA } from '@/config/types';
 import { createYaml } from '@/utils/create-yaml';

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -486,9 +486,7 @@ export default {
   },
 
   clone(ctx, { resource } = {}) {
-    const copy = cloneDeep(resource.toJSON());
-
-    return classify(ctx, copy, true);
+    return classify(ctx, resource.toJSON(), true);
   },
 
   promptMove({ commit, state }, resources) {

--- a/plugins/steve/normalize.js
+++ b/plugins/steve/normalize.js
@@ -15,51 +15,41 @@ export function normalizeType(type) {
   return type;
 }
 
-/*
-export function parseType(type) {
-  const match = type.match(/^(.*)\.(v\d[^.]*)\.([^.]+)$/);
+const diffRootKeys = [
+  'actions', 'links', 'status', '__rehydrate', '__clone'
+];
 
-  if ( match ) {
-    return {
-      group:   match[1],
-      version: match[2],
-      type:    match[3]
-    };
-  }
-}
+const diffMetadataKeys = [
+  'ownerReferences',
+  'selfLink',
+  'creationTimestamp',
+  'deletionTimestamp',
+  'state',
+  'fields',
+  'relationships',
+  'generation',
+  'managedFields',
+  'resourceVersion',
+];
 
-export function stripVersion(type) {
-  const match = parseType(type);
+const newRootKeys = [
+  'actions', 'links', 'status', 'id'
+];
 
-  if ( !match ) {
-    return type;
-  }
-
-  return `${ match.group }.${ match.type }`;
-}
-*/
+const newMetadataKeys = [
+  ...diffMetadataKeys,
+  'uid',
+];
 
 export function cleanForNew(obj) {
-  delete obj.id;
-  delete obj.actions;
-  delete obj.links;
-  delete obj.status;
+  const m = obj.metadata || {};
 
-  if ( obj.metadata ) {
-    const m = obj.metadata;
+  dropKeys(obj, newRootKeys);
+  dropKeys(m, newMetadataKeys);
+  dropCattleKeys(m.annotations);
+  dropCattleKeys(m.labels);
 
-    m.name = '';
-    delete m.uid;
-    delete m.ownerReferences;
-    delete m.generation;
-    delete m.resourceVersion;
-    delete m.selfLink;
-    delete m.creationTimestamp;
-    delete m.deletionTimestamp;
-    delete m.state;
-    dropKeys(m.annotations);
-    dropKeys(m.labels);
-  }
+  m.name = '';
 
   if ( obj?.spec?.crd?.spec?.names?.kind ) {
     obj.spec.crd.spec.names.kind = '';
@@ -68,8 +58,41 @@ export function cleanForNew(obj) {
   return obj;
 }
 
-function dropKeys(obj) {
-  Object.keys(obj || {}).forEach((key) => {
+export function cleanForDiff(obj) {
+  const m = obj.metadata || {};
+
+  if ( !m.labels ) {
+    m.labels = {};
+  }
+
+  if ( !m.annotations ) {
+    m.annotations = {};
+  }
+
+  dropKeys(obj, diffRootKeys);
+  dropKeys(m, diffMetadataKeys);
+  dropCattleKeys(m.annotations);
+  dropCattleKeys(m.labels);
+
+  return obj;
+}
+
+function dropKeys(obj, keys) {
+  if ( !obj ) {
+    return;
+  }
+
+  for ( const k of keys ) {
+    delete obj[k];
+  }
+}
+
+function dropCattleKeys(obj) {
+  if ( !obj ) {
+    return;
+  }
+
+  Object.keys(obj).forEach((key) => {
     if ( !!key.match(/(^|field\.)cattle\.io(\/.*|$)/) ) {
       delete obj[key];
     }

--- a/plugins/steve/normalize.js
+++ b/plugins/steve/normalize.js
@@ -1,4 +1,5 @@
 import { SCHEMA } from '@/config/types';
+import isObject from 'lodash/isObject';
 
 export const KEY_FIELD_FOR = {
   [SCHEMA]:  '_id',
@@ -69,12 +70,27 @@ export function cleanForDiff(obj) {
     m.annotations = {};
   }
 
+  dropUnderscores(obj);
   dropKeys(obj, diffRootKeys);
   dropKeys(m, diffMetadataKeys);
   dropCattleKeys(m.annotations);
   dropCattleKeys(m.labels);
 
   return obj;
+}
+
+function dropUnderscores(obj) {
+  for ( const k in obj ) {
+    if ( k.startsWith('__') ) {
+      delete obj[k];
+    } else {
+      const v = obj[k];
+
+      if ( isObject(v) ) {
+        dropUnderscores(v);
+      }
+    }
+  }
 }
 
 function dropKeys(obj, keys) {

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -11,7 +11,7 @@ import { addObject, addObjects, findBy, removeAt } from '@/utils/array';
 import CustomValidators from '@/utils/custom-validators';
 import { downloadFile, generateZip } from '@/utils/download';
 import { eachLimit } from '@/utils/promise';
-import { get } from '@/utils/object';
+import { clone, get } from '@/utils/object';
 import { DEV } from '@/store/prefs';
 import { sortableNumericSuffix } from '@/utils/sort';
 import {
@@ -1492,7 +1492,7 @@ export default class Resource {
       if ( this[k]?.toJSON ) {
         out[k] = this[k].toJSON();
       } else {
-        out[k] = this[k];
+        out[k] = clone(this[k]);
       }
     }
 

--- a/utils/string.js
+++ b/utils/string.js
@@ -254,6 +254,24 @@ export function splitObjectPath(path) {
   return path.split('.');
 }
 
+export function joinObjectPath(ary) {
+  let out = '';
+
+  for ( const p of ary ) {
+    if ( p.includes('.') ) {
+      out += `."${ p }"`;
+    } else {
+      out += `.${ p }`;
+    }
+  }
+
+  if ( out.startsWith('.') ) {
+    out = out.substr(1);
+  }
+
+  return out;
+}
+
 export function shortenedImage(image) {
   return (image || '')
     .replace(/^(index\.)?docker.io\/(library\/)?/, '')


### PR DESCRIPTION
#1324

If a save PUT returns a 409 conflict error, something has changed on the server side (/ liveValue) since they started editing and the resourceVersion submitted is too old.  This does not necessarily mean that any changes requested _actually_ conflict.  For example you might be editing the image name and someone changed the scale while you were editing.

This changes the edit flow to keep track of 3 copies of the target resource.
  - value: The clone created at the time the user clicks edit that they are manipulating
  - liveValue: The 'live' object still in the store (previously "originalModel")
  - initialValue: A new clone created at the time the user clicks edit.  This doesn't get written to but is used to tell what the user has changed.

Then we generate a list of the changes made between `initialValue` and `value` to get what (someone) has changed in the background, and another one from `initialValue` to `value` to get what the user has changed.

If there are no actually conflicting changes, apply the new info from the live copy, update the resourceVersion and re-trigger save.

If there are one or more actual conflicts (e.g. spec.replicas was initially 3, you changed it to 4 but something else changed it to 5 while you were editing), replace the value with the current one from the server and tell the user to figure it out what they want now.
