### PR TITLE
Use patch when updating storage class default

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1744,6 +1744,10 @@ containerResourceLimit:
   requestsMemory: Memory Reservation
 
 
+resource:
+  errors:
+    update: "Error updating {name}"
+
 cruResource:
   backToForm: Back to Form
   backBody: You will lose any changes made to the YAML.

--- a/shell/models/storage.k8s.io.storageclass.js
+++ b/shell/models/storage.k8s.io.storageclass.js
@@ -79,9 +79,22 @@ export default class extends SteveModel {
   }
 
   updateDefault(value) {
+    // Update model so that the list reflects the change straight away
     this.setAnnotation(STORAGE.DEFAULT_STORAGE_CLASS, value.toString());
     this.setAnnotation(STORAGE.BETA_DEFAULT_STORAGE_CLASS, value.toString());
-    this.save();
+
+    // Patch the annotations rather than saving the whole object, as ssome storage classes
+    // won't allow the complete object to be saved again
+    const data = {
+      metadata: {
+        annotations: {
+          [STORAGE.DEFAULT_STORAGE_CLASS]:      value.toString(),
+          [STORAGE.BETA_DEFAULT_STORAGE_CLASS]: value.toString()
+        }
+      }
+    };
+
+    return this.patch(data, {}, true, true);
   }
 
   setDefault() {

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1034,17 +1034,35 @@ export default class Resource {
 
   // ------------------------------------------------------------------
 
-  patch(data, opt = {}) {
+  patch(data, opt = {}, merge = false, alertOnError = false) {
     if ( !opt.url ) {
-      opt.url = this.linkFor('self');
+      // Workaround for the links not being correct - view link is the only one that seems correct
+      opt.url = this.linkFor('view') || this.linkFor('self');
     }
 
     opt.method = 'patch';
     opt.headers = opt.headers || {};
-    opt.headers['content-type'] = 'application/json-patch+json';
+
+    if (!opt.headers['content-type']) {
+      const contentType = merge ? 'application/strategic-merge-patch+json' : 'application/json-patch+json';
+
+      opt.headers['content-type'] = contentType;
+    }
     opt.data = data;
 
-    return this.$dispatch('request', { opt, type: this.type } );
+    const dispatch = this.$dispatch('request', { opt, type: this.type } );
+
+    return !alertOnError ? dispatch : dispatch.catch((e) => {
+      const title = this.t('resource.errors.update', { name: this.name });
+
+      console.error(title, e); // eslint-disable-line no-console
+
+      this.$dispatch('growl/error', {
+        title,
+        message: e?.message,
+        timeout: 5000
+      }, { root: true });
+    });
   }
 
   save() {


### PR DESCRIPTION
Fixes #5831 

Need to patch the storage class rather than save to set default status - with some storage providers, doing a full save is rejected after creation.