### PR TITLE
Fix RKE2 cluster kube upgrade

### DIFF
--- a/components/dialog/AddonConfigConfirmationDialog.vue
+++ b/components/dialog/AddonConfigConfirmationDialog.vue
@@ -22,10 +22,14 @@ export default {
   },
   methods: {
     continue(value) {
-      this.resources[0](value);
+      if (this.resources[0]) {
+        this.resources[0](value);
+        delete this.resources[0];
+        this.$emit('close', value);
+      }
     },
+
     close() {
-      this.$emit('close', false);
       this.continue(false);
     },
 
@@ -34,7 +38,6 @@ export default {
     },
 
     apply(buttonDone) {
-      this.$emit('close', true);
       this.continue(true);
     }
   }


### PR DESCRIPTION
- On upgrade of an RKE2 cluster's kube version a new modal is shown warning about addon config (https://github.com/rancher/dashboard/pull/5775)
- This didn't work. The `apply` fn triggers the `closing` fn (via the `close` event and registerBackgroundClosing) which acts like a `cancel`. This happens all before the `apply` fn can send it's success response.
- Fix is to ensure we only send one response and close the modal only once