### PR TITLE
Cluster Manager and Cluster Dashboard show different age for same cluster

### DIFF
--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -1,6 +1,8 @@
 <script>
 import { KUBERNETES, PROJECT } from '@shell/config/labels-annotations';
-import { FLEET, NAMESPACE, MANAGEMENT, HELM } from '@shell/config/types';
+import {
+  FLEET, NAMESPACE, MANAGEMENT, HELM, CAPI
+} from '@shell/config/types';
 import ButtonGroup from '@shell/components/ButtonGroup';
 import { BadgeState } from '@components/BadgeState';
 import { Banner } from '@components/Banner';
@@ -354,6 +356,16 @@ export default {
 
       return parent?.location;
     },
+
+    // provision.cluster uses custom model prop 'creationTimestamp'
+    // unlike other resources which default to 'metadata.creationTimestamp'
+    creationTimestamp() {
+      if (this.resource === CAPI.RANCHER_CLUSTER) {
+        return get(this.value, 'creationTimestamp');
+      }
+
+      return get(this.value, 'metadata.creationTimestamp');
+    }
   },
 
   methods: {
@@ -392,7 +404,7 @@ export default {
           <span v-if="isNamespace && project">{{ t("resourceDetail.masthead.project") }}: <nuxt-link :to="project.detailLocation">{{ project.nameDisplay }}</nuxt-link></span>
           <span v-else-if="isWorkspace">{{ t("resourceDetail.masthead.workspace") }}: <nuxt-link :to="workspaceLocation">{{ namespace }}</nuxt-link></span>
           <span v-else-if="namespace && !hasMultipleNamespaces">{{ t("resourceDetail.masthead.namespace") }}: <nuxt-link :to="namespaceLocation">{{ namespace }}</nuxt-link></span>
-          <span v-if="parent.showAge">{{ t("resourceDetail.masthead.age") }}: <LiveDate class="live-date" :value="get(value, 'metadata.creationTimestamp')" /></span>
+          <span v-if="parent.showAge">{{ t("resourceDetail.masthead.age") }}: <LiveDate class="live-date" :value="creationTimestamp" /></span>
           <span v-if="value.showPodRestarts">{{ t("resourceDetail.masthead.restartCount") }}:<span class="live-data"> {{ value.restartCount }}</span></span>
         </div>
       </div>

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -1,8 +1,6 @@
 <script>
 import { KUBERNETES, PROJECT } from '@shell/config/labels-annotations';
-import {
-  FLEET, NAMESPACE, MANAGEMENT, HELM, CAPI
-} from '@shell/config/types';
+import { FLEET, NAMESPACE, MANAGEMENT, HELM } from '@shell/config/types';
 import ButtonGroup from '@shell/components/ButtonGroup';
 import { BadgeState } from '@components/BadgeState';
 import { Banner } from '@components/Banner';
@@ -356,16 +354,6 @@ export default {
 
       return parent?.location;
     },
-
-    // provision.cluster uses custom model prop 'creationTimestamp'
-    // unlike other resources which default to 'metadata.creationTimestamp'
-    creationTimestamp() {
-      if (this.resource === CAPI.RANCHER_CLUSTER) {
-        return get(this.value, 'creationTimestamp');
-      }
-
-      return get(this.value, 'metadata.creationTimestamp');
-    }
   },
 
   methods: {
@@ -404,7 +392,7 @@ export default {
           <span v-if="isNamespace && project">{{ t("resourceDetail.masthead.project") }}: <nuxt-link :to="project.detailLocation">{{ project.nameDisplay }}</nuxt-link></span>
           <span v-else-if="isWorkspace">{{ t("resourceDetail.masthead.workspace") }}: <nuxt-link :to="workspaceLocation">{{ namespace }}</nuxt-link></span>
           <span v-else-if="namespace && !hasMultipleNamespaces">{{ t("resourceDetail.masthead.namespace") }}: <nuxt-link :to="namespaceLocation">{{ namespace }}</nuxt-link></span>
-          <span v-if="parent.showAge">{{ t("resourceDetail.masthead.age") }}: <LiveDate class="live-date" :value="creationTimestamp" /></span>
+          <span v-if="parent.showAge">{{ t("resourceDetail.masthead.age") }}: <LiveDate class="live-date" :value="value.creationTimestamp" /></span>
           <span v-if="value.showPodRestarts">{{ t("resourceDetail.masthead.restartCount") }}:<span class="live-data"> {{ value.restartCount }}</span></span>
         </div>
       </div>

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -10,6 +10,14 @@ import { DSL } from '@shell/store/type-map';
 
 export const NAME = 'manager';
 
+// hack the table header for AGE on provisioning.cluster
+// to display the custom model prop 'creationTimestamp'
+const PROV_CLUSTER_AGE_HEADER = { ...AGE };
+
+PROV_CLUSTER_AGE_HEADER.value = 'creationTimestamp';
+PROV_CLUSTER_AGE_HEADER.getValue = row => row.creationTimestamp;
+PROV_CLUSTER_AGE_HEADER.sort = 'creationTimestamp:desc';
+
 export function init(store) {
   const {
     product,
@@ -157,7 +165,7 @@ export function init(store) {
       formatter: 'ClusterProvider',
     },
     MACHINE_SUMMARY,
-    AGE,
+    PROV_CLUSTER_AGE_HEADER,
     {
       name:  'explorer',
       label: ' ',

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -10,14 +10,6 @@ import { DSL } from '@shell/store/type-map';
 
 export const NAME = 'manager';
 
-// hack the table header for AGE on provisioning.cluster
-// to display the custom model prop 'creationTimestamp'
-const PROV_CLUSTER_AGE_HEADER = { ...AGE };
-
-PROV_CLUSTER_AGE_HEADER.value = 'creationTimestamp';
-PROV_CLUSTER_AGE_HEADER.getValue = row => row.creationTimestamp;
-PROV_CLUSTER_AGE_HEADER.sort = 'creationTimestamp:desc';
-
 export function init(store) {
   const {
     product,
@@ -165,7 +157,7 @@ export function init(store) {
       formatter: 'ClusterProvider',
     },
     MACHINE_SUMMARY,
-    PROV_CLUSTER_AGE_HEADER,
+    AGE,
     {
       name:  'explorer',
       label: ' ',

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -220,9 +220,9 @@ export const PODS = {
 export const AGE = {
   name:      'age',
   labelKey:  'tableHeaders.age',
-  value:     'metadata.creationTimestamp',
-  getValue:  row => row.metadata?.creationTimestamp,
-  sort:      'metadata.creationTimestamp:desc',
+  value:     'creationTimestamp',
+  getValue:  row => row.creationTimestamp,
+  sort:      'creationTimestamp:desc',
   search:    false,
   formatter: 'LiveDate',
   width:     100,

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -33,6 +33,21 @@ export default class ProvCluster extends SteveModel {
     return out;
   }
 
+  // using this computed because on the provisioning cluster we are
+  // displaying the oldest age between provisioning.cluster and management.cluster
+  // so that on a version upgrade of Rancher (ex: 2.5.x to 2.6.x)
+  // we can have the correct age of the cluster displayed on the UI side
+  get creationTimestamp() {
+    const provCreationTimestamp = Date.parse(this.metadata.creationTimestamp);
+    const mgmtCreationTimestamp = Date.parse(this.mgmt?.metadata?.creationTimestamp);
+
+    if (mgmtCreationTimestamp && mgmtCreationTimestamp < provCreationTimestamp) {
+      return this.mgmt?.metadata?.creationTimestamp;
+    }
+
+    return this.metadata.creationTimestamp;
+  }
+
   get availableActions() {
     // No actions for Harvester clusters
     if (this.isHarvester) {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -38,14 +38,14 @@ export default class ProvCluster extends SteveModel {
   // so that on a version upgrade of Rancher (ex: 2.5.x to 2.6.x)
   // we can have the correct age of the cluster displayed on the UI side
   get creationTimestamp() {
-    const provCreationTimestamp = Date.parse(this.metadata.creationTimestamp);
+    const provCreationTimestamp = Date.parse(this.metadata?.creationTimestamp);
     const mgmtCreationTimestamp = Date.parse(this.mgmt?.metadata?.creationTimestamp);
 
     if (mgmtCreationTimestamp && mgmtCreationTimestamp < provCreationTimestamp) {
       return this.mgmt?.metadata?.creationTimestamp;
     }
 
-    return this.metadata.creationTimestamp;
+    return super.creationTimestamp;
   }
 
   get availableActions() {

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1816,4 +1816,8 @@ export default class Resource {
 
     return out;
   }
+
+  get creationTimestamp() {
+    return this.metadata?.creationTimestamp;
+  }
 }


### PR DESCRIPTION
Addresses Github issue: [#4966](https://github.com/rancher/dashboard/issues/4966)
Addresses Zube issue: [#4988](https://zube.io/rancher/dashboard-ui/c/4988)

- Create custom model prop for `provisioning.cluster` in order to display correct age of a cluster in the case of an upgrade in Rancher version

**New date prop for list view table headers for `prov.cluster` _(hacked the date itself to make sure it worked where I wanted)_**
<img width="804" alt="Screenshot 2022-05-19 at 15 00 16" src="https://user-images.githubusercontent.com/97888974/169315704-7a8c4b31-f682-4532-9fa9-16a77d14b896.png">

**New date prop for detail view in `prov.cluster`**
<img width="804" alt="Screenshot 2022-05-19 at 15 00 23" src="https://user-images.githubusercontent.com/97888974/169315728-d95ed3ef-3f98-4a27-a029-2b40dfaba830.png">

**Cluster Dashboard view remains with `mgmt cluster` date**
<img width="804" alt="Screenshot 2022-05-19 at 15 17 04" src="https://user-images.githubusercontent.com/97888974/169315740-7295bb80-74ad-4b82-a12c-37e2b2216659.png">


