### PR TITLE
Button dropdown select icon not centered

### DIFF
--- a/components/ButtonDropdown.vue
+++ b/components/ButtonDropdown.vue
@@ -270,6 +270,8 @@ export default {
 
       &:after {
         color: var(--link);
+        line-height: 1;
+        padding-top: 5px;
       }
     }
   }


### PR DESCRIPTION
Fixes #5562 

Simple css updates to address svg icon not being centered properly. Kept a limited scope to buttonDropdown component to avoid edge cases issues with other v-select components. 

![2022-05-02_02-05-59 (1)](https://user-images.githubusercontent.com/13671297/166211045-f685049a-3774-4e91-ab4f-16b621c68a53.gif)

