### PR TITLE
Move `Cluster Members` list out of RBAC

### DIFF
--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -56,6 +56,7 @@ export function init(store) {
     'projects-namespaces',
     'namespaces',
     NODE,
+    VIRTUAL_TYPES.CLUSTER_MEMBERS,
   ], 'cluster');
   basicType([
     SERVICE,
@@ -79,15 +80,11 @@ export function init(store) {
     WORKLOAD_TYPES.CRON_JOB,
     POD,
   ], 'workload');
-  basicType([
-    'cluster-members',
-  ], 'rbac');
 
   weightGroup('cluster', 99, true);
   weightGroup('workload', 98, true);
   weightGroup('serviceDiscovery', 96, true);
   weightGroup('storage', 95, true);
-  weightGroup('rbac', 94, true);
   weightType(POD, -1, true);
 
   for (const key in WORKLOAD_TYPES) {
@@ -224,11 +221,11 @@ export function init(store) {
 
   virtualType({
     label:       store.getters['i18n/t']('members.clusterMembers'),
-    group:      'rbac',
+    group:      'cluster',
     namespaced:  false,
     name:        VIRTUAL_TYPES.CLUSTER_MEMBERS,
     icon:       'globe',
-    weight:      100,
+    weight:      -1,
     route:       { name: 'c-cluster-product-members' },
     exact:       true,
     ifHaveType:  {


### PR DESCRIPTION
Addresses Github issue: [#4985](https://github.com/rancher/dashboard/issues/4985)
Addresses Zube issue: [#5007](https://zube.io/rancher/dashboard-ui/c/5007)

- Move 'cluster members' config from 'rbac' tab to 'Cluster' tab

**Preview**
<img width="1623" alt="Screenshot 2022-01-28 at 15 59 03" src="https://user-images.githubusercontent.com/97888974/151580125-7f799098-d007-4507-b9bd-76c9bf75a0de.png">

