### PR TITLE
Make CRU footer actions stick to the bottom

### DIFF
--- a/assets/styles/base/_helpers.scss
+++ b/assets/styles/base/_helpers.scss
@@ -215,6 +215,12 @@ $spacing-property-map: (
   height: 100%;
 }
 
+.filled-height {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
 .full-width {
   width: 100%;
 }

--- a/assets/styles/base/_variables.scss
+++ b/assets/styles/base/_variables.scss
@@ -48,3 +48,10 @@ $breakpoints: (
 );
 
 $font-size-h2: 21px;
+
+/*
+ * Global spacing variables
+ */
+$space-s: 10px;
+$space-m: 20px;
+$space-l: 40px;

--- a/assets/styles/global/_labeled-input.scss
+++ b/assets/styles/global/_labeled-input.scss
@@ -3,6 +3,7 @@
   display: table;
   border-collapse: separate;
   min-height: $input-height;
+  z-index: 0; // Prevent label from cover other elements outside of the input
 
   LABEL {
     position: absolute;

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -244,7 +244,7 @@ export default {
 </script>
 
 <template>
-  <section>
+  <section class="cru">
     <form :is="(isView? 'div' : 'form')" class="create-resource-container">
       <div
         v-if="showSubtypeSelection"
@@ -312,41 +312,40 @@ export default {
         >
           <slot />
         </div>
-        <div class="controls-row">
-          <slot name="form-footer">
-            <CruResourceFooter
-              :mode="mode"
-              :is-form="showAsForm"
-              :show-cancel="showCancel"
-              @cancel-confirmed="confirmCancel"
-            >
-              <!-- Pass down templates provided by the caller -->
-              <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope">
-                <slot :name="slot" v-bind="scope" />
-              </template>
+        <slot name="form-footer">
+          <CruResourceFooter
+            class="cru__footer"
+            :mode="mode"
+            :is-form="showAsForm"
+            :show-cancel="showCancel"
+            @cancel-confirmed="confirmCancel"
+          >
+            <!-- Pass down templates provided by the caller -->
+            <template v-for="(_, slot) of $scopedSlots" v-slot:[slot]="scope">
+              <slot :name="slot" v-bind="scope" />
+            </template>
 
-              <template #default>
-                <div v-if="!isView">
-                  <button
-                    v-if="canYaml && (_selectedSubtype || !subtypes.length) && canEditYaml"
-                    type="button"
-                    class="btn role-secondary"
-                    @click="showPreviewYaml"
-                  >
-                    <t k="cruResource.previewYaml" />
-                  </button>
-                  <AsyncButton
-                    v-if="!showSubtypeSelection"
-                    ref="save"
-                    :disabled="!canSave"
-                    :mode="finishButtonMode || mode"
-                    @click="$emit('finish', $event)"
-                  />
-                </div>
-              </template>
-            </CruResourceFooter>
-          </slot>
-        </div>
+            <template #default>
+              <div v-if="!isView">
+                <button
+                  v-if="canYaml && (_selectedSubtype || !subtypes.length) && canEditYaml"
+                  type="button"
+                  class="btn role-secondary"
+                  @click="showPreviewYaml"
+                >
+                  <t k="cruResource.previewYaml" />
+                </button>
+                <AsyncButton
+                  v-if="!showSubtypeSelection"
+                  ref="save"
+                  :disabled="!canSave"
+                  :mode="finishButtonMode || mode"
+                  @click="$emit('finish', $event)"
+                />
+              </div>
+            </template>
+          </CruResourceFooter>
+        </slot>
       </template>
 
       <section
@@ -367,49 +366,48 @@ export default {
           @error="e=>$emit('error', e)"
         >
           <template #yamlFooter="{yamlSave, showPreview, yamlPreview, yamlUnpreview}">
-            <div class="controls-row">
-              <slot name="cru-yaml-footer">
-                <CruResourceFooter
-                  :done-route="doneRoute"
-                  :mode="mode"
-                  :is-form="showAsForm"
-                  @cancel-confirmed="confirmCancel"
-                >
-                  <template #default="{checkCancel}">
-                    <div class="controls-middle">
-                      <button
-                        v-if="showPreview"
-                        type="button"
-                        class="btn role-secondary"
-                        @click="yamlUnpreview"
-                      >
-                        <t k="resourceYaml.buttons.continue" />
-                      </button>
-                      <button
-                        v-if="!showPreview && isEdit"
-                        :disabled="!canDiff"
-                        type="button"
-                        class="btn role-secondary"
-                        @click="yamlPreview"
-                      >
-                        <t k="resourceYaml.buttons.diff" />
-                      </button>
-                    </div>
-                    <div v-if="_selectedSubtype || !subtypes.length" class="controls-right">
-                      <button type="button" class="btn role-secondary" @click="checkCancel(false)">
-                        <t k="cruResource.backToForm" />
-                      </button>
-                      <AsyncButton
-                        v-if="!showSubtypeSelection"
-                        :disabled="!canSave"
-                        :action-label="isEdit ? t('generic.save') : t('generic.create')"
-                        @click="cb=>yamlSave(cb)"
-                      />
-                    </div>
-                  </template>
-                </CruResourceFooter>
-              </slot>
-            </div>
+            <slot name="cru-yaml-footer">
+              <CruResourceFooter
+                class="cru__footer"
+                :done-route="doneRoute"
+                :mode="mode"
+                :is-form="showAsForm"
+                @cancel-confirmed="confirmCancel"
+              >
+                <template #default="{checkCancel}">
+                  <div class="controls-middle">
+                    <button
+                      v-if="showPreview"
+                      type="button"
+                      class="btn role-secondary"
+                      @click="yamlUnpreview"
+                    >
+                      <t k="resourceYaml.buttons.continue" />
+                    </button>
+                    <button
+                      v-if="!showPreview && isEdit"
+                      :disabled="!canDiff"
+                      type="button"
+                      class="btn role-secondary"
+                      @click="yamlPreview"
+                    >
+                      <t k="resourceYaml.buttons.diff" />
+                    </button>
+                  </div>
+                  <div v-if="_selectedSubtype || !subtypes.length" class="controls-right">
+                    <button type="button" class="btn role-secondary" @click="checkCancel(false)">
+                      <t k="cruResource.backToForm" />
+                    </button>
+                    <AsyncButton
+                      v-if="!showSubtypeSelection"
+                      :disabled="!canSave"
+                      :action-label="isEdit ? t('generic.save') : t('generic.create')"
+                      @click="cb=>yamlSave(cb)"
+                    />
+                  </div>
+                </template>
+              </CruResourceFooter>
+            </slot>
           </template>
         </ResourceYaml>
       </section>
@@ -483,6 +481,21 @@ $logo: 60px;
     object-fit: contain;
     position: relative;
     top: 2px;
+  }
+}
+
+.cru {
+  &__footer {
+    right: 0;
+    position: sticky;
+    bottom: 0;
+    background-color: var(--header-bg);
+    border-top: var(--header-border-size) solid var(--header-border);
+
+    // Overrides outlet padding
+    margin-left: -$space-m;
+    margin-right: -$space-m;
+    padding: $space-s $space-m;
   }
 }
 

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -245,7 +245,10 @@ export default {
 
 <template>
   <section class="cru">
-    <form :is="(isView? 'div' : 'form')" class="create-resource-container">
+    <form
+      :is="(isView? 'div' : 'form')"
+      class="create-resource-container cru__form"
+    >
       <div
         v-if="showSubtypeSelection"
         class="subtypes-container"
@@ -308,7 +311,7 @@ export default {
       <template v-if="showAsForm">
         <div
           v-if="_selectedSubtype || !subtypes.length"
-          class="resource-container"
+          class="resource-container cru__content"
         >
           <slot />
         </div>
@@ -350,7 +353,7 @@ export default {
 
       <section
         v-else
-        class="cru-resource-yaml-container"
+        class="cru-resource-yaml-container cru__content"
       >
         <ResourceYaml
           ref="resourceyaml"
@@ -485,6 +488,20 @@ $logo: 60px;
 }
 
 .cru {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+  &__content {
+    flex-grow: 1;
+  }
+
   &__footer {
     right: 0;
     position: sticky;
@@ -495,6 +512,7 @@ $logo: 60px;
     // Overrides outlet padding
     margin-left: -$space-m;
     margin-right: -$space-m;
+    margin-bottom: -$space-m;
     padding: $space-s $space-m;
   }
 }

--- a/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -143,7 +143,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <form v-else>
+  <form v-else class="filled-height">
     <CruResource
       :done-route="doneRoute"
       :mode="mode"

--- a/edit/cloudcredential.vue
+++ b/edit/cloudcredential.vue
@@ -245,7 +245,7 @@ export default {
 </script>
 
 <template>
-  <form>
+  <form class="filled-height">
     <Loading v-if="$fetchState.pending" />
     <CruResource
       v-else

--- a/edit/secret/index.vue
+++ b/edit/secret/index.vue
@@ -260,7 +260,7 @@ export default {
 </script>
 
 <template>
-  <form>
+  <form class="filled-height">
     <Loading v-if="$fetchState.pending" />
     <CruResource
       v-else

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -778,7 +778,7 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
 
-  <form v-else>
+  <form v-else class="filled-height">
     <CruResource
       :validation-passed="true"
       :selected-subtype="type"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -750,7 +750,7 @@ export default {
     .outlet {
       display: flex;
       flex-direction: column;
-      padding: 20px;
+      padding: $space-m;
       min-height: 100%;
     }
 

--- a/models/fleet.cattle.io.cluster.js
+++ b/models/fleet.cattle.io.cluster.js
@@ -34,7 +34,7 @@ export default class FleetCluster extends SteveModel {
 
     insertAt(out, 3, {
       action:     'assignTo',
-      label:      'Change workspace&hellip;',
+      label:      'Change workspace',
       icon:       'icon icon-copy',
       bulkable:   true,
       bulkAction: 'assignToBulk',


### PR DESCRIPTION
#2512

### Root cause
While editing content, the buttons are always hidden at the bottom, while it is convenient to display them always.

### What was fixed, or what changes have occurred
- All the `CruResource` components containers have been filled, so the footer will be always pushed to the bottom
- Set `.labeled-input` class z-index to 0 preventing labels to hover other elements
- `.filled-height` utility class has been created to fill vertically the container, in case of empty pages or not overflowing
- Spacing variables have been added to be reuse for consistency in the whole project
- `fleet.cattle.io.cluster.js` action menu has been corrected while reviewing another issue, by removing ellipsis

### Areas or cases that should be tested
Any edit view where we want to keep the buttons sticky to the bottom.

### What areas could experience regressions?
Since our layout provides some padding, it has been mandatory to use negative margin for the footer altogether with the same paddding.

### Are the repro steps accurate/minimal?
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


![Screenshot from 2022-03-10 10-02-30](https://user-images.githubusercontent.com/5009481/157629166-468e6da3-b2bf-4b8c-852e-7b5f8bbeb802.png)

![Screenshot from 2022-03-10 14-12-21](https://user-images.githubusercontent.com/5009481/157669069-56e53f83-92be-4221-8c56-5985109a4ceb.png)
