### PR TITLE
Show custom icons for custom RKE1 node drivers

### DIFF
--- a/components/SelectIconGrid.vue
+++ b/components/SelectIconGrid.vue
@@ -102,7 +102,8 @@ export default {
       </div>
 
       <div class="logo">
-        <LazyImage :src="get(r, iconField)" />
+        <i v-if="r.iconClass" :class="r.iconClass" />
+        <LazyImage v-else :src="get(r, iconField)" />
       </div>
       <h4 class="name">
         {{ get(r, nameField) }}
@@ -213,6 +214,15 @@ export default {
           object-fit: contain;
           position: relative;
           top: 2px;
+        }
+
+        i {
+          background-position: center;
+          background-repeat: no-repeat;
+          display: flex;
+          height: $logo - 4px;
+          margin: 2px;
+          width: $logo - 4px;
         }
       }
 

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -31,6 +31,9 @@ const SORT_GROUPS = {
   custom2:   5,
 };
 
+// uSed to proxy stylesheets for custom drviers that provide custom UI (RKE1)
+const PROXY_ENDPOINT = '/meta/proxy';
+
 export default {
   name: 'CruCluster',
 
@@ -132,6 +135,22 @@ export default {
 
       set(this.value.metadata, 'namespace', DEFAULT_WORKSPACE);
     }
+
+    // For the node drivers, look for custom UI that we can use to show an icon (if not built-in)
+    this.nodeDrivers.forEach((driver) => {
+      if (!driver.spec?.builtin && driver.spec?.uiUrl && driver.spec?.active) {
+        const name = driver.spec?.displayName || driver.id;
+        let cssUrl = driver.spec.uiUrl.replace(/\.js$/, '.css');
+
+        if (cssUrl.startsWith('http://') || cssUrl.startsWith('https://')) {
+          cssUrl = `${ PROXY_ENDPOINT }/${ cssUrl }`;
+        }
+
+        this.loadStylesheet(cssUrl, `driver-ui-css-${ driver.id }`);
+
+        this.iconClasses[name] = `machine-driver ${ name }`;
+      }
+    });
   },
 
   data() {
@@ -147,6 +166,7 @@ export default {
       isImport,
       providerCluster:  null,
       emberLink:        null,
+      iconClasses:      {},
     };
   },
 
@@ -228,7 +248,7 @@ export default {
 
         if (this.isRke1 ) {
           machineTypes.forEach((id) => {
-            addType(id, 'rke1', false, `/g/clusters/add/launch/${ id }`);
+            addType(id, 'rke1', false, `/g/clusters/add/launch/${ id }`, this.iconClasses[id]);
           });
 
           addType('custom', 'custom1', false, '/g/clusters/add/launch/custom');
@@ -243,17 +263,25 @@ export default {
 
       return out;
 
-      function addType(id, group, disabled = false, link = null) {
+      function addType(id, group, disabled = false, link = null, iconClass = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
         const techPreview = getters['i18n/t']('generic.techPreview');
         const isTechPreview = group === 'rke2' || group === 'custom2';
         let tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
-        let icon = require('~/assets/images/generic-driver.svg');
+
+        // Always prefer the built-in icon if there is one
+        let icon;
 
         try {
           icon = require(`~/assets/images/providers/${ id }.svg`);
         } catch (e) {}
+
+        if (icon) {
+          iconClass = undefined;
+        } else if (!iconClass) {
+          icon = require('~/assets/images/generic-driver.svg');
+        }
 
         if (group === 'rke2' && id === 'harvester') {
           const experimental = getters['i18n/t']('generic.experimental');
@@ -266,6 +294,7 @@ export default {
           label,
           description,
           icon,
+          iconClass,
           group,
           disabled,
           link,
@@ -306,6 +335,30 @@ export default {
   },
 
   methods: {
+    loadStylesheet(url, id) {
+      if ( !id ) {
+        console.error('loadStylesheet called without an id'); // eslint-disable-line no-console
+
+        return;
+      }
+
+      // Check if the stylesheet has already been loaded
+      if ( $(`#${id}`).length > 0 ) { // eslint-disable-line
+        return;
+      }
+
+      const link = document.createElement('link');
+
+      link.onerror = () => {
+        link.remove();
+      };
+      link.rel = 'stylesheet';
+      link.src = url;
+      link.href = url;
+      link.id = id;
+      document.getElementsByTagName('HEAD')[0].appendChild(link);
+    },
+
     cancel() {
       this.$router.push({
         name:   'c-cluster-product-resource',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -326,7 +326,7 @@ module.exports = {
     '/v3':           proxyWsOpts(api), // Rancher API
     '/v3-public':    proxyOpts(api), // Rancher Unauthed API
     '/api-ui':       proxyOpts(api), // Browser API UI
-    '/meta':         proxyOpts(api), // Browser API UI
+    '/meta':         proxyMetaOpts(api), // Browser API UI
     '/v1-*':         proxyOpts(api), // SAML, KDM, etc
     // These are for Ember embedding
     '/c/*/edit':     proxyOpts('https://127.0.0.1:8000'), // Can't proxy all of /c because that's used by Vue too
@@ -360,6 +360,18 @@ module.exports = {
   typescript: { typeCheck: { eslint: { files: './**/*.{ts,js,vue}' } } }
 };
 
+function proxyMetaOpts(target) {
+  return {
+    target,
+    followRedirects: true,
+    secure:          !dev,
+    onProxyReq,
+    onProxyReqWs,
+    onError,
+    onProxyRes,
+  };
+}
+
 function proxyOpts(target) {
   return {
     target,
@@ -386,9 +398,11 @@ function proxyWsOpts(target) {
 }
 
 function onProxyReq(proxyReq, req) {
-  proxyReq.setHeader('x-api-host', req.headers['host']);
-  proxyReq.setHeader('x-forwarded-proto', 'https');
-  // console.log(proxyReq.getHeaders());
+  if (!(proxyReq._currentRequest && proxyReq._currentRequest._headerSent)) {
+    proxyReq.setHeader('x-api-host', req.headers['host']);
+    proxyReq.setHeader('x-forwarded-proto', 'https');
+    // console.log(proxyReq.getHeaders());
+  }
 }
 
 function onProxyReqWs(proxyReq, req, socket, options, head) {


### PR DESCRIPTION
Fixes #3124 

This PR fixes the issue where we do not show custom icons for custom node driver (RKE1). Instead, we currently show a default cluster icon.

With this PR, the icon is loaded in the same way as with Cluster Manager.

(To add a custom node driver for testing, see: https://github.com/nwmac/cluster-driver#example-rancher-cluster-icon

Example (see the 'test' driver):

![image](https://user-images.githubusercontent.com/1955897/154261678-32513706-4f9a-4048-85e7-60648bf614fa.png)

Before this PR, this shows as:

![image](https://user-images.githubusercontent.com/1955897/154262023-929d96db-cb81-4eee-b5bd-f529c3908be5.png)
