### PR TITLE
Can configure 'drain before delete' for RKE2/K3s machine pools

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1419,6 +1419,9 @@ cluster:
           }
     quantity:
       label: Machine Count
+    drain:
+      header: Drain
+      label: Drain Before Delete
     role:
       label: Roles
     labels:

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -105,7 +105,17 @@ export default {
           :required="true"
         />
       </div>
-      <div class="col span-6 pt-5">
+      <div class="col span-2 pt-5">
+        <h3>
+          {{ t('cluster.machinePool.drain.header') }}
+        </h3>
+        <Checkbox
+          v-model="value.pool.drainBeforeDelete"
+          :mode="mode"
+          :label="t('cluster.machinePool.drain.label')"
+        />
+      </div>
+      <div class="col span-4 pt-5">
         <h3>
           {{ t('cluster.machinePool.role.label') }}
         </h3>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4448 by adding a checkbox to the K3s/RKE2 cluster provisioning forms that allows the 'drain before delete' setting to be configured for RKE2 and K3s machine pools.

To test this PR, I went to the form for RK2 cluster provisioning and confirmed the checkbox was there and that it was modifying the appropriate field in YAML, which is `spec.rkeConfig.machinePools.drainBeforeDelete`. Jake confirmed that YAML value is right.
<img width="1192" alt="Screen Shot 2022-01-12 at 12 53 16 PM" src="https://user-images.githubusercontent.com/20599230/149214177-d1e6a648-854f-46cb-92af-30d5e3180b08.png">
<img width="409" alt="Screen Shot 2022-01-12 at 1 10 26 PM" src="https://user-images.githubusercontent.com/20599230/149214248-01f4b88a-152b-40ee-8aa6-0ad9d88d5d21.png">

