### PR TITLE
Change name of event emitted for secret selector

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -271,7 +271,7 @@ export default {
       @search:focus="onFocus"
       @search="onSearch"
       @open="onOpen"
-      @option:selecting="$emit('input', $event)"
+      @option:selecting="$emit('selecting', $event)"
     >
       <template #option="option">
         <template v-if="option.kind === 'group'">

--- a/shell/components/form/SimpleSecretSelector.vue
+++ b/shell/components/form/SimpleSecretSelector.vue
@@ -135,7 +135,7 @@ export default {
         :options="secretNames"
         :label="secretNameLabel"
         :mode="mode"
-        @input="updateSecretName(name)"
+        @selecting="updateSecretName(name)"
       />
       <LabeledSelect
         v-model="key"
@@ -144,7 +144,7 @@ export default {
         :options="keys"
         :label="keyNameLabel"
         :mode="mode"
-        @input="updateSecretKey(key)"
+        @selecting="updateSecretKey(key)"
       />
     </div>
   </div>


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5984

Follow-up to https://github.com/rancher/dashboard/pull/5989

In this PR https://github.com/rancher/dashboard/pull/5850 I modified the LabeledInput component to make it emit an event that I needed for the new SimpleSecretSelector component, which is used only by AlertmanagerConfig receivers. The event could have been named anything. So I could have called it 'eventSpecificallyForSelectingReceiverSecret', but instead I went with the name 'input' because the component was supposed to be generic.

But it turns out the former name would have been better, because emitting the 'input' event more times has created this bug. https://github.com/rancher/dashboard/issues/5984

So I renamed the event to "selecting", which still sounds generic but is not used anywhere else in the dashboard. Renaming it (instead of removing it) is needed to fix the bug while retaining functionality for the secret selector.

I tested this PR by following the steps to reproduce https://github.com/rancher/dashboard/issues/5984 and it worked. 