### PR TITLE
Fix chevron direction on subrow expand

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -672,7 +672,15 @@ export default {
                   {{ row.mainRowKey }}<Checkbox class="selection-checkbox" :data-node-id="get(row,keyField)" :value="selectedRows.includes(row)" />
                 </td>
                 <td v-if="subExpandColumn" class="row-expand" align="middle">
-                  <i data-title="Toggle Expand" :class="{icon: true, 'icon-chevron-right': true, 'icon-chevron-down': !!expanded[get(row, keyField)]}" @click.stop="toggleExpand(row)" />
+                  <i
+                    data-title="Toggle Expand"
+                    :class="{
+                      icon: true,
+                      'icon-chevron-right': !isExpanded(row),
+                      'icon-chevron-down': isExpanded(row)
+                    }"
+                    @click.stop="toggleExpand(row)"
+                  />
                 </td>
                 <template v-for="col in columns">
                   <slot


### PR DESCRIPTION
#5533 

This fixes the expandable sub-row chevron not changing direction when clicked.

https://user-images.githubusercontent.com/40806497/160457547-ae53a277-9d27-4e13-81ab-b5a0c38fccee.mp4

 ---

There was an existing method that would determine if the row was expanded (`isExpanded`), this method wasn't being used.