### PR TITLE
Add action for node force-machine-remove

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2792,6 +2792,7 @@ node:
     downloadSSHKey: Download SSH Key
     downloadNodeConfig: Download Keys
     scaleDown: Scale Down
+    forceDelete: Force Delete
 
 persistentVolume:
   pluginConfiguration:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3307,6 +3307,12 @@ prometheusRule:
     name: Time Series Name
     removeRecord: Remove Record
 
+promptForceRemove:
+  modalTitle: Are you sure?
+  removeWarning: "There was an issue with deleting underlying infrastructure. If you proceed with this action, the Machine <b>{nameToMatch}</b> will be deleted from Rancher only. It's highly recommended to manually delete any referenced infrastructure."
+  forceDelete: Force Delete
+  confirmName: "Enter in the pool name below to confirm:"
+
 promptRemove:
   title: Are you sure?
   andOthers: |-

--- a/components/dialog/ForceMachineRemoveDialog.vue
+++ b/components/dialog/ForceMachineRemoveDialog.vue
@@ -21,8 +21,18 @@ export default {
     }
   },
 
+  async fetch() {
+    const ref = this.machine.spec.infrastructureRef;
+    const id = `${ ref.namespace }/${ ref.name }`;
+    const kind = `rke-machine.cattle.io.${ ref.kind.toLowerCase() }`;
+
+    this.machineRef = await this.$store.dispatch('management/find', { type: kind, id });
+  },
+
   data() {
-    return { errors: [], confirmName: '' };
+    return {
+      errors: [], confirmName: '', machineRef: null
+    };
   },
 
   computed: {
@@ -52,9 +62,9 @@ export default {
 
     async remove(buttonDone) {
       try {
-        await this.machine.forceMachineRemove();
-        this.close();
+        await this.machine.forceMachineRemove(this.machineRef);
         buttonDone(true);
+        this.close();
       } catch (e) {
         this.errors = exceptionToErrorsArray(e);
         buttonDone(false);

--- a/components/dialog/ForceMachineRemoveDialog.vue
+++ b/components/dialog/ForceMachineRemoveDialog.vue
@@ -1,0 +1,98 @@
+<script>
+import { mapGetters } from 'vuex';
+import { exceptionToErrorsArray } from '@/utils/error';
+import AsyncButton from '@/components/AsyncButton';
+import Banner from '@/components/Banner';
+import Card from '@/components/Card';
+import CopyToClipboardText from '@/components/CopyToClipboardText';
+
+export default {
+  components: {
+    AsyncButton,
+    Banner,
+    Card,
+    CopyToClipboardText
+  },
+
+  props:      {
+    resources: {
+      type:     Array,
+      required: true
+    }
+  },
+
+  data() {
+    return { errors: [], confirmName: '' };
+  },
+
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+
+    machine() {
+      return this.resources[0];
+    },
+
+    nameToMatch() {
+      return this.machine.spec.infrastructureRef.name;
+    },
+
+    deleteDisabled() {
+      const confirmFailed = this.confirmName !== this.nameToMatch;
+
+      return this.preventDelete || confirmFailed;
+    },
+  },
+
+  methods: {
+    close() {
+      this.confirmName = '';
+      this.errors = [];
+      this.$emit('close');
+    },
+
+    async remove(buttonDone) {
+      try {
+        await this.machine.forceMachineRemove();
+        this.close();
+        buttonDone(true);
+      } catch (e) {
+        this.errors = exceptionToErrorsArray(e);
+        buttonDone(false);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <Card class="prompt-restore" :show-highlight-border="false">
+    <h4 slot="title" class="text-default-text">
+      {{ t('promptForceRemove.modalTitle') }}
+    </h4>
+    <div slot="body" class="pl-10 pr-10">
+      <span
+        v-html="t('promptForceRemove.removeWarning', { nameToMatch }, true)"
+      ></span>
+      <div class="mt-10 mb-10">
+        {{ t('promptForceRemove.confirmName') }}
+      </div>
+      <div class="mb-10">
+        <CopyToClipboardText :text="nameToMatch" />
+      </div>
+      <input id="confirm" v-model="confirmName" type="text" />
+      <Banner v-for="(error, i) in errors" :key="i" class="" color="error" :label="error" />
+    </div>
+    <template #actions>
+      <button class="btn role-secondary mr-10" @click="close">
+        {{ t('generic.cancel') }}
+      </button>
+      <AsyncButton mode="delete" class="btn bg-error ml-10" :disabled="deleteDisabled" @click="remove" />
+    </template>
+  </Card>
+</template>
+
+<style lang='scss' scoped>
+  .actions {
+    text-align: right;
+  }
+</style>

--- a/components/dialog/ForceMachineRemoveDialog.vue
+++ b/components/dialog/ForceMachineRemoveDialog.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import { exceptionToErrorsArray } from '@/utils/error';
+import { alternateLabel } from '@/utils/platform';
 import AsyncButton from '@/components/AsyncButton';
 import Banner from '@/components/Banner';
 import Card from '@/components/Card';
@@ -21,18 +22,8 @@ export default {
     }
   },
 
-  async fetch() {
-    const ref = this.machine.spec.infrastructureRef;
-    const id = `${ ref.namespace }/${ ref.name }`;
-    const kind = `rke-machine.cattle.io.${ ref.kind.toLowerCase() }`;
-
-    this.machineRef = await this.$store.dispatch('management/find', { type: kind, id });
-  },
-
   data() {
-    return {
-      errors: [], confirmName: '', machineRef: null
-    };
+    return { errors: [], confirmName: '' };
   },
 
   computed: {
@@ -51,6 +42,10 @@ export default {
 
       return this.preventDelete || confirmFailed;
     },
+
+    protip() {
+      return this.t('promptRemove.protip', { alternateLabel });
+    },
   },
 
   methods: {
@@ -62,7 +57,7 @@ export default {
 
     async remove(buttonDone) {
       try {
-        await this.machine.forceMachineRemove(this.machineRef);
+        await this.machine.forceMachineRemove();
         buttonDone(true);
         this.close();
       } catch (e) {
@@ -90,6 +85,9 @@ export default {
         <CopyToClipboardText :text="nameToMatch" />
       </div>
       <input id="confirm" v-model="confirmName" type="text" />
+      <div class="text-info mt-20">
+        {{ protip }}
+      </div>
       <Banner v-for="(error, i) in errors" :key="i" class="" color="error" :label="error" />
     </div>
     <template #actions>

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -43,11 +43,12 @@ export const MACHINE_ROLES = {
 };
 
 export const CAPI = {
-  DEPLOYMENT_NAME:   'cluster.x-k8s.io/deployment-name',
-  CREDENTIAL_DRIVER: 'provisioning.cattle.io/driver',
-  CLUSTER_NAMESPACE: 'cluster.x-k8s.io/cluster-namespace',
-  MACHINE_NAME:      'cluster.x-k8s.io/machine',
-  PROVIDER:          'provider.cattle.io'
+  DEPLOYMENT_NAME:      'cluster.x-k8s.io/deployment-name',
+  CREDENTIAL_DRIVER:    'provisioning.cattle.io/driver',
+  CLUSTER_NAMESPACE:    'cluster.x-k8s.io/cluster-namespace',
+  FORCE_MACHINE_REMOVE: 'provisioning.cattle.io/force-machine-remove',
+  MACHINE_NAME:         'cluster.x-k8s.io/machine',
+  PROVIDER:             'provider.cattle.io'
 };
 
 export const CATALOG = {

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -28,7 +28,7 @@ export default class CapiMachine extends SteveModel {
       action:     'toggleForceRemoveModal',
       altAction:  'forceMachineRemove',
       enabled:    !!this.isRemoveForceable,
-      label:      'Force Delete',
+      label:      this.t('node.actions.forceDelete'),
       icon:       'icon icon-trash',
     };
 
@@ -68,7 +68,7 @@ export default class CapiMachine extends SteveModel {
   async forceMachineRemove() {
     const machine = await this.machineRef();
 
-    machine.setAnnotation('provisioning.cattle.io/force-machine-remove', 'true');
+    machine.setAnnotation(CAPI_LABELS.FORCE_MACHINE_REMOVE, 'true');
     await machine.save();
   }
 

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -64,9 +64,9 @@ export default class CapiMachine extends SteveModel {
     });
   }
 
-  async forceMachineRemove() {
-    this.setAnnotation('provisioning.cattle.io/force-machine-remove', 'true');
-    await this.save();
+  async forceMachineRemove(machine) {
+    await machine.setAnnotation('provisioning.cattle.io/force-machine-remove', 'true');
+    await machine.save();
   }
 
   get cluster() {

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -26,6 +26,7 @@ export default class CapiMachine extends SteveModel {
     };
     const forceRemove = {
       action:     'toggleForceRemoveModal',
+      altAction:  'forceMachineRemove',
       enabled:    !!this.isRemoveForceable,
       label:      'Force Delete',
       icon:       'icon icon-trash',
@@ -64,9 +65,19 @@ export default class CapiMachine extends SteveModel {
     });
   }
 
-  async forceMachineRemove(machine) {
-    await machine.setAnnotation('provisioning.cattle.io/force-machine-remove', 'true');
+  async forceMachineRemove() {
+    const machine = await this.machineRef();
+
+    machine.setAnnotation('provisioning.cattle.io/force-machine-remove', 'true');
     await machine.save();
+  }
+
+  async machineRef() {
+    const ref = this.spec.infrastructureRef;
+    const id = `${ ref.namespace }/${ ref.name }`;
+    const kind = `rke-machine.cattle.io.${ ref.kind.toLowerCase() }`;
+
+    return await this.$dispatch('find', { type: kind, id });
   }
 
   get cluster() {


### PR DESCRIPTION
Reference #4538 

This adds support for force removing a RKE2 pool in a cluster that is stuck in deleting state.


https://user-images.githubusercontent.com/40806497/142700416-49c0ea41-f517-491b-973d-b794b2f15330.mp4



**To Test**

On 2.6-head commit id: 78b25c3

- Deploy an RKE2 cluster with 2 nodes
- Invalidate the cloud credentials used to provision the cluster by deleting the access token on the cloud provider side (e.g. Digital Ocean / AWS API token).
- Delete the cluster
- The cluster is stuck in deleting state
- Select `Force Delete` from action menu for a node
- The node get removed and the cluster gets deleted from rancher

