### PR TITLE
Fix namespace filter event path returning undefined

### DIFF
--- a/components/nav/NamespaceFilter.vue
+++ b/components/nav/NamespaceFilter.vue
@@ -393,7 +393,7 @@ export default {
       }
     },
     mouseOver(event) {
-      const el = event.path.find(e => e.classList.contains('ns-option'));
+      const el = event?.path?.find(e => e.classList.contains('ns-option'));
 
       this.activeElement = el;
     },


### PR DESCRIPTION
In some cases where the `mouseOver` `event.path` is undefined, namespace filtering is unusable.

https://user-images.githubusercontent.com/40806497/159507655-f1a7c2e5-435b-4cfa-a79d-8d117cf410cc.mp4


### Root cause
`event.path` is undefined.
### What was fixed, or what changes have occurred
Instead of returning undefined `mouseOver` will return `null` if `event.path` is undefined
### Areas or cases that should be tested
Any area that has the namespace filter component in the top nav
### What areas could experience regressions?
Same as above
### Are the repro steps accurate/minimal?
Yes