### PR TITLE
Adding a confirmation modal to RKE2 providers when a user selects a new kubernetes version

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -277,6 +277,10 @@ accountAndKeys:
 addClusterMemberDialog:
   title: Add Cluster Member
 
+addonConfigConfirmation:
+  title: Add-On Config Reset
+  body: Changing the Kubernetes Version can reset the Add-On Config values. You should check that the values are as expected before continuing.
+
 addProjectMemberDialog:
   title: Add Project Member
 

--- a/components/AsyncButton.vue
+++ b/components/AsyncButton.vue
@@ -201,11 +201,15 @@ export default Vue.extend({
       this.$emit('click', cb);
     },
 
-    done(success: boolean) {
-      this.phase = (success ? SUCCESS : ERROR );
-      this.timer = setTimeout(() => {
-        this.timerDone();
-      }, this.delay );
+    done(success: boolean | 'cancelled') {
+      if (success === 'cancelled') {
+        this.phase = ACTION;
+      } else {
+        this.phase = (success ? SUCCESS : ERROR );
+        this.timer = setTimeout(() => {
+          this.timerDone();
+        }, this.delay );
+      }
     },
 
     timerDone() {

--- a/components/PromptModal.vue
+++ b/components/PromptModal.vue
@@ -5,7 +5,7 @@ import { importDialog } from '@/utils/dynamic-importer';
 
 export default {
   data() {
-    return { opened: false };
+    return { opened: false, backgroundClosing: null };
   },
 
   computed:   {
@@ -55,8 +55,16 @@ export default {
 
       this.errors = [];
       this.$store.commit('action-menu/togglePromptModal');
+      if (this.backgroundClosing) {
+        this.backgroundClosing();
+      }
     },
-  }
+
+    // We're using register instead of just making use of $refs because the $refs is always undefined when referencing the component
+    registerBackgroundClosing(fn) {
+      this.$set(this, 'backgroundClosing', fn);
+    }
+  },
 };
 </script>
 
@@ -69,7 +77,7 @@ export default {
     :scrollable="true"
     @closed="close()"
   >
-    <component :is="component" v-if="opened && component" :resources="resources" @close="close()" />
+    <component :is="component" v-if="opened && component" :resources="resources" :register-background-closing="registerBackgroundClosing" @close="close()" />
   </modal>
 </template>
 

--- a/components/dialog/AddonConfigConfirmationDialog.vue
+++ b/components/dialog/AddonConfigConfirmationDialog.vue
@@ -1,0 +1,73 @@
+<script>
+import AsyncButton from '@/components/AsyncButton';
+import Card from '@/components/Card';
+
+export default {
+  components: {
+    Card,
+    AsyncButton,
+  },
+  props:      {
+    resources: {
+      type:     Array,
+      required: true
+    },
+    registerBackgroundClosing: {
+      type:     Function,
+      required: true
+    }
+  },
+  created() {
+    this.registerBackgroundClosing(this.closing);
+  },
+  methods: {
+    continue(value) {
+      this.resources[0](value);
+    },
+    close() {
+      this.$emit('close', false);
+      this.continue(false);
+    },
+
+    closing() {
+      this.continue(false);
+    },
+
+    apply(buttonDone) {
+      this.$emit('close', true);
+      this.continue(true);
+    }
+  }
+};
+</script>
+
+<template>
+  <Card class="addon-config-confirmation" :show-highlight-border="false">
+    <h4 slot="title" class="text-default-text">
+      {{ t('addonConfigConfirmation.title') }}
+    </h4>
+
+    <template slot="body">
+      <slot name="body">
+        {{ t('addonConfigConfirmation.body') }}
+      </slot>
+    </template>
+
+    <div slot="actions" class="bottom">
+      <button type="button" class="btn role-secondary mr-10" @click="close">
+        {{ t('generic.cancel') }}
+      </button>
+      <AsyncButton
+        mode="continue"
+        @click="apply"
+      />
+    </div>
+  </Card>
+</template>
+<style lang='scss' scoped>
+  ::v-deep .card-actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+  }
+</style>

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1109,9 +1109,23 @@ export default {
       });
     },
 
+    showAddonConfirmation() {
+      return new Promise((resolve, reject) => {
+        this.$store.dispatch('cluster/promptModal', { component: 'AddonConfigConfirmationDialog', resources: [value => resolve(value)] });
+      });
+    },
+
     async saveOverride(btnCb) {
       if ( this.errors ) {
         clear(this.errors);
+      }
+
+      if (this.isEdit && this.liveValue?.spec?.kubernetesVersion !== this.value?.spec?.kubernetesVersion) {
+        const shouldContinue = await this.showAddonConfirmation();
+
+        if (!shouldContinue) {
+          return btnCb('cancelled');
+        }
       }
 
       for (const [index] of this.machinePools.entries()) { // validator machine config


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #5672
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This tries to go a little further to prevent users from accidentally breaking their clusters when changing kubernetes versions.

### Technical notes summary
This should only show when editing the cluster and when the kubernetes version has changed.

### Areas or cases that should be tested
RKE2 Clusters when editing and changing the kubernetes versions

### Areas which could experience regressions
Modals, the save button changing phase.

### Screenshot/Video
![image](https://user-images.githubusercontent.com/55104481/165880129-86803b90-24e0-4fe0-a9ef-cab8071d52de.png)