### PR TITLE
NameNsDescription Updates

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -1,7 +1,7 @@
 <script>
 import isEmpty from 'lodash/isEmpty';
 import { createYaml } from '@shell/utils/create-yaml';
-import { clone } from '@shell/utils/object';
+import { clone, get } from '@shell/utils/object';
 import { SCHEMA } from '@shell/config/types';
 import ResourceYaml from '@shell/components/ResourceYaml';
 import { Banner } from '@components/Banner';
@@ -100,11 +100,10 @@ export default {
       default: ''
     },
 
-    // Used to allow creating namespaces that are not
-    // for Kubernetes resources, for example, an Epinio namespace.
+    // Location of `namespace` value within the resource. Used when creating the namespace
     namespaceKey: {
       type:    String,
-      default: ''
+      default: 'metadata.namespace'
     }
   },
 
@@ -299,13 +298,7 @@ export default {
 
       if (this.createNamespace) {
         try {
-          let newNamespace = null;
-
-          if (this.namespaceKey) {
-            newNamespace = await this.$store.dispatch(`${ inStore }/createNamespace`, { name: this.resource[this.namespaceKey] }, { root: true });
-          } else {
-            newNamespace = await this.$store.dispatch(`${ inStore }/createNamespace`, { name: this.resource.metadata.namespace }, { root: true });
-          }
+          const newNamespace = await this.$store.dispatch(`${ inStore }/createNamespace`, { name: get(this.resource, this.namespaceKey) }, { root: true });
 
           newNamespace.applyDefaults();
           await newNamespace.save();

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -426,7 +426,6 @@ button {
   margin-right: 10px;
 
   cursor: pointer;
-  color: rgb(255, 0, 0);
 }
 
 .row {

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -423,7 +423,7 @@ button {
   position: relative;
   top: -35px;
   float: right;
-  margin-right: 10px;
+  margin-right: 7px;
 
   cursor: pointer;
 }

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -1,4 +1,5 @@
 <script>
+import Vue from 'vue';
 import { mapGetters } from 'vuex';
 import { get, set } from '@shell/utils/object';
 import { sortBy } from '@shell/utils/sort';
@@ -326,6 +327,7 @@ export default {
       if (e.value === '') { // The blank value in the dropdown is labeled "Create a New Namespace"
         this.createNamespace = true;
         this.$parent.$emit('createNamespace', true);
+        Vue.nextTick(() => this.$refs.namespace.focus());
       } else {
         this.createNamespace = false;
         this.$parent.$emit('createNamespace', false);

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -901,7 +901,7 @@ export default {
         :mode="mode"
         @change="name=value.metadata.name"
       />
-      <div class="row mb-10">
+      <div v-if="isCronJob || isReplicable || (isReplicable && isStatefulSet) || containerOptions.length > 1" class="row mb-20">
         <div v-if="isCronJob" class="col span-3">
           <LabeledInput
             v-model="spec.schedule"

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -901,7 +901,7 @@ export default {
         :mode="mode"
         @change="name=value.metadata.name"
       />
-      <div v-if="isCronJob || isReplicable || (isReplicable && isStatefulSet) || containerOptions.length > 1" class="row mb-20">
+      <div v-if="isCronJob || isReplicable || isStatefulSet || containerOptions.length > 1" class="row mb-20">
         <div v-if="isCronJob" class="col span-3">
           <LabeledInput
             v-model="spec.schedule"
@@ -922,7 +922,7 @@ export default {
             :label="t('workload.replicas')"
           />
         </div>
-        <div v-if="isReplicable && isStatefulSet" class="col span-3">
+        <div v-if="isStatefulSet" class="col span-3">
           <LabeledSelect
             v-model="spec.serviceName"
             option-label="metadata.name"

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -902,7 +902,7 @@ export default {
         @change="name=value.metadata.name"
       />
       <div class="row mb-10">
-        <div v-if="isCronJob" class="col span-4">
+        <div v-if="isCronJob" class="col span-3">
           <LabeledInput
             v-model="spec.schedule"
             type="cron"
@@ -912,7 +912,7 @@ export default {
             placeholder="0 * * * *"
           />
         </div>
-        <div v-if="isStatefulSet || isDeployment" class="col span-4">
+        <div v-if="isReplicable" class="col span-3">
           <LabeledInput
             v-model.number="spec.replicas"
             type="number"
@@ -922,7 +922,7 @@ export default {
             :label="t('workload.replicas')"
           />
         </div>
-        <div v-if="isStatefulSet" class="col span-4">
+        <div v-if="isReplicable && isStatefulSet" class="col span-3">
           <LabeledSelect
             v-model="spec.serviceName"
             option-label="metadata.name"


### PR DESCRIPTION
UX Changes
- Cancel cross should be a standard colour rather than red
  ![image](https://user-images.githubusercontent.com/18697775/173337245-b293b281-6306-4eb5-937c-052835c596c7.png)
  vs
  ![image](https://user-images.githubusercontent.com/18697775/173337066-43de8db2-1b83-4cc4-b327-22bfd938f909.png)
- Align cancel `x` with select container drop down's arrow (not shown above)
- When choosing to create a namespace set the focus to newly exposed input field (avoids user having to click again)
- Align additional fields for deployment types with fields above (previously fields below were much bigger than above)
- Align margin bottom of NameNsDescription and workload specific field row
  - Also ensure row (with margin) only shows when it has to

UX Questions
- The container selector is now dangling on the end of a row of input fields. I thought to move it to the start, however then the selector is in the middle (reading left to right over rows) of input fields. Not sure where the selector should ultimately end up

Function Fixes
- Ensure additional fields for deployment types show (replica sets was missing for deployments
- Ensure CruResource `namespaceKey` works for paths (they'll be used for the same purpose)
  - align CruResource `namespaceKey` with NameNsDescription `namespaceKey`
  - reduce complexity
  - This follows on from the conversation in https://github.com/rancher/dashboard/pull/6084
 

Overall Visible Changes

Before
![image](https://user-images.githubusercontent.com/18697775/173348247-e59822de-1813-45e1-8203-395535f20033.png)

After
![image](https://user-images.githubusercontent.com/18697775/173350336-97294f26-0434-490e-bae5-ecd0d8e40812.png)

