### PR TITLE
AWS Marketplace Integration: generate support config 

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6743,6 +6743,7 @@ support:
     addLabel: "Please enter a valid Subscription ID:"
     removeTitle: Remove your ID?
     removeBody: "Note: This will not affect your subscription."
+
   suse:
     title: "Great News - You're covered"
     editBrand: Customize UI Theme
@@ -6750,6 +6751,9 @@ support:
       title: Get Support
       text: Login to SUSE Customer Center to access support for your subscription
       action: SUSE Customer Center
+      aws:
+        generateConfig: Generate Support Config
+        text: 'Login to SUSE Customer Center to access support for your subscription. Need to open a new support case? Download a support config file below.'
   promos:
     one:
       title: 24x7 Support

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -1,4 +1,4 @@
-import { MANAGEMENT } from '@shell/config/types';
+import { CATALOG, MANAGEMENT } from '@shell/config/types';
 import { getVendor } from '@shell/config/private-label';
 import { SETTING } from '@shell/config/settings';
 import { findBy } from '@shell/utils/array';
@@ -7,10 +7,13 @@ import { createCssVars } from '@shell/utils/color';
 export default {
   async fetch() {
     this.globalSettings = await this.$store.getters['management/all'](MANAGEMENT.SETTING);
+    if ( this.$store.getters['management/canList'](CATALOG.APP) ) {
+      this.apps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP });
+    }
   },
 
   data() {
-    return { globalSettings: [], brandCookie: null };
+    return { globalSettings: [], apps: [] };
   },
 
   computed: {
@@ -34,6 +37,10 @@ export default {
 
     theme() {
       return this.$store.getters['prefs/theme'];
+    },
+
+    cspAdapter() {
+      return findBy(this.apps, 'metadata.name', 'csp-adapter' );
     }
   },
 
@@ -60,6 +67,33 @@ export default {
         this.setCustomColor(this.linkColor, 'link');
       }
     },
