### PR TITLE
Cluster shell resize icon click correctly minimizes window instead of closing it

### DIFF
--- a/components/nav/WindowManager/index.vue
+++ b/components/nav/WindowManager/index.vue
@@ -92,7 +92,7 @@ export default {
 
     hide() {
       if ( this.tabs.length ) {
-        document.documentElement.style.setProperty('--wm-height', `calc(var(--wm-tab-height) + 2px)`);
+        document.documentElement.style.setProperty('--wm-height', `31px`);
       } else {
         document.documentElement.style.setProperty('--wm-height', '0');
       }

--- a/components/nav/WindowManager/index.vue
+++ b/components/nav/WindowManager/index.vue
@@ -92,7 +92,7 @@ export default {
 
     hide() {
       if ( this.tabs.length ) {
-        document.documentElement.style.setProperty('--wm-height', `31px`);
+        document.documentElement.style.setProperty('--wm-height', `calc(var(--wm-tab-height, 29px) + 2px)`);
       } else {
         document.documentElement.style.setProperty('--wm-height', '0');
       }


### PR DESCRIPTION
This PR addresses #5209 

The test this pr 

- Navigate to a cluster
- Open the shell
- Click on the resize icon
- Shell window should minimize to the bottom of the window
Previous incorrect functionality closed the window

![2022-03-29_00-00-36 (1)](https://user-images.githubusercontent.com/13671297/160552579-c68362c5-4494-4ee1-940c-a850ed05f85b.gif)
