### PR TITLE
Toggle Menu & Install Monitoring for Rancher Desktop build

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -477,11 +477,11 @@ export default {
     }
 
     grid-template-areas:  "header-left top a header-right"; // TODO what's a good name for a here
-    grid-template-columns: var(--header-height) calc(var(--nav-width) - var(--header-height)) 1fr min-content min-content;
+    grid-template-columns: min-content 1fr min-content min-content;
     grid-template-rows:    var(--header-height);
 
     &.simple {
-      grid-template-columns: var(--header-height) min-content 1fr min-content min-content;
+      grid-template-columns: min-content 1fr min-content min-content;
     }
 
     .cluster {

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -207,43 +207,45 @@ export default {
 
 <template>
   <header :class="{'simple': simple}">
-    <div class="menu-spacer">
-      <n-link v-if="isSingleVirtualCluster" :to="harvesterDashboard">
-        <img
-          class="side-menu-logo"
-          src="~/assets/images/providers/harvester.svg"
-        />
-      </n-link>
-    </div>
-    <div v-if="!simple" class="product">
-      <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-tooltip="nameTooltip" class="cluster">
+    <div class="rd-header-left">
+      <div class="menu-spacer">
+        <n-link v-if="isSingleVirtualCluster" :to="harvesterDashboard">
+          <img
+            class="side-menu-logo"
+            src="~/assets/images/providers/harvester.svg"
+          />
+        </n-link>
+      </div>
+      <div v-if="!simple" class="product">
+        <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-tooltip="nameTooltip" class="cluster">
+          <div v-if="isSingleVirtualCluster" class="product-name">
+            {{ t('product.harvester') }}
+          </div>
+          <template v-else>
+            <ClusterProviderIcon v-if="currentCluster" :cluster="currentCluster" class="mr-10" />
+            <div v-if="currentCluster" ref="clusterName" class="cluster-name">
+              {{ currentCluster.spec.displayName }}
+            </div>
+            <ClusterBadge v-if="currentCluster" :cluster="currentCluster" class="ml-10" />
+            <div v-if="!currentCluster" class="simple-title">
+              <BrandImage class="side-menu-logo-img" file-name="rancher-logo.svg" />
+            </div>
+          </template>
+        </div>
+        <div v-if="currentProduct && !currentProduct.showClusterSwitcher" class="cluster">
+          <div class="product-name">
+            {{ prod }}
+          </div>
+        </div>
+      </div>
+      <div v-else class="simple-title">
         <div v-if="isSingleVirtualCluster" class="product-name">
           {{ t('product.harvester') }}
         </div>
-        <template v-else>
-          <ClusterProviderIcon v-if="currentCluster" :cluster="currentCluster" class="mr-10" />
-          <div v-if="currentCluster" ref="clusterName" class="cluster-name">
-            {{ currentCluster.spec.displayName }}
-          </div>
-          <ClusterBadge v-if="currentCluster" :cluster="currentCluster" class="ml-10" />
-          <div v-if="!currentCluster" class="simple-title">
-            <BrandImage class="side-menu-logo-img" file-name="rancher-logo.svg" />
-          </div>
-        </template>
-      </div>
-      <div v-if="currentProduct && !currentProduct.showClusterSwitcher" class="cluster">
-        <div class="product-name">
-          {{ prod }}
-        </div>
-      </div>
-    </div>
-    <div v-else class="simple-title">
-      <div v-if="isSingleVirtualCluster" class="product-name">
-        {{ t('product.harvester') }}
-      </div>
 
-      <div v-else class="side-menu-logo">
-        <BrandImage class="side-menu-logo-img" file-name="rancher-logo.svg" />
+        <div v-else class="side-menu-logo">
+          <BrandImage class="side-menu-logo-img" file-name="rancher-logo.svg" />
+        </div>
       </div>
     </div>
 
@@ -474,17 +476,12 @@ export default {
       }
     }
 
-    grid-template-areas:  "menu product top a header-right"; // TODO what's a good name for a here
+    grid-template-areas:  "header-left top a header-right"; // TODO what's a good name for a here
     grid-template-columns: var(--header-height) calc(var(--nav-width) - var(--header-height)) 1fr min-content min-content;
     grid-template-rows:    var(--header-height);
 
     &.simple {
       grid-template-columns: var(--header-height) min-content 1fr min-content min-content;
-    }
-
-    > .menu-spacer {
-      width: 65px;
-      grid-area: menu;
     }
 
     .cluster {
@@ -495,29 +492,6 @@ export default {
       .cluster-name {
         font-size: 16px;
       }
-    }
-
-    > .product {
-      grid-area: product;
-      align-items: center;
-      position: relative;
-      display: flex;
-
-      .logo {
-        height: 30px;
-        position: absolute;
-        top: 9px;
-        left: 0;
-        z-index: 2;
-
-        img {
-          height: 30px;
-        }
-      }
-    }
-
-    .product-name {
-      font-size: 16px;
     }
 
     .side-menu-logo {
@@ -541,8 +515,38 @@ export default {
       border-bottom: var(--header-border-size) solid var(--header-border);
     }
 
-    .menu-spacer {
-      grid-area: menu;
+    .rd-header-left {
+      display: flex;
+      flex-direction: row;
+      grid-area: header-left;
+
+      > .menu-spacer {
+        width: 65px;
+        min-width: 65px;
+      }
+
+      > .product {
+        grid-area: product;
+        align-items: center;
+        position: relative;
+        display: flex;
+
+        .logo {
+          height: 30px;
+          position: absolute;
+          top: 9px;
+          left: 0;
+          z-index: 2;
+
+          img {
+            height: 30px;
+          }
+        }
+      }
+
+      .product-name {
+        font-size: 16px;
+      }
     }
 
     .rd-header-right {

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -528,8 +528,8 @@ export default {
       grid-area: header-left;
 
       > .menu-spacer {
-        width: 65px;
-        min-width: 65px;
+        width: 55px;
+        min-width: 55px;
       }
 
       > .product {

--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -98,6 +98,10 @@ export default {
       return !this.featureRancherDesktop;
     },
 
+    showNavigation() {
+      return !this.featureRancherDesktop;
+    },
+
     featureRancherDesktop() {
       return this.$config.rancherEnv === 'desktop';
     },
@@ -208,7 +212,10 @@ export default {
 <template>
   <header :class="{'simple': simple}">
     <div class="rd-header-left">
-      <div class="menu-spacer">
+      <div
+        v-if="showNavigation"
+        class="menu-spacer"
+      >
         <n-link v-if="isSingleVirtualCluster" :to="harvesterDashboard">
           <img
             class="side-menu-logo"

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -149,6 +149,10 @@ export default {
     hasSupport() {
       return this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.SUPPORTED )?.value === 'true';
     },
+
+    showMenu() {
+      return this.$config.rancherEnv !== 'desktop';
+    },
   },
 
   watch: {
@@ -202,8 +206,12 @@ export default {
 };
 </script>
 <template>
-  <div>
-    <div class="menu" :class="{'raised': shown, 'unraised':!shown}" @click="toggle()">
+  <div v-if="showMenu">
+    <div
+      class="menu"
+      :class="{'raised': shown, 'unraised':!shown}"
+      @click="toggle()"
+    >
       <svg class="menu-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none" /><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" /></svg>
     </div>
     <div v-if="shown" class="side-menu-glass" @click="hide()"></div>

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -150,8 +150,8 @@ export default {
       return this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.SUPPORTED )?.value === 'true';
     },
 
-    showMenu() {
-      return this.$config.rancherEnv !== 'desktop';
+    hideMenu() {
+      return this.$config.rancherEnv === 'desktop';
     },
   },
 
@@ -206,7 +206,7 @@ export default {
 };
 </script>
 <template>
-  <div v-if="showMenu">
+  <div v-if="!hideMenu">
     <div
       class="menu"
       :class="{'raised': shown, 'unraised':!shown}"

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -304,8 +304,12 @@ export default {
       return this.showClusterMetrics || this.showK8sMetrics || this.showEtcdMetrics;
     },
 
+    featureRancherDesktop() {
+      return this.$config.rancherEnv === 'desktop';
+    },
+
     showMonitoringInstall() {
-      return this.$config.rancherEnv !== 'desktop' && !monitoringStatus.v2 && !monitoringStatus.v1;
+      return !this.featureRancherDesktop && !monitoringStatus.v2 && !monitoringStatus.v1;
     }
   },
 

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -302,6 +302,10 @@ export default {
 
     hasMetricsTabs() {
       return this.showClusterMetrics || this.showK8sMetrics || this.showEtcdMetrics;
+    },
+
+    showMonitoringInstall() {
+      return this.$config.rancherEnv !== 'desktop' && !monitoringStatus.v2 && !monitoringStatus.v1;
     }
   },
 
@@ -397,7 +401,7 @@ export default {
         <span><LiveDate :value="currentCluster.metadata.creationTimestamp" :add-suffix="true" :show-tooltip="true" /></span>
       </div>
       <div :style="{'flex':1}" />
-      <div v-if="!monitoringStatus.v2 && !monitoringStatus.v1">
+      <div v-if="showMonitoringInstall">
         <n-link :to="{name: 'c-cluster-explorer-tools'}" class="monitoring-install">
           <i class="icon icon-gear" />
           <span>{{ t('glance.installMonitoring') }}</span>


### PR DESCRIPTION
This toggles UI elements related to the top level menu and the prompt to install monitoring for Rancher Desktop builds. This PR also groups the menu spacer and product sections into a generic grid area named `rd-header-left` to simplify the task of adapting the header for toggled elements.

There should be no discernible changes between this PR and current state unless the environment variable `RANCHER_ENV=desktop` is set at the time of build. If you see anything visual or behavioral changes, please consider them as a regression so that they can be fixed before merge.  

supports rancher-sandbox/rancher-desktop#1364