### PR TITLE
Add back storybook scripts to the package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,12 @@
     "cy:open": "cypress open",
     "e2e:pre": "NODE_ENV=dev yarn build",
     "e2e:run": "NODE_ENV=dev START_SERVER_AND_TEST_INSECURE=1 start-server-and-test start  https://localhost:8005/ cy:run",
-    "e2e:dev": "start-server-and-test dev https://localhost:8005 cy:open"
+    "e2e:dev": "start-server-and-test dev https://localhost:8005 cy:open",
+    "storybook": "yarn run install-storybook && start-storybook -s .storybook/public,assets -p 6006",
+    "build-storybook": "yarn run install-storybook && build-storybook -s .storybook/public,assets",
+    "install-storybook": "./scripts/storybook-install",
+    "remove-storybook": "./scripts/storybook-install -d",
+    "remove-storybook-deps": "./scripts/storybook-install -r"    
   },
   "dependencies": {
     "@aws-sdk/client-ec2": "^3.1.0",


### PR DESCRIPTION
Looks like with the plugin work, we lost the storybook scripts in the package file.

This PR brings them back.