### PR TITLE
[2.5.13] Backport #4947

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -570,11 +570,9 @@ catalog:
     multiCluster:
       label: This is a Multi-cluster App and it cannot be modified here.
       legacy:
-        label: You will need to turn on
-        target: Legacy Features
+        description: 'You will need to enable <a href="{target}">Legacy Features</a>'
       mcm:
-        label: Navigate to
-        target: Multi-cluster Apps
+        description: Navigate to <a href="{target}">Multi-cluster Apps</a>
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -539,15 +539,6 @@ catalog:
       requiresMissing: 'This chart requires another chart that provides {name}, but none was was found.'
       insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
       insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
-      legacy:
-        label: This is a {legacyType} App and it cannot be modified here
-        enableLegacy:
-          prompt: You will need to enable Legacy Features to edit this App
-          goto: Go to Feature Flag settings
-        navigate: Navigate to {legacyType} Apps
-        category:
-          legacy: Legacy
-          mcm: Multi-cluster
     header:
       install: 'Install {name}'
       installGeneric: Install Chart

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -540,9 +540,11 @@ catalog:
       insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
       insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
       legacy:
-        label: This is a {legacyType} App and it cannot be modified here.
-        enableLegacy: You will need to enable <a href="{target}">Legacy Features</a> to edit this App.
-        navigate: Navigate to <a href="{target}">{legacyType} Apps</a>
+        label: This is a {legacyType} App and it cannot be modified here
+        enableLegacy:
+          prompt: You will need to enable Legacy Features to edit this App
+          goto: Go to Feature Flag settings
+        navigate: Navigate to {legacyType} Apps
         category:
           legacy: Legacy
           mcm: Multi-cluster

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -539,6 +539,13 @@ catalog:
       requiresMissing: 'This chart requires another chart that provides {name}, but none was was found.'
       insufficientCpu: 'This chart requires {need, number} CPU cores, but the cluster only has {have, number} available.'
       insufficientMemory: 'This chart requires {need} of memory, but the cluster only has {have} available.'
+      legacy:
+        label: This is a {legacyType} App and it cannot be modified here.
+        enableLegacy: You will need to enable <a href="{target}">Legacy Features</a> to edit this App.
+        navigate: Navigate to <a href="{target}">{legacyType} Apps</a>
+        category:
+          legacy: Legacy
+          mcm: Multi-cluster
     header:
       install: 'Install {name}'
       installGeneric: Install Chart
@@ -567,12 +574,6 @@ catalog:
             other { seconds }
           }
       wait: Wait
-    multiCluster:
-      label: This is a Multi-cluster App and it cannot be modified here.
-      legacy:
-        description: 'You will need to enable <a href="{target}">Legacy Features</a>'
-      mcm:
-        description: Navigate to <a href="{target}">Multi-cluster Apps</a>
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -567,6 +567,14 @@ catalog:
             other { seconds }
           }
       wait: Wait
+    multiCluster:
+      label: This is a Multi-cluster App and it cannot be modified here.
+      legacy:
+        label: You will need to turn on
+        target: Legacy Features
+      mcm:
+        label: Navigate to
+        target: Multi-cluster Apps
     namespaceIsInProject: "This chart's target namespace, <code>{namespace}</code>, already exists and cannot be added to a different project."
     project: Install into Project
     section:

