### PR TITLE
fix merge order and objects involved for rke2 configs

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1022,7 +1022,7 @@ export default {
         // We don't allow the user to edit any of the fields in metadata from the UI so it's safe to override it with the
         // metadata defined by the latest backend value. This is primarily used to ensure the resourceVersion is up to date.
         delete clonedCurrentConfig.metadata;
-        machinePool.config = merge(machinePool.config, clonedLatestConfig);
+        machinePool.config = merge(clonedLatestConfig, clonedCurrentConfig);
       }
     },
 


### PR DESCRIPTION
Addresses Github issue: [#6180](https://github.com/rancher/dashboard/issues/6180)

- Apply fix on merge of RKE2 configs object so that changes done on the UI apply

Notes:
- Seems that order of params was wrong (`source` vals superseed the `object` vals), as also the objects themselves. I think what we want is to apply the changed config options (without metadata) on the latest config fetched from the BE
[Lodash docs for merge](https://lodash.com/docs/#merge)
