### PR TITLE
Ensure fleet cluster fetches norman cluster in a consistent way

### DIFF
--- a/models/fleet.cattle.io.cluster.js
+++ b/models/fleet.cattle.io.cluster.js
@@ -116,7 +116,7 @@ export default class FleetCluster extends SteveModel {
   }
 
   get norman() {
-    const norman = this.$rootGetters['rancher/byId'](NORMAN.CLUSTER, this.mgmt.id);
+    const norman = this.$rootGetters['rancher/byId'](NORMAN.CLUSTER, this.metadata.labels?.[FLEET_LABELS.CLUSTER_NAME]);
 
     return norman;
   }


### PR DESCRIPTION
- Follows on from https://github.com/rancher/dashboard/pull/4801
- edit/fleet.cattle.io.cluster uses `labels?.[FLEET_LABELS.CLUSTER_NAME]`
- this change simply matches that