### PR TITLE
When deploying to cluster group with no clusters, still counting resources

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1790,6 +1790,7 @@ fleet:
       other {# bundles are hidden as they belong to Harvester clusters that can not be used with Continuous Delivery}
       }  
   fleetSummary:
+    noClustersGitRepo: This git repo is not targeting any clusters
     state:
       ready: 'Ready'
       info: 'Transitioning'

--- a/detail/fleet.cattle.io.gitrepo.vue
+++ b/detail/fleet.cattle.io.gitrepo.vue
@@ -1,6 +1,7 @@
 <script>
 import ResourceTabs from '@/components/form/ResourceTabs';
 import ResourcesSummary from '@/components/fleet/ResourcesSummary';
+import Banner from '@/components/Banner';
 import FleetResources from '@/components/fleet/FleetResources';
 import Tab from '@/components/Tabbed/Tab';
 import { FLEET } from '@/config/types';
@@ -11,6 +12,7 @@ export default {
   components: {
     FleetResources,
     ResourcesSummary,
+    Banner,
     ResourceTabs,
     Tab,
   },
@@ -26,12 +28,27 @@ export default {
     await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER });
     await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER_GROUP });
   },
+  computed: {
+    gitRepoHasClusters() {
+      return this.value.status.desiredReadyClusters;
+    }
+  },
 };
 </script>
 
 <template>
   <div class="mt-20">
-    <ResourcesSummary :value="value.status.resourceCounts" />
+    <ResourcesSummary
+      v-if="gitRepoHasClusters"
+      :value="value.status.resourceCounts"
+    />
+    <Banner
+      v-else
+      color="info"
+      class="mb-40"
+    >
+      {{ t('fleet.fleetSummary.noClustersGitRepo') }}
+    </Banner>
 
     <ResourceTabs v-model="value" mode="view" class="mt-20">
       <Tab label="Resources" name="resources" :weight="20">


### PR DESCRIPTION
Addresses Github issue: [#1617](https://github.com/rancher/dashboard/issues/1617)
Addresses Zube issue: [#1620](https://zube.io/rancher/dashboard-ui/c/1620)

- Add Banner with info to be displayed instead of resources count when we don't have any clusters associated with the workspace/repo
- Remove unmapped resources count (by default - comes from another PR) such as `Info`, `Warning`, `Error`

Preview:
<img width="1590" alt="Screenshot 2022-02-18 at 10 44 43" src="https://user-images.githubusercontent.com/97888974/154675657-54fd4b4c-366c-4086-b258-887ad4546bde.png">
<img width="1622" alt="Screenshot 2022-02-23 at 10 08 38" src="https://user-images.githubusercontent.com/97888974/155299204-d12587df-5392-4230-ac42-1a7e384a591f.png">
 