### PR TITLE
Change default cluster upgrade stragetgy to drain = false

### DIFF
--- a/edit/provisioning.cattle.io.cluster/DrainOptions.vue
+++ b/edit/provisioning.cattle.io.cluster/DrainOptions.vue
@@ -6,7 +6,7 @@ import UnitInput from '@/components/form/UnitInput.vue';
 const DEFAULTS = {
   deleteEmptyDirData:              true, // Show; Kill pods using emptyDir volumes and lose the data
   disableEviction:                 false, // Hide; false = evict pods, true = delete pods
-  enabled:                         true, // Show; true = Nodes must be drained before upgrade; false = YOLO
+  enabled:                         false, // Show; true = Nodes must be drained before upgrade; false = YOLO
   force:                           false, // Show; true = Delete standalone pods, false = fail if there are any
   gracePeriod:                     -1, // Show; Pod shut down time, negative value uses pod default
   ignoreDaemonSets:                true, // Hide; true = work, false = never work because there's always daemonSets
@@ -105,8 +105,18 @@ export default {
       </div>
       <div>
         <Checkbox v-model="customTimeout" label="Timeout after" @input="update" />
-        <UnitInput v-if="customTimeout" v-model="timeout" label="Drain Timeout" suffix="Seconds" @input="update" />
+        <UnitInput v-if="customTimeout" v-model="timeout" label="Drain Timeout" suffix="Seconds" @input="update" class="drain-timeout" />
       </div>
     </template>
   </div>
 </template>
+
+<style lang="scss" scoped>
+  $drain-timeout-index: 18px;
+
+  .drain-timeout {
+    margin-top: 5px;
+    margin-left: $drain-timeout-index;
+    width: calc(100% - $drain-timeout-index);
+  }
+</style>

--- a/edit/provisioning.cattle.io.cluster/DrainOptions.vue
+++ b/edit/provisioning.cattle.io.cluster/DrainOptions.vue
@@ -105,7 +105,14 @@ export default {
       </div>
       <div>
         <Checkbox v-model="customTimeout" label="Timeout after" @input="update" />
-        <UnitInput v-if="customTimeout" v-model="timeout" label="Drain Timeout" suffix="Seconds" @input="update" class="drain-timeout" />
+        <UnitInput
+          v-if="customTimeout"
+          v-model="timeout"
+          label="Drain Timeout"
+          suffix="Seconds"
+          class="drain-timeout"
+          @input="update"
+        />
       </div>
     </template>
   </div>


### PR DESCRIPTION
Fixes #5829 

This PR changes back default drain strategy to No.

Before:

![Screenshot 2022-05-05 at 12 22 54](https://user-images.githubusercontent.com/1955897/166914796-32237e79-5fa4-46f0-ae12-186bcf86ec65.png)

After:

![Screenshot 2022-05-05 at 12 29 50](https://user-images.githubusercontent.com/1955897/166914791-fe6df617-4e51-47f9-bf88-1a72e89189e5.png)

I've also improved the styling of the timeout input box so that it has some top margin and is indented to show it related ot the checkbox above:

![image](https://user-images.githubusercontent.com/1955897/166914896-f83cf034-a0e3-4f09-a47a-d0cb217f26e6.png)
