### PR TITLE
StatefulSet "Service Name" required, but not marked

### DIFF
--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -808,6 +808,7 @@ export default {
                 :mode="mode"
                 :label="t('workload.serviceName')"
                 :options="headlessServices"
+                required
               />
             </template>
           </NameNsDescription>


### PR DESCRIPTION
This PR addresses issue #4811 by making 'Service Name' a required field when creating a StatefulSet

To test this pr

1. From your cluster navigate to Workload > StatefulSets
2. Click the Create button
3. The 'Service Name' field should now have a red 'required' asterisk 