### PR TITLE
Scale down specific RKE2 machine

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3411,6 +3411,11 @@ promptForceRemove:
   forceDelete: Force Delete
   confirmName: "Enter in the pool name below to confirm:"
 
+promptScaleMachineDown:
+  attemptingToRemove: "You are attempting to delete {count} {type}"
+  retainedMachine1: At least one Machine with role Control Plane must exist,
+  retainedMachine2: <b>{ name }</b> will remain
+
 promptRemove:
   title: Are you sure?
   andOthers: |-

--- a/components/dialog/GenericPrompt.vue
+++ b/components/dialog/GenericPrompt.vue
@@ -59,8 +59,12 @@ export default {
   <Card class="prompt-restore" :show-highlight-border="false">
     <h4 slot="title" class="text-default-text" v-html="title" />
 
-    <div slot="body" class="pl-10 pr-10" style="min-height: 50px; display: flex;" v-html="body">
-    </div>
+    <template slot="body">
+      <slot name="body">
+        <div class="pl-10 pr-10" style="min-height: 50px; display: flex;" v-html="body">
+        </div>
+      </slot>
+    </template>
 
     <div slot="actions" class="bottom">
       <Banner v-for="(err, i) in errors" :key="i" color="error" :label="err" />

--- a/components/dialog/GenericPrompt.vue
+++ b/components/dialog/GenericPrompt.vue
@@ -47,6 +47,7 @@ export default {
         await this.applyAction(buttonDone);
         this.close();
       } catch (err) {
+        console.error(err); // eslint-disable-line
         this.errors = exceptionToErrorsArray(err);
         buttonDone(false);
       }

--- a/components/dialog/ScaleMachineDownDialog.vue
+++ b/components/dialog/ScaleMachineDownDialog.vue
@@ -66,7 +66,7 @@ export default {
         return res;
       }, new Map());
 
-      // Mark all machines for deletion and then scale down their pool
+      // Mark all machines for deletion and then scale down their pool to the new size
       const flatArray = Array.from(poolInfo.entries());
 
       await Promise.all(flatArray.map(([pool, machines]) => {
@@ -79,7 +79,7 @@ export default {
           .then(() => pool.scalePool(-machines.length, false));
       }));
 
-      // Pool scale info is kept in the cluster itself
+      // Pool scale info is kept in the cluster itself, so now we've made the changes we can save them
       await this.cluster.save();
     }
   }

