### PR TITLE
Private registry mirrors in YAML are properly displayed in form

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -271,11 +271,11 @@ export default {
           supported:        this.supported(row),
         };
 
-        for ( const k of this.preserveKeys ) {
+        this.preserveKeys?.map((k) => {
           if ( typeof row[k] !== 'undefined' ) {
             entry[k] = row[k];
           }
-        }
+        });
 
         rows.push(entry);
       }

--- a/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -24,7 +24,7 @@ export default {
     for ( const hostname in mirrorMap ) {
       entries.push({
         hostname,
-        endpoints: (mirrorMap[hostname].entries || []).join(', '),
+        endpoints: (mirrorMap[hostname].endpoint || []).join(', '),
       });
     }
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4701. 

This fix makes it so that if you provision an RKE2 cluster with a private registry with a mirror, the mirror will render properly in the edit config form. The relevant cluster YAML is as follows:

```
registries:
      mirrors:
        registry1.com:
          endpoint:
          - registry2.com
```

Before:
<img width="743" alt="Screen Shot 2021-12-03 at 1 45 12 PM" src="https://user-images.githubusercontent.com/20599230/144673150-83aac0f2-b1ed-4e91-94b4-7079fab0a647.png">

After:
<img width="1120" alt="Screen Shot 2021-12-03 at 2 07 09 PM" src="https://user-images.githubusercontent.com/20599230/144673168-f06abc4b-b000-459f-ab1c-8c6d14389856.png">


