### PR TITLE
Fix bug where cluster name is cropped

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -516,7 +516,7 @@ export default {
       }
     }
 
-     .cluster {
+    .cluster {
       align-items: center;
       display: flex;
       height: 32px;

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -164,7 +164,7 @@ export default {
 
   methods: {
     // Sizes the product area of the header such that it shrinks to ensure the whole header bar can be shown
-    // where possible - we use a miniumum width of 32px which is enough to just show the product icon
+    // where possible - we use a minimum width of 32px which is enough to just show the product icon
     layoutHeader() {
       const header = this.$refs.header;
       const product = this.$refs.product;

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -256,7 +256,7 @@ export default {
       </n-link>
     </div>
     <div v-if="!simple" ref="product" class="product">
-      <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-tooltip="nameTooltip" class="cluster">
+      <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-tooltip="nameTooltip" class="cluster cluster-clipped">
         <div v-if="isSingleVirtualCluster" class="product-name">
           {{ t('product.harvester') }}
         </div>
@@ -523,6 +523,11 @@ export default {
       white-space: nowrap;
       .cluster-name {
         font-size: 16px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+      &.cluster-clipped {
+        overflow: hidden;
       }
     }
 

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -163,7 +163,7 @@ export default {
   },
 
   methods: {
-    // Sizes the product area of the header such that it shrinks to ensure the whole header abr can be shown
+    // Sizes the product area of the header such that it shrinks to ensure the whole header bar can be shown
     // where possible - we use a miniumum width of 32px which is enough to just show the product icon
     layoutHeader() {
       const header = this.$refs.header;

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -1,5 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
+import debounce from 'lodash/debounce';
 import { NORMAN, HCI } from '@/config/types';
 import { NAME as VIRTUAL } from '@/config/product/harvester';
 import { ucFirst } from '@/utils/string';
@@ -151,9 +152,45 @@ export default {
 
   mounted() {
     this.checkClusterName();
+    this.debouncedLayoutHeader = debounce(this.layoutHeader, 400);
+    window.addEventListener('resize', this.debouncedLayoutHeader);
+
+    this.$nextTick(() => this.layoutHeader(null, true));
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('resize', this.debouncedLayoutHeader);
   },
 
   methods: {
+    // Sizes the product area of the header such that it shrinks to ensure the whole header abr can be shown
+    // where possible - we use a miniumum width of 32px which is enough to just show the product icon
+    layoutHeader() {
+      const header = this.$refs.header;
+      const product = this.$refs.product;
+
+      if (!header || !product) {
+        return;
+      }
+
+      // If the product element has an exact size, remove it and then recalculate
+      if (product.style.width) {
+        product.style.width = '';
+
+        this.$nextTick(() => this.layoutHeader());
+
+        return;
+      }
+
+      const overflow = header.scrollWidth - window.innerWidth;
+
+      if (overflow > 0) {
+        const w = Math.max(32, product.offsetWidth - overflow);
+
+        // Set exact width on the product div so that the content in it fits that available space
+        product.style.width = `${ w }px`;
+      }
+    },
     showMenu(show) {
       if (this.$refs.popover) {
         if (show) {
@@ -206,7 +243,10 @@ export default {
 </script>
 
 <template>
-  <header :class="{'simple': simple}">
+  <header ref="header">
+    <div>
+      <TopLevelMenu v-if="isMultiCluster || !isSingleVirtualCluster"></TopLevelMenu>
+    </div>
     <div class="menu-spacer">
       <n-link v-if="isSingleVirtualCluster" :to="harvesterDashboard">
         <img
@@ -215,7 +255,7 @@ export default {
         />
       </n-link>
     </div>
-    <div v-if="!simple" class="product">
+    <div v-if="!simple" ref="product" class="product">
       <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-tooltip="nameTooltip" class="cluster">
         <div v-if="isSingleVirtualCluster" class="product-name">
           {{ t('product.harvester') }}
@@ -247,9 +287,7 @@ export default {
       </div>
     </div>
 
-    <div>
-      <TopLevelMenu v-if="isMultiCluster || !isSingleVirtualCluster"></TopLevelMenu>
-    </div>
+    <div class="spacer"></div>
 
     <div class="rd-header-right">
       <HarvesterUpgrade v-if="isVirtualCluster" />
@@ -423,7 +461,15 @@ export default {
 </template>
 <style lang="scss" scoped>
   HEADER {
-    display: grid;
+    display: flex;
+
+    > .spacer {
+      flex: 1;
+    }
+
+    > .menu-spacer {
+      flex: 0 0 calc(var(--header-height) + 10px);
+    }
 
     .title {
       border-left: 1px solid var(--header-border);
@@ -452,10 +498,6 @@ export default {
       }
     }
 
-    > * {
-      padding: 0 5px;
-    }
-
     .back {
       padding-top: 6px;
 
@@ -474,20 +516,7 @@ export default {
       }
     }
 
-    grid-template-areas:  "menu product top a header-right"; // TODO what's a good name for a here
-    grid-template-columns: var(--header-height) calc(var(--nav-width) - var(--header-height)) 1fr min-content min-content;
-    grid-template-rows:    var(--header-height);
-
-    &.simple {
-      grid-template-columns: var(--header-height) min-content 1fr min-content min-content;
-    }
-
-    > .menu-spacer {
-      width: 65px;
-      grid-area: menu;
-    }
-
-    .cluster {
+     .cluster {
       align-items: center;
       display: flex;
       height: 32px;
@@ -498,7 +527,6 @@ export default {
     }
 
     > .product {
-      grid-area: product;
       align-items: center;
       position: relative;
       display: flex;
@@ -541,15 +569,10 @@ export default {
       border-bottom: var(--header-border-size) solid var(--header-border);
     }
 
-    .menu-spacer {
-      grid-area: menu;
-    }
-
     .rd-header-right {
       display: flex;
       flex-direction: row;
       padding: 0;
-      grid-area: header-right;
 
       > * {
         padding: 0 5px;

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -247,11 +247,13 @@ export default {
                   :to="{ name: 'c-cluster', params: { cluster: c.id } }"
                 >
                   <ClusterProviderIcon :small="true" :cluster="c" class="rancher-provider-icon mr-10" />
-                  <div>{{ c.label }}</div>
+                  <div class="cluster-name">
+                    {{ c.label }}
+                  </div>
                 </nuxt-link>
                 <span v-else class="option-disabled cluster selector disabled">
                   <ClusterProviderIcon :small="true" :cluster="c" class="rancher-provider-icon mr-10" />
-                  <div>{{ c.label }}</div>
+                  <div class="cluster-name">{{ c.label }}</div>
                 </span>
               </div>
               <div v-if="clustersFiltered.length === 0" class="none-matching">
@@ -537,11 +539,14 @@ export default {
         align-items: center;
         display: flex;
         height: $option-height;
+
+        white-space: nowrap;
         &:focus {
           outline: 0;
         }
         .cluster-name {
-          font-size: 16px;
+          text-overflow: ellipsis;
+          overflow: hidden;
         }
         > img {
           max-height: $icon-size;


### PR DESCRIPTION
Fixes a bug where the cluster name is restricted to the side nav width - width the addition of cluster badges this means the name is easily cropped, e.g.:

<img width="1262" alt="Screenshot 2022-02-25 at 14 42 09" src="https://user-images.githubusercontent.com/1955897/155798158-b71c7300-4c1c-4d70-903a-43650f67f3c8.png">

This PR changes the header to use flex layout which is a little cleaner.

If also adds a resize handler which ensures that the cluster name div is sized so that the header fits the width of the window, by setting an exact width in which the product info will then be fit.