### PR TITLE
Show that k3s is in tech preview

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1616,6 +1616,7 @@ cluster:
         false: Only available inside the cluster
         true: Exposed to the public interface
   k3s:
+    techPreview: K3s provisioning is in Tech Preview
     systemService:
       coredns: 'CoreDNS'
       local-storage: 'Local Storage'

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -314,7 +314,12 @@ export default {
     >
       <template #option="option">
         <template v-if="option.kind === 'group'">
-          <b>{{ getOptionLabel(option) }}</b>
+          <div class="vs__option-kind-group">
+            <b>{{ getOptionLabel(option) }}</b>
+            <div v-if="option.badge">
+              {{ option.badge }}
+            </div>
+          </div>
         </template>
         <template v-else-if="option.kind === 'divider'">
           <hr />
@@ -411,6 +416,24 @@ export default {
     .vs__selected-options {
       padding: 8px 0 7px 0;
     }
+  }
+}
+
+// Styling for option group badge
+.vs__dropdown-menu .vs__dropdown-option .vs__option-kind-group {
+  display: flex;
+  > b {
+    flex: 1;
+  }
+  > div {
+    background-color: var(--primary);
+    border-radius: 4px;
+    color: var(--primary-text);
+    font-size: 12px;
+    height: 18px;
+    line-height: 18px;
+    margin-top: 1px;
+    padding: 0 10px;
   }
 }
 </style>

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -305,6 +305,12 @@ export default {
       return this.value.spec.rkeConfig.machineSelectorConfig.find(x => !x.machineLabelSelector).config;
     },
 
+    showK3sTechPreviewWarning() {
+      const selectedVersion = this.value?.spec?.kubernetesVersion || 'none';
+
+      return !!this.k3sVersions.find(v => v.version === selectedVersion);
+    },
+
     // kubeletConfigs() {
     //   return this.value.spec.rkeConfig.machineSelectorConfig.filter(x => !!x.machineLabelSelector);
     // },
@@ -361,7 +367,11 @@ export default {
 
       if ( showK3s ) {
         if ( showRke2 ) {
-          out.push({ kind: 'group', label: this.t('cluster.provider.k3s') });
+          out.push({
+            kind:  'group',
+            label: this.t('cluster.provider.k3s'),
+            badge: this.t('generic.techPreview')
+          });
         }
 
         out.push(...k3s);
@@ -1508,6 +1518,9 @@ export default {
                 :options="versionOptions"
                 label-key="cluster.kubernetesVersion.label"
               />
+              <div v-if="showK3sTechPreviewWarning" class="k3s-tech-preview-info">
+                {{ t('cluster.k3s.techPreview') }}
+              </div>
             </div>
             <div v-if="showCloudProvider" class="col span-6">
               <LabeledSelect
@@ -1972,3 +1985,9 @@ export default {
     </template>
   </CruResource>
 </template>
+<style lang="scss" scoped>
+  .k3s-tech-preview-info {
+    color: var(--error);
+    padding-top: 10px;
+  }
+</style>


### PR DESCRIPTION
Fixes #5318 

This PR fixes the issue above - RKE2 is no longer in tech preview but K3s still is, so we need to indicate that to the user.

In the version dropdown, we now show a tech preview badge next to k3s:

![image](https://user-images.githubusercontent.com/1955897/157269492-5b3d6c23-76c1-4f03-bcbb-a18f670bc3fa.png)

When you select a k3s version we show a warning below the version drop down:

![image](https://user-images.githubusercontent.com/1955897/157269527-51cd5104-f7b5-430b-8861-c54bf6a37395.png)
