### PR TITLE
Remove 'tech preview' tag from RKE2/K3s cluster provisioning buttons

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -266,11 +266,8 @@ export default {
       function addType(id, group, disabled = false, link = null, iconClass = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
-        const techPreview = getters['i18n/t']('generic.techPreview');
-        const isTechPreview = group === 'rke2' || group === 'custom2';
-        let tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
+        const tag = '';
 
-        // Always prefer the built-in icon if there is one
         let icon;
 
         try {
@@ -281,12 +278,6 @@ export default {
           iconClass = undefined;
         } else if (!iconClass) {
           icon = require('~/assets/images/generic-driver.svg');
-        }
-
-        if (group === 'rke2' && id === 'harvester') {
-          const experimental = getters['i18n/t']('generic.experimental');
-
-          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: experimental }, '');
         }
 
         const subtype = {

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -268,6 +268,7 @@ export default {
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
         const tag = '';
 
+        // Always prefer the built-in icon if there is one
         let icon;
 
         try {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4852 and https://github.com/rancher/dashboard/issues/4919 by removing "Tech Preview" from the cluster provisioning page when RKE2/K3s is selected.

This PR is ready for review, but it should not be merged until the cluster provisioning work for v2.6.4 is complete.

Before:

<img width="1252" alt="Screen Shot 2022-01-12 at 1 29 19 PM" src="https://user-images.githubusercontent.com/20599230/149218502-ae2f810f-944b-4f60-a483-3486ae2e6e1e.png">

After:

<img width="1108" alt="Screen Shot 2022-01-18 at 6 33 03 PM" src="https://user-images.githubusercontent.com/20599230/150046804-569a9e52-9bd4-4e53-9467-7e734e2fb0e1.png">

