### PR TITLE
Increase the timeout and provide better messaging for the timeout when creating clusters

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1483,6 +1483,7 @@ cluster:
       label: Auto Replace
       toolTip: If greater than 0, nodes that are unreachable for this duration will be automatically deleted and replaced.
       unit: "Minutes"
+  managementTimeout: The cluster to become available. It's possible the cluster was created. We suggest checking the clusters page before trying to create another.
   memberRoles:
     removeMessage: 'Note: Removing a user will not remove their project permissions'
     addClusterMember:

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -252,7 +252,7 @@ export default class ProvCluster extends SteveModel {
     }, `set provisioner`, timeout, interval);
   }
 
-  waitForMgmt(timeout, interval) {
+  waitForMgmt(timeout = 60000, interval) {
     return this.waitForTestFn(() => {
       // `this` instance isn't getting updated with `status.clusterName`
       // Workaround - Get fresh copy from the store
@@ -260,7 +260,7 @@ export default class ProvCluster extends SteveModel {
       const name = this.status?.clusterName || pCluster?.status?.clusterName;
 
       return name && !!this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, name);
-    }, `mgmt cluster create`, timeout, interval);
+    }, this.$rootGetters['i18n/t']('cluster.managementTimeout'), timeout, interval);
   }
 
   get provisioner() {


### PR DESCRIPTION
### Summary
The error was occurring because we were hitting a timeout when waiting for the management cluster to become available. I doubled the timeout time to reduce the likelihood of this happening and made the error message more clear.

rancher/dashboard#6010

### Areas which could experience regressions
Any rke2, harvester or import provisioning.

### Screenshot/Video
![image](https://user-images.githubusercontent.com/55104481/172713277-cd1e538d-8d25-46e3-b364-2950befacbb1.png)