### PR TITLE
Add additional metadata to workload detail view

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3830,6 +3830,7 @@ resourceDetail:
     created: Created
     deleted: Deleted
     description: Description
+    endpoints: Endpoints
     labels: Labels
     ownerReferences: |-
       {count, plural,

--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -198,6 +198,7 @@ export default {
 
       .detail {
         margin-right: 20px;
+        margin-bottom: 3px;
       }
     }
 

--- a/components/DetailTop.vue
+++ b/components/DetailTop.vue
@@ -3,9 +3,12 @@ import Tag from '@/components/Tag';
 import isEmpty from 'lodash/isEmpty';
 import DetailText from '@/components/DetailText';
 import { _VIEW } from '@/config/query-params';
+import WorkloadDetailEndpoints from '@/components/formatter/WorkloadDetailEndpoints';
 
 export default {
-  components: { DetailText, Tag },
+  components: {
+    DetailText, Tag, WorkloadDetailEndpoints
+  },
 
   props: {
     value: {
@@ -57,6 +60,14 @@ export default {
 
     hasDetails() {
       return !isEmpty(this.details);
+    },
+
+    hasEndpoints() {
+      return !isEmpty(this.value.endpoints);
+    },
+
+    endpoints() {
+      return this.value.endpoints;
     },
 
     hasLabels() {
@@ -121,6 +132,13 @@ export default {
       </div>
     </div>
 
+    <div v-if="hasEndpoints" class="endpoints">
+      <span class="label">
+        {{ t('resourceDetail.detailTop.endpoints') }}:
+      </span>
+      <WorkloadDetailEndpoints v-model="endpoints" />
+    </div>
+
     <div v-if="hasLabels" class="labels">
       <div class="tags">
         <span class="label">
@@ -176,6 +194,10 @@ export default {
         margin: math.div($spacing, 2) $spacing 0 math.div($spacing, 2);
         font-size: 12px;
       }
+    }
+
+    .endpoints {
+      padding-bottom: 1px;
     }
 
     .annotation {

--- a/components/formatter/WorkloadDetailEndpoints.vue
+++ b/components/formatter/WorkloadDetailEndpoints.vue
@@ -93,14 +93,18 @@ export default {
 
 <style lang="scss" scoped>
 .endpoint-tag {
-  margin: 2px 4px 2px 0;
+  display: inline-block;
+}
+.endpoint-tag:not(:first-of-type) {
+  margin: 2px 4px 0 2px;
 }
 .endpoint-link:after {
-  content: ",\a0";
+  content: ',\a0';
   display: inline-block;
-  color: var(--default-text)
-  }
+  color: var(--default-text);
+}
 .endpoint-link:last-of-type:after {
-  content: ''
-  }
+  content: '';
+}
+
 </style>

--- a/components/formatter/WorkloadDetailEndpoints.vue
+++ b/components/formatter/WorkloadDetailEndpoints.vue
@@ -1,0 +1,108 @@
+<script>
+import { NODE } from '@/config/types';
+import Tag from '@/components/Tag';
+
+export default {
+  props: {
+    value: {
+      type:     [Array, String],
+      default: null,
+    },
+    row: {
+      type:     Object,
+      required: true
+    },
+    col: {
+      type:     Object,
+      required: true
+    },
+  },
+
+  components: { Tag },
+
+  computed: {
+    nodes() {
+      return this.$store.getters['cluster/all'](NODE);
+    },
+    // value may be JSON from "field.cattle.io/publicEndpoints" label
+    parsed() {
+      const nodes = this.nodes;
+      const nodeWithExternal = nodes.find(node => !!node.externalIp) || {};
+      const externalIp = nodeWithExternal.externalIp;
+
+      if ( this.value && this.value.length ) {
+        let out ;
+
+        try {
+          out = JSON.parse(this.value);
+          out.forEach((endpoint) => {
+            let protocol = 'http';
+
+            if (endpoint.port === 443) {
+              protocol = 'https';
+            }
+
+            if (endpoint.addresses) {
+              endpoint.link = `${ protocol }://${ endpoint.addresses[0] }:${ endpoint.port }`;
+            } else if (externalIp) {
+              endpoint.link = `${ protocol }://${ externalIp }:${ endpoint.port }`;
+            } else {
+              endpoint.display = `[${ this.t('servicesPage.anyNode') }]:${ endpoint.port }`;
+            }
+          });
+
+          return out;
+        } catch (err) {
+          return this.value[0];
+        }
+      }
+
+      return null;
+    },
+
+    protocol() {
+      const { parsed } = this;
+
+      if ( parsed) {
+        if (this.parsed[0].protocol) {
+          return this.parsed[0].protocol;
+        }
+
+        const match = parsed.match(/^([^:]+):\/\//);
+
+        if ( match ) {
+          return match[1];
+        } else {
+          return 'link';
+        }
+      }
+
+      return null;
+    }
+  },
+};
+</script>
+
+<template>
+  <span>
+    <template v-for="endpoint in parsed">
+      <Tag v-if="endpoint.display" :key="endpoint.display" class="endpoint-tag">{{ endpoint.display }}</Tag>
+      <a
+        v-else
+        :key="endpoint.link"
+        class="endpoint-tag"
+        :href="endpoint.link"
+        target="_blank"
+        rel="nofollow noopener noreferrer"
+      >
+        <Tag v-if="endpoint.port">{{ endpoint.port }}/</Tag>{{ endpoint.protocol }}
+      </a>
+    </template>
+  </span>
+</template>
+
+<style lang="scss" scoped>
+.endpoint-tag {
+  margin: 2px 4px 2px 0;
+}
+</style>

--- a/components/formatter/WorkloadDetailEndpoints.vue
+++ b/components/formatter/WorkloadDetailEndpoints.vue
@@ -8,14 +8,6 @@ export default {
       type:     [Array, String],
       default: null,
     },
-    row: {
-      type:     Object,
-      required: true
-    },
-    col: {
-      type:     Object,
-      required: true
-    },
   },
 
   components: { Tag },
@@ -90,13 +82,11 @@ export default {
       <a
         v-else
         :key="endpoint.link"
-        class="endpoint-tag"
+        class="endpoint-link"
         :href="endpoint.link"
         target="_blank"
         rel="nofollow noopener noreferrer"
-      >
-        <Tag v-if="endpoint.port">{{ endpoint.port }}/</Tag>{{ endpoint.protocol }}
-      </a>
+      ><span v-if="endpoint.port">{{ endpoint.port }}/</span>{{ endpoint.protocol }}</a>
     </template>
   </span>
 </template>
@@ -105,4 +95,12 @@ export default {
 .endpoint-tag {
   margin: 2px 4px 2px 0;
 }
+.endpoint-link:after {
+  content: ",\a0";
+  display: inline-block;
+  color: var(--default-text)
+  }
+.endpoint-link:last-of-type:after {
+  content: ''
+  }
 </style>

--- a/models/workload.js
+++ b/models/workload.js
@@ -1,5 +1,7 @@
 import { findBy, insertAt } from '@/utils/array';
-import { TARGET_WORKLOADS, TIMESTAMP, UI_MANAGED, HCI as HCI_LABELS_ANNOTATIONS } from '@/config/labels-annotations';
+import {
+  TARGET_WORKLOADS, TIMESTAMP, UI_MANAGED, HCI as HCI_LABELS_ANNOTATIONS, CATTLE_PUBLIC_ENDPOINTS
+} from '@/config/labels-annotations';
 import { WORKLOAD_TYPES, SERVICE, POD } from '@/config/types';
 import { clone, get, set } from '@/utils/object';
 import day from 'dayjs';
@@ -281,9 +283,59 @@ export default class Workload extends SteveModel {
     return initContainers;
   }
 
+  get endpoint() {
+    return this?.metadata?.annotations[CATTLE_PUBLIC_ENDPOINTS];
+  }
+
+  get desired() {
+    return this.spec?.replicas || 0;
+  }
+
+  get available() {
+    return this.status?.readyReplicas || 0;
+  }
+
+  get ready() {
+    const readyReplicas = Math.max(0, (this.status?.replicas || 0) - (this.status?.unavailableReplicas || 0));
+
+    if (this.type === WORKLOAD_TYPES.DAEMON_SET) {
+      return readyReplicas;
+    }
+
+    return `${ readyReplicas }/${ this.desired }`;
+  }
+
+  get unavailable() {
+    return this.status?.unavailableReplicas || 0;
+  }
+
+  get upToDate() {
+    return this.status?.updatedReplicas;
+  }
+
   get details() {
     const out = [];
     const type = this._type ? this._type : this.type;
+
+    const detailItem = {
+      endpoint:  {
+        label:     'Endpoints',
+        content:   this.endpoint,
+        formatter: 'WorkloadDetailEndpoints'
+      },
+      ready:     {
+        label:     'Ready',
+        content:   this.ready
+      },
+      upToDate:  {
+        label:     'Up-to-date',
+        content:   this.upToDate
+      },
+      available: {
+        label:     'Available',
+        content:   this.available
+      }
+    };
 
     if (type === WORKLOAD_TYPES.JOB) {
       const { completionTime, startTime } = this.status;
@@ -337,6 +389,34 @@ export default class Workload extends SteveModel {
       content:   this.imageNames,
       formatter: 'PodImages'
     });
+
+    switch (type) {
+    case WORKLOAD_TYPES.DEPLOYMENT:
+      out.push(detailItem.ready, detailItem.upToDate, detailItem.available, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.DAEMON_SET:
+      out.push(detailItem.ready, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.REPLICA_SET:
+      out.push(detailItem.ready, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.STATEFUL_SET:
+      out.push(detailItem.ready, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.REPLICATION_CONTROLLER:
+      out.push(detailItem.ready, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.JOB:
+      out.push(detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.CRON_JOB:
+      out.push(detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.POD:
+      out.push(detailItem.ready);
+      break;
+    default: break;
+    }
 
     return out;
   }

--- a/models/workload.js
+++ b/models/workload.js
@@ -8,6 +8,7 @@ import day from 'dayjs';
 import SteveModel from '@/plugins/steve/steve-class';
 import { shortenedImage } from '@/utils/string';
 import { convertSelectorObj, matching } from '@/utils/selector';
+import { SEPARATOR } from '@/components/DetailTop';
 
 export default class Workload extends SteveModel {
   // remove clone as yaml/edit as yaml until API supported
@@ -283,7 +284,7 @@ export default class Workload extends SteveModel {
     return initContainers;
   }
 
-  get endpoints() {
+  get endpoint() {
     return this?.metadata?.annotations[CATTLE_PUBLIC_ENDPOINTS];
   }
 
@@ -299,7 +300,7 @@ export default class Workload extends SteveModel {
     const readyReplicas = Math.max(0, (this.status?.replicas || 0) - (this.status?.unavailableReplicas || 0));
 
     if (this.type === WORKLOAD_TYPES.DAEMON_SET) {
-      return this.status?.numberReady;
+      return readyReplicas;
     }
 
     return `${ readyReplicas }/${ this.desired }`;
@@ -318,6 +319,11 @@ export default class Workload extends SteveModel {
     const type = this._type ? this._type : this.type;
 
     const detailItem = {
+      endpoint:  {
+        label:     'Endpoints',
+        content:   this.endpoint,
+        formatter: 'WorkloadDetailEndpoints'
+      },
       ready:     {
         label:     'Ready',
         content:   this.ready
@@ -385,16 +391,32 @@ export default class Workload extends SteveModel {
       formatter: 'PodImages'
     });
 
-    function readyTypes(type) {
-      const types = [WORKLOAD_TYPES.DAEMON_SET, WORKLOAD_TYPES.REPLICA_SET, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.REPLICATION_CONTROLLER];
-
-      return types.filter(x => x === type);
-    }
-
-    if (type === WORKLOAD_TYPES.DEPLOYMENT) {
-      out.push(detailItem.ready, detailItem.upToDate, detailItem.available);
-    } else if (readyTypes(type)) {
+    switch (type) {
+    case WORKLOAD_TYPES.DEPLOYMENT:
+      out.push(detailItem.ready, detailItem.upToDate, detailItem.available, SEPARATOR, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.DAEMON_SET:
+      out.push(detailItem.ready, SEPARATOR, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.REPLICA_SET:
+      out.push(detailItem.ready, SEPARATOR, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.STATEFUL_SET:
+      out.push(detailItem.ready, SEPARATOR, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.REPLICATION_CONTROLLER:
+      out.push(detailItem.ready, SEPARATOR, detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.JOB:
+      out.push(detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.CRON_JOB:
+      out.push(detailItem.endpoint);
+      break;
+    case WORKLOAD_TYPES.POD:
       out.push(detailItem.ready);
+      break;
+    default: break;
     }
 
     return out;

--- a/models/workload.js
+++ b/models/workload.js
@@ -283,7 +283,7 @@ export default class Workload extends SteveModel {
     return initContainers;
   }
 
-  get endpoint() {
+  get endpoints() {
     return this?.metadata?.annotations[CATTLE_PUBLIC_ENDPOINTS];
   }
 
@@ -299,7 +299,7 @@ export default class Workload extends SteveModel {
     const readyReplicas = Math.max(0, (this.status?.replicas || 0) - (this.status?.unavailableReplicas || 0));
 
     if (this.type === WORKLOAD_TYPES.DAEMON_SET) {
-      return readyReplicas;
+      return this.status?.numberReady;
     }
 
     return `${ readyReplicas }/${ this.desired }`;
@@ -318,11 +318,6 @@ export default class Workload extends SteveModel {
     const type = this._type ? this._type : this.type;
 
     const detailItem = {
-      endpoint:  {
-        label:     'Endpoints',
-        content:   this.endpoint,
-        formatter: 'WorkloadDetailEndpoints'
-      },
       ready:     {
         label:     'Ready',
         content:   this.ready
@@ -390,32 +385,16 @@ export default class Workload extends SteveModel {
       formatter: 'PodImages'
     });
 
-    switch (type) {
-    case WORKLOAD_TYPES.DEPLOYMENT:
-      out.push(detailItem.ready, detailItem.upToDate, detailItem.available, detailItem.endpoint);
-      break;
-    case WORKLOAD_TYPES.DAEMON_SET:
-      out.push(detailItem.ready, detailItem.endpoint);
-      break;
-    case WORKLOAD_TYPES.REPLICA_SET:
-      out.push(detailItem.ready, detailItem.endpoint);
-      break;
-    case WORKLOAD_TYPES.STATEFUL_SET:
-      out.push(detailItem.ready, detailItem.endpoint);
-      break;
-    case WORKLOAD_TYPES.REPLICATION_CONTROLLER:
-      out.push(detailItem.ready, detailItem.endpoint);
-      break;
-    case WORKLOAD_TYPES.JOB:
-      out.push(detailItem.endpoint);
-      break;
-    case WORKLOAD_TYPES.CRON_JOB:
-      out.push(detailItem.endpoint);
-      break;
-    case WORKLOAD_TYPES.POD:
+    function readyTypes(type) {
+      const types = [WORKLOAD_TYPES.DAEMON_SET, WORKLOAD_TYPES.REPLICA_SET, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.REPLICATION_CONTROLLER];
+
+      return types.filter(x => x === type);
+    }
+
+    if (type === WORKLOAD_TYPES.DEPLOYMENT) {
+      out.push(detailItem.ready, detailItem.upToDate, detailItem.available);
+    } else if (readyTypes(type)) {
       out.push(detailItem.ready);
-      break;
-    default: break;
     }
 
     return out;


### PR DESCRIPTION
This PR addresses #5463 by adding additional metadata to workload detail view. 

In addition to the already existing `image`, `labels`, and `annotations` data, this PR aims to also add `endpoints`, `available`, `ready`, and `up-to-date` information. 

To test this PR, navigate to any workload and verify that the new details at the top of each page match the same data from the workload's list view. 

<img width="1194" alt="Screen Shot 2022-04-07 at 2 22 19 AM" src="https://user-images.githubusercontent.com/13671297/162167918-511f1add-12b8-40fb-84ca-ada7dde7b593.png">

