### PR TITLE
Handle non string values in tables - #4504

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -2,7 +2,7 @@
 import { mapState } from 'vuex';
 import { dasherize, ucFirst } from '@/utils/string';
 import { get, clone } from '@/utils/object';
-import { isArray, removeObject, filterBy } from '@/utils/array';
+import { removeObject, filterBy } from '@/utils/array';
 import Checkbox from '@/components/form/Checkbox';
 import ActionDropdown from '@/components/ActionDropdown';
 import $ from 'jquery';
@@ -418,11 +418,26 @@ export default {
         return '';
       }
 
-      if ( isArray(out) ) {
-        return out[0];
+      return out;
+    },
+
+    /**
+     * Format values to render in the sorted table
+     * In the absence of predefined formatter table would use this
+     *
+     * @param {Object} row
+     * @param {Object} col
+     *
+     * @return {String}
+     */
+    formatValue(row, col) {
+      const valFor = this.valueFor(row, col);
+
+      if ( Array.isArray(valFor) ) {
+        return valFor.join(', ');
       }
 
-      return out;
+      return valFor;
     },
 
     isExpanded(row) {
@@ -673,7 +688,7 @@ export default {
                           v-bind="col.formatterOpts"
                         />
                         <template v-else-if="valueFor(row,col) !== ''">
-                          {{ valueFor(row,col) }}
+                          {{ formatValue(row,col) }}
                         </template>
                         <template v-else-if="col.dashIfEmpty">
                           <span class="text-muted">&mdash;</span>


### PR DESCRIPTION
## Summary

Issue #4504 - When creating new cluster flow, getting an error: TypeError: this.value.join is not a function.

## Technical notes
- Column values can be any type. e.g. String, array etc.
- Usually the col.formatter define the component dynamically which would use to render the values. 
- In a previous commit following change was introduced that handles situations where `col.formatter` doesn't exist and has a single value and returns a string.

https://github.com/rancher/dashboard/commit/1208725f6af71e50ba3d8ff35458d54cbe4f840b#diff-1a2277d92947d83bba624b418c7879f3fa45d44df0bb93f741aa3ae7c4b7df43R421-R424

- This means that now when `col.formatter` is `LIST` component and it throws an exception because it's expecting an array, instead of a string.
- Therefore new function `formatValue()` was added to handle situations where `col.formatter` is not defined instead of modifying the original value before it get passed into `valueFor`

## Steps to test
1. Cluster flow
   1. Install rancher logging v2 chart on an active cluster
   2. Create Secret
   3. Create Cluster Output
   4. Create `Cluster Flow` pointing to the Cluster Output in step 3
   5. Click `Create`
   6. It should not throw errors anymore.

2. Should also test other tables to ensure that this change haven't broken something elsewhere.
