### PR TITLE
Update cursor to pointer for sortable column headers

### DIFF
--- a/components/SortableTable/THead.vue
+++ b/components/SortableTable/THead.vue
@@ -153,6 +153,8 @@ export default {
 
 <style lang="scss" scoped>
   .sortable > SPAN {
+    cursor: pointer;
+    user-select: none;
     white-space: nowrap;
     &:hover,
     &:active {


### PR DESCRIPTION
This backports an enhancement that was made over on Rancher Desktop to make it more obvious that a column is sortable by changing the mouse cursor to a pointer instead of the I-beam. 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>