### PR TITLE
Prevent edit-as-yaml for RKE1 clusters

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -1,5 +1,6 @@
 <script>
 import Type from '@/components/nav/Type';
+import isEqual from 'lodash/isEqual';
 export default {
   name: 'Group',
 
@@ -145,9 +146,11 @@ export default {
         if (item.children && this.hasActiveRoute(item)) {
           return true;
         } else if (item.route) {
-          const route = this.$router.resolve(item.route);
+          const { cluster, product, resource } = this.$route.params;
 
-          if (this.$route.fullPath === route.route.fullPath) {
+          if (isEqual({
+            cluster, product, resource
+          }, item.route.params )) {
             return true;
           }
         }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -166,6 +166,7 @@ export default {
 
       return { name: `c-cluster-${ product }-support` };
     },
+
   },
 
   watch: {
@@ -195,7 +196,6 @@ export default {
       if ( !isEqual(a, b) ) {
         // Immediately update because you'll see it come in later
         this.getGroups();
-        this.wantNavSync = true;
       }
     },
 
@@ -210,7 +210,6 @@ export default {
       if ( !isEqual(a, b) ) {
         // Immediately update because you'll see it come in later
         this.getGroups();
-        this.wantNavSync = true;
       }
     },
 
@@ -252,12 +251,9 @@ export default {
     },
 
     $route(a, b) {
-      debugger;
-      if (this.wantNavSync && !isEqual(a, b)) {
-        this.wantNavSync = false;
-        this.$nextTick(() => this.syncNav());
-      }
-    }
+      this.$nextTick(() => this.syncNav());
+    },
+
   },
 
   async created() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -252,6 +252,7 @@ export default {
     },
 
     $route(a, b) {
+      debugger;
       if (this.wantNavSync && !isEqual(a, b)) {
         this.wantNavSync = false;
         this.$nextTick(() => this.syncNav());

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -1,4 +1,3 @@
-import { _EDIT, _YAML, AS, MODE } from '@/config/query-params';
 import { CAPI, MANAGEMENT, NORMAN } from '@/config/types';
 import { classify } from '@/plugins/steve/classify';
 import SteveModel from '@/plugins/steve/steve-class';
@@ -7,6 +6,7 @@ import { get, set } from '@/utils/object';
 import { sortBy } from '@/utils/sort';
 import { ucFirst } from '@/utils/string';
 import { compare } from '@/utils/version';
+import { AS, MODE, _VIEW, _YAML } from '@/config/query-params';
 
 export const DEFAULT_WORKSPACE = 'fleet-default';
 
@@ -112,7 +112,7 @@ export default class ProvCluster extends SteveModel {
     return out;
   }
 
-  goToEditYaml() {
+  goToViewYaml() {
     let location;
 
     if ( !this.isRke2 ) {
@@ -125,11 +125,19 @@ export default class ProvCluster extends SteveModel {
 
     location.query = {
       ...location.query,
-      [MODE]: _EDIT,
+      [MODE]: _VIEW,
       [AS]:   _YAML
     };
 
     this.currentRouter().push(location);
+  }
+
+  get canEditYaml() {
+    if (!this.isRke2) {
+      return false;
+    }
+
+    return super.canEditYaml;
   }
 
   get isImported() {


### PR DESCRIPTION
#4051 - This PR disables the yaml-editing view for RKE1 provisioning clusters because they can only be edited through the iFramed ember ('config' views). This PR also fixes a more general nav bug outlined in the comments that still applies to the 'view yaml' action for rke1 clusters.