### PR TITLE
Fix storybook github action job name typo

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
 jobs:
-  publsh:
+  publish:
     if: github.repository_owner == 'rancher'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes a typo in the name - doesn't cause any issue in practice, since this is an arbitrary name, but it annoys the vscode spell checker. 