### PR TITLE
Replace JQuery in TextAreaAutoGrow and Checkbox

### DIFF
--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -37,7 +37,6 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "7.14.0",
-    "jquery": "^3.6.0",
     "jsonpath-plus": "^6.0.1",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -1,6 +1,4 @@
 <script>
-// TODO: Issue #5070 Remove jquery dep
-import $ from 'jquery';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import { addObject, removeObject } from '@shell/utils/array';
 
@@ -85,12 +83,14 @@ export default {
         return;
       }
 
-      const click = $.Event('click');
-
-      click.shiftKey = event.shiftKey;
-      click.altKey = event.altKey;
-      click.ctrlKey = event.ctrlKey;
-      click.metaKey = event.metaKey;
+      const click = new CustomEvent('click', {
+        bubbles: true,
+        cancelable: false,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey
+      })
 
       // Flip the value
       if (this.isMulti()) {
@@ -102,7 +102,7 @@ export default {
         this.$emit('input', this.value);
       } else {
         this.$emit('input', !this.value);
-        $(this.$el).trigger(click);
+        this.$el.dispatchEvent(click);
       }
     },
 

--- a/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
+++ b/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
@@ -1,5 +1,4 @@
 <script>
-import $ from 'jquery';
 import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 
@@ -68,7 +67,7 @@ export default {
   },
 
   mounted() {
-    $(this.$refs.ta).css('height', `${ this.curHeight }px`);
+    this.$refs.ta.style.height = `${ this.curHeight }px`;
     this.$nextTick(() => {
       this.autoSize();
     });
@@ -91,15 +90,15 @@ export default {
         return;
       }
 
-      const $el = $(el);
+      const $el = el;
 
-      $el.css('height', '1px');
+      $el.style.height = '1px';
 
-      const border = parseInt($el.css('borderTopWidth'), 10) || 0 + parseInt($el.css('borderBottomWidth'), 10) || 0;
+      const border = parseInt(getComputedStyle($el)['borderTopWidth'], 10) || 0 + parseInt(getComputedStyle($el)['borderBottomWidth'], 10) || 0;
       const neu = Math.max(this.minHeight, Math.min(el.scrollHeight + border, this.maxHeight));
 
-      $el.css('overflowY', (el.scrollHeight > neu ? 'auto' : 'hidden'));
-      $el.css('height', `${ neu }px`);
+      $el.style.overflowY = el.scrollHeight > neu ? 'auto' : 'hidden';
+      $el.style.height = `${ neu }px`;
 
       this.curHeight = neu;
     }

--- a/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
+++ b/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
@@ -92,7 +92,7 @@ export default {
 
       el.style.height = '1px';
 
-      const border = parseInt(getComputedStyle(el)['borderTopWidth'], 10) || 0 + parseInt(getComputedStyle(el)['borderBottomWidth'], 10) || 0;
+      const border = parseInt(getComputedStyle(el).getPropertyValue('borderTopWidth'), 10) || 0 + parseInt(getComputedStyle(el).getPropertyValue('borderBottomWidth'), 10) || 0;
       const neu = Math.max(this.minHeight, Math.min(el.scrollHeight + border, this.maxHeight));
 
       el.style.overflowY = el.scrollHeight > neu ? 'auto' : 'hidden';

--- a/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
+++ b/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
@@ -90,15 +90,13 @@ export default {
         return;
       }
 
-      const $el = el;
+      el.style.height = '1px';
 
-      $el.style.height = '1px';
-
-      const border = parseInt(getComputedStyle($el)['borderTopWidth'], 10) || 0 + parseInt(getComputedStyle($el)['borderBottomWidth'], 10) || 0;
+      const border = parseInt(getComputedStyle(el)['borderTopWidth'], 10) || 0 + parseInt(getComputedStyle(el)['borderBottomWidth'], 10) || 0;
       const neu = Math.max(this.minHeight, Math.min(el.scrollHeight + border, this.maxHeight));
 
-      $el.style.overflowY = el.scrollHeight > neu ? 'auto' : 'hidden';
-      $el.style.height = `${ neu }px`;
+      el.style.overflowY = el.scrollHeight > neu ? 'auto' : 'hidden';
+      el.style.height = `${ neu }px`;
 
       this.curHeight = neu;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11106,11 +11106,6 @@ jquery@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
 
-jquery@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
-
 js-base64@^2.1.9:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.3.tgz#7afdb9b57aa7717e15d370b66e8f36a9cb835dc3"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This removes the JQuery dependency from `TextAreaAutoGrow.vue` and `Checkbox.vue` by replacing jquery implementations with browser api implementations. 

- Triggering Custom Events 
  - Replace `$(this.$el).trigger(click);` with `this.$el.dispatchEvent(click);` 
  - See MDN docs for [creating a custom event](https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events#adding_custom_data_%E2%80%93_customevent) 
- Setting Styles
  - Replaces ```$(this.$refs.ta).css('height', `${ this.curHeight }px`);``` with ```this.$refs.ta.style.height = `${ this.curHeight }px`;```
  - See MDN docs for [HTMLElement.style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style)
- Getting Styles
  - Replaces `$el.css('borderTopWidth')` with `getComputedStyle(el).getPropertyValue('borderTopWidth')`
  - See MDN docs for [Window.getComputedStyle()](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle)

Contributes to #5070 
<!-- Define findings related to the feature or bug issue. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

We need to check for regressions in any page that makes use of 

- `Checkbox.vue`
- `TextAreaAutoGrow.vue`
- `LabeledInput.vue` (makes use of `TextAreaAutoGrow.vue`)
