### PR TITLE
change worker nodes concurrency back to 10%

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -265,7 +265,7 @@ export default {
       set(this.value.spec.rkeConfig, 'upgradeStrategy', {
         controlPlaneConcurrency:  '1',
         controlPlaneDrainOptions: {},
-        workerConcurrency:        '1',
+        workerConcurrency:        '10%',
         workerDrainOptions:       {},
       });
     }


### PR DESCRIPTION
Addresses Github issue: [#5112](https://github.com/rancher/dashboard/issues/5112)
Addresses Zube issue: [#5136](https://zube.io/rancher/dashboard-ui/c/5136)

- change worker nodes concurrency back to 10%