### PR TITLE
Global Setting: Separate Banners into its own side nav item

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6173,6 +6173,34 @@ featureFlags:
     title: Waiting for Restart
     wait: This may take a few moments
 
+banner:
+  label: Fixed Banners
+  settingName: Banners
+  text: Text
+  buttonText: Accept Button Text
+  textColor: Text Color
+  background: Background Color
+  showHeader: Show Banner in Header
+  showFooter: Show Banner in Footer
+  showConsent: Show Consent Banner on Login Screen
+  showAsDialog:
+    defaultButtonText: Accept
+    label: Show Login Consent as a modal dialog
+    tooltip: Show a modal dialog on the login screen that must be accepted by a user before they can login
+  bannerAlignment:
+    label: Text Alignment
+    leftOption: Left
+    centerOption: Center
+    rightOption: Right
+  bannerDecoration:
+    label: Text Decoration
+    bannerBold: Bold
+    bannerItalic: Italic
+    bannerUnderline: Underline
+  bannerFontSize:
+    label: 'Font Size'
+  consent: Consent Banner
+
 branding:
   label: Branding
   directoryName: Brand Asset Directory Name
@@ -6195,32 +6223,6 @@ branding:
     issuesUrl: Issue Reporting URL
     invalidUrl: The issue reporting value must be a complete URL, including protocol.
     communityLinks: Show Rancher community support links
-  uiBanner:
-    label: Fixed Banners
-    text: Text
-    buttonText: Accept Button Text
-    textColor: Text Color
-    background: Background Color
-    showHeader: Show Banner in Header
-    showFooter: Show Banner in Footer
-    showConsent: Show Consent Banner on Login Screen
-    showAsDialog:
-      defaultButtonText: Accept
-      label: Show Login Consent as a modal dialog
-      tooltip: Show a modal dialog on the login screen that must be accepted by a user before they can login
-    bannerAlignment:
-      label: Text Alignment
-      leftOption: Left
-      centerOption: Center
-      rightOption: Right
-    bannerDecoration:
-      label: Text Decoration
-      bannerBold: Bold
-      bannerItalic: Italic
-      bannerUnderline: Underline
-    bannerFontSize:
-      label: 'Font Size'
-    consent: Consent Banner
   color:
     label: Primary Color
     tip: You can override the primary color used throughout the UI with a custom color of your choice.

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6176,6 +6176,9 @@ featureFlags:
 banner:
   label: Fixed Banners
   settingName: Banners
+  headerBanner: Header Banner
+  footerBanner: Footer Banner
+  loginScreenBanner: Login Screen Banner
   text: Text
   buttonText: Accept Button Text
   textColor: Text Color

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -6275,6 +6275,30 @@ featureFlags:
     multi-cluster-management: Kubernetes集群的多集群配置和管理。
     rke2: 启用RKE2
 
+banner:
+  label: 固定横幅
+  settingName: 横幅
+  text: 文本
+  textColor: 文本颜色
+  background: 背景颜色
+  showHeader: 在页眉中显示横幅
+  showFooter: 在页脚中显示横幅
+  showConsent: 在登录页面显示同意横幅
+  bannerAlignment:
+    label: 文字对齐
+    leftOption: 左对齐
+    centerOption: 居中
+    rightOption: 右对齐
+  bannerDecoration:
+    label: 文字装饰
+    bannerBold: 加粗
+    bannerItalic: 斜体
+    bannerUnderline: 下划线
+  bannerFontSize:
+    label: '字体大小'
+  consent: 同意横幅
+  
+
 branding:
   label: 公司品牌
   directoryName: 品牌资产目录名称
@@ -6297,27 +6321,6 @@ branding:
     issuesUrl: 问题报告 URL
     invalidUrl: 必须是包括协议头的完整 URL。
     communityLinks: 显示 Rancher 社区支持链接
-  uiBanner:
-    label: 固定横幅
-    text: 文本
-    textColor: 文本颜色
-    background: 背景颜色
-    showHeader: 在页眉中显示横幅
-    showFooter: 在页脚中显示横幅
-    showConsent: 在登录页面显示同意横幅
-    bannerAlignment:
-      label: 文字对齐
-      leftOption: 左对齐
-      centerOption: 居中
-      rightOption: 右对齐
-    bannerDecoration:
-      label: 文字装饰
-      bannerBold: 加粗
-      bannerItalic: 斜体
-      bannerUnderline: 下划线
-    bannerFontSize:
-      label: '字体大小'
-    consent: 同意横幅
   color:
     label: 主颜色
     tip: 使用自定义颜色替换整个 UI 中使用的主颜色。

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -6278,6 +6278,9 @@ featureFlags:
 banner:
   label: 固定横幅
   settingName: 横幅
