### PR TITLE
fix default nav group expansion

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -1,6 +1,5 @@
 <script>
 import Type from '@/components/nav/Type';
-import isEqual from 'lodash/isEqual';
 export default {
   name: 'Group',
 
@@ -146,11 +145,10 @@ export default {
         if (item.children && this.hasActiveRoute(item)) {
           return true;
         } else if (item.route) {
-          const { cluster, product, resource } = this.$route.params;
+          const navLevels = ['cluster', 'product', 'resource'];
+          const matchesNavLevel = navLevels.filter(param => !this.$route.params[param] || this.$route.params[param] !== item.route.params[param]).length === 0;
 
-          if (isEqual({
-            cluster, product, resource
-          }, item.route.params )) {
+          if (matchesNavLevel || this.$router.resolve(item.route).route.fullPath === this.$route.fullPath) {
             return true;
           }
         }

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,1 @@
-{"experimentalSessionSupport": true}
+{"experimentalSessionSupport": true, "testFiles":"*.spec.ts"}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -496,7 +496,13 @@ export default {
         // Only expand one group - so after the first has been expanded, no more will
         // This prevents the 'More Resources' group being expanded in addition to the normal group
         let canExpand = true;
+        const expanded = refs.filter(grp => grp.isExpanded)[0];
 
+        if (expanded && expanded.hasActiveRoute()) {
+          this.$nextTick(() => expanded.syncNav());
+
+          return;
+        }
         refs.forEach((grp) => {
           if (!grp.group.isRoot) {
             grp.isExpanded = false;


### PR DESCRIPTION
As part of this pr #4617 I attempted to make nav groups re-sync when the route changes, so the correct group is expanded when navigating directly to a resource per [this](https://github.com/rancher/dashboard/issues/4051#issuecomment-974306842) comment, but this change borks group expansion for a few resources with a different route structure, like projects/namespaces. This PR updates the nav logic so that:
- a nav item is considered active if the current route's cluster, product, and resource params match if defined, or if the full path is exactly the same
- if the currently expanded group contains an active nav item, the nav tree wont expand other groups

You can see how it was broken/is fixed by running the e2e `inappmenu.spec.ts` tests