### PR TITLE
Fix ws won't reconnect after user logout and then login

### DIFF
--- a/plugins/steve/subscribe.js
+++ b/plugins/steve/subscribe.js
@@ -97,6 +97,7 @@ export const actions = {
     const url = `${ state.config.baseUrl }/subscribe`;
 
     if ( socket ) {
+      socket.setAutoReconnect(true);
       socket.setUrl(url);
     } else {
       socket = new Socket(`${ state.config.baseUrl }/subscribe`);

--- a/utils/socket.js
+++ b/utils/socket.js
@@ -173,6 +173,10 @@ export default class Socket extends EventTarget {
     }
   }
 
+  setAutoReconnect(autoReconnect) {
+    this.autoReconnect = autoReconnect;
+  }
+
   // "Private"
   _close() {
     const socket = this.socket;


### PR DESCRIPTION
- https://github.com/harvester/harvester/issues/1377
- https://github.com/rancher/dashboard/issues/4347

**Verify Steps**
- Login Rancher, and check `window.s.state.rancher.socket.autoReconnect` in chrome dev console, That would be "true"
- Logout and Login again, check `autoReconnect`, the value should be "true".

**Addictionl Context**
https://github.com/harvester/harvester/issues/1377#issuecomment-971382356