### PR TITLE
JS Error on cluster tools page when Rancher repo was deleted

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -841,6 +841,7 @@ catalog:
       placeholder: 'e.g. https://charts.rancher.io'
   tools:
     header: Cluster Tools
+    noTools: "No Cluster Tools found"
     action:
       install: Install
       upgrade: Upgrade/Edit

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -847,6 +847,7 @@ catalog:
       placeholder: '例如：https://charts.rancher.io'
   tools:
     header: 集群工具
+    noTools: "未找到集群工具"
     action:
       install: 安装
       upgrade: 升级/编辑

--- a/components/IconMessage.vue
+++ b/components/IconMessage.vue
@@ -26,7 +26,7 @@ export default {
 </script>
 
 <template>
-  <div class="icon-message" :class="{'vertical': vertical}">
+  <div class="message-icon" :class="{'vertical': vertical}">
     <i class="icon" :class="{ [icon]: true, [iconState]: !!iconState}" />
     <div class="message">
       <slot name="message">
@@ -47,7 +47,7 @@ export default {
     width: 100%;
   }
 
-  .icon-message {
+  .message-icon {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -10,10 +10,11 @@ import AppSummaryGraph from '@/components/formatter/AppSummaryGraph';
 import { sortBy } from '@/utils/sort';
 import { LEGACY } from '@/store/features';
 import { isAlternate } from '@/utils/platform';
+import IconMessage from '@/components/IconMessage';
 
 export default {
   components: {
-    AppSummaryGraph, LazyImage, Loading
+    AppSummaryGraph, LazyImage, Loading, IconMessage
   },
 
   async fetch() {
@@ -116,7 +117,7 @@ export default {
         clusterProvider,
         showDeprecated: this.showDeprecated,
         showHidden:     this.showHidden,
-        showRepos:      [this.rancherCatalog._key],
+        showRepos:      [this.rancherCatalog?._key],
         showTypes:      [CATALOG_ANNOTATIONS._CLUSTER_TOOL],
       });
 
@@ -179,7 +180,7 @@ export default {
         chartName:        `v1-${ id }`,
         key:              `v1-${ id }`,
         versions:         this.getLegacyVersions(`rancher-${ id }`),
-        repoKey:          this.rancherCatalog._key,
+        repoKey:          this.rancherCatalog?._key,
         legacy:           true,
         legacyPage:       id,
         iconName:         `icon-${ id }`,
@@ -392,10 +393,10 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <div v-else>
+  <div v-else-if="options.length">
     <h1 v-html="t('catalog.tools.header')" />
 
-    <div v-if="options.length" class="grid">
+    <div class="grid">
       <div
         v-for="opt in options"
         :key="opt.chart.id"
@@ -455,5 +456,8 @@ export default {
         </div>
       </div>
     </div>
+  </div>
+  <div v-else>
+    <IconMessage icon="icon-warning" message-key="catalog.tools.noTools" />
   </div>
 </template>

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -18,7 +18,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('catalog/load');
+    await this.$store.dispatch('catalog/load', { force: true, reset: true });
 
     const query = this.$route.query;
     const projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });


### PR DESCRIPTION
Addresses Github issue: [#4988](https://github.com/rancher/dashboard/issues/4988)
Addresses Zube issue: [#5010](https://zube.io/rancher/dashboard-ui/c/5010)

- fixes js error when deleting rancher repo and entering cluster tools 
- adds notification message when no cluster tools are available (when we delete rancher repo on a new cluster)

**Preview empty state**
<img width="1767" alt="Screenshot 2022-02-03 at 15 32 15" src="https://user-images.githubusercontent.com/97888974/152377808-82177aa4-8a58-4f1a-a337-735b48c75cb7.png">

Note:
1) Had to rename the class of the component `IconMessage` because there is an "automatic" style modifier for `icon-` which "forced" the font style for the whole component to be `icons`, overriding the body font even for the text part (for the whole component)