### PR TITLE
Prevent Codemirror elements to float over others

### DIFF
--- a/components/CodeMirror.vue
+++ b/components/CodeMirror.vue
@@ -111,8 +111,12 @@ export default {
 </template>
 
 <style lang="scss">
-  .code-mirror .vue-codemirror .CodeMirror {
-    height: initial;
-    background: none
+  .code-mirror {
+    z-index: 0;
+
+    .vue-codemirror .CodeMirror {
+      height: initial;
+      background: none
+    }
   }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5483
Edit of YAML is prevented due overlapping elements.

### Occurred changes and/or fixed issues
Corrected Codemirror wrapper from overlapping.

### Technical notes summary
Codemirror elements have `z-index` increased relatively to the whole UI, instead of defining container to be 0, which means to not overlap.

### Areas or cases that should be tested
Yam editor.

### Areas which could experience regressions
Anywhere we use Codemirror with cross-component styling `::v-deep ` may be affected. However I have not encountered further `z-index` definitions.

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/159700537-3cba446e-abcc-44e5-898e-4823198dc812.mp4

