### PR TITLE
Can scale workload from workload detail page

### DIFF
--- a/components/form/PlusMinus.vue
+++ b/components/form/PlusMinus.vue
@@ -5,6 +5,10 @@ export default {
       type:     Number,
       required: true,
     },
+    label: {
+      type:    String,
+      default: ''
+    },
     minusTooltip: {
       type:    String,
       default: null,
@@ -41,6 +45,7 @@ export default {
 
 <template>
   <div class="plus-minus">
+    <span v-if="label" class="label">{{ label }} </span>
     <button v-tooltip="minusTooltip" :disabled="disabled || !canMinus" type="button" class="btn btn-sm role-secondary" @click="$emit('minus')">
       <i class="icon icon-sm icon-minus" />
     </button>
@@ -68,5 +73,8 @@ export default {
     align-items: center;
     justify-content: center;
   }
+}
+.label {
+  padding-right: 1em;
 }
 </style>

--- a/detail/workload/index.vue
+++ b/detail/workload/index.vue
@@ -12,7 +12,10 @@ import DashboardMetrics from '@/components/DashboardMetrics';
 import V1WorkloadMetrics from '@/mixins/v1-workload-metrics';
 import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@/utils/grafana';
+import PlusMinus from '@/components/form/PlusMinus';
+import { SCALABLE_WORKLOAD_TYPES } from '~/config/types';
 
+const SCALABLE_TYPES = Object.values(SCALABLE_WORKLOAD_TYPES);
 const WORKLOAD_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-workload-pods-1/rancher-workload-pods?orgId=1';
 const WORKLOAD_METRICS_SUMMARY_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-workload-1/rancher-workload?orgId=1';
 
@@ -41,7 +44,8 @@ export default {
     Loading,
     ResourceTabs,
     CountGauge,
-    SortableTable
+    SortableTable,
+    PlusMinus
   },
 
   mixins: [CreateEditView, V1WorkloadMetrics],
@@ -65,12 +69,20 @@ export default {
 
   data() {
     return {
-      allPods: null, allJobs: [], WORKLOAD_METRICS_DETAIL_URL, WORKLOAD_METRICS_SUMMARY_URL, showMetrics: false
+      allPods:     null,
+      allJobs:     [],
+      WORKLOAD_METRICS_DETAIL_URL,
+      WORKLOAD_METRICS_SUMMARY_URL,
+      showMetrics: false,
     };
   },
 
   computed:   {
     ...mapGetters(['currentCluster']),
+
+    isActive() {
+      return this.value.metadata.state.name === 'active';
+    },
 
     isJob() {
       return this.value.type === WORKLOAD_TYPES.JOB;
@@ -171,14 +183,51 @@ export default {
       const total = this.isCronJob ? this.totalRuns : this.value.pods.length;
 
       return !jobGauges.find(jg => jg.count === total);
-    }
+    },
+
+    canScale() {
+      return !!SCALABLE_TYPES.includes(this.value.type) && this.value.canUpdate;
+    },
   },
+  methods: {
+    async scale(isUp) {
+      try {
+        if (isUp) {
+          await this.value.scaleUp();
+        } else {
+          await this.value.scaleDown();
+        }
+      } catch (err) {
+        this.$store.dispatch('growl/fromError', {
+          title: this.t('workload.list.errorCannotScale', { direction: isUp ? 'up' : 'down', workloadName: this.value.name }),
+          err
+        },
+        { root: true });
+      }
+    },
+    async scaleDown() {
+      await this.scale(false);
+    },
+    async scaleUp() {
+      await this.scale(true);
+    },
+  }
 };
 </script>
 
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else>
+    <div v-if="canScale" class="right-align flex">
+      <PlusMinus
+        class="text-right"
+        :label="t('tableHeaders.scale')"
+        :value="value.spec.replicas"
+        :disabled="!isActive"
+        @minus="scaleDown"
+        @plus="scaleUp"
+      />
+    </div>
     <h3>
       {{ isJob || isCronJob ? t('workload.detailTop.runs') :t('workload.detailTop.pods') }}
     </h3>
@@ -249,6 +298,9 @@ export default {
 </template>
 
 <style lang='scss' scoped>
+.right-align {
+  float: right;
+}
 .gauges {
   display: flex;
   justify-content: space-around;


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5114

New `Scale` buttons:
<img width="1298" alt="Screen Shot 2022-03-28 at 8 29 12 PM" src="https://user-images.githubusercontent.com/20599230/160528529-14b8f9b1-136b-4f1e-84c8-0daa8b65b1e6.png">

To test this PR,

1. I created a Deployment of `nginx:latest` in the default namespace.
2. I went to the Deployment detail page and scaled it up and down with the plus and minus buttons. The workload state changed and the buttons were disabled while transitioning.
3. I temporarily hardcoded an error just to make sure an error message shows up properly when needed (see screenshot below).

Example of how an error is displayed:
<img width="1280" alt="Screen Shot 2022-03-28 at 8 28 31 PM" src="https://user-images.githubusercontent.com/20599230/160528468-7953e0ac-c933-482f-aaa5-118539126d60.png">


