### PR TITLE
Rename Assign to into Change worspace for cluster prompt menu actions

### DIFF
--- a/models/fleet.cattle.io.cluster.js
+++ b/models/fleet.cattle.io.cluster.js
@@ -34,7 +34,7 @@ export default class FleetCluster extends SteveModel {
 
     insertAt(out, 3, {
       action:     'assignTo',
-      label:      'Assign to&hellip;',
+      label:      'Change workspace&hellip;',
       icon:       'icon icon-copy',
       bulkable:   true,
       bulkAction: 'assignToBulk',


### PR DESCRIPTION
Renamed prompt menu from `Assign to...` into `Change worspace...`.

Path: `/c/<CLUSTER>/fleet/fleet.cattle.io.cluster`

![Screenshot from 2022-03-09 14-00-56](https://user-images.githubusercontent.com/5009481/157446794-137c56eb-b834-4214-af53-67a89a78c8b0.png)
