### PR TITLE
Add build for Rancher Desktop embed of dashboard

### DIFF
--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -20,9 +20,11 @@ jobs:
     
     - name: Install & Build
       run: |
+        mkdir release
         yarn install --frozen-lockfile
         NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-        tar -czf embed-rancher-desktop.tar.gz dist/embed-rancher-desktop
+        tar -czf release/embed-rancher-desktop.tar.gz dist/embed-rancher-desktop
+        sha512sum release/embed-rancher-desktop.tar.gz > release/embed-rancher-desktop.tar.gz.sha512sum"
 
     - name: Upload Build
       uses: actions/upload-artifact@v2
@@ -35,5 +37,6 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: embed-rancher-desktop.tar.gz
+        file: release/*
         tag: ${{ github.ref }}
+        file_glob: true

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         mkdir ${{ env.RELEASE_DIR }}
         yarn install --frozen-lockfile
-        NUXT_ENV_commit=${{ GITHUB_SHA} } NUXT_ENV_version=${{ GITHUB_REF_NAME }} OUTPUT_DIR=${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
+        NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
         tar -czf ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz ${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }}
         sha512sum ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz > ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz.sha512sum
 

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -24,7 +24,7 @@ jobs:
         yarn install --frozen-lockfile
         NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
         tar -czf release/embed-rancher-desktop.tar.gz dist/embed-rancher-desktop
-        sha512sum release/embed-rancher-desktop.tar.gz > release/embed-rancher-desktop.tar.gz.sha512sum"
+        sha512sum release/embed-rancher-desktop.tar.gz > release/embed-rancher-desktop.tar.gz.sha512sum
 
     - name: Upload Build
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -3,7 +3,7 @@ name: Build and Release Rancher Dashboard - Rancher Desktop Embed
 on:
   push:
     tags:
-      - '*'
+        - 'v**-desktop*'
   
 jobs:
   build:
@@ -17,15 +17,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '12.x'
-    
-    - name: Get Branch Name
-      run: |
-        echo "NOT FAIL"
-        echo "${GITHUB_REF#refs/heads/}"
-        echo "${GITHUB_REF_NAME}"
-        echo "NOT FAIL"
-        echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: get_branch
     
     - name: Install & Build
       run: |

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -27,6 +27,6 @@ jobs:
     - name: Upload Build
       uses: actions/upload-artifact@v2
       with:
-        path: embed-rancher-desktop
+        path: embed-rancher-desktop.tar.gz
         name: embed-rancher-desktop
         if-no-files-found: error

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         yarn install --frozen-lockfile
         NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-        tar -czf dist/embed-rancher-desktop embed-rancher-desktop
+        tar -czf embed-rancher-desktop.tar.gz dist/embed-rancher-desktop
 
     - name: Upload Build
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -27,6 +27,6 @@ jobs:
     - name: Upload Build
       uses: actions/upload-artifact@v2
       with:
-        path: embed-rancher-desktop.tar.gz
+        path: dist/embed-rancher-desktop
         name: embed-rancher-desktop
         if-no-files-found: error

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -25,23 +25,23 @@ jobs:
     
     - name: Install & Build
       run: |
-        mkdir ${{ RELEASE_DIR }}
+        mkdir ${{ env.RELEASE_DIR }}
         yarn install --frozen-lockfile
-        NUXT_ENV_commit=${{ GITHUB_SHA} } NUXT_ENV_version=${{ GITHUB_REF_NAME }} OUTPUT_DIR=${{ OUTPUT_DIR }}/${{ ARTIFACT_NAME }} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-        tar -czf ${{ RELEASE_DIR }}/${{ ARTIFACT_NAME }}.tar.gz ${{ OUTPUT_DIR }}/${{ ARTIFACT_NAME }}
-        sha512sum ${{ RELEASE_DIR }}/${{ ARTIFACT_NAME }}.tar.gz > ${{ RELEASE_DIR }}/${{ ARTIFACT_NAME }}.tar.gz.sha512sum
+        NUXT_ENV_commit=${{ GITHUB_SHA} } NUXT_ENV_version=${{ GITHUB_REF_NAME }} OUTPUT_DIR=${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
+        tar -czf ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz ${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }}
+        sha512sum ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz > ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz.sha512sum
 
     - name: Upload Build
       uses: actions/upload-artifact@v2
       with:
-        path: ${{ OUTPUT_DIR }}/${{ ARTIFACT_NAME }}
-        name: ${{ ARTIFACT_NAME }}
+        path: ${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }}
+        name: ${{ env.ARTIFACT_NAME }}
         if-no-files-found: error
 
     - name: Upload Assets
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ RELEASE_DIR }}/*
+        file: ${{ env.RELEASE_DIR }}/*
         tag: ${{ github.ref }}
         file_glob: true

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -19,8 +19,9 @@ jobs:
         node-version: '12.x'
     
     - name: Install & Build
-      run: yarn
-      run: NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
+      run: |
+        yarn install --frozen-lockfile
+        NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
         
     - name: Upload Build
       uses: actions/upload-artifact@v2

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -28,7 +28,7 @@ jobs:
         mkdir ${{ env.RELEASE_DIR }}
         yarn install --frozen-lockfile
         NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-        tar -czf ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz ${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }}
+        tar -czf ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz -C ${{ env.OUTPUT_DIR }}/${{ env.ARTIFACT_NAME }} .
         sha512sum ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz > ${{ env.RELEASE_DIR }}/${{ env.ARTIFACT_NAME }}.tar.gz.sha512sum
 
     - name: Upload Build

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -25,23 +25,23 @@ jobs:
     
     - name: Install & Build
       run: |
-        mkdir ${RELEASE_DIR}
+        mkdir ${{ RELEASE_DIR }}
         yarn install --frozen-lockfile
-        NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=${OUTPUT_DIR}/${ARTIFACT_NAME} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-        tar -czf ${RELEASE_DIR}/${ARTIFACT_NAME}.tar.gz ${OUTPUT_DIR}/${ARTIFACT_NAME}
-        sha512sum ${RELEASE_DIR}/${ARTIFACT_NAME}.tar.gz > ${RELEASE_DIR}/${ARTIFACT_NAME}.tar.gz.sha512sum
+        NUXT_ENV_commit=${{ GITHUB_SHA} } NUXT_ENV_version=${{ GITHUB_REF_NAME }} OUTPUT_DIR=${{ OUTPUT_DIR }}/${{ ARTIFACT_NAME }} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
+        tar -czf ${{ RELEASE_DIR }}/${{ ARTIFACT_NAME }}.tar.gz ${{ OUTPUT_DIR }}/${{ ARTIFACT_NAME }}
+        sha512sum ${{ RELEASE_DIR }}/${{ ARTIFACT_NAME }}.tar.gz > ${{ RELEASE_DIR }}/${{ ARTIFACT_NAME }}.tar.gz.sha512sum
 
     - name: Upload Build
       uses: actions/upload-artifact@v2
       with:
-        path: ${OUTPUT_DIR}/${ARTIFACT_NAME}
-        name: ${ARTIFACT_NAME}
+        path: ${{ OUTPUT_DIR }}/${{ ARTIFACT_NAME }}
+        name: ${{ ARTIFACT_NAME }}
         if-no-files-found: error
 
     - name: Upload Assets
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${RELEASE_DIR}/*
+        file: ${{ RELEASE_DIR }}/*
         tag: ${{ github.ref }}
         file_glob: true

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -3,7 +3,7 @@ name: Build and Release Rancher Dashboard - Rancher Desktop Embed
 on:
   push:
     tags:
-        - 'v**-desktop*'
+        - 'desktop-v*'
 
 env:
   OUTPUT_DIR: dist

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -1,0 +1,30 @@
+name: Build and Release Rancher Dashboard - Rancher Desktop Embed
+
+on:
+  push:
+    branch:
+      - 'feature/rancher-desktop-builds'
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      build:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+      
+      - name: Install & Build
+        run: yarn
+        run: NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
+          
+      - name: Upload Build
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/embed-rancher-desktop
+          if-no-files-found: error

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -8,7 +8,7 @@ on:
 env:
   OUTPUT_DIR: dist
   RELEASE_DIR: release
-  ARTIFACT_NAME: embed-rancher-desktop  
+  ARTIFACT_NAME: rancher-dashboard-desktop-embed
   
 jobs:
   build:

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -9,22 +9,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      build:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12.x'
-      
-      - name: Install & Build
-        run: yarn
-        run: NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-          
-      - name: Upload Build
-        uses: actions/upload-artifact@v2
-        with:
-          path: dist/embed-rancher-desktop
-          if-no-files-found: error
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12.x'
+    
+    - name: Install & Build
+      run: yarn
+      run: NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
+        
+    - name: Upload Build
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/embed-rancher-desktop
+        if-no-files-found: error

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -19,7 +19,12 @@ jobs:
         node-version: '12.x'
     
     - name: Get Branch Name
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: |
+        echo "NOT FAIL"
+        echo "${GITHUB_REF#refs/heads/}"
+        echo "${GITHUB_REF_NAME}"
+        echo "NOT FAIL"
+        echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: get_branch
     
     - name: Install & Build

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -22,9 +22,11 @@ jobs:
       run: |
         yarn install --frozen-lockfile
         NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-        
+        tar -czf dist/embed-rancher-desktop embed-rancher-desktop
+
     - name: Upload Build
       uses: actions/upload-artifact@v2
       with:
-        path: dist/embed-rancher-desktop
+        path: embed-rancher-desktop
+        name: embed-rancher-desktop
         if-no-files-found: error

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
         - 'v**-desktop*'
+
+env:
+  OUTPUT_DIR: dist
+  RELEASE_DIR: release
+  ARTIFACT_NAME: embed-rancher-desktop  
   
 jobs:
   build:
@@ -20,23 +25,23 @@ jobs:
     
     - name: Install & Build
       run: |
-        mkdir release
+        mkdir ${RELEASE_DIR}
         yarn install --frozen-lockfile
-        NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=dist/embed-rancher-desktop ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
-        tar -czf release/embed-rancher-desktop.tar.gz dist/embed-rancher-desktop
-        sha512sum release/embed-rancher-desktop.tar.gz > release/embed-rancher-desktop.tar.gz.sha512sum
+        NUXT_ENV_commit=${GITHUB_SHA} NUXT_ENV_version=${GITHUB_REF_NAME} OUTPUT_DIR=${OUTPUT_DIR}/${ARTIFACT_NAME} ROUTER_BASE='/dashboard' RANCHER_ENV=desktop yarn run build --spa
+        tar -czf ${RELEASE_DIR}/${ARTIFACT_NAME}.tar.gz ${OUTPUT_DIR}/${ARTIFACT_NAME}
+        sha512sum ${RELEASE_DIR}/${ARTIFACT_NAME}.tar.gz > ${RELEASE_DIR}/${ARTIFACT_NAME}.tar.gz.sha512sum
 
     - name: Upload Build
       uses: actions/upload-artifact@v2
       with:
-        path: dist/embed-rancher-desktop
-        name: embed-rancher-desktop
+        path: ${OUTPUT_DIR}/${ARTIFACT_NAME}
+        name: ${ARTIFACT_NAME}
         if-no-files-found: error
 
     - name: Upload Assets
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: release/*
+        file: ${RELEASE_DIR}/*
         tag: ${{ github.ref }}
         file_glob: true

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -2,12 +2,13 @@ name: Build and Release Rancher Dashboard - Rancher Desktop Embed
 
 on:
   push:
-    branch:
-      - 'feature/rancher-desktop-builds'
+    tags:
+      - '*'
   
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/feature/rancher-desktop-builds'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -30,3 +31,10 @@ jobs:
         path: dist/embed-rancher-desktop
         name: embed-rancher-desktop
         if-no-files-found: error
+
+    - name: Upload Assets
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: embed-rancher-desktop.tar.gz
+        tag: ${{ github.ref }}

--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/feature/rancher-desktop-builds'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -18,6 +17,10 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '12.x'
+    
+    - name: Get Branch Name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: get_branch
     
     - name: Install & Build
       run: |


### PR DESCRIPTION
This allows us to release dashboard artifacts that are meant to be embedded into Rancher Desktop. My current approach for achieving this goal is to trigger a build when a tag matches the given pattern `v**-desktop*` (e.g. v2.6.3-desktop). 

This build sets the variable `RANCHER_ENV=desktop`, creates archive of the build, generates a checksum, and uploads the artifacts to the release. Rancher Desktop will then be able to download these artifacts at build-time and bundle a customized version of Dashboard into the final product. 

Example release from my fork:

https://github.com/rak-phillip/dashboard/releases/tag/v2.6.3-desktop.11

supports rancher-sandbox/rancher-desktop#1192
