### PR TITLE
Allow editing PVC

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4116,7 +4116,7 @@ storageClass:
       later: Bind and provision a persistent volume once a Pod using the PersistentVolumeClaim is created
     mountOptions:
       label: Mount Options
-      addlabel: Add Option
+      addLabel: Add Option
   aws-ebs:
     title: Amazon EBS Disk
     volumeType:

--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -131,7 +131,6 @@ export function init(store) {
 
   configureType(NODE, { isCreatable: false, isEditable: true });
   configureType(WORKLOAD_TYPES.JOB, { isEditable: false, match: WORKLOAD_TYPES.JOB });
-  configureType(PVC, { isEditable: false });
   configureType(MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, { isEditable: false });
   configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false });
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });


### PR DESCRIPTION
The storage size, labels and annotations of a PVC can be edited in Kubernetes. If the PVC's StorageClass does not support Volume Expansion, an error will be shown.

Addresses https://github.com/rancher/dashboard/issues/3115

Create View has now a Labels & Annotations section, but otherwise did not change:
![Bildschirmfoto 2022-02-24 um 18 48 19](https://user-images.githubusercontent.com/243056/155579720-43956418-79d1-4ca9-b240-485e19a30c9d.png)
![Bildschirmfoto 2022-02-24 um 18 48 14](https://user-images.githubusercontent.com/243056/155579726-65e7e715-563f-413a-83f9-2adfe0943ea8.png)
![Bildschirmfoto 2022-02-24 um 18 48 11](https://user-images.githubusercontent.com/243056/155579729-aa7fbfa6-75a6-46de-a05a-e02099150f21.png)

Detail View did not change:
![Bildschirmfoto 2022-02-24 um 18 48 37](https://user-images.githubusercontent.com/243056/155579785-07f46408-3336-418d-96c6-49e9cb0bcbc3.png)
![Bildschirmfoto 2022-02-24 um 18 48 31](https://user-images.githubusercontent.com/243056/155579790-1df11de5-efd5-4158-8032-e0e4800526ef.png)

Edit View allows editing the size and labels and annotations:
![Bildschirmfoto 2022-02-24 um 18 48 55](https://user-images.githubusercontent.com/243056/155579913-b1d985d6-8cc6-4470-8d40-0babad00f1b9.png)
![Bildschirmfoto 2022-02-24 um 18 48 48](https://user-images.githubusercontent.com/243056/155579918-c8ff4f6b-d291-4b91-b25b-22235ad1df84.png)
![Bildschirmfoto 2022-02-24 um 18 48 44](https://user-images.githubusercontent.com/243056/155579922-cdce6e95-4c18-4a59-8aee-d77f0e84a46a.png)

If the StorageClass does not support VolumeExpansion, an error is shown:
![Bildschirmfoto 2022-02-24 um 18 49 13](https://user-images.githubusercontent.com/243056/155579984-68c8343d-b5de-417a-9123-d7cfdb3f0250.png)

