### PR TITLE
Fix lint errors for node 16

### DIFF
--- a/chart/istio.vue
+++ b/chart/istio.vue
@@ -1,9 +1,9 @@
 <script>
 import debounce from 'lodash/debounce';
 import jsyaml from 'js-yaml';
+import { mapGetters } from 'vuex';
 import Checkbox from '@/components/form/Checkbox';
 import YamlEditor from '@/components/YamlEditor';
-import { mapGetters } from 'vuex';
 import FileSelector from '@/components/form/FileSelector';
 import Tab from '@/components/Tabbed/Tab';
 import Banner from '@/components/Banner';

--- a/chart/monitoring/ClusterSelector.vue
+++ b/chart/monitoring/ClusterSelector.vue
@@ -1,9 +1,9 @@
 <script>
 import isEmpty from 'lodash/isEmpty';
-import LabeledSelect from '@/components/form/LabeledSelect';
 import { mapGetters } from 'vuex';
-import { findBy } from '@/utils/array';
 import sortBy from 'lodash/sortBy';
+import LabeledSelect from '@/components/form/LabeledSelect';
+import { findBy } from '@/utils/array';
 
 const MANAGED_CONFIG_KEYS = [
   'kubeControllerManager',

--- a/chart/rancher-backup/S3.vue
+++ b/chart/rancher-backup/S3.vue
@@ -1,9 +1,9 @@
 <script>
+import { mapGetters } from 'vuex';
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import FileSelector from '@/components/form/FileSelector';
 import LabeledSelect from '@/components/form/LabeledSelect';
-import { mapGetters } from 'vuex';
 export default {
   components: {
     LabeledInput,

--- a/chart/rancher-backup/index.vue
+++ b/chart/rancher-backup/index.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import Tab from '@/components/Tabbed/Tab';
 import S3 from '@/chart/rancher-backup/S3';
 import RadioGroup from '@/components/form/RadioGroup';
@@ -8,7 +9,6 @@ import Banner from '@/components/Banner';
 import { get } from '@/utils/object';
 import { allHash } from '@/utils/promise';
 import { STORAGE_CLASS, SECRET, PV } from '@/config/types';
-import { mapGetters } from 'vuex';
 import { STORAGE } from '@/config/labels-annotations';
 
 export default {

--- a/components/AlertTable.vue
+++ b/components/AlertTable.vue
@@ -1,9 +1,10 @@
 <script>
-import isEmpty from 'lodash/isEmpty';
 import Poller from '@/utils/poller';
 import SortableTable from '@/components/SortableTable';
 import { ENDPOINTS } from '@/config/types';
 import { mapGetters } from 'vuex';
+import isEmpty from 'lodash/isEmpty';
+
 const CATTLE_MONITORING_NAMESPACE = 'cattle-monitoring-system';
 const ALERTMANAGER_POLL_RATE_MS = 30000;
 const MAX_FAILURES = 2;

--- a/components/AlertTable.vue
+++ b/components/AlertTable.vue
@@ -1,9 +1,9 @@
 <script>
+import { mapGetters } from 'vuex';
+import isEmpty from 'lodash/isEmpty';
 import Poller from '@/utils/poller';
 import SortableTable from '@/components/SortableTable';
 import { ENDPOINTS } from '@/config/types';
-import { mapGetters } from 'vuex';
-import isEmpty from 'lodash/isEmpty';
 
 const CATTLE_MONITORING_NAMESPACE = 'cattle-monitoring-system';
 const ALERTMANAGER_POLL_RATE_MS = 30000;

--- a/components/AsyncButton.vue
+++ b/components/AsyncButton.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import typeHelper from '@/utils/type-helpers';
 import Vue from 'vue';
+import typeHelper from '@/utils/type-helpers';
 
 const ACTION = 'action';
 const WAITING = 'waiting';

--- a/components/AsyncButton.vue
+++ b/components/AsyncButton.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
-import Vue from 'vue';
 import typeHelper from '@/utils/type-helpers';
+import Vue from 'vue';
 
 const ACTION = 'action';
 const WAITING = 'waiting';

--- a/components/ButtonDropdown.vue
+++ b/components/ButtonDropdown.vue
@@ -1,9 +1,9 @@
 <script>
 import { createPopper } from '@popperjs/core';
-import { get } from '@/utils/object';
 import isString from 'lodash/isString';
-import VueSelectOverrides from '@/mixins/vue-select-overrides';
 import $ from 'jquery';
+import { get } from '@/utils/object';
+import VueSelectOverrides from '@/mixins/vue-select-overrides';
 
 export default {
   mixins: [VueSelectOverrides],

--- a/components/CommunityLinks.vue
+++ b/components/CommunityLinks.vue
@@ -1,10 +1,10 @@
 <script>
+import { mapGetters } from 'vuex';
 import { options } from '@/config/footer';
 import SimpleBox from '@/components/SimpleBox';
 import Closeable from '@/mixins/closeable';
 import { MANAGEMENT } from '@/config/types';
 import { SETTING } from '@/config/settings';
-import { mapGetters } from 'vuex';
 
 export default {
   components: { SimpleBox },

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -1,12 +1,12 @@
 <script>
 import isEmpty from 'lodash/isEmpty';
+import { mapGetters } from 'vuex';
 import { createYaml } from '@/utils/create-yaml';
 import { clone } from '@/utils/object';
 import { SCHEMA } from '@/config/types';
 import ResourceYaml from '@/components/ResourceYaml';
 import Banner from '@/components/Banner';
 import AsyncButton from '@/components/AsyncButton';
-import { mapGetters } from 'vuex';
 import { stringify } from '@/utils/error';
 import CruResourceFooter from '@/components/CruResourceFooter';
 import {

--- a/components/DashboardMetrics.vue
+++ b/components/DashboardMetrics.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import DashboardOptions from '@/components/DashboardOptions';
 import GrafanaDashboard from '@/components/GrafanaDashboard';
-import { mapGetters } from 'vuex';
 
 export default {
   components: { DashboardOptions, GrafanaDashboard },

--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -1,8 +1,8 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
 import Tag from '@/components/Tag';
 import DetailText from '@/components/DetailText';
 import { _VIEW } from '@/config/query-params';
-import isEmpty from 'lodash/isEmpty';
 
 export default {
   components: { DetailText, Tag },

--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -1,8 +1,8 @@
 <script>
 import Tag from '@/components/Tag';
-import isEmpty from 'lodash/isEmpty';
 import DetailText from '@/components/DetailText';
 import { _VIEW } from '@/config/query-params';
+import isEmpty from 'lodash/isEmpty';
 
 export default {
   components: { DetailText, Tag },

--- a/components/EmberPage.vue
+++ b/components/EmberPage.vue
@@ -1,6 +1,6 @@
 <script>
-import Loading from '@/components/Loading';
 import { mapGetters, mapState } from 'vuex';
+import Loading from '@/components/Loading';
 import { NAME as MANAGER } from '@/config/product/manager';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { SETTING } from '@/config/settings';

--- a/components/EtcdInfoBanner.vue
+++ b/components/EtcdInfoBanner.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import Banner from '@/components/Banner';
 import Loading from '@/components/Loading';
-import { mapGetters } from 'vuex';
 import { hasLeader, leaderChanges, failedProposals } from '@/utils/grafana';
 
 export default {

--- a/components/FixedBanner.vue
+++ b/components/FixedBanner.vue
@@ -1,7 +1,7 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
 import { MANAGEMENT } from '@/config/types';
 import { SETTING } from '@/config/settings';
-import isEmpty from 'lodash/isEmpty';
 
 export default {
   props: {

--- a/components/InputOrDisplay.vue
+++ b/components/InputOrDisplay.vue
@@ -1,6 +1,6 @@
 <script>
-import Vue from 'vue';
 import { _VIEW } from '@/config/query-params';
+import Vue from 'vue';
 
 const component = Vue.component('InputOrDisplay', {
   render(h) {

--- a/components/InputOrDisplay.vue
+++ b/components/InputOrDisplay.vue
@@ -1,6 +1,6 @@
 <script>
-import { _VIEW } from '@/config/query-params';
 import Vue from 'vue';
+import { _VIEW } from '@/config/query-params';
 
 const component = Vue.component('InputOrDisplay', {
   render(h) {

--- a/components/Questions/Array.vue
+++ b/components/Questions/Array.vue
@@ -1,6 +1,6 @@
 <script>
-import ArrayList from '@/components/form/ArrayList';
 import Question from './Question';
+import ArrayList from '@/components/form/ArrayList';
 
 export default {
   components: { ArrayList },

--- a/components/Questions/Boolean.vue
+++ b/components/Questions/Boolean.vue
@@ -1,6 +1,6 @@
 <script>
-import Checkbox from '@/components/form/Checkbox';
 import Question from './Question';
+import Checkbox from '@/components/form/Checkbox';
 
 export default {
   components: { Checkbox },

--- a/components/Questions/CloudCredential.vue
+++ b/components/Questions/CloudCredential.vue
@@ -1,7 +1,7 @@
 <script>
+import Question from './Question';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import { NORMAN } from '@/config/types';
-import Question from './Question';
 
 export default {
   components: { LabeledSelect },

--- a/components/Questions/Enum.vue
+++ b/components/Questions/Enum.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledSelect from '@/components/form/LabeledSelect';
 import Question from './Question';
+import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
   components: { LabeledSelect },

--- a/components/Questions/Float.vue
+++ b/components/Questions/Float.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import Question from './Question';
+import LabeledInput from '@/components/form/LabeledInput';
 
 //  @TODO valid_chars, invalid_chars
 

--- a/components/Questions/Int.vue
+++ b/components/Questions/Int.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import Question from './Question';
+import LabeledInput from '@/components/form/LabeledInput';
 
 //  @TODO valid_chars, invalid_chars
 

--- a/components/Questions/QuestionMap.vue
+++ b/components/Questions/QuestionMap.vue
@@ -1,6 +1,6 @@
 <script>
-import KeyValue from '@/components/form/KeyValue';
 import Question from './Question';
+import KeyValue from '@/components/form/KeyValue';
 
 export default {
   name:       'QuestionMap',

--- a/components/Questions/Reference.vue
+++ b/components/Questions/Reference.vue
@@ -1,9 +1,9 @@
 <script>
+import Question from './Question';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import { filterBy } from '@/utils/array';
 import { PVC, STORAGE_CLASS } from '@/config/types';
-import Question from './Question';
 
 // Older versions of rancher document these words as valid types
 const LEGACY_MAP = {

--- a/components/Questions/String.vue
+++ b/components/Questions/String.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import Question from './Question';
+import LabeledInput from '@/components/form/LabeledInput';
 
 //  @TODO valid_chars, invalid_chars
 

--- a/components/Questions/index.vue
+++ b/components/Questions/index.vue
@@ -1,9 +1,6 @@
 <script>
 import Jexl from 'jexl';
-import Tab from '@/components/Tabbed/Tab';
-import { get, set } from '@/utils/object';
 import sortBy from 'lodash/sortBy';
-import { _EDIT } from '@/config/query-params';
 import StringType from './String';
 import BooleanType from './Boolean';
 import EnumType from './Enum';
@@ -13,6 +10,9 @@ import ArrayType from './Array';
 import MapType from './QuestionMap';
 import ReferenceType from './Reference';
 import CloudCredentialType from './CloudCredential';
+import { _EDIT } from '@/config/query-params';
+import { get, set } from '@/utils/object';
+import Tab from '@/components/Tabbed/Tab';
 
 export const knownTypes = {
   string:          StringType,

--- a/components/ResourceList/index.vue
+++ b/components/ResourceList/index.vue
@@ -1,7 +1,7 @@
 <script>
+import Masthead from './Masthead';
 import ResourceTable from '@/components/ResourceTable';
 import Loading from '@/components/Loading';
-import Masthead from './Masthead';
 
 export default {
   components: {

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -1,4 +1,6 @@
 <script>
+import jsyaml from 'js-yaml';
+import { exceptionToErrorsArray } from '../utils/error';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import FileSelector from '@/components/form/FileSelector';
 import Footer from '@/components/form/Footer';
@@ -13,8 +15,6 @@ import {
   _EDIT,
 } from '@/config/query-params';
 import { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
-import jsyaml from 'js-yaml';
-import { exceptionToErrorsArray } from '../utils/error';
 
 export default {
   components: {

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -1,11 +1,9 @@
 <script>
-import jsyaml from 'js-yaml';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import FileSelector from '@/components/form/FileSelector';
 import Footer from '@/components/form/Footer';
 import { ANNOTATIONS_TO_FOLD } from '@/config/labels-annotations';
 import { ensureRegex } from '@/utils/string';
-
 import {
   _CREATE,
   _VIEW,
@@ -15,6 +13,7 @@ import {
   _EDIT,
 } from '@/config/query-params';
 import { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
+import jsyaml from 'js-yaml';
 import { exceptionToErrorsArray } from '../utils/error';
 
 export default {

--- a/components/SortableTable/THead.vue
+++ b/components/SortableTable/THead.vue
@@ -1,8 +1,8 @@
 <script>
+import { SOME, NONE } from './selection';
 import { queryParamsFor } from '@/plugins/extend-router';
 import { SORT_BY, DESCENDING } from '@/config/query-params';
 import Checkbox from '@/components/form/Checkbox';
-import { SOME, NONE } from './selection';
 
 export default {
   components: { Checkbox },

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -1,10 +1,5 @@
 <script>
 import { mapState } from 'vuex';
-import { dasherize, ucFirst } from '@/utils/string';
-import { get, clone } from '@/utils/object';
-import { removeObject, filterBy } from '@/utils/array';
-import Checkbox from '@/components/form/Checkbox';
-import ActionDropdown from '@/components/ActionDropdown';
 import $ from 'jquery';
 import throttle from 'lodash/throttle';
 import debounce from 'lodash/debounce';
@@ -14,6 +9,11 @@ import selection from './selection';
 import sorting from './sorting';
 import paging from './paging';
 import grouping from './grouping';
+import ActionDropdown from '@/components/ActionDropdown';
+import Checkbox from '@/components/form/Checkbox';
+import { removeObject, filterBy } from '@/utils/array';
+import { get, clone } from '@/utils/object';
+import { dasherize, ucFirst } from '@/utils/string';
 
 export const COLUMN_BREAKPOINTS = {
   /**

--- a/components/SortableTable/selection.js
+++ b/components/SortableTable/selection.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
+import selectionStore from './selectionStore';
 import { isMore, isRange, suppressContextMenu, isAlternate } from '@/utils/platform';
 import { get } from '@/utils/object';
 import { randomStr } from '@/utils/string';
-import selectionStore from './selectionStore';
 export const ALL = 'all';
 export const SOME = 'some';
 export const NONE = 'none';

--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -1,9 +1,9 @@
 <script>
 import head from 'lodash/head';
 import isEmpty from 'lodash/isEmpty';
+import findIndex from 'lodash/findIndex';
 import { addObject, removeObject, findBy } from '@/utils/array';
 import { sortBy } from '@/utils/sort';
-import findIndex from 'lodash/findIndex';
 
 export default {
   name: 'Tabbed',

--- a/components/VMConsoleBar.vue
+++ b/components/VMConsoleBar.vue
@@ -1,6 +1,6 @@
 <script>
-import ButtonDropdown from '@/components/ButtonDropdown';
 import { mapGetters } from 'vuex';
+import ButtonDropdown from '@/components/ButtonDropdown';
 
 export default {
   name: 'VMConsoleBar',

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -1,10 +1,10 @@
 <script>
-import { mapPref, DIFF } from '@/store/prefs';
-import { saferDump } from '@/utils/create-yaml';
 import jsyaml from 'js-yaml';
 import isEmpty from 'lodash/isEmpty';
 import CodeMirror from './CodeMirror';
 import FileDiff from './FileDiff';
+import { saferDump } from '@/utils/create-yaml';
+import { mapPref, DIFF } from '@/store/prefs';
 
 export const EDITOR_MODES = {
   EDIT_CODE: 'EDIT_CODE',

--- a/components/YamlEditor.vue
+++ b/components/YamlEditor.vue
@@ -1,8 +1,8 @@
 <script>
-import jsyaml from 'js-yaml';
 import { mapPref, DIFF } from '@/store/prefs';
-import isEmpty from 'lodash/isEmpty';
 import { saferDump } from '@/utils/create-yaml';
+import jsyaml from 'js-yaml';
+import isEmpty from 'lodash/isEmpty';
 import CodeMirror from './CodeMirror';
 import FileDiff from './FileDiff';
 

--- a/components/auth/RoleDetailEdit.vue
+++ b/components/auth/RoleDetailEdit.vue
@@ -1,4 +1,5 @@
 <script>
+import capitalize from 'lodash/capitalize';
 import { MANAGEMENT } from '@/config/types';
 import CruResource from '@/components/CruResource';
 import CreateEditView from '@/mixins/create-edit-view';
@@ -14,7 +15,6 @@ import SortableTable from '@/components/SortableTable';
 import { _DETAIL } from '@/config/query-params';
 import { SUBTYPE_MAPPING, VERBS } from '@/models/management.cattle.io.roletemplate';
 import Loading from '@/components/Loading';
-import capitalize from 'lodash/capitalize';
 
 const GLOBAL = SUBTYPE_MAPPING.GLOBAL.key;
 const CLUSTER = SUBTYPE_MAPPING.CLUSTER.key;

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -1,9 +1,9 @@
 <script>
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Principal from '@/components/auth/Principal';
-import debounce from 'lodash/debounce';
 import { _EDIT } from '@/config/query-params';
 import { NORMAN } from '@/config/types';
+import debounce from 'lodash/debounce';
 
 export default {
   components: {

--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -1,9 +1,9 @@
 <script>
+import debounce from 'lodash/debounce';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Principal from '@/components/auth/Principal';
 import { _EDIT } from '@/config/query-params';
 import { NORMAN } from '@/config/types';
-import debounce from 'lodash/debounce';
 
 export default {
   components: {

--- a/components/dialog/DrainNode.vue
+++ b/components/dialog/DrainNode.vue
@@ -1,13 +1,13 @@
 <script>
-import Vue from 'vue';
 import AsyncButton from '@/components/AsyncButton';
 import Banner from '@/components/Banner';
 import Card from '@/components/Card';
 import RadioGroup from '@/components/form/RadioGroup';
 import UnitInput from '@/components/form/UnitInput';
 import { _EDIT, _VIEW } from '@/config/query-params';
-
 import { exceptionToErrorsArray } from '@/utils/error';
+
+import Vue from 'vue';
 
 export default {
   components: {

--- a/components/dialog/DrainNode.vue
+++ b/components/dialog/DrainNode.vue
@@ -1,4 +1,5 @@
 <script>
+import Vue from 'vue';
 import AsyncButton from '@/components/AsyncButton';
 import Banner from '@/components/Banner';
 import Card from '@/components/Card';
@@ -6,8 +7,6 @@ import RadioGroup from '@/components/form/RadioGroup';
 import UnitInput from '@/components/form/UnitInput';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { exceptionToErrorsArray } from '@/utils/error';
-
-import Vue from 'vue';
 
 export default {
   components: {

--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -1,6 +1,7 @@
 <script>
-import AsyncButton from '@/components/AsyncButton';
 import day from 'dayjs';
+import { mapGetters } from 'vuex';
+import AsyncButton from '@/components/AsyncButton';
 import Card from '@/components/Card';
 import { exceptionToErrorsArray } from '@/utils/error';
 import LabeledSelect from '@/components/form/LabeledSelect';
@@ -8,7 +9,6 @@ import Banner from '@/components/Banner';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import { WORKLOAD_TYPES } from '@/config/types';
 import { diffFrom } from '@/utils/time';
-import { mapGetters } from 'vuex';
 
 export default {
   components: {

--- a/components/dialog/RotateEncryptionKeyDialog.vue
+++ b/components/dialog/RotateEncryptionKeyDialog.vue
@@ -1,11 +1,11 @@
 <script>
+import day from 'dayjs';
 import AsyncButton from '@/components/AsyncButton';
 import Card from '@/components/Card';
 import Banner from '@/components/Banner';
 import { exceptionToErrorsArray } from '@/utils/error';
 import { NORMAN } from '@/config/types';
 import { sortBy } from '@/utils/sort';
-import day from 'dayjs';
 import { escapeHtml } from '@/utils/string';
 import { DATE_FORMAT, TIME_FORMAT } from '@/store/prefs';
 

--- a/components/dialog/harvester/AddHotplugModal.vue
+++ b/components/dialog/harvester/AddHotplugModal.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import { exceptionToErrorsArray } from '@/utils/error';
 import { sortBy } from '@/utils/sort';
-import { mapGetters } from 'vuex';
 import { PVC } from '@/config/types';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 import Card from '@/components/Card';

--- a/components/dialog/harvester/BackupModal.vue
+++ b/components/dialog/harvester/BackupModal.vue
@@ -1,6 +1,6 @@
 <script>
-import { exceptionToErrorsArray } from '@/utils/error';
 import { mapGetters } from 'vuex';
+import { exceptionToErrorsArray } from '@/utils/error';
 import Card from '@/components/Card';
 import Banner from '@/components/Banner';
 import AsyncButton from '@/components/AsyncButton';

--- a/components/dialog/harvester/CloneTemplate.vue
+++ b/components/dialog/harvester/CloneTemplate.vue
@@ -1,6 +1,6 @@
 <script>
-import { exceptionToErrorsArray } from '@/utils/error';
 import { mapGetters } from 'vuex';
+import { exceptionToErrorsArray } from '@/utils/error';
 
 import Card from '@/components/Card';
 import Banner from '@/components/Banner';

--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -1,9 +1,9 @@
 <script>
+import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { removeAt } from '@/utils/array';
 import TextAreaAutoGrow from '@/components/form/TextAreaAutoGrow';
 import { clone } from '@/utils/object';
-import debounce from 'lodash/debounce';
 
 const DEFAULT_PROTIP = 'Tip: Paste lines into any list field for easy bulk entry';
 

--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -1,9 +1,9 @@
 <script>
-import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { removeAt } from '@/utils/array';
 import TextAreaAutoGrow from '@/components/form/TextAreaAutoGrow';
 import { clone } from '@/utils/object';
+import debounce from 'lodash/debounce';
 
 const DEFAULT_PROTIP = 'Tip: Paste lines into any list field for easy bulk entry';
 

--- a/components/form/Command.vue
+++ b/components/form/Command.vue
@@ -1,11 +1,10 @@
 <script>
+import Vue from 'vue';
 import LabeledInput from '@/components/form/LabeledInput';
 import ShellInput from '@/components/form/ShellInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Checkbox from '@/components/form/Checkbox';
 import EnvVars from '@/components/form/EnvVars';
-
-import Vue from 'vue';
 
 export default {
   components: {

--- a/components/form/Command.vue
+++ b/components/form/Command.vue
@@ -1,11 +1,11 @@
 <script>
-import Vue from 'vue';
-
 import LabeledInput from '@/components/form/LabeledInput';
 import ShellInput from '@/components/form/ShellInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Checkbox from '@/components/form/Checkbox';
 import EnvVars from '@/components/form/EnvVars';
+
+import Vue from 'vue';
 
 export default {
   components: {

--- a/components/form/EnvVars.vue
+++ b/components/form/EnvVars.vue
@@ -1,8 +1,8 @@
 <script>
 import ValueFromResource from '@/components/form/ValueFromResource';
-import debounce from 'lodash/debounce';
 import { randomStr } from '@/utils/string';
 import { _VIEW } from '@/config/query-params';
+import debounce from 'lodash/debounce';
 
 export default {
   components: { ValueFromResource },

--- a/components/form/EnvVars.vue
+++ b/components/form/EnvVars.vue
@@ -1,8 +1,8 @@
 <script>
+import debounce from 'lodash/debounce';
 import ValueFromResource from '@/components/form/ValueFromResource';
 import { randomStr } from '@/utils/string';
 import { _VIEW } from '@/config/query-params';
-import debounce from 'lodash/debounce';
 
 export default {
   components: { ValueFromResource },

--- a/components/form/Footer.vue
+++ b/components/form/Footer.vue
@@ -1,9 +1,8 @@
 <script lang="ts">
+import Vue from 'vue';
 import { _VIEW } from '@/config/query-params';
 import AsyncButton, { AsyncButtonCallback } from '@/components/AsyncButton.vue';
 import Banner from '@/components/Banner.vue';
-
-import Vue from 'vue';
 
 export default Vue.extend({
   components: {

--- a/components/form/Footer.vue
+++ b/components/form/Footer.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
-import Vue from 'vue';
 import { _VIEW } from '@/config/query-params';
 import AsyncButton, { AsyncButtonCallback } from '@/components/AsyncButton.vue';
 import Banner from '@/components/Banner.vue';
+
+import Vue from 'vue';
 
 export default Vue.extend({
   components: {

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -1,10 +1,10 @@
 <script>
+import cronstrue from 'cronstrue';
+import { isValidCron } from 'cron-validator';
 import LabeledFormElement from '@/mixins/labeled-form-element';
 import TextAreaAutoGrow from '@/components/form/TextAreaAutoGrow';
 import LabeledTooltip from '@/components/form/LabeledTooltip';
 import { escapeHtml } from '@/utils/string';
-import cronstrue from 'cronstrue';
-import { isValidCron } from 'cron-validator';
 
 export default {
   components: { LabeledTooltip, TextAreaAutoGrow },

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -1,11 +1,11 @@
 <script>
 import { createPopper } from '@popperjs/core';
+import $ from 'jquery';
 import LabeledFormElement from '@/mixins/labeled-form-element';
 import { findBy } from '@/utils/array';
 import { get } from '@/utils/object';
 import LabeledTooltip from '@/components/form/LabeledTooltip';
 import VueSelectOverrides from '@/mixins/vue-select-overrides';
-import $ from 'jquery';
 import { onClickOption } from '@/utils/select';
 
 export default {

--- a/components/form/LifecycleHooks.vue
+++ b/components/form/LifecycleHooks.vue
@@ -1,9 +1,9 @@
 <script>
-import Vue from 'vue';
-
 import HookOption from '@/components/form/HookOption';
 import { _VIEW } from '@/config/query-params';
 import { isEmpty } from '@/utils/object';
+
+import Vue from 'vue';
 
 export default {
   components: { HookOption },

--- a/components/form/LifecycleHooks.vue
+++ b/components/form/LifecycleHooks.vue
@@ -1,9 +1,8 @@
 <script>
+import Vue from 'vue';
 import HookOption from '@/components/form/HookOption';
 import { _VIEW } from '@/config/query-params';
 import { isEmpty } from '@/utils/object';
-
-import Vue from 'vue';
 
 export default {
   components: { HookOption },

--- a/components/form/MatchExpressions.vue
+++ b/components/form/MatchExpressions.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import { NODE, POD } from '@/config/types';
 import Select from '@/components/form/Select';
-import { mapGetters } from 'vuex';
 import { isArray, removeObject } from '@/utils/array';
 import { clone } from '@/utils/object';
 import { convert, simplify } from '@/utils/selector';

--- a/components/form/Networking.vue
+++ b/components/form/Networking.vue
@@ -1,9 +1,9 @@
 <script>
+import { mapGetters } from 'vuex';
 import ArrayList from '@/components/form/ArrayList';
 import KeyValue from '@/components/form/KeyValue';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
-import { mapGetters } from 'vuex';
 
 const CLUSTER_FIRST = 'ClusterFirst';
 const CLUSTER_FIRST_HOST = 'ClusterFirstWithHostNet';

--- a/components/form/NodeAffinity.vue
+++ b/components/form/NodeAffinity.vue
@@ -1,6 +1,6 @@
 <script>
-import { _VIEW } from '@/config/query-params';
 import { mapGetters } from 'vuex';
+import { _VIEW } from '@/config/query-params';
 import { get, isEmpty, clone } from '@/utils/object';
 import { NODE } from '@/config/types';
 import MatchExpressions from '@/components/form/MatchExpressions';

--- a/components/form/PodAffinity.vue
+++ b/components/form/PodAffinity.vue
@@ -1,4 +1,5 @@
 <script>
+import debounce from 'lodash/debounce';
 import { _VIEW } from '@/config/query-params';
 import { get, set, isEmpty, clone } from '@/utils/object';
 import { POD, NODE, NAMESPACE } from '@/config/types';
@@ -9,7 +10,6 @@ import LabeledInput from '@/components/form/LabeledInput';
 import { randomStr } from '@/utils/string';
 import { sortBy } from '@/utils/sort';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
-import debounce from 'lodash/debounce';
 
 export default {
   components: {

--- a/components/form/PodAffinity.vue
+++ b/components/form/PodAffinity.vue
@@ -8,8 +8,8 @@ import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import { randomStr } from '@/utils/string';
 import { sortBy } from '@/utils/sort';
-import debounce from 'lodash/debounce';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
+import debounce from 'lodash/debounce';
 
 export default {
   components: {

--- a/components/form/PodSecurity.vue
+++ b/components/form/PodSecurity.vue
@@ -1,8 +1,8 @@
 <script>
+import { mapGetters } from 'vuex';
 import RadioGroup from '@/components/form/RadioGroup';
 import ArrayList from '@/components/form/ArrayList';
 import KeyValue from '@/components/form/KeyValue';
-import { mapGetters } from 'vuex';
 import LabeledInput from '@/components/form/LabeledInput';
 
 export default {

--- a/components/form/ResourceQuota/NamespaceRow.vue
+++ b/components/form/ResourceQuota/NamespaceRow.vue
@@ -1,9 +1,9 @@
 <script>
+import { ROW_COMPUTED } from './shared';
 import Select from '@/components/form/Select';
 import UnitInput from '@/components/form/UnitInput';
 import PercentageBar from '@/components/PercentageBar';
 import { formatSi, parseSi } from '@/utils/units';
-import { ROW_COMPUTED } from './shared';
 
 export default {
   components: {

--- a/components/form/ResourceQuota/Project.vue
+++ b/components/form/ResourceQuota/Project.vue
@@ -1,7 +1,7 @@
 <script>
-import ArrayList from '@/components/form/ArrayList';
 import Row from './ProjectRow';
 import { QUOTA_COMPUTED } from './shared';
+import ArrayList from '@/components/form/ArrayList';
 
 export default {
   components: { ArrayList, Row },

--- a/components/form/ResourceQuota/ProjectRow.vue
+++ b/components/form/ResourceQuota/ProjectRow.vue
@@ -1,7 +1,7 @@
 <script>
+import { ROW_COMPUTED } from './shared';
 import Select from '@/components/form/Select';
 import UnitInput from '@/components/form/UnitInput';
-import { ROW_COMPUTED } from './shared';
 
 export default {
   components: { Select, UnitInput },

--- a/components/form/SecretSelector.vue
+++ b/components/form/SecretSelector.vue
@@ -1,9 +1,9 @@
 <script>
+import sortBy from 'lodash/sortBy';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import { SECRET } from '@/config/types';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { TYPES } from '@/models/secret';
-import sortBy from 'lodash/sortBy';
 
 const NONE = '__[[NONE]]__';
 

--- a/components/form/Security.vue
+++ b/components/form/Security.vue
@@ -1,8 +1,8 @@
 <script>
+import { mapGetters } from 'vuex';
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import { _VIEW } from '@/config/query-params';
-import { mapGetters } from 'vuex';
 import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {

--- a/components/form/Select.vue
+++ b/components/form/Select.vue
@@ -1,10 +1,10 @@
 <script>
 import { createPopper } from '@popperjs/core';
+import $ from 'jquery';
 import { get } from '@/utils/object';
 import LabeledFormElement from '@/mixins/labeled-form-element';
 import VueSelectOverrides from '@/mixins/vue-select-overrides';
 import LabeledTooltip from '@/components/form/LabeledTooltip';
-import $ from 'jquery';
 import { onClickOption } from '@/utils/select';
 
 export default {

--- a/components/form/SerialConsole/index.vue
+++ b/components/form/SerialConsole/index.vue
@@ -1,7 +1,5 @@
 <script>
 import { allHash } from '@/utils/promise';
-import debounce from 'lodash/debounce';
-
 import Socket, {
   EVENT_CONNECTED,
   EVENT_CONNECTING,
@@ -9,6 +7,7 @@ import Socket, {
   EVENT_MESSAGE,
   EVENT_CONNECT_ERROR,
 } from '@/utils/socket';
+import debounce from 'lodash/debounce';
 
 export default {
   props:      {

--- a/components/form/SerialConsole/index.vue
+++ b/components/form/SerialConsole/index.vue
@@ -1,4 +1,5 @@
 <script>
+import debounce from 'lodash/debounce';
 import { allHash } from '@/utils/promise';
 import Socket, {
   EVENT_CONNECTED,
@@ -7,7 +8,6 @@ import Socket, {
   EVENT_MESSAGE,
   EVENT_CONNECT_ERROR,
 } from '@/utils/socket';
-import debounce from 'lodash/debounce';
 
 export default {
   props:      {

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -1,9 +1,9 @@
 <script>
-import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { removeAt } from '@/utils/array';
 import { clone } from '@/utils/object';
 import Select from '@/components/form/Select';
+import debounce from 'lodash/debounce';
 
 export default {
   components: { Select },

--- a/components/form/ServicePorts.vue
+++ b/components/form/ServicePorts.vue
@@ -1,9 +1,9 @@
 <script>
+import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { removeAt } from '@/utils/array';
 import { clone } from '@/utils/object';
 import Select from '@/components/form/Select';
-import debounce from 'lodash/debounce';
 
 export default {
   components: { Select },

--- a/components/form/TextAreaAutoGrow.vue
+++ b/components/form/TextAreaAutoGrow.vue
@@ -1,7 +1,7 @@
 <script>
 import $ from 'jquery';
-import { _EDIT, _VIEW } from '@/config/query-params';
 import debounce from 'lodash/debounce';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   inheritAttrs: false,

--- a/components/form/TextAreaAutoGrow.vue
+++ b/components/form/TextAreaAutoGrow.vue
@@ -1,7 +1,7 @@
 <script>
 import $ from 'jquery';
-import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@/config/query-params';
+import debounce from 'lodash/debounce';
 
 export default {
   inheritAttrs: false,

--- a/components/formatter/CloudInitType.vue
+++ b/components/formatter/CloudInitType.vue
@@ -1,6 +1,6 @@
 <script>
-import { HCI } from '@/config/labels-annotations';
 import { mapGetters } from 'vuex';
+import { HCI } from '@/config/labels-annotations';
 
 export default {
   props: {

--- a/components/formatter/HarvesterIpAddress.vue
+++ b/components/formatter/HarvesterIpAddress.vue
@@ -1,9 +1,9 @@
 <script>
-import compact from 'lodash/compact';
 import { get } from '@/utils/object';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 import { HCI } from '@/config/types';
 import CopyToClipboard from '@/components/CopyToClipboard';
+import compact from 'lodash/compact';
 
 export default {
   components: { CopyToClipboard },

--- a/components/formatter/HarvesterIpAddress.vue
+++ b/components/formatter/HarvesterIpAddress.vue
@@ -1,9 +1,9 @@
 <script>
+import compact from 'lodash/compact';
 import { get } from '@/utils/object';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 import { HCI } from '@/config/types';
 import CopyToClipboard from '@/components/CopyToClipboard';
-import compact from 'lodash/compact';
 
 export default {
   components: { CopyToClipboard },

--- a/components/formatter/InternalExternalIP.vue
+++ b/components/formatter/InternalExternalIP.vue
@@ -1,7 +1,8 @@
 <script>
-import { isV4Format, isV6Format } from 'ip';
 import CopyToClipboard from '@/components/CopyToClipboard';
 import { mapGetters } from 'vuex';
+import { isV4Format, isV6Format } from 'ip';
+
 export default {
   components: { CopyToClipboard },
   props:      {

--- a/components/formatter/InternalExternalIP.vue
+++ b/components/formatter/InternalExternalIP.vue
@@ -1,7 +1,7 @@
 <script>
-import CopyToClipboard from '@/components/CopyToClipboard';
 import { mapGetters } from 'vuex';
 import { isV4Format, isV6Format } from 'ip';
+import CopyToClipboard from '@/components/CopyToClipboard';
 
 export default {
   components: { CopyToClipboard },

--- a/components/formatter/ServiceTargets.vue
+++ b/components/formatter/ServiceTargets.vue
@@ -1,9 +1,9 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
+import has from 'lodash/has';
 import { CATTLE_PUBLIC_ENDPOINTS } from '@/config/labels-annotations';
 import Endpoints from '@/components/formatter/Endpoints';
 import { isMaybeSecure } from '@/utils/url';
-import isEmpty from 'lodash/isEmpty';
-import has from 'lodash/has';
 
 export default {
   components: { Endpoints },

--- a/components/formatter/ServiceTargets.vue
+++ b/components/formatter/ServiceTargets.vue
@@ -1,9 +1,9 @@
 <script>
-import isEmpty from 'lodash/isEmpty';
 import { CATTLE_PUBLIC_ENDPOINTS } from '@/config/labels-annotations';
 import Endpoints from '@/components/formatter/Endpoints';
-import has from 'lodash/has';
 import { isMaybeSecure } from '@/utils/url';
+import isEmpty from 'lodash/isEmpty';
+import has from 'lodash/has';
 
 export default {
   components: { Endpoints },

--- a/components/formatter/VirtualServiceGateways.vue
+++ b/components/formatter/VirtualServiceGateways.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import { get } from '@/utils/object';
 import { ISTIO } from '@/config/types';
-import { mapGetters } from 'vuex';
 export default {
   props: {
     value: {

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -1,5 +1,9 @@
 <script>
 import { mapGetters } from 'vuex';
+import NamespaceFilter from './NamespaceFilter';
+import WorkspaceSwitcher from './WorkspaceSwitcher';
+import TopLevelMenu from './TopLevelMenu';
+import Jump from './Jump';
 import { NORMAN, HCI } from '@/config/types';
 import { NAME as VIRTUAL } from '@/config/product/harvester';
 import { ucFirst } from '@/utils/string';
@@ -9,10 +13,6 @@ import BrandImage from '@/components/BrandImage';
 import { getProduct } from '@/config/private-label';
 import RancherProviderIcon from '@/components/RancherProviderIcon';
 import { LOGGED_OUT } from '@/config/query-params';
-import NamespaceFilter from './NamespaceFilter';
-import WorkspaceSwitcher from './WorkspaceSwitcher';
-import TopLevelMenu from './TopLevelMenu';
-import Jump from './Jump';
 
 const PAGE_HEADER_ACTION = 'page-action';
 

--- a/components/nav/Jump.vue
+++ b/components/nav/Jump.vue
@@ -1,8 +1,8 @@
 <script>
-import debounce from 'lodash/debounce';
-import Group from '@/components/nav/Group';
 import { isMac } from '@/utils/platform';
 import { BOTH, ALL } from '@/store/type-map';
+import Group from '@/components/nav/Group';
+import debounce from 'lodash/debounce';
 
 export default {
   components: { Group },

--- a/components/nav/Jump.vue
+++ b/components/nav/Jump.vue
@@ -1,8 +1,8 @@
 <script>
+import debounce from 'lodash/debounce';
 import { isMac } from '@/utils/platform';
 import { BOTH, ALL } from '@/store/type-map';
 import Group from '@/components/nav/Group';
-import debounce from 'lodash/debounce';
 
 export default {
   components: { Group },

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -1,8 +1,8 @@
 <script>
-import BrandImage from '@/components/BrandImage';
-import RancherProviderIcon from '@/components/RancherProviderIcon';
 import { mapGetters } from 'vuex';
 import $ from 'jquery';
+import BrandImage from '@/components/BrandImage';
+import RancherProviderIcon from '@/components/RancherProviderIcon';
 import { MANAGEMENT } from '@/config/types';
 import { mapPref, DEV, MENU_MAX_CLUSTERS } from '@/store/prefs';
 import { sortBy } from '@/utils/sort';

--- a/components/nav/WindowManager/ChartReadme.vue
+++ b/components/nav/WindowManager/ChartReadme.vue
@@ -1,6 +1,6 @@
 <script>
-import ChartReadme from '@/components/ChartReadme';
 import Window from './Window';
+import ChartReadme from '@/components/ChartReadme';
 
 export default {
   components: { Window, ChartReadme },

--- a/components/nav/WindowManager/ContainerLogs.vue
+++ b/components/nav/WindowManager/ContainerLogs.vue
@@ -1,6 +1,8 @@
 <script>
 import { saveAs } from 'file-saver';
 import AnsiUp from 'ansi_up';
+import day from 'dayjs';
+import Window from './Window';
 import { addParams } from '@/utils/url';
 import { base64Decode } from '@/utils/crypto';
 import {
@@ -10,7 +12,6 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import Checkbox from '@/components/form/Checkbox';
 import AsyncButton from '@/components/AsyncButton';
 import Select from '@/components/form/Select';
-import day from 'dayjs';
 
 import { escapeHtml, escapeRegex } from '@/utils/string';
 
@@ -21,7 +22,6 @@ import Socket, {
   //  EVENT_FRAME_TIMEOUT,
   EVENT_CONNECT_ERROR
 } from '@/utils/socket';
-import Window from './Window';
 
 let lastId = 1;
 const ansiup = new AnsiUp();

--- a/components/nav/WindowManager/ContainerShell.vue
+++ b/components/nav/WindowManager/ContainerShell.vue
@@ -3,8 +3,8 @@ import { allHash } from '@/utils/promise';
 import { addParams } from '@/utils/url';
 import { base64Decode, base64Encode } from '@/utils/crypto';
 import Select from '@/components/form/Select';
-import isEmpty from 'lodash/isEmpty';
 import { NODE } from '@/config/types';
+import isEmpty from 'lodash/isEmpty';
 
 import Socket, {
   EVENT_CONNECTED,

--- a/components/nav/WindowManager/ContainerShell.vue
+++ b/components/nav/WindowManager/ContainerShell.vue
@@ -1,10 +1,11 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
+import Window from './Window';
 import { allHash } from '@/utils/promise';
 import { addParams } from '@/utils/url';
 import { base64Decode, base64Encode } from '@/utils/crypto';
 import Select from '@/components/form/Select';
 import { NODE } from '@/config/types';
-import isEmpty from 'lodash/isEmpty';
 
 import Socket, {
   EVENT_CONNECTED,
@@ -14,7 +15,6 @@ import Socket, {
   //  EVENT_FRAME_TIMEOUT,
   EVENT_CONNECT_ERROR,
 } from '@/utils/socket';
-import Window from './Window';
 
 const DEFAULT_COMMAND = [
   '/bin/sh',

--- a/components/nav/WindowManager/KubectlShell.vue
+++ b/components/nav/WindowManager/KubectlShell.vue
@@ -1,6 +1,6 @@
 <script>
-import { addParams } from '@/utils/url';
 import ContainerShell from './ContainerShell';
+import { addParams } from '@/utils/url';
 
 export default {
   extends: ContainerShell,

--- a/components/nav/WindowManager/index.vue
+++ b/components/nav/WindowManager/index.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapState } from 'vuex';
-import debounce from 'lodash/debounce';
 import { screenRect, boundingRect } from '@/utils/position';
+import debounce from 'lodash/debounce';
 
 export default {
   data() {

--- a/components/nav/WindowManager/index.vue
+++ b/components/nav/WindowManager/index.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapState } from 'vuex';
-import { screenRect, boundingRect } from '@/utils/position';
 import debounce from 'lodash/debounce';
+import { screenRect, boundingRect } from '@/utils/position';
 
 export default {
   data() {

--- a/components/nav/WorkspaceSwitcher.vue
+++ b/components/nav/WorkspaceSwitcher.vue
@@ -1,6 +1,6 @@
 <script>
-import { WORKSPACE } from '@/store/prefs';
 import { mapState } from 'vuex';
+import { WORKSPACE } from '@/store/prefs';
 import Select from '@/components/form/Select';
 
 export default {

--- a/detail/autoscaling.horizontalpodautoscaler/index.vue
+++ b/detail/autoscaling.horizontalpodautoscaler/index.vue
@@ -1,11 +1,11 @@
 <script>
+import camelCase from 'lodash/camelCase';
+import keys from 'lodash/keys';
+import startCase from 'lodash/startCase';
 import CreateEditView from '@/mixins/create-edit-view';
 import ResourceTabs from '@/components/form/ResourceTabs';
 import Tab from '@/components/Tabbed/Tab';
 import InfoBox from '@/components/InfoBox';
-import camelCase from 'lodash/camelCase';
-import keys from 'lodash/keys';
-import startCase from 'lodash/startCase';
 import { findBy } from '@/utils/array';
 import { get } from '@/utils/object';
 

--- a/detail/catalog.cattle.io.app.vue
+++ b/detail/catalog.cattle.io.app.vue
@@ -1,4 +1,6 @@
 <script>
+import jsyaml from 'js-yaml';
+import merge from 'lodash/merge';
 import YamlEditor from '@/components/YamlEditor';
 import Loading from '@/components/Loading';
 import Markdown from '@/components/Markdown';
@@ -6,8 +8,6 @@ import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
 import Banner from '@/components/Banner';
 import RelatedResources from '@/components/RelatedResources';
-import jsyaml from 'js-yaml';
-import merge from 'lodash/merge';
 
 export default {
   name: 'DetailRelease',

--- a/detail/cis.cattle.io.clusterscan.vue
+++ b/detail/cis.cattle.io.clusterscan.vue
@@ -1,10 +1,10 @@
 <script>
+import day from 'dayjs';
 import Date from '@/components/formatter/Date';
 import SortableTable from '@/components/SortableTable';
 import Banner from '@/components/Banner';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Loading from '@/components/Loading';
-import day from 'dayjs';
 import { DATE_FORMAT, TIME_FORMAT } from '@/store/prefs';
 import { escapeHtml, randomStr } from '@/utils/string';
 import { CIS } from '@/config/types';

--- a/detail/harvesterhci.io.host/index.vue
+++ b/detail/harvesterhci.io.host/index.vue
@@ -1,4 +1,8 @@
 <script>
+import Basic from './HarvesterHostBasic';
+import Instance from './VirtualMachineInstance';
+import Disk from './HarvesterHostDisk';
+import Network from './HarvesterHostNetwork';
 import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
 import metricPoller from '@/mixins/metric-poller';
@@ -10,10 +14,6 @@ import { formatSi } from '@/utils/units';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import { findBy } from '@/utils/array';
 import { clone } from '@/utils/object';
-import Basic from './HarvesterHostBasic';
-import Instance from './VirtualMachineInstance';
-import Disk from './HarvesterHostDisk';
-import Network from './HarvesterHostNetwork';
 
 export default {
   name: 'DetailHost',

--- a/detail/kubevirt.io.virtualmachine/index.vue
+++ b/detail/kubevirt.io.virtualmachine/index.vue
@@ -1,5 +1,9 @@
 <script>
 import { mapGetters } from 'vuex';
+import Events from './VirtualMachineTabs/VirtualMachineEvents';
+import Migration from './VirtualMachineTabs/VirtualMachineMigration';
+import OverviewBasics from './VirtualMachineTabs/VirtualMachineBasics';
+import OverviewKeypairs from './VirtualMachineTabs/VirtualMachineKeypairs';
 import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
 import { EVENT, HCI, SERVICE } from '@/config/types';
@@ -12,10 +16,6 @@ import { allDashboardsExist } from '@/utils/grafana';
 import CloudConfig from '@/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig';
 import Volume from '@/edit/kubevirt.io.virtualmachine/VirtualMachineVolume';
 import Network from '@/edit/kubevirt.io.virtualmachine/VirtualMachineNetwork';
-import Events from './VirtualMachineTabs/VirtualMachineEvents';
-import Migration from './VirtualMachineTabs/VirtualMachineMigration';
-import OverviewBasics from './VirtualMachineTabs/VirtualMachineBasics';
-import OverviewKeypairs from './VirtualMachineTabs/VirtualMachineKeypairs';
 
 const VM_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/harvester-vm-detail-1/vm-info-detail?orgId=1';
 

--- a/detail/node.vue
+++ b/detail/node.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import ConsumptionGauge from '@/components/ConsumptionGauge';
 import Alert from '@/components/Alert';
 import SortableTable from '@/components/SortableTable';
@@ -16,7 +17,6 @@ import { METRIC, POD } from '@/config/types';
 import createEditView from '@/mixins/create-edit-view';
 import { formatSi, exponentNeeded, UNITS } from '@/utils/units';
 import DashboardMetrics from '@/components/DashboardMetrics';
-import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@/utils/grafana';
 import Loading from '@/components/Loading';
 import metricPoller from '@/mixins/metric-poller';

--- a/detail/pod.vue
+++ b/detail/pod.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import CreateEditView from '@/mixins/create-edit-view';
 import Tab from '@/components/Tabbed/Tab';
 import ResourceTabs from '@/components/form/ResourceTabs';
@@ -8,7 +9,6 @@ import { sortableNumericSuffix } from '@/utils/sort';
 import { findBy } from '@/utils/array';
 import DashboardMetrics from '@/components/DashboardMetrics';
 import V1WorkloadMetrics from '@/mixins/v1-workload-metrics';
-import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@/utils/grafana';
 import Loading from '@/components/Loading';
 import LabeledSelect from '@/components/form/LabeledSelect';

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -1,4 +1,6 @@
 <script>
+import AnsiUp from 'ansi_up';
+import day from 'dayjs';
 import Loading from '@/components/Loading';
 import Banner from '@/components/Banner';
 import ResourceTable from '@/components/ResourceTable';
@@ -13,8 +15,6 @@ import {
 } from '@/config/table-headers';
 import CustomCommand from '@/edit/provisioning.cattle.io.cluster/CustomCommand';
 import AsyncButton from '@/components/AsyncButton.vue';
-import AnsiUp from 'ansi_up';
-import day from 'dayjs';
 import { addParams } from '@/utils/url';
 import { base64Decode } from '@/utils/crypto';
 import { DATE_FORMAT, TIME_FORMAT } from '@/store/prefs';

--- a/detail/workload/index.vue
+++ b/detail/workload/index.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import CreateEditView from '@/mixins/create-edit-view';
 import { STATE, NAME, NODE, POD_IMAGES } from '@/config/table-headers';
 import { POD, WORKLOAD_TYPES } from '@/config/types';
@@ -10,7 +11,6 @@ import CountGauge from '@/components/CountGauge';
 import { allHash } from '@/utils/promise';
 import DashboardMetrics from '@/components/DashboardMetrics';
 import V1WorkloadMetrics from '@/mixins/v1-workload-metrics';
-import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@/utils/grafana';
 
 const WORKLOAD_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-workload-pods-1/rancher-workload-pods?orgId=1';

--- a/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -1,4 +1,7 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
+import find from 'lodash/find';
+import endsWith from 'lodash/endsWith';
 import CreateEditView from '@/mixins/create-edit-view';
 
 import CruResource from '@/components/CruResource';
@@ -14,9 +17,6 @@ import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import { DEFAULT_RESOURCE_METRIC } from '@/edit/autoscaling.horizontalpodautoscaler/resource-metric';
 
 import { API_SERVICE, SCALABLE_WORKLOAD_TYPES } from '@/config/types';
-import isEmpty from 'lodash/isEmpty';
-import find from 'lodash/find';
-import endsWith from 'lodash/endsWith';
 import { findBy } from '@/utils/array';
 
 const RESOURCE_METRICS_API_GROUP = 'metrics.k8s.io';

--- a/edit/autoscaling.horizontalpodautoscaler/metric-target.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/metric-target.vue
@@ -1,8 +1,8 @@
 <script>
+import filter from 'lodash/filter';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import LabeledInput from '@/components/form/LabeledInput';
 import { findBy } from '@/utils/array';
-import filter from 'lodash/filter';
 import UnitInput from '@/components/form/UnitInput';
 import { parseSi } from '@/utils/units';
 

--- a/edit/cis.cattle.io.clusterscan.vue
+++ b/edit/cis.cattle.io.clusterscan.vue
@@ -1,4 +1,6 @@
 <script>
+import { mapGetters } from 'vuex';
+import { isValidCron } from 'cron-validator';
 import CruResource from '@/components/CruResource';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import LabeledInput from '@/components/form/LabeledInput';
@@ -6,14 +8,12 @@ import UnitInput from '@/components/form/UnitInput';
 import Banner from '@/components/Banner';
 import Loading from '@/components/Loading';
 import { CIS, CONFIG_MAP } from '@/config/types';
-import { mapGetters } from 'vuex';
 import createEditView from '@/mixins/create-edit-view';
 import { allHash } from '@/utils/promise';
 import Checkbox from '@/components/form/Checkbox';
 import RadioGroup from '@/components/form/RadioGroup';
 import { get } from '@/utils/object';
 import { _VIEW, _CREATE } from '@/config/query-params';
-import { isValidCron } from 'cron-validator';
 
 const semver = require('semver');
 

--- a/edit/cis.cattle.io.clusterscanbenchmark.vue
+++ b/edit/cis.cattle.io.clusterscanbenchmark.vue
@@ -1,10 +1,10 @@
 <script>
+import { mapGetters } from 'vuex';
 import createEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import LabeledInput from '@/components/form/LabeledInput';
 import NameNsDescription from '@/components/form/NameNsDescription';
-import { mapGetters } from 'vuex';
 import { CONFIG_MAP } from '@/config/types';
 const providers = ['aks', 'docker', 'eks', 'gke', 'k3s', 'minikube', 'rke-windows', 'rke', 'rke2'];
 

--- a/edit/cis.cattle.io.clusterscanprofile.vue
+++ b/edit/cis.cattle.io.clusterscanprofile.vue
@@ -1,10 +1,10 @@
 <script>
+import { mapGetters } from 'vuex';
 import NameNsDescription from '@/components/form/NameNsDescription';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import ArrayList from '@/components/form/ArrayList';
 import createEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
-import { mapGetters } from 'vuex';
 import { CIS } from '@/config/types';
 const semver = require('semver');
 

--- a/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -1,6 +1,9 @@
 <script>
 import Vue from 'vue';
 import merge from 'lodash/merge';
+import NamespaceList, { NAMESPACE_FILTERS_HELPER } from './NamespaceList';
+import MatchKinds from './MatchKinds';
+import Scope, { SCOPE_OPTIONS } from './Scope';
 import { ucFirst } from '@/utils/string';
 import { isSimpleKeyValue } from '@/utils/object';
 import { _CREATE, _VIEW } from '@/config/query-params';
@@ -15,9 +18,6 @@ import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import CruResource from '@/components/CruResource';
 import { ENFORCEMENT_ACTION_VALUES } from '@/models/constraints.gatekeeper.sh.constraint';
 import { saferDump } from '@/utils/create-yaml';
-import NamespaceList, { NAMESPACE_FILTERS_HELPER } from './NamespaceList';
-import MatchKinds from './MatchKinds';
-import Scope, { SCOPE_OPTIONS } from './Scope';
 
 function findConstraintTypes(schemas) {
   return schemas

--- a/edit/fleet.cattle.io.clustergroup.vue
+++ b/edit/fleet.cattle.io.clustergroup.vue
@@ -1,4 +1,5 @@
 <script>
+import throttle from 'lodash/throttle';
 import Banner from '@/components/Banner';
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
@@ -10,7 +11,6 @@ import NameNsDescription from '@/components/form/NameNsDescription';
 import { set } from '@/utils/object';
 import { FLEET } from '@/config/types';
 import { convert, matching, simplify } from '@/utils/selector';
-import throttle from 'lodash/throttle';
 
 export default {
   name: 'CruClusterGroup',

--- a/edit/fleet.cattle.io.gitrepo.vue
+++ b/edit/fleet.cattle.io.gitrepo.vue
@@ -1,6 +1,7 @@
 <script>
-import { exceptionToErrorsArray } from '@/utils/error';
 import { mapGetters } from 'vuex';
+import jsyaml from 'js-yaml';
+import { exceptionToErrorsArray } from '@/utils/error';
 import { FLEET, VIRTUAL_HARVESTER_PROVIDER } from '@/config/types';
 import { set } from '@/utils/object';
 import ArrayList from '@/components/form/ArrayList';
@@ -8,7 +9,6 @@ import Banner from '@/components/Banner';
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
 import InputWithSelect from '@/components/form/InputWithSelect';
-import jsyaml from 'js-yaml';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import RadioGroup from '@/components/form/RadioGroup';

--- a/edit/harvesterhci.io.host/index.vue
+++ b/edit/harvesterhci.io.host/index.vue
@@ -1,6 +1,7 @@
 <script>
 import pickBy from 'lodash/pickBy';
 import { mapGetters } from 'vuex';
+import HarvesterDisk from './HarvesterDisk';
 import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
 import Footer from '@/components/form/Footer';
@@ -22,7 +23,6 @@ import { exceptionToErrorsArray } from '@/utils/error';
 import KeyValue from '@/components/form/KeyValue';
 import { sortBy } from '@/utils/sort';
 import Banner from '@/components/Banner';
-import HarvesterDisk from './HarvesterDisk';
 
 const LONGHORN_SYSTEM = 'longhorn-system';
 

--- a/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/index.vue
+++ b/edit/kubevirt.io.virtualmachine/VirtualMachineCloudConfig/index.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 
+import DataTemplate from './DataTemplate';
 import LabeledInput from '@/components/form/LabeledInput';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import ModalWithCard from '@/components/ModalWithCard';
@@ -8,7 +9,6 @@ import ModalWithCard from '@/components/ModalWithCard';
 import { CONFIG_MAP } from '@/config/types';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 import { _VIEW } from '@/config/query-params';
-import DataTemplate from './DataTemplate';
 
 const _NEW = '_NEW';
 const _NONE = '_NONE';

--- a/edit/logging-flow/index.vue
+++ b/edit/logging-flow/index.vue
@@ -1,4 +1,7 @@
 <script>
+import jsyaml from 'js-yaml';
+import isEmpty from 'lodash/isEmpty';
+import Match from './Match';
 import Banner from '@/components/Banner';
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
@@ -7,7 +10,6 @@ import NameNsDescription from '@/components/form/NameNsDescription';
 import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
 import { LOGGING, NODE, POD, SCHEMA } from '@/config/types';
-import jsyaml from 'js-yaml';
 import { createYaml } from '@/utils/create-yaml';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import { allHash } from '@/utils/promise';
@@ -15,10 +17,8 @@ import { isArray, uniq } from '@/utils/array';
 import { matchRuleIsPopulated } from '@/models/logging.banzaicloud.io.flow';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import { clone, set } from '@/utils/object';
-import isEmpty from 'lodash/isEmpty';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import { exceptionToErrorsArray } from '@/utils/error';
-import Match from './Match';
 
 function emptyMatch(include = true) {
   const rule = {

--- a/edit/logging.banzaicloud.io.output/index.vue
+++ b/edit/logging.banzaicloud.io.output/index.vue
@@ -1,4 +1,7 @@
 <script>
+import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
+import jsyaml from 'js-yaml';
 import CreateEditView from '@/mixins/create-edit-view';
 import { SECRET, LOGGING, SCHEMA } from '@/config/types';
 import Tabbed from '@/components/Tabbed';
@@ -11,9 +14,6 @@ import Banner from '@/components/Banner';
 import { PROVIDERS } from '@/models/logging.banzaicloud.io.output';
 import { _VIEW } from '@/config/query-params';
 import { clone, set } from '@/utils/object';
-import isEqual from 'lodash/isEqual';
-import isEmpty from 'lodash/isEmpty';
-import jsyaml from 'js-yaml';
 import { createYaml } from '@/utils/create-yaml';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 

--- a/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
+++ b/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
@@ -1,8 +1,8 @@
 <script>
+import { updatePort, protocol } from './utils';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import SecretSelector from '@/components/form/SecretSelector';
-import { updatePort, protocol } from './utils';
 
 export default {
   components: {

--- a/edit/logging.banzaicloud.io.output/providers/forward.vue
+++ b/edit/logging.banzaicloud.io.output/providers/forward.vue
@@ -1,7 +1,7 @@
 <script>
+import { updatePort } from './utils';
 import LabeledInput from '@/components/form/LabeledInput';
 import SecretSelector from '@/components/form/SecretSelector';
-import { updatePort } from './utils';
 
 export default {
   components: { LabeledInput, SecretSelector },

--- a/edit/logging.banzaicloud.io.output/providers/kafka.vue
+++ b/edit/logging.banzaicloud.io.output/providers/kafka.vue
@@ -1,8 +1,8 @@
 <script>
+import { protocol } from './utils';
 import LabeledInput from '@/components/form/LabeledInput';
 import SecretSelector from '@/components/form/SecretSelector';
 import Checkbox from '@/components/form/Checkbox';
-import { protocol } from './utils';
 
 export default {
   components: {

--- a/edit/logging.banzaicloud.io.output/providers/logz.vue
+++ b/edit/logging.banzaicloud.io.output/providers/logz.vue
@@ -1,8 +1,8 @@
 <script>
+import { updatePort } from './utils';
 import Checkbox from '@/components/form/Checkbox';
 import LabeledInput from '@/components/form/LabeledInput';
 import SecretSelector from '@/components/form/SecretSelector';
-import { updatePort } from './utils';
 
 export default {
   components: {

--- a/edit/logging.banzaicloud.io.output/providers/splunkHec.vue
+++ b/edit/logging.banzaicloud.io.output/providers/splunkHec.vue
@@ -1,9 +1,9 @@
 <script>
+import { protocol, updatePort } from './utils';
 import SecretSelector from '@/components/form/SecretSelector';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Checkbox from '@/components/form/Checkbox';
-import { protocol, updatePort } from './utils';
 
 export default {
   components: {

--- a/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -1,12 +1,12 @@
 <script>
 import has from 'lodash/has';
 
+import AlertingRule from './AlertingRule';
+import RecordingRule from './RecordingRule';
 import Banner from '@/components/Banner';
 import { removeAt } from '@/utils/array';
 import { _VIEW } from '@/config/query-params';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
-import AlertingRule from './AlertingRule';
-import RecordingRule from './RecordingRule';
 
 export default {
   components: {

--- a/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -1,4 +1,7 @@
 <script>
+import isString from 'lodash/isString';
+import isEmpty from 'lodash/isEmpty';
+import GroupRules from './GroupRules';
 import CreateEditView from '@/mixins/create-edit-view';
 
 import { removeAt } from '@/utils/array';
@@ -11,9 +14,6 @@ import Tab from '@/components/Tabbed/Tab';
 import Tabbed from '@/components/Tabbed';
 import UnitInput from '@/components/form/UnitInput';
 import { _CREATE } from '@/config/query-params';
-import isString from 'lodash/isString';
-import isEmpty from 'lodash/isEmpty';
-import GroupRules from './GroupRules';
 
 export default {
   components: {

--- a/edit/monitoring.coreos.com.receiver/auth.vue
+++ b/edit/monitoring.coreos.com.receiver/auth.vue
@@ -1,7 +1,7 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
-import isEmpty from 'lodash/isEmpty';
 
 export default {
   components: { LabeledInput, LabeledSelect },

--- a/edit/monitoring.coreos.com.receiver/index.vue
+++ b/edit/monitoring.coreos.com.receiver/index.vue
@@ -1,4 +1,5 @@
 <script>
+import jsyaml from 'js-yaml';
 import { MONITORING } from '@/config/types';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import Loading from '@/components/Loading';
@@ -9,7 +10,6 @@ import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import CreateEditView from '@/mixins/create-edit-view';
-import jsyaml from 'js-yaml';
 import { RECEIVERS_TYPES } from '@/models/monitoring.coreos.com.receiver';
 import ButtonDropdown from '@/components/ButtonDropdown';
 

--- a/edit/monitoring.coreos.com.receiver/types/email.vue
+++ b/edit/monitoring.coreos.com.receiver/types/email.vue
@@ -1,7 +1,7 @@
 <script>
+import TLS from '../tls';
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
-import TLS from '../tls';
 
 export default {
   components: {

--- a/edit/monitoring.coreos.com.receiver/types/webhook.vue
+++ b/edit/monitoring.coreos.com.receiver/types/webhook.vue
@@ -1,11 +1,11 @@
 <script>
+import TLS from '../tls';
+import Auth from '../auth';
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import Banner from '@/components/Banner';
 import { _VIEW } from '@/config/query-params';
 import { ALIBABA_CLOUD_SMS_URL, MS_TEAMS_URL } from '@/edit/monitoring.coreos.com.receiver/types/webhook.add.vue';
-import TLS from '../tls';
-import Auth from '../auth';
 
 export default {
   components: {

--- a/edit/networking.istio.io.destinationrule/index.vue
+++ b/edit/networking.istio.io.destinationrule/index.vue
@@ -1,4 +1,5 @@
 <script>
+import LoadBalancer from './LoadBalancer';
 import NameNsDescription from '@/components/form/NameNsDescription';
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
@@ -8,7 +9,6 @@ import Tabbed from '@/components/Tabbed';
 import KeyValue from '@/components/form/KeyValue';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import { get, set } from '@/utils/object';
-import LoadBalancer from './LoadBalancer';
 
 export default {
   components: {

--- a/edit/networking.k8s.io.ingress/Certificates.vue
+++ b/edit/networking.k8s.io.ingress/Certificates.vue
@@ -1,9 +1,9 @@
 <script>
+import Certificate from './Certificate';
 import SortableTable from '@/components/SortableTable';
 import { _EDIT, _VIEW } from '@/config/query-params';
 import { SECRET } from '@/config/types';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
-import Certificate from './Certificate';
 
 export default {
   components: {

--- a/edit/networking.k8s.io.ingress/Rule.vue
+++ b/edit/networking.k8s.io.ingress/Rule.vue
@@ -1,7 +1,7 @@
 <script>
+import { random32 } from '../../utils/string';
 import RulePath from '@/edit/networking.k8s.io.ingress/RulePath';
 import LabeledInput from '@/components/form/LabeledInput';
-import { random32 } from '../../utils/string';
 
 export default {
   components: { RulePath, LabeledInput },

--- a/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/edit/networking.k8s.io.ingress/RulePath.vue
@@ -1,9 +1,9 @@
 <script>
+import debounce from 'lodash/debounce';
 import InputWithSelect from '@/components/form/InputWithSelect';
 import LabeledInput from '@/components/form/LabeledInput';
 import Select from '@/components/form/Select';
 import { get, set } from '@/utils/object';
-import debounce from 'lodash/debounce';
 
 export default {
   components: {

--- a/edit/networking.k8s.io.ingress/Rules.vue
+++ b/edit/networking.k8s.io.ingress/Rules.vue
@@ -1,11 +1,11 @@
 <script>
+import Rule from './Rule';
 import { WORKLOAD_TYPES } from '@/config/types';
 import Loading from '@/components/Loading';
 import SortableTable from '@/components/SortableTable';
 import { _VIEW } from '@/config/query-params';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import { random32 } from '@/utils/string';
-import Rule from './Rule';
 
 export default {
   components: {

--- a/edit/networking.k8s.io.ingress/index.vue
+++ b/edit/networking.k8s.io.ingress/index.vue
@@ -1,4 +1,7 @@
 <script>
+import DefaultBackend from './DefaultBackend';
+import Certificates from './Certificates';
+import Rules from './Rules';
 import { allHash } from '@/utils/promise';
 import { SECRET, SERVICE } from '@/config/types';
 import NameNsDescription from '@/components/form/NameNsDescription';
@@ -9,9 +12,6 @@ import Labels from '@/components/form/Labels';
 import Tabbed from '@/components/Tabbed';
 import { get, set } from '@/utils/object';
 import { TYPES } from '@/models/secret';
-import DefaultBackend from './DefaultBackend';
-import Certificates from './Certificates';
-import Rules from './Rules';
 
 export default {
   name:       'CRUIngress',

--- a/edit/persistentvolume/index.vue
+++ b/edit/persistentvolume/index.vue
@@ -1,4 +1,5 @@
 <script>
+import uniq from 'lodash/uniq';
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
 import NameNsDescription from '@/components/form/NameNsDescription';
@@ -10,7 +11,6 @@ import Tab from '@/components/Tabbed/Tab';
 import Tabbed from '@/components/Tabbed';
 import NodeAffinity from '@/components/form/NodeAffinity';
 import Checkbox from '@/components/form/Checkbox';
-import uniq from 'lodash/uniq';
 import UnitInput from '@/components/form/UnitInput';
 import { NODE, PVC, STORAGE_CLASS } from '@/config/types';
 import Loading from '@/components/Loading';

--- a/edit/persistentvolumeclaim.vue
+++ b/edit/persistentvolumeclaim.vue
@@ -1,4 +1,5 @@
 <script>
+import uniq from 'lodash/uniq';
 import Checkbox from '@/components/form/Checkbox';
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
@@ -7,7 +8,6 @@ import Tab from '@/components/Tabbed/Tab';
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import UnitInput from '@/components/form/UnitInput';
-import uniq from 'lodash/uniq';
 import { _CREATE } from '@/config/query-params';
 import { STORAGE_CLASS, PV } from '@/config/types';
 import StatusTable from '@/components/StatusTable';

--- a/edit/provisioning.cattle.io.cluster/ACE.vue
+++ b/edit/provisioning.cattle.io.cluster/ACE.vue
@@ -1,9 +1,9 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
 import RadioGroup from '@/components/form/RadioGroup';
 import LabeledInput from '@/components/form/LabeledInput';
 import FileSelector, { createOnSelected } from '@/components/form/FileSelector';
 import { set } from '@/utils/object';
-import isEmpty from 'lodash/isEmpty';
 
 export default {
   components: {

--- a/edit/provisioning.cattle.io.cluster/import.vue
+++ b/edit/provisioning.cattle.io.cluster/import.vue
@@ -1,4 +1,6 @@
 <script>
+import Labels from './Labels';
+import AgentEnv from './AgentEnv';
 import CreateEditView from '@/mixins/create-edit-view';
 
 import CruResource from '@/components/CruResource';
@@ -14,8 +16,6 @@ import { NAME as HARVESTER_MANAGER } from '@/config/product/harvester-manager';
 import { HARVESTER as HARVESTER_FEATURE, mapFeature } from '@/store/features';
 import { addObject } from '@/utils/array';
 import { HIDE_DESC, mapPref } from '@/store/prefs';
-import Labels from './Labels';
-import AgentEnv from './AgentEnv';
 
 const HARVESTER_HIDE_KEY = 'cm-harvester-import';
 

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -1,4 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
+import Rke2Config from './rke2';
+import Import from './import';
 import CreateEditView from '@/mixins/create-edit-view';
 import Loading from '@/components/Loading';
 import CruResource from '@/components/CruResource';
@@ -7,7 +10,6 @@ import EmberPage from '@/components/EmberPage';
 import ToggleSwitch from '@/components/form/ToggleSwitch';
 import { CHART, FROM_CLUSTER, SUB_TYPE, _IMPORT } from '@/config/query-params';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
-import { mapGetters } from 'vuex';
 import { sortBy } from '@/utils/sort';
 import { set } from '@/utils/object';
 import { mapPref, PROVISIONER, _RKE1, _RKE2 } from '@/store/prefs';
@@ -17,8 +19,6 @@ import { CAPI, MANAGEMENT } from '@/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE } from '@/store/features';
 import { allHash } from '@/utils/promise';
 import { BLANK_CLUSTER } from '@/store';
-import Rke2Config from './rke2';
-import Import from './import';
 
 const SORT_GROUPS = {
   template:  1,

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -5,6 +5,16 @@ import isArray from 'lodash/isArray';
 import merge from 'lodash/merge';
 import { mapGetters } from 'vuex';
 
+import semver from 'semver';
+import ACE from './ACE';
+import AgentEnv from './AgentEnv';
+import DrainOptions from './DrainOptions';
+import Labels from './Labels';
+import MachinePool from './MachinePool';
+import RegistryConfigs from './RegistryConfigs';
+import RegistryMirrors from './RegistryMirrors';
+import S3Config from './S3Config';
+import SelectCredential from './SelectCredential';
 import CreateEditView from '@/mixins/create-edit-view';
 
 import { CAPI, MANAGEMENT, NORMAN, SCHEMA } from '@/config/types';
@@ -42,18 +52,8 @@ import { normalizeName } from '@/components/form/NameNsDescription.vue';
 import ClusterMembershipEditor from '@/components/form/Members/ClusterMembershipEditor';
 import SelectOrCreateAuthSecret from '@/components/form/SelectOrCreateAuthSecret';
 import { LEGACY } from '@/store/features';
-import semver from 'semver';
 import { canViewClusterMembershipEditor } from '@/components/form/Members/ClusterMembershipEditor.vue';
 import { SETTING } from '@/config/settings';
-import ACE from './ACE';
-import AgentEnv from './AgentEnv';
-import DrainOptions from './DrainOptions';
-import Labels from './Labels';
-import MachinePool from './MachinePool';
-import RegistryConfigs from './RegistryConfigs';
-import RegistryMirrors from './RegistryMirrors';
-import S3Config from './S3Config';
-import SelectCredential from './SelectCredential';
 
 const PUBLIC = 'public';
 const PRIVATE = 'private';

--- a/edit/resources.cattle.io.backup.vue
+++ b/edit/resources.cattle.io.backup.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import CruResource from '@/components/CruResource';
 import createEditView from '@/mixins/create-edit-view';
 import LabeledInput from '@/components/form/LabeledInput';
@@ -9,7 +10,6 @@ import RadioGroup from '@/components/form/RadioGroup';
 import NameNsDescription from '@/components/form/NameNsDescription';
 import Loading from '@/components/Loading';
 import S3 from '@/chart/rancher-backup/S3';
-import { mapGetters } from 'vuex';
 import { SECRET, BACKUP_RESTORE, CATALOG } from '@/config/types';
 import { allHash } from '@/utils/promise';
 import { NAMESPACE, _VIEW } from '@/config/query-params';

--- a/edit/resources.cattle.io.restore.vue
+++ b/edit/resources.cattle.io.restore.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import CruResource from '@/components/CruResource';
 import createEditView from '@/mixins/create-edit-view';
 import LabeledInput from '@/components/form/LabeledInput';
@@ -8,7 +9,6 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import Loading from '@/components/Loading';
 import RadioGroup from '@/components/form/RadioGroup';
 import S3 from '@/chart/rancher-backup/S3';
-import { mapGetters } from 'vuex';
 import { SECRET, BACKUP_RESTORE, CATALOG } from '@/config/types';
 import { allHash } from '@/utils/promise';
 import { get } from '@/utils/object';

--- a/edit/workload/Job.vue
+++ b/edit/workload/Job.vue
@@ -1,9 +1,9 @@
 <script>
+import { mapGetters } from 'vuex';
 import { WORKLOAD_TYPES } from '@/config/types';
 import UnitInput from '@/components/form/UnitInput';
 import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';
-import { mapGetters } from 'vuex';
 
 export default {
   components: {

--- a/edit/workload/Upgrading.vue
+++ b/edit/workload/Upgrading.vue
@@ -1,10 +1,10 @@
 <script>
+import { mapGetters } from 'vuex';
 import { get } from '@/utils/object';
 import RadioGroup from '@/components/form/RadioGroup';
 import UnitInput from '@/components/form/UnitInput';
 import { WORKLOAD_TYPES } from '@/config/types';
 import { _CREATE } from '@/config/query-params';
-import { mapGetters } from 'vuex';
 import InputWithSelect from '@/components/form/InputWithSelect';
 
 export default {

--- a/edit/workload/VolumeClaimTemplate.vue
+++ b/edit/workload/VolumeClaimTemplate.vue
@@ -1,6 +1,6 @@
 <script>
-import Mount from '@/edit/workload/storage/Mount';
 import { mapGetters } from 'vuex';
+import Mount from '@/edit/workload/storage/Mount';
 import PersistentVolumeClaim from '@/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim.vue';
 import { PVC } from '@/config/types';
 import { _VIEW } from '@/config/query-params';

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -1,5 +1,6 @@
 <script>
 import omitBy from 'lodash/omitBy';
+import { mapGetters } from 'vuex';
 import { cleanUp } from '@/utils/object';
 import {
   CONFIG_MAP, SECRET, WORKLOAD_TYPES, NODE, SERVICE, PVC, SERVICE_ACCOUNT
@@ -23,7 +24,6 @@ import WorkloadPorts from '@/components/form/WorkloadPorts';
 import ContainerResourceLimit from '@/components/ContainerResourceLimit';
 import KeyValue from '@/components/form/KeyValue';
 import Tabbed from '@/components/Tabbed';
-import { mapGetters } from 'vuex';
 import NodeScheduling from '@/components/form/NodeScheduling';
 import PodAffinity from '@/components/form/PodAffinity';
 import Tolerations from '@/components/form/Tolerations';

--- a/edit/workload/storage/Mount.vue
+++ b/edit/workload/storage/Mount.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
-import { mapGetters } from 'vuex';
 import { removeObject } from '@/utils/array';
 export default {
   components: { LabeledInput, Checkbox },

--- a/edit/workload/storage/awsElasticBlockStore.vue
+++ b/edit/workload/storage/awsElasticBlockStore.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import { mapGetters } from 'vuex';
+import LabeledInput from '@/components/form/LabeledInput';
 
 export default {
   components: { LabeledInput },

--- a/edit/workload/storage/azureDisk.vue
+++ b/edit/workload/storage/azureDisk.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import LabeledInput from '@/components/form/LabeledInput';
 import RadioGroup from '@/components/form/RadioGroup';
-import { mapGetters } from 'vuex';
 
 export default {
   components: { LabeledInput, RadioGroup },

--- a/edit/workload/storage/azureFile.vue
+++ b/edit/workload/storage/azureFile.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import { mapGetters } from 'vuex';
+import LabeledInput from '@/components/form/LabeledInput';
 
 export default {
   components: { LabeledInput },

--- a/edit/workload/storage/csi/index.vue
+++ b/edit/workload/storage/csi/index.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledSelect from '@/components/form/LabeledSelect';
 import { mapGetters } from 'vuex';
+import LabeledSelect from '@/components/form/LabeledSelect';
 
 export default {
   components: { LabeledSelect },

--- a/edit/workload/storage/ephemeralVolume/index.vue
+++ b/edit/workload/storage/ephemeralVolume/index.vue
@@ -1,9 +1,9 @@
 <script>
+import { mapGetters } from 'vuex';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import Mount from '@/edit/workload/storage/Mount';
-import { mapGetters } from 'vuex';
 
 export default {
   components: {

--- a/edit/workload/storage/gcePersistentDisk.vue
+++ b/edit/workload/storage/gcePersistentDisk.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import { mapGetters } from 'vuex';
+import LabeledInput from '@/components/form/LabeledInput';
 
 export default {
   components: { LabeledInput },

--- a/edit/workload/storage/index.vue
+++ b/edit/workload/storage/index.vue
@@ -1,11 +1,11 @@
 <script>
+import jsyaml from 'js-yaml';
 import { PVC } from '@/config/types';
 import { removeObjects, addObjects } from '@/utils/array.js';
 import ButtonDropdown from '@/components/ButtonDropdown';
 import Mount from '@/edit/workload/storage/Mount';
 import { _VIEW } from '@/config/query-params';
 import CodeMirror from '@/components/CodeMirror';
-import jsyaml from 'js-yaml';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import { randomStr } from '@/utils/string';
 

--- a/edit/workload/storage/persistentVolumeClaim/index.vue
+++ b/edit/workload/storage/persistentVolumeClaim/index.vue
@@ -1,8 +1,8 @@
 <script>
+import { mapGetters } from 'vuex';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Checkbox from '@/components/form/Checkbox';
-import { mapGetters } from 'vuex';
 import PersistentVolumeClaim from '@/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim';
 import { PVC } from '@/config/types';
 

--- a/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim.vue
+++ b/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim.vue
@@ -1,10 +1,10 @@
 <script>
+import { mapGetters } from 'vuex';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import UnitInput from '@/components/form/UnitInput';
 import RadioGroup from '@/components/form/RadioGroup';
 import Checkbox from '@/components/form/Checkbox';
 import LabeledInput from '@/components/form/LabeledInput';
-import { mapGetters } from 'vuex';
 import { removeObject, addObject } from '@/utils/array';
 import { STORAGE_CLASS, PV } from '@/config/types';
 import { allHash } from '@/utils/promise';

--- a/edit/workload/storage/vsphereVolume.vue
+++ b/edit/workload/storage/vsphereVolume.vue
@@ -1,6 +1,6 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import { mapGetters } from 'vuex';
+import LabeledInput from '@/components/form/LabeledInput';
 
 export default {
   components: { LabeledInput },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,7 @@
 <script>
 import debounce from 'lodash/debounce';
 import { mapState, mapGetters } from 'vuex';
+import isEqual from 'lodash/isEqual';
 import { mapPref, DEV, FAVORITE_TYPES, AFTER_LOGIN_ROUTE } from '@/store/prefs';
 import ActionMenu from '@/components/ActionMenu';
 import GrowlManager from '@/components/GrowlManager';
@@ -21,7 +22,6 @@ import { addObjects, replaceWith, clear, addObject } from '@/utils/array';
 import { NAME as EXPLORER } from '@/config/product/explorer';
 import { NAME as NAVLINKS } from '@/config/product/navlinks';
 import { NAME as HARVESTER } from '@/config/product/harvester';
-import isEqual from 'lodash/isEqual';
 import { ucFirst } from '@/utils/string';
 import { getVersionInfo, markSeenReleaseNotes } from '@/utils/version';
 import { sortBy } from '@/utils/sort';

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapState } from 'vuex';
 import ResourceTable from '@/components/ResourceTable';
 import Loading from '@/components/Loading';
 import Masthead from '@/components/ResourceList/Masthead';
@@ -7,7 +8,6 @@ import AsyncButton from '@/components/AsyncButton';
 import { applyProducts } from '@/store/type-map';
 import { NAME } from '@/config/product/auth';
 import { MODE, _EDIT } from '@/config/query-params';
-import { mapState } from 'vuex';
 
 export default {
   components: {

--- a/list/harvesterhci.io.dashboard/index.vue
+++ b/list/harvesterhci.io.dashboard/index.vue
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import minMax from 'dayjs/plugin/minMax';
 import utc from 'dayjs/plugin/utc';
 import { mapGetters } from 'vuex';
+import HarvesterUpgrade from './HarvesterUpgrade';
 import Loading from '@/components/Loading';
 import SortableTable from '@/components/SortableTable';
 import { allHash } from '@/utils/promise';
@@ -18,7 +19,6 @@ import Tab from '@/components/Tabbed/Tab';
 import DashboardMetrics from '@/components/DashboardMetrics';
 import metricPoller from '@/mixins/metric-poller';
 import { allDashboardsExist } from '@/utils/grafana';
-import HarvesterUpgrade from './HarvesterUpgrade';
 
 dayjs.extend(utc);
 dayjs.extend(minMax);

--- a/list/ui.cattle.io.navlink.vue
+++ b/list/ui.cattle.io.navlink.vue
@@ -1,6 +1,6 @@
 <script>
-import ResourceTable from '@/components/ResourceTable';
 import { mapGetters } from 'vuex';
+import ResourceTable from '@/components/ResourceTable';
 
 export default {
   name:       'ListNavLink',

--- a/machine-config/azure.vue
+++ b/machine-config/azure.vue
@@ -1,10 +1,10 @@
 <script>
+import merge from 'lodash/merge';
+import isEmpty from 'lodash/isEmpty';
 import Loading from '@/components/Loading';
 import CreateEditView from '@/mixins/create-edit-view';
 import { stringify, exceptionToErrorsArray } from '@/utils/error';
 import Banner from '@/components/Banner';
-import merge from 'lodash/merge';
-import isEmpty from 'lodash/isEmpty';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';

--- a/machine-config/harvester.vue
+++ b/machine-config/harvester.vue
@@ -1,5 +1,6 @@
 <script>
 import isEmpty from 'lodash/isEmpty';
+import { mapGetters } from 'vuex';
 import Loading from '@/components/Loading';
 import CreateEditView from '@/mixins/create-edit-view';
 import LabeledSelect from '@/components/form/LabeledSelect';
@@ -9,7 +10,6 @@ import YamlEditor from '@/components/YamlEditor';
 import Banner from '@/components/Banner';
 
 import { get } from '@/utils/object';
-import { mapGetters } from 'vuex';
 import {
   HCI, NAMESPACE, MANAGEMENT, CONFIG_MAP, NORMAN
 } from '@/config/types';

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -1,3 +1,4 @@
+import difference from 'lodash/difference';
 import { _EDIT } from '@/config/query-params';
 import { NORMAN, MANAGEMENT } from '@/config/types';
 import { AFTER_SAVE_HOOKS, BEFORE_SAVE_HOOKS } from '@/mixins/child-hook';
@@ -5,7 +6,6 @@ import { BASE_SCOPES } from '@/store/auth';
 import { addObject, findBy } from '@/utils/array';
 import { set } from '@/utils/object';
 import { exceptionToErrorsArray } from '@/utils/error';
-import difference from 'lodash/difference';
 
 export default {
   beforeCreate() {

--- a/mixins/create-edit-view/index.js
+++ b/mixins/create-edit-view/index.js
@@ -1,5 +1,5 @@
-import { _EDIT, _YAML } from '@/config/query-params';
 import impl from './impl';
+import { _EDIT, _YAML } from '@/config/query-params';
 
 export default {
   ...impl,

--- a/mixins/labeled-form-element.js
+++ b/mixins/labeled-form-element.js
@@ -1,5 +1,5 @@
-import { _EDIT, _VIEW } from '@/config/query-params';
 import $ from 'jquery';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   inheritAttrs: false,

--- a/models/apps.deployment.js
+++ b/models/apps.deployment.js
@@ -1,5 +1,5 @@
-import { WORKLOAD_TYPES } from '@/config/types';
 import Workload from './workload';
+import { WORKLOAD_TYPES } from '@/config/types';
 
 export default class Deployment extends Workload {
   get replicaSetId() {

--- a/models/batch.cronjob.js
+++ b/models/batch.cronjob.js
@@ -1,7 +1,7 @@
+import Workload from './workload';
 import { insertAt } from '@/utils/array';
 import { clone } from '@/utils/object';
 import { WORKLOAD_TYPES } from '@/config/types';
-import Workload from './workload';
 
 export default class CronJob extends Workload {
   get state() {

--- a/models/cis.cattle.io.clusterscan.js
+++ b/models/cis.cattle.io.clusterscan.js
@@ -1,10 +1,10 @@
+import day from 'dayjs';
 import { _CREATE, _EDIT } from '@/config/query-params';
 import { CIS } from '@/config/types';
 import { findBy } from '@/utils/array';
 import { downloadFile, generateZip } from '@/utils/download';
 import { get, isEmpty, set } from '@/utils/object';
 import { sortBy } from '@/utils/sort';
-import day from 'dayjs';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export default class ClusterScan extends SteveModel {

--- a/models/cluster/node.js
+++ b/models/cluster/node.js
@@ -1,10 +1,10 @@
+import findLast from 'lodash/findLast';
 import { formatPercent } from '@/utils/string';
 import { CAPI as CAPI_ANNOTATIONS, NODE_ROLES, RKE } from '@/config/labels-annotations.js';
 import {
   CAPI, MANAGEMENT, METRIC, NORMAN, POD
 } from '@/config/types';
 import { parseSi } from '@/utils/units';
-import findLast from 'lodash/findLast';
 
 import SteveModel from '@/plugins/steve/steve-class';
 

--- a/models/fleet.cattle.io.gitrepo.js
+++ b/models/fleet.cattle.io.gitrepo.js
@@ -1,5 +1,5 @@
-import { convert, matching, convertSelectorObj } from '@/utils/selector';
 import jsyaml from 'js-yaml';
+import { convert, matching, convertSelectorObj } from '@/utils/selector';
 import { escapeHtml } from '@/utils/string';
 import { FLEET } from '@/config/types';
 import { FLEET as FLEET_ANNOTATIONS } from '@/config/labels-annotations';

--- a/models/group.principal.js
+++ b/models/group.principal.js
@@ -1,6 +1,6 @@
+import Principal from './principal';
 import { MANAGEMENT, NORMAN } from '@/config/types';
 import { clone } from '@/utils/object';
-import Principal from './principal';
 
 export default class Group extends Principal {
   get canViewInApi() {

--- a/models/harvester/node.js
+++ b/models/harvester/node.js
@@ -1,8 +1,8 @@
 import pickBy from 'lodash/pickBy';
+import findLast from 'lodash/findLast';
 import { HCI, LONGHORN, POD } from '@/config/types';
 import { HCI as HCI_ANNOTATIONS } from '@/config/labels-annotations';
 import { clone } from '@/utils/object';
-import findLast from 'lodash/findLast';
 import { colorForState, stateDisplay } from '@/plugins/steve/resource-class';
 import SteveModel from '@/plugins/steve/steve-class';
 import { parseSi } from '@/utils/units';

--- a/models/logging.banzaicloud.io.clusterflow.js
+++ b/models/logging.banzaicloud.io.clusterflow.js
@@ -1,6 +1,6 @@
-import { LOGGING } from '@/config/types';
 import uniq from 'lodash/uniq';
 import Flow from './logging.banzaicloud.io.flow';
+import { LOGGING } from '@/config/types';
 
 export default class LogClusterFlow extends Flow {
   get allOutputs() {

--- a/models/logging.banzaicloud.io.flow.js
+++ b/models/logging.banzaicloud.io.flow.js
@@ -1,6 +1,6 @@
+import uniq from 'lodash/uniq';
 import { LOGGING } from '@/config/types';
 import { set } from '@/utils/object';
-import uniq from 'lodash/uniq';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export function matchRuleIsPopulated(rule) {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -1,17 +1,17 @@
 import Vue from 'vue';
+import jsyaml from 'js-yaml';
+import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 import { CATALOG } from '@/config/labels-annotations';
 import { NODE, FLEET, MANAGEMENT } from '@/config/types';
 import { insertAt } from '@/utils/array';
 import { downloadFile } from '@/utils/download';
 import { parseSi } from '@/utils/units';
-import jsyaml from 'js-yaml';
 import { eachLimit } from '@/utils/promise';
 import { addParams } from '@/utils/url';
 import { isEmpty } from '@/utils/object';
 import { NAME as HARVESTER } from '@/config/product/harvester';
 import { isHarvesterCluster } from '@/utils/cluster';
 import HybridModel from '@/plugins/steve/hybrid-class';
-import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 
 // See translation file cluster.providers for list of providers
 // If the logo is not named with the provider name, add an override here

--- a/models/management.cattle.io.globalrole.js
+++ b/models/management.cattle.io.globalrole.js
@@ -1,11 +1,11 @@
+import Vue from 'vue';
+import Role from './rbac.authorization.k8s.io.role';
 import { DESCRIPTION } from '@/config/labels-annotations';
 import { SCHEMA, NORMAN } from '@/config/types';
 import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@/models/management.cattle.io.roletemplate';
 import { uniq } from '@/utils/array';
-import Vue from 'vue';
 import { get } from '@/utils/object';
 import HybridModel from '@/plugins/steve/hybrid-class';
-import Role from './rbac.authorization.k8s.io.role';
 
 const BASE = 'user-base';
 const USER = 'user';

--- a/models/management.cattle.io.roletemplate.js
+++ b/models/management.cattle.io.roletemplate.js
@@ -1,9 +1,9 @@
 import Vue from 'vue';
+import Role from './rbac.authorization.k8s.io.role';
 import { get } from '@/utils/object';
 import { DESCRIPTION } from '@/config/labels-annotations';
 import { NORMAN } from '@/config/types';
 import HybridModel from '@/plugins/steve/hybrid-class';
-import Role from './rbac.authorization.k8s.io.role';
 
 export const CATTLE_API_GROUP = '.cattle.io';
 

--- a/models/monitoring.coreos.com.receiver.js
+++ b/models/monitoring.coreos.com.receiver.js
@@ -1,7 +1,7 @@
+import jsyaml from 'js-yaml';
 import { canCreate, updateConfig } from '@/utils/alertmanagerconfig';
 import { isEmpty } from '@/utils/object';
 import { MONITORING } from '@/config/types';
-import jsyaml from 'js-yaml';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export const RECEIVERS_TYPES = [

--- a/models/monitoring.coreos.com.route.js
+++ b/models/monitoring.coreos.com.route.js
@@ -1,8 +1,8 @@
+import jsyaml from 'js-yaml';
 import { isEmpty, set } from '@/utils/object';
 import { areRoutesSupportedFormat, canCreate, createDefaultRouteName, updateConfig } from '@/utils/alertmanagerconfig';
 import { MONITORING } from '@/config/types';
 import { NAME as MONITORING_PRODUCT } from '@/config/product/monitoring';
-import jsyaml from 'js-yaml';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export const ROOT_NAME = 'root';

--- a/models/namespace.js
+++ b/models/namespace.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import SYSTEM_NAMESPACES from '@/config/system-namespaces';
 import {
   PROJECT, SYSTEM_NAMESPACE, ISTIO as ISTIO_LABELS, FLEET, RESOURCE_QUOTA
@@ -8,7 +9,6 @@ import { get, set } from '@/utils/object';
 import { escapeHtml } from '@/utils/string';
 import { insertAt, isArray } from '@/utils/array';
 import SteveModel from '@/plugins/steve/steve-class';
-import Vue from 'vue';
 
 const OBSCURE_NAMESPACE_PREFIX = [
   'c-', // cluster namesapce

--- a/models/networking.k8s.io.ingress.js
+++ b/models/networking.k8s.io.ingress.js
@@ -1,7 +1,7 @@
-import { SECRET, SERVICE } from '@/config/types';
 import isUrl from 'is-url';
-import { get } from '@/utils/object';
 import isEmpty from 'lodash/isEmpty';
+import { SECRET, SERVICE } from '@/config/types';
+import { get } from '@/utils/object';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export default class Ingress extends SteveModel {

--- a/models/persistentvolumeclaim.js
+++ b/models/persistentvolumeclaim.js
@@ -1,6 +1,6 @@
 
-import { _CLONE } from '@/config/query-params';
 import Vue from 'vue';
+import { _CLONE } from '@/config/query-params';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export default class PVC extends SteveModel {

--- a/models/rbac.authorization.k8s.io.clusterrole.js
+++ b/models/rbac.authorization.k8s.io.clusterrole.js
@@ -1,6 +1,6 @@
+import Role from './rbac.authorization.k8s.io.role';
 import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@/models/management.cattle.io.roletemplate';
 import { uniq } from '@/utils/array';
-import Role from './rbac.authorization.k8s.io.role';
 
 export default class ClusterRole extends Role {
   get subtype() {

--- a/models/workload.js
+++ b/models/workload.js
@@ -1,8 +1,8 @@
+import day from 'dayjs';
 import { findBy, insertAt } from '@/utils/array';
 import { TARGET_WORKLOADS, TIMESTAMP, UI_MANAGED } from '@/config/labels-annotations';
 import { WORKLOAD_TYPES, SERVICE, POD } from '@/config/types';
 import { clone, get, set } from '@/utils/object';
-import day from 'dayjs';
 import SteveModel from '@/plugins/steve/steve-class';
 import { shortenedImage } from '@/utils/string';
 import { convertSelectorObj, matching } from '~/utils/selector';

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -235,7 +235,9 @@ module.exports = {
       plugins: [
         ['@babel/plugin-transform-modules-commonjs'],
         // Should be resolved in nuxt  v.2.15.5, see https://github.com/nuxt/nuxt.js/issues/9224#issuecomment-835742221
-        ['@babel/plugin-proposal-private-methods', { loose: true }]
+        ['@babel/plugin-proposal-private-methods', { loose: true }],
+        ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+        ['@babel/plugin-proposal-class-properties', { loose: true }],
       ],
     }
   },

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -1,11 +1,11 @@
 <script>
+import { mapGetters } from 'vuex';
 import BackLink from '@/components/BackLink';
 import PromptChangePassword from '@/components/PromptChangePassword';
 import { NORMAN } from '@/config/types';
 import Loading from '@/components/Loading';
 import Principal from '@/components/auth/Principal';
 import BackRoute from '@/mixins/back-link';
-import { mapGetters } from 'vuex';
 
 import Banner from '@/components/Banner';
 import ResourceTable from '@/components/ResourceTable';

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import { removeObject } from '@/utils/array';
 import { USERNAME } from '@/config/cookies';
 import LabeledInput from '@/components/form/LabeledInput';
@@ -12,7 +13,6 @@ import Checkbox from '@/components/form/Checkbox';
 import Password from '@/components/form/Password';
 import { sortBy } from '@/utils/sort';
 import { configType } from '@/models/management.cattle.io.authconfig';
-import { mapGetters } from 'vuex';
 import { importLogin } from '@/utils/dynamic-importer';
 import { _ALL_IF_AUTHED, _MULTI } from '@/plugins/steve/actions';
 import { MANAGEMENT, NORMAN } from '@/config/types';

--- a/pages/c/_cluster/apps/charts/chart.vue
+++ b/pages/c/_cluster/apps/charts/chart.vue
@@ -1,11 +1,11 @@
 <script>
+import isEqual from 'lodash/isEqual';
 import Loading from '@/components/Loading';
 import ChartMixin from '@/mixins/chart';
 import Banner from '@/components/Banner';
 import ChartReadme from '@/components/ChartReadme';
 import LazyImage from '@/components/LazyImage';
 import DateFormatter from '@/components/formatter/Date';
-import isEqual from 'lodash/isEqual';
 import { CHART, REPO, REPO_TYPE, VERSION } from '@/config/query-params';
 
 export default {

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import AsyncButton from '@/components/AsyncButton';
 import Loading from '@/components/Loading';
 import Banner from '@/components/Banner';
@@ -8,7 +9,6 @@ import {
 } from '@/config/query-params';
 import { lcFirst } from '@/utils/string';
 import { sortBy } from '@/utils/sort';
-import { mapGetters } from 'vuex';
 import Checkbox from '@/components/form/Checkbox';
 import Select from '@/components/form/Select';
 import { mapPref, HIDE_REPOS, SHOW_PRE_RELEASE } from '@/store/prefs';

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -2,9 +2,10 @@
 import jsyaml from 'js-yaml';
 import merge from 'lodash/merge';
 import isEqual from 'lodash/isEqual';
+import { mapGetters } from 'vuex';
+import Vue from 'vue';
 import { mapPref, DIFF } from '@/store/prefs';
 import { mapFeature, MULTI_CLUSTER, LEGACY } from '@/store/features';
-import { mapGetters } from 'vuex';
 
 import Banner from '@/components/Banner';
 import ButtonGroup from '@/components/ButtonGroup';
@@ -32,7 +33,6 @@ import { CATALOG as CATALOG_ANNOTATIONS, PROJECT } from '@/config/labels-annotat
 import { exceptionToErrorsArray } from '@/utils/error';
 import { clone, diff, get, set } from '@/utils/object';
 import { findBy, insertAt } from '@/utils/array';
-import Vue from 'vue';
 import { saferDump } from '@/utils/create-yaml';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
 

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -1,7 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import Loading from '@/components/Loading';
 import DashboardMetrics from '@/components/DashboardMetrics';
-import { mapGetters } from 'vuex';
 import SortableTable from '@/components/SortableTable';
 import { allHash } from '@/utils/promise';
 import AlertTable from '@/components/AlertTable';

--- a/pages/fail-whale.vue
+++ b/pages/fail-whale.vue
@@ -1,6 +1,6 @@
 <script>
-import BrandImage from '@/components/BrandImage';
 import { mapState } from 'vuex';
+import BrandImage from '@/components/BrandImage';
 import { stringify } from '@/utils/error';
 import { getVendor } from '@/config/private-label';
 import { NAME as HARVESTER } from '@/config/product/harvester';

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters, mapState } from 'vuex';
 import { mapPref, AFTER_LOGIN_ROUTE, READ_WHATS_NEW, HIDE_HOME_PAGE_CARDS } from '@/store/prefs';
 import Banner from '@/components/Banner';
 import BannerGraphic from '@/components/BannerGraphic';
@@ -9,7 +10,6 @@ import CommunityLinks from '@/components/CommunityLinks';
 import SimpleBox from '@/components/SimpleBox';
 import LandingPagePreference from '@/components/LandingPagePreference';
 import SingleClusterInfo from '@/components/SingleClusterInfo';
-import { mapGetters, mapState } from 'vuex';
 import { MANAGEMENT, CAPI } from '@/config/types';
 import { NAME as MANAGER } from '@/config/product/manager';
 import { STATE } from '@/config/table-headers';

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,7 +1,7 @@
 import https from 'https';
-import { CSRF } from '@/config/cookies';
 import { parse as setCookieParser } from 'set-cookie-parser';
 import pkg from '../package.json';
+import { CSRF } from '@/config/cookies';
 
 export default function({
   $axios, $cookies, isDev, req

--- a/plugins/lookup.js
+++ b/plugins/lookup.js
@@ -1,5 +1,5 @@
-import { get, set } from '@/utils/object';
 import $ from 'jquery';
+import { get, set } from '@/utils/object';
 
 const DEFAULT_NS = 'cluster';
 

--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -1,5 +1,7 @@
 import https from 'https';
 import merge from 'lodash/merge';
+import { normalizeType } from './normalize';
+import { classify } from './classify';
 import { SCHEMA } from '@/config/types';
 import { createYaml } from '@/utils/create-yaml';
 import { SPOOFED_API_PREFIX, SPOOFED_PREFIX } from '@/store/type-map';
@@ -7,8 +9,6 @@ import { addParam } from '@/utils/url';
 import { isArray } from '@/utils/array';
 import { deferred } from '@/utils/promise';
 import { streamingSupported, streamJson } from '@/utils/stream';
-import { normalizeType } from './normalize';
-import { classify } from './classify';
 
 export const _ALL = 'all';
 export const _MULTI = 'multi';

--- a/plugins/steve/getters.js
+++ b/plugins/steve/getters.js
@@ -1,11 +1,11 @@
+import { normalizeType, KEY_FIELD_FOR } from './normalize';
+import urlOptions from './urloptions';
+import mutations from './mutations';
 import { SCHEMA } from '@/config/types';
 import { matches } from '@/utils/selector';
 import { typeMunge, typeRef, SIMPLE_TYPES } from '@/utils/create-yaml';
 import { splitObjectPath } from '@/utils/string';
 import { parseType } from '@/models/schema';
-import { normalizeType, KEY_FIELD_FOR } from './normalize';
-import urlOptions from './urloptions';
-import mutations from './mutations';
 
 export default {
   all: (state, getters) => (type) => {

--- a/plugins/steve/hybrid-class.js
+++ b/plugins/steve/hybrid-class.js
@@ -1,9 +1,9 @@
-import { ANNOTATIONS_TO_IGNORE_REGEX, LABELS_TO_IGNORE_REGEX } from '@/config/labels-annotations';
 import omitBy from 'lodash/omitBy';
 import pickBy from 'lodash/pickBy';
 import Vue from 'vue';
-import { matchesSomeRegex } from '@/utils/string';
 import Resource from './resource-class';
+import { matchesSomeRegex } from '@/utils/string';
+import { ANNOTATIONS_TO_IGNORE_REGEX, LABELS_TO_IGNORE_REGEX } from '@/config/labels-annotations';
 
 // these are defined elsewhere in Steve models and will cause the error  "Cannot set property <whatever> of [object Object] which has only a getter" if defined at top-level
 export function cleanHybridResources(data) {

--- a/plugins/steve/index.js
+++ b/plugins/steve/index.js
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 
-import { isArray } from '@/utils/array';
 import actions from './actions';
 import getters from './getters';
 import mutations from './mutations';
@@ -11,6 +10,7 @@ import {
 } from './subscribe';
 import { classify } from './classify';
 import { keyFieldFor } from './normalize';
+import { isArray } from '@/utils/array';
 
 function SteveFactory(namespace, baseUrl) {
   return {

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -1,10 +1,10 @@
 import Vue from 'vue';
-import { addObject, addObjects, clear, removeObject } from '@/utils/array';
-import { SCHEMA } from '@/config/types';
-import HybridModel, { cleanHybridResources } from '@/plugins/steve/hybrid-class';
 import { normalizeType, KEY_FIELD_FOR } from './normalize';
 import { classify } from './classify';
 import { keyForSubscribe } from './subscribe';
+import { addObject, addObjects, clear, removeObject } from '@/utils/array';
+import { SCHEMA } from '@/config/types';
+import HybridModel, { cleanHybridResources } from '@/plugins/steve/hybrid-class';
 
 function registerType(state, type) {
   let cache = state.types[type];

--- a/plugins/steve/normalize.js
+++ b/plugins/steve/normalize.js
@@ -1,5 +1,5 @@
-import { SCHEMA } from '@/config/types';
 import isObject from 'lodash/isObject';
+import { SCHEMA } from '@/config/types';
 
 export const KEY_FIELD_FOR = {
   [SCHEMA]:  '_id',

--- a/plugins/steve/norman-class.js
+++ b/plugins/steve/norman-class.js
@@ -1,8 +1,8 @@
-import { ANNOTATIONS_TO_IGNORE_REGEX, LABELS_TO_IGNORE_REGEX } from '@/config/labels-annotations';
 import pickBy from 'lodash/pickBy';
 import Vue from 'vue';
-import { matchesSomeRegex } from '@/utils/string';
 import Resource from './resource-class';
+import { matchesSomeRegex } from '@/utils/string';
+import { ANNOTATIONS_TO_IGNORE_REGEX, LABELS_TO_IGNORE_REGEX } from '@/config/labels-annotations';
 
 export default class NormanModel extends Resource {
   setLabels(val) {

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -7,6 +7,7 @@ import forIn from 'lodash/forIn';
 import uniq from 'lodash/uniq';
 import Vue from 'vue';
 
+import { cleanForNew, normalizeType } from './normalize';
 import { addObject, addObjects, findBy, removeAt } from '@/utils/array';
 import CustomValidators from '@/utils/custom-validators';
 import { downloadFile, generateZip } from '@/utils/download';
@@ -31,8 +32,6 @@ import { NORMAN_NAME } from '@/config/labels-annotations';
 import {
   AS, _YAML, MODE, _CLONE, _EDIT, _VIEW, _UNFLAG, _CONFIG
 } from '@/config/query-params';
-
-import { cleanForNew, normalizeType } from './normalize';
 
 const STRING_LIKE_TYPES = [
   'string',

--- a/plugins/steve/steve-class.js
+++ b/plugins/steve/steve-class.js
@@ -1,5 +1,5 @@
-import { DESCRIPTION } from '@/config/labels-annotations';
 import HybridModel from './hybrid-class';
+import { DESCRIPTION } from '@/config/labels-annotations';
 
 export default class SteveModel extends HybridModel {
   get name() {

--- a/promptRemove/kubevirt.io.virtualmachine.vue
+++ b/promptRemove/kubevirt.io.virtualmachine.vue
@@ -1,8 +1,8 @@
 <script>
 import { mapState, mapGetters } from 'vuex';
+import Parse from 'url-parse';
 import { HCI } from '@/config/types';
 import { isEmpty } from '@/utils/object';
-import Parse from 'url-parse';
 
 export default {
   name: 'HarvesterPromptRemove',

--- a/store/aws.js
+++ b/store/aws.js
@@ -1,7 +1,7 @@
+import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 import { sortBy } from '@/utils/sort';
 import { randomStr } from '@/utils/string';
 import { parseSi } from '@/utils/units';
-import { FetchHttpHandler } from '@aws-sdk/fetch-http-handler';
 
 export const state = () => {
   return {};

--- a/store/index.js
+++ b/store/index.js
@@ -1,3 +1,4 @@
+import semver from 'semver';
 import Steve from '@/plugins/steve';
 import {
   COUNT, NAMESPACE, NORMAN, MANAGEMENT, FLEET, UI, VIRTUAL_HARVESTER_PROVIDER, HCI
@@ -14,7 +15,6 @@ import { setBrand, setVendor } from '@/config/private-label';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
 import { addParam } from '@/utils/url';
 import { SETTING } from '@/config/settings';
-import semver from 'semver';
 import { BY_TYPE, NORMAN as NORMAN_CLASS } from '@/plugins/steve/classify';
 import { NAME as VIRTUAL } from '@/config/product/harvester';
 import { BACK_TO } from '@/config/local-storage';

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -111,6 +111,7 @@
 //   mapWeight,
 //   continueOnMatch
 // )
+import isObject from 'lodash/isObject';
 import { AGE, NAME, NAMESPACE, STATE } from '@/config/table-headers';
 import { COUNT, SCHEMA, MANAGEMENT } from '@/config/types';
 import { DEV, EXPANDED_GROUPS, FAVORITE_TYPES } from '@/store/prefs';
@@ -126,7 +127,6 @@ import {
 } from '@/utils/dynamic-importer';
 
 import { NAME as EXPLORER } from '@/config/product/explorer';
-import isObject from 'lodash/isObject';
 import { normalizeType } from '@/plugins/steve/normalize';
 import { sortBy } from '@/utils/sort';
 import { haveV1Monitoring, haveV2Monitoring } from '@/utils/monitoring';

--- a/utils/alertmanagerconfig.js
+++ b/utils/alertmanagerconfig.js
@@ -1,8 +1,8 @@
 import jsyaml from 'js-yaml';
+import isEmpty from 'lodash/isEmpty';
 import { base64Decode, base64Encode } from '@/utils/crypto';
 import { MONITORING, SECRET } from '@/config/types';
 import { get, set } from '@/utils/object';
-import isEmpty from 'lodash/isEmpty';
 import { ROOT_NAME } from '@/models/monitoring.coreos.com.route';
 
 const DEFAULT_SECRET_ID = 'cattle-monitoring-system/alertmanager-rancher-monitoring-alertmanager';

--- a/utils/create-yaml.js
+++ b/utils/create-yaml.js
@@ -1,6 +1,6 @@
+import jsyaml from 'js-yaml';
 import { indent as _indent } from '@/utils/string';
 import { addObject, findBy, removeObject, removeObjects } from '@/utils/array';
-import jsyaml from 'js-yaml';
 import { cleanUp } from '@/utils/object';
 
 export const SIMPLE_TYPES = [

--- a/utils/validators/role-template.js
+++ b/utils/validators/role-template.js
@@ -1,5 +1,5 @@
-import { RBAC } from '@/config/types';
 import isEmpty from 'lodash/isEmpty';
+import { RBAC } from '@/config/types';
 
 export function roleTemplateRules(rules = [], getters, errors, validatorArgs = []) {
   if (rules.some(rule => isEmpty(rule.verbs))) {

--- a/utils/version.js
+++ b/utils/version.js
@@ -1,5 +1,5 @@
-import { sortableNumericSuffix } from '@/utils/sort';
 import semver from 'semver';
+import { sortableNumericSuffix } from '@/utils/sort';
 import { MANAGEMENT } from '@/config/types';
 import { READ_WHATS_NEW, SEEN_WHATS_NEW } from '@/store/prefs';
 


### PR DESCRIPTION
This updates ordering of imports to prep for node 16. 

Updating to node 16 introduces a whole host of lint warnings about ordering of imports. Rather than silence the rule, I figured it would be easy enough to fix the warnings. This change shouldn't come with any impact to the project itself.

#4820 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>