### PR TITLE
Rke2 windows charts

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -709,10 +709,10 @@ catalog:
       rancher: '{vendor}'
     deploysOn: Deploys on {os}
     header: Charts
-    noCharts: 'There are no charts available, have you added any repos?'
-    noWindows: Your catalogs do not contain any charts capable of being deployed on a Windows cluster.
+    noWindows: Your repos do not contain any charts capable of being deployed on a cluster with Windows nodes.
+    noWindowsAndLinux: Your repos do not contain any charts capable of being deployed on a cluster with both Windows and Linux worker nodes.
     operatingSystems:
-      all: All OSs
+      all: All Operating Systems
       linux: Linux
       windows: Windows
     search: Filter

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -850,6 +850,9 @@ catalog:
       edit: Edit
       remove: Remove
       manage: Manage
+  os:
+    versionIncompatible: "This version is not compatible with all worker nodes' operating systems"
+    chartIncompatible: "This chart is not compatible with all worker nodes' operating systems"
 
 changePassword:
   title: Change Password

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -88,6 +88,7 @@ export const CATALOG = {
 
   SUPPORTED_OS: 'catalog.cattle.io/os',
   PERMITTED_OS: 'catalog.cattle.io/permits-os',
+  DEPLOYED_OS:   'catalog.cattle.io/deploys-on-os',
 
   MIGRATED: 'apps.cattle.io/migrated',
 };

--- a/list/catalog.cattle.io.app.vue
+++ b/list/catalog.cattle.io.app.vue
@@ -32,7 +32,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <ResourceTable v-else :schema="schema" :rows="rows">
+  <ResourceTable v-else class="apps" :schema="schema" :rows="rows">
     <template #cell:upgrade="{row}">
       <span v-if="row.upgradeAvailable" class="badge-state bg-warning hand" @click="row.goToUpgrade(row.upgradeAvailable)">
         {{ row.upgradeAvailable }}
@@ -42,3 +42,9 @@ export default {
     </template>
   </ResourceTable>
 </template>
+
+<style scoped>
+.apps ::v-deep .state-description{
+  color: var(--error)
+}
+</style>

--- a/machine-config/vmwarevsphere.vue
+++ b/machine-config/vmwarevsphere.vue
@@ -14,7 +14,7 @@ import ArrayListSelect from '@/components/form/ArrayListSelect';
 import YamlEditor from '@/components/YamlEditor';
 import { get, set } from '@/utils/object';
 import { integerString, keyValueStrings } from '@/utils/computed';
-import { _CREATE, _EDIT } from '@/config/query-params';
+import { _CREATE } from '@/config/query-params';
 
 const SENTINEL = '__SENTINEL__';
 const VAPP_MODE = {
@@ -167,10 +167,6 @@ export default {
       }
     } catch (e) {
       this.errors = exceptionToErrorsArray(e);
-    }
-
-    if (this.mode === _EDIT ) {
-    // TODO get installed apps
     }
   },
 

--- a/machine-config/vmwarevsphere.vue
+++ b/machine-config/vmwarevsphere.vue
@@ -14,7 +14,7 @@ import ArrayListSelect from '@/components/form/ArrayListSelect';
 import YamlEditor from '@/components/YamlEditor';
 import { get, set } from '@/utils/object';
 import { integerString, keyValueStrings } from '@/utils/computed';
-import { _CREATE } from '@/config/query-params';
+import { _CREATE, _EDIT } from '@/config/query-params';
 
 const SENTINEL = '__SENTINEL__';
 const VAPP_MODE = {
@@ -167,6 +167,10 @@ export default {
       }
     } catch (e) {
       this.errors = exceptionToErrorsArray(e);
+    }
+
+    if (this.mode === _EDIT ) {
+    // TODO get installed apps
     }
   },
 

