### PR TITLE
Allow pods table to be grouped by node

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3667,6 +3667,7 @@ resourceTable:
     none: Flat List
     namespace: Group by Namespace
     project: Group by Project
+    node: Group by Node
   groupLabel:
     cluster: "<span>Cluster:</span> {name}"
     namespace: "<span>Namespace:</span> {name}"
@@ -3679,6 +3680,7 @@ resourceTable:
     workspace: "<span>Workspace:</span> {name}"
     notInANodePool: "Not in a Pool"
     nodePool: "<span>Pool:</span> {name} ({count})"
+    node: "<span>Node:</span> {name}"
 
 resourceTabs:
   conditions:

--- a/components/ResourceTable.vue
+++ b/components/ResourceTable.vue
@@ -8,6 +8,9 @@ import { NAMESPACE } from '@/config/table-headers';
 import { findBy } from '@/utils/array';
 import { NAME as HARVESTER } from '@/config/product/harvester';
 
+// Default group-by in the case the group stored in the preference does not apply
+const DEFAULT_GROUP = 'namespace';
+
 export default {
   components: { ButtonGroup, SortableTable },
 
@@ -175,7 +178,27 @@ export default {
       });
     },
 
-    group: mapPref(GROUP_RESOURCES),
+    _group: mapPref(GROUP_RESOURCES),
+
+    // The group stored in the preference (above) might not be valid for this resource table - so ensure we
+    // choose a group that is applicable (the default)
+    // This saves us from having to store a group preference per resource type - given that custom groupings aer not used much
+    // and it feels like a good UX to be able to keep the namespace/flat grouping across tables
+    group: {
+      get() {
+        // Check group is valid
+        const exists = this.groupOptions.find(g => g.value === this._group);
+
+        if (!exists) {
+          return DEFAULT_GROUP;
+        }
+
+        return this._group;
+      },
+      set(value) {
+        this._group = value;
+      }
+    },
 
     showGrouping() {
       if ( this.groupable === null ) {

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -136,6 +136,19 @@ export function init(store) {
   configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false });
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });
 
+  // Allow Pods to be grouped by node
+  configureType(POD, {
+    listGroups: [
+      {
+        icon:       'icon-cluster',
+        value:      'node',
+        field:      'groupByNode',
+        hideColumn: NODE_COL.name,
+        tooltipKey: 'resourceTable.groupBy.node'
+      }
+    ]
+  });
+
   setGroupDefaultType('serviceDiscovery', SERVICE);
 
   configureType('workload', {

--- a/models/pod.js
+++ b/models/pod.js
@@ -2,7 +2,7 @@ import { insertAt } from '@/utils/array';
 import { colorForState, stateDisplay } from '@/plugins/steve/resource-class';
 import { NODE, WORKLOAD_TYPES } from '@/config/types';
 import SteveModel from '@/plugins/steve/steve-class';
-import { shortenedImage } from '@/utils/string';
+import { escapeHtml, shortenedImage } from '@/utils/string';
 
 export const WORKLOAD_PRIORITY = {
   [WORKLOAD_TYPES.DEPLOYMENT]:             1,
@@ -158,5 +158,12 @@ export default class Pod extends SteveModel {
 
   get isRunning() {
     return this.status.phase === 'Running';
+  }
+
+  // Use by pod list to group the pods by node
+  get groupByNode() {
+    const name = this.spec?.nodeName || this.$rootGetters['i18n/t']('generic.none');
+
+    return this.$rootGetters['i18n/t']('resourceTable.groupLabel.node', { name: escapeHtml(name) });
   }
 }

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -423,6 +423,7 @@ export const getters = {
       showAge:     true,
       canYaml:     true,
       namespaced:  null,
+      listGroups:  [],
     };
 
     return (schemaOrType) => {


### PR DESCRIPTION
Fixes #5073 

This PR adds the ability to group pods by node in the pods list view under workloads.

![image](https://user-images.githubusercontent.com/1955897/153035826-4019075b-40b8-4acc-9d6f-d4d2ad5e9a3b.png)
