### PR TITLE
Fix F5 VirtualServer translation bug

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4247,11 +4247,7 @@ tableHeaders:
   endpoints: Endpoints
   flow: Flow
   gitRepos: Git Repos
-  host: |-
-    {count, plural,
-      one { Host }
-      other { Hosts }
-    }
+  host: Host
   health: Health
   id: ID
   image: Image

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -4241,11 +4241,7 @@ tableHeaders:
   endpoints: 端点
   flow: Flow
   gitRepos: Git 仓库
-  host: |-
-    {count, plural,
-      one { 主机 }
-      other { 主机 }
-    }
+  host: 主机
   health: 健康
   id: ID
   image: 镜像


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/34790

Call method `t(labelKey)`：https://github.com/rancher/dashboard/blob/24c58844c8fe2d0679af1048ed9734473f8d234b/store/type-map.js#L940

Unsupported format：
```
host: |-
    {count, plural,
      one { Host }
      other { Hosts }
    }
```