### PR TITLE
Fix config map binary data bug

### DIFF
--- a/components/DetailText.vue
+++ b/components/DetailText.vue
@@ -79,7 +79,18 @@ export default {
 
     body() {
       if (this.isBinary) {
-        return this.t('detailText.binary', { n: this.size });
+        // It is base64 encoded, so adjust size
+        let realSize = (3 * this.size / 4) ;
+
+        // Might be one or two padding characters
+        if (this.value.length > 0 && this.value[this.value.length - 1] === '=') {
+          realSize--;
+          if (this.value.length > 1 && this.value[this.value.length - 2] === '=') {
+            realSize--;
+          }
+        }
+
+        return this.t('detailText.binary', { n: realSize });
       }
 
       if (this.expanded) {
@@ -147,7 +158,7 @@ export default {
     </h5>
 
     <span v-if="isEmpty" v-t="'detailText.empty'" class="text-italic" />
-    <span v-else-if="isBinary" class="text-italic">{{ t('detailText.binary', {n: size}) }}</span>
+    <span v-else-if="isBinary" class="text-italic">{{ body }}</span>
 
     <CodeMirror
       v-else-if="jsonStr"

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -24,6 +24,12 @@ export default {
       default: null,
     },
 
+    // If the user supplies this array, then it indicates which keys should be shown as binary
+    binaryValueKeys: {
+      type:    [Array, Object],
+      default: null
+    },
+
     mode: {
       type:    String,
       default: _EDIT,
@@ -244,6 +250,12 @@ export default {
 
       Object.keys(input).forEach((key) => {
         let value = input[key];
+        let binary = !asciiLike(value);
+
+        // If we think it is binary, just check if we were given the list of binary keys that we should not be treating it as ascii
+        if (this.binaryValueKeys) {
+          binary = this.binaryValueKeys.findIndex(k => k === key) !== -1;
+        }
 
         if ( this.valueBase64 ) {
           value = base64Decode(value);
@@ -251,7 +263,7 @@ export default {
         rows.push({
           key,
           value,
-          binary:    !asciiLike(value),
+          binary,
           supported: true,
         });
       });

--- a/edit/configmap.vue
+++ b/edit/configmap.vue
@@ -26,12 +26,20 @@ export default {
     const { binaryData = {}, data = {} } = this.value;
 
     const decodedBinaryData = {};
+    const binaryValueKeys = [];
 
     Object.keys(binaryData).forEach((key) => {
       decodedBinaryData[key] = base64Decode(binaryData[key]);
+      binaryValueKeys.push(key);
     });
 
-    return { allData: { ...decodedBinaryData, ...data } };
+    return {
+      allData: {
+        ...decodedBinaryData,
+        ...data
+      },
+      binaryValueKeys
+    };
   },
 
   watch: {
@@ -82,6 +90,7 @@ export default {
         <KeyValue
           key="data"
           v-model="allData"
+          :binary-value-keys="binaryValueKeys"
           :mode="mode"
           :protip="t('configmap.tabs.data.protip')"
           :initial-empty-row="true"


### PR DESCRIPTION
Fixes #5311

This PR fixes this by allowing the config map edit/view config page to indicate which keys are binary.

After PR: (See issue above for before PR)

![image](https://user-images.githubusercontent.com/1955897/157075873-36734c82-3bbb-4f28-ac87-6163dc83c21d.png)

![image](https://user-images.githubusercontent.com/1955897/157075912-08136f7b-400c-440a-ab63-5e520f8f294a.png)


