### PR TITLE
Fix bug where table can jump back to page 1 after page change

### DIFF
--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -56,17 +56,7 @@ export default {
       if ( this.page > 1 && from > last ) {
         this.setPage(this.totalPages);
       }
-    },
-
-    sortFields(old, neu) {
-      if ( old.join(',') === neu.join(',') ) {
-        // Nothing really changed
-
-      }
-
-      // Go back to the first page when sort changes
-      this.setPage(1);
-    },
+    }
   },
 
   methods: {

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -96,7 +96,9 @@ export default {
     changeSort(sort, desc) {
       this.sortBy = sort;
       this.descending = desc;
-      this.currentPage = 1;
+
+      // Always go back to the first page when the sort is changed
+      this.setPage(1);
     },
   },
 };


### PR DESCRIPTION
Fixes #6138 

There is a watch for the sort fields changing - this always returns to the first page.

For some reason, this is getting called and the page is being reset.

This PR fixes the issue and tidies up the code.
