### PR TITLE
Fix provider argument for cloud-provider dropdown

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -434,7 +434,7 @@ export default {
       const preferred = this.$store.getters['plugins/cloudProviderForDriver'](this.provider);
 
       for ( const opt of this.agentArgs['cloud-provider-name'].options ) {
-        if ( (!preferred && opt !== HARVESTER) || opt === preferred || opt === 'external' || preferred === HARVESTER) {
+        if ( (!!preferred && opt !== HARVESTER) || opt === preferred || opt === 'external' || preferred === HARVESTER) {
           out.push({
             label: this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ opt }".label`, null, opt),
             value: opt,


### PR DESCRIPTION
Reference #5080 

**Issue**
The dropdown selector for Cloud Providers when creating an RKE2 cluster for Linode, DigitalOcean are showing providers which are not applicable.

**Cause**
The logic that filtered based on the cloud provider already existed but was not properly checking for a null property.

**Fix**
 Add a null coalescing operator which will fix for both Linode and DigitalOcean providers.

_DigitalOcean example:_
![digitalocean](https://user-images.githubusercontent.com/40806497/156792417-84860d3b-eb89-4439-8445-0c91f72aee5d.png)

--- 

_AWS example:_
![aws](https://user-images.githubusercontent.com/40806497/156792484-1d3fe255-0cbe-49fe-b2c3-e7554cc03957.png)

