### PR TITLE
add icons to name column in alertmanagerConfig and receiver tables

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -4618,6 +4618,7 @@ tableHeaders:
   ready: Ready
   reason: Reason
   receivers: Receivers
+  receiverTypes: Receiver Types
   reclaimPolicy: Reclaim Policy
   registrationNamespace: Registration Namespace
   repo: Repo

--- a/components/formatter/LinkDetail.vue
+++ b/components/formatter/LinkDetail.vue
@@ -14,18 +14,11 @@ export default {
     reference: {
       type:    String,
       default: null,
-    },
-    getCustomDetailLink: {
-      type:    Function,
-      default: null
     }
   },
 
   computed: {
     to() {
-      if (this.getCustomDetailLink) {
-        return this.getCustomDetailLink(this.row);
-      }
       if ( this.row && this.reference ) {
         return get(this.row, this.reference);
       }

--- a/components/formatter/LinkDetail.vue
+++ b/components/formatter/LinkDetail.vue
@@ -14,11 +14,18 @@ export default {
     reference: {
       type:    String,
       default: null,
+    },
+    getCustomDetailLink: {
+      type:    Function,
+      default: null
     }
   },
 
   computed: {
     to() {
+      if (this.getCustomDetailLink) {
+        return this.getCustomDetailLink(this.row);
+      }
       if ( this.row && this.reference ) {
         return get(this.row, this.reference);
       }

--- a/components/formatter/ReceiverIcons.vue
+++ b/components/formatter/ReceiverIcons.vue
@@ -10,21 +10,9 @@ export default {
     row: {
       type:     Object,
       required: true
-    },
-    // this is used to pass through a detail link for instances in which 'row' is not a kubernetes resource/ doesn't have resource-class methods like detailLocation
-    getCustomDetailLink: {
-      type:    Function,
-      default: null
     }
   },
   computed: {
-    to() {
-      if (this.getCustomDetailLink) {
-        return this.getCustomDetailLink(this.row);
-      }
-
-      return this.row?.detailLocation;
-    },
 
     types() {
     // get count and logo for all configured types in every receiver in the alertmanagerconfig
@@ -85,6 +73,14 @@ export default {
       }
 
       return types;
+    },
+
+    countDisplay(type, count) {
+      if (count > 1) {
+        return `${ type }(x${ count })`;
+      }
+
+      return type;
     }
   }
 };
@@ -92,17 +88,19 @@ export default {
 
 <template>
   <span class="name-container">
-    <n-link v-if="to" :to="to">
-      {{ value }}
-    </n-link>
-    <span v-else>{{ value }}</span>
-    <template v-for="(type, i) in types">
-      <div :key="i" class="logo">
+    <template v-for="(type, key, i) in types">
+      <div :key="key" class="logo">
         <img :src="type.logo" />
       </div>
-      <span v-if="type.count>1" :key="i" class="text-muted">
-        {{ `(x${type.count})` }}
+      <span :key="key+i">
+        <span v-if="i<Object.keys(types).length-1" class="comma">
+          {{ `${countDisplay(key, type.count)}, ` }}
+        </span>
+        <span v-else>
+          {{ countDisplay(key, type.count) }}
+        </span>
       </span>
+
     </template>
   </span>
 </template>
@@ -119,5 +117,8 @@ export default {
   .name-container{
     display: flex;
     align-items: center;
+  }
+  .comma{
+    margin-right: 2px;
   }
 </style>

--- a/components/formatter/ReceiverIcons.vue
+++ b/components/formatter/ReceiverIcons.vue
@@ -1,0 +1,123 @@
+<script>
+import { RECEIVERS_TYPES } from '@/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue';
+import { MONITORING } from '~/config/types';
+export default {
+  props:      {
+    value: {
+      type:     String,
+      default: ''
+    },
+    row: {
+      type:     Object,
+      required: true
+    },
+    // this is used to pass through a detail link for instances in which 'row' is not a kubernetes resource/ doesn't have resource-class methods like detailLocation
+    getCustomDetailLink: {
+      type:    Function,
+      default: null
+    }
+  },
+  computed: {
+    to() {
+      if (this.getCustomDetailLink) {
+        return this.getCustomDetailLink(this.row);
+      }
+
+      return this.row?.detailLocation;
+    },
+
+    types() {
+    // get count and logo for all configured types in every receiver in the alertmanagerconfig
+      if (this.row?.type === MONITORING.ALERTMANAGERCONFIG) {
+        const receivers = this.row?.spec?.receivers;
+
+        if (receivers && receivers.length > 0) {
+          return receivers.reduce((totals, receiver) => {
+            const counts = this.getReceiverTypes(receiver);
+
+            Object.keys(counts).forEach((type) => {
+              if (!totals[type]) {
+                totals[type] = {
+                  count: counts[type].count,
+                  logo:  counts[type].logo
+                };
+              } else {
+                totals[type].count += counts[type].count;
+              }
+            });
+
+            return totals;
+          }, {});
+        }
+
+        return null;
+      } else {
+        // if not alertmanagerconfig, this is an individual receiver
+        return this.getReceiverTypes(this.row);
+      }
+    }
+  },
+  methods: {
+    // get count and logo for each type configured in a given receiver
+    getReceiverTypes(receiver) {
+      // iterate through predefined types and sum the number configured in this receiver
+      const types = RECEIVERS_TYPES
+        .reduce((types, type) => {
+          if (type.name !== 'custom' && receiver?.[type.key]?.length > 0) {
+            types[this.t(type.label)] = { count: receiver?.[type.key]?.length, logo: type.logo };
+          }
+
+          return types;
+        }, {});
+
+      // if there are keys other than those defined in RECEIVERS_TYPES and 'name', assume they're custom types and sum them under "custom"
+      const expectedKeys = RECEIVERS_TYPES.map(type => type.key).filter(key => key !== 'custom');
+
+      expectedKeys.push('name');
+      const customKeys = Object.keys(receiver)
+        .filter(key => !expectedKeys.includes(key));
+
+      if (customKeys.length > 0) {
+        const customType = RECEIVERS_TYPES.find(type => type.name === 'custom');
+        const customLabel = this.t(customType.label);
+
+        types[customLabel] = { count: customKeys.length, logo: customType.logo };
+      }
+
+      return types;
+    }
+  }
+};
+</script>
+
+<template>
+  <span class="name-container">
+    <n-link v-if="to" :to="to">
+      {{ value }}
+    </n-link>
+    <span v-else>{{ value }}</span>
+    <template v-for="(type, i) in types">
+      <div :key="i" class="logo">
+        <img :src="type.logo" />
+      </div>
+      <span v-if="type.count>1" :key="i" class="text-muted">
+        {{ `(x${type.count})` }}
+      </span>
+    </template>
+  </span>
+</template>
+
+<style scoped lang='scss'>
+  .logo{
+    display: inline;
+    height: 1.3em;
+
+    img{
+      height: 1.3em;
+    }
+  }
+  .name-container{
+    display: flex;
+    align-items: center;
+  }
+</style>

--- a/config/product/monitoring.js
+++ b/config/product/monitoring.js
@@ -255,11 +255,13 @@ export function init(store) {
 
   headers(ALERTMANAGERCONFIG, [
     STATE,
-    { ...NAME_COL, formatter: 'ReceiverIcons' },
+    NAME_COL,
     NAMESPACE_COL,
     {
-      name:     'receivers',
-      labelKey: 'tableHeaders.receivers'
+      name:      'receivers',
+      labelKey:  'tableHeaders.receivers',
+      formatter: 'ReceiverIcons',
+      value:     'name'
     },
   ]);
 

--- a/config/product/monitoring.js
+++ b/config/product/monitoring.js
@@ -255,7 +255,7 @@ export function init(store) {
 
   headers(ALERTMANAGERCONFIG, [
     STATE,
-    NAME_COL,
+    { ...NAME_COL, formatter: 'ReceiverIcons' },
     NAMESPACE_COL,
     {
       name:     'receivers',

--- a/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -66,7 +66,7 @@ export default {
           labelKey:      'tableHeaders.name',
           value:         'name',
           sort:          ['nameSort'],
-          formatter:     'LinkDetail',
+          formatter:     'ReceiverIcons',
           canBeVariable: true,
         }
         // Add more columns

--- a/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -66,6 +66,13 @@ export default {
           labelKey:      'tableHeaders.name',
           value:         'name',
           sort:          ['nameSort'],
+          formatter:     'LinkDetail',
+          canBeVariable: true,
+        },
+        {
+          name:          'type',
+          labelKey:      'tableHeaders.type',
+          value:         'name',
           formatter:     'ReceiverIcons',
           canBeVariable: true,
         }

--- a/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -333,7 +333,7 @@ export default {
     $margin: 10px;
     $logo: 60px;
 
-    .box-container {
+    .box-container.create-resource-container {
       display: flex;
       justify-content: space-between;
       flex-wrap: wrap;


### PR DESCRIPTION

Fixes #5744 

This PR adds a table formatter for alertmanagerConfigs and their receivers in order to add logos for each receiver type next to the name. I've moved the `getCustomDetailLink` logic from `LinkDetail` to the new formatter because I think it was only being used for receivers, correct me if I'm wrong @catherineluse 

Icons for alertmanagerconfigs:
![Screen Shot 2022-05-04 at 4 49 25 PM](https://user-images.githubusercontent.com/42977925/166845813-4ca68e33-bde5-4475-9d59-7b52ece94d13.png)

Icons for individual receivers:
![Screen Shot 2022-05-04 at 4 49 33 PM](https://user-images.githubusercontent.com/42977925/166845823-cd1f61d8-f7b8-41e3-99ad-8e44e9c0141d.png)

