### PR TITLE
scope styles in FleetRepos component so that it does not override oth…

### DIFF
--- a/components/fleet/FleetRepos.vue
+++ b/components/fleet/FleetRepos.vue
@@ -136,7 +136,7 @@ export default {
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .cluster-count-info {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Addresses Github issue: [#5349](https://github.com/rancher/dashboard/issues/5349)
Addresses Zube issue: [#5374](https://zube.io/rancher/dashboard-ui/c/5374)

-  scope styles in FleetRepos component so that it does not override other styles in the project

**Result**
<img width="1604" alt="Screenshot 2022-03-10 at 14 02 04" src="https://user-images.githubusercontent.com/97888974/157679318-4842fadd-b4fa-4341-bad3-3aef24c56a4f.png">
