### PR TITLE
Ensure namespace resource quota annotation is set correctly

### DIFF
--- a/components/form/ResourceQuota/NamespaceRow.vue
+++ b/components/form/ResourceQuota/NamespaceRow.vue
@@ -120,7 +120,10 @@ export default {
       const parsedNewValue = parseSi(newValue, this.siOptions) || 0;
       const min = Math.max(parsedNewValue, 0);
       const max = Math.min(min, this.max);
-      const value = formatSi(max, this.siOptions);
+      const value = formatSi(max, {
+        ...this.siOptions,
+        addSuffixSpace: false
+      });
 
       this.$emit('input', this.type, value);
     }

--- a/utils/units.js
+++ b/utils/units.js
@@ -4,6 +4,7 @@ export const FRACTIONAL = ['', 'm', 'u', 'n', 'p', 'f', 'a', 'z', 'y']; // milli
 export function formatSi(inValue, {
   increment = 1000,
   addSuffix = true,
+  addSuffixSpace = true,
   suffix = '',
   firstSuffix = null,
   startingExponent = 0,
@@ -37,10 +38,14 @@ export function formatSi(inValue, {
   }
 
   if ( addSuffix ) {
+    if (addSuffixSpace) {
+      out += ` `;
+    }
+
     if ( exp === 0 && firstSuffix !== null) {
-      out += ` ${ firstSuffix }`;
+      out += `${ firstSuffix }`;
     } else {
-      out += ` ${ divide ? UNITS[exp] : FRACTIONAL[exp] }${ suffix }` || '';
+      out += `${ divide ? UNITS[exp] : FRACTIONAL[exp] }${ suffix }` || '';
     }
   }
 


### PR DESCRIPTION
- #4804
- Annotation should not have space between value and unit
- I had a quick look around the usages of `formatSi` and most of them don't include the unit