### PR TITLE
Hide plugins nav unless running in dev mode

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -112,14 +112,17 @@ export default {
       const items = options.filter(opt => opt.category === 'configuration');
 
       // Add plugin page
-      items.push({
-        label:   'Plugins',
-        inStore: 'management',
-        icon:    'icon-gear',
-        value:   'plugins',
-        weight:  1,
-        to:      { name: 'plugins' },
-      });
+      // Ony when developing for now
+      if (process.env.dev) {
+        items.push({
+          label:   'Plugins',
+          inStore: 'management',
+          icon:    'icon-gear',
+          value:   'plugins',
+          weight:  1,
+          to:      { name: 'plugins' },
+        });
+      }
 
       return items;
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["@types/node", "@types/jest", "@nuxt/types"]
   },
-  "exclude": ["node_modules", ".nuxt", "dist", "cypress", "shell/creators"]
+  "exclude": ["node_modules", ".nuxt", "dist", "dist-pkg", "cypress", "shell/creators"]
 }


### PR DESCRIPTION
Hides plugins in the top-level nav for now, since they are still in development

Adds `dist-pkg` folder to the tsconfig excludes, to avoid errors when packages have been built and are in this folder.