### PR TITLE
Group ProjectHelmChart resources under Helm, not K3s

### DIFF
--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -116,7 +116,8 @@ export function init(store) {
   mapGroup(/^(.*\.)?tigera\.io$/, 'Tigera');
   mapGroup(/^(.*\.)?longhorn(\.rancher)?\.io$/, 'Longhorn');
   mapGroup(/^(.*\.)?(fleet|gitjob)\.cattle\.io$/, 'Fleet');
-  mapGroup(/^(.*\.)?(helm|k3s)\.cattle\.io$/, 'K3s');
+  mapGroup(/^(.*\.)?(k3s)\.cattle\.io$/, 'K3s');
+  mapGroup(/^(.*\.)?(helm)\.cattle\.io$/, 'Helm');
   mapGroup(/^(.*\.)?upgrade\.cattle\.io$/, 'Upgrade Controller');
   mapGroup(/^(.*\.)?cis\.cattle\.io$/, 'CIS');
   mapGroup(/^(.*\.)?traefik\.containo\.us$/, 'Træfik');


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5746 by changing how resource type names are mapped to group names in the side nav of cluster explorer.

Previously, both `helm` and `k3s` in the type name mapped to the K3s group name. Now `k3s` maps to K3s and `helm` maps to Helm.

To test this PR,

1. I installed the monitoring app and the Prometheus Federator app in a downstream RKE2 cluster.
2. Went to cluster explorer in the downstream cluster. In the top nav, clicked the magnifying glass. Confirmed that when searching for `proj...` you can see Project Monitors grouped under Helm.
3. In the side nav of cluster explorer, you can also see Project Monitors grouped under Helm.

<img width="1222" alt="Screen Shot 2022-05-27 at 3 08 49 AM" src="https://user-images.githubusercontent.com/20599230/170681339-2f77d519-dddb-4267-a142-c1416896b816.png">

<img width="366" alt="Screen Shot 2022-05-27 at 3 09 20 AM" src="https://user-images.githubusercontent.com/20599230/170681386-3efbcdb0-4d94-4922-8674-5fa2394ff76f.png">



