### PR TITLE
Split Network Policy rule CIDR error message out

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3014,7 +3014,8 @@ networkpolicy:
         label: CIDR
         placeholder: e.g. 1.1.1.0/24
       addExcept: Add exception
-      invalidCidrs: "Invalid CIDRs: {invalidCidrs}"
+      invalidCidr: "Invalid CIDR"
+      invalidExceptionCidrs: "Invalid Exceptions: "
     podSelector:
       label: Pod Selector
     namespaceSelector:

--- a/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -65,6 +65,7 @@ export default {
       portOptions:   ['TCP', 'UDP'],
       matchingPods,
       matchingNamespaces,
+      invalidCidr:    null,
       invalidCidrs:    [],
       TARGET_OPTION_IP_BLOCK,
       TARGET_OPTION_NAMESPACE_SELECTOR,
@@ -145,10 +146,14 @@ export default {
     validateCIDR() {
       const exceptCidrs = this.value[TARGET_OPTION_IP_BLOCK].except || [];
 
-      this.invalidCidrs = exceptCidrs.filter(cidr => !isValidCIDR(cidr));
+      this.invalidCidrs = exceptCidrs
+        .filter(cidr => !isValidCIDR(cidr))
+        .map(invalidCidr => invalidCidr || '<blank>');
 
       if (this.value[TARGET_OPTION_IP_BLOCK].cidr && !isValidCIDR(this.value[TARGET_OPTION_IP_BLOCK].cidr)) {
-        this.invalidCidrs.push(this.value[TARGET_OPTION_IP_BLOCK].cidr);
+        this.invalidCidr = this.value[TARGET_OPTION_IP_BLOCK].cidr;
+      } else {
+        this.invalidCidr = null;
       }
     },
     updateMatches: throttle(function() {
@@ -201,10 +206,12 @@ export default {
       </div>
     </div>
     <div v-if="targetType === TARGET_OPTION_IP_BLOCK">
-      <div v-if="invalidCidrs.length > 0" class="row mb-10">
+      <div v-if="invalidCidr || invalidCidrs.length" class="row mb-10">
         <div class="col span-12">
           <Banner color="error">
-            <span v-html="t('networkpolicy.rules.ipBlock.invalidCidrs', { invalidCidrs })" />
+            <t v-if="invalidCidr" k="networkpolicy.rules.ipBlock.invalidCidr" />
+            <br v-if="invalidCidr && invalidCidrs.length">
+            <t v-if="invalidCidrs.length" k="networkpolicy.rules.ipBlock.invalidExceptionCidrs" />{{ invalidCidrs.join(', ') }}
           </Banner>
         </div>
       </div>


### PR DESCRIPTION
- Split out CIDR and exception error message from a single list to two
- Show `<blank>` in the error message for an empty rule
- This process probably needs a rework, but should be done after https://github.com/rancher/dashboard/pull/4999
- fixes blocking issue from https://github.com/rancher/dashboard/issues/4729#issuecomment-1069589044