### PR TITLE
Inconsistencies with Cluster metrics across the UI

### DIFF
--- a/components/formatter/PercentageBar.vue
+++ b/components/formatter/PercentageBar.vue
@@ -31,7 +31,7 @@ export default {
 
 <template>
   <p v-if="!value || value === '0'">
-    N/A
+    {{ t('generic.na') }}
   </p>
   <PercentageBarComponent
     v-else

--- a/components/formatter/PercentageBar.vue
+++ b/components/formatter/PercentageBar.vue
@@ -30,5 +30,12 @@ export default {
 </script>
 
 <template>
-  <PercentageBarComponent :value="percentage" :show-percentage="true" />
+  <p v-if="!value || value === '0'">
+    N/A
+  </p>
+  <PercentageBarComponent
+    v-else
+    :value="percentage"
+    :show-percentage="true"
+  />
 </template>

--- a/components/formatter/PodsUsage.vue
+++ b/components/formatter/PodsUsage.vue
@@ -9,10 +9,15 @@ export default {
     },
   },
   data() {
-    return { podsUsage: null };
+    return {
+      loading:   true,
+      podsUsage: null
+    };
   },
   async fetch() {
     const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.row?.id }/v1/counts` });
+
+    this.loading = false;
     const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
     const totalPods = this.row?.status?.allocatable?.pods;
 
@@ -26,7 +31,10 @@ export default {
 </script>
 
 <template>
-  <p>{{ podsUsage }}</p>
+  <i v-if="loading" class="icon icon-spinner icon-spin" />
+  <p v-else>
+    {{ podsUsage }}
+  </p>
 </template>
 
 <style lang="scss" scoped>

--- a/components/formatter/PodsUsage.vue
+++ b/components/formatter/PodsUsage.vue
@@ -3,14 +3,8 @@ import { POD } from '@/config/types';
 export default {
   name:  'PodsUsage',
   props: {
-    clusterId: {
-      type:     String,
-      default:  '',
-      required: true
-    },
-    totalPods: {
-      type:     String,
-      default:  '',
+    row: {
+      type:     Object,
       required: true
     },
   },
@@ -18,11 +12,14 @@ export default {
     return { podsUsage: null };
   },
   async fetch() {
-    const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.clusterId }/v1/counts` });
-    const usedPods = req.data?.[0]?.counts[POD]?.summary?.count;
+    const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.row?.id }/v1/counts` });
+    const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
+    const totalPods = this.row?.status?.allocatable?.pods;
 
-    if (usedPods) {
-      this.podsUsage = `${ usedPods }/${ this.totalPods }`;
+    if (totalPods) {
+      this.podsUsage = `${ usedPods }/${ totalPods }`;
+    } else {
+      this.podsUsage = '——';
     }
   }
 };

--- a/components/formatter/PodsUsage.vue
+++ b/components/formatter/PodsUsage.vue
@@ -1,0 +1,37 @@
+<script>
+import { POD } from '@/config/types';
+export default {
+  name:  'PodsUsage',
+  props: {
+    clusterId: {
+      type:     String,
+      default:  '',
+      required: true
+    },
+    totalPods: {
+      type:     String,
+      default:  '',
+      required: true
+    },
+  },
+  data() {
+    return { podsUsage: null };
+  },
+  async fetch() {
+    const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.clusterId }/v1/counts` });
+    const usedPods = req.data?.[0]?.counts[POD]?.summary?.count;
+
+    if (usedPods) {
+      this.podsUsage = `${ usedPods }/${ this.totalPods }`;
+    }
+  }
+};
+</script>
+
+<template>
+  <p>{{ podsUsage }}</p>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/components/formatter/PodsUsage.vue
+++ b/components/formatter/PodsUsage.vue
@@ -14,19 +14,21 @@ export default {
       podsUsage: null
     };
   },
-  async fetch() {
-    const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.row?.id }/v1/counts` });
+  methods: {
+    async startDelayedLoading() {
+      const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.row?.id }/v1/counts` });
 
-    this.loading = false;
-    const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
-    const totalPods = this.row?.status?.allocatable?.pods;
+      this.loading = false;
+      const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
+      const totalPods = this.row?.status?.allocatable?.pods;
 
-    if (totalPods) {
-      this.podsUsage = `${ usedPods }/${ totalPods }`;
-    } else {
-      this.podsUsage = '——';
+      if (totalPods) {
+        this.podsUsage = `${ usedPods }/${ totalPods }`;
+      } else {
+        this.podsUsage = '——';
+      }
     }
-  }
+  },
 };
 </script>
 

