### PR TITLE
[2.6.5] Fixes error where secret value is not encoded on save

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -387,7 +387,7 @@ export default {
             if (this.valueTrim && asciiLike(value)) {
               value = value.trim();
             }
-            if (row.canEncode) {
+            if ( value && this.handleBase64 ) {
               value = base64Encode(value);
             }
             if ( key && (value || this.valueCanBeEmpty) ) {


### PR DESCRIPTION
Fixes #5907

Reversed some added logic added to step where value is encoded

@aalves08 this reverses part of your last commit that I didn't fully dissect so it may introduce regressions. Feel free to change as you see fit before merging.