--- a/mixins/chart.js
+++ b/mixins/chart.js
@@ -61,8 +61,7 @@ export default {
     },
 
     mappedVersions() {
-      // TODO remove other
-      const isRancher = this.chart?.certified === 'rancher' || this.chart?.certified === 'other' ;
+      const isRancher = this.chart?.certified === 'rancher';
       const versions = this.chart?.versions || [];
       const selectedVersion = this.targetVersion;
       const OSs = this.currentCluster?.workerOSs;

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -9,6 +9,7 @@ import { SHOW_PRE_RELEASE } from '@/store/prefs';
 import { set } from '@/utils/object';
 
 import SteveModel from '@/plugins/steve/steve-class';
+import { compatibleVersionsFor } from '~/store/catalog';
 
 export default class CatalogApp extends SteveModel {
   showMasthead(mode) {
@@ -78,7 +79,8 @@ export default class CatalogApp extends SteveModel {
       return null;
     }
 
-    const isWindows = this.$rootGetters['currentCluster'].providerOs === 'windows';
+    const workerOSs = this.$rootGetters['currentCluster'].workerOSs;
+
     const showPreRelease = this.$rootGetters['prefs/get'](SHOW_PRE_RELEASE);
 
     const thisVersion = this.spec?.chart?.metadata?.version;
@@ -88,16 +90,12 @@ export default class CatalogApp extends SteveModel {
       versions = chart.versions.filter(v => !isPrerelease(v.version));
     }
 
+    versions = compatibleVersionsFor(chart, workerOSs, showPreRelease);
+
     const newestChart = versions?.[0];
     const newestVersion = newestChart?.version;
 
     if ( !thisVersion || !newestVersion ) {
-      return null;
-    }
-
-    if (isWindows && newestChart?.annotations?.['catalog.cattle.io/os'] === 'linux') {
-      return null;
-    } else if (!isWindows && newestChart?.annotations?.['catalog.cattle.io/os'] === 'windows') {
       return null;
     }
 

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -9,7 +9,7 @@ import { SHOW_PRE_RELEASE } from '@/store/prefs';
 import { set } from '@/utils/object';
 
 import SteveModel from '@/plugins/steve/steve-class';
-import { compatibleVersionsFor } from '~/store/catalog';
+import { compatibleVersionsFor } from '@/store/catalog';
 
 export default class CatalogApp extends SteveModel {
   showMasthead(mode) {
@@ -72,7 +72,6 @@ export default class CatalogApp extends SteveModel {
       // Things managed by fleet shouldn't show upgrade available even if there might be.
       return false;
     }
-
     const chart = this.matchingChart(false);
 
     if ( !chart ) {
@@ -114,6 +113,39 @@ export default class CatalogApp extends SteveModel {
     }
 
     return sortable(version);
+  }
+
+  get currentVersionCompatible() {
+    const workerOSs = this.$rootGetters['currentCluster'].workerOSs;
+
+    const chart = this.matchingChart(false);
+    const thisVersion = this.spec?.chart?.metadata?.version;
+
+    if (!chart) {
+      return true;
+    }
+
+    const versionInChart = chart.versions.find(version => version.version === thisVersion);
+
+    if (!versionInChart) {
+      return true;
+    }
+    const compatibleVersions = compatibleVersionsFor(chart, workerOSs, true) || [];
+
+    const thisVersionCompatible = !!compatibleVersions.find(version => version.version === thisVersion);
+
+    return thisVersionCompatible;
+  }
+
+  get stateDescription() {
+    if (this.currentVersionCompatible) {
+      return null;
+    }
+    if (this.upgradeAvailable) {
+      return this.t('catalog.os.versionIncompatible');
+    }
+
+    return this.t('catalog.os.chartIncompatible');
   }
 
   goToUpgrade(forceVersion, fromTools) {

--- a/models/chart.js
+++ b/models/chart.js
@@ -6,14 +6,15 @@ import { BLANK_CLUSTER } from '@/store';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export default class Chart extends SteveModel {
+  // TODO redo to accomodate rke2 and permits-os annotation
   queryParams(from, hideSideNav) {
     let version;
     const chartVersions = this.versions;
     const currentCluster = this.$rootGetters['currentCluster'];
 
     const clusterProvider = currentCluster?.status.provider || 'other';
-    const windowsVersions = (chartVersions, 'windows');
-    const linuxVersions = compatibleVersionsFor(chartVersions, 'linux');
+    const windowsVersions = (this, 'windows');
+    const linuxVersions = compatibleVersionsFor(this, 'linux');
 
     if (clusterProvider === 'rke.windows' && windowsVersions.length > 0) {
       version = windowsVersions[0].version;

--- a/models/chart.js
+++ b/models/chart.js
@@ -6,22 +6,17 @@ import { BLANK_CLUSTER } from '@/store';
 import SteveModel from '@/plugins/steve/steve-class';
 
 export default class Chart extends SteveModel {
-  // TODO redo to accomodate rke2 and permits-os annotation
   queryParams(from, hideSideNav) {
     let version;
     const chartVersions = this.versions;
     const currentCluster = this.$rootGetters['currentCluster'];
+    const workerOSs = currentCluster.workerOSs;
+    const compatibleVersions = compatibleVersionsFor(this, workerOSs);
 
-    const clusterProvider = currentCluster?.status.provider || 'other';
-    const windowsVersions = (this, 'windows');
-    const linuxVersions = compatibleVersionsFor(this, 'linux');
-
-    if (clusterProvider === 'rke.windows' && windowsVersions.length > 0) {
-      version = windowsVersions[0].version;
-    } else if (clusterProvider !== 'rke.windows' && linuxVersions.length > 0) {
-      version = linuxVersions[0].version;
+    if (compatibleVersions.length) {
+      version = compatibleVersions[0];
     } else {
-      version = chartVersions[0].version;
+      version = chartVersions[0];
     }
 
     const out = {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -13,6 +13,7 @@ import { NAME as HARVESTER } from '@/config/product/harvester';
 import { isHarvesterCluster } from '@/utils/cluster';
 import HybridModel from '@/plugins/steve/hybrid-class';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
+import { LINUX, WINDOWS } from '~/store/catalog';
 
 // See translation file cluster.providers for list of providers
 // If the logo is not named with the provider name, add an override here
@@ -173,7 +174,7 @@ export default class MgmtCluster extends HybridModel {
   }
 
   get providerOs() {
-    if ( this.status?.provider.endsWith('.windows') ) {
+    if ( this.status?.provider.endsWith('.windows')) {
       return 'windows';
     }
 
@@ -182,6 +183,30 @@ export default class MgmtCluster extends HybridModel {
 
   get providerOsLogo() {
     return require(`~/assets/images/vendor/${ this.providerOs }.svg`);
+  }
+
+  get workerOSs() {
+    // rke1 clusters always have at least one linux worker
+    // rke2 clusters report linux workers in mgmt cluster status
+    const rke2WindowsWorkers = this.status?.windowsWorkerCount;
+    const rke2LinuxWorkers = this.status?.linuxWorkerCount;
+
+    if (rke2WindowsWorkers || rke2LinuxWorkers ) {
+      const out = [];
+
+      if (rke2WindowsWorkers) {
+        out.push(WINDOWS);
+      }
+      if (rke2LinuxWorkers) {
+        out.push(LINUX);
+      }
+
+      return out;
+    } else if (this.providerOs === WINDOWS) {
+      return [LINUX, WINDOWS];
+    }
+
+    return [LINUX];
   }
 
   get isLocal() {

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -186,7 +186,7 @@ export default class MgmtCluster extends HybridModel {
   }
 
   get workerOSs() {
-    // rke1 clusters always have at least one linux worker
+    // rke1 clusters have windows support defined on create
     // rke2 clusters report linux workers in mgmt cluster status
     const rke2WindowsWorkers = this.status?.windowsWorkerCount;
     const rke2LinuxWorkers = this.status?.linuxWorkerCount;
@@ -203,7 +203,7 @@ export default class MgmtCluster extends HybridModel {
 
       return out;
     } else if (this.providerOs === WINDOWS) {
-      return [LINUX, WINDOWS];
+      return [WINDOWS];
     }
 
     return [LINUX];

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -12,8 +12,8 @@ import { isEmpty } from '@/utils/object';
 import { NAME as HARVESTER } from '@/config/product/harvester';
 import { isHarvesterCluster } from '@/utils/cluster';
 import HybridModel from '@/plugins/steve/hybrid-class';
+import { LINUX, WINDOWS } from '@/store/catalog';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
-import { LINUX, WINDOWS } from '~/store/catalog';
 
 // See translation file cluster.providers for list of providers
 // If the logo is not named with the provider name, add an override here

--- a/pages/c/_cluster/apps/charts/chart.vue
+++ b/pages/c/_cluster/apps/charts/chart.vue
@@ -7,6 +7,8 @@ import LazyImage from '@/components/LazyImage';
 import DateFormatter from '@/components/formatter/Date';
 import isEqual from 'lodash/isEqual';
 import { CHART, REPO, REPO_TYPE, VERSION } from '@/config/query-params';
+import { mapGetters } from 'vuex';
+import { compatibleVersionsFor } from '@/store/catalog';
 
 export default {
   components: {
@@ -33,6 +35,8 @@ export default {
   },
 
   computed: {
+    ...mapGetters(['currentCluster']),
+
     versions() {
       return this.showMoreVersions ? this.mappedVersions : this.mappedVersions.slice(0, this.showLastVersions);
     },
@@ -55,6 +59,27 @@ export default {
         };
       });
     },
+
+    osWarning() {
+      if (this.chart) {
+        const compatible = compatibleVersionsFor(this.chart, this.currentCluster.workerOSs, this.showPreRelease );
+
+        const currentlyCompatible = !!compatible.find((version) => {
+          return version.version === this.targetVersion;
+        });
+
+        // TODO translations
+        if (currentlyCompatible) {
+          return false;
+        } else if (compatible.length > 0) {
+          return "This chart is not compatible with your worker nodes' operating systems";
+        } else {
+          return "This chart is not compatible with your worker nodes' operating systems";
+        }
+      }
+
+      return false;
+    }
 
   },
 
@@ -107,7 +132,10 @@ export default {
           {{ t(`asyncButton.${action}.action` ) }}
         </button>
       </div>
-      <div v-if="requires.length || warnings.length || targetedAppWarning" class="mt-20">
+      <div v-if="requires.length || warnings.length || targetedAppWarning || osWarning" class="mt-20">
+        <Banner v-if="osWarning" color="error">
+          <span v-html="osWarning" />
+        </Banner>
         <Banner v-for="msg in requires" :key="msg" color="error">
           <span v-html="msg" />
         </Banner>

--- a/pages/c/_cluster/apps/charts/chart.vue
+++ b/pages/c/_cluster/apps/charts/chart.vue
@@ -68,13 +68,12 @@ export default {
           return version.version === this.targetVersion;
         });
 
-        // TODO translations
         if (currentlyCompatible) {
           return false;
         } else if (compatible.length > 0) {
-          return "This chart is not compatible with your worker nodes' operating systems";
+          return this.t('catalog.os.versionIncompatible');
         } else {
-          return "This chart is not compatible with your worker nodes' operating systems";
+          return this.t('catalog.os.chartIncompatible');
         }
       }
 

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -140,9 +140,7 @@ export default {
       const enabledCharts = (this.enabledCharts || []);
 
       return filterAndArrangeCharts(enabledCharts, {
-        // TODO not this
-        // operatingSystems: this.currentCluster.workerOSs,
-        operatingSystems: ['windows', 'linux'],
+        operatingSystems: this.currentCluster.workerOSs,
         category:         this.category,
         searchQuery:      this.searchQuery,
         showDeprecated:   this.showDeprecated,

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -67,7 +67,7 @@ export default {
       allInstalled:    null,
       v1SystemCatalog: null,
       systemProject:   null,
-      legacyEnabled
+      legacyEnabled,
     };
   },
 
@@ -113,12 +113,12 @@ export default {
       const enabledCharts = (this.allCharts || []);
 
       let charts = filterAndArrangeCharts(enabledCharts, {
-        isWindows:      this.currentCluster.providerOs === 'windows',
+        operatingSystems: this.currentCluster.workerOSs,
         clusterProvider,
-        showDeprecated: this.showDeprecated,
-        showHidden:     this.showHidden,
-        showRepos:      [this.rancherCatalog?._key],
-        showTypes:      [CATALOG_ANNOTATIONS._CLUSTER_TOOL],
+        showDeprecated:   this.showDeprecated,
+        showHidden:       this.showHidden,
+        showRepos:        [this.rancherCatalog?._key],
+        showTypes:        [CATALOG_ANNOTATIONS._CLUSTER_TOOL],
       });
 
       //  If legacy support is enabled, show V1 charts for some V1 Cluster tools

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -3,13 +3,14 @@ import { CATALOG as CATALOG_ANNOTATIONS } from '@/config/labels-annotations';
 import { addParams } from '@/utils/url';
 import { allHash, allHashSettled } from '@/utils/promise';
 import { clone } from '@/utils/object';
-import { findBy, addObject, filterBy } from '@/utils/array';
+import { findBy, addObject, filterBy, isArray } from '@/utils/array';
 import { stringify } from '@/utils/error';
 import { classify } from '@/plugins/steve/classify';
 import { sortBy } from '@/utils/sort';
 import { importChart } from '@/utils/dynamic-importer';
 import { ensureRegex } from '@/utils/string';
 import { isPrerelease } from '@/utils/version';
+import difference from 'lodash/difference';
 
 const ALLOWED_CATEGORIES = [
   'Storage',
@@ -29,6 +30,9 @@ const CERTIFIED_SORTS = {
   [CATALOG_ANNOTATIONS._PARTNER]:      2,
   other:                               3,
 };
+
+export const WINDOWS = 'windows';
+export const LINUX = 'linux';
 
 export const state = function() {
   return {
@@ -462,6 +466,18 @@ function addChart(ctx, map, chart, repo) {
   let obj = map[key];
 
   const certifiedAnnotation = chart.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED];
+
+  // TODO delete this if block
+  // if (certifiedAnnotation === CATALOG_ANNOTATIONS._RANCHER) {
+  //   const pretendBoth = chart.name.includes('monitoring') || chart.name.includes('istio') || chart.name.includes('logging');
+  //   const pretendWindows = chart.name.includes('longhorn');
+
+  //   if (pretendWindows) {
+  //     chart.annotations[CATALOG_ANNOTATIONS.PERMITTED_OS] = WINDOWS;
+  //   } else if (pretendBoth) {
+  //     chart.annotations[CATALOG_ANNOTATIONS.PERMITTED_OS] = `${ WINDOWS },${ LINUX }`;
+  //   }
+  // }
   let certified = null;
   let sideLabel = null;
 
@@ -568,15 +584,29 @@ function normalizeCategory(c) {
   return c.replace(/\s+/g, '').toLowerCase();
 }
 
-export function compatibleVersionsFor(versions, os, includePrerelease = true) {
+/*
+catalog.cattle.io/deplys-on-os: OS -> requires global.cattle.OS.enabled: true
+  default: nothing
+catalog.cattle.io/permits-os: OS -> will break on clusters containing nodes that are not OS
+  default if not found: catalog.cattle.io/permits-os: linux
+*/
+export function compatibleVersionsFor(chart, os, includePrerelease = true) {
+  const versions = chart.versions;
+  // TODO remove other
+  const isRancher = chart.certified === 'rancher' || chart.certified === 'other';
+
+  if (os && !isArray(os)) {
+    os = [os];
+  }
+
   return versions.filter((ver) => {
-    const osAnnotation = ver?.annotations?.[CATALOG_ANNOTATIONS.SUPPORTED_OS];
+    const osPermitted = (ver?.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || LINUX).split(',');
 
     if ( !includePrerelease && isPrerelease(ver.version) ) {
       return false;
     }
 
-    if (!osAnnotation || !os || osAnnotation === os) {
+    if ( !os || difference(os, osPermitted).length === 0 || !isRancher) {
       return true;
     }
 
@@ -585,7 +615,7 @@ export function compatibleVersionsFor(versions, os, includePrerelease = true) {
 }
 
 export function filterAndArrangeCharts(charts, {
-  os,
+  operatingSystems,
   category,
   searchQuery,
   showDeprecated = false,
@@ -597,8 +627,6 @@ export function filterAndArrangeCharts(charts, {
   hideTypes = [],
 } = {}) {
   const out = charts.filter((c) => {
-    const { versions: chartVersions = [] } = c;
-
     if (
       ( c.deprecated && !showDeprecated ) ||
       ( c.hidden && !showHidden ) ||
@@ -609,7 +637,7 @@ export function filterAndArrangeCharts(charts, {
       return false;
     }
 
-    if (compatibleVersionsFor(chartVersions, os, showPrerelease).length <= 0) {
+    if (compatibleVersionsFor(c, operatingSystems, showPrerelease).length <= 0) {
       // There's no versions compatible with the specified os
       return false;
     }

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -467,17 +467,6 @@ function addChart(ctx, map, chart, repo) {
 
   const certifiedAnnotation = chart.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED];
 
-  // TODO delete this if block
-  // if (certifiedAnnotation === CATALOG_ANNOTATIONS._RANCHER) {
-  //   const pretendBoth = chart.name.includes('monitoring') || chart.name.includes('istio') || chart.name.includes('logging');
-  //   const pretendWindows = chart.name.includes('longhorn');
-
-  //   if (pretendWindows) {
-  //     chart.annotations[CATALOG_ANNOTATIONS.PERMITTED_OS] = WINDOWS;
-  //   } else if (pretendBoth) {
-  //     chart.annotations[CATALOG_ANNOTATIONS.PERMITTED_OS] = `${ WINDOWS },${ LINUX }`;
-  //   }
-  // }
   let certified = null;
   let sideLabel = null;
 

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -581,8 +581,7 @@ catalog.cattle.io/permits-os: OS -> will break on clusters containing nodes that
 */
 export function compatibleVersionsFor(chart, os, includePrerelease = true) {
   const versions = chart.versions;
-  // TODO remove other
-  const isRancher = chart.certified === 'rancher' || chart.certified === 'other';
+  const isRancher = chart.certified === 'rancher';
 
   if (os && !isArray(os)) {
     os = [os];


### PR DESCRIPTION
#5056 
#5055 
#5057 
#5054 
#4983 
(Gary's in the process of separating out the arch requirements as we wont have backend for that in 2.6.4)

See #5137 for a detailed explanation - currently we're using the `'catalog.cattle.io/os'` annotation to infer if an app is windows or linux only; the windows team has added a `'catalog.cattle.io/permits-os'` annotation to more explicitly define which apps will work on windows, linux or mixed node clusters. Since we have greater confidence in an app's compatibility I made the filtering happen behind the scenes. Additionally there are warnings on app install/upgrade and list views.

The backend team is validating whether these new annotations are accurate, so it's enough on the UI side to spoof a windows/mixed cluster [here](https://github.com/rancher/dashboard/compare/master...mantis-toboggan-md:rke2-windows-charts?expand=1#diff-3428bcbbe7b3e89e79dbc7633dfb63ba6f3bb2f3d3ff604ef1849983e618fef1R188) and verify filtering and messages accurately reflect the new annotation.

![Screen Shot 2022-02-24 at 9 27 01 AM](https://user-images.githubusercontent.com/42977925/155567976-5ca6b775-38e6-4a0b-87ac-1f20a4cb4341.png)
![Screen Shot 2022-02-24 at 9 27 57 AM](https://user-images.githubusercontent.com/42977925/155567982-602a8084-ad8d-4f29-9fdb-48bf3e33efc9.png)



