### PR TITLE
Change tls certificate options selection - #5198

### DIFF
--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -9,6 +9,8 @@ import $ from 'jquery';
 import { onClickOption } from '@/utils/select';
 
 export default {
+  name: 'LabeledSelect',
+
   components: { LabeledTooltip },
   mixins:     [LabeledFormElement, VueSelectOverrides],
 

--- a/edit/fleet.cattle.io.gitrepo.vue
+++ b/edit/fleet.cattle.io.gitrepo.vue
@@ -393,7 +393,6 @@ export default {
 
     <template v-if="isTls">
       <div class="spacer" />
-
       <h3 v-t="'fleet.gitRepo.tls.label'" />
       <div class="row">
         <div class="col span-6">
@@ -413,85 +412,84 @@ export default {
           />
         </div>
       </div>
+    </template>
+    <div class="spacer" />
 
-      <div class="spacer" />
-
-      <h2 v-t="'fleet.gitRepo.paths.label'" />
-      <ArrayList
-        v-model="value.spec.paths"
-        :mode="mode"
-        :initial-empty-row="false"
-        :value-placeholder="t('fleet.gitRepo.paths.placeholder')"
-        :add-label="t('fleet.gitRepo.paths.addLabel')"
-      >
-        <template #empty>
-          <Banner label-key="fleet.gitRepo.paths.empty" />
-        </template>
-      </ArrayList>
-
-      <div class="spacer" />
-
-      <h2 v-t="isLocal ? 'fleet.gitRepo.target.labelLocal' : 'fleet.gitRepo.target.label'" />
-
-      <template v-if="!isLocal">
-        <div class="row">
-          <div class="col span-6">
-            <LabeledSelect
-              v-model="targetMode"
-              :options="targetOptions"
-              option-key="value"
-              :mode="mode"
-              :selectable="option => !option.disabled"
-              :label="t('fleet.gitRepo.target.selectLabel')"
-            >
-              <template v-slot:option="opt">
-                <hr v-if="opt.kind === 'divider'">
-                <div v-else-if="opt.kind === 'title'">
-                  {{ opt.label }}
-                </div>
-                <div v-else>
-                  {{ opt.label }}
-                </div>
-              </template>
-            </LabeledSelect>
-          </div>
-        </div>
-
-        <div v-if="targetMode === 'advanced'" class="row mt-10">
-          <div class="col span-12">
-            <YamlEditor v-model="targetAdvanced" />
-          </div>
-        </div>
-
-        <Banner v-for="(err, i) in targetAdvancedErrors" :key="i" color="error" :label="err" />
+    <h2 v-t="'fleet.gitRepo.paths.label'" />
+    <ArrayList
+      v-model="value.spec.paths"
+      :mode="mode"
+      :initial-empty-row="false"
+      :value-placeholder="t('fleet.gitRepo.paths.placeholder')"
+      :add-label="t('fleet.gitRepo.paths.addLabel')"
+    >
+      <template #empty>
+        <Banner label-key="fleet.gitRepo.paths.empty" />
       </template>
+    </ArrayList>
 
-      <div class="row mt-20">
+    <div class="spacer" />
+
+    <h2 v-t="isLocal ? 'fleet.gitRepo.target.labelLocal' : 'fleet.gitRepo.target.label'" />
+
+    <template v-if="!isLocal">
+      <div class="row">
         <div class="col span-6">
-          <LabeledInput
-            v-model="value.spec.serviceAccount"
-            label-key="fleet.gitRepo.serviceAccount.label"
-            placeholder-key="fleet.gitRepo.serviceAccount.placeholder"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model="value.spec.targetNamespace"
-            label-key="fleet.gitRepo.targetNamespace.label"
-            placeholder-key="fleet.gitRepo.targetNamespace.placeholder"
-            label="Target Namespace"
-            placeholder="Optional: Require all resources to be in this namespace"
-          />
+          <LabeledSelect
+            v-model="targetMode"
+            :options="targetOptions"
+            option-key="value"
+            :mode="mode"
+            :selectable="option => !option.disabled"
+            :label="t('fleet.gitRepo.target.selectLabel')"
+          >
+            <template v-slot:option="opt">
+              <hr v-if="opt.kind === 'divider'">
+              <div v-else-if="opt.kind === 'title'">
+                {{ opt.label }}
+              </div>
+              <div v-else>
+                {{ opt.label }}
+              </div>
+            </template>
+          </LabeledSelect>
         </div>
       </div>
 
-      <div class="spacer" />
+      <div v-if="targetMode === 'advanced'" class="row mt-10">
+        <div class="col span-12">
+          <YamlEditor v-model="targetAdvanced" />
+        </div>
+      </div>
 
-      <Labels
-        :value="value"
-        :mode="mode"
-        :display-side-by-side="false"
-      />
+      <Banner v-for="(err, i) in targetAdvancedErrors" :key="i" color="error" :label="err" />
     </template>
+
+    <div class="row mt-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.spec.serviceAccount"
+          label-key="fleet.gitRepo.serviceAccount.label"
+          placeholder-key="fleet.gitRepo.serviceAccount.placeholder"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.spec.targetNamespace"
+          label-key="fleet.gitRepo.targetNamespace.label"
+          placeholder-key="fleet.gitRepo.targetNamespace.placeholder"
+          label="Target Namespace"
+          placeholder="Optional: Require all resources to be in this namespace"
+        />
+      </div>
+    </div>
+
+    <div class="spacer" />
+
+    <Labels
+      :value="value"
+      :mode="mode"
+      :display-side-by-side="false"
+    />
   </CruResource>
 </template>

--- a/edit/fleet.cattle.io.gitrepo.vue
+++ b/edit/fleet.cattle.io.gitrepo.vue
@@ -225,8 +225,19 @@ export default {
     },
   },
 
+  created() {
+    this.registerBeforeHook(this.cleanTLS, 'cleanTLS');
+  },
+
   methods: {
     set,
+
+    cleanTLS() {
+      if (!this.isTls) {
+        delete this.value.spec.insecureSkipTLSVerify;
+        delete this.value.spec.caBundle;
+      }
+    },
 
     updateAuth(val, key) {
       const spec = this.value.spec;

--- a/edit/fleet.cattle.io.gitrepo.vue
+++ b/edit/fleet.cattle.io.gitrepo.vue
@@ -11,7 +11,6 @@ import InputWithSelect from '@/components/form/InputWithSelect';
 import jsyaml from 'js-yaml';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
-import RadioGroup from '@/components/form/RadioGroup';
 import Labels from '@/components/form/Labels';
 import Loading from '@/components/Loading';
 import NameNsDescription from '@/components/form/NameNsDescription';
@@ -40,8 +39,7 @@ export default {
     Loading,
     NameNsDescription,
     YamlEditor,
-    RadioGroup,
-    SelectOrCreateAuthSecret,
+    SelectOrCreateAuthSecret
   },
 
   mixins: [CreateEditView],
@@ -311,6 +309,10 @@ export default {
       }
     },
 
+    updateTlsMode(event) {
+      this.tlsMode = event;
+    },
+
     updateTls() {
       const spec = this.value.spec;
 
@@ -404,14 +406,14 @@ export default {
 
     <template v-if="isTls">
       <div class="spacer" />
-      <h3 v-t="'fleet.gitRepo.tls.label'" />
       <div class="row">
         <div class="col span-6">
-          <RadioGroup
-            v-model="tlsMode"
-            name="tlsMode"
+          <LabeledSelect
+            :label="t('fleet.gitRepo.tls.label')"
             :mode="mode"
+            :value="tlsMode"
             :options="tlsOptions"
+            @input="updateTlsMode($event)"
           />
         </div>
         <div v-if="tlsMode === _SPECIFY" class="col span-6">


### PR DESCRIPTION
## Summary

Issue #5198  - Change fleet add repository TLS certification options to a dropdown

## Steps to test
1. Navigate to Continuous delivery > Git repos.
2. Click on `create` or `Add repository` on top right.
3. The option to select TLS certificate now should be dropdown. 
4. There should be no functional change. Behaviour of form creation is the same. Only difference is radio buttons are now a dropdown.

NB: Original issue #5198 shows additional UI changes to the form. Those changes are out of the scope from this PR.

https://user-images.githubusercontent.com/1387263/156330625-af01f40e-8a7a-47d0-9d85-066390704bb8.mov


