### PR TITLE
Show more headers in workload pods list (including age)

### DIFF
--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -1,8 +1,6 @@
 <script>
 import CreateEditView from '@shell/mixins/create-edit-view';
-import {
-  STATE, NAME, NODE, POD_IMAGES, POD_RESTARTS
-} from '@shell/config/table-headers';
+import { NAMESPACE as NAMESPACE_COL } from '@shell/config/table-headers';
 import { POD, WORKLOAD_TYPES, SCALABLE_WORKLOAD_TYPES } from '@shell/config/types';
 import SortableTable from '@shell/components/SortableTable';
 import Tab from '@shell/components/Tabbed/Tab';
@@ -152,13 +150,7 @@ export default {
     },
 
     podHeaders() {
-      return [
-        STATE,
-        NAME,
-        NODE,
-        POD_IMAGES,
-        POD_RESTARTS
-      ];
+      return this.$store.getters['type-map/headersFor'](this.podSchema).filter(h => h !== NAMESPACE_COL);
     },
 
     graphVarsWorkload() {


### PR DESCRIPTION
- Customers have stated the AGE column was missing from this view
  - Request came from a customer interview
- Go one step further and ensure that all columns (minus namespace) are shown
- Changes
  ![image](https://user-images.githubusercontent.com/18697775/173639678-048f67a8-e44a-4647-96c8-63ab8e0bbb62.png) 
- This contributes to SURE-4759 but does not fully resolve it
  - SURE-4759 is for a different customer who has asked for more
  - See issue for screenshots of this change and existing cluster manager changes

