### PR TITLE
fix chart mixin error if required gvr provider not found

### DIFF
--- a/mixins/chart.js
+++ b/mixins/chart.js
@@ -200,9 +200,9 @@ export default {
 
           const provider = this.provider(gvr);
 
-          const url = this.$router.resolve(this.chartLocation(true, gvr)).href;
-
           if ( provider ) {
+            const url = this.$router.resolve(this.chartLocation(true, provider)).href;
+
             requires.push(this.t('catalog.install.error.requiresFound', {
               url,
               name: provider.name
@@ -332,8 +332,8 @@ export default {
     /**
      * Location of chart install or details page for either the current chart or from gvr
      */
-    chartLocation(install = false, gvr) {
-      const provider = gvr ? this.provider(gvr) : {
+    chartLocation(install = false, prov) {
+      const provider = prov || {
         repoType: this.chart.repoType,
         repoName: this.chart.repoName,
         name:     this.chart.chartName,


### PR DESCRIPTION
This issue arose from a slack conversation in which we found that the install page for a chart will explode if the chart has a `catalog.cattle.io/requires-gvr` annotation and there are no charts containing a matching `catalog.cattle.io/providers-gvr` annotation.

The UI was already attempting to catch this error; ensuring `chartLocation` is only called when a provider (chart) is found is sufficient. I opted to also update `chartLocation` to accept the parameter it actually needs, `provider` rather than the `gvr`, that may or may not lead to a `provider`. (the mixin is the only place its called this way)
![Screen Shot 2022-02-03 at 4 17 51 PM](https://user-images.githubusercontent.com/42977925/152445395-65bf64cc-5f38-4a15-9d09-1208daa063e4.png)
 