### PR TITLE
HARVESTER: Limit all VMs of the Harvester guest cluster in the same namespace

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -50,6 +50,16 @@ export default {
       type:     String,
       required: true,
     },
+
+    idx: {
+      type:     Number,
+      required: true,
+    },
+
+    machinePools: {
+      type:    Array,
+      default: () => []
+    },
   },
 
   data() {
@@ -177,6 +187,8 @@ export default {
       :value="value.config"
       :provider="provider"
       :credential-id="credentialId"
+      :pool-index="idx"
+      :machine-pools="machinePools"
       @error="e=>errors = e"
     />
     <Banner v-else color="info" label="You do not have access to see this machine pool's configuration." />

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1567,7 +1567,7 @@ export default {
           @addTab="addMachinePool($event)"
           @removeTab="removeMachinePool($event)"
         >
-          <template v-for="obj in machinePools">
+          <template v-for="(obj, idx) in machinePools">
             <Tab v-if="!obj.remove" :key="obj.id" :name="obj.id" :label="obj.pool.name || '(Not Named)'" :show-header="false">
               <MachinePool
                 ref="pool"
@@ -1576,6 +1576,8 @@ export default {
                 :mode="mode"
                 :provider="provider"
                 :credential-id="credentialId"
+                :idx="idx"
+                :machine-pools="machinePools"
                 @error="e=>errors = e"
               />
             </Tab>

--- a/shell/machine-config/harvester.vue
+++ b/shell/machine-config/harvester.vue
@@ -43,6 +43,16 @@ export default {
       type:    Boolean,
       default: false
     },
+
+    poolIndex: {
+      type:     Number,
+      required: true,
+    },
+
+    machinePools: {
+      type:    Array,
+      default: () => []
+    },
   },
 
   async fetch() {
@@ -204,6 +214,10 @@ export default {
         };
       });
     },
+
+    namespaceDisabled() {
+      return this.disabledEdit || this.poolIndex > 0;
+    },
   },
 
   watch: {
@@ -229,6 +243,17 @@ export default {
       this.$refs.userDataYamlEditor.refresh();
       this.value.userData = base64Encode(neu);
     },
+
+    machinePools: {
+      handler(pools) {
+        const vmNamespace = pools[0].config.vmNamespace;
+
+        if (this.poolIndex > 0 && this.value.vmNamespace !== vmNamespace) {
+          this.value.vmNamespace = vmNamespace;
+        }
+      },
+      deep: true,
+    }
   },
 
   methods: {
@@ -369,7 +394,7 @@ export default {
             :options="namespaceOptions"
             :searchable="true"
             :required="true"
-            :disabled="disabledEdit"
+            :disabled="namespaceDisabled"
             label-key="cluster.credential.harvester.namespace"
             :placeholder="t('cluster.harvester.machinePool.namespace.placeholder')"
           />
@@ -380,7 +405,7 @@ export default {
             label-key="cluster.credential.harvester.namespace"
             :required="true"
             :mode="mode"
-            :disabled="disabledEdit"
+            :disabled="namespaceDisabled"
             :placeholder="t('cluster.harvester.machinePool.namespace.placeholder')"
           />
         </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Limit all VMs of the Harvester guest cluster in the same namespace


<!-- Define findings related to the feature or bug issue. -->



### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2354

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

As the virtual machines are in the same namespace, we added a limitation for the cluster created. Only the first pool can select the namespace, the other pool is disabled and will sync with the first node pool namespace. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Harvester node driver 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Harvester node driver 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/18737885/173780891-03928faf-1196-472a-a36c-fecee042c0c9.png)