### PR TITLE
node details fail if there is an image without a name

### DIFF
--- a/detail/node.vue
+++ b/detail/node.vue
@@ -150,7 +150,7 @@ export default {
 
       return images.map(image => ({
         // image.names[1] typically has the user friendly name but on occasion there's only one name and we should use that
-        name:      image.names[1] || image.names[0],
+        name:      image.names ? (image.names[1] || image.names[0]) : '---',
         sizeBytes: image.sizeBytes
       }));
     },


### PR DESCRIPTION
Addresses Github issue: [#5408](https://github.com/rancher/dashboard/issues/5408)
Addresses Zube issue: [#5434](https://zube.io/rancher/dashboard-ui/c/5434)

- add fallback for when node image name is not defined
