### PR TITLE
Resync watch resource if receive stop event

### DIFF
--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -8,6 +8,7 @@ import Socket, {
   EVENT_CONNECT_ERROR
 } from '@shell/utils/socket';
 import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
+import { SCHEMA } from '@shell/config/types';
 
 export const NO_WATCH = 'NO_WATCH';
 export const NO_SCHEMA = 'NO_SCHEMA';
@@ -299,6 +300,12 @@ export const actions = {
       return;
     }
 
+    if (resourceType === SCHEMA) {
+      await dispatch('loadSchemas', true);
+
+      return;
+    }
+
     let have, want;
 
     if ( selector ) {
@@ -442,9 +449,10 @@ export const actions = {
     const type = msg.resourceType;
     const obj = {
       type,
-      id:        msg.id,
-      namespace: msg.namespace,
-      selector:  msg.selector
+      resourceType: type,
+      id:           msg.id,
+      namespace:    msg.namespace,
+      selector:     msg.selector,
     };
 
     // console.warn(`Resource stop: [${ getters.storeName }]`, msg); // eslint-disable-line no-console
@@ -457,7 +465,7 @@ export const actions = {
       setTimeout(() => {
         // Delay a bit so that immediate start/error/stop causes
         // only a slow infinite loop instead of a tight one.
-        dispatch('watch', obj);
+        dispatch('resyncWatch', obj);
       }, 5000);
     }
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->
https://github.com/rancher/dashboard/issues/5997



### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Call the `dispatch('resyncWatch', obj)`  instead of the `dispatch('watch', obj);`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The UI should not compare the resourceVersion of a collection with the resourceVersion of a collection element to get the maximum value as the watch's resourceVersion parameter, because the resourceVersion of a collection is not the same concept as the resourceVersion of a collection element, refer to the following Link:
https://kubernetes.io/docs/reference/using-api/api-concepts/#resourceversion-in-metadata

ui code: 
https://github.com/rancher/dashboard/blob/master/shell/plugins/steve/subscribe.js#L604-L612

