### PR TITLE
Add feedback to the CopyToClipboardText component

### DIFF
--- a/shell/components/CopyToClipboardText.vue
+++ b/shell/components/CopyToClipboardText.vue
@@ -12,10 +12,30 @@ export default {
     }
   },
 
+  data() {
+    return { copied: false };
+  },
+
   methods: {
     clicked(event) {
-      event.preventDefault();
-      this.$copyText(this.text);
+      if (!this.copied) {
+        event.preventDefault();
+        this.$copyText(this.text);
+        this.copied = true;
+
+        let t = event.target;
+
+        if (t.tagName === 'I') {
+          t = t.parentElement || t;
+        }
+        t.classList.add('copied');
+        setTimeout(() => {
+          try {
+            t.classList.remove('copied');
+            this.copied = false;
+          } catch (_e) {}
+        }, 500);
+      }
     },
   }
 };
@@ -23,7 +43,7 @@ export default {
 
 <template>
   <a class="copy-to-clipboard-text" :class="{'plain': plain}" href="#" @click="clicked">
-    {{ text }} <i class="icon icon-copy" />
+    {{ text }} <i v-if="!copied" class="icon icon-copy" /><i v-else class="icon icon-checkmark" />
   </a>
 </template>
 <style lang="scss" scoped>
@@ -34,6 +54,11 @@ export default {
       &:hover {
         text-decoration: none;
       }
+    }
+
+    &.copied {
+      pointer-events: none;
+      color: var(--success);
     }
   }
 </style>

--- a/shell/components/CopyToClipboardText.vue
+++ b/shell/components/CopyToClipboardText.vue
@@ -28,12 +28,8 @@ export default {
         if (t.tagName === 'I') {
           t = t.parentElement || t;
         }
-        t.classList.add('copied');
         setTimeout(() => {
-          try {
-            t.classList.remove('copied');
-            this.copied = false;
-          } catch (_e) {}
+          this.copied = false;
         }, 500);
       }
     },
@@ -42,8 +38,8 @@ export default {
 </script>
 
 <template>
-  <a class="copy-to-clipboard-text" :class="{'plain': plain}" href="#" @click="clicked">
-    {{ text }} <i v-if="!copied" class="icon icon-copy" /><i v-else class="icon icon-checkmark" />
+  <a class="copy-to-clipboard-text" :class="{ 'copied': copied, 'plain': plain}" href="#" @click="clicked">
+    {{ text }} <i class="icon" :class="{ 'icon-copy': !copied, 'icon-checkmark': copied}" />
   </a>
 </template>
 <style lang="scss" scoped>


### PR DESCRIPTION
Fixes #5688

Adds feedback when you copy on a text link that can be copied - turns green for a half a second and the icon changes to a tick rather than the copy icon.
![image](https://user-images.githubusercontent.com/1955897/165988146-dc318e12-aae2-430f-9098-f985aa11a7ee.png)