### PR TITLE
Add tooltip for Project Namespace Resource Quotas

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6711,6 +6711,12 @@ resourceQuota:
     unitlessPlaceholder: e.g. 10
   add:
     label: Add Resource
+  tooltip:
+    reserved: 'Other Namespaces:'
+    namespace: 'This Namespace:'
+    available: 'Available:'
+    max: 'Total:'
+
 
 
 ##############################

--- a/shell/components/form/ResourceQuota/NamespaceRow.vue
+++ b/shell/components/form/ResourceQuota/NamespaceRow.vue
@@ -101,6 +101,9 @@ export default {
     max() {
       return this.projectLimit - this.namespaceContribution;
     },
+    availableResourceQuotas() {
+      return formatSi(this.projectLimit - this.totalContribution, { ...this.siOptions, addSuffixSpace: false });
+    },
     slices() {
       const out = [];
 
@@ -112,7 +115,42 @@ export default {
       });
 
       return out;
-    }
+    },
+    tooltip() {
+      const t = this.$store.getters['i18n/t'];
+      const out = [
+        {
+          label: t('resourceQuota.tooltip.reserved'),
+          value: this.namespaceResourceQuotaLimits[0][this.type],
+        },
+        {
+          label: t('resourceQuota.tooltip.namespace'),
+          value: this.value.limit[this.type]
+        },
+        {
+          label: t('resourceQuota.tooltip.available'),
+          value: this.availableResourceQuotas
+        },
+        {
+          label: t('resourceQuota.tooltip.max'),
+          value: this.projectResourceQuotaLimits[this.type]
+        }
+      ];
+
+      let formattedTooltip = '<div class="quota-percentage-tooltip">';
+
+      (out || []).forEach((v) => {
+        formattedTooltip += `
+        <div style='margin-top: 5px; display: flex; justify-content: space-between;'>
+          ${ v.label }
+          <span style='margin-left: 20px;'>${ v.value }</span>
+        </div>`;
+      });
+      formattedTooltip += '</div>';
+
+      return formattedTooltip;
+    },
+
   },
 
   methods: {
@@ -140,7 +178,13 @@ export default {
       :options="types"
     />
     <div class="resource-availability mr-10">
-      <PercentageBar class="percentage-bar" :value="percentageUsed" :slices="slices" :color-stops="{'100': '--primary'}" />
+      <PercentageBar
+        v-tooltip="tooltip"
+        class="percentage-bar"
+        :value="percentageUsed"
+        :slices="slices"
+        :color-stops="{'100': '--primary'}"
+      />
     </div>
     <UnitInput
       :value="value.limit[type]"

--- a/shell/components/form/ResourceQuota/NamespaceRow.vue
+++ b/shell/components/form/ResourceQuota/NamespaceRow.vue
@@ -121,7 +121,7 @@ export default {
       const out = [
         {
           label: t('resourceQuota.tooltip.reserved'),
-          value: this.namespaceResourceQuotaLimits[0][this.type],
+          value: formatSi(this.namespaceContribution, { ...this.siOptions, addSuffixSpace: false }),
         },
         {
           label: t('resourceQuota.tooltip.namespace'),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5807 

Adds hover tooltip similar to previous behavior seen in ember ui to show project resource quotas. 

![2022-05-10_01-45-01](https://user-images.githubusercontent.com/13671297/167588145-6807731b-0ef0-4da2-b936-b840178d032b.png)

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->