### PR TITLE
Adds in form validation mixin, error reporting on inputs, and a few examples

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -1,12 +1,23 @@
 
 import { mount } from '@vue/test-utils';
 import { LabeledInput } from './index';
+import Vue from 'vue';
+import Vuex from 'vuex';
 
 describe('component: LabeledInput', () => {
   it('should emit input only once', () => {
     const value = '2';
     const delay = 1;
-    const wrapper = mount(LabeledInput, { propsData: { delay } });
+    const wrapper = mount(LabeledInput, { 
+      propsData: { delay },
+      mocks:      {
+        $store: {
+          getters: {
+            'i18n/t': jest.fn()
+          }
+        }
+      }
+    });
 
     jest.useFakeTimers();
     wrapper.find('input').setValue('1');

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -122,6 +122,12 @@ export default (
       return !!this.tooltip || !!this.tooltipKey;
     },
 
+    tooltipValue(): string | undefined {
+      if (this.hasTooltip) {
+        return this.tooltipKey ? this.t(this.tooltipKey) : this.tooltip
+      }
+    },
+
     /**
      * Determines if the Labeled Input makes use of the suffix slot.
      */
@@ -248,7 +254,7 @@ export default (
         <t v-if="labelKey" :k="labelKey" />
         <template v-else-if="label">{{ label }}</template>
 
-        <span v-if="required" class="required">*</span>
+        <span v-if="requiredField" class="required">*</span>
       </label>
     </slot>
 
@@ -290,16 +296,15 @@ export default (
 
     <slot name="suffix" />
     <LabeledTooltip
-      v-if="tooltipKey && !focused"
+      v-if="hasTooltip && !focused"
       :hover="hoverTooltip"
-      :value="t(tooltipKey)"
+      :value="tooltipValue"
       :status="status"
     />
     <LabeledTooltip
-      v-else-if="tooltip && !focused"
+      v-if="!!validationMessage"
       :hover="hoverTooltip"
-      :value="tooltip"
-      :status="status"
+      :value="validationMessage"
     />
     <label v-if="cronHint" class="cron-label">{{ cronHint }}</label>
     <label v-if="subLabel" class="sub-label">{{ subLabel }}</label>

--- a/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
+++ b/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
@@ -27,6 +27,11 @@ export default Vue.extend({
       type:    Boolean,
       default: true
     }
+  },
+  computed: {
+    iconClass() {
+      return this.status === 'error' ? 'icon-warning' : 'icon-info';
+    }
   }
 });
 </script>
@@ -34,10 +39,10 @@ export default Vue.extend({
 <template>
   <div ref="container" class="labeled-tooltip" :class="{[status]: true, hoverable: hover}">
     <template v-if="hover">
-      <i v-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value" :class="{'hover':!value}" class="icon icon-info status-icon" />
+      <i v-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value" :class="{'hover':!value, [iconClass]: true}" class="icon status-icon" />
     </template>
     <template v-else>
-      <i :class="{'hover':!value}" class="icon icon-info status-icon" />
+      <i :class="{'hover':!value}" class="icon status-icon" />
       <div v-if="value" class="tooltip" x-placement="bottom">
         <div class="tooltip-arrow" />
         <div class="tooltip-inner">
@@ -61,12 +66,11 @@ export default Vue.extend({
     }
 
      .status-icon {
-         position:  absolute;
-         right: 30px;
-         top: $input-padding-lg;
-         font-size: 20px;
-         z-index: z-index(hoverOverContent);
-
+        position:  absolute;
+        right: 30px;
+        top: $input-padding-lg;
+        font-size: 20px;
+        z-index: z-index(hoverOverContent);
      }
 
     .tooltip {
@@ -105,6 +109,11 @@ export default Vue.extend({
 
     &.error {
         @include tooltipColors(var(--error));
+
+        .status-icon {
+          top: 7px;
+          right: 5px;
+        }
     }
 
     &.warning {

--- a/shell/assets/styles/global/_labeled-input.scss
+++ b/shell/assets/styles/global/_labeled-input.scss
@@ -23,6 +23,7 @@
     transition-timing-function: ease-in-out;
     color: var(--input-label);
     pointer-events: none;
+    width: calc(100% - 20px);
     i {
       pointer-events: initial;
     }
@@ -123,6 +124,10 @@
     padding-top: 5px;
     left: 0;
     color: var(--input-label);
+  }
+
+  .validation-message, .sub-label.validation-message {
+    color: var(--error);
   }
 
 

--- a/shell/assets/styles/global/_select.scss
+++ b/shell/assets/styles/global/_select.scss
@@ -28,6 +28,15 @@
     color: var(--error);
   }
 
+  label {
+    width: calc(100% - 20px);
+  }
+
+  .validation-message {
+    color: var(--error);
+    float: right;
+  }
+
   &.focused {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4933,6 +4933,7 @@ validation:
     route:
       match: At least one Match or Match Regex must be selected
       interval: '"{key}" must be of a format with digits followed by a unit i.e. 1h, 2m, 30s'
+  tab: "One or more fields in this tab contain a form validation error"
 
 wizard:
   previous: Previous

--- a/shell/components/Tabbed/Tab.vue
+++ b/shell/components/Tabbed/Tab.vue
@@ -32,6 +32,10 @@ export default {
       type:    Boolean,
       default: null
     },
+    error: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   data() {

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -117,6 +117,9 @@ export default {
   },
 
   methods: {
+    hasIcon(tab) {
+      return tab.displayAlertIcon || (tab.error && !tab.active);
+    },
     hashChange() {
       if (!this.scrollOnChange) {
         const scrollable = document.getElementsByTagName('main')[0];
@@ -220,7 +223,7 @@ export default {
         v-for="tab in sortedTabs"
         :id="tab.name"
         :key="tab.name"
-        :class="{tab: true, active: tab.active, disabled: tab.disabled}"
+        :class="{tab: true, active: tab.active, disabled: tab.disabled, error: (tab.error)}"
         role="presentation"
       >
         <a
@@ -230,7 +233,7 @@ export default {
           @click.prevent="select(tab.name, $event)"
         >
           <span>{{ tab.labelDisplay }}</span>
-          <i v-if="tab.displayAlertIcon" class="conditions-alert-icon icon-error icon-lg" />
+          <i v-if="hasIcon(tab)" v-tooltip="t('validation.tab')" class="conditions-alert-icon icon-warning icon-lg" />
         </a>
       </li>
       <li v-if="sideTabs && !sortedTabs.length" class="tab disabled">
@@ -317,6 +320,12 @@ export default {
           text-decoration: none;
         }
       }
+
+      &.error {
+          & A>i {
+            color: var(--error);
+          }
+        }
     }
   }
 

--- a/shell/components/form/Error.vue
+++ b/shell/components/form/Error.vue
@@ -1,0 +1,43 @@
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+
+type Rule = (v?: string) => undefined | string;
+
+export default Vue.extend<any, any, any, any>({
+  props: {
+    value: {
+      default: null,
+      type:    [String, Object, Number, Array]
+    },
+    rules: {
+      default:   () => [],
+      type:       Array as PropType<Rule[]>,
+    }
+  },
+  data() {
+    return {};
+  },
+  computed: {
+    validationMessage(): undefined | string {
+      const ruleMessages = [];
+      const value = this.value;
+
+      for (const rule of this.rules) {
+        const message = rule(value);
+
+        if (message) {
+          ruleMessages.push(message);
+        }
+      }
+      if (ruleMessages.length > 0) {
+        return ruleMessages.join(', ');
+      }
+
+      return '';
+    }
+  }
+});
+</script>
+<template>
+  <span class="text-error" data-testid="error-span">{{ validationMessage }}</span>
+</template>

--- a/shell/components/form/InputWithSelect.vue
+++ b/shell/components/form/InputWithSelect.vue
@@ -75,6 +75,14 @@ export default {
       type:    String,
       default: '',
     },
+    textRules: {
+      default: () => [],
+      type:    Array,
+    },
+    selectRules: {
+      default: () => [],
+      type:    Array,
+    }
 
   },
 
@@ -129,6 +137,7 @@ export default {
       :option-label="optionLabel"
       :placement="$attrs.placement ? $attrs.placement : null"
       :v-bind="$attrs"
+      :rules="selectRules"
       @input="change"
     />
     <Select
@@ -158,6 +167,7 @@ export default {
       :disabled="disabled || textDisabled"
       :required="textRequired"
       :mode="mode"
+      :rules="textRules"
       v-bind="$attrs"
     >
       <template #label>

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -242,7 +242,7 @@ export default {
         <t v-if="labelKey" :k="labelKey" />
         <template v-else-if="label">{{ label }}</template>
 
-        <span v-if="required" class="required">*</span>
+        <span v-if="requiredField" class="required">*</span>
       </label>
     </div>
     <v-select
@@ -286,6 +286,7 @@ export default {
         </template>
         <div v-else @mousedown="(e) => onClickOption(option, e)">
           {{ getOptionLabel(option) }}
+          <i v-if="option.error" class="icon icon-warning pull-right" style="font-size: 20px;" />
         </div>
       </template>
       <!-- Pass down templates provided by the caller -->
@@ -299,6 +300,11 @@ export default {
       :hover="hoverTooltip"
       :value="tooltip"
       :status="status"
+    />
+    <LabeledTooltip
+      v-else-if="!!validationMessage"
+      :hover="hoverTooltip"
+      :value="validationMessage"
     />
   </div>
 </template>

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -140,6 +140,14 @@ export default {
     horizontal: {
       type:    Boolean,
       default: true,
+    },
+    rules: {
+      default: () => ({
+        namespace:   [],
+        name:        [],
+        description: []
+      }),
+      type: Object,
     }
   },
 
@@ -349,6 +357,7 @@ export default {
         :mode="mode"
         :min-height="30"
         :required="nameRequired"
+        :rules="rules.namespace"
       />
       <button
         aria="Cancel create"
@@ -359,7 +368,7 @@ export default {
       >
         <i
           v-tooltip="t('generic.cancel')"
-          class="icon icon-lg icon-close "
+          class="icon icon-lg icon-close align-value"
         />
       </button>
     </div>
@@ -375,6 +384,7 @@ export default {
         :multiple="false"
         :label="t('namespace.label')"
         :placeholder="t('namespace.selectOrCreate')"
+        :rules="rules.namespace"
         required
         @selecting="selectNamespace"
       />
@@ -391,6 +401,7 @@ export default {
         :mode="mode"
         :min-height="30"
         :required="nameRequired"
+        :rules="rules.name"
       />
     </div>
 
@@ -403,6 +414,7 @@ export default {
         :label="t(descriptionLabel)"
         :placeholder="t(descriptionPlaceholder)"
         :min-height="30"
+        :rules="rules.description"
       />
     </div>
 
@@ -428,6 +440,10 @@ button {
   margin-right: 7px;
 
   cursor: pointer;
+
+  .align-value {
+    padding-top: 7px;
+  }
 }
 
 .row {

--- a/shell/components/form/ServicePorts.vue
+++ b/shell/components/form/ServicePorts.vue
@@ -4,9 +4,10 @@ import { _EDIT, _VIEW } from '@shell/config/query-params';
 import { removeAt } from '@shell/utils/array';
 import { clone } from '@shell/utils/object';
 import Select from '@shell/components/form/Select';
+import Error from '@shell/components/form/Error';
 
 export default {
-  components: { Select },
+  components: { Select, Error },
   props:      {
     value: {
       type:    Array,
@@ -27,6 +28,12 @@ export default {
     autoAddIfEmpty: {
       type:    Boolean,
       default: true,
+    },
+    rules: {
+      default:   () => [],
+      type:      Array,
+      // we only want functions in the rules array
+      validator: rules => rules.every(rule => ['function'].includes(typeof rule))
     }
   },
 
@@ -204,6 +211,7 @@ export default {
             <t k="generic.remove" />
           </button>
         </div>
+        <Error :value="{...row, idx}" :rules="rules" />
       </div>
     </div>
     <div v-if="showAdd" class="footer">

--- a/shell/components/form/__tests__/Error.test.ts
+++ b/shell/components/form/__tests__/Error.test.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils';
+import Error from '@shell/components/form/Error.vue';
+
+type Rule = (val?: string) => undefined | string;
+
+describe('component: Error', () => {
+  it('should not display any error text if no test functions provided', () => {
+    const value = 'testValue';
+    const rules: Rule[] = [];
+
+    const wrapper = mount(Error, { propsData: { value, rules } });
+
+    const element = wrapper.find('[data-testid="error-span"]');
+
+    expect(element.text()).toBe('');
+  });
+  it('should not display any error text if provided test returns undefined', () => {
+    const value = 'testValue';
+    const rules: Rule[] = [() => undefined, () => undefined];
+
+    const wrapper = mount(Error, { propsData: { value, rules } });
+
+    const element = wrapper.find('[data-testid="error-span"]');
+
+    expect(element.text()).toBe('');
+  });
+  it('should properly pass the component value property to test function', () => {
+    const value = 'testValue';
+    const rules: Rule[] = [val => val];
+
+    const wrapper = mount(Error, { propsData: { value, rules } });
+    const element = wrapper.find('[data-testid="error-span"]');
+
+    expect(element.text()).toBe('testValue');
+  });
+  it('should display error text if provided test return string', () => {
+    const value = 'testValue';
+    const rules: Rule[] = [() => 'testError', () => undefined];
+
+    const wrapper = mount(Error, { propsData: { value, rules } });
+
+    const element = wrapper.find('[data-testid="error-span"]');
+
+    expect(element.text()).toBe('testError');
+  });
+  it('should properly concatenate error text if more than one error returned', () => {
+    const value = 'testValue';
+    const rules: Rule[] = [() => 'testError1', () => 'testError2'];
+
+    const wrapper = mount(Error, { propsData: { value, rules } });
+
+    const element = wrapper.find('[data-testid="error-span"]');
+
+    expect(element.text()).toBe('testError1, testError2');
+  });
+});

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 import ContainerResourceLimit from '@shell/components/ContainerResourceLimit';
 import CreateEditView from '@shell/mixins/create-edit-view';
+import FormValidation from '@shell/mixins/form-validation';
 import CruResource from '@shell/components/CruResource';
 import Labels from '@shell/components/form/Labels';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
@@ -23,7 +24,7 @@ export default {
     ContainerResourceLimit, CruResource, Labels, LabeledSelect, NameNsDescription, ProjectMembershipEditor, ResourceQuota, Tabbed, Tab, Banner
   },
 
-  mixins: [CreateEditView],
+  mixins: [CreateEditView, FormValidation],
   async fetch() {
     if ( this.$store.getters['management/canList'](MANAGEMENT.POD_SECURITY_POLICY_TEMPLATE) ) {
       this.allPSPs = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.POD_SECURITY_POLICY_TEMPLATE });
@@ -49,7 +50,8 @@ export default {
       membershipHasOwner:         false,
       membershipUpdate:   {},
       HARVESTER_TYPES,
-      RANCHER_TYPES
+      RANCHER_TYPES,
+      fvFormRuleSets:       [{ path: 'spec.displayName', rules: ['required'] }],
     };
   },
   computed: {
@@ -187,11 +189,12 @@ export default {
   <CruResource
     class="project"
     :done-route="'c-cluster-product-projectsnamespaces'"
-    :errors="errors"
+    :errors="fvUnreportedValidationErrors"
     :mode="mode"
     :resource="value"
     :subtypes="[]"
     :can-yaml="false"
+    :validation-passed="fvFormIsValid"
     @error="e=>errors = e"
     @finish="save"
     @cancel="done"
@@ -204,6 +207,7 @@ export default {
       :description-disabled="isDescriptionDisabled"
       name-key="spec.displayName"
       :normalize-name="false"
+      :rules="{ name: fvGetAndReportPathRules('spec.displayName'), namespace: [], description: [] }"
     />
     <div class="row mb-20">
       <div class="col span-3">

--- a/shell/mixins/form-validation.js
+++ b/shell/mixins/form-validation.js
@@ -1,0 +1,114 @@
+import { getAllValues } from '@/shell/utils/object';
+import formRulesGenerator from '@/shell/utils/validators/formRules/index';
+
+export default {
+  data() {
+    return {
+      fvFormRuleSets: [
+        /* fvFormRuleSets define the validation rules for the entire form. These should almost always be overridden in the form-component using the mixin
+        example:
+        {
+          path:  'container.image', // required: defines the path of the value to be tested against it's rules. Looks for the relevant path in `this.value` unless an is passed in via rootObject
+          rootObject: { container: { image: 'name' } } // optional: redirects the path to the object passed here,
+          rules: ['noSpaces', 'noPeriods'], // required: array of strings that match which validator functions to run against the value of the field defined by the path (and optionally the rulesets rootObject),
+          translationKey: 'Image Name', // optional: defines the displaykey, overrides displaykeys that may otherwise be passed into the translation
+        }
+        */
+      ],
+      fvReportedValidationPaths: [
+        // an array of strings that track which ruleset paths have been bound to a field for error reporting
+        // tracked in a seperate array from the actual rulesets since we want the option of keeping track of modelValidationRules without mutating the model itself
+        // you may place a path in here manually as part of your form's data props...
+        // ... or you may place a path in here programitcally by using the "fvGetAndReportPathRules" method
+      ]
+    };
+  },
+
+  methods: {
+    // returns an array of validator functions based off path property of the ruleset, use this if you want the array but you don't want the form to track that the rules have been bound to a field
+    fvGetPathRules(path) {
+      return this.fvRulesets.find(ruleset => ruleset.path === path)?.rules || [];
+    },
+    // returns an array of validator functions and pushes the path of the relevant ruleset into fvReportedValidationPaths so that we know any error messages are handled by the field using it
+    fvGetAndReportPathRules(path) {
+      const rules = this.fvGetPathRules(path);
+
+      if (rules.length > 0 && !this.fvReportedValidationPaths.includes(path)) {
+        this.fvReportedValidationPaths = [...this.fvReportedValidationPaths, path];
+      }
+
+      return rules;
+    },
+    fvGetPathValues(path) { // validates that the path is one that belongs to a ruleset (either a formRuleset or from the modelValidationRules) and returns its value(s) in an array
+      // returns even single values as an array to simplify validation logic since some fields may have multiple values
+      const relevantRuleset = this.fvRulesets.find(ruleset => ruleset.path === path);
+
+      if (!relevantRuleset) {
+        return [];
+      }
+
+      return getAllValues(relevantRuleset?.rootObject || this.value, relevantRuleset?.path);
+    },
+    fvGetPathErrors(paths = []) { // gets errors from multiple paths, usually used externally to check a single path but used within the mixin to check all paths for errors
+      const messages = paths.reduce((acc, path) => {
+        const pathErrors = [];
+        const relevantRules = this.fvGetPathRules(path);
+        const relevantValues = this.fvGetPathValues(path).map((val, idx, arr) => (arr.length > 1 && typeof val === 'object' && !Array.isArray(val) && val !== null ? { ...val, idx } : val));
+
+        relevantRules.forEach((rule) => {
+          relevantValues.forEach((value) => {
+            pathErrors.push(rule(value));
+          });
+        });
+
+        return [...acc, ...pathErrors].filter(error => !!error);
+      }, []);
+
+      return messages;
+    },
+  },
+  computed: {
+    // rulesets is a combination of the rules defined in the fvFormRuleSets array and the modelValidationRules in the model. Theoretically, a form could just use the rulesets defined in the model however in practice this can be limiting
+    fvRulesets() {
+      const nullValidator = () => undefined;
+
+      return [
+        ...this.fvFormRuleSets.map((ruleset) => {
+          const formRules = formRulesGenerator(this.$store.getters['i18n/t'], { displayKey: ruleset?.translationKey ? this.$store.getters['i18n/t'](ruleset.translationKey) : 'Value' });
+
+          return {
+            ...ruleset,
+            rules:               ruleset.rules.map(rule => formRules[rule] || nullValidator),
+            formValidationRule: true
+          };
+        }),
+        ...(this?.value?.modelValidationRules || []).map(rule => ({
+          ...rule,
+          formValidationRule: false
+        }))
+      ];
+    },
+    fvUnreportedValidationErrors() { // if either the fvFormRuleSets or the modelValidationRules throw an error and the associated path isn't in the reportValidationPaths then it'll show up here.
+      // useful for throwing unreported errors into a generic banner
+      const paths = this.fvRulesets
+        .filter(ruleset => !!ruleset.formValidationRule && !this.fvReportedValidationPaths.includes(ruleset.path))
+        .map(ruleset => ruleset.path);
+
+      const formErrors = this.fvGetPathErrors(paths);
+
+      const modelErrors = this.value.customValidationErrors(this.value, this.fvReportedValidationPaths); // the model already has a means of producing errors, not reinventing the wheel... yet...
+
+      return [...formErrors, ...modelErrors, ...(this.errors || [])];
+    },
+    fvValidationErrors() { // checks for any and all errors, regardless of being bound, from the model, or from the form
+      const paths = this.fvRulesets.filter(ruleset => !!ruleset.formValidationRule).map(ruleset => ruleset.path);
+      const formErrors = this.fvGetPathErrors(paths);
+      const modelErrors = this.value.customValidationErrors(this.value); // the model already has a means of producing errors, not reinventing the wheel... yet...
+
+      return [...formErrors, ...modelErrors, ...(this.errors || [])];
+    },
+    fvFormIsValid() {
+      return this.fvValidationErrors.length === 0;
+    }
+  }
+};

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -272,6 +272,7 @@ export default class Workload extends SteveModel {
         required:       true,
         type:           'string',
         validators:     ['cronSchedule'],
+        translationKey: 'workload.cronSchedule'
       });
     }
 

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -36,6 +36,25 @@ export function set(obj, path, value) {
   return obj;
 }
 
+export function getAllValues(obj, path) {
+  const keysInOrder = path.split('.');
+  let currentValue = [obj];
+
+  keysInOrder.forEach((currentKey) => {
+    currentValue = currentValue.map((indexValue) => {
+      if (Array.isArray(indexValue)) {
+        return indexValue.map(arr => arr[currentKey]).flat();
+      } else if (indexValue) {
+        return indexValue[currentKey];
+      } else {
+        return null;
+      }
+    }).flat();
+  });
+
+  return currentValue.filter(val => val !== null);
+}
+
 export function get(obj, path) {
   if ( !path) {
     throw new Error('Cannot translate an empty input. The t function requires a string.');

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -1,0 +1,892 @@
+import formRulesGenerator from '@/shell/utils/validators/formRules/index';
+
+const mockT = (key: string, args: any) => {
+  return JSON.stringify({
+    message: key,
+    ...args
+  });
+};
+
+describe('formRules', () => {
+  const formRules = formRulesGenerator(mockT, { displayKey: 'testDisplayKey' });
+
+  it('"required" : returns undefined when value supplied', () => {
+    const testValue = 'foo';
+    const formRuleResult = formRules.required(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"required" : returns the correct message when value undefined', () => {
+    const formRuleResult = formRules.required(undefined);
+    const expectedResult = JSON.stringify({
+      message: 'validation.required',
+      key:     'testDisplayKey'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"cronSchedule" : returns undefined when valid cron string value supplied', () => {
+    const testValue = '0 * * * *';
+    const formRuleResult = formRules.cronSchedule(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"cronSchedule" : returns the correct message when invalid cron string value supplied', () => {
+    // specific logic of what constitutes a cron string is in the "cronstrue" function in an external library and not tested here
+    const testValue = '0 * * **';
+    const formRuleResult = formRules.cronSchedule(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.invalidCron' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"isHttps" : returns undefined when valid https url value is supplied', () => {
+    const testValue = 'https://url.com';
+    const formRuleResult = formRules.isHttps('server-url')(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"isHttps" : returns correct message when http url value is supplied', () => {
+    const testValue = 'http://url.com';
+    const formRuleResult = formRules.isHttps('server-url')(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.setting.serverUrl.https' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"interval" : returns undefined when valid hour interval value is supplied', () => {
+    const testValue = '5h';
+    const formRuleResult = formRules.interval(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"interval" : returns undefined when valid minute interval value is supplied', () => {
+    const testValue = '5m';
+    const formRuleResult = formRules.interval(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"interval" : returns undefined when valid second interval value is supplied', () => {
+    const testValue = '5s';
+    const formRuleResult = formRules.interval(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"interval" : returns correct message when interval unit is supplied but not integer', () => {
+    const testValue = 's';
+    const formRuleResult = formRules.interval(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.monitoring.route.interval',
+      key:     'testDisplayKey'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"interval" : returns correct message when interval integer is supplied but not unit', () => {
+    const testValue = '5';
+    const formRuleResult = formRules.interval(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.monitoring.route.interval',
+      key:     'testDisplayKey'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"containerImage" : returns undefined when valid container with image is supplied', () => {
+    const testValue = { image: 'imageName' };
+    const formRuleResult = formRules.containerImage(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"containerImage" : returns correct message when container without image is supplied', () => {
+    const testValue = { name: 'testName' };
+    const formRuleResult = formRules.containerImage(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'workload.validation.containerImage',
+      name:     testValue.name
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"containerImages" : returns undefined when valid jobTemplate value is supplied', () => {
+    const testValue = { jobTemplate: { spec: { template: { spec: { containers: [{ image: 'imageName', name: 'name' }] } } } } };
+    const formRuleResult = formRules.containerImages(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"containerImages" : returns undefined when valid non-jobTemplate value is supplied', () => {
+    const testValue = { template: { spec: { containers: [{ image: 'imageName', name: 'name' }] } } };
+    const formRuleResult = formRules.containerImages(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"containerImages" : returns correct message when supplied value contains no containers', () => {
+    const testValue = { template: { spec: { containers: [] } } };
+    const formRuleResult = formRules.containerImages(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.required',
+      key:     JSON.stringify({ message: 'workload.container.titles.containers' })
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"containerImages" : returns correct message when supplied value has containers but one has no image', () => {
+    const testValue = { template: { spec: { containers: [{ name: 'testName' }] } } };
+    const formRuleResult = formRules.containerImages(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'workload.validation.containerImage',
+      name:     'testName'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"ruleGroups" : returns undefined when rulegroups are supplied', () => {
+    const testValue = { groups: ['group1'] };
+    const formRuleResult = formRules.ruleGroups(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"groupsAreValid" : returns undefined when valid rulegroups are supplied', () => {
+    const testValue = [
+      {
+        name:  'group',
+        rules: [
+          {
+            alert:  { name: 'alertname' },
+            record: { name: 'recordname' },
+            expr:   { name: 'exprname' },
+            labels: ['label1']
+          }
+        ]
+      }
+    ];
+    const formRuleResult = formRules.groupsAreValid(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"groupsAreValid" : returns correct message when rules are empty', () => {
+    const testValue = [
+      {
+        name:  'group',
+        rules: []
+      }
+    ];
+    const formRuleResult = formRules.groupsAreValid(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.prometheusRule.groups.valid.singleEntry',
+      index:     1
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"groupsAreValid" : returns correct message when rule alert is empty', () => {
+    const testValue = [
+      {
+        name:  'group',
+        rules: [
+          {
+            alert:  '',
+            record: '',
+            expr:   '',
+            labels: { severity: 'none' }
+          }
+        ]
+      }
+    ];
+    const formRuleResult = formRules.groupsAreValid(testValue);
+    const expectedResult = JSON.stringify({
+      message:    'validation.prometheusRule.groups.valid.rule.alertName',
+      groupIndex: 1,
+      ruleIndex:  1
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"groupsAreValid" : returns correct message when rule record is empty', () => {
+    const testValue = [
+      {
+        name:  'group',
+        rules: [
+          {
+            alert:  'name',
+            record: '',
+            expr:   '',
+            labels: { severity: 'none' }
+          }
+        ]
+      }
+    ];
+    const formRuleResult = formRules.groupsAreValid(testValue);
+    const expectedResult = JSON.stringify({
+      message:    'validation.prometheusRule.groups.valid.rule.recordName',
+      groupIndex: 1,
+      ruleIndex:  1
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"groupsAreValid" : returns correct message when rule expr is empty', () => {
+    const testValue = [
+      {
+        name:  'group',
+        rules: [
+          {
+            alert:  'name',
+            record: 'record',
+            expr:   '',
+            labels: { severity: 'none' }
+          }
+        ]
+      }
+    ];
+    const formRuleResult = formRules.groupsAreValid(testValue);
+    const expectedResult = JSON.stringify({
+      message:    'validation.prometheusRule.groups.valid.rule.expr',
+      groupIndex: 1,
+      ruleIndex:  1
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"groupsAreValid" : returns correct message when rule labels is empty', () => {
+    const testValue = [
+      {
+        name:  'group',
+        rules: [
+          {
+            alert:  'name',
+            record: 'record',
+            expr:   'expr',
+            labels: {}
+          }
+        ]
+      }
+    ];
+    const formRuleResult = formRules.groupsAreValid(testValue);
+    const expectedResult = JSON.stringify({
+      message:    'validation.prometheusRule.groups.valid.rule.labels',
+      groupIndex: 1,
+      ruleIndex:  1
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"matching" : returns undefined when is not empty and match_re is not empty', () => {
+    const testValue = { match: 'matchValue', match_re: 'match_reValue' };
+    const formRuleResult = formRules.matching(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"matching" : returns undefined when match is empty and match_re is not empty', () => {
+    const testValue = { match: '', match_re: 'match_reValue' };
+    const formRuleResult = formRules.matching(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"matching" : returns undefined when match is not empty and match_re is empty', () => {
+    const testValue = { match: 'matchValue', match_re: '' };
+    const formRuleResult = formRules.matching(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"matching" : returns correct message when match is empty and match_re is empty', () => {
+    const testValue = { match: '', match_re: '' };
+    const formRuleResult = formRules.matching(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.monitoring.route.match' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"clusterName" : returns undefined when "isRke2" is false', () => {
+    const testValue = 'clusterName';
+    const formRuleResult = formRules.clusterName(false)(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"clusterName" : returns undefined when "isRke2" is true and clusterName is valid', () => {
+    const testValue = 'clustername';
+    const formRuleResult = formRules.clusterName(true)(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"clusterName" : returns correct message when "isRke2" is true and clusterName is 5 characters long with "c-" as a prefix', () => {
+    const testValue = 'c-12345';
+    const formRuleResult = formRules.clusterName(true)(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.cluster.name' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"clusterName" : returns undefined when "isRke2" is true and clusterName is less than 5 characters long with "c-" as a prefix', () => {
+    const testValue = 'c-1234';
+    const formRuleResult = formRules.clusterName(true)(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"clusterName" : returns undefined when "isRke2" is true and clusterName is more than 5 characters long with "c-" as a prefix', () => {
+    const testValue = 'c-123456';
+    const formRuleResult = formRules.clusterName(true)(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"roleTemplateRules" : returns undefined when type is RBAC role and value contains valid rules', () => {
+    const testValue: [{}] = [
+      {
+        verbs: ['verb1'], resources: ['resource1'], apiGroups: ['apiGroup1']
+      }
+    ];
+    const formRuleResult = formRules.roleTemplateRules('rbac.authorization.k8s.io.role')(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"roleTemplateRules" : returns correct message when type is RBAC role and value is missing verbs', () => {
+    const testValue: [{}] = [
+      {
+        verbs: [], resources: ['resource1'], apiGroups: ['apiGroup1']
+      }
+    ];
+    const formRuleResult = formRules.roleTemplateRules('rbac.authorization.k8s.io.role')(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.roleTemplate.roleTemplateRules.missingVerb' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"roleTemplateRules" : returns correct message when type is RBAC role and value is missing resources', () => {
+    const testValue: [{}] = [
+      {
+        verbs: ['verb1'], resources: [], apiGroups: ['apiGroup1']
+      }
+    ];
+    const formRuleResult = formRules.roleTemplateRules('rbac.authorization.k8s.io.role')(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.roleTemplate.roleTemplateRules.missingResource' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"roleTemplateRules" : returns correct message when type is RBAC role and value is missing apiGroups', () => {
+    const testValue: [{}] = [
+      {
+        verbs: ['verb1'], resources: ['resource1'], apiGroups: []
+      }
+    ];
+    const formRuleResult = formRules.roleTemplateRules('rbac.authorization.k8s.io.role')(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.roleTemplate.roleTemplateRules.missingApiGroup' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"roleTemplateRules" : returns undefined when type is not RBAC role and value contains valid rules', () => {
+    const testValue: [{}] = [
+      {
+        verbs: ['verb1'], nonResourceURLs: ['nonResourceURL1'], resources: ['resource1'], apiGroups: ['apiGroup1']
+      }
+    ];
+    const formRuleResult = formRules.roleTemplateRules('nonrbactype')(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"roleTemplateRules" : returns undefined when type is not RBAC role and value is missing resources and nonResourceURLs and apiGroups', () => {
+    const testValue: [{}] = [
+      {
+        verbs: ['verb1'], nonResourceURLs: [], resources: [], apiGroups: []
+      }
+    ];
+    const formRuleResult = formRules.roleTemplateRules('nonrbactype')(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.roleTemplate.roleTemplateRules.missingOneResource' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"servicePort" : returns undefined when servicePort is valid', () => {
+    const testValue = {
+      name:       'portName',
+      nodePort:   '8081',
+      port:       '8082',
+      targetPort: '8083',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"servicePort" : returns correct message when servicePort name is empty', () => {
+    const testValue = {
+      name:       '',
+      nodePort:   '8081',
+      port:       '8082',
+      targetPort: '8083',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.service.ports.name.required', position: 1 });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"servicePort" : returns correct message when servicePort nodePort is not an integer', () => {
+    const testValue = {
+      name:       'portName',
+      nodePort:   'test',
+      port:       '8082',
+      targetPort: '8083',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.service.ports.nodePort.requiredInt', position: 1 });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"servicePort" : returns correct message when servicePort port is not an integer', () => {
+    const testValue = {
+      name:       'portName',
+      nodePort:   '8081',
+      port:       'test',
+      targetPort: '8083',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.service.ports.port.requiredInt', position: 1 });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"servicePort" : returns correct message when port is not provided', () => {
+    const testValue = {
+      name:       'portName',
+      nodePort:   '8081',
+      targetPort: '8083',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.service.ports.port.required', position: 1 });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"servicePort" : returns correct message when targetPort port is not an integer', () => {
+    const testValue = {
+      name:       'portName',
+      nodePort:   '8081',
+      port:       '8082',
+      targetPort: 'test',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars', key: 'testDisplayKey', count: 2, chars: '[ ]'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"servicePort" : returns correct message when targetPort port is below the valid range', () => {
+    const testValue = {
+      name:       'portName',
+      nodePort:   '8081',
+      port:       '8082',
+      targetPort: '0',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.service.ports.targetPort.between', position: 1 });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"servicePort" : returns correct message when targetPort port is above the valid range', () => {
+    const testValue = {
+      name:       'portName',
+      nodePort:   '8081',
+      port:       '8082',
+      targetPort: '65536',
+      idx:        0
+    };
+    const formRuleResult = formRules.servicePort(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.service.ports.targetPort.between', position: 1 });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"clusterIp" : always returns undefined', () => {
+    const formRuleResult = formRules.clusterIp('');
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"externalName" : returns undefined when value is a valid externalName', () => {
+    const testValue = 'test';
+    const formRuleResult = formRules.externalName(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"externalName" : returns expected message when value empty', () => {
+    const testValue = '';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.service.externalName.none' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when value starts with a dot', () => {
+    const testValue = '.hostname';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.startDot', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when value starts is too long for a hostname', () => {
+    const testValue = 'There.are.many.variations.of.passages.of.Lorem.Ipsum.available.but.the.majority.have.suffered.alteration.in.some.form.by.injected.humour.or.randomised.words.which.dont.look.even.slightly.believable.If.you.are.going.to.use.a.passage.of.Lorem.Ipsum.you.need';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.hostname.tooLong', key: 'testDisplayKey', max: 253
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when value contains invalid characters', () => {
+    const testValue = 'www.host*name.com';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars', key: 'testDisplayKey', count: 1, chars: '*'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when hostname label starts with a dash', () => {
+    const testValue = 'www.-hostname.com';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.startHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when hostname label ends with a dash', () => {
+    const testValue = 'www.hostname-.com';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.endHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when hostname label contains a double-dash at the third character position', () => {
+    const testValue = 'www.ho--stname.com';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.doubleHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when hostname label is empty', () => {
+    const testValue = 'www..com';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.hostname.emptyLabel', key: 'testDisplayKey', min: 1
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"externalName" : returns expected message when hostname label is too long', () => {
+    const testValue = 'www.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.com';
+    const formRuleResult = formRules.externalName(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.hostname.tooLongLabel', key: 'testDisplayKey', max: 63
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"backupTarget" : returns undefined when value is valid backupTarget', () => {
+    const testValue = JSON.stringify({ type: 'type' });
+    const formRuleResult = formRules.backupTarget(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"backupTarget" : returns expected message when value is backupTarget without a type', () => {
+    const testValue = JSON.stringify({});
+    const formRuleResult = formRules.backupTarget(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.required', key: 'Type' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"backupTarget" : returns expected message when value is backupTarget with a type of s3 but no accessKeyId', () => {
+    const testValue = JSON.stringify({ type: 's3' });
+    const formRuleResult = formRules.backupTarget(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.required', key: 'accessKeyId' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"backupTarget" : returns expected message when value is backupTarget with a type of s3 but no secretAccessKey', () => {
+    const testValue = JSON.stringify({ type: 's3', accessKeyId: 'id' });
+    const formRuleResult = formRules.backupTarget(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.required', key: 'secretAccessKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"backupTarget" : returns expected message when value is backupTarget with a type of s3 but no bucketRegion', () => {
+    const testValue = JSON.stringify({
+      type: 's3', accessKeyId: 'id', secretAccessKey: 'key'
+    });
+    const formRuleResult = formRules.backupTarget(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.required', key: 'bucketRegion' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"backupTarget" : returns expected message when value is backupTarget with a type of s3 but no bucketName', () => {
+    const testValue = JSON.stringify({
+      type: 's3', accessKeyId: 'id', secretAccessKey: 'key', bucketRegion: 'region'
+    });
+    const formRuleResult = formRules.backupTarget(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.required', key: 'bucketName' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"backupTarget" : returns undefined when value is backupTarget with a type of s3 and all other values', () => {
+    const testValue = JSON.stringify({
+      type: 's3', accessKeyId: 'id', secretAccessKey: 'key', bucketRegion: 'region', bucketName: 'name'
+    });
+    const formRuleResult = formRules.backupTarget(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"imageUrl" : returns undefined when value is a valid imageUrl', () => {
+    const testValue = 'https://url/image.iso';
+    const formRuleResult = formRules.imageUrl(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"imageUrl" : returns expected message when value has an invalid file extension', () => {
+    const testValue = 'https://url/image.isi';
+    const formRuleResult = formRules.imageUrl(testValue);
+    const expectedResult = JSON.stringify({ message: 'harvester.validation.image.ruleTip' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"fileRequired" : returns undefined when value has an image name key', () => {
+    const testValue = { 'harvesterhci.io/image-name': 'test' };
+    const formRuleResult = formRules.fileRequired(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"fileRequired" : returns expected message when value is invalid', () => {
+    const testValue = {};
+    const formRuleResult = formRules.fileRequired(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.required', key: JSON.stringify({ message: 'harvester.image.fileName' }) });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"dnsLabel" : returns undefined when valid dnsLabel value is supplied', () => {
+    const testValue = 'bob';
+    const formRuleResult = formRules.dnsLabel(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"dnsLabel" : returns correct message when dnsLabel value with invalid characters is supplied', () => {
+    const testValue = 'bob*bob';
+    const formRuleResult = formRules.dnsLabel(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars',
+      key:     'testDisplayKey',
+      count:   1,
+      chars:   '*'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"dnsLabel" : returns correct message when  dnsLabel value that starts with a dash is supplied', () => {
+    const testValue = '-bob';
+    const formRuleResult = formRules.dnsLabel(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.label.startHyphen',
+      key:     'testDisplayKey'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"dnsLabel" : returns correct message when  dnsLabel value that ends with a dash is supplied', () => {
+    const testValue = 'bob-';
+    const formRuleResult = formRules.dnsLabel(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.label.endHyphen',
+      key:     'testDisplayKey'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"dnsLabel" : returns correct message when dnsLabel value with double-dash after first two characters is supplied', () => {
+    const testValue = 'jo--jane';
+    const formRuleResult = formRules.dnsLabel(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.doubleHyphen',
+      key:     'testDisplayKey'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"dnsLabel" : returns correct message when dnsLabel value is too long', () => {
+    const testValue = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz';
+    const formRuleResult = formRules.dnsLabel(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.label.tooLongLabel',
+      key:     'testDisplayKey',
+      max:     63
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  // this rule is pretty much identical to the standard dnsLabel other than the dnsLabel length
+  it('"dnsLabelIanaServiceName" : returns correct message when dnsLabel value is too long', () => {
+    const testValue = '0123456789abcdef';
+    const formRuleResult = formRules.dnsLabelIanaServiceName(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.label.tooLongLabel',
+      key:     'testDisplayKey',
+      max:     15
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  // this rule is pretty much identical to the standard dnsLabel other than the startNumber test
+  it('"dnsLabelRestricted" : returns correct message when dnsLabel starts with a number', () => {
+    const testValue = '1testUrl';
+    const formRuleResult = formRules.dnsLabelRestricted(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.label.startNumber',
+      key:     'testDisplayKey'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  // this rule is pretty much identical to the standard dnsLabel other than the startNumber test
+  it('"hostName" : returns undefined when value is valid hostname', () => {
+    const testValue = 'www.url.com';
+    const formRuleResult = formRules.hostname(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"hostName" : returns expected message when value starts with a dot', () => {
+    const testValue = '.hostname';
+    const formRuleResult = formRules.hostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.startDot', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"hostName" : returns expected message when value starts is too long for a hostname', () => {
+    const testValue = 'There.are.many.variations.of.passages.of.Lorem.Ipsum.available.but.the.majority.have.suffered.alteration.in.some.form.by.injected.humour.or.randomised.words.which.dont.look.even.slightly.believable.If.you.are.going.to.use.a.passage.of.Lorem.Ipsum.you.need';
+    const formRuleResult = formRules.hostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.hostname.tooLong', key: 'testDisplayKey', max: 253
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"hostName" : returns expected message when value contains invalid characters', () => {
+    const testValue = 'www.host*name.com';
+    const formRuleResult = formRules.hostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars', key: 'testDisplayKey', count: 1, chars: '*'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"hostName" : returns expected message when hostname label starts with a dash', () => {
+    const testValue = 'www.-hostname.com';
+    const formRuleResult = formRules.hostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.startHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"hostName" : returns expected message when hostname label ends with a dash', () => {
+    const testValue = 'www.hostname-.com';
+    const formRuleResult = formRules.hostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.endHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"hostName" : returns expected message when hostname label contains a double-dash at the third character position', () => {
+    const testValue = 'www.ho--stname.com';
+    const formRuleResult = formRules.hostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.doubleHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"hostName" : returns expected message when hostname label is too long', () => {
+    const testValue = 'www.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.com';
+    const formRuleResult = formRules.hostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.hostname.tooLongLabel', key: 'testDisplayKey', max: 63
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"testRule" : always returns the expected string', () => {
+    const formRuleResult = formRules.testRule('');
+    const expectedResult = 'This is an error returned by the testRule validator';
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+});

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -1,0 +1,397 @@
+import { RBAC } from '@/shell/config/types';
+import { HCI } from '@/shell/config/labels-annotations';
+import isEmpty from 'lodash/isEmpty';
+import has from 'lodash/has';
+// import uniq from 'lodash/uniq';
+import cronstrue from 'cronstrue';
+
+export type Validator = (val: any, arg?: any) => undefined | string;
+
+export type ValidatorFactory = (arg1: any, arg2?: any) => Validator
+
+type Port = {
+  name?: string,
+  nodePort?: string,
+  port?: string,
+  targetPort?: string,
+  idx: number
+}
+
+const httpsKeys = [
+  'server-url'
+];
+
+const runValidators = (val: any, validators: Validator[]) => {
+  for (const validator of validators) {
+    const message = validator(val);
+
+    if (message) {
+      return message;
+    }
+  }
+};
+
+// "t" is the function name we use for getting a translated string
+export default function(t: (key: string, options?: any) => string, opt: {displayKey?: string} = {}) {
+  const { displayKey = 'Value' } = opt;
+
+  // utility validators these validators only get used by other validators
+  const startDot: ValidatorFactory = (label: string): Validator => (val: string) => val?.slice(0, 1) === '.' ? t(`validation.dns.${ label }.startDot`, { key: displayKey }) : undefined;
+
+  // this one should technically be used for restricted hostnames but it doesn't look like the existing code will ever call validateHostName with restricted set to true.
+  // const endDot = label => val => val?.slice(-1) === '.' ? t(`validation.dns.${ label }.endDot`, { key: displayKey }) : undefined;
+
+  const startNumber: ValidatorFactory = (label: string): Validator => (val: string) => val?.slice(0, 1)?.match(/[0-9]/) ? t(`validation.dns.${ label }.startNumber`, { key: displayKey }) : undefined;
+
+  const startHyphen: ValidatorFactory = (label: string): Validator => (val: string) => val?.slice(0, 1) === '-' ? t(`validation.dns.${ label }.startHyphen`, { key: displayKey }) : undefined;
+
+  const endHyphen: ValidatorFactory = (label: string): Validator => (val: string) => val?.slice(-1) === '-' ? t(`validation.dns.${ label }.endHyphen`, { key: displayKey }) : undefined;
+
+  const dnsChars: Validator = (val: string) => {
+    const matchedChars = val?.match(/[^${ 'A-Za-z0-9-' }]/g);
+
+    if (matchedChars) {
+      return t('validation.chars', {
+        key: displayKey, count: matchedChars.length, chars: matchedChars.join(' ')
+      });
+    }
+
+    return undefined;
+  };
+
+  // the weird edge case here deals with internationalized domain names which are prepended with 'xn--'
+  // https://datatracker.ietf.org/doc/html/rfc5891#section-4.2.3.1
+  const dnsDoubleDash: Validator = (val: string) => (val?.substr(2, 2) === '--' && val?.substr(0, 2) !== 'xn') ? t(`validation.dns.doubleHyphen`, { key: displayKey }) : undefined;
+
+  const dnsIanaServiceNameDoubleDash: Validator = (val: string) => (val?.substr(2, 2) === '--' && val?.substr(0, 2) !== 'xn') ? t(`validation.dns.doubleHyphen`, { key: displayKey }) : undefined;
+
+  const dnsEmpty: ValidatorFactory = (label: string): Validator => (val = '') => val.length === 0 ? t(`validation.dns.${ label }.emptyLabel`, { key: displayKey, min: 1 }) : undefined;
+
+  const dnsTooLong: ValidatorFactory = (label: string, length = 63): Validator => (val = '') => val.length > length ? t(`validation.dns.${ label }.tooLongLabel`, { key: displayKey, max: length }) : undefined;
+
+  const hostnameEmpty: Validator = (val = '') => val.length === 0 ? t('validation.dns.hostname.empty', { key: displayKey }) : undefined;
+
+  const hostnameTooLong: Validator = (val = '') => val.length > 253 ? t('validation.dns.hostname.tooLong', { key: displayKey, max: 253 }) : undefined;
+
+  const required: Validator = (val: any) => !val && val !== false ? t('validation.required', { key: displayKey }) : undefined;
+
+  const cronSchedule: Validator = (val: string) => {
+    try {
+      cronstrue.toString(val);
+    } catch (e) {
+      return t('validation.invalidCron');
+    }
+  };
+
+  const isHttps: ValidatorFactory = (key: string) => {
+    const isHttps: Validator = (val: string) => httpsKeys.includes(key) && !val.toLowerCase().startsWith('https://') ? t('validation.setting.serverUrl.https') : undefined;
+
+    return isHttps;
+  };
+
+  const interval: Validator = (val: string) => !/^\d+[hms]$/.test(val) ? t('validation.monitoring.route.interval', { key: displayKey }) : undefined;
+
+  const containerImage: Validator = (val: any) => !val?.image ? t('workload.validation.containerImage', { name: val.name }) : undefined;
+
+  const containerImages: Validator = (val: any | [any]) => {
+    const containers = val.jobTemplate ? val?.jobTemplate?.spec?.template?.spec?.containers : val?.template?.spec?.containers;
+
+    if (!containers || !containers.length) {
+      return t('validation.required', { key: t('workload.container.titles.containers') });
+    }
+
+    // making sure each container has an imagename
+    return containers.map((container: any) => containerImage(container)).find((containerError: string) => containerError);
+  };
+
+  const dnsLabel: Validator = (val: string) => {
+    const validators = [
+      dnsChars,
+      startHyphen('label'),
+      endHyphen('label'),
+      dnsDoubleDash,
+      // dnsEmpty('label'), // questionable as to if this is needed if the field is also required...
+      dnsTooLong('label')
+    ];
+
+    return runValidators(val, validators);
+  };
+
+  const dnsLabelIanaServiceName: Validator = (val: string) => {
+    const validators = [
+      dnsChars,
+      startHyphen('label'),
+      endHyphen('label'),
+      dnsIanaServiceNameDoubleDash,
+      dnsEmpty('label'), // questionable as to if this is needed if the field is also required...
+      dnsTooLong('label', 15)
+    ];
+
+    return runValidators(val, validators);
+  };
+
+  const dnsLabelRestricted: Validator = (val: string) => {
+    const validators = [
+      dnsChars,
+      startNumber('label'),
+      startHyphen('label'),
+      endHyphen('label'),
+      dnsDoubleDash,
+      dnsEmpty('label'), // questionable as to if this is needed if the field is also required...
+      dnsTooLong('label')
+    ];
+
+    return runValidators(val, validators);
+  };
+
+  const hostname: Validator = (val: string) => {
+    const validators = [
+      startDot('hostname'),
+      hostnameEmpty,
+      hostnameTooLong
+    ];
+
+    const hostNameMessage = runValidators(val, validators);
+
+    if (hostNameMessage) {
+      return hostNameMessage;
+    }
+
+    const labels = val.split('.');
+    const labelValidators = [
+      dnsChars,
+      startHyphen('hostname'),
+      endHyphen('hostname'),
+      dnsDoubleDash,
+      dnsEmpty('hostname'),
+      dnsTooLong('hostname')
+    ];
+
+    for ( let i = 0; i < labels.length; i++ ) {
+      const labelMessage = runValidators(labels[i], labelValidators);
+
+      if (labelMessage) {
+        return labelMessage;
+      }
+    }
+  };
+
+  const externalName: Validator = (val: string) => {
+    if (isEmpty(val)) {
+      return t('validation.service.externalName.none');
+    } else {
+      return hostname(val);
+    }
+  };
+
+  const testRule = (val: string | undefined) => {
+    return 'This is an error returned by the testRule validator';
+  };
+
+  const ruleGroups: Validator = (val: {groups?: any}) => isEmpty(val?.groups) ? t('validation.prometheusRule.groups.required') : undefined;
+
+  const clusterName: ValidatorFactory = (isRke2: boolean): Validator => (val: string | undefined) => isRke2 && (val || '')?.match(/^(c-.{5}|local)$/i) ? t('validation.cluster.name') : undefined;
+
+  const servicePort = (val: Port) => {
+    const {
+      name,
+      nodePort,
+      port: pPort,
+      targetPort,
+      idx
+    } = val;
+
+    const nodePortIsInt = nodePort ? !isNaN(parseInt(nodePort, 10)) : false;
+    const pPortIsInt = pPort ? !isNaN(parseInt(pPort, 10)) : false;
+    const targetPortIsInt = targetPort || targetPort === '0' ? !isNaN(parseInt(targetPort, 10)) : false;
+
+    if (isEmpty(name)) {
+      return t('validation.service.ports.name.required', { position: idx + 1 });
+    }
+
+    if (nodePort && !nodePortIsInt) {
+      return t('validation.service.ports.nodePort.requiredInt', { position: idx + 1 });
+    }
+
+    if (pPort) {
+      if (!pPortIsInt) {
+        return t('validation.service.ports.port.requiredInt', { position: idx + 1 });
+      }
+    } else {
+      return t('validation.service.ports.port.required', { position: idx + 1 });
+    }
+
+    if (targetPort || targetPort === '0') {
+      if (!targetPortIsInt) {
+        const ianaServiceNameErrors = dnsLabelIanaServiceName(val.toString());
+
+        if (ianaServiceNameErrors) {
+          return ianaServiceNameErrors;
+        }
+      } else if (parseInt(targetPort, 10) < 1 || parseInt(targetPort, 10) > 65535) {
+        return t('validation.service.ports.targetPort.between', { position: idx + 1 });
+      }
+    } else {
+      return t('validation.service.ports.targetPort.required', { position: idx + 1 });
+    }
+
+    return undefined;
+  };
+
+  const groupIsValid: Validator = (val, readableIndex) => {
+    let returnMessage: string | undefined;
+
+    if (isEmpty(val?.name)) {
+      return t('validation.prometheusRule.groups.valid.name', { index: readableIndex });
+    }
+
+    if (isEmpty(val.rules)) {
+      return t('validation.prometheusRule.groups.valid.singleEntry', { index: readableIndex });
+    } else {
+      val.rules.forEach((rule: any, idx: number) => {
+        const readableRuleIndex = idx + 1;
+
+        if (has(rule, 'alert') && isEmpty(rule?.alert) && !returnMessage) {
+          returnMessage = t('validation.prometheusRule.groups.valid.rule.alertName', { groupIndex: readableIndex, ruleIndex: readableRuleIndex });
+        } else if (has(rule, 'record') && isEmpty(rule?.record)) {
+          returnMessage = t('validation.prometheusRule.groups.valid.rule.recordName', { groupIndex: readableIndex, ruleIndex: readableRuleIndex });
+        }
+
+        if ((has(rule, 'expr') && isEmpty(rule.expr) && !returnMessage) || (!has(rule, 'expr') && !returnMessage)) {
+          returnMessage = t('validation.prometheusRule.groups.valid.rule.expr', { groupIndex: readableIndex, ruleIndex: readableRuleIndex });
+        }
+
+        if (has(rule, 'alert')) {
+          if (
+            (has(rule, 'labels') && isEmpty(rule.labels) && !returnMessage) ||
+            (!has(rule, 'labels') && !returnMessage)
+          ) {
+            returnMessage = t('validation.prometheusRule.groups.valid.rule.labels', { groupIndex: readableIndex, ruleIndex: readableRuleIndex });
+          }
+        }
+      });
+    }
+
+    return returnMessage;
+  };
+
+  const groupsAreValid: Validator = (val) => {
+    const groups = [...val]; // making a new array in the function because I'm gonna mutate it later...
+    let message;
+
+    groups.forEach((group, idx, arr) => {
+      message = groupIsValid(group, idx + 1);
+      if (!!message) {
+        arr.length = idx + 1; // this is a tricksy way of breaking a forEach loop since we just want the first message
+      }
+    });
+
+    return message;
+  };
+
+  const matching: Validator = (val) => {
+    if (isEmpty(val?.match) && isEmpty(val?.['match_re'])) {
+      return t('validation.monitoring.route.match');
+    }
+  };
+
+  const roleTemplateRules: ValidatorFactory = (type): Validator => (val = []) => {
+    if (val.some((rule: any) => isEmpty(rule.verbs))) {
+      return t('validation.roleTemplate.roleTemplateRules.missingVerb');
+    }
+
+    if (type === RBAC.ROLE) {
+      if (val.some((rule: any) => isEmpty(rule.resources))) {
+        return t('validation.roleTemplate.roleTemplateRules.missingResource');
+      }
+
+      if (val.some((rule: any) => isEmpty(rule.apiGroups))) {
+        return t('validation.roleTemplate.roleTemplateRules.missingApiGroup');
+      }
+    } else if (val.some((rule: any) => isEmpty(rule.resources) && isEmpty(rule.nonResourceURLs) && isEmpty(rule.apiGroups))) {
+      return t('validation.roleTemplate.roleTemplateRules.missingOneResource');
+    }
+
+    return undefined;
+  };
+
+  // The existing validator for clusterIp never actually returns an error
+  const clusterIp: Validator = val => undefined;
+
+  const backupTarget: Validator = (val) => {
+    const parseValue = JSON.parse(val);
+    const type = parseValue.type;
+
+    if (!type) {
+      return t('validation.required', { key: 'Type' });
+    }
+
+    if (type === 's3') {
+      if (!parseValue.accessKeyId) {
+        return t('validation.required', { key: 'accessKeyId' });
+      }
+
+      if (!parseValue.secretAccessKey) {
+        return t('validation.required', { key: 'secretAccessKey' });
+      }
+
+      if (!parseValue.bucketRegion) {
+        return t('validation.required', { key: 'bucketRegion' });
+      }
+
+      if (!parseValue.bucketName) {
+        return t('validation.required', { key: 'bucketName' });
+      }
+    }
+
+    return undefined;
+  };
+
+  const imageUrl: Validator = (val) => {
+    const VM_IMAGE_FILE_FORMAT = ['qcow', 'qcow2', 'raw', 'img', 'iso'];
+
+    if (!val || val === '') {
+      return undefined;
+    }
+
+    const urlSlug = val.split('/').pop();
+    const fileExtension = urlSlug.split('.').pop().toLowerCase();
+
+    if (!VM_IMAGE_FILE_FORMAT.includes(fileExtension)) {
+      return t('harvester.validation.image.ruleTip');
+    }
+
+    return undefined;
+  };
+
+  const fileRequired: Validator = (val = {}) => {
+    if (!val[HCI.IMAGE_NAME]) {
+      return t('validation.required', { key: t('harvester.image.fileName') });
+    }
+  };
+
+  return {
+    required,
+    cronSchedule,
+    isHttps,
+    interval,
+    containerImage,
+    containerImages,
+    ruleGroups,
+    groupsAreValid,
+    matching,
+    clusterName,
+    roleTemplateRules,
+    servicePort,
+    clusterIp,
+    externalName,
+    backupTarget,
+    imageUrl,
+    fileRequired,
+    dnsLabel,
+    dnsLabelIanaServiceName,
+    dnsLabelRestricted,
+    hostname,
+    testRule
+  };
+}


### PR DESCRIPTION
Adds in form validation mixin for use with cru-resource mixin to validate values in form payload and provide feedback to the user.

Also adds in rule based validation to labeled input fields, fields will display error messages in a rule returns a message, validated in real time.

Specific instructions for both included in developer docs, a few example forms have implemented the mixin and field "rules" property as an example, and a couple additional components have been implemented and/or extended to allow for more robust error messaging to users.