### PR TITLE
Add input for droplet tags on DigitalOcean rke2 clusters

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1224,6 +1224,9 @@ cluster:
           =1 {# vCPU}
           other {# vCPUs}
         }, {disk} GB Disk ({value})
+      tags:
+        label: Droplet Tags
+        placeholder: e.g. my_server
     vsphere:
       hostOptions:
         any: Any

--- a/machine-config/digitalocean.vue
+++ b/machine-config/digitalocean.vue
@@ -6,6 +6,7 @@ import ArrayList from '@/components/form/ArrayList';
 import Checkbox from '@/components/form/Checkbox';
 import { NORMAN } from '@/config/types';
 import { stringify, exceptionToErrorsArray } from '@/utils/error';
+import { _CREATE } from '@/config/query-params';
 import Banner from '@/components/Banner';
 
 export default {
@@ -111,6 +112,16 @@ export default {
     'value.image': 'updateUsername',
   },
 
+  computed: {
+    isCreate() {
+      if (this.mode === _CREATE) {
+        return true;
+      }
+
+      return false;
+    }
+  },
+
   methods: {
     stringify,
 
@@ -210,6 +221,9 @@ export default {
           :protip="false"
           :title="t('cluster.machineConfig.digitalocean.tags.label')"
           :value-placeholder="t('cluster.machineConfig.digitalocean.tags.placeholder')"
+          :disabled="!isCreate"
+          :add-allowed="isCreate"
+          :remove-allowed="isCreate"
           @input="updateTags"
         />
       </div>

--- a/machine-config/digitalocean.vue
+++ b/machine-config/digitalocean.vue
@@ -114,11 +114,7 @@ export default {
 
   computed: {
     isCreate() {
-      if (this.mode === _CREATE) {
-        return true;
-      }
-
-      return false;
+      return this.mode === _CREATE;
     }
   },
 

--- a/machine-config/digitalocean.vue
+++ b/machine-config/digitalocean.vue
@@ -2,6 +2,7 @@
 import Loading from '@/components/Loading';
 import CreateEditView from '@/mixins/create-edit-view';
 import LabeledSelect from '@/components/form/LabeledSelect';
+import ArrayList from '@/components/form/ArrayList';
 import Checkbox from '@/components/form/Checkbox';
 import { NORMAN } from '@/config/types';
 import { stringify, exceptionToErrorsArray } from '@/utils/error';
@@ -9,7 +10,7 @@ import Banner from '@/components/Banner';
 
 export default {
   components: {
-    Loading, LabeledSelect, Checkbox, Banner
+    Loading, LabeledSelect, ArrayList, Checkbox, Banner
   },
 
   mixins: [CreateEditView],
@@ -87,11 +88,18 @@ export default {
   },
 
   data() {
+    let tags = null;
+
+    if (this.value.tags) {
+      tags = this.value.tags.split(',');
+    }
+
     return {
       credential:      null,
       regionOptions:   null,
       imageOptions:    null,
       instanceOptions: null,
+      tags
     };
   },
 
@@ -113,6 +121,10 @@ export default {
         this.value.sshUser = undefined;
       }
     },
+
+    updateTags() {
+      this.$set(this.value, 'tags', this.tags.join());
+    }
   },
 };
 </script>
@@ -187,6 +199,18 @@ export default {
           :mode="mode"
           :disabled="disabled"
           label="Private Networking"
+        />
+      </div>
+    </div>
+    <div class="row mt-20">
+      <div class="col span-6">
+        <ArrayList
+          v-model="tags"
+          :mode="mode"
+          :protip="false"
+          :title="t('cluster.machineConfig.digitalocean.tags.label')"
+          :value-placeholder="t('cluster.machineConfig.digitalocean.tags.placeholder')"
+          @input="updateTags"
         />
       </div>
     </div>


### PR DESCRIPTION
This feature adds an input for Tags on a DigitalOcean Droplet when creating an rke2 cluster.

**To test**
- Create rke2 cluster with DigitalOcean as the provider
- In the Machine Config add a Droplet tag
- See the tag in the DigitalOcean dashboard