### PR TITLE
Floating banner in the Branding page is missing

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6131,6 +6131,7 @@ typeDescription:
   #       Should fit on one line.
   #       If you link to anything external, it MUST have
   #       target="_blank" rel="noopener noreferrer nofollow"
+  branding: "Branding allows for the users to change the overall branding of Rancher."
   chart: "All charts have at least one version that is installable on clusters with Linux and Windows nodes unless otherwise indicated."
   cis.cattle.io.clusterscanbenchmark: A benchmark version is the name of benchmark to run using kube-bench as well as the valid configuration parameters for that benchmark.
   cis.cattle.io.clusterscanprofile: A profile is the configuration for the CIS scan, which is the benchmark versions to use and any specific tests to skip in that benchmark.

--- a/shell/pages/c/_cluster/settings/brand.vue
+++ b/shell/pages/c/_cluster/settings/brand.vue
@@ -1,6 +1,7 @@
 <script>
 import LabeledInput from '@shell/components/form/LabeledInput';
 import ColorInput from '@shell/components/form/ColorInput';
+import TypeDescription from '@shell/components/TypeDescription';
 
 import Checkbox from '@shell/components/form/Checkbox';
 import FileSelector from '@shell/components/form/FileSelector';
@@ -21,7 +22,7 @@ export default {
   layout: 'authenticated',
 
   components: {
-    LabeledInput, Checkbox, FileSelector, Loading, SimpleBox, AsyncButton, Banner, ColorInput
+    LabeledInput, Checkbox, FileSelector, Loading, SimpleBox, AsyncButton, Banner, ColorInput, TypeDescription
   },
 
   async fetch() {
@@ -189,6 +190,7 @@ export default {
     <h1 class="mb-20">
       {{ t('branding.label') }}
     </h1>
+    <TypeDescription resource="branding" />
     <div>
       <div class="row mb-20">
         <div class="col span-6">


### PR DESCRIPTION
Addresses Github issue: [#5708](https://github.com/rancher/dashboard/issues/5708)
Addresses Zube issue: [#5736](https://zube.io/rancher/dashboard-ui/c/5736)

- add banner to Branding settings page

