### PR TITLE
Can't create a new project after not specifying Namespace Default Limit once: error never clears when a value is provided

### DIFF
--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -112,22 +112,7 @@ export default {
   methods: {
     async save(saveCb) {
       try {
-        if ( this.value.spec?.resourceQuota?.limit && !Object.keys(this.value.spec.resourceQuota.limit).length ) {
-          delete this.value.spec.resourceQuota.limit;
-        }
-
-        if ( this.value.spec?.resourceQuota && !Object.keys(this.value.spec.resourceQuota).length ) {
-          delete this.value.spec.resourceQuota;
-        }
-
-        if ( this.value.spec?.namespaceDefaultResourceQuota?.limit && !Object.keys(this.value.spec.namespaceDefaultResourceQuota.limit).length ) {
-          delete this.value.spec.namespaceDefaultResourceQuota.limit;
-        }
-
-        if ( this.value.spec?.namespaceDefaultResourceQuota && !Object.keys(this.value.spec.namespaceDefaultResourceQuota).length ) {
-          delete this.value.spec.namespaceDefaultResourceQuota;
-        }
-
+        // clear up of the unused resourceQuotas will now be done on the model side
         const savedProject = await this.value.save();
 
         if (this.membershipUpdate.save) {

--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -2,6 +2,26 @@ import { DEFAULT_PROJECT, SYSTEM_PROJECT } from '@/config/labels-annotations';
 import { MANAGEMENT, NAMESPACE, NORMAN } from '@/config/types';
 import HybridModel from '@/plugins/steve/hybrid-class';
 
+function clearResourceQuotas(val, type) {
+  if (Object.keys(val[type].limit).length) {
+    Object.keys(val[type].limit).forEach((key) => {
+      if (!val[type].limit[key]) {
+        delete val[type].limit[key];
+      }
+    });
+  }
+
+  if ( val[type]?.limit && !Object.keys(val[type].limit).length ) {
+    delete val[type].limit;
+  }
+
+  if ( val[type] && !Object.keys(val[type]).length ) {
+    delete val[type];
+  }
+
+  return val[type];
+}
+
 export default class Project extends HybridModel {
   get isSystem() {
     return this.metadata?.labels?.[SYSTEM_PROJECT] === 'true';
@@ -68,8 +88,8 @@ export default class Project extends HybridModel {
         clusterId:                     this.$rootGetters['currentCluster'].id,
         creatorId:                     this.$rootGetters['auth/principalId'],
         containerDefaultResourceLimit: this.spec.containerDefaultResourceLimit,
-        namespaceDefaultResourceQuota: this.spec.namespaceDefaultResourceQuota,
-        resourceQuota:                 this.spec.resourceQuota,
+        namespaceDefaultResourceQuota: clearResourceQuotas(JSON.parse(JSON.stringify(this.spec)), 'namespaceDefaultResourceQuota'),
+        resourceQuota:                 clearResourceQuotas(JSON.parse(JSON.stringify(this.spec)), 'resourceQuota'),
       }, { root: true });
 
       // The backend seemingly required both labels/annotation and metadata.labels/annotations or it doesn't save the labels and annotations
@@ -91,8 +111,8 @@ export default class Project extends HybridModel {
       normanProject.setLabels(this.metadata.labels);
       normanProject.description = this.spec.description;
       normanProject.containerDefaultResourceLimit = this.spec.containerDefaultResourceLimit;
-      normanProject.namespaceDefaultResourceQuota = this.spec.namespaceDefaultResourceQuota;
-      normanProject.resourceQuota = this.spec.resourceQuota;
+      normanProject.namespaceDefaultResourceQuota = clearResourceQuotas(JSON.parse(JSON.stringify(this.spec)), 'namespaceDefaultResourceQuota');
+      normanProject.resourceQuota = clearResourceQuotas(JSON.parse(JSON.stringify(this.spec)), 'resourceQuota');
 
       return normanProject;
     })();


### PR DESCRIPTION
Addresses Github issue: [#5000](https://github.com/rancher/dashboard/issues/5000)
Addresses Zube issue: [#5022](https://zube.io/rancher/dashboard-ui/c/5022)

- fix issue where clearing up `resourceQuota` props was corrupting the model and creating a blocking error on the interface that prevented the creation of a namespace