### PR TITLE
Fix machine scale conflicts

### DIFF
--- a/mixins/create-edit-view/impl.js
+++ b/mixins/create-edit-view/impl.js
@@ -164,7 +164,7 @@ export default {
       } catch (err) {
         // Conflict, the resource being edited has changed since starting editing
         if ( err.status === 409 && depth === 0 ) {
-          const errors = await this.conflict(err);
+          const errors = this.conflict();
 
           if ( errors === false ) {
             // It was automatically figured out, save again

--- a/mixins/create-edit-view/impl.js
+++ b/mixins/create-edit-view/impl.js
@@ -4,8 +4,7 @@ import { exceptionToErrorsArray } from '@/utils/error';
 import ChildHook, { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
 import { clear } from '@/utils/array';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
-import { applyChangeset, changeset, changesetConflicts } from '@/utils/object';
-import { cleanForDiff } from '@/plugins/steve/normalize';
+import { handleConflict } from '@/plugins/steve/normalize';
 
 export default {
   mixins: [ChildHook],
@@ -121,30 +120,7 @@ export default {
     // If they are resolved, return a false-y value
     // Else they can't be resolved, return an array of errors to show to the user.
     conflict() {
-      const orig = cleanForDiff(this.initialValue.toJSON());
-      const user = cleanForDiff(this.value.toJSON());
-      const cur = cleanForDiff(this.liveValue.toJSON());
-
-      const bgChange = changeset(orig, cur);
-      const userChange = changeset(orig, user);
-      const actualConflicts = changesetConflicts(bgChange, userChange);
-
-      console.log('Background Change', bgChange); // eslint-disable-line no-console
-      console.log('User Change', userChange); // eslint-disable-line no-console
-      console.log('Conflicts', actualConflicts); // eslint-disable-line no-console
-
-      this.value.metadata.resourceVersion = this.liveValue.metadata.resourceVersion;
-      applyChangeset(this.value, bgChange);
-
-      if ( actualConflicts.length ) {
-        // Stop the save and let the user inspect and continue editing
-        const out = [this.$store.getters['i18n/t']('validation.conflict', { fields: actualConflicts.join(', '), fieldCount: actualConflicts.length })];
-
-        return out;
-      } else {
-        // The save can continue
-        return false;
-      }
+      return handleConflict(this.initialValue.toJSON(), this.value, this.liveValue, this.$store.getters);
     },
 
     async save(buttonDone, url, depth = 0) {

--- a/plugins/steve/normalize.js
+++ b/plugins/steve/normalize.js
@@ -1,5 +1,6 @@
 import { SCHEMA } from '@/config/types';
 import isObject from 'lodash/isObject';
+import { applyChangeset, changeset, changesetConflicts } from '~/utils/object';
 
 export const KEY_FIELD_FOR = {
   [SCHEMA]:  '_id',
@@ -113,4 +114,34 @@ function dropCattleKeys(obj) {
       delete obj[key];
     }
   });
+}
+
+// Detect and resolve conflicts from a 409 response.
+// If they are resolved, return a false-y value
+// Else they can't be resolved, return an array of errors to show to the user.
+export function handleConflict(initialValueJSON, value, liveValue, rootGetters) {
+  const orig = cleanForDiff(initialValueJSON);
+  const user = cleanForDiff(value.toJSON());
+  const cur = cleanForDiff(liveValue.toJSON());
+
+  const bgChange = changeset(orig, cur);
+  const userChange = changeset(orig, user);
+  const actualConflicts = changesetConflicts(bgChange, userChange);
+
+  console.log('Background Change', bgChange); // eslint-disable-line no-console
+  console.log('User Change', userChange); // eslint-disable-line no-console
+  console.log('Conflicts', actualConflicts); // eslint-disable-line no-console
+
+  value.metadata.resourceVersion = liveValue.metadata.resourceVersion;
+  applyChangeset(value, bgChange);
+
+  if ( actualConflicts.length ) {
+    // Stop the save and let the user inspect and continue editing
+    const out = [rootGetters['i18n/t']('validation.conflict', { fields: actualConflicts.join(', '), fieldCount: actualConflicts.length })];
+
+    return out;
+  } else {
+    // The save can continue
+    return false;
+  }
 }


### PR DESCRIPTION
- When scaling a machine pool there's lots of status updates to the cluster
- This means hitting a 409 conflict error when trying to scale an already scaling pool is likely
- There already exists a way to check for actual conflicts and retrying the save, though this was only for the CreateEditView component
  - Also fixed causing this to not to try the second save (`conflict` method is not async) 
- That process has now become generic and is used when scaling pools
- Also fix bug where scale errors weren't caught (errors returned via rejected promise weren't caught)
- fixes #5029


Edit, also fixes #5030