### PR TITLE
Can't create an Opaque secret using plain text as value

### DIFF
--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -447,6 +447,7 @@ export default {
         [this.keyName]:   (split[0] || '').trim(),
         [this.valueName]: (split[1] || '').trim(),
         supported:        true,
+        canEncode:        this.handleBase64,
         binary:           this.displayValuesAsBinary
       }));
 

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -277,6 +277,7 @@ export default {
         [this.keyName]:   '',
         [this.valueName]: '',
         binary:           false,
+        canEncode:        this.handleBase64,
         supported:        true
       });
     }
@@ -322,7 +323,8 @@ export default {
         [this.valueName]: value,
       };
 
-      obj.binary = this.displayValuesAsBinary;
+      obj.binary = false;
+      obj.canEncode = this.handleBase64;
       obj.supported = true;
       this.rows.push(obj);
       this.queueUpdate();


### PR DESCRIPTION
Addresses Github issue: [#5907](https://github.com/rancher/dashboard/issues/5907)
Addresses Zube issue: [#5936](https://zube.io/rancher/dashboard-ui/c/5936)

- fix issue where user could not create opaque secret from `edit config` interface in `Secrets`