### PR TITLE
[UI]  - close button not visible

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -26,7 +26,7 @@ $z-indexes: (
   tableGroup: 10,
   fixedTableHeader: 11,
 
-  modalOverlay: 20,
+  modalOverlay: 1000,
   modalContent: 21,
 
   tooltip: 30,

--- a/shell/assets/styles/vendor/vue-js-modal.scss
+++ b/shell/assets/styles/vendor/vue-js-modal.scss
@@ -3,6 +3,10 @@
 .v--modal-overlay {
   background-color: var(--overlay-bg);
   z-index: z-index('modalOverlay');
+
+  .v--modal-box {
+    overflow-y: auto;
+  }
 }
 
 .v--modal {

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -92,7 +92,7 @@ export default {
     & .v--modal-box.v--modal {
       width: var(--prompt-modal-width) !important;
       left: unset !important;
-      margin: auto !important
+      margin: auto !important;
     }
   }
 </style>


### PR DESCRIPTION
Addresses Github issue: [#5796](https://github.com/rancher/dashboard/issues/5796)
Addresses Zube issue: [Zube #5825](https://zube.io/rancher/dashboard-ui/c/5825)

- add missing semicolon on css rule 
- increase modal z-index so that header elements don't appear over it 
- add overflow-y when modal vertical height is less that the height of its content

**Preview** (_not from this particular modal, but the problem is the same on all modals_)
<img width="1992" alt="Screenshot 2022-05-05 at 14 32 02" src="https://user-images.githubusercontent.com/97888974/166940887-b65fb77f-832c-4d66-980d-006f2205b10f.png">
