### PR TITLE
Add namespace filter to monitoring and logging products

### DIFF
--- a/config/product/logging.js
+++ b/config/product/logging.js
@@ -17,9 +17,10 @@ export function init(store) {
   } = DSL(store, NAME);
 
   product({
-    ifHaveGroup: /^(.*\.)?logging\.banzaicloud\.io$/,
-    icon:        'logging',
-    weight:      89,
+    ifHaveGroup:         /^(.*\.)?logging\.banzaicloud\.io$/,
+    icon:                'logging',
+    showNamespaceFilter: true,
+    weight:              89,
   });
 
   basicType([

--- a/config/product/monitoring.js
+++ b/config/product/monitoring.js
@@ -32,9 +32,10 @@ export function init(store) {
   } = MONITORING;
 
   product({
-    ifHave:     IF_HAVE.V2_MONITORING, // possible RBAC issue here if mon turned on but user doesn't have view/read roles on pod monitors
-    icon:       'monitoring',
-    weight:     90,
+    ifHave:              IF_HAVE.V2_MONITORING, // possible RBAC issue here if mon turned on but user doesn't have view/read roles on pod monitors
+    icon:                'monitoring',
+    showNamespaceFilter: true,
+    weight:              90,
   });
 
   virtualType({


### PR DESCRIPTION
Reference #4998 

Adding the namespace filter to the monitoring and logging products.

Monitoring:
![monitoring](https://user-images.githubusercontent.com/40806497/151588413-093ff1a8-9985-4c36-b9e9-123b01430fe8.png)

Logging:
![logging](https://user-images.githubusercontent.com/40806497/151588472-7e9f9375-9768-4d94-bd40-96bd6679d081.png)

