### PR TITLE
Auth redirect preserve destination URL

### DIFF
--- a/config/local-storage.js
+++ b/config/local-storage.js
@@ -2,3 +2,5 @@
 export const GITHUB_REPOS = 'githubRepos';
 export const GITHUB_SCOPES = 'githubScopes';
 export const _DATE = 'Updated';
+
+export const BACK_TO = 'backTo';

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -12,6 +12,7 @@ import { ClusterNotFoundError } from '@/utils/error';
 import { get } from '@/utils/object';
 import { AFTER_LOGIN_ROUTE } from '@/store/prefs';
 import { NAME as VIRTUAL } from '@/config/product/harvester';
+import { BACK_TO } from '@/config/local-storage';
 
 let beforeEachSetup = false;
 
@@ -208,6 +209,14 @@ export default async function({
         }
       }
     }
+  }
+
+  const backTo = window.localStorage.getItem(BACK_TO);
+
+  if (backTo) {
+    window.localStorage.removeItem(BACK_TO);
+
+    window.location.href = backTo;
   }
 
   // Load stuff

--- a/store/index.js
+++ b/store/index.js
@@ -17,6 +17,7 @@ import { SETTING } from '@/config/settings';
 import semver from 'semver';
 import { BY_TYPE, NORMAN as NORMAN_CLASS } from '@/plugins/steve/classify';
 import { NAME as VIRTUAL } from '@/config/product/harvester';
+import { BACK_TO } from '@/config/local-storage';
 
 // Disables strict mode for all store instances to prevent warning about changing state outside of mutations
 // becaues it's more efficient to do that sometimes.
@@ -841,6 +842,12 @@ export const actions = {
     if ( route.name === 'index' ) {
       router.replace('/auth/login');
     } else {
+      const backTo = window.localStorage.getItem(BACK_TO);
+
+      if (!backTo && !route.query[LOGGED_OUT]) {
+        window.localStorage.setItem(BACK_TO, window.location.href);
+      }
+
       const QUERY = (LOGGED_OUT in route.query) ? LOGGED_OUT : TIMED_OUT;
 
       router.replace(`/auth/login?${ QUERY }`);


### PR DESCRIPTION
#4478 - this PR ports the URL-preservation logic from the Ember UI to the dashboard. The URL is saved the same way a the [old ui ](https://github.com/rancher/ui/blob/98c658f5eb2a3e5a139fa9cfc76ee7810cb67526/app/application/route.js#L171) so if a user gets booted to the dashboard login from an Ember route they'll be redirected back to that page.