### PR TITLE
fix nav Group's groupSelected

### DIFF
--- a/components/nav/Group.vue
+++ b/components/nav/Group.vue
@@ -93,8 +93,8 @@ export default {
     },
 
     groupSelected() {
-      // Don't auto-select first group entry if we're already expanded
-      if (this.isExpanded) {
+      // Don't auto-select first group entry if we're already expanded and contain the currently-selected nav item
+      if (this.hasActiveRoute() && this.isExpanded) {
         return;
       }
 


### PR DESCRIPTION
#4368 - we were aborting the function call that selects the first nav item in a group when the group is expanded; that assumes that an expanded group is the active group, which is not necessarily true (see ticket repro steps).