### PR TITLE
Give the cluster badge more space

### DIFF
--- a/components/ClusterBadge.vue
+++ b/components/ClusterBadge.vue
@@ -27,7 +27,7 @@ export default {
     border-radius: 10px;
     font-size: 12px;
     padding: 2px 10px;
-    max-width: 200px;
+    max-width: 250px;
     text-overflow: ellipsis;
     overflow: hidden;
   }


### PR DESCRIPTION
Fixes #5293 

This PR allows the Cluster Badge to have more width.

The issue is that we set a 32 character max width and a 200 pixel max width - so there was a mismatch as you couldn't fix 32 chars of text in the 200 pixels without it overflowing and showing the text ellipsis.

Note that you can still overflow - it very much depends on the text you enter as to what the pixel width of that will be when it renders.