### PR TITLE
NVIDIA GPU Limit/Reservation added to Workload form

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -184,6 +184,7 @@ suffix:
   milliCpus: milli CPUs
   cores: Cores
   cpus: CPUs
+  gpus: GPUs
   ib: iB
   mib: MiB
   gb: GB
@@ -1702,10 +1703,12 @@ configmap:
 
 containerResourceLimit:
   cpuPlaceholder: e.g. 1000
+  gpuPlaceholder: e.g. 1
   helpText: Configure how much of the resources the container can consume by default.
   helpTextDetail: The amount of resources the container can consume by default.
   label: Container Default Resource Limit
   limitsCpu: CPU Limit
+  limitsGpu: NVIDIA GPU Limit/Reservation
   limitsMemory: Memory Limit
   memPlaceholder: e.g. 128
   requestsCpu: CPU Reservation

--- a/components/ContainerResourceLimit.vue
+++ b/components/ContainerResourceLimit.vue
@@ -39,11 +39,11 @@ export default {
 
   data() {
     const {
-      limitsCpu, limitsMemory, requestsCpu, requestsMemory
+      limitsCpu, limitsMemory, requestsCpu, requestsMemory, limitsGpu
     } = this.value;
 
     return {
-      limitsCpu, limitsMemory, requestsCpu, requestsMemory, viewMode: _VIEW
+      limitsCpu, limitsMemory, requestsCpu, requestsMemory, limitsGpu, viewMode: _VIEW
     };
   },
 
@@ -75,12 +75,14 @@ export default {
         limitsMemory,
         requestsCpu,
         requestsMemory,
+        limitsGpu
       } = this;
 
       this.$emit('input', cleanUp({
         limitsCpu,
         limitsMemory,
         requestsCpu,
+        limitsGpu,
         requestsMemory
       }));
     },
@@ -91,6 +93,7 @@ export default {
         limitsMemory,
         requestsCpu,
         requestsMemory,
+        limitsGpu
       } = this;
       const namespace = this.namespace; // no deep copy in destructure proxy yet
 
@@ -98,6 +101,7 @@ export default {
         limitsCpu,
         limitsMemory,
         requestsCpu,
+        limitsGpu,
         requestsMemory
       });
 
@@ -117,12 +121,14 @@ export default {
           limitsMemory,
           requestsCpu,
           requestsMemory,
+          limitsGpu
         } = JSON.parse(defaults);
 
         this.limitsCpu = limitsCpu;
         this.limitsMemory = limitsMemory;
         this.requestsCpu = requestsCpu;
         this.requestsMemory = requestsMemory;
+        this.limitsGpu = limitsGpu;
       }
     },
   }
@@ -168,7 +174,7 @@ export default {
       </span>
     </div>
 
-    <div class="row">
+    <div class="row mb-20">
       <span class="col span-6">
         <UnitInput
           v-model="limitsCpu"
@@ -190,6 +196,18 @@ export default {
           :input-exponent="2"
           :increment="1024"
           :output-modifier="true"
+          @input="updateLimits"
+        />
+      </span>
+    </div>
+    <div class="row">
+      <span class="col span-6">
+        <UnitInput
+          v-model="limitsGpu"
+          :placeholder="t('containerResourceLimit.gpuPlaceholder')"
+          :label="t('containerResourceLimit.limitsGpu')"
+          :mode="mode"
+          :base-unit="t('suffix.gpus')"
           @input="updateLimits"
         />
       </span>

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -51,6 +51,8 @@ const TAB_WEIGHT_MAP = {
   volumeClaimTemplates: 89,
 };
 
+const GPU_KEY = 'nvidia.com/gpu';
+
 export default {
   name:       'CruWorkload',
   components: {
@@ -289,16 +291,16 @@ export default {
     flatResources: {
       get() {
         const { limits = {}, requests = {} } = this.container.resources || {};
-        const { cpu:limitsCpu, memory:limitsMemory } = limits;
-        const { cpu:requestsCpu, memory:requestsMemory } = requests;
+        const { cpu: limitsCpu, memory: limitsMemory, [GPU_KEY]: limitsGpu } = limits;
+        const { cpu: requestsCpu, memory: requestsMemory } = requests;
 
         return {
-          limitsCpu, limitsMemory, requestsCpu, requestsMemory
+          limitsCpu, limitsMemory, requestsCpu, requestsMemory, limitsGpu
         };
       },
       set(neu) {
         const {
-          limitsCpu, limitsMemory, requestsCpu, requestsMemory
+          limitsCpu, limitsMemory, requestsCpu, requestsMemory, limitsGpu
         } = neu;
 
         const out = {
@@ -307,8 +309,9 @@ export default {
             memory: requestsMemory
           },
           limits: {
-            cpu:    limitsCpu,
-            memory: limitsMemory
+            cpu:       limitsCpu,
+            memory:    limitsMemory,
+            [GPU_KEY]: limitsGpu
           }
         };
 


### PR DESCRIPTION
This addresses issue #5005 

To test this PR:
- Workloads > Jobs > Create
- Under Resources tab, a new input NVIDIA GPU Limit/Reservation has been added
- Add a positive integer number
- Inspect the yaml to see the new field

![2022-02-28_20-43-59](https://user-images.githubusercontent.com/13671297/156100892-bde39c4e-d468-4952-8c07-5f6f9ccb1bca.jpg)

