### PR TITLE
update charts os badges, remove filtering

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -722,8 +722,8 @@ catalog:
       partner: Partner
       rancher: '{vendor}'
     deploysOnWindows: Deploys on Windows
-    windowsIncompatible: Incompatible with Windows
-    versionWindowsIncompatible: Version Incompatible with Windows
+    windowsIncompatible: Linux only
+    versionWindowsIncompatible: Linux only version
     header: Charts
     noCharts: 'There are no charts available, have you added any repos?'
     noWindows: Your repos do not contain any charts capable of being deployed on a cluster with Windows nodes.

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -721,7 +721,9 @@ catalog:
       other: Other
       partner: Partner
       rancher: '{vendor}'
-    deploysOn: Deploys on {os}
+    deploysOnWindows: Deploys on Windows
+    windowsIncompatible: Incompatible with Windows
+    versionWindowsIncompatible: Version Incompatible with Windows
     header: Charts
     noCharts: 'There are no charts available, have you added any repos?'
     noWindows: Your repos do not contain any charts capable of being deployed on a cluster with Windows nodes.
@@ -866,8 +868,8 @@ catalog:
       remove: Remove
       manage: Manage
   os:
-    versionIncompatible: "This version is not compatible with all worker nodes' operating systems"
-    chartIncompatible: "This chart is not compatible with all worker nodes' operating systems"
+    versionIncompatible: "This version is not compatible with Windows nodes."
+    chartIncompatible: "This chart is not compatible with Windows nodes."
 
 changePassword:
   title: Change Password
@@ -5999,6 +6001,7 @@ typeDescription:
   #       Should fit on one line.
   #       If you link to anything external, it MUST have
   #       target="_blank" rel="noopener noreferrer nofollow"
+  chart: "All charts have at least one version that is installable on clusters with Linux and Windows nodes unless otherwise indicated."
   cis.cattle.io.clusterscanbenchmark: A benchmark version is the name of benchmark to run using kube-bench as well as the valid configuration parameters for that benchmark.
   cis.cattle.io.clusterscanprofile: A profile is the configuration for the CIS scan, which is the benchmark versions to use and any specific tests to skip in that benchmark.
   cis.cattle.io.clusterscan: A scan is created to trigger a CIS scan on the cluster based on the defined profile. A report is created after the scan is completed.

