### PR TITLE
Resolving an issue where the default product value wasn't being used when a consumer passed undefined

### DIFF
--- a/components/formatter/LinkName.vue
+++ b/components/formatter/LinkName.vue
@@ -32,7 +32,7 @@ export default {
         resource:  this.type,
         namespace: this.namespace,
         id:        this.value,
-        product:   this.product,
+        product:   this.product || EXPLORER,
       };
 
       return { name, params };


### PR DESCRIPTION
This fixes a problem where the NODE table header was rendering unusable links in pod tables.

rancher/dashboard#5727

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
This fixes broken links to Node pages seen on both the Node and Deployments page within the pod table.

### Occurred changes and/or fixed issues
- Node and Deployments

### Technical notes summary
The product was undefined even though the prop has a default for EXPLORER. This seems to indicate that vue allows you to override a default value with undefined.

### Areas or cases that should be tested
Node and Deployment pages both have a table with node links.

### Areas which could experience regressions
Anywhere with a LinkName but that's very unlikely.