### PR TITLE
Update error style of input box

### DIFF
--- a/assets/styles/base/_mixins.scss
+++ b/assets/styles/base/_mixins.scss
@@ -121,7 +121,7 @@
 }
 
 @mixin input-status-color {
-  &:not(.focused) {
+  &, &.focused {
     &.success {
       border: solid 1px var(--success);
       input, .selected {

--- a/assets/styles/base/_mixins.scss
+++ b/assets/styles/base/_mixins.scss
@@ -146,7 +146,8 @@
 
     &.error {
       border: solid 1px var(--error);
-      input, .selected {
+
+      > label {
         color: var(--error);
       }
 


### PR DESCRIPTION
This PR beings in the relevant part from https://github.com/rancher/dashboard/pull/5376/files now that other changes to the controls has been merged.

This is a minor change to the input boxes to show the label in the error color when an error is present, e.g.

![image](https://user-images.githubusercontent.com/1955897/159763653-7fa8c149-eb95-43f0-9901-da5ca6805a19.png)

