### PR TITLE
Can select or create namespace

### DIFF
--- a/assets/styles/global/_labeled-input.scss
+++ b/assets/styles/global/_labeled-input.scss
@@ -65,7 +65,7 @@
     background-color: transparent;
     outline: 0;
     box-shadow: none;
-    padding: $input-padding-lg 0 0 0;
+    padding: $input-padding-lg 0 0 1px;
     line-height: calc(#{$input-line-height} + 1px);
 
     &.no-label {

--- a/assets/styles/vendor/vue-select.scss
+++ b/assets/styles/vendor/vue-select.scss
@@ -211,7 +211,6 @@ $transition-duration: 150ms;
   width: 0;
   max-width: 100%;
   flex-grow: 1;
-  margin-left: $input-padding-sm;
 }
 
 .vs__search::placeholder {

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2905,6 +2905,10 @@ namespace:
   move: Move
   total: Total
   workloads: Workloads
+  selectNamespaceButton: Use an existing namespace
+  selectNamespaceLabel: Select Namespace
+  addNamespaceButton: Add to a new namespace
+  addNamespaceLabel: Create Namespace
   resourceStates:
       success: 'Active'
       info: 'Transitioning'

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -301,6 +301,10 @@ export default {
 
 <style lang='scss' scoped>
 .labeled-select {
+  // Prevent namespace field from wiggling or changing
+  // height when it is toggled from a LabeledInput to a
+  // LabeledSelect.
+  padding-bottom: 4px;
   position: relative;
 
   &.no-label.compact-input {
@@ -329,7 +333,9 @@ export default {
   }
 
   .labeled-container {
-    padding: $input-padding-sm 0 0 $input-padding-sm;
+    // Make LabeledSelect and LabeledInput the same height so they
+    // don't wiggle when you toggle between them.
+    padding: 7px 0 0 $input-padding-sm;
 
     label {
       margin: 0;

--- a/components/form/NameNsDescription.vue
+++ b/components/form/NameNsDescription.vue
@@ -1,12 +1,12 @@
 <script>
 import { mapGetters } from 'vuex';
 import { get, set } from '@/utils/object';
-import { sortBy } from '@/utils/sort';
 import { NAMESPACE } from '@/config/types';
 import { DESCRIPTION } from '@/config/labels-annotations';
 import { _VIEW, _EDIT } from '@/config/query-params';
 import LabeledInput from '@/components/form/LabeledInput';
 import InputWithSelect from '@/components/form/InputWithSelect';
+import getAvailableNamespaces from '@/utils/namespaces';
 
 export function normalizeName(str) {
   return (str || '')
@@ -183,31 +183,7 @@ export default {
     },
 
     namespaces() {
-      const inStore = this.$store.getters['currentStore'](this.namespaceType);
-      const choices = this.$store.getters[`${ inStore }/all`](this.namespaceType);
-
-      const out = sortBy(
-        choices.filter( (N) => {
-          const isSettingSystemNamespace = this.$store.getters['systemNamespaces'].includes(N.metadata.name);
-
-          return this.isVirtualCluster ? !N.isSystem && !N.isFleetManaged && !isSettingSystemNamespace : true;
-        }).map((obj) => {
-          return {
-            label: obj.nameDisplay,
-            value: obj.id,
-          };
-        }),
-        'label'
-      );
-
-      if (this.forceNamespace) {
-        out.unshift({
-          label: this.forceNamespace,
-          value: this.forceNamespace,
-        });
-      }
-
-      return out;
+      return getAvailableNamespaces(this);
     },
 
     isView() {

--- a/utils/namespaces.js
+++ b/utils/namespaces.js
@@ -1,0 +1,33 @@
+import { sortBy } from '@/utils/sort';
+
+// This method is used by the NameNsDescription component and by the create/edit
+// workload form to provide namespaces to choose from.
+const getAvailableNamespaces = (resource) => {
+  const inStore = resource.$store.getters['currentStore'](resource.namespaceType || 'namespace');
+  const choices = resource.$store.getters[`${ inStore }/all`](resource.namespaceType || 'namespace');
+
+  const out = sortBy(
+    choices.filter( (N) => {
+      const isSettingSystemNamespace = resource.$store.getters['systemNamespaces'].includes(N.metadata.name);
+
+      return resource.isVirtualCluster ? !N.isSystem && !N.isFleetManaged && !isSettingSystemNamespace : true;
+    }).map((obj) => {
+      return {
+        label: obj.nameDisplay,
+        value: obj.id,
+      };
+    }),
+    'label'
+  );
+
+  if (resource.forceNamespace) {
+    out.unshift({
+      label: resource.forceNamespace,
+      value: resource.forceNamespace,
+    });
+  }
+
+  return out;
+};
+
+export default getAvailableNamespaces;


### PR DESCRIPTION
Edit: Refactoring the PR based on a new design
![Project Configuration Pane2](https://user-images.githubusercontent.com/20599230/162606268-cea78f08-10de-4243-9ab9-b982619f1bc7.png)


-----

This PR partly addresses https://github.com/rancher/dashboard/issues/2513 by making it so that you can create a new namespace from the workload creation forms instead of only being able to select existing namespaces. It is also a prerequisite for addressing this issue https://github.com/rancher/dashboard/issues/4861

When you select an existing namespace, it looks like this:
![Screen Shot 2022-04-08 at 2 16 58 AM](https://user-images.githubusercontent.com/20599230/162406174-ef4396cd-5fe4-48ed-9e6e-dcd4b16ae552.png)

When you create a new namespace, it looks like this:
![Screen Shot 2022-04-08 at 2 20 05 AM](https://user-images.githubusercontent.com/20599230/162406314-316b48c1-f7fe-4d5c-8abe-2adf166a7c5f.png)

For comparison, here is Lauren's mockup:

![image](https://user-images.githubusercontent.com/20599230/162406385-74371f64-44f3-44d3-ade9-0cc5e30a8766.png)


## Notes on implementation

Edit: Refactoring this PR to be smarter about it https://github.com/rancher/dashboard/pull/5598#issuecomment-1094195374

This PR intentionally does not modify the existing `NameNsDescription` component in the UI, for the following reasons:

- This can't be a drop-in replacement for `NameNsDescription` because in order for this to work, you have to also change what happens when the form submit button is clicked.
- We have many implementations of `save` for different resources, so that would have to be addressed on a case-by-case basis.

This PR also intentionally does NOT create a new component with a group of form fields for name, description and create/select namespace. I think in general we should avoid reusing groups of inputs for the following reasons:

- It creates deeply nested components that are hard to read, and hard to trace the flow of information as child components pass data to parent components and rename it at every step. (If you use NameNsDescription, your actual input is nested three levels deep, with props and events going through all three levels.)
- Reusing groups of fields might seem convenient at first, but then business logic creeps into the component to make it appropriate for different contexts. And then it's hard to understand the business logic in the reused component because it's out of context. Then you get counterintuitive behavior - for example, `InputWithSelect` can conditionally render only an input instead of an input with a select. Before you know it, the reused component becomes so overloaded, the reused component isn't convenient anymore - it is brittle and overcomplicated for most use cases.
- They prevent us from being able to use `v-model` to clearly and simply map form state to inputs.

This also intentionally does NOT create a beforeSaveHook to maintain the state of the new namespace that is created. The problem with the beforeSaveHooks is that they cause errors if their state is not cleared when appropriate, and they are hard to understand for people who are new to this code base. Instead of using a hook, I wrote the logic for creating a namespace in such a way that is intended to be easier to understand:

```js
async submitNamespaceAndWorkload() {
      if (this.createNamespaceIsSelected) {
        const newNamespace = await this.$store.dispatch('cluster/create', {
          type:     NAMESPACE,
          metadata: { name: this.value.metadata.namespace }
        }, { root: true });
        newNamespace.applyDefaults();
        newNamespace.save();
      }
      await this.save();
    },
```

## Summary of changes in this PR

- In the workload form (the form that is reused for Deployment, DaemonSet, StatefulSet, CronJob and Job) I replaced the nested `NameNsDescription` component with a flat structure of inputs. When `Use an existing namespace` is clicked, the select becomes an input.
- Made CSS changes so that the LabeledSelect and LabeledInput have equal height and padding in this case so that you don't see wiggling when the input is toggled. I tried to be careful to make changes that wouldn't mess up other forms.
- Reorganized some other workload fields by necessity because previously they had been nested inside `NameNsDescription` as additional columns in the top row, and they didn't fit into Lauren's three-column mockup.
- Some workload fields are conditionally rendered based on the workload type. By flattening the form structure I made this logic clearer and easier to understand. The logic is as follows:
  - If the workload in a CronJob, show the cron schedule field.
  - If the workload is a StatefulSet or a Deployment, show the replicas field.
  - If the workload is a StatefulSet, show the services select menu.

Here's a before and after of the StatefulSet form - 

Before:

![Screen Shot 2022-04-08 at 2 50 32 AM](https://user-images.githubusercontent.com/20599230/162411863-f0a666db-b2da-42c5-8690-84527d23e245.png)

After:
![Screen Shot 2022-04-08 at 2 50 40 AM](https://user-images.githubusercontent.com/20599230/162411887-d59b2d92-1e79-4284-af8a-b5fd295339fc.png)


The original issue was requesting this feature in general, and this PR only affects workload forms. But I could easily make this change to other PRs.

This PR does not let you create a namespace in a project. If someone requests that feature later, it can be done in a separate issue/PR.

## Testing

I created workloads in new and existing namespaces.