### PR TITLE
Revert "Set select always full height to match input container"

### DIFF
--- a/assets/styles/global/_select.scss
+++ b/assets/styles/global/_select.scss
@@ -13,7 +13,6 @@
   > .unlabeled-select:not(.taggable) {
     min-height: $input-height;
     padding-bottom: calc(#{$input-padding-sm}/2);
-    height: 100%;
   }
 }
 


### PR DESCRIPTION
**Original issue:** #5215 
This reverts commit b26a88ea4093bf4df59028e257576bccc5ed06de.

Reference #5246 for explanation of reverting