### PR TITLE
Save secret when provisioning cluster with registry

### DIFF
--- a/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -29,6 +29,14 @@ export default {
       type:     Object,
       required: true,
     },
+
+    clusterRegisterBeforeHook: {
+      // We use this hook instead of the create hook from the CreateEditView
+      // mixin because this is a form within a form, therefore we
+      // need the hook from the parent component.
+      type:     Function,
+      required: true
+    }
   },
 
   data() {
@@ -108,7 +116,7 @@ export default {
 
             <SelectOrCreateAuthSecret
               v-model="row.value.authConfigSecretName"
-              :register-before-hook="registerBeforeHook"
+              :register-before-hook="clusterRegisterBeforeHook"
               in-store="management"
               :allow-ssh="false"
               :allow-rke="true"

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1635,7 +1635,7 @@ export default {
               v-model="value"
               class="mt-20"
               :mode="mode"
-              :register-before-hook="registerBeforeHook"
+              :cluster-register-before-hook="registerBeforeHook"
             />
           </template>
         </Tab>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4137

To test this PR,

1. I set up a private registry
2. Provisioned a K3s cluster, and in the **Registries** tab I went to **configure advanced containerd mirroring and registry authentication options**
3. Clicked **Add registry** and entered hostname
4. In the authentication section, created an HTTP basic auth secret for the private registry credentials
5. Clicked **Create** and saw that the cluster was successfully provisioned using the private registry

I tested it on RKE2 as well and it worked.

Initially the private registry didn't work with the RKE2 cluster, but it worked after I made sure that the registry included all the images for the specific RKE2 version (rke2-images-all.linux-amd64.txt). https://github.com/rancher/rke2/releases/tag/v1.21.6%2Brke2r1 Normally the air gapped rancher installation images include the RKE2 provisioning images, but my list was outdated.