### PR TITLE
Clarify that routes/receivers in AlertmanagerConfigs don't show on Routes and Receivers pages

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -2809,7 +2809,7 @@ monitoring:
     empty: Alerts have not been configured for any accessible namespaces.
     getStarted: Get started by clicking Create to configure an alert.
     receiverTooltip: This route will direct alerts to the selected receiver, which must be defined in the same AlertmanagerConfig.
-    deprecationWarning: The Route and Receiver resources are deprecated. We recommend configuring alerts in AlertmanagerConfigs.
+    deprecationWarning: The Route and Receiver resources are deprecated. Going forward, routes and receivers should not be managed as separate Kubernetes resources on this page. They should be configured as YAML fields in an AlertmanagerConfig resource.
     routeInfo: This form supports configuring one route that directs traffic to a receiver. Alerts can be directed to more receiver(s) by configuring child routes in YAML.
     receiverFormNames:
       create: Create Receiver in AlertmanagerConfig


### PR DESCRIPTION
This PR is addresses https://github.com/rancher/dashboard/issues/5818

The problem here is that it can be confusing or counterintuitive that the words "routes" and "receivers" are being used to mean different things. A route can be a Route custom resource, or it can be a configuration block within an AlertmanagerConfig custom resource. We want to avoid setting up the expectation that if you add a route to an AlertmanagerConfig, it will show up on the Routes page. Because the resources and are handled as separate things (and the details of how they are configured are slightly different in spite of having the same names).

I updated the note on the deprecated Routes/Receivers to try to clarify things.
<img width="1269" alt="Screen Shot 2022-05-06 at 3 11 50 AM" src="https://user-images.githubusercontent.com/20599230/167113735-82a0f296-942b-4aa0-a2ff-68ad650496ed.png">

