### PR TITLE
Add UI for NetworkPolicies

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -75,7 +75,7 @@ generic:
   enable: Enable
   disable: Disable
   experimental: Experimental
-  
+
   deprecated: Deprecated
   placeholder: "e.g. {text}"
   moreInfo: More Info
@@ -150,7 +150,7 @@ nav:
     preferences: Preferences
     accountAndKeys: Account & API Keys
     logOut: Log Out
-  failWhale: 
+  failWhale:
     reload: Reload
     separator: or
 
@@ -679,7 +679,7 @@ catalog:
     section:
       notes: Release Notes
       readme: Chart README
-      resources: 
+      resources:
         label: Resources
         busy: The related resources will appear when {app} is fully installed.
       values: Values YAML
@@ -1097,7 +1097,7 @@ cluster:
       image: Image
       network: Network Name
       sshUser: SSH User
-      userData: 
+      userData:
         label: User Data Template
         title: "User Data:"
       networkData:
@@ -1111,7 +1111,7 @@ cluster:
     label: Cluster Description
     placeholder: Any text you want that better describes this cluster
   harvester:
-    importNotice: Import Harvester Clusters via 
+    importNotice: Import Harvester Clusters via
     warning:
       label: This is a Harvester Cluster - enable the Harvester feature flag to manage it
       state: Warning
@@ -1119,14 +1119,14 @@ cluster:
       There {count, plural,
       =1 {is 1 Harvester cluster that is not shown}
       other {are # Harvester clusters that are not shown}
-      }  
+      }
     registration:
       step1: "1. Go to the <code>Advanced / Settings</code> page of the target Harvester's UI."
       step2: '2. Find the <code>cluster-registration-url</code> setting and click the <code><i class="icon icon-actions" ></i></code> -> <code>Edit Setting</code> button.'
       step3: "3. Input the following registration URL and click the <code>Save</code> button."
       step4: "Registration URL"
     machinePool:
-      cpu: 
+      cpu:
         placeholder: e.g. 2
       memory:
         placeholder: e.g. 4
@@ -1263,7 +1263,7 @@ cluster:
         auto: Use vApp to configure networks with network protocol profiles
         manual: Provide a custom vApp config
         restoreType: Restore Type
-        transport: 
+        transport:
           label: OVF environment transport
           tooltip: com.vmware.guestInfo or iso
           placeholder: e.g. com.vmware.guestInfo
@@ -1300,7 +1300,7 @@ cluster:
         resourcePool: Resource Pool
         dataStore: Data Store
         folder: Folder
-        host: 
+        host:
           label: Host
           note: Specific host to create VM on (leave blank for standalone ESXi or for cluster with DRS)
       instanceOptions:
@@ -1310,13 +1310,13 @@ cluster:
         memory: Memory
         disk: Disk
         creationMethod: Creation method
-        template: 
+        template:
           label: Template
           none: No Templates Found
         contentLibrary: Content library
         libraryTemplate: Library template
         virtualMachine: Virtual machine
-        osIsoUrl: 
+        osIsoUrl:
           label: OS ISO URL
           placeholder: 'Default: Latest rancheros-vmware image'
         cloudInit:
@@ -1333,7 +1333,7 @@ cluster:
         label: Custom attributes (legacy)
         description: Custom attributes allow you to attach metadata to objects in the vSphere inventory to make it easier to sort and search for these objects.
         add: Add custom attribute
-    amazonEc2: 
+    amazonEc2:
       region: Region
       zone: Zone
       instanceType: Instance Type
@@ -1350,21 +1350,21 @@ cluster:
       ami:
         label: AMI ID
         placeholder: 'Default: A recent Ubuntu LTS'
-      sshUser: 
+      sshUser:
         label: SSH Username for AMI
         placeholder: 'Default: ubuntu'
         tooltip: 'The username that exists in the selected AMI; Provisioning will SSH to the node with this.'
       securityGroup:
         title: Security Group
         vpcId: '(select a VPC/Subnet first)'
-        mode: 
+        mode:
           default: 'Standard: Automatically create and use a "{defaultGroup}"; security group'
           custom: 'Choose one or more existing security groups:'
       volumeType:
         label: EBS Root Volume Type
         placeholder: 'Default: gp2'
       encryptEbsVolume: Encrypt EBS Volume
-      kmsKey: 
+      kmsKey:
         label: KMS Key ARN
         text: 'You do not have permission to list KMS keys, but may still be able to enter a Key ARN if you know one.'
       requestSpotInstance: Request Spot Instance
@@ -1377,7 +1377,7 @@ cluster:
       httpEndpoint: Allow access to EC2 metadata
       httpTokens: Use tokens for metadata
       tagTitle: EC2 Tags
-  addOns: 
+  addOns:
     additionalManifest:
       title: Additional Manifest
       tooltip: 'Additional Kubernetes Manifest YAML to be applied to the cluster on startup.'
@@ -1544,7 +1544,7 @@ cluster:
       rke2-metrics-server: 'Metrics Server'
       header: System Services
     cni:
-      label: Container Network 
+      label: Container Network
     cloudProvider:
       label: Cloud Provider
       header: Cloud Provider Config
@@ -1776,19 +1776,19 @@ fleet:
       There {count, plural,
       =1 {is 1 Harvester cluster that is hidden as this can not be used with Continuous Delivery}
       other {are # Harvester clusters that are hidden as they can not be used with Continuous Delivery}
-      }  
+      }
   tokens:
     harvester: |-
       {count, plural,
       =1 {1 token is hidden as it belongs to a Harvester cluster that can not be used with Continuous Delivery}
       other {# tokens are hidden as they belong to Harvester clusters that can not be used with Continuous Delivery}
-      }  
+      }
   bundles:
     harvester: |-
       {count, plural,
       =1 {1 bundle is hidden as it belongs to a Harvester cluster that can not be used with Continuous Delivery}
       other {# bundles are hidden as they belong to Harvester clusters that can not be used with Continuous Delivery}
-      }  
+      }
   fleetSummary:
     state:
       ready: 'Ready'
