### PR TITLE
Rotating encryption keys action is available for RKE2 clusters

### DIFF
--- a/components/dialog/RotateEncryptionKeyDialog.vue
+++ b/components/dialog/RotateEncryptionKeyDialog.vue
@@ -1,9 +1,10 @@
 <script>
+import { SNAPSHOT, NORMAN } from '@/config/types';
 import AsyncButton from '@/components/AsyncButton';
 import Card from '@/components/Card';
 import Banner from '@/components/Banner';
 import { exceptionToErrorsArray } from '@/utils/error';
-import { NORMAN } from '@/config/types';
+
 import { sortBy } from '@/utils/sort';
 import day from 'dayjs';
 import { escapeHtml } from '@/utils/string';
@@ -35,7 +36,7 @@ export default {
     }
 
     if (c.isRke2 && this.$store.getters['isRancher']) {
-      etcdBackups = c.etcdSnapshots;
+      etcdBackups = await this.$store.dispatch('management/findAll', { type: SNAPSHOT });
       etcdBackups = etcdBackups.filter(backup => backup.clusterId === c.id);
     }
 

--- a/components/dialog/RotateEncryptionKeyDialog.vue
+++ b/components/dialog/RotateEncryptionKeyDialog.vue
@@ -9,7 +9,7 @@ import { sortBy } from '@/utils/sort';
 import day from 'dayjs';
 import { escapeHtml } from '@/utils/string';
 import { DATE_FORMAT, TIME_FORMAT } from '@/store/prefs';
-import { set } from '@/utils/object';
+import { set } from 'lodash';
 
 export default {
   components: {
@@ -26,32 +26,23 @@ export default {
   },
 
   async fetch() {
-    const c = this.cluster;
-
-    let etcdBackups = [];
-
-    if ( c.isRke1 && this.$store.getters['isRancher'] ) {
-      etcdBackups = await this.$store.dispatch('rancher/findAll', { type: NORMAN.ETCD_BACKUP });
-      etcdBackups = etcdBackups.filter(backup => backup.clusterId === c.metadata.name);
+    if (!this.$store.getters['isRancher']) {
+      // This fetch function is getting snapshots, which are associated
+      // with cluster manager. Rancher Desktop doesn't come with cluster
+      // manager, so for Rancher Desktop we return nothing.
+      return [];
     }
 
-    if (c.isRke2 && this.$store.getters['isRancher']) {
-      etcdBackups = await this.$store.dispatch('management/findAll', { type: SNAPSHOT });
-      etcdBackups = etcdBackups.filter(backup => backup.clusterId === c.id);
-    }
+    const etcdBackups = await this.getEtcdBackups();
 
-    const backups = sortBy(etcdBackups, ['created']).reverse();
-    const dateFormat = escapeHtml(this.$store.getters['prefs/get'](DATE_FORMAT));
-    const timeFormat = escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
-
-    if (backups.length > 0) {
+    if (etcdBackups.length > 0) {
+      const backups = sortBy(etcdBackups, ['created']).reverse();
       const name = backups[0].id.split(':');
-      const d = day(backups[0].created).format(dateFormat);
-      const t = day(backups[0].created).format(timeFormat);
+      const createdDate = backups[0].created;
 
       this.latestBackup = {
         name: name[0],
-        date: `${ d } ${ t }`,
+        date: this.getFormattedCreatedDate(createdDate)
       };
     }
   },
@@ -71,16 +62,45 @@ export default {
       this.$emit('close');
     },
 
+    async getEtcdBackups() {
+      if ( this.cluster.isRke1) {
+        let etcdBackups = await this.$store.dispatch('rancher/findAll', { type: NORMAN.ETCD_BACKUP });
+
+        etcdBackups = etcdBackups.filter(backup => backup.clusterId === this.cluster.metadata.name);
+
+        return etcdBackups;
+      }
+
+      if (this.cluster.isRke2) {
+        let etcdBackups = await this.$store.dispatch('management/findAll', { type: SNAPSHOT });
+
+        etcdBackups = etcdBackups.filter(backup => backup.clusterId === this.cluster.id);
+
+        return etcdBackups;
+      }
+
+      return [];
+    },
+
+    getFormattedCreatedDate(createdDate) {
+      const dateFormat = escapeHtml(this.$store.getters['prefs/get'](DATE_FORMAT));
+      const timeFormat = escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
+      const d = day(createdDate).format(dateFormat);
+      const t = day(createdDate).format(timeFormat);
+
+      return `${ d } ${ t }`;
+    },
+
     async apply(buttonDone) {
       const isRke2 = this.cluster.isRke2;
 
       try {
         if (isRke2) {
-          const currentGeneration = this.cluster.spec?.rkeConfig?.rotateCertificates?.generation || 0;
+          const currentGeneration = this.cluster.spec?.rkeConfig?.rotateEncryptionKeys?.generation || 0;
 
           // To rotate the encryption keys, increment
           // rkeConfig.rotateEncyrptionKeys.generation in the YAML.
-          set(this.cluster, 'spec.rkeConfig', { rotateEncryptionKeys: { generation: currentGeneration + 1 } });
+          set(this.cluster, 'spec.rkeConfig.rotateEncryptionKeys.generation', currentGeneration + 1);
           await this.cluster.save();
         } else {
           await this.cluster.mgmt.doAction('rotateEncryptionKey');

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -103,7 +103,7 @@ export default class ProvCluster extends SteveModel {
       action:     'rotateEncryptionKey',
       label:      this.$rootGetters['i18n/t']('nav.rotateEncryptionKeys'),
       icon:       'icon icon-refresh',
-      enabled:     this.isRke1 && this.mgmt?.hasAction('rotateEncryptionKey') && this.mgmt?.isReady,
+      enabled:     (this.isRke2 && this.mgmt?.isReady && this.canUpdate) || (this.isRke1 && this.mgmt?.hasAction('rotateEncryptionKey') && this.mgmt?.isReady),
     });
 
     insertAt(out, idx++, {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4540 by making it so that the context menu for an RKE2 cluster now saves the cluster YAML in order to rotate the encryption keys.
<img width="1217" alt="Screen Shot 2022-02-28 at 6 14 27 PM" src="https://user-images.githubusercontent.com/20599230/156086258-73f96406-5631-4e58-8bfe-9a8538f0f2e1.png">

Jake said that in order to trigger a key rotation, all we need to do is update the cluster YAML to increment `spec.rkeConfig.rotateEncryptionKeys.generation`.

To test this PR,

1. I provisioned a downstream RKE2 cluster
2. I created a snapshot of the cluster (because the modal for key rotation requires that a snapshot exists before keys can be rotated)
2. I confirmed that the Rotate Encryption Keys action was available in the action menu
3. The modal that appears confirms that I have a snapshot. I clicked **Rotate**
4. I confirmed that the `spec.rkeConfig.rotateEncryptionKeys.generation` value was incremented in the network request
<img width="457" alt="Screen Shot 2022-02-17 at 1 20 47 AM" src="https://user-images.githubusercontent.com/20599230/154437312-ad8fb7de-81e2-4d88-b7cd-daf19764c5a1.png">

This PR/issue is very similar to https://github.com/rancher/dashboard/pull/5123 and the notes on that PR also apply to this one.