### PR TITLE
Pass data when emitting finish event

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -280,7 +280,7 @@ export default {
 
         // If the attempt to create the new namespace
         // is successful, save the resource.
-        this.$emit('finish');
+        this.$emit('finish', buttonDone);
       } catch (err) {
         // After the attempt to create the namespace,
         // show any applicable errors if the namespace is

--- a/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
+++ b/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
@@ -1,6 +1,7 @@
 <script>
 import CreateEditView from '@shell/mixins/create-edit-view';
 import CruResource from '@shell/components/CruResource';
+import Banner from 'pkg/rancher-components/src/components/Banner/Banner.vue';
 import { MANAGEMENT } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import ClusterPermissionsEditor from '@shell/components/form/Members/ClusterPermissionsEditor';
@@ -8,6 +9,7 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 
 export default {
   components: {
+    Banner,
     ClusterPermissionsEditor,
     CruResource,
     Loading,


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/6153


# QA Template

## Root cause
The root cause is that in a PR that modified the CruResource component, I accidentally removed the data that had previously been passed when emitting the `finish` event. https://github.com/rancher/dashboard/pull/6084/files#diff-3949ec5a78c462b58bebb75bc06ccea895056a12129a9a8b8841dac3dd6b07d0R283
 
## What was fixed, or what changes have occurred
I created a PR https://github.com/rancher/dashboard/pull/6156 that passes event data when emitting the `finish` event:

https://github.com/rancher/dashboard/compare/fix-cruresource?expand=1#diff-3949ec5a78c462b58bebb75bc06ccea895056a12129a9a8b8841dac3dd6b07d0R283

This is what the CruResource component had already been doing before my PR accidentally removed it: 

https://github.com/rancher/dashboard/pull/6084/files#diff-3949ec5a78c462b58bebb75bc06ccea895056a12129a9a8b8841dac3dd6b07d0L384
 
## Areas or cases that should be tested
Same as the steps to reproduce the issue
 
## What areas could experience regressions?
The CruResource component is used in every form, but this PR is restoring functionality it already had previously, so I wouldn't expect a regression
 
## Are the repro steps accurate/minimal?
yes