### PR TITLE
Implement drone-plugin-fossa

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -308,3 +308,19 @@ steps:
     target: releases.rancher.com/dashboard/${DRONE_TAG}.tar.gz
     token:
       from_secret: google_auth_key
+
+---
+
+kind: pipeline
+name: fossa
+
+steps:
+- name: fossa
+  image: rancher/drone-fossa:latest
+  settings:
+    api_key:
+      from_secret: FOSSA_API_KEY
+  when:
+    instance:
+      - drone-publish.rancher.io
+

--- a/docs/developer/fossa.md
+++ b/docs/developer/fossa.md
@@ -1,0 +1,4 @@
+# FOSSA
+
+FOSSA is part of our efforts to ensure license compliance and scan for CVEs in dependencies. The results are published to a Fossa dashboard, you can request access to the Fossa dashboard via SUSE IT SD.
+


### PR DESCRIPTION
By default, this plugin will run the analyze command per the generic CI documentation for FOSSA.