### PR TITLE
Pass correct props into Ember when editing RKE template clusters

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -104,30 +104,6 @@ export default {
       set(this.value, 'spec', {});
     }
 
-    // Explicitly asked from query string?
-    if ( this.subType ) {
-      // For RKE1 Cluster, set the ember link so that we load the page rather than using RKE2 create
-      if (this.isRke1) {
-        const selected = this.subTypes.find(s => s.id === this.subType);
-
-        this.emberLink = selected?.link;
-      }
-      await this.selectType(this.subType, false);
-    // } else if ( this.value.isImported ) {
-    //   // Edit exiting import
-    //   this.isImport = true;
-    //   this.selectType('import', false);
-    } else if ( this.value.isRke2 && this.value.isCustom ) {
-      // Edit exiting custom
-      this.selectType('custom', false);
-    } else if ( this.value.isRke2 && this.value.machineProvider ) {
-      // Edit exiting RKE2
-      this.selectType(this.value.machineProvider, false);
-    } else if ( this.value.mgmt?.emberEditPath ) {
-      // Iframe an old page
-      this.emberLink = this.value.mgmt.emberEditPath;
-    }
-
     if ( !this.value.id ) {
       if ( !this.value.metadata ) {
         set(this.value, 'metadata', {});
@@ -165,7 +141,6 @@ export default {
       chart,
       isImport,
       providerCluster:  null,
-      emberLink:        null,
       iconClasses:      {},
     };
   },
@@ -175,6 +150,40 @@ export default {
     preferredProvisioner: mapPref(PROVISIONER),
     _RKE1:                () => _RKE1,
     _RKE2:                () => _RKE2,
+
+    emberLink() {
+      // Explicitly asked from query string?
+      if ( this.subType ) {
+        // For RKE1 Cluster, set the ember link so that we load the page rather than using RKE2 create
+        if (this.isRke1) {
+          const selected = this.subTypes.find(s => s.id === this.subType);
+
+          return selected?.link;
+        }
+        this.selectType(this.subType, false);
+
+        // } else if ( this.value.isImported ) {
+        //   // Edit exiting import
+        //   this.isImport = true;
+        //   this.selectType('import', false);
+        return '';
+      } else if ( this.value.isRke2 && this.value.isCustom ) {
+        // Edit exiting custom
+        this.selectType('custom', false);
+
+        return '';
+      } else if ( this.value.isRke2 && this.value.machineProvider ) {
+        // Edit exiting RKE2
+        this.selectType(this.value.machineProvider, false);
+
+        return '';
+      } else if ( this.value.mgmt?.emberEditPath ) {
+        // Iframe an old page
+        return this.value.mgmt.emberEditPath;
+      }
+
+      return '';
+    },
 
     rke2Enabled: mapFeature(RKE2_FEATURE),
 

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -95,18 +95,31 @@ export default class MgmtCluster extends HybridModel {
     return null;
   }
 
+  get rkeTemplateVersion() {
+    return this.spec?.clusterTemplateRevisionName;
+  }
+
   get emberEditPath() {
     // Ember wants one word called provider to tell what component to show, but has much indirect mapping to figure out what it is.
     let provider;
+    let clusterTemplateRevision;
 
     // Provisioner is the "<something>Config" in the model
     const provisioner = KONTAINER_TO_DRIVER[(this.provisioner || '').toLowerCase()] || this.provisioner;
 
     if ( provisioner === 'rancherKubernetesEngine' ) {
+      // Look for a cloud provider in one of the node templates
       if ( this.machinePools?.[0] ) {
         provider = this.machinePools[0]?.nodeTemplate?.spec?.driver || null;
       } else {
         provider = 'custom';
+      }
+
+      // If the RKE1 cluster is created from an RKE template, we need
+      // to get the template version to pass into the Ember UI for
+      // the iFramed edit cluster form
+      if (this.rkeTemplateVersion) {
+        clusterTemplateRevision = this.rkeTemplateVersion;
       }
     } else if ( this.driver ) {
       provider = this.driver;
@@ -116,7 +129,7 @@ export default class MgmtCluster extends HybridModel {
       provider = 'import';
     }
 
-    const qp = { provider };
+    const qp = { provider, clusterTemplateRevision };
 
     // Copied out of https://github.com/rancher/ui/blob/20f56dc54c4fc09b5f911e533cb751c13609adaf/app/models/cluster.js#L844
     if ( provider === 'import' && isEmpty(this.eksConfig) && isEmpty(this.gkeConfig) ) {
@@ -133,7 +146,9 @@ export default class MgmtCluster extends HybridModel {
       qp.clusterTemplateRevision = this.clusterTemplateRevisionId;
     }
 
-    return addParams(`/c/${ escape(this.id) }/edit`, qp);
+    const path = addParams(`/c/${ escape(this.id) }/edit`, qp);
+
+    return path;
   }
 
   get groupByLabel() {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5395 and https://github.com/rancher/dashboard/issues/5032 by making it so that if you have a cluster that was created from an RKE template, then you go to Edit Config, the Rancher UI now passes the RKE template version into the iFramed Ember page that contains the form. The Ember UI requires the RKE template version to render the form properly.

## Testing

### Testing for https://github.com/rancher/dashboard/issues/5395 - Edit Config form should fully render

To test this PR I used Anupama's setup and did this:

1. Using Anupama's setup, logged in as an admin
2. Created an RKE template with no overrides allowed
3. Created another RKE template with a few overrides allowed
4. Added a cluster owner to the new cluster templates so that the cluster owner can use them
5. Logged in as a cluster owner
6. Created two RKE1 clusters, one for each template
7. Went to the Edit Config forms for both clusters and confirmed that both forms are fully rendering
8. Updated the overrides on the second cluster
9. Confirmed that after editing the overrides, the edit config form was still fully rendering

I also confirmed that the Edit Config form also renders properly for RKE1 clusters that were not created from an RKE template.

### Testing for https://github.com/rancher/dashboard/issues/5032 - Overridden values not showing up in edit config for the RKE1 cluster
This is testing to make sure that if you override values in a cluster that was created from a cluster template, your new values are used as the defaults the next time you edit the cluster.

1. Logged in as an admin
2. Created an RKE template with a few overrides allowed. Specifically I allowed overrides for:

- Node Port Range
- Nginx Default Backend
- Project Network Isolation
- Network Provider
- Secrets Encryption

3. Created an RKE1 cluster from the RKE template, overriding all values
4. Went to edit config, confirmed that my new values were the defaults
5. Edited some more values and saved
6. Went to edit config again, confirmed that my new values are still the defaults

I also made sure the edit config form was still rendering as expected for RKE1 clusters that were created from RKE templates that did not allow overrides, as well as for RKE clusters not created from a template.

### Testing navigation between multiple cluster config forms

This PR also fixes another glitch that Anupama observed. If you had two RKE clusters created from two different RKE templates, then navigating to one form would break the other form. This was happening because the `emberLink` was only computed one time, so the same link was being incorrectly used for both forms. I fixed it by turning `emberLink` into a computed property. Now the link is different for each cluster even even if you don't refresh the page.