### PR TITLE
Use real node state to show machine state summary

### DIFF
--- a/models/management.cattle.io.nodepool.js
+++ b/models/management.cattle.io.nodepool.js
@@ -74,16 +74,48 @@ export default class MgmtNodePool extends HybridModel {
     return this.$getters['all'](MANAGEMENT.NODE).filter(node => node.spec.nodePoolName === nodePoolName);
   }
 
+  get nodeSummary() {
+    const res = {
+      errored:       0,
+      transitioning: 0,
+      unavailable:   0,
+      count:         0
+    };
+
+    if (!this.nodes) {
+      return res;
+    }
+
+    return this.nodes.reduce((res, n) => {
+      if (n.metadata.state.error ) {
+        res.errored++;
+      } else if (n.metadata.state.transitioning) {
+        res.transitioning++;
+      } else if (n.state !== 'active') {
+        res.unavailable++;
+      }
+
+      return res;
+    }, {
+      ...res,
+      count: this.nodes.length
+    });
+  }
+
   get desired() {
     return this.spec?.quantity || 0;
   }
 
   get pending() {
-    return Math.max(0, this.desired - (this.nodes?.length || 0));
+    return this.nodeSummary.transitioning;
   }
 
   get ready() {
-    return Math.max(0, (this.nodes?.length || 0) - (this.pending || 0));
+    return Math.max(0, this.nodeSummary.count - this.nodeSummary.unavailable);
+  }
+
+  get unavailable() {
+    return this.nodeSummary.errored;
   }
 
   get stateParts() {
@@ -94,6 +126,13 @@ export default class MgmtNodePool extends HybridModel {
         textColor: 'text-info',
         value:     this.pending,
         sort:      1,
+      },
+      {
+        label:     'Unavailable',
+        color:     'bg-error',
+        textColor: 'text-error',
+        value:     this.unavailable,
+        sort:      3,
       },
       {
         label:     'Ready',


### PR DESCRIPTION
fixes #5443
alternative to #5570

- Use node metadata state to summarise `pending` and `ready`
- Add `unavailable` to cover nodes in error state
- All should be mutually exclusive to avoid duplicates
- Use common `nodeSummary` to reduce getter churn

Note 1 - We do this for RKE1 because we don't have the replica set info and we already fetch all nodes. It doesn't make sense to do this also for RKE2 as we have replica sets and fetching all machines is a large overhead.

Note 2 - It would be nice to show actual node state's here instead of `pending`, etc, but that would make the RKE2 stats look out of place
