### PR TITLE
Second batch of AlertmanagerConfig form changes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2800,8 +2800,9 @@ monitoring:
     description: Routes and receivers for project alerting and cluster alerting are configured within AlertmanagerConfig resources.
     empty: Alerts have not been configured for any accessible namespaces.
     getStarted: Get started by clicking Create to configure an alert.
-    receiverTooltip: Must match the name of a receiver defined in the same AlertmanagerConfig.
+    receiverTooltip: This route will direct alerts to the selected receiver, which must be defined in the same AlertmanagerConfig.
     deprecationWarning: The Route and Receiver resources are deprecated. We recommend configuring alerts in AlertmanagerConfigs.
+    routeInfo: This form supports configuring one route that directs traffic to a receiver. To forward alerts to more receiver(s), add child routes in YAML.
     receiverFormNames:
       create: Create Receiver in AlertmanagerConfig
       edit: Edit Receiver in AlertmanagerConfig

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2764,6 +2764,7 @@ monitoring:
       Warning: Prometheus Operators are currently deployed. Deploying multiple Prometheus Operators onto one cluster is not currently supported. Please remove all other Prometheus Operator deployments from this cluster before trying to install this chart.
       If you are migrating from an older version of {vendor} with Monitoring enabled, please disable Monitoring on this cluster completely before attempting to install this chart.
   receiver:
+    addReceiver: Add Receiver
     fields:
       name: Name
     tls:
@@ -2807,6 +2808,7 @@ monitoring:
       create: Create Receiver in AlertmanagerConfig
       edit: Edit Receiver in AlertmanagerConfig
       detail: Receiver in AlertmanagerConfig
+    disabledReceiverButton: The receiver form is available after the AlertmanagerConfig is created
   installSteps:
     uninstallV1:
       stepTitle: Uninstall V1

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2801,6 +2801,11 @@ monitoring:
     empty: Alerts have not been configured for any accessible namespaces.
     getStarted: Get started by clicking Create to configure an alert.
     receiverTooltip: Must match the name of a receiver defined in the same AlertmanagerConfig.
+    deprecationWarning: The Route and Receiver resources are deprecated. We recommend configuring alerts in AlertmanagerConfigs.
+    receiverFormNames:
+      create: Create Receiver in AlertmanagerConfig
+      edit: Edit Receiver in AlertmanagerConfig
+      detail: Receiver in AlertmanagerConfig
   installSteps:
     uninstallV1:
       stepTitle: Uninstall V1

--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2802,7 +2802,7 @@ monitoring:
     getStarted: Get started by clicking Create to configure an alert.
     receiverTooltip: This route will direct alerts to the selected receiver, which must be defined in the same AlertmanagerConfig.
     deprecationWarning: The Route and Receiver resources are deprecated. We recommend configuring alerts in AlertmanagerConfigs.
-    routeInfo: This form supports configuring one route that directs traffic to a receiver. To forward alerts to more receiver(s), add child routes in YAML.
+    routeInfo: This form supports configuring one route that directs traffic to a receiver. Alerts can be directed to more receiver(s) by configuring child routes in YAML.
     receiverFormNames:
       create: Create Receiver in AlertmanagerConfig
       edit: Edit Receiver in AlertmanagerConfig

--- a/components/ActionMenu.vue
+++ b/components/ActionMenu.vue
@@ -168,7 +168,8 @@ export default {
           fudgeY:    elem ? 4 : 0,
           positionX: (elem ? AUTO : CENTER),
           positionY: AUTO,
-        });
+        }, true );
+
         this.style.visibility = 'visible';
 
         return;

--- a/components/ActionMenu.vue
+++ b/components/ActionMenu.vue
@@ -190,7 +190,12 @@ export default {
         // If an action list item is clicked, this
         // component emits that event, then we assume the parent
         // component will execute the action.
-        this.$emit(action.action);
+        this.$emit(action.action, {
+          action,
+          event,
+          ...args,
+          route: this.$route
+        });
       } else {
         // If the state of this component is controlled
         // by Vuex, mutate the store when an action is clicked.

--- a/components/ResourceTable.vue
+++ b/components/ResourceTable.vue
@@ -337,6 +337,10 @@ export default {
 
       return defaultTableSortGenerationFn(this.schema, this.$store);
     },
+
+    handleActionButtonClick(event) {
+      this.$emit('clickedActionButton', event);
+    }
   }
 };
 </script>
