### PR TITLE
improve RKE2 snapshot error reporting

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1641,6 +1641,7 @@ cluster:
         other {A snapshot has been requested for {count} clusters}
       }
     groupLabel: Location
+    failed: "Snapshot from {time} failed"
   tabs:
     ace: Authorized Endpoint
     addons: Add-On Config

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -9,7 +9,7 @@ import Tab from '@/components/Tabbed/Tab';
 import { allHash } from '@/utils/promise';
 import { CAPI, MANAGEMENT, NORMAN, SNAPSHOT } from '@/config/types';
 import {
-  STATE, NAME as NAME_COL, AGE, AGE_NORMAN, STATE_NORMAN, ROLES, MACHINE_NODE_OS, MANAGEMENT_NODE_OS
+  STATE, NAME as NAME_COL, AGE, AGE_NORMAN, STATE_NORMAN, ROLES, MACHINE_NODE_OS, MANAGEMENT_NODE_OS, NAME
 } from '@/config/table-headers';
 import CustomCommand from '@/edit/provisioning.cattle.io.cluster/CustomCommand';
 import AsyncButton from '@/components/AsyncButton.vue';
@@ -313,14 +313,10 @@ export default {
 
     rke2SnapshotHeaders() {
       return [
-        STATE_NORMAN,
         {
-          name:          'name',
-          labelKey:      'tableHeaders.name',
-          value:         'nameDisplay',
-          sort:          ['nameSort'],
-          canBeVariable: true,
+          ...STATE_NORMAN, value: 'snapshotFile.status', formatterOpts: { arbitrary: true }
         },
+        NAME,
         {
           name:      'size',
           labelKey:  'tableHeaders.size',
@@ -623,6 +619,7 @@ export default {
 
       <Tab v-if="showSnapshots" name="snapshots" label="Snapshots" :weight="1">
         <SortableTable
+          class="snapshots"
           :headers="value.isRke1 ? rke1SnapshotHeaders : rke2SnapshotHeaders"
           default-sort-by="age"
           :table-actions="value.isRke1"
@@ -707,4 +704,10 @@ export default {
     }
   }
 }
+
+.snapshots ::v-deep .state-description{
+  font-size: .8em;
+  color: var(--error);
+}
+
 </style>

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -3,7 +3,7 @@ import Banner from '@/components/Banner';
 import ResourceTable from '@/components/ResourceTable';
 import Masthead from '@/components/ResourceList/Masthead';
 import { allHash } from '@/utils/promise';
-import { CAPI, MANAGEMENT } from '@/config/types';
+import { CAPI, MANAGEMENT, SNAPSHOT } from '@/config/types';
 import { MODE, _IMPORT } from '@/config/query-params';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@/utils/cluster';
 import { mapFeature, HARVESTER as HARVESTER_FEATURE } from '@/store/features';
@@ -18,6 +18,8 @@ export default {
     const hash = {
       mgmtClusters:       this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
       rancherClusters:    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
+      etcdSnapshots:    this.$store.dispatch('management/findAll', { type: SNAPSHOT }),
+
     };
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE) ) {

--- a/plugins/steve/resource-class.js
+++ b/plugins/steve/resource-class.js
@@ -144,6 +144,7 @@ export const STATES_ENUM = {
   STOPPING:         'stopping',
   SUCCEEDED:        'succeeded',
   SUCCESS:          'success',
+  SUCCESSFUL:          'successful',
   SUPERSEDED:       'superseded',
   SUSPENDED:        'suspended',
   UNAVAILABLE:      'unavailable',
@@ -384,6 +385,9 @@ export const STATES = {
   },
   [STATES_ENUM.SUCCESS]:            {
     color: 'success', icon: 'dot-open', label: 'Success'
+  },
+  [STATES_ENUM.SUCCESSFUL]:            {
+    color: 'success', icon: 'dot-open', label: 'Successful'
   },
   [STATES_ENUM.SUPERSEDED]:         {
     color: 'info', icon: 'dot-open', label: 'Superseded'


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5651 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
According to Chris Kim's comment [here](https://github.com/rancher/dashboard/issues/5651#issuecomment-1099608657) we can pull more detailed status info about snapshots from the `snapshotFile` property.
- add snapshot error info to the cluster error icon in the management cluster list
- use `snapshotFile.status` for the snapshot table state column
- decode and display error messages in the snapshot table

![Screen Shot 2022-04-20 at 9 30 42 AM](https://user-images.githubusercontent.com/42977925/164280874-70650578-5484-4928-890a-a36a695e463c.png)
![Screen Shot 2022-04-20 at 9 32 04 AM](https://user-images.githubusercontent.com/42977925/164280881-7b8636eb-8b08-4481-a8e8-acb654af1199.png)

