### PR TITLE
Fix subrow chevron direction when expanded

### DIFF
--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -882,8 +882,8 @@ export default {
                     data-title="Toggle Expand"
                     :class="{
                       icon: true,
-                      'icon-chevron-right': !isExpanded(row.row),
-                      'icon-chevron-down': isExpanded(row.row)
+                      'icon-chevron-right': !expanded[row.row[keyField]],
+                      'icon-chevron-down': !!expanded[row.row[keyField]]
                     }"
                     @click.stop="toggleExpand(row.row)"
                   />

--- a/components/SortableTable/index.vue
+++ b/components/SortableTable/index.vue
@@ -882,8 +882,8 @@ export default {
                     data-title="Toggle Expand"
                     :class="{
                       icon: true,
-                      'icon-chevron-right': !expanded[row[keyField]],
-                      'icon-chevron-down': !!expanded[row[keyField]]
+                      'icon-chevron-right': !isExpanded(row.row),
+                      'icon-chevron-down': isExpanded(row.row)
                     }"
                     @click.stop="toggleExpand(row.row)"
                   />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#5533 
<!-- Define findings related to the feature or bug issue. -->

The issue was caused by being passed the incorrect value for `row` to determine if the row is expanded.

### Occurred changes and/or fixed issues
Now passing `row.row` to the method `isExpanded`.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://user-images.githubusercontent.com/40806497/166674695-85d02210-bcaf-40b8-a327-6fd60d502cbd.mp4


