### PR TITLE
Add a warning to the local cluster members page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2660,6 +2660,7 @@ members:
     custom:
       label: Custom
       description: Choose individual roles for this user.
+  localClusterWarning: "Caution: This is the cluster that Rancher is using as a data store.  Only administrators should be given write access to this cluster. Users with write access to this cluster can use it to grant themselves access to any other cluster managed by this installation."
 
 membershipEditor:
   label: Members

--- a/shell/pages/c/_cluster/_product/members/index.vue
+++ b/shell/pages/c/_cluster/_product/members/index.vue
@@ -5,6 +5,7 @@ import Loading from '@shell/components/Loading';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { AGE, ROLE, STATE, PRINCIPAL } from '@shell/config/table-headers';
 import { canViewClusterPermissionsEditor } from '@shell/components/form/Members/ClusterPermissionsEditor.vue';
+import Banner from '@components/Banner/Banner.vue';
 
 /**
  * Explorer members page.
@@ -15,7 +16,7 @@ export default {
   name: 'ExplorerMembers',
 
   components: {
-    Loading, Masthead, ResourceTable
+    Banner, Loading, Masthead, ResourceTable
   },
 
   async fetch() {
@@ -64,6 +65,9 @@ export default {
     canManageMembers() {
       return canViewClusterPermissionsEditor(this.$store);
     },
+    isLocal() {
+      return this.$store.getters['currentCluster'].isLocal;
+    }
   },
 };
 </script>
@@ -78,6 +82,7 @@ export default {
       :create-location="createLocation"
       :create-button-label="t('members.createActionLabel')"
     />
+    <Banner v-if="isLocal" color="error" :label="t('members.localClusterWarning')" />
     <ResourceTable
       :schema="schema"
       :headers="headers"


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This informs the user of the implications of adding a member to the local cluster. This warning already existed in ember.

rancher/dashboard#6098

### Occurred changes and/or fixed issues
Only the cluster member pages should be affected.

### Areas or cases that should be tested
Local and non local clusters

### Screenshot/Video
![image](https://user-images.githubusercontent.com/55104481/172665871-cf9eaa69-acbd-4b88-9aac-91e5041585dd.png)