### PR TITLE
[2.5.13] Fix Installed Apps list when containing apps from helm cli

### DIFF
--- a/models/catalog.cattle.io.app.js
+++ b/models/catalog.cattle.io.app.js
@@ -7,6 +7,7 @@ import { compare, isPrerelease, sortable } from '@/utils/version';
 import { filterBy } from '@/utils/array';
 import { CATALOG, NORMAN } from '@/config/types';
 import { SHOW_PRE_RELEASE } from '@/store/prefs';
+import { get } from '@/utils/object';
 
 export default {
   showMasthead() {
@@ -215,7 +216,7 @@ export default {
   },
 
   deployedAsLegacy() {
-    if ( this.spec.values ) {
+    if ( get(this, 'spec.values.global')) {
       const { clusterName, projectName } = this.spec?.values?.global;
 
       if ( clusterName && projectName ) {


### PR DESCRIPTION
FIxes #5639 

Apps installed via helm cli may have `spec.values` defined but no `spec.values.global`

Edit: this was fixed [here](https://github.com/rancher/dashboard/commit/e1cb9a2f6c48d3960aa088c7368c8831705b8bbc) for 2.6: I didn't grab that actual commit since it happened post resource classification