### PR TITLE
Remove 'tech preview' tag from RKE2/K3s Havester provisioning

### DIFF
--- a/edit/provisioning.cattle.io.cluster/index.vue
+++ b/edit/provisioning.cattle.io.cluster/index.vue
@@ -287,10 +287,8 @@ export default {
       function addType(id, group, disabled = false, link = null, iconClass = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
-        const techPreview = getters['i18n/t']('generic.techPreview');
-        let tag = '';
+        const tag = '';
 
-        // Always prefer the built-in icon if there is one
         let icon;
 
         try {
@@ -301,10 +299,6 @@ export default {
           iconClass = undefined;
         } else if (!iconClass) {
           icon = require('~/assets/images/generic-driver.svg');
-        }
-
-        if (group === 'rke2' && id === 'harvester') {
-          tag = getters['i18n/withFallback'](`cluster.providerTag.rke2."${ id }"`, { tag: techPreview }, '');
         }
 
         const subtype = {


### PR DESCRIPTION
This removes the Tech Preview label for the Harvester cluster provider.

### Before
![image](https://user-images.githubusercontent.com/835961/165135393-cabb6b48-6387-4f23-90f8-4529ddaae296.png)

### After
![image](https://user-images.githubusercontent.com/835961/165135788-d14d68a8-441e-4007-aed8-9e86e7fd5f36.png)

closes #5700 
