### PR TITLE
Add ability to create/edit nav link

### DIFF
--- a/assets/styles/global/_select.scss
+++ b/assets/styles/global/_select.scss
@@ -13,6 +13,7 @@
   > .unlabeled-select:not(.taggable) {
     min-height: $input-height;
     padding-bottom: calc(#{$input-padding-sm}/2);
+    height: 100%;
   }
 }
 

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2866,6 +2866,55 @@ namespaceList:
   selectLabel: Namespace
   addLabel: Add Namespace
 
+navLink:
+  name:
+    label: Name
+    placeholder: 'e.g. foo-bar'
+  label:
+    label: Display name
+    placeholder: 'Text displayed for the link'
+  tabs: 
+    link:
+      label: Link type
+      type:
+        label: Link type
+        service: Link to service
+        url: Link to URL
+      toURL:
+        label: Destination URL
+        placeholder: 'e.g. https://rancher.com'
+      toService:
+        service:
+          label: Service (namespace/name)
+          placeholder: 'e.g. cattle-system/rancher-webhook'
+        path:
+          label: Path
+          placeholder: 'e.g. proxy/?orgId=1'
+        port:
+          label: Port
+          placeholder: 'e.g. 80'
+        scheme:
+          label: Scheme
+          placeholder: 'e.g. http'
+    target:
+      label: Window target
+      option:
+        blank: New window
+        self: Replace window
+        named: Custom named window
+      namedValue: 
+        label: Window name
+    group:
+      label: Group
+      group:
+        label: Group name
+        tooltip: Assign link to a group
+      sideLabel:
+        label: Link Label
+      description:
+        label: Link description
+      iconSrc:
+        label: Add image
 node:
   list:
     pool: Pool

--- a/components/form/FileImageSelector.vue
+++ b/components/form/FileImageSelector.vue
@@ -1,0 +1,115 @@
+<script>
+import LazyImage from '@/components/LazyImage';
+import FileSelector from '@/components/form/FileSelector';
+import { _VIEW } from '@/config/query-params';
+
+export default {
+  components: { FileSelector, LazyImage },
+  props:      {
+    value: {
+      type:    String,
+      default: null,
+    },
+    mode: {
+      type:    String,
+      default: null,
+    },
+    label: {
+      type:    String,
+      default: null,
+    }
+  },
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    }
+  },
+  methods: {
+    /**
+     * Set icon data64
+     * @param {string} event
+     */
+    setIcon(event) {
+      this.$emit('input', event);
+    }
+  }
+};
+</script>
+
+<template>
+  <FileSelector
+    v-if="!value && !isView"
+    :value="value"
+    class="btn role-primary"
+    :mode="mode"
+    :read-as-data-url="true"
+    :label="label"
+    @selected="setIcon"
+  />
+
+  <div
+    v-else
+    class="loader"
+    :class="{ 'loader--editable': !isView }"
+    @click="setIcon()"
+  >
+    <LazyImage
+      :src="value"
+      class="loader__image"
+    />
+    <i class="loader__clear icon icon-trash icon-lg"></i>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+$logo: 60px;
+
+.loader {
+  position: relative;
+  width: $logo;
+  height: $logo;
+
+  &--editable {
+    cursor: pointer;
+  }
+
+  &__image {
+    width: 100%;
+    height: 100%;
+    border-radius: calc(2 * var(--border-radius));
+    overflow: hidden;
+    background-color: white;
+
+    img {
+      object-fit: contain;
+    }
+  }
+
+  &__clear {
+    display: none;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%,-50%);
+    z-index: 1;
+  }
+
+  &--editable:hover &__clear {
+    display: inline-block;
+  }
+
+  &--editable:hover {
+    &:after {
+      content: '';
+      border-radius: calc(2 * var(--border-radius));
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: var(--overlay-bg);
+    }
+
+  }
+}
+</style>

--- a/components/form/FileImageSelector.vue
+++ b/components/form/FileImageSelector.vue
@@ -10,14 +10,27 @@ export default {
       type:    String,
       default: null,
     },
+    /**
+     * Edit mode for viewing restrictions
+     */
     mode: {
       type:    String,
       default: null,
     },
