### PR TITLE
Fix yarn.lock resolution of Rancher icons

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12118,7 +12118,7 @@ ramda@~0.27.1:
 
 rancher-icons@rancher/icons#v2.0.0:
   version "2.0.0"
-  resolved "https://codeload.github.com/rancher/icons/tar.gz/4f8a94214e6158d69fdbaf50e800b84176e68686"
+  resolved "https://codeload.github.com/rancher/icons/tar.gz/557a218db623f25193ed9bb2dba0fed964215bdc"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
The commit in yarn.lock points to and old version of Rancher icons (due to updating an existing 2.0.0 version of the icons)