### PR TITLE
Fix doneLocation bug when route name does not include -id or -namespace

### DIFF
--- a/components/PromptRemove.vue
+++ b/components/PromptRemove.vue
@@ -88,10 +88,18 @@ export default {
       if (params.id && (params.id === this.toRemove[0]?.metadata?.name || params.id === this.toRemove[0].id)) {
         let { name = '' } = currentRoute;
 
-        name = name.slice(0, name.indexOf('-id'));
+        const idIndex = name.indexOf('-id');
+
+        if (idIndex !== -1) {
+          name = name.slice(0, idIndex);
+        }
 
         if (params.namespace) {
-          name = name.slice(0, name.indexOf('-namespace'));
+          const namespaceIndex = name.indexOf('-namespace');
+
+          if (namespaceIndex !== -1) {
+            name = name.slice(0, namespaceIndex);
+          }
           delete params.namespace;
         }
         delete params.id;


### PR DESCRIPTION
Addresses #4766 

The doneLocation assumes that if there is an id param or namespace param that the route name will include references to them.

It does not always - in the cluster case, the route is `c-cluster-product-resource`.

We then look for `-id` in the name and return -1, which we feed into slice, which removes the last char from the name. We do the same for `-namespace``.

Thus we end up with a route name of `c-cluster-product-resour` which does not exist.

This PR checks that the route name includes the expected param references before trying to remove them.