### PR TITLE
HARVESTER: Update RKE2 default cloud config path

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1024,6 +1024,7 @@ export default {
 
         set(this.agentConfig, 'cloud-provider-config', res.data);
         set(this.chartValues, `${ HARVESTER_CLOUD_PROVIDER }.clusterName`, this.value.metadata.name);
+        set(this.chartValues, `${ HARVESTER_CLOUD_PROVIDER }.cloudConfigPath`, '/var/lib/rancher/rke2/etc/config-files/cloud-provider-config');
       }
 
       await this.save(btnCb);


### PR DESCRIPTION
- https://github.com/harvester/harvester/issues/1658

- should set RKE2 default cloud config path to  `/var/lib/rancher/rke2/etc/config-files/cloud-provider-config` via `helmChartConfig` as the default path of chart is updated via https://github.com/harvester/charts/pull/58/files#diff-00e1ad718da686a8dd7b7dd718d74b46cbf640b160fcd09e51e4ef5edcb59922R14