### PR TITLE
`Steve` DNS related resource types can cause confusion

### DIFF
--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -92,6 +92,7 @@ export function init(store) {
     componentForType(WORKLOAD_TYPES[key], WORKLOAD);
   }
 
+  ignoreType(MANAGEMENT.GLOBAL_DNS_PROVIDER); // Old, managed in multi-cluster-apps
   ignoreType('events.k8s.io.event'); // Old, moved into core
   ignoreType('extensions.ingress'); // Old, moved into networking
   ignoreType(MANAGEMENT.PROJECT);

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -167,7 +167,8 @@ export const MANAGEMENT = {
   GLOBAL_ROLE_BINDING:           'management.cattle.io.globalrolebinding',
   POD_SECURITY_POLICY_TEMPLATE:  'management.cattle.io.podsecuritypolicytemplate',
   MANAGED_CHART:                 'management.cattle.io.managedchart',
-  USER_NOTIFICATION:             'management.cattle.io.rancherusernotification'
+  USER_NOTIFICATION:             'management.cattle.io.rancherusernotification',
+  GLOBAL_DNS_PROVIDER:           'management.cattle.io.globaldnsprovider'
 };
 
 export const CAPI = {


### PR DESCRIPTION
Addresses Github issue: [#4792](https://github.com/rancher/dashboard/issues/4792)
Addresses Zube issue: [#4811](https://zube.io/rancher/dashboard-ui/c/4811)

- remove `globalDnsProvider` from `more resources` in side menu

**Menu entry in `Multi-cluster-apps`**
![Screenshot 2022-05-18 at 11 12 28](https://user-images.githubusercontent.com/97888974/169016620-b16e0893-5921-4df9-8167-517883153722.png)

**Menu entry removed from `More Resources` - `Rancher`**
![Screenshot 2022-05-18 at 11 12 48](https://user-images.githubusercontent.com/97888974/169016633-30a06d03-602a-47d3-a26b-5eacaf611b55.png)
