### PR TITLE
Home Page clusters table fetches counts for clusters that are not ready

### DIFF
--- a/components/formatter/PodsUsage.vue
+++ b/components/formatter/PodsUsage.vue
@@ -16,16 +16,18 @@ export default {
   },
   methods: {
     async startDelayedLoading() {
-      const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.row?.id }/v1/counts` });
+      if (this.row?.isReady) {
+        const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.row?.id }/v1/counts` });
 
-      this.loading = false;
-      const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
-      const totalPods = this.row?.status?.allocatable?.pods;
+        this.loading = false;
+        const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
+        const totalPods = this.row?.status?.allocatable?.pods;
 
-      if (totalPods) {
-        this.podsUsage = `${ usedPods }/${ totalPods }`;
-      } else {
-        this.podsUsage = '——';
+        if (totalPods) {
+          this.podsUsage = `${ usedPods }/${ totalPods }`;
+        } else {
+          this.podsUsage = '——';
+        }
       }
     }
   },

--- a/components/formatter/PodsUsage.vue
+++ b/components/formatter/PodsUsage.vue
@@ -28,6 +28,9 @@ export default {
         } else {
           this.podsUsage = '——';
         }
+      } else {
+        this.loading = false;
+        this.podsUsage = '——';
       }
     }
   },

--- a/components/formatter/__tests__/PodsUsage.test.ts
+++ b/components/formatter/__tests__/PodsUsage.test.ts
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils';
+import PodsUsage from '@/components/formatter/PodsUsage.vue';
+
+describe('component: PodsUsage', () => {
+  it('should not display values if data is not ready', () => {
+    const wrapper = mount(PodsUsage, {
+      propsData: { row: {} },
+      mocks:     { $store: { dispatch: { 'management/request': jest.fn() } } }
+    });
+
+    const element = wrapper.find('p').element;
+
+    expect(element).toBeUndefined();
+  });
+
+  it('should display spinning icon', () => {
+    const wrapper = mount(PodsUsage, {
+      propsData: { row: {} },
+      mocks:     { $store: { dispatch: { 'management/request': jest.fn() } } }
+    });
+
+    const element = wrapper.find('i').element;
+
+    expect(element).toBeDefined();
+  });
+
+  it('should display podsUsage value', () => {
+    const wrapper = mount(PodsUsage, {
+      propsData: { row: { isReady: true } },
+      data:      () => ({ loading: false }),
+      mocks:     { $store: { dispatch: { 'management/request': jest.fn() } } }
+    });
+
+    const element = wrapper.find('p').element;
+
+    expect(element.textContent).toBeDefined();
+  });
+});


### PR DESCRIPTION
Addresses Github issue: [#5717](https://github.com/rancher/dashboard/issues/5717)
Addresses Zube issue: [#5746](https://zube.io/rancher/dashboard-ui/c/5746)

- Fixes issue by triggering call to `/counts` endpoint only if cluster is Ready
