### PR TITLE
Add warning banner for existing workload port service names

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5780,6 +5780,7 @@ workloadPorts:
   addPort: Add Port
   remove: Remove
   addHost: Add Host
+  warning: 'The service port name: "{ originalName }" is already in use, please enter a new name or delete the service.'
 
 podAffinity:
   addLabel: Add Pod Selector

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5780,7 +5780,6 @@ workloadPorts:
   addPort: Add Port
   remove: Remove
   addHost: Add Host
-  warning: 'The service port name: "{ originalName }" is already in use, please enter a new name or delete the service.'
 
 podAffinity:
   addLabel: Add Pod Selector

--- a/components/form/WorkloadPorts.vue
+++ b/components/form/WorkloadPorts.vue
@@ -3,11 +3,13 @@ import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { removeAt, findBy } from '@/utils/array';
 import { clone } from '@/utils/object';
+import Banner from '@/components/Banner';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
   components: {
+    Banner,
     LabeledInput,
     LabeledSelect,
   },
@@ -123,6 +125,8 @@ export default {
         hostIP:        null,
         _showHost:     false,
         _serviceType:  '',
+        _needsNewName: false,
+        _originalName: null
       });
 
       this.queueUpdate();
@@ -155,10 +159,17 @@ export default {
     },
 
     selectServiceType(row) {
-      delete row.name;
-      if (row._listeningPort) {
-        delete row._listeningPort;
-      }
+      this.services.map((svc) => {
+        const selectedService = svc.spec.ports.filter(port => port.name === row._name);
+
+        if (selectedService) {
+          delete row.name;
+
+          row._needsNewName = true;
+          row._originalName = selectedService[0]?.name;
+        }
+      });
+
       this.queueUpdate();
     },
 
