### PR TITLE
Fix two fleet issues

### DIFF
--- a/models/fleet.cattle.io.cluster.js
+++ b/models/fleet.cattle.io.cluster.js
@@ -116,7 +116,7 @@ export default class FleetCluster extends SteveModel {
   }
 
   get norman() {
-    const norman = this.$rootGetters['rancher/byId'](NORMAN.CLUSTER, this.metadata.name);
+    const norman = this.$rootGetters['rancher/byId'](NORMAN.CLUSTER, this.mgmt.id);
 
     return norman;
   }

--- a/models/management.cattle.io.fleetworkspace.js
+++ b/models/management.cattle.io.fleetworkspace.js
@@ -56,7 +56,7 @@ export default class Workspace extends HybridModel {
   async save() {
     const norman = await this.norman;
 
-    return norman.save();
+    await norman.save();
   }
 
   async remove() {


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/4798

- Caused by the `CreateEditView` component's `actuallySave` trying to `assign` annotations when no set'er exist in the root resource
- The steve workspace uses a norman.save()... and returns itself a norman object which is assigned to the initial steve object
- short term fix - skip this assign step
- long term - ensure we return the updated steve object. also need to investigate other `return norman.save()` uses
 
https://github.com/rancher/dashboard/issues/4799
- The assignTo modal tries to clone the norman cluster, this fails as the steve fleet cluster is looking for the norman cluster using the wrong id (metadata.name --> mgmt.id)
- long term - we need to also investigate if the labels are correctly assigned