+    /**
+     * Displayed label for the upload button
+     */
     label: {
       type:    String,
       default: null,
-    }
+    },
+    /**
+     * Default already adopted value for size limitation on images in bytes
+     */
+    byteLimit: {
+      type:    Number,
+      default: 200000
+    },
   },
   computed: {
     isView() {
@@ -43,6 +56,7 @@ export default {
     class="btn role-primary"
     :mode="mode"
     :read-as-data-url="true"
+    :byte-limit="byteLimit"
     :label="label"
     @selected="setIcon"
   />

--- a/components/nav/Type.vue
+++ b/components/nav/Type.vue
@@ -56,10 +56,13 @@ export default {
     },
 
     selectType() {
-      const typePath = this.$router.resolve(this.type.route)?.route?.fullPath;
+      // Prevent issues if custom NavLink is used #5047
+      if (this.type?.route) {
+        const typePath = this.$router.resolve(this.type.route)?.route?.fullPath;
 
-      if (typePath !== this.$route.fullPath) {
-        this.$emit('selected');
+        if (typePath !== this.$route.fullPath) {
+          this.$emit('selected');
+        }
       }
     }
   }

--- a/components/nav/Type.vue
+++ b/components/nav/Type.vue
@@ -120,7 +120,7 @@ export default {
       overflow: hidden;
       text-overflow: ellipsis;
 
-      &.no-icon {
+      &:not(.nav-type) &.no-icon {
         padding-left: 3px;
       }
 

--- a/config/nuxt-paths.js
+++ b/config/nuxt-paths.js
@@ -1,0 +1,7 @@
+export const CLUSTER_PATH = {
+  ROOT:         'c-cluster',
+  PRODUCT:      'c-cluster-product',
+  RESOURCE:     'c-cluster-product-resource',
+  RESOURCE_ID:  'c-cluster-product-resource-id',
+  NAMESPACE_ID: 'c-cluster-product-resource-namespace-id',
+};

--- a/config/page-actions.js
+++ b/config/page-actions.js
@@ -1,0 +1,3 @@
+export const RESET_CARDS_ACTION = 'reset-homepage-cards';
+export const SET_LOGIN_ACTION = 'set-as-login';
+export const ADD_CUSTOM_NAV_LINK = 'add-custom-nav-link';

--- a/config/schema.js
+++ b/config/schema.js
@@ -16,3 +16,5 @@ export const PRIMITIVE_TYPES = {
   json:      'json',
   version:   'version',
 };
+
+export const PROTOCOLS = ['http', 'https'];

--- a/edit/ui.cattle.io.navlink.vue
+++ b/edit/ui.cattle.io.navlink.vue
@@ -1,0 +1,430 @@
+<script>
+import { isNull, isUndefined } from 'lodash';
+import CreateEditView from '@/mixins/create-edit-view';
+import { SERVICE } from '@/config/types';
+import { PROTOCOLS } from '@/config/schema';
+import CruResource from '@/components/CruResource';
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import FileImageSelector from '@/components/form/FileImageSelector';
+import NameNsDescription, { normalizeName } from '@/components/form/NameNsDescription';
+import Tab from '@/components/Tabbed/Tab';
+import Tabbed from '@/components/Tabbed';
+import LabeledSelect from '@/components/form/LabeledSelect.vue';
+
+const LINK_TYPE_URL = 'url';
+const LINK_TYPE_SERVICE = 'service';
+const LINK_TARGET_NAMED = 'LINK_TARGET_NAMED';
+const LINK_TARGET_BLANK = '_blank';
+const LINK_TARGET_SELF = '_self';
+
+export default {
+  mixins:     [CreateEditView],
+  components: {
+    CruResource,
+    LabeledInput,
+    RadioGroup,
+    NameNsDescription,
+    Tabbed,
+    Tab,
+    FileImageSelector,
+    LabeledSelect
+  },
+  data() {
+    return {
+      targetOptions:  [
+        {
+          value: LINK_TARGET_BLANK,
+          label: this.t('navLink.tabs.target.option.blank'),
+        },
+        {
+          value: LINK_TARGET_SELF,
+          label: this.t('navLink.tabs.target.option.self'),
+        },
+        {
+          value: LINK_TARGET_NAMED,
+          label: this.t('navLink.tabs.target.option.named'),
+        }
+      ],
+      urlTypeOptions: [
+        {
+          value: LINK_TYPE_URL,
+          label: this.t('navLink.tabs.link.type.url')
+        },
+        {
+          value: LINK_TYPE_SERVICE,
+          label: this.t('navLink.tabs.link.type.service')
+        }
+      ],
+      currentLinkType:   null,
+      targetName:        null,
+      currentTarget:     LINK_TARGET_BLANK,
+      protocolsOptions:  PROTOCOLS,
+      services:         [],
+      currentService:   null,
+    };
+  },
+  props:      {
+    value: {
+      type:     Object,
+      required: true,
+      default:  () => {}
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+  },
+  computed:   {
+    /**
+     * Identify type of navLink and clear model on value change
+     */
+    linkType: {
+      get() {
+        return this.currentLinkType;
+      },
+      set(type) {
+        switch (type) {
+        case LINK_TYPE_URL:
+          delete this.value.spec.toService;
+          this.$set(this.value.spec, 'toURL', '');
+          break;
+        case LINK_TYPE_SERVICE:
+          delete this.value.spec.toURL;
+          this.$set(this.value.spec, 'toService', {});
+          break;
+        // No default
+        }
+        this.currentLinkType = type;
+      }
+    },
+    isService() {
+      return Boolean(this.value.spec.toService);
+    },
+    isURL() {
+      return !isNull(this.value.spec.toURL) && !isUndefined(this.value.spec.toURL);
+    },
+    isNamedWindow() {
+      return this.currentTarget === LINK_TARGET_NAMED;
+    },
+    mappedServices() {
+      return this.services.map(({ id, metadata: { name, namespace } }) => ({
+        label: id, id, name, namespace
+      }) );
+    },
+  },
+  async fetch() {
+    this.services = await this.$store
+      .dispatch('cluster/findAll', { type: SERVICE });
+  },
+  methods:    {
+    /**
+     * Set the target of the navLink
+     * It will assign namedWindow value for named target cases
+     * @param {string} value
+     */
+    setTargetValue(value) {
+      switch (value) {
+      case LINK_TARGET_SELF:
+      case LINK_TARGET_BLANK:
+        this.$set(this.value.spec, 'target', value);
+        break;
+      default:
+        this.$set(this.value.spec, 'target', this.targetName);
+        break;
+      }
+    },
+    /**
+     * Identify target option based on value and update UI accordingly
+     * Note: Custom target name is not directly bound to the resource
+     */
+    setTargetOption() {
+      const value = this.value.spec.target;
+
+      switch (value) {
+      case LINK_TARGET_SELF:
+      case LINK_TARGET_BLANK:
+        this.currentTarget = value;
+        break;
+      default:
+        this.currentTarget = LINK_TARGET_NAMED;
+        this.targetName = value;
+        break;
+      }
+    },
+    /**
+     * Set URL type based on existing data
+     */
+    setUrlType() {
+      if (this.isURL) {
+        this.currentLinkType = LINK_TYPE_URL;
+      }
+      if (this.isService) {
+        this.currentLinkType = LINK_TYPE_SERVICE;
+      }
+    },
+    /**
+     * Initialize resource on creation
+     */
+    setDefaultValues() {
+      if (!this.value.spec) {
+        // Link to URL is set as default option from the data
+        this.$set(this.value, 'spec', { toURL: '' });
+      }
+      if (!this.value.metadata) {
+        this.$set(this.value, 'metadata', {});
+      }
+      if (!this.value.spec.target) {
+        this.$set(this.value.spec, 'target', LINK_TARGET_BLANK);
+      }
+    },
+    /**
+     * Set namespace and name from the selected service
+     * @param {label: string, id: string, name: string, namespace: string} service
+     */
+    setService(service) {
+      if (service) {
+        const { name, namespace } = service;
+
+        this.$set(this.value.spec.toService, 'name', name);
+        this.$set(this.value.spec.toService, 'namespace', namespace);
+      }
+    },
+    /**
+     * Set paired values of namespace and name for the service
+     */
+    setCurrentService() {
+      const name = this.value.spec.toService?.name;
+      const namespace = this.value.spec.toService?.namespace;
+
+      if (name && namespace) {
+        this.currentService = `${ namespace }/${ name }`;
+      }
+    },
+    /**
+     * Generate automatically kebab case for the displayed label
+     */
+    setName() {
+      this.$set(this.value.metadata, 'name', normalizeName(this.value.spec.label));
+    },
+    /**
+     * Get error chained validation based on existing label
+     * @param {string} label
+     */
+    getError(label) {
+      return this.$store.getters['i18n/t']('validation.required', { key: this.t(label) });
+    },
+    /**
+     * Verify all fields are fulfilled or display footer notification
+     */
+    validate() {
+      const errors = [];
+
+      switch (this.currentLinkType) {
+      case LINK_TYPE_URL:
+        if (!this.value.spec.toURL) {
+          errors.push(this.getError('navLink.tabs.link.toURL.label'));
+        }
+        break;
+
+      case LINK_TYPE_SERVICE:
+        if (!this.value.spec.toService.name || !this.value.spec.toService.namespace) {
+          errors.push(this.getError(`navLink.tabs.link.toService.service.label`));
+        }
+
+        if (!this.value.spec.toService.scheme) {
+          errors.push(this.getError(`navLink.tabs.link.toService.scheme.label`));
+        }
+        break;
+
+        // no default
+      }
+
+      if (!this.value.metadata.name) {
+        errors.push(this.getError('navLink.name.label'));
+      }
+
+      if (errors.length) {
+        throw (errors.join('\n'));
+      }
+    },
+  },
+  created() {
+    this.setDefaultValues();
+    this.setUrlType();
+    this.setTargetOption();
+    this.setCurrentService();
+    // Validate error presence by allowing or resetting submission process
+    if (this.registerBeforeHook) {
+      this.registerBeforeHook(this.validate);
+    }
+  }
+};
+</script>
+
+<template>
+  <CruResource
+    :can-yaml="!isCreate"
+    :mode="mode"
+    :resource="value"
+    :errors="errors"
+    :cancel-event="true"
+    @error="e=>errors = e"
+    @finish="save"
+    @cancel="done()"
+  >
+    <NameNsDescription
+      v-model="value"
+      :namespaced="false"
+      :namespace-disabled="true"
+      :mode="mode"
+      name-key="metadata.name"
+      description-key="spec.label"
+      name-label="navLink.name.label"
+      name-placeholder="navLink.name.placeholder"
+      description-label="navLink.label.label"
+      description-placeholder="navLink.label.placeholder"
+    />
+
+    <Tabbed
+      :side-tabs="true"
+    >
+      <Tab
+        name="link"
+        :label="t('navLink.tabs.link.label')"
+      >
+        <div class="row mb-20">
+          <div class="col span-6">
+            <RadioGroup
+              v-model="linkType"
+              name="type"
+              :mode="mode"
+              :options="urlTypeOptions"
+            />
+          </div>
+        </div>
+
+        <template v-if="isURL">
+          <div class="row mb-20">
+            <LabeledInput
+              v-model="value.spec.toURL"
+              :mode="mode"
+              :label="t('navLink.tabs.link.toURL.label')"
+              :required="isURL"
+              :placeholder="t('navLink.tabs.link.toURL.placeholder')"
+            />
+          </div>
+        </template>
+        <template v-if="isService">
+          <div class="row mb-20">
+            <div class="col span-2">
+              <LabeledSelect
+                v-model="value.spec.toService.scheme"
+                :mode="mode"
+                :label="t('navLink.tabs.link.toService.scheme.label')"
+                :required="isService"
+                :options="protocolsOptions"
+                :placeholder="t('navLink.tabs.link.toService.scheme.placeholder')"
+              />
+            </div>
+            <div class="col span-5">
+              <LabeledSelect
+                v-model="currentService"
+                :mode="mode"
+                :label="t('navLink.tabs.link.toService.service.label')"
+                :options="mappedServices"
+                :required="isService"
+                :placeholder="t('navLink.tabs.link.toService.service.placeholder')"
+                @input="setService"
+              />
+            </div>
+            <div class="col span-2">
+              <LabeledInput
+                v-model="value.spec.toService.port"
+                :mode="mode"
+                :label="t('navLink.tabs.link.toService.port.label')"
+                type="number"
+                :placeholder="t('navLink.tabs.link.toService.port.placeholder')"
+              />
+            </div>
+            <div class="col span-3">
+              <LabeledInput
+                v-model="value.spec.toService.path"
+                :mode="mode"
+                :label="t('navLink.tabs.link.toService.path.label')"
+                :placeholder="t('navLink.tabs.link.toService.path.placeholder')"
+              />
+            </div>
+          </div>
+        </template>
+      </Tab>
+
+      <Tab
+        name="target"
+        :label="t('navLink.tabs.target.label')"
+      >
+        <div class="row mb-20">
+          <div class="col span-6">
+            <RadioGroup
+              v-model="currentTarget"
+              name="type"
+              :mode="mode"
+              :options="targetOptions"
+              :required="true"
+              @input="setTargetValue($event)"
+            />
+          </div>
+          <div class="col span-6">
+            <LabeledInput
+              v-if="isNamedWindow"
+              v-model="targetName"
+              :mode="mode"
+              :label="t('navLink.tabs.target.namedValue.label')"
+              @input="setTargetValue($event);"
+            />
+          </div>
+        </div>
+      </Tab>
+
+      <Tab
+        name="group"
+        :label="t('navLink.tabs.group.label')"
+      >
+        <div class="row mb-20">
+          <div class="col span-6">
+            <LabeledInput
+              v-model="value.spec.group"
+              :mode="mode"
+              :tooltip="t('navLink.tabs.group.group.tooltip')"
+              :label="t('navLink.tabs.group.group.label')"
+            />
+          </div>
+          <div class="col span-6">
+            <LabeledInput
+              v-model="value.spec.sideLabel"
+              :mode="mode"
+              :label="t('navLink.tabs.group.sideLabel.label')"
+            />
+          </div>
+        </div>
+
+        <div class="row mb-20">
+          <div class="col span-6">
+            <LabeledInput
+              v-model="value.spec.description"
+              :mode="mode"
+              :label="t('navLink.tabs.group.description.label')"
+            />
+          </div>
+          <div class="col span-2">
+            <FileImageSelector
+              v-model="value.spec.iconSrc"
+              :mode="mode"
+              :label="t('navLink.tabs.group.iconSrc.label')"
+            />
+          </div>
+        </div>
+      </Tab>
+    </Tabbed>
+  </CruResource>
+</template>

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -23,8 +23,7 @@ import { SETTING } from '@/config/settings';
 import { BLANK_CLUSTER } from '@/store';
 import { filterOnlyKubernetesClusters } from '@/utils/cluster';
 
-const SET_LOGIN_ACTION = 'set-as-login';
-const RESET_CARDS_ACTION = 'reset-homepage-cards';
+import { RESET_CARDS_ACTION, SET_LOGIN_ACTION } from '@/config/page-actions';
 
 export default {
   name:       'Home',
@@ -189,11 +188,21 @@ export default {
   },
 
   methods: {
+    /**
+     * Define actions for each navigation link
+     * @param {*} action
+     */
     handlePageAction(action) {
-      if (action.action === RESET_CARDS_ACTION) {
+      switch (action.action) {
+      case RESET_CARDS_ACTION:
         this.resetCards();
-      } else if (action.action === SET_LOGIN_ACTION) {
+        break;
+
+      case SET_LOGIN_ACTION:
         this.afterLoginRoute = 'home';
+        break;
+
+      // no default
       }
     },
 


### PR DESCRIPTION
#5047

## Resource edit
Added `edit` resource  page `ui.cattle.io.navlink` for link creation, based on provided documentations in the issue.

On create, value is initialized and set default as URL

- Custom target window `value.spec.target`  is mapped and set as follow:
  - On page loaded, if not `_blank`, nor `_self` and has value, it's set as named and value injected in the input
  - On radio change, option value is set except if named, then it's set from the input
  - On input type, value is set

![Screenshot from 2022-02-16 13-56-13](https://user-images.githubusercontent.com/5009481/154269486-29092567-d928-47c1-ae1b-94893a801307.png)

- Link type
  - On page loaded is identified if is URL or Service, based on resource data, then passed to UI
  - On link type change, respective unchecked values are removed
- Service paired values namespace/name
  - On page loaded `value.spec.toService.namespace` and `value.spec.toService.name` are set as current service to the UI
  - On service selection `namespace` and `name` are set

![Screenshot from 2022-02-16 13-56-37](https://user-images.githubusercontent.com/5009481/154269431-bf4e15f3-b615-4728-9b88-a95b196947e3.png)
 
- Group
  - Set all the group information in the same tab
  - Adopted new file image uploader
  - Added tooltip for the label

![Screenshot from 2022-02-16 13-56-20](https://user-images.githubusercontent.com/5009481/154269686-ee6e8eff-446e-4285-9636-99abcb56c160.png)

## Validation

Added validation of missing fields using the `registerBeforeHook` hook definition on creation.

![Screenshot from 2022-02-18 16-03-13](https://user-images.githubusercontent.com/5009481/154708213-f2bc21c0-b9cc-4b1b-9109-e82e8b17dee7.png)

## Image uploader
Tested with:
- SVG
- Big images
- Size limited images
- Add/Remove image
- Edit/View/Create mode

Value used:
- icon size lg: https://github.com/rancher/dashboard/blob/master/assets/styles/fonts/_icons.scss
- overlay: https://github.com/rancher/dashboard/blob/master/assets/styles/themes/_dark.scss#L83

![file_image_upload](https://user-images.githubusercontent.com/5009481/154270117-c9e41572-62cc-4030-898d-40be1ef82688.png)

# Extras
- Added `config/page-actions.js` cases
- Added cluster paths to `config/types.js`, e.g. `c-cluster-product-resource`
- Replaced chained conditions with switches for `pages/home.vue` and `layouts/default.vue`
- Fixed issue with `.select` components net being full height
- Created `components/form/FileImageSelector.vue` for uploading images; sizes of the component have been set fixed for now
- Corrected group custom NavLink alignment
- Corrected external link error on navigation through custom NavLink