### PR TITLE
UI expired session doesn't redirect us to the login page

### DIFF
--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -24,11 +24,11 @@ import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import { NAME as NAVLINKS } from '@shell/config/product/navlinks';
 import { NAME as HARVESTER } from '@shell/config/product/harvester';
 import isEqual from 'lodash/isEqual';
-import { ucFirst } from '@/utils/string';
-import { getVersionInfo, markSeenReleaseNotes } from '@/utils/version';
-import { sortBy } from '@/utils/sort';
-import PageHeaderActions from '@/mixins/page-actions';
-import BrowserTabVisibility from '@/mixins/browser-tab-visibility';
+import { ucFirst } from '@shell/utils/string';
+import { getVersionInfo, markSeenReleaseNotes } from '@shell/utils/version';
+import { sortBy } from '@shell/utils/sort';
+import PageHeaderActions from '@shell/mixins/page-actions';
+import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 
 const SET_LOGIN_ACTION = 'set-as-login';
 

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -272,11 +272,6 @@ export default {
   mounted() {
     // Sync the navigation tree on fresh load
     this.$nextTick(() => this.syncNav());
-
-    this.setTabVisibilityListener(true);
-  },
-  beforeDestroy() {
-    this.setTabVisibilityListener(false);
   },
 
   methods: {

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -24,10 +24,11 @@ import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import { NAME as NAVLINKS } from '@shell/config/product/navlinks';
 import { NAME as HARVESTER } from '@shell/config/product/harvester';
 import isEqual from 'lodash/isEqual';
-import { ucFirst } from '@shell/utils/string';
-import { getVersionInfo, markSeenReleaseNotes } from '@shell/utils/version';
-import { sortBy } from '@shell/utils/sort';
-import PageHeaderActions from '@shell/mixins/page-actions';
+import { ucFirst } from '@/utils/string';
+import { getVersionInfo, markSeenReleaseNotes } from '@/utils/version';
+import { sortBy } from '@/utils/sort';
+import PageHeaderActions from '@/mixins/page-actions';
+import BrowserTabVisibility from '@/mixins/browser-tab-visibility';
 
 const SET_LOGIN_ACTION = 'set-as-login';
 
@@ -48,7 +49,7 @@ export default {
     AzureWarning
   },
 
-  mixins: [PageHeaderActions, Brand],
+  mixins: [PageHeaderActions, Brand, BrowserTabVisibility],
 
   data() {
     return {
@@ -271,6 +272,11 @@ export default {
   mounted() {
     // Sync the navigation tree on fresh load
     this.$nextTick(() => this.syncNav());
+
+    this.setTabVisibilityListener(true);
+  },
+  beforeDestroy() {
+    this.setTabVisibilityListener(false);
   },
 
   methods: {

--- a/shell/layouts/home.vue
+++ b/shell/layouts/home.vue
@@ -1,11 +1,12 @@
 <script>
-import Header from '@shell/components/nav/Header';
-import Brand from '@shell/mixins/brand';
-import FixedBanner from '@shell/components/FixedBanner';
-import GrowlManager from '@shell/components/GrowlManager';
+import Header from '@/components/nav/Header';
+import Brand from '@/mixins/brand';
+import FixedBanner from '@/components/FixedBanner';
+import GrowlManager from '@/components/GrowlManager';
+import { mapPref, DEV } from '@shell/store/prefs';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
-import { mapPref, DEV } from '@shell/store/prefs';
+import BrowserTabVisibility from '@/mixins/browser-tab-visibility';
 
 export default {
 
@@ -17,9 +18,16 @@ export default {
     AwsComplianceBanner
   },
 
-  mixins: [Brand],
+  mixins: [Brand, BrowserTabVisibility],
 
   middleware: ['authenticated'],
+
+  mounted() {
+    this.setTabVisibilityListener(true);
+  },
+  beforeDestroy() {
+    this.setTabVisibilityListener(false);
+  },
 
   data() {
     return {

--- a/shell/layouts/home.vue
+++ b/shell/layouts/home.vue
@@ -1,12 +1,12 @@
 <script>
-import Header from '@/components/nav/Header';
-import Brand from '@/mixins/brand';
-import FixedBanner from '@/components/FixedBanner';
-import GrowlManager from '@/components/GrowlManager';
+import Header from '@shell/components/nav/Header';
+import Brand from '@shell/mixins/brand';
+import FixedBanner from '@shell/components/FixedBanner';
+import GrowlManager from '@shell/components/GrowlManager';
 import { mapPref, DEV } from '@shell/store/prefs';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
-import BrowserTabVisibility from '@/mixins/browser-tab-visibility';
+import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 
 export default {
 

--- a/shell/layouts/home.vue
+++ b/shell/layouts/home.vue
@@ -22,13 +22,6 @@ export default {
 
   middleware: ['authenticated'],
 
-  mounted() {
-    this.setTabVisibilityListener(true);
-  },
-  beforeDestroy() {
-    this.setTabVisibilityListener(false);
-  },
-
   data() {
     return {
       // Assume home pages have routes where the name is the key to use for string lookup

--- a/shell/layouts/plain.vue
+++ b/shell/layouts/plain.vue
@@ -9,6 +9,7 @@ import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
+import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 
 export default {
 
@@ -26,7 +27,7 @@ export default {
 
   middleware: ['authenticated'],
 
-  mixins: [Brand],
+  mixins: [Brand, BrowserTabVisibility],
 
   data() {
     return {

--- a/shell/mixins/browser-tab-visibility.js
+++ b/shell/mixins/browser-tab-visibility.js
@@ -25,12 +25,12 @@ export default {
   },
 
   mounted() {
-    if (!this.isSingleProduct) {
+    if (!this.isSingleProduct || this.isSingleProduct?.enableSessionCheck) {
       this.setTabVisibilityListener(true);
     }
   },
   beforeDestroy() {
-    if (!this.isSingleProduct) {
+    if (!this.isSingleProduct || this.isSingleProduct?.enableSessionCheck) {
       this.setTabVisibilityListener(false);
     }
   },

--- a/shell/mixins/browser-tab-visibility.js
+++ b/shell/mixins/browser-tab-visibility.js
@@ -5,14 +5,11 @@ export default {
     setTabVisibilityListener(isAdd) {
       const method = isAdd ? 'addEventListener' : 'removeEventListener';
 
-      isAdd ? console.log('SETTING TAB VIS LISTENER') : console.log('REMOVING TAB VIS LISTENER');
       document[method]('visibilitychange', this.visibilityChange, true);
     },
 
     async visibilityChange() {
-      console.log('VIS CHANGE TRIGGERED!');
       if (!document.hidden) {
-        console.log('PINGING SERVER FROM TAB VISIBILITY LISTENER');
         await this.$store.dispatch('rancher/findAll', {
           type: NORMAN.USER,
           opt:  {

--- a/shell/mixins/browser-tab-visibility.js
+++ b/shell/mixins/browser-tab-visibility.js
@@ -1,7 +1,9 @@
 import { NORMAN } from '@shell/config/types';
+import { mapGetters } from 'vuex';
 
 export default {
-  methods: {
+  computed: { ...mapGetters(['isSingleProduct']) },
+  methods:  {
     setTabVisibilityListener(isAdd) {
       const method = isAdd ? 'addEventListener' : 'removeEventListener';
 
@@ -20,5 +22,16 @@ export default {
         });
       }
     },
+  },
+
+  mounted() {
+    if (!this.isSingleProduct) {
+      this.setTabVisibilityListener(true);
+    }
+  },
+  beforeDestroy() {
+    if (!this.isSingleProduct) {
+      this.setTabVisibilityListener(false);
+    }
   },
 };

--- a/shell/mixins/browser-tab-visibility.js
+++ b/shell/mixins/browser-tab-visibility.js
@@ -1,0 +1,27 @@
+import { NORMAN } from '@/config/types';
+
+export default {
+  methods: {
+    setTabVisibilityListener(isAdd) {
+      const method = isAdd ? 'addEventListener' : 'removeEventListener';
+
+      isAdd ? console.log('SETTING TAB VIS LISTENER') : console.log('REMOVING TAB VIS LISTENER');
+      document[method]('visibilitychange', this.visibilityChange, true);
+    },
+
+    async visibilityChange() {
+      console.log('VIS CHANGE TRIGGERED!');
+      if (!document.hidden) {
+        console.log('PINGING SERVER FROM TAB VISIBILITY LISTENER');
+        await this.$store.dispatch('rancher/findAll', {
+          type: NORMAN.USER,
+          opt:  {
+            url:    '/v3/users',
+            filter: { me: true },
+            force:  true
+          }
+        });
+      }
+    },
+  },
+};

--- a/shell/mixins/browser-tab-visibility.js
+++ b/shell/mixins/browser-tab-visibility.js
@@ -1,4 +1,4 @@
-import { NORMAN } from '@/config/types';
+import { NORMAN } from '@shell/config/types';
 
 export default {
   methods: {

--- a/shell/mixins/browser-tab-visibility.js
+++ b/shell/mixins/browser-tab-visibility.js
@@ -25,12 +25,12 @@ export default {
   },
 
   mounted() {
-    if (!this.isSingleProduct || this.isSingleProduct?.enableSessionCheck) {
+    if ((!this.isSingleProduct || this.isSingleProduct?.enableSessionCheck) && this.$config.rancherEnv !== 'desktop') {
       this.setTabVisibilityListener(true);
     }
   },
   beforeDestroy() {
-    if (!this.isSingleProduct || this.isSingleProduct?.enableSessionCheck) {
+    if ((!this.isSingleProduct || this.isSingleProduct?.enableSessionCheck) && this.$config.rancherEnv !== 'desktop') {
       this.setTabVisibilityListener(false);
     }
   },

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -420,6 +420,7 @@ export const getters = {
             resource: HCI.DASHBOARD,
           }
         },
+        enableSessionCheck: true
       };
     }
 


### PR DESCRIPTION
Addresses Github issue: [#5418](https://github.com/rancher/dashboard/issues/5418)
Addresses Zube issue: [#5444](https://zube.io/rancher/dashboard-ui/c/5444)

- add logic to handle expired sessions by redirecting user to login page

**Repro steps**
- Login to Rancher UI
- Open up another tab (can be blank) on the same browser instance
- Click between tabs
- Check if the "ping" is being done to fetch the user

**Other scenarios**
- Lock your mac and then log back in your mac. Go to the tab. "ping" on Network should have occurred
- Remove session token, click on another tab, then go back to rancher tab (it should log out the user after "ping" fails)