### PR TITLE
Error messages appear below form buttons

### DIFF
--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -20,6 +20,10 @@ export default Vue.extend({
     closable: {
       type:    Boolean,
       default: false,
+    },
+    stacked: {
+      type:    Boolean,
+      default: false,
     }
   },
   computed: {
@@ -34,7 +38,14 @@ export default Vue.extend({
 });
 </script>
 <template>
-  <div class="banner" :class="{[color]: true, closable}">
+  <div
+    class="banner"
+    :class="{
+      [color]: true,
+      closable,
+      stacked
+    }"
+  >
     <slot>
       <t v-if="labelKey" :k="labelKey" :raw="true" />
       <span v-else-if="messageLabel">{{ messageLabel }}</span>
@@ -56,6 +67,19 @@ export default Vue.extend({
     transition: all 0.2s ease;
     position: relative;
     line-height: 20px;
+
+    &.stacked {
+      padding: 0 10px;
+      margin: 0;
+      transition: none;
+
+      &:first-child {
+        padding-top: 10px;
+      }
+      &:last-child {
+        padding-bottom: 10px;
+      }
+    }
 
     &.closable {
       padding-right: 40px;

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -184,6 +184,13 @@ export default {
       }
     },
 
+    /**
+     * Dismiss given error
+     */
+    closeError(index) {
+      this.errors.splice(index, 1);
+    },
+
     emitOrRoute() {
       if ( this.cancelEvent ) {
         this.$emit('cancel');
@@ -249,6 +256,20 @@ export default {
       :is="(isView? 'div' : 'form')"
       class="create-resource-container cru__form"
     >
+      <div
+        class="cru__errors"
+        :v-if="errors.length"
+      >
+        <Banner
+          v-for="(err, i) in errors"
+          :key="i"
+          color="error"
+          :label="stringify(err)"
+          :stacked="true"
+          :closable="true"
+          @close="closeError(i)"
+        />
+      </div>
       <div
         v-if="showSubtypeSelection"
         class="subtypes-container"
@@ -414,16 +435,6 @@ export default {
           </template>
         </ResourceYaml>
       </section>
-
-      <div
-        v-for="(err, idx) in errors"
-        :key="idx"
-      >
-        <Banner
-          color="error"
-          :label="stringify(err)"
-        />
-      </div>
     </form>
   </section>
 </template>
@@ -511,6 +522,14 @@ $logo-space: 100px;
     margin-right: -$space-m;
     margin-bottom: -$space-m;
     padding: $space-s $space-m;
+  }
+
+  &__errors {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: var(--header-bg);
+    margin: 10px 0;
   }
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5515
Correct issue with the CRU form errors hidden below the action footer.

### Occurred changes and/or fixed issues
Editor view forms errors are now stuck to the top and can be dismissed.

### Technical notes summary
Extended `Banner` component capabilities, allowing to stack.

Since it seems like our current configuration does not allow to tests components which use Typescript, this is postponed to another time.

### Areas or cases that should be tested
Any editor and YAML editor, e.g. deployments `/c/local/explorer/apps.deployment/create#general`.

### Areas which could experience regressions
Not aware of any collateral side effect.

### Screenshot/Video
![Screenshot from 2022-03-31 18-56-47](https://user-images.githubusercontent.com/5009481/161109998-c3781a0d-cddc-49a8-9c03-1d159b0c6eda.png)
![Screenshot from 2022-03-31 18-56-30](https://user-images.githubusercontent.com/5009481/161110005-f874228e-6fa2-4f46-9141-4cea7c159a9d.png)
![Screenshot from 2022-03-31 18-59-47](https://user-images.githubusercontent.com/5009481/161110101-a3d9f991-06cb-40a5-85d9-9eb16ca24632.png)
![Screenshot from 2022-03-31 18-59-38](https://user-images.githubusercontent.com/5009481/161110114-cc9463c0-e19b-461d-8864-85ccefd79ea6.png)
