### PR TITLE
Fixing how we initialize s3 backups in rke2 clusters

### DIFF
--- a/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -13,7 +13,9 @@ import { DEFAULT_WORKSPACE } from '@/models/provisioning.cattle.io.cluster';
 
 import { findBy, removeObject, clear } from '@/utils/array';
 import { createYaml } from '@/utils/create-yaml';
-import { clone, diff, set, get } from '@/utils/object';
+import {
+  clone, diff, set, get, isEmpty
+} from '@/utils/object';
 import { allHash } from '@/utils/promise';
 import { sortBy } from '@/utils/sort';
 import { camelToTitle, nlToBr } from '@/utils/string';
@@ -824,7 +826,10 @@ export default {
   watch: {
     s3Backup(neu) {
       if ( neu ) {
-        set(this.rkeConfig.etcd, 's3', {});
+        // We need to make sure that s3 doesn't already have an existing value otherwise when editing a cluster with s3 defined this will clear s3.
+        if (isEmpty(this.rkeConfig.etcd?.s3)) {
+          set(this.rkeConfig.etcd, 's3', {});
+        }
       } else {
         set(this.rkeConfig.etcd, 's3', null);
       }


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
On initialization we were setting the s3Backup. This would trigger a watcher which would overwrite the s3 values.

fixes #5865 
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
Enabling/disabling s3 backups when creating/editing clusters.

### Areas which could experience regressions
Enabling/disabling s3 backups when creating/editing clusters.