### PR TITLE
Networking options for K3s/RKE2 clusters can't change after cluster is created

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1587,6 +1587,7 @@ cluster:
       label: Drain Nodes
       toolTip: Draining preemptively removes the pods on each node so there are no running workloads on the nodes being upgraded.  Upgrading without draining is faster and causes less shuffling around, but pods may still be restarted depending on the upgrade being performed.
     address:
+      tooltip: Cluster networking values cannot be changed after the cluster is created.
       header: Addressing
       clusterCidr:
         label: Cluster CIDR

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -249,27 +249,28 @@ export default {
     }
 
     return {
-      loadedOnce:           false,
-      lastIdx:              0,
-      allPSPs:              null,
-      nodeComponent:        null,
-      credentialId:         null,
-      credential:           null,
-      machinePools:         null,
-      rke2Versions:         null,
-      k3sVersions:          null,
-      rke2Channels:         [],
-      k3sChannels:          [],
-      s3Backup:             false,
-      versionInfo:          {},
-      membershipUpdate:     {},
-      systemRegistry:       null,
-      registryHost:         null,
-      registryMode:         null,
-      registrySecret:       null,
-      userChartValues:      {},
-      userChartValuesTemp:  {},
-      addonsRev:            0,
+      loadedOnce:              false,
+      lastIdx:                 0,
+      allPSPs:                 null,
+      nodeComponent:           null,
+      credentialId:            null,
+      credential:              null,
+      machinePools:            null,
+      rke2Versions:            null,
+      k3sVersions:             null,
+      rke2Channels:            [],
+      k3sChannels:             [],
+      s3Backup:                false,
+      versionInfo:             {},
+      membershipUpdate:        {},
+      systemRegistry:          null,
+      registryHost:            null,
+      registryMode:            null,
+      registrySecret:          null,
+      userChartValues:         {},
+      userChartValuesTemp:     {},
+      addonsRev:               0,
+      clusterIsAlreadyCreated: !!this.value.id
     };
   },
 
@@ -1541,6 +1542,7 @@ export default {
               <LabeledSelect
                 v-model="agentConfig['cloud-provider-name']"
                 :mode="mode"
+                :disabled="clusterIsAlreadyCreated"
                 :options="cloudProviderOptions"
                 :label="t('cluster.rke2.cloudProvider.label')"
               />
@@ -1551,6 +1553,7 @@ export default {
               <LabeledSelect
                 v-model="serverConfig.cni"
                 :mode="mode"
+                :disabled="clusterIsAlreadyCreated"
                 :options="serverArgs.cni.options"
                 :label="t('cluster.rke2.cni.label')"
               />
@@ -1719,6 +1722,7 @@ export default {
         <Tab v-if="haveArgInfo" name="networking" label-key="cluster.tabs.networking">
           <h3>
             {{ t('cluster.rke2.address.header') }}
+            <i v-tooltip="t('cluster.rke2.address.tooltip')" class="icon icon-info" />
           </h3>
           <Banner v-if="showIpv6Warning" color="warning">
             {{ t('cluster.rke2.address.ipv6.warning') }}
@@ -1728,6 +1732,7 @@ export default {
               <LabeledInput
                 v-model="serverConfig['cluster-cidr']"
                 :mode="mode"
+                :disabled="clusterIsAlreadyCreated"
                 :label="t('cluster.rke2.address.clusterCidr.label')"
               />
             </div>
@@ -1735,6 +1740,7 @@ export default {
               <LabeledInput
                 v-model="serverConfig['service-cidr']"
                 :mode="mode"
+                :disabled="clusterIsAlreadyCreated"
                 :label="t('cluster.rke2.address.serviceCidr.label')"
               />
             </div>
@@ -1745,6 +1751,7 @@ export default {
               <LabeledInput
                 v-model="serverConfig['cluster-dns']"
                 :mode="mode"
+                :disabled="clusterIsAlreadyCreated"
                 :label="t('cluster.rke2.address.dns.label')"
               />
             </div>
@@ -1752,6 +1759,7 @@ export default {
               <LabeledInput
                 v-model="serverConfig['cluster-domain']"
                 :mode="mode"
+                :disabled="clusterIsAlreadyCreated"
                 :label="t('cluster.rke2.address.domain.label')"
               />
             </div>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5294 by making it so that the following values for networking can't change after a K3s/RKE2 cluster is created:

In the basics tab:

- Cloud provider
- Container network

In the networking tab:

- Cluster CIDR
- Service CIDR
- Cluster DNS
- Cluster Domain

Note: NodePort Service Port Range should not be disabled because it's enabled for RKE1 clusters.

<img width="1123" alt="Screen Shot 2022-03-13 at 3 55 02 PM" src="https://user-images.githubusercontent.com/20599230/158082772-037eb17f-25b1-453f-92e3-f0403a90be6f.png">
<img width="1216" alt="Screen Shot 2022-03-14 at 3 59 35 PM" src="https://user-images.githubusercontent.com/20599230/158274558-1fe755de-2251-4408-9126-30cfe10ccc22.png">




## Testing

To test this PR, I provisioned an RKE2 cluster and confirmed that the above fields were disabled in the form. I also confirmed that when you create a new K3s/RKE2 cluster, the fields are not disabled.



