### PR TITLE
Fix `globalSettings` error in console

### DIFF
--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -12,7 +12,7 @@ export default {
   },
 
   data() {
-    return { globalSettings: [], apps: [] };
+    return { apps: [] };
   },
 
   computed: {


### PR DESCRIPTION
- caused by bad merge from epinio-dev --> master
- globalSetting was moved to a `computed` property but wasn't removed from `data`