@@ -2528,7 +2528,7 @@ login:
   welcome: Welcome to {vendor}
   loggedOut: You have been logged out.
   loginAgain: Log in again to continue.
-  serverError:  
+  serverError:
     authFailedCreds: "Logging in failed: Check credentials, or your account may not be authorized to log in."
     authFailed: "Logging in failed: Your account may not be authorized to log in."
     unknown: "An unknown error occurred while attempting to login. Please contact your system administrator."
@@ -2877,7 +2877,7 @@ navLink:
   label:
     label: Display name
     placeholder: 'Text displayed for the link'
-  tabs: 
+  tabs:
     link:
       label: Link type
       type:
@@ -2906,7 +2906,7 @@ navLink:
         blank: New window
         self: Replace window
         named: Custom named window
-      namedValue: 
+      namedValue:
         label: Window name
     group:
       label: Group
@@ -2919,6 +2919,66 @@ navLink:
         label: Link description
       iconSrc:
         label: Add image
+networkpolicy:
+  egress:
+    label: Egress Rules
+    enable: Configure egress rules to restrict outgoing traffic
+    ruleLabel: Targets
+    ruleHint: Outgoing traffic is only allowed to the configured targets
+    portHint: Outgoing traffic is only allowed to connect to the configured ports
+  ingress:
+    label: Ingress Rules
+    enable: Configure ingress rules to restrict incoming traffic
+    ruleLabel: Sources
+    ruleHint: Incoming traffic is only allowed from the configured sources
+    portHint: Incoming traffic is only allowed to connect to the configured ports
+  labelsAnnotations:
+    label: Labels & Annotations
+  rules:
+    ruleLabel: Rule {index}
+    addPort: Add allowed port
+    type: Rule type
+    ingress:
+      add: Add allowed traffic source
+    egress:
+      add: Add allowed traffic target
+    ports:
+      label: Allowed ports
+      port:
+        label: Port
+        placeholder: e.g. 8080
+      protocol: Protocol
+    ipBlock:
+      label: IP block
+      exceptions: Exceptions
+      cidr:
+        label: CIDR
+        placeholder: e.g. 1.1.1.0/24
+      addExcept: Add exception
+      invalidCidrs: "Invalid CIDRs: {invalidCidrs}"
+    podSelector:
+      label: Pod Selector
+    namespaceSelector:
+      label: Namespace Selector
+  config:
+    label: Configuration
+  selectors:
+    label: Selectors
+    hint: The NetworkPolicy is applied to the selected Pods
+    matchingPods:
+      matchesSome: |-
+        {matched, plural,
+          =0 {Matches 0 of {total, number} pods}
+          =1 {Matches 1 of {total, number} pods: "{sample}"}
+          other {Matches {matched, number} of {total, number} existing pods, including "{sample}"}
+        }
+    matchingNamespaces:
+      matchesSome: |-
+        {matched, plural,
+          =0 {Matches 0 of {total, number} namespaces}
+          =1 {Matches 1 of {total, number} namespaces: "{sample}"}
+          other {Matches {matched, number} of {total, number} existing namespaces, including "{sample}"}
+        }
 node:
   list:
     pool: Pool
@@ -3274,7 +3334,7 @@ persistentVolumeClaim:
   name: Persistent Volume Claim Name
   accessModes: Access Modes
   accessModesOptions:
-    singleNodeRW: Single-Node Read/Write 
+    singleNodeRW: Single-Node Read/Write
     manyNodeR: Many-Node Read-Only
     manyNodeRW: Many-Node Read/Write
   capacity: Capacity
@@ -3856,7 +3916,7 @@ secret:
     'kubernetes.io/basic-auth':
       description: 'Authentication with a username and password'
       docLink: https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
-    'Opaque': 
+    'Opaque':
       description: Default type of Secret using key-value pairs
       docLink: https://kubernetes.io/docs/concepts/configuration/secret/#opaque-secrets
     'kubernetes.io/dockerconfigjson':
@@ -4634,7 +4694,7 @@ validation:
         ianaAt: 'Port Rule [{position}] - Target Port '
         required: 'Port Rule [{position}] - Target Port is required'
   setting:
-    serverUrl: 
+    serverUrl:
       https: server-url must be https.
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
@@ -4752,10 +4812,10 @@ workload:
     imagePullSecrets: Pull Secrets
     init: Init Container
     lifecycleHook:
-      postStart: 
+      postStart:
         label: PostStart
         add: Add PostStart Hook
-      preStop: 
+      preStop:
         label: PreStop
         add: Add PreStop Hook
       exec:
@@ -5161,7 +5221,7 @@ harvester:
       title: 'Generate Template'
       name: 'Name'
       description: 'Description'
-      message: 
+      message:
         tip: Please enter a template name!
         success: 'Template { templateName } created successfully.'
         failed: 'Failed generated template!'
@@ -5175,7 +5235,7 @@ harvester:
       failedMessage: Latest migration failed!
       title: Migration
       fields:
-        nodeName: 
+        nodeName:
           label: Target Node
           placeholder: Choose Target Node
     ejectCDROM:
@@ -5276,7 +5336,7 @@ harvester:
     cpu: CPU
     storage: Storage
     noFileChosen: No file chosen
