### PR TITLE
Home Page clusters table fetches counts for clusters that are not ready

### DIFF
--- a/components/formatter/PodsUsage.vue
+++ b/components/formatter/PodsUsage.vue
@@ -26,11 +26,11 @@ export default {
         if (totalPods) {
           this.podsUsage = `${ usedPods }/${ totalPods }`;
         } else {
-          this.podsUsage = '——';
+          this.podsUsage = '—';
         }
       } else {
         this.loading = false;
-        this.podsUsage = '——';
+        this.podsUsage = '—';
       }
     }
   },


### PR DESCRIPTION
Addresses Github issue: [#5717](https://github.com/rancher/dashboard/issues/5717)
Addresses Zube issue: [#5746](https://zube.io/rancher/dashboard-ui/c/5746)

- fix default dash symbol for when Pods col is empty