### PR TITLE
Hide Mgmt Cluster type in Cluster Management Advanced group

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -998,7 +998,7 @@ cluster:
       note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-On Config tab.'
     harvester:
       label: Harvester
-  copyConfig: Copy Config to Clipboard
+  copyConfig: Copy KubeConfig to Clipboard
   custom:
     nodeRole:
       label: Node Role

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -2,7 +2,6 @@ import { AGE, NAME as NAME_COL, STATE } from '@shell/config/table-headers';
 import {
   CAPI,
   CATALOG,
-  MANAGEMENT,
   NORMAN,
   HCI
 } from '@shell/config/types';
@@ -115,7 +114,6 @@ export function init(store) {
   configureType(CATALOG.CLUSTER_REPO, { showListMasthead: false });
 
   basicType([
-    MANAGEMENT.CLUSTER,
     CAPI.MACHINE_DEPLOYMENT,
     CAPI.MACHINE_SET,
     CAPI.MACHINE,

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -59,10 +59,10 @@ export default class MgmtCluster extends HybridModel {
     });
 
     insertAt(out, 2, {
-      action:     'copyKubeConfig',
+      action:     'copyConfig',
       label:      this.t('cluster.copyConfig'),
       bulkable:   false,
-      enabled:    true,
+      enabled:    this.$rootGetters['isRancher'] && this.hasAction('generateKubeconfig'),
       icon:       'icon icon-copy',
     });
 

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -59,7 +59,7 @@ export default class MgmtCluster extends HybridModel {
     });
 
     insertAt(out, 2, {
-      action:     'copyConfig',
+      action:     'copyKubeConfig',
       label:      this.t('cluster.copyConfig'),
       bulkable:   false,
       enabled:    this.$rootGetters['isRancher'] && this.hasAction('generateKubeconfig'),

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -76,6 +76,12 @@ export default class ProvCluster extends SteveModel {
         bulkable:   true,
         enabled:    this.mgmt?.hasAction('generateKubeconfig') && ready,
       }, {
+        action:     'copyKubeConfig',
+        label:      this.t('cluster.copyConfig'),
+        bulkable:   false,
+        enabled:    this.mgmt?.hasAction('generateKubeconfig') && ready,
+        icon:       'icon icon-copy',
+      }, {
         action:     'snapshotAction',
         label:      this.$rootGetters['i18n/t']('nav.takeSnapshot'),
         icon:       'icon icon-snapshot',
@@ -404,6 +410,10 @@ export default class ProvCluster extends SteveModel {
 
   generateKubeConfig() {
     return this.mgmt?.generateKubeConfig();
+  }
+
+  copyKubeConfig() {
+    return this.mgmt?.copyKubeConfig();
   }
 
   downloadKubeConfig() {


### PR DESCRIPTION
Fixes #5839

See issue for details - simple fix.

I noticed that the mgmt resource allows copy to clipboard of kubeconfig where as the provisioning does not - this PR fixes that as well.

