### PR TITLE
Fix logic for enabling/disabling legacy v1 cluster tools

### DIFF
--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -240,10 +240,11 @@ export default {
         v1.app = v1App;
 
         if (v2) {
-          if (v2.app) {
+          if (v1.app) {
+            v2.app = undefined;
+            v2.blocked = true;
+          } else if (v2.app) {
             v1.blocked = true;
-          } else {
-            v2.blocked = !!v1App;
           }
         }
       }


### PR DESCRIPTION
Addresses #3825 

Version numbers looked fine for me - but there was an issue where with the v1 app installed, the v2 app was showing as being installed - this PR updates the logic for this in Cluster Tools.
