### PR TITLE
Add check for legacy or mcapp to remove upgrade button

### DIFF
--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -101,6 +101,10 @@ export default class CatalogApp extends SteveModel {
       return null;
     }
 
+    if ( this.deployedAsLegacy || this.deployedAsMultiCluster ) {
+      return null;
+    }
+
     if ( compare(thisVersion, newestVersion) < 0 ) {
       return cleanupVersion(newestVersion);
     }


### PR DESCRIPTION
Reference #4676 

**Original Issue**

If an app was launched using the old UI (prior to v2.6.3) it should no longer be upgrade-able from the dashboard. The `Upgrade Available` button is still showing, although the user will not be able to upgrade the app.

<img width="1388" alt="144323063-3ca1ae0e-a25c-47ae-b34f-8609fa0eb51d" src="https://user-images.githubusercontent.com/40806497/144486939-74c7c434-4fc7-474c-82af-1d8419f86db2.png">

**Fix**

This will remove the upgrade available button from the list view for an app that is considered `legacy` or `multi-cluster`.

![old-ebs](https://user-images.githubusercontent.com/40806497/144487375-f55a4ad3-4f57-4cd2-a802-c05b08d811c5.png)

**To Test**

- `rancher:v2.6.2` is required to install an app using the Ember UI.
- Follow the instructions [here](https://github.com/rancher/dashboard/issues/4121#issuecomment-983813921) to install the app.
- Check the `Installed Apps` page to see upgrade icon is removed. 
