### PR TITLE
#5753 Add systemProjectId to global.cattle into payload for chart installation

### DIFF
--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -798,6 +798,8 @@ export default {
       }
 
       const cluster = this.currentCluster;
+      const projects = this.$store.getters['management/all'](MANAGEMENT.PROJECT);
+      const systemProjectId = projects.find(p => p.spec?.displayName === 'System')?.id || '';
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
       const isWindows = (cluster.workerOSs || []).includes(WINDOWS);
@@ -808,6 +810,7 @@ export default {
       setIfNotSet(cattle, 'clusterName', cluster?.nameDisplay);
       setIfNotSet(cattle, 'systemDefaultRegistry', defaultRegistry);
       setIfNotSet(global, 'systemDefaultRegistry', defaultRegistry);
+      setIfNotSet(global, 'cattle.systemProjectId', systemProjectId);
       setIfNotSet(cattle, 'url', serverUrl);
       setIfNotSet(cattle, 'rkePathPrefix', pathPrefix);
       setIfNotSet(cattle, 'rkeWindowsPathPrefix', windowsPathPrefix);


### PR DESCRIPTION
### Summary
Fixes #5753 
If systemProjectId is not part of the chart's global.cattle object during chart installation, this will automatically add it to the payload of the post request
### Occurred changes and/or fixed issues
All charts will now include systemProjectId in the payload of their post request (during chart installation). Charts that require this value should now work if the value isn't filled out, other charts will ignore the value if it's not used.

### Technical notes summary
added `setIfNotSet(global, 'cattle.systemProjectId', systemProjectId);` to install.vue

### Areas or cases that should be tested
Install any chart, check network calls for post request, notice systemProjectId under global>cattle in the payload of the request

### Areas which could experience regressions
This affects all chart installations but shouldn't have any adverse effects

### Screenshot/Video
<img width="896" alt="image" src="https://user-images.githubusercontent.com/37550899/167046292-00e7a469-405c-4f9f-8ecc-7bb95e9d4375.png">