### PR TITLE
Sort initial suggestion of options in the select principal drop down

### DIFF
--- a/components/auth/SelectPrincipal.vue
+++ b/components/auth/SelectPrincipal.vue
@@ -73,7 +73,9 @@ export default {
         }
 
         return true;
-      }).map(x => x.id);
+      })
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(x => x.id);
 
       return out;
     },


### PR DESCRIPTION
- name is normally used as a primary label, so sort on that
- only sort the initial suggestion, not the response of a search
  - search response should hopefully be sorted with respect to proximity to the query
- Addresses #4685
  - This effects anywhere we show the option to select a principal, for instance in the Groups --> Assign Roles page 
  - ![image](https://user-images.githubusercontent.com/18697775/148519862-a6c3bb46-956b-4a14-911d-fde988da7914.png)
  - As per above this PR does not sort the principals shown after the user has searched for one, the result set that comes from the backend should be sorted given the proximity to the search 

Note - If there's any strangeness with the visibility of the groups assign button I'll update this PR with #4880