### PR TITLE
ClusterId is concatenated onto systemProjectId, removed via split

### DIFF
--- a/pages/c/_cluster/apps/charts/install.vue
+++ b/pages/c/_cluster/apps/charts/install.vue
@@ -799,7 +799,7 @@ export default {
 
       const cluster = this.currentCluster;
       const projects = this.$store.getters['management/all'](MANAGEMENT.PROJECT);
-      const systemProjectId = projects.find(p => p.spec?.displayName === 'System')?.id || '';
+      const systemProjectId = projects.find(p => p.spec?.displayName === 'System')?.id?.split('/')?.[1] || '';
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
       const isWindows = (cluster.workerOSs || []).includes(WINDOWS);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5861 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
method used for obtaining systemProjectId on chart installation has clusterId concatenated onto it. Removed the clusterId.

### Technical notes summary
install any chart via apps, inspect payload on post request to API to see that the global.cattle.systemProjectId value now only includes the projectId and not the clusterId prepended to the projectId

### Areas which could experience regressions
none that I'm aware of