### PR TITLE
Add auto complete for affinity topology keys

### DIFF
--- a/components/form/PodAffinity.vue
+++ b/components/form/PodAffinity.vue
@@ -10,6 +10,7 @@ import { randomStr } from '@/utils/string';
 import { sortBy } from '@/utils/sort';
 import debounce from 'lodash/debounce';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
+import { getUniqueLabelKeys } from '@/utils/array';
 
 export default {
   components: {
@@ -28,7 +29,12 @@ export default {
     mode: {
       type:    String,
       default: 'create'
-    }
+    },
+
+    nodes: {
+      type:    Array,
+      default: () => []
+    },
   },
 
   data() {
@@ -93,6 +99,10 @@ export default {
 
       return out;
     },
+
+    existingNodeLabels() {
+      return getUniqueLabelKeys(this.nodes);
+    }
   },
   created() {
     this.queueUpdate = debounce(this.update, 500);
@@ -235,12 +245,18 @@ export default {
           <div class="spacer"></div>
           <div class="row">
             <div class="col span-12">
-              <LabeledInput
+              <LabeledSelect
                 v-model="props.row.value.topologyKey"
+                :taggable="true"
+                :searchable="true"
+                :close-on-select="false"
                 :mode="mode"
                 required
                 :label="t('workload.scheduling.affinity.topologyKey.label')"
                 :placeholder="t('workload.scheduling.affinity.topologyKey.placeholder')"
+                :options="existingNodeLabels"
+                :disabled="mode==='view'"
+                @input="update"
               />
             </div>
           </div>

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -123,7 +123,8 @@ export default {
 
     this.allSecrets = hash.secrets || [];
     this.allConfigMaps = hash.configMaps || [];
-    this.allNodes = (hash.nodes || []).map(node => node.id);
+    this.allNodeObjects = hash.nodes || [];
+    this.allNodes = this.allNodeObjects.map(node => node.id);
     this.allServices = hash.services || [];
     this.pvcs = hash.pvcs || [];
     this.sas = hash.sas || [];
@@ -172,6 +173,7 @@ export default {
     return {
       allConfigMaps:     [],
       allNodes:          null,
+      allNodeObjects:    [],
       allSecrets:        [],
       allServices:       [],
       name:              this.value?.metadata?.name || null,
@@ -1011,7 +1013,7 @@ export default {
           </template>
         </Tab>
         <Tab :label="t('workload.container.titles.podScheduling')" name="podScheduling" :weight="tabWeightMap['podScheduling']">
-          <PodAffinity :mode="mode" :value="podTemplateSpec" />
+          <PodAffinity :mode="mode" :value="podTemplateSpec" :nodes="allNodeObjects" />
         </Tab>
         <Tab :label="t('workload.container.titles.nodeScheduling')" name="nodeScheduling" :weight="tabWeightMap['nodeScheduling']">
           <NodeScheduling :mode="mode" :value="podTemplateSpec" :nodes="allNodes" />

--- a/utils/__tests__/array.test.ts
+++ b/utils/__tests__/array.test.ts
@@ -1,5 +1,5 @@
 import {
-  addObject, addObjects, clear, filterBy, findBy, insertAt, isArray, removeAt, removeObject, removeObjects, replaceWith, sameContents, uniq
+  addObject, addObjects, clear, filterBy, findBy, getUniqueLabelKeys, insertAt, isArray, removeAt, removeObject, removeObjects, replaceWith, sameContents, uniq
 } from '~/utils/array';
 
 interface Obj {
@@ -470,5 +470,33 @@ describe('fx: replaceWith', () => {
 
     expect(a).toStrictEqual(c);
     expect(a).toBe(b);
+  });
+});
+
+describe('fx: getUniqueLabelKeys', () => {
+  it('should get list of unique resource labels', () => {
+    const resources = [
+      {
+        metadata: {
+          labels: {
+            keyOne: 'value',
+            keyTwo: 'value',
+          }
+        }
+      },
+      {
+        metadata: {
+          labels: {
+            keyOne:   'value',
+            keyThree: 'value',
+          }
+        }
+      },
+    ] as unknown as { metadata: { labels: { [name: string]: string} } }[] ;
+
+    const expected = ['keyOne', 'keyThree', 'keyTwo'];
+    const result = getUniqueLabelKeys(resources);
+
+    expect(result).toStrictEqual(expected);
   });
 });

--- a/utils/array.ts
+++ b/utils/array.ts
@@ -166,3 +166,14 @@ export function uniq<T>(ary: T[]): T[] {
 
   return out;
 }
+
+interface KubeResource { metadata: { labels: { [name: string]: string} } } // Migrate to central kube types resource when those are brought in
+export function getUniqueLabelKeys<T extends KubeResource>(aryResources: T[]): string[] {
+  const uniqueObj = aryResources.reduce((res, r) => {
+    Object.keys(r.metadata.labels).forEach(l => (res[l] = true));
+
+    return res;
+  }, {} as {[label: string]: boolean});
+
+  return Object.keys(uniqueObj).sort();
+}


### PR DESCRIPTION
When configuring a pod affinity on a workload, you have to enter a topologyKey. This can be any node label key. For more details see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity.

To make the configuration easier, this PR changes the input field to a select which offers all existing node label keys, with the option to also add keys that are not present as labels yet.

![Bildschirmfoto 2022-03-02 um 16 22 18](https://user-images.githubusercontent.com/243056/156392738-683e6357-1265-450a-ac20-d66d8fefda1c.png)

