### PR TITLE
Fix handle error message in edit vs create view #5345

### DIFF
--- a/mixins/create-edit-view/impl.js
+++ b/mixins/create-edit-view/impl.js
@@ -7,6 +7,9 @@ import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
 import { handleConflict } from '@/plugins/steve/normalize';
 
 export default {
+
+  name: 'CreateEditView',
+
   mixins: [ChildHook],
 
   mounted() {
@@ -163,7 +166,7 @@ export default {
         this.done();
       } catch (err) {
         // Conflict, the resource being edited has changed since starting editing
-        if ( err.status === 409 && depth === 0 ) {
+        if ( err.status === 409 && depth === 0 && this.isEdit) {
           const errors = this.conflict();
 
           if ( errors === false ) {


### PR DESCRIPTION
## Summary

Issue #5345 - Wrong error message when creating repo with same name in same workspace.

## Technical notes
https://github.com/rancher/dashboard/issues/5345#issuecomment-1063945469

## Steps to test
1. Navigate to continuous deliver and then click on Add Repository.
2. Make a note of the name that was given when creating the repository.
3. After successfully adding first repository, click the button again and give the same name as the previous repository.
4. It should show the error `gitrepos.fleet.cattle.io "......." already exists`

<img width="856" alt="image" src="https://user-images.githubusercontent.com/1387263/157867198-13b220e1-948d-4696-af2f-2e8cf8bc7324.png">

