### PR TITLE
Table column headers aren't vertically aligned

### DIFF
--- a/components/SortableTable/THead.vue
+++ b/components/SortableTable/THead.vue
@@ -152,8 +152,7 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-   .sortable > SPAN {
-    display: inline-block;
+  .sortable > SPAN {
     white-space: nowrap;
     &:hover,
     &:active {
@@ -176,6 +175,11 @@ export default {
     font-weight: normal;
     border: 0;
     color: var(--body-text);
+
+    &:not(.sortable) > SPAN {
+      display: block;
+      margin-bottom: 2px;
+    }
 
     & A {
       color: var(--body-text);


### PR DESCRIPTION
Addresses Github issue: [#4629](https://github.com/rancher/dashboard/issues/4629)
Addresses Zube issue: [#4647](https://zube.io/rancher/dashboard-ui/c/4647)

- Fixes vertical misalignment of table headers

**Result**
<img width="1868" alt="Screenshot 2022-01-27 at 14 15 08" src="https://user-images.githubusercontent.com/97888974/151377127-f2745742-9293-46b3-85dc-30916c410e8d.png">

<img width="1868" alt="Screenshot 2022-01-27 at 14 14 58" src="https://user-images.githubusercontent.com/97888974/151377107-6f3da8a4-8f39-4a3b-b482-4131347c6b31.png">

