### PR TITLE
Adding a warning banner to the Add-On Config Tab

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1398,6 +1398,7 @@ cluster:
       httpTokens: Use tokens for metadata
       tagTitle: EC2 Tags
   addOns:
+    dependencyBanner: Add-On Configurations can vary between Kubernetes versions. Changing the Kubernetes version may reset the values below.
     additionalManifest:
       title: Additional Manifest
       tooltip: 'Additional Kubernetes Manifest YAML to be applied to the cluster on startup.'

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1906,6 +1906,12 @@ export default {
         </Tab>
 
         <Tab name="addons" label-key="cluster.tabs.addons" @active="showAddons">
+          <Banner
+            v-if="isEdit"
+            color="warning"
+          >
+            {{ t('cluster.addOns.dependencyBanner') }}
+          </Banner>
           <div v-if="versionInfo && addonVersions.length" :key="addonsRev">
             <div v-for="v in addonVersions" :key="v._key">
               <h3>{{ labelForAddon(v.name) }}</h3>


### PR DESCRIPTION
Adding a warning banner to the Add-On Config Tab

This warning informs the user that the add-on config tab will have it's values reset if the kubernetes version is changed. 

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5672 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
This occurs because the config is driven by chart/s that are dependent on the kubernetes version.

### Areas or cases that should be tested
Any provider that can see the Add-on Config tab should see this banner on the 

### Areas which could experience regressions
Just a visual change

### Screenshot/Video
![image](https://user-images.githubusercontent.com/55104481/165793208-bb27da14-3958-4220-b564-6489e1a81e01.png)
