### PR TITLE
Fix overlapping height for LabeledSelect input

### DIFF
--- a/components/form/Probe.vue
+++ b/components/form/Probe.vue
@@ -302,12 +302,13 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+.title {
+  margin-bottom: 10px;
+}
 
-  .title {
-    margin-bottom: 10px;
+::v-deep .labeled-select {
+  &:not(taggable) {
+    height: auto !important;
   }
-  ::v-deep .labeled-select {
-    height: auto;
-  }
-
+}
 </style>


### PR DESCRIPTION
Reference #5215 

This fixes the issue of the `LabeledSelect` component height being force to 100% of the row. 

**Before**:
![badinputs](https://user-images.githubusercontent.com/40806497/156201099-2f45c6d1-2839-41a1-b7db-7e74871d01a8.png)

**After**
![goodinputs](https://user-images.githubusercontent.com/40806497/156201134-7e704556-705c-40d3-9352-c55bd5648174.png)

