### PR TITLE
Adding operating system filtering tot he charts page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -685,6 +685,10 @@ catalog:
     header: Charts
     noCharts: 'There are no charts available, have you added any repos?'
     noWindows: Your catalogs do not contain any charts capable of being deployed on a Windows cluster.
+    operatingSystems:
+      all: All OSs
+      linux: Linux
+      windows: Windows
     search: Filter
   install:
     action:

--- a/config/query-params.js
+++ b/config/query-params.js
@@ -57,6 +57,7 @@ export const NAME = 'name';
 export const NAMESPACE = 'namespace';
 export const DESCRIPTION = 'description';
 export const CATEGORY = 'category';
+export const OPERATING_SYSTEM = 'os';
 export const DEPRECATED = 'deprecated';
 export const HIDDEN = 'hidden';
 export const FROM_TOOLS = 'tools';

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -4,7 +4,7 @@ import Loading from '@/components/Loading';
 import Banner from '@/components/Banner';
 import SelectIconGrid from '@/components/SelectIconGrid';
 import {
-  REPO_TYPE, REPO, CHART, VERSION, SEARCH_QUERY, _FLAGGED, CATEGORY, DEPRECATED, HIDDEN
+  REPO_TYPE, REPO, CHART, VERSION, SEARCH_QUERY, _FLAGGED, CATEGORY, DEPRECATED, HIDDEN, OPERATING_SYSTEM
 } from '@/config/query-params';
 import { lcFirst } from '@/utils/string';
 import { sortBy } from '@/utils/sort';
@@ -35,6 +35,7 @@ export default {
     this.showDeprecated = query[DEPRECATED] === _FLAGGED;
     this.showHidden = query[HIDDEN] === _FLAGGED;
     this.category = query[CATEGORY] || '';
+    this.operatingSystem = query[OPERATING_SYSTEM] || this.defaultOperatingSystem;
     this.allRepos = this.areAllEnabled();
   },
 
