### PR TITLE
Update package versions and update publishing script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Rancher Dashboard",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",
-  "author": "Rancher Labs, Inc.",
+  "author": "SUSE",
   "private": true,
   "engines": {
     "node": ">=12"

--- a/pkg/epinio/package.json
+++ b/pkg/epinio/package.json
@@ -4,9 +4,8 @@
   "version": "0.6.2",
   "private": false,
   "rancher": true,
-  "publishConfig": {
-    "registry": "http://localhost:4873"
-  },
+  "license": "Apache-2.0",
+  "author": "SUSE",  
   "scripts": {
     "dev": "./node_modules/.bin/nuxt dev",
     "nuxt": "./node_modules/.bin/nuxt"

--- a/shell/creators/app/app.package.json
+++ b/shell/creators/app/app.package.json
@@ -2,9 +2,6 @@
   "name": "NAME",
   "version": "0.1.0",
   "private": false,
-  "publishConfig": {
-    "registry": "http://localhost:4873"
-  },
   "engines": {
     "node": ">=12"
   },

--- a/shell/creators/app/package.json
+++ b/shell/creators/app/package.json
@@ -1,18 +1,15 @@
 {
   "name": "@rancher/create-app",
-  "description": "UI Application generator",
-  "version": "0.1.56",
+  "description": "Rancher UI Application generator",
+  "version": "0.0.0",
   "license": "Apache-2.0",
-  "author": "Rancher Labs, Inc.",
+  "author": "SUSE",
   "private": false,
   "bin": "./init",
   "files": [
     "*.*",
     "init"
   ],
-  "publishConfig": {
-    "registry": "http://localhost:4873"
-  },
   "engines": {
     "node": ">=12"
   },

--- a/shell/creators/pkg/package.json
+++ b/shell/creators/pkg/package.json
@@ -1,18 +1,15 @@
 {
   "name": "@rancher/create-pkg",
-  "description": "UI Package generator",
-  "version": "0.1.37",
+  "description": "Rancher UI Package generator",
+  "version": "0.0.0",
   "license": "Apache-2.0",
-  "author": "Rancher Labs, Inc.",
+  "author": "SUSE",
   "private": false,
   "bin": "./init",
   "files": [
     "*.*",
     "init"
   ],
-  "publishConfig": {
-    "registry": "http://localhost:4873"
-  },
   "engines": {
     "node": ">=12"
   },

--- a/shell/creators/pkg/pkg.package.json
+++ b/shell/creators/pkg/pkg.package.json
@@ -4,9 +4,6 @@
   "version": "0.1.0",
   "private": false,
   "rancher": true,
-  "publishConfig": {
-    "registry": "http://localhost:4873"
-  },
   "scripts": {},
   "engines": {
     "node": ">=12"

--- a/shell/package.json
+++ b/shell/package.json
@@ -1,14 +1,11 @@
 {
   "name": "@rancher/shell",
-  "version": "0.6.26",
+  "version": "0.1.0",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",
-  "author": "Rancher Labs, Inc.",
+  "author": "SUSE",
   "private": false,
-  "publishConfig": {
-    "registry": "http://localhost:4873"
-  },
   "engines": {
     "node": ">=12"
   },

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -3,17 +3,56 @@
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BASE_DIR="$( cd $SCRIPT_DIR && cd ../.. & pwd)"
 SHELL_DIR=$BASE_DIR/shell/
+PUBLISH_ARGS="--no-git-tag-version --access public"
 
 echo "Publishing Shell Packages"
 
-pushd ${SHELL_DIR}
-yarn publish . --patch --no-git-tag-version
-popd
+# We use the version from the shell package for the creator packages
+# Need to copy them to a temporary location, so we can patch the version number
+# before publishing
 
-pushd ${SHELL_DIR}/creators/app
-yarn publish . --patch --no-git-tag-version
-popd
+# To set a token for NPM registry auth: `npm config set //registry.npmjs.org/:_authToken <TOKEN>``
 
-pushd ${SHELL_DIR}/creators/pkg
-yarn publish . --patch --no-git-tag-version
-popd
+PKG_DIST=$BASE_DIR/dist-pkg/creators
+mkdir -p ${PKG_DIST}
+rm -rf ${PKG_DIST}/app
+rm -rf ${PKG_DIST}/pkg
+
+pushd ${SHELL_DIR} > /dev/null
+
+PKG_VERSION=`node -p "require('./package.json').version"`
+popd > /dev/null
+
+echo "Publishing version: $PKG_VERSION"
+
+cp -R ${SHELL_DIR}/creators/app ${PKG_DIST}
+cp -R ${SHELL_DIR}/creators/pkg ${PKG_DIST}
+
+sed -i.bak -e "s/0.0.0/"$PKG_VERSION"/g" ${PKG_DIST}/app/package.json
+sed -i.bak -e "s/0.0.0/"$PKG_VERSION"/g" ${PKG_DIST}/pkg/package.json
+
+rm ${PKG_DIST}/app/package.json.bak
+rm ${PKG_DIST}/pkg/package.json.bak
+
+function publish() {
+  NAME=$1
+  FOLDER=$2
+
+  echo "Publishing ${NAME} from ${FOLDER}"
+  pushd ${FOLDER} > /dev/null
+  yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS}
+  RET=$?
+  popd > /dev/null
+
+  if [ $RET -ne 0 ]; then
+    echo "Error publishing package ${NAME}"
+  fi
+}
+
+# Publish the packages - don't tag the git repo and don't auto-increment the version number
+publish "Shell" ${SHELL_DIR}
+
+publish "Application creator" ${PKG_DIST}/app
+publish "Package creator" ${PKG_DIST}/pkg
+
+echo "Done"


### PR DESCRIPTION
Update package files and improve script to publish shell and creators to npm.

Removes `publishConfig` localhost registry configuration in some of the package files that was only for local testing during development.