### PR TITLE
Label Harvester provisioning with RKE2 as tech preview

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -247,7 +247,7 @@ export default {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
         const techPreview = getters['i18n/t']('generic.techPreview');
-        const isTechPreview = ( group === 'rke2' || group === 'custom2' ) && id !== 'harvester';
+        const isTechPreview = group === 'rke2' || group === 'custom2';
         const tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
         let icon = require('~/assets/images/generic-driver.svg');
 


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/4919

For RKE1, Harvester has no label. For RKE2, it has no label:
![Screen Shot 2022-01-21 at 12 27 30 PM](https://user-images.githubusercontent.com/20599230/150588816-6321a6e4-3c15-421a-9355-8fed412227e3.png)
![Screen Shot 2022-01-21 at 12 27 20 PM](https://user-images.githubusercontent.com/20599230/150588820-9feb6028-031b-4eac-a0af-70cb9981708c.png)

