### PR TITLE
Address performance issues with cluster dashboard events table

### DIFF
--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -1,5 +1,6 @@
 import {
   CONFIG_MAP,
+  EVENT,
   NODE, SECRET, INGRESS,
   WORKLOAD, WORKLOAD_TYPES, SERVICE, HPA, NETWORK_POLICY, PV, PVC, STORAGE_CLASS, POD,
   RBAC,
@@ -134,6 +135,8 @@ export function init(store) {
   configureType(MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, { isEditable: false });
   configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false });
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });
+
+  configureType(EVENT, { limit: 500 });
 
   // Allow Pods to be grouped by node
   configureType(POD, {

--- a/models/event.js
+++ b/models/event.js
@@ -16,4 +16,8 @@ export default class K8sEvent extends SteveModel {
   get displayMessage() {
     return ucFirst(this.message);
   }
+
+  get timestamp() {
+    return this.lastTimestamp || this.metadata?.creationTimestamp;
+  }
 }

--- a/pages/c/_cluster/explorer/EventsTable.vue
+++ b/pages/c/_cluster/explorer/EventsTable.vue
@@ -1,0 +1,88 @@
+<script>
+
+import SortableTable from '@/components/SortableTable';
+import { REASON } from '@/config/table-headers';
+import { EVENT } from '@/config/types';
+import { fetchClusterResources } from './explorer-utils';
+
+export default {
+  components: { SortableTable },
+
+  async fetch() {
+    this.events = await fetchClusterResources(this.$store, EVENT);
+  },
+
+  data() {
+    const reason = {
+      ...REASON,
+      ...{ canBeVariable: true },
+      width: 130,
+    };
+
+    const eventHeaders = [
+      reason,
+      {
+        name:          'resource',
+        label:         'Resource',
+        labelKey:      'clusterIndexPage.sections.events.resource.label',
+        value:         'displayInvolvedObject',
+        sort:          ['involvedObject.kind', 'involvedObject.name'],
+        canBeVariable: true,
+      },
+      {
+        name:          'date',
+        label:         'Date',
+        labelKey:      'clusterIndexPage.sections.events.date.label',
+        value:         'timestamp',
+        sort:          'timestamp:desc',
+        formatter:     'Date',
+        width:         220,
+        defaultSort:   true,
+      },
+    ];
+
+    return {
+      events: [],
+      eventHeaders,
+    };
+  }
+};
+</script>
+
+<template>
+  <div v-if="$fetchState.pending" class="events-loading">
+    <i class="icon icon-spin icon-spinner icon-lg" />
+    <div v-html="t('generic.loading', {}, true)" />
+  </div>
+  <SortableTable
+    v-else
+    :rows="events"
+    :headers="eventHeaders"
+    key-field="id"
+    :search="false"
+    :table-actions="false"
+    :row-actions="false"
+    :paging="true"
+    :rows-per-page="10"
+    default-sort-by="date"
+  >
+    <template #cell:resource="{row, value}">
+      <n-link :to="row.detailLocation">
+        {{ value }}
+      </n-link>
+      <div v-if="row.message">
+        {{ row.displayMessage }}
+      </div>
+    </template>
+  </SortableTable>
+</template>
+<style lang="scss" scoped>
+  .events-loading {
+    align-items: center;
+    display: flex;
+
+    > i {
+      margin-right: 5px;
+    }
+  }
+</style>

--- a/pages/c/_cluster/explorer/explorer-utils.js
+++ b/pages/c/_cluster/explorer/explorer-utils.js
@@ -1,0 +1,17 @@
+export async function fetchClusterResources(store, type, opt = {}) {
+  const schema = store.getters['cluster/schemaFor'](type);
+
+  if (schema) {
+    try {
+      const resources = await store.dispatch('cluster/findAll', { type, opt });
+
+      return resources;
+    } catch (err) {
+      console.error(`Failed fetching cluster resource ${ type } with error:`, err); // eslint-disable-line no-console
+
+      return [];
+    }
+  }
+
+  return [];
+}

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -8,7 +8,6 @@ import Banner from '@/components/Banner';
 import { parseSi, createMemoryValues } from '@/utils/units';
 import {
   NAME,
-  REASON,
   ROLES,
   STATE,
 } from '@/config/table-headers';

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -98,36 +98,6 @@ export default {
 
   data() {
     const clusterCounts = this.$store.getters[`cluster/all`](COUNT);
-    const reason = {
-      ...REASON,
-      ...{ canBeVariable: true },
-      width: 120
-    };
-
-    const eventHeaders = [
-      reason,
-      {
-        name:          'resource',
-        label:         'Resource',
-        labelKey:      'clusterIndexPage.sections.events.resource.label',
-        value:         'displayInvolvedObject',
-        sort:          ['involvedObject.kind', 'involvedObject.name'],
-        canBeVariable: true,
-      },
-      {
-        align:         'right',
-        name:          'date',
-        label:         'Date',
-        labelKey:      'clusterIndexPage.sections.events.date.label',
-        value:         'lastTimestamp',
-        sort:          'lastTimestamp:desc',
-        formatter:     'LiveDate',
-        formatterOpts: { addSuffix: true },
-        width:         125,
-        defaultSort:   true,
-      },
-    ];
-
     const nodeHeaders = [
       STATE,
       NAME,
@@ -135,7 +105,6 @@ export default {
     ];
 
     return {
-      eventHeaders,
       nodeHeaders,
       constraints:         [],
       events:              [],


### PR DESCRIPTION
The events table on the cluster dashboard has performance issues with large number of events.

This PR mitigates this by restricting the number of events we store to 500:

- Adds an optional limit to the options for a type
- Updates loadAll to restrict the resources to the limit when applicable
- Updates load to ensure that when a new resource is added, an old one is removed if this would take us over the limit
- Sets a limit of 500 on the event type
- Factors the events list into a separate component and makes the resource loading non-blocking with its own loading indicator
- Uses a normal data rather than live date on the events table
- Fixes bug where some events don't have `lastTimestamp` - and adds a fallback to `metadata.creationTimestamp`