### PR TITLE
NVIDIA GPU Limit/Reservation updates limits as well as requests 

### DIFF
--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -798,20 +798,13 @@ export default {
       }
     },
     nvidiaIsValid(nvidiaGpuLimit) {
-      console.log(`nvidiaIsValid running.. nvidiaGpuLimit: ${ nvidiaGpuLimit }`);
       if (!Number.isInteger(nvidiaGpuLimit)) {
-        console.log(`!Number.isInteger(nvidiaGpuLimit)?:`, !Number.isInteger(nvidiaGpuLimit));
-
         return false;
       }
       if (nvidiaGpuLimit === undefined) {
-        console.log(`nvidiaGpuLimit === undefined?:`, nvidiaGpuLimit === undefined);
-
         return false;
       }
       if (nvidiaGpuLimit < 1) {
-        console.log(`nvidiaGpuLimit < 1:`, nvidiaGpuLimit < 1);
-
         return false;
       } else {
         return true;

--- a/edit/workload/index.vue
+++ b/edit/workload/index.vue
@@ -578,6 +578,20 @@ export default {
         }
       }
 
+      const containerResources = template.spec.containers[0].resources;
+      const nvidiaGpuLimit = containerResources?.limits[GPU_KEY];
+
+      // Though not required, requests are also set to mirror the ember ui
+      if (nvidiaGpuLimit > 0) {
+        containerResources.requests[GPU_KEY] = nvidiaGpuLimit;
+      }
+      if (nvidiaGpuLimit === undefined || nvidiaGpuLimit === 0 ) {
+        try {
+          delete containerResources.limits[GPU_KEY];
+          delete containerResources.requests[GPU_KEY];
+        } catch {}
+      }
+
       const nodeAffinity = template?.spec?.affinity?.nodeAffinity || {};
       const podAffinity = template?.spec?.affinity?.podAffinity || {};
       const podAntiAffinity = template?.spec?.affinity?.podAntiAffinity || {};


### PR DESCRIPTION
Related to issue #5005 and expands on PR [5237](https://github.com/rancher/dashboard/pull/5237)

This PR adds logic to duplicate `resources.limits.'nvidia.com/gpu'` value to `requests` as well. 

Though setting requests is optional, we are doing so to mirror the existing behavior of the ember ui.

eg:
```
resources:
  limits:
    nvidia.com/gpu: 1
  requests:
    nvidia.com/gpu: 1
```
