### PR TITLE
Add a keyboard shortcut to open the Kubectl shell

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -93,7 +93,7 @@ nav:
     options: KubeConfig Options
   import: Import YAML
   home: Home
-  shell: Kubectl Shell
+  shell: Kubectl Shell {key}
   support: |-
     {hasSupport, select,
       true {Support}

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -93,7 +93,7 @@ nav:
     options: KubeConfig 选项
   import: 导入 YAML
   home: 首页
-  shell: Kubectl Shell
+  shell: Kubectl Shell {key}
   support: |-
     {hasSupport, select,
       true {支持}

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -37,7 +37,7 @@ export default {
 
   data() {
     const searchShortcut = isMac ? '(\u2318-K)' : '(Ctrl+K)';
-    const shellShortcut = isMac ? '(\u2318-\')' : '(Ctrl+\')';
+    const shellShortcut = '(Ctrl+`)';
 
     return {
       show:        false,
@@ -267,7 +267,7 @@ export default {
         <button
           v-if="showKubeShell"
           v-tooltip="t('nav.shell', {key: shellShortcut})"
-          v-shortkey="{windows: ['ctrl', '\''], mac: ['meta', '\'']}"
+          v-shortkey="{windows: ['ctrl', '`'], mac: ['meta', '`']}"
           :disabled="!shellEnabled"
           type="button"
           class="btn header-btn role-tertiary"

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -37,11 +37,13 @@ export default {
 
   data() {
     const searchShortcut = isMac ? '(\u2318-K)' : '(Ctrl+K)';
+    const shellShortcut = isMac ? '(\u2318-\')' : '(Ctrl+\')';
 
     return {
       show:        false,
       showTooltip: false,
       searchShortcut,
+      shellShortcut,
       VIRTUAL,
       LOGGED_OUT,
     };
@@ -264,10 +266,12 @@ export default {
 
         <button
           v-if="showKubeShell"
-          v-tooltip="t('nav.shell')"
+          v-tooltip="t('nav.shell', {key: shellShortcut})"
+          v-shortkey="{windows: ['ctrl', '\''], mac: ['meta', '\'']}"
           :disabled="!shellEnabled"
           type="button"
           class="btn header-btn role-tertiary"
+          @shortkey="currentCluster.openShell()"
           @click="currentCluster.openShell()"
         >
           <i class="icon icon-terminal icon-lg" />


### PR DESCRIPTION
Addresses Github issue: [#4736](https://github.com/rancher/dashboard/issues/4736)
Addresses Zube issue: [#4754](https://zube.io/rancher/dashboard-ui/c/4754)

Added shortcut to kubectl shell button + information on tooltip

<img width="1744" alt="Screenshot 2022-01-21 at 16 11 25" src="https://user-images.githubusercontent.com/97888974/150561011-edaa7a05-f061-4bc5-a9df-d8448b304665.png">

