### PR TITLE
Ensure custom detail page for a Pod shows correctly

### DIFF
--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -129,7 +129,7 @@ import {
   ensureRegex, escapeHtml, escapeRegex, ucFirst, pluralize
 } from '@shell/utils/string';
 import {
-  importList, importDetail, importEdit, listProducts, loadProduct, importCustomPromptRemove, resolveList, resolveEdit, resolveWindowComponent, importWindowComponent
+  importList, importDetail, importEdit, listProducts, loadProduct, importCustomPromptRemove, resolveList, resolveEdit, resolveWindowComponent, importWindowComponent, resolveDetail
 
 } from '@shell/utils/dynamic-importer';
 
@@ -1043,7 +1043,7 @@ export const getters = {
     return (rawType, subType) => {
       const key = getters.componentFor(rawType, subType);
 
-      return hasCustom(state, rootState, 'detail', key, key => resolveList(key));
+      return hasCustom(state, rootState, 'detail', key, key => resolveDetail(key));
     };
   },
 


### PR DESCRIPTION
- Previously the YAML was shown and not the custom detail page
- Affected any resource that had a custom detail component but no custom list component
- Caused by a related partial fix https://github.com/rancher/dashboard/pull/5957
