### PR TITLE
re-disable s3 backup

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1681,7 +1681,7 @@ export default {
             </div>
           </div>
 
-          <template v-if="rkeConfig.etcd.disableSnapshots !== true">
+          <template v-if="false && rkeConfig.etcd.disableSnapshots !== true">
             <div class="spacer" />
 
             <RadioGroup


### PR DESCRIPTION
fixes #5466 - disable s3 backup configuration, which was disabled [here](https://github.com/rancher/dashboard/pull/3993/commits/cd95382289c954dd6f6750aedbc3de9095169460) and re-enabled [here](https://github.com/rancher/dashboard/pull/5196/commits/437286dd1a91ab870e2c35a973895ba3282d29b4)