-  
+
   validation:
     custom:
       tooLongName: '"Name" cannot be more than {max} characters.'
@@ -5302,7 +5362,7 @@ harvester:
     image:
       ruleTip: 'The URL you have entered ends in an extension that we do not support. We only accept image files that end in .img, .iso, .qcow, .qcow2, .raw.'
       ruleFileTip: 'The file you have chosen ends in an extension that we do not support. We only accept image files that end in .img, .iso, .qcow, .qcow2, .raw.'
-  
+
   dashboard:
     label: Dashboard
     header: "Harvester Cluster: {cluster}"
@@ -5396,12 +5456,12 @@ harvester:
     label: Virtual Machines
     osType: OS Type
     instance:
-      singleInstance: 
-      multipleInstance: 
+      singleInstance:
+      multipleInstance:
       single:
         label: Single Instance
         nameLabel: Name
-        host: 
+        host:
           label: Hostname
           placeholder: default to the virtual machine name.
       multiple:
@@ -5410,7 +5470,7 @@ harvester:
         count: Count
         countTip: Count should be between 1 and 10
         nameLabel: Name Prefix
-        host: 
+        host:
           label: Host Prefix Name
           placeholder: default to the virtual machine name.
     useTemplate:
@@ -5559,8 +5619,8 @@ harvester:
         down: No events in the past hour
       console:
         down: This Virtual Machine is down. Please start it to access its console.
-     
-  volume: 
+
+  volume:
     label: Volumes
     tabs:
       basics: Basics
@@ -5631,7 +5691,7 @@ harvester:
       layer3Network: Route
     message:
       vlanInactive: 'VLAN network is inactive at {name} host'
-      premise: 
+      premise:
         prefix: 'You must configure a network in'
         middle: 'Settings'
         suffic: 'before creating a new network.'
@@ -5702,14 +5762,14 @@ harvester:
     title: Harvester Support
     kubeconfig:
       title: Download KubeConfig
-      titleDescription: Download kubeconfig for debugging. 
-  
+      titleDescription: Download kubeconfig for debugging.
+
   namespace:
     label: Namespaces
 
   projectNamespace:
     label: Projects/Namespaces
-  
+
   service:
     title: Add-on Config
     ipam:
@@ -5729,7 +5789,7 @@ harvester:
       label: Health Check Timeout
     healthCheckEnabled:
       label: Health Check
-  
+
   vip:
     namespace:
       label: Namespace
@@ -5738,13 +5798,13 @@ harvester:
       invalid: '"CIRD" is invalid.'
     add:
       label: Add IP Pools
-  
+
   sslParameters:
-    protocols: 
+    protocols:
       label: Protocols
     ciphers:
       label: Ciphers
-    
+
 ##############################
 # Model Properties
 ##############################
@@ -5841,7 +5901,7 @@ typeDescription:
   monitoring.coreos.com.prometheusrule: A Prometheus Rule resource defines both recording and/or alert rules. A recording rule can pre-compute values and save the results. Alerting rules allow you to define conditions on when to send notifications to AlertManager.
   monitoring.coreos.com.prometheus: A Prometheus server is a Prometheus deployment whose scrape configuration and rules are determined by selected ServiceMonitors, PodMonitors, and PrometheusRules and whose alerts will be sent to all selected Alertmanagers with the custom resource's configuration.
   monitoring.coreos.com.alertmanager: An alert manager is deployment whose configuration will be specified by a secret in the same namespace, which determines which alerts should go to which receiver.
-  node: The base Kubernetes Node resource represents a virtual or physical machine which hosts deployments. To manage the machine lifecyle, if available, go to Cluster Management.   
+  node: The base Kubernetes Node resource represents a virtual or physical machine which hosts deployments. To manage the machine lifecyle, if available, go to Cluster Management.
   catalog.cattle.io.clusterrepo: 'A chart repository is a Helm repository or {vendor} git based application catalog. It provides the list of available charts in the cluster.'
   catalog.cattle.io.clusterrepo.local: ' A chart repository is a Helm repository or {vendor} git based application catalog. It provides the list of available charts in the cluster. Cluster Templates are deployed via Helm charts.'
   catalog.cattle.io.operation: An operation is the list of recent Helm operations that have been applied to the cluster.
