### PR TITLE
Multiple issues in Fleet (Dashboard and gitRepo Graph views)

### DIFF
--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -91,7 +91,7 @@ export default class FleetBundle extends SteveModel {
   }
 
   get stateObj() {
-    const errorState = this.status.conditions.find((item) => {
+    const errorState = this.status?.conditions?.find((item) => {
       const { error, message } = item;
       const errState = !!error;
 

--- a/shell/pages/c/_cluster/fleet/GitRepoGraphConfig.js
+++ b/shell/pages/c/_cluster/fleet/GitRepoGraphConfig.js
@@ -65,7 +65,7 @@ export const gitRepoGraphConfig = {
 
       bds.forEach((bd) => {
         const bdLowercaseState = bd.state ? bd.state.toLowerCase() : 'unknown';
-        const bdStateColor = STATES[bdLowercaseState].color;
+        const bdStateColor = STATES[bdLowercaseState]?.color;
 
         const cluster = data.clustersList.find((cluster) => {
           const clusterString = `${ cluster.namespace }-${ cluster.name }`;

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -89,6 +89,7 @@ export const STATES_ENUM = {
   DEGRADED:         'degraded',
   DENIED:           'denied',
   DEPLOYED:         'deployed',
+  DEPLOYING:         'deploying',
   DISABLED:         'disabled',
   DISCONNECTED:     'disconnected',
   DRAINED:          'drained',
@@ -427,6 +428,9 @@ export const STATES = {
   },
   [STATES_ENUM.WARNING]:            {
     color: 'warning', icon: 'error', label: 'Warning', compoundIcon: 'warning'
+  },
+  [STATES_ENUM.DEPLOYING]:            {
+    color: 'info', icon: 'info', label: 'Deploying', compoundIcon: 'info'
   },
 };
 

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -429,7 +429,7 @@ export const STATES = {
   [STATES_ENUM.WARNING]:            {
     color: 'warning', icon: 'error', label: 'Warning', compoundIcon: 'warning'
   },
-  [STATES_ENUM.DEPLOYING]:            {
+  [STATES_ENUM.DEPLOYING]:          {
     color: 'info', icon: 'info', label: 'Deploying', compoundIcon: 'info'
   },
 };

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -89,7 +89,7 @@ export const STATES_ENUM = {
   DEGRADED:         'degraded',
   DENIED:           'denied',
   DEPLOYED:         'deployed',
-  DEPLOYING:         'deploying',
+  DEPLOYING:        'deploying',
   DISABLED:         'disabled',
   DISCONNECTED:     'disconnected',
   DRAINED:          'drained',


### PR DESCRIPTION
Addresses Github issue: [#6007](https://github.com/rancher/dashboard/issues/6007)
Addresses Zube issue: [#6036](https://zube.io/rancher/dashboard-ui/c/6036)

- add missing prop check for `stateObj` in `FleetBundle` model
- add missing prop check for `color` when state is not defined as ENUM in `gitRepoChartConfig`
- add missing state `deploying` to state ENUM