### PR TITLE
Ensure node pool / nodes are shown for imported clusters

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -85,10 +85,10 @@ export default {
 
     const fetchTwo = {};
 
-    const machineDeloymentTemplateType = fetchOneRes.machineDeployments?.[0]?.templateType;
+    const machineDeploymentTemplateType = fetchOneRes.machineDeployments?.[0]?.templateType;
 
-    if (machineDeloymentTemplateType && this.$store.getters['management/schemaFor'](machineDeloymentTemplateType) ) {
-      fetchTwo.mdtt = this.$store.dispatch('management/findAll', { type: machineDeloymentTemplateType });
+    if (machineDeploymentTemplateType && this.$store.getters['management/schemaFor'](machineDeploymentTemplateType) ) {
+      fetchTwo.mdtt = this.$store.dispatch('management/findAll', { type: machineDeploymentTemplateType });
     }
 
     if (!this.showMachines) {


### PR DESCRIPTION
- Looks like the `provisioning.cattle.io.cluster` `provisioner` property now changes from `imported` to `<detected type>` on successful import.
- This causes the node/node pool tab in the cluster management cluster page to be hidden (gates fetching nodes on   `this.value.isImported || this.value.isRke1`).
- We now always try to show machines pools / machines first and if not available fall back on node pools / nodes.
- This does lead to a longer load time, but removes any imported/rke1 shenanigans

Addresses https://github.com/rancher/dashboard/issues/4711