### PR TITLE
[Forward port] Can configure SSL version, SSL verify in Elasticsearch Output form

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2271,6 +2271,8 @@ logging:
       label: Client Key from Secret
       placeholder: Paste in the client key
     clientKeyPass: Client Key Pass from Secret
+    verifySsl: Verify SSL
+    sslVersion: SSL Version
   gelf:
     host: Host
     port: Port

--- a/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
+++ b/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
@@ -2,11 +2,13 @@
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import SecretSelector from '@/components/form/SecretSelector';
-import { updatePort, protocol } from './utils';
+import Checkbox from '@/components/form/Checkbox';
+import { _CREATE } from '@/config/query-params';
+import { updatePort, protocol, sslVersions } from './utils';
 
 export default {
   components: {
-    LabeledInput, LabeledSelect, SecretSelector
+    LabeledInput, LabeledSelect, SecretSelector, Checkbox
   },
   props:      {
     value: {
@@ -29,7 +31,15 @@ export default {
     }
   },
   data() {
-    return { protocolOptions: protocol };
+    if (this.mode === _CREATE) {
+      // Require SSL verification by default
+      this.$set(this.value, 'ssl_verify', true);
+
+      // Use the SSL version TLSv1_2 by default to match Ember
+      this.$set(this.value, 'ssl_version', sslVersions[0]);
+    }
+
+    return { protocolOptions: protocol, sslVersions };
   },
   computed: {
     port: {
@@ -157,5 +167,29 @@ export default {
         />
       </div>
     </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.ssl_version"
+          :mode="mode"
+          :disabled="disabled"
+          :options="sslVersions"
+          :label="t('logging.elasticsearch.sslVersion')"
+        />
+      </div>
+      <div class="col span-6">
+        <Checkbox
+          v-model="value.ssl_verify"
+          :label="t('logging.elasticsearch.verifySsl')"
+          :disabled="disabled"
+          :mode="mode"
+        />
+      </div>
+    </div>
   </div>
 </template>
+<style>
+.row {
+  margin-bottom: 5px;
+}
+</style>

--- a/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
+++ b/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
@@ -32,11 +32,19 @@ export default {
   },
   data() {
     if (this.mode === _CREATE) {
+      // Set default values only if no values are already
+      // present. This allows changes to default values to persist
+      // after navigating to YAML and back.
+
       // Require SSL verification by default
-      this.$set(this.value, 'ssl_verify', true);
+      if (typeof this.value.ssl_verify === 'undefined') {
+        this.$set(this.value, 'ssl_verify', true);
+      }
 
       // Use the SSL version TLSv1_2 by default to match Ember
-      this.$set(this.value, 'ssl_version', sslVersions[0]);
+      if (typeof this.value.ssl_version === 'undefined') {
+        this.$set(this.value, 'ssl_version', sslVersions[0]);
+      }
     }
 
     return { protocolOptions: protocol, sslVersions };

--- a/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
+++ b/edit/logging.banzaicloud.io.output/providers/elasticsearch.vue
@@ -177,7 +177,7 @@ export default {
           :label="t('logging.elasticsearch.sslVersion')"
         />
       </div>
-      <div class="col span-6">
+      <div class="col span-6 vertically-center">
         <Checkbox
           v-model="value.ssl_verify"
           :label="t('logging.elasticsearch.verifySsl')"
@@ -191,5 +191,8 @@ export default {
 <style>
 .row {
   margin-bottom: 5px;
+}
+.vertically-center {
+  padding: 20px 0;
 }
 </style>

--- a/edit/logging.banzaicloud.io.output/providers/utils.js
+++ b/edit/logging.banzaicloud.io.output/providers/utils.js
@@ -1,5 +1,7 @@
 export const protocol = ['http', 'https'];
 
+export const sslVersions = ['TLSv1_2', 'TLSv1_1', 'SSLv23', 'TLSv1'];
+
 export function updatePort(setter, port) {
   // We set the value to 0 then the actual value because if we exceed the maximum of
   // 65535 all subsequent values will continue to return 65535 which vue ignores and

--- a/edit/logging.banzaicloud.io.output/providers/utils.js
+++ b/edit/logging.banzaicloud.io.output/providers/utils.js
@@ -1,6 +1,7 @@
 export const protocol = ['http', 'https'];
 
-export const sslVersions = ['TLSv1_2', 'TLSv1_1', 'SSLv23', 'TLSv1'];
+// Order from newest to oldest
+export const sslVersions = ['TLSv1_2', 'TLSv1_1', 'TLSv1', 'SSLv23'];
 
 export function updatePort(setter, port) {
   // We set the value to 0 then the actual value because if we exceed the maximum of


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4753 by adding two fields to the logging output form for Elasticsearch. These fields allow you to configure the YAML directives `ssl_version` and `ssl_verify`.

The Ember equivalent is in the above linked issue. In the internal ticket for this issue, it said we should make `ssl_verify` true by default.

To test this PR,

1. I installed the logging application on a downstream cluster
2. Went to the downstream cluster's dashboard and clicked **Logging > Outputs**
3. In the **Output** type dropdown, selected Elasticsearch (not AWS Elasticsearch)
4. In the Connection section, verified that the new **SSL Version** dropdown has the same options as Ember did (TLSv1_2, TLSv1_1, SSLv23 and TLSv1). Source: https://github.com/rancher/ui/blob/master/lib/logging/addon/components/logging/form-log-ssl/component.js#L8 The default value is TLSv1_2, same as Ember.
5. Also in the Connection section, verified that the **Verify SSL** checkbox is checked by default.
6. Checked the YAML and made sure the `ssl_version` and `ssl_verify` directives under Elasticsearch matched the form fields.

<img width="1301" alt="Screen Shot 2022-01-06 at 6 34 16 PM" src="https://user-images.githubusercontent.com/20599230/148477381-99fc2907-4f15-40c9-a272-fb966b6bfe36.png">
<img width="308" alt="Screen Shot 2022-01-06 at 6 41 14 PM" src="https://user-images.githubusercontent.com/20599230/148477439-da7c1241-2c63-4a9d-acbb-0f7fe9cacb4d.png">

