### PR TITLE
Add support for toggle of UI elements based on runtime config

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -248,15 +248,15 @@ export default {
     <div>
       <TopLevelMenu v-if="isMultiCluster || !isSingleVirtualCluster"></TopLevelMenu>
     </div>
-    <div
-      v-if="currentCluster && !simple && (currentProduct.showNamespaceFilter || currentProduct.showWorkspaceSwitcher)"
-      class="top"
-    >
-      <NamespaceFilter v-if="clusterReady && currentProduct && (currentProduct.showNamespaceFilter || isExplorer)" />
-      <WorkspaceSwitcher v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher" />
-    </div>
 
     <div class="rd-header-right">
+      <div
+        v-if="currentCluster && !simple && (currentProduct.showNamespaceFilter || currentProduct.showWorkspaceSwitcher)"
+        class="top"
+      >
+        <NamespaceFilter v-if="clusterReady && currentProduct && (currentProduct.showNamespaceFilter || isExplorer)" />
+        <WorkspaceSwitcher v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher" />
+      </div>
       <div v-if="currentCluster && !simple" class="header-buttons">
         <template v-if="currentProduct && currentProduct.showClusterSwitcher">
           <button
@@ -476,11 +476,7 @@ export default {
     grid-template-rows:    var(--header-height);
 
     &.simple {
-<<<<<<< HEAD
-      grid-template-columns: var(--header-height) auto min-content min-content min-content min-content var(--header-height);
-=======
       grid-template-columns: var(--header-height) min-content 1fr min-content min-content;
->>>>>>> b0dbf552 (Update simple headers)
     }
 
     > .menu-spacer {
@@ -551,44 +547,44 @@ export default {
       grid-area: menu;
     }
 
-    > .top {
-      grid-area: top;
-      padding-top: 6px;
-
-      INPUT[type='search']::placeholder,
-      .vs__open-indicator,
-      .vs__selected {
-        color: var(--header-btn-bg) !important;
-        background: var(--header-btn-bg);
-        border-radius: var(--border-radius);
-        border: none;
-        margin: 0 35px 0 25px!important;
-      }
-
-      .vs__selected {
-        background: rgba(255, 255, 255, 0.15);
-        border-color: rgba(255, 255, 255, 0.25);
-      }
-
-      .vs__deselect {
-        fill: var(--header-btn-bg);
-      }
-
-      .filter .vs__dropdown-toggle {
-        background: var(--header-btn-bg);
-        border-radius: var(--border-radius);
-        border: none;
-        margin: 0 35px 0 25px!important;
-      }
-    }
-
     .rd-header-right {
       display: flex;
       flex-direction: row;
       padding: 0;
+      grid-area: header-right;
 
       > * {
         padding: 0 5px;
+      }
+
+      > .top {
+        padding-top: 6px;
+
+        INPUT[type='search']::placeholder,
+        .vs__open-indicator,
+        .vs__selected {
+          color: var(--header-btn-bg) !important;
+          background: var(--header-btn-bg);
+          border-radius: var(--border-radius);
+          border: none;
+          margin: 0 35px 0 25px!important;
+        }
+
+        .vs__selected {
+          background: rgba(255, 255, 255, 0.15);
+          border-color: rgba(255, 255, 255, 0.25);
+        }
+
+        .vs__deselect {
+          fill: var(--header-btn-bg);
+        }
+
+        .filter .vs__dropdown-toggle {
+          background: var(--header-btn-bg);
+          border-radius: var(--border-radius);
+          border: none;
+          margin: 0 35px 0 25px!important;
+        }
       }
 
       .header-buttons {

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -88,6 +88,10 @@ export default {
       return !this.currentProduct?.hideCopyConfig;
     },
 
+    showUserMenu() {
+      return this.$config.rancherEnv !== 'desktop';
+    },
+
     importEnabled() {
       return !!this.currentCluster?.actions?.apply;
     },
@@ -351,7 +355,14 @@ export default {
 
       <div class="header-spacer"></div>
 
-      <div class="user user-menu" tabindex="0" @blur="showMenu(false)" @click="showMenu(true)" @focus.capture="showMenu(true)">
+      <div
+        v-if="showUserMenu"
+        class="user user-menu"
+        tabindex="0"
+        @blur="showMenu(false)"
+        @click="showMenu(true)"
+        @focus.capture="showMenu(true)"
+      >
         <v-popover
           ref="popover"
           placement="bottom-end"

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -88,8 +88,16 @@ export default {
       return !this.currentProduct?.hideCopyConfig;
     },
 
+    showPageActions() {
+      return !this.featureRancherDesktop && this.pageActions?.length;
+    },
+
     showUserMenu() {
-      return this.$config.rancherEnv !== 'desktop';
+      return !this.featureRancherDesktop;
+    },
+
+    featureRancherDesktop() {
+      return this.$config.rancherEnv === 'desktop';
     },
 
     importEnabled() {
@@ -329,8 +337,16 @@ export default {
         </modal>
       </div>
 
-      <div v-if="pageActions && pageActions.length" class="actions">
-        <i class="icon icon-actions" @blur="showPageActionsMenu(false)" @click="showPageActionsMenu(true)" @focus.capture="showPageActionsMenu(true)" />
+      <div
+        v-if="showPageActions"
+        class="actions"
+      >
+        <i
+          class="icon icon-actions"
+          @blur="showPageActionsMenu(false)"
+          @click="showPageActionsMenu(true)"
+          @focus.capture="showPageActionsMenu(true)"
+        />
         <v-popover
           ref="pageActions"
           placement="bottom-end"

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -395,11 +395,6 @@ export default {
   HEADER {
     display: grid;
 
-    .rd-header-right {
-      display: flex;
-      flex-direction: row;
-    }
-
     .title {
       border-left: 1px solid var(--header-border);
       padding-left: 10px;
@@ -431,21 +426,6 @@ export default {
       padding: 0 5px;
     }
 
-    .actions {
-      align-items: center;
-      cursor: pointer;
-      display: flex;
-      grid-area: header-actions;
-
-      > I {
-        font-size: 18px;
-        padding: 6px;
-        &:hover {
-          color: var(--link);
-        }
-      }
-    }
-
     .back {
       padding-top: 6px;
 
@@ -464,37 +444,7 @@ export default {
       }
     }
 
-    .user-menu {
-      padding-top: 9.5px;
-    }
-
-    ::v-deep > div > .btn.role-tertiary {
-      border: 1px solid var(--header-btn-bg);
-      border: none;
-      background: var(--header-btn-bg);
-      color: var(--header-btn-text);
-      padding: 0 10px;
-      line-height: 32px;
-      min-height: 32px;
-
-      i {
-        // Ideally same height as the parent button, but this means tooltip needs adjusting (which is it's own can of worms)
-        line-height: 20px;
-      }
-
-      &:hover {
-        background: var(--primary);
-        color: #fff;
-      }
-
-      &[disabled=disabled] {
-        background-color: rgba(0,0,0,0.25) !important;
-        color: var(--header-btn-text) !important;
-        opacity: 0.7;
-      }
-    }
-
-    grid-template-areas:  "menu product top a header-right";
+    grid-template-areas:  "menu product top a header-right"; // TODO what's a good name for a here
     grid-template-columns: var(--header-height) calc(var(--nav-width) - var(--header-height)) 1fr min-content min-content;
     grid-template-rows:    var(--header-height);
 
@@ -541,22 +491,6 @@ export default {
       }
     }
 
-    .header-buttons {
-      align-items: center;
-      display: flex;
-      grid-area: buttons;
-      margin-top: 1px;
-
-      // Spacing between header buttons
-      .btn:not(:last-of-type) {
-        margin-right: 10px;
-      }
-
-      .btn:focus {
-        box-shadow: none;
-      }
-    }
-
     .product-name {
       font-size: 16px;
     }
@@ -582,18 +516,8 @@ export default {
       border-bottom: var(--header-border-size) solid var(--header-border);
     }
 
-    .header-btn {
-      width: 40px;
-    }
-
     .menu-spacer {
       grid-area: menu;
-    }
-
-    > .header-spacer {
-      grid-area: cluster;
-      background-color: var(--header-bg);
-      position: relative;
     }
 
     > .top {
@@ -627,43 +551,121 @@ export default {
       }
     }
 
-    > .user {
-      outline: none;
+    .rd-header-right {
+      display: flex;
+      flex-direction: row;
+      padding: 0;
 
-      .v-popover {
-        display: flex;
-        ::v-deep .trigger{
-        .user-image {
-            display: flex;
-          }
-        }
+      > * {
+        padding: 0 5px;
       }
 
-      .user-image {
-        display: flex;
+      .header-buttons {
         align-items: center;
+        display: flex;
+        margin-top: 1px;
+
+        // Spacing between header buttons
+        .btn:not(:last-of-type) {
+          margin-right: 10px;
+        }
+
+        .btn:focus {
+          box-shadow: none;
+        }
       }
 
-      &:focus {
-        .v-popover {
-          ::v-deep .trigger {
-            line-height: 0;
-            .user-image {
-              max-height: 40px;
-            }
-            .user-image > * {
-              @include form-focus
-            }
+      .header-btn {
+        width: 40px;
+      }
+
+      ::v-deep > div > .btn.role-tertiary {
+        border: 1px solid var(--header-btn-bg);
+        border: none;
+        background: var(--header-btn-bg);
+        color: var(--header-btn-text);
+        padding: 0 10px;
+        line-height: 32px;
+        min-height: 32px;
+
+        i {
+          // Ideally same height as the parent button, but this means tooltip needs adjusting (which is it's own can of worms)
+          line-height: 20px;
+        }
+
+        &:hover {
+          background: var(--primary);
+          color: #fff;
+        }
+
+        &[disabled=disabled] {
+          background-color: rgba(0,0,0,0.25) !important;
+          color: var(--header-btn-text) !important;
+          opacity: 0.7;
+        }
+      }
+
+      .actions {
+        align-items: center;
+        cursor: pointer;
+        display: flex;
+
+        > I {
+          font-size: 18px;
+          padding: 6px;
+          &:hover {
+            color: var(--link);
           }
         }
       }
 
-      grid-area: user;
-      background-color: var(--header-bg);
+      .header-spacer {
+        background-color: var(--header-bg);
+        position: relative;
+      }
 
-      .avatar-round {
-        border: 0;
-        border-radius: 50%;
+      .user-menu {
+        padding-top: 9.5px;
+      }
+
+      > .user {
+        outline: none;
+        width: var(--header-height);
+
+        .v-popover {
+          display: flex;
+          ::v-deep .trigger{
+          .user-image {
+              display: flex;
+            }
+          }
+        }
+
+        .user-image {
+          display: flex;
+          align-items: center;
+        }
+
+        &:focus {
+          .v-popover {
+            ::v-deep .trigger {
+              line-height: 0;
+              .user-image {
+                max-height: 40px;
+              }
+              .user-image > * {
+                @include form-focus
+              }
+            }
+          }
+        }
+
+        background-color: var(--header-bg);
+
+        .avatar-round {
+          border: 0;
+          border-radius: 50%;
+        }
       }
     }
   }

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -460,7 +460,11 @@ export default {
     grid-template-rows:    var(--header-height);
 
     &.simple {
+<<<<<<< HEAD
       grid-template-columns: var(--header-height) auto min-content min-content min-content min-content var(--header-height);
+=======
+      grid-template-columns: var(--header-height) min-content 1fr min-content min-content;
+>>>>>>> b0dbf552 (Update simple headers)
     }
 
     > .menu-spacer {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -75,6 +75,8 @@ module.exports = {
     pl,
   },
 
+  publicRuntimeConfig: { rancherEnv: process.env.RANCHER_ENV || 'web' },
+
   buildDir: dev ? '.nuxt' : '.nuxt-prod',
 
   buildModules: [


### PR DESCRIPTION
This introduces the ability to toggle certain UI elements based on the runtime config. Updates had to be made to the header in order to properly support toggling certain elements. For example, this is a rough outline of the structure for the header before the change:

![Untitled-2022-01-24-0922](https://user-images.githubusercontent.com/835961/151855519-b7d5b073-5a81-485b-bbd1-506a61a5548d.png)

Removing any given element would still reserve space in the header

![Untitled-2022-01-24-0922(2)](https://user-images.githubusercontent.com/835961/151855782-767d251f-be29-4cdb-b20f-74d661478ad9.png)

After the change, all actions are grouped in an area that is named `rd-header-right`:

![Untitled-2022-01-24-0922(1)](https://user-images.githubusercontent.com/835961/151855609-08466ecf-ae9d-4a51-8bff-6f7edd673760.png)

Removing elements from `rd-header-right` causes `top` to fill the remaining space and display remaining elements to the right-hand side of the screen

![Untitled-2022-01-24-0922(3)](https://user-images.githubusercontent.com/835961/151862237-0b5b3421-de19-4d89-8cde-41afce9d0e5d.png)

We shouldn't see any observable changes as a result of this PR without making use of the environment variable during development

```
❯ API=https://127.0.0.1:9443 ROUTER_BASE=/dashboard RANCHER_ENV=desktop yarn dev --spa
```

Supports work for Rancher Desktop

rancher-sandbox/rancher-desktop#1364