### PR TITLE
Fix issue where private registry auth can be changed in view mode

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1844,6 +1844,7 @@ export default {
             v-model="registrySecret"
             :register-before-hook="registerBeforeHook"
             :hook-priority="1"
+            :mode="mode"
             in-store="management"
             :allow-ssh="false"
             :allow-rke="true"


### PR DESCRIPTION
Fixes #5130 

This PR ensures that the `mode` property is set on the control for the private registry authentication select dropdown so that in view config mode, this control is not editable.