### PR TITLE
rke2 provisioning: empty s3 object is effectively disabled; default d…

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1586,6 +1586,7 @@ cluster:
     drain:
       label: Drain Nodes
       toolTip: Draining preemptively removes the pods on each node so there are no running workloads on the nodes being upgraded.  Upgrading without draining is faster and causes less shuffling around, but pods may still be restarted depending on the upgrade being performed.
+    deleteEmptyDir: "By default, pods using emptyDir volumes will be deleted on upgrade. Operations reliant on emptyDir volumes persisting through the pod's lifecycle may be impacted."
     address:
       tooltip: Cluster networking values cannot be changed after the cluster is created.
       header: Addressing

--- a/edit/provisioning.cattle.io.cluster/DrainOptions.vue
+++ b/edit/provisioning.cattle.io.cluster/DrainOptions.vue
@@ -4,9 +4,9 @@ import Checkbox from '@/components/form/Checkbox.vue';
 import UnitInput from '@/components/form/UnitInput.vue';
 
 const DEFAULTS = {
-  deleteEmptyDirData:              false, // Show; Kill pods using emptyDir volumes and lose the data
+  deleteEmptyDirData:              true, // Show; Kill pods using emptyDir volumes and lose the data
   disableEviction:                 false, // Hide; false = evict pods, true = delete pods
-  enabled:                         false, // Show; true = Nodes must be drained before upgrade; false = YOLO
+  enabled:                         true, // Show; true = Nodes must be drained before upgrade; false = YOLO
   force:                           false, // Show; true = Delete standalone pods, false = fail if there are any
   gracePeriod:                     -1, // Show; Pod shut down time, negative value uses pod default
   ignoreDaemonSets:                true, // Hide; true = work, false = never work because there's always daemonSets
@@ -46,6 +46,10 @@ export default {
     out.customTimeout = out.timeout >= 0;
 
     return out;
+  },
+
+  created() {
+    this.update();
   },
 
   methods: {

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1449,7 +1449,8 @@ export default {
           set(rkeConfig.chartValues, name, userValues);
         }
       });
-    }
+    },
+    get
   },
 };
 </script>
@@ -1731,7 +1732,7 @@ export default {
             />
 
             <S3Config
-              v-if="rkeConfig.etcd.s3"
+              v-if="s3Backup"
               v-model="rkeConfig.etcd.s3"
               :namespace="value.metadata.namespace"
               :register-before-hook="registerBeforeHook"
@@ -1827,6 +1828,9 @@ export default {
         </Tab>
 
         <Tab name="upgrade" label-key="cluster.tabs.upgrade">
+          <Banner v-if="get(rkeConfig, 'upgradeStrategy.controlPlaneDrainOptions.deleteEmptyDirData')" color="warning">
+            {{ t('cluster.rke2.deleteEmptyDir', {}, true) }}
+          </Banner>
           <div class="row">
             <div class="col span-6">
               <h3>Control Plane</h3>


### PR DESCRIPTION
#5657 - treat an empty s3 object as 'disabled': we can do this by keying the display of s3 configuration more directly to the s3 radio group
#5618 - update upgrade strategy defaults, make a more prominent warning about emptyDir volumes per Chris Kim's comment [here](https://github.com/rancher/rancher/issues/36969#issuecomment-1095367950) 