### PR TITLE
Fix base64 decode when string is undefined

### DIFF
--- a/utils/crypto/index.js
+++ b/utils/crypto/index.js
@@ -45,7 +45,7 @@ export function base64DecodeToBuffer(string) {
 }
 
 export function base64Decode(string) {
-  return base64DecodeToBuffer(string.replace(/[-_]/g, char => char === '-' ? '+' : '/')).toString();
+  return !string ? string : base64DecodeToBuffer(string.replace(/[-_]/g, char => char === '-' ? '+' : '/')).toString();
 }
 
 export function md5(data, digest, callback) {


### PR DESCRIPTION
Fixes #5026 

In both the detail view for secrets and the model, we use the base64decode utility - we assume that for secrets like basic auth, that a username and password key are present - if they are not, we pass undefined to the utility which errors.

This PR just ensures that the base64decode function handles undefined correctly.