### PR TITLE
Add API Endpoint to the API Keys page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -227,6 +227,7 @@ accountAndKeys:
   apiKeys:
     title: API Keys
     notAllowed: You do not have permission to manage API Keys
+    apiEndpoint: "API Endpoint:"
     add:
       description:
         label: Description

--- a/config/settings.js
+++ b/config/settings.js
@@ -16,7 +16,8 @@ export const SETTING = {
     LINUX:                          'cli-url-linux',
   },
 
-  CA_CERTS: 'cacerts',
+  API_HOST:                         'api-host',
+  CA_CERTS:                         'cacerts',
 
   AUTH_TOKEN_MAX_TTL_MINUTES:       'auth-token-max-ttl-minutes',
   KUBECONFIG_GENERATE_TOKEN:        'kubeconfig-generate-token',

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -30,12 +30,15 @@ export default {
     // Get all settings - the API host setting may not be set, so this avoids a 404 request if we look for the specific setting
     const allSettings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.SETTING });
     const apiHostSetting = allSettings.find(i => i.id === SETTING.API_HOST);
+    const serverUrlSetting = allSettings.find(i => i.id === SETTING.SERVER_URL);
 
     this.apiHostSetting = apiHostSetting?.value;
+    this.serverUrlSetting = serverUrlSetting?.value;
   },
   data() {
     return {
       apiHostSetting:    null,
+      serverUrlSetting:  null,
       rows:              null,
       canChangePassword: false
     };
@@ -55,8 +58,8 @@ export default {
         setting = `http://${ setting }`;
       }
 
-      // Note in Ember it used app.apiServer which is only used for dev
-      let url = setting || '';
+      // Use Server Setting URL if the api host setting is not set
+      let url = setting || this.serverUrlSetting;
 
       // If the URL is relative, add on the current base URL from the browser
       if ( url.indexOf('http') !== 0 ) {

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -9,11 +9,14 @@ import { mapGetters } from 'vuex';
 
 import Banner from '@/components/Banner';
 import ResourceTable from '@/components/ResourceTable';
+import CopyToClipboardText from '@/components/CopyToClipboardText';
+
+const API_ENDPOINT = '/v3';
 
 export default {
   layout:     'plain',
   components: {
-    BackLink, Banner, PromptChangePassword, Loading, ResourceTable, Principal
+    CopyToClipboardText, BackLink, Banner, PromptChangePassword, Loading, ResourceTable, Principal
   },
   mixins: [BackRoute],
   async fetch() {
@@ -34,6 +37,20 @@ export default {
 
     apiKeyheaders() {
       return this.apiKeySchema ? this.$store.getters['type-map/headersFor'](this.apiKeySchema) : [];
+    },
+
+    apiUrl() {
+      // Port of Ember code for API Url - see: https://github.com/rancher/ui/blob/8e07c492673171731f3b26af14c978bc103d1828/lib/shared/addon/endpoint/service.js#L58
+      // Note: Ember had two values - one that was displayed and one that was copied to the clipboard - we just use the later
+      // This means we ignore the API_HOST setting (not clear if this is still supported)
+      const path = API_ENDPOINT.replace(/^\/+/, '');
+      let authBase = '/';
+
+      if (process.client) {
+        authBase = `${ window.location.origin }/`;
+      }
+
+      return `${ authBase }${ path }`;
     },
 
     apiKeySchema() {
@@ -121,7 +138,13 @@ export default {
 
     <hr />
     <div class="keys-header">
-      <h4 v-t="'accountAndKeys.apiKeys.title'" />
+      <div>
+        <h4 v-t="'accountAndKeys.apiKeys.title'" />
+        <div class="api-url">
+          <span>{{ t("accountAndKeys.apiKeys.apiEndpoint") }}</span>
+          <CopyToClipboardText :text="apiUrl" />
+        </div>
+      </div>
       <button v-if="apiKeySchema" class="btn role-primary add mb-20" @click="addKey">
         {{ t('accountAndKeys.apiKeys.add.label') }}
       </button>
@@ -155,7 +178,7 @@ export default {
 
   .keys-header {
     display: flex;
-    h4 {
+    div {
       flex: 1;
     }
   }
@@ -165,6 +188,14 @@ export default {
     flex-direction: column;
     .add {
       align-self: flex-end;
+    }
+  }
+
+  .api-url {
+    display: flex;
+
+    > span {
+      margin-right: 6px;
     }
   }
 </style>


### PR DESCRIPTION
Addresses #4869

This PR adds the API Endpoint to the API Keys (for consistency with the of Ember UI).

The old UI used two URLs - one that was displayed and a 2nd that was copied to the clipboard when clicked. In most cases they would be the same - the display one had extra logic to use the API_HOST setting if set.

I think it makes more sense to only use one URL - the one shown should be the same a the one copied.

I have used the simpler logic that does not use the API_HOST setting - @vincent99 is this still used?