### PR TITLE
Ensure the correct version is set for the install chart query param

### DIFF
--- a/models/chart.js
+++ b/models/chart.js
@@ -14,9 +14,9 @@ export default class Chart extends SteveModel {
     const compatibleVersions = compatibleVersionsFor(this, workerOSs);
 
     if (compatibleVersions.length) {
-      version = compatibleVersions[0];
+      version = compatibleVersions[0].version;
     } else {
-      version = chartVersions[0];
+      version = chartVersions[0].version;
     }
 
     const out = {


### PR DESCRIPTION
- The version name query param was the whole version object instead of just the name
- fixes #5248, #5249