### PR TITLE
Add auto-replace option for K3s/RKE2 machine pools

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1441,7 +1441,7 @@ cluster:
       label: Kubernetes Node Labels
     autoReplace:
       label: Auto Replace
-      toolTip: If greater than 0, nodes that are unreachable for this long will be automatically deleted and replaced.
+      toolTip: If greater than 0, nodes that are unreachable for this duration will be automatically deleted and replaced.
       unit: "Minutes"
   memberRoles:
     removeMessage: 'Note: Removing a user will not remove their project permissions'

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1439,6 +1439,10 @@ cluster:
       label: Roles
     labels:
       label: Kubernetes Node Labels
+    autoReplace:
+      label: Auto Replace
+      toolTip: If greater than 0, nodes that are unreachable for this long will be automatically deleted and replaced.
+      unit: "Minutes"
   memberRoles:
     removeMessage: 'Note: Removing a user will not remove their project permissions'
     addClusterMember:

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -202,7 +202,7 @@ export default {
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 
 .hideArrows {
   /* Hide arrows on number input

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -45,6 +45,11 @@ export default {
       type:    Number,
       default: null,
     },
+
+    hideArrows: {
+      type:    Boolean,
+      default: false
+    }
   },
 
   computed: {
@@ -132,6 +137,7 @@ export default {
       disabled: isDisabled,
       [status]: status,
       suffix: hasSuffix,
+      hideArrows
     }"
   >
     <slot name="label">
@@ -195,3 +201,24 @@ export default {
     <label v-if="subLabel" class="sub-label">{{ subLabel }}</label>
   </div>
 </template>
+
+<style lang="scss">
+
+.hideArrows {
+  /* Hide arrows on number input
+when it overlaps with the unit */
+
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type=number] {
+    -moz-appearance: textfield;
+  }
+}
+
+</style>

