### PR TITLE
Enable unit tests with Jest for Typescript components

### DIFF
--- a/components/CopyCode.vue
+++ b/components/CopyCode.vue
@@ -36,12 +36,27 @@ export default {
       });
       this.$emit('copied');
     },
+  },
+
+  computed: {
+    tooltip() {
+      const content = this.copied ? 'Copied!' : 'Click to Copy';
+
+      return {
+        content,
+        hideOnTargetClick: false
+      };
+    }
   }
 };
 </script>
 
 <template>
-  <code v-tooltip="{'content': copied ? 'Copied!' : 'Click to Copy', hideOnTargetClick: false}" class="copy" @click.stop.prevent="clicked"><slot /></code>
+  <code
+    v-tooltip="tooltip"
+    class="copy"
+    @click.stop.prevent="clicked"
+  ><slot /></code>
 </template>
 
 <style lang="scss" scoped>

--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -269,6 +269,7 @@ export default {
     >
       <div
         v-if="hasErrors"
+        id="cru-errors"
         class="cru__errors"
       >
         <Banner

--- a/components/CruResourceFooter.vue
+++ b/components/CruResourceFooter.vue
@@ -75,6 +75,7 @@ export default {
     <slot name="cancel">
       <button
         v-if="!isView && showCancel"
+        id="cru-cancel"
         type="button"
         class="btn role-secondary"
         @click="confirmCancelRequired ? checkCancel(true) : $emit('cancel-confirmed', true)"

--- a/components/__tests__/Banner.test.ts
+++ b/components/__tests__/Banner.test.ts
@@ -1,0 +1,14 @@
+import { mount } from '@vue/test-utils';
+import Banner from '@/components/Banner.vue';
+
+describe('component: Banner', () => {
+  it('should display text based on label', async() => {
+    const label = 'test';
+    const wrapper = mount(Banner);
+
+    await wrapper.setProps({ label });
+    const element = wrapper.find('span').element;
+
+    expect(element.textContent).toBe(label);
+  });
+});

--- a/components/__tests__/Banner.test.ts
+++ b/components/__tests__/Banner.test.ts
@@ -2,11 +2,10 @@ import { mount } from '@vue/test-utils';
 import Banner from '@/components/Banner.vue';
 
 describe('component: Banner', () => {
-  it('should display text based on label', async() => {
+  it('should display text based on label', () => {
     const label = 'test';
-    const wrapper = mount(Banner);
+    const wrapper = mount(Banner, { propsData: { label } });
 
-    await wrapper.setProps({ label });
     const element = wrapper.find('span').element;
 
     expect(element.textContent).toBe(label);

--- a/components/__tests__/CopyCode.test.ts
+++ b/components/__tests__/CopyCode.test.ts
@@ -1,0 +1,21 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import CopyCode from '@/components/CopyCode.vue';
+import VTooltip from 'v-tooltip';
+
+const localVue = createLocalVue();
+
+localVue.use(VTooltip);
+
+describe('component: CopyCode', () => {
+  it('should emit copied after click', async() => {
+    const wrapper = mount(CopyCode, {
+      localVue,
+      mocks: { $copyText: () => new Promise(() => undefined) },
+      slots: { default: '<div></div>' }
+    });
+
+    await wrapper.find('code').trigger('click');
+
+    expect(wrapper.emitted('copied')).toHaveLength(1);
+  });
+});

--- a/components/__tests__/CruResource.test.ts
+++ b/components/__tests__/CruResource.test.ts
@@ -1,0 +1,73 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import CruResource from '@/components/CruResource.vue';
+import { _EDIT, _YAML } from '@/config/query-params';
+import VModal from 'vue-js-modal';
+
+const localVue = createLocalVue();
+
+localVue.use(VModal);
+
+describe('component: CruResource', () => {
+  it('should hide Cancel button', () => {
+    const wrapper = mount(CruResource, {
+      localVue,
+      propsData: {
+        canYaml:  false,
+        mode:     _EDIT,
+        resource: {}
+      },
+      mocks: {
+        $store: {
+          getters: {
+            currentStore:              () => 'current_store',
+            'current_store/schemaFor': jest.fn(),
+            'current_store/all':       jest.fn(),
+            'i18n/t':                  jest.fn(),
+            'i18n/exists':             jest.fn(),
+          }
+        },
+        $route:  { query: { AS: _YAML } },
+        $router: { applyQuery: jest.fn() },
+      }
+    });
+
+    const element = wrapper.find('#cru-cancel').element;
+
+    expect(element).toBeDefined();
+  });
+
+  it('should display errors', () => {
+    const errors = ['mistake!', 'BiG MiStAke11'];
+    const wrapper = mount(CruResource, {
+      localVue,
+      propsData: {
+        canYaml:  false,
+        mode:     _EDIT,
+        resource: {},
+        errors
+      },
+      components: {
+        ResourceYaml:               { template: '<div></div> ' },
+        ResourceCancelModal:        { template: '<div></div> ' },
+      },
+      mocks:      {
+        $store: {
+          getters: {
+            currentStore:              () => 'current_store',
+            'current_store/schemaFor': jest.fn(),
+            'current_store/all':       jest.fn(),
+            'i18n/t':                  jest.fn(),
+            'i18n/exists':             jest.fn(),
+          }
+        },
+        $route:  { query: { AS: _YAML } },
+        $router: { applyQuery: jest.fn() },
+      }
+    });
+
+    const node = wrapper.find('#cru-errors');
+
+    expect(node.element.childElementCount).toBe(errors.length);
+    expect(node.text()).toBe(`${ errors[0] } ${ errors[1] }`);
+  });
+});

--- a/components/form/__tests__/ArrayListGrouped.test.ts
+++ b/components/form/__tests__/ArrayListGrouped.test.ts
@@ -3,7 +3,7 @@ import ArrayListGrouped from '@/components/form/ArrayListGrouped.vue';
 
 describe('component: ArrayListGrouped', () => {
   it('should display enabled add button', () => {
-    const wrapper = mount(ArrayListGrouped, { mocks: { $store: { getters: { 'i18n/t': jest.fn() } } } });
+    const wrapper = mount(ArrayListGrouped);
     const button = wrapper.find('[data-testid^="add-item"]').element as HTMLInputElement;
 
     expect(button.disabled).toBe(false);
@@ -11,10 +11,7 @@ describe('component: ArrayListGrouped', () => {
 
   it('should add more items', async() => {
     const wrapper = mount(ArrayListGrouped, {
-      mocks: {
-        propsData: { value: ['a', 'b'] },
-        $store:    { getters: { 'i18n/t': jest.fn() } }
-      },
+      mocks: { propsData: { value: ['a', 'b'] } },
       slots: { default: '<div id="test"/>' }
     });
     const button = wrapper.find('[data-testid^="add-item"]');
@@ -28,10 +25,7 @@ describe('component: ArrayListGrouped', () => {
 
   it('should allow to remove items', async() => {
     const wrapper = mount(ArrayListGrouped, {
-      mocks: {
-        propsData: { value: ['a', 'b'] },
-        $store:    { getters: { 'i18n/t': jest.fn() } }
-      },
+      mocks: { propsData: { value: ['a', 'b'] } },
       slots: { default: '<div id="test"/>' }
     });
 

--- a/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -202,7 +202,10 @@ function sanitizeValue(v) {
     <InfoBox :step="showAdvanced ? 3 : 2" class="step-box">
       <h3 v-t="'cluster.custom.registrationCommand.label'" />
       <h4 v-t="'cluster.custom.registrationCommand.linuxDetail'" />
-      <CopyCode class="m-10 p-10">
+      <CopyCode
+        id="copiedLinux"
+        class="m-10 p-10"
+      >
         {{ linuxCommand }}
       </CopyCode>
       <Checkbox v-if="clusterToken.insecureNodeCommand" v-model="insecure" label-key="cluster.custom.registrationCommand.insecure" />
@@ -211,7 +214,11 @@ function sanitizeValue(v) {
         <hr class="mt-20 mb-20" />
         <h4 v-t="'cluster.custom.registrationCommand.windowsDetail'" />
         <template v-if="readyForWindows">
-          <CopyCode class="m-10 p-10" @copied="copiedWindows">
+          <CopyCode
+            id="copiedWindows"
+            class="m-10 p-10"
+            @copied="copiedWindows"
+          >
             {{ windowsCommand }}
           </CopyCode>
           <Checkbox

--- a/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.tests.ts
+++ b/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.tests.ts
@@ -1,37 +1,42 @@
-import { mount } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import CustomCommand from '@/edit/provisioning.cattle.io.cluster/CustomCommand.vue';
+import VTooltip from 'v-tooltip';
+
+const localVue = createLocalVue();
+
+localVue.use(VTooltip);
 
 describe('component: CustomCommand', () => {
-  it('should add more items', () => {
+  it('should return linux commands with the right flags based on cluster information', () => {
     const token = 'MY_TOKEN';
     const ip = 'MY_IP';
     const checkSum = 'MY_CHECKSUM';
     const wrapper = mount(CustomCommand, {
-      mocks: {
-        propsData: {
-          cluster:      {},
-          clusterToken: {
-            insecureWindowsNodeCommand: ` curl.exe --insecure -fL ${ ip }/wins-agent-install.ps1 -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server ${ ip } -Label 'cattle.io / os=windows' -Token ${ token } -Worker -CaChecksum ${ checkSum }`,
-            windowsNodeCommand:         `curl.exe -fL ${ ip }/wins-agent-install.ps1 -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server ${ ip } -Label 'cattle.io/os=windows' -Token ${ token } -Worker -CaChecksum ${ checkSum }`
-          }
-        },
-        data: {
-          address:         '',
-          controlPlane:    true,
-          etcd:            true,
-          insecure:        false,
-          internalAddress: '',
-          labels:          {},
-          nodeName:        '',
-          taints:          [],
-          worker:          true,
-        },
-        $store: { getters: { 'i18n/t': jest.fn() } }
+      propsData: {
+        cluster:      {},
+        clusterToken: {
+          insecureNodeCommand: ` curl --insecure -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum }`,
+          nodeCommand:         ` curl -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum }`
+        }
       },
+      localVue,
+      // stubs: { CopyCode: { template: '<div></div> ' } },
+      data:     () => ({
+        address:         '',
+        controlPlane:    true,
+        etcd:            true,
+        insecure:        false,
+        internalAddress: '',
+        labels:          {},
+        nodeName:        '',
+        taints:          [],
+        worker:          true,
+      }),
     });
-    const value = `curl -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum } --etcd --controlplane --worker`;
-    const element = wrapper.find('code').element;
 
-    expect(element.textContent).toBe(value);
+    const value = `curl -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum } --etcd --controlplane --worker`;
+    const element = wrapper.find('#copiedLinux').element;
+
+    expect(element.textContent).toContain(value);
   });
 });

--- a/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.tests.ts
+++ b/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.tests.ts
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils';
+import CustomCommand from '@/edit/provisioning.cattle.io.cluster/CustomCommand.vue';
+
+describe('component: CustomCommand', () => {
+  it('should add more items', () => {
+    const token = 'MY_TOKEN';
+    const ip = 'MY_IP';
+    const checkSum = 'MY_CHECKSUM';
+    const wrapper = mount(CustomCommand, {
+      mocks: {
+        propsData: {
+          cluster:      {},
+          clusterToken: {
+            insecureWindowsNodeCommand: ` curl.exe --insecure -fL ${ ip }/wins-agent-install.ps1 -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server ${ ip } -Label 'cattle.io / os=windows' -Token ${ token } -Worker -CaChecksum ${ checkSum }`,
+            windowsNodeCommand:         `curl.exe -fL ${ ip }/wins-agent-install.ps1 -o install.ps1; Set-ExecutionPolicy Bypass -Scope Process -Force; ./install.ps1 -Server ${ ip } -Label 'cattle.io/os=windows' -Token ${ token } -Worker -CaChecksum ${ checkSum }`
+          }
+        },
+        data: {
+          address:         '',
+          controlPlane:    true,
+          etcd:            true,
+          insecure:        false,
+          internalAddress: '',
+          labels:          {},
+          nodeName:        '',
+          taints:          [],
+          worker:          true,
+        },
+        $store: { getters: { 'i18n/t': jest.fn() } }
+      },
+    });
+    const value = `curl -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum } --etcd --controlplane --worker`;
+    const element = wrapper.find('code').element;
+
+    expect(element.textContent).toBe(value);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
     // process js with `babel-jest`
     '^.+\\.js$':   '<rootDir>/node_modules/babel-jest',
     // process `*.vue` files with `vue-jest`
-    '.*\\.(vue)$': '<rootDir>/node_modules/vue-jest',
+    '.*\\.(vue)$': '<rootDir>/node_modules/@vue/vue2-jest',
     // process `*.ts` files with `ts-jest`
     '^.+\\.tsx?$': 'ts-jest'
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
-  testEnvironment: 'jsdom',
-  modulePaths:       [
+  testEnvironment:              'jsdom',
+  setupFilesAfterEnv: ['./jest.setup.js'],
+  modulePaths:                  [
     '<rootDir>'
   ],
   // tell Jest to handle `*.vue` files

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,28 @@
+import { config } from '@vue/test-utils';
+
+config.mocks['$store'] = { getters: { 'i18n/t': jest.fn() } };
+
 /**
  * Global configuration for Jest tests
  */
+beforeAll(() => {
+});
+
+/**
+ * Common initialization for each test, required for resetting states
+ */
 beforeEach(() => {
+
+});
+
+/**
+ * Clean up after each test
+ */
+afterEach(() => {
+});
+
+/**
+ * Clean up after all tests
+ */
+afterAll(() => {
 });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,5 @@
+/**
+ * Global configuration for Jest tests
+ */
+beforeEach(() => {
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,11 @@
 import { config } from '@vue/test-utils';
+import { directiveSsr as t } from '@/plugins/i18n';
 
 config.mocks['$store'] = { getters: { 'i18n/t': jest.fn() } };
+config.directives = { t };
+
+// Overrides some components
+// config.stubs['my-component'] = { template: "<div></div> "};
 
 /**
  * Global configuration for Jest tests
@@ -12,7 +17,8 @@ beforeAll(() => {
  * Common initialization for each test, required for resetting states
  */
 beforeEach(() => {
-
+  // jest.resetModules(); // Use this function inside your test if you need to remove any cache stored
+  // jest.clearAllMocks(); // Use this function inside your test if you need to reset mocks
 });
 
 /**

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@types/lodash": "^4.14.178",
     "@types/node": "^16.4.3",
     "@vue/test-utils": "1.2.1",
+    "@vue/vue2-jest": "^27.0.0",
     "add": "^2.0.6",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
@@ -141,7 +142,6 @@
     "start-server-and-test": "^1.13.1",
     "style-loader": "^1.1.2",
     "ts-jest": "^27.1.3",
-    "vue-jest": "^3.0.7",
     "yarn": "^1.22.4"
   },
   "nyc": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,6 +1274,20 @@
     "@babel/traverse" "^7.16.7"
     "@babel/types" "^7.16.7"
 
+"@babel/helper-module-transforms@^7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz#3943c7f777139e7954a5355c815263741a9c1cbd"
+  integrity sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-simple-access" "^7.17.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+
 "@babel/helper-optimise-call-expression@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
@@ -1350,6 +1364,13 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz#d656654b9ea08dbb9659b69d61063ccd343ff0f7"
   dependencies:
     "@babel/types" "^7.16.7"
+
+"@babel/helper-simple-access@^7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz#aaa473de92b7987c6dfa7ce9a7d9674724823367"
+  integrity sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==
+  dependencies:
+    "@babel/types" "^7.17.0"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.11.0":
   version "7.11.0"
@@ -1844,6 +1865,16 @@
     "@babel/helper-module-transforms" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-simple-access" "^7.10.4"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-commonjs@^7.2.0":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz#274be1a2087beec0254d4abd4d86e52442e1e5b6"
+  integrity sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.17.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-simple-access" "^7.17.7"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-systemjs@^7.10.4":
@@ -3354,14 +3385,6 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
 
-"@types/strip-bom@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
-
-"@types/strip-json-comments@0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
-
 "@types/tapable@*", "@types/tapable@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
@@ -3638,6 +3661,17 @@
     dom-event-types "^1.0.0"
     lodash "^4.17.15"
     pretty "^2.0.0"
+
+"@vue/vue2-jest@^27.0.0":
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/vue2-jest/-/vue2-jest-27.0.0.tgz#456076e27f7fa0179a37b04baea3e0b3cf786c6d"
+  integrity sha512-r8YGOuqEWpAf2wGfgxfOL6Jce3WYOMcYji2qd8kuDe466ZsybHFeMryMJi6JrELOOI+MCA/8eFsSOx1KoJa7Dg==
+  dependencies:
+    "@babel/plugin-transform-modules-commonjs" "^7.2.0"
+    "@vue/component-compiler-utils" "^3.1.0"
+    chalk "^2.1.0"
+    css-tree "^2.0.1"
+    source-map "0.5.6"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4183,14 +4217,6 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-babel-code-frame@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
-
 babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
@@ -4232,12 +4258,6 @@ babel-loader@^8.0.6, babel-loader@^8.1.0:
     mkdirp "^0.5.3"
     pify "^4.0.1"
     schema-utils "^2.6.5"
-
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  dependencies:
-    babel-runtime "^6.22.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -4290,22 +4310,6 @@ babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
-  version "6.26.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
-  dependencies:
-    babel-plugin-transform-strict-mode "^6.24.1"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-types "^6.26.0"
-
-babel-plugin-transform-strict-mode@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-
 babel-plugin-transform-vue-jsx@^3.5.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-3.7.0.tgz#d40492e6692a36b594f7e9a1928f43e969740960"
@@ -4345,50 +4349,6 @@ babel-preset-vue@^2.0.2:
     babel-plugin-jsx-v-model "^2.0.1"
     babel-plugin-syntax-jsx "^6.18.0"
     babel-plugin-transform-vue-jsx "^3.5.0"
-
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-template@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
-
-babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.24.1, babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -5072,10 +5032,6 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clone@2.x:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -5349,10 +5305,6 @@ core-js@3:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
 
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-
 core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -5552,6 +5504,14 @@ css-tree@1.0.0-alpha.39:
     mdn-data "2.0.6"
     source-map "^0.6.1"
 
+css-tree@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.1.0.tgz#170e27ccf94e7c5facb183765c25898be843d1d2"
+  integrity sha512-PcysZRzToBbrpoUrZ9qfblRIRf8zbEAkU0AIpQFtgkFK0vSbzOmBCvdSAx2Zg7Xx5wiYJKUKk0NMP7kxevie/A==
+  dependencies:
+    mdn-data "2.0.27"
+    source-map-js "^1.0.1"
+
 css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
@@ -5559,15 +5519,6 @@ css-what@2.1:
 css-what@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
-
-css@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  dependencies:
-    inherits "^2.0.3"
-    source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
 
 cssdb@^4.4.0:
   version "4.4.0"
@@ -6000,14 +5951,7 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
 
-deasync@^0.1.15:
-  version "0.1.24"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.24.tgz#6ecc9c6ff9eba64a4f4572ae3c4db77fed09268a"
-  dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^1.7.1"
-
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -7022,12 +6966,6 @@ extract-css-chunks-webpack-plugin@^4.7.5:
     webpack-external-import "^2.2.4"
     webpack-sources "^1.1.0"
 
-extract-from-css@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/extract-from-css/-/extract-from-css-0.4.4.tgz#1ea7df2e7c7c6eb9922fa08e8adaea486f6f8f92"
-  dependencies:
-    css "^2.1.0"
-
 extract-zip@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
@@ -7161,7 +7099,7 @@ finalhandler@1.1.2, finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-babel-config@^1.1.0, find-babel-config@^1.2.0:
+find-babel-config@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
   dependencies:
@@ -7562,10 +7500,6 @@ globals@^13.6.0, globals@^13.9.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.10.0.tgz#60ba56c3ac2ca845cfbf4faeca727ad9dd204676"
   dependencies:
     type-fest "^0.20.2"
-
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^11.0.1:
   version "11.0.1"
@@ -9025,15 +8959,6 @@ js-beautify@^1.6.12:
     mkdirp "~1.0.3"
     nopt "^4.0.3"
 
-js-beautify@^1.6.14:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.14.0.tgz#2ce790c555d53ce1e3d7363227acf5dc69024c2d"
-  dependencies:
-    config-chain "^1.1.12"
-    editorconfig "^0.15.3"
-    glob "^7.1.3"
-    nopt "^5.0.0"
-
 js-cookie@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
@@ -9041,10 +8966,6 @@ js-cookie@^2.2.0:
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml-loader@^1.2.2:
   version "1.2.2"
@@ -9481,7 +9402,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0:
+lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
 
@@ -9624,6 +9545,11 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdn-data@2.0.27:
+  version "2.0.27"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.27.tgz#1710baa7b0db8176d3b3d565ccb7915fc69525ab"
+  integrity sha512-kwqO0I0jtWr25KcfLm9pia8vLZ8qoAKhWZuZMbneJq3jjBD3gl5nZs8l8Tu3ZBlBAHVQtDur9rdDGyvtfVraHQ==
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -9936,17 +9862,6 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-node-addon-api@^1.7.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
-
-node-cache@^4.1.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.1.tgz#efd8474dee4edec4138cdded580f5516500f7334"
-  dependencies:
-    clone "2.x"
-    lodash "^4.17.15"
-
 node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -10044,12 +9959,6 @@ nopt@^4.0.3:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
-
-nopt@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
-  dependencies:
-    abbrev "1"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -11666,10 +11575,6 @@ regenerate@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-
 regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
@@ -12306,7 +12211,12 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-js@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   dependencies:
@@ -12625,13 +12535,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
 
-strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 style-loader@^1.1.2:
   version "1.2.1"
@@ -12863,10 +12773,6 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -12985,15 +12891,6 @@ tsconfig-paths@^3.9.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
-
-tsconfig@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
-  dependencies:
-    "@types/strip-bom" "^3.0.0"
-    "@types/strip-json-comments" "0.0.30"
-    strip-bom "^3.0.0"
-    strip-json-comments "^2.0.0"
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
@@ -13411,22 +13308,6 @@ vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
 
-vue-jest@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-3.0.7.tgz#a6d29758a5cb4d750f5d1242212be39be4296a33"
-  dependencies:
-    babel-plugin-transform-es2015-modules-commonjs "^6.26.0"
-    chalk "^2.1.0"
-    deasync "^0.1.15"
-    extract-from-css "^0.4.4"
-    find-babel-config "^1.1.0"
-    js-beautify "^1.6.14"
-    node-cache "^4.1.1"
-    object-assign "^4.1.1"
-    source-map "^0.5.6"
-    tsconfig "^7.0.0"
-    vue-template-es2015-compiler "^1.6.0"
-
 vue-js-modal@^1.3.31:
   version "1.3.35"
   resolved "https://registry.yarnpkg.com/vue-js-modal/-/vue-js-modal-1.3.35.tgz#5f54de1a30a5f977121bfe6b2a1a5498bce2752a"
@@ -13497,7 +13378,7 @@ vue-template-compiler@^2.6.12:
     de-indent "^1.0.2"
     he "^1.1.0"
 
-vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
+vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
 


### PR DESCRIPTION
### Summary
Fixes #5610
Allow to create unit tests for Typescript components by correcting the global configuration.

### Occurred changes and/or fixed issues
Seems like from Jest 26 to 27, the library used for Vue unit tests is different. Switching to `@vue/vue2-jest` solved the issue.
Note: Seems necessary to delete packages and reinstall them.

### Technical notes summary
Together with this change, there have been introduced also other tests, both to ensure the ability to tests but also to provide examples for other cases. It also included to add global configuration.

- Created Jest global configuration
- Mocked i18n getters and directives in global configurations
- Added tests
  - CopyCode, as it included mocks for plugin, global, slots and cases with Promises
  - CustomCommand, as it included other components
  - Banner, as Typescript component
  - CruResource, as very complex component containing all the type of mocks

### Areas or cases that should be tested
Just execute unit tests with `yarn test`

### Areas which could experience regressions
None.

### Screenshot/Video
Check logs of the actions.