### PR TITLE
Fix bug where delay loading only worked on scroll with live columns

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -492,7 +492,7 @@ export default {
     dasherize,
 
     onScroll() {
-      if (this.hasLiveColumns) {
+      if (this.hasLiveColumns || this.hasDelayedColumns) {
         clearTimeout(this._liveColumnsTimer);
         clearTimeout(this._scrollTimer);
         clearTimeout(this._delayedColumnsTimer);


### PR DESCRIPTION
Fixes a bug in Sortable Table where the delayed columns would not update on scroll if there was no live column in the table.