### PR TITLE
Fix NeuVector casing in side nav

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -182,6 +182,7 @@ product:
   clusterManagement: Cluster Management
   monitoring: Monitoring
   mcapps: Multi-cluster Apps
+  neuvector: NeuVector
   harvesterManager: Virtualization Management
   harvester: Harvester
   rancher: Rancher

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -185,6 +185,7 @@ product:
   clusterManagement: 集群管理
   monitoring: 监控
   mcapps: 多集群应用
+  neuvector: NeuVector
   harvesterManager: 虚拟化管理
   harvester: Harvester
   rancher: Rancher


### PR DESCRIPTION
Fixes #6012 

There was no product label set for `neuvector` to it was giving the default capitalisation.

After fix:

![image](https://user-images.githubusercontent.com/1955897/172048161-8478b7ec-f185-4b11-8b50-3afbe8c05cd4.png)
