### PR TITLE
Always show cluster resources in the side navigation

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -325,7 +325,8 @@ export default {
         namespaces = Object.keys(this.namespaces);
       }
 
-      const namespaceMode = this.$store.getters['namespaceMode'];
+      // Always show cluster-level types, regardless of the namespace filter
+      const namespaceMode = 'both';
       const out = [];
       const loadProducts = this.isExplorer ? [EXPLORER] : [];
       const productMap = this.activeProducts.reduce((acc, p) => {


### PR DESCRIPTION
Fixes #5053 
Fixes #5147 

This PR fixes the namespace mode so that we always show cluster-level resources regardless of the namespace selection. Changing the nav as the current behaviour has confused many people.

Note: For 2.6.4, we are leaving the small icons in which indicate if a resource is a cluster-level or namespaced resource, so there is still a visual indicator.