### PR TITLE
Add simple mechanism to simulate large numbers of resources

### DIFF
--- a/docs/developer/stress-test.md
+++ b/docs/developer/stress-test.md
@@ -1,0 +1,48 @@
+# Stress Testing
+
+In some situations it is useful to test the Dashboard UI with large numbers of resources (e.g. node, deployments) without having
+to actually have a system available with that scale.
+
+When run in development mode, you can enable simple scale simulation by setting the `PERF_TEST` environment variable to `true`, for example:
+
+```
+PERF_TEST=true yarn dev
+```
+
+When the `PERF_TEST` environment variable is set, the UI adds an intercept into the `loadAll` function in the store - this allows
+the code in `plugins/peformanceTesting.js` to modify the resources when they are loaded into the store.
+
+Note that this only intercepts the initial load, not subsequent updates.
+
+Developers can modify `plugins/peformanceTesting.js` to simulate the scale that they wish to test with.
+
+Modify the `PERF_DATA` object in this file - each key is the name of a type whose scale you wish to change, for example:
+
+```
+const PERF_DATA = {
+  node: {
+    count:     800,
+    statusRow: 2,
+  }
+};
+```
+
+This will simulate 800 nodes and ensure that every 1 in 2 (on average) nodes will have a status set that will cause a status row to appear in the list views.
+
+The code in peformanceTesting will use the existing resources for the given type as templates and round-robin copy them to generate a list with the required number.
+
+The copied resources will have their age reset to the current date and time and have names and ids generated.
+
+You may also specify a custom function in a `custom` field for a type, this function takes the resource and index, for example below we will set every generated resource to have an error state:
+
+```
+const PERF_DATA = {
+  node: {
+    count:     800,
+    statusRow: 2,
+    custom:    (node, index) => { node.metadata.state.error = true}
+  }
+};
+```
+  
+The custom fucntion is only applied to generated resources, not the existing resources that are used to generate them.

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -17,6 +17,7 @@ const dev = (process.env.NODE_ENV !== 'production');
 const devPorts = dev || process.env.DEV_PORTS === 'true';
 const pl = process.env.PL || STANDARD;
 const commit = process.env.COMMIT || 'head';
+const perfTest = (process.env.PERF_TEST === 'true'); // Enable performance testing when in dev
 
 let api = process.env.API || 'http://localhost:8989';
 
@@ -73,6 +74,7 @@ module.exports = {
     version,
     dev,
     pl,
+    perfTest,
   },
 
   publicRuntimeConfig: { rancherEnv: process.env.RANCHER_ENV || 'web' },
