### PR TITLE
Fix edit Fleet GitRepo initial target mode

### DIFF
--- a/models/fleet.cattle.io.gitrepo.js
+++ b/models/fleet.cattle.io.gitrepo.js
@@ -241,20 +241,20 @@ export default class GitRepo extends SteveModel {
     } else if ( targets.length === 1) {
       const target = targets[0];
 
-      if ( target.clusterGroup ) {
+      if (Object.keys(target).length > 1) {
+        // There are multiple properties in a single target, so use the 'advanced' mode
+        // (otherwise any existing content is nuked for what we provide)
+        mode = 'advanced';
+      } else if ( target.clusterGroup ) {
         clusterGroup = target.clusterGroup;
 
         if ( !mode ) {
           mode = 'clusterGroup';
         }
-      }
-
-      if ( target.clusterName ) {
+      } else if ( target.clusterName ) {
         mode = 'cluster';
         cluster = target.clusterName;
-      }
-
-      if ( target.clusterSelector ) {
+      } else if ( target.clusterSelector ) {
         if ( Object.keys(target.clusterSelector).length === 0 ) {
           mode = 'all';
         } else {


### PR DESCRIPTION
- `fleet.cattle.io.GitRepo` `spec.targets` can contain multiple selectors per target
  - https://fleet.rancher.io/gitrepo-targets/#target-matching
  - (WIP - Just waiting on more feedback from fleet team)
- The UI only shows form components for single selector targets, anything else is an 'advanced' mode where user can enter free text/yaml 
- When attempting to edit a GitRepo that has a multi-selector target we previously weren't detecting this and forcing the user to use a single target mode (thus removing anything else in that target on save)
- We now correctly identify this case and start in the correct 'advanced' mode
- Addresses #4788