### PR TITLE
Fix env var import extra empty value

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -366,9 +366,12 @@ export default {
         const lines = value.split('\n');
 
         lines.forEach((line) => {
-          const [key, value] = line.split('=');
+          // Ignore empty lines
+          if (line.length) {
+            const [key, value] = line.split('=');
 
-          this.add(key, value);
+            this.add(key, value);
+          }
         });
       }
     },


### PR DESCRIPTION
Addresses #4619 

Simple fix to ignore blank lines when parsing key/values from file