### PR TITLE
Fix alignment of KeyValue control

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -570,7 +570,7 @@ export default {
               :class="{'conceal': valueConcealed}"
               :mode="mode"
               :placeholder="valuePlaceholder"
-              :min-height="61"
+              :min-height="40"
               :spellcheck="false"
               @input="queueUpdate"
             />
@@ -673,7 +673,8 @@ export default {
   }
 
   input {
-    height: $input-height;
+    height: 40px;
+    line-height: 1;
   }
 
   .footer {

--- a/components/form/Taints.vue
+++ b/components/form/Taints.vue
@@ -68,9 +68,16 @@ export default {
         <Select
           v-model="row.effect"
           :options="effectOptions"
+          class="compact-select"
           @input="queueUpdate"
         />
       </template>
     </KeyValue>
   </div>
 </template>
+
+<style lang="scss" scoped>
+  .compact-select {
+    height: 40px;
+  }
+</style>


### PR DESCRIPTION
Addresses #4371 

This is a specific fix for the KeyValue alignment issue.

I've reduced the height of the controls - I think this looks better as well as fixing the alignment issue.

I can review the controls after 2.6.3