### PR TITLE
Don't hide cluster events when v2 monitoring is installed

### DIFF
--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -389,30 +389,34 @@ export default {
       <EmberPage inline="ember-anchor" :src="v1MonitoringURL" />
     </div>
 
-    <div class="mb-40 mt-40">
-      <h3>{{ hasMonitoring ?t('clusterIndexPage.sections.alerts.label') :t('clusterIndexPage.sections.events.label') }}</h3>
-      <AlertTable v-if="hasMonitoring" />
-      <SortableTable
-        v-else
-        :rows="events"
-        :headers="eventHeaders"
-        key-field="id"
-        :search="false"
-        :table-actions="false"
-        :row-actions="false"
-        :paging="true"
-        :rows-per-page="10"
-        default-sort-by="date"
-      >
-        <template #cell:resource="{row, value}">
-          <n-link :to="row.detailLocation">
-            {{ value }}
-          </n-link>
-          <div v-if="row.message">
-            {{ row.displayMessage }}
-          </div>
-        </template>
-      </SortableTable>
+    <div class="mt-30">
+      <Tabbed>
+        <Tab name="cluster-events" :label="t('clusterIndexPage.sections.events.label')" :weight="2">
+          <SortableTable
+            :rows="events"
+            :headers="eventHeaders"
+            key-field="id"
+            :search="false"
+            :table-actions="false"
+            :row-actions="false"
+            :paging="true"
+            :rows-per-page="10"
+            default-sort-by="date"
+          >
+            <template #cell:resource="{row, value}">
+              <n-link :to="row.detailLocation">
+                {{ value }}
+              </n-link>
+              <div v-if="row.message">
+                {{ row.displayMessage }}
+              </div>
+            </template>
+          </SortableTable>
+        </Tab>
+        <Tab v-if="hasMonitoring" name="cluster-alerts" :label="t('clusterIndexPage.sections.alerts.label')" :weight="1">
+          <AlertTable />
+        </Tab>
+      </Tabbed>
     </div>
     <Tabbed v-if="hasMetricsTabs" class="mt-30">
       <Tab v-if="showClusterMetrics" name="cluster-metrics" :label="t('clusterIndexPage.sections.clusterMetrics.label')" :weight="2">


### PR DESCRIPTION
Fixes #4911 

This PR addresses the issue above - we now use a tabbed view and always show the events tab plus then show the alerts tab when v2 monitoring is installed.