### PR TITLE
Improve handling of missing cluster when navigating directly to it

### DIFF
--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -199,7 +199,7 @@ export default async function({
           if ( status === 401 ) {
             notLoggedIn();
           } else {
-            store.commit('setError', e);
+            store.commit('setError', { error: e, locationError: new Error('Auth Middleware') });
             if ( process.server ) {
               redirect(302, '/fail-whale');
             }
@@ -210,6 +210,7 @@ export default async function({
       }
     }
   }
+
   if (!process.server) {
     const backTo = window.localStorage.getItem(BACK_TO);
 
@@ -303,7 +304,7 @@ export default async function({
     if ( e instanceof ClusterNotFoundError ) {
       return redirect(302, '/home');
     } else {
-      store.commit('setError', e);
+      store.commit('setError', { error: e, locationError: new Error('Auth Middleware') });
 
       return redirect(302, '/fail-whale');
     }

--- a/store/index.js
+++ b/store/index.js
@@ -463,10 +463,13 @@ export const mutations = {
     state.productId = neu;
   },
 
-  setError(state, obj) {
+  setError(state, { error: obj, locationError }) {
     const err = new ApiError(obj);
 
     console.log('Loading error', err); // eslint-disable-line no-console
+    // Location of error, with description and stack trace
+    console.log('Loading error location', locationError); // eslint-disable-line no-console
+    console.log('Loading original error', obj); // eslint-disable-line no-console
 
     state.error = err;
     state.cameFromError = true;
@@ -643,11 +646,18 @@ export const actions = {
 
     // See if it really exists
     try {
-      await dispatch('management/find', {
+      const cluster = await dispatch('management/find', {
         type: MANAGEMENT.CLUSTER,
         id,
         opt:  { url: `${ MANAGEMENT.CLUSTER }s/${ escape(id) }` }
       });
+
+      if (!cluster.isReady) {
+        // Treat an unready cluster the same as a missing one. This ensures that we safely take user to the home page instead of showing
+        // an error page (useful if they've set the cluster as their home page and don't want to change their landing location)
+        console.warn('Cluster is not ready, cannot load it:', cluster.nameDisplay); // eslint-disable-line no-console
+        throw new Error('Unready cluster');
+      }
     } catch {
       commit('setCluster', null);
       commit('cluster/applyConfig', { baseUrl: null });
@@ -917,7 +927,8 @@ export const actions = {
   },
 
   loadingError({ commit, state }, err) {
-    commit('setError', err);
+    commit('setError', { error: err, locationError: new Error('loadingError') });
+
     const router = state.$router;
 
     router.replace('/fail-whale');


### PR DESCRIPTION
- When a cluster exists but is not available redirect to the home page instead of showing the fail whale
  - Without this we show fail whale with `{"data":"lost connection to cluster: failed to find Session for client stv-cluster-c-m-ssxwtz7r"}`
  - Alternative is to not redirect to home but show fail whale with specific message ("This cluster is unavailable")
- Improve error handling of `setError` by providing actual location error occurred
- Partially addresses #5004
  - That issue states a different error message is returned. Need to investigate how 2.6.3 handles similar issue