### PR TITLE
Fix minor namespace filter glitch

### DIFF
--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -762,7 +762,7 @@ export default {
 
       .ns-values {
         display: flex;
-        overflow-x: hidden;
+        overflow: hidden;
 
         .ns-value {
           align-items: center;


### PR DESCRIPTION
Fixes a minor issue where vertical scrollbar can appear:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/1955897/157900451-e43acb26-4665-4107-8f3a-b5f6ede6e7f0.png">