@@ -375,7 +377,7 @@ function proxyMetaOpts(target) {
 function proxyOpts(target) {
   return {
     target,
-    secure: !dev,
+    secure: !devPorts,
     onProxyReq,
     onProxyReqWs,
     onError,
@@ -384,7 +386,7 @@ function proxyOpts(target) {
 }
 
 function onProxyRes(proxyRes, req, res) {
-  if (dev) {
+  if (devPorts) {
     proxyRes.headers['X-Frame-Options'] = 'ALLOWALL';
   }
 }

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -5,6 +5,7 @@ import HybridModel, { cleanHybridResources } from '@/plugins/steve/hybrid-class'
 import { normalizeType, KEY_FIELD_FOR } from './normalize';
 import { classify } from './classify';
 import { keyForSubscribe } from './subscribe';
+// import { perfLoadAll } from './performanceTesting';
 
 function registerType(state, type) {
   let cache = state.types[type];
@@ -168,6 +169,11 @@ export default {
     if (limit) {
       data = data.slice(-limit);
     }
+
+    // Uncomment for performance testing (uncomment import as well)
+    // if (process.env.dev) {
+    //   data = perfLoadAll(type, data);
+    // }
 
     const keyField = KEY_FIELD_FOR[type] || KEY_FIELD_FOR['default'];
     const proxies = data.map(x => classify(ctx, x));

--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -5,7 +5,7 @@ import HybridModel, { cleanHybridResources } from '@/plugins/steve/hybrid-class'
 import { normalizeType, KEY_FIELD_FOR } from './normalize';
 import { classify } from './classify';
 import { keyForSubscribe } from './subscribe';
-// import { perfLoadAll } from './performanceTesting';
+import { perfLoadAll } from './performanceTesting';
 
 function registerType(state, type) {
   let cache = state.types[type];
@@ -170,10 +170,10 @@ export default {
       data = data.slice(-limit);
     }
 
-    // Uncomment for performance testing (uncomment import as well)
-    // if (process.env.dev) {
-    //   data = perfLoadAll(type, data);
-    // }
+    // Performance testing in dev and when env var is set
+    if (process.env.dev && process.env.perfTest) {
+      data = perfLoadAll(type, data);
+    }
 
     const keyField = KEY_FIELD_FOR[type] || KEY_FIELD_FOR['default'];
     const proxies = data.map(x => classify(ctx, x));

--- a/plugins/steve/performanceTesting.js
+++ b/plugins/steve/performanceTesting.js
@@ -78,7 +78,7 @@ function replicate(data, config) {
 
   data.forEach(d => templates.push(JSON.stringify(d)));
 
-  const newData = [ ...data ];
+  const newData = [...data];
 
   // We already have the elemnts in data... just need to pad out
   const remaining = config.count - data.length;

--- a/plugins/steve/performanceTesting.js
+++ b/plugins/steve/performanceTesting.js
@@ -1,0 +1,116 @@
+import day from 'dayjs';
+
+// This code should not be included in a production build
+// This allows you to simulate large numbers of resources
+
+// Fake extra resources to simulate scale
+const PERF_DATA = {
+  node: {
+    count:     600,
+    statusRow: 0,
+  },
+  'apps.deployment': {
+    count:     4000,
+    statusRow: 2
+  },
+  pod: {
+    count:     4000,
+    statusRow: 10
+  }
+};
+
+const DEFAULTS = {
+  count:     1, // One copy of each resource
+  statusRow: 0, // Don't add any status rows (0 = None, 1 = All, N = 1 out of N)
+  custom:    null // Custom function that can modify each row = takes node and index - e.g. (node, index) => { node.metadata.state.error = true}
+};
+
+export function perfLoadAll(type, data) {
+  // console.log(`${ type }`);
+  if (data.length === 0) {
+    return data;
+  }
+
+  const n = data[0];
+
+  if (!n.apiVersion) {
+    return data;
+  }
+
+  let config = PERF_DATA[type];
+
+  if (!config) {
+    return data;
+  }
+
+  if (typeof config === 'number') {
+    config = { count: config };
+  }
+
+  config = {
+    ...DEFAULTS,
+    ...config
+  };
+
+  return replicate(data, config);
+}
+
+function randNum(max) {
+  return Math.floor(Math.random() * max);
+}
+
+function replicate(data, config) {
+  if (data.length === 0) {
+    return data;
+  }
+
+  // Pretend there are none of the resource type
+  if (config.count === 0) {
+    return [];
+  }
+
+  const templates = [];
+  let j = 0;
+
+  data.forEach(d => templates.push(JSON.stringify(d)));
+
+  data = [];
+
+  for (let i = 0; i < config.count; i++) {
+    const newNode = JSON.parse(templates[j]);
+
+    newNode.id = `${ newNode.id }_${ i }`;
+    newNode.metadata.uid = `uid_${ i }_${ Math.random() * 1000 }`;
+    newNode.metadata.name = `${ newNode.metadata?.name }_${ i }`;
+    newNode.metadata.creationTimestamp = day().format();
+    data.push(newNode);
+
+    if (config.statusRow > 0) {
+      // Fake a status row one in N times, where N is the statusRow setting
+      const addStatusRow = config.statusRow === 1 ? true : randNum(config.statusRow) === 0;
+
+      if (addStatusRow) {
+        newNode.metadata.state = newNode.metadata.state || {};
+        const isError = randNum(2) === 0;
+
+        if (isError) {
+          newNode.metadata.state.error = true;
+        } else {
+          newNode.metadata.state.transitioning = true;
+        }
+        newNode.metadata.state.message = `Test state description for ${ newNode.metadata.name }`;
+      }
+    }
+
+    if (config.custom) {
+      config.custom(newNode, i);
+    }
+
+    j++;
+    if (j === templates.length) {
+      j = 0;
+    }
+  }
+
+  return data;
+}

--- a/plugins/steve/performanceTesting.js
+++ b/plugins/steve/performanceTesting.js
@@ -63,10 +63,14 @@ function replicate(data, config) {
   if (data.length === 0) {
     return data;
   }
-
+  
   // Pretend there are none of the resource type
   if (config.count === 0) {
     return [];
+  }
+
+  if (config.count <= data.length) {
+    return data.slice(0, config.count);
   }
 
   const templates = [];
@@ -74,16 +78,19 @@ function replicate(data, config) {
 
   data.forEach(d => templates.push(JSON.stringify(d)));
 
-  data = [];
+  const newData = [ ...data ];
 
-  for (let i = 0; i < config.count; i++) {
+  // We already have the elemnts in data... just need to pad out
+  const remaining = config.count - data.length;
+
+  for (let i = 0; i < remaining; i++) {
     const newNode = JSON.parse(templates[j]);
 
     newNode.id = `${ newNode.id }_${ i }`;
     newNode.metadata.uid = `uid_${ i }_${ Math.random() * 1000 }`;
     newNode.metadata.name = `${ newNode.metadata?.name }_${ i }`;
     newNode.metadata.creationTimestamp = day().format();
-    data.push(newNode);
+    newData.push(newNode);
 
     if (config.statusRow > 0) {
       // Fake a status row one in N times, where N is the statusRow setting
@@ -112,5 +119,5 @@ function replicate(data, config) {
     }
   }
 
-  return data;
+  return newData;
 }

--- a/plugins/steve/performanceTesting.js
+++ b/plugins/steve/performanceTesting.js
@@ -6,12 +6,12 @@ import day from 'dayjs';
 // Fake extra resources to simulate scale
 const PERF_DATA = {
   node: {
-    count:     600,
-    statusRow: 0,
+    count:     800,
+    statusRow: 2,
   },
   'apps.deployment': {
     count:     4000,
-    statusRow: 2
+    statusRow: 5
   },
   pod: {
     count:     4000,
@@ -63,7 +63,7 @@ function replicate(data, config) {
   if (data.length === 0) {
     return data;
   }
-  
+
   // Pretend there are none of the resource type
   if (config.count === 0) {
     return [];


### PR DESCRIPTION
This PR adds a simple mechanism for simulating large numbers of resources to help diagnose performance issues in the browser.

The code is currently commented out in `mutations.js` and is intended to be used in development only.

A new `performanceTesting.js` file allows a developer to configure different scales for resources - this is used by the `loadAll` function in the store to scale up from the actual number of resources to the desired.

For any resource type, you can configure how many you'd like to simulate - when loadAll is called, we will use the existing resources of the given type, duplicating each in turn to get to the desired count.

The age for each resource is reset to now (this helps testing live table columns) and you can also configure whether the state for a given resource should be set such that a sub-row would be shown in the list table for the resource.

Finally, you can also provide a custom function in the configuration of a resource to make custom changes to the resources being generated.

