### PR TITLE
Can add ProjectHelmChart resource to custom roles

### DIFF
--- a/shell/config/roles.ts
+++ b/shell/config/roles.ts
@@ -266,6 +266,11 @@ export const SCOPED_RESOURCES = {
         'Events',
       ]
     },
+    'helm.cattle.io': {
+      resources: [
+        'ProjectHelmCharts',
+      ]
+    },
     'monitoring.coreos.com': {
       resources: [
         'Alertmanagers',

--- a/shell/edit/helm.cattle.io.projecthelmchart.vue
+++ b/shell/edit/helm.cattle.io.projecthelmchart.vue
@@ -123,7 +123,7 @@ export default {
     <div class="row">
       <div class="col span-12">
         <Tabbed
-          v-if="!!currentNamespace"
+          v-if="!!currentNamespace && selectedNamespaceQuestions"
           ref="tabs"
           :side-tabs="true"
         >


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5747 by adding the ProjectHelmChart resource to the list of resources available to choose from when you create a custom role.

To test this PR,

1. I went to Users & Authentication > Roles.
2. Created a project role and confirmed that you can select `ProjectHelmCharts` from the `helm.cattle.io` API group.
<img width="1591" alt="Screen Shot 2022-05-27 at 2 36 59 AM" src="https://user-images.githubusercontent.com/20599230/170675988-e6d51256-a210-4b3e-a1b6-3ed151c07f1e.png">
3. Confirmed that when you select `ProjectHelmCharts`, the `helm.cattle.io` API group is automatically populated in the API Groups field.


4. Gave all verbs to the role and named it `test-project-helm-chart`. Finished creating the role.

Then I confirmed that the role gives a standard user sufficient permissions by doing the following:

5. Installed the monitoring app in the `system` project on a downstream RKE2 cluster.
6. Installed the Prometheus Federator app on the downstream cluster.
7. Created a project monitor in the `default` project. (This is basically just another name for ProjectHelmChart.)
8. Created a standard user named `test-user`.
9. Went to the `default` project and added `test-user` to the project. Selected the role `test-project-helm-chart` when adding the user.
<img width="1672" alt="Screen Shot 2022-05-27 at 2 39 47 AM" src="https://user-images.githubusercontent.com/20599230/170677102-19ef310e-d00d-456e-b0e0-14a5c3e5f2a8.png">
10. Confirmed that I could see the existing project helm chart listed under More Resources > K3s > Project Monitors. Note: The K3s grouping will change to Helm in the future.
<img width="1489" alt="Screen Shot 2022-05-27 at 2 41 14 AM" src="https://user-images.githubusercontent.com/20599230/170677392-734a5cd3-4547-448f-8467-00c4c772e90f.png">
11. Confirmed that the standard user could edit the project monitor description. Note: The standard user doesn't have permission to see the source for the questions.yaml, so I hid that if the source was not present to prevent the UI from crashing.

