### PR TITLE
Fix arguments for remove on click

### DIFF
--- a/components/form/ArrayList.vue
+++ b/components/form/ArrayList.vue
@@ -290,7 +290,7 @@ export default {
               :disabled="isView"
               class="btn role-link"
               :data-testid="`remove-item-${idx}`"
-              @click="remove(idx, row)"
+              @click="remove(row, idx)"
             >
               {{ removeLabel }}
             </button>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes an issue where members of `ArrayList.vue` would be removed at the wrong index by reordering the arguments to match the parameter order for `remove`. 

Fixes #5874

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Anything that makes use of `ArrayList.vue` but depends on the wrong ordering of arguments; I doubt that this would be the case, as this looks to be a regression introduced in #5629. I expect that other consumers of `ArrayList` regressed and bugs were not reported as of yet.


Signed-off-by: Phillip Rak <rak.phillip@gmail.com>