### PR TITLE
Revert rke2 tech preview

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -266,7 +266,9 @@ export default {
       function addType(id, group, disabled = false, link = null, iconClass = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
-        const tag = '';
+        const techPreview = getters['i18n/t']('generic.techPreview');
+        const isTechPreview = group === 'rke2' || group === 'custom2';
+        let tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
 
         // Always prefer the built-in icon if there is one
         let icon;
@@ -279,6 +281,12 @@ export default {
           iconClass = undefined;
         } else if (!iconClass) {
           icon = require('~/assets/images/generic-driver.svg');
+        }
+
+        if (group === 'rke2' && id === 'harvester') {
+          const experimental = getters['i18n/t']('generic.experimental');
+
+          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: experimental }, '');
         }
 
         const subtype = {

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -306,9 +306,11 @@ export default {
     },
 
     showK3sTechPreviewWarning() {
-      const selectedVersion = this.value?.spec?.kubernetesVersion || 'none';
+      // NOTE: Put this back in when RKE2 is out of tech preview, but K3s is not
+      // const selectedVersion = this.value?.spec?.kubernetesVersion || 'none';
 
-      return !!this.k3sVersions.find(v => v.version === selectedVersion);
+      // return !!this.k3sVersions.find(v => v.version === selectedVersion);
+      return false;
     },
 
     // kubeletConfigs() {
@@ -370,7 +372,8 @@ export default {
           out.push({
             kind:  'group',
             label: this.t('cluster.provider.k3s'),
-            badge: this.t('generic.techPreview')
+            // NOTE: Put this back in when RKE2 is out of tech preview, but K3s is not
+            // badge: this.t('generic.techPreview')
           });
         }
 


### PR DESCRIPTION
fixes #5359 

- Reverts commit to remove RKE2 tech preview
- Disables extra code that marked K3s as tech preview (since now covered by RKE2 tech preview badge)

![image](https://user-images.githubusercontent.com/1955897/157860896-a5e2f2fc-9f46-46f2-a686-23613973df78.png)
