### PR TITLE
add icons for permits-os label

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -75,6 +75,7 @@ generic:
   enable: Enable
   disable: Disable
   experimental: Experimental
+  
   deprecated: Deprecated
   placeholder: "e.g. {text}"
   moreInfo: More Info
@@ -706,6 +707,7 @@ catalog:
       other: Other
       partner: Partner
       rancher: '{vendor}'
+    deploysOn: Deploys on {os}
     header: Charts
     noCharts: 'There are no charts available, have you added any repos?'
     noWindows: Your catalogs do not contain any charts capable of being deployed on a Windows cluster.

--- a/components/SelectIconGrid.vue
+++ b/components/SelectIconGrid.vue
@@ -1,6 +1,7 @@
 <script>
 import LazyImage from '@/components/LazyImage';
 import { get } from '@/utils/object';
+import capitalize from 'lodash/capitalize';
 
 export default {
   components: { LazyImage },
@@ -77,7 +78,8 @@ export default {
       }
 
       this.$emit('clicked', row, idx);
-    }
+    },
+    capitalize
   },
 };
 </script>
@@ -96,7 +98,11 @@ export default {
       @click="select(r, idx)"
     >
       <div class="side-label" :class="{'indicator': true }" />
-
+      <div v-if="r.permittedOSs">
+        <label v-for="os in r.permittedOSs" :key="os" class="os-label" :class="{[os]:true}">
+          {{ t('catalog.charts.deploysOn', {os:capitalize(os)}) }}
+        </label>
+      </div>
       <div v-if="get(r, sideLabelField)" class="side-label" :class="{'indicator': false }">
         <label>{{ get(r, sideLabelField) }}</label>
       </div>
@@ -119,7 +125,7 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  $height: 110px;
+  $height: 130px;
   $side: 15px;
   $margin: 10px;
   $logo: 60px;
@@ -183,7 +189,9 @@ export default {
           left: 0;
         }
 
-        label {
+      }
+
+      .side-label label, label.os-label{
           font-size: 12px;
           line-height: 12px;
           text-align: center;
@@ -193,8 +201,18 @@ export default {
           // Override default form label properties
           color: var(--card-badge-text);
           margin: 0;
-        }
+      }
 
+      .os-label {
+        position: absolute;
+        bottom: 10px;
+        padding: 2px 5px;
+        &.linux{
+          left: 10px;
+        }
+        &.windows{
+          right: 10px;
+        }
       }
 
       .logo {
@@ -252,35 +270,35 @@ export default {
 
       // @TODO figure out how to templatize these
       &.color1 {
-        .side-label { background-color: var(--app-color1-accent); label { color: var(--app-color1-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color1-accent); label { color: var(--app-color1-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color1-accent); }
       }
       &.color2 {
-        .side-label { background-color: var(--app-color2-accent); label { color: var(--app-color2-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color2-accent); label { color: var(--app-color2-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color2-accent); }
       }
       &.color3 {
-        .side-label { background-color: var(--app-color3-accent); label { color: var(--app-color3-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color3-accent); label { color: var(--app-color3-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color3-accent); }
       }
       &.color4 {
-        .side-label { background-color: var(--app-color4-accent); label { color: var(--app-color4-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color4-accent); label { color: var(--app-color4-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color4-accent); }
       }
       &.color5 {
-        .side-label { background-color: var(--app-color5-accent); label { color: var(--app-color5-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color5-accent); label { color: var(--app-color5-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color5-accent); }
       }
       &.color6 {
-        .side-label { background-color: var(--app-color6-accent); label { color: var(--app-color6-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color6-accent); label { color: var(--app-color6-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color6-accent); }
       }
       &.color7 {
-        .side-label { background-color: var(--app-color7-accent); label { color: var(--app-color7-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color7-accent); label { color: var(--app-color7-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color7-accent); }
       }
       &.color8 {
-        .side-label { background-color: var(--app-color8-accent); label { color: var(--app-color8-accent-text); } }
+        .side-label, .os-label { background-color: var(--app-color8-accent); label { color: var(--app-color8-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color8-accent); }
       }
 

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -87,6 +87,7 @@ export const CATALOG = {
   DISPLAY_NAME:     'catalog.cattle.io/display-name',
 
   SUPPORTED_OS: 'catalog.cattle.io/os',
+  PERMITTED_OS: 'catalog.cattle.io/permits-os',
 
   MIGRATED: 'apps.cattle.io/migrated',
 };

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -512,6 +512,7 @@ function addChart(ctx, map, chart, repo) {
       targetName:       chart.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME],
       scope:            chart.annotations?.[CATALOG_ANNOTATIONS.SCOPE],
       provides:         [],
+      permittedOSs:      certifiedAnnotation === 'rancher' ? (chart.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || 'linux').split(',') : null
     });
 
     map[key] = obj;


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/5172
In the below screenshot, pink are charts with the new `catalog.cattle.io/permits-os` annotation; the green charts with a certified rancher annotation demonstrate the fallback behavior for rancher charts (assume linux-only), and lack of fallback for non-rancher charts
If you want to test with the updated chart repo, configure a gitrepo:

url: `https://github.com/luthermonson/charts.git` branch: `one-commit-to-rule-them-all`


![Screen Shot 2022-02-18 at 3 24 51 PM](https://user-images.githubusercontent.com/42977925/154769428-46c670e7-ba8a-4a98-bcd2-48315ed128ca.png)

