### PR TITLE
Show the same id twice

### DIFF
--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -70,7 +70,9 @@ function load(state, { data, ctx, existing }) {
   if ( existing && !existing.id ) {
     // A specific proxy instance to used was passed in (for create -> save),
     // use it instead of making a new proxy
-    entry = replace(existing, data);
+    const _existing = cache.map.get(id) || existing;
+
+    entry = replace(_existing, data);
     addObject(cache.list, entry);
     cache.map.set(id, entry);
     // console.log('### Mutation added from existing proxy', type, id);


### PR DESCRIPTION
# links
- https://github.com/harvester/harvester/issues/1111

When the network is slow, the code will go to https://github.com/rancher/dashboard/blob/6fbdc3c2a5961578b928d192ce9e805b62da7d0b/plugins/steve/mutations.js#L88 , and then to  https://github.com/rancher/dashboard/blob/6fbdc3c2a5961578b928d192ce9e805b62da7d0b/plugins/steve/mutations.js#L71, So I think when replacing the object we should first determine if it is in cache.map, if it exists we should replace the object in cache instead of the this value at save。



