### PR TITLE
Accessibility: setting HTML page language

### DIFF
--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -169,6 +169,13 @@ export const mutations = {
   },
 
   setSelected(state, locale) {
+    // this will set the lang param on HTML (best place to add this action since all locale changes go through this mutation)
+    if (locale === NONE) {
+      document.querySelector('html').removeAttribute('lang');
+    } else {
+      document.querySelector('html').setAttribute('lang', locale);
+    }
+
     state.selected = locale;
   },
 


### PR DESCRIPTION
Addresses Github issue: [#4381](https://github.com/rancher/dashboard/issues/4381)
Addresses Zube issue: [#4399](https://zube.io/rancher/dashboard-ui/c/4399)

- change HTML lang attribute when language changes on the UI

**Comment:**
On Nuxt one can set the `head` attributes either [globally](https://nuxtjs.org/docs/features/meta-tags-seo/#global-settings) (nuxt.config) or [locally](https://nuxtjs.org/docs/features/meta-tags-seo/#local-settings) (per page).
Since changing it locally is not an option (we would have to manually set it for each page), from my investigation I don't think it's possible to set globally in a dynamic fashion.
With that in mind, the solution adopted is to set the `lang` attribute via JS when the language is changed (or initially set) in the UI.