### PR TITLE
Fix table header alignment and size

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -713,7 +713,7 @@ export default {
   <div ref="container">
     <div :class="{'titled': $slots.title && $slots.title.length}" class="sortable-table-header">
       <slot name="title" />
-      <div v-if="showHeaderRow" class="fixed-header-actions" :class="{'fixed-header-actions': true, button: true}">
+      <div v-if="showHeaderRow" class="fixed-header-actions" :class="{button: !!$slots['header-button']}">
         <div :class="bulkActionsClass" class="bulk">
           <slot name="header-left">
             <template v-if="tableActions">
@@ -1320,6 +1320,7 @@ $spacing: 10px;
   .search {
     grid-area: search;
     text-align: right;
+    justify-content: flex-end;
   }
 
   .bulk-actions-dropdown {


### PR DESCRIPTION
Fixes #5721 

The Project Monitoring PR changed the width of the header buttons area - this results in our filter boxes being wider than they were - this PR fixes this and only uses the wider width if a header button slot is present.

It also ensures that the search area is right-aligned.