### PR TITLE
Allow local cluster to be hidden

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -6428,6 +6428,7 @@ advancedSettings:
     'harv-auto-disk-provision-paths': Specify the disks(using glob pattern) that Harvester will automatically add as VM storage.
     'harv-support-bundle-image': Support bundle image configuration. Find different versions in <a href="https://hub.docker.com/r/rancher/support-bundle-kit/tags" target="_blank">rancher/support-bundle-kit</a>.
     'harvester-monitoring': Specifies the monitoring configuration that the Harvester's built-in Prometheus will use.
+    'hide-local-cluster': Hide the local cluster
   editHelp:
     'ui-banners': This setting takes a JSON object containing 3 root parameters; <code>banner</code>, <code>showHeader</code>, <code>showFooter</code>. <code>banner</code> is an object containing; <code>textColor</code>, <code>background</code>, and <code>text</code>, where <code>textColor</code> and <code>background</code> are any valid CSS color value.
   enum:

--- a/components/LandingPagePreference.vue
+++ b/components/LandingPagePreference.vue
@@ -5,7 +5,7 @@ import RadioGroup from '@/components/form/RadioGroup';
 import RadioButton from '@/components/form/RadioButton';
 import Select from '@/components/form/Select';
 import { MANAGEMENT } from '@/config/types';
