### PR TITLE
Minor text renames

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -165,7 +165,7 @@ nav:
     separator: or
 
 product:
-  apps: Apps & Marketplace
+  apps: Apps
   auth: Users & Authentication
   backup: Rancher Backups
   cis: CIS Benchmark
@@ -6363,7 +6363,7 @@ registryConfig:
 ##############################
 
 advancedSettings:
-  label: Advanced Settings
+  label: Settings
   subtext: Typical users will not need to change these. Proceed with caution, incorrect values can break your {appName} installation. Settings which have been customized from default settings are tagged 'Modified'.
   show: Show
   hide: Hide

--- a/config/product/settings.js
+++ b/config/product/settings.js
@@ -34,7 +34,7 @@ export function init(store) {
     labelKey:       'advancedSettings.label',
     name:           'settings',
     namespaced:     false,
-    weight:         99,
+    weight:         100,
     icon:           'folder',
     route:          {
       name:   'c-cluster-product-resource',


### PR DESCRIPTION
This PR completes the updates of a couple of renames - some of these are done in other styling PRs that are being reapplied to the codebase and split up - this PR covers just the name changes:

Advanced Settings -> Settings
Apps & Marketplace -> Apps

The weight of the settings type is bumped up to ensure it stays first (the rename moves it alphabetically down in the sort order)