### PR TITLE
allow doneRoute to be an object

### DIFF
--- a/components/CruResource.vue
+++ b/components/CruResource.vue
@@ -24,7 +24,7 @@ export default {
 
   props: {
     doneRoute: {
-      type:    String,
+      type:    [String, Object],
       default: null
     },
 

--- a/components/ResourceYaml.vue
+++ b/components/ResourceYaml.vue
@@ -16,6 +16,7 @@ import {
 } from '@/config/query-params';
 import { BEFORE_SAVE_HOOKS, AFTER_SAVE_HOOKS } from '@/mixins/child-hook';
 import { exceptionToErrorsArray } from '../utils/error';
+import { typeOf } from '@/utils/sort';
 
 export default {
   components: {
@@ -46,7 +47,7 @@ export default {
     },
 
     doneRoute: {
-      type:    String,
+      type:    [String, Object],
       default: null,
     },
 
@@ -312,6 +313,11 @@ export default {
         return typeof (this.doneOverride) === 'function' ? this.doneOverride() : this.$router.replace(this.doneOverride);
       }
       if ( !this.doneRoute ) {
+        return;
+      }
+      if (typeOf(this.doneRoute) === 'object') {
+        this.$router.replace(this.doneRoute);
+
         return;
       }
       this.$router.replace({

--- a/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -242,7 +242,7 @@ export default {
 <template>
   <CruResource
     class="receiver"
-    :done-route="getReceiverDetailRoute(value.name)"
+    :done-route="alertmanagerConfigResource.getAlertmanagerConfigDetailRoute()"
     :mode="mode"
     :resource="alertmanagerConfigResource"
     :subtypes="[]"


### PR DESCRIPTION
#5877 - this PR updates the `doneRoute` used in receivers to be the alertmanagerconfig detail view, and updates ResourceYaml to allow `doneRoute` to be an object. (ResourceYaml already allows route objects via `doneOverride` but the instance used in CruResource sets `doneOverride` to a model property which wont work for this use case)