### PR TITLE
Bug fix for can't create service as a user with Manage Workloads permission

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4713,6 +4713,7 @@ workload:
     name: Container Name
     noResourceLimits: There are no resource requirements configured.
     noPorts: There are no ports configured.
+    noServiceAccess: You do not have permission to create or manage services
     ports:
       createService: Service Type
       noCreateService: Do not create a service

--- a/components/form/WorkloadPorts.vue
+++ b/components/form/WorkloadPorts.vue
@@ -9,7 +9,7 @@ import LabeledSelect from '@/components/form/LabeledSelect';
 import { HCI as HCI_LABELS_ANNOTATIONS } from '@/config/labels-annotations';
 import { isHarvesterSatisfiesVersion } from '@/utils/cluster';
 import { NAME as HARVESTER } from '@/config/product/harvester';
-import { CAPI } from '@/config/types';
+import { CAPI, SERVICE } from '@/config/types';
 
 export default {
   components: {
@@ -65,6 +65,14 @@ export default {
 
   computed: {
     ...mapGetters(['currentCluster']),
+
+    canNotAccessService() {
+      return !this.$store.getters['cluster/schemaFor'](SERVICE);
+    },
+
+    serviceTypeTooltip() {
+      return this.canNotAccessService ? this.t('workload.container.noServiceAccess') : undefined;
+    },
 
     isView() {
       return this.mode === _VIEW;
@@ -268,6 +276,8 @@ export default {
           :mode="mode"
           :label="t('workload.container.ports.createService')"
           :options="serviceTypes"
+          :disabled="canNotAccessService"
+          :tooltip="serviceTypeTooltip"
           @input="queueUpdate"
         />
       </div>

--- a/edit/workload/storage/index.vue
+++ b/edit/workload/storage/index.vue
@@ -63,7 +63,11 @@ export default {
   },
 
   async fetch() {
-    this.pvcs = await this.$store.dispatch('cluster/findAll', { type: PVC });
+    if ( this.$store.getters['cluster/schemaFor'](PVC) ) {
+      this.pvcs = await this.$store.dispatch('cluster/findAll', { type: PVC });
+    } else {
+      this.pvcs = [];
+    }
   },
 
   data() {

--- a/models/workload.js
+++ b/models/workload.js
@@ -410,7 +410,9 @@ export default class Workload extends SteveModel {
     this.containers.forEach(container => ports.push(...(container.ports || [])));
     (this.initContainers || []).forEach(container => ports.push(...(container.ports || [])));
 
-    const services = await this.getServicesOwned();
+    // Only get services owned if we can access the service resource
+    const canAccessServices = this.$getters['schemaFor'](SERVICE);
+    const services = canAccessServices ? await this.getServicesOwned() : [];
     const clusterIPServicePorts = [];
     const loadBalancerServicePorts = [];
     const nodePortServicePorts = [];


### PR DESCRIPTION
Fixes #4867

Users with the Project-level 'Manage Workloads' permission can't access services.

Updated UI for workloads to better check access to resource types (this fixes a few errors in the console log as well).

Dropdown allowing users to change the service type is disabled in this case, as the user can not create services.
