### PR TITLE
Initialize always auth errors as empty list

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -1,5 +1,5 @@
 <script>
-import { isEmpty, isArray } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { createYaml } from '@/utils/create-yaml';
 import { clone } from '@/utils/object';
 import { SCHEMA } from '@/config/types';
@@ -162,7 +162,15 @@ export default {
 
       return false;
     },
-    ...mapGetters({ t: 'i18n/t' })
+
+    ...mapGetters({ t: 'i18n/t' }),
+
+    /**
+     * Prevent issues for malformed types injection
+     */
+    hasErrors() {
+      return this.errors?.length && Array.isArray(this.errors);
+    }
   },
 
   created() {
@@ -249,12 +257,6 @@ export default {
       this.$refs.save.clicked();
     },
 
-    /**
-     * Prevent issues for malformed types injection
-     */
-    hasErrors() {
-      return this.errors?.length && isArray(this.errors);
-    }
   }
 };
 </script>
@@ -267,7 +269,7 @@ export default {
     >
       <div
         class="cru__errors"
-        :v-if="hasErrors()"
+        :v-if="hasErrors"
       >
         <Banner
           v-for="(err, i) in errors"

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -1,5 +1,5 @@
 <script>
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty, isArray } from 'lodash';
 import { createYaml } from '@/utils/create-yaml';
 import { clone } from '@/utils/object';
 import { SCHEMA } from '@/config/types';
@@ -247,6 +247,13 @@ export default {
 
     save() {
       this.$refs.save.clicked();
+    },
+
+    /**
+     * Prevent issues for malformed types injection
+     */
+    hasErrors() {
+      return this.errors?.length && isArray(this.errors);
     }
   }
 };
@@ -260,7 +267,7 @@ export default {
     >
       <div
         class="cru__errors"
-        :v-if="errors.length"
+        :v-if="hasErrors()"
       >
         <Banner
           v-for="(err, i) in errors"

--- a/edit/auth/ldap/index.vue
+++ b/edit/auth/ldap/index.vue
@@ -126,12 +126,11 @@ export default {
           </div>
         </div>
       </template>
-    </CruResource>
-
-    <div v-if="!model.enabled" class="row">
-      <div class="col span-12">
-        <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+      <div v-if="!model.enabled" class="row">
+        <div class="col span-12">
+          <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+        </div>
       </div>
-    </div>
+    </CruResource>
   </div>
 </template>

--- a/edit/auth/oidc.vue
+++ b/edit/auth/oidc.vue
@@ -249,11 +249,11 @@ export default {
           </div>
         </div>
       </template>
-    </CruResource>
-    <div v-if="!model.enabled" class="row">
-      <div class="col span-12">
-        <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+      <div v-if="!model.enabled" class="row">
+        <div class="col span-12">
+          <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+        </div>
       </div>
-    </div>
+    </CruResource>
   </div>
 </template>

--- a/edit/auth/saml.vue
+++ b/edit/auth/saml.vue
@@ -212,11 +212,11 @@ export default {
           </div>
         </div>
       </template>
-    </CruResource>
-    <div v-if="!model.enabled" class="row">
-      <div class="col span-12">
-        <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+      <div v-if="!model.enabled" class="row">
+        <div class="col span-12">
+          <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+        </div>
       </div>
-    </div>
+    </CruResource>
   </div>
 </template>

--- a/mixins/auth-config.js
+++ b/mixins/auth-config.js
@@ -26,7 +26,7 @@ export default {
       editConfig:     false,
       model:          null,
       serverSetting:  null,
-      errors:         null,
+      errors:         [],
       originalModel:  null,
       principals:     [],
       authConfigName: this.$route.params.id,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5615
Prevent to break application while entering in authentication provider edit view.

### Occurred changes and/or fixed issues
In case of authentication, Initialized errors are not defined as list.

### Technical notes summary
It seems like the rendering also differ in case of SSR, so the component is also always loaded.

### Areas or cases that should be tested
Auth provider edit view `/c/local/auth/config/github?mode=edit`

### Areas which could experience regressions
Any view containing form which has the errors initialized, which is pretty much anything from the last commit.

### Screenshot/Video
<img width="978" alt="Screenshot 2022-04-11 at 21 33 35" src="https://user-images.githubusercontent.com/5009481/162815899-4bb802f2-ad01-4f9d-9400-7c32b6b1875d.png">
