### PR TITLE
`isRke2` computed property works for cluster owners

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -193,6 +193,8 @@ export default {
 
     provisioner: {
       get() {
+        // This can incorrectly return rke1 instead
+        // of rke2 for cluster owners.
         if ( !this.rke2Enabled ) {
           return _RKE1;
         }
@@ -210,7 +212,7 @@ export default {
     },
 
     isRke2() {
-      return this.provisioner === _RKE2;
+      return this.value.isRke2;
     },
 
     templateOptions() {


### PR DESCRIPTION
This is a stopgap solution for https://github.com/rancher/dashboard/issues/5442

The better solution would be to refactor the `provisioner` computed property so that it doesn't return the wrong type of cluster for cluster owners. This is a workaround in the interest of time. For now, I saw that the cluster model already had an `isRke2` getter that worked for cluster owners, so I just used that instead of the existing method, which had a dependency on the broken `provisioner`.

To test this PR,

1. As an admin, I created an RKE2 cluster and a K3s cluster
2. Created a standard user
3. Added the user to each cluster as a cluster owner
4. Logged in as the standard user
5. For each cluster, went to the cluster in Cluster Manager, went to Edit Config and confirmed that the form rendered correctly