### PR TITLE
Fix bug where hifen is incorrectly introduced in masthead title

### DIFF
--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -100,8 +100,8 @@ export default {
       return null;
     },
 
-    resourceSubtypeString() {
-      return this.resourceSubtype?.length ? `${ this.resourceSubtype } -` : this.resourceSubtype;
+    shouldHifenize() {
+      return (this.mode === 'view' || this.mode === 'edit') && this.resourceSubtype?.length && this.value?.nameDisplay?.length;
     },
 
     namespaceLocation() {
@@ -329,7 +329,7 @@ export default {
             </nuxt-link>
             <span v-else>{{ parent.displayName }}:</span>
             <span v-if="value.detailPageHeaderActionOverride && value.detailPageHeaderActionOverride(realMode)">{{ value.detailPageHeaderActionOverride(realMode) }}</span>
-            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtypeString" :name="value.nameDisplay" />
+            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtype" :name="shouldHifenize ? ` - ${ value.nameDisplay }` : value.nameDisplay" />
             <BadgeState v-if="!isCreate && parent.showState" class="masthead-state" :value="value" />
           </h1>
         </div>


### PR DESCRIPTION
- Fixes bug where hifen is incorrectly introduced in masthead title

**Before**
![155569287-a33af6c5-296a-4f68-a67d-747878c3cc2d](https://user-images.githubusercontent.com/97888974/155695654-2f9f6633-0cb6-4d3f-93d6-053ecec6ef80.png)

**After**
<img width="1654" alt="Screenshot 2022-02-25 at 09 53 21" src="https://user-images.githubusercontent.com/97888974/155695702-c140fbfd-4212-4fe3-858e-3acb0f71455d.png">
<img width="1654" alt="Screenshot 2022-02-25 at 09 53 43" src="https://user-images.githubusercontent.com/97888974/155695726-754ff504-da01-42c4-aace-985febe439fa.png">
<img width="1654" alt="Screenshot 2022-02-25 at 09 53 16" src="https://user-images.githubusercontent.com/97888974/155695737-82c7133e-79b3-45db-b37a-bb5f1f33e7ca.png">
<img width="1654" alt="Screenshot 2022-02-25 at 09 53 47" src="https://user-images.githubusercontent.com/97888974/155695745-f4d83ab4-8061-4be9-850f-8c499d0c2c5b.png">

