### PR TITLE
`Save RKE Template` option is seen for a Std user who is cluster owner

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -76,6 +76,7 @@ export default {
     if ( this.value.isRke1 && this.$store.getters['isRancher'] ) {
       fetchOne.etcdBackups = this.$store.dispatch('rancher/findAll', { type: NORMAN.ETCD_BACKUP });
 
+      fetchOne.normanClusters = this.$store.dispatch('rancher/findAll', { type: NORMAN.CLUSTER });
       fetchOne.normanNodePools = this.$store.dispatch('rancher/findAll', { type: NORMAN.NODE_POOL });
     }
 

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -3,7 +3,7 @@ import Banner from '@shell/components/Banner';
 import ResourceTable from '@shell/components/ResourceTable';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { allHash } from '@shell/utils/promise';
-import { CAPI, MANAGEMENT, SNAPSHOT } from '@shell/config/types';
+import { CAPI, MANAGEMENT, SNAPSHOT, NORMAN } from '@shell/config/types';
 import { MODE, _IMPORT } from '@shell/config/query-params';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
 import { mapFeature, HARVESTER as HARVESTER_FEATURE } from '@shell/store/features';
@@ -16,8 +16,9 @@ export default {
 
   async fetch() {
     const hash = {
-      mgmtClusters:       this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
-      rancherClusters:    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
+      normanClusters:  this.$store.dispatch('rancher/findAll', { type: NORMAN.CLUSTER }),
+      mgmtClusters:    this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
+      rancherClusters: this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
     };
 
     if ( this.$store.getters['management/canList'](SNAPSHOT) ) {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -67,7 +67,9 @@ export default class ProvCluster extends SteveModel {
       canUpdateClusterTemplate = true;
     }
 
-    const canSaveRKETemplate = this.isRke1 && this.mgmt?.status?.driver === 'rancherKubernetesEngine' && !this.mgmt?.spec?.clusterTemplateName && this.hasLink('update') && canUpdateClusterTemplate;
+    const normanClusterSaveTemplateAction = !!this.normanCluster?.actions?.saveAsTemplate;
+
+    const canSaveRKETemplate = this.isRke1 && this.mgmt?.status?.driver === 'rancherKubernetesEngine' && !this.mgmt?.spec?.clusterTemplateName && this.hasLink('update') && canUpdateClusterTemplate && normanClusterSaveTemplateAction;
 
     const actions = [
       // Note: Actions are not supported in the Steve API, so we check
@@ -121,6 +123,18 @@ export default class ProvCluster extends SteveModel {
       }, { divider: true }];
 
     return actions.concat(out);
+  }
+
+  get normanCluster() {
+    const name = this.status?.clusterName;
+
+    if ( !name ) {
+      return null;
+    }
+
+    const out = this.$rootGetters['rancher/byId'](NORMAN.CLUSTER, name);
+
+    return out;
   }
 
   goToViewYaml() {


### PR DESCRIPTION
Addresses Github issue: [#5787](https://github.com/rancher/dashboard/issues/5787)
Addresses Zube issue: [#5816](https://zube.io/rancher/dashboard-ui/c/5816)

- update permissions check for action 'save RKE template' on cluster provisioning list view