@@ -359,6 +363,7 @@ export default {
     :get-custom-detail-link="getCustomDetailLink"
     key-field="_key"
     :sort-generation-fn="safeSortGenerationFn"
+    @clickedActionButton="handleActionButtonClick"
     v-on="$listeners"
   >
     <template v-if="showGrouping" #header-middle>

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -704,6 +704,22 @@ export default {
       const hasStateDescription = row.stateDescription;
 
       return hasInjectedSubRows || hasStateDescription;
+    },
+
+    handleActionButtonClick(i, event) {
+      // Each row in the table gets its own ref with
+      // a number based on its index. If you are using
+      // an ActionMenu that doen't have a dependency on Vuex,
+      // these refs are useful because you can reuse the
+      // same ActionMenu component on a page with many different
+      // target elements in a list,
+      // so you can still avoid the performance problems that
+      // could result if the ActionMenu was in every row. The menu
+      // will open on whichever target element is clicked.
+      this.$emit('clickedActionButton', {
+        event,
+        targetElement: this.$refs[`actionButton${ i }`][0],
+      });
     }
   }
 };
@@ -930,7 +946,15 @@ export default {
                 </template>
                 <td v-if="rowActions" align="middle">
                   <slot name="row-actions" :row="row">
-                    <button aria-haspopup="true" aria-expanded="false" type="button" class="btn btn-sm role-multi-action actions">
+                    <button
+                      :id="`actionButton+${i}+${(row.row && row.row.name) ? row.row.name : ''}`"
+                      :ref="`actionButton${i}`"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                      type="button"
+                      class="btn btn-sm role-multi-action actions"
+                      @click="handleActionButtonClick(i, $event)"
+                    >
                       <i class="icon icon-actions" />
                     </button>
                   </slot>

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -898,6 +898,7 @@ export default {
                           :col="col.col"
                           v-bind="col.col.formatterOpts"
                           :row-key="row.key"
+                          :get-custom-detail-link="getCustomDetailLink"
                         />
                         <component
                           :is="col.component"
@@ -916,7 +917,6 @@ export default {
                           :col="col.col"
                           v-bind="col.col.formatterOpts"
                           :row-key="row.key"
-                          :get-custom-detail-link="getCustomDetailLink"
                         />
                         <template v-else-if="col.value !== ''">
                           {{ col.formatted }}

--- a/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -11,7 +11,7 @@ import { EDITOR_MODES } from '@/components/YamlEditor';
 import { RECEIVERS_TYPES } from '@/models/monitoring.coreos.com.receiver';
 import RouteConfig from './routeConfig';
 import ResourceTable from '@/components/ResourceTable';
-import { _VIEW, _CREATE, _CONFIG } from '@/config/query-params';
+import { _VIEW, _CONFIG } from '@/config/query-params';
 
 export default {
   components: {
@@ -36,24 +36,9 @@ export default {
     const receiverOptions = this.value.spec.receivers.map(receiver => receiver.name);
 
     return {
-      config:             _CONFIG,
-      createReceiverLink: {
-        name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
-        params: {
-          cluster:              this.$store.getters['clusterId'],
-          alertmanagerconfigid: this.value.id
-        },
-        query: { mode: _CREATE, currentView: _CONFIG }
-      },
+      config:               _CONFIG,
+      createReceiverLink:   this.value.getCreateReceiverRoute(),
       defaultReceiverValues,
-      editReceiverLink: {
-        name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
-        params: {
-          cluster:              this.$store.getters['clusterId'],
-          alertmanagerconfigid: this.value.id
-        },
-        query: { mode: _CREATE, currentView: _CONFIG }
-      },
       receiverTableHeaders: [
         {
           name:          'name',
@@ -94,23 +79,10 @@ export default {
         };
       });
     },
-    addNewReceiver(name) {
-      // ToDo: uncomment and implement this code
-      // const existingReceiversOfSelectedType = this.value.spec.receivers[this.newReceiverType] || []
-
-      // this.value.spec.receivers[this.newReceiverType] = this.value.spec.receivers;
-    },
     getReceiverDetailLink(receiverData) {
-      return {
-        name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
-        params: {
-          cluster:              this.$store.getters['clusterId'],
-          alertmanagerconfigid: this.value.id
-        },
-        query: {
-          mode: _VIEW, receiverName: receiverData.name, currentView: _CONFIG
-        }
-      };
+      if (receiverData && receiverData.name) {
+        return this.value.getReceiverDetailLink(receiverData.name);
+      }
     },
   }
 };

--- a/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -12,7 +12,7 @@ import { RECEIVERS_TYPES } from '@/models/monitoring.coreos.com.receiver';
 import RouteConfig from './routeConfig';
 import ResourceTable from '@/components/ResourceTable';
 import ActionMenu from '@/components/ActionMenu';
-import { _EDIT, _VIEW, _CONFIG } from '@/config/query-params';
+import { _CREATE, _EDIT, _VIEW, _CONFIG } from '@/config/query-params';
 
 export default {
   components: {
@@ -56,6 +56,7 @@ export default {
       actionMenuTargetElement:  null,
       actionMenuTargetEvent:    null,
       config:                   _CONFIG,
+      create:                   _CREATE,
       createReceiverLink:       this.value.getCreateReceiverRoute(),
       defaultReceiverValues,
       receiverActionMenuIsOpen: false,
@@ -201,8 +202,13 @@ export default {
         >
           <template #header-button>
             <nuxt-link v-if="createReceiverLink && createReceiverLink.name" :to="createReceiverLink">
-              <button class="btn role-primary">
-                Create Receiver
+              <button
+                class="btn role-primary"
+                :disabled="mode === create"
+                :tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
+              >
+                {{ t('monitoring.receiver.addReceiver') }}
+                <i v-if="mode === create" v-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')" class="icon icon-info" />
               </button>
             </nuxt-link>
           </template>
@@ -234,5 +240,11 @@ export default {
     &[real-mode=view] .label {
       color: var(--input-label);
     }
+  }
+  button {
+    margin-left: 0.5em;
+  }
+  a:hover {
+      text-decoration: none;
   }
 </style>

--- a/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -100,10 +100,6 @@ export default {
       type:     Function,
       required:  true
     },
-    doneLocationOverride: {
-      type:     Object,
-      required:  true
-    }
   },
 
   mixins: [CreateEditView],
@@ -220,11 +216,11 @@ export default {
     },
 
     redirectAfterCancel() {
-      this.$router.push(this.doneLocationOverride);
+      this.$router.push(this.alertmanagerConfigResource.getAlertmanagerConfigDetailRoute());
     },
 
     redirectToAlertmanagerConfig() {
-      this.$router.push(this.doneLocationOverride);
+      this.$router.push(this.alertmanagerConfigResource.getAlertmanagerConfigDetailRoute());
     },
 
     createAddOptions(receiverType) {

--- a/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
@@ -1,14 +1,18 @@
 <script>
 import ArrayList from '@/components/form/ArrayList';
 import KeyValue from '@/components/form/KeyValue';
+import Banner from '@/components/Banner';
 import LabeledInput from '@/components/form/LabeledInput';
+import LabeledSelect from '@/components/form/LabeledSelect';
 import { _VIEW } from '@/config/query-params';
 
 export default {
   components: {
     ArrayList,
+    Banner,
     KeyValue,
     LabeledInput,
+    LabeledSelect
   },
   props: {
     mode: {
@@ -27,36 +31,25 @@ export default {
   data() {
     return { isView: _VIEW };
   },
-  methods: {
-    updateSelectValue(event) {
-      // this.value.receivers = event;
-
-      this.$set(this.value, 'receivers', event);
-    },
-  }
 
 };
 
 </script>
 <template>
   <div>
+    <h3>Receiver <i v-tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')" class="icon icon-info" /></h3>
+    <Banner
+      color="info"
+      :label="t('monitoring.alertmanagerConfig.routeInfo')"
+    />
     <div class="row mb-20">
       <div class="col span-6">
-        <!-- ToDo: uncomment and implement this code -->
-        <!-- <LabeledSelect
-          :value="value.receivers"
-          class="lg"
-          :label="t('monitoringRoute.receiver.oneOrMoreLabel')"
-          :taggable="true"
-          :searchable="true"
-          :options="receiverOptions"
-          :multiple="true"
+        <LabeledSelect
+          v-model="value.receiver"
           :mode="mode"
-          :tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')"
-          @input="updateSelectValue"
-        /> -->
-        <v-select>
-        </v-select>
+
+          :options="receiverOptions"
+        />
       </div>
     </div>
     <h3>Grouping</h3>

--- a/edit/monitoring.coreos.com.receiver/auth.vue
+++ b/edit/monitoring.coreos.com.receiver/auth.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import isEmpty from 'lodash/isEmpty';

--- a/edit/monitoring.coreos.com.receiver/index.vue
+++ b/edit/monitoring.coreos.com.receiver/index.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import { MONITORING } from '@/config/types';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import Loading from '@/components/Loading';

--- a/edit/monitoring.coreos.com.receiver/tls.vue
+++ b/edit/monitoring.coreos.com.receiver/tls.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import LabeledInput from '@/components/form/LabeledInput';
 import Banner from '@/components/Banner';
 

--- a/edit/monitoring.coreos.com.receiver/types/email.vue
+++ b/edit/monitoring.coreos.com.receiver/types/email.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import TLS from '../tls';

--- a/edit/monitoring.coreos.com.receiver/types/opsgenie.vue
+++ b/edit/monitoring.coreos.com.receiver/types/opsgenie.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import ArrayList from '@/components/form/ArrayList';
 import LabeledInput from '@/components/form/LabeledInput';
 import Select from '@/components/form/Select';

--- a/edit/monitoring.coreos.com.receiver/types/pagerduty.vue
+++ b/edit/monitoring.coreos.com.receiver/types/pagerduty.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Checkbox from '@/components/form/Checkbox';

--- a/edit/monitoring.coreos.com.receiver/types/slack.vue
+++ b/edit/monitoring.coreos.com.receiver/types/slack.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import { _CREATE } from '@/config/query-params';

--- a/edit/monitoring.coreos.com.receiver/types/webhook.vue
+++ b/edit/monitoring.coreos.com.receiver/types/webhook.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import Banner from '@/components/Banner';

--- a/edit/monitoring.coreos.com.route.vue
+++ b/edit/monitoring.coreos.com.route.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to route configuration should be made to the route form
+ * that is based on the AlertmanagerConfig resource, which has a
+ * different API. The new forms are located in
+ * @/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue.
+ */
 import CruResource from '@/components/CruResource';
 import ArrayList from '@/components/form/ArrayList';
 import KeyValue from '@/components/form/KeyValue';

--- a/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -1,4 +1,8 @@
 import SteveModel from '@/plugins/steve/steve-class';
+import { MONITORING } from '@/config/types';
+import {
+  _YAML, _CREATE, _EDIT, _VIEW, _CONFIG
+} from '@/config/query-params';
 import { set } from '@/utils/object';
 
 export default class AlertmanagerConfig extends SteveModel {
@@ -25,5 +29,73 @@ export default class AlertmanagerConfig extends SteveModel {
     };
 
     set(this, 'spec', defaultSpec);
+  }
+
+  getAlertmanagerConfigDetailRoute() {
+    return {
+      name:   'c-cluster-product-resource-namespace-id',
+      params: {
+        cluster:   this.$rootGetters['clusterId'],
+        product:   'monitoring',
+        resource:  MONITORING.ALERTMANAGERCONFIG,
+        namespace: this.metadata?.namespace,
+        id:        this.name,
+      },
+      hash: '#receivers'
+    };
+  }
+
+  getCreateReceiverRoute() {
+    return {
+      name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
+      params: {
+        cluster:              this.$rootGetters['clusterId'],
+        alertmanagerconfigid: this.id
+      },
+      query: { mode: _CREATE, currentView: _CONFIG }
+    };
+  }
+
+  getReceiverDetailLink(receiverName) {
+    return {
+      name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
+      params: {
+        cluster:              this.$rootGetters['clusterId'],
+        alertmanagerconfigid: this.id
+      },
+      query: {
+        mode: _VIEW, receiverName, currentView: _CONFIG
+      }
+    };
+  }
+
+  getEditReceiverYamlRoute(receiverName) {
+    return {
+      name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
+      params: {
+        cluster:              this.$rootGetters['clusterId'],
+        alertmanagerconfigid: this.id
+      },
+      query: {
+        mode:         this.mode || _EDIT,
+        receiverName,
+        currentView:  _YAML
+      }
+    };
+  }
+
+  getEditReceiverConfigRoute(receiverName, queryMode) {
+    return {
+      name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
+      params: {
+        cluster:              this.$store.getters['clusterId'],
+        alertmanagerconfigid: this.id
+      },
+      query: {
+        mode:         queryMode || _EDIT,
+        receiverName,
+        currentView:  _CONFIG
+      }
+    };
   }
 }

--- a/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -1,8 +1,6 @@
 import SteveModel from '@/plugins/steve/steve-class';
 import { MONITORING } from '@/config/types';
-import {
-  _YAML, _CREATE, _EDIT, _VIEW, _CONFIG
-} from '@/config/query-params';
+import { _YAML, _CREATE, _VIEW, _CONFIG } from '@/config/query-params';
 import { set } from '@/utils/object';
 
 export default class AlertmanagerConfig extends SteveModel {

--- a/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -31,9 +31,37 @@ export default class AlertmanagerConfig extends SteveModel {
     set(this, 'spec', defaultSpec);
   }
 
+  get _availableActions() {
+    const out = super._availableActions;
+
+    return out;
+  }
+
+  getReceiverActions(alertmanagerConfigActions) {
+    return alertmanagerConfigActions.filter((actionData) => {
+      if (actionData.divider) {
+        return true;
+      }
+      switch (actionData.action) {
+      case 'goToEdit':
+        return true;
+      case 'goToEditYaml':
+        return true;
+      case 'promptRemove':
+        return true;
+      default:
+        return false;
+      }
+    });
+  }
+
+  get alertmanagerConfigDoneRouteName() {
+    return 'c-cluster-product-resource-namespace-id';
+  }
+
   getAlertmanagerConfigDetailRoute() {
     return {
-      name:   'c-cluster-product-resource-namespace-id',
+      name:   this.alertmanagerConfigDoneRouteName,
       params: {
         cluster:   this.$rootGetters['clusterId'],
         product:   'monitoring',
@@ -69,7 +97,7 @@ export default class AlertmanagerConfig extends SteveModel {
     };
   }
 
-  getEditReceiverYamlRoute(receiverName) {
+  getEditReceiverYamlRoute(receiverName, queryMode) {
     return {
       name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
       params: {
@@ -77,7 +105,7 @@ export default class AlertmanagerConfig extends SteveModel {
         alertmanagerconfigid: this.id
       },
       query: {
-        mode:         this.mode || _EDIT,
+        mode:         queryMode || _VIEW,
         receiverName,
         currentView:  _YAML
       }
@@ -88,11 +116,11 @@ export default class AlertmanagerConfig extends SteveModel {
     return {
       name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
       params: {
-        cluster:              this.$store.getters['clusterId'],
+        cluster:              this.$rootGetters['clusterId'],
         alertmanagerconfigid: this.id
       },
       query: {
-        mode:         queryMode || _EDIT,
+        mode:         queryMode || _VIEW,
         receiverName,
         currentView:  _CONFIG
       }

--- a/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
+++ b/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
@@ -54,7 +54,7 @@ export default {
       actionMenuTargetElement:       null,
       actionMenuTargetEvent:         null,
       alertmanagerConfigId:          '',
-      alertmanagerConfigResource:    {},
+      alertmanagerConfigResource:    null,
       alertmanagerConfigDetailRoute: null,
       config:                        _CONFIG,
       create:                        _CREATE,
@@ -82,6 +82,26 @@ export default {
     currentView() {
       return this.$route.query.currentView;
     },
+    receiverActions() {
+      const alertmanagerConfigActions = this.alertmanagerConfigResource?.availableActions;
+
+      if (!alertmanagerConfigActions) {
+        return [];
+      }
+
+      // Receivers are not a separate resource, so they
+      // should only have a subset of the AlertmanagerConfig
+      // actions. So we take AlertmanagerConfig's actions and filter
+      // out any that don't apply.
+      // Example action data:
+      // {
+      //     "action": "goToEdit",
+      //     "label": "Edit Config",
+      //     "icon": "icon icon-edit",
+      //     "enabled": true
+      // },
+      return this.alertmanagerConfigResource.getReceiverActions(alertmanagerConfigActions);
+    },
     resourceYaml() {
       const resource = this.alertmanagerConfigResource;
 
@@ -93,7 +113,6 @@ export default {
 
       return out;
     },
-
     mode() {
       // Use the route as a dependency of the
       // computed property so that the component
@@ -109,39 +128,6 @@ export default {
       }
 
       return EDITOR_MODES.EDIT_CODE;
-    },
-
-    receiverActions() {
-      const alertmanagerConfigActions = this.alertmanagerConfigResource?.availableActions || [];
-
-      // Receivers are not a separate resource, so they
-      // should only have a subset of the AlertmanagerConfig
-      // actions. So we take AlertmanagerConfig's actions and filter
-      // out any that don't apply.
-      // Example action data:
-      // {
-      //     "action": "goToEdit",
-      //     "label": "Edit Config",
-      //     "icon": "icon icon-edit",
-      //     "enabled": true
-      // },
-      const receiverActions = alertmanagerConfigActions.filter((actionData) => {
-        if (actionData.divider) {
-          return true;
-        }
-        switch (actionData.action) {
-        case 'goToEdit':
-          return true;
-        case 'goToEditYaml':
-          return true;
-        case 'promptRemove':
-          return true;
-        default:
-          return false;
-        }
-      });
-
-      return receiverActions;
     },
     heading() {
       switch (this.$route.query.mode) {
@@ -179,7 +165,6 @@ export default {
 
       this.alertmanagerConfigResource.save(...arguments);
     },
-
     handleButtonGroupClick(event) {
       if (event === this.yaml) {
         this.goToEditYaml(this.view);
@@ -188,34 +173,29 @@ export default {
         this.goToEdit(this.view);
       }
     },
-
     toggleReceiverActionMenu() {
       this.receiverActionMenuIsOpen = !this.receiverActionMenuIsOpen;
     },
-
     handleReceiverActionMenuClick(event) {
       this.actionMenuTargetElement = this.$refs.actions;
       this.actionMenuTargetEvent = event;
       this.toggleReceiverActionMenu();
     },
-
-    goToEdit(queryMode) {
+    goToEdit() {
     // 'goToEdit' is the exact name of an action for AlertmanagerConfig
     // and this method executes the action.
-      this.$router.push(this.alertmanagerConfigResource.getEditReceiverConfigRoute(this.receiverValue.name, queryMode));
+      this.$router.push(this.alertmanagerConfigResource.getEditReceiverConfigRoute(this.receiverValue.name, _EDIT));
     },
-    goToEditYaml(queryMode) {
+    goToEditYaml() {
     // 'goToEditYaml' is the exact name of an action for AlertmanagerConfig
     // and this method executes the action.
-      this.$router.push(this.alertmanagerConfigResource.getEditReceiverYamlRoute(this.receiverValue.name));
+      this.$router.push(this.alertmanagerConfigResource.getEditReceiverYamlRoute(this.receiverValue.name, _EDIT));
     },
     promptRemove(actionData) {
-    // 'promptRemove' is the exact name of an action for AlertmanagerConfig
-    // and this method executes the action.
-
+      // 'promptRemove' is the exact name of an action for AlertmanagerConfig
+      // and this method executes the action.
       // Get the name of the receiver to delete from the action info.
       const nameOfReceiverToDelete = actionData.route.query.receiverName;
-
       // Remove it from the configuration of the parent AlertmanagerConfig
       // resource.
       const existingReceivers = this.alertmanagerConfigResource.spec.receivers;
@@ -224,7 +204,6 @@ export default {
       });
 
       this.alertmanagerConfigResource.spec.receivers = receiversMinusDeletedItem;
-
       // After saving the AlertmanagerConfig, the resource has been deleted.
       this.alertmanagerConfigResource.save(...arguments);
       this.$router.push(this.alertmanagerConfigResource.getAlertmanagerConfigDetailRoute());
@@ -266,20 +245,20 @@ export default {
       </div>
     </header>
     <ResourceYaml
-      v-if="currentView === yaml"
+      v-if="currentView === yaml && alertmanagerConfigResource"
       ref="resourceyaml"
       :value="alertmanagerConfigResource"
       :mode="mode"
       :initial-yaml-for-diff="null"
       :yaml="resourceYaml"
       :offer-preview="mode === edit"
-      :done-route="alertmanagerConfigDetailRoute.name"
+      :done-route="alertmanagerConfigResource.alertmanagerConfigDoneRouteName"
       :done-override="alertmanagerConfigDetailRoute"
       :apply-hooks="alertmanagerConfigResource.applyHooks"
       @error="e=>$emit('error', e)"
     />
     <ReceiverConfig
-      v-if="currentView === config || currentView === detail"
+      v-if="(currentView === config || currentView === detail) && alertmanagerConfigResource"
       :value="receiverValue"
       :mode="mode"
       :alertmanager-config-id="alertmanagerConfigId"

--- a/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
+++ b/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
@@ -158,11 +158,11 @@ export default {
     heading() {
       switch (this.$route.query.mode) {
       case this.create:
-        return 'Create Receiver in AlertmanagerConfig';
+        return this.t('monitoring.alertmanagerConfig.receiverFormNames.create');
       case this.edit:
-        return 'Edit Receiver in AlertmanagerConfig';
+        return this.t('monitoring.alertmanagerConfig.receiverFormNames.edit');
       default:
-        return 'Receiver in AlertmanagerConfig';
+        return this.t('monitoring.alertmanagerConfig.receiverFormNames.detail');
       }
     },
   },

--- a/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
+++ b/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
@@ -42,8 +42,8 @@ export default {
     }
 
     this.alertmanagerConfigId = alertmanagerConfigResource.id;
-
     this.alertmanagerConfigResource = alertmanagerConfigResource;
+    this.alertmanagerConfigDetailRoute = alertmanagerConfigResource.getAlertmanagerConfigDetailRoute();
   },
 
   // take edit link and edit request from AlertmanagerConfig resource
@@ -51,20 +51,21 @@ export default {
 
   data() {
     return {
-      actionMenuTargetElement:     null,
-      actionMenuTargetEvent:       null,
-      alertmanagerConfigId:        '',
-      alertmanagerConfigResource:  {},
-      config:                      _CONFIG,
-      create:                      _CREATE,
-      detail:                      _DETAIL,
-      edit:                        _EDIT,
-      receiverActionMenuIsOpen:    false,
-      receiverName:                '',
-      receiverValue:               {},
-      showPreview:                 false,
-      view:                        _VIEW,
-      viewOptions:                [
+      actionMenuTargetElement:       null,
+      actionMenuTargetEvent:         null,
+      alertmanagerConfigId:          '',
+      alertmanagerConfigResource:    {},
+      alertmanagerConfigDetailRoute: null,
+      config:                        _CONFIG,
+      create:                        _CREATE,
+      detail:                        _DETAIL,
+      edit:                          _EDIT,
+      receiverActionMenuIsOpen:      false,
+      receiverName:                  '',
+      receiverValue:                 {},
+      showPreview:                   false,
+      view:                          _VIEW,
+      viewOptions:                   [
         {
           labelKey: 'resourceDetail.masthead.config',
           value:    'config',
@@ -109,20 +110,7 @@ export default {
 
       return EDITOR_MODES.EDIT_CODE;
     },
-    doneLocationOverride() {
-      // Go to AlertmanagerConfig detail page
-      return {
-        name:   'c-cluster-product-resource-namespace-id',
-        params: {
-          cluster:   this.$store.getters['clusterId'],
-          product:   'monitoring',
-          resource:  MONITORING.ALERTMANAGERCONFIG,
-          namespace: this.alertmanagerConfigResource?.metadata?.namespace,
-          id:        this.alertmanagerConfigResource?.name,
-        },
-        hash: '#receivers'
-      };
-    },
+
     receiverActions() {
       const alertmanagerConfigActions = this.alertmanagerConfigResource?.availableActions || [];
 
@@ -214,34 +202,12 @@ export default {
     goToEdit(queryMode) {
     // 'goToEdit' is the exact name of an action for AlertmanagerConfig
     // and this method executes the action.
-      this.$router.push({
-        name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
-        params: {
-          cluster:              this.$store.getters['clusterId'],
-          alertmanagerconfigid: this.alertmanagerConfigId
-        },
-        query: {
-          mode:         queryMode || this.edit,
-          receiverName: this.receiverValue.name,
-          currentView:  this.config
-        }
-      });
+      this.$router.push(this.alertmanagerConfigResource.getEditReceiverConfigRoute(this.receiverValue.name, queryMode));
     },
     goToEditYaml(queryMode) {
     // 'goToEditYaml' is the exact name of an action for AlertmanagerConfig
     // and this method executes the action.
-      this.$router.push({
-        name:   'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver',
-        params: {
-          cluster:              this.$store.getters['clusterId'],
-          alertmanagerconfigid: this.alertmanagerConfigId
-        },
-        query: {
-          mode:         queryMode || this.edit,
-          receiverName: this.receiverValue.name,
-          currentView:  this.yaml
-        }
-      });
+      this.$router.push(this.alertmanagerConfigResource.getEditReceiverYamlRoute(this.receiverValue.name));
     },
     promptRemove(actionData) {
     // 'promptRemove' is the exact name of an action for AlertmanagerConfig
@@ -261,7 +227,7 @@ export default {
 
       // After saving the AlertmanagerConfig, the resource has been deleted.
       this.alertmanagerConfigResource.save(...arguments);
-      this.$router.push(this.doneLocationOverride);
+      this.$router.push(this.alertmanagerConfigResource.getAlertmanagerConfigDetailRoute());
     }
   }
 };
@@ -307,8 +273,8 @@ export default {
       :initial-yaml-for-diff="null"
       :yaml="resourceYaml"
       :offer-preview="mode === edit"
-      :done-route="doneLocationOverride.name"
-      :done-override="doneLocationOverride"
+      :done-route="alertmanagerConfigDetailRoute.name"
+      :done-override="alertmanagerConfigDetailRoute"
       :apply-hooks="alertmanagerConfigResource.applyHooks"
       @error="e=>$emit('error', e)"
     />
@@ -319,7 +285,7 @@ export default {
       :alertmanager-config-id="alertmanagerConfigId"
       :alertmanager-config-resource="alertmanagerConfigResource"
       :save-override="saveOverride"
-      :done-location-override="doneLocationOverride"
+      :done-location-override="alertmanagerConfigDetailRoute"
     />
     <ActionMenu
       :custom-actions="receiverActions"

--- a/pages/c/_cluster/monitoring/route-receiver/_id.vue
+++ b/pages/c/_cluster/monitoring/route-receiver/_id.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import ResourceDetail from '@/components/ResourceDetail';
 
 export default {

--- a/pages/c/_cluster/monitoring/route-receiver/create.vue
+++ b/pages/c/_cluster/monitoring/route-receiver/create.vue
@@ -1,4 +1,12 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import ResourceDetail from '@/components/ResourceDetail';
 
 export default {

--- a/pages/c/_cluster/monitoring/route-receiver/index.vue
+++ b/pages/c/_cluster/monitoring/route-receiver/index.vue
@@ -1,8 +1,17 @@
 <script>
+/**
+ * The Route and Receiver resources are deprecated. Going forward,
+ * routes and receivers should be configured within AlertmanagerConfigs.
+ * Any updates to receiver configuration forms, such as Slack/email/PagerDuty
+ * etc, should be made to the receiver forms that are based on the
+ * AlertmanagerConfig resource, which has a different API. The new forms are
+ * located in @/edit/monitoring.coreos.com.alertmanagerconfig/types.
+ */
 import ResourceTable from '@/components/ResourceTable';
 import Loading from '@/components/Loading';
 import Tabbed from '@/components/Tabbed';
 import Tab from '@/components/Tabbed/Tab';
+import Banner from '@/components/Banner';
 import { MONITORING } from '@/config/types';
 import { areRoutesSupportedFormat, getSecret } from '@/utils/alertmanagerconfig';
 import { MODE, _EDIT } from '@/config/query-params';
@@ -10,10 +19,11 @@ import { MODE, _EDIT } from '@/config/query-params';
 export default {
   name:       'ListRoute',
   components: {
+    Banner,
     Loading,
     ResourceTable,
-    Tabbed,
     Tab,
+    Tabbed,
   },
 
   async fetch() {
@@ -63,13 +73,19 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else>
-    <div class="row header mb-40">
+    <div class="row header mb-10">
       <h1>  {{ t('monitoring.routesAndReceivers') }}</h1>
       <div>
         <button class="btn btn-lg role-primary float right" @click="$router.push(createRoute)">
           {{ t('resourceList.head.create') }}
         </button>
       </div>
+    </div>
+    <div class="row">
+      <Banner
+        color="info"
+        :label="t('monitoring.alertmanagerConfig.deprecationWarning')"
+      />
     </div>
     <Tabbed ref="tabs" :default-tab="initTab">
       <Tab :name="routeSchema.id" :label="$store.getters['type-map/labelFor'](routeSchema, 2)">

--- a/utils/position.js
+++ b/utils/position.js
@@ -53,7 +53,7 @@ export function screenRect() {
   };
 }
 
-export function fitOnScreen(contentElem, triggerElemOrEvent, opt) {
+export function fitOnScreen(contentElem, triggerElemOrEvent, opt, useDefaults) {
   let {
     positionX = AUTO, // Preferred horizontal position
     positionY = AUTO, // Preferred vertical position
@@ -79,15 +79,16 @@ export function fitOnScreen(contentElem, triggerElemOrEvent, opt) {
 
   if (contentElem) {
     content = boundingRect(contentElem);
-  } else {
-    // Use a basic default menu size
+  }
+
+  if (useDefaults) {
     content = {
       top:    0,
-      right:  147.075,
-      bottom: 163.411,
+      right:  147,
+      bottom: 163,
       left:   0,
-      width:  147.075,
-      height: 163.411
+      width:  147,
+      height: 80
     };
   }
 


### PR DESCRIPTION
Changes in this PR:

New stuff:
- In the receiver list view, the context menus on each table row have "Edit Config," "Edit as Yaml" and "Delete" context menu options.
- Can now select a receiver for your route in the AlertmanagerConfig. (Note: I misread the API docs - it is a single select, not a multiselect. This means the only way you can route the alerts to multiple receivers is by creating child routes in YAML, so I added an info banner to that effect - see screenshot below.)
- Added banner warning that Route and Receiver resources are deprecated.
- When you are creating an AlertmanagerConfig, I have the "Create Receiver" button disabled with the tooltip "The receiver form is available after the AlertmanagerConfig is created." I haven't figured out the best way to handle creating both an AlertmanagerConfig and receiver(s) within it at the same time. We can discuss how to improve that when we have a little more time.

Fixes:
- Fixed bugs in which refreshing the "Edit Config" page or "Edit as YAML" page made the data appear empty.
- Fixed CSS issues with the action menu.
- Moved custom receiver nav links/routes into AlertmanagerConfig resource model to make it more organized.


<img width="1006" alt="Screen Shot 2022-04-25 at 9 20 40 PM" src="https://user-images.githubusercontent.com/20599230/165234056-b02a2573-3dbc-43d7-930d-e3878bd511f8.png">


Not included in this PR, will be coming in a separate PR:

- Secret selectors for receiver config forms.
- More receiver details showing in the AlertmanagerConfig list view.