### PR TITLE
Update import a Harvester Cluster instructions

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1093,7 +1093,7 @@ cluster:
       other {are # Harvester clusters that are not shown}
       }  
     registration:
-      step1: "1. Go to the <code>Global Settings / Advanced Settings</code> page of the target Harvester's UI."
+      step1: "1. Go to the <code>Advanced / Settings</code> page of the target Harvester's UI."
       step2: '2. Find the <code>cluster-registration-url</code> setting and click the <code><i class="icon icon-actions" ></i></code> -> <code>Edit Setting</code> button.'
       step3: "3. Input the following registration URL and click the <code>Save</code> button."
       step4: "Registration URL"


### PR DESCRIPTION
@n313893254 I think I previously recommended the older text during a PR review, however in hindsight the instructions refer to the `Settings` location in a multi-cluster environment instead of the target harvester cluster's single cluster `Settings` location. Is this new change correct?