### PR TITLE
Namespace filter fixes

### DIFF
--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -6,6 +6,11 @@ import { sortBy } from '@/utils/sort';
 import { isArray, addObjects, findBy, filterBy } from '@/utils/array';
 import Select from '@/components/form/Select';
 import { NAME as HARVESTER } from '@/config/product/harvester';
+import {
+  ALL_USER, ALL, ALL_SYSTEM, ALL_ORPHANS, NAMESPACED_YES, NAMESPACED_NO
+} from '@/store';
+
+const SPECIAL = 'special';
 
 export default {
   components: { Select },
@@ -44,28 +49,28 @@ export default {
       if (!this.isVirtualCluster) {
         out = [
           {
-            id:    'all',
-            kind:  'special',
+            id:    ALL,
+            kind:  SPECIAL,
             label: t('nav.ns.all'),
           },
           {
-            id:    'all://user',
-            kind:  'special',
+            id:    ALL_USER,
+            kind:  SPECIAL,
             label: t('nav.ns.user'),
           },
           {
-            id:    'all://system',
-            kind:  'special',
+            id:    ALL_SYSTEM,
+            kind:  SPECIAL,
             label: t('nav.ns.system'),
           },
           {
-            id:    'namespaced://true',
-            kind:  'special',
+            id:    NAMESPACED_YES,
+            kind:  SPECIAL,
             label: t('nav.ns.namespaced'),
           },
           {
-            id:    'namespaced://false',
-            kind:  'special',
+            id:    NAMESPACED_NO,
+            kind:  SPECIAL,
             label: t('nav.ns.clusterLevel'),
           },
         ];
@@ -147,7 +152,7 @@ export default {
           }
 
           out.push({
-            id:       'all://orphans',
+            id:       ALL_ORPHANS,
             kind:     'project',
             label:    t('nav.ns.orphan'),
             disabled: true,
@@ -191,7 +196,7 @@ export default {
       get() {
         const prefs = this.$store.getters['prefs/get'](NAMESPACE_FILTERS);
         const clusterId = this.$store.getters['clusterId'];
-        const values = prefs[clusterId] || ['all://user'];
+        const values = prefs[clusterId] || [ALL_USER];
         const options = this.options;
 
         // Remove values that are not valid options
@@ -210,16 +215,16 @@ export default {
         neu = neu.filter(x => !!x.id);
 
         const last = neu[neu.length - 1];
-        const lastIsSpecial = last?.kind === 'special';
-        const hadUser = !!old.find(x => x.id === 'all://user');
-        const hadAll = !!old.find(x => x.id === 'all');
+        const lastIsSpecial = last?.kind === SPECIAL;
+        const hadUser = !!old.find(x => x.id === ALL_USER);
+        const hadAll = !!old.find(x => x.id === ALL);
 
         if (lastIsSpecial) {
           neu = [last];
         }
 
         if (neu.length > 1) {
-          neu = neu.filter(x => x.kind !== 'special');
+          neu = neu.filter(x => x.kind !== SPECIAL);
         }
 
         if (neu.find(x => x.id === 'all')) {
@@ -231,7 +236,7 @@ export default {
         // If there as something selected and you remove it, go back to user by default
         // Unless it was user or all
         if (neu.length === 0 && !hadUser && !hadAll) {
-          ids = ['all://user'];
+          ids = [ALL_USER];
         } else {
           ids = neu.map(x => x.id);
         }

--- a/store/index.js
+++ b/store/index.js
@@ -23,6 +23,13 @@ import { NAME as VIRTUAL } from '@/config/product/harvester';
 export const strict = false;
 
 export const BLANK_CLUSTER = '_';
+export const ALL = 'all';
+export const ALL_SYSTEM = 'all://system';
+export const ALL_USER = 'all://user';
+export const ALL_ORPHANS = 'all://orphans';
+export const NAMESPACED_PREFIX = 'namespaced://';
+export const NAMESPACED_YES = 'namespaced://true';
+export const NAMESPACED_NO = 'namespaced://false';
 
 export const plugins = [
   Steve({
@@ -178,7 +185,7 @@ export const getters = {
       return true;
     }
 
-    return state.namespaceFilters.filter(x => !`${ x }`.startsWith('namespaced://')).length === 0;
+    return state.namespaceFilters.filter(x => !`${ x }`.startsWith(NAMESPACED_PREFIX)).length === 0;
   },
 
   isMultipleNamespaces(state, getters) {
@@ -206,7 +213,7 @@ export const getters = {
   },
 
   namespaceFilters(state) {
-    const filters = state.namespaceFilters.filter(x => !!x && !`${ x }`.startsWith('namespaced://'));
+    const filters = state.namespaceFilters.filter(x => !!x && !`${ x }`.startsWith(NAMESPACED_PREFIX));
 
     return filters;
   },
@@ -220,9 +227,9 @@ export const getters = {
     }
 
     // Explicitly asking
-    if ( filters.includes('namespaced://true') ) {
+    if ( filters.includes(NAMESPACED_YES) ) {
       return NAMESPACED;
-    } else if ( filters.includes('namespaced://false') ) {
+    } else if ( filters.includes(NAMESPACED_NO) ) {
       return CLUSTER_LEVEL;
     }
 
@@ -263,11 +270,11 @@ export const getters = {
       }
 
       const namespaces = getters[`${ inStore }/all`](NAMESPACE);
-      const filters = state.namespaceFilters.filter(x => !!x && !`${ x }`.startsWith('namespaced://'));
+      const filters = state.namespaceFilters.filter(x => !!x && !`${ x }`.startsWith(NAMESPACED_PREFIX));
       const includeAll = getters.isAllNamespaces;
-      const includeSystem = filters.includes('all://system');
-      const includeUser = filters.includes('all://user');
-      const includeOrphans = filters.includes('all://orphans');
+      const includeSystem = filters.includes(ALL_SYSTEM);
+      const includeUser = filters.includes(ALL_USER);
+      const includeOrphans = filters.includes(ALL_ORPHANS);
 
       // Special cases to pull in all the user, system, or orphaned namespaces
       if ( includeAll || includeOrphans || includeSystem || includeUser ) {
@@ -672,8 +679,10 @@ export const actions = {
 
     await dispatch('cleanNamespaces');
 
+    const filters = getters['prefs/get'](NAMESPACE_FILTERS)?.[id];
+
     commit('updateNamespaces', {
-      filters: getters['prefs/get'](NAMESPACE_FILTERS)?.[id] || [],
+      filters: filters || [ALL_USER],
       all:     res.namespaces
     });
 

--- a/store/index.js
+++ b/store/index.js
@@ -800,7 +800,8 @@ export const actions = {
 
   async cleanNamespaces({ getters, dispatch }) {
     // Initialise / Remove any filters that the user no-longer has access to
-    const clusters = await dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
+    await dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }); // So they can be got byId below
+
     const filters = getters['prefs/get'](NAMESPACE_FILTERS);
 
     if ( !filters ) {
@@ -814,11 +815,11 @@ export const actions = {
 
     const cleanFilters = {};
 
-    Object.entries(filters).forEach(([clusterId, pref]) => {
-      if (clusters.find(c => c.id === clusterId)) {
-        cleanFilters[clusterId] = pref;
+    for ( const id in filters ) {
+      if ( getters['management/byId'](MANAGEMENT.CLUSTER, id) ) {
+        cleanFilters[id] = filters[id];
       }
-    });
+    }
 
     if (Object.keys(filters).length !== Object.keys(cleanFilters).length) {
       console.debug('Unknown clusters have been removed from namespace filters list (before/after)', filters, cleanFilters); // eslint-disable-line no-console

--- a/store/index.js
+++ b/store/index.js
@@ -803,7 +803,7 @@ export const actions = {
     const clusters = await dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
     const filters = getters['prefs/get'](NAMESPACE_FILTERS);
 
-    if (!filters || !filters.length) {
+    if ( !filters ) {
       dispatch('prefs/set', {
         key:   NAMESPACE_FILTERS,
         value: { }

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -43,8 +43,6 @@ const asCookie = true; // Store as a cookie so that it's available before auth +
 // Keys must be lowercase and valid dns label (a-z 0-9 -)
 export const CLUSTER = create('cluster', '');
 export const LAST_NAMESPACE = create('last-namespace', '');
-// Pre-2.6.1 value which may exist when switching between version
-// export const NAMESPACE_FILTERS_LEGACY = create('ns', ['all://user'], { parseJSON });
 export const NAMESPACE_FILTERS = create('ns-by-cluster', {}, { parseJSON });
 export const WORKSPACE = create('workspace', '');
 export const EXPANDED_GROUPS = create('open-groups', ['cluster', 'rbac', 'serviceDiscovery', 'storage', 'workload'], { parseJSON });


### PR DESCRIPTION
#3523

[This change](https://github.com/rancher/dashboard/commit/ad83a8fd970488dc1d3e5948fcd20db774645617#diff-2886ae8dc0ffc0d351cc2e75fe977ac32d0067891113a6ec3c25c3761edb9633R613 ) caused the immediate complaint.. the default for actual filtering changed to be `[]` (== All Namespaces) while the dropdown still defaulted to `['all://user']` (== All User), so the dropdown showed all user but the ui applied all namespaces.

This is not the original issue's problem, since this didn't exist yet, but the original was also not reproducible anyway...

- Fix defaults to match (above)
- Use constants everywhere instead of strings that have to match spread around
- Fix `cleanNamespaces` always clearing all the saved values so that it will actually remember multiple namespaces
- Use `getters.byId` hashmap lookups instead of repeated O(n) `ary.find()`s to see if clusters need cleaning or not.