### PR TITLE
Upcate caniuse-lite

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5081,8 +5081,8 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001097, caniuse-lite@^1.0.30001133, caniuse-lite@^1.0.30001219:
-  version "1.0.30001237"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
+  version "1.0.30001286"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz#3e9debad420419618cfdf52dc9b6572b28a8fff6"
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Update caniuse-lite to avoid the console messsages:

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

NOTE: I did this manually, since using the command `npx browserslist@latest --update-db` updated yarn.lock to use`registry.npmjs.org`for this package.