### PR TITLE
Add unique key to ingress rules

### DIFF
--- a/edit/networking.k8s.io.ingress/Rules.vue
+++ b/edit/networking.k8s.io.ingress/Rules.vue
@@ -4,6 +4,7 @@ import Loading from '@/components/Loading';
 import SortableTable from '@/components/SortableTable';
 import { _VIEW } from '@/config/query-params';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
+import { random32 } from '@/utils/string';
 import Rule from './Rule';
 
 export default {
@@ -35,6 +36,14 @@ export default {
 
   async fetch() {
     await Promise.all(Object.values(WORKLOAD_TYPES).map(type => this.$store.dispatch('cluster/findAll', { type })));
+  },
+
+  beforeUpdate() {
+    for (const rule of this.value.spec.rules) {
+      if (!rule.vKey) {
+        this.$set(rule, 'vKey', random32(1));
+      }
+    }
   },
 
   computed: {
@@ -113,6 +122,7 @@ export default {
       <template #default="props">
         <Rule
           ref="lastRule"
+          :key="props.row.value.vKey"
           v-model="props.row.value"
           :service-targets="serviceTargets"
           :ingress="value"


### PR DESCRIPTION
Reference #4400 

**Original Issue**
Deleting multiple `ingress` rules would show the last rule of an array of rules to be deleted instead of the selected rule. The spec was being saved correctly, only the UI was showing something different.

**Cause**
Each `Rule` component did not have a unique `key`, so Vue would automatically select the last known object in the array to delete.

**Fix**
Added a method in the `beforeUpdate` hook to generate a unique `vKey` for each `Rule` component.


https://user-images.githubusercontent.com/40806497/141495016-aac279a4-1d79-4d76-95dd-9479f9914d7c.mp4


