### PR TITLE
Allow login consent banner to be displayed as a dialog

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6187,11 +6187,16 @@ branding:
   uiBanner:
     label: Fixed Banners
     text: Text
+    buttonText: Accept Button Text
     textColor: Text Color
     background: Background Color
     showHeader: Show Banner in Header
     showFooter: Show Banner in Footer
     showConsent: Show Consent Banner on Login Screen
+    showAsDialog:
+      defaultButtonText: Accept
+      label: Show Consent Banner on Login Screen
+      tooltip: Show a modal dialog on the login screen that must be accepted by a user before they can login
     bannerAlignment:
       label: Text Alignment
       leftOption: Left

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6195,7 +6195,7 @@ branding:
     showConsent: Show Consent Banner on Login Screen
     showAsDialog:
       defaultButtonText: Accept
-      label: Show Consent Banner on Login Screen
+      label: Show Login Consent as a modal dialog
       tooltip: Show a modal dialog on the login screen that must be accepted by a user before they can login
     bannerAlignment:
       label: Text Alignment

--- a/components/FixedBanner.vue
+++ b/components/FixedBanner.vue
@@ -114,7 +114,7 @@ export default {
 
 <template>
   <div v-if="showBanner">
-    <div v-if="!showAsDialog" class="banner" :style="bannerStyle">
+    <div v-if="!showAsDialog" class="banner" :style="bannerStyle" :class="{'banner-consent': showConsent}">
       {{ banner.text }}
     </div>
     <div v-else-if="showDialog">
@@ -140,6 +140,14 @@ export default {
     height: 2em;
     width: 100%;
     padding: 0 20px;
+
+    &.banner-consent {
+      position: absolute;
+      height: unset;
+      min-height: 2em;
+      max-height: 4em;
+      overflow: hidden;
+    }
   }
   .banner-dialog, .banner-dialog-glass {
     position: absolute;
@@ -178,6 +186,10 @@ export default {
 
       button {
         margin-top: 10px;
+        max-width: 50%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         width: fit-content;
       }
     }

--- a/components/FixedBanner.vue
+++ b/components/FixedBanner.vue
@@ -25,12 +25,19 @@ export default {
 
   data() {
     return {
+      showDialog:      true,
       showHeader:      false,
       showFooter:      false,
       showConsent:     false,
       banner:          {},
       bannerSetting:   null
     };
+  },
+
+  methods: {
+    hideDialog() {
+      this.showDialog = false;
+    }
   },
 
   computed: {
@@ -45,7 +52,12 @@ export default {
         'text-decoration':  this.banner.textDecoration ? 'underline' : ''
       };
     },
-
+    dialogStyle() {
+      return {
+        color:              this.banner.color,
+        'background-color': this.banner.background
+      };
+    },
     showBanner() {
       if (!this.banner.text && !this.banner.background) {
         return false;
@@ -60,6 +72,10 @@ export default {
       }
 
       return null;
+    },
+
+    showAsDialog() {
+      return !!this.banner.button;
     }
   },
 
@@ -97,17 +113,73 @@ export default {
 </script>
 
 <template>
-  <div v-if="showBanner" class="banner" :style="bannerStyle">
-    {{ banner.text }}
+  <div v-if="showBanner">
+    <div v-if="!showAsDialog" class="banner" :style="bannerStyle">
+      {{ banner.text }}
+    </div>
+    <div v-else-if="showDialog">
+      <div class="banner-dialog-glass"></div>
+      <div class="banner-dialog">
+        <div class="banner-dialog-frame" :style="dialogStyle">
+          <div class="banner" :style="bannerStyle">
+            {{ banner.text }}
+          </div>
+          <button class="btn role-primary" @click="hideDialog()">
+            {{ banner.button }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
-<style scoped>
-    .banner {
-        text-align: center;
-        line-height: 2em;
-        height: 2em;
-        width: 100%;
-        padding: 0 20px;
+<style lang="scss" scoped>
+  .banner {
+    text-align: center;
+    line-height: 2em;
+    height: 2em;
+    width: 100%;
+    padding: 0 20px;
+  }
+  .banner-dialog, .banner-dialog-glass {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100vw;
+    height: 100vh;
+  }
+  .banner-dialog-glass {
+    z-index: 5000;
+    background-color: var(--default);
+    opacity: 0.75;
+  }
+  .banner-dialog {
+    z-index: 5001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .banner-dialog-frame {
+      border: 2px solid var(--border);
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+      padding: 20px;
+      height: fit-content;
+      width: fit-content;
+      min-width: 50%;
+      max-width: 80%;
+      max-height: 90%;
+
+      .banner {
+        height: initial;
+        overflow-y: auto;
+      }
+
+      button {
+        margin-top: 10px;
+        width: fit-content;
+      }
     }
+  }
 </style>

--- a/components/form/BannerSettings.vue
+++ b/components/form/BannerSettings.vue
@@ -26,10 +26,31 @@ export default ({
   },
 
   data() {
+    const showAsDialog = !!this.value[this.bannerType].button || false;
+    const buttonText = this.value[this.bannerType].button || this.t('branding.uiBanner.showAsDialog.defaultButtonText');
+
     return {
+      showAsDialog,
+      buttonText,
       uiBannerFontSizeOptions: ['10px', '12px', '14px', '16px', '18px', '20px'],
       themeVars:               { bannerTextColor: getComputedStyle(document.body).getPropertyValue('--banner-text-color') }
     };
+  },
+
+  watch: {
+    showAsDialog(neu, old) {
+      if (neu !== old && !neu) {
+        this.value[this.bannerType].button = '';
+      } else {
+        this.value[this.bannerType].button = this.buttonText;
+      }
+    },
+
+    buttonText(neu, old) {
+      if (neu !== old) {
+        this.value[this.bannerType].button = neu;
+      }
+    }
   },
 
   computed: {
@@ -72,6 +93,17 @@ export default ({
       <div class="row">
         <div class="col span-6">
           <LabeledInput v-model="value[bannerType].text" :label="t('branding.uiBanner.text')" />
+          <div v-if="bannerType === 'bannerConsent'" class="mt-10">
+            <Checkbox
+              v-model="showAsDialog"
+              name="bannerDecoration"
+              class="banner-decoration-checkbox"
+              :mode="mode"
+              :label="t('branding.uiBanner.showAsDialog.label')"
+              :tooltip="t('branding.uiBanner.showAsDialog.tooltip')"
+            />
+            <LabeledInput v-model="buttonText" :disabled="!showAsDialog" :label="t('branding.uiBanner.buttonText')" />
+          </div>
         </div>
         <div class="col span-2">
           <RadioGroup

--- a/components/form/BannerSettings.vue
+++ b/components/form/BannerSettings.vue
@@ -26,14 +26,17 @@ export default ({
   },
 
   data() {
-    const showAsDialog = !!this.value[this.bannerType].button || false;
-    const buttonText = this.value[this.bannerType].button || this.t('branding.uiBanner.showAsDialog.defaultButtonText');
+    const showAsDialog = !!this.value[this.bannerType]?.button || false;
+    const buttonText = this.value[this.bannerType]?.button || this.t('branding.uiBanner.showAsDialog.defaultButtonText');
 
     return {
       showAsDialog,
       buttonText,
       uiBannerFontSizeOptions: ['10px', '12px', '14px', '16px', '18px', '20px'],
-      themeVars:               { bannerTextColor: getComputedStyle(document.body).getPropertyValue('--banner-text-color') }
+      themeVars:               {
+        bannerBgColor:   getComputedStyle(document.body).getPropertyValue('--default'),
+        bannerTextColor: getComputedStyle(document.body).getPropertyValue('--banner-text-color')
+      }
     };
   },
 
@@ -142,7 +145,7 @@ export default ({
           <ColorInput v-model="value[bannerType].color" :default-value="themeVars.bannerTextColor" :label="t('branding.uiBanner.textColor')" />
         </div>
         <div class="col span-6">
-          <ColorInput v-model="value[bannerType].background" :label="t('branding.uiBanner.background')" />
+          <ColorInput v-model="value[bannerType].background" :default-value="themeVars.bannerBgColor" :label="t('branding.uiBanner.background')" />
         </div>
       </div>
     </div>

--- a/components/form/ColorInput.vue
+++ b/components/form/ColorInput.vue
@@ -34,6 +34,11 @@ export default {
     inputValue() {
       return this.value ? this.value : this.defaultValue;
     }
+  },
+
+  mounted() {
+    // Ensures that if the default value is used, the model is updated with it
+    this.$emit('input', this.inputValue);
   }
 };
 </script>
@@ -45,7 +50,7 @@ export default {
       <span :style="{'background-color': inputValue}" class="color-display">
         <input ref="input" type="color" :value="inputValue" @input="$emit('input', $event.target.value)" />
       </span>
-      <span class="text-muted">{{ inputValue }}</span>
+      <span class="text-muted color-value">{{ inputValue }}</span>
     </div>
   </div>
 </template>
@@ -59,11 +64,15 @@ export default {
   LABEL{
     display: block;
   }
+
   .preview-container{
     &:hover {
       cursor: pointer;
     }
 
+    .color-value {
+      margin-left: 4px;
+    }
   }
 
   .color-display{

--- a/pages/c/_cluster/settings/brand.vue
+++ b/pages/c/_cluster/settings/brand.vue
@@ -51,6 +51,7 @@ const DEFAULT_BANNER_SETTING = {
     fontSize:        '14px',
     textDecoration:  null,
     text:            null,
+    button:          null,
   },
   showHeader:   'false',
   showFooter:   'false',


### PR DESCRIPTION
Addresses #4719 

This PR adds support for configuring and showing the login banner as a dialog that needs to be acknowledged as an alternative to displaying it as a page banner on the login screen.

The configuration page has been updated to include a checkbox and text input - allowing the user to indicate that they want a modal display and for them to be able to set the text that should appear in the button that is shown:
![Screenshot 2022-01-12 at 15 38 46](https://user-images.githubusercontent.com/1955897/149172060-12ea6981-34e6-419a-a7f7-fbfc35240f18.png)

On the login page this is presented as follows when enabled:

![Screenshot 2022-01-12 at 15 39 47](https://user-images.githubusercontent.com/1955897/149172202-0164b35e-4d73-49e8-afc2-c3b81e6d7a5b.png)