@@ -6103,7 +6163,7 @@ typeLabel:
     {count, plural,
       one { Bundle }
       other { Bundles }
-    } 
+    }
   fleet.cattle.io.clusterregistrationtoken: |-
     {count, plural,
       one { Cluster Registration Token }
@@ -6170,7 +6230,7 @@ registryMirror:
   addLabel: Add Mirror
 
 registryConfig:
-  header: Registry Authentication 
+  header: Registry Authentication
   toolTip: 'When an image needs to be pulled from the given registry hostname, this information will be used to verify the identity of the registry and authenticate to it.'
   addLabel: Add Registry
 
@@ -6269,7 +6329,7 @@ featureFlags:
     Some features require a restart of the {vendor} server to change.
     This will result in a short outage of the API and UI, but not affect running clusters or workloads.
   promptActivate: Please confirm that you want to activate the feature flag "{flag}"
-  promptDeactivate: Please confirm that you want to deactivate the feature flag "{flag}"    
+  promptDeactivate: Please confirm that you want to deactivate the feature flag "{flag}"
   restartRequired: "Note: Updating this feature flag requires a restart"
   restart:
     title: Waiting for Restart
@@ -6361,7 +6421,7 @@ resourceQuota:
   services: Services
   servicesLoadBalancers: Services Load Balancers
   servicesNodePorts: Service Node Ports
-  namespaceLimit: 
+  namespaceLimit:
     label: Limit
   projectLimit:
     label: Project Limit

--- a/edit/networking.k8s.io.networkpolicy/PolicyRule.vue
+++ b/edit/networking.k8s.io.networkpolicy/PolicyRule.vue
@@ -1,0 +1,91 @@
+<script>
+
+import PolicyRulePort from '@/edit/networking.k8s.io.networkpolicy/PolicyRulePort';
+import ArrayListGrouped from '@/components/form/ArrayListGrouped';
+import { _EDIT } from '@/config/query-params';
+import PolicyRuleTarget from '@/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget';
+
+export default {
+  components: {
+    ArrayListGrouped, PolicyRulePort, PolicyRuleTarget
+  },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      },
+    },
+    mode: {
+      type:    String,
+      default: _EDIT,
+    },
+    type: {
+      type:    String,
+      default: 'ingress'
+    },
+    namespace: {
+      type:    String,
+      default: ''
+    },
+    allPods: {
+      type:    Array,
+      default: () => {
+        return [];
+      },
+    },
+    allNamespaces: {
+      type:    Array,
+      default: () => {
+        return [];
+      },
+    },
+  },
+  data() {
+    return { targetKey: this.type === 'ingress' ? 'from' : 'to' };
+  }
+};
+</script>
+
+<template>
+  <div class="rule">
+    <div class="row mb-40">
+      <div class="col span-12">
+        <h2>
+          {{ t(`networkpolicy.${type}.ruleLabel`) }}
+          <i v-tooltip="t(`networkpolicy.${type}.ruleHint`)" class="icon icon-info" />
+        </h2>
+        <ArrayListGrouped v-model="value[targetKey]" :add-label="t(`networkpolicy.rules.${type}.add`)" :default-add-value="{}" :mode="mode">
+          <template #default="props">
+            <PolicyRuleTarget
+              ref="lastTarget"
+              v-model="props.row.value"
+              :mode="mode"
+              :type="type"
+              :namespace="namespace"
+              :all-namespaces="allNamespaces"
+              :all-pods="allPods"
+            />
+          </template>
+        </ArrayListGrouped>
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-12">
+        <h2>
+          {{ t('networkpolicy.rules.ports.label') }}
+          <i v-tooltip="t(`networkpolicy.${type}.portHint`)" class="icon icon-info" />
+        </h2>
+        <ArrayListGrouped v-model="value.ports" :add-label="t('networkpolicy.rules.addPort')" :default-add-value="{}" :mode="mode">
+          <template #default="props">
+            <PolicyRulePort
+              ref="lastPort"
+              v-model="props.row.value"
+              :mode="mode"
+            />
+          </template>
+        </ArrayListGrouped>
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/networking.k8s.io.networkpolicy/PolicyRulePort.vue
+++ b/edit/networking.k8s.io.networkpolicy/PolicyRulePort.vue
@@ -1,0 +1,50 @@
+<script>
+
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import { _EDIT } from '@/config/query-params';
+
+export default {
+  components: { LabeledInput, LabeledSelect },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      },
+    },
+    mode: {
+      type:    String,
+      default: _EDIT,
+    },
+  },
+  data() {
+    return { portOptions: ['TCP', 'UDP'] };
+  }
+};
+</script>
+
+<template>
+  <div class="row">
+    <div class="col span-4">
+      <LabeledInput
+        v-model.number="value.port"
+        :mode="mode"
+        type="number"
+        min="1"
+        max="65535"
+        :placeholder="t('networkpolicy.rules.ports.port.placeholder')"
+        :label="t('networkpolicy.rules.ports.port.label')"
+      />
+    </div>
+    <div class="col span-4">
+      <LabeledSelect
+        v-model="value.protocol"
+        :mode="mode"
+        :options="portOptions"
+        :multiple="false"
+        :label="t('networkpolicy.rules.ports.protocol')"
+      />
+    </div>
+  </div>
+</template>

