### PR TITLE
Giving cluster name a max length of 63 characters

### DIFF
--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -556,6 +556,7 @@ export default class ProvCluster extends SteveModel {
         path:           'metadata.name',
         translationKey: 'cluster.name.label',
         validators:     [`clusterName:${ this.isRke2 }`],
+        maxLength:      63,
       },
     ];
   }


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Added the maxLength property to the cluster validation.


Fixes #5214

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://user-images.githubusercontent.com/55104481/166319877-6dcd300b-b56f-4b46-b36a-63bf8763761a.png)
