### PR TITLE
wrong cluster resources count #5331

### DIFF
--- a/components/ResourceSummary.vue
+++ b/components/ResourceSummary.vue
@@ -113,7 +113,7 @@ export default {
 <template>
   <div>
     <SimpleBox class="container" :class="{'has-link': !!location}" @click="goToResource">
-      <h1>{{ resourceCounts.useful }}</h1>
+      <h1>{{ resourceCounts.total }}</h1>
       <h3>
         {{ name }}
       </h3>

--- a/pages/c/_cluster/explorer/index.vue
+++ b/pages/c/_cluster/explorer/index.vue
@@ -56,6 +56,8 @@ const COMPONENT_STATUS = [
 ];
 
 export default {
+  name: 'ClusterExplorerIndexPage',
+
   components: {
     EtcdInfoBanner,
     DashboardMetrics,
@@ -158,7 +160,15 @@ export default {
     },
 
     accessibleResources() {
-      return RESOURCES.filter(resource => this.$store.getters['cluster/schemaFor'](resource));
+      // This is a list of IDs for allowed resources counts.
+      const defaultAllowedResources = Object.keys(this.clusterCounts?.[0].counts).filter((typeId) => {
+        return this.$store.getters['type-map/isIgnored']({ id: typeId });
+      });
+
+      // Merge with RESOURCES list
+      const allowedResources = [...new Set([...defaultAllowedResources, ...RESOURCES])];
+
+      return allowedResources.filter(resource => this.$store.getters['cluster/schemaFor'](resource));
     },
 
     componentServices() {


### PR DESCRIPTION
## Summary

Issue #5331 - Total Resources count is wrong 

## Technical notes

- Currently list shows only specific resource count list - `["namespace", "networking.k8s.io.ingress", "persistentvolume", "apps.deployment", "apps.statefulset", "batch.job", "apps.daemonset", "service"]`
https://github.com/rancher/dashboard/blob/v2.6.3/pages/c/_cluster/explorer/index.vue#L43

- Instead retrieve all counts associated with the cluster `this.$store.getters[`cluster/all`](COUNT)`. 
- Filter that list by ignored resources types defined here by `ignoreType`
https://github.com/rancher/dashboard/blob/master/config/product/explorer.js#L95-L100
https://github.com/rancher/dashboard/blob/master/config/product/explorer.js#L292-L304
- Following getter `isIgnored` returns a boolean if resource is ignored
https://github.com/rancher/dashboard/blob/v2.6.3/store/type-map.js#L1125-L1155

- Solution involve by merging `RESOURCES` list with not ignored list of resources because e.g. `NAMESPACE` is in ignored list by default. Then retrieving the counts

## Steps to test
1. Navigate to Explore cluster > cluster.
2. It should show higher resource count.

