### PR TITLE
Fixes bug in dropdown when project no longer exists by filtering it out.

### DIFF
--- a/shell/edit/helm.cattle.io.projecthelmchart.vue
+++ b/shell/edit/helm.cattle.io.projecthelmchart.vue
@@ -80,7 +80,7 @@ export default {
     namespaceFilter(namespace) {
       const excludeProjects = [...this.systemNamespaces?.systemProjectLabelValues || [], this.systemNamespaces?.projectReleaseLabelValue];
 
-      return namespace?.metadata?.labels?.['helm.cattle.io/helm-project-operated'] && !excludeProjects.includes(namespace.projectId);
+      return namespace?.project && namespace?.metadata?.labels?.['helm.cattle.io/helm-project-operated'] && !excludeProjects.includes(namespace.projectId);
     },
     namespaceMapper(namespace) {
       return {


### PR DESCRIPTION
Summary
Fixes https://github.com/rancher/dashboard/issues/5897
Bug occurs when project is deleted and one of the orphaned namespaces is still listed as project operated and still has a projectId in it's annotations.

Occurred changes and/or fixed issues
Fix ensures that the model can still find a project that matches the projectId