### PR TITLE
Add support Linode rke2/k3s provisioning

### DIFF
--- a/machine-config/linode.vue
+++ b/machine-config/linode.vue
@@ -29,7 +29,7 @@ export default {
     this.errors = [];
 
     try {
-      if (this.credentialId) {
+      if ( this.credentialId ) {
         this.credential = await this.$store.dispatch('rancher/find', {
           type: NORMAN.CLOUD_CREDENTIAL,
           id:   this.credentialId
@@ -44,13 +44,13 @@ export default {
 
       let defaultRegion = 'us-west';
 
-      if (!this.regionOptions.find(x => x.value === defaultRegion)) {
+      if ( !this.regionOptions.find(x => x.value === defaultRegion) ) {
         defaultRegion = this.regionOptions[0]?.value;
       }
 
       const region = this.value.region || this.credential?.defaultRegion || defaultRegion;
 
-      if (!this.value.region) {
+      if ( !this.value.region ) {
         this.value.region = region;
       }
 
@@ -58,15 +58,15 @@ export default {
 
       let defaultInstanceType = 'g6-standard-2';
 
-      if (!this.instanceOptions.find(x => x.value === defaultInstanceType)) {
+      if ( !this.instanceOptions.find(x => x.value === defaultInstanceType) ) {
         defaultInstanceType = this.instanceOptions.find(x => x.memoryGb >= 4)?.value;
 
-        if (!defaultInstanceType) {
+        if ( !defaultInstanceType ) {
           defaultInstanceType = this.instanceOptions[0].value;
         }
       }
 
-      if (!this.value.instanceType) {
+      if ( !this.value.instanceType ) {
         this.value.instanceType = defaultInstanceType;
       }
 
@@ -74,13 +74,15 @@ export default {
 
       let defaultImage = 'linode/ubuntu20.04';
 
-      if (!this.imageOptions.find(x => x.value === defaultImage)) {
+      if ( !this.imageOptions.find(x => x.value === defaultImage) ) {
         defaultImage = this.imageOptions[0].value;
       }
 
-      if (!this.value.image) {
+      if ( !this.value.image ) {
         this.value.image = defaultImage;
       }
+
+      this.updateInterfaces();
     } catch (e) {
       this.errors = exceptionToErrorsArray(e);
     }
@@ -107,7 +109,15 @@ export default {
     }
   },
 
-  methods: { stringify }
+  methods: {
+    stringify,
+
+    updateInterfaces() {
+      if ( !this.value.interfaces ) {
+        this.value.interfaces = [];
+      }
+    }
+  }
 };
 </script>
 

--- a/machine-config/linode.vue
+++ b/machine-config/linode.vue
@@ -1,0 +1,166 @@
+<script>
+import { NORMAN } from '@/config/types';
+import { exceptionToErrorsArray, stringify } from '@/utils/error';
+import { _CREATE } from '@/config/query-params';
+import CreateEditView from '@/mixins/create-edit-view';
+import Loading from '@/components/Loading';
+import Banner from '@/components/Banner';
+import LabeledSelect from '@/components/form/LabeledSelect';
+
+export default {
+  components: {
+    Loading, Banner, LabeledSelect
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    credentialId: {
+      type:     String,
+      required: true
+    },
+    disabled: {
+      type:    Boolean,
+      default: false
+    }
+  },
+
+  async fetch() {
+    this.errors = [];
+
+    try {
+      if (this.credentialId) {
+        this.credential = await this.$store.dispatch('rancher/find', {
+          type: NORMAN.CLOUD_CREDENTIAL,
+          id:   this.credentialId
+        });
+      }
+    } catch (e) {
+      this.credential = null;
+    }
+
+    try {
+      this.regionOptions = await this.$store.dispatch('linode/regionOptions', { credentialId: this.credentialId });
+
+      let defaultRegion = 'us-west';
+
+      if (!this.regionOptions.find(x => x.value === defaultRegion)) {
+        defaultRegion = this.regionOptions[0]?.value;
+      }
+
+      const region = this.value.region || this.credential?.defaultRegion || defaultRegion;
+
+      if (!this.value.region) {
+        this.value.region = region;
+      }
+
+      this.instanceOptions = await this.$store.dispatch('linode/instanceOptions', { credentialId: this.credentialId });
+
+      let defaultInstanceType = 'g6-standard-2';
+
+      if (!this.instanceOptions.find(x => x.value === defaultInstanceType)) {
+        defaultInstanceType = this.instanceOptions.find(x => x.memoryGb >= 4)?.value;
+
+        if (!defaultInstanceType) {
+          defaultInstanceType = this.instanceOptions[0].value;
+        }
+      }
+
+      if (!this.value.instanceType) {
+        this.value.instanceType = defaultInstanceType;
+      }
+
+      this.imageOptions = await this.$store.dispatch('linode/imageOptions', { credentialId: this.credentialId });
+
+      let defaultImage = 'linode/ubuntu20.04';
+
+      if (!this.imageOptions.find(x => x.value === defaultImage)) {
+        defaultImage = this.imageOptions[0].value;
+      }
+
+      if (!this.value.image) {
+        this.value.image = defaultImage;
+      }
+    } catch (e) {
+      this.errors = exceptionToErrorsArray(e);
+    }
+  },
+
+  data() {
+    return {
+      credential:      null,
+      regionOptions:   null,
+      instanceOptions: null,
+      imageOptions:    null
+    };
+  },
+
+  watch: {
+    'credentialId'() {
+      this.$fetch();
+    },
+  },
+
+  computed: {
+    isCreate() {
+      return this.mode === _CREATE;
+    }
+  },
+
+  methods: { stringify }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" :delayed="true" />
+  <div v-else-if="errors.length">
+    <div
+      v-for="(err, idx) in errors"
+      :key="idx"
+    >
+      <Banner
+        color="error"
+        :label="stringify(err)"
+      />
+    </div>
+  </div>
+  <div v-else>
+    <div class="row mt-20">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.region"
+          :mode="mode"
+          :options="regionOptions"
+          :searchable="true"
+          :required="true"
+          :disabled="disabled"
+          label="Region"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.instanceType"
+          :mode="mode"
+          :options="instanceOptions"
+          :searchable="true"
+          :required="true"
+          :disabled="disabled"
+          label="Type"
+        />
+      </div>
+    </div>
+    <div class="row mt-20">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.image"
+          :mode="mode"
+          :options="imageOptions"
+          :searchable="true"
+          :required="true"
+          :disabled="disabled"
+          label="OS Image"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/store/linode.js
+++ b/store/linode.js
@@ -112,8 +112,6 @@ export const actions = {
 
     if ( credentialId ) {
       headers['X-API-CattleAuth-Header'] = `Bearer credID=${ credentialId } passwordField=token`;
-    } else if ( token ) {
-      headers['X-API-Auth-Header'] = `Bearer ${ token }`;
     }
 
     const res = await dispatch('management/request', {

--- a/store/linode.js
+++ b/store/linode.js
@@ -112,6 +112,8 @@ export const actions = {
 
     if ( credentialId ) {
       headers['X-API-CattleAuth-Header'] = `Bearer credID=${ credentialId } passwordField=token`;
+    } else if ( token ) {
+      headers['X-API-Auth-Header'] = `Bearer ${ token }`;
     }
 
     const res = await dispatch('management/request', {


### PR DESCRIPTION
Reference rancher/dashboard#3261 

This adds the `machine-config` for creating rke2/k3s clusters with Linode as the provider.

**To Test**
- Add API token for Linode in the Cloud Providers section
- Create an rke2/k3s cluster using Linode 
 