### PR TITLE
Add workload tab to cluster namespace

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2860,6 +2860,7 @@ namespace:
   disableAutoInjection: Disable Istio Auto Injection
   move: Move
   total: Total
+  workloads: Workloads
   resourceStates:
       success: 'Active'
       info: 'Transitioning'

--- a/config/schema.js
+++ b/config/schema.js
@@ -1,3 +1,5 @@
+import { SCHEMA } from '@/config/types';
+
 export const COLLECTION_TYPES = {
   array: 'array',
   map:   'map',
@@ -18,3 +20,13 @@ export const PRIMITIVE_TYPES = {
 };
 
 export const PROTOCOLS = ['http', 'https'];
+
+export const WORKLOAD_SCHEMA = {
+  id:         'workload',
+  type:       SCHEMA,
+  attributes: {
+    kind:       'Workload',
+    namespaced: true
+  },
+  metadata: { name: 'workload' },
+};


### PR DESCRIPTION
#5115

Added tab to cluster namespace detail view (`/c/local/explorer/namespace/<NAMESPACE>#Workloads`)

![Screenshot from 2022-03-02 20-15-52](https://user-images.githubusercontent.com/5009481/156434598-ed92813f-f7a4-442e-8aea-cc30e9005c78.png)
![Screenshot from 2022-03-02 20-15-58](https://user-images.githubusercontent.com/5009481/156434611-03e830f6-d718-43b7-8c7f-32f3c3684acc.png)


## QA
- Create any Workload type (`/c/local/explorer/workload/create`)
- Navigate back to the namespace detail view
- Verify types of workloads to match namespace and other not mentioned requirements (I am not certain about spawned jobs)



## Notes 
- Added `WORKLOAD_SCHEMA` to the related schema config file
