### PR TITLE
Feature/5553 rke2 snapshot location

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1640,6 +1640,7 @@ cluster:
         =1 { A snapshot has been requested for 1 cluster }
         other {A snapshot has been requested for {count} clusters}
       }
+    groupLabel: Location
   tabs:
     ace: Authorized Endpoint
     addons: Add-On Config

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -624,6 +624,8 @@ export default {
           :table-actions="value.isRke1"
           :rows="value.isRke1 ? rke1Snapshots : rke2Snapshots"
           :search="false"
+          :groupable="true"
+          :group-by="`$['metadata']['annotations']['etcdsnapshot.rke.io/storage']`"
         >
           <template #header-right>
             <AsyncButton
@@ -632,6 +634,13 @@ export default {
               :disabled="!isClusterReady"
               @click="takeSnapshot"
             />
+          </template>
+          <template #group-by="{group}">
+            <div class="group-bar">
+              <div class="group-tab">
+                {{ t('cluster.snapshot.groupLabel') }}: {{ group.key }}
+              </div>
+            </div>
           </template>
         </SortableTable>
       </Tab>

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -373,6 +373,10 @@ export default {
 
     hasWindowsMachine() {
       return this.machines.some(machine => get(machine, 'status.nodeInfo.operatingSystem') === 'windows');
+    },
+
+    snapshotsGroupBy() {
+      return `$['metadata']['annotations']['etcdsnapshot.rke.io/storage']`;
     }
   },
 
@@ -625,7 +629,7 @@ export default {
           :rows="value.isRke1 ? rke1Snapshots : rke2Snapshots"
           :search="false"
           :groupable="true"
-          :group-by="`$['metadata']['annotations']['etcdsnapshot.rke.io/storage']`"
+          :group-by="snapshotsGroupBy"
         >
           <template #header-right>
             <AsyncButton

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1685,7 +1685,7 @@ export default {
             </div>
           </div>
 
-          <template v-if="false && rkeConfig.etcd.disableSnapshots !== true">
+          <template v-if="rkeConfig.etcd.disableSnapshots !== true">
             <div class="spacer" />
 
             <RadioGroup


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This groups snapshots by their location. Duplicate snapshots were reported, when snapshots were actually stored both locally and in S3 storage. 

Fixes #5553
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Creating RKE2 Clusters should have `Backup Snapshots to S3` enabled under `Cluster Configuration` => `etcd`.

### Screenshot/Video

#### Cluster Config

![image](https://user-images.githubusercontent.com/835961/162843364-3234f521-6e64-49dc-b35c-14d050ae6ee8.png)

#### Snapshots with single location

![image](https://user-images.githubusercontent.com/835961/162843500-0bd539fe-08c9-4e69-8a78-7abe6ad9bcbf.png)

#### Snapshots with Local and S3

![image](https://user-images.githubusercontent.com/835961/162843548-5788beba-7899-4af9-9f69-d773e4847dee.png)
