### PR TITLE
Show all container images in Workload view

### DIFF
--- a/components/formatter/PodImages.vue
+++ b/components/formatter/PodImages.vue
@@ -25,6 +25,19 @@ export default {
       } else {
         return this.value;
       }
+    },
+    imageLabels() {
+      if (Array.isArray(this.images) && this.images.length > 1) {
+        let imagesNames = '<span style="text-decoration: underline">Images:</span><br/><br/>';
+
+        this.images.forEach((name, i) => {
+          imagesNames += `&#8226; ${ name }<br>`;
+        });
+
+        return imagesNames;
+      }
+
+      return null;
     }
   }
 
@@ -34,6 +47,10 @@ export default {
 <template>
   <span>
     <span>{{ images[0] }}</span><br>
-    <span v-if="images.length-1>0" class="plus-more">{{ t('generic.plusMore', {n:images.length-1}) }}</span>
+    <span
+      v-if="images.length-1>0"
+      v-tooltip.bottom="imageLabels"
+      class="plus-more"
+    >{{ t('generic.plusMore', {n:images.length-1}) }}</span>
   </span>
 </template>


### PR DESCRIPTION
Addresses Github issue: [#4736](https://github.com/rancher/dashboard/issues/4626)
Addresses Zube issue: [#4644](https://zube.io/rancher/dashboard-ui/c/4644)

Added tooltip with all container images in Workload view

<img width="1512" alt="Screenshot 2022-01-24 at 13 48 26" src="https://user-images.githubusercontent.com/97888974/150795168-79e07616-cfea-4aeb-83d3-8902a397ef05.png">

