### PR TITLE
Fix JS error when upgrading app that was installed with the helm cli

### DIFF
--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -240,8 +240,8 @@ export default class CatalogApp extends SteveModel {
 
   get deployedAsLegacy() {
     return async() => {
-      if (this.spec.values) {
-        const { clusterName, projectName } = this.spec?.values?.global;
+      if (this.spec?.values?.global) {
+        const { clusterName, projectName } = this.spec.values.global;
 
         if (clusterName && projectName) {
           try {


### PR DESCRIPTION
`.spec.values.global` is not present when an app wasn't installed through Rancher.

JS error:

```
fetch.client.js?2293:75 Error in fetch(): TypeError: Cannot read properties of undefined (reading 'clusterName')
    at _callee4$ (catalog.cattle.io.app.js?9e85:244:17)
    at tryCatch (runtime.js?96cf:45:15)
    at Generator.invoke [as _invoke] (runtime.js?96cf:274:1)
    at Generator.prototype.<computed> [as next] (runtime.js?96cf:97:1)
    at asyncGeneratorStep (asyncToGenerator.js?1da1:3:1)
    at _next (asyncToGenerator.js?1da1:25:1)
    at eval (asyncToGenerator.js?1da1:32:1)
    at new Promise (<anonymous>)
    at CatalogApp.eval (asyncToGenerator.js?1da1:21:1)
    at _callee$ (install.vue?8e63:107:1)
```

Addresses https://github.com/rancher/dashboard/issues/4959
