### PR TITLE
Add feedback to the copy kubeconfig header button

### DIFF
--- a/components/nav/Header.vue
+++ b/components/nav/Header.vue
@@ -241,8 +241,12 @@ export default {
       });
     },
 
-    async copyKubeConfig(event) {
+    copyKubeConfig(event) {
       const button = event.target?.parentElement;
+
+      if (this.kubeConfigCopying) {
+        return;
+      }
 
       this.kubeConfigCopying = true;
 
@@ -251,16 +255,16 @@ export default {
       }
 
       // Make sure we wait at least 1 second so that the user can see the visual indication that the config has been copied
-      await allHash({
+      allHash({
         copy:     this.currentCluster.copyKubeConfig(),
         minDelay: new Promise(resolve => setTimeout(resolve, 1000))
+      }).finally(() => {
+        this.kubeConfigCopying = false;
+
+        if (button) {
+          button.classList.remove('header-btn-active');
+        }
       });
-
-      this.kubeConfigCopying = false;
-
-      if (button) {
-        button.classList.remove('header-btn-active');
-      }
     }
   }
 };


### PR DESCRIPTION
Fixes #5627 

Adds a visual indication when the kubeconfig copy to clipboard button is pressed.

![image](https://user-images.githubusercontent.com/1955897/162948227-e89c02e3-0e12-48c0-81bb-936bad27cb1b.png)
