### PR TITLE
Fix Storybook build

### DIFF
--- a/stories/Icons.stories.mdx
+++ b/stories/Icons.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/addon-docs';
-import icons from '~/assets/fonts/icons/selection.json';
 
 <style>{`
 .sb-icons {
@@ -37,12 +36,5 @@ e.g.
 
 <pre>&lt;i class="icon icon-show" /&gt;</pre>
 
+<p>Current icon set can be viewd here: <a href="https://rancher.github.io/icons/" target="_blank">Rancher Icons</a></p>
 <br/><br/>
-<div className="sb-icons">
-{icons.icons.map((icon, index) => (
-  <div className="sb-icon" key={index}>
-    <div>{function(icon) { const name = icon.properties.name.split(','); return `icon-${name[0]}`}(icon)}</div>
-    <i className={function(icon) { const name = icon.properties.name.split(','); return `icon icon-${name[0]}`; }(icon)} />
-  </div>
-))}
-</div>


### PR DESCRIPTION
Storybook build was broken by change or icon font being brought in from the rancher/icons repository.

This PR fixes this by removing the reference to the old `selection.json` file that no longer exists - we don't include an index of icons in the Storybook for now - we reference back to the one generated from the rancher icons GitHub repository.