### PR TITLE
Neill/5346/cluster health condition icon

### DIFF
--- a/components/formatter/ClusterLink.vue
+++ b/components/formatter/ClusterLink.vue
@@ -1,0 +1,88 @@
+<script>
+import { get } from '@/utils/object';
+
+export default {
+  props:      {
+    value: {
+      type:     String,
+      default: ''
+    },
+    row: {
+      type:     Object,
+      required: true
+    },
+    reference: {
+      type:    String,
+      default: null,
+    }
+  },
+  computed:   {
+    to() {
+      if ( this.row && this.reference ) {
+        return get(this.row, this.reference);
+      }
+
+      return this.row?.detailLocation;
+    },
+    clusterHasIssues() {
+      return this.row.status?.conditions?.some(condition => condition.error === true);
+    },
+    statusErrorConditions() {
+      if (this.clusterHasIssues) {
+        return this.row?.status.conditions.filter(condition => condition.error === true);
+      }
+
+      return false;
+    },
+    formattedConditions() {
+      if (this.clusterHasIssues) {
+        const filteredConditions = this.statusErrorConditions;
+        const formattedTooltip = [];
+
+        filteredConditions
+          .forEach((c) => {
+            formattedTooltip.push(`<p>${ [c.type] } (${ c.status })</p>`);
+          });
+
+        return formattedTooltip.toString().replaceAll(',', '');
+      }
+
+      return false;
+    },
+  }
+};
+
+</script>
+<template>
+  <span>
+    <n-link v-if="to" :to="to">
+      {{ value }}
+    </n-link>
+    <span v-else>{{ value }}</span>
+    <i
+      v-if="clusterHasIssues"
+      v-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
+      class="conditions-alert-icon icon-error icon-lg"
+    />
+  </span>
+</template>
+
+<style lang="scss" scoped>
+  .conditions-alert-icon {
+    color: var(--error);
+    padding-left: 2px;
+  }
+  ::v-deep {
+    .labeled-tooltip, .status-icon {
+      position: relative;
+      display: inline;
+      left: auto;
+      right: auto;
+      top: 2px;
+      bottom: auto;
+    }
+  }
+  .mytooltip ul {
+    outline: 1px dashed red;
+  }
+</style>

--- a/config/product/manager.js
+++ b/config/product/manager.js
@@ -136,7 +136,14 @@ export function init(store) {
 
   headers(CAPI.RANCHER_CLUSTER, [
     STATE,
-    NAME_COL,
+    {
+      name:          'name',
+      labelKey:      'tableHeaders.name',
+      value:         'nameDisplay',
+      sort:          ['nameSort'],
+      formatter:     'ClusterLink',
+      canBeVariable: true,
+    },
     {
       name:     'kubernetesVersion',
       labelKey: 'tableHeaders.version',


### PR DESCRIPTION
This PR addresses #5183 and #5346 by adding a new formatter component similar to the existing LinkDetail component.

To test this PR, create a cluster with one or more status condition error states (memory pressure, disk pressure, etc)

The cluster management page will now display a red error icon next to any clusters with errors.
Hovering over the icon will show a tooltip with the status conditions in error.

<img width="1258" alt="2022-03-29_03-00-21" src="https://user-images.githubusercontent.com/13671297/160586628-41d69da8-aace-45e2-b1c2-7ab0ec5245b7.png">


