### PR TITLE
Fix for race condition loading management.cattle.io.cluster schema

### DIFF
--- a/plugins/steve/actions.js
+++ b/plugins/steve/actions.js
@@ -15,6 +15,9 @@ export const _MULTI = 'multi';
 export const _ALL_IF_AUTHED = 'allIfAuthed';
 export const _NONE = 'none';
 
+const SCHEMA_CHECK_RETRIES = 15;
+const SCHEMA_CHECK_RETRY_LOG = 10;
+
 export default {
   async request({ state, dispatch, rootGetters }, opt) {
     // Handle spoofed types instead of making an actual request
@@ -565,4 +568,28 @@ export default {
       return res;
     }
   },
+
+  // Wait for a schema that is expected to exist that may not have been loaded yet (for instance when loadCluster is still running).
+  async waitForSchema({ getters, dispatch }, { type }) {
+    let tries = SCHEMA_CHECK_RETRIES;
+    let schema = null;
+
+    while (!schema && tries > 0) {
+      schema = getters['schemaFor'](type);
+
+      if (!schema) {
+        if (tries === SCHEMA_CHECK_RETRY_LOG) {
+          console.warn(`Schema for ${ type } not available... retrying...`); // eslint-disable-line no-console
+        }
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        tries--;
+      }
+    }
+
+    if (tries === 0) {
+      // Ran out of tries - fetch the schemas again
+      console.warn(`Schema for ${ type } still unavailable... loading schemas again...`); // eslint-disable-line no-console
+      await dispatch('loadSchemas', true);
+    }
+  }
 };

--- a/store/index.js
+++ b/store/index.js
@@ -32,37 +32,6 @@ export const NAMESPACED_PREFIX = 'namespaced://';
 export const NAMESPACED_YES = 'namespaced://true';
 export const NAMESPACED_NO = 'namespaced://false';
 
-const SCHEMA_CHECK_RETRIES = 15;
-const SCHEMA_CHECK_RETRY_LOG = 10;
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-// Helper to wait for mgmt cluster schema
-async function waitForMgmtClusterSchemaAvailable({ getters, dispatch }) {
-  let tries = SCHEMA_CHECK_RETRIES;
-  let schema = null;
-
-  while (!schema && tries > 0) {
-    schema = getters['management/schemaFor'](MANAGEMENT.CLUSTER);
-
-    if (!schema) {
-      if (tries === SCHEMA_CHECK_RETRY_LOG) {
-        console.warn(`Schema for ${ MANAGEMENT.CLUSTER } not available... retrying...`); // eslint-disable-line no-console
-      }
-      await sleep(1000);
-      tries--;
-    }
-  }
-
-  if (tries === 0) {
-    // Ran out of tries - fetch the schemas again
-    console.warn(`Schema for ${ MANAGEMENT.CLUSTER } still unavailable... loading schemas again...`); // eslint-disable-line no-console
-    await dispatch('management/loadSchemas', true);
-  }
-}
-
 export const plugins = [
   Steve({
     namespace:      'management',
@@ -670,7 +639,7 @@ export const actions = {
 
     // This is a workaround for a timing issue where the mgmt cluster schema may not be available
     // Try and wait until the schema exists before proceeding
-    await waitForMgmtClusterSchemaAvailable({ getters, dispatch });
+    await dispatch('management/waitForSchema', { type: MANAGEMENT.CLUSTER });
 
     // See if it really exists
     try {


### PR DESCRIPTION
Fixes #5313 
Fixes #4967 

This PR fixes the issue reported in both the above issues - there is a rare race condition that leads to the fail-whale page being displayed:

![image](https://user-images.githubusercontent.com/1955897/157195663-21b28e92-703e-4d31-b32f-7ea52464d978.png)

Tracing through the code, the problem is that `middleware/authenticated.js` on line 265, we dispatch calls to load the management and cluster stores in parallel. The management store will load all schemas (see `store/index.js` line 538). The cluster store assumes that the schema for the management cluster is avaialable (see `store.js` line 677).

There is a race condition where if the schemas are not loaded, the call to load the cluster will fail and you'll get bumped to the fail-whale page.

This PR fixes this by adding a wait into the `loadCluster` code - we don't want to load the schemas in multiple places - we assume that the schemas are in the process of being loaded and wait up to 15 seconds for them - after 10 seconds we log a message to the browser console and after 15 if we still don't have the schemas, we request them synchronously (this should not be needed, but is a fail-safe).

This is hard to test, but from the description above you should be able to understand how this can happen.

Developers can test by:

Commenting out line 673 in `store/index.js` - this essentially removes the fix in this PR. The line to comment out is:

```
    await waitForMgmtClusterSchemaAvailable({ getters, dispatch });
```

Now, change line 538 in `store/index.js` from:

```
      mgmtSchemas:    dispatch('management/loadSchemas', true),
```

to:

```
      mgmtSchemas:    (new Promise(resolve => setTimeout(resolve, 5000))).then(() => dispatch('management/loadSchemas', true)),
```

This will add a 5 second delay to the loading of schemas.

In the UI, refresh to the page for the local cluster, i.e. https://127.0.0.1:8005/c/local/explorer

You should see the fail-whale page.

Now uncomment line 673 in `store/index.js` to put back in the fix from this PR and try again and everything should load correctly.