### PR TITLE
Fix node table column sorting

### DIFF
--- a/config/table-headers.js
+++ b/config/table-headers.js
@@ -182,7 +182,7 @@ export const VERSION = {
 export const CPU = {
   name:      'cpu',
   labelKey:  'tableHeaders.cpu',
-  sort:      'cpu',
+  sort:      'cpuUsage',
   search:    false,
   value:     'cpuUsagePercentage',
   formatter: 'PercentageBar',
@@ -192,7 +192,7 @@ export const CPU = {
 export const RAM = {
   name:      'ram',
   labelKey:  'tableHeaders.ram',
-  sort:      'ram',
+  sort:      'ramUsage',
   search:    false,
   value:     'ramUsagePercentage',
   formatter: 'PercentageBar',
@@ -210,7 +210,7 @@ export const PRINCIPAL = {
 export const PODS = {
   name:      'pods',
   labelKey:  'tableHeaders.pods',
-  sort:      'pods',
+  sort:      'podConsumed',
   search:    false,
   value:     'podConsumedUsage',
   formatter: 'PercentageBar',


### PR DESCRIPTION
Fixes #5165

This PR fixes the above issue - the RAM, CPU and PODS columns had the wrong value for the sort column, so the sorting was nor working correctly.

To Test: With a cluster with multiple nodes, verify that on the nodes table for the cluster that you can sort by CPU, Memory and Pods in the table