### PR TITLE
Fix empty cluster list for standard user

### DIFF
--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -67,7 +67,7 @@ export default {
     }
 
     if ( this.$store.getters['management/canList'](SNAPSHOT) ) {
-      fetchOne.machines = this.$store.dispatch('management/findAll', { type: SNAPSHOT });
+      fetchOne.snapshots = this.$store.dispatch('management/findAll', { type: SNAPSHOT });
     }
 
     if (this.value.isImported || this.value.isCustom) {

--- a/detail/provisioning.cattle.io.cluster.vue
+++ b/detail/provisioning.cattle.io.cluster.vue
@@ -229,7 +229,13 @@ export default {
     },
 
     showSnapshots() {
-      return this.value.isRke2 || this.value.isRke1;
+      if (this.value.isRke1) {
+        return this.$store.getters['rancher/canList'](NORMAN.ETCD_BACKUP);
+      } else if (this.value.isRke2) {
+        return this.$store.getters['management/canList'](SNAPSHOT);
+      }
+
+      return false;
     },
 
     machineHeaders() {

--- a/list/provisioning.cattle.io.cluster.vue
+++ b/list/provisioning.cattle.io.cluster.vue
@@ -18,9 +18,11 @@ export default {
     const hash = {
       mgmtClusters:       this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
       rancherClusters:    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
-      etcdSnapshots:    this.$store.dispatch('management/findAll', { type: SNAPSHOT }),
-
     };
+
+    if ( this.$store.getters['management/canList'](SNAPSHOT) ) {
+      hash.etcdSnapshots = this.$store.dispatch('management/findAll', { type: SNAPSHOT });
+    }
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE) ) {
       hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });


### PR DESCRIPTION
Fixes #5725 
Fixes #5711 

Standard user can not access snapshots - the cluster page did not account for this.

Also fixes a bug where on the detail page, we were reusing the same has field (machines) for the snapshots.