### PR TITLE
Make side nav and home page cluster lists be consistent with provisioning list

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -57,7 +57,16 @@ export default {
 
     clusters() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-      const kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all), this.$store);
+     const pClusters = this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
+      let kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all), this.$store);
+      const available = pClusters.reduce((p, c) => {
+        p[c.mgmt] = p;
+        return p;
+      }, {});
+      // Filter to only show mgmt clusters that exist for the available provisionning clusters
+      // Addresses issue where a mgmt cluster can take some time to get cleaned up after the corresponding
+      // provisionning cluster has been deleted
+      kubeClusters = kubeClusters.filter(c => !!available[c]);
 
       return kubeClusters.map((x) => {
         return {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -3,7 +3,7 @@ import BrandImage from '@shell/components/BrandImage';
 import ClusterProviderIcon from '@shell/components/ClusterProviderIcon';
 import { mapGetters } from 'vuex';
 import $ from 'jquery';
-import { MANAGEMENT } from '@shell/config/types';
+import { CAPI, MANAGEMENT } from '@shell/config/types';
 import { mapPref, DEV, MENU_MAX_CLUSTERS } from '@shell/store/prefs';
 import { sortBy } from '@shell/utils/sort';
 import { ucFirst } from '@shell/utils/string';
@@ -57,12 +57,14 @@ export default {
 
     clusters() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-     const pClusters = this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
+      const pClusters = this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
       let kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all), this.$store);
       const available = pClusters.reduce((p, c) => {
         p[c.mgmt] = p;
+
         return p;
       }, {});
+
       // Filter to only show mgmt clusters that exist for the available provisionning clusters
       // Addresses issue where a mgmt cluster can take some time to get cleaned up after the corresponding
       // provisionning cluster has been deleted

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -60,7 +60,7 @@ export default {
       const pClusters = this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
       let kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all), this.$store);
       const available = pClusters.reduce((p, c) => {
-        p[c.mgmt] = p;
+        p[c.mgmt] = true;
 
         return p;
       }, {});


### PR DESCRIPTION
Fixes #4355 

Currently the side nav and home page show the list of clusters using the management cluster resource where as the cluster management page uses the provisioning cluster resource - this leads to inconsistencies - e.g. as described in the issue above.

This PR changes the side nav and home page to use the provisioning resource.

It also uses the ClusterProvider formatter so that that provider presentation on the home page is consistent with the cluster list in cluster management.