### PR TITLE
Excludes packages from .env file instead of hardcoded

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,7 @@
   },
   "javascript.preferences.importModuleSpecifier": "non-relative",
   "typescript.preferences.importModuleSpecifier": "non-relative",
+  "cSpell.words": [
+    "epinio"
+  ],
 }

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ During the transition to the new folder structured in 2.6.5 required by the plug
 For more information on plugins see [Plugins](./docs/developer/PLUGINS.md).
 
 ## Running for Development
-Create an `.env` file, this will allow us to specify a Rancher API endpoint and exclude different packages.
-```bash
-# Create your new .env file
-cp env.template .env
-```
-
 This is what you probably want to get started.
 ```bash
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@ During the transition to the new folder structured in 2.6.5 required by the plug
 - Run the script `./scripts/rejig` to move folders to their new location in the `shell` folder and update the appropriate import statements
   Use this to convert older PRs to the new format
 - Run the script `./scripts/rejig -d` to move folders to their old location and update imports again
-  Use this to convert newer branches to the old format (possibly useful for branches) 
+  Use this to convert newer branches to the old format (possibly useful for branches)
 
 For more information on plugins see [Plugins](./docs/developer/PLUGINS.md).
 
 ## Running for Development
+Create an .env file, this will allow us to specifiy an Rancher API endpoint and exclude different packages.
+```bash
+# Create your new .env file
+cp env.template .env
+```
 This is what you probably want to get started.
 ```bash
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ During the transition to the new folder structured in 2.6.5 required by the plug
 For more information on plugins see [Plugins](./docs/developer/PLUGINS.md).
 
 ## Running for Development
-Create an .env file, this will allow us to specifiy an Rancher API endpoint and exclude different packages.
+Create an `.env` file, this will allow us to specify a Rancher API endpoint and exclude different packages.
 ```bash
 # Create your new .env file
 cp env.template .env
 ```
+
 This is what you probably want to get started.
 ```bash
 # Install dependencies

--- a/docs/developer/PLUGINS.md
+++ b/docs/developer/PLUGINS.md
@@ -4,7 +4,7 @@ During the transition to the new folder structured in 2.6.5 required by the plug
 - Run the script `./scripts/rejig` to move folders to their new location in the `shell` folder and update the appropriate import statements
   Use this to convert older PRs to the new format
 - Run the script `./scripts/rejig -d` to move folders to their old location and update imports again
-  Use this to convert newer branches to the old format (possibly useful for branches) 
+  Use this to convert newer branches to the old format (possibly useful for branches)
   > IMPORTANT - This script contains a `git reset --hard`
 
 ## Step 1
@@ -175,13 +175,26 @@ The `testplugin` plugin will be built and the output placed in `dist-pkg\testplu
 Next, edit the `nuxt.config.js` file in the root folder and replace it with this:
 
 ```
-import config from '@rancher/shell/nuxt.config';
+import config from './shell/nuxt.config';
+
+// Excludes the following plugins if there's no .env file.
+const excludes = process.env.EXCLUDES_PKG || 'epinio, rancher-components, testplugin';
 
 export default config(__dirname, {
-  excludes:   ['testplugin'],
-  autoImport: []
+  excludes: excludes.replace(/\s/g, '').split(','),
+  // excludes: ['fleet', 'example']
+  // autoLoad: ['fleet', 'example']
 });
+```
 
+**NOTE**: If you're actively working with Plugins, we can make use of the `.env` file instead of hardcoded the excludes in the `nuxt.config.js` file so your changes on the file won't be tracked by Git.
+
+```
+# First, create the .env file from template
+cp env.example .env
+
+# Then, add the following to the .env file
+EXCLUDES_PKG='epinio, rancher-components, testplugin'
 ```
 
 What we have done here is add the `testplugin` plugin to the `excludes` configuration - this means that when we build and run the UI, we won't include the `testplugin` plugin.

--- a/env.template
+++ b/env.template
@@ -1,5 +1,5 @@
 # Rancher API Endpoint
 API="URL"
 
-# Packages to exclude
+# Packages to exclude. Running `yarn clean` may be required in order for changes to take affect.
 EXCLUDES_PKG="epinio, rancher-components"

--- a/env.template
+++ b/env.template
@@ -1,0 +1,5 @@
+# Rancher API Endpoint
+API="URL"
+
+# Packages to exclude
+EXCLUDES_PKG="epinio, rancher-comonents"

--- a/env.template
+++ b/env.template
@@ -2,4 +2,4 @@
 API="URL"
 
 # Packages to exclude
-EXCLUDES_PKG="epinio, rancher-comonents"
+EXCLUDES_PKG="epinio, rancher-components"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 import config from './shell/nuxt.config';
 
 export default config(__dirname, {
-  excludes: ['epinio', 'rancher-components'],
+  excludes: [...process.env.EXCLUDES_PKG.split(',')],
   // excludes: ['fleet', 'example']
   // autoLoad: ['fleet', 'example']
 });

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,7 +4,7 @@ import config from './shell/nuxt.config';
 const excludes = process.env.EXCLUDES_PKG || 'epinio, rancher-components';
 
 export default config(__dirname, {
-  excludes: excludes.trim().split(','),
+  excludes: excludes.replace(/\s/g, '').split(','),
   // excludes: ['fleet', 'example']
   // autoLoad: ['fleet', 'example']
 });

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 import config from './shell/nuxt.config';
 
 export default config(__dirname, {
-  excludes: [...process.env.EXCLUDES_PKG.split(',')],
+  excludes: [...(process.env.EXCLUDES_PKG?.split(',') || ['epinio', 'rancher-comonents'])],
   // excludes: ['fleet', 'example']
   // autoLoad: ['fleet', 'example']
 });

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,10 @@
 import config from './shell/nuxt.config';
 
+// Excludes the following plugins if there's no .env file.
+const excludes = process.env.EXCLUDES_PKG || 'epinio, rancher-components';
+
 export default config(__dirname, {
-  excludes: [...(process.env.EXCLUDES_PKG?.split(',') || ['epinio', 'rancher-comonents'])],
+  excludes: excludes.trim().split(','),
   // excludes: ['fleet', 'example']
   // autoLoad: ['fleet', 'example']
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/dashboard/issues/6074
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Changes the excludes pkg from nuxt.config.js to `.env` with a default behaviour for when we don't have an .env file.
