### PR TITLE
Can configure AlertmanagerConfig routes with new API

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2928,12 +2928,19 @@ alertmanagerConfigReceiver:
 monitoringRoute:
   groups:
     label: Group By
+    addGroupByLabel: Labels to Group Alerts By
   info: This is the top-level Route used by Alertmanager as the default destination for any Alerts that do not match any other Routes. This Route must exist and cannot be deleted.
   interval:
     label: Group Interval
   matching:
     info: The root route has to match everything so matching cannot be configured.
     label: Match
+    addMatcher: Add Matcher
+    matchType: Match Type
+    name: Name
+    nameTooltip: Label to match
+    value: Value
+    valueTooltip: Label value to match
   receiver:
     type: Receiver Type
     add: Add Receiver

--- a/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
@@ -1,16 +1,16 @@
 <script>
 import ArrayList from '@/components/form/ArrayList';
-import KeyValue from '@/components/form/KeyValue';
 import Banner from '@/components/Banner';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import { _VIEW } from '@/config/query-params';
+import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 
 export default {
   components: {
     ArrayList,
     Banner,
-    KeyValue,
+    ArrayListGrouped,
     LabeledInput,
     LabeledSelect
   },
@@ -29,7 +29,18 @@ export default {
     },
   },
   data() {
-    return { isView: _VIEW };
+    this.$set(this.value, 'matchers', this.value.matchers || []);
+    this.$set(this.value, 'groupBy', this.value.groupBy || []);
+
+    return {
+      isView:     _VIEW,
+      matchTypes: [
+        { label: 'Match Equal', value: '=' },
+        { label: 'Match Not Equal', value: '!=' },
+        { label: 'Match Regexp', value: '=~' },
+        { label: 'Match Not Regexp', value: '!~' },
+      ]
+    };
   },
 
 };
@@ -47,7 +58,6 @@ export default {
         <LabeledSelect
           v-model="value.receiver"
           :mode="mode"
-
           :options="receiverOptions"
         />
       </div>
@@ -56,18 +66,14 @@ export default {
     <div class="row mb-20">
       <div class="col span-6">
         <span class="label">
-          {{ t("monitoringRoute.groups.label") }}:
+          {{ t("monitoringRoute.groups.addGroupByLabel'") }}
         </span>
         <ArrayList
-          v-if="!isView || (value.groupBy && value.groupBy.length > 0)"
           v-model="value.groupBy"
-          :label="t('monitoringRoute.groups.label')"
+          class="mt-10"
           :mode="mode"
           :initial-empty-row="true"
         />
-        <div v-else>
-          {{ t('generic.none') }}
-        </div>
       </div>
     </div>
     <h3>Waiting and Intervals</h3>
@@ -97,43 +103,42 @@ export default {
       </div>
     </div>
 
-    <h3>Matching</h3>
-    <div class="row mb-20">
-      <div class="col span-12">
-        <span class="label">
-          {{ t('monitoringRoute.matching.label') }}
-        </span>
-        <KeyValue
-          v-if="!isView || Object.keys(value.match || {}).length > 0"
-          v-model="value.match"
-          :options="receiverOptions"
-          :label="t('monitoringRoute.receiver.label')"
-          :mode="mode"
-          :read-allowed="false"
-          :add-label="t('monitoringRoute.receiver.addMatch')"
-        />
-        <div v-else>
-          {{ t('generic.none') }}
+    <h3>Matchers</h3>
+    <ArrayListGrouped
+      v-model="value.matchers"
+      class="mt-20"
+      :mode="mode"
+      :add-label="t('monitoringRoute.matching.addMatcher')"
+      :default-add-value="{matchers:[]}"
+    >
+      <template #default="props">
+        <div class="row mt-20 mb-20">
+          <div class="col span-4">
+            <LabeledInput
+              v-model="props.row.value.name"
+              :label="t('monitoringRoute.matching.name')"
+              :tooltip="t('monitoringRoute.matching.nameTooltip')"
+              :mode="mode"
+            />
+          </div>
+          <div class="col span-4">
+            <LabeledInput
+              v-model="props.row.value.value"
+              :label="t('monitoringRoute.matching.value')"
+              :tooltip="t('monitoringRoute.matching.valueTooltip')"
+              :mode="mode"
+            />
+          </div>
+          <div class="col span-4">
+            <LabeledSelect
+              v-model="props.row.value.matchType"
+              :label="t('monitoringRoute.matching.matchType')"
+              :mode="mode"
+              :options="matchTypes"
+            />
+          </div>
         </div>
-      </div>
-    </div>
-    <div class="row mt-40">
-      <div class="col span-12">
-        <span class="label">
-          {{ t('monitoringRoute.regex.label') }}:
-        </span>
-        <KeyValue
-          v-if="!isView || Object.keys(value.matchers || {}).length > 0"
-          v-model="value.matchers"
-          :label="t('monitoringRoute.receiver.label')"
-          :mode="mode"
-          :read-allowed="false"
-          add-label="Add match regex"
-        />
-        <div v-else>
-          {{ t('generic.none') }}
-        </div>
-      </div>
-    </div>
+      </template>
+    </ArrayListGrouped>
   </div>
 </template>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5819

# QA Template

## Root cause
The input fields didn't match the required YAML format of the new routes API. So the fix was to add/change the fields for grouping and matching to become compatible with the new API.
 
## What was fixed, or what changes have occurred
I updated two sections of the route form on the Route tab within the AlertmanagerConfig detail page.

 The first is the Grouping section, which should now allow you to enter a list of strings that will be used to group alerts by label:
<img width="765" alt="Screen Shot 2022-05-06 at 2 07 19 AM" src="https://user-images.githubusercontent.com/20599230/167103169-35203803-1579-422d-9438-8a9155abf853.png">

The second is the Matchers section, which now lets you pick names and values of alert labels to use for matching. Each name/value pair comes with a dropdown menu that lets you pick which kind of comparison you want:
<img width="1335" alt="Screen Shot 2022-05-06 at 2 14 25 AM" src="https://user-images.githubusercontent.com/20599230/167103627-9ae67f56-99b9-4172-8495-c1afa410f80b.png">

The relevant API docs for matchers are here: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#matcher

The possible values for match types are taken from the AlertmanagerConfig go code: https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go#L872

## Areas or cases that should be tested

We should test the ability to create or edit a route on the Route tab with labels for grouping and some matchers.

We should validate that when you add labels to the Grouping section, the resulting YAML looks like this:

```yaml
route:
    groupBy:
      - dthdthdht
      - hnthtnh
```

We should also validate that the matchers let you create each type of matcher, resulting in a YAML list like this:

```yaml
matchers:
      - name: dtdth
        value: iuaiaueioueid
        matchType: '=' // match equal
      - name: oud
        value: uoduoe
        matchType: '!=' // match not equal
      - name: uaeidaeid
        value: adaud
        matchType: '=~' // match equal regex
      - name: x;x
        value: ouded
        matchType: '!~' // match not equal regex
```
 
## What areas could experience regressions?
Can't think of any