--- a/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -1,0 +1,275 @@
+<script>
+
+import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import { _EDIT } from '@/config/query-params';
+import MatchExpressions from '@/components/form/MatchExpressions';
+import { convert, matching, simplify } from '@/utils/selector';
+import { POD } from '@/config/types';
+import ArrayList from '@/components/form/ArrayList';
+import Banner from '@/components/Banner';
+import throttle from 'lodash/throttle';
+import { isValidCIDR } from '@/utils/validators/cidr';
+
+const TARGET_OPTION_IP_BLOCK = 'ipBlock';
+const TARGET_OPTION_NAMESPACE_SELECTOR = 'namespaceSelector';
+const TARGET_OPTION_POD_SELECTOR = 'podSelector';
+
+export default {
+  components: {
+    ArrayList, Banner, LabeledInput, LabeledSelect, MatchExpressions
+  },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      },
+    },
+    mode: {
+      type:    String,
+      default: _EDIT,
+    },
+    type: {
+      type:    String,
+      default: 'ingress'
+    },
+    namespace: {
+      type:    String,
+      default: ''
+    },
+    allPods: {
+      type:    Array,
+      default: () => {
+        return [];
+      },
+    },
+    allNamespaces: {
+      type:    Array,
+      default: () => {
+        return [];
+      },
+    },
+  },
+  data() {
+    if (!this.value[TARGET_OPTION_IP_BLOCK] && !this.value[TARGET_OPTION_POD_SELECTOR] && !this.value[TARGET_OPTION_NAMESPACE_SELECTOR]) {
+      this.$nextTick(() => {
+        this.$set(this.value, TARGET_OPTION_IP_BLOCK, {});
+      });
+    }
+
+    const matchingPods = this.getMatchingPods();
+    const matchingNamespaces = this.getMatchingNamespaces();
+
+    return {
+      portOptions:   ['TCP', 'UDP'],
+      matchingPods,
+      matchingNamespaces,
+      invalidCidrs:    [],
+      TARGET_OPTION_IP_BLOCK,
+      TARGET_OPTION_NAMESPACE_SELECTOR,
+      TARGET_OPTION_POD_SELECTOR,
+      POD,
+      targetOptions: [
+        TARGET_OPTION_IP_BLOCK,
+        TARGET_OPTION_NAMESPACE_SELECTOR,
+        TARGET_OPTION_POD_SELECTOR
+      ],
+    };
+  },
+  computed: {
+    podSelectorExpressions: {
+      get() {
+        return convert(
+          this.value[TARGET_OPTION_POD_SELECTOR]?.matchLabels || {},
+          this.value[TARGET_OPTION_POD_SELECTOR]?.matchExpressions || []
+        );
+      },
+      set(podSelectorExpressions) {
+        this.$set(this.value, TARGET_OPTION_POD_SELECTOR, simplify(podSelectorExpressions));
+      }
+    },
+    namespaceSelectorExpressions: {
+      get() {
+        return convert(
+          this.value[TARGET_OPTION_NAMESPACE_SELECTOR]?.matchLabels || {},
+          this.value[TARGET_OPTION_NAMESPACE_SELECTOR]?.matchExpressions || []
+        );
+      },
+      set(namespaceSelectorExpressions) {
+        this.$set(this.value, TARGET_OPTION_NAMESPACE_SELECTOR, simplify(namespaceSelectorExpressions));
+      }
+    },
+    selectTargetOptions() {
+      const selectTargetOptions = [];
+
+      for (const option of this.targetOptions) {
+        selectTargetOptions.push({
+          label: this.t(`networkpolicy.rules.${ option }.label`),
+          value: option,
+        });
+      }
+
+      return selectTargetOptions;
+    },
+    targetType: {
+      get() {
+        for (const option of this.targetOptions) {
+          if (this.value[option]) {
+            return option;
+          }
+        }
+
+        return null;
+      },
+      set(targetType) {
+        this.$delete(this.value, TARGET_OPTION_IP_BLOCK);
+        this.$delete(this.value, TARGET_OPTION_NAMESPACE_SELECTOR);
+        this.$delete(this.value, TARGET_OPTION_POD_SELECTOR);
+        this.$nextTick(() => {
+          this.$set(this.value, targetType, {});
+        });
+      }
+    }
+  },
+  watch: {
+    namespace:                    'updateMatches',
+    'value.podSelector':          'updateMatches',
+    'value.namespaceSelector':    'updateMatches',
+    'value.ipBlock.cidr':         'validateCIDR',
+    'value.ipBlock.except':       'validateCIDR',
+    podSelectorExpressions:       'updateMatches',
+    namespaceSelectorExpressions: 'updateMatches',
+  },
+  methods: {
+    validateCIDR() {
+      const exceptCidrs = this.value[TARGET_OPTION_IP_BLOCK].except || [];
+
+      this.invalidCidrs = exceptCidrs.filter(cidr => !isValidCIDR(cidr));
+
+      if (this.value[TARGET_OPTION_IP_BLOCK].cidr && !isValidCIDR(this.value[TARGET_OPTION_IP_BLOCK].cidr)) {
+        this.invalidCidrs.push(this.value[TARGET_OPTION_IP_BLOCK].cidr);
+      }
+    },
+    updateMatches: throttle(function() {
+      this.matchingPods = this.getMatchingPods();
+      this.matchingNamespaces = this.getMatchingNamespaces();
+    }, 250, { leading: true }),
+    getMatchingPods() {
+      const allInNamespace = this.allPods.filter(pod => pod.metadata.namespace === this.namespace);
+      const match = matching(allInNamespace, this.podSelectorExpressions);
+      const matched = match.length || 0;
+      const sample = match[0]?.nameDisplay;
+
+      return {
+        matched,
+        matches: match,
+        none:    matched === 0,
+        sample,
+        total:   allInNamespace.length,
+      };
+    },
+    getMatchingNamespaces() {
+      const allNamespaces = this.allNamespaces;
+      const match = matching(allNamespaces, this.namespaceSelectorExpressions);
+      const matched = match.length || 0;
+      const sample = match[0]?.nameDisplay;
+
+      return {
+        matched,
+        matches: match,
+        none:    matched === 0,
+        sample,
+        total:   allNamespaces.length,
+      };
+    },
+  }
+};
+</script>
+
+<template>
+  <div class="rule">
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="targetType"
+          :mode="mode"
+          :options="selectTargetOptions"
+          :multiple="false"
+          :label="t('networkpolicy.rules.type')"
+        />
+      </div>
+    </div>
+    <div v-if="targetType === TARGET_OPTION_IP_BLOCK">
+      <div v-if="invalidCidrs.length > 0" class="row mb-10">
+        <div class="col span-12">
+          <Banner color="error">
+            <span v-html="t('networkpolicy.rules.ipBlock.invalidCidrs', { invalidCidrs })" />
+          </Banner>
+        </div>
+      </div>
+      <div class="row mb-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value[TARGET_OPTION_IP_BLOCK].cidr"
+            :mode="mode"
+            :placeholder="t('networkpolicy.rules.ipBlock.cidr.placeholder')"
+            :label="t('networkpolicy.rules.ipBlock.cidr.label')"
+          />
+        </div>
+      </div>
+      <div class="row mb-0">
+        <div class="col span-12">
+          <ArrayList
+            v-model="value[TARGET_OPTION_IP_BLOCK].except"
+            :add-label="t('networkpolicy.rules.ipBlock.addExcept')"
+            :mode="mode"
+            :show-header="true"
+            :value-label="t('networkpolicy.rules.ipBlock.exceptions')"
+            :value-placeholder="t('networkpolicy.rules.ipBlock.cidr.placeholder')"
+          />
+        </div>
+      </div>
+    </div>
+    <div v-if="targetType === TARGET_OPTION_POD_SELECTOR">
+      <div class="row">
+        <div class="col span-12">
+          <Banner color="success">
+            <span v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
+          </Banner>
+        </div>
+      </div>
+      <div class="row mb-0">
+        <div class="col span-12">
+          <MatchExpressions
+            v-model="podSelectorExpressions"
+            :mode="mode"
+            :show-remove="false"
+            :initial-empty-row="true"
+            :type="POD"
+          />
+        </div>
+      </div>
+    </div>
+    <div v-if="targetType === TARGET_OPTION_NAMESPACE_SELECTOR">
+      <div class="row">
+        <div class="col span-12">
+          <Banner color="success">
+            <span v-html="t('networkpolicy.selectors.matchingNamespaces.matchesSome', matchingNamespaces)" />
+          </Banner>
+        </div>
+      </div>
+      <div class="row mb-0">
+        <div class="col span-12">
+          <MatchExpressions
+            v-model="namespaceSelectorExpressions"
+            :mode="mode"
+            :show-remove="false"
+            :initial-empty-row="true"
+            :type="POD"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
+++ b/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
@@ -1,0 +1,96 @@
+<script>
+
+import PolicyRule from '@/edit/networking.k8s.io.networkpolicy/PolicyRule';
+import { _EDIT } from '@/config/query-params';
+import Tab from '@/components/Tabbed/Tab';
+import Tabbed from '@/components/Tabbed';
+import { removeAt } from '@/utils/array';
+
+export default {
+  components: {
+    PolicyRule, Tabbed, Tab
+  },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+      }
+    },
+    mode: {
+      type:    String,
+      default: _EDIT
+    },
+    type: {
+      type:    String,
+      default: 'ingress'
+    },
+    allPods: {
+      type:    Array,
+      default: () => {
+        return [];
+      },
+    },
+    allNamespaces: {
+      type:    Array,
+      default: () => {
+        return [];
+      },
+    },
+  },
+  data() {
+    if (!this.value.spec[this.type]) {
+      this.$set(this.value.spec, this.type, []);
+    }
+
+    return {};
+  },
+  methods: {
+    addPolicyRule() {
+      this.value.spec[this.type].push({});
+    },
+    removePolicyRule(idx) {
+      removeAt(this.value.spec[this.type], idx);
+    },
+    policyRouleLabel(idx) {
+      return this.t('networkpolicy.rules.ruleLabel', { index: idx + 1 });
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div class="row">
+      <h2 v-html="t(`networkpolicy.${ type }.label`)" />
+    </div>
+    <div class="row mb-40">
+      <div class="col span-12">
+        <Tabbed
+          :side-tabs="true"
+          :show-tabs-add-remove="mode !== 'view'"
+          @addTab="addPolicyRule"
+          @removeTab="removePolicyRule"
+        >
+          <Tab
+            v-for="(policyRule, idx) in value.spec[type]"
+            :key="'filtered-rule-' + type + idx"
+            :name="'rule-' + type + idx"
+            :label="policyRouleLabel(idx)"
+            :show-header="false"
+            class="container-group"
+          >
+            <PolicyRule
+              ref="lastRule"
+              v-model="value.spec[type][idx]"
+              :mode="mode"
+              :type="type"
+              :namespace="value.metadata.namespace"
+              :all-namespaces="allNamespaces"
+              :all-pods="allPods"
+            />
+          </Tab>
+        </Tabbed>
+      </div>
+    </div>
+  </div>
+</template>

--- a/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
+++ b/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
@@ -60,9 +60,6 @@ export default {
 
 <template>
   <div>
-    <div class="row">
-      <h2 v-html="t(`networkpolicy.${ type }.label`)" />
-    </div>
     <div class="row mb-40">
       <div class="col span-12">
         <Tabbed

--- a/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/edit/networking.k8s.io.networkpolicy/index.vue
@@ -184,17 +184,36 @@ export default {
     <div class="row mb-40">
       <div class="col span-12">
         <Tabbed :side-tabs="true">
-          <Tab
-            name="selectors"
-            :label="t('networkpolicy.config.label')"
-          >
-            <div class="row mb-10">
-              <Checkbox v-model="hasIngressPolicies" :mode="mode" :label="t('networkpolicy.ingress.enable')" />
-            </div>
-            <div class="row mb-20">
-              <Checkbox v-model="hasEgressPolicies" :mode="mode" :label="t('networkpolicy.egress.enable')" />
-            </div>
-            <h2 class="mb-0">
+          <Tab name="ingress" label-key="networkpolicy.ingress.label" :show-header="false" :weight="3">
+            <h2 class="">
+              {{ t('networkpolicy.ingress.label') }}
+            </h2>
+            <Checkbox v-model="hasIngressPolicies" class="mt-20 mb-10" :mode="mode" :label="t('networkpolicy.ingress.enable')" />
+            <PolicyRules
+              v-if="hasIngressPolicies"
+              v-model="value"
+              type="ingress"
+              :mode="mode"
+              :all-namespaces="allNamespaces"
+              :all-pods="allPods"
+            ></PolicyRules>
+          </Tab>
+          <Tab name="egress" label-key="networkpolicy.egress.label" :show-header="false" :weight="2">
+            <h2>
+              {{ t('networkpolicy.egress.label') }}
+            </h2>
+            <Checkbox v-model="hasEgressPolicies" class="mt-20 mb-10" :mode="mode" :label="t('networkpolicy.egress.enable')" />
+            <PolicyRules
+              v-if="hasEgressPolicies"
+              v-model="value"
+              type="egress"
+              :mode="mode"
+              :all-namespaces="allNamespaces"
+              :all-pods="allPods"
+            ></PolicyRules>
+          </Tab>
+          <Tab name="selectors" label-key="networkpolicy.selectors.label" :show-header="false" :weight="1">
+            <h2>
               {{ t('networkpolicy.selectors.label') }}
               <i v-tooltip="t('networkpolicy.selectors.hint')" class="icon icon-info" />
             </h2>
@@ -244,21 +263,5 @@ export default {
         </Tabbed>
       </div>
     </div>
-    <PolicyRules
-      v-if="hasIngressPolicies"
-      v-model="value"
-      type="ingress"
-      :mode="mode"
-      :all-namespaces="allNamespaces"
-      :all-pods="allPods"
-    ></PolicyRules>
-    <PolicyRules
-      v-if="hasEgressPolicies"
-      v-model="value"
-      type="egress"
-      :mode="mode"
-      :all-namespaces="allNamespaces"
-      :all-pods="allPods"
-    ></PolicyRules>
   </CruResource>
 </template>

--- a/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/edit/networking.k8s.io.networkpolicy/index.vue
@@ -1,0 +1,264 @@
+<script>
+import throttle from 'lodash/throttle';
+import CreateEditView from '@/mixins/create-edit-view';
+import NameNsDescription from '@/components/form/NameNsDescription';
+import Tab from '@/components/Tabbed/Tab';
+import Tabbed from '@/components/Tabbed';
+import CruResource from '@/components/CruResource';
+import Banner from '@/components/Banner';
+import Labels from '@/components/form/Labels';
+import { NAMESPACE, POD } from '@/config/types';
+import { convert, matching, simplify } from '@/utils/selector';
+import Checkbox from '@/components/form/Checkbox';
+import { addObject, removeObject } from '@/utils/array';
+import MatchExpressions from '@/components/form/MatchExpressions';
+import PolicyRules from '@/edit/networking.k8s.io.networkpolicy/PolicyRules';
+import ResourceTable from '@/components/ResourceTable';
+import { allHash } from '@/utils/promise';
+
+const POLICY_TYPES = {
+  INGRESS: 'Ingress',
+  EGRESS:  'Egress',
+};
+
+export default {
+  // Props are found in CreateEditView
+  // props: {},
+
+  components: {
+    Banner,
+    Checkbox,
+    CruResource,
+    Labels,
+    MatchExpressions,
+    NameNsDescription,
+    PolicyRules,
+    ResourceTable,
+    Tab,
+    Tabbed,
+  },
+
+  mixins: [CreateEditView],
+
+  async fetch() {
+    const hash = await allHash({
+      allPods:        this.$store.dispatch('cluster/findAll', { type: POD }),
+      allNamespaces:  this.$store.dispatch('cluster/findAll', { type: NAMESPACE }),
+    });
+
+    this.allPods = hash.allPods;
+    this.allNamespaces = hash.allNamespaces;
+
+    this.updateMatchingPods();
+  },
+
+  data() {
+    if ( !this.value.spec ) {
+      this.$set(this.value, 'spec', {
+        policyTypes: [],
+        podSelector: {
+          matchExpressions: [],
+          matchLabels:      {},
+        }
+      });
+    }
+
+    const matchingPods = {
+      matched: 0,
+      matches: [],
+      none:    true,
+      sample:  null,
+      total:   0,
+    };
+
+    return {
+      POD,
+      matchingPods,
+      allPods:            [],
+      allNamespaces:      [],
+      podTableHeaders:    this.$store.getters['type-map/headersFor'](
+        this.$store.getters['cluster/schemaFor'](POD)
+      ),
+    };
+  },
+
+  computed: {
+    podSchema() {
+      return this.$store.getters['cluster/schemaFor'](POD);
+    },
+    hasIngressPolicies: {
+      get() {
+        return this.value.spec.policyTypes.includes(POLICY_TYPES.INGRESS);
+      },
+      set(hasIngressPolicies) {
+        let policyTypes = this.value.spec.policyTypes;
+
+        if (hasIngressPolicies) {
+          addObject(policyTypes, POLICY_TYPES.INGRESS);
+          if (!this.value.spec.ingress) {
+            this.$set(this.value.spec, 'ingress', []);
+          }
+        } else {
+          policyTypes = removeObject(policyTypes, POLICY_TYPES.INGRESS);
+          this.$delete(this.value.spec, 'ingress');
+        }
+
+        this.$set(this.value.spec, 'policyTypes', policyTypes);
+      }
+    },
+    hasEgressPolicies: {
+      get() {
+        return this.value.spec.policyTypes.includes(POLICY_TYPES.EGRESS);
+      },
+      set(hasEgressPolicies) {
+        let policyTypes = this.value.spec.policyTypes;
+
+        if (hasEgressPolicies) {
+          addObject(policyTypes, POLICY_TYPES.EGRESS);
+          if (!this.value.spec.egress) {
+            this.$set(this.value.spec, 'egress', []);
+          }
+        } else {
+          policyTypes = removeObject(policyTypes, POLICY_TYPES.EGRESS);
+          this.$delete(this.value.spec, 'egress');
+        }
+
+        this.$set(this.value.spec, 'policyTypes', policyTypes);
+      }
+    },
+    podSelectorExpressions: {
+      get() {
+        return convert(
+          this.value.spec.podSelector.matchLabels || {},
+          this.value.spec.podSelector.matchExpressions || []
+        );
+      },
+      set(podSelectorExpressions) {
+        this.$set(this.value.spec, 'podSelector', simplify(podSelectorExpressions));
+      }
+    },
+  },
+
+  watch: {
+    'value.metadata.namespace': 'updateMatchingPods',
+    'value.spec.podSelector':   'updateMatchingPods',
+  },
+
+  methods: {
+    updateMatchingPods: throttle(function() {
+      const allInNamespace = this.allPods.filter(pod => pod.metadata.namespace === this.value.metadata.namespace);
+      const match = matching(allInNamespace, this.podSelectorExpressions);
+      const matched = match.length || 0;
+      const sample = match[0]?.nameDisplay;
+
+      this.matchingPods = {
+        matched,
+        matches: match,
+        none:    matched === 0,
+        sample,
+        total:   allInNamespace.length,
+      };
+    }, 250, { leading: true }),
+  },
+};
+</script>
+
+<template>
+  <CruResource
+    :done-route="doneRoute"
+    :mode="mode"
+    :resource="value"
+    :subtypes="[]"
+    :validation-passed="true"
+    :errors="errors"
+    @error="(e) => (errors = e)"
+    @finish="save"
+    @cancel="done"
+  >
+    <NameNsDescription
+      v-if="!isView"
+      :value="value"
+      :mode="mode"
+    />
+
+    <div class="row mb-40">
+      <div class="col span-12">
+        <Tabbed :side-tabs="true">
+          <Tab
+            name="selectors"
+            :label="t('networkpolicy.config.label')"
+          >
+            <div class="row mb-10">
+              <Checkbox v-model="hasIngressPolicies" :mode="mode" :label="t('networkpolicy.ingress.enable')" />
+            </div>
+            <div class="row mb-20">
+              <Checkbox v-model="hasEgressPolicies" :mode="mode" :label="t('networkpolicy.egress.enable')" />
+            </div>
+            <h2 class="mb-0">
+              {{ t('networkpolicy.selectors.label') }}
+              <i v-tooltip="t('networkpolicy.selectors.hint')" class="icon icon-info" />
+            </h2>
+            <div class="row">
+              <div class="col span-12">
+                <MatchExpressions
+                  v-model="podSelectorExpressions"
+                  :mode="mode"
+                  :show-remove="false"
+                  :type="POD"
+                />
+              </div>
+            </div>
+            <div class="row">
+              <div class="col span-12">
+                <Banner color="success">
+                  <span v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
+                </Banner>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col span-12">
+                <ResourceTable
+                  :rows="matchingPods.matches"
+                  :headers="podTableHeaders"
+                  key-field="id"
+                  :table-actions="false"
+                  :schema="podSchema"
+                  :groupable="false"
+                  :search="false"
+                />
+              </div>
+            </div>
+          </Tab>
+          <Tab
+            name="labels-and-annotations"
+            :label="t('networkpolicy.labelsAnnotations.label', {}, true)"
+            :weight="-1"
+          >
+            <Labels
+              :default-container-class="'labels-and-annotations-container'"
+              :value="value"
+              :mode="mode"
+              :display-side-by-side="false"
+            />
+          </Tab>
+        </Tabbed>
+      </div>
+    </div>
+    <PolicyRules
+      v-if="hasIngressPolicies"
+      v-model="value"
+      type="ingress"
+      :mode="mode"
+      :all-namespaces="allNamespaces"
+      :all-pods="allPods"
+    ></PolicyRules>
+    <PolicyRules
+      v-if="hasEgressPolicies"
+      v-model="value"
+      type="egress"
+      :mode="mode"
+      :all-namespaces="allNamespaces"
+      :all-pods="allPods"
+    ></PolicyRules>
+  </CruResource>
+</template>

--- a/utils/validators/cidr.js
+++ b/utils/validators/cidr.js
@@ -1,0 +1,5 @@
+const validCIDRregex = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/(3[0-2]|2[0-9]|1[0-9]|[0-9])$/;
+
+export function isValidCIDR(cidr) {
+  return !!cidr.match(validCIDRregex);
+}


### PR DESCRIPTION
NetworkPolicies are one of the more complex Kubernetes resources. But they are also frequently used in enterprise contexts to restrict incoming and outgoing traffic of pods. A UI would make this much more accessible, especially for Kubernetes beginners.

Some screenshots:

![Bildschirmfoto 2021-12-08 um 11 36 54](https://user-images.githubusercontent.com/243056/145194737-855d3710-3138-4f2d-8af0-15b5f2a41ea6.png)
![Bildschirmfoto 2021-12-08 um 11 37 03](https://user-images.githubusercontent.com/243056/145194748-ccd38b54-d8ee-4f32-b9e8-3338b908ab6f.png)
![Bildschirmfoto 2021-12-08 um 11 37 14](https://user-images.githubusercontent.com/243056/145194751-4a9aab8f-0bff-4844-b4b6-28f1aa8c9b97.png)
![Bildschirmfoto 2021-12-08 um 11 39 30](https://user-images.githubusercontent.com/243056/145194756-2ddf2d06-f4da-4ebf-a308-e9dbee6315db.png)
![Bildschirmfoto 2021-12-08 um 11 39 49](https://user-images.githubusercontent.com/243056/145194757-9622019e-7647-4dcf-90ef-73c16352e5b6.png)

Adresses: #4729

