### PR TITLE
Workload events tab

### DIFF
--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -58,6 +58,11 @@ export default {
     needRelated: {
       type:    Boolean,
       default: true
+    },
+
+    alwaysShowEvents: {
+      type:    Boolean,
+      default: false
     }
   },
 
@@ -84,7 +89,7 @@ export default {
       return this.isView && this.needConditions && this.value?.type && this.$store.getters[`${ inStore }/pathExistsInSchema`](this.value.type, 'status.conditions');
     },
     showEvents() {
-      return this.isView && this.needEvents && !this.$fetchState.pending && this.hasEvents && this.events.length;
+      return this.isView && this.needEvents && !this.$fetchState.pending && this.hasEvents && (this.events.length || this.alwaysShowEvents);
     },
     showRelated() {
       return this.isView && this.needRelated && !this.$fetchState.pending;
@@ -92,14 +97,20 @@ export default {
     eventHeaders() {
       return [
         {
+          name:  'type',
+          label: this.t('tableHeaders.type'),
+          value: 'eventType',
+          sort:  'eventType',
+        },
+        {
           name:  'reason',
-          label: 'Reason',
+          label: this.t('tableHeaders.reason'),
           value: 'reason',
           sort:  'reason',
         },
         {
           name:          'date',
-          label:         'Updated',
+          label:         this.t('tableHeaders.updated'),
           value:         'date',
           sort:          'date:desc',
           formatter:     'LiveDate',
@@ -108,7 +119,7 @@ export default {
         },
         {
           name:  'message',
-          label: 'Message',
+          label: this.t('tableHeaders.message'),
           value: 'message',
           sort:  'message',
         },
@@ -119,9 +130,10 @@ export default {
         return event.involvedObject?.uid === this.value?.metadata?.uid;
       }).map((event) => {
         return {
-          reason:  (`${ event.reason || 'Unknown' }${ event.count > 1 ? ` (${ event.count })` : '' }`).trim(),
-          message: event.message || 'Unknown',
-          date:    event.lastTimestamp || event.firstTimestamp || event.metadata.creationTimestamp,
+          reason:    (`${ event.reason || this.t('generic.unknown') }${ event.count > 1 ? ` (${ event.count })` : '' }`).trim(),
+          message:   event.message || this.t('generic.unknown'),
+          date:      event.lastTimestamp || event.firstTimestamp || event.metadata.creationTimestamp,
+          eventType: event.eventType
         };
       });
     },

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -257,7 +257,7 @@ export default {
         />
       </template>
     </div>
-    <ResourceTabs :value="value">
+    <ResourceTabs :value="value" :always-show-events="true">
       <Tab v-if="isCronJob" name="jobs" :label="t('tableHeaders.jobs')" :weight="4">
         <SortableTable
           :rows="value.jobs"

--- a/shell/models/event.js
+++ b/shell/models/event.js
@@ -20,4 +20,8 @@ export default class K8sEvent extends SteveModel {
   get timestamp() {
     return this.lastTimestamp || this.metadata?.creationTimestamp;
   }
+
+  get eventType() {
+    return this._type;
+  }
 }


### PR DESCRIPTION
Fixes #6057 

For workload types, always show the recent event tabs. Since these are schedulable resources, it is useful to see the tab - this gives parity with the Ember UI.

I did not show the tab in all cases, as for other resource types it may lead to lots of tabs - this is generally less relevant, so can be shown only when there are recent events.

Also added the event type column, so that the view shows the same data as the Ember UI.

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/1955897/170698770-b6b86611-598d-4938-aba1-6bd50d8aad0f.png">
