### PR TITLE
Move window event listeners out of ssr

### DIFF
--- a/components/SortableTable/actions.js
+++ b/components/SortableTable/actions.js
@@ -16,7 +16,7 @@ export default {
     };
   },
 
-  beforeDestroyed() {
+  beforeDestroy() {
     window.removeEventListener('resize', this.updateHiddenBulkActions);
   },
 

--- a/components/SortableTable/actions.js
+++ b/components/SortableTable/actions.js
@@ -16,13 +16,12 @@ export default {
     };
   },
 
-  created() {
-    window.addEventListener('resize', this.updateHiddenBulkActions);
-  },
-  destroyed() {
+  beforeDestroyed() {
     window.removeEventListener('resize', this.updateHiddenBulkActions);
   },
+
   mounted() {
+    window.addEventListener('resize', this.updateHiddenBulkActions);
     this.updateHiddenBulkActions();
   },
 


### PR DESCRIPTION
Reference #4899 

_Issue_
The event listeners on the `window` object are being fired in ssr, which is causing the `window is not defined` error.

_Fix_
Move event listeners into `mounted()` and `beforeDestroyed()` hooks.