### PR TITLE
Fix 404/error page

### DIFF
--- a/docs/developer/style.md
+++ b/docs/developer/style.md
@@ -4,14 +4,6 @@
 
 SCSS Styles can be found in `assets/styles/`. It's recommended to browse through some of the common styles in `_helpers.scss` and `_mixins.scss`.
 
-### Examples
-
-The following pages contain example components and their styling
-
-- Buttons - `<dashboard url>/design-system`
-- Form Controls - `<dashboard url>/design-system/form-controls`
-- Provider Images - `<dashboard url>/design-system/provider-images`
-
 ### Icons 
 Icons are font based and can be shown via the icon class
 

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -623,6 +623,10 @@ export default {
       <div class="wm">
         <WindowManager />
       </div>
+      <main v-if="!clusterId">
+        <!-- Always ensure there's an outlet to cover 404 cases get directed to error page -->
+        <nuxt class="outlet" />
+      </main>
     </div>
     <FixedBanner :footer="true" />
     <GrowlManager />


### PR DESCRIPTION
- Currently the default layout does not expose an outlet if there is no ready cluster
- This means unknown routes like `/aaa` cannot show the error page
  - A header and blank page is shown instead
  - ![image](https://user-images.githubusercontent.com/18697775/173404234-bf3b83f9-5d23-4562-b3e2-fc8a0017e8dd.png)
- Fix is to add the outlet when we don't have a cluster id
  - ![image](https://user-images.githubusercontent.com/18697775/173404395-ae0bbae1-5503-46fc-a80a-708264d2a3bc.png)
- The default layout shouldn't be used when there is no cluster (see `plain` layout), so this should be safe

Additionally remove some legacy references to `design-system` - fixes https://github.com/rancher/dashboard/issues/5613