### PR TITLE
Add secret selectors for Slack, PagerDuty, OpsGenie, Webhook and Email

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2812,8 +2812,27 @@ monitoring:
     receiverFormNames:
       create: Create Receiver in AlertmanagerConfig
       edit: Edit Receiver in AlertmanagerConfig
+      editYaml: Edit AlertmanagerConfig
       detail: Receiver in AlertmanagerConfig
     disabledReceiverButton: The receiver form is available after the AlertmanagerConfig is created
+    email:
+      username: Auth Username
+      password: Secret with Auth Password
+    slack:
+      apiUrl: Secret with Slack Webhook URL
+    pagerDuty:
+      routingKey: Secret with Routing Key
+      serviceKey: Secret with Service Key
+    opsgenie:
+      apiKey: Secret with API Key
+    webhook:
+      url: URL
+      urlSecret: URL Secret
+      urlSecretTooltip: 'urlSecret takes precedence over url. One of urlSecret and url should be defined.'
+    auth:
+      bearerTokenSecret: Bearer Token Secret
+      basicAuthUsername: Secret with Basic Auth Username
+      basicAuthPassword: Secret with Basic Auth Password
   installSteps:
     uninstallV1:
       stepTitle: Uninstall V1
@@ -2860,7 +2879,7 @@ monitoringReceiver:
     title: Webhook Config
     urlTooltip: For some webhooks this a url that points to the service DNS
     modifyNamespace: If <pre class="inline-block m-0 p-0 vertical-middle">rancher-alerting-drivers</pre> default values were changed, please update the url below in the format http://&lt;new_service_name&gt;.&lt;new_namespace&gt.svc.&lt;port&gt/&lt;path&gt
-    banner: To use MS Teams or SMS you will need to have <pre class="inline-block m-0 p-0 vertical-middle">rancher-alerting-drivers</pre> installed first.
+    banner: To use MS Teams or SMS you will need to have at least one instance of <pre class="inline-block m-0 p-0 vertical-middle">rancher-alerting-drivers</pre> installed first.
     add:
       generic: Generic
       msTeams: MS Teams
@@ -2888,13 +2907,13 @@ monitoringReceiver:
       label: Enable send resolved alerts
 
 alertmanagerConfigReceiver:
+  secretKeyId: Key Id from Secret
   name: Receiver Name
   addButton: Add Receiver
   receivers: Receivers
-  namespaceWarning: Could not render the secret selector because no namespace was found.
+  namespaceWarning: Could not render the secret selector because no namespace was found to get secrets from.
   receiverTypes: "The following receiver types can be edited in forms: Email, Slack, PagerDuty, Opsgenie and Webhook. For other receiver types, edit the AlertmanagerConfig YAML."
   slack:
-    keyId: Key Id from Secret
     webhookUrl: Webhook URL
     apiUrlTooltip: The secret's key that contains the Slack webhook URL. The secret needs to be in the same namespace as the AlertmanagerConfig object and accessible by the Prometheus Operator.
 monitoringRoute:

