### PR TITLE
projectHelmChart masthead now shows projectName instead of it's own name

### DIFF
--- a/components/ResourceDetail/Masthead.vue
+++ b/components/ResourceDetail/Masthead.vue
@@ -1,6 +1,6 @@
 <script>
 import { KUBERNETES, PROJECT } from '@/config/labels-annotations';
-import { FLEET, NAMESPACE, MANAGEMENT } from '@/config/types';
+import { FLEET, NAMESPACE, MANAGEMENT, HELM } from '@/config/types';
 import ButtonGroup from '@/components/ButtonGroup';
 import BadgeState from '@/components/BadgeState';
 import Banner from '@/components/Banner';
@@ -11,6 +11,7 @@ import {
   AS, _DETAIL, _CONFIG, _YAML, MODE, _CREATE, _EDIT, _VIEW, _UNFLAG
 } from '@/config/query-params';
 
+// ToDo: this component seem to be picking up a lot of logic from special cases, could be simplified down to parameters and then customized per use-case via wrapper component
 export default {
   components: {
     BadgeState, Banner, ButtonGroup
@@ -94,6 +95,10 @@ export default {
 
     isProject() {
       return this.schema?.id === MANAGEMENT.PROJECT;
+    },
+
+    isProjectHelmChart() {
+      return this.schema?.id === HELM.PROJECTHELMCHART;
     },
 
     hasMultipleNamespaces() {
@@ -307,6 +312,16 @@ export default {
         managedBy,
       };
     },
+
+    displayName() {
+      let displayName = this.value.nameDisplay;
+
+      if (this.isProjectHelmChart) {
+        displayName = this.value.projectDisplayName;
+      }
+
+      return this.shouldHifenize ? ` - ${ displayName }` : displayName;
+    }
   },
 
   methods: {
@@ -337,7 +352,7 @@ export default {
             </nuxt-link>
             <span v-else>{{ parent.displayName }}:</span>
             <span v-if="value.detailPageHeaderActionOverride && value.detailPageHeaderActionOverride(realMode)">{{ value.detailPageHeaderActionOverride(realMode) }}</span>
-            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtype" :name="shouldHifenize ? ` - ${ value.nameDisplay }` : value.nameDisplay" />
+            <t v-else :k="'resourceDetail.header.' + realMode" :subtype="resourceSubtype" :name="displayName" />
             <BadgeState v-if="!isCreate && parent.showState" class="masthead-state" :value="value" />
           </h1>
         </div>


### PR DESCRIPTION
It's not meaningful to show the projectHelmChart name in the masthead since it's always going to be "project-monitoring".