### PR TITLE
Custom login error messages - #5427

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6400,6 +6400,7 @@ advancedSettings:
     'kubeconfig-token-ttl-minutes': 'Custom max TTL (in minutes) on a kubeconfig token.'
     'rke-metadata-config': 'Configure RKE metadata refresh parameters.'
     'ui-banners': 'Classification banner is used to display a custom fixed banner in the header, footer, or both.'
+    'custom-notifications': Edit custom notifications
     'ui-consent-banner': 'Banner is used to display a custom consent banner presented to users during login.'
     'ui-default-landing': 'The default page users land on after login.'
     'brand': Folder name for an alternative theme defined in '/assets/brand'
@@ -6522,7 +6523,13 @@ branding:
     tip: You can override the link color used throughout the UI with a custom color of your choice.
     useCustom: Use a Custom Link Color
     example: Link Example
-
+notifications:
+  header: Custom notifications
+  menuLabel: 'Custom Notifications'
+  loginError:
+    header: Custom Error Messages
+    showCheckboxLabel: Show custom login error 
+    messageLabel: Text to display
 resourceQuota:
   label: Resource Quotas
   headers:

--- a/components/form/BannerSettings.vue
+++ b/components/form/BannerSettings.vue
@@ -7,6 +7,8 @@ import RadioGroup from '@/components/form/RadioGroup';
 import { _EDIT, _VIEW } from '@/config/query-params';
 
 export default ({
+  name: 'BannerSettings',
+
   props: {
     value: {
       type:    Object,

--- a/components/form/NotificationSettings.vue
+++ b/components/form/NotificationSettings.vue
@@ -1,0 +1,59 @@
+<script>
+import LabeledInput from '@/components/form/LabeledInput';
+import Checkbox from '@/components/form/Checkbox';
+
+export default ({
+
+  name: 'NotificationSettings',
+
+  props: {
+    value: {
+      type:    Object,
+      default: () => {}
+    },
+  },
+
+  components: { LabeledInput, Checkbox },
+});
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <Checkbox
+          :value="value.showMessage === 'true'"
+          :label="t('notifications.loginError.showCheckboxLabel')"
+          @input="e=>$set(value, 'showMessage', e.toString())"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <div class="row">
+          <div class="col span-12">
+            <LabeledInput
+              v-model="value.message"
+              :disabled="value.showMessage === 'false'"
+              :label="t('notifications.loginError.messageLabel')"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang='scss'>
+.banner-decoration-checkbox {
+  position: relative;
+  display: inline-flex;
+  align-items: flex-start;
+  margin: 0;
+  cursor: pointer;
+  user-select: none;
+  border-radius: var(--border-radius);
+  padding-bottom: 5px;
+  height: 24px;
+}
+</style>

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -123,6 +123,7 @@ export default {
 
       providers:          [],
       providerComponents: [],
+      customLoginError:    {}
     };
   },
 
@@ -149,15 +150,34 @@ export default {
       return this.err;
     },
 
+    errorToDisplay() {
+      if (this.customLoginError?.showMessage === 'true' && this.customLoginError?.message && this.errorMessage) {
+        return `${ this.customLoginError.message } \n ${ this.errorMessage }`;
+      }
+
+      if (this.errorMessage) {
+        return this.errorMessage;
+      }
+
+      return '';
+    },
+
     kubectlCmd() {
       return "kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{.data.bootstrapPassword|base64decode}}{{\"\\n\"}}'";
     }
+
   },
 
   created() {
     this.providerComponents = this.providers.map((name) => {
       return importLogin(configType[name]);
     });
+  },
+
+  async fetch() {
+    const { value } = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.BANNERS });
+
+    this.customLoginError = JSON.parse(value).loginError;
   },
 
   mounted() {
@@ -263,7 +283,7 @@ export default {
           {{ t('login.welcome', {vendor}) }}
         </h1>
         <div class="login-messages">
-          <Banner v-if="errorMessage" :label="errorMessage" color="error" />
+          <Banner v-if="errorToDisplay" :label="errorToDisplay" color="error" />
           <h4 v-else-if="loggedOut" class="text-success text-center">
             {{ t('login.loggedOut') }}
           </h4>

--- a/pages/c/_cluster/settings/banners.vue
+++ b/pages/c/_cluster/settings/banners.vue
@@ -12,9 +12,11 @@ import { getVendor } from '@/config/private-label';
 import { SETTING } from '@/config/settings';
 import { clone } from '@/utils/object';
 import { _EDIT, _VIEW } from '@/config/query-params';
+import NotificationSettings from '@/components/form/NotificationSettings.vue';
 
 const DEFAULT_BANNER_SETTING = {
-  bannerHeader: {
+  loginError:   { message: '', showMessage: 'false' },
+  bannerHeader:    {
     background:      null,
     color:           null,
     textAlignment:   'center',
@@ -54,7 +56,12 @@ export default {
   layout: 'authenticated',
 
   components: {
-    Checkbox, Loading, AsyncButton, Banner, BannerSettings
+    Checkbox,
+    Loading,
+    AsyncButton,
+    Banner,
+    BannerSettings,
+    NotificationSettings
   },
 
   async fetch() {
@@ -107,7 +114,7 @@ export default {
   methods: {
     checkOrUpdateLegacyUIBannerSetting(parsedBanner) {
       const {
-        bannerHeader, bannerFooter, bannerConsent, banner
+        bannerHeader, bannerFooter, bannerConsent, banner, loginError
       } = parsedBanner;
 
       if (isEmpty(bannerHeader) && isEmpty(bannerFooter) && isEmpty(bannerConsent)) {
@@ -124,6 +131,7 @@ export default {
           neu = {
             bannerHeader:  { ...cloned },
             bannerFooter:  { ...cloned },
+            loginError:    { ...DEFAULT_BANNER_SETTING.loginError, loginError: loginError?.showMessage === 'false' ? 'false' : 'true' },
             bannerConsent: { ...DEFAULT_BANNER_SETTING.bannerConsent },
             showHeader:    parsedBanner?.showHeader === 'true' ? 'true' : 'false',
             showFooter:    parsedBanner?.showFooter === 'true' ? 'true' : 'false',
@@ -137,6 +145,10 @@ export default {
       // If user has existing banners, they may not have consent banner - use default value
       if (isEmpty(bannerConsent)) {
         parsedBanner.bannerConsent = { ...DEFAULT_BANNER_SETTING.bannerConsent };
+      }
+
+      if (isEmpty(loginError)) {
+        parsedBanner.loginError = { ...DEFAULT_BANNER_SETTING.loginError };
       }
 
       return parsedBanner;
@@ -235,6 +247,13 @@ export default {
           :mode="consentMode"
         />
       </template>
+      <h2 class="mt-40 mb-40">
+        {{ t('notifications.loginError.header') }}
+      </h2>
+      <NotificationSettings
+        v-model="bannerVal.loginError"
+        :label="t('notifications.loginError.messageLabel')"
+      />
     </div>
     <template v-for="err in errors">
       <Banner :key="err" color="error" :label="err" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes #5401 - Add support for Custom Login Failed Message 

### Technical notes summary
1. Updated the `pages/c/_cluster/settings/banners.vue` section to have extra 2 fields to disable / enable show custom login error message.
2. Created `components/form/NotificationSettings.vue` which include checkbox and input field.
3. Original error message still shown 
4. The `loginError` field is added to `ui-banners` field in the settings and new settings are saved in there.

### Areas or cases that should be tested
1. Navigate to Global settings > Brands > Scroll to bottom
5. Select the checkbox to show the message and type in the message in the text box below
6. Logout or open an incognito tag. Type in wrong user/password
    1. it should show the error message
7. Un check the checkbox > apply 
    1. Refresh the login page and try again. 
    2. It should not display the message
8. check the checkbox and remove the message (empty) > apply
    1. Refresh the login page and try again. 
    2. It should not display the message

https://user-images.githubusercontent.com/1387263/161841807-fdd1324b-24bc-4287-8a00-769d27e55c68.mov


