### PR TITLE
Add increment to Project Limit unit input

### DIFF
--- a/components/form/ResourceQuota/ProjectRow.vue
+++ b/components/form/ResourceQuota/ProjectRow.vue
@@ -52,6 +52,7 @@ export default {
       class="mr-10"
       :mode="mode"
       :placeholder="typeOption.placeholder"
+      :increment="typeOption.increment"
       :input-exponent="typeOption.inputExponent"
       :base-unit="typeOption.baseUnit"
       :output-modifier="true"


### PR DESCRIPTION
This fixes a bug where the Project Limit display unit for the Memory Limit resource quota was `MB` instead of `MiB` by adding an increment to the field in question. 

The display unit was displaying as `MB` because `components/form/UnitInput.vue` has a default value of `1000` for increment and will only format as `MiB` if the increment is 1024.

#4742