### PR TITLE
Fix issue where app upgrade fails is no v3 project resource

### DIFF
--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -228,17 +228,21 @@ export default class CatalogApp extends SteveModel {
         const { clusterName, projectName } = this.spec?.values?.global;
 
         if (clusterName && projectName) {
-          const legacyApp = await this.$dispatch('rancher/find', {
-            type: NORMAN.APP,
-            id:   `${ projectName }:${ this.metadata?.name }`,
-            opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
-          }, { root: true });
+          try {
+            const legacyApp = await this.$dispatch('rancher/find', {
+              type: NORMAN.APP,
+              id:   `${ projectName }:${ this.metadata?.name }`,
+              opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
+            }, { root: true });
 
-          if (legacyApp) {
-            return legacyApp;
-          }
+            if (legacyApp) {
+              return legacyApp;
+            }
+          } catch (e) {}
         }
       }
+
+      return false;
     };
   }
 }


### PR DESCRIPTION
Addresses #4402 

When an app is migrated, the /v3/project resource is deleted, so the API call we do fails and this breaks the UI.

This PR wraps this in a try/catch, so we don't fail if the legacy app can not be found.