### PR TITLE
Fix issue where build output would contain invalid urls

### DIFF
--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -351,7 +351,10 @@ export default function(dir, _appConfig) {
         useShortDoctype:            !dev
       },
 
-      filenames: { chunk: ({ isDev }) => isDev ? '[name].js' : '[name].[contenthash].js' },
+      // Don't include `[name]` in prod file names
+      // This flattens out the folder structure (avoids crazy paths like `_nuxt/pages/account/create-key/pages/c/_cluster/_product/_resource/_id/pages/c/_cluster/_product/_resource`)
+      // and uses nuxt's workaround to address issues with filenames containing `//` (see https://github.com/nuxt/nuxt.js/issues/8274)
+      filenames: { chunk: ({ isDev }) => isDev ? '[name].js' : '[contenthash].js' },
       // @TODO figure out how to split chunks up better, by product
       // optimization: {
       //   splitChunks: {


### PR DESCRIPTION
- When using `ui-dashboard-index` `https://releases.rancher.com/dashboard/latest/index.html` naving to 'Create' style pages resulted in page refresh
- Caused by 404 on some files with urls containing `//`
- Fix is to remove `[name]` in prod file names (see https://github.com/nuxt/nuxt.js/issues/8274)
  - This also flattens out the folder structure (avoids crazy paths like `_nuxt/pages/account/create-key/pages/c/_cluster/_product/_resource/_id/pages/c/_cluster/_product/_resource`)
  - ![image](https://user-images.githubusercontent.com/18697775/167821005-cf84cb2e-2055-409a-bb9a-c0f06658533a.png)
  - vs
  - ![image](https://user-images.githubusercontent.com/18697775/167819498-a3f388a2-8341-47bb-b7d4-2e79505ff931.png)

