### PR TITLE
Harvester: Rename experimental to tech preview

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -284,9 +284,7 @@ export default {
         }
 
         if (group === 'rke2' && id === 'harvester') {
-          const experimental = getters['i18n/t']('generic.experimental');
-
-          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: experimental }, '');
+          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: techPreview }, '');
         }
 
         const subtype = {


### PR DESCRIPTION
Show 'Tech Preview' and not 'Experimental' for Harvester cluster creation on RKE2 - this makes it consistent with the other RKE2 options.