### PR TITLE
Feature/5186 unitinput blur

### DIFF
--- a/shell/components/form/LabeledInput.vue
+++ b/shell/components/form/LabeledInput.vue
@@ -151,8 +151,8 @@ export default {
       this.onFocusLabeled();
     },
 
-    onBlur() {
-      this.$emit('blur');
+    onBlur(event) {
+      this.$emit('blur', event);
       this.onBlurLabeled();
     },
 

--- a/shell/components/form/UnitInput.vue
+++ b/shell/components/form/UnitInput.vue
@@ -215,7 +215,7 @@ export default {
     :required="required"
     :placeholder="placeholder"
     :hide-arrows="hideArrows"
-    @input="update($event)"
+    @blur="update($event.target.value)"
   >
     <template #suffix>
       <div

--- a/shell/components/form/UnitInput.vue
+++ b/shell/components/form/UnitInput.vue
@@ -125,7 +125,7 @@ export default {
      */
     delay: {
       type:    Number,
-      default: 500
+      default: 0
     }
   },
 

--- a/shell/components/form/__tests__/UnitInput.test.ts
+++ b/shell/components/form/__tests__/UnitInput.test.ts
@@ -27,7 +27,6 @@ describe('component: UnitInput', () => {
     const wrapper = mount(UnitInput, {
       propsData: {
         value: 1,
-        delay: 0,
         mode
       }
     });
@@ -41,7 +40,7 @@ describe('component: UnitInput', () => {
     ['2G', '2000000000'],
     ['3', '3'],
   ])('should parse values with SI modifier %p and return %p', (value, expected) => {
-    const wrapper = mount(UnitInput, { propsData: { value, delay: 0 } });
+    const wrapper = mount(UnitInput, { propsData: { value } });
     const label = wrapper.findComponent(LabeledInput);
 
     expect(label.props('value')).toBe(expected);
@@ -55,7 +54,6 @@ describe('component: UnitInput', () => {
         value: 1,
         inputExponent,
         baseUnit,
-        delay: 0
       }
     });
     const expectedUnits = `${ UNITS[inputExponent] }${ baseUnit }`;
@@ -71,7 +69,7 @@ describe('component: UnitInput', () => {
   ])('should (%p) force use of SI modifier and return %p', async(outputModifier, expected) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, inputExponent: 3, outputModifier: !outputModifier, delay: 0
+        value: 1, inputExponent: 3, outputModifier: !outputModifier
       }
     });
     const inputWrapper = wrapper.find('input');
@@ -89,7 +87,6 @@ describe('component: UnitInput', () => {
         value:          1,
         inputExponent,
         outputModifier: true,
-        delay:          0
       }
     });
 
@@ -104,7 +101,7 @@ describe('component: UnitInput', () => {
   ])('based on increment %p and exponent M, it should use binary modifier and return unit %p', (increment, expected) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, inputExponent: 2, increment, delay: 0
+        value: 1, inputExponent: 2, increment
       }
     });
 
@@ -117,7 +114,7 @@ describe('component: UnitInput', () => {
   ])('should force emission of value type as %p', (outputAs) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, inputExponent: 3, outputAs, delay: 0
+        value: 1, inputExponent: 3, outputAs
       }
     });
 
