### PR TITLE
HARVESTER: Fix Grafana metrics reload failure

### DIFF
--- a/components/GrafanaDashboard.vue
+++ b/components/GrafanaDashboard.vue
@@ -83,20 +83,26 @@ export default {
 
       this.interval = setInterval(() => {
         try {
-          const errorElements = this.$refs.frame.contentWindow.document.getElementsByClassName('alert-error');
-          const errorCornerElements = this.$refs.frame.contentWindow.document.getElementsByClassName('panel-info-corner--error');
-          const panelInFullScreenElements = this.$refs.frame.contentWindow.document.getElementsByClassName('panel-in-fullscreen');
-          const panelContainerElements = this.$refs.frame.contentWindow.document.getElementsByClassName('panel-container');
+          const graphWindow = this.$refs.frame?.contentWindow;
+          const errorElements = graphWindow.document.getElementsByClassName('alert-error');
+          const errorCornerElements = graphWindow.document.getElementsByClassName('panel-info-corner--error');
+          const panelInFullScreenElements = graphWindow.document.getElementsByClassName('panel-in-fullscreen');
+          const panelContainerElements = graphWindow.document.getElementsByClassName('panel-container');
           const error = errorElements.length > 0 || errorCornerElements.length > 0;
           const loaded = panelInFullScreenElements.length > 0 || panelContainerElements.length > 0;
+          const errorMessageElms = graphWindow.document.getElementsByTagName('pre');
+          const errorMessage = errorMessageElms.length > 0 ? errorMessageElms[0].innerText : '';
+          const isFailure = errorMessage.includes('"status": "Failure"');
 
           if (error) {
             throw new Error('An error was detected in the iframe');
           }
 
           this.$set(this, 'loading', !loaded);
+          this.$set(this, 'error', isFailure);
         } catch (ex) {
           this.$set(this, 'error', true);
+          this.$set(this, 'loading', false);
           clearInterval(this.interval);
           this.interval = null;
         }
@@ -184,7 +190,12 @@ export default {
         }
       `;
 
-      this.graphDocument.head.appendChild(style);
+      const graphWindow = this.$refs.frame?.contentWindow;
+      const graphDocument = graphWindow?.document;
+
+      if (graphDocument.head) {
+        graphDocument.head.appendChild(style);
+      }
     },
 
     inject() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes Grafana metrics reload failure
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- https://github.com/harvester/harvester/issues/2150
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Fix reload won't show the metrics when the reload is successful.
- Fix injectCss doesn't work after reload because the `window.document` is changed and `graphDocument` didn;t recompute.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Reproduce Steps: https://github.com/harvester/harvester/issues/2150#issuecomment-1099972410

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->