### PR TITLE
Enable filtering by project name on project/namespaces page

### DIFF
--- a/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -90,6 +90,7 @@ export default {
           groupByLabel:     `${ ('resourceTable.groupLabel.notInAProject') }-${ project.id }`,
           isFake:           true,
           mainRowKey:       project.id,
+          nameDisplay:      project.spec?.displayName, // Enable filtering by the project name
           project,
           availableActions: []
         };


### PR DESCRIPTION
Fixes #5626

This PR adds the nameDisplay property to the fake row for an empty project so that it shows up when you filter.