### PR TITLE
Default upgrade strategy for Control plane is should be 1 when provisioning RKE2 clusters

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -233,9 +233,9 @@ export default {
 
     if ( !this.value.spec.rkeConfig.upgradeStrategy ) {
       set(this.value.spec.rkeConfig, 'upgradeStrategy', {
-        controlPlaneConcurrency:  '10%',
+        controlPlaneConcurrency:  '1',
         controlPlaneDrainOptions: {},
-        workerConcurrency:        '10%',
+        workerConcurrency:        '1',
         workerDrainOptions:       {},
       });
     }


### PR DESCRIPTION
Addresses Github issue: [#5112](https://github.com/rancher/dashboard/issues/5112)
Addresses Zube issue: [#5136](https://zube.io/rancher/dashboard-ui/c/5136)

- change rke2 upgradeStrategy to 1 concurrent `controlplane` and `worker`