### PR TITLE
Fixes: user switching embedded dashboards when first has already failed

### DIFF
--- a/components/GrafanaDashboard.vue
+++ b/components/GrafanaDashboard.vue
@@ -55,7 +55,7 @@ export default {
   },
   watch: {
     currentUrl() {
-      if (this.graphHistory) {
+      if (this.graphHistory && this.graphWindow?.angular) {
         const angularElement = this.graphWindow.angular.element(this.graphDocument.querySelector('.grafana-app'));
         const injector = angularElement.injector();
 


### PR DESCRIPTION
If a dashboard fails to load and then a user uses the button-group to switch between "Detail" and "Summary" then the page no longer crashes