### PR TITLE
RBAC role to provide project-owner permissions while limiting quota management

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3534,6 +3534,7 @@ probe:
     placeholder: Select a check type
 
 project:
+  membersEditOnly: For users which can only manage projects members, please note that for new members added, their roles need to match the permissions that the current user has available
   members:
     label: Members
   containerDefaultResourceLimit: Container Default Resource Limit

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -3534,7 +3534,7 @@ probe:
     placeholder: Select a check type
 
 project:
-  membersEditOnly: For users which can only manage projects members, please note that for new members added, their roles need to match the permissions that the current user has available
+  membersEditOnly: Only permissions equal to or below those of the current user can be applied
   members:
     label: Members
   containerDefaultResourceLimit: Container Default Resource Limit

--- a/components/form/NameNsDescription.vue
+++ b/components/form/NameNsDescription.vue
@@ -101,6 +101,10 @@ export default {
       type:    String,
       default: 'nameNsDescription.description.placeholder',
     },
+    descriptionDisabled: {
+      type:    Boolean,
+      default: false,
+    },
     // Use specific fields on the value instead of the normal metadata locations
     nameKey: {
       type:    String,
@@ -334,6 +338,7 @@ export default {
           key="description"
           v-model="description"
           :mode="mode"
+          :disabled="descriptionDisabled"
           :label="t(descriptionLabel)"
           :placeholder="t(descriptionPlaceholder)"
           :min-height="30"

--- a/components/form/ResourceQuota/ProjectRow.vue
+++ b/components/form/ResourceQuota/ProjectRow.vue
@@ -46,7 +46,7 @@ export default {
 </script>
 <template>
   <div v-if="typeOption" class="row">
-    <Select class="mr-10" :value="type" :options="types" @input="updateType($event)" />
+    <Select class="mr-10" :mode="mode" :value="type" :options="types" @input="updateType($event)" />
     <UnitInput
       v-model="value.spec.resourceQuota.limit[type]"
       class="mr-10"

--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -60,9 +60,7 @@ export default {
     },
 
     canEditProject() {
-      const projectOptions = this.$store.getters['type-map/optionsFor'](MANAGEMENT.PROJECT);
-
-      return !!(this.value?.links?.update && projectOptions && projectOptions.isEditable);
+      return this.value?.links?.update;
     },
 
     isDescriptionDisabled() {

--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -55,7 +55,7 @@ export default {
   computed: {
     ...mapGetters(['currentCluster']),
 
-    canManageMembers() {
+    canViewMembers() {
       return canViewProjectMembershipEditor(this.$store);
     },
 
@@ -187,11 +187,6 @@ export default {
     @finish="save"
     @cancel="done"
   >
-    <Banner
-      v-if="showBannerForOnlyManagingMembers"
-      color="info"
-      :label="t('project.membersEditOnly')"
-    />
     <NameNsDescription
       v-model="value"
       :mode="mode"
@@ -215,11 +210,16 @@ export default {
     </div>
     <Tabbed :side-tabs="true">
       <Tab
-        v-if="canManageMembers"
+        v-if="canViewMembers"
         name="members"
         :label="t('project.members.label')"
         :weight="10"
       >
+        <Banner
+          v-if="showBannerForOnlyManagingMembers"
+          color="info"
+          :label="t('project.membersEditOnly')"
+        />
         <ProjectMembershipEditor
           :mode="mode"
           :parent-id="value.id"

--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -141,7 +141,7 @@ export default {
           const savedProject = await this.value.save();
 
           if (this.membershipUpdate.save) {
-            this.membershipUpdate.save(savedProject.id);
+            await this.membershipUpdate.save(savedProject.id);
           }
         } else if (this.mode === _EDIT) {
           if (this.canEditProject) {
@@ -152,7 +152,7 @@ export default {
           if (this.membershipUpdate.save) {
             const norman = await this.value.norman;
 
-            this.membershipUpdate.save(norman.id);
+            await this.membershipUpdate.save(norman.id);
           }
         }
 

--- a/edit/management.cattle.io.project.vue
+++ b/edit/management.cattle.io.project.vue
@@ -65,8 +65,12 @@ export default {
       return !!(this.value?.links?.update && projectOptions && projectOptions.isEditable);
     },
 
+    isDescriptionDisabled() {
+      return (this.mode === _EDIT && !this.canEditProject) || false;
+    },
+
     canEditTabElements() {
-      if (!this.canEditProject) {
+      if (this.mode === _EDIT && !this.canEditProject) {
         return _VIEW;
       }
 
@@ -193,7 +197,7 @@ export default {
       :mode="mode"
       :namespaced="false"
       description-key="spec.description"
-      :description-disabled="!canEditProject"
+      :description-disabled="isDescriptionDisabled"
       name-key="spec.displayName"
       :normalize-name="false"
     />

--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -117,4 +117,15 @@ export default class Project extends HybridModel {
       return normanProject;
     })();
   }
+
+  // users with permissions for projectroletemplatebindings should be able to manage members on projects
+  get canUpdate() {
+    const canUpdateRoleBindings = this.$rootGetters['type-map/optionsFor']('management.cattle.io.projectroletemplatebindings');
+
+    return super.canUpdate || canUpdateRoleBindings.isEditable;
+  }
+
+  get canEditYaml() {
+    return this.schema?.resourceMethods?.find(x => x === 'blocked-PUT') ? false : super.canUpdate;
+  }
 }

--- a/models/management.cattle.io.project.js
+++ b/models/management.cattle.io.project.js
@@ -120,9 +120,13 @@ export default class Project extends HybridModel {
 
   // users with permissions for projectroletemplatebindings should be able to manage members on projects
   get canUpdate() {
-    const canUpdateRoleBindings = this.$rootGetters['type-map/optionsFor']('management.cattle.io.projectroletemplatebindings');
+    return super.canUpdate || this.canUpdateProjectBindings;
+  }
 
-    return super.canUpdate || canUpdateRoleBindings.isEditable;
+  get canUpdateProjectBindings() {
+    const schema = this.$rootGetters[`rancher/schemaFor`](NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
+
+    return schema?.collectionMethods.includes('POST');
   }
 
   get canEditYaml() {


### PR DESCRIPTION
Addresses Github issue: [#5417](https://github.com/rancher/dashboard/issues/5417)
Addresses Zube issue: [#5443](https://zube.io/rancher/dashboard-ui/c/5443)

- update `project` model to take into account `projectroletemplatebindings` to be able to manage project members 
- update `project` edit view to accomodate `projectroletemplatebindings` permissions and remove areas of the ui which should not be accessed 
- update `NameNsDescription` component to be able to disable description field if needed
- add `Banner` to `project` edit view to display disclaimer to user which are able to manage members but not the project itself

How to test:
1) create two users:
- both standard users, one to be project admin (**padmin**) and another just for testing (**test**)

2) create a new role as **Project Admin**, based on this YAML (role that the client wants to keep using when updating from `2.5.x` to `2.6-head`):
```
administrative: false
apiVersion: management.cattle.io/v3
builtin: false
clusterCreatorDefault: false
context: project
description: ""
displayName: Project Admin
external: false
hidden: false
kind: RoleTemplate
locked: false
metadata:
  annotations:
    cleanup.cattle.io/rtUpgradeCluster: "true"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"management.cattle.io/v3","builtin":false,"context":"project","description":"","displayName":"Project Admin","external":false,"hidden":false,"kind":"RoleTemplate","metadata":{"annotations":{},"name":"project-admin"},"projectCreatorDefault":true,"roleTemplateNames":["admin"],"rules":[{"apiGroups":["*"],"resources":["persistentvolumes"],"verbs":["get","list","watch"]},{"apiGroups":["*"],"resources":["storageclasses"],"verbs":["get","list","watch"]},{"apiGroups":["*"],"resources":["namespaces"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["projectmonitorgraphs"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["projectcatalogs"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["projectalertgroups"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["projectalertrules"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["projectloggings"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["projectroletemplatebindings"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["monitoring.coreos.com"],"resources":["prometheuses","prometheusRules","serviceMonitors"],"verbs":["*"]},{"apiGroups":["*"],"resources":["apps"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["apprevisions"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["pipelines"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["*"],"resources":["pipelineexecutions"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["keda.k8s.io"],"resources":["scaledobjects"],"verbs":["create","delete","get","list","patch","update","watch"]},{"apiGroups":["catalog.cattle.io"],"resources":["clusterrepos"],"verbs":["get","list","watch"]},{"apiGroups":["catalog.cattle.io"],"resources":["operations"],"verbs":["get","list","watch"]},{"apiGroups":["catalog.cattle.io"],"resources":["releases"],"verbs":["get","list","watch"]},{"apiGroups":["catalog.cattle.io"],"resources":["apps"],"verbs":["get","list","watch"]},{"apiGroups":["management.cattle.io"],"resources":["clusters"],"verbs":["get"]},{"apiGroups":["batch"],"resources":["jobs"],"verbs":["get","watch","list","create","delete","patch","update"]},{"apiGroups":["batch"],"resources":["jobs/log"],"verbs":["get","list"]},{"apiGroups":["*"],"resources":["events"],"verbs":["create","update","patch"]},{"apiGroups":["kdmp.portworx.com"],"resources":["dataexports"],"verbs":["*"]}]}
    lifecycle.cattle.io/create.mgmt-auth-roletemplate-lifecycle: "true"
  creationTimestamp: "2020-08-17T18:21:12Z"
  finalizers:
  - controller.cattle.io/mgmt-auth-roletemplate-lifecycle
  generation: 6
  name: project-admin
projectCreatorDefault: true
roleTemplateNames:
- admin
rules:
- apiGroups:
  - '*'
  resources:
  - persistentvolumes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - '*'
  resources:
  - storageclasses
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - '*'
  resources:
  - namespaces
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - projectmonitorgraphs
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - projectcatalogs
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - projectalertgroups
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - projectalertrules
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - projectloggings
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - projectroletemplatebindings
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - monitoring.coreos.com
  resources:
  - prometheuses
  - prometheusRules
  - serviceMonitors
  verbs:
  - '*'
- apiGroups:
  - '*'
  resources:
  - apps
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - apprevisions
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - pipelines
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - '*'
  resources:
  - pipelineexecutions
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - keda.k8s.io
  resources:
  - scaledobjects
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - catalog.cattle.io
  resources:
  - clusterrepos
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - catalog.cattle.io
  resources:
  - operations
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - catalog.cattle.io
  resources:
  - releases
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - catalog.cattle.io
  resources:
  - apps
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - management.cattle.io
  resources:
  - clusters
  verbs:
  - get
- apiGroups:
  - batch
  resources:
  - jobs
  verbs:
  - get
  - watch
  - list
  - create
  - delete
  - patch
  - update
- apiGroups:
  - batch
  resources:
  - jobs/log
  verbs:
  - get
  - list
- apiGroups:
  - '*'
  resources:
  - events
  verbs:
  - create
  - update
  - patch
- apiGroups:
  - kdmp.portworx.com
  resources:
  - dataexports
  verbs:
  - '*'
```

3) As admin, create a new project, then assign the user **padmin** to the project with role **Project Admin**

4) In an incognito browser window, login as user **padmin** and edit the project which was assigned to the user

5) Edit the members list by adding **test** user with `custom project permissions` -> select only `View Project Catalogs` (the user giving access may only provide credentials for which he has access to in terms of roles/actions)

6) after hitting save, **test** user should be added to the project by **padmin**