### PR TITLE
New User Default Role Toggle is Broken in Rancher UI

### DIFF
--- a/components/auth/RoleDetailEdit.vue
+++ b/components/auth/RoleDetailEdit.vue
@@ -899,13 +899,12 @@ export default {
       <div v-if="isRancherType" class="row">
         <div class="col span-6">
           <RadioGroup
-            :value="value.default"
+            v-model="value.newUserDefault"
             name="storageSource"
             :label="defaultLabel"
             class="mb-10"
             :options="newUserDefaultOptions"
             :mode="mode"
-            @input="value.updateDefault"
           />
         </div>
         <div v-if="isRancherRoleTemplate" class="col span-6">

--- a/components/form/RadioButton.vue
+++ b/components/form/RadioButton.vue
@@ -116,6 +116,7 @@ export default {
       <label
         v-if="label"
         :class="[ muteLabel ? 'text-muted' : '', 'radio-label', 'm-0']"
+        :for="name"
         v-html="label"
       >
         <slot name="label">{{ label }}</slot>
@@ -137,7 +138,7 @@ $fontColor: var(--input-label);
   display: flex;
   flex-direction: column;
   LABEL {
-    color: var(--input-label)
+    color: var(--input-label);
   }
 }
 
@@ -153,12 +154,19 @@ $fontColor: var(--input-label);
   display: inline-flex;
   align-items: flex-start;
   margin: 0;
-  cursor: pointer;
   user-select: none;
   border-radius: var(--border-radius);
   padding-bottom: 5px;
 
-  &.disabled {
+  &,
+  .radio-label,
+  .radio-button-outer-container-description {
+    cursor: pointer;
+  }
+
+  &.disabled,
+  &.disabled .radio-label,
+  &.disabled .radio-button-outer-container-description {
     cursor: not-allowed
   }
 

--- a/models/management.cattle.io.globalrole.js
+++ b/models/management.cattle.io.globalrole.js
@@ -31,11 +31,16 @@ export default class GlobalRole extends SteveModel {
   }
 
   get nameDisplay() {
-    return this.$rootGetters['i18n/withFallback'](`rbac.globalRoles.role.${ this.id }.label`, this.displayName || this.metadata?.name || this.id);
+    const path = `rbac.globalRoles.role.${ this.id }.label`;
+    const label = this.displayName || this.metadata?.name || this.id;
+
+    return this.$rootGetters['i18n/withFallback'](path, label);
   }
 
   get descriptionDisplay() {
-    return this.description || this.metadata?.annotations?.[DESCRIPTION] || this.$rootGetters['i18n/withFallback'](`rbac.globalRoles.role.${ this.id }.description`, this.t(`rbac.globalRoles.unknownRole.description`));
+    return this.description ||
+    this.metadata?.annotations?.[DESCRIPTION] ||
+    this.$rootGetters['i18n/withFallback'](`rbac.globalRoles.role.${ this.id }.description`, this.t(`rbac.globalRoles.unknownRole.description`));
   }
 
   get isSpecial() {
@@ -96,6 +101,9 @@ export default class GlobalRole extends SteveModel {
     return this.$dispatch(`rancher/create`, { type: NORMAN.GLOBAL_ROLE, name: this.displayName }, { root: true });
   }
 
+  /**
+   * Due to issues in the Steve API, we need to switch to Norman API for handle and save this model
+   */
   get norman() {
     return (async() => {
       const norman = await this.basicNorman;

--- a/models/management.cattle.io.globalrole.js
+++ b/models/management.cattle.io.globalrole.js
@@ -2,7 +2,6 @@ import { DESCRIPTION } from '@/config/labels-annotations';
 import { SCHEMA, NORMAN } from '@/config/types';
 import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@/models/management.cattle.io.roletemplate';
 import { uniq } from '@/utils/array';
-import Vue from 'vue';
 import { get } from '@/utils/object';
 import SteveModel from '@/plugins/steve/steve-class';
 import Role from './rbac.authorization.k8s.io.role';
@@ -53,10 +52,6 @@ export default class GlobalRole extends SteveModel {
 
   get default() {
     return !!this.newUserDefault;
-  }
-
-  updateDefault(value) {
-    Vue.set(this, 'newUserDefault', value);
   }
 
   get allResources() {

--- a/models/management.cattle.io.globalrolebinding.js
+++ b/models/management.cattle.io.globalrolebinding.js
@@ -38,6 +38,7 @@ export default class GRB extends HybridModel {
 
       norman.globalRoleId = this.globalRoleName;
       norman.userId = this.userName;
+      norman.newUserDefault = this.newUserDefault;
       norman.groupPrincipalId = this.groupPrincipalName;
 
       return norman;

--- a/models/management.cattle.io.roletemplate.js
+++ b/models/management.cattle.io.roletemplate.js
@@ -149,6 +149,7 @@ export default class RoleTemplate extends SteveModel {
 
       norman.rules = this.rules;
       norman.locked = this.locked;
+      norman.newUserDefault = this.newUserDefault;
       norman.clusterCreatorDefault = this.clusterCreatorDefault || false;
       norman.projectCreatorDefault = this.projectCreatorDefault || false;
       norman.context = this.context;

--- a/plugins/steve/steve-class.js
+++ b/plugins/steve/steve-class.js
@@ -13,4 +13,19 @@ export default class SteveModel extends HybridModel {
   get description() {
     return this.metadata?.annotations?.[DESCRIPTION] || this.spec?.description || this._description;
   }
+
+  /**
+   * Set description based on the type of model available with private fallback
+   */
+  set description(value) {
+    if (this.metadata?.annotations) {
+      this.metadata.annotations[DESCRIPTION] = value;
+    }
+
+    if (this.spec) {
+      this.spec.description = value;
+    }
+
+    this._description = value;
+  }
 }


### PR DESCRIPTION
#4992

Allow users not  to select `New User Default`.

Interested areas:
- `models/management.cattle.io.globalrole.js`
- `models/management.cattle.io.globalrolebinding.js`
- `models/management.cattle.io.roletemplate.js`

https://user-images.githubusercontent.com/5009481/157936423-100e20c1-04a2-4338-8192-585e0ebc9e43.mp4

## Collateral fixed issues

### Name/displayName glitch

On resource update and deletion an errors about model `set` missing prevented to modify the value and on list reload it displayed `name` instead of `displayName`. Obviously this also prevented to set the description.

For this purpose the `SteveModel` has been extended to support `set` for description.

https://user-images.githubusercontent.com/5009481/157936997-7202db33-a2ed-4546-8436-cc9d1d39a44d.mp4

### Radio labels

Radio buttons now can be clicked from the label as in native HTML 1.0 and display a cursor as for the input.


