### PR TITLE
Adding validation for the IAM Instance Profile Name which is required when the amazon cloud provider is selected

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -1673,6 +1673,8 @@ cluster:
   toggle:
     v1: RKE1
     v2: RKE2/K3s
+  validation:
+    iamInstanceProfileName: If the Amazon cloud provider is selected the "IAM Instance Profile Name" must be defined for each Machine Pool
 
 clusterIndexPage:
   hardwareResourceGauge:

--- a/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -31,6 +31,11 @@ export default {
       required: true,
     },
 
+    cluster: {
+      type:     Object,
+      default: () => ({})
+    },
+
     credentialId: {
       type:     String,
       required: true,
@@ -162,11 +167,11 @@ export default {
       </div>
     </div>
     <hr class="mt-10" />
-
     <component
       :is="configComponent"
       v-if="value.config"
       ref="configComponent"
+      :cluster="cluster"
       :uuid="uuid"
       :mode="mode"
       :value="value.config"

--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -331,9 +331,7 @@ export default {
     },
 
     agentConfig() {
-      // The one we want is the first one with no selector.
-      // If there are multiple with no selector, that will fall under the unsupported message below.
-      return this.value.spec.rkeConfig.machineSelectorConfig.find(x => !x.machineLabelSelector).config;
+      return this.value.agentConfig;
     },
 
     showK3sTechPreviewWarning() {
@@ -1125,6 +1123,14 @@ export default {
         }
       }
 
+      if (this.value.cloudProvider === 'aws') {
+        const missingProfileName = this.machinePools.some(mp => !mp.config.iamInstanceProfile);
+
+        if (missingProfileName) {
+          this.errors.push(this.t('cluster.validation.iamInstanceProfileName', {}, true));
+        }
+      }
+
       for (const [index] of this.machinePools.entries()) { // validator machine config
         if ( typeof this.$refs.pool[index]?.test === 'function' ) {
           try {
@@ -1556,6 +1562,7 @@ export default {
               <MachinePool
                 ref="pool"
                 :value="obj"
+                :cluster="value"
                 :mode="mode"
                 :provider="provider"
                 :credential-id="credentialId"

--- a/machine-config/amazonec2.vue
+++ b/machine-config/amazonec2.vue
@@ -29,6 +29,11 @@ export default {
       required: true,
     },
 
+    cluster: {
+      type:     Object,
+      default: () => ({})
+    },
+
     credentialId: {
       type:     String,
       required: true,
@@ -147,6 +152,10 @@ export default {
         this.t('cluster.machineConfig.amazonEc2.securityGroup.mode.default', { defaultGroup: DEFAULT_GROUP }),
         this.t('cluster.machineConfig.amazonEc2.securityGroup.mode.custom')
       ];
+    },
+
+    isIamInstanceProfileNameRequired() {
+      return this.cluster?.cloudProvider === 'aws';
     },
 
     instanceOptions() {
@@ -476,6 +485,7 @@ export default {
               v-model="value.iamInstanceProfile"
               :mode="mode"
               :disabled="disabled"
+              :required="isIamInstanceProfileNameRequired"
               :tooltip="t('cluster.machineConfig.amazonEc2.iamInstanceProfile.tooltip')"
               :label="t('cluster.machineConfig.amazonEc2.iamInstanceProfile.label')"
             />

--- a/models/provisioning.cattle.io.cluster.js
+++ b/models/provisioning.cattle.io.cluster.js
@@ -560,6 +560,16 @@ export default class ProvCluster extends SteveModel {
     ];
   }
 
+  get agentConfig() {
+    // The one we want is the first one with no selector.
+    // If there are multiple with no selector, that will fall under the unsupported message below.
+    return this.spec.rkeConfig.machineSelectorConfig.find(x => !x.machineLabelSelector).config;
+  }
+
+  get cloudProvider() {
+    return this.agentConfig['cloud-provider-name'];
+  }
+
   get canClone() {
     return false;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #5517
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
Anywhere that an aws cloud provider could be selected could cause this to happen. I only identified ec2 rke2 as a spot.

### Areas which could experience regressions
Anywhere that an aws cloud provider could be selected could cause this to happen. I only identified ec2 rke2 as a spot.

### Screenshot/Video

https://user-images.githubusercontent.com/55104481/167209225-ff870185-6ae1-4e92-a776-ae3cc43d58ea.mp4


