### PR TITLE
No longer see errors when adding authorized principals

### DIFF
--- a/components/auth/Principal.vue
+++ b/components/auth/Principal.vue
@@ -20,6 +20,8 @@ export default {
   },
 
   async fetch() {
+    this.principal = this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.value);
+
     if ( this.principal ) {
       return;
     }
@@ -39,7 +41,7 @@ export default {
 
   data() {
     // Load from cache immediately if possible
-    return { principal: this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.value) };
+    return { principal: null };
   },
 
   computed: {


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5876

This PR prevents the 'Unable to fetch principal info' error that is shown when a user tries to add authorized users and groups to the list of users who should be able to log in to Rancher. The error was seen on this page:

<img width="1561" alt="Screen Shot 2022-05-09 at 1 32 58 PM" src="https://user-images.githubusercontent.com/20599230/167492920-1e8dda2f-95d2-4a36-9aea-97f4f39dcfdc.png">

In 2.6.4, there was no async call to fetch principal info in this page.

# QA Template

## Root cause
The UI attempts to make an async call to `/v3/principals/<principalId>`. On this page, `principalId` is undefined, so the API call was going to `/v3/principals/undefined`, which causes an error.
 
## What was fixed, or what changes have occurred

Anupama showed that in v2.6.4, there was no async call to get the principal details on this page. So it looks like the bad API call was not needed.

The API call was originally added in https://github.com/rancher/dashboard/pull/3064 to add support for the Keycloak OIDC provider, but it isn't needed in the context of this page.

The async code was not supposed to run if the principal data was already in the store, and in this case the data is already in the store. But the code executed anyway because the thing that loads info from the store (the getter in `data`) was running after the code in `fetch`.

So I made it when it checks if the principal data already exists, it looks for it in the store and finds it there. Now we have the same behavior as v2.6.4.
 
## Areas or cases that should be tested
Adding authorized users from OpenLDAP (same steps as reproducing the issue)
 
## What areas could experience regressions?
Can't think of any
