### PR TITLE
Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- This template is for Devs to give QA details before moving the issue To-Test -->
+### Summary
+Fixes #
+<!-- Define findings related to the feature or bug issue. -->
+
+### Occurred changes and/or fixed issues
+<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
+
+### Technical notes summary
+<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
+
+### Areas or cases that should be tested
+<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
+<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
+
+### Areas which could experience regressions
+<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
+
+### Screenshot/Video
+<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


### PR DESCRIPTION
### Summary
Fixes #5434
Some PR are missing important information for the QA, so we created a template mentioning key point to be filled up.

### Occurred changes and/or fixed issues
This template will be proposed on the next PR.

### Technical notes summary
We may consider to extend this template with several ones within a folder.
Template have been rephrased and enriched from [the original](https://confluence.suse.com/display/EN/Issue+template+for+Devs+to+fill).

### Areas or cases that should be tested
This cannot be tested before merged, so just content has to be reviewed.

### Areas which could experience regressions
This file does not affect the rest of the code.

### Screenshot/Video
Unavailable.