### PR TITLE
Assign status to pod containers so it displays errors and warnings

### DIFF
--- a/detail/pod.vue
+++ b/detail/pod.vue
@@ -59,17 +59,25 @@ export default {
 
       return (containers || []).map((container) => {
         const status = findBy(statuses, 'name', container.name);
+        const state = status.state || {};
+
+        // There can be only one member of a `ContainerState`
+        const s = Object.values(state)[0];
+        const reason = s.reason || '';
+        const message = s.message || '';
+        const showBracket = s.reason && s.message;
 
         return {
           ...container,
           status:           status || {},
-          stateDisplay:     this.value.containerStateDisplay(container),
-          stateBackground:  this.value.containerStateColor(container).replace('text', 'bg'),
+          stateDisplay:     this.value.containerStateDisplay(status),
+          stateBackground:  this.value.containerStateColor(status).replace('text', 'bg'),
           nameSort:         sortableNumericSuffix(container.name).toLowerCase(),
-          readyIcon:        container?.status?.ready ? 'icon-checkmark icon-2x text-success ml-5' : 'icon-x icon-2x text-error ml-5',
+          readyIcon:        status?.ready ? 'icon-checkmark icon-2x text-success ml-5' : 'icon-x icon-2x text-error ml-5',
           availableActions: this.value.containerActions,
           stateObj:         status, // Required if there's a description
-          stateDescription: status, // Required to display the description
+          stateDescription: `${ reason }${ showBracket ? ' (' : '' }${ message }${ showBracket ? ')' : '' }`, // Required to display the description
+          initIcon:         this.value.containerIsInit(container) ? 'icon-checkmark icon-2x text-success ml-5' : 'icon-minus icon-2x text-muted ml-5',
 
           // Call openShell here so that opening the shell
           // at the container level still has 'this' in scope.
@@ -102,13 +110,23 @@ export default {
           formatter:     'IconText',
           formatterOpts: { iconKey: 'readyIcon' },
           align:         'left',
-          width:         75
+          width:         75,
+          sort:          'readyIcon'
         },
         {
           ...SIMPLE_NAME,
           value: 'name'
         },
         IMAGE,
+        {
+          name:          'isInit',
+          labelKey:      'workload.container.init',
+          formatter:     'IconText',
+          formatterOpts: { iconKey: 'initIcon' },
+          align:         'left',
+          width:         75,
+          sort:          'initIcon'
+        },
         {
           name:     'restarts',
           labelKey: 'tableHeaders.restarts',
@@ -165,18 +183,6 @@ export default {
       this.metricsID = id;
       this.selection = c;
     },
-
-    // getStateDescription(status) {
-    //   console.log(status);
-    //   // const states = status
-    //   //   .map(({ state }) => state)
-    //   //   .map(({ error, message }) => [error, message]);
-    //   // const description = flatten(compact(states))
-    //   //   .map(({ reason, message }) => `${ reason }:${ message }`);
-
-    //   return 'this is a description';
-    //   // return description;
-    // }
   }
 };
 </script>

--- a/models/pod.js
+++ b/models/pod.js
@@ -92,16 +92,22 @@ export default class Pod extends SteveModel {
     }, { root: true });
   }
 
-  containerStateDisplay(container) {
-    const state = Object.keys(container.state || {})[0];
+  containerStateDisplay(status) {
+    const state = Object.keys(status.state || {})[0];
 
     return stateDisplay(state);
   }
 
-  containerStateColor(container) {
-    const state = Object.keys(container.state || {})[0];
+  containerStateColor(status) {
+    const state = Object.keys(status.state || {})[0];
 
     return colorForState(state);
+  }
+
+  containerIsInit(container) {
+    const { initContainers = [] } = this.spec;
+
+    return initContainers.includes(container);
   }
 
   get imageNames() {


### PR DESCRIPTION
rancher/dashboard#5285

### Root cause
Due conversion from Steve to Norman model, the `status` value was missing for the Pod row.

### What was fixed, or what changes have occurred
Mapped statuses to each container (row), so it gets displayed within the related table row in case of warnings or errors.

### Areas or cases that should be tested
This change will affect exclusively the Pod list

### What areas could experience regressions?
None expected, however the status value is assigned 3 times: 
- `name`, existing assignment
- `stateObj`, it seems required by the table component in order to avoid errors and to display the description
- `state`, where to actually provide the description

### Are the repro steps accurate/minimal?
- Create a deployment with a pod with an image that does not exist, e.g. Deployment name 'test', image: 'does-not-exist'
- Go to Deployments 
- Select the deployment 
- Select the pod

### Screenshot/Video
![Screenshot from 2022-03-10 16-51-32](https://user-images.githubusercontent.com/5009481/157704356-752540b9-78d7-4b47-80fc-5c454aec55d3.png)

