### PR TITLE
Sort revisions by revision number

### DIFF
--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -152,7 +152,8 @@ export default {
       return {
         label:    optionLabel,
         value:    revision,
-        disabled: isCurrentRevision
+        disabled: isCurrentRevision,
+        revisionNumber
       };
     },
     getOptionLabel(option) {

--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -103,15 +103,17 @@ export default {
           return hasRelationshipWithCurrentWorkload( replicaSet );
         });
 
-        const revisionOptions = workloadRevisions.map( (revision ) => {
-          const isCurrentRevision = this.getRevisionNumber(revision) === this.currentRevisionNumber;
+        const revisionOptions = workloadRevisions
+          .map( (revision ) => {
+            const isCurrentRevision = this.getRevisionNumber(revision) === this.currentRevisionNumber;
 
-          if (isCurrentRevision) {
-            this.currentRevision = revision;
-          }
+            if (isCurrentRevision) {
+              this.currentRevision = revision;
+            }
 
-          return this.buildRevisionOption( revision );
-        });
+            return this.buildRevisionOption( revision );
+          })
+          .sort((a, b) => b.revisionNumber - a.revisionNumber);
 
         this.revisions = revisionOptions;
       })


### PR DESCRIPTION
This sorts the list of revisions by the revision number. It looks like there are some scenarios where revisions can be received out of order, so we make use the revision number to sort revisions in descending order.

#4842