@@ -132,7 +129,7 @@ describe('component: UnitInput', () => {
   ])('should appended base unit %p value to SI modifier and return %p', (baseUnit, expected) => {
     const wrapper = mount(UnitInput, {
       propsData: {
-        value: 1, baseUnit, inputExponent: 2, delay: 0
+        value: 1, baseUnit, inputExponent: 2
       }
     });
     const addonText = wrapper.find('.addon').text();
@@ -142,11 +139,7 @@ describe('component: UnitInput', () => {
 
   it('should display suffix outside of the value', () => {
     const suffix = 'seconds';
-    const wrapper = mount(UnitInput, {
-      propsData: {
-        value: 1, suffix, delay: 0
-      }
-    });
+    const wrapper = mount(UnitInput, { propsData: { value: 1, suffix } });
     const addonText = wrapper.find('.addon').text();
 
     wrapper.find('input').setValue(1);
@@ -156,7 +149,7 @@ describe('component: UnitInput', () => {
   });
 
   it('should format value to a valid integer', () => {
-    const wrapper = mount(UnitInput, { propsData: { delay: 0 } });
+    const wrapper = mount(UnitInput);
     const value = '096';
     const expectation = 96;
 

--- a/shell/components/form/__tests__/UnitInput.test.ts
+++ b/shell/components/form/__tests__/UnitInput.test.ts
@@ -16,8 +16,9 @@ describe('component: UnitInput', () => {
 
     await input.setValue(2);
     await input.setValue(4);
+    input.trigger('blur');
 
-    expect(wrapper.emitted('input')).toHaveLength(2);
+    expect(wrapper.emitted('input')).toHaveLength(1);
   });
 
   it.each([
@@ -76,6 +77,7 @@ describe('component: UnitInput', () => {
 
     await wrapper.setProps({ outputModifier });
     await inputWrapper.setValue(3);
+    inputWrapper.trigger('blur');
 
     expect(wrapper.emitted('input')![0][0]).toBe(expected);
   });
@@ -89,8 +91,10 @@ describe('component: UnitInput', () => {
         outputModifier: true,
       }
     });
+    const input = wrapper.find('input');
 
-    await wrapper.find('input').setValue(2);
+    await input.setValue(2);
+    input.trigger('blur');
 
     expect(wrapper.emitted('input')![0][0]).toContain(UNITS[inputExponent]);
   });
@@ -118,7 +122,10 @@ describe('component: UnitInput', () => {
       }
     });
 
-    wrapper.find('input').setValue(2);
+    const input = wrapper.find('input');
+
+    input.setValue(2);
+    input.trigger('blur');
 
     expect(typeof wrapper.emitted('input')![0][0]).toBe(outputAs);
   });
@@ -142,7 +149,10 @@ describe('component: UnitInput', () => {
     const wrapper = mount(UnitInput, { propsData: { value: 1, suffix } });
     const addonText = wrapper.find('.addon').text();
 
-    wrapper.find('input').setValue(1);
+    const input = wrapper.find('input');
+
+    input.setValue(1);
+    input.trigger('blur');
 
     expect(addonText).toBe(suffix);
     expect(wrapper.emitted('input')![0][0]).not.toContain(suffix);
@@ -152,8 +162,10 @@ describe('component: UnitInput', () => {
     const wrapper = mount(UnitInput);
     const value = '096';
     const expectation = 96;
+    const input = wrapper.find('input');
 
-    wrapper.find('input').setValue(value);
+    input.setValue(value);
+    input.trigger('blur');
 
     expect(wrapper.emitted('input')![0][0]).toBe(expectation);
   });
@@ -162,11 +174,14 @@ describe('component: UnitInput', () => {
     const value = 5096;
     const delay = 1;
     const wrapper = mount(UnitInput, { propsData: { delay } });
+    const input = wrapper.find('input');
 
     jest.useFakeTimers();
-    wrapper.find('input').setValue('4096');
-    wrapper.find('input').setValue('096');
-    wrapper.find('input').setValue(value);
+
+    input.setValue('4096');
+    input.setValue('096');
+    input.setValue(value);
+    input.trigger('blur');
     jest.advanceTimersByTime(delay);
     jest.useRealTimers();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5186
Change emission to blur instead of type for unit inputs

### Occurred changes and/or fixed issues
Removed delay and changed emission on blur

### Technical notes summary
Added event of label input for blur events.

### Areas or cases that should be tested
As in ticket description

### Areas which could experience regressions
Any form with unit.

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/168832311-4d818ac7-a0f5-4cbd-85c4-03e735ff696c.mov

