### PR TITLE
Error when switching between fleet-default and fleet-local workspaces in continuous delivery > clusters

### DIFF
--- a/components/nav/WorkspaceSwitcher.vue
+++ b/components/nav/WorkspaceSwitcher.vue
@@ -15,8 +15,10 @@ export default {
       },
 
       set(value) {
-        this.$store.commit('updateWorkspace', { value });
-        this.$store.dispatch('prefs/set', { key: WORKSPACE, value });
+        if (value !== this.value) {
+          this.$store.commit('updateWorkspace', { value });
+          this.$store.dispatch('prefs/set', { key: WORKSPACE, value });
+        }
       },
     },
 

--- a/components/nav/WorkspaceSwitcher.vue
+++ b/components/nav/WorkspaceSwitcher.vue
@@ -15,10 +15,8 @@ export default {
       },
 
       set(value) {
-        if (value !== this.value) {
-          this.$store.commit('updateWorkspace', { value });
-          this.$store.dispatch('prefs/set', { key: WORKSPACE, value });
-        }
+        this.$store.commit('updateWorkspace', { value });
+        this.$store.dispatch('prefs/set', { key: WORKSPACE, value });
       },
     },
 


### PR DESCRIPTION
Addresses Github issue: [#4907](https://github.com/rancher/dashboard/issues/4907)
Addresses Zube issue: [#4927](https://zube.io/rancher/dashboard-ui/c/4927)

- Add condition to prevent duplication of requests to the server in regards to saving/updating the user preferences for the workspace

Issue was causing the duplication of requests to the server to update the user preferences and 90% of the times one of them was failing...
<img width="1824" alt="Screenshot 2022-02-15 at 15 39 44" src="https://user-images.githubusercontent.com/97888974/154099081-f16c47df-dd35-47b3-9672-db81c266188a.png">

I believe this was happening because this:
https://github.com/rancher/dashboard/blob/master/components/nav/WorkspaceSwitcher.vue#L18

was doing the state change and then the setter would run again:
https://github.com/rancher/dashboard/blob/master/components/nav/WorkspaceSwitcher.vue#L17

Triggering it again... Why it wasn't stuck on a loop? Not entirely sure, but may be something to do with object references (the mutation is a Vue.set also)

to prevent this, I added a condition to prevent duplication of requests (check file changes)

<img width="1824" alt="Screenshot 2022-02-15 at 15 40 19" src="https://user-images.githubusercontent.com/97888974/154099917-dff77664-f290-4f4f-b326-c9496e28e69b.png">

Updating the list with the new data based on the workspace change may take a few seconds because the information will come via WS I assume, but I did not witness any "non-updating" list scenarios here, so it should be ok I assume.

