### PR TITLE
Add dispatch step to update tag in rancher/rancher

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -196,6 +196,17 @@ steps:
     token:
       from_secret: google_auth_key
 
+- name: create-pr-in-rancher
+  image: curlimages/curl:7.81.0
+  user: root
+  environment:
+    PAT_USERNAME:
+      from_secret: pat_username
+    PAT_TOKEN:
+      from_secret: github_token
+  commands:
+  - apk -U --no-cache add bash
+  - scripts/create-pr-in-rancher
 ---
 kind: pipeline
 name: embedded-master

--- a/scripts/create-pr-in-rancher
+++ b/scripts/create-pr-in-rancher
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+if [[ $DRONE_TAG != v2* ]]; then
+  echo "Tag ${DRONE_TAG} is not a Rancher tag, not dispatching workflow for rancher/rancher"
+  exit 0
+fi
+
+REPO="https://api.github.com/repos/rancher/rancher/actions/workflows/replace-env-value.yml/dispatches"
+
+# Only use first two parts, delimited by dot
+# v2.6.5 becomes v2.6, end result: release/v2.6
+ACTION_TARGET_BRANCH="release/$(echo $DRONE_TAG | cut -f1,2 -d".")"
+
+echo "Dispatching to branch ${ACTION_TARGET_BRANCH} with INPUT_ENVVALUE=${DRONE_TAG}"
+
+# send dispatch event to workflow
+curl -XPOST -u "${PAT_USERNAME}:${PAT_TOKEN}" \
+        -H "Accept: application/vnd.github.v3+json"  \
+        -H "Content-Type: application/json" $REPO \
+        --data '{"ref":"'"${ACTION_TARGET_BRANCH}"'","inputs":{"INPUT_FILEPATH":"package/Dockerfile","INPUT_ENVVAR":"CATTLE_DASHBOARD_UI_VERSION","INPUT_ENVVALUE":"'"${DRONE_TAG}"'"}}'


### PR DESCRIPTION
Follow-up to https://github.com/rancher/dashboard/pull/5737 which was reverted because it broke the build. I think because this step introduces `depends_on`, it causes the other steps to be executed in parallel causing ordering problems. This PR has the same changes without `depends_on`.