### PR TITLE
Update rke2 cloud provider selection

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -439,12 +439,18 @@ export default {
     },
 
     cloudProviderOptions() {
-      const out = [{ label: '(None)', value: '' }];
+      const out = [{ label: '(Default)', value: '' }];
 
       const preferred = this.$store.getters['plugins/cloudProviderForDriver'](this.provider);
 
       for ( const opt of this.agentArgs['cloud-provider-name'].options ) {
-        if ( (!preferred && opt !== HARVESTER) || opt === preferred || opt === 'external' || preferred === HARVESTER) {
+        // If we don't have a preferred provider... show all options
+        const showAllOptions = preferred === undefined;
+        // If we have a preferred provider... only show default, preferred and external
+        const isPreferred = opt === preferred;
+        const isExternal = opt === 'external';
+
+        if (showAllOptions || isPreferred || isExternal) {
           out.push({
             label: this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ opt }".label`, null, opt),
             value: opt,

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -439,7 +439,7 @@ export default {
     },
 
     cloudProviderOptions() {
-      const out = [{ label: '(Default)', value: '' }];
+      const out = [{ label: '(None)', value: '' }];
 
       const preferred = this.$store.getters['plugins/cloudProviderForDriver'](this.provider);
 

--- a/store/plugins.js
+++ b/store/plugins.js
@@ -102,8 +102,12 @@ export const suffixFields = [
 const driverToCloudProviderMap = {
   amazonec2:     'aws',
   azure:         'azure',
-  vmwarevsphere: 'rancher-vsphere',
+  digitalocean:  '', // Show restricted options
   harvester:     'harvester',
+  linode:        '', // Show restricted options
+  vmwarevsphere: 'rancher-vsphere',
+
+  custom: undefined // Show all options
 };
 
 // Dynamically loaded drivers can call this eventually to register their options


### PR DESCRIPTION
- Only show cloud providers applicable to the type of cluster selected
  - If a preferred cloud provider is configured for a cluster type only show the it, 'exteranal' and none/default
  - If a preferred cloud provider is not configured show all options
- ~Shows 'default' instead of 'none' to cover case of the basic rancher provider~
  - This will be covered in another issue/PR 
- Related #5300
- Fixes #5080

Examples

> Update - `(Default)` has been changed back to the original  `(None)`

### Provider - EC2
![image](https://user-images.githubusercontent.com/18697775/157484620-2b9a2d24-cb0c-4c5c-80d2-28ab28f893d9.png)

### Provider - DO
![image](https://user-images.githubusercontent.com/18697775/157484768-4e75d3d0-eca5-41a7-a551-92403a5bbe85.png)

### Provider - Harvester
![image](https://user-images.githubusercontent.com/18697775/157484850-48b24e64-b907-40fc-85d8-d14ea27a1eac.png)

### Provider - Custom 
![image](https://user-images.githubusercontent.com/18697775/157483905-4ad19a71-f98a-4b0a-a4b0-06df2a152325.png)