--- a/components/dialog/ScaleMachineDownDialog.vue
+++ b/components/dialog/ScaleMachineDownDialog.vue
@@ -1,0 +1,92 @@
+<script>
+import { CAPI as CAPI_LABELS } from '@/config/labels-annotations';
+import GenericPrompt from './GenericPrompt';
+
+export default {
+  components: { GenericPrompt },
+
+  props:      {
+    resources: {
+      type:     Array,
+      required: true
+    }
+  },
+
+  data() {
+    const allToDelete = Array.isArray(this.resources) ? this.resources : [this.resources];
+
+    // Not all machines can be deleted, there must always be at least one left with the role of control plane in the cluster
+    const allToDeleteByType = allToDelete.reduce((res, m) => {
+      if (m.isControlPlane) {
+        res.controlPlane.push(m);
+      } else {
+        res.others.push(m);
+      }
+
+      return res;
+    }, { controlPlane: [], others: [] });
+
+    const totalControlPlanes = allToDelete[0].cluster.machines.filter(m => m.isControlPlane).length;
+    const controlPlanesToDelete = allToDeleteByType.controlPlane.length;
+    // If we're attempting to remove all control plan machines.... ignore one
+    const ignoredControlPlane = totalControlPlanes - controlPlanesToDelete === 0 ? allToDeleteByType.controlPlane.pop() : undefined;
+    const safeMachinesToDelete = [...allToDeleteByType.controlPlane, ...allToDeleteByType.others];
+
+    return {
+      allToDelete,
+      safeMachinesToDelete,
+      ignoredControlPlane,
+      type:   this.$store.getters['type-map/labelFor'](allToDelete[0].schema, allToDelete.length),
+      config: {
+        title:       this.t('promptRemove.title'),
+        applyMode:   'delete',
+        applyAction: this.remove,
+      }
+    };
+  },
+
+  methods: {
+
+    async remove() {
+      // Set the `delete-machine` annotation on each machine and then scale down the pool to the new size
+      await Promise.all(this.safeMachinesToDelete.map((machine) => {
+        machine.setAnnotation(CAPI_LABELS.DELETE_MACHINE, 'true');
+
+        return machine.save();
+      }));
+      await this.safeMachinesToDelete[0].pool.scalePool(-this.safeMachinesToDelete.length);
+    }
+  }
+};
+</script>
+
+<template>
+  <GenericPrompt :resources="[config]" @close="$emit('close')">
+    <template slot="body">
+      <div class="pl-10 pr-10 mt-20 mb-20 body">
+        <div v-if="allToDelete.length === 1">
+          {{ t('promptRemove.attemptingToRemove', { type }) }} <b>{{ safeMachinesToDelete[0].name }}</b>
+        </div>
+        <div v-else>
+          {{ t('promptScaleMachineDown.attemptingToRemove', { type, count: allToDelete.length }, true) }}
+        </div>
+        <div v-if="ignoredControlPlane" class="retained-machine">
+          <span>{{ t('promptScaleMachineDown.retainedMachine1') }}</span>
+          <span v-html="t('promptScaleMachineDown.retainedMachine2', { name: ignoredControlPlane.name }, true)"></span>
+        </div>
+      </div>
+    </template>
+  </GenericPrompt>
+</template>
+
+<style lang='scss' scoped>
+  .body {
+    div:not(:last-of-type) {
+      padding-bottom: 15px;
+    }
+    .retained-machine {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -49,6 +49,7 @@ export const CAPI = {
   CLUSTER_NAMESPACE:    'cluster.x-k8s.io/cluster-namespace',
   FORCE_MACHINE_REMOVE: 'provisioning.cattle.io/force-machine-remove',
   MACHINE_NAME:         'cluster.x-k8s.io/machine',
+  DELETE_MACHINE:       'cluster.k8s.io/delete-machine',
   PROVIDER:             'provider.cattle.io'
 };
 

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -49,7 +49,7 @@ export const CAPI = {
   CLUSTER_NAMESPACE:    'cluster.x-k8s.io/cluster-namespace',
   FORCE_MACHINE_REMOVE: 'provisioning.cattle.io/force-machine-remove',
   MACHINE_NAME:         'cluster.x-k8s.io/machine',
-  DELETE_MACHINE:       'cluster.k8s.io/delete-machine',
+  DELETE_MACHINE:       'cluster.x-k8s.io/delete-machine',
   PROVIDER:             'provider.cattle.io'
 };
 

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -189,15 +189,7 @@ export default {
     },
 
     machines() {
-      const machines = this.allMachines.filter((x) => {
-        if ( x.metadata?.namespace !== this.value.metadata.namespace ) {
-          return false;
-        }
-
-        return x.spec?.clusterName === this.value.metadata.name;
-      });
-
-      return [...machines, ...this.fakeMachines];
+      return [...this.value.machines, ...this.fakeMachines];
     },
 
     nodes() {

--- a/models/cluster.x-k8s.io.machinedeployment.js
+++ b/models/cluster.x-k8s.io.machinedeployment.js
@@ -80,12 +80,14 @@ export default class CapiMachineDeployment extends SteveModel {
     return this.status?.unavailableReplicas || 0;
   }
 
-  scalePool(delta) {
+  scalePool(delta, save = true) {
     const clustersMachinePool = this.cluster.spec.rkeConfig.machinePools.find(mp => `${ this.cluster.id }-${ mp.name }` === this.id);
 
     if (clustersMachinePool) {
       clustersMachinePool.quantity += delta;
-      this.cluster.save();
+      if (save) {
+        this.cluster.save();
+      }
     }
   }
 

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -299,6 +299,16 @@ export default class ProvCluster extends SteveModel {
     return this.$rootGetters['management/all'](MANAGEMENT.NODE).filter(node => node.id.startsWith(this.mgmtClusterId));
   }
 
+  get machines() {
+    return this.$rootGetters['management/all'](CAPI.MACHINE).filter((machine) => {
+      if ( machine.metadata?.namespace !== this.metadata.namespace ) {
+        return false;
+      }
+
+      return machine.spec?.clusterName === this.metadata.name;
+    });
+  }
+
   get displayName() {
     if ( this.mgmt && !this.isRke2 ) {
       return this.mgmt.spec.displayName;


### PR DESCRIPTION
- Adds the scale down action to an RKE2 machine
- Cater for case where at lease one machine with a role of Control Plane must exist
- rancher/dashboard#4446
- ~~This doesn't actually work yet (annotation might not be correct), seeking clarification on process in original issue~~ Annotation supplied in issue had typo, now fixed