### PR TITLE
Fix three of the prominent code typos

### DIFF
--- a/mixins/harvester-vm/index.js
+++ b/mixins/harvester-vm/index.js
@@ -608,7 +608,7 @@ export default {
         userDataJson.ssh_authorized_keys = this.getSSHListValue(this.sshKey);
       }
 
-      if (userDataJson.ssh_authorized_keys && userDataJson.ssh_authorized_keys.lenght === 0) {
+      if (userDataJson.ssh_authorized_keys && userDataJson.ssh_authorized_keys.length === 0) {
         delete userDataJson.ssh_authorized_keys;
       }
 

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -211,7 +211,7 @@ export default {
         name:   'c-cluster-explorer-tools-pages-page',
         params: {
           cluster: cluster.id,
-          prodct:  'explorer',
+          product: 'explorer',
           page:    id,
         }
       };

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -1339,7 +1339,7 @@ export default class Resource {
         const allOfResourceType = this.$rootGetters['cluster/all']( type );
 
         this.ownersByType[kind].forEach((resource, idx) => {
-          const resourceInstance = allOfResourceType.find(resource => resource?.metdata?.uid === resource.uid);
+          const resourceInstance = allOfResourceType.find(resourceByType => resourceByType?.metadata?.uid === resource.uid);
 
           if (resourceInstance) {
             owners.push(resourceInstance);


### PR DESCRIPTION
- Two are harvester related
  - @WuJun2016 Could you take a quick look at these? I'm most concerned about the fix to `owners`. From what I can tell this works with `metadata.ownerReferences` which is only used in Harvester land. I couldn't get it to fire though with the Harvester i have running locally. Could you validate this and the other fix works?
- One is v1 legacy chart related

