### PR TITLE
Rotate certs action is available for RKE2 clusters

### DIFF
--- a/components/dialog/RotateCertificatesDialog.vue
+++ b/components/dialog/RotateCertificatesDialog.vue
@@ -78,14 +78,11 @@ export default {
 
           set(this.cluster, 'spec.rkeConfig.rotateCertificates', {
             generation:     currentGeneration + 1,
-            caCertificates: true,
             services:       this.selectedService ? [this.selectedService] : null
           });
 
           await this.cluster.save();
         } else {
-          const cluster = this.cluster.mgmt;
-
           await this.cluster.mgmt.cluster.doAction('rotateCertificates', params);
         }
         buttonDone(true);

--- a/components/dialog/RotateCertificatesDialog.vue
+++ b/components/dialog/RotateCertificatesDialog.vue
@@ -86,7 +86,7 @@ export default {
         } else {
           const cluster = this.cluster.mgmt;
 
-          await cluster.doAction('rotateCertificates', params);
+          await this.cluster.mgmt.cluster.doAction('rotateCertificates', params);
         }
         buttonDone(true);
         this.close();

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -97,7 +97,7 @@ export default class ProvCluster extends SteveModel {
       action:     'rotateCertificates',
       label:      this.$rootGetters['i18n/t']('nav.rotateCertificates'),
       icon:       'icon icon-backup',
-      enabled:    this.mgmt?.hasAction('rotateCertificates') && this.mgmt?.isReady,
+      enabled:    (this.isRke2 && this.mgmt?.isReady && this.canUpdate) || (this.mgmt?.hasAction('rotateCertificates') && this.mgmt?.isReady),
     });
 
     insertAt(out, idx++, {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4485 by adding an action to the context menu for Rancher provisioned RKE2 clusters.
<img width="992" alt="Screen Shot 2022-02-14 at 5 16 23 PM" src="https://user-images.githubusercontent.com/20599230/153968594-d223e0e6-9857-4c99-a431-34ab893bf35e.png">
<img width="809" alt="Screen Shot 2022-02-14 at 5 18 05 PM" src="https://user-images.githubusercontent.com/20599230/153968728-ac6783ab-ab71-4b91-93ce-a3d9527a584c.png">

To test this PR,

1. I provisioned an RKE2 cluster in Rancher
2. I rotated the certs, trying both options - "rotate all service certificates" and "rotate an individual service"
3. In both cases the cluster went into provisioning state and came back successfully

Notes:

- The Steve API doesn't support actions, so we patch the cluster to update the cert configuration in `cluster.spec.rkeConfig.rotateCertificates`. See https://github.com/rancher/dashboard/issues/4485#issuecomment-1032932115
- For an example of similar logic for handling an action like this for an RKE2 cluster, see the component for restoring clusters from snapshot https://github.com/rancher/dashboard/blob/master/components/PromptRestore.vue#L132
- The logic for showing the action is the same as the logic for figuring out whether to show the restore snapshot option for RKE2 clusters https://github.com/rancher/dashboard/blob/master/models/provisioning.cattle.io.cluster.js#L62
