### PR TITLE
Show change password errors on edit

### DIFF
--- a/components/form/ChangePassword.vue
+++ b/components/form/ChangePassword.vue
@@ -174,6 +174,7 @@ export default {
     // Catch the 'create' case and there's no content
     this.validate();
   },
+
   methods: {
     passwordsMatch() {
       const match = this.passwordNew === this.passwordConfirm;
@@ -182,9 +183,11 @@ export default {
 
       return match;
     },
+
     baseIsUserGenPasswordValid() {
       return this.passwordsMatch() && !!this.passwordNew;
     },
+
     isValid() {
       if (this.isChange) {
         return !!this.passwordCurrent && (this.isRandomGenerated ? true : this.baseIsUserGenPasswordValid());
@@ -206,6 +209,7 @@ export default {
 
       return false;
     },
+
     validate() {
       const isValid = this.isValid();
 
@@ -220,6 +224,7 @@ export default {
         userChangeOnLogin: this.userChangeOnLogin
       });
     },
+
     async save(user) {
       if (this.isChange) {
         await this.changePassword();
@@ -227,9 +232,10 @@ export default {
           await this.deleteKeys();
         }
       } else if (this.isEdit) {
-        this.setPassword(user);
+        return this.setPassword(user);
       }
     },
+
     async setPassword(user) {
       // Error handling is catered for by caller
       await this.$store.dispatch('rancher/resourceAction', {
@@ -239,6 +245,7 @@ export default {
         body:          { newPassword: this.isRandomGenerated ? this.form.genP : this.form.newP },
       });
     },
+
     async changePassword() {
       try {
         await this.$store.dispatch('rancher/collectionAction', {
@@ -254,6 +261,7 @@ export default {
         throw err;
       }
     },
+
     async deleteKeys() {
       try {
         const tokens = await this.$store.dispatch('rancher/findAll', {

--- a/edit/management.cattle.io.user.vue
+++ b/edit/management.cattle.io.user.vue
@@ -115,6 +115,7 @@ export default {
         buttonDone(false);
       }
     },
+
     async createUser() {
       // Ensure username is unique (this does not happen in the backend)
       const users = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.USER });
@@ -137,6 +138,7 @@ export default {
 
       return this.$store.dispatch('management/find', { type: MANAGEMENT.USER, id: newNormanUser.id });
     },
+
     async editUser() {
       if (!this.credentialsChanged) {
         return;
@@ -150,7 +152,7 @@ export default {
       // Save change of password
       // - Password must be changed before editing mustChangePassword (setpassword action sets this to false)
       if (this.form.password.password) {
-        this.$refs.changePassword.save(normanUser);
+        await this.$refs.changePassword.save(normanUser);
 
         // Why the wait? Without these the user updates below are ignored
         // - The update request succeeds and shows the correct values in it's response.
@@ -164,8 +166,10 @@ export default {
       normanUser.description = this.form.description;
       normanUser._name = this.form.displayName;
       normanUser.mustChangePassword = this.form.password.userChangeOnLogin;
-      await normanUser.save();
+
+      return normanUser.save();
     },
+
     async updateRoles(userId) {
       if (this.$refs.grb) {
         await this.$refs.grb.save(userId);


### PR DESCRIPTION
Wait for the change password response and show the error it contains on the edit screen, instead of blindly continuing.
