### PR TITLE
Fix noCharts Yaml in apps & Market place - #5325

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -723,6 +723,7 @@ catalog:
       rancher: '{vendor}'
     deploysOn: Deploys on {os}
     header: Charts
+    noCharts: 'There are no charts available, have you added any repos?'
     noWindows: Your repos do not contain any charts capable of being deployed on a cluster with Windows nodes.
     noWindowsAndLinux: Your repos do not contain any charts capable of being deployed on a cluster with both Windows and Linux worker nodes.
     operatingSystems:


### PR DESCRIPTION
## Summary

Issue #5325 - Apps & Marketplace no charts view missing yaml.

## Steps to test
1. Navigate to any cluster via Cluster explorer > Cluster name
2. Click on `charts` tab in Apps and Market Place
3. In the filter text box type in any string so that no charts are shown.

<img width="1294" alt="image" src="https://user-images.githubusercontent.com/1387263/157842615-449568a0-72ce-4c33-956e-e350d516e598.png">

