### PR TITLE
Fix pod count gauge

### DIFF
--- a/components/HardwareResourceGauge.vue
+++ b/components/HardwareResourceGauge.vue
@@ -67,7 +67,7 @@ export default {
       <h3>
         {{ name }}
       </h3>
-      <div v-if=" reserved && (reserved.total || reserved.useful)">
+      <div v-if="reserved && (reserved.total || reserved.useful)" class="hw-gauge">
         <ConsumptionGauge
           :capacity="reserved.total"
           :used="reserved.useful"
@@ -83,7 +83,7 @@ export default {
           </template>
         </ConsumptionGauge>
       </div>
-      <div v-if=" used && used.useful" class="mt-20">
+      <div v-if="used && used.useful" class="hw-gauge">
         <ConsumptionGauge
           :capacity="used.total"
           :used="used.useful"
@@ -111,6 +111,10 @@ export default {
     position: relative;
     display: flex;
     flex-direction: column;
+
+    .hw-gauge:not(:first-of-type) {
+      margin-top: 20px;
+    }
 
     .values {
       font-size: 12px;

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -25,6 +25,7 @@ import {
   WORKLOAD_TYPES,
   COUNT,
   CATALOG,
+  POD,
 } from '@/config/types';
 import { findBy } from '@/utils/array';
 import { mapPref, CLUSTER_TOOLS_TIP } from '@/store/prefs';
@@ -219,9 +220,11 @@ export default {
     },
 
     podsUsed() {
+      const pods = resourceCounts(this.$store, POD);
+
       return {
         total:  parseSi(this.currentCluster?.status?.allocatable?.pods || '0'),
-        useful: parseSi(this.currentCluster?.status?.requested?.pods || '0')
+        useful: pods.total
       };
     },
 


### PR DESCRIPTION
Addresses #4609 

- Pod used count was coming from the reserved metric and was 0, leading to the gauge being hidden. Fixed to use the pod count
- Also fixed alignment issue between the used and reserved gauges