### PR TITLE
Bug fix (Kubewarden): Save on editing cluster admission policy 

### DIFF
--- a/edit/policies.kubewarden.io.clusteradmissionpolicy/ClusterAdmissionPolicy.vue
+++ b/edit/policies.kubewarden.io.clusteradmissionpolicy/ClusterAdmissionPolicy.vue
@@ -5,11 +5,13 @@ import createEditView from '@/mixins/create-edit-view';
 
 import LabeledInput from '@/components/form/LabeledInput';
 import NameNsDescription from '@/components/form/NameNsDescription';
+import ShellInput from '~/components/form/ShellInput';
 
 export default {
   components: {
     LabeledInput,
     NameNsDescription,
+    ShellInput,
   },
 
   mixins: [createEditView],
@@ -75,16 +77,16 @@ export default {
 
       <div v-for="rule in rules" :key="rule.vKey" class="rule">
         <div class="col">
-          <LabeledInput v-model="rule.apiGroups" :mode="mode" label="API Groups" />
+          <ShellInput v-model="rule.apiGroups" :mode="mode" label="API Groups" />
         </div>
         <div class="col">
-          <LabeledInput v-model="rule.apiVersions" :mode="mode" label="API Versions" />
+          <ShellInput v-model="rule.apiVersions" :mode="mode" label="API Versions" />
         </div>
         <div class="col">
-          <LabeledInput v-model="rule.operations" :mode="mode" label="Operations" />
+          <ShellInput v-model="rule.operations" :mode="mode" label="Operations" />
         </div>
         <div class="col">
-          <LabeledInput v-model="rule.resources" :mode="mode" label="Resources" />
+          <ShellInput v-model="rule.resources" :mode="mode" label="Resources" />
         </div>
       </div>
     </template>

--- a/edit/policies.kubewarden.io.clusteradmissionpolicy/index.vue
+++ b/edit/policies.kubewarden.io.clusteradmissionpolicy/index.vue
@@ -52,6 +52,15 @@ export default {
   },
 
   methods: {
+    async finish() {
+      try {
+        await this.save();
+      } catch (e) {
+        console.error(`Error when saving: ${ e }`); // eslint-disable-line no-console
+        this.errors.push(e);
+      }
+    },
+
     selectType(type) {
       if (!this.type && type) {
         this.$router.replace({ params: { resource: type } });
@@ -69,6 +78,7 @@ export default {
     v-else
     :mode="realMode"
     :resource="value"
+    @finish="finish"
   >
     <ClusterAdmissionPolicy
       :value="value"


### PR DESCRIPTION
[Reference](https://github.com/kubewarden/ui/issues/15)

This fixes the issue of the config not being saved when editing an existing ClusterAdmissionPolicy

**Cause**
1. No action was being called when `Save` was pressed
2. The input fields would change the type from an array of strings to just one string, causing the spec to be incorrect