+
+    cspAdapter(neu) {
+      if (neu && !this.brand) {
+        const brandSetting = findBy(this.globalSettings, 'id', SETTING.BRAND);
+
+        if (brandSetting) {
+          brandSetting.value = 'suse';
+          brandSetting.save();
+        } else {
+          const schema = this.$store.getters['management/schemaFor'](MANAGEMENT.SETTING);
+          const url = schema?.linkFor('collection');
+
+          if (url) {
+            this.$store.dispatch('management/create', {
+              type: MANAGEMENT.SETTING, metadata: { name: SETTING.BRAND }, value: 'suse', default: ''
+            }).then(setting => setting.save());
+          }
+        }
+      } else if (!neu) {
+        const brandSetting = findBy(this.globalSettings, 'id', SETTING.BRAND);
+
+        if (brandSetting) {
+          brandSetting.value = '';
+          brandSetting.save();
+        }
+      }
+    }
   },
   methods: {
     setCustomColor(color, name = 'primary') {

--- a/shell/pages/support/index.vue
+++ b/shell/pages/support/index.vue
@@ -5,7 +5,7 @@ import AsyncButton from '@shell/components/AsyncButton';
 import IndentedPanel from '@shell/components/IndentedPanel';
 import { Card } from '@components/Card';
 import CommunityLinks from '@shell/components/CommunityLinks';
-import { MANAGEMENT } from '@shell/config/types';
+import { MANAGEMENT, SERVICE } from '@shell/config/types';
 import { getVendor, setBrand } from '@shell/config/private-label';
 import { SETTING } from '@shell/config/settings';
 import { findBy } from '@shell/utils/array';
@@ -89,7 +89,7 @@ export default {
         return false;
       }
 
-      return `${ this.cspAdapter.proxyUrl('https', '443') }generate/supportconfig`;
+      return `${ this.cspAdapter.proxyUrl('https', '443') }v1/generateSUSERancherSupportConfig`;
     },
 
     hasSupport() {

--- a/shell/pages/support/index.vue
+++ b/shell/pages/support/index.vue
@@ -8,6 +8,8 @@ import CommunityLinks from '@shell/components/CommunityLinks';
 import { MANAGEMENT } from '@shell/config/types';
 import { getVendor, setBrand } from '@shell/config/private-label';
 import { SETTING } from '@shell/config/settings';
+import { findBy } from '@shell/utils/array';
+import { addParam } from '@shell/utils/url';
 
 const KEY_REGEX = /^[0-9a-fA-F]{16}$/;
 
@@ -45,6 +47,9 @@ export default {
       return setting;
     };
 
+    if ( this.$store.getters['management/canList'](SERVICE) ) {
+      this.svcs = await this.$store.dispatch('management/findAll', { type: SERVICE });
+    }
     this.supportSetting = await fetchOrCreateSetting('has-support', 'false');
     this.brandSetting = await fetchOrCreateSetting(SETTING.BRAND, '');
     this.communitySetting = await fetchOrCreateSetting(SETTING.COMMUNITY_LINKS, 'true');
@@ -54,6 +59,7 @@ export default {
 
   data() {
     return {
+      svcs:             [],
       vendor:               getVendor(),
       supportKey:           '',
       supportSetting:       null,
@@ -70,8 +76,24 @@ export default {
   },
 
   computed: {
+    cspAdapter() {
+      return findBy(this.svcs, 'id', 'cattle-system/rancher-csp-adapter' );
+    },
+
+    hasAWSSupport() {
+      return !!this.cspAdapter;
+    },
+
+    supportConfigLink() {
+      if (!this.cspAdapter) {
+        return false;
+      }
+
+      return `${ this.cspAdapter.proxyUrl('https', '443') }generate/supportconfig`;
+    },
+
     hasSupport() {
-      return this.supportSetting?.value && this.supportSetting?.value !== 'false';
+      return (this.supportSetting?.value && this.supportSetting?.value !== 'false') || this.hasAWSSupport;
     },
 
     options() {
@@ -85,6 +107,10 @@ export default {
     validSupportKey() {
       return !!this.supportKey.match(KEY_REGEX);
     },
+
+    sccLink() {
+      return this.hasAWSSupport ? addParam('https://scc.suse.com', 'from_marketplace', '1') : 'https://scc.suse.com';
+    }
   },
 
   methods: {
@@ -126,7 +152,7 @@ export default {
       if (input) {
         input.focus();
       }
-    }
+    },
   }
 };
 </script>
@@ -141,9 +167,14 @@ export default {
             <h2>{{ t('support.suse.access.title') }}</h2>
             <div>
               <p class="pb-10">
-                {{ t('support.suse.access.text') }}
+                {{ hasAWSSupport ? t("support.suse.access.aws.text") : t("support.suse.access.text") }}
               </p>
-              <a href="https://scc.suse.com" target="_blank" rel="noopener noreferrer nofollow">{{ t('support.suse.access.action') }} <i class="icon icon-external-link" /></a>
+              <a v-if="hasAWSSupport" class="mr-5 btn role-secondary btn-sm" :href="supportConfigLink">
+                {{ t('support.suse.access.aws.generateConfig') }}
+              </a>
+              <a :href="sccLink" target="_blank" rel="noopener noreferrer nofollow">
+                {{ t('support.suse.access.action') }} <i class="icon icon-external-link" />
+              </a>
             </div>
           </div>
           <div class="boxes">
@@ -165,7 +196,7 @@ export default {
               {{ t('support.subscription.addSubscription') }}
             </button>
           </div>
-          <div v-if="hasSupport" class="register row">
+          <div v-if="hasSupport && !hasAWSSupport" class="register row">
             <a class="remove-link" @click="showDialog(true)">
               {{ t('support.subscription.removeSubscription') }}
             </a>


### PR DESCRIPTION
### Summary
#4916 - this PR adds UI support for Rancher support purchased through AWS: see [this comment](https://github.com/rancher/dashboard/issues/4916#issuecomment-1106741816) to set up the dev environment.


### Occurred changes and/or fixed issues
The support page watches for the existence of the `csp-adapter` helm app and shows the option to download a support config file when it exists. The brand mixin also checks for the `csp-adapter` app and sets the theme to (supported) SUSE green by changing the `brand` global setting.

### Screenshot/Video
![Screen Shot 2022-04-28 at 12 13 46 PM](https://user-images.githubusercontent.com/42977925/165829257-04e88995-abc8-4652-a62a-e1f707ec62fd.png)

