### PR TITLE
Hide buttons in Deployment/Config tabs when in view mode

### DIFF
--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -280,6 +280,7 @@ export default {
               type="button"
               :disabled="isView"
               class="btn role-link"
+              :data-testid="`remove-item-${idx}`"
               @click="remove(idx)"
             >
               {{ removeLabel }}
@@ -300,6 +301,7 @@ export default {
           type="button"
           class="btn role-tertiary add"
           :disabled="loading"
+          data-testid="add-item"
           @click="add()"
         >
           <i v-if="loading" class="mr-5 icon icon-spinner icon-spin icon-lg" />

--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -276,7 +276,12 @@ export default {
         </slot>
         <div v-if="showRemove" class="remove">
           <slot name="remove-button" :remove="() => remove(idx)" :i="idx" :row="row">
-            <button type="button" :disabled="isView" class="btn role-link" @click="remove(idx)">
+            <button
+              type="button"
+              :disabled="isView"
+              class="btn role-link"
+              @click="remove(idx)"
+            >
               {{ removeLabel }}
             </button>
           </slot>
@@ -291,8 +296,14 @@ export default {
     </div>
     <div v-if="showAdd && !isView" class="footer">
       <slot v-if="showAdd" name="add">
-        <button type="button" class="btn role-tertiary add" :disabled="loading" @click="add()">
-          <i v-if="loading" class="mr-5 icon icon-spinner icon-spin icon-lg" />  {{ addLabel }}
+        <button
+          type="button"
+          class="btn role-tertiary add"
+          :disabled="loading"
+          @click="add()"
+        >
+          <i v-if="loading" class="mr-5 icon icon-spinner icon-spin icon-lg" />
+          {{ addLabel }}
         </button>
       </slot>
     </div>

--- a/components/form/ArrayListGrouped.vue
+++ b/components/form/ArrayListGrouped.vue
@@ -6,14 +6,25 @@ import { _EDIT, _VIEW } from '@/config/query-params';
 export default {
   components: { ArrayList, InfoBox },
   props:      {
+    /**
+     * Allow to remove items by value or computation
+     */
     canRemove: {
       type:    [Boolean, Function],
       default: true,
     },
+
+    /**
+     * Allow to extend list
+     */
     canAdd: {
       type:    Boolean,
       default: true,
     },
+
+    /**
+     * Form mode for the component
+     */
     mode: {
       type:    String,
       default: _EDIT,
@@ -30,6 +41,9 @@ export default {
   },
 
   methods: {
+    /**
+     * Verify if row can be removed by mode, function and declaration
+     */
     canRemoveRow(row, idx) {
       if ( this.isDisabled || this.isView ) {
         return false;

--- a/components/form/ArrayListGrouped.vue
+++ b/components/form/ArrayListGrouped.vue
@@ -1,7 +1,7 @@
 <script>
 import ArrayList from '@/components/form/ArrayList';
 import InfoBox from '@/components/InfoBox';
-import { _VIEW } from '@/config/query-params';
+import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default {
   components: { ArrayList, InfoBox },
@@ -9,18 +9,29 @@ export default {
     canRemove: {
       type:    [Boolean, Function],
       default: true,
-    }
+    },
+    canAdd: {
+      type:    Boolean,
+      default: true,
+    },
+    mode: {
+      type:    String,
+      default: _EDIT,
+    },
   },
 
   computed:   {
     isDisabled() {
       return this.$attrs.mode === _VIEW;
+    },
+    isView() {
+      return this.mode === _VIEW;
     }
   },
 
   methods: {
     canRemoveRow(row, idx) {
-      if ( this.isDisabled ) {
+      if ( this.isDisabled || this.isView ) {
         return false;
       }
 
@@ -35,14 +46,26 @@ export default {
 </script>
 
 <template>
-  <ArrayList class="array-list-grouped" v-bind="$attrs" @input="$emit('input', $event)" @add="$emit('add')">
+  <ArrayList
+    class="array-list-grouped"
+    v-bind="$attrs"
+    :add-allowed="canAdd && !isView"
+    :mode="mode"
+    @input="$emit('input', $event)"
+    @add="$emit('add')"
+  >
     <template v-slot:columns="scope">
       <InfoBox>
         <slot v-bind="scope" />
       </InfoBox>
     </template>
     <template v-slot:remove-button="scope">
-      <button v-if="canRemoveRow(scope.row, scope.i)" type="button" class="btn role-link close btn-sm" @click="scope.remove">
+      <button
+        v-if="canRemoveRow(scope.row, scope.i)"
+        type="button"
+        class="btn role-link close btn-sm"
+        @click="scope.remove"
+      >
         <i class="icon icon-2x icon-x" />
       </button>
       <span v-else></span>

--- a/components/form/ArrayListGrouped.vue
+++ b/components/form/ArrayListGrouped.vue
@@ -32,9 +32,6 @@ export default {
   },
 
   computed:   {
-    isDisabled() {
-      return this.$attrs.mode === _VIEW;
-    },
     isView() {
       return this.mode === _VIEW;
     }
@@ -45,7 +42,7 @@ export default {
      * Verify if row can be removed by mode, function and declaration
      */
     canRemoveRow(row, idx) {
-      if ( this.isDisabled || this.isView ) {
+      if ( this.isView ) {
         return false;
       }
 

--- a/components/form/ArrayListGrouped.vue
+++ b/components/form/ArrayListGrouped.vue
@@ -64,6 +64,7 @@ export default {
         v-if="canRemoveRow(scope.row, scope.i)"
         type="button"
         class="btn role-link close btn-sm"
+        :data-testid="`remove-row-${scope.i}`"
         @click="scope.remove"
       >
         <i class="icon icon-2x icon-x" />

--- a/components/form/EnvVars.vue
+++ b/components/form/EnvVars.vue
@@ -107,8 +107,8 @@ export default {
       />
     </div>
     <button
+      v-if="!isView"
       v-t="'workload.container.command.addEnvVar'"
-      :disabled="isView"
       type="button"
       class="btn role-tertiary add"
       @click="addFromReference"

--- a/components/form/EnvVars.vue
+++ b/components/form/EnvVars.vue
@@ -111,6 +111,7 @@ export default {
       v-t="'workload.container.command.addEnvVar'"
       type="button"
       class="btn role-tertiary add"
+      data-testid="add-env-var"
       @click="addFromReference"
     />
   </div>

--- a/components/form/EnvVars.vue
+++ b/components/form/EnvVars.vue
@@ -8,6 +8,9 @@ export default {
   components: { ValueFromResource },
 
   props: {
+    /**
+     * Form mode for the component
+     */
     mode: {
       type:     String,
       required: true,
@@ -20,7 +23,9 @@ export default {
       type:     Array,
       required: true
     },
-    // container spec
+    /**
+     * Container spec
+     */
     value: {
       type:    Object,
       default: () => {

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -214,6 +214,10 @@ export default {
       type:    String,
       default: 'icon-minus',
     },
+    removeAllowed: {
+      type:    Boolean,
+      default: true,
+    },
     fileModifier: {
       type:    Function,
       default: (name, value) => ({ name, value })
@@ -295,7 +299,7 @@ export default {
     },
 
     containerStyle() {
-      const gap = !this.isView ? ' 50px' : '';
+      const gap = this.canRemove ? ' 50px' : '';
       const size = 2 + this.extraColumns.length;
 
       return `grid-template-columns: repeat(${ size }, 1fr)${ gap };`;
@@ -312,6 +316,13 @@ export default {
       }
 
       return this.keyOptions;
+    },
+
+    /**
+     * Prevent removal if expressly not allowed and not in view mode
+     */
+    canRemove() {
+      return !this.isView && this.removeAllowed;
     }
   },
 
@@ -506,7 +517,7 @@ export default {
         <label v-for="c in extraColumns" :key="c">
           <slot :name="'label:'+c">{{ c }}</slot>
         </label>
-        <slot v-if="!isView" name="remove">
+        <slot v-if="canRemove" name="remove">
           <span />
         </slot>
       </template>
@@ -594,7 +605,7 @@ export default {
         </div>
 
         <div
-          v-if="!isView"
+          v-if="canRemove"
           :key="i"
           class="kv-item remove"
           :data-testid="`remove-column-${i}`"

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -597,6 +597,7 @@ export default {
           v-if="!isView"
           :key="i"
           class="kv-item remove"
+          :data-testid="`remove-column-${i}`"
         >
           <slot name="removeButton" :remove="remove" :row="row">
             <button type="button" :disabled="isView" class="btn role-link" @click="remove(i)">

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -214,11 +214,6 @@ export default {
       type:    String,
       default: 'icon-minus',
     },
-    removeAllowed: {
-      type:    Boolean,
-      default: true,
-    },
-
     fileModifier: {
       type:    Function,
       default: (name, value) => ({ name, value })
@@ -300,7 +295,10 @@ export default {
     },
 
     containerStyle() {
-      return `grid-template-columns: repeat(${ 2 + this.extraColumns.length }, 1fr)${ this.removeAllowed ? ' 50px' : '' };`;
+      const gap = !this.isView ? '" 50px"' : '""';
+      const size = 2 + this.extraColumns.length;
+
+      return `grid-template-columns: repeat(${ size }, 1fr)${ gap };`;
     },
 
     usedKeyOptions() {
@@ -508,7 +506,7 @@ export default {
         <label v-for="c in extraColumns" :key="c">
           <slot :name="'label:'+c">{{ c }}</slot>
         </label>
-        <slot v-if="removeAllowed" name="remove">
+        <slot v-if="!isView" name="remove">
           <span />
         </slot>
       </template>
@@ -595,7 +593,11 @@ export default {
           <slot :name="'col:' + c" :row="row" :queue-update="queueUpdate" />
         </div>
 
-        <div v-if="removeAllowed" :key="i" class="kv-item remove">
+        <div
+          v-if="!isView"
+          :key="i"
+          class="kv-item remove"
+        >
           <slot name="removeButton" :remove="remove" :row="row">
             <button type="button" :disabled="isView" class="btn role-link" @click="remove(i)">
               {{ removeLabel || t('generic.remove') }}

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -295,7 +295,7 @@ export default {
     },
 
     containerStyle() {
-      const gap = !this.isView ? '" 50px"' : '""';
+      const gap = !this.isView ? ' 50px' : '';
       const size = 2 + this.extraColumns.length;
 
       return `grid-template-columns: repeat(${ size }, 1fr)${ gap };`;

--- a/components/form/PodAffinity.vue
+++ b/components/form/PodAffinity.vue
@@ -174,7 +174,13 @@ export default {
 <template>
   <div :style="{'width':'100%'}" class="row" @input="queueUpdate">
     <div class="col span-12">
-      <ArrayListGrouped v-model="allSelectorTerms" class="mt-20" :default-add-value="{matchExpressions:[]}" :add-label="t('workload.scheduling.affinity.addNodeSelector')">
+      <ArrayListGrouped
+        v-model="allSelectorTerms"
+        class="mt-20"
+        :default-add-value="{ matchExpressions: [] }"
+        :mode="mode"
+        :add-label="t('workload.scheduling.affinity.addNodeSelector')"
+      >
         <template #default="props">
           <div class="row mt-20 mb-20">
             <div class="col span-6">

--- a/components/form/ServiceNameSelect.vue
+++ b/components/form/ServiceNameSelect.vue
@@ -140,6 +140,7 @@ export default {
         v-if="!isView"
         type="button"
         class="btn role-secondary"
+        data-testid="clear-search"
         @click="clearSearch($event)"
       >
         {{ t("generic.clear") }}

--- a/components/form/ServiceNameSelect.vue
+++ b/components/form/ServiceNameSelect.vue
@@ -136,8 +136,13 @@ export default {
         :v-bind="$attrs"
         @input="changeSelected"
       />
-      <button :disabled="isView" type="button" class="btn role-secondary" @click="clearSearch($event);">
-        {{ t('generic.clear') }}
+      <button
+        v-if="!isView"
+        type="button"
+        class="btn role-secondary"
+        @click="clearSearch($event)"
+      >
+        {{ t("generic.clear") }}
       </button>
     </div>
     <template v-if="serviceNameNew">

--- a/types/form.ts
+++ b/types/form.ts
@@ -1,0 +1,1 @@
+export type FormMode = 'create' | 'view' | 'edit' | 'clone' | 'stage' | 'import';


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/5035

Removed buttons for the following tabs of Demployment/Config viiew:

General

![Screenshot from 2022-02-03 15-36-05](https://user-images.githubusercontent.com/5009481/152363853-99dc8799-dc03-4449-9439-853d4fc0654b.png)

Labels & Annotations

![Screenshot from 2022-02-03 15-36-32](https://user-images.githubusercontent.com/5009481/152363915-854b1fea-135e-4024-86be-4ecf79d5ad87.png)

Pod Scheduling

![Screenshot from 2022-02-03 15-36-48](https://user-images.githubusercontent.com/5009481/152363944-4f02006f-d162-446c-8032-aa7e5da2748c.png)

- `KeyValue.vue` 
  - As the value `removeAllowed` is not computed nor adopted, it has been replaced by `isView`, which seems to be the reason of this leftover; prop has been removed accordingly
- `ArrayListGrouped.vue `
  - `IsDisabled` computation seems not working or not integrated correctly, as the value returns `false` also in case of view mode; therefore it has been replaced with `mode`, while prop is kept to avoid issues
  - `CanAdd` has been added to allow enforced cases, default value left to `true` to match existing cases
  - ` mode `/`isView` logic has also been added to match other existing cases, as part of the issue requirement to cover global scope. 

# Extras 

- Attributes to the buttons have been added for future unit/E2E tests purposes; value defined based on Cypress guidelines https://docs.cypress.io/guides/references/best-practices
- Added code comments for components which may be listed in a styleguide
- Added type for form modes, assumed by constant values