### PR TITLE
Shorten snapshot name by using `snapshotFile.name`

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -314,7 +314,7 @@ export default {
         {
           name:          'name',
           labelKey:      'tableHeaders.name',
-          value:         'nameDisplay',
+          value:         'snapshotFile.name',
           sort:          ['nameSort'],
           canBeVariable: true,
         },


### PR DESCRIPTION
### Testing Notes

This one should be pretty simple:

* create an rke2 cluster with multiple etcd nodes
* take a snapshot
* snapshot names should be a shorter version than the one that is currently in use

### Notes

There's also an annotation, `etcdsnapshot.rke.io/snapshot-file-name` that produces the same value. `snapshotFile.name` was just easier to access..

### Before

![image](https://user-images.githubusercontent.com/835961/156612216-88b6af27-f775-4ac2-a60f-fc2fa0222741.png)

### After 

![image](https://user-images.githubusercontent.com/835961/156612259-35ed67ec-3543-461c-b2e9-605ed253c216.png)

closes #5260 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>