### PR TITLE
Standard user can upgrade apps

### DIFF
--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -216,13 +216,18 @@ export default class CatalogApp extends SteveModel {
 
   get deployedAsMultiCluster() {
     return async() => {
-      const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
+      try {
+        const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true })
+          .catch(() => {
+            throw new Error("You don't have permission to list multi-cluster apps");
+          });
 
-      if (mcapps) {
-        return mcapps.find(mcapp => mcapp.spec?.targets?.find(target => target.appName === this.metadata?.name));
-      }
+        if (mcapps) {
+          return mcapps.find(mcapp => mcapp.spec?.targets?.find(target => target.appName === this.metadata?.name));
+        }
+      } catch (e) {}
 
-      return null;
+      return false;
     };
   }
 

--- a/plugins/steve/getters.js
+++ b/plugins/steve/getters.js
@@ -225,6 +225,10 @@ export default {
       }
 
       url = schema.links.collection;
+
+      if ( !url ) {
+        throw new Error(`You don't have permission to list this type: ${ type }`);
+      }
       if ( id ) {
         url += `/${ id }`;
       }


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4720 by adding some error handling to the app install/upgrade page.

Specifically, when we check to see if an app is a multi-cluster app, we fetch all multi-cluster apps, then check to see if the current app is named in the results. If we don't have permission to fetch all multi-cluster apps, we assume the current app is not a multi-cluster app. Vince said this may not always be a safe assumption, but it is the best solution for now. In the future if we keep having issues, we can request the backend to add an annotation to apps to make it easier for the UI to determine which type of app it is.

To test this PR,

1. I created a standard user
2. While logged in as the standard user, I created a downstream cluster
3. I installed a v2 app (CIS Benchmark tool) on the downstream cluster
4. From **Apps & Marketplace > Installed Apps**, I upgraded the app
5. The upgrade form rendered successfully
<img width="1298" alt="Screen Shot 2021-12-13 at 10 52 42 AM" src="https://user-images.githubusercontent.com/20599230/145864772-d1d0ceaf-df06-4601-ad57-be58d9df57c1.png">
<img width="1309" alt="Screen Shot 2021-12-13 at 10 52 52 AM" src="https://user-images.githubusercontent.com/20599230/145864763-84e452a8-e982-49b3-aaa3-00d25b3ecf33.png">


