### PR TITLE
Fixing questions for the generic machine config

### DIFF
--- a/components/Questions/index.vue
+++ b/components/Questions/index.vue
@@ -214,6 +214,10 @@ export default {
       }
     },
 
+    chartName() {
+      return this.source.chart?.name;
+    },
+
     groups() {
       const map = {};
       const defaultGroup = 'Questions';
@@ -223,7 +227,7 @@ export default {
         const group = q.group || defaultGroup;
 
         const normalized = group.trim().toLowerCase();
-        const name = this.$store.getters['i18n/withFallback'](`charts.${ this.source.chart.name }.group.${ camelCase(group) }`, null, group);
+        const name = this.$store.getters['i18n/withFallback'](`charts.${ this.chartName }.group.${ camelCase(group) }`, null, group);
 
         if ( !map[normalized] ) {
           map[normalized] = {
@@ -440,7 +444,7 @@ export default {
             :target-namespace="targetNamespace"
             :value="get(value, q.variable)"
             :disabled="disabled"
-            :chart-name="source.chart.name"
+            :chart-name="chartName"
             @input="update(q.variable, $event)"
           />
         </div>
@@ -465,7 +469,7 @@ export default {
             :mode="mode"
             :value="get(value, q.variable)"
             :disabled="disabled"
-            :chart-name="source.chart.name"
+            :chart-name="chartName"
             @input="update(q.variable, $event)"
           />
         </div>


### PR DESCRIPTION
We were referencing source.chart.name within the questions component even when questions weren't being used for charts.

This change makes it so we only use the chart name if it's present. If it's not present there were already existing fallback mechanisms in place.

rancher/dashboard#5065

![image](https://user-images.githubusercontent.com/55104481/153609297-ce3bc379-9c01-4e77-9c7c-c8d3e6d6f73c.png)
