### PR TITLE
State of Machine in Cluster Management page is seen as Active when the node is in Provisioning state

### DIFF
--- a/models/management.cattle.io.nodepool.js
+++ b/models/management.cattle.io.nodepool.js
@@ -79,11 +79,11 @@ export default class MgmtNodePool extends HybridModel {
   }
 
   get pending() {
-    return Math.max(0, this.desired - (this.nodes?.length || 0));
+    return this.nodes?.length ? this.nodes.filter(node => node.state !== 'active').length : 0;
   }
 
   get ready() {
-    return Math.max(0, (this.nodes?.length || 0) - (this.pending || 0));
+    return this.desired - this.pending;
   }
 
   get stateParts() {


### PR DESCRIPTION
Addresses Github issue: [#5443](https://github.com/rancher/dashboard/issues/5443)
Addresses Zube issue: [#5469](https://zube.io/rancher/dashboard-ui/c/5469)

- Fix pending and ready counts for `MgmtNodePool` model

**Preview:**
<img width="1730" alt="Screenshot 2022-04-04 at 13 39 01" src="https://user-images.githubusercontent.com/97888974/161565605-2dcb6ad3-cc75-4a07-b09f-f421659bd0bc.png">

