### PR TITLE
resourceQuota: Address issue where removing existing quotas wasn't being reflected on the saved obj

### DIFF
--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -143,7 +143,7 @@ export default {
           }
         } else if (this.mode === _EDIT) {
           if (this.canEditProject) {
-            await this.value.save();
+            await this.value.save(true);
           }
 
           // // we allow users with permissions for projectroletemplatebindings to be able to manage members on projects

--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -72,11 +72,7 @@ export default class Project extends HybridModel {
   async save(forceReplaceOnReq) {
     const norman = await this.norman;
 
-    if (forceReplaceOnReq) {
-      norman.setReplaceFlagForNormanReq();
-    }
-
-    const newValue = await norman.save();
+    const newValue = await norman.save({ replace: forceReplaceOnReq });
 
     newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
 

--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -69,8 +69,12 @@ export default class Project extends HybridModel {
     return this.listLocation;
   }
 
-  async save() {
+  async save(forceReplaceOnReq) {
     const norman = await this.norman;
+
+    if (forceReplaceOnReq) {
+      norman.setReplaceFlagForNormanReq();
+    }
 
     const newValue = await norman.save();
 

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1116,12 +1116,12 @@ export default class Resource {
       opt.data.annotations = opt.data._annotations;
     }
 
-    // handle __replace__ opt as a query param _replace=true for norman PUT requests
-    if (opt?.data.__replace__ && opt.method === 'put') {
+    // handle "replace" opt as a query param _replace=true for norman PUT requests
+    if (opt?.replace && opt.method === 'put') {
       const argParam = opt.url.includes('?') ? '&' : '?';
 
       opt.url = `${ opt.url }${ argParam }_replace=true`;
-      delete opt.data.__replace__;
+      delete opt.replace;
     }
 
     try {

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1116,10 +1116,16 @@ export default class Resource {
       opt.data.annotations = opt.data._annotations;
     }
 
+    // handle __replace__ opt as a query param _replace=true for norman PUT requests
+    if (opt?.data.__replace__ && opt.method === 'put') {
+      const argParam = opt.url.includes('?') ? '&' : '?';
+
+      opt.url = `${ opt.url }${ argParam }_replace=true`;
+      delete opt.data.__replace__;
+    }
+
     try {
       const res = await this.$dispatch('request', { opt, type: this.type } );
-
-      // console.log('### Resource Save', this.type, this.id);
 
       // Steve sometimes returns Table responses instead of the resource you just saved.. ignore
       if ( res && res.kind !== 'Table') {

--- a/shell/plugins/steve/norman-class.js
+++ b/shell/plugins/steve/norman-class.js
@@ -56,4 +56,11 @@ export default class NormanModel extends Resource {
       Vue.set(this, key, { ...spec[key] });
     });
   }
+
+  // hack to set _replace=true for PUT requests on Norman saves (check implementation on resource-class.js)
+  // This is the only was to prevent merging of objects, which in turn can cause undesired side effects for data on nested objects
+  // https://github.com/rancher/rancher/issues/35688#issuecomment-1130046378
+  setReplaceFlagForNormanReq() {
+    Vue.set(this, '__replace__', true);
+  }
 }

--- a/shell/plugins/steve/norman-class.js
+++ b/shell/plugins/steve/norman-class.js
@@ -56,11 +56,4 @@ export default class NormanModel extends Resource {
       Vue.set(this, key, { ...spec[key] });
     });
   }
-
-  // hack to set _replace=true for PUT requests on Norman saves (check implementation on resource-class.js)
-  // This is the only was to prevent merging of objects, which in turn can cause undesired side effects for data on nested objects
-  // https://github.com/rancher/rancher/issues/35688#issuecomment-1130046378
-  setReplaceFlagForNormanReq() {
-    Vue.set(this, '__replace__', true);
-  }
 }


### PR DESCRIPTION
Addresses Github issue: [#5173](https://github.com/rancher/dashboard/issues/5173)
Addresses Zube issue: [#5197](https://zube.io/rancher/dashboard-ui/c/5197)

- add `_replace=true` query param to `projects` `PUT` request in order to update nested object properties of the object correctly on the database (check comment of BE dev [here](https://github.com/rancher/rancher/issues/35688#issuecomment-1130046378) in regards to the issue reported to the BE regarding the `Project` `resourceQuotas` update)