### PR TITLE
Show error on NeuVector page if `cattle-neuvector-system` namespace does not exist

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2569,6 +2569,8 @@ longhorn:
         na: Resource Unavailable
 
 neuvector:
+  errors:
+    namespaceError: Could not detect official NeuVector chart
   overview:
     title: Overview
     subtitle: "Powered by: <a href='https://github.com/neuvector' target='_blank' rel='noopener nofollow noreferrer'>NeuVector</a>"

--- a/pages/c/_cluster/neuvector/index.vue
+++ b/pages/c/_cluster/neuvector/index.vue
@@ -6,16 +6,29 @@ import InstallRedirect from '@/utils/install-redirect';
 import { NAME, CHART_NAME } from '@/config/product/neuvector';
 
 import LazyImage from '@/components/LazyImage';
+import Banner from '@/components/Banner';
+import { NAMESPACE } from '@/config/types';
+
+const NEUVECTOR_NAMESPACE = 'cattle-neuvector-system';
 
 export default {
-  components: { LazyImage },
+  components: { LazyImage, Banner },
 
   middleware: InstallRedirect(NAME, CHART_NAME),
 
   data() {
+    let hasNeuVectorNamespace = false;
+
+    const allNamespaces = this.$store.getters[`cluster/all`](NAMESPACE);
+
+    hasNeuVectorNamespace = allNamespaces.filter((namespace) => {
+      return namespace.metadata.name === NEUVECTOR_NAMESPACE;
+    }).length === 1;
+
     return {
-      externalLinks:   [],
-      neuvectorImgSrc: require('~/assets/images/vendor/neuvector.svg'),
+      externalLinks:         [],
+      neuvectorImgSrc:       require('~/assets/images/vendor/neuvector.svg'),
+      hasNeuVectorNamespace,
     };
   },
 
@@ -28,7 +41,7 @@ export default {
         iconSrc:     this.neuvectorImgSrc,
         label:       'neuvector.overview.linkedList.neuvector.label',
         description:   'neuvector.overview.linkedList.neuvector.description',
-        link:        `/k8s/clusters/${ this.currentCluster.id }/api/v1/namespaces/cattle-neuvector-system/services/https:neuvector-service-webui:8443/proxy`
+        link:        `/k8s/clusters/${ this.currentCluster.id }/api/v1/namespaces/${ NEUVECTOR_NAMESPACE }/services/https:neuvector-service-webui:8443/proxy`
       },
     ];
   }
@@ -47,7 +60,9 @@ export default {
         </div>
       </div>
     </header>
-    <div class="links">
+    <Banner v-if="!hasNeuVectorNamespace" color="error" :label="t('neuvector.errors.namespaceError')">
+    </Banner>
+    <div v-if="hasNeuVectorNamespace" class="links">
       <div v-for="fel in externalLinks" :key="fel.label" class="link-container">
         <a :href="fel.link" target="_blank" rel="noopener noreferrer">
           <div class="link-logo">

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -747,7 +747,7 @@ export const getters = {
 
   allTypes(state, getters, rootState, rootGetters) {
     return (product, mode = ALL) => {
-      const module = findBy(state.products, 'name', product).inStore;
+      const module = findBy(state.products, 'name', product)?.inStore || 'cluster';
       const schemas = rootGetters[`${ module }/all`](SCHEMA);
       const counts = rootGetters[`${ module }/all`](COUNT)?.[0]?.counts || {};
       const isDev = rootGetters['prefs/get'](DEV);


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5556

There is a problem with the existing the way the existing NeuVector link detects if NeuVector is installed. It currently checks for the existence of custom resources with `neuvector.com` in the type name. (https://github.com/rancher/dashboard/pull/5292/files#diff-571ffe869cf6d0dff84024da127acbb3d14330ba13cc2df51c398c0c32e5bfc0R10)

This isn't specific enough because if a user has installed the NeuVector partner chart, they will see a link that doesn't work. We only want to show the link to users who installed the official Rancher NeuVector chart which runs the UI in the `cattle-neuvector-system` namespace.

## Summary of Changes

When you install the official Rancher NeuVector chart using the steps described here https://github.com/rancher/dashboard/pull/5292, the NeuVector link still shows up normally:
<img width="703" alt="Screen Shot 2022-04-13 at 1 27 04 PM" src="https://user-images.githubusercontent.com/20599230/163267189-dbf6fcc1-ae92-4889-927e-81518794dcd4.png">

But when you install the NeuVector partner chart, I've added an error that explains why the button is not available. Caleb suggested this language:

<img width="813" alt="Screen Shot 2022-04-13 at 2 26 15 PM" src="https://user-images.githubusercontent.com/20599230/163273254-8ba7dfa2-6f59-4f0a-a8cc-a378e8e9031e.png">

