### PR TITLE
Prevent registry secrets from overriding each other

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -288,6 +288,7 @@ export default {
         supported:        true
       });
     }
+
     return { rows };
   },
 

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -280,7 +280,6 @@ export default {
         rows.push(entry);
       }
     }
-
     if ( !rows.length && this.initialEmptyRow ) {
       rows.push({
         [this.keyName]:   '',
@@ -289,7 +288,6 @@ export default {
         supported:        true
       });
     }
-
     return { rows };
   },
 
@@ -511,7 +509,6 @@ export default {
           <span />
         </slot>
       </template>
-
       <template v-if="!rows.length && isView">
         <div class="kv-item key text-muted">
           &mdash;

--- a/components/form/SelectOrCreateAuthSecret.vue
+++ b/components/form/SelectOrCreateAuthSecret.vue
@@ -92,6 +92,11 @@ export default {
       default: 'registerAuthSecret'
     },
 
+    appendUniqueIdToHook: {
+      type:    Boolean,
+      default: false
+    },
+
     hookPriority: {
       type:    Number,
       default: 99,
@@ -153,6 +158,7 @@ export default {
 
       publicKey:  '',
       privateKey: '',
+      uniqueId:   new Date().getTime() // Allows form state to be individually tracked if the form is in a list
     };
   },
 
@@ -318,7 +324,9 @@ export default {
 
   created() {
     if (this.registerBeforeHook) {
-      this.registerBeforeHook(this.doCreate, this.hookName, this.hookPriority);
+      const hookName = this.appendUniqueIdToHook ? this.hookName + this.uniqueId : this.hookName;
+
+      this.registerBeforeHook(this.doCreate, hookName, this.hookPriority);
     } else {
       throw new Error('Before Hook is missing');
     }

--- a/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -117,6 +117,7 @@ export default {
             <SelectOrCreateAuthSecret
               v-model="row.value.authConfigSecretName"
               :register-before-hook="clusterRegisterBeforeHook"
+              :append-unique-id-to-hook="true"
               in-store="management"
               :allow-ssh="false"
               :allow-rke="true"

--- a/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -27,7 +27,6 @@ export default {
         endpoints: (mirrorMap[hostname].endpoint || []).join(', '),
       });
     }
-
     return { entries };
   },
 

--- a/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -27,6 +27,7 @@ export default {
         endpoints: (mirrorMap[hostname].endpoint || []).join(', '),
       });
     }
+
     return { entries };
   },
 


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/4137

This PR solves a problem where if you create multiple secrets at once, only the last secret was created. The cause was that each secret used the same beforeSaveHook with the same name as all the others, so the last one would override the others. This PR gives a unique ID to the hooks so that multiple secrets can be created at once.

To test this PR, I created an RKE2 cluster with the private registry values in the section called `Configure advanced containerd and registry authentication options`:

- registry hostname for Rancher images: registry1.com
- mirrors: registry1.com => registry2.com
- registry authentication:
  - registry1.com: Create a HTTP Basic Auth Secret (used random inputs)
  - registry2.com: Create a HTTP Basic Auth Secret (used random inputs)

After the cluster was created, the two secrets were both created properly:
<img width="1420" alt="Screen Shot 2021-12-02 at 7 26 56 PM" src="https://user-images.githubusercontent.com/20599230/144535477-5eb22a16-f22c-42d1-b8e1-28e74ef7ae12.png">

And the registry YAML was created properly in the cluster YAML:

```
registries:
      configs:
        registry1.com:
          authConfigSecretName: registryconfig-auth-4w7xq
        registry2.com:
          authConfigSecretName: registryconfig-auth-j7zkq
      mirrors:
        registry1.com:
          endpoint:
            - registry2.com
```
