### PR TITLE
Expose `row.row` as row-actions slot prop

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -945,7 +945,10 @@ export default {
                   </slot>
                 </template>
                 <td v-if="rowActions" align="middle">
-                  <slot name="row-actions" :row="row">
+                  <slot
+                    name="row-actions"
+                    :row="row.row"
+                  >
                     <button
                       :id="`actionButton+${i}+${(row.row && row.row.name) ? row.row.name : ''}`"
                       :ref="`actionButton${i}`"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This backports a fix for an issue uncovered with Sortable Table in Rancher Desktop. We noticed a regression in the way we access row values via the `row-actions` slot prop. Where we used to be able to access row data via `<template #row-actions="{row}">`, we now had to make use of ` <template #row-actions="{row.row}">`. 

The `row.row` pattern was introduced in #5435. Other slots were updated (e.g. `sub-row`), but this one appears to have been missed.  

backports fix for rancher-sandbox/rancher-desktop#2244

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Any component that makes use of the `row-actions` slot. I was unable to uncover any in Rancher Dashboard, but I'd recommend searching for instances on your own.

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>