### PR TITLE
Fix missing alert messages in alert table

### DIFF
--- a/components/formatter/RunBookLink.vue
+++ b/components/formatter/RunBookLink.vue
@@ -10,6 +10,6 @@ export default {
 </script>
 
 <template>
-  <a v-if="value.runbook_url" rel="nofollow noopener noreferrer" target="_blank" :href="value.runbook_url">{{ value.message }} <i class="icon icon-external-link" /></a>
-  <span v-else>{{ value.message }}</span>
+  <a v-if="value.runbook_url" rel="nofollow noopener noreferrer" target="_blank" :href="value.runbook_url">{{ value.message || value.description }} <i class="icon icon-external-link" /></a>
+  <span v-else>{{ value.message || value.description }}</span>
 </template>


### PR DESCRIPTION
From the alerts bundled with rancher-monitoring only 13 contain a message annotation, 111 have the alert message in a description annotation.

Before:
![Bildschirmfoto 2022-01-06 um 19 09 38](https://user-images.githubusercontent.com/243056/148447679-c12a6e88-437b-4ed0-9d72-c9c2a7992916.png)

After:
![Bildschirmfoto 2022-01-06 um 19 11 38](https://user-images.githubusercontent.com/243056/148447687-b8766901-a242-4b95-b207-66fa9c1cd20b.png)


Addresses https://github.com/rancher/dashboard/issues/4883