+  headerBanner: 标题横幅
+  footerBanner: 页脚横幅
+  loginScreenBanner: 登录屏幕横幅
   text: 文本
   textColor: 文本颜色
   background: 背景颜色

--- a/components/form/BannerSettings.vue
+++ b/components/form/BannerSettings.vue
@@ -4,6 +4,7 @@ import ColorInput from '@/components/form/ColorInput';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import RadioGroup from '@/components/form/RadioGroup';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default ({
   props: {
@@ -12,8 +13,11 @@ export default ({
       default: () => {}
     },
     mode: {
-      type:    String,
-      default: 'edit',
+      type: String,
+      validator(value) {
+        return [_EDIT, _VIEW].includes(value);
+      },
+      default: _EDIT,
     },
     bannerType: {
       type:     String,
@@ -68,6 +72,10 @@ export default ({
       return { options, labels };
     },
 
+    isUiDisabled() {
+      return this.mode === _VIEW;
+    },
+
     textDecorationOptions() {
       const options = [
         {
@@ -95,7 +103,11 @@ export default ({
     <div class="col span-12">
       <div class="row">
         <div class="col span-6">
-          <LabeledInput v-model="value[bannerType].text" :label="t('banner.text')" />
+          <LabeledInput
+            v-model="value[bannerType].text"
+            :disabled="isUiDisabled"
+            :label="t('banner.text')"
+          />
           <div v-if="bannerType === 'bannerConsent'" class="mt-10">
             <Checkbox
               v-model="showAsDialog"
@@ -105,7 +117,11 @@ export default ({
               :label="t('banner.showAsDialog.label')"
               :tooltip="t('banner.showAsDialog.tooltip')"
             />
-            <LabeledInput v-model="buttonText" :disabled="!showAsDialog" :label="t('banner.buttonText')" />
+            <LabeledInput
+              v-model="buttonText"
+              :disabled="!showAsDialog || isUiDisabled"
+              :label="t('banner.buttonText')"
+            />
           </div>
         </div>
         <div class="col span-2">
@@ -135,6 +151,7 @@ export default ({
         <div class="col span-2">
           <LabeledSelect
             v-model="value[bannerType].fontSize"
+            :disabled="isUiDisabled"
             :label="t('banner.bannerFontSize.label')"
             :options="uiBannerFontSizeOptions"
           />
@@ -142,10 +159,20 @@ export default ({
       </div>
       <div class="row mt-10">
         <div class="col span-6">
-          <ColorInput v-model="value[bannerType].color" :default-value="themeVars.bannerTextColor" :label="t('banner.textColor')" />
+          <ColorInput
+            v-model="value[bannerType].color"
+            :default-value="themeVars.bannerTextColor"
+            :label="t('banner.textColor')"
+            :mode="mode"
+          />
         </div>
         <div class="col span-6">
-          <ColorInput v-model="value[bannerType].background" :default-value="themeVars.bannerBgColor" :label="t('banner.background')" />
+          <ColorInput
+            v-model="value[bannerType].background"
+            :default-value="themeVars.bannerBgColor"
+            :label="t('banner.background')"
+            :mode="mode"
+          />
         </div>
       </div>
     </div>

--- a/components/form/BannerSettings.vue
+++ b/components/form/BannerSettings.vue
@@ -27,7 +27,7 @@ export default ({
 
   data() {
     const showAsDialog = !!this.value[this.bannerType]?.button || false;
-    const buttonText = this.value[this.bannerType]?.button || this.t('branding.uiBanner.showAsDialog.defaultButtonText');
+    const buttonText = this.value[this.bannerType]?.button || this.t('banner.showAsDialog.defaultButtonText');
 
     return {
       showAsDialog,
@@ -60,9 +60,9 @@ export default ({
     radioOptions() {
       const options = ['left', 'center', 'right'];
       const labels = [
-        this.t('branding.uiBanner.bannerAlignment.leftOption'),
-        this.t('branding.uiBanner.bannerAlignment.centerOption'),
-        this.t('branding.uiBanner.bannerAlignment.rightOption'),
+        this.t('banner.bannerAlignment.leftOption'),
+        this.t('banner.bannerAlignment.centerOption'),
+        this.t('banner.bannerAlignment.rightOption'),
       ];
 
       return { options, labels };
@@ -72,15 +72,15 @@ export default ({
       const options = [
         {
           style:  'fontWeight',
-          label:  this.t('branding.uiBanner.bannerDecoration.bannerBold')
+          label:  this.t('banner.bannerDecoration.bannerBold')
         },
         {
           style:  'fontStyle',
-          label:  this.t('branding.uiBanner.bannerDecoration.bannerItalic')
+          label:  this.t('banner.bannerDecoration.bannerItalic')
         },
         {
           style:  'textDecoration',
-          label:  this.t('branding.uiBanner.bannerDecoration.bannerUnderline')
+          label:  this.t('banner.bannerDecoration.bannerUnderline')
         }
       ];
 
@@ -95,24 +95,24 @@ export default ({
     <div class="col span-12">
       <div class="row">
         <div class="col span-6">
-          <LabeledInput v-model="value[bannerType].text" :label="t('branding.uiBanner.text')" />
+          <LabeledInput v-model="value[bannerType].text" :label="t('banner.text')" />
           <div v-if="bannerType === 'bannerConsent'" class="mt-10">
             <Checkbox
               v-model="showAsDialog"
               name="bannerDecoration"
               class="banner-decoration-checkbox"
               :mode="mode"
-              :label="t('branding.uiBanner.showAsDialog.label')"
-              :tooltip="t('branding.uiBanner.showAsDialog.tooltip')"
+              :label="t('banner.showAsDialog.label')"
+              :tooltip="t('banner.showAsDialog.tooltip')"
             />
-            <LabeledInput v-model="buttonText" :disabled="!showAsDialog" :label="t('branding.uiBanner.buttonText')" />
+            <LabeledInput v-model="buttonText" :disabled="!showAsDialog" :label="t('banner.buttonText')" />
           </div>
         </div>
         <div class="col span-2">
           <RadioGroup
             v-model="value[bannerType].textAlignment"
             name="bannerAlignment"
-            :label="t('branding.uiBanner.bannerAlignment.label')"
+            :label="t('banner.bannerAlignment.label')"
             :options="radioOptions.options"
             :labels="radioOptions.labels"
             :mode="mode"
@@ -120,7 +120,7 @@ export default ({
         </div>
         <div class="col span-2">
           <h3>
-            {{ t('branding.uiBanner.bannerDecoration.label') }}
+            {{ t('banner.bannerDecoration.label') }}
           </h3>
           <div v-for="o in textDecorationOptions" :key="o.style">
             <Checkbox
@@ -135,17 +135,17 @@ export default ({
         <div class="col span-2">
           <LabeledSelect
             v-model="value[bannerType].fontSize"
-            :label="t('branding.uiBanner.bannerFontSize.label')"
+            :label="t('banner.bannerFontSize.label')"
             :options="uiBannerFontSizeOptions"
           />
         </div>
       </div>
       <div class="row mt-10">
         <div class="col span-6">
-          <ColorInput v-model="value[bannerType].color" :default-value="themeVars.bannerTextColor" :label="t('branding.uiBanner.textColor')" />
+          <ColorInput v-model="value[bannerType].color" :default-value="themeVars.bannerTextColor" :label="t('banner.textColor')" />
         </div>
         <div class="col span-6">
-          <ColorInput v-model="value[bannerType].background" :default-value="themeVars.bannerBgColor" :label="t('branding.uiBanner.background')" />
+          <ColorInput v-model="value[bannerType].background" :default-value="themeVars.bannerBgColor" :label="t('banner.background')" />
         </div>
       </div>
     </div>

--- a/components/form/ColorInput.vue
+++ b/components/form/ColorInput.vue
@@ -1,4 +1,6 @@
 <script>
+import { _EDIT, _VIEW } from '@/config/query-params';
+
 export default {
   props: {
     value: {
@@ -22,9 +24,19 @@ export default {
     },
 
     mode: {
-      type:    String,
-      default: 'edit'
+      type: String,
+      validator(value) {
+        return [_EDIT, _VIEW].includes(value);
+      },
+      default: _EDIT,
     }
+  },
+
+  data() {
+    return {
+      viewMode: _VIEW,
+      editMode: _EDIT
+    };
   },
 
   computed: {
@@ -44,11 +56,17 @@ export default {
 </script>
 
 <template>
-  <div class="color-input" :class="{[mode]:mode}">
+  <div class="color-input" :class="{[mode]:mode, disabled: mode !== editMode}">
     <label class="text-label"><t v-if="labelKey" :k="labelKey" :raw="true" />{{ label }}</label>
     <div class="preview-container" @click.stop="$refs.input.click">
       <span :style="{'background-color': inputValue}" class="color-display">
-        <input ref="input" type="color" :value="inputValue" @input="$emit('input', $event.target.value)" />
+        <input
+          ref="input"
+          type="color"
+          :disabled="mode !== editMode"
+          :value="inputValue"
+          @input="$emit('input', $event.target.value)"
+        />
       </span>
       <span class="text-muted color-value">{{ inputValue }}</span>
     </div>
@@ -60,6 +78,27 @@ export default {
   border: 1px solid var(--border);
   border-radius: var(--border-radius);
   padding: 10px;
+
+  &.disabled, &.disabled .selected, &[disabled], &[disabled]:hover {
+    color: var(--input-disabled-text);
+    background-color: var(--input-disabled-bg);
+    outline-width: 0;
+    border-color: var(--input-disabled-border);
+    cursor: not-allowed;
+
+    label, span, div, input {
+      cursor: not-allowed !important;
+    }
+
+    label {
+      color: var(--input-disabled-label);
+      display: inline-block;
+      z-index: 1;
+    }
+    &::placeholder {
+        color: var(--input-disabled-placeholder);
+    }
+  }
 
   LABEL{
     display: block;

--- a/config/product/settings.js
+++ b/config/product/settings.js
@@ -71,10 +71,21 @@ export function init(store) {
     route:          { name: 'c-cluster-settings-brand' }
   });
 
+  virtualType({
+    ifHaveType:     MANAGEMENT.SETTING,
+    labelKey:       'banner.settingName',
+    name:           'banners',
+    namespaced:     false,
+    weight:         98,
+    icon:           'folder',
+    route:          { name: 'c-cluster-settings-banners' }
+  });
+
   basicType([
     'settings',
     'features',
-    'brand'
+    'brand',
+    'banners'
   ]);
 
   configureType(MANAGEMENT.SETTING, {

--- a/pages/c/_cluster/settings/banners.vue
+++ b/pages/c/_cluster/settings/banners.vue
@@ -174,7 +174,10 @@ export default {
 
       <template>
         <!-- Header Settings -->
-        <div class="row mt-20 mb-20">
+        <h2 class="mt-40 mb-40">
+          {{ t('banner.headerBanner') }}
+        </h2>
+        <div class="row mb-20">
           <div class="col span-6">
             <Checkbox
               :value="bannerVal.showHeader === 'true'"
@@ -191,6 +194,9 @@ export default {
         />
 
         <!-- Footer settings -->
+        <h2 class="mt-40 mb-40">
+          {{ t('banner.footerBanner') }}
+        </h2>
         <div class="row mt-40 mb-20">
           <div class="col span-6">
             <Checkbox
@@ -209,6 +215,9 @@ export default {
       </template>
 
       <!-- Consent settings -->
+      <h2 class="mt-40 mb-40">
+        {{ t('banner.loginScreenBanner') }}
+      </h2>
       <template>
         <div class="row mt-40 mb-20">
           <div class="col span-6">

--- a/pages/c/_cluster/settings/banners.vue
+++ b/pages/c/_cluster/settings/banners.vue
@@ -1,0 +1,204 @@
+<script>
+import isEmpty from 'lodash/isEmpty';
+
+import Checkbox from '@/components/form/Checkbox';
+import Loading from '@/components/Loading';
+import AsyncButton from '@/components/AsyncButton';
+import Banner from '@/components/Banner';
+import BannerSettings from '@/components/form/BannerSettings';
+import { allHash } from '@/utils/promise';
+import { MANAGEMENT } from '@/config/types';
+import { getVendor } from '@/config/private-label';
+import { SETTING } from '@/config/settings';
+import { clone } from '@/utils/object';
+import { _EDIT, _VIEW } from '@/config/query-params';
+
+const DEFAULT_BANNER_SETTING = {
+  bannerHeader: {
+    background:      null,
+    color:           null,
+    textAlignment:   'center',
+    fontWeight:      null,
+    fontStyle:       null,
+    fontSize:        '14px',
+    textDecoration:  null,
+    text:            null,
+  },
+  bannerFooter: {
+    background:      null,
+    color:           null,
+    textAlignment:   'center',
+    fontWeight:      null,
+    fontStyle:       null,
+    fontSize:        '14px',
+    textDecoration:  null,
+    text:            null
+  },
+  bannerConsent:  {
+    background:      null,
+    color:           null,
+    textAlignment:   'center',
+    fontWeight:      null,
+    fontStyle:       null,
+    fontSize:        '14px',
+    textDecoration:  null,
+    text:            null,
+    button:          null,
+  },
+  showHeader:   'false',
+  showFooter:   'false',
+  showConsent:  'false'
+};
+
+export default {
+  layout: 'authenticated',
+
+  components: {
+    Checkbox, Loading, AsyncButton, Banner, BannerSettings
+  },
+
+  async fetch() {
+    const hash = await allHash({ uiBannerSetting: this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.BANNERS }) });
+
+    Object.assign(this, hash);
+  },
+
+  data() {
+    return {
+      vendor: getVendor(),
+
+      uiBannerSetting: null,
+      bannerVal:       {},
+
+      errors: [],
+
+    };
+  },
+
+  computed: {
+    mode() {
+      const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
+
+      return schema?.resourceMethods?.includes('PUT') ? _EDIT : _VIEW;
+    }
+  },
+
+  watch: {
+    uiBannerSetting(neu) {
+      if (neu?.value && neu.value !== '') {
+        try {
+          const parsedBanner = JSON.parse(neu.value);
+
+          this.bannerVal = this.checkOrUpdateLegacyUIBannerSetting(parsedBanner);
+        } catch {}
+      }
+    }
+  },
+
+  methods: {
+    checkOrUpdateLegacyUIBannerSetting(parsedBanner) {
+      const {
+        bannerHeader, bannerFooter, bannerConsent, banner
+      } = parsedBanner;
+
+      if (isEmpty(bannerHeader) && isEmpty(bannerFooter) && isEmpty(bannerConsent)) {
+        let neu = DEFAULT_BANNER_SETTING;
+
+        if (!isEmpty(banner)) {
+          const cloned = clone(( banner ?? {} ));
+
+          if (cloned?.textColor) {
+            cloned['color'] = cloned.textColor;
+            delete cloned.textColor;
+          }
+
+          neu = {
+            bannerHeader:  { ...cloned },
+            bannerFooter:  { ...cloned },
+            bannerConsent: { ...DEFAULT_BANNER_SETTING.bannerConsent },
+            showHeader:    parsedBanner?.showHeader === 'true' ? 'true' : 'false',
+            showFooter:    parsedBanner?.showFooter === 'true' ? 'true' : 'false',
+            showConsent:   parsedBanner?.showConsent === 'true' ? 'true' : 'false'
+          };
+        }
+
+        return neu;
+      }
+
+      // If user has existing banners, they may not have consent banner - use default value
+      if (isEmpty(bannerConsent)) {
+        parsedBanner.bannerConsent = { ...DEFAULT_BANNER_SETTING.bannerConsent };
+      }
+
+      return parsedBanner;
+    },
+
+    async save(btnCB) {
+      this.uiBannerSetting.value = JSON.stringify(this.bannerVal);
+
+      this.errors = [];
+
+      try {
+        await Promise.all([
+          this.uiBannerSetting.save()
+        ]);
+        btnCB(true);
+      } catch (err) {
+        this.errors.push(err);
+        btnCB(false);
+      }
+    },
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <h1 class="mb-20">
+      {{ t('banner.label') }}
+    </h1>
+    <div>
+      <label class="text-label">
+        {{ t(`advancedSettings.descriptions.${ 'ui-banners' }`, {}, true) }}
+      </label>
+
+      <template>
+        <!-- Header Settings -->
+        <div class="row mt-20 mb-20">
+          <div class="col span-6">
+            <Checkbox :value="bannerVal.showHeader === 'true'" :label="t('banner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
+          </div>
+        </div>
+        <BannerSettings v-if="bannerVal.showHeader === 'true'" v-model="bannerVal" banner-type="bannerHeader" :mode="mode" />
+
+        <!-- Footer settings -->
+        <div class="row mt-20 mb-20">
+          <div class="col span-6">
+            <Checkbox :value="bannerVal.showFooter === 'true'" :label="t('banner.showFooter')" :mode="mode" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
+          </div>
+        </div>
+        <BannerSettings v-if="bannerVal.showFooter === 'true'" v-model="bannerVal" banner-type="bannerFooter" :mode="mode" />
+      </template>
+
+      <!-- Consent settings -->
+      <template>
+        <div class="row mt-20 mb-20">
+          <div class="col span-6">
+            <Checkbox :value="bannerVal.showConsent === 'true'" :label="t('banner.showConsent')" :mode="mode" @input="e => $set(bannerVal, 'showConsent', e.toString())" />
+          </div>
+        </div>
+        <BannerSettings v-if="bannerVal.showConsent === 'true'" v-model="bannerVal" banner-type="bannerConsent" :mode="mode" />
+      </template>
+    </div>
+    <template v-for="err in errors">
+      <Banner :key="err" color="error" :label="err" />
+    </template>
+    <div>
+      <AsyncButton class="pull-right mt-20" mode="apply" @click="save" />
+    </div>
+  </div>
+</template>
+
+<style scoped lang='scss'>
+</style>

--- a/pages/c/_cluster/settings/banners.vue
+++ b/pages/c/_cluster/settings/banners.vue
@@ -80,6 +80,15 @@ export default {
       const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
 
       return schema?.resourceMethods?.includes('PUT') ? _EDIT : _VIEW;
+    },
+    headerMode() {
+      return this.bannerVal?.showHeader === 'true' ? _EDIT : _VIEW;
+    },
+    footerMode() {
+      return this.bannerVal?.showFooter === 'true' ? _EDIT : _VIEW;
+    },
+    consentMode() {
+      return this.bannerVal?.showConsent === 'true' ? _EDIT : _VIEW;
     }
   },
 
@@ -167,32 +176,55 @@ export default {
         <!-- Header Settings -->
         <div class="row mt-20 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showHeader === 'true'" :label="t('banner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
+            <Checkbox
+              :value="bannerVal.showHeader === 'true'"
+              :label="t('banner.showHeader')"
+              :mode="mode"
+              @input="e=>$set(bannerVal, 'showHeader', e.toString())"
+            />
           </div>
         </div>
-        <div style="position: relative">
-          <!-- <BannerSettings v-if="bannerVal.showHeader === 'true'" v-model="bannerVal" banner-type="bannerHeader" :mode="mode" /> -->
-          <div class="overlay" />
-          <BannerSettings v-model="bannerVal" banner-type="bannerHeader" :mode="mode" />
-        </div>
+        <BannerSettings
+          v-model="bannerVal"
+          banner-type="bannerHeader"
+          :mode="headerMode"
+        />
 
         <!-- Footer settings -->
-        <div class="row mt-20 mb-20">
+        <div class="row mt-40 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showFooter === 'true'" :label="t('banner.showFooter')" :mode="mode" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
+            <Checkbox
+              :value="bannerVal.showFooter === 'true'"
+              :label="t('banner.showFooter')"
+              :mode="mode"
+              @input="e=>$set(bannerVal, 'showFooter', e.toString())"
+            />
           </div>
         </div>
-        <BannerSettings v-if="bannerVal.showFooter === 'true'" v-model="bannerVal" banner-type="bannerFooter" :mode="mode" />
+        <BannerSettings
+          v-model="bannerVal"
+          banner-type="bannerFooter"
+          :mode="footerMode"
+        />
       </template>
 
       <!-- Consent settings -->
       <template>
-        <div class="row mt-20 mb-20">
+        <div class="row mt-40 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showConsent === 'true'" :label="t('banner.showConsent')" :mode="mode" @input="e => $set(bannerVal, 'showConsent', e.toString())" />
+            <Checkbox
+              :value="bannerVal.showConsent === 'true'"
+              :label="t('banner.showConsent')"
+              :mode="mode"
+              @input="e => $set(bannerVal, 'showConsent', e.toString())"
+            />
           </div>
         </div>
-        <BannerSettings v-if="bannerVal.showConsent === 'true'" v-model="bannerVal" banner-type="bannerConsent" :mode="mode" />
+        <BannerSettings
+          v-model="bannerVal"
+          banner-type="bannerConsent"
+          :mode="consentMode"
+        />
       </template>
     </div>
     <template v-for="err in errors">

--- a/pages/c/_cluster/settings/banners.vue
+++ b/pages/c/_cluster/settings/banners.vue
@@ -170,7 +170,11 @@ export default {
             <Checkbox :value="bannerVal.showHeader === 'true'" :label="t('banner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
           </div>
         </div>
-        <BannerSettings v-if="bannerVal.showHeader === 'true'" v-model="bannerVal" banner-type="bannerHeader" :mode="mode" />
+        <div style="position: relative">
+          <!-- <BannerSettings v-if="bannerVal.showHeader === 'true'" v-model="bannerVal" banner-type="bannerHeader" :mode="mode" /> -->
+          <div class="overlay" />
+          <BannerSettings v-model="bannerVal" banner-type="bannerHeader" :mode="mode" />
+        </div>
 
         <!-- Footer settings -->
         <div class="row mt-20 mb-20">
@@ -201,4 +205,13 @@ export default {
 </template>
 
 <style scoped lang='scss'>
+.overlay {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--overlay-bg);
+  z-index: 1;
+}
 </style>

--- a/pages/c/_cluster/settings/brand.vue
+++ b/pages/c/_cluster/settings/brand.vue
@@ -1,6 +1,4 @@
 <script>
-import isEmpty from 'lodash/isEmpty';
-
 import LabeledInput from '@/components/form/LabeledInput';
 import ColorInput from '@/components/form/ColorInput';
 
@@ -10,66 +8,26 @@ import SimpleBox from '@/components/SimpleBox';
 import Loading from '@/components/Loading';
 import AsyncButton from '@/components/AsyncButton';
 import Banner from '@/components/Banner';
-import BannerSettings from '@/components/form/BannerSettings';
 import { allHash } from '@/utils/promise';
 import { MANAGEMENT } from '@/config/types';
 import { getVendor, setVendor } from '@/config/private-label';
 import { SETTING, fetchOrCreateSetting } from '@/config/settings';
-import { clone } from '@/utils/object';
 import { _EDIT, _VIEW } from '@/config/query-params';
 
 const Color = require('color');
 const parse = require('url-parse');
 
-const DEFAULT_BANNER_SETTING = {
-  bannerHeader: {
-    background:      null,
-    color:           null,
-    textAlignment:   'center',
-    fontWeight:      null,
-    fontStyle:       null,
-    fontSize:        '14px',
-    textDecoration:  null,
-    text:            null,
-  },
-  bannerFooter: {
-    background:      null,
-    color:           null,
-    textAlignment:   'center',
-    fontWeight:      null,
-    fontStyle:       null,
-    fontSize:        '14px',
-    textDecoration:  null,
-    text:            null
-  },
-  bannerConsent:  {
-    background:      null,
-    color:           null,
-    textAlignment:   'center',
-    fontWeight:      null,
-    fontStyle:       null,
-    fontSize:        '14px',
-    textDecoration:  null,
-    text:            null,
-    button:          null,
-  },
-  showHeader:   'false',
-  showFooter:   'false',
-  showConsent:  'false'
-};
-
 export default {
   layout: 'authenticated',
 
   components: {
-    LabeledInput, Checkbox, FileSelector, Loading, SimpleBox, AsyncButton, Banner, BannerSettings, ColorInput
+    LabeledInput, Checkbox, FileSelector, Loading, SimpleBox, AsyncButton, Banner, ColorInput
   },
 
   async fetch() {
     const hash = await allHash({
       uiPLSetting:            this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.PL }),
       uiIssuesSetting:        this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.ISSUES }),
-      uiBannerSetting:        this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.BANNERS }),
       uiLogoDarkSetting:      fetchOrCreateSetting(this.$store, SETTING.LOGO_DARK, ''),
       uiLogoLightSetting:     fetchOrCreateSetting(this.$store, SETTING.LOGO_LIGHT, ''),
       uiColorSetting:         fetchOrCreateSetting(this.$store, SETTING.PRIMARY_COLOR, ''),
@@ -109,9 +67,6 @@ export default {
 
       uiIssuesSetting: {},
 
-      uiBannerSetting: null,
-      bannerVal:       {},
-
       uiLogoDarkSetting:  {},
       uiLogoDark:         '',
       uiLogoLightSetting: {},
@@ -140,18 +95,6 @@ export default {
     }
   },
 
-  watch: {
-    uiBannerSetting(neu) {
-      if (neu?.value && neu.value !== '') {
-        try {
-          const parsedBanner = JSON.parse(neu.value);
-
-          this.bannerVal = this.checkOrUpdateLegacyUIBannerSetting(parsedBanner);
-        } catch {}
-      }
-    }
-  },
-
   mounted() {
     let uiColor = getComputedStyle(document.body).getPropertyValue('--primary');
     let uiLinkColor = getComputedStyle(document.body).getPropertyValue('--link');
@@ -168,43 +111,6 @@ export default {
   },
 
   methods: {
-    checkOrUpdateLegacyUIBannerSetting(parsedBanner) {
-      const {
-        bannerHeader, bannerFooter, bannerConsent, banner
-      } = parsedBanner;
-
-      if (isEmpty(bannerHeader) && isEmpty(bannerFooter) && isEmpty(bannerConsent)) {
-        let neu = DEFAULT_BANNER_SETTING;
-
-        if (!isEmpty(banner)) {
-          const cloned = clone(( banner ?? {} ));
-
-          if (cloned?.textColor) {
-            cloned['color'] = cloned.textColor;
-            delete cloned.textColor;
-          }
-
-          neu = {
-            bannerHeader:  { ...cloned },
-            bannerFooter:  { ...cloned },
-            bannerConsent: { ...DEFAULT_BANNER_SETTING.bannerConsent },
-            showHeader:    parsedBanner?.showHeader === 'true' ? 'true' : 'false',
-            showFooter:    parsedBanner?.showFooter === 'true' ? 'true' : 'false',
-            showConsent:   parsedBanner?.showConsent === 'true' ? 'true' : 'false'
-          };
-        }
-
-        return neu;
-      }
-
-      // If user has existing banners, they may not have consent banner - use default value
-      if (isEmpty(bannerConsent)) {
-        parsedBanner.bannerConsent = { ...DEFAULT_BANNER_SETTING.bannerConsent };
-      }
-
-      return parsedBanner;
-    },
-
     updateLogo(img, key) {
       this[key] = img;
     },
@@ -232,8 +138,6 @@ export default {
       }
       this.uiPLSetting.value = this.uiPLSetting.value.replaceAll(/[\<>&=#()"]/gm, '');
 
-      this.uiBannerSetting.value = JSON.stringify(this.bannerVal);
-
       if (this.customizeLogo) {
         this.uiLogoLightSetting.value = this.uiLogoLight;
         this.uiLogoDarkSetting.value = this.uiLogoDark;
@@ -260,7 +164,6 @@ export default {
         await Promise.all([
           this.uiPLSetting.save(),
           this.uiIssuesSetting.save(),
-          this.uiBannerSetting.save(),
           this.uiLogoDarkSetting.save(),
           this.uiLogoLightSetting.save(),
           this.uiColorSetting.save(),
@@ -393,41 +296,6 @@ export default {
           </a>
         </span>
       </div>
-
-      <h3 class="mb-5 pb-5 mt-40">
-        {{ t('banner.label') }}
-      </h3>
-      <label class="text-label">
-        {{ t(`advancedSettings.descriptions.${ 'ui-banners' }`, {}, true) }}
-      </label>
-
-      <template>
-        <!-- Header Settings -->
-        <div class="row mt-20 mb-20">
-          <div class="col span-6">
-            <Checkbox :value="bannerVal.showHeader === 'true'" :label="t('banner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
-          </div>
-        </div>
-        <BannerSettings v-if="bannerVal.showHeader === 'true'" v-model="bannerVal" banner-type="bannerHeader" :mode="mode" />
-
-        <!-- Footer settings -->
-        <div class="row mt-20 mb-20">
-          <div class="col span-6">
-            <Checkbox :value="bannerVal.showFooter === 'true'" :label="t('banner.showFooter')" :mode="mode" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
-          </div>
-        </div>
-        <BannerSettings v-if="bannerVal.showFooter === 'true'" v-model="bannerVal" banner-type="bannerFooter" :mode="mode" />
-      </template>
-
-      <!-- Consent settings -->
-      <template>
-        <div class="row mt-20 mb-20">
-          <div class="col span-6">
-            <Checkbox :value="bannerVal.showConsent === 'true'" :label="t('banner.showConsent')" :mode="mode" @input="e => $set(bannerVal, 'showConsent', e.toString())" />
-          </div>
-        </div>
-        <BannerSettings v-if="bannerVal.showConsent === 'true'" v-model="bannerVal" banner-type="bannerConsent" :mode="mode" />
-      </template>
     </div>
     <template v-for="err in errors">
       <Banner :key="err" color="error" :label="err" />

--- a/pages/c/_cluster/settings/brand.vue
+++ b/pages/c/_cluster/settings/brand.vue
@@ -395,7 +395,7 @@ export default {
       </div>
 
       <h3 class="mb-5 pb-5 mt-40">
-        {{ t('branding.uiBanner.label') }}
+        {{ t('banner.label') }}
       </h3>
       <label class="text-label">
         {{ t(`advancedSettings.descriptions.${ 'ui-banners' }`, {}, true) }}
@@ -405,7 +405,7 @@ export default {
         <!-- Header Settings -->
         <div class="row mt-20 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showHeader === 'true'" :label="t('branding.uiBanner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
+            <Checkbox :value="bannerVal.showHeader === 'true'" :label="t('banner.showHeader')" :mode="mode" @input="e=>$set(bannerVal, 'showHeader', e.toString())" />
           </div>
         </div>
         <BannerSettings v-if="bannerVal.showHeader === 'true'" v-model="bannerVal" banner-type="bannerHeader" :mode="mode" />
@@ -413,7 +413,7 @@ export default {
         <!-- Footer settings -->
         <div class="row mt-20 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showFooter === 'true'" :label="t('branding.uiBanner.showFooter')" :mode="mode" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
+            <Checkbox :value="bannerVal.showFooter === 'true'" :label="t('banner.showFooter')" :mode="mode" @input="e=>$set(bannerVal, 'showFooter', e.toString())" />
           </div>
         </div>
         <BannerSettings v-if="bannerVal.showFooter === 'true'" v-model="bannerVal" banner-type="bannerFooter" :mode="mode" />
@@ -423,7 +423,7 @@ export default {
       <template>
         <div class="row mt-20 mb-20">
           <div class="col span-6">
-            <Checkbox :value="bannerVal.showConsent === 'true'" :label="t('branding.uiBanner.showConsent')" :mode="mode" @input="e => $set(bannerVal, 'showConsent', e.toString())" />
+            <Checkbox :value="bannerVal.showConsent === 'true'" :label="t('banner.showConsent')" :mode="mode" @input="e => $set(bannerVal, 'showConsent', e.toString())" />
           </div>
         </div>
         <BannerSettings v-if="bannerVal.showConsent === 'true'" v-model="bannerVal" banner-type="bannerConsent" :mode="mode" />


### PR DESCRIPTION
Addresses Github issue: [#4969](https://github.com/rancher/dashboard/issues/4969)
Addresses Zube issue: [#4991](https://zube.io/rancher/dashboard-ui/c/4991)

- Created a section for Banner config on the "Global Settings" area
- Removed any references of Banner config from Branding
- BannerSettings now displays each section by default
- Fixed BannerSettings to disable UI elements when checkbox in section is not selected

**Dark Mode**
<img width="1665" alt="Screenshot 2022-02-02 at 10 05 07" src="https://user-images.githubusercontent.com/97888974/152133198-7a913a83-e976-497b-815b-900a53ea7408.png">


**Light Mode**
<img width="1665" alt="Screenshot 2022-02-02 at 10 04 33" src="https://user-images.githubusercontent.com/97888974/152133219-bf31cf72-7a10-4b2d-9109-8fef09a03433.png">


@lvuch any comments/changes regarding the visual outcome?