### PR TITLE
Code diff for rolling back a workload improvements

### DIFF
--- a/components/dialog/RollbackWorkloadDialog.vue
+++ b/components/dialog/RollbackWorkloadDialog.vue
@@ -9,6 +9,7 @@ import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import { WORKLOAD_TYPES } from '@/config/types';
 import { diffFrom } from '@/utils/time';
 import { mapGetters } from 'vuex';
+import pick from 'lodash/pick';
 
 export default {
   components: {
@@ -79,6 +80,9 @@ export default {
     },
     selectedRevisionId() {
       return this.selectedRevision.id;
+    },
+    sanitizedSelectedRevision() {
+      return this.sanitizeYaml(this.selectedRevision);
     }
   },
   fetch() {
@@ -165,6 +169,9 @@ export default {
       if (dialogs.length === 1) {
         dialogs[0].style.setProperty('--prompt-modal-width', width);
       }
+    },
+    sanitizeYaml(revision) {
+      return pick(revision, ['spec.template.spec']);
     }
   }
 };
@@ -194,8 +201,8 @@ export default {
       <YamlEditor
         v-if="selectedRevision && showDiff"
         :key="selectedRevisionId"
-        v-model="selectedRevision"
-        :initial-yaml-values="currentRevision"
+        v-model="sanitizedSelectedRevision"
+        :initial-yaml-values="sanitizeYaml(currentRevision)"
         class="mt-10 "
         :editor-mode="editorMode"
         :as-object="true"


### PR DESCRIPTION
This pr addresses issue #4636 by adding 1) yamleditor diff types 'Unified/Split' and 2) filtering out unnecessary yaml diff fields

To test this PR:

1. Create a Deployment under Workloads using a specific nginix Image of your choosing. (eg nginix:1.21.3)
2. Edit Config the newly created deployment and change the nginix Image to another version (eg nginix:latest)
3. Now that you have an multiple revisions you can select the Rollback menu option for the deployment
4. When the modal displays, select your previous revision and click the Show Diff button to display the yaml code diff
5. Unnecessary yaml keys such as apiVersion, kind, metadata, etc are no longer shown in the code diff 