-import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+import { filterHiddenLocalCluster, filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 export default {
   components: {
@@ -72,7 +72,7 @@ export default {
     routeDropdownOptions() {
       // Drop-down shows list of clusters that can ber set as login landing page
       const out = [];
-      const kubeClusters = filterOnlyKubernetesClusters(this.clusters);
+      const kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(this.clusters), this.$store);
 
       kubeClusters.forEach((c) => {
         if (c.isReady) {

--- a/components/formatter/LiveExpiryBadgeState.vue
+++ b/components/formatter/LiveExpiryBadgeState.vue
@@ -8,7 +8,7 @@ export default {
   components: { BadgeState },
 
   props: {
-    value: {
+    row: {
       type:    Object,
       default: null,
     },
@@ -25,7 +25,7 @@ export default {
   },
 
   watch: {
-    value() {
+    row() {
       this.update();
     }
   },
@@ -36,12 +36,12 @@ export default {
 
   methods: {
     update() {
-      const state = this.value.state;
+      const state = this.row.state;
 
       clearTimeout(this.timer);
-      if (state !== 'expired' && this.value.expiresAt) {
+      if (state !== 'expired' && this.row.expiresAt) {
         // Not expired and has an expiry date, so set a timer to update the state once its expired
-        const expiry = day(this.value.expiresAt);
+        const expiry = day(this.row.expiresAt);
         const now = day();
         const timeToExpire = expiry.diff(now);
 

--- a/components/nav/TopLevelMenu.vue
+++ b/components/nav/TopLevelMenu.vue
@@ -11,7 +11,7 @@ import { KEY } from '@/utils/platform';
 import { getVersionInfo } from '@/utils/version';
 import { LEGACY } from '@/store/features';
 import { SETTING } from '@/config/settings';
-import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@/utils/cluster';
 
 const UNKNOWN = 'unknown';
 const UI_VERSION = process.env.VERSION || UNKNOWN;
@@ -57,7 +57,7 @@ export default {
 
     clusters() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-      const kubeClusters = filterOnlyKubernetesClusters(all);
+      const kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all), this.$store);
 
       return kubeClusters.map((x) => {
         return {

--- a/config/settings.js
+++ b/config/settings.js
@@ -19,6 +19,8 @@ export const SETTING = {
   API_HOST:                         'api-host',
   CA_CERTS:                         'cacerts',
 
+  // Allow the local cluste to be hidden
+  HIDE_LOCAL_CLUSTER:               'hide-local-cluster',
   AUTH_TOKEN_MAX_TTL_MINUTES:       'auth-token-max-ttl-minutes',
   KUBECONFIG_GENERATE_TOKEN:        'kubeconfig-generate-token',
   KUBECONFIG_TOKEN_TTL_MINUTES:     'kubeconfig-token-ttl-minutes',

--- a/config/settings.js
+++ b/config/settings.js
@@ -88,6 +88,7 @@ export const ALLOWED_SETTINGS = {
     kind:    'enum',
     options: ['prompt', 'in', 'out']
   },
+  [SETTING.HIDE_LOCAL_CLUSTER]: { kind: 'boolean' },
 };
 
 // harvester Settings ID

--- a/edit/token.vue
+++ b/edit/token.vue
@@ -12,7 +12,7 @@ import RadioGroup from '@/components/form/RadioGroup';
 import Select from '@/components/form/Select';
 import CreateEditView from '@/mixins/create-edit-view';
 import { diffFrom } from '@/utils/time';
-import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+import { filterHiddenLocalCluster, filterOnlyKubernetesClusters } from '@/utils/cluster';
 
 export default {
   components: {
@@ -57,7 +57,7 @@ export default {
     ...mapGetters({ t: 'i18n/t' }),
     scopes() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-      const kubeClusters = filterOnlyKubernetesClusters(all);
+      const kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all), this.$store);
       let out = kubeClusters.map(opt => ({ value: opt.id, label: opt.nameDisplay }));
 
       out = sortBy(out, ['label']);

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -5,7 +5,7 @@ import Masthead from '@/components/ResourceList/Masthead';
 import { allHash } from '@/utils/promise';
 import { CAPI, MANAGEMENT } from '@/config/types';
 import { MODE, _IMPORT } from '@/config/query-params';
-import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@/utils/cluster';
 import { mapFeature, HARVESTER as HARVESTER_FEATURE } from '@/store/features';
 import { NAME as EXPLORER } from '@/config/product/explorer';
 
@@ -55,11 +55,11 @@ export default {
     rows() {
       // If Harvester feature is enabled, hide Harvester Clusters
       if (this.harvesterEnabled) {
-        return filterOnlyKubernetesClusters(this.rancherClusters);
+        return filterHiddenLocalCluster(filterOnlyKubernetesClusters(this.rancherClusters), this.$store);
       }
 
       // Otherwise, show Harvester clusters - these will be shown with a warning
-      return this.rancherClusters;
+      return filterHiddenLocalCluster(this.rancherClusters, this.$store);
     },
 
     hiddenHarvesterCount() {

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -20,7 +20,7 @@ import { getVendor } from '@/config/private-label';
 import { mapFeature, MULTI_CLUSTER } from '@/store/features';
 import { SETTING } from '@/config/settings';
 import { BLANK_CLUSTER } from '@/store';
-import { filterOnlyKubernetesClusters } from '@/utils/cluster';
+import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@/utils/cluster';
 
 import { RESET_CARDS_ACTION, SET_LOGIN_ACTION } from '@/config/page-actions';
 
@@ -185,7 +185,7 @@ export default {
     ...mapGetters(['currentCluster', 'defaultClusterId']),
 
     kubeClusters() {
-      return filterOnlyKubernetesClusters(this.clusters);
+      return filterHiddenLocalCluster(filterOnlyKubernetesClusters(this.clusters), this.$store);
     }
   },
 

--- a/utils/cluster.js
+++ b/utils/cluster.js
@@ -1,6 +1,7 @@
 import semver from 'semver';
 import { CAPI } from '@/config/labels-annotations';
-import { VIRTUAL_HARVESTER_PROVIDER } from '@/config/types';
+import { MANAGEMENT, VIRTUAL_HARVESTER_PROVIDER } from '@/config/types';
+import { SETTING } from '@/config/settings';
 
 // Filter out any clusters that are not Kubernetes Clusters
 // Currently this removes Harvester clusters
@@ -25,4 +26,20 @@ export function isHarvesterSatisfiesVersion(version = '') {
   } else {
     return semver.satisfies(semver.coerce(version), '>=v1.21.4+rke2r4');
   }
+}
+
+export function filterHiddenLocalCluster(mgmtClusters, store) {
+  const hideLocalSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.HIDE_LOCAL_CLUSTER) || {};
+  const value = hideLocalSetting.value || hideLocalSetting.default || 'false';
+  const hideLocal = value === 'true';
+
+  if (!hideLocal) {
+    return mgmtClusters;
+  }
+
+  return mgmtClusters.filter((c) => {
+    const target = c.mgmt || c;
+
+    return !target.isLocal;
+  });
 }


### PR DESCRIPTION
Fixes #4193

This PR adds support for the setting that allows the local cluster to be hidden - in the old UI we supported this setting but in dashboard we do not - this PR fixes this.

To Test:

Open the shell on the local cluster and run:

```
kubectl patch settings.management.cattle.io hide-local-cluster --type merge -p '{"value":"true"}'
```

Refresh the dashboard UI - the local cluster should no longer be shown:

- On the home screen cluster list
- On the cluster list under Cluster Management
- In the slide-in top-level menu cluster list

