### PR TITLE
Add support for Linode cloud credentials

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1025,6 +1025,11 @@ cluster:
         label: Access Token
         placeholder: Your DigitalOcean API Access Token
     label: Cloud Credential
+    linode:
+      accessToken:
+        help: Paste in a Personal Access Token from the Linode <a href="https://cloud.linode.com/profile/tokens" target="_blank" rel="noopener noreferrer nofollow">API Tokens</a> screen.
+        label: Access Token
+        placeholder: Your Linode API Access Token
     name:
       label: Credential Name
       placeholder: Name for this credential (optional)
@@ -1234,6 +1239,12 @@ cluster:
       tags:
         label: Droplet Tags
         placeholder: e.g. my_server
+    linode:
+      typeLabel: |-
+        {label}, {vcpus, plural,
+          =1 {# vCPU}
+          other {# vCPUs}
+        }, {disk} GB Disk ({value})
     vsphere:
       hostOptions:
         any: Any

--- a/cloud-credential/linode.vue
+++ b/cloud-credential/linode.vue
@@ -1,0 +1,44 @@
+<script>
+import CreateEditView from '@/mixins/create-edit-view';
+import LabeledInput from '@/components/form/LabeledInput';
+
+export default {
+  components: { LabeledInput },
+  mixins:     [CreateEditView],
+
+  watch: {
+    'value.decodedData.accessToken'(neu) {
+      this.$emit('validationChanged', !!neu);
+    }
+  },
+
+  methods: {
+    async test() {
+      try {
+        await this.$store.dispatch('linode/request', {
+          token:   this.value.decodedData.accessToken,
+          command: 'regions'
+        });
+
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <LabeledInput
+      :value="value.decodedData.accessToken"
+      label-key="cluster.credential.linode.accessToken.label"
+      placeholder-key="cluster.credential.linode.accessToken.placeholder"
+      type="password"
+      :mode="mode"
+      @input="value.setData('accessToken', $event);"
+    />
+    <p class="text-muted mt-10" v-html="t('cluster.credential.linode.accessToken.help', {}, true)" />
+  </div>
+</template>

--- a/cloud-credential/linode.vue
+++ b/cloud-credential/linode.vue
@@ -7,7 +7,7 @@ export default {
   mixins:     [CreateEditView],
 
   watch: {
-    'value.decodedData.accessToken'(neu) {
+    'value.decodedData.token'(neu) {
       this.$emit('validationChanged', !!neu);
     }
   },
@@ -16,7 +16,7 @@ export default {
     async test() {
       try {
         await this.$store.dispatch('linode/request', {
-          token:   this.value.decodedData.accessToken,
+          token:   this.value.decodedData.token,
           command: 'profile'
         });
 
@@ -32,12 +32,12 @@ export default {
 <template>
   <div>
     <LabeledInput
-      :value="value.decodedData.accessToken"
+      :value="value.decodedData.token"
       label-key="cluster.credential.linode.accessToken.label"
       placeholder-key="cluster.credential.linode.accessToken.placeholder"
       type="password"
       :mode="mode"
-      @input="value.setData('accessToken', $event);"
+      @input="value.setData('token', $event);"
     />
     <p class="text-muted mt-10" v-html="t('cluster.credential.linode.accessToken.help', {}, true)" />
   </div>

--- a/cloud-credential/linode.vue
+++ b/cloud-credential/linode.vue
@@ -17,7 +17,7 @@ export default {
       try {
         await this.$store.dispatch('linode/request', {
           token:   this.value.decodedData.accessToken,
-          command: 'regions'
+          command: 'profile'
         });
 
         return true;

--- a/store/linode.js
+++ b/store/linode.js
@@ -1,0 +1,75 @@
+import { addParam, addParams } from '@/utils/url';
+
+const ENDPOINT = 'api.linode.com/v4';
+
+export const state = () => {
+  return { cache: {} };
+};
+
+export const mutations = {
+  setCache(state, { credentialId, key, value }) {
+    let cache = state.cache[credentialId];
+
+    if ( !cache ) {
+      cache = {};
+      state.cache[credentialId] = cache;
+    }
+
+    cache[key] = value;
+  },
+};
+
+export const getters = {
+  fromCache: state => ({ credentialId, key }) => {
+    return state.cache[credentialId]?.[key];
+  },
+};
+
+export const actions = {
+  async request({ dispatch }, {
+    token, credentialId, command, opt, out
+  }) {
+    opt = opt || {};
+
+    let url = '/meta/proxy/';
+
+    if ( opt.url ) {
+      url += opt.url.replace(/^https?:\/\//, '');
+    } else {
+      url += `${ ENDPOINT }/${ command }`;
+      url = addParam(url, 'per_page', opt.per_page || 1000);
+      url = addParams(url, opt.params || {});
+    }
+
+    const headers = { Accept: 'application/json' };
+
+    if ( credentialId ) {
+      headers['X-API-CattleAuth-Header'] = `Bearer credID=${ credentialId } passwordField=token`;
+    } else if ( token ) {
+      headers['X-API-Auth-Header'] = `Bearer ${ token }`;
+    }
+
+    const res = await dispatch('management/request', {
+      url,
+      headers,
+      redirectUnauthorized: false,
+    }, { root: true });
+
+    if ( out ) {
+      out[command] = out[command].concat(res[command]);
+    } else {
+      out = res;
+    }
+
+    // De-pagination
+    if ( res?.links?.pages?.next ) {
+      opt.url = res.links.pages.next;
+
+      return dispatch('request', {
+        token, credentialId, command, opt, out
+      });
+    }
+
+    return out;
+  }
+};

--- a/store/plugins.js
+++ b/store/plugins.js
@@ -20,6 +20,11 @@ const credentialOptions = {
     publicMode: 'full',
     keys:       ['subscriptionId', 'tenantId', 'clientId', 'clientSecret']
   },
+  linode: {
+    publicKey:  'accessToken',
+    publicMode: 'prefix',
+    keys:       'accessToken'
+  }
 };
 
 // Credential drivers that rke1 supports

--- a/store/plugins.js
+++ b/store/plugins.js
@@ -21,9 +21,9 @@ const credentialOptions = {
     keys:       ['subscriptionId', 'tenantId', 'clientId', 'clientSecret']
   },
   linode: {
-    publicKey:  'accessToken',
+    publicKey:  'token',
     publicMode: 'prefix',
-    keys:       'accessToken'
+    keys:       'token'
   }
 };
 


### PR DESCRIPTION
Reference #3599 

This adds support for Linode cloud credentials for rke2 clusters

_Note:_ Currently we do not have support for creating the clusters in Linode, that issue is tracked [here](https://github.com/rancher/dashboard/issues/3261).

**To Test**
- Go to Cluster Management => Cloud Credentials
- Add Linode Credentials

![linode-creds](https://user-images.githubusercontent.com/40806497/149377563-e863d484-92e8-4dd6-8e07-7692cb0b6560.png)

