### PR TITLE
Use a delayed loading column for Pod Restarts

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -436,10 +436,23 @@ export default {
       return !!delaeydColumns;
     },
 
+    columnFormmatterIDs() {
+      const columnsIds = {};
+
+      this.columns.forEach((c) => {
+        if (c.formatter) {
+          columnsIds[c.formatter] = dasherize(c.formatter);
+        }
+      });
+
+      return columnsIds;
+    },
+
     // Generate row and column data for easier rendering in the template
     // ensures we only call methods like `valueFor` once
     displayRows() {
       const rows = [];
+      const columnFormmatterIDs = this.columnFormmatterIDs;
 
       this.groupedRows.forEach((grp) => {
         const group = {
@@ -463,7 +476,7 @@ export default {
           group.rows.push(rowData);
 
           this.columns.forEach((c) => {
-            const value = this.valueFor(row, c);
+            const value = c.delayLoading ? undefined : this.valueFor(row, c);
             let component;
             let formatted = value;
             let needRef = false;
@@ -486,7 +499,7 @@ export default {
               delayed:   c.delayLoading,
               live:      c.formatter?.startsWith('Live') || c.liveUpdates,
               label:     this.labelFor(c),
-              dasherize: dasherize(c.formatter || ''),
+              dasherize: columnFormmatterIDs[c.formatter] || '',
             });
           });
         });
@@ -601,7 +614,8 @@ export default {
         return col.value(row);
       }
 
-      // console.warn(`Performance: Table valueFor: ${ col.name } ${ col.value }`); // Use to debug table columns using expensive value getters
+      // Use to debug table columns using expensive value getters
+      // console.warn(`Performance: Table valueFor: ${ col.name } ${ col.value }`); // eslint-disable-line no-console
 
       const expr = col.value || col.name;
       const out = get(row, expr);

--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -56,17 +56,7 @@ export default {
       if ( this.page > 1 && from > last ) {
         this.setPage(this.totalPages);
       }
-    },
-
-    sortFields(old, neu) {
-      if ( old.join(',') === neu.join(',') ) {
-        // Nothing really changed
-
-      }
-
-      // Go back to the first page when sort changes
-      this.setPage(1);
-    },
+    }
   },
 
   methods: {

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -96,7 +96,9 @@ export default {
     changeSort(sort, desc) {
       this.sortBy = sort;
       this.descending = desc;
-      this.currentPage = 1;
+
+      // Always go back to the first page when the sort is changed
+      this.setPage(1);
     },
   },
 };

--- a/shell/components/formatter/DelayedValue.vue
+++ b/shell/components/formatter/DelayedValue.vue
@@ -1,0 +1,43 @@
+<script>
+export default {
+  props: {
+    row: {
+      type:     Object,
+      required: true
+    },
+    col: {
+      type:     Object,
+      required: true
+    },
+  },
+
+  data() {
+    return { loading: true };
+  },
+
+  computed: {
+    value() {
+      return this.col.value(this.row);
+    }
+  },
+
+  methods:  {
+    startDelayedLoading() {
+      this.loading = false;
+    }
+  }
+};
+</script>
+
+<template>
+  <i v-if="loading" class="icon icon-spinner delayed-loader" />
+  <span v-else>{{ value }}</span>
+</template>
+
+<style lang="scss" scoped>
+  .delayed-loader {
+    font-size: 16px;
+    height: 16px;
+    width: 16px;
+  }
+</style>

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -269,9 +269,12 @@ export const POD_IMAGES = {
 };
 
 export const POD_RESTARTS = {
-  name:      'pod_restarts',
-  labelKey:  'tableHeaders.podRestarts',
-  value:     'restartCount'
+  name:         'pod_restarts',
+  labelKey:     'tableHeaders.podRestarts',
+  formatter:    'DelayedValue',
+  delayLoading: true,
+  value:        'restartCount',
+  getValue:     row => row.restartCount,
 };
 
 export const ENDPOINTS = {
@@ -414,6 +417,7 @@ export const TYPE = {
   name:     'type',
   labelKey: 'tableHeaders.type',
   value:    'typeDisplay',
+  getValue: row => row.typeDisplay,
   sort:     ['typeDisplay'],
   width:    100,
 };
@@ -636,6 +640,7 @@ export const WORKLOAD_HEALTH_SCALE = {
   name:         'workloadHealthScale',
   labelKey:     'tableHeaders.health',
   formatter:    'WorkloadHealthScale',
+  getValue:     () => undefined,
   width:        150,
   skipSelect:   true,
   delayLoading: true,

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -5,7 +5,7 @@ import { perfLoadAll } from '@shell/plugins/steve/performanceTesting';
 export default {
   loadAll(state, { type, data, ctx }) {
     // Performance testing in dev and when env var is set
-    if (process.env.dev && process.env.perfTest) {
+    if (process.env.dev && !!process.env.perfTest) {
       data = perfLoadAll(type, data);
     }
 

--- a/shell/plugins/steve/performanceTesting.js
+++ b/shell/plugins/steve/performanceTesting.js
@@ -19,6 +19,11 @@ const PERF_DATA = {
   },
 };
 
+// Log a warning when performance data simulation is enabled
+if (!!process.env.perfTest && process.env.dev ) {
+  console.warn('Performance Testing data enabled', PERF_DATA); // eslint-disable-line no-console
+}
+
 const DEFAULTS = {
   count:     1, // One copy of each resource
   statusRow: 0, // Don't add any status rows (0 = None, 1 = All, N = 1 out of N)


### PR DESCRIPTION
Fixes #6140 

Includes PR: #6139

This PR adds a new formatter - `DelayedValue` and uses that for the pod restarts column.

It also adds value getters for two more columns and makes a minor tweak to the sortable table so that column IDs are calculated once up-front rather than every time for each row (a small optimisation to reduce calls to the `dasherize` function).

We also optimise slightly so that we don't get values for delayed columns in `displayRows` - since the delayed loading formatter will do this when it is ready to display the column.