--- a/config/types.js
+++ b/config/types.js
@@ -129,7 +129,6 @@ export const MANAGEMENT = {
   CLUSTER:                       'management.cattle.io.cluster',
   CLUSTER_ROLE_TEMPLATE_BINDING: 'management.cattle.io.clusterroletemplatebinding',
   FEATURE:                       'management.cattle.io.feature',
-  MULTI_CLUSTER_APP:             'management.cattle.io.multiclusterapp',
   GROUP:                         'management.cattle.io.group',
   NODE_POOL:                     'management.cattle.io.nodepool',
   NODE_TEMPLATE:                 'management.cattle.io.nodetemplate',

--- a/config/types.js
+++ b/config/types.js
@@ -128,6 +128,7 @@ export const MANAGEMENT = {
   CLUSTER:                       'management.cattle.io.cluster',
   CLUSTER_ROLE_TEMPLATE_BINDING: 'management.cattle.io.clusterroletemplatebinding',
   FEATURE:                       'management.cattle.io.feature',
+  MULTI_CLUSTER_APP:             'management.cattle.io.multiclusterapp',
   GROUP:                         'management.cattle.io.group',
   NODE_POOL:                     'management.cattle.io.nodepool',
   NODE_TEMPLATE:                 'management.cattle.io.nodetemplate',

--- a/config/types.js
+++ b/config/types.js
@@ -9,7 +9,7 @@ export const STEVE = { PREFERENCE: 'userpreference' };
 // Old APIs via Norman
 // Base: /v3
 export const NORMAN = {
-  APP:         'app',
+  APP:                           'app',
   AUTH_CONFIG:                   'authconfig',
   ETCD_BACKUP:                   'etcdbackup',
   CLUSTER_TOKEN:                 'clusterregistrationtoken',

--- a/config/types.js
+++ b/config/types.js
@@ -9,6 +9,7 @@ export const STEVE = { PREFERENCE: 'userpreference' };
 // Old APIs via Norman
 // Base: /v3
 export const NORMAN = {
+  APP:         'app',
   AUTH_CONFIG: 'authconfig',
   CLUSTER:                       'cluster',
   PRINCIPAL:   'principal',

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -228,17 +228,21 @@ export default {
         const { clusterName, projectName } = this.spec?.values?.global;
 
         if (clusterName && projectName) {
-          const legacyApp = await this.$dispatch('rancher/find', {
-            type: NORMAN.APP,
-            id:   `${ projectName }:${ this.metadata?.name }`,
-            opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
-          }, { root: true });
+          try {
+            const legacyApp = await this.$dispatch('rancher/find', {
+              type: NORMAN.APP,
+              id:   `${ projectName }:${ this.metadata?.name }`,
+              opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
+            }, { root: true });
 
-          if (legacyApp) {
-            return legacyApp;
-          }
+            if (legacyApp) {
+              return legacyApp;
+            }
+          } catch (e) {}
         }
       }
+
+      return false;
     };
   }
 }

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -67,6 +67,10 @@ export default {
     // null = no upgrade found
     // object = version available to upgrade to
 
+    if ( this.deployedAsLegacy ) {
+      return false;
+    }
+
     if ( this.spec?.chart?.metadata?.annotations?.[FLEET.BUNDLE_ID] ) {
       // Things managed by fleet shouldn't show ugrade available even if there might be.
       return false;

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -5,7 +5,7 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, FLEET } from '@/config/labels-annotations';
 import { compare, isPrerelease, sortable } from '@/utils/version';
 import { filterBy } from '@/utils/array';
-import { CATALOG, MANAGEMENT, NORMAN } from '@/config/types';
+import { CATALOG, NORMAN } from '@/config/types';
 import { SHOW_PRE_RELEASE } from '@/store/prefs';
 
 export default {

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -5,7 +5,7 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, FLEET } from '@/config/labels-annotations';
 import { compare, isPrerelease, sortable } from '@/utils/version';
 import { filterBy } from '@/utils/array';
-import { CATALOG, MANAGEMENT } from '@/config/types';
+import { CATALOG, MANAGEMENT, NORMAN } from '@/config/types';
 import { SHOW_PRE_RELEASE } from '@/store/prefs';
 
 export default {
@@ -225,6 +225,26 @@ export default {
       }
 
       return null;
+    };
+  }
+
+  get deployedAsLegacy() {
+    return async() => {
+      if (this.spec.values) {
+        const { clusterName, projectName } = this.spec?.values?.global;
+
+        if (clusterName && projectName) {
+          const legacyApp = await this.$dispatch('rancher/find', {
+            type: NORMAN.APP,
+            id:   `${ projectName }:${ this.metadata?.name }`,
+            opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
+          }, { root: true });
+
+          if (legacyApp) {
+            return legacyApp;
+          }
+        }
+      }
     };
   }
 }

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -215,7 +215,7 @@ export default {
       const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
 
       if (mcapps) {
-        return mcapps.find(mcapp => mcapp.spec.targets.find(target => target.appName === this.metadata?.name));
+        return mcapps.find(mcapp => mcapp.spec?.targets?.find(target => target.appName === this.metadata?.name));
       }
 
       return null;

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -215,13 +215,7 @@ export default {
       const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
 
       if (mcapps) {
-        for (let i = 0 ; i < mcapps.length ; i++) {
-          const res = mcapps[i].spec?.targets?.find(target => target.appName === this.metadata?.name);
-
-          if (res) {
-            return res;
-          }
-        }
+        return mcapps.find(mcapp => mcapp.spec.targets.find(target => target.appName === this.metadata?.name));
       }
 
       return null;

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -5,7 +5,7 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, FLEET } from '@/config/labels-annotations';
 import { compare, isPrerelease, sortable } from '@/utils/version';
 import { filterBy } from '@/utils/array';
-import { CATALOG } from '@/config/types';
+import { CATALOG, MANAGEMENT } from '@/config/types';
 import { SHOW_PRE_RELEASE } from '@/store/prefs';
 
 export default {
@@ -30,7 +30,7 @@ export default {
 
     const upgrade = {
       action:     'goToUpgrade',
-      enabled:    !this.currentVersionHasNoChart,
+      enabled:    true,
       icon:       'icon icon-fw icon-edit',
       label:      this.t('catalog.install.action.goToUpgrade'),
     };
@@ -208,8 +208,26 @@ export default {
 
   deployedResources() {
     return filterBy(this.metadata?.relationships || [], 'rel', 'helmresource');
-  },
-};
+  }
+
+  get deployedAsMultiCluster() {
+    return async() => {
+      const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
+
+      if (mcapps) {
+        for (let i = 0 ; i < mcapps.length ; i++) {
+          const res = mcapps[i].spec?.targets?.find(target => target.appName === this.metadata?.name);
+
+          if (res) {
+            return res;
+          }
+        }
+      }
+
+      return null;
+    };
+  }
+}
 
 function cleanupVersion(version) {
   if ( !version ) {

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -30,7 +30,7 @@ export default {
 
     const upgrade = {
       action:     'goToUpgrade',
-      enabled:    true,
+      enabled:    !this.currentVersionHasNoChart,
       icon:       'icon icon-fw icon-edit',
       label:      this.t('catalog.install.action.goToUpgrade'),
     };

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -68,7 +68,7 @@ export default {
     // object = version available to upgrade to
 
     if ( this.deployedAsLegacy ) {
-      return false;
+      return null;
     }
 
     if ( this.spec?.chart?.metadata?.annotations?.[FLEET.BUNDLE_ID] ) {

--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -30,7 +30,7 @@ export default {
 
     const upgrade = {
       action:     'goToUpgrade',
-      enabled:    !!this.deployedAsLegacy && !!this.deployedAsMultiCluster,
+      enabled:    !this.deployedAsLegacy,
       icon:       'icon icon-fw icon-edit',
       label:      this.t('catalog.install.action.goToUpgrade'),
     };
@@ -210,32 +210,20 @@ export default {
     return filterBy(this.metadata?.relationships || [], 'rel', 'helmresource');
   },
 
-  async deployedAsMultiCluster() {
-    try {
-      const mcapps = await this.$dispatch('management/findAll', { type: MANAGEMENT.MULTI_CLUSTER_APP }, { root: true });
-
-      if ( mcapps ) {
-        return mcapps.find(mcapp => mcapp.spec?.targets?.find(target => target.appName === this.metadata?.name));
-      }
-    } catch (e) {}
-
-    return false;
-  },
-
-  async deployedAsLegacy() {
+  deployedAsLegacy() {
     if ( this.spec.values ) {
       const { clusterName, projectName } = this.spec?.values?.global;
 
       if ( clusterName && projectName ) {
         try {
-          const legacyApp = await this.$dispatch('rancher/find', {
+          const legacyApp = this.$dispatch('rancher/find', {
             type: NORMAN.APP,
-            id:   `${ projectName }:${ this.metadata?.name }`,
-            opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata?.name }` }
+            id:   `${ projectName }:${ this.metadata.name }`,
+            opt:  { url: `/v3/project/${ clusterName }:${ projectName }/apps/${ projectName }:${ this.metadata.name }` }
           }, { root: true });
 
           if ( legacyApp ) {
-            return legacyApp;
+            return true;
           }
         } catch (e) {}
       }


### PR DESCRIPTION
### Summary
Fixes #4947

The backport had a number of incompatible commits. I committed the relevant code and added a bit that would fix the issue of apps not being upgradable if they came from the ember side. 

### Occurred changes and/or fixed issues
Following the course of action from the previous commits, the "Edit/Upgrade" action is now no longer available for apps which are considered `legacy`.

### Technical notes summary
We are checking for a match of any given app within Norman by the `id` and `url` of the app: 
 - `/v3/api/<cluster-name>:<project-name>/apps/<project-name>:<app.metadata.name>`

Also we were checking for multi-cluster apps before, which is unnecessary as the app will appear as legacy regardless.  

### Areas or cases that should be tested
- Install an app on the local cluster from the ClusterManager (ember) view
- Navigate to the Cluster Explorer => Apps & Marketplace => Installed Apps
- View the actions of the recently installed app
