### PR TITLE
Fixes and Improvements to PVCs

### DIFF
--- a/edit/persistentvolumeclaim.vue
+++ b/edit/persistentvolumeclaim.vue
@@ -231,7 +231,10 @@ export default {
         </div>
       </Tab>
       <Tab name="customize" :label="t('persistentVolumeClaim.customize.label')" :weight="3">
-        <h3>Access Modes</h3>
+        <div class="access">
+          <h3>{{ t('persistentVolumeClaim.accessModes') }}</h3>
+          <span class="text-error">*</span>
+        </div>
         <div><Checkbox v-model="readWriteOnce" :label="t('persistentVolumeClaim.customize.accessModes.readWriteOnce')" :mode="mode" /></div>
         <div><Checkbox v-model="readOnlyMany" :label="t('persistentVolumeClaim.customize.accessModes.readOnlyMany')" :mode="mode" /></div>
         <div><Checkbox v-model="readWriteMany" :label="t('persistentVolumeClaim.customize.accessModes.readWriteMany')" :mode="mode" /></div>
@@ -242,3 +245,10 @@ export default {
     </ResourceTabs>
   </CruResource>
 </template>
+
+<style lang='scss' scoped>
+.access {
+  display: flex;
+  flex-direction: row;
+}
+</style>

--- a/edit/workload/storage/index.vue
+++ b/edit/workload/storage/index.vue
@@ -250,6 +250,7 @@ export default {
     <ArrayListGrouped
       :key="containerVolumes.length"
       v-model="containerVolumes"
+      :mode="mode"
     >
       <template #default="props">
         <h3>{{ headerFor(volumeType(props.row.value)) }}</h3>
@@ -257,7 +258,6 @@ export default {
           <component
             :is="componentFor(volumeType(props.row.value))"
             v-if="componentFor(volumeType(props.row.value))"
-            :key="props.row.value"
             :value="props.row.value"
             :pod-spec="value"
             :mode="mode"

--- a/edit/workload/storage/persistentVolumeClaim/index.vue
+++ b/edit/workload/storage/persistentVolumeClaim/index.vue
@@ -100,7 +100,7 @@ export default {
 </script>
 
 <template>
-  <div>
+  <div v-if="value.__newPvc">
     <div>
       <div v-if="createNew" class="bordered-section">
         <PersistentVolumeClaim
@@ -118,7 +118,6 @@ export default {
         </div>
         <div class="col span-6">
           <LabeledSelect v-if="!createNew" v-model="value.persistentVolumeClaim.claimName" :mode="mode" :label="t('workload.storage.subtypes.persistentVolumeClaim')" :options="pvcs" />
-          <LabeledInput v-else-if="pvc" :mode="mode" disabled :label="t('workload.storage.subtypes.persistentVolumeClaim')" :value="pvc.metadata.name" />
         </div>
       </div>
       <div class="row">

--- a/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim.vue
+++ b/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim.vue
@@ -106,9 +106,8 @@ export default {
     this.value.uniqueId = this.uniqueId;
     this.$emit('createUniqueId');
     if (this.registerBeforeHook) {
-      // Append the uniqueID to the PVC hook name so that
-      // form state for each can be deleted individually
-      this.registerBeforeHook(this.value.save, this.savePvcHookName + this.uniqueId);
+      // Append the uniqueID to the PVC hook name so that form state for each can be deleted individually
+      this.registerBeforeHook(this.value.save, this.savePvcHookName + this.uniqueId, undefined, this.value);
     }
   },
 
@@ -179,7 +178,10 @@ export default {
 
     <div class="row mb-10">
       <div class="col span-6">
-        <t class="text-label" k="persistentVolumeClaim.accessModes" />
+        <div class="access-modes">
+          <t class="text-label" k="persistentVolumeClaim.accessModes" />
+          <span class="text-error">*</span>
+        </div>
         <div class="access-modes">
           <Checkbox :mode="mode" :value="value.spec.accessModes.includes('ReadWriteOnce')" label="Single-Node Read/Write" @input="e=>updateMode('ReadWriteOnce', e)" />
           <Checkbox :mode="mode" :value="value.spec.accessModes.includes('ReadOnlyMany')" label="Many-Node Read-Only" @input="e=>updateMode('ReadOnlyMany', e)" />
@@ -194,8 +196,8 @@ export default {
 </template>
 
 <style lang='scss'>
-    .access-modes {
-        display: flex;
-        flex-direction: row;
-    }
+.access-modes {
+  display: flex;
+  flex-direction: row;
+}
 </style>

--- a/mixins/child-hook.js
+++ b/mixins/child-hook.js
@@ -8,8 +8,8 @@ export const AFTER_SAVE_HOOKS = '_afterSaveHooks';
 
 export default {
   methods: {
-    registerBeforeHook(boundFn, name, priority) {
-      this._registerHook(BEFORE_SAVE_HOOKS, boundFn, name, priority);
+    registerBeforeHook(boundFn, name, priority = 99, boundFnContext) {
+      this._registerHook(BEFORE_SAVE_HOOKS, boundFn, name, priority, boundFnContext);
     },
 
     unregisterBeforeSaveHook(name) {
@@ -34,13 +34,13 @@ export default {
 
       for ( const x of hooks ) {
         console.debug('Applying hook', x.name); // eslint-disable-line no-console
-        out[x.name] = await x.fn.apply(this, args);
+        out[x.name] = await x.fn.apply(x.fnContext || this, args);
       }
 
       return out;
     },
 
-    _registerHook(key, fn, name, priority) {
+    _registerHook(key, fn, name, priority, fnContext) {
       if ( !key ) {
         throw new Error('Must specify key');
       }
@@ -66,11 +66,13 @@ export default {
       if ( entry ) {
         entry.priority = priority;
         entry.fn = fn;
+        entry.fnContext = fnContext;
       } else {
         entry = {
           name,
           priority,
-          fn
+          fn,
+          fnContext
         };
 
         hooks.push(entry);

--- a/mixins/create-edit-view/impl.js
+++ b/mixins/create-edit-view/impl.js
@@ -199,7 +199,8 @@ export default {
         } else {
           this.errors = exceptionToErrorsArray(err);
         }
-
+        // Provide a stack trace for easier debugging of save errors
+        console.error('CreateEditView mixin failed to save: ', err); // eslint-disable-line no-console
         buttonDone && buttonDone(false);
       }
     },


### PR DESCRIPTION
- Ensure inline created PVCs are created when creating a Workload - https://github.com/rancher/dashboard/issues/4582
  - When workload saves it ends up calling a beforeHook using a pvc resource's 'save'
  - The pvc was then lost when the child-hook mechanism `apply`d the CreateEditView mixin as `this`
  - Now we allow the registerBeforeHook process to access a context (i.e. `this`) for a fn

Fix two warnings
- non-primitive key in storage/index.vue
- missing pvc value in workload storage tab caused error, so remove as it's not used
- block until we have a new pvc in workload storage tab

Improvements
- Show a required dot for Access Modes (needs at least one)
- Localise `Access Modes` text in Create PVC page
- Hide Create/Remove storage volume buttons in create/edit workload storage tab

For testing i would suggest 
- Create/Edit of a PVC within the context of a workload
- Create/Edit of a PVC just straight from the PVC list
