### PR TITLE
Errors are not displaying when standard user attempts to create a project with non-default Pod Security Policy

### DIFF
--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -74,11 +74,15 @@ export default class Project extends HybridModel {
 
     const newValue = await norman.save({ replace: forceReplaceOnReq });
 
-    newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
+    try {
+      await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
 
-    await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
+      await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
 
-    return newValue;
+      return newValue;
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   async remove() {


### PR DESCRIPTION
Fixes #5964 

Update save logic to catch promise errors and pass to CRU form if found

To test: 
- Create RKE Cluster
- Create new user (member)
- Enable Pod Security Policy at cluster level
- Add new user to cluster and project
- Log in as new user
- Create new project in cluster and select a pod security policy (eg Restricted)
- Error message should display as banner at top of page

![Screen Shot 2022-06-14 at 7 15 29 AM](https://user-images.githubusercontent.com/13671297/173599471-486ebc4b-7330-4a59-9575-1ef09d03c135.png)
