### PR TITLE
Remove unrequired & unused styling

### DIFF
--- a/pages/auth/setup.vue
+++ b/pages/auth/setup.vue
@@ -336,7 +336,7 @@ export default {
             <div class="checkbox mt-40">
               <Checkbox v-model="telemetry" label-key="setup.telemetry" />
             </div>
-            <div class="checkbox pt-10 eula">
+            <div class="checkbox pt-10">
               <Checkbox v-model="eula">
                 <template #label>
                   <t k="setup.eula" :raw="true" :name="productName" />
@@ -417,14 +417,6 @@ export default {
       line-height: 20px;
     }
 
-    .eula {
-      align-items: center;
-      display: flex;
-
-      span {
-        margin-left: 5px;
-      }
-    }
   }
 
   .landscape {


### PR DESCRIPTION
- `.eula span` was previously not applied due to scoping, but a recent change meant it then did
- this caused the T&C checkbox label to have a double margin, so removed the style to fix
- ![image](https://user-images.githubusercontent.com/18697775/146347124-a6076d06-0cc6-44c5-a6dc-8be1b0eeab79.png)
- also removed the parent `.eula` link as this isn't required