### PR TITLE
Add a suffix of 'i' to when increment is 1024

### DIFF
--- a/components/form/ResourceQuota/NamespaceRow.vue
+++ b/components/form/ResourceQuota/NamespaceRow.vue
@@ -78,6 +78,7 @@ export default {
         maxExponent: this.typeOption.inputExponent,
         minExponent: this.typeOption.inputExponent,
         increment:   this.typeOption.increment,
+        suffix:      this.typeOption.increment === 1024 ? 'i' : ''
       };
     },
     namespaceLimits() {


### PR DESCRIPTION
This adds a suffix of `i` if the increment is `1024` when trying to parse values for the namespace row resource quota. Similar to what we do with `components/form/UnitInput.vue`, we want to make sure that we're making use of the binary modifier when working with unit conversions.

This is a quick-fix that works for the namespace row, but I'm thinking that we might want to review a better place to handle this directly in `utils/units.js`.. I didn't want to make that change today and risk breaking something elsewhere without more thorough testing.

See https://github.com/rancher/dashboard/issues/4412#issuecomment-994876515 for testing instructions

#4412