### PR TITLE
Fix `Duplicate keys detected` in endpoint formatter

### DIFF
--- a/shell/components/formatter/Endpoints.vue
+++ b/shell/components/formatter/Endpoints.vue
@@ -82,11 +82,11 @@ export default {
 
 <template>
   <span>
-    <template v-for="endpoint in parsed">
+    <template v-for="(endpoint, index) in parsed">
       <span v-if="endpoint.display" :key="endpoint.display" class="block">{{ endpoint.display }}</span>
       <a
         v-else
-        :key="endpoint.link"
+        :key="index + endpoint.link"
         class="block"
         :href="endpoint.link"
         target="_blank"


### PR DESCRIPTION
- In the workloads list the Endpoints column can show multiple endpoints
- These are `key`ed by `endpoint.link`
- Endpoint links are not guaranteed to be unique (I've got a system that shows this, available on request)
