### PR TITLE
Disable consent banner text overflow wrap

### DIFF
--- a/components/FixedBanner.vue
+++ b/components/FixedBanner.vue
@@ -170,7 +170,6 @@ export default {
   .banner {
     text-align: center;
     line-height: 2em;
-    height: 2em;
     width: 100%;
     padding: 0 20px;
 

--- a/components/FixedBanner.vue
+++ b/components/FixedBanner.vue
@@ -131,7 +131,7 @@ export default {
 
 <template>
   <div v-if="showBanner">
-    <div v-if="!showAsDialog" class="banner banner-banner" :style="bannerStyle" :class="{'banner-consent': consent}">
+    <div v-if="!showAsDialog" class="banner" :style="bannerStyle" :class="{'banner-consent': consent}">
       <!-- text as array to support line breaks programmatically rather than just exposing HTML -->
       <div v-if="isTextAnArray">
         <p v-for="(text, index) in banner.text" :key="index">
@@ -192,11 +192,6 @@ export default {
     z-index: 5000;
     background-color: var(--default);
     opacity: 0.75;
-  }
-  .banner-banner {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
   .banner-dialog {
     z-index: 5001;


### PR DESCRIPTION
This pr addresses #5333 by removing the css which previously hid text overflow. The full text will now display regardless of banner height.