### PR TITLE
Move bulk action `x of y` to avoid extra flicky flicking

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3926,7 +3926,7 @@ setup:
 sortableTable:
   actionAvailability:
     selected: "{actionable} selected"
-    some: "Available for {actionable} of the {total} selected"
+    some: "Affects {actionable} of {total}"
   noData: There are no rows which match your search query.
   noRows: There are no rows to show.
   noActions: No actions available

--- a/components/ActionDropdown.vue
+++ b/components/ActionDropdown.vue
@@ -61,7 +61,6 @@ export default {
       :class="{'one-action':!dualAction, [buttonSize]:true, 'disabled': disableButton}"
     >
       <v-popover
-        v-if="hasSlot('popover-content')"
         placement="bottom"
         :container="false"
         :disabled="disableButton"
@@ -78,8 +77,7 @@ export default {
             Button <i class="icon icon-chevron-down" />
           </button>
         </slot>
-
-        <template v-if="!disableButton" slot="popover">
+        <template #popover>
           <slot name="popover-content" />
         </template>
       </v-popover>

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -520,6 +520,7 @@ export default {
                 v-for="act in availableActions"
                 :id="act.action"
                 :key="act.action"
+                v-tooltip="actionTooltip"
                 type="button"
                 class="btn role-primary"
                 :class="{[bulkActionClass]:true}"
@@ -531,7 +532,7 @@ export default {
                 <i v-if="act.icon" :class="act.icon" />
                 <span v-html="act.label" />
               </button>
-              <ActionDropdown :id="bulkActionsDropdownId" class="bulk-actions-dropdown" :disable-button="!actionAvailability" size="sm">
+              <ActionDropdown :id="bulkActionsDropdownId" class="bulk-actions-dropdown" :disable-button="!tableSelected.length" size="sm">
                 <template #button-content>
                   <button ref="actionDropDown" class="btn bg-primary mr-0" :disabled="!tableSelected.length">
                     <i class="icon icon-gear" />
@@ -545,6 +546,10 @@ export default {
                       v-for="act in hiddenActions"
                       :key="act.action"
                       v-close-popover
+                      v-tooltip="{
+                        content: actionTooltip,
+                        placement: 'right'
+                      }"
                       :class="{ disabled: !act.enabled }"
                       @click="applyTableAction(act, null, $event)"
                       @mouseover="setBulkActionOfInterest(act)"
@@ -556,8 +561,8 @@ export default {
                   </ul>
                 </template>
               </ActionDropdown>
-              <label v-if="actionAvailability" :id="bulkActionAvailabilityId" class="action-availability">
-                {{ actionAvailability }}
+              <label v-if="selectedRowsText" :id="bulkActionAvailabilityId" class="action-availability">
+                {{ selectedRowsText }}
               </label>
             </template>
           </slot>


### PR DESCRIPTION
- The row of bulk actions reacts to the selection of rows via the selection text to the right of the row
- Normally this is a small and consistent `x selected` text which is taken into account when working out the row width
- However some tables (workspaces) can have actions that are only applicable to certain rows
- In those cases on mouse over of an action the selected text changes to a much bigger `Available for {actionable} of the {total} selected`
- This is again taken into account for row width which creates a lot of flickering when the cursor moves over/out of an action
- To resolve this move the `x of y` text into a tooltip
- Also removed the source of flickering when moving the cursor between actions

#4873
