### PR TITLE
Allow to close error banners within resource edit without break

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -188,7 +188,9 @@ export default {
      * Dismiss given error
      */
     closeError(index) {
-      this.errors.splice(index, 1);
+      const errors = this.errors.filter((_, i) => i !== index);
+
+      this.$emit('error', errors);
     },
 
     emitOrRoute() {


### PR DESCRIPTION
### Summary
Fixes #5515
With PR https://github.com/rancher/dashboard/pull/5554 the banner errors dismissal causes the app to break. This is aimed to prevent that issue

### Occurred changes and/or fixed issues
Changed errors list manipulation with error list emission.

### Technical notes summary
Prop was erroneously modified and caused errors.

### Areas or cases that should be tested
As in original ticket. 

### Areas which could experience regressions
As in original ticket. 

### Screenshot/Video
![Screenshot from 2022-04-01 15-42-01](https://user-images.githubusercontent.com/5009481/161285308-b212a6b3-c3c7-49ab-add0-f5cc890095e7.png)
