### PR TITLE
Remove experimental/tech preview tag from Harvester cluster provisioning

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -247,19 +247,13 @@ export default {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
         const techPreview = getters['i18n/t']('generic.techPreview');
-        const isTechPreview = group === 'rke2' || group === 'custom2';
-        let tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
+        const isTechPreview = ( group === 'rke2' || group === 'custom2' ) && id !== 'harvester';
+        const tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
         let icon = require('~/assets/images/generic-driver.svg');
 
         try {
           icon = require(`~/assets/images/providers/${ id }.svg`);
         } catch (e) {}
-
-        if (group === 'rke2' && id === 'harvester') {
-          const experimental = getters['i18n/t']('generic.experimental');
-
-          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: experimental }, '');
-        }
 
         const subtype = {
           id,


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4919 by removing the `experimental` tag from the button for Harvester cluster provisioning.

When the experimental tag was removed, a tech preview tag was the fallback, so I removed the code for adding the 'tech preview' tag on the Harvester button as well.

Note: Guangbo said the "External Harvester" part should not be removed. https://github.com/rancher/dashboard/pull/4910#issuecomment-1012662696

<img width="1099" alt="Screen Shot 2022-01-19 at 11 51 27 AM" src="https://user-images.githubusercontent.com/20599230/150195835-348c1f7a-26f3-4ab4-b2b3-cdd102a809b3.png">
