### PR TITLE
Fix age column for Norman resources

### DIFF
--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -231,6 +231,7 @@ export const AGE = {
 
 export const AGE_NORMAN = {
   ...AGE,
+  getValue:  row => row.created,
   value:     'created',
   sort:      'created:desc',
 };


### PR DESCRIPTION
Fixes #6097 
Fixes #5944 

A row value getter was added to the AGE column definition. The Norman AGE column definition inherits from this but did not override the new  getter, so it was using the Steve getter and getting an empty value.