### PR TITLE
set machineOS in rkeConfig to match machine-config os

### DIFF
--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -85,6 +85,9 @@ export default {
       if (neu) {
         this.value.pool.etcdRole = false;
         this.value.pool.controlPlaneRole = false;
+        this.value.pool.machineOS = 'windows';
+      } else {
+        this.value.pool.machineOS = 'linux';
       }
     }
   },

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -923,8 +923,7 @@ export default {
       config.applyDefaults(idx, this.machinePools);
 
       const name = `pool${ ++this.lastIdx }`;
-
-      this.machinePools.push({
+      const pool = {
         id:      name,
         config,
         remove: false,
@@ -944,7 +943,12 @@ export default {
             name:       null,
           },
         },
-      });
+      };
+
+      if (this.provider === 'vmwarevsphere') {
+        pool.pool.machineOS = 'linux';
+      }
+      this.machinePools.push(pool);
 
       this.$nextTick(() => {
         if ( this.$refs.pools?.select ) {


### PR DESCRIPTION
Fixes #5452 - the UI is currently setting `os` on the machine-config but it also needs to set `machineOS` in the rkeConfig.machinePool pool config. These values always need to match.
https://user-images.githubusercontent.com/42977925/159586806-b07e863c-27d2-4035-ba2a-a7e76b5e4ee6.mov

