### PR TITLE
SortableTable Performance: Optimise row mouse over/leave handlers

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -933,7 +933,13 @@ export default {
             :row="row.row"
             :sub-matches="subMatches"
           >
-            <tr v-if="row.row.stateDescription" :key="row.key + '-description'" class="state-description sub-row">
+            <tr
+              v-if="row.row.stateDescription"
+              :key="row[keyField] + '-description'"
+              class="state-description sub-row"
+              @mouseenter="onRowMouseEnter"
+              @mouseleave="onRowMouseLeave"
+            >
               <td v-if="tableActions" class="row-check" align="middle">
               </td>
               <td :colspan="fullColspan - (tableActions ? 1: 0)" :class="{ 'text-error' : row.row.stateObj.error }">

--- a/components/SortableTable/selection.js
+++ b/components/SortableTable/selection.js
@@ -14,14 +14,10 @@ export default {
     this._onRowClickBound = this.onRowClick.bind(this);
     this._onRowMousedownBound = this.onRowMousedown.bind(this);
     this._onRowContextBound = this.onRowContext.bind(this);
-    this._onRowMouseEnterBound = this.onRowMouseEnter.bind(this);
-    this._onRowMouseLeaveBound = this.onRowMouseLeave.bind(this);
 
     $table.on('click', '> TBODY > TR', this._onRowClickBound);
     $table.on('mousedown', '> TBODY > TR', this._onRowMousedownBound);
     $table.on('contextmenu', '> TBODY > TR', this._onRowContextBound);
-    $table.on('mouseenter', '> TBODY > TR', this._onRowMouseEnterBound);
-    $table.on('mouseleave', '> TBODY > TR', this._onRowMouseLeaveBound);
   },
 
   beforeDestroy() {
@@ -30,8 +26,6 @@ export default {
     $table.off('click', '> TBODY > TR', this._onRowClickBound);
     $table.off('mousedown', '> TBODY > TR', this._onRowMousedownBound);
     $table.off('contextmenu', '> TBODY > TR', this._onRowContextBound);
-    $table.off('mouseenter', '> TBODY > TR', this._onRowMouseEnterBound);
-    $table.off('mouseleave', '> TBODY > TR', this._onRowMouseLeaveBound);
   },
 
   computed: {
@@ -275,7 +269,7 @@ export default {
 
         this.$store.commit(`action-menu/show`, {
           resources,
-          elem: actionElement
+          event: e.originalEvent || e, // Handle jQuery event and raw event
         });
 
         return;


### PR DESCRIPTION
This PR reduces the number of mouse enter/leave handlers in the SortableTable.

Currently we add them to every row - their purpose is to ensure that when there is a sub-row, hovering the row/sub-row highlights both the row and its sub-row.

The highlighting of a sub-row for a row when a users hovers on the row is handled by css via the + operator - so we don't actually need to add mouse handlers to the rows for this behaviour.

This PR ensures we only add mouse enter/leave handlers for sub-rows - this needs to highlight the row above, which can't be done in css.

The handlers are moved to the Vue template rather than using jQuery.