### PR TITLE
Enable source map in Nuxt/Webpack configuration for debugging

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -156,7 +156,7 @@ module.exports = {
 
     extend(config, { isClient, isDev }) {
       if ( isDev ) {
-        config.devtool = 'eval-source-map';
+        config.devtool = 'cheap-module-source-map';
       } else {
         config.devtool = 'source-map';
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5589
As in issue description.

### Occurred changes and/or fixed issues
Nuxt/Webpack configuration is now allowing to debug code.

### Technical notes summary

`yarn dev` using the 2 different source map values:
#### `eval-source-map`
##### Start
```bash
✔ Client
  Compiled successfully in 28.07s

✔ Server
  Compiled successfully in 14.86s
```
##### Reloaded
```bash
✔ Client
  Compiled successfully in 16.86s

✔ Server
  Compiled successfully in 23.75s
```

#### `cheap-module-source-map`
##### Start
```bash
✔ Client
  Compiled successfully in 12.90s

✔ Server
  Compiled successfully in 16.61s
```

##### Reloaded
```bash
✔ Client
  Compiled successfully in 18.18s

✔ Server
  Compiled successfully in 10.67s
```

### Areas or cases that should be tested
None.

### Areas which could experience regressions
None.

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/162192132-305f831b-d022-4375-b20d-759acef370e3.mp4

