### PR TITLE
Fix bugs when refreshing on `/c/<clusterid>/neuvector`

### DIFF
--- a/components/HardwareResourceGauge.vue
+++ b/components/HardwareResourceGauge.vue
@@ -67,7 +67,7 @@ export default {
       <h3>
         {{ name }}
       </h3>
-      <div v-if="reserved && (reserved.total || reserved.useful)" class="hw-gauge">
+      <div v-if="reserved && (reserved.total !== undefined || reserved.useful !== undefined)" class="hw-gauge">
         <ConsumptionGauge
           :capacity="reserved.total"
           :used="reserved.useful"
@@ -98,7 +98,7 @@ export default {
           </template>
         </ConsumptionGauge>
       </div>
-      <div v-if="used && used.useful" class="hw-gauge">
+      <div v-if="used && used.useful !== undefined" class="hw-gauge">
         <ConsumptionGauge
           :capacity="used.total"
           :used="used.useful"

--- a/config/product/neuvector.js
+++ b/config/product/neuvector.js
@@ -1,7 +1,9 @@
 import { DSL, IF_HAVE } from '@/store/type-map';
 
-export const NAME = 'NeuVector';
-export const CHART_NAME = 'NeuVector';
+// These should match the name used in routes (either for loading a product or on chart install page)
+export const NAME = 'neuvector';
+export const CHART_NAME = 'neuvector';
+
 export const NEU_VECTOR_NAMESPACE = 'cattle-neuvector-system';
 
 export function init(store) {

--- a/pages/c/_cluster/neuvector/index.vue
+++ b/pages/c/_cluster/neuvector/index.vue
@@ -10,7 +10,7 @@ import LazyImage from '@/components/LazyImage';
 export default {
   components: { LazyImage },
 
-  middleware: InstallRedirect(NAME, CHART_NAME),
+  middleware: InstallRedirect(NAME, CHART_NAME, undefined, false),
 
   data() {
     return {

--- a/utils/install-redirect.js
+++ b/utils/install-redirect.js
@@ -1,6 +1,6 @@
 import { REPO_TYPE, REPO, CHART, VERSION } from '@/config/query-params';
 
-export default function(product, chartName, defaultResourceOrRoute) {
+export default function(product, chartName, defaultResourceOrRoute, install = true) {
   return async function middleware({ redirect, store } ) {
     const cluster = store.getters['currentCluster']?.id || 'local';
 
@@ -23,7 +23,7 @@ export default function(product, chartName, defaultResourceOrRoute) {
       }
 
       // Otherwise just let the middleware pass through
-    } else {
+    } else if (install) {
       // The product is not installed, redirect to the details chart
 
       await store.dispatch('catalog/load');
@@ -45,6 +45,11 @@ export default function(product, chartName, defaultResourceOrRoute) {
         // The chart's not available
         store.dispatch('loadingError', `Chart not found for ${ product }`);
       }
+    } else {
+      return redirect({
+        name:   'c-cluster-explorer',
+        params: { cluster },
+      });
     }
   };
 }


### PR DESCRIPTION
- Issues were related to refreshing on the neuvector product's page `/c/<clusterid>/neuvector`
- As admin the incorrect `NAME` was causing `allTypes` to fail on `findBy(state.products, 'name', product).inStore`
- As a user who cannot see the `cattle-neuvector-system` namespace
  - user could not see ns, so neuvector product was not loaded
  - `install-redirect` then tried to redirect user to install neuvector chart but failed to find it (case sensative name)
  - now instead we redirect user to cluster home page

Also fixed an issue on the cluster home page where users who could not see any pods saw an empty `Pods` card

Fixes #5770
