### PR TITLE
"Restore snapshot" action is not available in Cluster management page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -95,6 +95,11 @@ nav:
       true {Support}
       other {Get Support}
     }
+  restoreSnapshot: Restore Snapshot
+  rotateCertificates: Rotate Certificates
+  rotateEncryptionKeys: Rotate Encryption Keys
+  saveAsRKETemplate: Save as RKE Template
+  takeSnapshot: Take Snapshot
   group:
     cluster: Cluster
     inUse: More Resources

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3377,6 +3377,11 @@ promptRestore:
   name: Name
   date: Date
   fromS3: Restore from S3
+  label: Snapshot
+  placeholder: Select a snapshot to restore
+  notification:
+    title: Restore Snapshot
+    message: Restoring snapshot { selectedSnapshot } has started...
 
 promptRollback:
   modalTitle: Roll Back {workloadName}

--- a/components/PromptRestore.vue
+++ b/components/PromptRestore.vue
@@ -277,11 +277,15 @@ export default {
       min-height: 16px;
     }
 
-    .card-actions {
-      justify-content: end;
+    ::v-deep .card-container .card-actions {
+      display: block;
 
       button:not(:last-child) {
         margin-right: 10px;
+      }
+
+      .banner {
+        display: flex;
       }
     }
   }

--- a/components/PromptRestore.vue
+++ b/components/PromptRestore.vue
@@ -123,7 +123,7 @@ export default {
           return allSnapshots;
         })
         .catch((err) => {
-          console.error(err); // eslint-disable-line no-console
+          this.errors = exceptionToErrorsArray(err);
         });
     },
 

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -79,7 +79,7 @@ export default class ProvCluster extends SteveModel {
 
     insertAt(out, idx++, {
       action:     'snapshotAction',
-      label:      'Take Snapshot',
+      label:      this.$rootGetters['i18n/t']('nav.takeSnapshot'),
       icon:       'icon icon-snapshot',
       bulkAction: 'snapshotBulk',
       bulkable:   true,
@@ -88,28 +88,28 @@ export default class ProvCluster extends SteveModel {
 
     insertAt(out, idx++, {
       action:  'restoreSnapshotAction',
-      label:   'Restore Snapshot',
+      label:      this.$rootGetters['i18n/t']('nav.restoreSnapshot'),
       icon:    'icon icon-fw icon-backup-restore',
       enabled: canSnapshot,
     });
 
     insertAt(out, idx++, {
       action:     'rotateCertificates',
-      label:      'Rotate Certificates',
+      label:      this.$rootGetters['i18n/t']('nav.rotateCertificates'),
       icon:       'icon icon-backup',
       enabled:    this.mgmt?.hasAction('rotateCertificates') && this.mgmt?.isReady,
     });
 
     insertAt(out, idx++, {
       action:     'rotateEncryptionKey',
-      label:      'Rotate Encryption Keys',
+      label:      this.$rootGetters['i18n/t']('nav.rotateEncryptionKeys'),
       icon:       'icon icon-refresh',
       enabled:     this.isRke1 && this.mgmt?.hasAction('rotateEncryptionKey') && this.mgmt?.isReady,
     });
 
     insertAt(out, idx++, {
       action:     'saveAsRKETemplate',
-      label:      'Save as RKE Template',
+      label:      this.$rootGetters['i18n/t']('nav.saveAsRKETemplate'),
       icon:       'icon icon-folder',
       enabled:    this.isRke1 && this.mgmt?.status?.driver === 'rancherKubernetesEngine' && !this.mgmt?.spec?.clusterTemplateName && this.hasLink('update'),
     });

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -87,6 +87,13 @@ export default class ProvCluster extends SteveModel {
     });
 
     insertAt(out, idx++, {
+      action:  'restoreSnapshotAction',
+      label:   'Restore Snapshot',
+      icon:    'icon icon-fw icon-backup-restore',
+      enabled: canSnapshot,
+    });
+
+    insertAt(out, idx++, {
       action:     'rotateCertificates',
       label:      'Rotate Certificates',
       icon:       'icon icon-backup',
@@ -477,6 +484,10 @@ export default class ProvCluster extends SteveModel {
 
       return classify(this.$ctx, x);
     });
+  }
+
+  restoreSnapshotAction(resource = this) {
+    this.$dispatch('promptRestore', [resource]);
   }
 
   saveAsRKETemplate(resources = this) {


### PR DESCRIPTION
This PR aims to add the Restore Snapshot functionality to the Cluster Management view. 
Currently you are able to Take Snapshot from cluster view, but need to enter the cluster detail view in order to restore a snapshot. 

To test this PR: 

1. Create an RKE1 cluster
2. Create a few snapshots
2. From Cluster Management, select 'Restore Snapshot' from the action menu
3. The PromptRestore modal should display with a dropdown list of the newly created snapshots

https://github.com/rancher/dashboard/issues/4606


![2021-12-14_06-31-16 (1)](https://user-images.githubusercontent.com/13671297/146008004-0a6a8dd5-000e-4793-a4b8-c1f664989761.gif)

