### PR TITLE
HARVESTER: fixed multi-cluster projectNamespace error

### DIFF
--- a/detail/namespace.vue
+++ b/detail/namespace.vue
@@ -37,7 +37,8 @@ export default {
 
   computed: {
     namespacedCounts() {
-      const allClusterResourceCounts = this.$store.getters[`cluster/all`](COUNT)[0].counts;
+      const inStore = this.$store.getters['currentProduct'].inStore;
+      const allClusterResourceCounts = this.$store.getters[`${ inStore }/all`](COUNT)[0].counts;
       const statesByType = getStatesByType();
       const totalCountsOut = {
         success: 0,

--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -78,7 +78,9 @@ export default {
       return this.projects.filter(project => project.spec.clusterName === clusterId);
     },
     projectsWithoutNamespaces() {
-      return this.clusterProjects.filter(project => !!this.projectIdsWithNamespaces.find(item => item.endsWith(`/${ project.id }`)));
+      return this.clusterProjects.filter((project) => {
+        return !this.projectIdsWithNamespaces.find(item => project?.id?.endsWith(`/${ item }`));
+      });
     },
     // We're using this because we need to show projects as groups even if the project doesn't have any namespaces.
     rowsWithFakeNamespaces() {


### PR DESCRIPTION
# links
- https://github.com/harvester/harvester/issues/1574

For projects without namespace we should also show them in the list, otherwise there is no way to create namespace in the project