### PR TITLE
Fix minor issue with icon height on cluster tools page

### DIFF
--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -385,6 +385,10 @@ export default {
       .action {
         grid-area: action;
         white-space: nowrap;
+
+        button {
+          height: 30px;
+        }
       }
     }
   }


### PR DESCRIPTION
There is a minor sizing issue on the cluster tools page - the delete button is a different height to the install button:

![image](https://user-images.githubusercontent.com/1955897/152495450-b2817775-5210-4df4-b503-ea303d7bbb81.png)


This PR fixes this.