### PR TITLE
Fix a number of areas where the sticky footer consumes large amounts of space

### DIFF
--- a/assets/styles/global/_resource.scss
+++ b/assets/styles/global/_resource.scss
@@ -3,6 +3,8 @@
     display: flex;
     flex-wrap: wrap;
     width: 100%;
+    flex-direction:row;
+    align-content: baseline;
   }
   .subtype-content {
     width: 100%;
@@ -58,7 +60,6 @@
     }
 
     &:not(.top) {
-      align-items: top;
       flex-direction: column;
       justify-content: start;
       &:hover {

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -385,7 +385,7 @@ export default {
 
       <section
         v-else
-        class="cru-resource-yaml-container cru__content"
+        class="cru-resource-yaml-container resource-container cru__content"
       >
         <ResourceYaml
           ref="resourceyaml"
@@ -398,6 +398,7 @@ export default {
           :done-override="resource.doneOverride"
           :errors="errors"
           :apply-hooks="applyHooks"
+          class="resource-container cru__content"
           @error="e=>$emit('error', e)"
         >
           <template #yamlFooter="{yamlSave, showPreview, yamlPreview, yamlUnpreview}">

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -268,8 +268,8 @@ export default {
       class="create-resource-container cru__form"
     >
       <div
+        v-if="hasErrors"
         class="cru__errors"
-        :v-if="hasErrors"
       >
         <Banner
           v-for="(err, i) in errors"
@@ -283,7 +283,7 @@ export default {
       </div>
       <div
         v-if="showSubtypeSelection"
-        class="subtypes-container"
+        class="subtypes-container cru__content"
       >
         <slot name="subtypes" :subtypes="subtypes">
           <div
@@ -459,6 +459,12 @@ export default {
   }
 }
 .create-resource-container {
+
+  .resource-container {
+    display: flex; // Ensures content grows in child CruResources
+    flex-direction: column;
+  }
+
   .subtype-banner {
     .round-image {
       background-color: var(--primary);
@@ -506,6 +512,12 @@ $logo-space: 100px;
   }
 }
 
+form.create-resource-container .cru {
+  &__footer {
+    // Only show border when the mode is not view
+    border-top: var(--header-border-size) solid var(--header-border);
+  }
+}
 .cru {
   display: flex;
   flex-direction: column;
@@ -526,7 +538,6 @@ $logo-space: 100px;
     position: sticky;
     bottom: 0;
     background-color: var(--header-bg);
-    border-top: var(--header-border-size) solid var(--header-border);
 
     // Overrides outlet padding
     margin-left: -$space-m;

--- a/components/ResourceDetail/index.vue
+++ b/components/ResourceDetail/index.vue
@@ -62,6 +62,11 @@ export default {
       type:    String,
       default: null,
     },
+
+    flexContent: {
+      type:    Boolean,
+      default: false,
+    }
   },
   async fetch() {
     const store = this.$store;
@@ -348,6 +353,7 @@ export default {
       :offer-preview="offerPreview"
       :done-route="doneRoute"
       :done-override="value.doneOverride"
+      :class="{'flex-content': flexContent}"
     />
 
     <component
@@ -362,6 +368,7 @@ export default {
       :initial-value="initialModel"
       :live-value="liveModel"
       :real-mode="realMode"
+      :class="{'flex-content': flexContent}"
       @set-subtype="setSubtype"
     />
 
@@ -371,3 +378,11 @@ export default {
     <button v-if="isView" v-shortkey.once="['e']" class="hide" @shortkey="keyAction('goToEdit')" />
   </div>
 </template>
+
+<style lang='scss' scoped>
+.flex-content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+</style>

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -334,7 +334,7 @@ export default {
       ref="yamleditor"
       v-model="currentYaml"
       :initial-yaml-values="initialYaml"
-      class="yaml-editor"
+      class="yaml-editor flex-content"
       :editor-mode="editorMode"
       @onInput="onInput"
       @onReady="onReady"
@@ -386,6 +386,14 @@ export default {
   </div>
 </template>
 
+<style lang='scss' scoped>
+.flex-content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+</style>
+
 <style lang="scss">
 .resource-yaml {
   .yaml-editor {
@@ -396,4 +404,5 @@ export default {
     text-align: right;
   }
 }
+
 </style>

--- a/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -224,110 +224,108 @@ export default {
 };
 </script>
 <template>
-  <div>
-    <CruResource
-      :done-route="doneRoute"
-      :mode="mode"
-      :resource="value"
-      :selected-subtype="value.kind"
-      :subtypes="templateSubtypes"
-      :validation-passed="true"
-      :errors="errors"
-      @error="e=>errors = e"
-      @finish="save"
-      @select-type="selectTemplateSubtype"
-    >
-      <div v-if="value" class="gatekeeper-constraint">
-        <div>
-          <NameNsDescription
-            v-if="!isView"
-            :value="value"
+  <CruResource
+    :done-route="doneRoute"
+    :mode="mode"
+    :resource="value"
+    :selected-subtype="value.kind"
+    :subtypes="templateSubtypes"
+    :validation-passed="true"
+    :errors="errors"
+    @error="e=>errors = e"
+    @finish="save"
+    @select-type="selectTemplateSubtype"
+  >
+    <div v-if="value" class="gatekeeper-constraint">
+      <div>
+        <NameNsDescription
+          v-if="!isView"
+          :value="value"
+          :mode="mode"
+          :namespaced="false"
+        />
+      </div>
+      <div class="row mb-40">
+        <div class="col span-12">
+          <h3>Enforcement Action</h3>
+          <RadioGroup
+            v-model="value.spec.enforcementAction"
+            name="enforcementAction"
+            class="enforcement-action"
+            :options="enforcementActionOptions"
+            :labels="enforcementActionLabels"
             :mode="mode"
-            :namespaced="false"
           />
         </div>
-        <div class="row mb-40">
-          <div class="col span-12">
-            <h3>Enforcement Action</h3>
-            <RadioGroup
-              v-model="value.spec.enforcementAction"
-              name="enforcementAction"
-              class="enforcement-action"
-              :options="enforcementActionOptions"
-              :labels="enforcementActionLabels"
-              :mode="mode"
-            />
-          </div>
-        </div>
-        <Tabbed :side-tabs="true" @changed="onTabChanged">
-          <Tab name="namespaces" :label="t('gatekeeperConstraint.tab.namespaces.title')" :weight="3">
-            <div class="row">
-              <div class="col span-6">
-                <Scope v-model="value.spec.match.scope" :mode="mode" @input="onScopeChange($event)" />
-              </div>
-            </div>
-            <div v-if="showNamespaceLists" class="row mt-20">
-              <div class="col span-12">
-                <NamespaceList
-                  v-model="value.spec.match.namespaces"
-                  :label="t('gatekeeperConstraint.tab.namespaces.sub.namespaces')"
-                  tooltip="If defined, a constraint will only apply to resources in a listed namespace."
-                  :mode="mode"
-                  :namespace-filter="NAMESPACE_FILTERS_HELPER.nonSystem"
-                  add-label="Add Namespace"
-                />
-              </div>
-            </div>
-            <div v-if="showNamespaceLists" class="row mt-20">
-              <div class="col span-12">
-                <NamespaceList
-                  v-model="value.spec.match.excludedNamespaces"
-                  :label="t('gatekeeperConstraint.tab.namespaces.sub.excludedNamespaces')"
-                  tooltip="If defined, a constraint will only apply to resources not in a listed namespace."
-                  :mode="mode"
-                  add-label="Add Excluded Namespace"
-                />
-              </div>
-            </div>
-            <div class="row mt-40">
-              <div class="col span-12">
-                <h3>{{ t('gatekeeperConstraint.tab.namespaces.sub.namespaceSelector.title') }}</h3>
-                <RuleSelector
-                  v-model="value.spec.match.namespaceSelector.matchExpressions"
-                  add-label="Add Namespace Selector"
-                  :mode="mode"
-                />
-              </div>
-            </div>
-          </Tab>
-          <Tab name="rules" :label="t('gatekeeperConstraint.tab.rules.title')" :weight="2">
-            <div class="row">
-              <div class="col span-12">
-                <MatchKinds v-model="value.spec.match.kinds" :mode="mode" />
-              </div>
-            </div>
-            <div class="row mt-40">
-              <div class="col span-12">
-                <h3>{{ t('gatekeeperConstraint.tab.rules.sub.labelSelector.title') }}</h3>
-                <RuleSelector
-                  v-model="value.spec.match.labelSelector.matchExpressions"
-                  :add-label="t('gatekeeperConstraint.tab.rules.sub.labelSelector.addLabel')"
-                  :mode="mode"
-                />
-              </div>
-            </div>
-          </Tab>
-          <Tab name="parameters" :label="t('gatekeeperConstraint.tab.parameters.title')" :weight="1">
-            <YamlEditor
-              ref="yamlEditor"
-              v-model="parametersYaml"
-              class="yaml-editor"
-              :editor-mode="editorMode"
-              @newObject="$set(value.spec, 'parameters', $event)"
-            />
-          </Tab>
-        </Tabbed>
       </div>
-    </CruResource>
-  </div>
+      <Tabbed :side-tabs="true" @changed="onTabChanged">
+        <Tab name="namespaces" :label="t('gatekeeperConstraint.tab.namespaces.title')" :weight="3">
+          <div class="row">
+            <div class="col span-6">
+              <Scope v-model="value.spec.match.scope" :mode="mode" @input="onScopeChange($event)" />
+            </div>
+          </div>
+          <div v-if="showNamespaceLists" class="row mt-20">
+            <div class="col span-12">
+              <NamespaceList
+                v-model="value.spec.match.namespaces"
+                :label="t('gatekeeperConstraint.tab.namespaces.sub.namespaces')"
+                tooltip="If defined, a constraint will only apply to resources in a listed namespace."
+                :mode="mode"
+                :namespace-filter="NAMESPACE_FILTERS_HELPER.nonSystem"
+                add-label="Add Namespace"
+              />
+            </div>
+          </div>
+          <div v-if="showNamespaceLists" class="row mt-20">
+            <div class="col span-12">
+              <NamespaceList
+                v-model="value.spec.match.excludedNamespaces"
+                :label="t('gatekeeperConstraint.tab.namespaces.sub.excludedNamespaces')"
+                tooltip="If defined, a constraint will only apply to resources not in a listed namespace."
+                :mode="mode"
+                add-label="Add Excluded Namespace"
+              />
+            </div>
+          </div>
+          <div class="row mt-40">
+            <div class="col span-12">
+              <h3>{{ t('gatekeeperConstraint.tab.namespaces.sub.namespaceSelector.title') }}</h3>
+              <RuleSelector
+                v-model="value.spec.match.namespaceSelector.matchExpressions"
+                add-label="Add Namespace Selector"
+                :mode="mode"
+              />
+            </div>
+          </div>
+        </Tab>
+        <Tab name="rules" :label="t('gatekeeperConstraint.tab.rules.title')" :weight="2">
+          <div class="row">
+            <div class="col span-12">
+              <MatchKinds v-model="value.spec.match.kinds" :mode="mode" />
+            </div>
+          </div>
+          <div class="row mt-40">
+            <div class="col span-12">
+              <h3>{{ t('gatekeeperConstraint.tab.rules.sub.labelSelector.title') }}</h3>
+              <RuleSelector
+                v-model="value.spec.match.labelSelector.matchExpressions"
+                :add-label="t('gatekeeperConstraint.tab.rules.sub.labelSelector.addLabel')"
+                :mode="mode"
+              />
+            </div>
+          </div>
+        </Tab>
+        <Tab name="parameters" :label="t('gatekeeperConstraint.tab.parameters.title')" :weight="1">
+          <YamlEditor
+            ref="yamlEditor"
+            v-model="parametersYaml"
+            class="yaml-editor"
+            :editor-mode="editorMode"
+            @newObject="$set(value.spec, 'parameters', $event)"
+          />
+        </Tab>
+      </Tabbed>
+    </div>
+  </CruResource>
 </template>

--- a/edit/management.cattle.io.user.vue
+++ b/edit/management.cattle.io.user.vue
@@ -181,72 +181,71 @@ export default {
 
 <template>
   <Loading v-if="!value" />
-  <div v-else>
-    <CruResource
-      :done-route="doneRoute"
-      :mode="mode"
-      :resource="value"
-      :validation-passed="valid"
-      :errors="errors"
-      :can-yaml="false"
-      class="create-edit"
-      @finish="save"
-    >
-      <div class="credentials">
-        <h2> {{ t("user.edit.credentials.label") }}</h2>
-        <div class="row">
-          <div class="col span-4">
-            <LabeledInput
-              ref="name"
-              v-model="form.username"
-              label-key="user.edit.credentials.username.label"
-              placeholder-key="user.edit.credentials.username.placeholder"
-              :required="isCreate"
-              :readonly="isEdit"
-              :disabled="isView || isEdit"
-              :ignore-password-managers="!isCreate"
-            />
-          </div>
-          <div class="col span-4">
-            <LabeledInput
-              v-model="form.displayName"
-              label-key="user.edit.credentials.displayName.label"
-              placeholder-key="user.edit.credentials.displayName.placeholder"
-              :disabled="isView"
-            />
-          </div>
+  <CruResource
+    v-else
+    :done-route="doneRoute"
+    :mode="mode"
+    :resource="value"
+    :validation-passed="valid"
+    :errors="errors"
+    :can-yaml="false"
+    class="create-edit"
+    @finish="save"
+  >
+    <div class="credentials">
+      <h2> {{ t("user.edit.credentials.label") }}</h2>
+      <div class="row">
+        <div class="col span-4">
+          <LabeledInput
+            ref="name"
+            v-model="form.username"
+            label-key="user.edit.credentials.username.label"
+            placeholder-key="user.edit.credentials.username.placeholder"
+            :required="isCreate"
+            :readonly="isEdit"
+            :disabled="isView || isEdit"
+            :ignore-password-managers="!isCreate"
+          />
         </div>
-        <div class="row mt-20 mb-10">
-          <div class="col span-8">
-            <LabeledInput
-              v-model="form.description"
-              label-key="user.edit.credentials.userDescription.label"
-              placeholder-key="user.edit.credentials.userDescription.placeholder"
-              :disabled="isView"
-            />
-          </div>
+        <div class="col span-4">
+          <LabeledInput
+            v-model="form.displayName"
+            label-key="user.edit.credentials.displayName.label"
+            placeholder-key="user.edit.credentials.displayName.placeholder"
+            :disabled="isView"
+          />
         </div>
+      </div>
+      <div class="row mt-20 mb-10">
+        <div class="col span-8">
+          <LabeledInput
+            v-model="form.description"
+            label-key="user.edit.credentials.userDescription.label"
+            placeholder-key="user.edit.credentials.userDescription.placeholder"
+            :disabled="isView"
+          />
+        </div>
+      </div>
 
-        <ChangePassword
-          v-if="!isView"
-          ref="changePassword"
-          v-model="form.password"
-          :mode="mode"
-          :must-change-password="value.mustChangePassword"
-          @valid="validation.password = $event"
-        />
-      </div>
-      <div v-if="showGlobalRoles" class="global-permissions">
-        <GlobalRoleBindings
-          ref="grb"
-          :user-id="value.id || liveValue.id"
-          :mode="mode"
-          :real-mode="realMode"
-          type="user"
-          @hasChanges="validation.rolesChanged = $event"
-          @canLogIn="validation.roles = $event"
-        />
-      </div>
-    </CruResource>
-  </div>
+      <ChangePassword
+        v-if="!isView"
+        ref="changePassword"
+        v-model="form.password"
+        :mode="mode"
+        :must-change-password="value.mustChangePassword"
+        @valid="validation.password = $event"
+      />
+    </div>
+    <div v-if="showGlobalRoles" class="global-permissions">
+      <GlobalRoleBindings
+        ref="grb"
+        :user-id="value.id || liveValue.id"
+        :mode="mode"
+        :real-mode="realMode"
+        type="user"
+        @hasChanges="validation.rolesChanged = $event"
+        @canLogIn="validation.roles = $event"
+      />
+    </div>
+  </CruResource>
 </template>

--- a/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -35,6 +35,10 @@ export default {
     cancel: {
       type:     Function,
       required: true,
+    },
+    showingForm: {
+      type:     Boolean,
+      required: true,
     }
   },
 
@@ -222,6 +226,8 @@ export default {
     :cancel-event="true"
     :errors="errors"
     finish-button-mode="continue"
+    class="select-credentials"
+    :class="{'select-credentials__showingForm': showingForm}"
     @finish="save"
     @cancel="cancel"
     @error="e=>errors = e"
@@ -272,3 +278,12 @@ export default {
     </template>
   </CruResource>
 </template>
+
+<style lang='scss' scoped>
+  .select-credentials {
+    flex-grow: 1; // Do grow when on own
+    &__showingForm {
+      flex-grow: 0; // Don't grow when in rke2 form
+    }
+  }
+</style>

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -501,11 +501,6 @@ export default {
 </template>
 
 <style lang='scss'>
-  .create-cluster > .create-resource-container > .subtypes-container {
-    flex-direction:column;
-  }
-</style>
-<style lang='scss'>
   .grouped-type {
     position: relative;
   }

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -447,6 +447,7 @@ export default {
     :errors="errors"
     :subtypes="subTypes"
     :cancel-event="true"
+    class="create-cluster"
     @finish="save"
     @cancel="cancel"
     @select-type="selectType"
@@ -499,6 +500,11 @@ export default {
   </CruResource>
 </template>
 
+<style lang='scss'>
+  .create-cluster > .create-resource-container > .subtypes-container {
+    flex-direction:column;
+  }
+</style>
 <style lang='scss'>
   .grouped-type {
     position: relative;

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -819,6 +819,10 @@ export default {
       }
 
       return null;
+    },
+
+    showForm() {
+      return this.credentialId || !this.needCredential;
     }
   },
 
@@ -1464,6 +1468,7 @@ export default {
     :done-route="doneRoute"
     :apply-hooks="applyHooks"
     :generate-yaml="generateYaml"
+    class="rke2"
     @done="done"
     @finish="saveOverride"
     @cancel="cancel"
@@ -1481,9 +1486,10 @@ export default {
       :mode="mode"
       :provider="provider"
       :cancel="cancelCredential"
+      :showing-form="showForm"
     />
 
-    <div v-if="credentialId || !needCredential" class="mt-20">
+    <div v-if="showForm" class="mt-20">
       <NameNsDescription
         v-if="!isView"
         v-model="value"
@@ -2040,6 +2046,7 @@ export default {
     </template>
   </CruResource>
 </template>
+
 <style lang="scss" scoped>
   .k3s-tech-preview-info {
     color: var(--error);

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -822,7 +822,7 @@ export default {
     },
 
     showForm() {
-      return this.credentialId || !this.needCredential;
+      return !!this.credentialId || !this.needCredential;
     }
   },
 

--- a/pages/c/_cluster/auth/config/_id.vue
+++ b/pages/c/_cluster/auth/config/_id.vue
@@ -28,5 +28,5 @@ export default {
 </script>
 
 <template>
-  <ResourceDetail :resource-override="AUTH_CONFIG" />
+  <ResourceDetail :resource-override="AUTH_CONFIG" :flex-content="true" />
 </template>


### PR DESCRIPTION
- Fixes #5643
- Mostly caused by non-standard ways the CruResource was being used

Effected Areas / Places to test
Note - Only need to visit pages, shouldn't need to make any changes to resources
- Cluster create/import screens (types, credentials (create new / existing), import, rke2)
- Auth providers (shortest form is keycloak saml)
- Create/Edit resource types - project, namespace, some random others
- Create/Edit resource types that have sub-types (secrets, workloads, OPA Gateway / Constraints)

Also Addressed
- Only show top border of the footer if CruResource is in edit view (View a kube resource and go to the `Config` tab)
- Fixed hide of errors (div was shown regardless of number of errors)