### PR TITLE
Assert that annotations is not undefined

### DIFF
--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -230,7 +230,7 @@ export default class MgmtCluster extends HybridModel {
 
   // Custom badge to show for the Cluster (if the appropriate annotations are set)
   get badge() {
-    const text = this.metadata?.annotations[CLUSTER_BADGE.TEXT];
+    const text = this.metadata?.annotations?.[CLUSTER_BADGE.TEXT];
 
     if (!text) {
       return undefined;


### PR DESCRIPTION
This fixes a bug that I've come across where undefined annotations caused the menu to stop working.

closes #5133 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>