### PR TITLE
Use correct name for Network Attachment Definition Resource

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6246,8 +6246,8 @@ typeLabel:
     }
   k8s.cni.cncf.io.networkattachmentdefinition: |-
     {count, plural,
-      one { Network }
-      other { Networks }
+      one { Network Attachment Definition }
+      other { Network Attachment Definitions }
     }
   harvesterhci.io.volume: |-
     {count, plural,


### PR DESCRIPTION
Fixes #4962

We show the `k8s.cni.cncf.io.NetworkAttachmentDefintiion` resource as 'Networks' - this PR changes the label we use to the full resource name to avoid confusion.