### PR TITLE
Fix SortableTable filtering regexp for IPs.

### DIFF
--- a/components/SortableTable/filtering.js
+++ b/components/SortableTable/filtering.js
@@ -200,7 +200,7 @@ function matches(fields, token, item) {
       const tokenMayBeIp = ipLike.test(token);
 
       if ( tokenMayBeIp ) {
-        const re = new RegExp(`(?:^|\.)${ token }(?:\.|$)`);
+        const re = new RegExp(`(?:^|\\.)${ token }(?:\\.|$)`);
 
         if ( re.test(val) ) {
           return true;


### PR DESCRIPTION
We construct a RegExp string via string literal interpolation, then pass it to the RegExp constructor.  This means we need an extra level of backslash escaping to ensure the constructor gets escapes correctly.