### PR TITLE
Simplify box on home page that allows user to change landing location

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2328,8 +2328,9 @@ landing:
     title: Commercial Support
     body: Learn about commercial support
   landingPrefs:
-    title: What do you want to see when you log in?
-    body: "You can change where you land when you login:"
+    title: You can change what you see when you login via preferences
+    userPrefs: Preferences
+    body: "You can change where you land when you login"
     options:
       homePage: Take me to the home page
       lastVisited: Take me to the area I last visited

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -7,7 +7,6 @@ import SortableTable from '@/components/SortableTable';
 import BadgeState from '@/components/BadgeState';
 import CommunityLinks from '@/components/CommunityLinks';
 import SimpleBox from '@/components/SimpleBox';
-import LandingPagePreference from '@/components/LandingPagePreference';
 import SingleClusterInfo from '@/components/SingleClusterInfo';
 import { mapGetters, mapState } from 'vuex';
 import { MANAGEMENT, CAPI } from '@/config/types';
@@ -36,7 +35,6 @@ export default {
     BadgeState,
     CommunityLinks,
     SimpleBox,
-    LandingPagePreference,
     SingleClusterInfo
   },
 
@@ -108,6 +106,10 @@ export default {
 
     readWhatsNewAlready() {
       return readReleaseNotes(this.$store);
+    },
+
+    showSetLoginBanner() {
+      return this.homePageCards?.setLoginPage;
     },
 
     showSidePanel() {
@@ -240,9 +242,28 @@ export default {
       this.$router.push({ name: 'docs-doc', params: { doc: 'whats-new' } });
     },
 
+    showUserPrefs() {
+      this.$router.push({ name: 'prefs' });
+    },
+
     async resetCards() {
       await this.$store.dispatch('prefs/set', { key: HIDE_HOME_PAGE_CARDS, value: {} });
       await this.$store.dispatch('prefs/set', { key: READ_WHATS_NEW, value: '' });
+    },
+
+    async closeSetLoginBanner(retry = 0) {
+      let value = this.$store.getters['prefs/get'](HIDE_HOME_PAGE_CARDS);
+
+      if (value === true || value === false || value.length > 0) {
+        value = {};
+      }
+      value.setLoginPage = true;
+
+      const res = await this.$store.dispatch('prefs/set', { key: HIDE_HOME_PAGE_CARDS, value });
+
+      if (retry === 0 && res?.type === 'error' && res?.status === 500) {
+        await this.closeSetLoginBanner(retry + 1);
+      }
     }
   }
 };
@@ -279,9 +300,16 @@ export default {
               </nuxt-link>
             </div>
           </SimpleBox>
-          <SimpleBox :title="t('landing.landingPrefs.title')" :pref="HIDE_HOME_PAGE_CARDS" pref-key="setLoginPage" class="panel">
-            <LandingPagePreference />
-          </SimpleBox>
+
+          <div v-if="!showSetLoginBanner" class="mt-5 mb-10 row">
+            <div class="col span-12">
+              <Banner color="set-login-page" :closable="true" @close="closeSetLoginBanner()">
+                <div>{{ t('landing.landingPrefs.title') }}</div>
+                <a class="hand mr-20" @click.prevent.stop="showUserPrefs"><span v-html="t('landing.landingPrefs.userPrefs')" /></a>
+              </Banner>
+            </div>
+          </div>
+
           <div class="row panel">
             <div v-if="mcm" class="col span-12">
               <SortableTable :table-actions="false" :row-actions="false" key-field="id" :rows="kubeClusters" :headers="clusterHeaders">
@@ -369,7 +397,7 @@ export default {
   </div>
 </template>
 <style lang='scss' scoped>
-  .banner.info.whats-new {
+  .banner.info.whats-new, .banner.set-login-page {
     border: 0;
     margin-top: 10px;
     display: flex;
@@ -381,6 +409,9 @@ export default {
     > a {
       align-self: flex-end;
     }
+  }
+  .banner.set-login-page {
+    border: 1px solid var(--border);
   }
   .table-heading {
     align-items: center;

--- a/store/prefs.js
+++ b/store/prefs.js
@@ -276,6 +276,9 @@ export const actions = {
         }
       } catch (e) {
         // Well it failed, but not much to do about it...
+
+        // Return the error
+        return { type: e.type, status: e.status };
       }
     }
   },


### PR DESCRIPTION
This PR replaces the box for changing landing page prefs on the home page with one that directs the user to the preferences page.

Replaces this:

![image](https://user-images.githubusercontent.com/1955897/159678738-033ec86b-43a4-4af2-b9a0-bba624811568.png)

with this:

![image](https://user-images.githubusercontent.com/1955897/159679095-df9c66cf-f244-455a-b7e5-2148f0a29737.png)

The main reason for doing this is to simplify the page and also with the updates to select boxes, the select box will be grey as it is not enabled by default, and this draws the user eye to the box, which we don't want.