### PR TITLE
Fleet: Update colours of badges featuring counts in Fleet Dashboard view to convey status information

### DIFF
--- a/pages/c/_cluster/fleet/index.vue
+++ b/pages/c/_cluster/fleet/index.vue
@@ -2,6 +2,7 @@
 import { mapState } from 'vuex';
 import { FLEET } from '@/config/types';
 import { WORKSPACE } from '@/store/prefs';
+import { STATES_ENUM, STATES, getStateLabel } from '@/plugins/steve/resource-class';
 import { allHash } from '@/utils/promise';
 import Loading from '@/components/Loading';
 import CollapsibleCard from '@/components/CollapsibleCard.vue';
@@ -118,28 +119,91 @@ export default {
       });
     },
     badgeClass(area, row) {
+      // classes are defined in the themes SASS files...
       switch (area) {
       case 'clusters':
         if (row.clusterInfo?.ready === row.clusterInfo?.total && row.clusterInfo?.ready) {
-          return 'green-badge';
+          return 'bg-success';
         }
 
-        return 'red-badge';
+        return 'bg-warning badge-class-default';
       case 'bundles':
-        if (row.bundlesReady?.length === row.bundles.length && row.bundlesReady?.length) {
-          return 'green-badge';
+        if (row.bundles?.length && row.bundles?.every(bundle => bundle.state?.toLowerCase() === STATES_ENUM.ACTIVE)) {
+          return `bg-${ STATES[STATES_ENUM.ACTIVE].color || 'unknown' }`;
+        }
+        if (row.bundles?.length && row.bundles?.some(bundle => bundle.state?.toLowerCase() === STATES_ENUM.ERR_APPLIED)) {
+          return `bg-${ STATES[STATES_ENUM.ERR_APPLIED].color || 'unknown' }`;
+        }
+        if (row.bundles?.length && row.bundles?.some(bundle => bundle.state?.toLowerCase() === STATES_ENUM.NOT_READY)) {
+          return `bg-${ STATES[STATES_ENUM.NOT_READY].color || 'unknown' }`;
         }
 
-        return 'red-badge';
+        if (row.bundlesReady?.length === row.bundles?.length && row.bundlesReady && row.bundles?.length) {
+          return 'bg-success';
+        }
+
+        return 'bg-warning badge-class-default';
       case 'resources':
-        if (row.status?.resourceCounts?.desiredReady === row.status?.resourceCounts?.ready && row.status?.resourceCounts?.desiredReady) {
-          return 'green-badge';
+        if (row.status?.resources?.length && row.status?.resources?.every(resource => resource.state?.toLowerCase() === STATES_ENUM.ACTIVE)) {
+          return `bg-${ STATES[STATES_ENUM.ACTIVE].color || 'unknown' }`;
+        }
+        if (row.status?.resources?.length && row.status?.resources?.some(resource => resource.state?.toLowerCase() === STATES_ENUM.ERR_APPLIED)) {
+          return `bg-${ STATES[STATES_ENUM.ERR_APPLIED].color || 'unknown' }`;
+        }
+        if (row.status?.resources?.length && row.status?.resources?.some(resource => resource.state?.toLowerCase() === STATES_ENUM.NOT_READY)) {
+          return `bg-${ STATES[STATES_ENUM.NOT_READY].color || 'unknown' }`;
         }
 
-        return 'red-badge';
+        if (row.status?.resourceCounts?.desiredReady === row.status?.resourceCounts?.ready && row.status?.resourceCounts?.desiredReady) {
+          return 'bg-success';
+        }
+
+        return 'bg-warning badge-class-default';
       default:
         return {};
       }
+    },
+    getTooltipInfo(area, row) {
+      switch (area) {
+      case 'clusters':
+        if (row.clusterInfo?.total) {
+          return `Ready: ${ row.clusterInfo?.ready }<br>Total: ${ row.clusterInfo?.total }`;
+        }
+
+        return '';
+      case 'bundles':
+        if (row.bundles?.length) {
+          return this.generateTooltipData(row.bundles);
+        }
+
+        return '';
+      case 'resources':
+        if (row.status?.resources?.length) {
+          return this.generateTooltipData(row.status?.resources);
+        }
+
+        return '';
+      default:
+        return {};
+      }
+    },
+    generateTooltipData(data) {
+      const infoObj = {};
+      let tooltipData = '';
+
+      data.forEach((item) => {
+        if (!infoObj[item.state]) {
+          infoObj[item.state] = 0;
+        }
+
+        infoObj[item.state]++;
+      });
+
+      Object.keys(infoObj).forEach((key) => {
+        tooltipData += `${ getStateLabel(key) }: ${ infoObj[key] }<br>`;
+      });
+
+      return tooltipData;
     },
     toggleCollapse(val, key) {
       this.$set(this.isCollapsed, key, val);
@@ -253,6 +317,7 @@ export default {
           >
             <template #cell:clustersReady="{row}">
               <span
+                v-tooltip.bottom="getTooltipInfo('clusters', row)"
                 class="cluster-count-info"
                 :class="badgeClass('clusters', row)"
               >
@@ -261,6 +326,7 @@ export default {
             </template>
             <template #cell:bundlesReady="{row}">
               <span
+                v-tooltip.bottom="getTooltipInfo('bundles', row)"
                 class="cluster-count-info"
                 :class="badgeClass('bundles', row)"
               >
@@ -269,6 +335,7 @@ export default {
             </template>
             <template #cell:resourcesReady="{row}">
               <span
+                v-tooltip.bottom="getTooltipInfo('resources', row)"
                 class="cluster-count-info"
                 :class="badgeClass('resources', row)"
               >
@@ -337,14 +404,7 @@ export default {
     padding: 4px 16px;
     border-radius: 16px;
     display: inline-block;
-    color: var(--primary-text);
-
-    &.red-badge {
-      background-color: var(--error);
-    }
-    &.green-badge {
-      background-color: var(--success);
-    }
+    cursor: default;
   }
 
   .header-icons {

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -68,93 +68,354 @@ const DEFAULT_ICON = 'x';
 const DEFAULT_WAIT_INTERVAL = 1000;
 const DEFAULT_WAIT_TMIMEOUT = 30000;
 
+export const STATES_ENUM = {
+  IN_USE:           'in-use',
+  IN_PROGRESS:      'in-progress',
+  PENDING_ROLLBACK: 'pending-rollback',
+  PENDING_UPGRADE:  'pending-upgrade',
+  ABORTED:          'aborted',
+  ACTIVATING:       'activating',
+  ACTIVE:           'active',
+  AVAILABLE:        'available',
+  BACKED_UP:        'backedup',
+  BOUND:            'bound',
+  BUILDING:         'building',
+  COMPLETED:        'completed',
+  CORDONED:         'cordoned',
+  COUNT:            'count',
+  CREATED:          'created',
+  CREATING:         'creating',
+  DEACTIVATING:     'deactivating',
+  DEGRADED:         'degraded',
+  DENIED:           'denied',
+  DEPLOYED:         'deployed',
+  DISABLED:         'disabled',
+  DISCONNECTED:     'disconnected',
+  DRAINED:          'drained',
+  DRAINING:         'draining',
+  ERR_APPLIED:      'errapplied',
+  ERROR:            'error',
+  ERRORING:         'erroring',
+  ERRORS:           'errors',
+  EXPIRED:          'expired',
+  FAIL:             'fail',
+  FAILED:           'failed',
+  HEALTHY:          'healthy',
+  INACTIVE:         'inactive',
+  INITIALIZING:     'initializing',
+  INPROGRESS:       'inprogress',
+  LOCKED:           'locked',
+  MIGRATING:        'migrating',
+  MISSING:          'missing',
+  MODIFIED:         'modified',
+  NOT_APPLICABLE:   'notApplicable',
+  NOT_APLLIED:      'notapplied',
+  NOT_READY:        'notready',
+  OFF:              'off',
+  ORPHANED:         'orphaned',
+  OTHER:            'other',
+  OUT_OF_SYNC:      'outofsync',
+  PASS:             'pass',
+  PASSED:           'passed',
+  PAUSED:           'paused',
+  PENDING:          'pending',
+  PROVISIONING:     'provisioning',
+  PROVISIONED:      'provisioned',
+  PURGED:           'purged',
+  PURGING:          'purging',
+  READY:            'ready',
+  RECONNECTING:     'reconnecting',
+  REGISTERING:      'registering',
+  REINITIALIZING:   'reinitializing',
+  RELEASED:         'released',
+  REMOVED:          'removed',
+  REMOVING:         'removing',
+  REQUESTED:        'requested',
+  RESTARTING:       'restarting',
+  RESTORING:        'restoring',
+  RESIZING:         'resizing',
+  RUNNING:          'running',
+  SKIP:             'skip',
+  SKIPPED:          'skipped',
+  STARTING:         'starting',
+  STOPPED:          'stopped',
+  STOPPING:         'stopping',
+  SUCCEEDED:        'succeeded',
+  SUCCESS:          'success',
+  SUPERSEDED:       'superseded',
+  SUSPENDED:        'suspended',
+  UNAVAILABLE:      'unavailable',
+  UNHEALTHY:        'unhealthy',
+  UNINSTALLED:      'uninstalled',
+  UNINSTALLING:     'uninstalling',
+  UNKNOWN:          'unknown',
+  UNTRIGGERED:      'untriggered',
+  UPDATING:         'updating',
+  WAIT_APPLIED:     'waitapplied',
+  WAIT_CHECKIN:     'waitcheckin',
+  WAITING:          'waiting',
+  WARNING:          'warning',
+};
+
 export const STATES = {
-  'in-use':           { color: 'success', icon: 'dot-open' },
-  'in-progress':      { color: 'info', icon: 'tag' },
-  'pending-rollback': { color: 'info', icon: 'dot-half' },
-  'pending-upgrade':  { color: 'info', icon: 'dot-half' },
-  aborted:            { color: 'warning', icon: 'error' },
-  activating:         { color: 'info', icon: 'tag' },
-  active:             { color: 'success', icon: 'dot-open' },
-  available:          { color: 'success', icon: 'dot-open' },
-  backedup:           { color: 'success', icon: 'backup' },
-  bound:              { color: 'success', icon: 'dot' },
-  building:           { color: 'success', icon: 'dot-open' },
-  completed:          { color: 'success', icon: 'dot' },
-  cordoned:           { color: 'info', icon: 'tag' },
-  count:              { color: 'success', icon: 'dot-open' },
-  created:            { color: 'info', icon: 'tag' },
-  creating:           { color: 'info', icon: 'tag' },
-  deactivating:       { color: 'info', icon: 'adjust' },
-  degraded:           { color: 'warning', icon: 'error' },
-  denied:             { color: 'error', icon: 'adjust' },
-  deployed:           { color: 'success', icon: 'dot-open' },
-  disabled:           { color: 'warning', icon: 'error' },
-  disconnected:       { color: 'warning', icon: 'error' },
-  drained:            { color: 'info', icon: 'tag' },
-  draining:           { color: 'warning', icon: 'tag' },
-  errapplied:         { color: 'error', icon: 'error' },
-  error:              { color: 'error', icon: 'error' },
-  erroring:           { color: 'error', icon: 'error' },
-  errors:             { color: 'error', icon: 'error' },
-  expired:            { color: 'warning', icon: 'error' },
-  fail:               { color: 'error', icon: 'error' },
-  failed:             { color: 'error', icon: 'error' },
-  healthy:            { color: 'success', icon: 'dot-open' },
-  inactive:           { color: 'error', icon: 'dot' },
-  initializing:       { color: 'warning', icon: 'error' },
-  inprogress:         { color: 'info', icon: 'spinner' },
-  locked:             { color: 'warning', icon: 'adjust' },
-  migrating:          { color: 'info', icon: 'info' },
-  missing:            { color: 'warning', icon: 'adjust' },
-  modified:           { color: 'warning', icon: 'edit' },
-  notApplicable:      { color: 'warning', icon: 'tag' },
-  notapplied:         { color: 'warning', icon: 'tag' },
-  notready:           { color: 'warning', icon: 'tag' },
-  off:                { color: 'darker', icon: 'error' },
-  orphaned:           { color: 'warning', icon: 'tag' },
-  other:              { color: 'info', icon: 'info' },
-  outofsync:          { color: 'warning', icon: 'tag' },
-  pass:               { color: 'success', icon: 'dot-dotfill' },
-  passed:             { color: 'success', icon: 'dot-dotfill' },
-  paused:             { color: 'info', icon: 'info' },
-  pending:            { color: 'info', icon: 'tag' },
-  provisioning:       { color: 'info', icon: 'dot' },
-  provisioned:        { color: 'success', icon: 'dot' },
-  purged:             { color: 'error', icon: 'purged' },
-  purging:            { color: 'info', icon: 'purged' },
-  ready:              { color: 'success', icon: 'dot-open' },
-  reconnecting:       { color: 'error', icon: 'error' },
-  registering:        { color: 'info', icon: 'tag' },
-  reinitializing:     { color: 'warning', icon: 'error' },
-  released:           { color: 'warning', icon: 'error' },
-  removed:            { color: 'error', icon: 'trash' },
-  removing:           { color: 'info', icon: 'trash' },
-  requested:          { color: 'info', icon: 'tag' },
-  restarting:         { color: 'info', icon: 'adjust' },
-  restoring:          { color: 'info', icon: 'medicalcross' },
-  resizing:           { color: 'warning', icon: 'dot' },
-  running:            { color: 'success', icon: 'dot-open' },
-  skip:               { color: 'info', icon: 'dot-open' },
-  skipped:            { color: 'info', icon: 'dot-open' },
-  starting:           { color: 'info', icon: 'adjust' },
-  stopped:            { color: 'error', icon: 'dot' },
-  stopping:           { color: 'info', icon: 'adjust' },
-  succeeded:          { color: 'success', icon: 'dot-dotfill' },
-  success:            { color: 'success', icon: 'dot-open' },
-  superseded:         { color: 'info', icon: 'dot-open' },
-  suspended:          { color: 'info', icon: 'pause' },
-  unavailable:        { color: 'error', icon: 'error' },
-  unhealthy:          { color: 'error', icon: 'error' },
-  uninstalled:        { color: 'info', icon: 'trash' },
-  uninstalling:       { color: 'info', icon: 'trash' },
-  unknown:            { color: 'warning', icon: 'x' },
-  untriggered:        { color: 'success', icon: 'tag' },
-  updating:           { color: 'warning', icon: 'tag' },
-  waitapplied:        { color: 'info', icon: 'tag' },
-  waitcheckin:        { color: 'warning', icon: 'tag' },
-  waiting:            { color: 'info', icon: 'tag' },
-  warning:            { color: 'warning', icon: 'error' },
+  [STATES_ENUM.IN_USE]:           {
+    color: 'success', icon: 'dot-open', label: 'In Use'
+  },
+  [STATES_ENUM.IN_PROGRESS]:      {
+    color: 'info', icon: 'tag', label: 'In Progress'
+  },
+  [STATES_ENUM.PENDING_ROLLBACK]: {
+    color: 'info', icon: 'dot-half', label: 'Pending Rollback'
+  },
+  [STATES_ENUM.PENDING_UPGRADE]:  {
+    color: 'info', icon: 'dot-half', label: 'Pending Update'
+  },
+  [STATES_ENUM.ABORTED]:            {
+    color: 'warning', icon: 'error', label: 'Aborted'
+  },
+  [STATES_ENUM.ACTIVATING]:         {
+    color: 'info', icon: 'tag', label: 'Activating'
+  },
+  [STATES_ENUM.ACTIVE]:             {
+    color: 'success', icon: 'dot-open', label: 'Active'
+  },
+  [STATES_ENUM.AVAILABLE]:          {
+    color: 'success', icon: 'dot-open', label: 'Available'
+  },
+  [STATES_ENUM.BACKED_UP]:           {
+    color: 'success', icon: 'backup', label: 'Backed Up'
+  },
+  [STATES_ENUM.BOUND]:              {
+    color: 'success', icon: 'dot', label: 'Bound'
+  },
+  [STATES_ENUM.BUILDING]:           {
+    color: 'success', icon: 'dot-open', label: 'Building'
+  },
+  [STATES_ENUM.COMPLETED]:          {
+    color: 'success', icon: 'dot', label: 'Completed'
+  },
+  [STATES_ENUM.CORDONED]:           {
+    color: 'info', icon: 'tag', label: 'Cordoned'
+  },
+  [STATES_ENUM.COUNT]:              {
+    color: 'success', icon: 'dot-open', label: 'Count'
+  },
+  [STATES_ENUM.CREATED]:            {
+    color: 'info', icon: 'tag', label: 'Created'
+  },
+  [STATES_ENUM.CREATING]:           {
+    color: 'info', icon: 'tag', label: 'Creating'
+  },
+  [STATES_ENUM.DEACTIVATING]:       {
+    color: 'info', icon: 'adjust', label: 'Deactivating'
+  },
+  [STATES_ENUM.DEGRADED]:           {
+    color: 'warning', icon: 'error', label: 'Degraded'
+  },
+  [STATES_ENUM.DENIED]:             {
+    color: 'error', icon: 'adjust', label: 'Denied'
+  },
+  [STATES_ENUM.DEPLOYED]:           {
+    color: 'success', icon: 'dot-open', label: 'Deployed'
+  },
+  [STATES_ENUM.DISABLED]:           {
+    color: 'warning', icon: 'error', label: 'Disabled'
+  },
+  [STATES_ENUM.DISCONNECTED]:       {
+    color: 'warning', icon: 'error', label: 'Disconnected'
+  },
+  [STATES_ENUM.DRAINED]:            {
+    color: 'info', icon: 'tag', label: 'Drained'
+  },
+  [STATES_ENUM.DRAINING]:           {
+    color: 'warning', icon: 'tag', label: 'Draining'
+  },
+  [STATES_ENUM.ERR_APPLIED]:         {
+    color: 'error', icon: 'error', label: 'Err Applied'
+  },
+  [STATES_ENUM.ERROR]:              {
+    color: 'error', icon: 'error', label: 'Error'
+  },
+  [STATES_ENUM.ERRORING]:           {
+    color: 'error', icon: 'error', label: 'Erroring'
+  },
+  [STATES_ENUM.ERRORS]:             {
+    color: 'error', icon: 'error', label: 'Errors'
+  },
+  [STATES_ENUM.EXPIRED]:            {
+    color: 'warning', icon: 'error', label: 'Expired'
+  },
+  [STATES_ENUM.FAIL]:               {
+    color: 'error', icon: 'error', label: 'Fail'
+  },
+  [STATES_ENUM.FAILED]:             {
+    color: 'error', icon: 'error', label: 'Failed'
+  },
+  [STATES_ENUM.HEALTHY]:            {
+    color: 'success', icon: 'dot-open', label: 'Healthy'
+  },
+  [STATES_ENUM.INACTIVE]:           {
+    color: 'error', icon: 'dot', label: 'Inactive'
+  },
+  [STATES_ENUM.INITIALIZING]:       {
+    color: 'warning', icon: 'error', label: 'Initializing'
+  },
+  [STATES_ENUM.INPROGRESS]:         {
+    color: 'info', icon: 'spinner', label: 'In Progress'
+  },
+  [STATES_ENUM.LOCKED]:             {
+    color: 'warning', icon: 'adjust', label: 'Locked'
+  },
+  [STATES_ENUM.MIGRATING]:          {
+    color: 'info', icon: 'info', label: 'Migrated'
+  },
+  [STATES_ENUM.MISSING]:            {
+    color: 'warning', icon: 'adjust', label: 'Missing'
+  },
+  [STATES_ENUM.MODIFIED]:           {
+    color: 'warning', icon: 'edit', label: 'Modified'
+  },
+  [STATES_ENUM.NOT_APPLICABLE]:      {
+    color: 'warning', icon: 'tag', label: 'Not Applicable'
+  },
+  [STATES_ENUM.NOT_APLLIED]:         {
+    color: 'warning', icon: 'tag', label: 'Not Applied'
+  },
+  [STATES_ENUM.NOT_READY]:           {
+    color: 'warning', icon: 'tag', label: 'Not Ready'
+  },
+  [STATES_ENUM.OFF]:                {
+    color: 'darker', icon: 'error', label: 'Off'
+  },
+  [STATES_ENUM.ORPHANED]:           {
+    color: 'warning', icon: 'tag', label: 'Orphaned'
+  },
+  [STATES_ENUM.OTHER]:              {
+    color: 'info', icon: 'info', label: 'Other'
+  },
+  [STATES_ENUM.OUT_OF_SYNC]:          {
+    color: 'warning', icon: 'tag', label: 'Out Of Sync'
+  },
+  [STATES_ENUM.PASS]:               {
+    color: 'success', icon: 'dot-dotfill', label: 'Pass'
+  },
+  [STATES_ENUM.PASSED]:             {
+    color: 'success', icon: 'dot-dotfill', label: 'Passed'
+  },
+  [STATES_ENUM.PAUSED]:             {
+    color: 'info', icon: 'info', label: 'Paused'
+  },
+  [STATES_ENUM.PENDING]:            {
+    color: 'info', icon: 'tag', label: 'Pending'
+  },
+  [STATES_ENUM.PROVISIONING]:       {
+    color: 'info', icon: 'dot', label: 'Provisioning'
+  },
+  [STATES_ENUM.PROVISIONED]:        {
+    color: 'success', icon: 'dot', label: 'Provisioned'
+  },
+  [STATES_ENUM.PURGED]:             {
+    color: 'error', icon: 'purged', label: 'Purged'
+  },
+  [STATES_ENUM.PURGING]:            {
+    color: 'info', icon: 'purged', label: 'Purging'
+  },
+  [STATES_ENUM.READY]:              {
+    color: 'success', icon: 'dot-open', label: 'Ready'
+  },
+  [STATES_ENUM.RECONNECTING]:       {
+    color: 'error', icon: 'error', label: 'Reconnecting'
+  },
+  [STATES_ENUM.REGISTERING]:        {
+    color: 'info', icon: 'tag', label: 'Registering'
+  },
+  [STATES_ENUM.REINITIALIZING]:     {
+    color: 'warning', icon: 'error', label: 'Reinitializing'
+  },
+  [STATES_ENUM.RELEASED]:           {
+    color: 'warning', icon: 'error', label: 'Released'
+  },
+  [STATES_ENUM.REMOVED]:            {
+    color: 'error', icon: 'trash', label: 'Removed'
+  },
+  [STATES_ENUM.REMOVING]:           {
+    color: 'info', icon: 'trash', label: 'Removing'
+  },
+  [STATES_ENUM.REQUESTED]:          {
+    color: 'info', icon: 'tag', label: 'Requested'
+  },
+  [STATES_ENUM.RESTARTING]:         {
+    color: 'info', icon: 'adjust', label: 'Restarting'
+  },
+  [STATES_ENUM.RESTORING]:          {
+    color: 'info', icon: 'medicalcross', label: 'Restoring'
+  },
+  [STATES_ENUM.RESIZING]:           {
+    color: 'warning', icon: 'dot', label: 'Resizing'
+  },
+  [STATES_ENUM.RUNNING]:            {
+    color: 'success', icon: 'dot-open', label: 'Running'
+  },
+  [STATES_ENUM.SKIP]:               {
+    color: 'info', icon: 'dot-open', label: 'Skip'
+  },
+  [STATES_ENUM.SKIPPED]:            {
+    color: 'info', icon: 'dot-open', label: 'Skipped'
+  },
+  [STATES_ENUM.STARTING]:           {
+    color: 'info', icon: 'adjust', label: 'Starting'
+  },
+  [STATES_ENUM.STOPPED]:            {
+    color: 'error', icon: 'dot', label: 'Stopped'
+  },
+  [STATES_ENUM.STOPPING]:           {
+    color: 'info', icon: 'adjust', label: 'Stopping'
+  },
+  [STATES_ENUM.SUCCEEDED]:          {
+    color: 'success', icon: 'dot-dotfill', label: 'Succeeded'
+  },
+  [STATES_ENUM.SUCCESS]:            {
+    color: 'success', icon: 'dot-open', label: 'Success'
+  },
+  [STATES_ENUM.SUPERSEDED]:         {
+    color: 'info', icon: 'dot-open', label: 'Superseded'
+  },
+  [STATES_ENUM.SUSPENDED]:          {
+    color: 'info', icon: 'pause', label: 'Suspended'
+  },
+  [STATES_ENUM.UNAVAILABLE]:        {
+    color: 'error', icon: 'error', label: 'Unavailable'
+  },
+  [STATES_ENUM.UNHEALTHY]:          {
+    color: 'error', icon: 'error', label: 'Unhealthy'
+  },
+  [STATES_ENUM.UNINSTALLED]:        {
+    color: 'info', icon: 'trash', label: 'Uninstalled'
+  },
+  [STATES_ENUM.UNINSTALLING]:       {
+    color: 'info', icon: 'trash', label: 'Uninstalling'
+  },
+  [STATES_ENUM.UNKNOWN]:            {
+    color: 'warning', icon: 'x', label: 'Unknown'
+  },
+  [STATES_ENUM.UNTRIGGERED]:        {
+    color: 'success', icon: 'tag', label: 'Untriggered'
+  },
+  [STATES_ENUM.UPDATING]:           {
+    color: 'warning', icon: 'tag', label: 'Updating'
+  },
+  [STATES_ENUM.WAIT_APPLIED]:        {
+    color: 'info', icon: 'tag', label: 'Wait Applied'
+  },
+  [STATES_ENUM.WAIT_CHECKIN]:        {
+    color: 'warning', icon: 'tag', label: 'Wait Checkin'
+  },
+  [STATES_ENUM.WAITING]:            {
+    color: 'info', icon: 'tag', label: 'Waiting'
+  },
+  [STATES_ENUM.WARNING]:            {
+    color: 'warning', icon: 'error', label: 'Warning'
+  },
 };
 
 export function getStatesByType(type = 'info') {
@@ -186,6 +447,12 @@ const SORT_ORDER = {
   success: 4,
   other:   5,
 };
+
+export function getStateLabel(state) {
+  const lowercaseState = state.toLowerCase();
+
+  return STATES[lowercaseState] ? STATES[lowercaseState].label : 'Unmapped State Label';
+}
 
 export function colorForState(state, isError, isTransitioning) {
   if ( isError ) {


### PR DESCRIPTION
Addresses Github issue: [#5232](https://github.com/rancher/dashboard/issues/5232)
Addresses Zube issue: [#5256](https://zube.io/rancher/dashboard-ui/c/5256)

- Changes colours of badges to reflect statuses of each resource type  
- Adds tooltips to badges in order to get an overview of the different states in each resource
- Creates STATE enum 
- Adds labels to states

**Preview**
<img width="1469" alt="Screenshot 2022-02-28 at 15 59 49" src="https://user-images.githubusercontent.com/97888974/156022943-837acd32-e5a9-497f-9851-bad1ebb0d332.png">

