### PR TITLE
Enable Custom Repo URL for Rancher Charts ClusterRepo

### DIFF
--- a/models/catalog.cattle.io.clusterrepo.js
+++ b/models/catalog.cattle.io.clusterrepo.js
@@ -72,11 +72,11 @@ export default class ClusterRepo extends SteveModel {
   }
 
   get isRancher() {
-    return this.isRancherSource && this.metadata.name === 'rancher-charts';
+    return this.metadata.name === 'rancher-charts';
   }
 
   get isPartner() {
-    return this.isRancherSource && this.metadata.name === 'rancher-partner-charts';
+    return this.metadata.name === 'rancher-partner-charts';
   }
 
   get color() {


### PR DESCRIPTION
Fix _Cluster Tools_ hanging forever when 'rancher-charts' Helm repository URL is changed:

The Rancher Dashboard UI lets you change the URL of the 'rancher-charts' Helm repository to an arbitrary value. But if you do so, the Cluster Tools (bottom left corner button) hangs forever in the 'Loading…' phase, since the UI only considers URLs ending with `rancher.io` as valid.

Technical details:
This loc here fails, due to `rancherCatalog` being null: https://github.com/rancher/dashboard/blob/de1a20415aa54c212a88a3b1f0deddd579cb9013/pages/c/_cluster/explorer/tools/index.vue#L119
`rancherCatalog` is null since no entry in the array fullfils this `find` condition: https://github.com/rancher/dashboard/blob/de1a20415aa54c212a88a3b1f0deddd579cb9013/pages/c/_cluster/explorer/tools/index.vue#L87