### PR TITLE
Remove grey from InputWithSelect control

### DIFF
--- a/components/form/InputWithSelect.vue
+++ b/components/form/InputWithSelect.vue
@@ -229,7 +229,6 @@ export default {
     &.unlabeled-select ::v-deep {
       box-shadow: none;
       width: 20%;
-      background-color: var(--input-bg-accent);
       border: solid 1px var(--input-border);
       margin-right: 1px; // push the input box right so the full focus outline of the select can be seen, z-index borks
       // position: relative;


### PR DESCRIPTION
Addresses #4003 

The grey used on the joined Input with Select control can be confused to mean its not enabled.

I've removed this grey - I think the joining of the controls gives enough context.

We only use this control in a few places