### PR TITLE
Move 'previous log' checkbox out of the cog menu

### DIFF
--- a/components/AsyncButton.vue
+++ b/components/AsyncButton.vue
@@ -234,12 +234,11 @@ export default Vue.extend({
     <i
       v-if="displayIcon"
       v-tooltip="tooltip"
-      :class="{icon: true, 'icon-lg': true, [displayIcon]: true}"
+      :class="{icon: true, 'icon-lg': true, [displayIcon]: true, 'pr-5': true}"
     />
     <span
       v-if="labelAs === 'text' && displayLabel"
       v-tooltip="tooltip"
-      class="pl-5"
       v-html="displayLabel"
     />
   </button>

--- a/components/nav/WindowManager/ContainerLogs.vue
+++ b/components/nav/WindowManager/ContainerLogs.vue
@@ -457,61 +457,73 @@ export default {
 <template>
   <Window :active="active" :before-close="cleanup">
     <template #title>
-      <Select
-        v-if="containerChoices.length > 0"
-        v-model="container"
-        :disabled="containerChoices.length === 1"
-        class="containerPicker pull-left"
-        :options="containerChoices"
-        :clearable="false"
-        placement="top"
-      >
-        <template #selected-option="option">
-          <t v-if="option" k="wm.containerLogs.containerName" :label="option.label" />
-        </template>
-      </Select>
-      <div class="log-action pull-left ml-5">
-        <button class="btn bg-primary" :disabled="isFollowing" @click="follow">
-          <t k="wm.containerLogs.follow" />
-        </button>
-        <button class="btn bg-primary" @click="clear">
-          <t k="wm.containerLogs.clear" />
-        </button>
-        <AsyncButton mode="download" @click="download" />
-      </div>
-
-      <div class="status log-action pull-right text-center p-10" style="min-width: 80px;">
-        <t :class="{'text-success': isOpen, 'text-error': !isOpen}" :k="isOpen ? 'wm.connection.connected' : 'wm.connection.disconnected'" />
-      </div>
-      <div class="log-action pull-right ml-5">
-        <input v-model="search" class="input-sm" type="search" :placeholder="t('wm.containerLogs.search')" />
-      </div>
-      <div class="log-action pull-right ml-5">
-        <v-popover
-          trigger="click"
+      <div class="wm-button-bar">
+        <Select
+          v-if="containerChoices.length > 0"
+          v-model="container"
+          :disabled="containerChoices.length === 1"
+          class="containerPicker"
+          :options="containerChoices"
+          :clearable="false"
           placement="top"
         >
-          <button class="btn bg-primary">
-            <i class="icon icon-gear" />
-          </button>
-
-          <template slot="popover">
-            <div class="filter-popup">
-              <LabeledSelect
-                v-model="range"
-                class="range"
-                :label="t('wm.containerLogs.range.label')"
-                :options="rangeOptions"
-                :clearable="false"
-                placement="top"
-                @input="toggleRange($event)"
-              />
-              <div><Checkbox :label="t('wm.containerLogs.previous')" :value="previous" @input="togglePrevious" /></div>
-              <div><Checkbox :label="t('wm.containerLogs.wrap')" :value="wrap" @input="toggleWrap " /></div>
-              <div><Checkbox :label="t('wm.containerLogs.timestamps')" :value="timestamps" @input="toggleTimestamps" /></div>
-            </div>
+          <template #selected-option="option">
+            <t v-if="option" k="wm.containerLogs.containerName" :label="option.label" />
           </template>
-        </v-popover>
+        </Select>
+        <div class="log-action ml-5">
+          <button class="btn bg-primary wm-btn" :disabled="isFollowing" @click="follow">
+            <t class="wm-btn-large" k="wm.containerLogs.follow" />
+            <i class="wm-btn-small icon icon-chevron-end" />
+          </button>
+          <button class="btn bg-primary wm-btn" @click="clear">
+            <t class="wm-btn-large" k="wm.containerLogs.clear" />
+            <i class="wm-btn-small icon icon-close" />
+          </button>
+          <AsyncButton mode="download" @click="download" />
+        </div>
+
+        <div class="wm-seperator"></div>
+
+        <div class="log-action log-previous ml-5">
+          <div><Checkbox :label="t('wm.containerLogs.previous')" :value="previous" @input="togglePrevious" /></div>
+        </div>
+
+        <div class="log-action ml-5">
+          <v-popover
+            trigger="click"
+            placement="top"
+          >
+            <button class="btn bg-primary btn-cog">
+              <i class="icon icon-gear" />
+              <i class="icon icon-chevron-up" />
+            </button>
+
+            <template slot="popover">
+              <div class="filter-popup">
+                <LabeledSelect
+                  v-model="range"
+                  class="range"
+                  :label="t('wm.containerLogs.range.label')"
+                  :options="rangeOptions"
+                  :clearable="false"
+                  placement="top"
+                  @input="toggleRange($event)"
+                />
+                <div><Checkbox :label="t('wm.containerLogs.wrap')" :value="wrap" @input="toggleWrap " /></div>
+                <div><Checkbox :label="t('wm.containerLogs.timestamps')" :value="timestamps" @input="toggleTimestamps" /></div>
+              </div>
+            </template>
+          </v-popover>
+        </div>
+
+        <div class="log-action ml-5">
+          <input v-model="search" class="input-sm" type="search" :placeholder="t('wm.containerLogs.search')" />
+        </div>
+
+        <div class="status log-action p-10">
+          <t :class="{'text-success': isOpen, 'text-error': !isOpen}" :k="isOpen ? 'wm.connection.connected' : 'wm.connection.disconnected'" />
+        </div>
       </div>
     </template>
     <template #body>
@@ -539,6 +551,19 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  .wm-button-bar {
+    display: flex;
+
+    .wm-seperator {
+      flex: 1;
+    }
+
+    .wm-btn-small {
+      display: none;
+      margin: 0;
+    }
+  }
+
   .logs-container {
     height: 100%;
     overflow: auto;
@@ -597,18 +622,49 @@ export default {
     > input {
       height: 30px;
     }
+
+    .btn-cog {
+      padding: 0 5px;
+      > i {
+        margin: 0;
+      }
+    }
+  }
+
+  .log-previous {
+    align-items: center;
+    display: flex;
+    height: 30px;
   }
 
   .status {
     align-items: center;
     display: flex;
-    min-width: 80px;
+    justify-content: flex-end;
+    min-width: 105px;
     height: 30px;
   }
 
   .filter-popup {
     > * {
       margin-bottom: 10px;
+    }
+  }
+
+  @media only screen and (max-width: 1060px) {
+    .wm-button-bar {
+      .wm-btn {
+        padding: 0 10px;
+
+        .wm-btn-large {
+          display: none;
+        }
+
+        .wm-btn-small {
+          display: inline;
+          margin: 0;
+        }
+      }
     }
   }
 </style>


### PR DESCRIPTION
Fixes #5149

This PR moves the 'Show previous log' checkbox out of the cog menu, so that is is more obvious.

Additionally:
- Changes the layout of the buttons area to flex so that it sizes properly
- Added a dropdown arrow to the cog button so it is clearer that it is a popup menu
- Makes the Follow and Clear buttons responsive, so that they reduce to an icon when space is tight
- Gives more space to the status message so that controls don't jiggle when it changes from connected to disconnected
- Fixes a minor styling issue in the AsyncButton control where there is extra margin on the left of the text when there is no icon

Here's how it looks now:
  
![image](https://user-images.githubusercontent.com/1955897/155606281-a859c6aa-a632-4f1f-8e52-76141ccafc97.png)

When smaller:

![image](https://user-images.githubusercontent.com/1955897/155606354-06b99b9b-1d56-4bb5-b90f-f134b3c80021.png)