@@ -204,102 +215,106 @@ export default {
     <div
       v-for="(row, idx) in rows"
       :key="idx"
-      class="ports-row"
-      :class="{'show-host':row._showHost}"
     >
-      <div class="service-type col">
-        <LabeledSelect
-          v-model="row._serviceType"
-          :mode="mode"
-          :label="t('workload.container.ports.createService')"
-          :options="serviceTypes"
-          @input="selectServiceType(row)"
-        />
+      <div
+        class="ports-row"
+        :class="{'show-host':row._showHost}"
+      >
+        <div class="service-type col">
+          <LabeledSelect
+            v-model="row._serviceType"
+            :mode="mode"
+            :label="t('workload.container.ports.createService')"
+            :options="serviceTypes"
+            @input="selectServiceType(row)"
+          />
+        </div>
+
+        <div class="portName">
+          <LabeledInput
+            ref="name"
+            v-model="row.name"
+            :mode="mode"
+            :label="t('workload.container.ports.name')"
+            @input="queueUpdate"
+          />
+        </div>
+
+        <div class="port">
+          <LabeledInput
+            v-model.number="row.containerPort"
+            :mode="mode"
+            type="number"
+            min="1"
+            max="65535"
+            placeholder="e.g. 8080"
+            :label="t('workload.container.ports.containerPort')"
+            @input="queueUpdate"
+          />
+        </div>
+
+        <div class="protocol col">
+          <LabeledSelect
+            v-model="row.protocol"
+            :mode="mode"
+            :options="workloadPortOptions"
+            :multiple="false"
+            :label="t('workload.container.ports.protocol')"
+            @input="queueUpdate"
+          />
+        </div>
+
+        <div v-if="row._showHost" class="targetPort">
+          <LabeledInput
+            ref="port"
+            v-model.number="row.hostPort"
+            :mode="mode"
+            type="number"
+            min="1"
+            max="65535"
+            placeholder="e.g. 80"
+            :label="t('workload.container.ports.hostPort')"
+            @input="queueUpdate"
+          />
+        </div>
+
+        <div v-if="row._showHost" class="hostip">
+          <LabeledInput
+            ref="port"
+            v-model="row.hostIP"
+            :mode="mode"
+            placeholder="e.g. 1.1.1.1"
+            :label="t('workload.container.ports.hostIP')"
+            @input="queueUpdate"
+          />
+        </div>
+
+        <div v-if="!row._showHost && row._serviceType !== 'LoadBalancer' && row._serviceType !== 'NodePort'" class="add-host">
+          <button :disabled="mode==='view'" type="button" class="btn btn-sm role-tertiary" @click="row._showHost = true">
+            {{ t('workloadPorts.addHost') }}
+          </button>
+        </div>
+
+        <div v-if="row._serviceType === 'LoadBalancer' || row._serviceType === 'NodePort'">
+          <LabeledInput
+            ref="port"
+            v-model.number="row._listeningPort"
+            type="number"
+            :mode="mode"
+            :label="t('workload.container.ports.listeningPort')"
+            :required="row._serviceType === 'LoadBalancer' "
+            @input="queueUpdate"
+          />
+        </div>
+
+        <div v-if="showRemove" class="remove">
+          <button type="button" class="btn role-link" @click="remove(idx)">
+            {{ t('workloadPorts.remove') }}
+          </button>
+        </div>
       </div>
 
-      <div class="portName">
-        <LabeledInput
-          ref="name"
-          v-model="row.name"
-          :mode="mode"
-          :label="t('workload.container.ports.name')"
-          @input="queueUpdate"
-        />
-      </div>
-
-      <div class="port">
-        <LabeledInput
-          v-model.number="row.containerPort"
-          :mode="mode"
-          type="number"
-          min="1"
-          max="65535"
-          placeholder="e.g. 8080"
-          :label="t('workload.container.ports.containerPort')"
-          @input="queueUpdate"
-        />
-      </div>
-
-      <div class="protocol col">
-        <LabeledSelect
-          v-model="row.protocol"
-          :mode="mode"
-          :options="workloadPortOptions"
-          :multiple="false"
-          :label="t('workload.container.ports.protocol')"
-          @input="queueUpdate"
-        />
-      </div>
-
-      <div v-if="row._showHost" class="targetPort">
-        <LabeledInput
-
-          ref="port"
-          v-model.number="row.hostPort"
-          :mode="mode"
-          type="number"
-          min="1"
-          max="65535"
-          placeholder="e.g. 80"
-          :label="t('workload.container.ports.hostPort')"
-          @input="queueUpdate"
-        />
-      </div>
-
-      <div v-if="row._showHost" class="hostip">
-        <LabeledInput
-          ref="port"
-          v-model="row.hostIP"
-          :mode="mode"
-          placeholder="e.g. 1.1.1.1"
-          :label="t('workload.container.ports.hostIP')"
-          @input="queueUpdate"
-        />
-      </div>
-
-      <div v-if="!row._showHost && row._serviceType !== 'LoadBalancer' && row._serviceType !== 'NodePort'" class="add-host">
-        <button :disabled="mode==='view'" type="button" class="btn btn-sm role-tertiary" @click="row._showHost = true">
-          {{ t('workloadPorts.addHost') }}
-        </button>
-      </div>
-
-      <div v-if="row._serviceType === 'LoadBalancer' || row._serviceType === 'NodePort'">
-        <LabeledInput
-          ref="port"
-          v-model.number="row._listeningPort"
-          type="number"
-          :mode="mode"
-          :label="t('workload.container.ports.listeningPort')"
-          :required="row._serviceType === 'LoadBalancer' "
-          @input="queueUpdate"
-        />
-      </div>
-
-      <div v-if="showRemove" class="remove">
-        <button type="button" class="btn role-link" @click="remove(idx)">
-          {{ t('workloadPorts.remove') }}
-        </button>
-      </div>
+      <Banner v-if="mode === 'edit' && row.name === row._originalName" color="warning" :label="t('workloadPorts.warning', { originalName: row._originalName }, true)" />
     </div>
     <div v-if="showAdd" class="footer">
       <button type="button" class="btn role-tertiary add" @click="add()">

--- a/models/workload.js
+++ b/models/workload.js
@@ -361,6 +361,10 @@ export default class Workload extends SteveModel {
     ports.forEach((port) => {
       const name = port.name ? port.name : `${ port.containerPort }${ port.protocol.toLowerCase() }${ port.hostPort || port._listeningPort || '' }`;
 
+      if (port._serviceType && port._serviceType !== '') {
+        return;
+      }
+
       port.name = name;
       if (loadBalancerServicePorts.length) {
         const portSpec = findBy(loadBalancerServicePorts, 'name', name);


### PR DESCRIPTION
Reference #4398 

**Original issue**
When editing a workload's service ports, if you change the `serviceType` and use the original name the config will not be saved.

**Cause**
This bug is caused by Kubernetes attempting to create a new service with a name that is being used by an existing service. 

According to the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) a `ClusterIP` is necessary for both `NodePort` and `LoadBalancer` service types.

>ClusterIP: Exposes the Service on a cluster-internal IP. Choosing this value makes the Service only reachable from within the cluster. This is the default ServiceType.
NodePort: Exposes the Service on each Node's IP at a static port (the NodePort). A ClusterIP Service, to which the NodePort Service routes, is automatically created. You'll be able to contact the NodePort Service, from outside the cluster, by requesting `<NodeIP>:<NodePort>`.
LoadBalancer: Exposes the Service externally using a cloud provider's load balancer. NodePort and ClusterIP Services, to which the external load balancer routes, are automatically created.

So if new a service type is selected a new name will be necessary as there will always be a `ClusterIP` service created regardless of the service type.   

Rather than forcibly deleting the service when a new `serviceType` is chosen, the user will be presented with a warning to enter a new name or to delete the existing service.

---

_Original service created_
![services](https://user-images.githubusercontent.com/40806497/142026936-f5dc043c-70a9-4472-a1f0-37bc2caa23ee.png)

_Ports detail_
![servicePorts](https://user-images.githubusercontent.com/40806497/142027081-49a4f60c-aea1-4bba-8dcc-cf0c36d3cc16.png)

---

_When a new name is given_
__Note the `ClusterIP` service__
![servicesTwo](https://user-images.githubusercontent.com/40806497/142027121-9702d2df-82a8-4cb5-88cf-dbe8e024c177.png)

---

**To test**

https://user-images.githubusercontent.com/40806497/142029448-23597876-0514-4d47-b5ff-efe4d26eb14c.mp4

