### PR TITLE
warn on adding windows node to cutom cluster

### DIFF
--- a/components/CopyCode.vue
+++ b/components/CopyCode.vue
@@ -34,6 +34,7 @@ export default {
           this.copied = false;
         }, 2000);
       });
+      this.$emit('copied');
     },
   }
 };

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -27,6 +27,7 @@ import Socket, {
   //  EVENT_FRAME_TIMEOUT,
   EVENT_CONNECT_ERROR
 } from '@/utils/socket';
+import { get } from '@/utils/object';
 
 let lastId = 1;
 const ansiup = new AnsiUp();
@@ -156,6 +157,8 @@ export default {
       logOpen:   false,
       logSocket: null,
       logs:      [],
+
+      showWindowsWarning: false
     };
   },
 
@@ -164,7 +167,7 @@ export default {
       if (neu) {
         this.$store.dispatch('rancher/findAll', { type: NORMAN.NODE });
       }
-    }
+    },
   },
 
   computed: {
@@ -366,6 +369,10 @@ export default {
 
     timeFormatStr() {
       return escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
+    },
+
+    hasWindowsMachine() {
+      return this.machines.some(machine => get(machine, 'status.nodeInfo.operatingSystem') === 'windows');
     }
   },
 
@@ -480,6 +487,8 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else>
+    <Banner v-if="showWindowsWarning" color="error" :label="t('cluster.banner.os', { newOS: 'Windows', existingOS: 'Linux' })" />
+
     <Banner v-if="$fetchState.error" color="error" :label="$fetchState.error" />
     <ResourceTabs v-model="value" :default-tab="defaultTab">
       <Tab v-if="showMachines" name="machine-pools" :label-key="value.isCustom ? 'cluster.tabs.machines' : 'cluster.tabs.machinePools'" :weight="4">
@@ -589,7 +598,7 @@ export default {
       </Tab>
 
       <Tab v-if="showRegistration" name="registration" :label="t('cluster.tabs.registration')" :weight="2">
-        <CustomCommand v-if="value.isCustom" :cluster-token="clusterToken" :cluster="value" />
+        <CustomCommand v-if="value.isCustom" :cluster-token="clusterToken" :cluster="value" @copied-windows="hasWindowsMachine ? null : showWindowsWarning = true" />
         <template v-else>
           <h4 v-html="t('cluster.import.commandInstructions', null, true)" />
           <CopyCode class="m-10 p-10">

--- a/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -139,6 +139,10 @@ export default {
     toggleAdvanced() {
       this.showAdvanced = !this.showAdvanced;
     },
+
+    copiedWindows() {
+      this.$emit('copied-windows');
+    }
   },
 };
 
@@ -207,7 +211,7 @@ function sanitizeValue(v) {
         <hr class="mt-20 mb-20" />
         <h4 v-t="'cluster.custom.registrationCommand.windowsDetail'" />
         <template v-if="readyForWindows">
-          <CopyCode class="m-10 p-10">
+          <CopyCode class="m-10 p-10" @copied="copiedWindows">
             {{ windowsCommand }}
           </CopyCode>
           <Checkbox

--- a/pages/c/_cluster/apps/charts/index.vue
+++ b/pages/c/_cluster/apps/charts/index.vue
@@ -140,8 +140,10 @@ export default {
 
     filteredCharts() {
       const enabledCharts = (this.enabledCharts || []);
+      const clusterProvider = this.currentCluster.status.provider || 'other';
 
       return filterAndArrangeCharts(enabledCharts, {
+        clusterProvider,
         category:         this.category,
         searchQuery:      this.searchQuery,
         showDeprecated:   this.showDeprecated,

--- a/store/catalog.js
+++ b/store/catalog.js
@@ -603,6 +603,7 @@ export function compatibleVersionsFor(chart, os, includePrerelease = true) {
 }
 
 export function filterAndArrangeCharts(charts, {
+  clusterProvider = '',
   operatingSystems,
   category,
   searchQuery,
@@ -621,7 +622,9 @@ export function filterAndArrangeCharts(charts, {
       ( hideRepos?.length && hideRepos.includes(c.repoKey) ) ||
       ( showRepos?.length && !showRepos.includes(c.repoKey) ) ||
       ( hideTypes?.length && hideTypes.includes(c.chartType) ) ||
-      ( showTypes?.length && !showTypes.includes(c.chartType) ) ) {
+      ( showTypes?.length && !showTypes.includes(c.chartType) ) ||
+      (c.chartName === 'rancher-wins-upgrader' && clusterProvider === 'rke2')
+    ) {
       return false;
     }
 


### PR DESCRIPTION
Fixes #5507 Fixes #5530
This PR hides the wins-upgrader chart for rke2 clusters and adds a warning about updating apps when adding a windows node to a custom rke2 cluster. The original ask in 5530 was to put a warning on the chart overview page, but determining if a given app was installed before or after adding a windows node requires more permissions than a user with access to apps and marketplace necessarily has so the warning is on the provisioning screen instead.

