### PR TITLE
Overflow wrap long text for state description

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -865,6 +865,7 @@ $spacing: 10px;
       &.state-description > td {
         font-size: 13px;
         padding-top: 0;
+        overflow-wrap: anywhere;
       }
     }
 


### PR DESCRIPTION
This resolves and issue with long contiguous strings of text would cause table contents to extend outside their container.