### PR TITLE
Fix Rancher Backup S3 CA field should be base64 encoded

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -686,7 +686,9 @@ backupRestoreOperator:
     bucketName: Bucket Name
     credentialSecretName: Credential Secret
     endpoint: Endpoint
-    endpointCA: Endpoint CA
+    endpointCA:
+      label: Endpoint CA
+      prompt: Endpoint CA must be Base64 encoded
     folder: Folder
     insecureTLSSkipVerify: Skip TLS Verifications
     region: Region

--- a/shell/chart/rancher-backup/S3.vue
+++ b/shell/chart/rancher-backup/S3.vue
@@ -50,9 +50,13 @@ export default {
 
   methods: {
     setCA(ca) {
-      const encoded = btoa(ca);
+      try {
+        const encoded = btoa(ca);
 
-      this.$set(this.value, 'endpointCA', encoded);
+        this.$set(this.value, 'endpointCA', encoded);
+      } catch (e) {
+        console.warn(e);
+      }
     }
   },
 

--- a/shell/chart/rancher-backup/S3.vue
+++ b/shell/chart/rancher-backup/S3.vue
@@ -55,6 +55,7 @@ export default {
 
         this.$set(this.value, 'endpointCA', encoded);
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.warn(e);
       }
     }

--- a/shell/chart/rancher-backup/S3.vue
+++ b/shell/chart/rancher-backup/S3.vue
@@ -48,6 +48,14 @@ export default {
     ...mapGetters({ t: 'i18n/t' })
   },
 
+  methods: {
+    setCA(ca) {
+      const encoded = btoa(ca);
+
+      this.$set(this.value, 'endpointCA', encoded);
+    }
+  },
+
   created() {
     const { credentialSecretName, credentialSecretNamespace } = this.value;
 
@@ -89,9 +97,29 @@ export default {
         <Checkbox v-model="value.insecureTLSSkipVerify" class="mt-10" :mode="mode" :label="t('backupRestoreOperator.s3.insecureTLSSkipVerify')" />
       </div>
       <div class="col span-6">
-        <LabeledInput v-model="value.endpointCA" :mode="mode" type="multiline" :label="t('backupRestoreOperator.s3.endpointCA')" />
-        <FileSelector v-if="mode!=='view'" class="btn btn-sm role-primary mt-5" :mode="mode" :label="t('generic.readFromFile')" @selected="e=>$set(value, 'endpointCA', e)" />
+        <LabeledInput v-model="value.endpointCA" :mode="mode" type="multiline" :label="t('backupRestoreOperator.s3.endpointCA.label')" />
+        <div class="ca-controls">
+          <FileSelector v-if="mode!=='view'" class="btn btn-sm role-primary mt-5" :mode="mode" :label="t('generic.readFromFile')" @selected="e=> setCA(e)" />
+          <div class="ca-tooltip">
+            <i v-tooltip="t('backupRestoreOperator.s3.endpointCA.prompt')" class="icon icon-info" />
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </template>
+<style lang="scss" scoped>
+  .ca-controls {
+    display: flex;
+
+    .ca-tooltip {
+      flex: 1;
+      margin-top: 4px;
+      text-align: right;
+
+      > i {
+        font-size: 16px;
+      };
+    }
+  }
+</style>


### PR DESCRIPTION
Fixes #4903 

When using a CA cert for s3 location for Rancher Backup install, reading from file should bas64 encode the certificate.