### PR TITLE
Minor styling improvements to info box

### DIFF
--- a/components/InfoBox.vue
+++ b/components/InfoBox.vue
@@ -20,10 +20,8 @@ export default {
 
 <style lang="scss" scoped>
   .info-box {
-    background-color: var(--tabbed-container-bg);
-    border: .5px solid var(--tabbed-border);
-    box-shadow: 0 0 10px var(--shadow);
-    padding: 20px;
+    border: 2px solid var(--tabbed-border);
+    padding: 10px;
     margin-bottom: 20px;
     border-radius: var(--border-radius);
     flex-grow: 1;
@@ -40,7 +38,11 @@ export default {
       color: var(--input-text);
       display: inline-block;
       padding: 5px 10px;
-  }
+    }
+
+    .step-list {
+      margin: 0;
+    }
 
     .info-column:not(:last-child) {
       border-right: 1px solid var(--tabbed-border);


### PR DESCRIPTION
This PR brings out the changes to InfoBox from PR: https://github.com/rancher/dashboard/issues/5520

The other changes in that PR are already in due to the input and select control styling PR.

I made a slight tweak, but now looks like this:

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/1955897/160111724-3bc9dac7-1387-4205-a082-e20e8270337e.png">
