### PR TITLE
[master]fix monitoring chart defaults for rke2/windows

### DIFF
--- a/chart/monitoring/index.vue
+++ b/chart/monitoring/index.vue
@@ -152,14 +152,16 @@ export default {
       };
 
       merge(this.value, extendedDefaults);
-      if (this.provider.startsWith('rke')) {
+
+      if (this.provider.startsWith('rke2')) {
+        this.$set(this.value.rke2IngressNginx, 'enabled', true);
+        this.$set(this.value.rke2Etcd, 'enabled', true);
+        this.$set(this.value.rkeEtcd, 'enabled', false);
+      } else if (this.provider.startsWith('rke')) {
         this.$set(this.value, 'ingressNginx', this.value.ingressNginx || {});
         this.$set(this.value.ingressNginx, 'enabled', true);
-
-        // For RKE2 ingress-nginx is installed in the kube-system namespace so we have to modify this configuration to support that.
-        if (this.provider.startsWith('rke2')) {
-          this.$set(this.value.ingressNginx, 'namespace', 'kube-system');
-        }
+      } else {
+        this.$set(this.value.rkeEtcd, 'enabled', false);
       }
     }
 

--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -36,7 +36,7 @@ import { findBy, insertAt } from '@/utils/array';
 import Vue from 'vue';
 import { saferDump } from '@/utils/create-yaml';
 import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
-import { LINUX } from '@/store/catalog';
+import { LINUX, WINDOWS } from '@/store/catalog';
 
 const VALUES_STATE = {
   FORM: 'FORM',
@@ -800,7 +800,7 @@ export default {
       const cluster = this.currentCluster;
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
-      const isWindows = cluster?.providerOs === 'windows';
+      const isWindows = (cluster.workerOSs || []).includes(WINDOWS);
       const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
       const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
 
@@ -833,7 +833,7 @@ export default {
       const cluster = this.$store.getters['currentCluster'];
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
-      const isWindows = cluster?.providerOs === 'windows';
+      const isWindows = (cluster.workerOSs || []).includes(WINDOWS);
       const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
       const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
 


### PR DESCRIPTION
fixes #5490, #5491, and #5492 
Clarifications from Arvind via slack:
 #5492 -  `rkeEtd.enabled` should be set `false` for any cluster that is not rke1
 
 #5490 - `rkeIngress.namespace` does not need to be modified for rke2 clusters.
 
 Testing #5491 is difficult without access to the fremont dc vpn: I've made a cluster with one Windows node and verified that monitoring, and its CRDs, installs with `global.cattle.windows.enabled=true`, and I can screenshare on Teams if necessary 