### PR TITLE
Ensure apps and marketplace app upgrade button shows

### DIFF
--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -101,10 +101,6 @@ export default class CatalogApp extends SteveModel {
       return null;
     }
 
-    if ( this.deployedAsLegacy || this.deployedAsMultiCluster ) {
-      return null;
-    }
-
     if ( compare(thisVersion, newestVersion) < 0 ) {
       return cleanupVersion(newestVersion);
     }


### PR DESCRIPTION
- This ensures standard apps show the upgrade
- It will also show an upgrade button for legacy / multi-cluster apps
- Legacy / mcapps button will take user to non legacy / mcapps install page
  which guides user to legacy install world
- This needs updating post-2.6.3, it's not a great solution but removes a blocking issue in a safe way. See https://github.com/rancher/dashboard/pull/4795#pullrequestreview-835364056 for more context
- #4786

![image](https://user-images.githubusercontent.com/18697775/146584576-6c82c43b-1395-4e85-bae3-282412dbf443.png)

![image](https://user-images.githubusercontent.com/18697775/146584626-51213bbf-7e8f-4fee-b153-0bafb77b7ee4.png)
