### PR TITLE
Switch isYamlCreatable action for masthead component

### DIFF
--- a/components/ResourceList/Masthead.vue
+++ b/components/ResourceList/Masthead.vue
@@ -98,7 +98,7 @@ export default {
         return this.isYamlCreatable;
       }
 
-      return this.schema && this._isCreatable && this.$store.getters['type-map/optionsFor'](this.resource).canEditYaml;
+      return this.schema && this._isCreatable && this.$store.getters['type-map/optionsFor'](this.resource).canYaml;
     },
 
     _isCreatable() {


### PR DESCRIPTION
Reference rancher/dashboard#4995

**Issue**
The `Create from Yaml` button in the Masthead component does not show on certain resources (tested with Network Policies) and any CRDs.

**Fix**
Switch which action the Masthead is using to determine if it should be shown.

![createfromyaml](https://user-images.githubusercontent.com/40806497/151390367-ed507e38-612e-47ff-8c15-8dc45e06fce6.png)


With [this PR](https://github.com/rancher/dashboard/pull/4481) we changed the action to look for any `blocked-PUT` permissions on any given resource, but this should only be determined when _editing_ a config with yaml, not creating.


This change will not effect the original issue of disallowing a user from editing certain resources.