### PR TITLE
Add Pod restart count to workload detail page

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3855,6 +3855,7 @@ resourceDetail:
     view: "{subtype} {name}"
   masthead:
     age: Age
+    restartCount: Pod Restarts
     defaultBannerMessage:
       error: This resource is currently in an error state, but there isn't a detailed message available.
       transitioning: This resource is currently in a transitioning state, but there isn't a detailed message available.
@@ -4522,6 +4523,7 @@ tableHeaders:
   persistentVolumeClaim: Persistent Volume Claim
   persistentVolumeSource: Source
   podImages: Image
+  podRestarts: Restarts
   pods: Pods
   port: Port
   protocol: Protocol

--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -337,7 +337,8 @@ export default {
           <span v-if="isNamespace && project">{{ t("resourceDetail.masthead.project") }}: {{ project.nameDisplay }}</span>
           <span v-else-if="isWorkspace">{{ t("resourceDetail.masthead.workspace") }}: <nuxt-link :to="workspaceLocation">{{ namespace }}</nuxt-link></span>
           <span v-else-if="namespace">{{ t("resourceDetail.masthead.namespace") }}: <nuxt-link :to="namespaceLocation">{{ namespace }}</nuxt-link></span>
-          <span v-if="parent.showAge">{{ t("resourceDetail.masthead.age") }}: <LiveDate class="live-date" :value="get(value, 'metadata.creationTimestamp')" /></span>
+          <span v-if="parent.showAge">{{ t("resourceDetail.masthead.age") }}: <LiveDate class="live-data" :value="get(value, 'metadata.creationTimestamp')" /></span>
+          <span v-if="value.showPodRestarts">{{ t("resourceDetail.masthead.restartCount") }}:<span class="live-data"> {{ value.restartCount }}</span></span>
         </div>
       </div>
       <slot name="right">
@@ -413,7 +414,7 @@ export default {
       margin: 5px 20px 5px 0px;
     }
 
-    .live-date {
+    .live-data {
       color: var(--body-text)
     }
   }

--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -262,6 +262,12 @@ export const POD_IMAGES = {
   formatter: 'PodImages'
 };
 
+export const POD_RESTARTS = {
+  name:      'pod_restarts',
+  labelKey:  'tableHeaders.podRestarts',
+  value:     'restartCount'
+};
+
 export const ENDPOINTS = {
   name:      'endpoint',
   labelKey:  'tableHeaders.endpoints',

--- a/detail/workload/index.vue
+++ b/detail/workload/index.vue
@@ -1,6 +1,8 @@
 <script>
 import CreateEditView from '@/mixins/create-edit-view';
-import { STATE, NAME, NODE, POD_IMAGES } from '@/config/table-headers';
+import {
+  STATE, NAME, NODE, POD_IMAGES, POD_RESTARTS
+} from '@/config/table-headers';
 import { POD, WORKLOAD_TYPES } from '@/config/types';
 import SortableTable from '@/components/SortableTable';
 import Tab from '@/components/Tabbed/Tab';
@@ -143,7 +145,8 @@ export default {
         STATE,
         NAME,
         NODE,
-        POD_IMAGES
+        POD_IMAGES,
+        POD_RESTARTS
       ];
     },
 

--- a/models/pod.js
+++ b/models/pod.js
@@ -172,4 +172,12 @@ export default class Pod extends SteveModel {
 
     return this.$rootGetters['i18n/t']('resourceTable.groupLabel.node', { name: escapeHtml(name) });
   }
+
+  get restartCount() {
+    if (this.status.containerStatuses) {
+      return this.status?.containerStatuses[0].restartCount || 0;
+    }
+
+    return 0;
+  }
 }

--- a/models/workload.js
+++ b/models/workload.js
@@ -182,6 +182,24 @@ export default class Workload extends SteveModel {
     return this.goToEdit({ sidecar: true });
   }
 
+  get showPodRestarts() {
+    return true;
+  }
+
+  get restartCount() {
+    const pods = this.pods;
+
+    let sum = 0;
+
+    pods.forEach((pod) => {
+      if (pod.status.containerStatuses) {
+        sum += pod.status?.containerStatuses[0].restartCount || 0;
+      }
+    });
+
+    return sum;
+  }
+
   get hasSidecars() {
     const podTemplateSpec = this.type === WORKLOAD_TYPES.CRON_JOB ? this?.spec?.jobTemplate?.spec?.template?.spec : this.spec?.template?.spec;
 


### PR DESCRIPTION
This PR addresses this issue https://github.com/rancher/dashboard/issues/5086 by adding the Pod restart count to the workload detail page.

In a list of Pods, the restart count is added as another column:
<img width="1078" alt="Screen Shot 2022-03-31 at 6 00 37 PM" src="https://user-images.githubusercontent.com/20599230/161176245-c83143c9-3f11-418b-a687-5ce44a5ba991.png">

At the top of the workload detail page, the restart count is a sum of the restarts of all the Pods in the workload:

<img width="429" alt="Screen Shot 2022-03-31 at 6 00 32 PM" src="https://user-images.githubusercontent.com/20599230/161176328-2c35e250-f1d7-4337-8137-8746b75882b2.png">


Note: The restart count measures failures of the Pod as a health check. So it won't be incremented if you do a "restart" with kubectl, because that is terminating Pods and creating new ones. For testing, we want to count restarts of the same Pod, which are only caused by failures.

To increment the restarts of a Pod for testing, I went to cluster explorer, went to an example Deployment and caused destruction:

1. I went to one of the Pods in the Deployment and went to three dots > Execute Shell
2. Got the PID of the process I wanted to kill: `ps aux`
3. Killed the process: `kill -9 <insert PID here>`
4. Confirmed that the restart count was incremented in the table row
5. Confirmed that the total restarts of all Pods in the Deployment was also incremented

My example deployment was from here https://kubernetes.io/docs/tutorials/stateless-application/expose-external-ip-address/ and it was a hello world that used Node, in my case I killed the Node process.