### PR TITLE
Fix display of username in Github auth note

### DIFF
--- a/edit/auth/github.vue
+++ b/edit/auth/github.vue
@@ -31,17 +31,7 @@ export default {
   mixins: [CreateEditView, AuthConfig],
 
   async fetch() {
-    await this.reloadModel();
-
-    const serverUrl = await this.$store.dispatch('management/find', {
-      type: MANAGEMENT.SETTING,
-      id:   'server-url',
-      opt:  { url: `/v1/{ MANAGEMENT.SETTING }/server-url` }
-    });
-
-    if ( serverUrl ) {
-      this.serverSetting = serverUrl.value;
-    }
+    await this.mixinFetch();
 
     this.targetType = (!this.model.hostname || this.model.hostname === 'github.com' ? 'public' : 'private');
     this.targetUrl = (this.model.tls ? 'https://' : 'http://') + (this.model.hostname || 'github.com');

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -17,41 +17,7 @@ export default {
   },
 
   async fetch() {
-    this.authConfigName = this.$route.params.id;
-
-    this.originalModel = await this.$store.dispatch('rancher/find', {
-      type: NORMAN.AUTH_CONFIG,
-      id:   this.authConfigName,
-      opt:  { url: `/v3/${ NORMAN.AUTH_CONFIG }/${ this.authConfigName }`, force: true }
-    });
-
-    const serverUrl = await this.$store.dispatch('management/find', {
-      type: MANAGEMENT.SETTING,
-      id:   'server-url',
-      opt:  { url: `/v1/${ MANAGEMENT.SETTING }/server-url` }
-    });
-
-    this.principals = await this.$store.dispatch('rancher/findAll', {
-      type: NORMAN.PRINCIPAL,
-      opt:  { url: '/v3/principals', force: true }
-    });
-
-    if ( serverUrl ) {
-      this.serverSetting = serverUrl.value;
-    }
-    this.model = await this.$store.dispatch(`rancher/clone`, { resource: this.originalModel });
-    if (this.model.openLdapConfig) {
-      this.showLdap = true;
-    }
-    if (this.value.configType === 'saml') {
-      if (!this.model.rancherApiHost || !this.model.rancherApiHost.length) {
-        this.$set(this.model, 'rancherApiHost', this.serverUrl);
-      }
-    }
-
-    if (!this.model.enabled) {
-      this.applyDefaults();
-    }
+    await this.mixinFetch();
   },
 
   data() {
@@ -111,6 +77,43 @@ export default {
   },
 
   methods: {
+    async mixinFetch() {
+      this.authConfigName = this.$route.params.id;
+
+      this.originalModel = await this.$store.dispatch('rancher/find', {
+        type: NORMAN.AUTH_CONFIG,
+        id:   this.authConfigName,
+        opt:  { url: `/v3/${ NORMAN.AUTH_CONFIG }/${ this.authConfigName }`, force: true }
+      });
+
+      const serverUrl = await this.$store.dispatch('management/find', {
+        type: MANAGEMENT.SETTING,
+        id:   'server-url',
+        opt:  { url: `/v1/${ MANAGEMENT.SETTING }/server-url` }
+      });
+
+      this.principals = await this.$store.dispatch('rancher/findAll', {
+        type: NORMAN.PRINCIPAL,
+        opt:  { url: '/v3/principals', force: true }
+      });
+
+      if ( serverUrl ) {
+        this.serverSetting = serverUrl.value;
+      }
+      this.model = await this.$store.dispatch(`rancher/clone`, { resource: this.originalModel });
+      if (this.model.openLdapConfig) {
+        this.showLdap = true;
+      }
+      if (this.value.configType === 'saml') {
+        if (!this.model.rancherApiHost || !this.model.rancherApiHost.length) {
+          this.$set(this.model, 'rancherApiHost', this.serverUrl);
+        }
+      }
+
+      if (!this.model.enabled) {
+        this.applyDefaults();
+      }
+    },
 
     async save(btnCb) {
       await this.applyHooks(BEFORE_SAVE_HOOKS);


### PR DESCRIPTION
- When configuring the github auth provider we show a notice at the bottom regarding the local user that will be paired with the github user
- This was empty as it relied on `principal`s being fetched in a mixin's fetch
- As the github component had it's own fetch the mixin fetch wasn't called
  -  https://nuxtjs.org/docs/features/data-fetching/
- Now we can call the underlying mixin's fetch from a parent component

![image](https://user-images.githubusercontent.com/18697775/148402779-68428efe-ecd3-4af7-9bbb-2a6064f3c0b6.png)
