### PR TITLE
Remove 'tech preview' tag from RKE2/K3s cluster provisioning buttons

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -289,6 +289,7 @@ export default {
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
         const tag = '';
 
+        // Always prefer the built-in icon if there is one
         let icon;
 
         try {

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -287,7 +287,8 @@ export default {
       function addType(id, group, disabled = false, link = null, iconClass = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
-        const tag = '';
+        const techPreview = getters['i18n/t']('generic.techPreview');
+        let tag = '';
 
         // Always prefer the built-in icon if there is one
         let icon;
@@ -300,6 +301,10 @@ export default {
           iconClass = undefined;
         } else if (!iconClass) {
           icon = require('~/assets/images/generic-driver.svg');
+        }
+
+        if (group === 'rke2' && id === 'harvester') {
+          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: techPreview }, '');
         }
 
         const subtype = {

--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -287,11 +287,8 @@ export default {
       function addType(id, group, disabled = false, link = null, iconClass = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
-        const techPreview = getters['i18n/t']('generic.techPreview');
-        const isTechPreview = group === 'rke2' || group === 'custom2';
-        let tag = isTechPreview ? techPreview : getters['i18n/withFallback'](`cluster.providerTag."${ id }"`, { techPreview }, '');
+        const tag = '';
 
-        // Always prefer the built-in icon if there is one
         let icon;
 
         try {
@@ -302,10 +299,6 @@ export default {
           iconClass = undefined;
         } else if (!iconClass) {
           icon = require('~/assets/images/generic-driver.svg');
-        }
-
-        if (group === 'rke2' && id === 'harvester') {
-          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: techPreview }, '');
         }
 
         const subtype = {


### PR DESCRIPTION
This removes the `Tech Preview` label from all providers on the cluster provisioning page, except for Harvester.

### Before

![image](https://user-images.githubusercontent.com/835961/164120109-cb6aa362-5c39-402c-99e4-4688631eab74.png)

### After

![image](https://user-images.githubusercontent.com/835961/164119950-c05e9757-20a9-41f5-8a5e-68496338b19d.png)

closes #5571