### PR TITLE
Use Ember's in-house JS expression evaluation logic for hyphenated variables

### DIFF
--- a/components/Questions/index.vue
+++ b/components/Questions/index.vue
@@ -63,58 +63,6 @@ export function schemaToQuestions(fields) {
   return out;
 }
 
-function evalExpr(expr, values) {
-  try {
-    const out = Jexl.evalSync(expr, values);
-
-    // console.log('Eval', expr, '=> ', out);
-
-    return out;
-  } catch (err) {
-    console.error('Error evaluating expression:', expr, values); // eslint-disable-line no-console
-
-    return true;
-  }
-}
-
-function shouldShow(q, values) {
-  let expr = q.if;
-
-  if ( expr === undefined && q.show_if !== undefined ) {
-    expr = migrate(q.show_if);
-  }
-
-  if ( expr ) {
-    const shown = !!evalExpr(expr, values);
-
-    return shown;
-  }
-
-  return true;
-}
-
-function shouldShowSub(q, values) {
-  // Sigh, both singular and plural are used in the wild...
-  let expr = ( q.subquestions_if === undefined ? q.subquestion_if : q.subquestions_if);
-  const old = ( q.show_subquestions_if === undefined ? q.show_subquestion_if : q.show_subquestions_if);
-
-  if ( !expr && old !== undefined ) {
-    if ( old === false || old === 'false' ) {
-      expr = `!${ q.variable }`;
-    } else if ( old === true || old === 'true' ) {
-      expr = `!!${ q.variable }`;
-    } else {
-      expr = `${ q.variable } == "${ old }"`;
-    }
-  }
-
-  if ( expr ) {
-    return evalExpr(expr, values);
-  }
-
-  return true;
-}
-
 function migrate(expr) {
   let out;
 
@@ -229,6 +177,7 @@ export default {
 
     shownQuestions() {
       const values = this.value;
+      const vm = this;
 
       if ( this.valueGeneration < 0 ) {
         // Pointless condition to get this to depend on generation and recompute
@@ -248,7 +197,7 @@ export default {
       return out;
 
       function addQuestion(q, depth = 1, parentGroup) {
-        if ( !shouldShow(q, values) ) {
+        if ( !vm.shouldShow(q, values) ) {
           return;
         }
 
@@ -257,7 +206,7 @@ export default {
 
         out.push(q);
 
-        if ( q.subquestions?.length && shouldShowSub(q, values) ) {
+        if ( q.subquestions?.length && vm.shouldShowSub(q, values) ) {
           for ( const sub of q.subquestions ) {
             addQuestion(sub, depth + 1, q.group);
           }
@@ -325,6 +274,149 @@ export default {
       if (this.emit) {
         this.$emit('updated');
       }
+    },
+    evalExpr(expr, values, question, allQuestions) {
+      try {
+        const out = Jexl.evalSync(expr, values);
+
+        // console.log('Eval', expr, '=> ', out);
+
+        // If the variable contains a hyphen, check if it evaluates to true
+        // according to the evaluation logic used in the old UI.
+        // This helps users avoid manual work to migrate from legacy apps.
+        if (!out && expr.includes('-')) {
+          const res = this.evaluate(question, allQuestions);
+
+          return res;
+        }
+
+        return out;
+      } catch (err) {
+        console.error('Error evaluating expression:', expr, values); // eslint-disable-line no-console
+
+        return true;
+      }
+    },
+    evaluate(question, allQuestions) {
+      if ( !question.show_if ) {
+        return true;
+      }
+      const and = question.show_if.split('&&');
+      const or = question.show_if.split('||');
+
+      let result;
+
+      if ( get(or, 'length') > 1 ) {
+        result = or.some(showIf => this.calExpression(showIf, allQuestions));
+      } else {
+        result = and.every(showIf => this.calExpression(showIf, allQuestions));
+      }
+
+      return result;
+    },
+    calExpression(showIf, allQuestions) {
+      if ( showIf.includes('!=')) {
+        return this.isNotEqual(showIf, allQuestions);
+      } else {
+        return this.isEqual(showIf, allQuestions);
+      }
+    },
+    isEqual(showIf, allQuestions) {
+      showIf = showIf.trim();
+      const variables = this.getVariables(showIf, '=');
+
+      if ( variables ) {
+        const left = this.stringifyAnswer(this.getAnswer(variables.left, allQuestions));
+        const right = this.stringifyAnswer(variables.right);
+
+        return left === right;
+      }
+
+      return false;
+    },
+    isNotEqual(showIf, allQuestions) {
+      showIf = showIf.trim();
+      const variables = this.getVariables(showIf, '!=');
+
+      if ( variables ) {
+        const left = this.stringifyAnswer(this.getAnswer(variables.left, allQuestions));
+        const right = this.stringifyAnswer(variables.right);
+
+        return left !== right;
+      }
+
+      return false;
+    },
+    getVariables(showIf, operator) {
+      if ( showIf.includes(operator)) {
+        const array = showIf.split(operator);
+
+        if ( array.length === 2 ) {
+          return {
+            left:  array[0],
+            right: array[1]
+          };
+        } else {
+          return null;
+        }
+      }
+
+      return null;
+    },
+    getAnswer(variable, questions) {
+      const found = questions.find(q => q.variable === variable);
+
+      if ( found ) {
+        // Equivalent to finding question.answer in Ember
+        return get(this.value, found.variable);
+      } else {
+        return variable;
+      }
+    },
+    stringifyAnswer(answer) {
+      if ( answer === undefined || answer === null ) {
+        return '';
+      } else if ( typeof answer === 'string' ) {
+        return answer;
+      } else {
+        return `${ answer }`;
+      }
+    },
+    shouldShow(q, values) {
+      let expr = q.if;
+
+      if ( expr === undefined && q.show_if !== undefined ) {
+        expr = migrate(q.show_if);
+      }
+
+      if ( expr ) {
+        const shown = !!this.evalExpr(expr, values, q, this.allQuestions);
+
+        return shown;
+      }
+
+      return true;
+    },
+    shouldShowSub(q, values) {
+      // Sigh, both singular and plural are used in the wild...
+      let expr = ( q.subquestions_if === undefined ? q.subquestion_if : q.subquestions_if);
+      const old = ( q.show_subquestions_if === undefined ? q.show_subquestion_if : q.show_subquestions_if);
+
+      if ( !expr && old !== undefined ) {
+        if ( old === false || old === 'false' ) {
+          expr = `!${ q.variable }`;
+        } else if ( old === true || old === 'true' ) {
+          expr = `!!${ q.variable }`;
+        } else {
+          expr = `${ q.variable } == "${ old }"`;
+        }
+      }
+
+      if ( expr ) {
+        return this.evalExpr(expr, values, q, this.allQuestions);
+      }
+
+      return true;
     }
   },
 };


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4706 by making it so that Javascript expressions in a legacy app's `Questions.yaml` will be evaluated in the same way in the dashboard as they were in Ember. This makes it so that if answers fields are conditionally rendered based on other answers, they will show and hide correctly.

The linked issue was caused because the dashboard uses the Jexl library to evaluate Javascript expressions and Jexl doesn't support hyphens. This makes sense as Javascript doesn't allow hyphens in variable names either. However, an exception needs be made in this case so that users migrating legacy apps won't have to do manual work to make the app's Questions form work properly.

The Ember UI didn't use Jexl as it had used its own custom-made in-house system for evaluating Javascript expressions. The logic for those evaluations is found here: https://github.com/rancher/ui/blob/master/lib/shared/addon/utils/evaluate.js

Since there have been no other problems with Jexl so far, I'm re-adding Ember's custom evaluation logic, but only using it for evaluating expressions that contain hyphens. Everything else should use Jexl, so these changes will only apply to this narrowly defined case where hyphens are used.

There are a lot of changes in this PR because I took the evaluation functions from Ember here https://github.com/rancher/ui/blob/master/lib/shared/addon/utils/evaluate.js and it took a bit of massaging to integrate them into the Questions component. But the mainly important change to look at is with the `evalExpr` function because `this.evaluate` is where the Ember logic now hooks into the existing function to evaluate expressions. https://github.com/rancher/dashboard/compare/master...catherineluse:questions-logic?expand=1#diff-c0094794cd40516fe1869ea6e95f7dcc764ec9d60f6d7449dccfc6fc174467dcR288

To test this PR,

1. In Rancher v2.6.3, I created this catalog `https://github.com/axeal/rancher-catalog.git` with the branch `case-00311126` as described in the linked issue
2. In Cluster Explorer, I went to Apps & Marketplace > Charts and clicked `json-exporter`
3. Clicked Install > Next
4. Went to the `rabbitmqEnabled` tab and toggled whether it was enabled
5. Confirmed that when `rabbitmqEnabled` is false, you can't see any other rabbitmq related fields
6. Confirmed that when `rabbitmqEnabled` is true, you can see the rabbitmq related tabs such as the rabbitmq Ingress settings tab with fields including rabbitmq Ingress TLS enabled, rabbitmq secretName, and rabbitmq certManager enabled
7. Went to the Influxdb enabled tab and toggled whether it was enabled
8. Confirmed that when influxdb enabled is false, no other influxdb related settings are shown
9. Confirmed that when influxdb is enabled and you go to InfluxDB Configuration Settings, fields are shown and hidden based on the influxdb Application Version. Specifically, when the version is V1, you only see the HTTP auth enabled checkbox. When it is V2, five more fields are shown.


![Screen Shot 2022-01-28 at 2 40 27 PM](https://user-images.githubusercontent.com/20599230/151628835-9575792e-c06a-498f-8acc-2d8b66d93db2.png)


![Screen Shot 2022-01-28 at 2 40 43 PM](https://user-images.githubusercontent.com/20599230/151628855-c96b78af-eaf3-4c2e-a860-c8f22ecf0b9c.png)
![Screen Shot 2022-01-28 at 2 41 11 PM](https://user-images.githubusercontent.com/20599230/151628878-3425925a-fa00-407a-aaba-52d6ed88d9c0.png)

![Screen Shot 2022-01-28 at 2 41 23 PM](https://user-images.githubusercontent.com/20599230/151628893-03217a02-da41-48df-b7d2-3a915da381dd.png)


