### PR TITLE
Bug: Cannot select clusters in the Cluster Management page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -93,7 +93,8 @@ nav:
     options: KubeConfig Options
   import: Import YAML
   home: Home
-  shell: Kubectl Shell {key}
+  shell: Kubectl Shell
+  shellShortcut: Kubectl Shell {key}
   support: |-
     {hasSupport, select,
       true {Support}

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -93,7 +93,8 @@ nav:
     options: KubeConfig 选项
   import: 导入 YAML
   home: 首页
-  shell: Kubectl Shell {key}
+  shell: Kubectl Shell
+  shellShortcut: Kubectl Shell {key}
   support: |-
     {hasSupport, select,
       true {支持}

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -266,7 +266,7 @@ export default {
 
         <button
           v-if="showKubeShell"
-          v-tooltip="t('nav.shell', {key: shellShortcut})"
+          v-tooltip="t('nav.shellShortcut', {key: shellShortcut})"
           v-shortkey="{windows: ['ctrl', '`'], mac: ['meta', '`']}"
           :disabled="!shellEnabled"
           type="button"


### PR DESCRIPTION
Addresses Github issue: [#4982](https://github.com/rancher/dashboard/issues/4982)
Addresses Zube issue: [#5004](https://zube.io/rancher/dashboard-ui/c/5004)

- Fixes issue with nav.shell being used as string and throwing error on console when no {key} is present