### PR TITLE
Explicitly return false if `findTrueValues` is falsy

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -179,13 +179,7 @@ export default Vue.extend({
      * @param value A collection of values for the checkbox.
      */
     findTrueValues(value: boolean[]): boolean {
-      const lookup = value.find(v => v === this.valueWhenTrue);
-
-      if (typeof lookup === 'undefined') {
-        throw new TypeError('Method findTrueValue is undefined');
-      }
-
-      return lookup;
+      return value.find(v => v === this.valueWhenTrue) || false;
     }
   }
 });


### PR DESCRIPTION
This explicitly returns false if no conditions can satisfy `value.find()` instead of throwing a type error if `undefined`. This still satisfies the `isChecked` computed prop in the same way that it behaved before the typescript conversion.

See also [PR #6073](https://github.com/rancher/dashboard/pull/6073/files#diff-06c482d4d2e8220ab950839aa5aca4dd6a6101f7b94f38c293e559c48049295d)

Fixes #6137 

Testing notes in issue.

### Context

[Array.prototype.find() returns `undefined` if no conditions satisfy the testing function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>