--- a/components/form/LabeledSelect.vue
+++ b/components/form/LabeledSelect.vue
@@ -271,6 +271,7 @@ export default {
       @search:focus="onFocus"
       @search="onSearch"
       @open="onOpen"
+      @option:selecting="$emit('input')"
     >
       <template #option="option">
         <template v-if="option.kind === 'group'">

--- a/components/form/SimpleSecretSelector.vue
+++ b/components/form/SimpleSecretSelector.vue
@@ -1,0 +1,191 @@
+<script>
+/**
+ * I created this component because the regular secret
+ * selector assumes secrets need to be in this format:
+ *
+ *  valueFrom:
+      secretKeyRef:
+        name: example-secret-name
+        key: example-secret-key
+
+   But for secrets for receivers in AlertmanagerConfigs,
+   it needed to be in this format:
+
+   name: example-secret-name
+   key: example-secret-key
+ */
+import LabeledSelect from '@/components/form/LabeledSelect';
+import { SECRET } from '@/config/types';
+import { _EDIT, _VIEW } from '@/config/query-params';
+import { TYPES } from '@/models/secret';
+import sortBy from 'lodash/sortBy';
+
+const NONE = '__[[NONE]]__';
+
+export default {
+  components: { LabeledSelect },
+
+  async fetch() {
+    // Make sure secrets are in the store so that the secret
+    // selectors in the receiver config forms will have secrets
+    // to choose from.
+    const allSecrets = await this.$store.dispatch('cluster/findAll', { type: SECRET });
+
+    const allSecretsInNamespace = allSecrets.filter(secret => this.types.includes(secret._type) && secret.namespace === this.namespace);
+
+    this.secrets = allSecretsInNamespace;
+  },
+
+  props: {
+    test:        { type: String, default: '' },
+    initialName: {
+      type:     String,
+      required: true
+    },
+    initialKey: {
+      type:     String,
+      required: true
+    },
+    namespace: {
+      type:     String,
+      required: true
+    },
+    types: {
+      type:    Array,
+      default: () => Object.values(TYPES)
+    },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+    secretNameLabel: {
+      type:    String,
+      default: 'Secret Name'
+    },
+    keyNameLabel: {
+      type:    String,
+      default: 'Key'
+    },
+    mode: {
+      type:     String,
+      default: _EDIT
+    },
+  },
+
+  data(props) {
+    return {
+      secrets: [],
+      name:    props.initialName,
+      key:     props.initialKey
+    };
+  },
+
+  computed: {
+    secretNames() {
+      const mappedSecrets = this.secrets.map(secret => ({
+        label: secret.name,
+        value: secret.name
+      })).sort();
+
+      return [{ label: 'None', value: NONE }, ...sortBy(mappedSecrets, 'label')];
+    },
+    keys() {
+      const secret = this.secrets.find(secret => secret.name === this.name) || {};
+
+      return Object.keys(secret.data || {}).map(key => ({
+        label: key,
+        value: key
+      }));
+    },
+    isView() {
+      return this.mode === _VIEW;
+    },
+    isKeyDisabled() {
+      return !this.isView && (!this.name || this.name === NONE || this.disabled);
+    }
+  },
+
+  methods: {
+    updateSecretName(value) {
+      if (value) {
+        this.$emit('updateSecretName', value);
+      }
+    },
+    updateSecretKey(value) {
+      if (value) {
+        this.$emit('updateSecretKey', value);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="secret-selector show-key-selector">
+    <div class="input-container">
+      <LabeledSelect
+        v-model="name"
+        class="col span-6"
+        :disabled="!isView && disabled"
+        :options="secretNames"
+        :label="secretNameLabel"
+        :mode="mode"
+        @input="updateSecretName"
+      />
+      <LabeledSelect
+        v-model="key"
+        class="col span-6"
+        :disabled="isKeyDisabled"
+        :options="keys"
+        :label="keyNameLabel"
+        :mode="mode"
+        @input="updateSecretKey"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.secret-selector {
+  width: 100%;
+  label {
+    display: block;
+  }
+
+  & .labeled-select {
+    min-height: $input-height;
+  }
+
+  & .vs__selected-options {
+    padding: 8px 0 7px 0;
+  }
+
+  & label {
+    display: inline-block;
+  }
+
+  &.show-key-selector {
+    .input-container > * {
+      display: inline-block;
+      width: 50%;
+
+      &.labeled-select.focused {
+        z-index: 10;
+      }
+
+      &:first-child {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        margin-right: 0;
+      }
+
+      &:last-child {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        border-left: none;
+        float: right;
+      }
+    }
+  }
+}
+</style>

--- a/edit/monitoring.coreos.com.alertmanagerconfig/auth.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/auth.vue
@@ -1,10 +1,11 @@
 <script>
-import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
+import SimpleSecretSelector from '@/components/form/SimpleSecretSelector';
 import isEmpty from 'lodash/isEmpty';
+import { _VIEW } from '@/config/query-params';
 
 export default {
-  components: { LabeledInput, LabeledSelect },
+  components: { LabeledSelect, SimpleSecretSelector },
   props:      {
     mode: {
       type:     String,
@@ -12,55 +13,209 @@ export default {
     },
     value: {
       type:     Object,
+      required: true,
+    },
+    namespace: {
+      type:     String,
       required: true
     }
   },
   data() {
-    this.$set(this.value, 'basic_auth', this.value.basic_auth || {});
+    this.$set(this.value, 'basicAuth', this.value.basicAuth || {});
 
     const authOptions = [
       {
-        value:   'none',
-        label:   this.t('monitoringReceiver.auth.none.label')
+        value: 'none',
+        label: this.t('monitoringReceiver.auth.none.label'),
       },
       {
-        value:   'basic_auth',
+        value:   'basicAuth',
         label:   this.t('monitoringReceiver.auth.basicAuth.label'),
-        default: {}
+        default: {},
       },
       {
-        value:   'bearer_token',
+        value:   'bearerTokenSecret',
         label:   this.t('monitoringReceiver.auth.bearerToken.label'),
-        default: ''
+        default: {},
       },
-      {
-        value:   'bearer_token_file',
-        label:   this.t('monitoringReceiver.auth.bearerTokenFile.label'),
-        default: ''
-      }
     ];
     const authTypes = authOptions.map(option => option.value);
-    const authType = authTypes.find(authType => !isEmpty(this.value[authType])) || authTypes[0];
+    const authType =
+      authTypes.find(authType => !isEmpty(this.value[authType])) ||
+      authTypes[0];
 
     this.initializeType(authOptions, authType);
 
     return {
       authOptions,
       authTypes,
-      authType
+      authType,
+      view:                               _VIEW,
+      initialBearerTokenSecretName:       this.value?.bearerSecretToken?.name ? this.value.bearerSecretToken.name : '',
+      initialBearerTokenSecretKey:        this.value?.bearerSecretToken?.key ? this.value.bearerSecretToken.key : '',
+      initialBasicAuthUsernameSecretName: this.value?.basicAuth?.username?.name ? this.value.basicAuth.username.name : '',
+      initialBasicAuthUsernameSecretKey:  this.value?.basicAuth?.username?.key ? this.value.basicAuth.username.key : '',
+      initialBasicAuthPasswordSecretName: this.value?.basicAuth?.password?.name ? this.value.basicAuth.password.name : '',
+      initialBasicAuthPasswordSecretKey:  this.value?.basicAuth?.password?.key ? this.value.basicAuth.password.key : ''
     };
   },
   methods: {
     initializeType(authOptions, type) {
       authOptions.forEach((authOption) => {
         if (authOption.value === type && type !== 'none') {
-          this.$set(this.value, authOption.value, this.value[authOption.value] || authOption.default);
+          this.$set(
+            this.value,
+            authOption.value,
+            this.value[authOption.value] || authOption.default
+          );
         } else if (typeof this.value[authOption.value] !== 'undefined') {
           this.$delete(this.value, authOption.value);
         }
       });
     },
-  }
+    updateBearerTokenSecretName(name) {
+      const existingKey = this.value.bearerTokenSecret?.key || '';
+
+      if (this.value.bearerTokenSecret) {
+        this.value.bearerTokenSecret = {
+          key: existingKey,
+          name,
+        };
+      } else {
+        this.value['bearerTokenSecret'] = {
+          key: '',
+          name,
+        };
+      }
+    },
+    updateBearerTokenSecretKey(key) {
+      const existingName = this.value.bearerTokenSecret?.name || '';
+
+      if (this.value.bearerTokenSecret) {
+        this.value.bearerTokenSecret = {
+          name: existingName,
+          key,
+        };
+      } else {
+        this.value['bearerTokenSecret'] = {
+          name: '',
+          key,
+        };
+      }
+    },
+    updateBasicAuthUsernameSecretName(name) {
+      if (!this.value.basicAuth) {
+        this.value['basicAuth'] = {
+          username: {
+            key: '',
+            name
+          },
+          password: {
+            key:  '',
+            name: ''
+          }
+        };
+      }
+
+      const existingKey = this.value.basicAuth.username?.key || '';
+
+      if (this.value.basicAuth.username) {
+        this.value.basicAuth.username = {
+          key: existingKey,
+          name,
+        };
+      } else {
+        this.value.basicAuth['username'] = {
+          key: '',
+          name,
+        };
+      }
+    },
+    updateBasicAuthUsernameSecretKey(key) {
+      if (!this.value.basicAuth) {
+        this.value['basicAuth'] = {
+          username: {
+            key,
+            name: ''
+          },
+          password: {
+            key:  '',
+            name: ''
+          }
+        };
+      }
+
+      const existingName = this.value.basicAuth.username?.name || '';
+
+      if (this.value.basicAuth.username) {
+        this.value.basicAuth.username = {
+          key,
+          name: existingName
+        };
+      } else {
+        this.value.basicAuth['username'] = {
+          key,
+          name: '',
+        };
+      }
+    },
+    updateBasicAuthPasswordSecretName(name) {
+      if (!this.value.basicAuth) {
+        this.value['basicAuth'] = {
+          username: {
+            key:  '',
+            name: ''
+          },
+          password: {
+            key: '',
+            name
+          }
+        };
+      }
+
+      const existingKey = this.value.basicAuth.password?.key || '';
+
+      if (this.value.basicAuth.password) {
+        this.value.basicAuth.password = {
+          key: existingKey,
+          name,
+        };
+      } else {
+        this.value.basicAuth['password'] = {
+          key: '',
+          name,
+        };
+      }
+    },
+    updateBasicAuthPasswordSecretKey(key) {
+      if (!this.value.basicAuth) {
+        this.value['basicAuth'] = {
+          username: {
+            key:  '',
+            name: ''
+          },
+          password: {
+            key,
+            name: ''
+          }
+        };
+      }
+
+      const existingName = this.value.basicAuth.password?.name || '';
+
+      if (this.value.basicAuth.password) {
+        this.value.basicAuth.password = {
+          key,
+          name: existingName,
+        };
+      } else {
+        this.value.basicAuth['password'] = {
+          key,
+          name: '',
+        };
+      }
+    }
+  },
 };
 </script>
 
@@ -68,38 +223,73 @@ export default {
   <div>
     <div class="row">
       <div class="col span-6">
-        <h3>{{ t('monitoringReceiver.auth.label') }}</h3>
+        <h3>{{ t("monitoringReceiver.auth.label") }}</h3>
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-12">
-        <LabeledSelect v-model="authType" :options="authOptions" label="Auth Type" @input="initializeType(authOptions, authType)" />
-      </div>
-    </div>
-    <div v-if="authType === 'basic_auth'" class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput v-model="value.basic_auth.username" :mode="mode" :label="t('monitoringReceiver.auth.username')" />
-      </div>
-      <div class="col span-6">
-        <LabeledInput v-model="value.basic_auth.password" :mode="mode" :label="t('monitoringReceiver.auth.password')" type="password" autocomplete="password" />
-      </div>
-    </div>
-    <div v-else-if="authType === 'bearer_token'" class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput
-          v-model="value.bearer_token"
-          :mode="mode"
-          :label="t('monitoringReceiver.auth.bearerToken.label')"
-          :placeholder="t('monitoringReceiver.auth.bearerToken.placeholder')"
-          type="password"
-          autocomplete="password"
+        <LabeledSelect
+          v-model="authType"
+          :disabled="mode === view"
+          :options="authOptions"
+          label="Auth Type"
+          @input="initializeType(authOptions, authType)"
         />
       </div>
     </div>
-    <div v-else-if="authType === 'bearer_token_file'" class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput v-model="value.bearer_token_file" :mode="mode" :label="t('monitoringReceiver.auth.bearerTokenFile.label')" :placeholder="t('monitoringReceiver.auth.bearerTokenFile.placeholder')" />
-      </div>
+    <div v-if="authType === 'basicAuth'" class="row mb-20">
+      <SimpleSecretSelector
+        v-if="namespace"
+        :initial-key="initialBasicAuthUsernameSecretKey"
+        :initial-name="initialBasicAuthUsernameSecretName"
+        :mode="mode"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="
+          t('monitoring.alertmanagerConfig.auth.basicAuthUsername')
+        "
+        @updateSecretName="updateBasicAuthUsernameSecretName"
+        @updateSecretKey="updateBasicAuthUsernameSecretKey"
+      />
+      <Banner v-else color="error">
+        {{ t("alertmanagerConfigReceiver.namespaceWarning") }}
+      </Banner>
+    </div>
+    <div v-if="authType === 'basicAuth'" class="row mb-20">
+      <SimpleSecretSelector
+        v-if="namespace"
+        :initial-key="initialBasicAuthPasswordSecretKey"
+        :initial-name="initialBasicAuthPasswordSecretName"
+        :mode="mode"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="
+          t('monitoring.alertmanagerConfig.auth.basicAuthPassword')
+        "
+        @updateSecretName="updateBasicAuthPasswordSecretName"
+        @updateSecretKey="updateBasicAuthPasswordSecretKey"
+      />
+      <Banner v-else color="error">
+        {{ t("alertmanagerConfigReceiver.namespaceWarning") }}
+      </Banner>
+    </div>
+    <div v-if="authType === 'bearerTokenSecret'" class="row mb-20">
+      <SimpleSecretSelector
+        v-if="namespace"
+        :initial-key="initialBearerTokenSecretKey"
+        :initial-name="initialBearerTokenSecretName"
+        :mode="mode"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="
+          t('monitoring.alertmanagerConfig.auth.bearerTokenSecret')
+        "
+        @updateSecretName="updateBearerTokenSecretName"
+        @updateSecretKey="updateBearerTokenSecretKey"
+      />
+      <Banner v-else color="error">
+        {{ t("alertmanagerConfigReceiver.namespaceWarning") }}
+      </Banner>
     </div>
   </div>
 </template>

--- a/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -150,8 +150,8 @@ export default {
       this.$router.push(this.alertmanagerConfigResource.getEditReceiverYamlRoute(this.selectedReceiverName, _EDIT));
     },
     promptRemove() {
-    // 'promptRemove' is the exact name of an action for AlertmanagerConfig
-    // and this method executes the action.
+      // 'promptRemove' is the exact name of an action for AlertmanagerConfig
+      // and this method executes the action.
       // Get the name of the receiver to delete from the action info.
       const nameOfReceiverToDelete = this.selectedReceiverName;
       // Remove it from the configuration of the parent AlertmanagerConfig
@@ -208,7 +208,11 @@ export default {
                 :tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
               >
                 {{ t('monitoring.receiver.addReceiver') }}
-                <i v-if="mode === create" v-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')" class="icon icon-info" />
+                <i
+                  v-if="mode === create"
+                  v-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
+                  class="icon icon-info"
+                />
               </button>
             </nuxt-link>
           </template>

--- a/edit/monitoring.coreos.com.alertmanagerconfig/tls.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/tls.vue
@@ -15,7 +15,7 @@ export default {
     }
   },
   data() {
-    this.$set(this.value, 'tls_config', this.value.tls_config || {});
+    this.$set(this.value, 'tlsConfig', this.value.tlsConfig || {});
 
     return {};
   },
@@ -32,15 +32,15 @@ export default {
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.tls_config.ca_file" :mode="mode" :label="t('monitoring.receiver.tls.caFilePath.label')" :placeholder="t('monitoring.receiver.tls.caFilePath.placeholder')" />
+        <LabeledInput v-model="value.tlsConfig.caFile" :mode="mode" :label="t('monitoring.receiver.tls.caFilePath.label')" :placeholder="t('monitoring.receiver.tls.caFilePath.placeholder')" />
       </div>
     </div>
     <div class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.tls_config.cert_file" :mode="mode" :label="t('monitoring.receiver.tls.certFilePath.label')" :placeholder="t('monitoring.receiver.tls.certFilePath.placeholder')" />
+        <LabeledInput v-model="value.tlsConfig.certFile" :mode="mode" :label="t('monitoring.receiver.tls.certFilePath.label')" :placeholder="t('monitoring.receiver.tls.certFilePath.placeholder')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.tls_config.key_file" :mode="mode" :label="t('monitoring.receiver.tls.keyFilePath.label')" :placeholder="t('monitoring.receiver.tls.keyFilePath.placeholder')" />
+        <LabeledInput v-model="value.tlsConfig.keyFile" :mode="mode" :label="t('monitoring.receiver.tls.keyFilePath.label')" :placeholder="t('monitoring.receiver.tls.keyFilePath.placeholder')" />
       </div>
     </div>
   </div>

--- a/edit/monitoring.coreos.com.alertmanagerconfig/types/email.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/types/email.vue
@@ -2,10 +2,12 @@
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import TLS from '../tls';
+import SimpleSecretSelector from '@/components/form/SimpleSecretSelector';
+import { _VIEW } from '@/config/query-params';
 
 export default {
   components: {
-    Checkbox, LabeledInput, TLS
+    Checkbox, LabeledInput, SimpleSecretSelector, TLS
   },
   props:      {
     mode: {
@@ -25,8 +27,45 @@ export default {
     this.$set(this.value, 'sendResolved', this.value.sendResolved || false);
     this.$set(this.value, 'requireTls', this.value.requireTls || false);
 
-    return {};
+    return {
+      view:                          _VIEW,
+      initialAuthPasswordSecretName:  this.value?.authPassword?.name ? this.value.authPassword.name : '',
+      initialAuthPasswordSecretKey:  this.value.authPassword?.key ? this.value.authPassword.key : ''
+    };
   },
+
+  methods: {
+    updateAuthPasswordSecretName(name) {
+      const existingKey = this.value.authPassword?.key || '';
+
+      if (this.value.authPassword) {
+        this.value.authPassword = {
+          key: existingKey,
+          name
+        };
+      } else {
+        this.value['authPassword'] = {
+          key: '',
+          name
+        };
+      }
+    },
+    updateAuthPasswordSecretKey(key) {
+      const existingName = this.value.authPassword?.name || '';
+
+      if (this.value.authPassword) {
+        this.value.authPassword = {
+          name: existingName,
+          key
+        };
+      } else {
+        this.value['authPassword'] = {
+          name: '',
+          key
+        };
+      }
+    }
+  }
 };
 </script>
 
@@ -63,15 +102,25 @@ export default {
     </div>
     <div v-if="namespace" class="row mb-20">
       <div class="col span-6">
-        <LabeledInput v-model="value.authUsername" :mode="mode" label="Username" placeholder="e.g. John" />
-      </div>
-      <div class="col span-6">
-        <LabeledInput v-model="value.authPassword" :mode="mode" label="Password" type="password" autocomplete="password" />
+        <LabeledInput v-model="value.authUsername" :mode="mode" :label="t('monitoring.alertmanagerConfig.email.username')" placeholder="e.g. John" />
       </div>
     </div>
-    <Banner v-else color="error">
-      {{ t('alertmanagerConfigReceiver.namespaceWarning') }}
-    </Banner>
+    <div class="row mb-20">
+      <SimpleSecretSelector
+        v-if="namespace"
+        :initial-key="initialAuthPasswordSecretKey"
+        :mode="mode"
+        :initial-name="initialAuthPasswordSecretName"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="t('monitoring.alertmanagerConfig.email.password')"
+        @updateSecretName="updateAuthPasswordSecretName"
+        @updateSecretKey="updateAuthPasswordSecretKey"
+      />
+      <Banner v-else color="error">
+        {{ t('alertmanagerConfigReceiver.namespaceWarning') }}
+      </Banner>
+    </div>
     <TLS v-model="value" class="mb-20" :mode="mode" />
   </div>
 </template>

--- a/edit/monitoring.coreos.com.alertmanagerconfig/types/opsgenie.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/types/opsgenie.vue
@@ -4,6 +4,7 @@ import LabeledInput from '@/components/form/LabeledInput';
 import Select from '@/components/form/Select';
 import Checkbox from '@/components/form/Checkbox';
 import InputWithSelect from '@/components/form/InputWithSelect';
+import SimpleSecretSelector from '@/components/form/SimpleSecretSelector';
 import { _VIEW } from '@/config/query-params';
 
 export const TARGETS = [
@@ -42,7 +43,7 @@ export const TYPES = [
 
 export default {
   components: {
-    ArrayList, Checkbox, InputWithSelect, LabeledInput, Select
+    ArrayList, Checkbox, InputWithSelect, LabeledInput, Select, SimpleSecretSelector
   },
   props:      {
     mode: {
@@ -81,7 +82,10 @@ export default {
       },
       responders,
       TARGETS,
-      TYPES
+      TYPES,
+      view:                          _VIEW,
+      initialApiKeySecretName:  this.value?.apiKey?.name ? this.value.apiKey.name : '',
+      initialApiKeySecretKey:  this.value?.apiKey?.key ? this.value.apiKey.key : ''
     };
   },
 
@@ -117,6 +121,36 @@ export default {
     },
     targetLabel(target) {
       return TARGETS.find(t => t.value === target).label;
+    },
+    updateApiKeySecretName(name) {
+      const existingKey = this.value.apiKey?.key || '';
+
+      if (this.value.apiKey) {
+        this.value.apiKey = {
+          key: existingKey,
+          name
+        };
+      } else {
+        this.value['apiKey'] = {
+          key: '',
+          name
+        };
+      }
+    },
+    updateApiKeySecretKey(key) {
+      const existingName = this.value.apiKey?.name || '';
+
+      if (this.value.apiKey) {
+        this.value.apiKey = {
+          name: existingName,
+          key
+        };
+      } else {
+        this.value['apiKey'] = {
+          name: '',
+          key
+        };
+      }
     }
   }
 };
@@ -129,17 +163,25 @@ export default {
         <h3>Target</h3>
       </div>
     </div>
-    <div v-if="namespace" class="row mb-20">
-      <div class="col span-12">
-        <LabeledInput v-model="value.apiKey" :mode="mode" label="API Key" />
-      </div>
+    <div class="row mb-20">
+      <SimpleSecretSelector
+        v-if="namespace"
+        :initial-key="initialApiKeySecretKey"
+        :mode="mode"
+        :initial-name="initialApiKeySecretName"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="t('monitoring.alertmanagerConfig.opsgenie.apiKey')"
+        @updateSecretName="updateApiKeySecretName"
+        @updateSecretKey="updateApiKeySecretKey"
+      />
+      <Banner v-else color="error">
+        {{ t('alertmanagerConfigReceiver.namespaceWarning') }}
+      </Banner>
     </div>
-    <Banner v-else color="error">
-      {{ t('alertmanagerConfigReceiver.namespaceWarning') }}
-    </Banner>
     <div class="row mb-20">
       <div class="col span-12">
-        <LabeledInput v-model="value.http_config.proxyUrl" :mode="mode" label="Proxy URL" placeholder="e.g. http://my-proxy/" />
+        <LabeledInput v-model="value.httpConfig.proxyUrl" :mode="mode" label="Proxy URL" placeholder="e.g. http://my-proxy/" />
       </div>
     </div>
     <div class="row mb-20">

--- a/edit/monitoring.coreos.com.alertmanagerconfig/types/pagerduty.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/types/pagerduty.vue
@@ -2,10 +2,12 @@
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import Checkbox from '@/components/form/Checkbox';
+import SimpleSecretSelector from '@/components/form/SimpleSecretSelector';
+import { _VIEW } from '@/config/query-params';
 
 export default {
   components: {
-    Checkbox, LabeledInput, LabeledSelect
+    Checkbox, LabeledInput, LabeledSelect, SimpleSecretSelector
   },
   props:      {
     mode: {
@@ -35,7 +37,12 @@ export default {
     return {
       integrationMapping,
       integrationTypeOptions,
-      integrationType: this.value.serviceKey ? integrationTypeOptions[1] : integrationTypeOptions[0]
+      integrationType:             this.value.serviceKey ? integrationTypeOptions[1] : integrationTypeOptions[0],
+      initialRoutingKeySecretKey:  this.value.routingKey?.key || '',
+      initialRoutingKeySecretName: this.value.routingKey?.name || '',
+      initialServiceKeySecretKey:  this.value.serviceKey?.key || '',
+      initialServiceKeySecretName: this.value.serviceKey?.name || '',
+      view:                        _VIEW
     };
   },
   watch: {
@@ -44,7 +51,70 @@ export default {
         this.value[this.integrationMapping[option]] = null;
       });
     }
+  },
+  methods: {
+    updateRoutingKeySecretName(name) {
+      const existingKey = this.value.routingKey?.key || '';
+
+      if (this.value.routingKey) {
+        this.value.routingKey = {
+          key: existingKey,
+          name
+        };
+      } else {
+        this.value['routingKey'] = {
+          key: '',
+          name
+        };
+      }
+    },
+    updateRoutingKeySecretKey(key) {
+      const existingName = this.value.routingKey?.name || '';
+
+      if (this.value.routingKey) {
+        this.value.routingKey = {
+          name: existingName,
+          key
+        };
+      } else {
+        this.value['routingKey'] = {
+          name: '',
+          key
+        };
+      }
+    },
+    updateServiceKeySecretName(name) {
+      const existingKey = this.value.serviceKey?.key || '';
+
+      if (this.value.serviceKey) {
+        this.value.serviceKey = {
+          key: existingKey,
+          name
+        };
+      } else {
+        this.value['serviceKey'] = {
+          key: '',
+          name
+        };
+      }
+    },
+    updateServiceKeySecretKey(key) {
+      const existingName = this.value.serviceKey?.name || '';
+
+      if (this.value.serviceKey) {
+        this.value.serviceKey = {
+          name: existingName,
+          key
+        };
+      } else {
+        this.value['serviceKey'] = {
+          name: '',
+          key
+        };
+      }
+    }
   }
+
 };
 </script>
 
@@ -59,13 +129,36 @@ export default {
       <div class="col span-6">
         <LabeledSelect v-model="integrationType" :options="integrationTypeOptions" :mode="mode" label="Integration Type" />
       </div>
-      <div class="col span-6">
-        <LabeledInput v-model="value[integrationMapping[integrationType]]" :mode="mode" label="Default Integration Key" />
-      </div>
+    </div>
+
+    <div v-if="namespace" class="row mb-20">
+      <SimpleSecretSelector
+        v-if="integrationType === 'Events API v2'"
+        :initial-key="initialRoutingKeySecretKey"
+        :mode="mode"
+        :initial-name="initialRoutingKeySecretName"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="t('monitoring.alertmanagerConfig.pagerDuty.routingKey')"
+        @updateSecretName="updateRoutingKeySecretName"
+        @updateSecretKey="updateRoutingKeySecretKey"
+      />
+      <SimpleSecretSelector
+        v-if="integrationType === 'Prometheus'"
+        :initial-key="initialServiceKeySecretKey"
+        :mode="mode"
+        :initial-name="initialServiceKeySecretName"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="t('monitoring.alertmanagerConfig.pagerDuty.serviceKey')"
+        @updateSecretName="updateServiceKeySecretName"
+        @updateSecretKey="updateServiceKeySecretKey"
+      />
     </div>
     <Banner v-else color="error">
       {{ t('alertmanagerConfigReceiver.namespaceWarning') }}
     </Banner>
+
     <div class="row mb-20">
       <div class="col span-12">
         <LabeledInput v-model="value.httpConfig.proxyUrl" :mode="mode" label="Proxy URL" placeholder="e.g. http://my-proxy/" />

--- a/edit/monitoring.coreos.com.alertmanagerconfig/types/slack.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/types/slack.vue
@@ -2,12 +2,12 @@
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import Banner from '@/components/Banner';
-import SecretSelector from '@/components/form/SecretSelector';
+import SimpleSecretSelector from '@/components/form/SimpleSecretSelector';
 import { _CREATE, _VIEW } from '@/config/query-params';
 
 export default {
   components: {
-    Banner, Checkbox, LabeledInput, SecretSelector
+    Banner, Checkbox, LabeledInput, SimpleSecretSelector
   },
   props:      {
     mode: {
@@ -35,8 +35,45 @@ export default {
       );
     }
 
-    return { view: _VIEW };
+    return {
+      view:              _VIEW,
+      initialSecretKey:  this.value?.apiURL?.key ? this.value.apiURL.key : '',
+      initialSecretName: this.value.apiURL?.name ? this.value.apiURL.name : ''
+    };
   },
+
+  methods: {
+    updateSecretName(name) {
+      const existingKey = this.value.apiURL?.key || '';
+
+      if (this.value.apiURL) {
+        this.value.apiURL = {
+          key: existingKey,
+          name
+        };
+      } else {
+        this.value['apiURL'] = {
+          key: '',
+          name
+        };
+      }
+    },
+    updateSecretKey(key) {
+      const existingName = this.value.apiURL?.name || '';
+
+      if (this.value.apiURL) {
+        this.value.apiURL = {
+          key,
+          name: existingName
+        };
+      } else {
+        this.value['apiURL'] = {
+          key,
+          name: ''
+        };
+      }
+    }
+  }
 };
 </script>
 
@@ -48,15 +85,17 @@ export default {
       </div>
     </div>
     <div class="row mb-20">
-      <SecretSelector
+      <SimpleSecretSelector
         v-if="namespace"
-        v-model="value.apiURL"
+        :initial-key="initialSecretKey"
         :mode="mode"
+        :initial-name="initialSecretName"
         :tooltip="t('alertmanagerConfigReceiver.slack.apiUrlTooltip')"
         :namespace="namespace"
         :disabled="mode === view"
-        :secret-name-label="t('alertmanagerConfigReceiver.slack.keyId')"
-        :show-key-selector="true"
+        :secret-name-label="t('monitoring.alertmanagerConfig.slack.apiUrl')"
+        @updateSecretName="updateSecretName"
+        @updateSecretKey="updateSecretKey"
       />
       <Banner v-else color="error">
         {{ t('alertmanagerConfigReceiver.namespaceWarning') }}

--- a/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.add.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.add.vue
@@ -42,11 +42,15 @@ export default {
     add({ value }) {
       switch (value) {
       case 'generic':
-        return this.model.push({});
+        this.model.push({});
+
+        return;
       case 'ms-teams':
-        return this.model.push({ url: MS_TEAMS_URL });
+        this.model.push({ url: MS_TEAMS_URL });
+
+        return;
       case 'alibaba-cloud-sms':
-        return this.model.push({ url: ALIBABA_CLOUD_SMS_URL });
+        this.model.push({ url: ALIBABA_CLOUD_SMS_URL });
       }
     }
   }

--- a/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.vue
@@ -1,7 +1,9 @@
 <script>
+
 import LabeledInput from '@/components/form/LabeledInput';
 import Checkbox from '@/components/form/Checkbox';
 import Banner from '@/components/Banner';
+import SimpleSecretSelector from '@/components/form/SimpleSecretSelector';
 import { _VIEW } from '@/config/query-params';
 import { ALIBABA_CLOUD_SMS_URL, MS_TEAMS_URL } from '@/edit/monitoring.coreos.com.receiver/types/webhook.add.vue';
 import TLS from '../tls';
@@ -9,7 +11,7 @@ import Auth from '../auth';
 
 export default {
   components: {
-    Auth, Banner, Checkbox, LabeledInput, TLS
+    Auth, Banner, Checkbox, LabeledInput, SimpleSecretSelector, TLS
   },
   props:      {
     mode: {
@@ -31,7 +33,44 @@ export default {
 
     const isDriverUrl = this.value.url === MS_TEAMS_URL || this.value.url === ALIBABA_CLOUD_SMS_URL;
 
-    return { showNamespaceBanner: isDriverUrl && this.mode !== _VIEW };
+    return {
+      showNamespaceBanner:  isDriverUrl && this.mode !== _VIEW,
+      view:                 _VIEW,
+      initialUrlSecretName:  this.value?.urlSecret?.name ? this.value.urlSecret.name : '',
+      initialUrlSecretKey:  this.value?.urlSecret?.key ? this.value.urlSecret.key : ''
+    };
+  },
+  methods: {
+    updateUrlSecretName(name) {
+      const existingKey = this.value.urlSecret?.key || '';
+
+      if (this.value.urlSecret) {
+        this.value.urlSecret = {
+          key: existingKey,
+          name
+        };
+      } else {
+        this.value['urlSecret'] = {
+          key: '',
+          name
+        };
+      }
+    },
+    updateUrlSecretKey(key) {
+      const existingName = this.value.urlSecret?.name || '';
+
+      if (this.value.urlSecret) {
+        this.value.urlSecret = {
+          name: existingName,
+          key
+        };
+      } else {
+        this.value['urlSecret'] = {
+          name: '',
+          key
+        };
+      }
+    }
   }
 };
 </script>
@@ -46,23 +85,41 @@ export default {
       </div>
     </div>
     <Banner v-if="showNamespaceBanner" color="info" v-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)" />
-    <div v-if="namespace" class="row mb-20">
-      <div class="col span-12">
-        <LabeledInput v-model="value.urlSecret" :mode="mode" label="URL" :tooltip="t('monitoringReceiver.webhook.urlTooltip')" />
-      </div>
-    </div>
-    <Banner v-else color="error">
-      {{ t('alertmanagerConfigReceiver.namespaceWarning') }}
-    </Banner>
     <div class="row mb-20">
       <div class="col span-12">
-        <LabeledInput v-model="value.httpConfig.proxyUrl" :mode="mode" :label="t('monitoringReceiver.shared.proxyUrl.label')" :placeholder="t('monitoringReceiver.shared.proxyUrl.placeholder')" />
+        <LabeledInput
+          v-model="value.url"
+          :mode="mode"
+          :label="t('monitoring.alertmanagerConfig.webhook.url')"
+          :tooltip="t('monitoring.alertmanagerConfig.webhook.urlSecretTooltip')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <SimpleSecretSelector
+        v-if="namespace"
+        :initial-key="initialUrlSecretKey"
+        :initial-name="initialUrlSecretName"
+        :mode="mode"
+        :namespace="namespace"
+        :disabled="mode === view"
+        :secret-name-label="t('monitoring.alertmanagerConfig.webhook.urlSecret')"
+        @updateSecretName="updateUrlSecretName"
+        @updateSecretKey="updateUrlSecretKey"
+      />
+      <Banner v-else color="error">
+        {{ t('alertmanagerConfigReceiver.namespaceWarning') }}
+      </Banner>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-12">
+        <LabeledInput v-model="value.httpConfig.proxyURL" :mode="mode" :label="t('monitoringReceiver.shared.proxyUrl.label')" :placeholder="t('monitoringReceiver.shared.proxyUrl.placeholder')" />
       </div>
     </div>
     <div class="row mb-20">
       <Checkbox v-model="value.sendResolved" :mode="mode" :label="t('monitoringReceiver.shared.sendResolved.label')" />
     </div>
     <TLS v-model="value.httpConfig" class="mb-20" :mode="mode" />
-    <Auth v-model="value.httpConfig" :mode="mode" />
+    <Auth v-model="value.httpConfig" :mode="mode" :namespace="namespace" />
   </div>
 </template>

--- a/edit/monitoring.coreos.com.receiver/types/webhook.add.vue
+++ b/edit/monitoring.coreos.com.receiver/types/webhook.add.vue
@@ -42,7 +42,9 @@ export default {
     add({ value }) {
       switch (value) {
       case 'generic':
-        return this.model.push({});
+        this.model.push({});
+
+        return;
       case 'ms-teams':
         return this.model.push({ url: MS_TEAMS_URL });
       case 'alibaba-cloud-sms':

--- a/edit/monitoring.coreos.com.receiver/types/webhook.vue
+++ b/edit/monitoring.coreos.com.receiver/types/webhook.vue
@@ -32,7 +32,6 @@ export default {
   data() {
     this.$set(this.value, 'http_config', this.value.http_config || {});
     this.$set(this.value, 'send_resolved', this.value.send_resolved || false);
-
     const isDriverUrl = this.value.url === MS_TEAMS_URL || this.value.url === ALIBABA_CLOUD_SMS_URL;
 
     return { showNamespaceBanner: isDriverUrl && this.mode !== _VIEW };

--- a/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -9,14 +9,11 @@ export default class AlertmanagerConfig extends SteveModel {
       return this.spec;
     }
     const existingReceivers = this.spec?.route?.receivers || [];
-    const existingReceiverNames = existingReceivers.map((receiver) => {
-      return receiver.name;
-    });
 
     const defaultSpec = {
       receivers: [...existingReceivers],
       route:     {
-        receivers:      existingReceiverNames,
+        receivers:      this.spec?.route?.receivers || [],
         groupBy:        this.spec?.route?.groupBy || [],
         groupWait:      this.spec?.route?.groupWait || '30s',
         groupInterval:  this.spec?.route?.groupInterval || '5m',

--- a/utils/object.js
+++ b/utils/object.js
@@ -37,6 +37,9 @@ export function set(obj, path, value) {
 }
 
 export function get(obj, path) {
+  if ( !path) {
+    throw new Error('Cannot translate an empty input. The t function requires a string.');
+  }
   if ( path.startsWith('$') ) {
     try {
       return JSONPath({


### PR DESCRIPTION
# QA template

## What was fixed, or what changes have occurred

This PR adds 6 secret selectors for receiver credentials and API keys:

1. Slack: Need to configure `apiUrl` with secret selector.
2. Webhook: Need to configure `urlSecret` with secret selector.

3 and 4: PagerDuty: `routingKey` and `serviceKey` need to be configured with secret selectors.

5: Opsgenie: `apiKey` needs secret selector.
6: Email: `authPassword` needs to be from secret selector.

There is a bug fix to make sure that when you save a receiver as yaml, the result is not a crash or blank page.

## Areas or cases that should be tested

We need to validate that when you change values in the form, it affects the right field in YAML. When values are updated in YAML and then saved, the values should show up the next time the receiver details are loaded.

Basically each field that we expose in form fields for receivers needs to be validated because unfortunately all the YAML fields changed from snake case to camel case.

For example, for Slack I tried it with dummy values:
<img width="1356" alt="Screen Shot 2022-05-03 at 4 55 23 PM" src="https://user-images.githubusercontent.com/20599230/166604496-1b12f97f-e353-493f-a971-1777d8dfdb55.png">

And then made sure all 4 of the dummy values showed up in the YAML view:
```
slackConfigs:
        - apiURL:
            key: password
            name: test-secret
          channel: dtdthdtn
          httpConfig: {}
          sendResolved: false
          text: '{{ template "slack.rancher.text" . }}'
```
The `httpConfig` section can be an empty object because I'm still working on that part (that config block has the TLS selectors).

The main API docs for the YAML is here:  https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#receiver

Here are the other example YAMLs that I used:

### Email

```
 emailConfigs:
        - sendResolved: false
          requireTls: false
          to: dudoidiuhd
          from: iuhiuehih
          smarthost: heihdit
          authUsername: tdtuidtui
          authPassword:
            name: test-secret
            key: password
```

### PagerDuty

If the integration type is set to "Events API V2", the `routerKey` value should be used:
```
pagerdutyConfigs:
        - sendResolved: true
          routingKey:
            name: test-secret
            key: test-secret-key
```

### Opsgenie

```
opsgenieConfigs:
        - sendResolved: true
          apiKey:
            name: test-secret
            key: password
```
If the integration type is set to Prometheus, the `serviceKey` value should be used:
```
pagerdutyConfigs:
        - sendResolved: true
          serviceKey:
            key: ''
            name: test-secret
```
### Webhook
```
webhookConfigs:
          sendResolved: false
          urlSecret:
            name: test-secret
            key: password
```

### What areas could experience regressions?
There is a bug fix to make sure that when you save a receiver as yaml, the result is not a crash or blank page. The navigation should be validated to make sure saves are working as expected


# Unfinished/not in this PR
There is a reused component that corresponds to the `httpConfig` field in YAML. It looks like this:
<img width="1114" alt="Screen Shot 2022-05-03 at 4 50 02 PM" src="https://user-images.githubusercontent.com/20599230/166602701-4cfa1fad-20f3-4988-8693-cf2fbf9085a3.png">

The SSL section is used for Email and Webhook configs. The Auth section appears under Webhook configs only. I'm still working on adding secret selectors for those sections and that will come in a separate PR.