### PR TITLE
SortableTable: Only use a single timer for live updates and pause on scroll

### DIFF
--- a/components/formatter/LiveDate.vue
+++ b/components/formatter/LiveDate.vue
@@ -37,8 +37,13 @@ export default {
     }
   },
 
+  mounted() {
+    // Set initial value;
+    this.liveUpdate(day());
+  },
+
   data() {
-    return { label: this.update() };
+    return { label: '-' };
   },
 
   computed: {
@@ -67,40 +72,30 @@ export default {
       }
 
       return out;
+    },
+
+    dayValue() {
+      return day(this.value);
     }
   },
 
   watch: {
     value() {
-      this.update();
+      this.liveUpdate(day());
     }
   },
 
-  beforeDestroy() {
-    clearTimeout(this.timer);
-  },
-
   methods: {
-    update() {
-      if ( !this.value || this.value === 'null' ) {
-        this.label = null;
-
-        return this.label;
-      }
-
-      clearTimeout(this.timer);
-
-      const value = day(this.value);
-      const now = day();
-      const diff = diffFrom(value, now);
+    liveUpdate(now) {
+      const diff = diffFrom(this.dayValue, now);
       const prefix = (diff.diff < 0 || !this.addPrefix ? '' : '-');
-      const suffix = '';
+
       let label = diff.label;
 
       if ( diff === 0 ) {
         label = 'Just now';
       } else {
-        label += ` ${ prefix } ${ this.t(diff.unitsKey, { count: diff.label }) } ${ suffix }`;
+        label += ` ${ prefix } ${ this.t(diff.unitsKey, { count: diff.label }) }`;
         label = label.trim();
       }
 
@@ -108,12 +103,8 @@ export default {
         this.label = label;
       }
 
-      this.timer = setTimeout(() => {
-        this.update();
-      }, 1000 * diff.next);
-
-      return this.label;
-    }
+      return diff.next || 1;
+    },
   }
 };
 </script>

--- a/list/node.vue
+++ b/list/node.vue
@@ -72,7 +72,7 @@ export default {
 
   computed: {
     hasWindowsNodes() {
-      return this.kubeNodes.some(node => node.status.nodeInfo.operatingSystem === 'windows');
+      return (this.kubeNodes || []).some(node => node.status.nodeInfo.operatingSystem === 'windows');
     },
     tableGroup: mapPref(GROUP_RESOURCES),
 


### PR DESCRIPTION
This PR changes the way that the LiveDate column works (and provides a mechanism we can use for all Live columns).

Currently, when there are 100 rows in a page on a sortable table with the Age column, we create a timer for every age field.

On some older browsers (Edge 91, for example), this makes it impossible to use the scroll bar to scroll through the list.

This PR makes 4 changes:

- Provides a mechanism where the SortableTable will use a single timer to update all live columns in the table
- Updates the LiveDate component to use this mechanism
- Updates SortableTable so that we pause live updating when the user is scrolling the page
- Slightly improves the performance of the LiveDate component

These updates may help with general page performance with large lists.