### PR TITLE
Get list of management clusters for the current product

### DIFF
--- a/list/management.cattle.io.cluster.vue
+++ b/list/management.cattle.io.cluster.vue
@@ -9,12 +9,15 @@ export default {
   components: { Loading, ResourceTable },
 
   async fetch() {
-    await this.$store.dispatch(`management/findAll`, { type: this.$attrs.resource });
+    await this.$store.dispatch(`${ this.inStore }/findAll`, { type: this.$attrs.resource });
   },
 
   computed: {
+    inStore() {
+      return this.$store.getters['currentProduct'].inStore;
+    },
     rows() {
-      const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
+      const all = this.$store.getters[`${ this.inStore }/all`](MANAGEMENT.CLUSTER);
 
       return filterOnlyKubernetesClusters(all);
     }


### PR DESCRIPTION
This fixes an issue where all the management clusters are listed while exploring a downstream cluster by getting a list of management clusters for the current product. This means that Cluster Management => Advanced => Mgmt Clusters should remain unchanged, as the product is still `management`, while Cluster Management => { downstreamCluster } Explore => More Resources => Rancher => Mgmt Clusters should only list the management clusters for the given product. 

#4667 