### PR TITLE
translations: Replace vendor tag with name tag

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4233,7 +4233,7 @@ setup:
     skip: Skip
     tip: What URL should be used for this {vendor} installation? All the nodes in your clusters will need to be able to reach this.
   setPassword: The first order of business is to set a strong password for the default <code>{username}</code> user. We suggest using this random one generated just for you, but enter your own if you like.
-  telemetry: Allow collection of <a href="{docsBase}/faq/telemetry/" target="_blank" rel="noopener noreferrer nofollow">anonymous statistics</a> to help us improve {vendor}.
+  telemetry: Allow collection of <a href="{docsBase}/faq/telemetry/" target="_blank" rel="noopener noreferrer nofollow">anonymous statistics</a> to help us improve {name}.
   useManual: Set a specific password to use
   useRandom: Use a randomly generated password
   welcome: Welcome to {vendor}!

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -4148,7 +4148,7 @@ setup:
     skip: 跳过
     tip: 此 {vendor} 安装应使用什么 URL？集群中的所有节点都需要能访问该 URL。
   setPassword: 请为默认用户 <code>{username}</code>设置强密码。建议使用生成的随机密码。你也可以自行设置。
-  telemetry: 允许收集<a href="{docsBase}/faq/telemetry/" target="_blank" rel="noopener noreferrer nofollow">匿名统计数据</a>，以帮我们改进 {vendor}。
+  telemetry: 允许收集<a href="{docsBase}/faq/telemetry/" target="_blank" rel="noopener noreferrer nofollow">匿名统计数据</a>，以帮我们改进 {name}。
   useManual: 设置密码
   useRandom: 使用随机生成的密码
   welcome: 欢迎使用 {vendor}！

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -335,7 +335,11 @@ export default {
             </template>
 
             <div class="checkbox mt-40">
-              <Checkbox id="checkbox-telemetry" v-model="telemetry" label-key="setup.telemetry" />
+              <Checkbox id="checkbox-telemetry" v-model="telemetry">
+                <template #label>
+                  <t k="setup.telemetry" :raw="true" :name="productName" />
+                </template>
+              </Checkbox>
             </div>
             <div class="checkbox pt-10 eula">
               <Checkbox id="checkbox-eula" v-model="eula">


### PR DESCRIPTION
### Summary

With custom branding [0]  telemetry sentence mentions custom company name instead of Rancher.

[0] https://rancher.com/docs/rancher/v2.6/en/admin-settings/branding/

### Screenshot/Video
![rancher_telemetry](https://user-images.githubusercontent.com/24898105/168076475-9bbc20e2-ec5c-4cce-8bf7-4fa4a6466b35.png)