--- a/list/node.vue
+++ b/list/node.vue
@@ -61,7 +61,6 @@ export default {
     const res = await allHash(hash);
 
     this.kubeNodes = res.kubeNodes;
-    console.log('KUBE NODES', this.kubeNodes);
   },
 
   data() {

--- a/list/node.vue
+++ b/list/node.vue
@@ -61,6 +61,7 @@ export default {
     const res = await allHash(hash);
 
     this.kubeNodes = res.kubeNodes;
+    console.log('KUBE NODES', this.kubeNodes);
   },
 
   data() {

--- a/models/cluster/node.js
+++ b/models/cluster/node.js
@@ -188,7 +188,7 @@ export default class ClusterNode extends SteveModel {
   }
 
   get podConsumed() {
-    return this.runningPods.length;
+    return this.pods.length;
   }
 
   get isPidPressureOk() {
@@ -346,10 +346,6 @@ export default class ClusterNode extends SteveModel {
     const allPods = this.$rootGetters['cluster/all'](POD);
 
     return allPods.filter(pod => pod.spec.nodeName === this.name);
-  }
-
-  get runningPods() {
-    return this.pods.filter(pod => pod.isRunning);
   }
 
   get confirmRemove() {

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -4,7 +4,6 @@ import Banner from '@/components/Banner';
 import BannerGraphic from '@/components/BannerGraphic';
 import IndentedPanel from '@/components/IndentedPanel';
 import SortableTable from '@/components/SortableTable';
-import PodsUsage from '@/components/formatter/PodsUsage';
 import BadgeState from '@/components/BadgeState';
 import CommunityLinks from '@/components/CommunityLinks';
 import SimpleBox from '@/components/SimpleBox';
@@ -37,7 +36,6 @@ export default {
     CommunityLinks,
     SimpleBox,
     SingleClusterInfo,
-    PodsUsage
   },
 
   mixins: [PageHeaderActions],
@@ -154,10 +152,11 @@ export default {
 
         },
         {
-          label: this.t('tableHeaders.pods'),
-          name:  'pods',
-          value: '',
-          sort:  ['status.allocatable.pods', 'status.available.pods']
+          label:     this.t('tableHeaders.pods'),
+          name:      'pods',
+          value:     '',
+          sort:      ['status.allocatable.pods', 'status.available.pods'],
+          formatter: 'PodsUsage'
         },
         // {
         //   name:  'explorer',
@@ -356,14 +355,6 @@ export default {
                 <template #col:memory="{row}">
                   <td v-if="memoryAllocatable(row) && !memoryAllocatable(row).match(/^0 [a-zA-z]/)">
                     {{ memoryAllocatable(row) }}
-                  </td>
-                  <td v-else>
-                    &mdash;
-                  </td>
-                </template>
-                <template #col:pods="{row}">
-                  <td v-if="row.status.allocatable && row.status.allocatable.pods!== '0'">
-                    <PodsUsage :cluster-id="row.id" :total-pods="`${row.status.allocatable.pods}`" />
                   </td>
                   <td v-else>
                     &mdash;

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -226,7 +226,6 @@ export default {
       return parseSi(cluster.status.allocatable?.cpu);
     },
     memoryAllocatable(cluster) {
-      console.log(cluster.status);
       const parsedAllocatable = (parseSi(cluster.status.allocatable?.memory) || 0).toString();
       const format = createMemoryFormat(parsedAllocatable);
 
@@ -350,7 +349,7 @@ export default {
                 </template>
                 <template #col:cpu="{row}">
                   <td v-if="cpuAllocatable(row)">
-                    {{ `${cpuUsed(row)}/${cpuAllocatable(row)} ${t('landing.clusters.cores', {count:cpuAllocatable(row) })}` }}
+                    {{ `${cpuAllocatable(row)} ${t('landing.clusters.cores', {count:cpuAllocatable(row) })}` }}
                   </td>
                   <td v-else>
                     &mdash;
@@ -358,7 +357,7 @@ export default {
                 </template>
                 <template #col:memory="{row}">
                   <td v-if="memoryAllocatable(row) && !memoryAllocatable(row).match(/^0 [a-zA-z]/)">
-                    {{ memoryReserved(row) }}
+                    {{ memoryAllocatable(row) }}
                   </td>
                   <td v-else>
                     &mdash;

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -157,9 +157,7 @@ export default {
           label: this.t('tableHeaders.pods'),
           name:  'pods',
           value: '',
-          sort:  ['status.allocatable.pods', 'status.available.pods'],
-          // delayLoading: true,
-          // formatter: 'NAME-OF-COMPONENT'
+          sort:  ['status.allocatable.pods', 'status.available.pods']
         },
         // {
         //   name:  'explorer',

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -4,6 +4,7 @@ import Banner from '@/components/Banner';
 import BannerGraphic from '@/components/BannerGraphic';
 import IndentedPanel from '@/components/IndentedPanel';
 import SortableTable from '@/components/SortableTable';
+import PodsUsage from '@/components/formatter/PodsUsage';
 import BadgeState from '@/components/BadgeState';
 import CommunityLinks from '@/components/CommunityLinks';
 import SimpleBox from '@/components/SimpleBox';
@@ -13,7 +14,7 @@ import { MANAGEMENT, CAPI } from '@/config/types';
 import { NAME as MANAGER } from '@/config/product/manager';
 import { STATE } from '@/config/table-headers';
 import { MODE, _IMPORT } from '@/config/query-params';
-import { createMemoryFormat, formatSi, parseSi } from '@/utils/units';
+import { createMemoryFormat, formatSi, parseSi, createMemoryValues } from '@/utils/units';
 import { getVersionInfo, readReleaseNotes, markReadReleaseNotes, markSeenReleaseNotes } from '@/utils/version';
 import PageHeaderActions from '@/mixins/page-actions';
 import { getVendor } from '@/config/private-label';
@@ -35,7 +36,8 @@ export default {
     BadgeState,
     CommunityLinks,
     SimpleBox,
-    SingleClusterInfo
+    SingleClusterInfo,
+    PodsUsage
   },
 
   mixins: [PageHeaderActions],
@@ -155,7 +157,9 @@ export default {
           label: this.t('tableHeaders.pods'),
           name:  'pods',
           value: '',
-          sort:  ['status.allocatable.pods', 'status.available.pods']
+          sort:  ['status.allocatable.pods', 'status.available.pods'],
+          // delayLoading: true,
+          // formatter: 'NAME-OF-COMPONENT'
         },
         // {
         //   name:  'explorer',
@@ -221,19 +225,18 @@ export default {
     cpuAllocatable(cluster) {
       return parseSi(cluster.status.allocatable?.cpu);
     },
-
-    memoryUsed(cluster) {
-      const parsedUsed = (parseSi(cluster.status.requested?.memory) || 0).toString();
-      const format = createMemoryFormat(parsedUsed);
-
-      return formatSi(parsedUsed, format);
-    },
-
     memoryAllocatable(cluster) {
+      console.log(cluster.status);
       const parsedAllocatable = (parseSi(cluster.status.allocatable?.memory) || 0).toString();
       const format = createMemoryFormat(parsedAllocatable);
 
       return formatSi(parsedAllocatable, format);
+    },
+
+    memoryReserved(cluster) {
+      const memValues = createMemoryValues(cluster?.status?.allocatable?.memory, cluster?.status?.requested?.memory);
+
+      return `${ memValues.useful }/${ memValues.total } ${ memValues.units }`;
     },
 
     showWhatsNew() {
@@ -355,7 +358,7 @@ export default {
                 </template>
                 <template #col:memory="{row}">
                   <td v-if="memoryAllocatable(row) && !memoryAllocatable(row).match(/^0 [a-zA-z]/)">
-                    {{ `${memoryUsed(row)}/${memoryAllocatable(row)}` }}
+                    {{ memoryReserved(row) }}
                   </td>
                   <td v-else>
                     &mdash;
@@ -363,7 +366,7 @@ export default {
                 </template>
                 <template #col:pods="{row}">
                   <td v-if="row.status.allocatable && row.status.allocatable.pods!== '0'">
-                    {{ `${row.status.requested.pods}/${row.status.allocatable.pods}` }}
+                    <PodsUsage :cluster-id="row.id" :total-pods="`${row.status.allocatable.pods}`" />
                   </td>
                   <td v-else>
                     &mdash;

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -152,11 +152,12 @@ export default {
 
         },
         {
-          label:     this.t('tableHeaders.pods'),
-          name:      'pods',
-          value:     '',
-          sort:      ['status.allocatable.pods', 'status.available.pods'],
-          formatter: 'PodsUsage'
+          label:        this.t('tableHeaders.pods'),
+          name:         'pods',
+          value:        '',
+          sort:         ['status.allocatable.pods', 'status.available.pods'],
+          formatter:    'PodsUsage',
+          delayLoading: true
         },
         // {
         //   name:  'explorer',


### PR DESCRIPTION
Addresses Github issue: [#5430](https://github.com/rancher/dashboard/issues/5430)
Addresses Zube issue: [#5456](https://zube.io/rancher/dashboard-ui/c/5456)


- Fix number of PODS on homepage cluster table by displaying the proper PODs usage (`PodsUsage` formatter)
- Fix units for MEM on homepage cluster table to always be GiB (consistent with the rest of the UI)
- Show **total** number of nodes rather that **useful** nodes in cluster dashboard view 
- Remove reserved info for CPU and MEM in cluster table in homepage 
- Fix PODs usage in nodes list view (matches cluster dashboard and cluster table in homepage)
- Display N/A when usage is zero for CPU, MEM, PODS in cluster `nodes list view`

**Preview**

_homepage_
<img width="1896" alt="Screenshot 2022-03-29 at 14 25 25" src="https://user-images.githubusercontent.com/97888974/160622485-fa4fd625-f3f2-4aad-913e-d3f757839b1d.png">

_nodes list view_
<img width="1896" alt="Screenshot 2022-03-29 at 14 25 14" src="https://user-images.githubusercontent.com/97888974/160622516-fcd85cdf-f8d6-4f7e-8488-acc12d536b16.png">

_cluster dashboard_
<img width="1896" alt="Screenshot 2022-03-29 at 14 25 41" src="https://user-images.githubusercontent.com/97888974/160622523-64df9e7d-2768-42fb-a0d8-c2cb379b5479.png">

