### PR TITLE
Fix listeningPort reactivity, workload port service type editing #4508

### DIFF
--- a/components/form/WorkloadPorts.vue
+++ b/components/form/WorkloadPorts.vue
@@ -161,7 +161,7 @@ export default {
         const portSpec = findBy(this.loadBalancerServicePorts, 'name', _name);
 
         if (portSpec) {
-          row._listeningPort = portSpec.port;
+          this.$set(row, '_listeningPort', portSpec.port);
 
           row._serviceType = 'LoadBalancer';
 
@@ -171,7 +171,7 @@ export default {
         const portSpec = findBy(this.nodePortServicePorts, 'name', _name);
 
         if (portSpec) {
-          row._listeningPort = portSpec.nodePort;
+          this.$set(row, '_listeningPort', portSpec.nodePort);
 
           row._serviceType = 'NodePort';
 
@@ -186,7 +186,7 @@ export default {
       }
 
       return '';
-    }
+    },
   },
 };
 </script>

--- a/models/workload.js
+++ b/models/workload.js
@@ -407,11 +407,12 @@ export default class Workload extends SteveModel {
     ports.forEach((port) => {
       const name = port.name ? port.name : `${ port.containerPort }${ port.protocol.toLowerCase() }${ port.hostPort || port._listeningPort || '' }`;
 
+      port.name = name;
+
       if (port._serviceType && port._serviceType !== '') {
         return;
       }
 
-      port.name = name;
       if (loadBalancerServicePorts.length) {
         const portSpec = findBy(loadBalancerServicePorts, 'name', name);
 
@@ -522,7 +523,6 @@ export default class Workload extends SteveModel {
         }
       });
     }
-
     ports.forEach((port) => {
       const portSpec = {
         name: port.name, protocol: port.protocol, port: port.containerPort, targetPort: port.containerPort


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/4398#issuecomment-977689584 - I figured this was related to the solution I suggested to Jordon so I picked up this ticket. I found two underlying problems going through the repro steps outlined in that comment. 
One is that in the process of updating `getPortsWithServiceType` to not overwrite a workload port's `_serviceType` we inadvertently stopped auto-assigning names to unnamed ports prior to saving. The name is used to map between services' ports and ports as they're defined in the workload spec so that was breaking the edit page - both the ability to change an existing listening port and to change the service type associated with a port. 
The other issue I found was that the 'Listening Port' input change's weren't being tracked. This took me ages to track down but the problem is ultimately that the `_listeningPort` property wasn't reactively added to the row (container port) object; using `$set` to add this object property fixes that issue. 

Edit: I just noticed the problem with listening port not updating is tracked in its own issue here #4508