### PR TITLE
Fix duplicate "Group by Project" views in Groups/Namespace - #4455

### DIFF
--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -78,8 +78,7 @@ export default {
       return this.projects.filter(project => project.spec.clusterName === clusterId);
     },
     projectsWithoutNamespaces() {
-      return this.clusterProjects
-        .filter(project => !this.projectIdsWithNamespaces.includes(project.name));
+      return this.clusterProjects.filter(project => !!this.projectIdsWithNamespaces.find(item => item.endsWith(`/${ project.id }`)));
     },
     // We're using this because we need to show projects as groups even if the project doesn't have any namespaces.
     rowsWithFakeNamespaces() {


### PR DESCRIPTION
## Summary

Issue #4455 - Projects in "Group by Project" view are duplicated

## Technical notes
- `/v1/namespaces` contains properties `field.cattle.io/projectId: p-b8pkf` or  `local:p-b8pkf`.
![image](https://user-images.githubusercontent.com/1387263/141450835-2e3a7274-edff-4958-a766-b83f306f155f.png)

- `/v1/management.cattle.io.projects` has  `id:"local/p-b8pkf"`.
![image](https://user-images.githubusercontent.com/1387263/141450961-f4e4408c-c601-4563-9db0-18debc49c991.png)

- This discrepancy in the properties cause the filter to break.
https://github.com/rancher/dashboard/blob/a17c7de013b524e970377b266fa15b95b45f0308/pages/c/_cluster/_product/projectsnamespaces.vue#L80-L83

- Fix was applied on UI iterate over the projects and match the IDs, instead of API to compensate for this discrepancy.

## Steps to test

1. Navigate to Explore Cluster > Local -> Projects/Namespaces
2. Scroll down and you should now only see 1 project view

![image](https://user-images.githubusercontent.com/1387263/141449652-c516ae4c-523a-4217-af8f-8df876ac0663.png)

  
