### PR TITLE
Add workloadSelector to deployment metadata labels

### DIFF
--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -544,6 +544,7 @@ export default {
     saveWorkload() {
       if (this.type !== WORKLOAD_TYPES.JOB && this.type !== WORKLOAD_TYPES.CRON_JOB && this.mode === _CREATE) {
         this.spec.selector = { matchLabels: this.value.workloadSelector };
+        Object.assign(this.value.metadata.labels, this.value.workloadSelector);
       }
 
       let template;


### PR DESCRIPTION
[Reference](https://github.com/rancher/rancher/issues/35690)

**Original error**

After editing a Node Port for a deployment workload, the `publicEndpoint` is not updated accordingly. The UI would show the original endpoint when in fact the endpoint had been updated to the intended port.

**Cause**

The `workloadSelector` label was not being set on the deployment metadata, and therefore wouldn't update the `publicEndpoint` route. See [this comment](https://github.com/rancher/rancher/issues/35690#issuecomment-988342391).

**Fix**

This will add the correct `workloadSelector` label to the deployment's `metadata.labels`.

https://user-images.githubusercontent.com/40806497/145477646-8cb63b33-95cb-497b-8be0-978a4c163528.mp4


