### PR TITLE
Ensure emberLink is set when creating and editing hosted kubernetes clusters

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -154,12 +154,13 @@ export default {
     emberLink() {
       // Explicitly asked from query string?
       if ( this.subType ) {
-        // For RKE1 Cluster, set the ember link so that we load the page rather than using RKE2 create
-        if (this.isRke1) {
-          const selected = this.subTypes.find(s => s.id === this.subType);
+        // For RKE1 and hosted Kubernetes Clusters, set the ember link so that we load the page rather than using RKE2 create
+        const selected = this.subTypes.find(s => s.id === this.subType);
 
-          return selected?.link;
+        if (selected?.link) {
+          return selected.link;
         }
+
         this.selectType(this.subType, false);
 
         // } else if ( this.value.isImported ) {
@@ -398,7 +399,6 @@ export default {
         return;
       }
 
-      this.emberLink = obj.link;
       this.$router.applyQuery({ [SUB_TYPE]: id });
       this.selectType(id);
     },


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/5423#issuecomment-1074310872 - This issue is _not_ specific to vSphere, but actually applies to the hosted Kubernetes cluster types. The UI should be showing an Ember page for these, but that stopped working as of [this](https://github.com/rancher/dashboard/commit/c14b9a63a8423d22f7ba26db9b83bde223a84f46) change, where the computation of `emberLink` was moved out of `fetch` and into a computed prop. When a cluster type is selected for creation, `clickedType` fires and sets emberLink [here](https://github.com/rancher/dashboard/blob/master/edit/provisioning.cattle.io.cluster/index.vue#L403) - that doesn't work with a computed prop of course, but I think the cleanest fix is to always use `subType.link` as the `emberLink` when present: it is only defined for cluster types that can't be made through vue, ie hosted kubernetes [here](https://github.com/rancher/dashboard/blob/master/edit/provisioning.cattle.io.cluster/index.vue#L242) and rke1/custom [here](https://github.com/rancher/dashboard/blob/master/edit/provisioning.cattle.io.cluster/index.vue#L262-L265)