### PR TITLE
Adding `Role` via the UI always errors with `"Name" is required`, despite providing one

### DIFF
--- a/models/rbac.authorization.k8s.io.role.js
+++ b/models/rbac.authorization.k8s.io.role.js
@@ -41,4 +41,12 @@ export default class Role extends SteveModel {
   get resources() {
     return uniq(this.clusterResources.map(r => r.attributes?.kind)).sort();
   }
+
+  set displayName(v) {
+    this.metadata.name = v;
+  }
+
+  get displayName() {
+    return this.metadata?.name;
+  }
 }


### PR DESCRIPTION
Addresses Github issue: [#4858](https://github.com/rancher/dashboard/issues/4858)
Addresses Zube issue: [#4878](https://zube.io/rancher/dashboard-ui/c/4878)

- Added getters and setters for `displayName` so that its binded to `metadata.name`

Notes:
1) The given input reads from the prop `displayName` rather than `name`, but if we changed the input model (file is `RoleDetailEdit.vue`) we would compromise other areas of the code that are working properly.

2) We could also change the validation rules for the element from `name` to`displayName` (check `rbac.authorization.k8s.io.role.js` custom validation rules), but that we be opposite of the server validation, which is using  the `name` prop.

3) Additionally checked the other models for the areas where  `RoleDetailEdit.vue` component is used at and all of them are working properly.