### PR TITLE
Fix PVC expansion and add to action menu

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3507,6 +3507,9 @@ persistentVolumeClaim:
     options:
       new: Use a Storage Class to provision a new Persistent Volume
       existing: Use an existing Persistent Volume
+  expand:
+    notSupported: Storage class does not support volume expansion
+    notBound: Only bound PVCs can be expanded
   volumeClaim:
     label: Volume Claim
     storageClass: Storage Class

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3508,6 +3508,7 @@ persistentVolumeClaim:
       new: Use a Storage Class to provision a new Persistent Volume
       existing: Use an existing Persistent Volume
   expand:
+    label: Expand
     notSupported: Storage class does not support volume expansion
     notBound: Only bound PVCs can be expanded
   volumeClaim:

--- a/shell/components/form/UnitInput.vue
+++ b/shell/components/form/UnitInput.vue
@@ -183,6 +183,14 @@ export default {
   },
 
   methods: {
+    focus() {
+      const comp = this.$refs.value;
+
+      if (comp) {
+        comp.focus();
+      }
+    },
+
     update(inputValue) {
       let out = inputValue === '' ? null : inputValue;
 
@@ -202,6 +210,7 @@ export default {
 
 <template>
   <LabeledInput
+    ref="value"
     :value="displayValue"
     v-bind="$attrs"
     type="number"

--- a/shell/config/query-params.js
+++ b/shell/config/query-params.js
@@ -39,6 +39,7 @@ export const _DETAIL = 'detail';
 export const _CONFIG = 'config';
 export const _YAML = 'yaml';
 export const _GRAPH = 'graph';
+export const FOCUS = 'focus';
 
 export const PREVIEW = 'preview';
 

--- a/shell/edit/persistentvolumeclaim.vue
+++ b/shell/edit/persistentvolumeclaim.vue
@@ -8,11 +8,12 @@ import { RadioGroup } from '@components/Form/Radio';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import UnitInput from '@shell/components/form/UnitInput';
 import uniq from 'lodash/uniq';
-import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
+import { _CREATE, _EDIT, FOCUS, _VIEW } from '@shell/config/query-params';
 import { STORAGE_CLASS, PV } from '@shell/config/types';
 import StatusTable from '@shell/components/StatusTable';
 import ResourceTabs from '@shell/components/form/ResourceTabs';
 import Labels from '@shell/components/form/Labels';
+import { Banner } from '@components/Banner';
 
 const DEFAULT_STORAGE = '10Gi';
 
@@ -20,6 +21,7 @@ export default {
   name: 'PersistentVolumeClaim',
 
   components: {
+    Banner,
     Checkbox,
     CruResource,
     LabeledSelect,
@@ -73,6 +75,8 @@ export default {
       this.$set(this.value.spec, 'accessModes', defaultAccessModes);
     }
 
+    const defaultTab = this.$route.query[FOCUS] || null;
+
     return {
       sourceOptions,
       source:                  this.value.spec.volumeName ? sourceOptions[1].value : sourceOptions[0].value,
@@ -80,6 +84,7 @@ export default {
       persistentVolumeOptions: [],
       persistentVolumes:       [],
       storageClassOptions:     [],
+      defaultTab,
     };
   },
   computed: {
@@ -122,13 +127,10 @@ export default {
         this.$set(this.value.spec, 'storageClassName', '');
       }
     },
-    allowVolumeExpansion() {
-      return this.$store.getters[`cluster/byId`](STORAGE_CLASS, this.value?.spec?.storageClassName)?.allowVolumeExpansion;
-    },
     storageAmountMode() {
       if (this.isCreate) {
         return _CREATE;
-      } else if (this.isEdit && this.allowVolumeExpansion) {
+      } else if (this.isEdit && this.value.expandable && this.value.bound) {
         return _EDIT;
       }
 
@@ -137,6 +139,13 @@ export default {
   },
   created() {
     this.registerBeforeHook(this.willSave, 'willSave');
+  },
+  mounted() {
+    const focus = this.$refs.volumeSize?.focus;
+
+    if (this.defaultTab === 'volumeclaim' && focus) {
+      setTimeout(() => focus());
+    }
   },
   methods: {
     checkboxSetter(key, value) {
@@ -191,7 +200,7 @@ export default {
       :namespaced="true"
     />
 
-    <ResourceTabs v-model="value" :mode="mode" :side-tabs="true">
+    <ResourceTabs v-model="value" :mode="mode" :side-tabs="true" :default-tab="defaultTab">
       <Tab name="volumeclaim" :label="t('persistentVolumeClaim.volumeClaim.label')" :weight="4">
         <div class="row">
           <div class="col span-6">
@@ -222,6 +231,7 @@ export default {
             <div class="row">
               <div class="col span-12 mt-10">
                 <UnitInput
+                  ref="volumeSize"
                   v-model="value.spec.resources.requests.storage"
                   :label="t('persistentVolumeClaim.volumeClaim.requestStorage')"
                   :mode="storageAmountMode"
@@ -230,6 +240,12 @@ export default {
                   :increment="1024"
                   :min="1"
                 />
+                <Banner v-if="isEdit && !value.expandable" color="info" class="mt-10">
+                  {{ t('persistentVolumeClaim.expand.notSupported') }}
+                </Banner>
+                <Banner v-else-if="isEdit && !value.bound" color="info" class="mt-10">
+                  {{ t('persistentVolumeClaim.expand.notBound') }}
+                </Banner>
               </div>
             </div>
           </div>

--- a/shell/list/persistentvolumeclaim.vue
+++ b/shell/list/persistentvolumeclaim.vue
@@ -1,0 +1,42 @@
+<script>
+import ResourceTable from '@shell/components/ResourceTable';
+import { STORAGE_CLASS } from '@shell/config/types';
+
+export default {
+  name:       'ListPersistentVolumeClaim',
+  components: { ResourceTable },
+
+  props: {
+    resource: {
+      type:     String,
+      required: true,
+    },
+
+    schema: {
+      type:     Object,
+      required: true,
+    },
+  },
+
+  async fetch() {
+    const inStore = this.$store.getters['currentStore']();
+
+    // Fetch storage classes so we can determine if a PVC can be expanded
+    this.$store.dispatch(`${ inStore }/findAll`, { type: STORAGE_CLASS });
+
+    this.rows = await this.$store.dispatch(`${ inStore }/findAll`, { type: this.resource });
+  },
+
+  data() {
+    return { rows: [] };
+  }
+};
+</script>
+
+<template>
+  <ResourceTable
+    :loading="$fetchState.pending"
+    :schema="schema"
+    :rows="rows"
+  />
+</template>

--- a/shell/models/persistentvolumeclaim.js
+++ b/shell/models/persistentvolumeclaim.js
@@ -43,7 +43,7 @@ export default class PVC extends SteveModel {
       action:     'goToEditVolumeSize',
       enabled:    this.expandable && this.bound,
       icon:       'icon icon-fw icon-plus',
-      label:      'Resize',
+      label:      this.t('persistentVolumeClaim.expand.label'),
     });
 
     return out;

--- a/shell/models/persistentvolumeclaim.js
+++ b/shell/models/persistentvolumeclaim.js
@@ -1,7 +1,17 @@
 
-import { _CLONE } from '@shell/config/query-params';
+import { insertAt } from '@shell/utils/array';
+import {
+  AS,
+  _CLONE,
+  FOCUS,
+  MODE,
+  _UNFLAG,
+  _EDIT
+} from '@shell/config/query-params';
 import Vue from 'vue';
 import SteveModel from '@shell/plugins/steve/steve-class';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+import { STORAGE_CLASS } from '@shell/config/types';
 
 export default class PVC extends SteveModel {
   applyDefaults(_, realMode) {
@@ -14,5 +24,41 @@ export default class PVC extends SteveModel {
       volumeName:       '',
       resources:        { requests: { storage } }
     });
+  }
+
+  get bound() {
+    return this.state === STATES_ENUM.BOUND;
+  }
+
+  get expandable() {
+    return !!this.$getters[`byId`](STORAGE_CLASS, this.spec?.storageClassName)?.allowVolumeExpansion;
+  }
+
+  get _availableActions() {
+    const out = super._availableActions;
+
+    // Add backwards, each one to the top
+    insertAt(out, 0, { divider: true });
+    insertAt(out, 0, {
+      action:     'goToEditVolumeSize',
+      enabled:    this.expandable && this.bound,
+      icon:       'icon icon-fw icon-plus',
+      label:      'Resize',
+    });
+
+    return out;
+  }
+
+  goToEditVolumeSize() {
+    const location = this.detailLocation;
+
+    location.query = {
+      ...location.query,
+      [MODE]:  _EDIT,
+      [AS]:    _UNFLAG,
+      [FOCUS]: 'volumeclaim'
+    };
+
+    this.currentRouter().push(location);
   }
 }


### PR DESCRIPTION
Fixes #5543 

This PR updates the PVC edit page so that it correctly allows volume expansion based on the underlying storage class and also the bound status of the PVC.

Also added a 'Resize' option to the action menu for a PVC that goes to the edit page with the size field focused.

The model requires that the storage classes have been retrieved in order to determine if a PVC can be resized, so a custom list for pvcs was added that ensures that these are fetched.

![image](https://user-images.githubusercontent.com/1955897/171252335-89f1ccba-7bf3-4450-8315-a52d49306faf.png)

![image](https://user-images.githubusercontent.com/1955897/171252408-70ee829a-2d61-4bc2-a690-bbf41d5593a0.png)

![image](https://user-images.githubusercontent.com/1955897/171252442-2547d04b-279b-49f8-b6bf-eb5bbe7ba9b9.png)
