### PR TITLE
Corrections to the logic for generating an emberLink

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -152,35 +152,43 @@ export default {
     _RKE2:                () => _RKE2,
 
     emberLink() {
-      // Explicitly asked from query string?
-      if ( this.subType ) {
-        // For RKE1 and hosted Kubernetes Clusters, set the ember link so that we load the page rather than using RKE2 create
-        const selected = this.subTypes.find(s => s.id === this.subType);
+      if (this.value) {
+        // For custom RKE2 clusters, don't load an Ember page.
+        // It should be the dashboard.
+        if ( this.value.isRke2 && (this.value.isCustom || this.subType === 'Custom')) {
+          // For admins, this.value.isCustom is used to check if it is a custom cluster.
+          // For cluster owners, this.subtype is used.
+          this.selectType('custom', false);
 
-        if (selected?.link) {
-          return selected.link;
+          return '';
+        }
+        if ( this.subType ) {
+          // For RKE2/K3s clusters provisioned in Rancher with node pools,
+          // do not use an iFramed Ember page.
+          if ( this.value.isRke2 && this.value.machineProvider ) {
+          // Edit existing RKE2
+            this.selectType(this.value.machineProvider, false);
+
+            return '';
+          }
+
+          // For RKE1 and hosted Kubernetes Clusters, set the ember link
+          // so that we load the page rather than using RKE2 create
+          const selected = this.subTypes.find(s => s.id === this.subType);
+
+          if (selected?.link) {
+            return selected.link;
+          }
+
+          this.selectType(this.subType, false);
+
+          return '';
         }
 
-        this.selectType(this.subType, false);
-
-        // } else if ( this.value.isImported ) {
-        //   // Edit exiting import
-        //   this.isImport = true;
-        //   this.selectType('import', false);
-        return '';
-      } else if ( this.value.isRke2 && this.value.isCustom ) {
-        // Edit exiting custom
-        this.selectType('custom', false);
-
-        return '';
-      } else if ( this.value.isRke2 && this.value.machineProvider ) {
-        // Edit exiting RKE2
-        this.selectType(this.value.machineProvider, false);
-
-        return '';
-      } else if ( this.value.mgmt?.emberEditPath ) {
+        if ( this.value.mgmt?.emberEditPath ) {
         // Iframe an old page
-        return this.value.mgmt.emberEditPath;
+          return this.value.mgmt.emberEditPath;
+        }
       }
 
       return '';

--- a/models/management.cattle.io.cluster.js
+++ b/models/management.cattle.io.cluster.js
@@ -129,7 +129,16 @@ export default class MgmtCluster extends HybridModel {
       provider = 'import';
     }
 
-    const qp = { provider, clusterTemplateRevision };
+    // Avoid passing falsy values as query parameters
+    const qp = { };
+
+    if (provider) {
+      qp['provider'] = provider;
+    }
+
+    if (clusterTemplateRevision) {
+      qp['clusterTemplateRevision'] = clusterTemplateRevision;
+    }
 
     // Copied out of https://github.com/rancher/ui/blob/20f56dc54c4fc09b5f911e533cb751c13609adaf/app/models/cluster.js#L844
     if ( provider === 'import' && isEmpty(this.eksConfig) && isEmpty(this.gkeConfig) ) {


### PR DESCRIPTION
This PR addresses the following issues:

- https://github.com/rancher/dashboard/issues/5442
- https://github.com/rancher/dashboard/issues/5395
- https://github.com/rancher/dashboard/issues/5455

In my previous PR, I changed the emberLink to a computed property without realizing that that could introduce errors into all the create/edit cluster pages. That was a necessary change to recompute the ember link for clusters created from different RKE template versions. But since the value was being recomputed, the logic for how the link was generated also needed to be revisited.

Previously, for K3s/RKE2 clusters provisioned in Rancher, the "selected" value used in the `emberLink` creation was wrong, pointing to an RKE1/create form instead of an RKE2/edit form:

```json
{
   "id":"digitalocean",
   "label":"DigitalOcean",
   "description":"",
   "icon":"/_nuxt/assets/images/providers/digitalocean.svg",
   "group":"rke1",
   "disabled":false,
   "link":"/g/clusters/add/launch/digitalocean",
   "tag":""
}
```

This PR changes the order of the logic so that the `select` value is set correctly.

Since the emberLink affects all cluster create/edit forms, I tested a bunch of different cluster types. Specifically I tested these scenarios:

- Confirmed that a cluster ower can edit a K3s/RKE2 cluster provisioned in Rancher.
- Confirmed (as an admin and as a cluster owner) that editing a hosted Kubernetes cluster still sees the correct iFramed Ember page (made sure Nancy's fix still works https://github.com/rancher/dashboard/pull/5469).
- Confirmed (as an admin and as a cluster owner) that when creating a new RKE1 cluster, the correct iFramed Ember form is used.
- Confirmed (as an admin and as a cluster owner) that when editing an RKE1 cluster, the correct iFramed form is used.
- Confirmed (as an admin and as a cluster owner) that you can create an RKE template and create an RKE1 cluster from the template.*
- Confirmed (as an admin and as a cluster owner) that you can edit/override values in an RKE1 cluster created from an RKE template.*
- Confirmed (as an admin and as a cluster owner) that you can create and edit a custom RKE1 cluster. It uses an iFramed Ember page.
- Confirmed (as an admin and as a cluster owner) that you can create and edit a custom RKE2 cluster. It's a dashboard page that does not include the node pool section.
- Confirmed (as an admin and as a cluster owner) that you can create and edit an imported K3s cluster.

*Outstanding issue: To edit a cluster created from an RKE template, the cluster owner must have permission to see the node template(s) and RKE template that the cluster was created with. The dashboard needs to know the `provider` (e.g. `digitalocean`) and it gets that value from looking at the node template. Ember didn't require this node template permission because it got the `provider` from the cluster data itself (specifically from a value called `clusterProvider`). I have opened a separate issue https://github.com/rancher/dashboard/issues/5475 about showing error messages showing more permissions are needed, or making the dashboard function the same way.