### PR TITLE
[2.5.12] rancher-logging: Fix generated YAML for logging output fields referencing file paths

### DIFF
--- a/components/form/SecretSelector.vue
+++ b/components/form/SecretSelector.vue
@@ -28,6 +28,10 @@ export default {
       type:    Boolean,
       default: false
     },
+    mountKey: {
+      type:    String,
+      default: 'valueFrom'
+    },
     nameKey: {
       type:    String,
       default: 'name'
@@ -57,7 +61,7 @@ export default {
   computed: {
     name: {
       get() {
-        const name = this.showKeySelector ? this.value?.valueFrom?.secretKeyRef?.[this.nameKey] : this.value;
+        const name = this.showKeySelector ? this.value?.[this.mountKey]?.secretKeyRef?.[this.nameKey] : this.value;
 
         return name || NONE;
       },
@@ -66,7 +70,7 @@ export default {
         const correctedName = isNone ? undefined : name;
 
         if (this.showKeySelector) {
-          this.$emit('input', { valueFrom: { secretKeyRef: { [this.nameKey]: correctedName, [this.keyKey]: '' } } });
+          this.$emit('input', { [this.mountKey]: { secretKeyRef: { [this.nameKey]: correctedName, [this.keyKey]: '' } } });
         } else {
           this.$emit('input', correctedName);
         }
@@ -75,10 +79,10 @@ export default {
 
     key: {
       get() {
-        return this.value?.valueFrom?.secretKeyRef?.[this.keyKey] || '';
+        return this.value?.[this.mountKey]?.secretKeyRef?.[this.keyKey] || '';
       },
       set(key) {
-        this.$emit('input', { valueFrom: { secretKeyRef: { [this.nameKey]: this.name, [this.keyKey]: key } } });
+        this.$emit('input', { [this.mountKey]: { secretKeyRef: { [this.nameKey]: this.name, [this.keyKey]: key } } });
       }
     },
     secrets() {

--- a/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
+++ b/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
@@ -114,6 +114,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ca_file"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -124,6 +125,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.client_cert"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -136,6 +138,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.client_key"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"

--- a/edit/logging.banzaicloud.io.output/providers/forward.vue
+++ b/edit/logging.banzaicloud.io.output/providers/forward.vue
@@ -111,6 +111,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.tls_client_cert_path"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -121,6 +122,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.tls_client_private_key_path"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"

--- a/edit/logging.banzaicloud.io.output/providers/kafka.vue
+++ b/edit/logging.banzaicloud.io.output/providers/kafka.vue
@@ -98,6 +98,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ssl_ca_cert"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -108,6 +109,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ssl_client_cert"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -120,6 +122,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ssl_client_cert_chain"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -130,6 +133,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ssl_client_cert_key"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"

--- a/edit/logging.banzaicloud.io.output/providers/loki.vue
+++ b/edit/logging.banzaicloud.io.output/providers/loki.vue
@@ -86,6 +86,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ca_cert"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -96,6 +97,7 @@ export default {
       <div class="col span-6 mb-10">
         <SecretSelector
           v-model="value.cert"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -108,6 +110,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.key"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"

--- a/edit/logging.banzaicloud.io.output/providers/splunkHec.vue
+++ b/edit/logging.banzaicloud.io.output/providers/splunkHec.vue
@@ -106,6 +106,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ca_file"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -116,6 +117,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.ca_path"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -128,6 +130,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.client_cert"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"
@@ -138,6 +141,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.client_key"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"

--- a/edit/logging.banzaicloud.io.output/providers/syslog.vue
+++ b/edit/logging.banzaicloud.io.output/providers/syslog.vue
@@ -105,6 +105,7 @@ export default {
       <div class="col span-6">
         <SecretSelector
           v-model="value.trusted_ca_path"
+          mount-key="mountFrom"
           :mode="mode"
           :namespace="namespace"
           :disabled="disabled"


### PR DESCRIPTION
Several logging output fields for ca and client certificates need to be provied as a file path in the fluentd config. For this, the secret which contains the value must be referenced in the output yaml with mountFrom instead of valueFrom. See https://banzaicloud.com/docs/one-eye/logging-operator/configuration/plugins/outputs/secret/.

Addresses https://github.com/rancher/rancher/issues/31810

Backports #4406 into release-2.5

#4578