### PR TITLE
re-do machinedeployment to cluster machinepool mapping

### DIFF
--- a/models/cluster.x-k8s.io.machinedeployment.js
+++ b/models/cluster.x-k8s.io.machinedeployment.js
@@ -80,16 +80,11 @@ export default class CapiMachineDeployment extends SteveModel {
     return this.status?.unavailableReplicas || 0;
   }
 
-  async scalePool(delta, save = true) {
-    const infrastructureRef = this.spec.template.spec.infrastructureRef;
-
-    const { name, namespace, kind } = infrastructureRef;
-
-    const machineTemplate = await this.$dispatch('find', { type: `rke-machine.cattle.io.${ kind }`, id: `${ namespace }/${ name }` });
-    const machineConfigName = machineTemplate.metadata.annotations['rke.cattle.io/cloned-from-name'];
+  scalePool(delta, save = true) {
+    const machineConfigName = this.template.metadata.annotations['rke.cattle.io/cloned-from-name'];
     const machinePools = this.cluster.spec.rkeConfig.machinePools;
 
-    const clustersMachinePool = (machinePools.filter(pool => pool.machineConfigRef.name === machineConfigName) || [])[0];
+    const clustersMachinePool = machinePools.find(pool => pool.machineConfigRef.name === machineConfigName);
 
     if (clustersMachinePool) {
       clustersMachinePool.quantity += delta;

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -59,6 +59,7 @@ const REMAP_STATE = {
   waitcheckin:              'Wait Check-In',
   off:                      'Disabled',
   waitingforinfrastructure: 'Waiting for Infra',
+  waitingfornoderef:        'Waiting for Node Ref'
 };
 
 const DEFAULT_COLOR = 'warning';


### PR DESCRIPTION
#4990 - this is dependent on a recent-ish backend change: https://github.com/rancher/rancher/pull/36269

This PR updates the RKE2 scalePool logic to address an issue with long cluster names, outlined [here]. (https://github.com/rancher/rancher/issues/35452#issue-1050296190) 

I'm not sure getting the `type` from `kind` here is the best idea; it worked when I tested with Linode and DO, but I'm open to alternatives:
```
const machineTemplate = await this.$dispatch('find', { type: `rke-machine.cattle.io.${ kind }`, id: `${ namespace }/${ name }` });
```
