### PR TITLE
Fixing several ResourceQuota issues

### DIFF
--- a/components/form/ResourceQuota/Namespace.vue
+++ b/components/form/ResourceQuota/Namespace.vue
@@ -35,7 +35,7 @@ export default {
   computed: {
     ...QUOTA_COMPUTED,
     projectResourceQuotaLimits() {
-      return this.project.spec.resourceQuota.limit;
+      return this.project?.spec?.resourceQuota?.limit || {};
     },
     namespaceResourceQuotaLimits() {
       return this.project.namespaces.map(namespace => ({
@@ -83,8 +83,8 @@ export default {
       </div>
     </div>
     <Row
-      v-for="limit in editableLimits"
-      :key="limit"
+      v-for="(limit, i) in editableLimits"
+      :key="project.id + i"
       :value="value.resourceQuota"
       :namespace="value"
       :mode="mode"

--- a/components/form/ResourceQuota/NamespaceRow.vue
+++ b/components/form/ResourceQuota/NamespaceRow.vue
@@ -56,7 +56,16 @@ export default {
   },
 
   mounted() {
-    this.update(this.defaultResourceQuotaLimits[this.type]);
+    // We want to update the value first so that the value will be rounded to the project limit.
+    // This is relevant when switching projects. If the value is 1200 and the project that it was
+    // switched to only has capacity for 800 more this will force the value to be set to 800.
+    if (this.value?.limit?.[this.type]) {
+      this.update(this.value.limit[this.type]);
+    }
+
+    if (!this.value?.limit?.[this.type]) {
+      this.update(this.defaultResourceQuotaLimits[this.type]);
+    }
   },
 
   computed: {
@@ -114,7 +123,7 @@ export default {
 
       this.$emit('input', this.type, value);
     }
-  },
+  }
 };
 </script>
 <template>

--- a/components/graph/Bar.vue
+++ b/components/graph/Bar.vue
@@ -41,7 +41,7 @@ export default {
 <template>
   <div class="bar" :style="barStyle">
     <div class="indicator" :style="indicatorStyle" />
-    <div v-for="sliceStyle in sliceStyles" :key="sliceStyle.left" class="slice" :style="sliceStyle" />
+    <div v-for="(sliceStyle, i) in sliceStyles" :key="i" class="slice" :style="sliceStyle" />
   </div>
 </template>
 

--- a/edit/namespace.vue
+++ b/edit/namespace.vue
@@ -34,10 +34,9 @@ export default {
   mixins: [CreateEditView],
 
   async fetch() {
-    const projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });
-    const projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID];
+    this.projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });
 
-    this.project = projects.find(p => p.id.includes(projectName));
+    this.project = this.projects.find(p => p.id.includes(this.projectName));
   },
 
   data() {
@@ -52,6 +51,7 @@ export default {
     return {
       originalQuotaId,
       project:                 null,
+      projects:                null,
       viewMode:                _VIEW,
       containerResourceLimits: this.value.annotations[CONTAINER_DEFAULT_RESOURCE_LIMIT] || this.getDefaultContainerResourceLimits(projectName),
       projectName,
@@ -97,6 +97,10 @@ export default {
 
     doneLocationOverride() {
       return this.value.listLocation;
+    },
+
+    showResourceQuota() {
+      return Object.keys(this.project?.spec?.resourceQuota?.limit || {}).length > 0;
     }
   },
 
@@ -105,6 +109,10 @@ export default {
       const limits = this.getDefaultContainerResourceLimits(newProject);
 
       this.$set(this, 'containerResourceLimits', limits);
+    },
+
+    projectName(newProjectName) {
+      this.$set(this, 'project', this.projects.find(p => p.id.includes(newProjectName)));
     }
   },
 
@@ -166,7 +174,7 @@ export default {
     </NameNsDescription>
 
     <Tabbed :side-tabs="true">
-      <Tab v-if="!isSingleVirtualCluster" :weight="1" name="container-resource-quotas" :label="t('namespace.resourceQuotas')">
+      <Tab v-if="!isSingleVirtualCluster && showResourceQuota" :weight="1" name="container-resource-quotas" :label="t('namespace.resourceQuotas')">
         <div class="row">
           <div class="col span-12">
             <p class="helper-text mb-10">


### PR DESCRIPTION
- The default value was overwriting the already set value when editing a namespace
- Editing wasn't working when the user switched projects in the middle of editing resource quotas
- Now hide the resource quota tab if there aren't any resources the namesapce should set
- Fixed two warnings related to the keys that we being used

https://github.com/rancher/dashboard/issues/4412#issuecomment-986487125