### PR TITLE
Show Upgradeable as "Managed" when catalog.cattle.io/hidden is true

### DIFF
--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -67,8 +67,12 @@ export default class CatalogApp extends SteveModel {
     // null = no upgrade found
     // object = version available to upgrade to
 
-    if ( this.spec?.chart?.metadata?.annotations?.[FLEET.BUNDLE_ID] ) {
-      // Things managed by fleet shouldn't show ugrade available even if there might be.
+    if (
+      this.spec?.chart?.metadata?.annotations?.[FLEET.BUNDLE_ID] ||
+      this.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.HIDDEN]
+    ) {
+      // Things managed by fleet shouldn't show upgrade available even if there
+      // might be.
       return false;
     }
 


### PR DESCRIPTION
This resolves an issue with Rancher displaying an upgrade option for Traefik managed by K3s in existing versions.  

New versions of K3s (tested with v1.21.7-rc1-k3s1) will provide a value for `fleet.cattle.io/bundle-id`, causing Upgradeable to display `Managed` for kube-system traefik. 

My concern about this solution is that making use of `catalog.cattle.io/hidden` might be a little overly aggressive in marking other installed apps as `Managed`, even when they are not. Perhaps, a better approach would be to check that the namespace is `kube-system` or something that we know is managed before attempting to hide the upgrade button.

#4442