### PR TITLE
Fleet: Workspace filter "moves" workspace group to the top on Fleet Dashboard

### DIFF
--- a/pages/c/_cluster/fleet/index.vue
+++ b/pages/c/_cluster/fleet/index.vue
@@ -86,17 +86,7 @@ export default {
   computed: {
     ...mapState(['workspace']),
     workspacesData() {
-      const workspaces = this.fleetWorkspaces.filter(ws => ws.repos.length);
-      const filterItem = workspaces.find(ws => ws.id === this.workspace);
-
-      if (filterItem) {
-        const filterIndex = workspaces.findIndex(ws => ws.id === this.workspace);
-
-        workspaces.splice(filterIndex, 1);
-        workspaces.unshift(filterItem);
-      }
-
-      return workspaces;
+      return this.fleetWorkspaces.filter(ws => ws.repos.length);
     },
     emptyWorkspaces() {
       return this.fleetWorkspaces.filter(ws => !ws.repos || !ws.repos.length);


### PR DESCRIPTION
Addresses Github issue: [#5406](https://github.com/rancher/dashboard/issues/5406)
Addresses Zube issue: [#5432](https://zube.io/rancher/dashboard-ui/c/5432)

- remove feature where workspace filter shifted the selected workspace information on fleet dashboard