### PR TITLE
Remove SElinux input from UI

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1549,7 +1549,7 @@ export default {
             <div class="col span-12 mt-20">
               <Checkbox v-if="serverArgs['secrets-encryption']" v-model="serverConfig['secrets-encryption']" :mode="mode" label="Encrypt Secrets" />
               <Checkbox v-model="value.spec.enableNetworkPolicy" :mode="mode" :label="t('cluster.rke2.enableNetworkPolicy.label')" />
-              <Checkbox v-if="agentArgs.selinux" v-model="agentConfig.selinux" :mode="mode" label="SELinux" />
+              <!-- <Checkbox v-if="agentArgs.selinux" v-model="agentConfig.selinux" :mode="mode" label="SELinux" /> -->
             </div>
           </div>
 


### PR DESCRIPTION
#5025 

This PR removes the SElinux checkbox input when provisioning the RKE2 node driver AWS cluster
