### PR TITLE
Prevent UnitInput computation while typing

### DIFF
--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -6,6 +6,7 @@ import LabeledTooltip from '@/components/form/LabeledTooltip';
 import { escapeHtml } from '@/utils/string';
 import cronstrue from 'cronstrue';
 import { isValidCron } from 'cron-validator';
+import { debounce } from 'lodash';
 
 export default {
   components: { LabeledTooltip, TextAreaAutoGrow },
@@ -50,6 +51,14 @@ export default {
     hideArrows: {
       type:    Boolean,
       default: false
+    },
+
+    /**
+     * Optionally delay on input while typing
+     */
+    delay: {
+      type:    Number,
+      default: 0
     }
   },
 
@@ -119,6 +128,14 @@ export default {
       }
     },
 
+    /**
+     * Emit on input with delay
+     * Note: Arrow function is avoided due context binding
+     */
+    onInput: debounce(function(value) {
+      this.$emit('input', value);
+    }, 500),
+
     onFocus() {
       this.onFocusLabeled();
     },
@@ -169,7 +186,7 @@ export default {
         :placeholder="_placeholder"
         autocapitalize="off"
         :class="{ conceal: type === 'multiline-password' }"
-        @input="$emit('input', $event)"
+        @input="onInput($event)"
         @focus="onFocus"
         @blur="onBlur"
       />
@@ -186,7 +203,7 @@ export default {
         autocomplete="off"
         autocapitalize="off"
         :data-lpignore="ignorePasswordManagers"
-        @input="$emit('input', $event.target.value)"
+        @input="onInput($event.target.value)"
         @focus="onFocus"
         @blur="onBlur"
       />

--- a/components/form/LabeledInput.vue
+++ b/components/form/LabeledInput.vue
@@ -63,6 +63,10 @@ export default {
   },
 
   computed: {
+    onInput() {
+      return this.delay ? debounce(this.delayInput, this.delay) : this.delayInput;
+    },
+
     hasLabel() {
       return this.isCompact ? false : !!this.label || !!this.labelKey || !!this.$slots.label;
     },
@@ -132,9 +136,9 @@ export default {
      * Emit on input with delay
      * Note: Arrow function is avoided due context binding
      */
-    onInput: debounce(function(value) {
+    delayInput(value) {
       this.$emit('input', value);
-    }, 500),
+    },
 
     onFocus() {
       this.onFocusLabeled();

--- a/components/form/UnitInput.vue
+++ b/components/form/UnitInput.vue
@@ -119,6 +119,14 @@ export default {
       type:    [String, Number],
       default: ''
     },
+
+    /**
+     * Optionally delay on input while typing
+     */
+    delay: {
+      type:    Number,
+      default: 500
+    }
   },
 
   computed: {
@@ -200,6 +208,7 @@ export default {
     :min="min"
     :mode="mode"
     :label="label"
+    :delay="delay"
     :label-key="labelKey"
     :tooltip="tooltip"
     :tooltip-key="tooltipKey"

--- a/components/form/__tests__/LabeledInput.test.ts
+++ b/components/form/__tests__/LabeledInput.test.ts
@@ -1,0 +1,20 @@
+
+import { mount } from '@vue/test-utils';
+import LabeledInput from '@/components/form/LabeledInput.vue';
+
+describe('component: LabeledInput', () => {
+  it('should emit input only once', () => {
+    const value = '2';
+    const delay = 1;
+    const wrapper = mount(LabeledInput, { propsData: { delay } });
+
+    jest.useFakeTimers();
+    wrapper.find('input').setValue('1');
+    wrapper.find('input').setValue(value);
+    jest.advanceTimersByTime(delay);
+    jest.useRealTimers();
+
+    expect(wrapper.emitted('input')).toHaveLength(1);
+    expect(wrapper.emitted('input')![0][0]).toBe(value);
+  });
+});

--- a/components/form/__tests__/UnitInput.test.ts
+++ b/components/form/__tests__/UnitInput.test.ts
@@ -3,7 +3,7 @@ import { UNITS } from '@/utils/units';
 import UnitInput from '@/components/form/UnitInput.vue';
 import LabeledInput from '@/components/form/LabeledInput.vue';
 
-describe('unitInput', () => {
+describe('component: UnitInput', () => {
   it('should renders', () => {
     const wrapper = mount(UnitInput, { propsData: { value: 1 } });
 
@@ -153,5 +153,31 @@ describe('unitInput', () => {
 
     expect(addonText).toBe(suffix);
     expect(wrapper.emitted('input')![0][0]).not.toContain(suffix);
+  });
+
+  it('should format value to a valid integer', () => {
+    const wrapper = mount(UnitInput, { propsData: { delay: 0 } });
+    const value = '096';
+    const expectation = 96;
+
+    wrapper.find('input').setValue(value);
+
+    expect(wrapper.emitted('input')![0][0]).toBe(expectation);
+  });
+
+  it('should not correct value to a valid integer while typing', () => {
+    const value = 5096;
+    const delay = 1;
+    const wrapper = mount(UnitInput, { propsData: { delay } });
+
+    jest.useFakeTimers();
+    wrapper.find('input').setValue('4096');
+    wrapper.find('input').setValue('096');
+    wrapper.find('input').setValue(value);
+    jest.advanceTimersByTime(delay);
+    jest.useRealTimers();
+
+    expect(wrapper.emitted('input')).toHaveLength(1);
+    expect(wrapper.emitted('input')![0][0]).toBe(value);
   });
 });

--- a/components/form/__tests__/UnitInput.test.ts
+++ b/components/form/__tests__/UnitInput.test.ts
@@ -10,12 +10,12 @@ describe('unitInput', () => {
     expect(wrapper.isVisible()).toBe(true);
   });
 
-  it('should emit input event on value change', () => {
-    const wrapper = mount(UnitInput, { propsData: { value: 1 } });
+  it('should emit input event on value change', async() => {
+    const wrapper = mount(UnitInput, { propsData: { value: 1, delay: 0 } });
     const input = wrapper.find('input');
 
-    input.setValue(2);
-    input.setValue(4);
+    await input.setValue(2);
+    await input.setValue(4);
 
     expect(wrapper.emitted('input')).toHaveLength(2);
   });
@@ -27,6 +27,7 @@ describe('unitInput', () => {
     const wrapper = mount(UnitInput, {
       propsData: {
         value: 1,
+        delay: 0,
         mode
       }
     });
@@ -40,7 +41,7 @@ describe('unitInput', () => {
     ['2G', '2000000000'],
     ['3', '3'],
   ])('should parse values with SI modifier %p and return %p', (value, expected) => {
-    const wrapper = mount(UnitInput, { propsData: { value } });
+    const wrapper = mount(UnitInput, { propsData: { value, delay: 0 } });
     const label = wrapper.findComponent(LabeledInput);
 
     expect(label.props('value')).toBe(expected);
@@ -53,7 +54,8 @@ describe('unitInput', () => {
       propsData: {
         value: 1,
         inputExponent,
-        baseUnit
+        baseUnit,
+        delay: 0
       }
     });
     const expectedUnits = `${ UNITS[inputExponent] }${ baseUnit }`;
@@ -69,29 +71,29 @@ describe('unitInput', () => {
   ])('should (%p) force use of SI modifier and return %p', async(outputModifier, expected) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, inputExponent: 3, outputModifier: !outputModifier
+        value: 1, inputExponent: 3, outputModifier: !outputModifier, delay: 0
       }
     });
     const inputWrapper = wrapper.find('input');
 
-    wrapper.setProps({ outputModifier });
-    await wrapper.vm.$nextTick();
-    inputWrapper.setValue(3);
+    await wrapper.setProps({ outputModifier });
+    await inputWrapper.setValue(3);
 
     expect(wrapper.emitted('input')![0][0]).toBe(expected);
   });
 
-  it('should display defined SI unit', () => {
+  it('should display defined SI unit', async() => {
     const inputExponent = 3;
     const wrapper = mount(UnitInput, {
       propsData: {
         value:          1,
         inputExponent,
-        outputModifier: true
+        outputModifier: true,
+        delay:          0
       }
     });
 
-    wrapper.find('input').setValue(2);
+    await wrapper.find('input').setValue(2);
 
     expect(wrapper.emitted('input')![0][0]).toContain(UNITS[inputExponent]);
   });
@@ -102,7 +104,7 @@ describe('unitInput', () => {
   ])('based on increment %p and exponent M, it should use binary modifier and return unit %p', (increment, expected) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, inputExponent: 2, increment
+        value: 1, inputExponent: 2, increment, delay: 0
       }
     });
 
@@ -115,7 +117,7 @@ describe('unitInput', () => {
   ])('should force emission of value type as %p', (outputAs) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, inputExponent: 3, outputAs
+        value: 1, inputExponent: 3, outputAs, delay: 0
       }
     });
 
@@ -130,7 +132,7 @@ describe('unitInput', () => {
   ])('should appended base unit %p value to SI modifier and return %p', (baseUnit, expected) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, baseUnit, inputExponent: 2
+        value: 1, baseUnit, inputExponent: 2, delay: 0
       }
     });
     const addonText = wrapper.find('.addon').text();
@@ -140,7 +142,11 @@ describe('unitInput', () => {
 
   it('should display suffix outside of the value', () => {
     const suffix = 'seconds';
-    const wrapper = mount(UnitInput, { propsData: { value: 1, suffix } });
+    const wrapper = mount(UnitInput, {
+      propsData: {
+        value: 1, suffix, delay: 0
+      }
+    });
     const addonText = wrapper.find('.addon').text();
 
     wrapper.find('input').setValue(1);


### PR DESCRIPTION
### Summary
Fixes #5186
Prevent to modify input values while typing, in particular for invalid or formatted values, e.g. `096`.

### Occurred changes and/or fixed issues
The issue is extended to every input field with unit value validation.

### Technical notes summary
- Added possibility to delay (debounce) input values for LabeledInput components
- Added delay for UnitInput, before parse the value, to avoid issues while typing

### Areas or cases that should be tested
As defined in the ticket.
Unit tests have been added and updated.

### Areas which could experience regressions
Every/any Unit Input case.

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/164283627-2cae1dd2-95bf-4b51-bf6b-1a13cd6f0ddc.mov

