### PR TITLE
Change header when navigating from receiver form to YAML

### DIFF
--- a/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
+++ b/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
@@ -134,7 +134,7 @@ export default {
       case this.create:
         return this.t('monitoring.alertmanagerConfig.receiverFormNames.create');
       case this.edit:
-        if (this.currentView === this.yaml) {
+        if (this.currentView === this.yaml || this.$route.query.as === this.yaml) {
           // When you edit as YAML, you edit the whole AlertmanagerConfig
           // at once, so the header is just "Edit AlertmanagerConfig"
           return this.t('monitoring.alertmanagerConfig.receiverFormNames.editYaml');


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/5879

Depends on https://github.com/rancher/dashboard/commit/1fb8fee218178031ee5047e0083992b03d6b633b to be merged first


Here is the edit receiver form:
<img width="1456" alt="Screen Shot 2022-05-26 at 4 13 47 PM" src="https://user-images.githubusercontent.com/20599230/170594269-08ce0673-f0e3-4856-9b32-72df22c94122.png">

When you click Edit As YAML, the header now changes to Edit AlertmanagerConfig:
<img width="1444" alt="Screen Shot 2022-05-26 at 4 13 53 PM" src="https://user-images.githubusercontent.com/20599230/170594308-ee2e2ebc-2d71-4eb6-8925-f920aae014a1.png">
