### PR TITLE
Prevent scaling machine pools to 0 if it also scales down the only etcd or controlplane machine

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -526,7 +526,7 @@ export default {
               </div>
               <div v-if="group.ref" class="right mr-45">
                 <template v-if="value.hasLink('update')">
-                  <button v-tooltip="t('node.list.scaleDown')" :disabled="!group.ref.canScalePool(-1)" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
+                  <button v-tooltip="t('node.list.scaleDown')" :disabled="!group.ref.canScaleDownPool()" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
                     <i class="icon icon-sm icon-minus" />
                   </button>
                   <button v-tooltip="t('node.list.scaleUp')" type="button" class="btn btn-sm role-secondary ml-10" @click="group.ref.scalePool(1)">

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -526,7 +526,7 @@ export default {
               </div>
               <div v-if="group.ref" class="right mr-45">
                 <template v-if="value.hasLink('update')">
-                  <button v-tooltip="t('node.list.scaleDown')" :disabled="group.ref.spec.replicas < 2" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
+                  <button v-tooltip="t('node.list.scaleDown')" :disabled="!group.ref.canScalePool(-1)" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
                     <i class="icon icon-sm icon-minus" />
                   </button>
                   <button v-tooltip="t('node.list.scaleUp')" type="button" class="btn btn-sm role-secondary ml-10" @click="group.ref.scalePool(1)">

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -7,7 +7,44 @@ import { insertAt, findBy } from '@/utils/array';
 import { get } from '@/utils/object';
 import { downloadUrl } from '@/utils/download';
 import SteveModel from '@/plugins/steve/steve-class';
+// Prevent scaling down control plane or etcd nodes to zero
+// This is a little overly optimised but avoids iterating over the whole machine set every time
+export function notOnlyOfRole(current, all) {
+  const foundType = { };
 
+  if (current.isControlPlane) {
+    foundType.isControlPlane = false;
+  }
+  if (current.isEtcd) {
+    foundType.isEtcd = false;
+  }
+  if (Object.keys(foundType).length === 0) {
+    return true; // It's neither type, so can always scale down
+  }
+
+  // If we have more than one of the required types then it's not the last of that type and can be scaled down
+  for (const m of all) {
+    Object.keys(foundType).forEach((type) => {
+      // Have we found this type?
+      if (m[type]) {
+        if (foundType[type]) {
+          // Another of this type exists, we don't need to check for it further
+          delete foundType[type];
+        } else {
+          // Record that we've found type
+          foundType[type] = true;
+        }
+      }
+    });
+
+    // Are there no types left to look for?
+    if (Object.keys(foundType).length === 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
 export default class CapiMachine extends SteveModel {
   get _availableActions() {
     const out = super._availableActions;
@@ -180,11 +217,11 @@ export default class CapiMachine extends SteveModel {
   }
 
   get canScaleDown() {
-    if (!this.canUpdate || !this.pool?.canUpdate || this.pool?.spec?.replicas < 2) {
+    if (!this.canUpdate || !this.pool?.canUpdate) {
       return false;
     }
 
-    return true;
+    return notOnlyOfRole(this, this.cluster.machines);
   }
 
   get roles() {

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -7,9 +7,17 @@ import { insertAt, findBy } from '@/utils/array';
 import { get } from '@/utils/object';
 import { downloadUrl } from '@/utils/download';
 import SteveModel from '@/plugins/steve/steve-class';
-// Prevent scaling down control plane or etcd nodes to zero
-// This is a little overly optimised but avoids iterating over the whole machine set every time
+
+/**
+ * Prevent scaling down control plane or etcd machines to zero
+ *
+ * @param {machine | machineDeployment} current
+ * @param {machine[]} all
+ * @returns
+ */
 export function notOnlyOfRole(current, all) {
+  // This is a little overly optimised but avoids iterating over all machines every time
+
   const foundType = { };
 
   if (current.isControlPlane) {

--- a/models/cluster.x-k8s.io.machine.js
+++ b/models/cluster.x-k8s.io.machine.js
@@ -180,47 +180,11 @@ export default class CapiMachine extends SteveModel {
   }
 
   get canScaleDown() {
-    if (!this.canUpdate || !this.pool?.canUpdate) {
+    if (!this.canUpdate || !this.pool?.canUpdate || this.pool?.spec?.replicas < 2) {
       return false;
     }
 
-    // Prevent scaling down control plane or etcd nodes to zero
-    // This is a little overly optimised but avoids iterating over the whole machine set every time
-    const foundType = { };
-
-    if (this.isControlPlane) {
-      foundType.isControlPlane = false;
-    }
-    if (this.isEtcd) {
-      foundType.isEtcd = false;
-    }
-
-    if (Object.keys(foundType).length === 0) {
-      return true; // It's neither type, so can always scale down
-    }
-
-    // If we have more than one of the required types then it's not the last of that type and can be scaled down
-    for (const m of this.cluster.machines) {
-      Object.keys(foundType).forEach((type) => {
-        // Have we found this type?
-        if (m[type]) {
-          if (foundType[type]) {
-            // Another of this type exists, we don't need to check for it further
-            delete foundType[type];
-          } else {
-            // Record that we've found type
-            foundType[type] = true;
-          }
-        }
-      });
-
-      // Are there no types left to look for?
-      if (Object.keys(foundType).length === 0) {
-        return true;
-      }
-    }
-
-    return false;
+    return true;
   }
 
   get roles() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5454 
The machine pool scale down button is disabled when the pool spec has only one replica defined; the individual pool scale down action menu option was disabled when the machine was the only instance of a controlplane or etcd role. This meant that if a cluster had one pool of workers with one worker machine, the pool couldn't be scaled down but the machine could. 

### Occurred changes and/or fixed issues
This PR updates the machine's `canScaleDown` function to prevent scaling down when it's the only machine in a pool. The role-checking logic is removed, since a machine can't be the only instance of a role without also being the only machine in its pool.