### PR TITLE
Add annotation to stop upgrades for managed charts

### DIFF
--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -91,6 +91,7 @@ export const CATALOG = {
   DEPLOYED_OS:   'catalog.cattle.io/deploys-on-os',
 
   MIGRATED: 'apps.cattle.io/migrated',
+  MANAGED:  'catalog.cattle.io/managed'
 };
 
 export const FLEET = {

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -68,7 +68,7 @@ export default class CatalogApp extends SteveModel {
     // null = no upgrade found
     // object = version available to upgrade to
 
-    if ( this.spec?.chart?.metadata?.annotations?.[FLEET.BUNDLE_ID] ) {
+    if ( this.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.MANAGED] ) {
       // Things managed by fleet shouldn't show upgrade available even if there might be.
       return false;
     }

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -68,7 +68,10 @@ export default class CatalogApp extends SteveModel {
     // null = no upgrade found
     // object = version available to upgrade to
 
-    if ( this.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.MANAGED] ) {
+    if (
+      this.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.MANAGED] ||
+      this.spec?.chart?.metadata?.annotations?.[FLEET.BUNDLE_ID]
+    ) {
       // Things managed by fleet shouldn't show upgrade available even if there might be.
       return false;
     }


### PR DESCRIPTION
Signed-off-by: Phillip Rak <rak.phillip@gmail.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This prepares for a new annotation that will be added to managed charts in k3s. We'll keep the check for `FLEET.BUNDLE_ID` because new annotation is expected to come at a later date and we don't want to change existing behavior.

Fixes #4442 
See #4621 for previous attempt and more discussion
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
The new `catalog.cattle.io/managed` annotation will be added to k3s at a later date. Existing behavior should be unchanged for now.
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
If you go into `Installed Apps` in `Apps and Marketplace`, the upgrade options should be unchanged.
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
`Installed Apps` in `Apps and Marketplace`
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
