### PR TITLE
Fix upgradable button on app list page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -719,7 +719,6 @@ catalog:
         navigate: Navigate to {legacyType} Apps
         category:
           legacy: Legacy
-          mcm: Multi-cluster
     header:
       install: 'Install {name}'
       installGeneric: Install Chart

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -4,7 +4,7 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, FLEET } from '@/config/labels-annotations';
 import { compare, isPrerelease, sortable } from '@/utils/version';
 import { filterBy } from '@/utils/array';
-import { CATALOG, MANAGEMENT, NORMAN } from '@/config/types';
+import { CATALOG, MANAGEMENT } from '@/config/types';
 import { SHOW_PRE_RELEASE } from '@/store/prefs';
 import { set } from '@/utils/object';
 
@@ -101,7 +101,7 @@ export default class CatalogApp extends SteveModel {
       return null;
     }
 
-    if ( this.deployedAsLegacy || this.deployedAsMultiCluster ) {
+    if ( this.deployedAsLegacy ) {
       return null;
     }
 
@@ -232,27 +232,13 @@ export default class CatalogApp extends SteveModel {
   }
 
   get deployedAsLegacy() {
-    return async() => {
-      if (this.spec.values) {
-        const { clusterName, projectName } = this.spec?.values?.global;
+    const rancherVersion = this.spec?.chart?.metadata?.annotations?.['catalog.cattle.io/rancher-version'];
 
-        if (clusterName && projectName) {
-          try {
-            const legacyApp = await this.$dispatch('rancher/find', {
-              type: NORMAN.APP,
-              id:   `${ projectName }:${ this.metadata?.name }`,
-              opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
-            }, { root: true });
+    if (rancherVersion === '< 2.6.3') {
+      return true;
+    }
 
-            if (legacyApp) {
-              return legacyApp;
-            }
-          } catch (e) {}
-        }
-      }
-
-      return false;
-    };
+    return false;
   }
 }
 

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -104,8 +104,7 @@ export default {
       this.forceNamespace = null;
     }
 
-    this.legacyApp = this.existing ? await this.existing.deployedAsLegacy() : false;
-    this.mcapp = this.existing ? await this.existing.deployedAsMultiCluster() : false;
+    this.legacyApp = this.existing ? this.existing.deployedAsLegacy : false;
 
     this.value = await this.$store.dispatch('cluster/create', {
       type:     'chartInstallAction',
@@ -220,7 +219,6 @@ export default {
       loadedVersion:          null,
       loadedVersionValues:    null,
       legacyApp:              null,
-      mcapp:                  null,
       mode:                   null,
       value:                  null,
       valuesComponent:        null,
@@ -283,10 +281,7 @@ export default {
 
       isPlainLayout: isPlainLayout(this.$route.query),
 
-      legacyDefs: {
-        legacy: this.t('catalog.install.error.legacy.category.legacy'),
-        mcm:    this.t('catalog.install.error.legacy.category.mcm')
-      }
+      legacyDefs: { legacy: this.t('catalog.install.error.legacy.category.legacy') }
     };
   },
 
@@ -522,10 +517,6 @@ export default {
     legacyAppRoute() {
       return { name: 'c-cluster-legacy-project' };
     },
-
-    mcmRoute() {
-      return { name: 'c-cluster-mcapps' };
-    }
   },
 
   watch: {
@@ -1015,7 +1006,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <div v-else-if="!legacyApp && !mcapp" class="install-steps" :class="{ 'isPlainLayout': isPlainLayout}">
+  <div v-else-if="!legacyApp" class="install-steps" :class="{ 'isPlainLayout': isPlainLayout}">
     <Wizard
       v-if="value"
       :steps="steps"
@@ -1339,7 +1330,7 @@ export default {
 
       <Banner color="warning" class="description">
         <span>
-          {{ t('catalog.install.error.legacy.label', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true) }}
+          {{ t('catalog.install.error.legacy.label', { legacyType: legacyDefs.legacy }, true) }}
         </span>
         <template v-if="!legacyEnabled">
           <span v-html="t('catalog.install.error.legacy.enableLegacy.prompt', true)" />
@@ -1348,8 +1339,8 @@ export default {
           </nuxt-link>
         </template>
         <template v-else>
-          <nuxt-link :to="mcapp ? mcmRoute : legacyAppRoute">
-            <span v-html="t('catalog.install.error.legacy.navigate', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true)" />
+          <nuxt-link :to="legacyAppRoute">
+            <span v-html="t('catalog.install.error.legacy.navigate', { legacyType: legacyDefs.legacy }, true)" />
           </nuxt-link>
         </template>
       </Banner>


### PR DESCRIPTION
rancher/dashboard#4786 

**Issue**
The upgrade button for an app would no longer show up on the list page.

**Cause**  
An async function was used to determine if an app was considered Legacy or Multi-cluster, as the promise was never fulfilled in the check it would always return null.

**Fix**
- Rewrote the `deployedAsLegacy` function to utilize the new annotation for apps created with a Rancher version being less than `v2.6.3` 
- Also removed the needless check for multi-cluster apps for the upgrade button as mcapps would not show up on this list page.

![fix-button](https://user-images.githubusercontent.com/40806497/146548534-bd36fdf2-6001-49b8-9031-4f76e5592f14.png)
 

**To test**
Add an app using a previous version (tested with Longhorn v1.2.2) - the upgrade button should appear