### PR TITLE
Quickly clicking between pages which contain lists can produce a console error

### DIFF
--- a/components/SortableTable/actions.js
+++ b/components/SortableTable/actions.js
@@ -102,6 +102,10 @@ export default {
      * Determine if any actions wrap over to a new line, if so group them into a dropdown instead
      */
     updateHiddenBulkActions: debounce(function() {
+      if (!this.$refs.container) {
+        return;
+      }
+
       const actionsContainer = this.$refs.container.querySelector(`.${ this.bulkActionsClass }`);
       const actionsDropdown = this.$refs.container.querySelector(`.${ this.bulkActionsDropdownClass }`);
 


### PR DESCRIPTION
Addresses Github issue: [#5240](https://github.com/rancher/dashboard/issues/5240)
Addresses Zube issue: [Zube #5264](https://zube.io/rancher/dashboard-ui/c/5264)

- fix issue where method `querySelector` was being applied to to an `undefined` `$refs.container` if we navigate quickly between pages with lists