### PR TITLE
AlertmanagerConfig detail page renders properly

### DIFF
--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -36,7 +36,7 @@ export default {
 
     this.alertmanagerConfigId = alertmanagerConfigId;
     this.alertmanagerConfigResource = alertmanagerConfigResource;
-    this.alertmanagerConfigDetailRoute = alertmanagerConfigResource.getAlertmanagerConfigDetailRoute();
+    this.alertmanagerConfigDetailRoute = alertmanagerConfigResource._detailLocation;
 
     const alertmanagerConfigActions = alertmanagerConfigResource.availableActions;
     const receiverActions = alertmanagerConfigResource.getReceiverActions(alertmanagerConfigActions);

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -229,7 +229,7 @@ export default {
     },
 
     redirectAfterCancel() {
-      this.$router.push(this.alertmanagerConfigResource.getAlertmanagerConfigDetailRoute());
+      this.$router.push(this.alertmanagerConfigResource._detailLocation);
     },
 
     createAddOptions(receiverType) {
@@ -242,7 +242,7 @@ export default {
 <template>
   <CruResource
     class="receiver"
-    :done-route="alertmanagerConfigResource.getAlertmanagerConfigDetailRoute()"
+    :done-route="alertmanagerConfigResource._detailLocation"
     :mode="mode"
     :resource="alertmanagerConfigResource"
     :subtypes="[]"

--- a/shell/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/shell/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -54,7 +54,7 @@ export default class AlertmanagerConfig extends SteveModel {
     return 'c-cluster-product-resource-namespace-id';
   }
 
-  getAlertmanagerConfigDetailRoute() {
+  get _detailLocation() {
     return {
       name:   this.alertmanagerConfigDoneRouteName,
       params: {
@@ -64,7 +64,8 @@ export default class AlertmanagerConfig extends SteveModel {
         namespace: this.metadata?.namespace,
         id:        this.name,
       },
-      hash: '#receivers'
+      hash:  '#receivers',
+      query: { as: 'config' }
     };
   }
 

--- a/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
+++ b/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
@@ -43,7 +43,7 @@ export default {
 
     this.alertmanagerConfigId = alertmanagerConfigResource.id;
     this.alertmanagerConfigResource = alertmanagerConfigResource;
-    this.alertmanagerConfigDetailRoute = alertmanagerConfigResource.getAlertmanagerConfigDetailRoute();
+    this.alertmanagerConfigDetailRoute = alertmanagerConfigResource._detailLocation;
   },
 
   // take edit link and edit request from AlertmanagerConfig resource
@@ -210,13 +210,13 @@ export default {
       this.alertmanagerConfigResource.spec.receivers = receiversMinusDeletedItem;
       // After saving the AlertmanagerConfig, the resource has been deleted.
       this.alertmanagerConfigResource.save(...arguments);
-      this.$router.push(this.alertmanagerConfigResource.getAlertmanagerConfigDetailRoute());
+      this.$router.push(this.alertmanagerConfigResource._detailLocation);
     },
     redirectToReceiverDetail(receiverName) {
       return this.alertmanagerConfigResource.getReceiverDetailLink(receiverName);
     },
     redirectToAlertmanagerConfigDetail() {
-      const route = this.alertmanagerConfigResource.getAlertmanagerConfigDetailRoute();
+      const route = this.alertmanagerConfigResource._detailLocation;
 
       this.$router.push(route);
     }


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6044 by passing the query "as: 'config'" into the AlertmanagerConfig detail route.

By default, it was using `as: 'detail'`, which made Rancher look for a nonexistent detail component.

To test, I used the same steps to reproduce the above linked issue.

<img width="1312" alt="Screen Shot 2022-05-26 at 2 32 13 PM" src="https://user-images.githubusercontent.com/20599230/170584654-8ecdd3d3-cbd5-4e7c-8050-47f6b66fb841.png">
