### PR TITLE
Resolve fleet cluster label saving issue

### DIFF
--- a/edit/fleet.cattle.io.cluster.vue
+++ b/edit/fleet.cattle.io.cluster.vue
@@ -35,8 +35,8 @@ export default {
       nc.metadata = {};
     }
 
-    nc.metadata.labels = nc._labels || {};
-    nc.metadata.annotations = nc._annotations || {};
+    nc.metadata.labels = nc.labels || {};
+    nc.metadata.annotations = nc.annotations || {};
 
     this.normanCluster = nc;
   },
@@ -56,11 +56,7 @@ export default {
       try {
         await this.value.save();
 
-        const nc = this.normanCluster;
-
-        nc._labels = nc.metadata.labels;
-        nc._annotations = nc.metadata.annotations;
-        await nc.save();
+        await this.normanCluster.save();
 
         this.done();
         buttonDone(true);

--- a/edit/fleet.cattle.io.cluster.vue
+++ b/edit/fleet.cattle.io.cluster.vue
@@ -35,9 +35,6 @@ export default {
       nc.metadata = {};
     }
 
-    nc.metadata.labels = nc.labels || {};
-    nc.metadata.annotations = nc.annotations || {};
-
     this.normanCluster = nc;
   },
 


### PR DESCRIPTION
This resolves an issue with Fleet Cluster labels that were not saving through the UI by removing the metadata assignment and just invoking `this.normanCluster.save()`.

Two things were uncovered while investigating this one:

1. `NormanModel` doesn't contain `_labels` or `_annotation` properties. This is a concern of mine, because there was an update from not too long ago that explicitly makes use of these properties and I don't believe that to be a mistake. This leads me to believe something has changed, but I don't know what
2. Assigning metadata values to the `labels` and `annotations` properties in `NormanModel` doesn't seem to make sense before saving. The labels component invokes `value.setLabels()` on `input`; `plugins/steve/norman-class.js` simply updates `this.labels` when `setLabels()` is invoked. It looks like something changed where we might have worked with metadata, but that no longer seems to be the case.

#4310