@@ -42,6 +43,7 @@ export default {
     return {
       allRepos:            null,
       category:            null,
+      operatingSystem:     null,
       searchQuery:         null,
       showDeprecated:      null,
       showHidden:          null,
@@ -151,7 +153,7 @@ export default {
       const enabledCharts = (this.enabledCharts || []);
 
       return filterAndArrangeCharts(enabledCharts, {
-        isWindows:      this.currentCluster.providerOs === 'windows',
+        os:             this.operatingSystem,
         category:       this.category,
         searchQuery:    this.searchQuery,
         showDeprecated: this.showDeprecated,
@@ -192,6 +194,67 @@ export default {
       return out;
     },
 
+    operatingSystemChartCounts() {
+      const counts = { linux: 0, windows: 0 };
+      const showPrerelease = this.$store.getters['prefs/get'](SHOW_PRE_RELEASE);
+
+      this.enabledCharts.forEach((chart) => {
+        const windowsVersions = compatibleVersionsFor(chart.versions, 'windows', showPrerelease);
+        const linuxVersions = compatibleVersionsFor(chart.versions, 'linux', showPrerelease);
+
+        if (windowsVersions.length > 0) {
+          counts['windows'] += 1;
+        }
+
+        if (linuxVersions.length > 0) {
+          counts['linux'] += 1;
+        }
+      });
+
+      return counts;
+    },
+
+    operatingSystemOptions() {
+      return [
+        {
+          label: this.t('catalog.charts.operatingSystems.all'),
+          value: '',
+          count: this.enabledCharts.length
+        },
+        {
+          label: this.t('catalog.charts.operatingSystems.linux'),
+          value: 'linux',
+          count: this.operatingSystemChartCounts.linux
+        },
+        {
+          label: this.t('catalog.charts.operatingSystems.windows'),
+          value: 'windows',
+          count: this.operatingSystemChartCounts.windows
+        }
+      ];
+    },
+
+    defaultOperatingSystem() {
+      const linuxCount = this.currentCluster.linuxWorkerCount;
+      const windowsCount = this.currentCluster.windowsWorkerCount;
+
+      if (linuxCount > windowsCount) {
+        return 'linux';
+      }
+
+      if (windowsCount > linuxCount) {
+        return 'windows';
+      }
+
+      return '';
+    },
+
+    showOperatingSystemOptions() {
+      const linuxCount = this.currentCluster.linuxWorkerCount;
+      const windowsCount = this.currentCluster.windowsWorkerCount;
+
+      return linuxCount > 0 && windowsCount > 0;
+    }
   },
 
   watch: {
@@ -201,6 +264,10 @@ export default {
 
     category(cat) {
       this.$router.applyQuery({ [CATEGORY]: cat || undefined });
+    },
+
+    operatingSystem(os) {
+      this.$router.applyQuery({ [OPERATING_SYSTEM]: os || undefined });
     },
   },
 
@@ -328,7 +395,7 @@ export default {
       </div>
     </header>
 
-    <div class="left-right-split">
+    <div class="left-right-split" :class="{'with-os-options': showOperatingSystemOptions}">
       <Select
         :searchable="false"
         :options="repoOptionsForDropdown"
@@ -360,6 +427,22 @@ export default {
         :clearable="false"
         :searchable="false"
         :options="categories"
+        placement="bottom"
+        label="label"
+        style="min-width: 200px;"
+        :reduce="opt => opt.value"
+      >
+        <template #option="opt">
+          {{ opt.label }} ({{ opt.count }})
+        </template>
+      </Select>
+
+      <Select
+        v-if="showOperatingSystemOptions"
+        v-model="operatingSystem"
+        :clearable="false"
+        :searchable="false"
+        :options="operatingSystemOptions"
         placement="bottom"
         label="label"
         style="min-width: 200px;"
@@ -409,6 +492,10 @@ export default {
     grid-template-columns: 50% auto auto 40px;
     align-content: center;
     grid-column-gap: 10px;
+
+    &.with-os-options {
+      grid-template-columns: 50% auto auto auto 40px;
+    }
   }
 
 .checkbox-select {

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -575,7 +575,7 @@ export function compatibleVersionsFor(versions, os, includePrerelease = true) {
       return false;
     }
 
-    if (!osAnnotation || osAnnotation === os) {
+    if (!osAnnotation || !os || osAnnotation === os) {
       return true;
     }
 
@@ -584,7 +584,7 @@ export function compatibleVersionsFor(versions, os, includePrerelease = true) {
 }
 
 export function filterAndArrangeCharts(charts, {
-  isWindows = false,
+  os,
   category,
   searchQuery,
   showDeprecated = false,
@@ -608,11 +608,8 @@ export function filterAndArrangeCharts(charts, {
       return false;
     }
 
-    if ( isWindows && compatibleVersionsFor(chartVersions, 'windows', showPrerelease).length <= 0) {
-      // There's no versions compatible with Windows
-      return false;
-    } else if ( !isWindows && compatibleVersionsFor(chartVersions, 'linux', showPrerelease).length <= 0) {
-      // There's no versions compatible with Linux
+    if (compatibleVersionsFor(chartVersions, os, showPrerelease).length <= 0) {
+      // There's no versions compatible with the specified os
       return false;
     }
 


### PR DESCRIPTION
rancher/dashboard#4223

- The options will show if there is at least 1 linux and windows worker node.
   - The option will be defaulted to the OS with the most worker nodes or to All OSs if there are equal nodes. 
- The page will only show windows charts if theres at least 1 windows worker node and 0 linux worker nodes.
- The page will only show linux charts if theres at least 1 linux worker node and 0 windows worker nodes.

![image](https://user-images.githubusercontent.com/55104481/143152383-0a681f9b-1358-4a81-ab36-a28bb6790e4f.png)
![image](https://user-images.githubusercontent.com/55104481/143152403-025550d4-23b3-45e6-bfa8-6f46aa52fc2d.png)
![image](https://user-images.githubusercontent.com/55104481/143152437-b19d8f5f-9754-40fd-8f0b-9fbb2fc472ad.png)


If you don't have access to windows nodes I tested this by just modifying the count at the top of the fetch method:
![image](https://user-images.githubusercontent.com/55104481/143152548-07d7a2e8-b7da-4d56-aaab-b975ff2687ce.png)

