### PR TITLE
Make helm chart list filters row responsive

### DIFF
--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -453,10 +453,18 @@ export default {
         </template>
       </Select>
 
-      <input ref="searchQuery" v-model="searchQuery" type="search" class="input-sm" :placeholder="t('catalog.charts.search')">
+      <div class="filter-block">
+        <input
+          ref="searchQuery"
+          v-model="searchQuery"
+          type="search"
+          class="input-sm"
+          :placeholder="t('catalog.charts.search')"
+        >
 
-      <button v-shortkey.once="['/']" class="hide" @shortkey="focusSearch()" />
-      <AsyncButton mode="refresh" size="sm" @click="refresh" />
+        <button v-shortkey.once="['/']" class="hide" @shortkey="focusSearch()" />
+        <AsyncButton class="refresh-btn" mode="refresh" size="sm" @click="refresh" />
+      </div>
     </div>
 
     <Banner v-for="err in loadingErrors" :key="err" color="error" :label="err" />
@@ -489,12 +497,41 @@ export default {
     z-index: z-index('fixedTableHeader');
     background: transparent;
     display: grid;
-    grid-template-columns: 50% auto auto 40px;
+    grid-template-columns: 40% auto auto;
     align-content: center;
     grid-column-gap: 10px;
 
+    .filter-block {
+      display: flex;
+    }
+    .refresh-btn {
+      width: 40px;
+      margin-left: 10px;
+    }
+
     &.with-os-options {
-      grid-template-columns: 50% auto auto auto 40px;
+      grid-template-columns: 40% auto auto auto;
+    }
+
+    @media only screen and (max-width: map-get($breakpoints, '--viewport-12')) {
+      &{
+        grid-template-columns: auto auto !important;
+        grid-template-rows: 40px 40px;
+        grid-row-gap: 20px;
+      }
+    }
+
+    @media only screen and (max-width: map-get($breakpoints, '--viewport-7')) {
+      &{
+        &{
+          grid-template-columns: auto !important;
+          grid-template-rows: 40px 40px 40px !important;
+
+          &.with-os-options {
+            grid-template-rows: 40px 40px 40px 40px !important;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Addresses Github issue: [#4646](https://github.com/rancher/dashboard/issues/4646)
Addresses Zube issue: [#4664](https://zube.io/rancher/dashboard-ui/c/4664)

- fix helm charts filters to make them responsive

**Preview**
<img width="1904" alt="Screenshot 2022-02-07 at 10 28 04" src="https://user-images.githubusercontent.com/97888974/152771152-413492ce-29fe-44b2-85ea-70282ad55dc1.png">
<img width="1382" alt="Screenshot 2022-02-07 at 10 28 11" src="https://user-images.githubusercontent.com/97888974/152771166-8f51fc19-748f-488d-90f7-8dc6cd07fb7d.png">
<img width="851" alt="Screenshot 2022-02-07 at 10 28 31" src="https://user-images.githubusercontent.com/97888974/152771172-630594f3-f9b7-4bc9-af62-6c1039e20b08.png">

