### PR TITLE
Fleet: Show clusters applicable to a git repo

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -5401,7 +5401,7 @@ harvester:
     input:
       name: Name
       memory: Memory
-      image: Imagek
+      image: Image
       sshKey: SSHKey
       sshKeyValue: SSH-Key
       MachineType: Machine Type

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1815,6 +1815,9 @@ fleet:
       verify: Require a valid certificate
       specify: Specify additional certificates to be accepted
       skip: Accept any certificate (insecure)
+    warningTooltip:
+      clusterGroup: There are no clusters in this Cluster Group
+      cluster: There are no clusters available
     workspace:
       label: Workspace
   clusterGroup:
@@ -5398,7 +5401,7 @@ harvester:
     input:
       name: Name
       memory: Memory
-      image: Image
+      image: Imagek
       sshKey: SSHKey
       sshKeyValue: SSH-Key
       MachineType: Machine Type

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -1815,6 +1815,9 @@ fleet:
       verify: 需要提供有效的证书
       specify: 指定接受的附加证书
       skip: 接受任何证书（不安全）
+    warningTooltip:
+      clusterGroup: 此集群组中没有集群
+      cluster: 没有可用的集群
     workspace:
       label: 工作空间
   clusterGroup:

--- a/assets/translations/zh-hans.yaml
+++ b/assets/translations/zh-hans.yaml
@@ -1815,9 +1815,6 @@ fleet:
       verify: 需要提供有效的证书
       specify: 指定接受的附加证书
       skip: 接受任何证书（不安全）
-    warningTooltip:
-      clusterGroup: 此集群组中没有集群
-      cluster: 没有可用的集群
     workspace:
       label: 工作空间
   clusterGroup:

--- a/components/FleetRepos.vue
+++ b/components/FleetRepos.vue
@@ -59,6 +59,11 @@ export default {
       return out;
     },
   },
+  methods: {
+    parseTargetMode(row) {
+      return row.targetInfo?.mode === 'clusterGroup' ? this.t('fleet.gitRepo.warningTooltip.clusterGroup') : this.t('fleet.gitRepo.warningTooltip.cluster');
+    }
+  },
 };
 </script>
 
@@ -89,7 +94,14 @@ export default {
     <template #cell:clustersReady="{row}">
       <span v-if="!row.clusterInfo" class="text-muted">&mdash;</span>
       <span v-else-if="row.clusterInfo.unready" class="text-warning">{{ row.clusterInfo.ready }}/{{ row.clusterInfo.total }}</span>
-      <span v-else>{{ row.clusterInfo.total }}</span>
+      <span v-else class="cluster-count-info">
+        {{ row.clusterInfo.total }}/{{ row.clusterInfo.total }}
+        <i
+          v-if="!row.clusterInfo.total"
+          v-tooltip.bottom="parseTargetMode(row)"
+          class="icon icon-warning"
+        />
+      </span>
     </template>
 
     <template #cell:target="{row}">
@@ -97,3 +109,16 @@ export default {
     </template>
   </ResourceTable>
 </template>
+
+<style lang="scss">
+.cluster-count-info {
+  display: flex;
+  align-items: center;
+
+  i {
+    margin-left: 5px;
+    font-size: 24px;
+    color: var(--warning);
+  }
+}
+</style>

--- a/components/FleetRepos.vue
+++ b/components/FleetRepos.vue
@@ -117,7 +117,7 @@ export default {
 
   i {
     margin-left: 5px;
-    font-size: 24px;
+    font-size: 22px;
     color: var(--warning);
   }
 }

--- a/components/FleetRepos.vue
+++ b/components/FleetRepos.vue
@@ -95,7 +95,7 @@ export default {
       <span v-if="!row.clusterInfo" class="text-muted">&mdash;</span>
       <span v-else-if="row.clusterInfo.unready" class="text-warning">{{ row.clusterInfo.ready }}/{{ row.clusterInfo.total }}</span>
       <span v-else class="cluster-count-info">
-        {{ row.clusterInfo.total }}/{{ row.clusterInfo.total }}
+        {{ row.clusterInfo.ready }}/{{ row.clusterInfo.total }}
         <i
           v-if="!row.clusterInfo.total"
           v-tooltip.bottom="parseTargetMode(row)"


### PR DESCRIPTION
Addresses Github issue: [#4929](https://github.com/rancher/dashboard/issues/4929)
Addresses Zube issue: [#4949](https://zube.io/rancher/dashboard-ui/c/4949)

- add clusters count to git repo list 
- add warning icon and tooltip with message when cluster count is zero

**Preview**
<img width="1664" alt="Screenshot 2022-02-07 at 14 23 42" src="https://user-images.githubusercontent.com/97888974/152808847-54bfc479-7366-4b2f-a540-8404cde085be.png">
<img width="1664" alt="Screenshot 2022-02-07 at 14 24 36" src="https://user-images.githubusercontent.com/97888974/152808858-758649fc-69f6-47ed-be33-4a7a28127015.png">


