### PR TITLE
load correct machine template type on provisioning cluster detail page

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -89,7 +89,11 @@ export default {
 
     const fetchTwo = {};
 
-    const machineDeploymentTemplateType = fetchOneRes.machineDeployments?.[0]?.templateType;
+    const thisClusterMachines = this.allMachineDeployments.filter((deployment) => {
+      return deployment?.spec?.clusterName === this.value.metadata.name;
+    });
+
+    const machineDeploymentTemplateType = thisClusterMachines?.[0]?.templateType;
 
     if (machineDeploymentTemplateType && this.$store.getters['management/schemaFor'](machineDeploymentTemplateType) ) {
       fetchTwo.mdtt = this.$store.dispatch('management/findAll', { type: machineDeploymentTemplateType });


### PR DESCRIPTION
#4990 (comments) - reproing this requires clusters from multiple providers. Make a few clusters, do a hard refresh, and notice that only one provider's clusters will load machine templates in detail views. No need to scale pools to see this; the table group labels will be missing provider, location, and size info for the 'broken' provider types.

