### PR TITLE
Dynamically group list bulk actions into dropdown given available width

### DIFF
--- a/components/ActionDropdown.vue
+++ b/components/ActionDropdown.vue
@@ -215,7 +215,7 @@ export default {
       text-align: left;
 
       LI {
-        padding: 10px 50px 10px 20px;
+        padding: 10px;
 
         &.divider {
           padding-top: 0px;

--- a/components/SortableTable/actions.js
+++ b/components/SortableTable/actions.js
@@ -1,0 +1,145 @@
+import { filterBy } from '@/utils/array';
+import debounce from 'lodash/debounce';
+
+export default {
+
+  data() {
+    return {
+      bulkActionsId:            'bulk',
+      bulkActionClass:          'bulk-action',
+      bulkActionsDropdownId:    'bulk-actions-dropdown',
+      bulkActionAvailabilityId: 'bulk-action-availability',
+
+      hiddenActions: [],
+    };
+  },
+
+  created() {
+    window.addEventListener('resize', this.updateHiddenBulkActions);
+  },
+  destroyed() {
+    window.removeEventListener('resize', this.updateHiddenBulkActions);
+  },
+  mounted() {
+    this.updateHiddenBulkActions();
+  },
+
+  watch: {
+    actionAvailability() {
+      this.updateHiddenBulkActions();
+    }
+  },
+
+  computed: {
+    availableActions() {
+      return this.$store.getters[`${ this.storeName }/forTable`].filter(act => !act.external);
+    },
+
+    hasExternalActions() {
+      return filterBy(this.$store.getters[`${ this.storeName }/forTable`], 'external', true).length > 0;
+    },
+
+    actionAvailability() {
+      if (!this.tableSelected || this.tableSelected.length === 0) {
+        return null;
+      }
+
+      const runnableTotal = this.tableSelected.filter(this.canRunBulkActionOfInterest).length;
+      const selectionTotal = this.tableSelected.length;
+      const tableTotal = this.arrangedRows.length;
+      const allOfSelectionIsActionable = runnableTotal === selectionTotal;
+      const useTableTotal = !this.actionOfInterest || allOfSelectionIsActionable;
+
+      const input = {
+        actionable: this.actionOfInterest ? runnableTotal : selectionTotal,
+        total:      useTableTotal ? tableTotal : selectionTotal,
+      };
+
+      const someActionable = this.actionOfInterest && !allOfSelectionIsActionable;
+      const key = someActionable ? 'sortableTable.actionAvailability.some' : 'sortableTable.actionAvailability.selected';
+
+      return this.t(key, input);
+    },
+
+  },
+
+  methods: {
+    /**
+     * Determine if any actions wrap over to a new line, if so group them into a dropdown instead
+     */
+    updateHiddenBulkActions: debounce(function() {
+      const actionsContainer = document.getElementById(this.bulkActionsId);
+
+      if (!actionsContainer) {
+        return;
+      }
+
+      // First determine if any actions will be hidden and the actions drop down needs to be shown
+      // To do this temporarily display affected elements (buttons and if applicable '<x> selected' text) to
+      // determine their size then cumulate those up until the width of the row is hit
+
+      const actionsContainerWidth = actionsContainer.offsetWidth;
+
+      const actionsHTMLCollection = document.getElementsByClassName(this.bulkActionClass);
+      const actions = Array.from(actionsHTMLCollection || []);
+
+      const actionAvailability = document.getElementById(this.bulkActionAvailabilityId);
+      let actionAvailabilityWidth = 0;
+
+      if (this.actionAvailability && actionAvailability) {
+        actionAvailability.style.display = 'inline-block';
+        actionAvailabilityWidth = actionAvailability.offsetWidth;
+      }
+
+      let cumulativeWidth = 0;
+      let showActionsDropdown = false;
+      let totalAvailableWidth = actionsContainerWidth - actionAvailabilityWidth;
+
+      for (const ba of actions) {
+        ba.style.display = 'inline-block';
+        const width = ba.offsetWidth + 10;
+
+        cumulativeWidth += width + 10;
+        if (cumulativeWidth >= totalAvailableWidth) {
+          showActionsDropdown = true;
+          break;
+        }
+      }
+
+      // Now that we know the actions drop down will be shown or not, do the same as above however taking into account the
+      // visibility of the drop down (which can consume space, thus pushing more actions into the drop down)
+      // Once done all buttons that don't fit in the row will not be visible and instead be listed in `hiddenActions`
+
+      const actionsDropdown = document.getElementById(this.bulkActionsDropdownId);
+      let actionsDropdownWidth = 0;
+
+      if (actionsDropdown) {
+        if (showActionsDropdown) {
+          actionsDropdown.style.display = 'inline-block';
+          actionsDropdownWidth = actionsDropdown.offsetWidth;
+        } else {
+          actionsDropdown.style.display = 'none';
+        }
+      }
+
+      cumulativeWidth = 0;
+      totalAvailableWidth = actionsContainerWidth - actionsDropdownWidth - actionAvailabilityWidth;
+
+      this.hiddenActions = [];
+
+      for (const ba of actions) {
+        const id = ba.attributes.getNamedItem('id').value;
+        const action = this.availableActions.find(aa => aa.action === id);
+        const width = ba.offsetWidth + 10;
+
+        cumulativeWidth += width + 10;
+        if (cumulativeWidth >= totalAvailableWidth) {
+          this.hiddenActions.push(action);
+          ba.style.display = 'none';
+        } else {
+          ba.style.display = 'inline-block';
+        }
+      }
+    }, 10)
+  }
+};

--- a/components/SortableTable/actions.js
+++ b/components/SortableTable/actions.js
@@ -1,4 +1,3 @@
-import { filterBy } from '@/utils/array';
 import debounce from 'lodash/debounce';
 
 export default {
@@ -33,10 +32,6 @@ export default {
   computed: {
     availableActions() {
       return this.$store.getters[`${ this.storeName }/forTable`].filter(act => !act.external);
-    },
-
-    hasExternalActions() {
-      return filterBy(this.$store.getters[`${ this.storeName }/forTable`], 'external', true).length > 0;
     },
 
     actionAvailability() {
@@ -128,12 +123,13 @@ export default {
       this.hiddenActions = [];
 
       for (const ba of actions) {
-        const id = ba.attributes.getNamedItem('id').value;
-        const action = this.availableActions.find(aa => aa.action === id);
         const width = ba.offsetWidth + 10;
 
         cumulativeWidth += width + 10;
         if (cumulativeWidth >= totalAvailableWidth) {
+          const id = ba.attributes.getNamedItem('id').value;
+          const action = this.availableActions.find(aa => aa.action === id);
+
           this.hiddenActions.push(action);
           ba.style.display = 'none';
         } else {

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -990,6 +990,7 @@ $spacing: 10px;
 
   .bulk {
     grid-area: bulk;
+    margin-top: 1px;
 
     $gap: 10px;
 
@@ -1002,7 +1003,10 @@ $spacing: 10px;
     }
 
     .action-availability {
+      display: none; // Handled dynamically
       margin-left: $gap;
+      vertical-align: middle;
+      margin-top: 2px;
     }
   }
 
@@ -1017,7 +1021,7 @@ $spacing: 10px;
   }
 
   .bulk-actions-dropdown {
-    display: none; // handled dynamically
+    display: none; // Handled dynamically
 
     .dropdown-button {
       background-color: var(--primary);

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -531,7 +531,7 @@ export default {
                 <i v-if="act.icon" :class="act.icon" />
                 <span v-html="act.label" />
               </button>
-              <ActionDropdown :id="bulkActionsDropdownId" class="external-actions" :disable-button="!actionAvailability" size="sm">
+              <ActionDropdown :id="bulkActionsDropdownId" class="bulk-actions-dropdown" :disable-button="!actionAvailability" size="sm">
                 <template #button-content>
                   <button class="btn bg-primary mr-0" :disabled="!actionAvailability">
                     <i class="icon icon-gear" />
@@ -1016,7 +1016,7 @@ $spacing: 10px;
     text-align: right;
   }
 
-  .external-actions {
+  .bulk-actions-dropdown {
     display: none; // handled dynamically
 
     .dropdown-button {

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -2,7 +2,7 @@
 import { mapState } from 'vuex';
 import { dasherize, ucFirst } from '@/utils/string';
 import { get, clone } from '@/utils/object';
-import { removeObject, filterBy } from '@/utils/array';
+import { removeObject } from '@/utils/array';
 import Checkbox from '@/components/form/Checkbox';
 import ActionDropdown from '@/components/ActionDropdown';
 import $ from 'jquery';
@@ -14,6 +14,7 @@ import selection from './selection';
 import sorting from './sorting';
 import paging from './paging';
 import grouping from './grouping';
+import actions from './actions';
 
 export const COLUMN_BREAKPOINTS = {
   /**
@@ -45,7 +46,7 @@ export default {
   components: {
     THead, Checkbox, ActionDropdown
   },
-  mixins: [filtering, sorting, paging, grouping, selection],
+  mixins: [filtering, sorting, paging, grouping, selection, actions],
 
   props: {
     headers: {
@@ -352,48 +353,12 @@ export default {
       return out;
     },
 
-    availableActions() {
-      return this.$store.getters[`${ this.storeName }/forTable`].filter(act => !act.external);
-    },
-
-    hasExternalActions() {
-      return filterBy(this.$store.getters[`${ this.storeName }/forTable`], 'external', true).length > 0;
-    },
-
-    externalActions() {
-      return this.$store.getters[`${ this.storeName }/forTable`].filter((act) => {
-        return act.external && act.enabled;
-      });
-    },
-
-    actionAvailability() {
-      if (this.tableSelected.length === 0) {
-        return null;
-      }
-
-      const runnableTotal = this.tableSelected.filter(this.canRunBulkActionOfInterest).length;
-      const selectionTotal = this.tableSelected.length;
-      const tableTotal = this.arrangedRows.length;
-      const allOfSelectionIsActionable = runnableTotal === selectionTotal;
-      const useTableTotal = !this.actionOfInterest || allOfSelectionIsActionable;
-
-      const input = {
-        actionable: this.actionOfInterest ? runnableTotal : selectionTotal,
-        total:      useTableTotal ? tableTotal : selectionTotal,
-      };
-
-      const someActionable = this.actionOfInterest && !allOfSelectionIsActionable;
-      const key = someActionable ? 'sortableTable.actionAvailability.some' : 'sortableTable.actionAvailability.selected';
-
-      return this.t(key, input);
-    },
-
     ...mapState({
       tableSelected(state) {
-        return state[this.storeName].tableSelected;
+        return state[this.storeName]?.tableSelected;
       },
       actionOfInterest(state) {
-        return state[this.storeName].actionOfInterest;
+        return state[this.storeName]?.actionOfInterest;
       }
     }),
 
@@ -548,14 +513,16 @@ export default {
     <div :class="{'titled': $slots.title && $slots.title.length}" class="sortable-table-header">
       <slot name="title" />
       <div v-if="showHeaderRow" class="fixed-header-actions">
-        <div class="bulk">
+        <div :id="bulkActionsId" class="bulk">
           <slot name="header-left">
             <template v-if="tableActions">
               <button
                 v-for="act in availableActions"
+                :id="act.action"
                 :key="act.action"
                 type="button"
                 class="btn role-primary"
+                :class="{[bulkActionClass]:true}"
                 :disabled="!act.enabled"
                 @click="applyTableAction(act, null, $event)"
                 @mouseover="setBulkActionOfInterest(act)"
@@ -564,9 +531,9 @@ export default {
                 <i v-if="act.icon" :class="act.icon" />
                 <span v-html="act.label" />
               </button>
-              <ActionDropdown v-if="hasExternalActions" class="external-actions" :disable-button="externalActions.length === 0" size="sm">
+              <ActionDropdown :id="bulkActionsDropdownId" class="external-actions" :disable-button="!actionAvailability" size="sm">
                 <template #button-content>
-                  <button class="btn bg-primary mr-0" :disabled="externalActions.length === 0">
+                  <button class="btn bg-primary mr-0" :disabled="!actionAvailability">
                     <i class="icon icon-gear" />
                     <span>{{ t('harvester.tableHeaders.actions') }}</span>
                     <i class="ml-10 icon icon-chevron-down" />
@@ -575,7 +542,7 @@ export default {
                 <template #popover-content>
                   <ul class="list-unstyled menu">
                     <li
-                      v-for="act in externalActions"
+                      v-for="act in hiddenActions"
                       :key="act.action"
                       v-close-popover
                       @click="applyTableAction(act, null, $event)"
@@ -588,8 +555,7 @@ export default {
                   </ul>
                 </template>
               </ActionDropdown>
-              <span />
-              <label v-if="actionAvailability" class="action-availability">
+              <label v-if="actionAvailability" :id="bulkActionAvailabilityId" class="action-availability">
                 {{ actionAvailability }}
               </label>
             </template>
@@ -1024,17 +990,25 @@ $spacing: 10px;
 
   .bulk {
     grid-area: bulk;
-    align-self: center;
 
-    BUTTON:not(:last-child) {
-      margin-right: 10px;
+    $gap: 10px;
+
+    & > BUTTON {
+      display: none; // Handled dynamically
+    }
+
+    & > BUTTON:not(:last-of-type) {
+      margin-right: $gap;
+    }
+
+    .action-availability {
+      margin-left: $gap;
     }
   }
 
   .middle {
     grid-area: middle;
     white-space: nowrap;
-    align-self: center;
   }
 
   .search {
@@ -1043,7 +1017,7 @@ $spacing: 10px;
   }
 
   .external-actions {
-    display:inline-block;
+    display: none; // handled dynamically
 
     .dropdown-button {
       background-color: var(--primary);

--- a/models/harvester/kubevirt.io.virtualmachine.js
+++ b/models/harvester/kubevirt.io.virtualmachine.js
@@ -81,7 +81,6 @@ export default class VirtVm extends SteveModel {
         icon:       'icon icon-close',
         label:      this.t('harvester.action.stop'),
         bulkable:   true,
-        external:   true,
       },
       {
         action:     'pauseVM',
@@ -101,7 +100,6 @@ export default class VirtVm extends SteveModel {
         icon:       'icon icon-refresh',
         label:      this.t('harvester.action.restart'),
         bulkable:   true,
-        external:   true,
       },
       {
         action:     'startVM',
@@ -109,7 +107,6 @@ export default class VirtVm extends SteveModel {
         icon:       'icon icon-play',
         label:      this.t('harvester.action.start'),
         bulkable:   true,
-        external:   true,
       },
       {
         action:     'backupVM',


### PR DESCRIPTION
- Move actions that wrap into the existing actions drop down (redesign todo)
- Remove the hard-coded action 'external' property which was previously determining actions drop down
  - This was only used in one place (see screenshots below) 
- Also moved list bulk action code out from SotableTable and into their own mixin
- Addresses #4873

![image](https://user-images.githubusercontent.com/18697775/148376534-5a6e433d-10ee-4112-acf6-0beb42ae42b8.png)

![image](https://user-images.githubusercontent.com/18697775/148376845-74cb77be-6207-4550-b183-69b8ffb7b94e.png)

![image](https://user-images.githubusercontent.com/18697775/148376776-2e47f804-cc75-46d0-9553-a71c370b1c49.png)




