### PR TITLE
Fix can't create monitoring route

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -132,7 +132,7 @@ export default {
       const inStore = this.$store.getters['currentStore'](this.resource);
       const schema = this.$store.getters[`${ inStore }/schemaFor`](this.resource.type);
 
-      return !schema.resourceMethods.find(x => x === 'blocked-PUT');
+      return !schema.resourceMethods?.find(x => x === 'blocked-PUT');
     },
 
     isView() {

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -1632,7 +1632,9 @@ function ifHaveVerb(rootGetters, module, verb, haveIds) {
   for ( const haveId of haveIds ) {
     const schema = rootGetters[`${ module }/schemaFor`](haveId);
     const want = verb.toLowerCase();
-    const have = [...schema.collectionMethods, ...schema.resourceMethods].map(x => x.toLowerCase());
+    const collectionMethods = schema.collectionMethods || [];
+    const resourceMethods = schema.resourceMethods || [];
+    const have = [...collectionMethods, ...resourceMethods].map(x => x.toLowerCase());
 
     if ( !have.includes(want) && !have.includes(`blocked-${ want }`) ) {
       return false;


### PR DESCRIPTION
Addresses #4581 

resourceMethods might not exist in the schema - which it does not on the monitoring route, leading to an error.

This PR fixes this bug.