### PR TITLE
Issue with displaying Errors messages

### DIFF
--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -21,7 +21,14 @@ export default {
       default: false,
     }
   },
-
+  computed: {
+    /**
+     * Return message text as label
+     */
+    messageLabel(): string {
+      return this.label?.message;
+    }
+  },
   methods: { nlToBr },
 };
 </script>
@@ -29,7 +36,7 @@ export default {
   <div class="banner" :class="{[color]: true, closable}">
     <slot>
       <t v-if="labelKey" :k="labelKey" :raw="true" />
-      <span v-else-if="label.message" v-html="JSON.stringify(label.message)" />
+      <span v-else-if="messageLabel">{{ messageLabel }}</span>
       <span v-else v-html="nlToBr(label)" />
     </slot>
     <div v-if="closable" class="closer" @click="$emit('close')">

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
-
+import Vue from 'vue';
 import { nlToBr } from '@/utils/string';
+import { stringify } from '@/utils/error';
 
-export default {
+export default Vue.extend({
   props: {
     color: {
       type:    String,
@@ -25,12 +26,12 @@ export default {
     /**
      * Return message text as label
      */
-    messageLabel(): string {
-      return this.label?.message;
+    messageLabel(): string | void {
+      return !(typeof this.label === 'string') ? stringify(this.label) : undefined;
     }
   },
   methods: { nlToBr },
-};
+});
 </script>
 <template>
   <div class="banner" :class="{[color]: true, closable}">

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -29,7 +29,6 @@ export default {
   <div class="banner" :class="{[color]: true, closable}">
     <slot>
       <t v-if="labelKey" :k="labelKey" :raw="true" />
-
       <span v-else-if="label.message" v-html="JSON.stringify(label.message)" />
       <span v-else v-html="nlToBr(label)" />
     </slot>

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -29,6 +29,8 @@ export default {
   <div class="banner" :class="{[color]: true, closable}">
     <slot>
       <t v-if="labelKey" :k="labelKey" :raw="true" />
+
+      <span v-else-if="label.message" v-html="JSON.stringify(label.message)" />
       <span v-else v-html="nlToBr(label)" />
     </slot>
     <div v-if="closable" class="closer" @click="$emit('close')">


### PR DESCRIPTION

Fixes: https://github.com/rancher/dashboard/issues/5213

This PR will fixes it by looking if the `label` objects includes a `message` propriety, if so it will stringify and display the Error message.

![image](https://user-images.githubusercontent.com/88777903/154276348-d6b5ace5-5597-48e2-9b60-d24935afe912.png)


## How to reproduce:

Edit any Pod configuration vía YAML and change any boolean value to something invalid like falsea , this will return a 400 Error and you'll be able to preview it.
