### PR TITLE
Add tooltip for groupBy field in AlertmanagerConfig route

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2947,6 +2947,7 @@ monitoringRoute:
   groups:
     label: Group By
     addGroupByLabel: Labels to Group Alerts By
+    groupByTooltip: Add each key-value pair as a string in the format key:value. The special label ... will aggregate by all possible labels. If provided, the ... must be the only element in the list.
   info: This is the top-level Route used by Alertmanager as the default destination for any Alerts that do not match any other Routes. This Route must exist and cannot be deleted.
   interval:
     label: Group Interval

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
@@ -12,7 +12,7 @@ export default {
     Banner,
     ArrayListGrouped,
     LabeledInput,
-    LabeledSelect
+    LabeledSelect,
   },
   props: {
     mode: {
@@ -21,11 +21,11 @@ export default {
     },
     value: {
       type:     Object,
-      required: true
+      required: true,
     },
     receiverOptions: {
       type:     Array,
-      required: true
+      required: true,
     },
   },
   data() {
@@ -39,16 +39,20 @@ export default {
         { label: 'Match Not Equal', value: '!=' },
         { label: 'Match Regexp', value: '=~' },
         { label: 'Match Not Regexp', value: '!~' },
-      ]
+      ],
     };
   },
-
 };
-
 </script>
 <template>
   <div>
-    <h3>Receiver <i v-tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')" class="icon icon-info" /></h3>
+    <h3>
+      Receiver
+      <i
+        v-tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')"
+        class="icon icon-info"
+      />
+    </h3>
     <Banner
       color="info"
       :label="t('monitoring.alertmanagerConfig.routeInfo')"
@@ -67,6 +71,10 @@ export default {
       <div class="col span-6">
         <span class="label">
           {{ t("monitoringRoute.groups.addGroupByLabel'") }}
+          <i
+            v-tooltip="t('monitoringRoute.groups.groupByTooltip')"
+            class="icon icon-info"
+          />
         </span>
         <ArrayList
           v-model="value.groupBy"
@@ -109,7 +117,7 @@ export default {
       class="mt-20"
       :mode="mode"
       :add-label="t('monitoringRoute.matching.addMatcher')"
-      :default-add-value="{matchers:[]}"
+      :default-add-value="{ matchers: [] }"
     >
       <template #default="props">
         <div class="row mt-20 mb-20">


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5885 by adding this tooltip:
<img width="1040" alt="Screen Shot 2022-05-18 at 9 46 57 PM" src="https://user-images.githubusercontent.com/20599230/169209835-3546aa52-bae9-4ecf-8938-65ae65395b74.png">
