### PR TITLE
Fix bug where extra dash is shown in masthead

### DIFF
--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -100,10 +100,6 @@ export default {
       return null;
     },
 
-    resourceSubtypeString() {
-      return this.resourceSubtype?.length ? `${ this.resourceSubtype } -` : this.resourceSubtype;
-    },
-
     namespaceLocation() {
       if (!this.isNamespace) {
         return {
@@ -329,7 +325,7 @@ export default {
             </nuxt-link>
             <span v-else>{{ parent.displayName }}:</span>
             <span v-if="value.detailPageHeaderActionOverride && value.detailPageHeaderActionOverride(realMode)">{{ value.detailPageHeaderActionOverride(realMode) }}</span>
-            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtypeString" :name="value.nameDisplay" />
+            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtype" :name="value.nameDisplay" />
             <BadgeState v-if="!isCreate && parent.showState" class="masthead-state" :value="value" />
           </h1>
         </div>


### PR DESCRIPTION
Fixes #5160  

This PR fixes a bug where an extra hyphen appears in the masthead, e.g.

![Screenshot 2022-02-24 at 16 47 09](https://user-images.githubusercontent.com/1955897/155569287-a33af6c5-296a-4f68-a67d-747878c3cc2d.png)

@aalves08 Looks like this was introduced in a commit you authored - any ideas what the intent was?
