### PR TITLE
Add link to certificate secrets on ingress detail page

### DIFF
--- a/shell/detail/networking.k8s.io.ingress.vue
+++ b/shell/detail/networking.k8s.io.ingress.vue
@@ -5,6 +5,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 import Rules from '@shell/edit/networking.k8s.io.ingress/Rules';
 import ResourceTabs from '@shell/components/form/ResourceTabs';
 import Tab from '@shell/components/Tabbed/Tab';
+import { SECRET_TYPES as TYPES } from '@shell/config/secret';
 
 export default {
   name:       'CRUIngress',
@@ -38,6 +39,13 @@ export default {
     firstTabLabel() {
       return this.isView ? this.t('ingress.rulesAndCertificates.title') : this.t('ingress.rules.title');
     },
+    certificates() {
+      return this.filterByCurrentResourceNamespace(this.allSecrets.filter(secret => secret._type === TYPES.TLS)).map((secret) => {
+        const { id } = secret;
+
+        return id.slice(id.indexOf('/') + 1);
+      });
+    },
   },
   methods: {
     filterByCurrentResourceNamespace(resources) {
@@ -51,7 +59,7 @@ export default {
 <template>
   <ResourceTabs v-model="value" mode="view" class="mt-20">
     <Tab label="Rules" name="rules" :weight="1">
-      <Rules v-model="value" :mode="mode" :service-targets="serviceTargets" />
+      <Rules v-model="value" :mode="mode" :service-targets="serviceTargets" :certificates="certificates" />
     </Tab>
   </ResourceTabs>
 </template>


### PR DESCRIPTION
### Summary
Add link to certificate secrets on ingress detail page

Fixes #6177

### Occurred changes and/or fixed issues
The ingress detail page now filters the already loaded secrets for certificate secrets in the ingress' namespace and passes them to the Rules component. The Rules component already had logic to create a link to the secret in the certificates column.

### Areas or cases that should be tested
The ingress detail page

### Areas which could experience regressions
The ingress detail page

### Screenshot/Video
Before
<img width="739" alt="Bildschirmfoto 2022-06-15 um 16 45 39" src="https://user-images.githubusercontent.com/243056/173857836-99af6475-a343-404a-9c16-60d3536530bc.png">

After
<img width="745" alt="Bildschirmfoto 2022-06-15 um 16 46 09" src="https://user-images.githubusercontent.com/243056/173857858-2867a62f-44a3-4d9e-b3d9-5c8815351187.png">

