### PR TITLE
Fleet: Remove underline from icon in git repo details -> conditions tab

### DIFF
--- a/components/Tabbed/index.vue
+++ b/components/Tabbed/index.vue
@@ -277,10 +277,16 @@ export default {
         display: flex;
         align-items: center;
         padding: 10px 15px;
+
+        &:hover {
+          text-decoration: none;
+          span {
+            text-decoration: underline;
+          }
+        }
       }
 
       .conditions-alert-icon {
-        text-decoration: none !important;
         color: var(--error);
         padding-left: 10px;
       }


### PR DESCRIPTION
Addresses Github issue: [#5351](https://github.com/rancher/dashboard/issues/5351)
Addresses Zube issue: [#5376](https://zube.io/rancher/dashboard-ui/c/5376)


- remove underline from conditions tab icon on hover
<img width="1604" alt="Screenshot 2022-03-10 at 15 30 08" src="https://user-images.githubusercontent.com/97888974/157696043-32872ea3-2b5f-4967-b7a6-5a58003b4c7c.png">
