### PR TITLE
catalogs-manage display name

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3446,8 +3446,8 @@ rbac:
         label: Configure Authentication
         description: Allows the user to enable, configure, and disable all Authentication provider settings.
       catalogs-manage:
-        label: Configure Catalogs
-        description: Allows the user to add, edit, and remove Catalogs.
+        label: Legacy Configure Catalogs
+        description: Allows the user to add, edit, and remove management.cattle.io based catalogs resources.
       clusters-manage:
         label: Manage all Clusters
         description: Allows the user to manage all clusters, including ones they are not a member of.


### PR DESCRIPTION
Issue:
- https://github.com/rancher/rancher/issues/34592

The global `catalogs-manage` role grants the following permissions:
```yaml
rules:
- apiGroups:
  - management.cattle.io
  resources:
  - catalogs
  - templates
  - templateversions
  verbs:
  - '*'
```
which don't apply to `catalog.cattle.io` resources, so change name to `Legacy Configure Catalogs` to indicate this