### PR TITLE
Additional info added for 'Enable developer tools and features' checkbox in user preferences

### DIFF
--- a/pkg/epinio/components/application/AppConfiguration.vue
+++ b/pkg/epinio/components/application/AppConfiguration.vue
@@ -133,6 +133,14 @@ export default Vue.extend<Data, any, any, any>({
           this.values.services = (this.initialApplication.services || []);
         }
       }
+    },
+
+    hasConfigs(neu, old) {
+      if (!old && neu) {
+        if (!!this.initialApplication?.configuration?.configurations) {
+          this.values = this.initialApplication.configuration.configurations?.filter((cc: string) => this.configurations.find((c: any) => c.value === cc)) || [];
+        }
+      }
     }
 
   },

--- a/pkg/epinio/detail/applications.vue
+++ b/pkg/epinio/detail/applications.vue
@@ -11,7 +11,6 @@ import ApplicationCard from '@/shell/components/cards/ApplicationCard.vue';
 
 interface Data {
 }
-
 // Data, Methods, Computed, Props
 export default Vue.extend<Data, any, any, any>({
   components: {
@@ -241,7 +240,6 @@ export default Vue.extend<Data, any, any, any>({
         padding: 0;
         display: grid;
         grid-template-columns: 1fr 1fr;
-
         li {
           margin: 5px;
           list-style: none;
@@ -290,7 +288,6 @@ export default Vue.extend<Data, any, any, any>({
     }
   }
 }
-
 .deployment {
   margin-bottom: 60px;
   .simple-box {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3577,6 +3577,7 @@ prefs:
     emacs: 'Emacs'
     vim: 'Vim'
   advanced: Advanced
+  advancedTooltip: Enables 'View in API' option, enables a 'none' locale option, <br />enables shortcuts to toggle 'none' locale (shift+l) and toggle light or dark theme (shift+t)
   dev:
     label: Enable Developer Tools & Features
   hideDesc:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3577,7 +3577,7 @@ prefs:
     emacs: 'Emacs'
     vim: 'Vim'
   advanced: Advanced
-  advancedTooltip: Enables 'View in API' option, enables a 'none' locale option, <br />enables shortcuts to toggle 'none' locale (shift+l) and toggle light or dark theme (shift+t)
+  advancedTooltip: Enables 'View in API' option, enables shortcut to toggle light or dark theme (shift+t)
   dev:
     label: Enable Developer Tools & Features
   hideDesc:

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -203,14 +203,18 @@ export default {
 
     <hr />
     <div class="row">
+      <div class="col span-3 prefs-advanced">
+        <h4 v-t="'prefs.advanced'" />
+        <Checkbox v-model="dev" :tooltip="t('prefs.advancedTooltip', {}, raw=true)" :label="t('prefs.dev.label', {}, true)" />
+        <Checkbox v-if="!isSingleVirtualCluster" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" />
+      </div>
+    </div>
+
+    <hr />
+    <div class="row">
       <div class="col span-8">
         <h4 v-t="'prefs.keymap.label'" />
         <ButtonGroup v-model="keymap" :options="keymapOptions" />
-      </div>
-      <div class="col span-4">
-        <h4 v-t="'prefs.advanced'" />
-        <Checkbox v-model="dev" :label="t('prefs.dev.label', {}, true)" />
-        <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" />
       </div>
     </div>
 
@@ -229,5 +233,9 @@ export default {
 <style lang="scss" scoped>
   hr {
     margin: 20px 0;
+  }
+
+  .prefs-advanced .checkbox-outer-container:not(:last-of-type) {
+    margin-bottom: 8px;
   }
 </style>

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -203,9 +203,10 @@ export default {
 
     <hr />
     <div class="row">
-      <div class="col span-3 prefs-advanced">
+      <div class="col prefs-advanced">
         <h4 v-t="'prefs.advanced'" />
         <Checkbox v-model="dev" :tooltip="t('prefs.advancedTooltip', {}, raw=true)" :label="t('prefs.dev.label', {}, true)" />
+        <br />
         <Checkbox v-if="!isSingleVirtualCluster" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" />
       </div>
     </div>

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import { MANAGEMENT, STEVE } from '@shell/config/types';
 import { clone } from '@shell/utils/object';
 import { SETTING } from '@shell/config/settings';
+import { findBy } from '~/shell/utils/array';
 
 const definitions = {};
 


### PR DESCRIPTION
This PR fixes #5370 by adding additional info when selecting 'enable developer tools & features' in user preferences. 

A tooltip has been added explaining the preference changes
Minor css changes have also been made to provide a better user experience

![2022-04-28_02-38-39 (1)](https://user-images.githubusercontent.com/13671297/165724967-6f8ea473-f592-4d3f-96c3-a8fdac5664e1.gif)

