### PR TITLE
Fix two home page bugs

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -935,7 +935,7 @@ export default {
           >
             <tr
               v-if="row.row.stateDescription"
-              :key="row[keyField] + '-description'"
+              :key="row.row[keyField] + '-description'"
               class="state-description sub-row"
               @mouseenter="onRowMouseEnter"
               @mouseleave="onRowMouseLeave"

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -322,18 +322,20 @@ export default {
                   </div>
                 </template>
                 <template v-if="canCreateCluster" #header-middle>
-                  <n-link
-                    :to="importLocation"
-                    class="btn btn-sm role-primary"
-                  >
-                    {{ t('cluster.importAction') }}
-                  </n-link>
-                  <n-link
-                    :to="createLocation"
-                    class="btn btn-sm role-primary"
-                  >
-                    {{ t('generic.create') }}
-                  </n-link>
+                  <div class="table-heading">
+                    <n-link
+                      :to="importLocation"
+                      class="btn btn-sm role-primary"
+                    >
+                      {{ t('cluster.importAction') }}
+                    </n-link>
+                    <n-link
+                      :to="createLocation"
+                      class="btn btn-sm role-primary"
+                    >
+                      {{ t('generic.create') }}
+                    </n-link>
+                  </div>
                 </template>
                 <template #col:name="{row}">
                   <td>
@@ -407,6 +409,12 @@ export default {
   }
   .table-heading {
     align-items: center;
+    display: flex;
+    height: 39px;
+
+    & > a {
+      margin-left: 5px;
+    }
   }
   .panel:not(:first-child) {
     margin-top: 20px;


### PR DESCRIPTION
- Fix error in console when lists contain sub rows `Duplicate keys detected: 'undefined-description'. This may cause an update error.`
  This occurred on home page when a cluster was in error
- Align clusters table header and buttons (vertically) centrally

Before
![image](https://user-images.githubusercontent.com/18697775/164780204-82ade376-c704-4210-b0d1-eb401d1f49cf.png)

After
![image](https://user-images.githubusercontent.com/18697775/164780249-fcae5b10-3491-4348-97ae-5e40acb85479.png)
