### PR TITLE
Fix double log in and other log in fixes/improvements

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -8,6 +8,7 @@ import Import from '@/components/Import';
 import BrandImage from '@/components/BrandImage';
 import { getProduct } from '@/config/private-label';
 import RancherProviderIcon from '@/components/RancherProviderIcon';
+import { LOGGED_OUT } from '@/config/query-params';
 import NamespaceFilter from './NamespaceFilter';
 import WorkspaceSwitcher from './WorkspaceSwitcher';
 import TopLevelMenu from './TopLevelMenu';
@@ -42,6 +43,7 @@ export default {
       showTooltip: false,
       searchShortcut,
       VIRTUAL,
+      LOGGED_OUT,
     };
   },
 
@@ -372,7 +374,7 @@ export default {
             <nuxt-link v-if="isRancher" tag="li" :to="{name: 'account'}" class="user-menu-item">
               <a>{{ t('nav.userMenu.accountAndKeys', {}, true) }} <i class="icon icon-fw icon-user" /></a>
             </nuxt-link>
-            <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'auth-logout'}" class="user-menu-item">
+            <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'auth-logout', query: { [LOGGED_OUT]: true }}" class="user-menu-item">
               <a @blur="showMenu(false)">{{ t('nav.userMenu.logOut') }} <i class="icon icon-fw icon-close" /></a>
             </nuxt-link>
           </ul>

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -205,9 +205,6 @@ export default {
 
     async loginLocal(buttonCb) {
       try {
-        this.err = null;
-        this.timedOut = null;
-        this.loggedOut = null;
         await this.$store.dispatch('auth/login', {
           provider: 'local',
           body:     {
@@ -244,6 +241,9 @@ export default {
         }
       } catch (err) {
         this.err = err;
+        this.timedOut = null;
+        this.loggedOut = null;
+
         buttonCb(false);
       }
     },

--- a/pages/auth/logout.vue
+++ b/pages/auth/logout.vue
@@ -1,12 +1,10 @@
 <script>
-import { LOGGED_OUT } from '@/config/query-params';
 
 export default {
   layout: 'unauthenticated',
 
   async asyncData({ redirect, store, router }) {
     await store.dispatch('auth/logout', null, { root: true });
-    redirect(302, `/auth/login?${ LOGGED_OUT }`);
   }
 };
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -868,7 +868,10 @@ export const actions = {
       if (!process.server) {
         const backTo = window.localStorage.getItem(BACK_TO);
 
-        if (!backTo && !route.query[LOGGED_OUT]) {
+        const isLogin = route.name === 'auth-login';
+        const isLogout = route.name === 'auth-logout';
+
+        if (!backTo && !isLogin && !isLogout) {
           window.localStorage.setItem(BACK_TO, window.location.href);
         }
       }


### PR DESCRIPTION
Fix issue of double log in #4716
- Only happened after logging out
- On log out flow goes Header logout button link --> logout.vue page --> auth/logout action --> onLogout action
- in onLogout a `backTo` was being set to the logout page
- when the user then logged in ui redirected to the `backTo` location, which was the logout page

Improvements to the logout process 
- in logout page remove duplicated redirect to login page (always happens in onLogout)
- ensure the login and logout pages are never saved as the backTo location (not just checking a param)

Remove wiggle of login page components #4202
- If an error banner or message is shown avoid the content jiggling when the user attempts to log in again