### PR TITLE
Define correct key path while sorting snapshots list by age

### DIFF
--- a/components/PromptRestore.vue
+++ b/components/PromptRestore.vue
@@ -69,7 +69,7 @@ export default {
       // because the name matches the clusterId field on the
       // snapshot, but the cluster ID doesn't.
       if (this.allSnapshots) {
-        const sortedSnapshots = sortBy(Object.values(this.allSnapshots), ['createdAt', 'created', 'metadata.creationTimestamp'], true);
+        const sortedSnapshots = sortBy(Object.values(this.allSnapshots), ['snapshotFile.createdAt', 'created', 'metadata.creationTimestamp'], true);
         const list = sortedSnapshots
           .filter((snapshot) => {
             const toRestoreClusterName = this.toRestore[0].clusterName || this.toRestore[0]?.metadata?.name;

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -328,7 +328,7 @@ export default {
         },
         {
           ...AGE,
-          sort:          'createdAt:desc',
+          sort:          'snapshotFile.createdAt:desc',
           canBeVariable: true
         },
       ];


### PR DESCRIPTION
#5267

Snapshot list is not sorting correctly by age, due a cropped path. Set full path for sorting correctly based on existing util.

![Screenshot from 2022-03-07 18-54-03](https://user-images.githubusercontent.com/5009481/157090272-6b5d34c3-ed86-4b04-8633-1a95643f05d2.png)

