### PR TITLE
Global, Cluster and Project Role Detail page detail sections show missing info

### DIFF
--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -36,7 +36,7 @@ export default {
       return [
         ...(this.moreDetails || []),
         ...(this.value?.details || []),
-      ].filter(x => !!`${ x.content }` && x.content !== undefined);
+      ].filter(x => !!`${ x.content }` && x.content !== undefined && x.content !== null);
     },
 
     labels() {

--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -36,7 +36,7 @@ export default {
       return [
         ...(this.moreDetails || []),
         ...(this.value?.details || []),
-      ].filter(x => !!`${ x.content }`);
+      ].filter(x => !!`${ x.content }` && x.content !== undefined);
     },
 
     labels() {

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -328,7 +328,7 @@ export default {
               {{ parent.displayName }}:
             </nuxt-link>
             <span v-else>{{ parent.displayName }}:</span>
-            <span v-if="value.detailPageHeaderActionOverride && value.detailPageHeaderActionOverride(realMode)">1111{{ value.detailPageHeaderActionOverride(realMode) }}</span>
+            <span v-if="value.detailPageHeaderActionOverride && value.detailPageHeaderActionOverride(realMode)">{{ value.detailPageHeaderActionOverride(realMode) }}</span>
             <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtypeString" :name="value.nameDisplay" />
             <BadgeState v-if="!isCreate && parent.showState" class="masthead-state" :value="value" />
           </h1>

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -100,6 +100,10 @@ export default {
       return null;
     },
 
+    resourceSubtypeString() {
+      return this.resourceSubtype && this.resourceSubtype.length ? `${ this.resourceSubtype } -` : this.resourceSubtype;
+    },
+
     namespaceLocation() {
       if (!this.isNamespace) {
         return {
@@ -324,8 +328,8 @@ export default {
               {{ parent.displayName }}:
             </nuxt-link>
             <span v-else>{{ parent.displayName }}:</span>
-            <span v-if="value.detailPageHeaderActionOverride && value.detailPageHeaderActionOverride(realMode)">{{ value.detailPageHeaderActionOverride(realMode) }}</span>
-            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtype" :name="value.nameDisplay" />
+            <span v-if="value.detailPageHeaderActionOverride && value.detailPageHeaderActionOverride(realMode)">1111{{ value.detailPageHeaderActionOverride(realMode) }}</span>
+            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtypeString" :name="value.nameDisplay" />
             <BadgeState v-if="!isCreate && parent.showState" class="masthead-state" :value="value" />
           </h1>
         </div>

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -101,7 +101,7 @@ export default {
     },
 
     resourceSubtypeString() {
-      return this.resourceSubtype && this.resourceSubtype.length ? `${ this.resourceSubtype } -` : this.resourceSubtype;
+      return this.resourceSubtype?.length ? `${ this.resourceSubtype } -` : this.resourceSubtype;
     },
 
     namespaceLocation() {

--- a/models/management.cattle.io.globalrole.js
+++ b/models/management.cattle.io.globalrole.js
@@ -4,7 +4,7 @@ import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@/models/management.cattle.io
 import { uniq } from '@/utils/array';
 import Vue from 'vue';
 import { get } from '@/utils/object';
-import HybridModel from '@/plugins/steve/hybrid-class';
+import SteveModel from '@/plugins/steve/steve-class';
 import Role from './rbac.authorization.k8s.io.role';
 
 const BASE = 'user-base';
@@ -14,7 +14,7 @@ const SPECIAL = [BASE, ADMIN, USER];
 
 const GLOBAL = SUBTYPE_MAPPING.GLOBAL.key;
 
-export default class GlobalRole extends HybridModel {
+export default class GlobalRole extends SteveModel {
   get customValidationRules() {
     return Role.customValidationRules();
   }

--- a/models/management.cattle.io.roletemplate.js
+++ b/models/management.cattle.io.roletemplate.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { get } from '@/utils/object';
 import { DESCRIPTION } from '@/config/labels-annotations';
 import { NORMAN } from '@/config/types';
-import HybridModel from '@/plugins/steve/hybrid-class';
+import SteveModel from '@/plugins/steve/steve-class';
 import Role from './rbac.authorization.k8s.io.role';
 
 export const CATTLE_API_GROUP = '.cattle.io';
@@ -226,7 +226,7 @@ const RESOURCES = [
   'WorkloadEntries'
 ];
 
-export default class RoleTemplate extends HybridModel {
+export default class RoleTemplate extends SteveModel {
   get customValidationRules() {
     return Role.customValidationRules();
   }


### PR DESCRIPTION
Addresses Github issue: [#4594](https://github.com/rancher/dashboard/issues/4594)
Addresses Zube issue: [#4612](https://zube.io/rancher/dashboard-ui/c/4612)

- Fix missing/empty fields being shown on the top part of the Global, Cluster and Project Role Detail page detail sections
- Add hifen to separate resourceSubtype from name for the title shown on the top part of the Global, Cluster and Project Role Detail page detail sections

**Before**:
<img width="1579" alt="Screenshot 2022-01-26 at 17 46 49" src="https://user-images.githubusercontent.com/97888974/151218321-27b7f0e1-455e-4143-924b-4b09df857feb.png">
<img width="1579" alt="Screenshot 2022-01-26 at 17 46 57" src="https://user-images.githubusercontent.com/97888974/151218330-ad8fccff-ae50-4dc6-98ad-6a59cf23e904.png">

**After**:
<img width="1579" alt="Screenshot 2022-01-26 at 17 47 35" src="https://user-images.githubusercontent.com/97888974/151218450-b81ce891-3d09-4351-bc89-c06b01c58d9d.png">
<img width="1579" alt="Screenshot 2022-01-26 at 17 47 44" src="https://user-images.githubusercontent.com/97888974/151218460-67f13a2d-01ad-429e-814c-8c523f65aa66.png">

