### PR TITLE
Validate Epinio service names

### DIFF
--- a/components/form/InputWithSelect.vue
+++ b/components/form/InputWithSelect.vue
@@ -70,6 +70,13 @@ export default {
       type:    String,
       default: '',
     },
+
+    validators: {
+      type:    Array,
+      default: () => {
+        return [];
+      }
+    }
   },
 
   data() {
@@ -105,7 +112,7 @@ export default {
       v-if="selectLabel"
       v-model="selected"
       :label="selectLabel"
-      :class="{ 'in-input': !isView }"
+      :class="{ 'in-input': !isView, 'validation-space': true}"
       :options="options"
       :searchable="false"
       :clearable="false"
@@ -146,7 +153,9 @@ export default {
       :disabled="disabled"
       :required="textRequired"
       :mode="mode"
+      :validators="validators"
       v-bind="$attrs"
+      @setValid="(isValid) => { $emit('setValid', isValid) }"
     >
       <template #label>
         <slot name="label" />
@@ -245,5 +254,11 @@ export default {
       }
     }
   }
+}
+
+.validation-space {
+  // Prevent an input from growing if the input next to
+  // it has validation errors
+  height: 61px;
 }
 </style>

--- a/components/form/NameNsDescription.vue
+++ b/components/form/NameNsDescription.vue
@@ -19,7 +19,10 @@ export function normalizeName(str) {
 }
 
 export default {
-  components: { LabeledInput, InputWithSelect },
+  components: {
+    LabeledInput,
+    InputWithSelect,
+  },
 
   props: {
     value: {
@@ -42,7 +45,10 @@ export default {
       type:    Array,
       default: () => [],
     },
-
+    minHeight: {
+      type:    Number,
+      default: 30
+    },
     nameLabel: {
       type:    String,
       default: 'nameNsDescription.name.label',
@@ -128,7 +134,13 @@ export default {
     horizontal: {
       type:    Boolean,
       default: true,
-    }
+    },
+    validators: {
+      type:    Array,
+      default: () => {
+        return [];
+      },
+    },
   },
 
   data() {
@@ -313,7 +325,9 @@ export default {
             :options="namespaces"
             :searchable="true"
             :taggable="namespaceNewAllowed"
+            :validators="validators"
             @input="changeNameAndNamespace($event)"
+            @setValid="(isValid) => { $emit('setValid', isValid) }"
           />
           <LabeledInput
             v-else
@@ -336,7 +350,7 @@ export default {
           :mode="mode"
           :label="t(descriptionLabel)"
           :placeholder="t(descriptionPlaceholder)"
-          :min-height="30"
+          :min-height="minHeight"
         />
       </div>
       <div


### PR DESCRIPTION
This PR validates that service names fulfill Kubernetes name requirements:

<img width="1271" alt="Screen Shot 2021-11-14 at 5 09 41 AM" src="https://user-images.githubusercontent.com/20599230/141732947-54d23072-2ed4-48cb-9207-0f78f7bb0b25.png">

There is not yet validation to make sure the service has at least one key-value pair, which is required on the back end. That can be in a separate PR.

The generic key-value pair component also doesn't validate that there are no duplicate keys because its underlying data structure is an array. But the value passed into the `v-model` for that component is an object, so when you try to create pairs with duplicate keys, it just drops all duplicates except for the last one. Before changing that I'd like to ask around and verify that there are no valid use cases for duplicated keys.