### PR TITLE
Always show the 'Not in a Project' group in the Project/Namespace list

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3560,6 +3560,7 @@ projectNamespaces:
   createProject: Create Project
   label: Projects/Namespaces
   noNamespaces: There are no namespaces defined.
+  noProjectNoNamespaces: All namespaces are in a project
 
 prometheusRule:
   alertingRules:

--- a/components/ResourceTable.vue
+++ b/components/ResourceTable.vue
@@ -11,6 +11,20 @@ import { NAME as HARVESTER } from '@/config/product/harvester';
 // Default group-by in the case the group stored in the preference does not apply
 const DEFAULT_GROUP = 'namespace';
 
+export const defaultTableSortGenerationFn = (schema, $store) => {
+  if ( !schema ) {
+    return null;
+  }
+
+  const resource = schema.id;
+  const inStore = $store.getters['currentStore'](resource);
+  const generation = $store.getters[`${ inStore }/currentGeneration`](resource);
+
+  if ( generation ) {
+    return `${ resource }/${ generation }`;
+  }
+};
+
 export default {
 
   name: 'ResourceTable',
@@ -77,6 +91,10 @@ export default {
     overflowY: {
       type:    Boolean,
       default: false
+    },
+    sortGenerationFn: {
+      type:    Function,
+      default: null,
     },
   },
 
@@ -303,18 +321,12 @@ export default {
       this.$refs.table.clearSelection();
     },
 
-    sortGenerationFn() {
-      if ( !this.schema ) {
-        return null;
+    safeSortGenerationFn() {
+      if (this.sortGenerationFn) {
+        return this.sortGenerationFn(this.schema, this.$store);
       }
 
-      const resource = this.schema.id;
-      const inStore = this.$store.getters['currentStore'](resource);
-      const generation = this.$store.getters[`${ inStore }/currentGeneration`](resource);
-
-      if ( generation ) {
-        return `${ resource }/${ generation }`;
-      }
+      return defaultTableSortGenerationFn(this.schema, this.$store);
     },
   }
 };
@@ -335,7 +347,7 @@ export default {
     :overflow-x="overflowX"
     :overflow-y="overflowY"
     key-field="_key"
-    :sort-generation-fn="sortGenerationFn"
+    :sort-generation-fn="safeSortGenerationFn"
     v-on="$listeners"
   >
     <template v-if="showGrouping" #header-middle>

--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -9,7 +9,7 @@ import Masthead from '@/components/ResourceList/Masthead';
 import { mapPref, GROUP_RESOURCES, DEV } from '@/store/prefs';
 import MoveModal from '@/components/MoveModal';
 import { NAME as HARVESTER } from '@/config/product/harvester';
-import { defaultTableSortGenerationFn } from '~/components/ResourceTable.vue';
+import { defaultTableSortGenerationFn } from '@/components/ResourceTable.vue';
 
 export default {
   name:       'ListNamespace',

--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -9,6 +9,7 @@ import Masthead from '@/components/ResourceList/Masthead';
 import { mapPref, GROUP_RESOURCES, DEV } from '@/store/prefs';
 import MoveModal from '@/components/MoveModal';
 import { NAME as HARVESTER } from '@/config/product/harvester';
+import { defaultTableSortGenerationFn } from '~/components/ResourceTable.vue';
 
 export default {
   name:       'ListNamespace',
@@ -86,13 +87,20 @@ export default {
     rowsWithFakeNamespaces() {
       const fakeRows = this.projectsWithoutNamespaces.map((project) => {
         return {
-          groupByLabel:     `${ ('resourceTable.groupLabel.notInAProject') }-${ project }`,
+          groupByLabel:     `${ ('resourceTable.groupLabel.notInAProject') }-${ project.id }`,
           isFake:           true,
           mainRowKey:       project.id,
           project,
           availableActions: []
         };
       });
+
+      if (this.showMockNotInProjectGroup) {
+        fakeRows.push( {
+          groupByLabel:     this.t('resourceTable.groupLabel.notInAProject'), // Same as the groupByLabel for the namespace model
+          mainRowKey:       'fake-empty',
+        });
+      }
 
       return [...this.rows, ...fakeRows];
     },
@@ -120,6 +128,10 @@ export default {
       return this.namespaces.filter((namespace) => {
         return isVirtualCluster && isVirtualProduct ? (!namespace.isSystem && !namespace.isObscure) : !namespace.isObscure;
       });
+    },
+
+    showMockNotInProjectGroup() {
+      return !this.rows.some(row => !row.project);
     }
   },
   methods: {
@@ -168,7 +180,17 @@ export default {
     },
     clearSelection() {
       this.$refs.table.clearSelection();
-    }
+    },
+
+    sortGenerationFn() {
+      // The sort generation function creates a unique value and is used to create a key including sort details.
+      // The unique key determines if the list is redrawn or a cached version is shown.
+      // Because we ensure the 'not in a project' group is there via a row, and timing issues, the unqiue key doesn't change
+      // after a namespace is removed... so the list won't update... so we need to inject a string to ensure the key is fresh
+      const base = defaultTableSortGenerationFn(this.schema, this.$store);
+
+      return base + (this.showMockNotInProjectGroup ? '-mock' : '');
+    },
   }
 };
 </script>
@@ -192,6 +214,7 @@ export default {
       :headers="headers"
       :rows="filteredRows"
       :groupable="true"
+      :sort-generation-fn="sortGenerationFn"
       group-tooltip="resourceTable.groupBy.project"
       key-field="_key"
       v-on="$listeners"
@@ -226,6 +249,13 @@ export default {
         <tr :key="project.id" class="main-row">
           <td class="empty text-center" colspan="5">
             {{ t('projectNamespaces.noNamespaces') }}
+          </td>
+        </tr>
+      </template>
+      <template #main-row:fake-empty>
+        <tr class="main-row">
+          <td class="empty text-center" colspan="5">
+            {{ t('projectNamespaces.noProjectNoNamespaces') }}
           </td>
         </tr>
       </template>


### PR DESCRIPTION
- When there are no namespaces that are not in a project add a fake namespace that will cause the group to show
- Ensure that when the last namespace in the `Not in a Project` group is removed the list updates
- Note - Users need to be in the 'group' view to see the `Not in a Project` group
- Note - Users can still click on any project's `Create Namespace` button and change the project to `(None)`
- Fixes #5322