### PR TITLE
Lh cards

### DIFF
--- a/assets/styles/global/_resource.scss
+++ b/assets/styles/global/_resource.scss
@@ -12,10 +12,17 @@
     border: 1px solid var(--border);
     border-radius: 0;
     display: flex;
-    flex-basis: 40%;
+    flex-basis: 48%;
     margin: 10px;
     min-height: 80px;
-    padding: 10px;
+    background-color: var(--body-bg);
+    align-content: flex-start;
+    border-radius: var(--border-radius);
+
+    .subtype-container {
+      display: flex;
+      align-items: stretch;
+    }
 
     &.disabled {
       cursor: not-allowed !important;
@@ -60,9 +67,6 @@
     }
 
     &:not(.top) {
-      align-items: top;
-      flex-direction: column;
-      justify-content: start;
       &:hover {
         cursor: pointer;
         box-shadow: 0px 0px 1px var(--outline-width) var(--outline);
@@ -72,20 +76,8 @@
     .round-image {
       border-radius: 50%;
       height: 50px;
-      margin-right: 10px;
       width: 50px;
       overflow: hidden;
-    }
-
-    .banner-abbrv {
-      align-items: center;
-      background-color: var(--primary);
-      color: white;
-      display: flex;
-      font-size: 2.5em;
-      height: 100%;
-      justify-content: center;
-      width: 100%;
     }
   }
 }

--- a/assets/styles/global/_resource.scss
+++ b/assets/styles/global/_resource.scss
@@ -22,6 +22,7 @@
     .subtype-container {
       display: flex;
       align-items: stretch;
+      flex: 1;
     }
 
     &.disabled {

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -464,11 +464,11 @@ $logo: 60px;
 };
 
 .subtype-body {
-  background-color: var(--body-bg);
   padding: 20px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: left;
+  flex: 1;
 }
 
 .subtype-logo {

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -438,8 +438,15 @@ export default {
 }
 .create-resource-container {
   .subtype-banner {
-    .round-image {
+    .banner-abbrv {
+      align-items: center;
       background-color: var(--primary);
+      color: var(--body-bg);
+      display: flex;
+      font-size: 2.5em;
+      height: 100%;
+      justify-content: center;
+      width: 100%;
     }
   }
 }
@@ -447,8 +454,6 @@ export default {
 $logo: 60px;
 
 .title {
-  margin-top: 20px;
-
   &.with-description {
     margin-top: 0;
   }
@@ -459,23 +464,25 @@ $logo: 60px;
 };
 
 .subtype-body {
-  margin-left: $logo + 10px;
+  background-color: var(--body-bg);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .subtype-logo {
-  align-items: center;
+  background-color: var(--box-bg);
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
   display: flex;
   justify-content: center;
-  position: absolute;
-  left: 0;
-  width: $logo;
-  height: $logo;
-  border-radius: calc(2 * var(--border-radius));
-  overflow: hidden;
-  background-color: white;
+  align-content: center;
+  align-items: center;
+  padding: 0 30px;
 
   > .round-image {
-    margin-right: 0;
+    width: $logo;
+    height: $logo;
   };
 
   img {

--- a/components/SelectIconGrid.vue
+++ b/components/SelectIconGrid.vue
@@ -97,7 +97,7 @@ export default {
       :class="{'has-description': !!get(r, descriptionField), 'has-side-label': !!get(r, sideLabelField), [colorFor(r, idx)]: true, disabled: get(r, disabledField) === true}"
       @click="select(r, idx)"
     >
-      <div class="side-label" :class="{'indicator': true }" />
+      <div class="side-label badge-state" :class="{'indicator': true }">
       <div v-if="r.deploysOnWindows">
         <label class="deploys-os-label">
           {{ t('catalog.charts.deploysOnWindows') }}
@@ -126,6 +126,7 @@ export default {
   </div>
   <div v-else class="m-50 text-center">
     <h1 v-t="noDataKey" />
+  </div>
   </div>
 </template>
 
@@ -183,15 +184,15 @@ export default {
       }
 
       .side-label {
-        position: absolute;
-        top: 10px;
-        right: 10px;
-        padding: 2px 5px;
+        // position: absolute;
+        // top: 10px;
+        // right: 10px;
+        // padding: 2px 5px;
 
         &.indicator {
-          top: 0;
-          right: 0;
-          left: 0;
+          // top: 0;
+          // right: 0;
+          // left: 0;
         }
 
       }


### PR DESCRIPTION
restyling cards:
- visual style
- utilize flex more over absolute positioning and set widths

Next up but not covered by this pr:
https://github.com/rancher/dashboard/issues/4380

Old:
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/3013118/154356365-80d939a0-01ab-40a0-a535-2b8da59e4eab.png">


New:
<img width="1257" alt="image" src="https://user-images.githubusercontent.com/3013118/154356126-ec605798-fde8-4c07-a3b8-3966384fafaf.png">

I could use feedback on how to make the children fill the parent element:
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/3013118/154357137-ae297d1d-6835-4697-ba8d-54873c4944e2.png">
