### PR TITLE
Pass global values when creating rancher-monitoring-crd

### DIFF
--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -956,13 +956,15 @@ export default {
         }
       }
 
+      // 'more' contains the values for the CRD chart, which needs the same
+      // global and cattle values as the chart.
       for ( const dependency of more ) {
         out.charts.unshift({
           chartName:   dependency.name,
           version:     dependency.version,
           releaseName: dependency.annotations[CATALOG_ANNOTATIONS.RELEASE_NAME] || dependency.name,
           projectId:   this.project,
-          values:      this.addGlobalValuesTo({}),
+          values:      this.addGlobalValuesTo({ global: values.global }),
           annotations: {
             ...migratedAnnotations,
             [CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE]: dependency.repoType,


### PR DESCRIPTION
This PR addresses [#4548](https://github.com/rancher/dashboard/issues/4548) by making it so that the same global values used to create the rancher-monitoring chart are also used when creating the rancher-monitoring-crd chart.

To test this PR,

1. On a downstream cluster, I went to install the monitoring application
2. I set `values.global.cattle.systemDefaultRegistry` to `docker.io`
3. Looked in network traffic, clicked install, and confirmed that a value is now included in the network request:
![Screen Shot 2022-01-20 at 2 13 01 PM](https://user-images.githubusercontent.com/20599230/150423001-a7da18a0-dd3f-46a0-8da3-293c4623473b.png)


4. Confirmed that the chart installed successfully


