### PR TITLE
Receiver credential secrets are deleted when secret is set to none

### DIFF
--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/email.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/email.vue
@@ -30,7 +30,8 @@ export default {
     return {
       view:                          _VIEW,
       initialAuthPasswordSecretName:  this.value?.authPassword?.name ? this.value.authPassword.name : '',
-      initialAuthPasswordSecretKey:  this.value.authPassword?.key ? this.value.authPassword.key : ''
+      initialAuthPasswordSecretKey:  this.value.authPassword?.key ? this.value.authPassword.key : '',
+      none:                          '__[[NONE]]__',
     };
   },
 
@@ -39,10 +40,14 @@ export default {
       const existingKey = this.value.authPassword?.key || '';
 
       if (this.value.authPassword) {
-        this.value.authPassword = {
-          key: existingKey,
-          name
-        };
+        if (name === this.none) {
+          delete this.value.authPassword;
+        } else {
+          this.value.authPassword = {
+            key: existingKey,
+            name,
+          };
+        }
       } else {
         this.value['authPassword'] = {
           key: '',

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/opsgenie.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/opsgenie.vue
@@ -85,7 +85,8 @@ export default {
       TYPES,
       view:                          _VIEW,
       initialApiKeySecretName:  this.value?.apiKey?.name ? this.value.apiKey.name : '',
-      initialApiKeySecretKey:  this.value?.apiKey?.key ? this.value.apiKey.key : ''
+      initialApiKeySecretKey:  this.value?.apiKey?.key ? this.value.apiKey.key : '',
+      none:                    '__[[NONE]]__',
     };
   },
 
@@ -126,10 +127,14 @@ export default {
       const existingKey = this.value.apiKey?.key || '';
 
       if (this.value.apiKey) {
-        this.value.apiKey = {
-          key: existingKey,
-          name
-        };
+        if (name === this.none) {
+          delete this.value.apiKey;
+        } else {
+          this.value.apiKey = {
+            key: existingKey,
+            name,
+          };
+        }
       } else {
         this.value['apiKey'] = {
           key: '',

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/pagerduty.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/pagerduty.vue
@@ -42,7 +42,8 @@ export default {
       initialRoutingKeySecretName: this.value.routingKey?.name || '',
       initialServiceKeySecretKey:  this.value.serviceKey?.key || '',
       initialServiceKeySecretName: this.value.serviceKey?.name || '',
-      view:                        _VIEW
+      view:                        _VIEW,
+      none:                        '__[[NONE]]__',
     };
   },
   watch: {
@@ -57,10 +58,14 @@ export default {
       const existingKey = this.value.routingKey?.key || '';
 
       if (this.value.routingKey) {
-        this.value.routingKey = {
-          key: existingKey,
-          name
-        };
+        if (name === this.none) {
+          delete this.value.routingKey;
+        } else {
+          this.value.routingKey = {
+            key: existingKey,
+            name,
+          };
+        }
       } else {
         this.value['routingKey'] = {
           key: '',
@@ -87,10 +92,14 @@ export default {
       const existingKey = this.value.serviceKey?.key || '';
 
       if (this.value.serviceKey) {
-        this.value.serviceKey = {
-          key: existingKey,
-          name
-        };
+        if (name === this.none) {
+          delete this.value.serviceKey;
+        } else {
+          this.value.serviceKey = {
+            key: existingKey,
+            name,
+          };
+        }
       } else {
         this.value['serviceKey'] = {
           key: '',

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/slack.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/slack.vue
@@ -38,7 +38,8 @@ export default {
     return {
       view:              _VIEW,
       initialSecretKey:  this.value?.apiURL?.key ? this.value.apiURL.key : '',
-      initialSecretName: this.value.apiURL?.name ? this.value.apiURL.name : ''
+      initialSecretName: this.value.apiURL?.name ? this.value.apiURL.name : '',
+      none:              '__[[NONE]]__',
     };
   },
 
@@ -47,10 +48,14 @@ export default {
       const existingKey = this.value.apiURL?.key || '';
 
       if (this.value.apiURL) {
-        this.value.apiURL = {
-          key: existingKey,
-          name
-        };
+        if (name === this.none) {
+          delete this.value.apiURL;
+        } else {
+          this.value.apiURL = {
+            key: existingKey,
+            name,
+          };
+        }
       } else {
         this.value['apiURL'] = {
           key: '',


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5875

The affected secrets are:


- email 
	- auth password secret
- opsgenie
	- API key secret
- pagerduty
	- routing key secret
	- service key secret
- slack
	- API URL secret
- webhook
	- URL secret - not in this PR because it was already done.

To test this PR, I validated that if you set and unset a secret for the above values, the secret is deleted and you can save the resource without any backend validation errors.

PR in draft because I think master needs some bug fixes from the 2.6.5 release branch before I can test this. https://github.com/rancher/dashboard/pull/5986