### PR TITLE
aws compliance banner

### DIFF
--- a/shell/components/AwsComplianceBanner.vue
+++ b/shell/components/AwsComplianceBanner.vue
@@ -1,0 +1,44 @@
+<script>
+// This component is used to show warnings when current usage exceeds support purchased through AWS Marketplace
+import { MANAGEMENT } from '@shell/config/types';
+
+export default {
+  async fetch() {
+    if ( this.$store.getters['management/schemaFor'](MANAGEMENT.USER_NOTIFICATION)) {
+      this.notifications = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.USER_NOTIFICATION });
+    }
+  },
+
+  data() {
+    return { notifications: [] };
+  },
+
+  computed: {
+    // The notification will always come from the csp-adapter component & there will be no more than one
+    // Backend will remove the notification when its no longer relevant
+    awsNotification() {
+      return this.notifications.find(notification => notification.componentName === 'csp-adapter');
+    }
+  }
+};
+</script>
+
+<template>
+  <div v-if="awsNotification" class="aws-compliance">
+    {{ awsNotification.message }}
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.aws-compliance {
+    background-color: var(--error);
+    color: var(--error-text);
+    line-height: 2em;
+    width: 100%;
+        text-align: center;
+
+    >p{
+        text-align: center;
+    }
+}
+</style>

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -166,7 +166,8 @@ export const MANAGEMENT = {
   GLOBAL_ROLE:                   'management.cattle.io.globalrole',
   GLOBAL_ROLE_BINDING:           'management.cattle.io.globalrolebinding',
   POD_SECURITY_POLICY_TEMPLATE:  'management.cattle.io.podsecuritypolicytemplate',
-  MANAGED_CHART:                 'management.cattle.io.managedchart'
+  MANAGED_CHART:                 'management.cattle.io.managedchart',
+  USER_NOTIFICATION:             'management.cattle.io.rancherusernotification'
 };
 
 export const CAPI = {

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -13,6 +13,7 @@ import Group from '@shell/components/nav/Group';
 import Header from '@shell/components/nav/Header';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
+import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import {
   COUNT, SCHEMA, MANAGEMENT, UI, CATALOG, HCI
 } from '@shell/config/types';
@@ -41,7 +42,8 @@ export default {
     Group,
     GrowlManager,
     WindowManager,
-    FixedBanner
+    FixedBanner,
+    AwsComplianceBanner
   },
 
   mixins: [PageHeaderActions, Brand],
@@ -531,7 +533,7 @@ export default {
 <template>
   <div class="dashboard-root">
     <FixedBanner :header="true" />
-
+    <AwsComplianceBanner />
     <div v-if="managementReady" class="dashboard-content">
       <Header />
       <nav v-if="clusterReady" class="side-nav">

--- a/shell/layouts/home.vue
+++ b/shell/layouts/home.vue
@@ -3,12 +3,16 @@ import Header from '@shell/components/nav/Header';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
+import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import { mapPref, DEV } from '@shell/store/prefs';
 
 export default {
 
   components: {
-    Header, FixedBanner, GrowlManager
+    AwsComplianceBanner,
+    Header,
+    FixedBanner,
+    GrowlManager
   },
 
   mixins: [Brand],
@@ -36,6 +40,8 @@ export default {
 <template>
   <div class="dashboard-root">
     <FixedBanner :header="true" />
+    <AwsComplianceBanner />
+
     <div class="dashboard-content">
       <Header :simple="true" />
 

--- a/shell/layouts/plain.vue
+++ b/shell/layouts/plain.vue
@@ -7,6 +7,7 @@ import IndentedPanel from '@shell/components/IndentedPanel';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
+import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 
 export default {
 
@@ -17,7 +18,9 @@ export default {
     IndentedPanel,
     PromptRemove,
     FixedBanner,
-    GrowlManager
+    GrowlManager,
+    AwsComplianceBanner
+
   },
 
   middleware: ['authenticated'],
@@ -37,6 +40,7 @@ export default {
 <template>
   <div class="dashboard-root">
     <FixedBanner :header="true" />
+    <AwsComplianceBanner />
 
     <div class="dashboard-content">
       <Header :simple="true" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5616 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds a banner component that will display a warning when a Rancher instance with support purchased through the AWS Marketplace has more nodes than they've purchased support for. 

### Technical notes summary
I created `rancherUserNotifications` through the Norman API to test this. I have a cluster with some I can share access to for testing porpoises.

Some notes about the rancherUserNotification object: 
   - the relevant notfication will always come from csp-adapter
   - there will never be more than one notification
   - the notification object will be removed by backend when the Rancher instance is no longer out of compliance
   - any user who can see the rancherUserNotification should be warned about compliance


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screen Shot 2022-06-01 at 11 20 06 AM](https://user-images.githubusercontent.com/42977925/171476603-f10d8f0e-cd97-439d-8a0f-63b2180d3f3b.png)

