### PR TITLE
Can't create an Opaque secret using plain text as value (2.6.5 branch)

### DIFF
--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -271,6 +271,7 @@ export default {
         [this.keyName]:   '',
         [this.valueName]: '',
         binary:           false,
+        canEncode:        this.handleBase64,
         supported:        true
       });
     }
@@ -316,7 +317,8 @@ export default {
         [this.valueName]: value,
       };
 
-      obj.binary = this.displayValuesAsBinary;
+      obj.binary = false;
+      obj.canEncode = this.handleBase64;
       obj.supported = true;
       this.rows.push(obj);
       this.queueUpdate();

--- a/components/form/KeyValue.vue
+++ b/components/form/KeyValue.vue
@@ -442,6 +442,7 @@ export default {
         [this.keyName]:   (split[0] || '').trim(),
         [this.valueName]: (split[1] || '').trim(),
         supported:        true,
+        canEncode:        this.handleBase64,
         binary:           this.displayValuesAsBinary
       }));
 


### PR DESCRIPTION
Addresses Github issue: [#5907](https://github.com/rancher/dashboard/issues/5907)
Addresses Zube issue: [#5936](https://zube.io/rancher/dashboard-ui/c/5936)

- fix issue where user could not create opaque secret from `edit config` interface in `Secrets`