### PR TITLE
Use same metric for pod state in workload list, workload detail and pod lists

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4712,10 +4712,6 @@ workload:
     pods: Pods by State
     runs: Runs
   gaugeStates:
-    active: Active
-    transitioning: Transitioning
-    warning: Warning
-    error: Error
     succeeded: Successful
     running: Running
     failed: Failed

--- a/components/CountGauge.vue
+++ b/components/CountGauge.vue
@@ -36,6 +36,10 @@ export default {
     plain: {
       type:    Boolean,
       default: false
+    },
+    graphical: {
+      type:    Boolean,
+      default: true
     }
   },
 
@@ -70,7 +74,7 @@ export default {
 
 <template>
   <GradientBox class="count-gauge" :class="{clickable}" :primary-color-var="primaryColorVar" :plain="plain" @click.native="visitLocation()">
-    <div class="graphical">
+    <div v-if="graphical" class="graphical">
       <GraphCircle v-if="percentage > 0" :primary-stroke-color="`rgba(var(${primaryColorVar}))`" secondary-stroke-color="rgb(var(--resource-gauge-back-circle))" :percentage="percentage" />
       <GraphCircle v-if="percentage === 0" :primary-stroke-color="`rgba(var(${primaryColorVar}))`" secondary-stroke-color="rgb(var(--resource-gauge-back-circle))" class="zero" :percentage="100" />
     </div>

--- a/components/form/PlusMinus.vue
+++ b/components/form/PlusMinus.vue
@@ -62,7 +62,8 @@ export default {
     background-color: var(--accent-btn);
   }
   .value {
-    width: 25px;
+    min-width: 25px;
+    max-width: 30px;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/components/formatter/WorkloadHealthScale.vue
+++ b/components/formatter/WorkloadHealthScale.vue
@@ -147,7 +147,7 @@ export default {
     <div :id="id" class="hs-popover__content" :class="{expanded, [id]:true}">
       <div>
         <div v-for="obj in parts" :key="obj.label" class="counts">
-          <span>{{ obj.label }}</span>
+          <span class="counts-label">{{ obj.label }}</span>
           <span>{{ obj.value }}</span>
         </div>
         <div v-if="canScale" class="text-center scale">
@@ -230,6 +230,12 @@ $width: 150px;
     .counts {
       display: flex;
       justify-content: space-between;
+
+      &-label {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
     .scale {
       margin-top: 10px;

--- a/detail/workload/index.vue
+++ b/detail/workload/index.vue
@@ -157,6 +157,20 @@ export default {
         kind:      WORKLOAD_TYPE_TO_KIND_MAPPING[this.value.type],
         workload:  this.graphVarsWorkload
       };
+    },
+
+    showPodGaugeCircles() {
+      const podGauges = Object.values(this.value.podGauges);
+      const total = this.value.pods.length;
+
+      return !podGauges.find(pg => pg.count === total);
+    },
+
+    showJobGaugeCircles() {
+      const jobGauges = Object.values(this.value.jobGauges);
+      const total = this.isCronJob ? this.totalRuns : this.value.pods.length;
+
+      return !jobGauges.find(jg => jg.count === total);
     }
   },
 };
@@ -168,13 +182,14 @@ export default {
     <h3>
       {{ isJob || isCronJob ? t('workload.detailTop.runs') :t('workload.detailTop.pods') }}
     </h3>
-    <div v-if="value.pods || value.jobGauges" class="gauges mb-20">
+    <div v-if="value.pods || value.jobGauges" class="gauges mb-20" :class="{'gauges__pods': !!value.pods}">
       <template v-if="value.jobGauges">
         <CountGauge
           v-for="(group, key) in value.jobGauges"
           :key="key"
           :total="isCronJob? totalRuns : value.pods.length"
           :useful="group.count || 0"
+          :graphical="showJobGaugeCircles"
           :primary-color-var="`--sizzle-${group.color}`"
           :name="t(`workload.gaugeStates.${key}`)"
         />
@@ -185,8 +200,9 @@ export default {
           :key="key"
           :total="value.pods.length"
           :useful="group.count || 0"
+          :graphical="showPodGaugeCircles"
           :primary-color-var="`--sizzle-${group.color}`"
-          :name="t(`workload.gaugeStates.${key}`)"
+          :name="key"
         />
       </template>
     </div>
@@ -233,13 +249,22 @@ export default {
   </div>
 </template>
 
-  <style lang='scss' scoped>
-  .gauges {
-    display: flex;
-    justify-content: space-around;
-    &>*{
+<style lang='scss' scoped>
+.gauges {
+  display: flex;
+  justify-content: space-around;
+  &>*{
     flex: 1;
     margin-right: $column-gutter;
+  }
+  &__pods {
+    flex-wrap: wrap;
+    justify-content: left;
+    .count-gauge {
+      width: 23%;
+      margin-bottom: 10px;
+      flex: initial;
+    }
   }
 }
 </style>

--- a/models/workload.js
+++ b/models/workload.js
@@ -639,33 +639,23 @@ export default class Workload extends SteveModel {
   }
 
   get podGauges() {
-    const out = {
-      active: { color: 'success' }, transitioning: { color: 'info' }, warning: { color: 'warning' }, error: { color: 'error' }
-    };
+    const out = { };
 
     if (!this.pods) {
       return out;
     }
 
     this.pods.map((pod) => {
-      const { status:{ phase } } = pod;
-      let group;
+      const { stateColor, stateDisplay } = pod;
 
-      switch (phase) {
-      case 'Running':
-        group = 'active';
-        break;
-      case 'Pending':
-        group = 'transitioning';
-        break;
-      case 'Failed':
-        group = 'error';
-        break;
-      default:
-        group = 'warning';
+      if (out[stateDisplay]) {
+        out[stateDisplay].count++;
+      } else {
+        out[stateDisplay] = {
+          color: stateColor.replace('text-', ''),
+          count: 1
+        };
       }
-
-      out[group].count ? out[group].count++ : out[group].count = 1;
     });
 
     return out;


### PR DESCRIPTION
- previously workload list and detail used pod status phase
- pod status phase can sometimes appear contradictory to pod state (#4745)
- so show the same in all three locations
- Note - Job related workloads remain unchanged

Also
- Workload detail count gauges... don't show percentage doughnut if they're
  all just circles (all in one state). Without variance these are confusing