--- a/components/form/UnitInput.vue
+++ b/components/form/UnitInput.vue
@@ -188,6 +188,7 @@ export default {
     :tooltip-key="tooltipKey"
     :required="required"
     :placeholder="placeholder"
+    :hide-arrows="true"
     @input="update($event)"
   >
     <template #suffix>

--- a/components/form/UnitInput.vue
+++ b/components/form/UnitInput.vue
@@ -42,6 +42,12 @@ export default {
       default: 'B',
     },
 
+    /* Hide arrows on number input when it overlaps with the unit */
+    hideArrows: {
+      type:    Boolean,
+      default: false
+    },
+
     // If set to 1024, binary modifier will be used eg MiB instead of MB
     increment: {
       type:    Number,
@@ -188,7 +194,7 @@ export default {
     :tooltip-key="tooltipKey"
     :required="required"
     :placeholder="placeholder"
-    :hide-arrows="true"
+    :hide-arrows="hideArrows"
     @input="update($event)"
   >
     <template #suffix>

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -8,6 +8,7 @@ import Taints from '@/components/form/Taints.vue';
 import KeyValue from '@/components/form/KeyValue.vue';
 import AdvancedSection from '@/components/AdvancedSection.vue';
 import Banner from '@/components/Banner';
+import UnitInput from '@/components/form/UnitInput.vue';
 import { randomStr } from '@/utils/string';
 
 export default {
@@ -19,6 +20,7 @@ export default {
     KeyValue,
     AdvancedSection,
     Banner,
+    UnitInput
   },
 
   props: {
@@ -44,7 +46,19 @@ export default {
   },
 
   data() {
-    return { uuid: randomStr() };
+    const parseDuration = (duration) => {
+      // The back end stores the timeout in Duration format, for example, "10m".
+      // Here we convert that string to an integer.
+      const numberString = duration.split('m')[0];
+
+      return parseInt(numberString);
+    };
+
+    return {
+      uuid: randomStr(),
+
+      unhealthyNodeTimeoutInteger: this.value.pool.unhealthyNodeTimeout ? parseDuration(this.value.pool.unhealthyNodeTimeout) : 0
+    };
   },
 
   computed: {
@@ -86,7 +100,7 @@ export default {
 <template>
   <div>
     <div class="row">
-      <div class="col span-4">
+      <div class="col span-2">
         <LabeledInput
           v-model="value.pool.name"
           :mode="mode"
@@ -105,6 +119,18 @@ export default {
           :required="true"
         />
       </div>
+      <div class="col span-3">
+        <UnitInput
+          v-model.number="unhealthyNodeTimeoutInteger"
+          :placeholder="t('containerResourceLimit.cpuPlaceholder')"
+          :label="t('cluster.machinePool.autoReplace.label')"
+          :mode="mode"
+          :output-modifier="true"
+          :base-unit="t('cluster.machinePool.autoReplace.unit')"
+          :tooltip="t('cluster.machinePool.autoReplace.toolTip')"
+          @input="value.pool.unhealthyNodeTimeout = `${unhealthyNodeTimeoutInteger}m`"
+        />
+      </div>
       <div class="col span-2 pt-5">
         <h3>
           {{ t('cluster.machinePool.drain.header') }}
@@ -115,7 +141,7 @@ export default {
           :label="t('cluster.machinePool.drain.label')"
         />
       </div>
-      <div class="col span-4 pt-5">
+      <div class="col span-3 pt-5">
         <h3>
           {{ t('cluster.machinePool.role.label') }}
         </h3>

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -51,7 +51,7 @@ export default {
       // Here we convert that string to an integer.
       const numberString = duration.split('m')[0];
 
-      return parseInt(numberString);
+      return parseInt(numberString, 10);
     };
 
     return {
@@ -100,7 +100,7 @@ export default {
 <template>
   <div>
     <div class="row">
-      <div class="col span-2">
+      <div class="col span-4">
         <LabeledInput
           v-model="value.pool.name"
           :mode="mode"
@@ -109,7 +109,7 @@ export default {
           :disabled="!value.config || !!value.config.id"
         />
       </div>
-      <div class="col span-2">
+      <div class="col span-4">
         <LabeledInput
           v-model.number="value.pool.quantity"
           :mode="mode"
@@ -119,29 +119,7 @@ export default {
           :required="true"
         />
       </div>
-      <div class="col span-3">
-        <UnitInput
-          v-model.number="unhealthyNodeTimeoutInteger"
-          :placeholder="t('containerResourceLimit.cpuPlaceholder')"
-          :label="t('cluster.machinePool.autoReplace.label')"
-          :mode="mode"
-          :output-modifier="true"
-          :base-unit="t('cluster.machinePool.autoReplace.unit')"
-          :tooltip="t('cluster.machinePool.autoReplace.toolTip')"
-          @input="value.pool.unhealthyNodeTimeout = `${unhealthyNodeTimeoutInteger}m`"
-        />
-      </div>
-      <div class="col span-2 pt-5">
-        <h3>
-          {{ t('cluster.machinePool.drain.header') }}
-        </h3>
-        <Checkbox
-          v-model="value.pool.drainBeforeDelete"
-          :mode="mode"
-          :label="t('cluster.machinePool.drain.label')"
-        />
-      </div>
-      <div class="col span-3 pt-5">
+      <div class="col span-4 pt-5">
         <h3>
           {{ t('cluster.machinePool.role.label') }}
         </h3>
@@ -162,7 +140,6 @@ export default {
         />
       </div>
     </div>
-
     <hr class="mt-10" />
 
     <component
@@ -182,7 +159,34 @@ export default {
       <portal-target :name="'advanced-' + uuid" multiple />
 
       <div class="spacer" />
-
+      <div class="row">
+        <div class="col span-4">
+          <h3>
+            {{ t('cluster.machinePool.autoReplace.label') }}
+            <i v-tooltip="t('cluster.machinePool.autoReplace.toolTip')" class="icon icon-info icon-lg" />
+          </h3>
+          <UnitInput
+            v-model.number="unhealthyNodeTimeoutInteger"
+            :hide-arrows="true"
+            :placeholder="t('containerResourceLimit.cpuPlaceholder')"
+            :mode="mode"
+            :output-modifier="true"
+            :base-unit="t('cluster.machinePool.autoReplace.unit')"
+            @input="value.pool.unhealthyNodeTimeout = `${unhealthyNodeTimeoutInteger}m`"
+          />
+        </div>
+        <div class="col span-4">
+          <h3>
+            {{ t('cluster.machinePool.drain.header') }}
+          </h3>
+          <Checkbox
+            v-model="value.pool.drainBeforeDelete"
+            :mode="mode"
+            :label="t('cluster.machinePool.drain.label')"
+          />
+        </div>
+      </div>
+      <div class="spacer" />
       <KeyValue
         v-model="value.pool.labels"
         :add-label="t('labels.addLabel')"

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -854,13 +854,14 @@ export default {
         update: false,
         pool:    {
           name,
-          etcdRole:         numCurrentPools === 0,
-          controlPlaneRole: numCurrentPools === 0,
-          workerRole:       true,
-          hostnamePrefix:   '',
-          labels:           {},
-          quantity:         1,
-          machineConfigRef:    {
+          etcdRole:             numCurrentPools === 0,
+          controlPlaneRole:     numCurrentPools === 0,
+          workerRole:           true,
+          hostnamePrefix:       '',
+          labels:               {},
+          quantity:             1,
+          unhealthyNodeTimeout: '0m',
+          machineConfigRef:     {
             kind:       this.machineConfigSchema.attributes.kind,
             name:       null,
           },


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4449 by adding a node auto-replace option for machine pools in the K3s/RKE2 cluster provisioning form.

Similar to the Ember UI, the input is taken from the user in minutes but sent to the back end in seconds.

<img width="1381" alt="Screen Shot 2022-02-03 at 10 42 56 PM" src="https://user-images.githubusercontent.com/20599230/152479400-4584dfe3-6575-4bb7-baf9-cb09b31d2b35.png">
<img width="1359" alt="Screen Shot 2022-02-03 at 10 43 02 PM" src="https://user-images.githubusercontent.com/20599230/152479506-69881e7a-fc59-4508-9fb8-23358ebe94ca.png">

Ember UI for reference:
<img width="1330" alt="Screen Shot 2022-02-03 at 6 45 37 PM" src="https://user-images.githubusercontent.com/20599230/152479668-92fe7917-ae57-406b-934f-57f071269b8b.png">

To test this PR, I

1. I created a cluster with two node pools, pool1 and pool2. Pool1 had etcd, controlplane and worker roles. Pool2 had only the worker role. Pool2 had the auto-replace option set to one minute.
2. I confirmed that when the cluster was created, the new `unhealthyNodeTimeout` option was sent in the network request to create the cluster. The timeout is in Kubernetes duration format, so 10 minutes would be the string "10m".
<img width="246" alt="Screen Shot 2022-02-04 at 3 49 07 PM" src="https://user-images.githubusercontent.com/20599230/152614583-9162ddae-08b4-4894-b27b-53494241f3b4.png">

3. Jacob said the fastest way to check that it works is to go to the `local` cluster and check if the machine health checks are being created. I confirmed that they are:

```
kubectl get machinehealthcheck -A
NAMESPACE       NAME       CLUSTER   EXPECTEDMACHINES   MAXUNHEALTHY   CURRENTHEALTHY   AGE
fleet-default   c2-pool1   c2                           100%                            3m51s
fleet-default   c2-pool2   c2                           100%                            3m51s
```

4. I went to Digital Ocean and deleted the node for pool2.
5. I went back to Rancher and saw that the status of the pool2 node was unknown.
<img width="1216" alt="Screen Shot 2022-02-04 at 1 03 45 AM" src="https://user-images.githubusercontent.com/20599230/152494465-54ee4e2e-4a19-4b95-9565-391a2e55ee12.png">
6. After a minute, the node for pool2 was back up and running.

