### PR TITLE
De-paginate project bindings

### DIFF
--- a/config/product/explorer.js
+++ b/config/product/explorer.js
@@ -133,8 +133,9 @@ export function init(store) {
   configureType(NODE, { isCreatable: false, isEditable: true });
   configureType(WORKLOAD_TYPES.JOB, { isEditable: false, match: WORKLOAD_TYPES.JOB });
   configureType(MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, { isEditable: false });
-  configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false });
+  configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false, depaginate: true });
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });
+  configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: true });
 
   configureType(EVENT, { limit: 500 });
 

--- a/config/types.js
+++ b/config/types.js
@@ -25,7 +25,7 @@ export const NORMAN = {
   NODE:                          'node',
   PRINCIPAL:                     'principal',
   PROJECT:                       'project',
-  PROJECT_ROLE_TEMPLATE_BINDING: 'projectRoleTemplateBinding',
+  PROJECT_ROLE_TEMPLATE_BINDING: 'projectroletemplatebinding',
   SPOOFED:                       { GROUP_PRINCIPAL: 'group.principal' },
   ROLE_TEMPLATE:                 'roleTemplate',
   TOKEN:                         'token',

--- a/store/type-map.js
+++ b/store/type-map.js
@@ -96,6 +96,7 @@
 //                               resource: undefined       -- Use this resource in ResourceDetails instead
 //                               resourceDetail: undefined -- Use this resource specifically for ResourceDetail's detail component
 //                               resourceEdit: undefined   -- Use this resource specifically for ResourceDetail's edit component
+//                               depaginate: undefined -- Use this to depaginate requests for this type
 //                           }
 // )
 // ignoreGroup(group):        Never show group or any types in it
@@ -439,6 +440,7 @@ export const getters = {
       canYaml:     true,
       namespaced:  null,
       listGroups:  [],
+      depaginate:  false,
     };
 
     return (schemaOrType) => {


### PR DESCRIPTION
### Summary
Fixes #5104
- De-paginate requests for `projectroletemplatebinding` and `management.cattle.io.projectroletemplatebinding`
- Add `depaginate` option for types
- lowercase type `projectroletemplatebinding` to ensure type options can be found

I've tested this manually by applying the `limit` param to both types. The correct calls are made and the Vuex store contains all the required results. I've also tested that updates over the socket to the `projectroletemplatebinding` continue to be received (project members page doesn't update automatically, but clicking away and returning shows those updates).

### Areas or cases that should be tested
- Project management (create/edit/delete)
- Project member management specifically (add/remove members)
- Environments with over 1000 project bindings (members of projects)