--- a/components/SelectIconGrid.vue
+++ b/components/SelectIconGrid.vue
@@ -98,9 +98,14 @@ export default {
       @click="select(r, idx)"
     >
       <div class="side-label" :class="{'indicator': true }" />
-      <div v-if="r.permittedOSs">
-        <label v-for="os in r.permittedOSs" :key="os" class="os-label" :class="{[os]:true}">
-          {{ t('catalog.charts.deploysOn', {os:capitalize(os)}) }}
+      <div v-if="r.deploysOnWindows">
+        <label class="deploys-os-label">
+          {{ t('catalog.charts.deploysOnWindows') }}
+        </label>
+      </div>
+      <div v-if="r.windowsIncompatible">
+        <label class="os-incompatible-label">
+          {{ t('catalog.charts.windowsIncompatible') }}
         </label>
       </div>
       <div v-if="get(r, sideLabelField)" class="side-label" :class="{'indicator': false }">
@@ -191,7 +196,7 @@ export default {
 
       }
 
-      .side-label label, label.os-label{
+      .side-label label, label.deploys-os-label, label.os-incompatible-label{
           font-size: 12px;
           line-height: 12px;
           text-align: center;
@@ -203,16 +208,16 @@ export default {
           margin: 0;
       }
 
-      .os-label {
+      .deploys-os-label, .os-incompatible-label {
         position: absolute;
         bottom: 10px;
         padding: 2px 5px;
-        &.linux{
-          left: 10px;
-        }
-        &.windows{
-          right: 10px;
-        }
+        right: 10px;
+      }
+
+      label.os-incompatible-label {
+        color: var(--warning);
+        background-color: var(--warning-banner-bg)
       }
 
       .logo {
@@ -245,7 +250,7 @@ export default {
       }
 
       &.rancher {
-        .side-label, .os-label {
+        .side-label, .deploys-os-label {
           background-color: var(--app-rancher-accent);
           label {
             color: var(--app-rancher-accent-text);
@@ -257,7 +262,7 @@ export default {
       }
 
       &.partner {
-        .side-label, .os-label {
+        .side-label, .deploys-os-label {
           background-color: var(--app-partner-accent);
           label {
             color: var(--app-partner-accent-text);
@@ -270,35 +275,35 @@ export default {
 
       // @TODO figure out how to templatize these
       &.color1 {
-        .side-label, .os-label { background-color: var(--app-color1-accent); label { color: var(--app-color1-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color1-accent); label { color: var(--app-color1-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color1-accent); }
       }
       &.color2 {
-        .side-label, .os-label { background-color: var(--app-color2-accent); label { color: var(--app-color2-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color2-accent); label { color: var(--app-color2-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color2-accent); }
       }
       &.color3 {
-        .side-label, .os-label { background-color: var(--app-color3-accent); label { color: var(--app-color3-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color3-accent); label { color: var(--app-color3-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color3-accent); }
       }
       &.color4 {
-        .side-label, .os-label { background-color: var(--app-color4-accent); label { color: var(--app-color4-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color4-accent); label { color: var(--app-color4-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color4-accent); }
       }
       &.color5 {
-        .side-label, .os-label { background-color: var(--app-color5-accent); label { color: var(--app-color5-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color5-accent); label { color: var(--app-color5-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color5-accent); }
       }
       &.color6 {
-        .side-label, .os-label { background-color: var(--app-color6-accent); label { color: var(--app-color6-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color6-accent); label { color: var(--app-color6-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color6-accent); }
       }
       &.color7 {
-        .side-label, .os-label { background-color: var(--app-color7-accent); label { color: var(--app-color7-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color7-accent); label { color: var(--app-color7-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color7-accent); }
       }
       &.color8 {
-        .side-label, .os-label { background-color: var(--app-color8-accent); label { color: var(--app-color8-accent-text); } }
+        .side-label, .deploys-os-label { background-color: var(--app-color8-accent); label { color: var(--app-color8-accent-text); } }
         &:hover:not(.disabled) { border-color: var(--app-color8-accent); }
       }
 

--- a/mixins/chart.js
+++ b/mixins/chart.js
@@ -61,7 +61,6 @@ export default {
     },
 
     mappedVersions() {
-      const isRancher = this.chart?.certified === 'rancher';
       const versions = this.chart?.versions || [];
       const selectedVersion = this.targetVersion;
       const OSs = this.currentCluster?.workerOSs;
@@ -79,22 +78,14 @@ export default {
           keywords:        version.keywords
         };
 
-        let permittedSystems;
+        const permittedSystems = (version?.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || LINUX).split(',');
 
-        if (version?.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS]) {
-          permittedSystems = version?.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS].split(',');
-        } else if (isRancher) {
-          permittedSystems = [LINUX];
+        if (permittedSystems.length > 0 && difference(OSs, permittedSystems).length > 0) {
+          nue.disabled = true;
         }
-
-        if (permittedSystems) {
-          if (permittedSystems.length > 0 && difference(OSs, permittedSystems).length > 0) {
-            nue.disabled = true;
-          }
-          // if only one OS is allowed, show '<OS>-only' on hover
-          if (permittedSystems.length === 1) {
-            nue.label = this.t(`catalog.install.versions.${ permittedSystems[0] }`, { ver: version.version });
-          }
+        // if only one OS is allowed, show '<OS>-only' on hover
+        if (permittedSystems.length === 1) {
+          nue.label = this.t(`catalog.install.versions.${ permittedSystems[0] }`, { ver: version.version });
         }
 
         if (!this.showPreRelease && isPrerelease(version.version)) {

--- a/pages/c/_cluster/apps/charts/chart.vue
+++ b/pages/c/_cluster/apps/charts/chart.vue
@@ -9,7 +9,7 @@ import isEqual from 'lodash/isEqual';
 import { CHART, REPO, REPO_TYPE, VERSION } from '@/config/query-params';
 import { mapGetters } from 'vuex';
 import { compatibleVersionsFor } from '@/store/catalog';
-
+import TypeDescription from '@/components/TypeDescription';
 export default {
   components: {
     Banner,
@@ -17,6 +17,7 @@ export default {
     DateFormatter,
     LazyImage,
     Loading,
+    TypeDescription
   },
 
   mixins: [
@@ -114,6 +115,8 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else>
+    <TypeDescription resource="chart" />
+
     <div v-if="chart" class="chart-header">
       <div class="name-logo-install">
         <div class="name-logo">
@@ -130,6 +133,9 @@ export default {
         <button v-if="!requires.length" type="button" class="btn role-primary" @click.prevent="install">
           {{ t(`asyncButton.${action}.action` ) }}
         </button>
+      </div>
+      <div v-if="chart.windowsIncompatible" class="mt-5">
+        <label class="os-label">{{ t('catalog.charts.windowsIncompatible') }}</label>
       </div>
       <div v-if="requires.length || warnings.length || targetedAppWarning || osWarning" class="mt-20">
         <Banner v-if="osWarning" color="error">
@@ -252,6 +258,11 @@ export default {
       h1 {
         margin: 0 20px;
       }
+    }
+
+    .os-label{
+      background-color: var(--warning-banner-bg);
+      color: var(--warning);
     }
 
     .btn {

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -3,6 +3,7 @@ import AsyncButton from '@/components/AsyncButton';
 import Loading from '@/components/Loading';
 import Banner from '@/components/Banner';
 import SelectIconGrid from '@/components/SelectIconGrid';
+import TypeDescription from '@/components/TypeDescription';
 import {
   REPO_TYPE, REPO, CHART, VERSION, SEARCH_QUERY, _FLAGGED, CATEGORY, DEPRECATED, HIDDEN, OPERATING_SYSTEM
 } from '@/config/query-params';
@@ -24,6 +25,7 @@ export default {
     Checkbox,
     Select,
     SelectIconGrid,
+    TypeDescription
   },
 
   async fetch() {
@@ -140,7 +142,6 @@ export default {
       const enabledCharts = (this.enabledCharts || []);
 
       return filterAndArrangeCharts(enabledCharts, {
-        operatingSystems: this.currentCluster.workerOSs,
         category:         this.category,
         searchQuery:      this.searchQuery,
         showDeprecated:   this.showDeprecated,
@@ -256,16 +257,14 @@ export default {
     selectChart(chart) {
       let version;
       const OSs = this.currentCluster.workerOSs;
-
       const showPrerelease = this.$store.getters['prefs/get'](SHOW_PRE_RELEASE);
       const compatibleVersions = compatibleVersionsFor(chart, OSs, showPrerelease);
+      const versions = chart.versions;
 
       if (compatibleVersions.length > 0) {
         version = compatibleVersions[0].version;
       } else {
-        console.warn(`Cannot select chart '${ chart.chartName }' (no compatible version available for '${ OSs.length > 1 ? `${ OSs[0] } and ${ OSs[1] }` : OSs[0] }')`); // eslint-disable-line no-console
-
-        return;
+        version = versions[0].version;
       }
 
       this.$router.push({
@@ -313,7 +312,7 @@ export default {
         </h1>
       </div>
     </header>
-
+    <TypeDescription resource="chart" />
     <div class="left-right-split">
       <Select
         :searchable="false"

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -21,6 +21,7 @@ import Tabbed from '@/components/Tabbed';
 import UnitInput from '@/components/form/UnitInput';
 import YamlEditor, { EDITOR_MODES } from '@/components/YamlEditor';
 import Wizard from '@/components/Wizard';
+import TypeDescription from '@/components/TypeDescription';
 import ChartMixin from '@/mixins/chart';
 import ChildHook, { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
 import { CATALOG, MANAGEMENT } from '@/config/types';
@@ -35,6 +36,7 @@ import { findBy, insertAt } from '@/utils/array';
 import Vue from 'vue';
 import { saferDump } from '@/utils/create-yaml';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
+import { LINUX } from '@/store/catalog';
 
 const VALUES_STATE = {
   FORM: 'FORM',
@@ -68,7 +70,8 @@ export default {
     Tabbed,
     UnitInput,
     YamlEditor,
-    Wizard
+    Wizard,
+    TypeDescription
   },
 
   mixins: [
@@ -525,6 +528,21 @@ export default {
 
     mcmRoute() {
       return { name: 'c-cluster-mcapps' };
+    },
+
+    windowsIncompatible() {
+      if (this.chart?.windowsIncompatible) {
+        return this.t('catalog.charts.windowsIncompatible');
+      }
+      if (this.versionInfo) {
+        const incompatibleVersion = !(this.versionInfo?.chart?.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || LINUX).includes('windows');
+
+        if (incompatibleVersion && !this.chart.windowsIncompatible) {
+          return this.t('catalog.charts.versionWindowsIncompatible');
+        }
+      }
+
+      return null;
     }
   },
 
@@ -1018,6 +1036,7 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else-if="!legacyApp && !mcapp" class="install-steps" :class="{ 'isPlainLayout': isPlainLayout}">
+    <TypeDescription resource="chart" />
     <Wizard
       v-if="value"
       :steps="steps"
@@ -1039,8 +1058,13 @@ export default {
         />
       </template>
       <template #bannerTitleImage>
-        <div class="logo-bg">
-          <LazyImage :src="chart ? chart.icon : ''" class="logo" />
+        <div>
+          <div class="logo-bg">
+            <LazyImage :src="chart ? chart.icon : ''" class="logo" />
+          </div>
+          <label v-if="windowsIncompatible" class="os-label">
+            {{ windowsIncompatible }}
+          </label>
         </div>
       </template>
       <template #basics>
@@ -1597,6 +1621,13 @@ export default {
       }
     }
   }
+}
+
+.os-label {
+  position: absolute;
+  background-color: var(--warning-banner-bg);
+  color:var(--warning);
+  margin-top: 5px;
 }
 
 </style>

--- a/pages/c/_cluster/explorer/tools/index.vue
+++ b/pages/c/_cluster/explorer/tools/index.vue
@@ -11,10 +11,11 @@ import { sortBy } from '@/utils/sort';
 import { LEGACY } from '@/store/features';
 import { isAlternate } from '@/utils/platform';
 import IconMessage from '@/components/IconMessage';
+import TypeDescription from '@/components/TypeDescription';
 
 export default {
   components: {
-    AppSummaryGraph, LazyImage, Loading, IconMessage
+    AppSummaryGraph, LazyImage, Loading, IconMessage, TypeDescription
   },
 
   async fetch() {
@@ -113,7 +114,6 @@ export default {
       const enabledCharts = (this.allCharts || []);
 
       let charts = filterAndArrangeCharts(enabledCharts, {
-        operatingSystems: this.currentCluster.workerOSs,
         clusterProvider,
         showDeprecated:   this.showDeprecated,
         showHidden:       this.showHidden,
@@ -356,6 +356,17 @@ export default {
         margin: 0;
       }
 
+      .os-label {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        padding: 3px;
+        font-size: 12px;
+        line-height: 12px;
+        background-color: var(--primary);
+        color: var(--primary-text);
+      }
+
       .version {
         color: var(--muted);
         white-space: nowrap;
@@ -399,6 +410,7 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <div v-else-if="options.length">
     <h1 v-html="t('catalog.tools.header')" />
+    <TypeDescription v-if="!legacyEnabled" resource="chart" />
 
     <div class="grid">
       <div
@@ -411,9 +423,12 @@ export default {
           <LazyImage v-else :src="opt.chart.icon" />
         </div>
         <div class="name-version">
-          <h3 class="name">
-            {{ opt.chart.chartNameDisplay }}
-          </h3>
+          <div>
+            <h3 class="name">
+              {{ opt.chart.chartNameDisplay }}
+            </h3>
+            <label v-if="opt.chart.deploysOnWindows" class="os-label">{{ t('catalog.charts.deploysOnWindows') }}</label>
+          </div>
           <div class="version">
             <template v-if="opt.app && opt.app.upgradeAvailable">
               v{{ opt.app.currentVersion }} <b><i class="icon icon-chevron-right" /> v{{ opt.app.upgradeAvailable }}</b>

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -494,30 +494,31 @@ function addChart(ctx, map, chart, repo) {
     if ( ctx ) { }
     obj = classify(ctx, {
       key,
-      type:             'chart',
-      id:               key,
+      type:                 'chart',
+      id:                   key,
       certified,
       sideLabel,
       repoType,
       repoName,
-      repoNameDisplay:  ctx.rootGetters['i18n/withFallback'](`catalog.repo.name."${ repoName }"`, null, repoName),
-      certifiedSort:    CERTIFIED_SORTS[certified] || 99,
-      icon:             chart.icon,
-      color:            repo.color,
-      chartType:        chart.annotations?.[CATALOG_ANNOTATIONS.TYPE] || CATALOG_ANNOTATIONS._APP,
-      chartName:        chart.name,
-      chartNameDisplay: chart.annotations?.[CATALOG_ANNOTATIONS.DISPLAY_NAME] || chart.name,
-      chartDescription: chart.description,
-      repoKey:          repo._key,
-      versions:         [],
-      categories:       filterCategories(chart.keywords),
-      deprecated:       !!chart.deprecated,
-      hidden:           !!chart.annotations?.[CATALOG_ANNOTATIONS.HIDDEN],
-      targetNamespace:  chart.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE],
-      targetName:       chart.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME],
-      scope:            chart.annotations?.[CATALOG_ANNOTATIONS.SCOPE],
-      provides:         [],
-      permittedOSs:      certifiedAnnotation === 'rancher' ? (chart.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || 'linux').split(',') : null
+      repoNameDisplay:      ctx.rootGetters['i18n/withFallback'](`catalog.repo.name."${ repoName }"`, null, repoName),
+      certifiedSort:        CERTIFIED_SORTS[certified] || 99,
+      icon:                 chart.icon,
+      color:                repo.color,
+      chartType:            chart.annotations?.[CATALOG_ANNOTATIONS.TYPE] || CATALOG_ANNOTATIONS._APP,
+      chartName:            chart.name,
+      chartNameDisplay:     chart.annotations?.[CATALOG_ANNOTATIONS.DISPLAY_NAME] || chart.name,
+      chartDescription:     chart.description,
+      repoKey:              repo._key,
+      versions:             [],
+      categories:           filterCategories(chart.keywords),
+      deprecated:           !!chart.deprecated,
+      hidden:               !!chart.annotations?.[CATALOG_ANNOTATIONS.HIDDEN],
+      targetNamespace:      chart.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE],
+      targetName:           chart.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME],
+      scope:                chart.annotations?.[CATALOG_ANNOTATIONS.SCOPE],
+      provides:             [],
+      windowsIncompatible:  !(chart.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || '').includes('windows'),
+      deploysOnWindows:     (chart.annotations?.[CATALOG_ANNOTATIONS.DEPLOYED_OS] || '').includes('windows')
     });
 
     map[key] = obj;
@@ -581,7 +582,6 @@ catalog.cattle.io/permits-os: OS -> will break on clusters containing nodes that
 */
 export function compatibleVersionsFor(chart, os, includePrerelease = true) {
   const versions = chart.versions;
-  const isRancher = chart.certified === 'rancher';
 
   if (os && !isArray(os)) {
     os = [os];
@@ -594,7 +594,7 @@ export function compatibleVersionsFor(chart, os, includePrerelease = true) {
       return false;
     }
 
-    if ( !os || difference(os, osPermitted).length === 0 || !isRancher) {
+    if ( !os || difference(os, osPermitted).length === 0) {
       return true;
     }
 


### PR DESCRIPTION
#5137 
#4983 
This PR updates the os badges on charts to better distinguish between charts that deploy on windows nodes, and charts that just wont break if there are windows nodes present in the cluster (they have taints to avoid scheduling on those nodes). It also applies these badges to the Cluster Tools page. 
In this PR:
- OS badges are now applied to non-Rancher charts as well
- all charts deploy on Linux so there are no Linux badges anymore, instead there is a user-dismissable warning in the app marketplace, chart overview, chart install page, and cluster tools page if legacy tools are not enabled ('legacy' feature flag)
- charts with the `deploys-on=linux,windows` have a badge indicating they deploy on Windows - currently this is only Logging and Monitoring
- charts without a `permits-os` annotation or whose `permits-os` annotation does not include Windows have a badge on overview and install pages indicating that they don't work with Windows clusters - currently this is all partner charts
- if installing a version of a chart that doesn't support Windows, a badge indicating this will appear in the wizard

![Screen Shot 2022-03-11 at 1 27 09 PM](https://user-images.githubusercontent.com/42977925/157957290-ca0b02a2-eee4-4850-9325-39f0ffe7b18a.png)
![Screen Shot 2022-03-11 at 1 15 27 PM](https://user-images.githubusercontent.com/42977925/157954385-89a39e8b-057e-49a2-b482-73a053a52131.png)
![Screen Shot 2022-03-11 at 1 15 58 PM](https://user-images.githubusercontent.com/42977925/157954407-b44a8e87-c74f-468c-86ef-ccfe258904d9.png)
![Screen Shot 2022-03-11 at 1 16 23 PM](https://user-images.githubusercontent.com/42977925/157954419-13c3ed30-c7cc-460a-a557-79c18bcfed50.png)
![Screen Shot 2022-03-11 at 1 40 28 PM](https://user-images.githubusercontent.com/42977925/157959531-e5764c6a-023e-4b1a-b009-578120e3477d.png)
![Screen Shot 2022-03-11 at 1 38 56 PM](https://user-images.githubusercontent.com/42977925/157959523-09b62eec-6187-4477-a6c1-cae1ddafb27a.png)


