### PR TITLE
Fix assign global roles as Restricted Admin

### DIFF
--- a/edit/group.principal.vue
+++ b/edit/group.principal.vue
@@ -24,7 +24,7 @@ export default {
       try {
         await this.$refs.grb.save();
 
-        await this.$store.dispatch('cluster/findAll', {
+        await this.$store.dispatch('management/findAll', {
           type: NORMAN.SPOOFED.GROUP_PRINCIPAL,
           opt:  { force: true }
         }, { root: true }); // See PromptRemove.vue

--- a/list/group.principal.vue
+++ b/list/group.principal.vue
@@ -8,6 +8,7 @@ import { applyProducts } from '@/store/type-map';
 import { NAME } from '@/config/product/auth';
 import { MODE, _EDIT } from '@/config/query-params';
 import { mapState } from 'vuex';
+import { BLANK_CLUSTER } from '@/store';
 
 export default {
   components: {
@@ -29,14 +30,18 @@ export default {
 
     this.canRefreshAccess = await this.$store.dispatch('rancher/request', { url: '/v3/users?limit=0' })
       .then(res => !!res?.actions?.refreshauthprovideraccess);
+
+    const grbSchema = this.$store.getters['rancher/schemaFor'](NORMAN.GLOBAL_ROLE_BINDING);
+
+    this.canCreateGlobalRoleBinding = grbSchema?.collectionMethods?.includes('POST');
   },
   data() {
     return {
-      rows:             [],
-      hasGroups:        false,
-      canRefreshAccess: false,
-      assignLocation:   {
-        path:   `/c/local/${ NAME }/${ NORMAN.SPOOFED.GROUP_PRINCIPAL }/assign-edit`,
+      rows:                        [],
+      canCreateGlobalRoleBinding:  false,
+      canRefreshAccess:            false,
+      assignLocation:              {
+        path:   `/c/${ BLANK_CLUSTER }/${ NAME }/${ NORMAN.SPOOFED.GROUP_PRINCIPAL }/assign-edit`,
         query: { [MODE]: _EDIT }
       },
       initialLoad: true,
@@ -65,10 +70,7 @@ export default {
       // Upfront load all global roles, this makes it easier to sync fetch them later on
       await this.$store.dispatch('management/findAll', { type: MANAGEMENT.GLOBAL_ROLE });
 
-      const principals = await this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL, opt: { url: '/v3/principals' } });
-
-      // Are there principals that are groups? (don't use rows, it's filtered by those with roles)
-      this.hasGroups = principals.filter(principal => principal.principalType === 'group')?.length;
+      await this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL, opt: { url: '/v3/principals' } });
     },
     async refreshGroupMemberships(buttonDone) {
       try {
@@ -92,7 +94,7 @@ export default {
       await applyProducts(this.$store);
 
       // Force spoofed type getInstances to execute again
-      this.rows = await this.$store.dispatch('cluster/findAll', {
+      this.rows = await this.$store.dispatch('management/findAll', {
         type: NORMAN.SPOOFED.GROUP_PRINCIPAL,
         opt:  { force }
       }, { root: true });
@@ -120,7 +122,7 @@ export default {
           @click="refreshGroupMemberships"
         />
         <n-link
-          v-if="hasGroups"
+          v-if="canCreateGlobalRoleBinding"
           :to="assignLocation"
           class="btn role-primary"
         >

--- a/pages/c/_cluster/auth/group.principal/assign-edit.vue
+++ b/pages/c/_cluster/auth/group.principal/assign-edit.vue
@@ -6,6 +6,7 @@ import { NORMAN } from '@/config/types';
 import { _VIEW, _EDIT } from '@/config/query-params';
 import { exceptionToErrorsArray } from '@/utils/error';
 import { NAME } from '@/config/product/auth';
+import { BLANK_CLUSTER } from '@/store';
 
 export default {
   components: {
@@ -45,7 +46,7 @@ export default {
       try {
         await this.$refs.grb.save();
 
-        await this.$store.dispatch('cluster/findAll', {
+        await this.$store.dispatch('management/findAll', {
           type: NORMAN.SPOOFED.GROUP_PRINCIPAL,
           opt:  { force: true }
         }, { root: true }); // See PromptRemove.vue
@@ -62,7 +63,7 @@ export default {
       this.$router.replace({
         name:   `c-cluster-product-resource`,
         params: {
-          cluster:  'local',
+          cluster:  BLANK_CLUSTER,
           product:  NAME,
           resource: NORMAN.SPOOFED.GROUP_PRINCIPAL,
         },


### PR DESCRIPTION
- Correctly gate the visibility of the button on roles rather than if principal list contains a group
  - principal list can contain some groups ... or none at all (an auth provider can return many many principals so list is trimmed)
- Ensure fetching spoofed group.principal uses correct store (auth product uses management store)
- Ensure navigation to and from assign roles page uses the blank cluster in routes (restricted user does not have access to local)
- Addresses #4834