### PR TITLE
Fix missing action label for download kubeconfig

### DIFF
--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -71,7 +71,7 @@ export default class ProvCluster extends SteveModel {
     insertAt(out, idx++, {
       action:     'downloadKubeConfig',
       bulkAction: 'downloadKubeConfigBulk',
-      label:      this.$rootGetters['i18n/t']('nav.kubeconfig'),
+      label:      this.$rootGetters['i18n/t']('nav.kubeconfig.download'),
       icon:       'icon icon-download',
       bulkable:   true,
       enabled:    this.mgmt?.hasAction('generateKubeconfig') && this.mgmt?.isReady,


### PR DESCRIPTION
- Cluster Management --> Clusters list --> second(ish) action
  ![image](https://user-images.githubusercontent.com/18697775/142916472-7f59f423-b641-4af4-ac3a-e92f8cf1f504.png)
