### PR TITLE
Change title of support block on home page when custom link set

### DIFF
--- a/assets/styles/global/_button.scss
+++ b/assets/styles/global/_button.scss
@@ -103,12 +103,15 @@ button,
   background: var(--accent-btn);
   border: solid 1px var(--primary);
   color: var(--primary);
-  line-height: $btn-height - 2px;
 
   &:focus, &.focused {
     background-color: var(--primary-hover-bg);
     color: var(--primary-text);
-  }  
+  }
+
+  &.btn:not(.btn-sm) {
+    line-height: $btn-height - 2px;
+  }
 }
 
 .role-link {

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2320,6 +2320,7 @@ landing:
   gettingStarted:
     title: Getting Started
     body: Take a look at the the quick getting started guide. For Cluster Manager users, learn more about where you can find your favorite features in the Dashboard UI.
+  support: Support
   community:
     title: Community Support
     docs: Docs

--- a/components/CommunityLinks.vue
+++ b/components/CommunityLinks.vue
@@ -44,8 +44,14 @@ export default {
         return options(this.uiIssuesSetting?.value, true);
       }
 
-      return options( this.uiIssuesSetting?.value);
+      return options(this.uiIssuesSetting?.value);
     },
+
+    title() {
+      const hasCustomizedFileIssueLink = this.uiIssuesSetting?.value;
+
+      return hasCustomizedFileIssueLink ? 'landing.support' : 'landing.community.title';
+    }
   },
   methods: {
     show() {
@@ -60,7 +66,7 @@ export default {
 
 <template>
   <div>
-    <SimpleBox :title="t('landing.community.title')" :pref="pref" :pref-key="prefKey">
+    <SimpleBox :title="t(title)" :pref="pref" :pref-key="prefKey">
       <div v-for="(value, name) in options" :key="name" class="support-link">
         <a v-t="name" :href="value" target="_blank" rel="noopener noreferrer nofollow" />
       </div>


### PR DESCRIPTION
Fixes #5461 

This PR changes the title of the support card on the home page to 'Support' instead of 'Community Support' when a custom link is set for the Issue Reporting URL, e.g.

![image](https://user-images.githubusercontent.com/1955897/160710574-54f929f8-e28f-46a3-a5ce-1c0414b27375.png)

To test, go to Global Settings -> Branding and under Support Links, enter a URL for the  Issue Reporting URL. Click 'Apply'.

On the Home page, the support card now has a title of 'Support' and not 'Community Support'.

Note: This PR also fixes an issue with a recent change to the tertiary button which fixed the line height to 38px - it now only does that for a button usage that is not a small button. This fixes a rendering issue with the cluster count on the home page.
