### PR TITLE
Fixes for setting custom favicon

### DIFF
--- a/shell/layouts/error.vue
+++ b/shell/layouts/error.vue
@@ -2,9 +2,10 @@
 import Brand from '@shell/mixins/brand';
 
 export default {
-  name:   'NuxtError',
+  name:       'NuxtError',
   mixins:     [Brand],
-  props:  {
+  middleware: ['unauthenticated'],
+  props:      {
     error: {
       type:    Object,
       default: null

--- a/shell/layouts/unauthenticated.vue
+++ b/shell/layouts/unauthenticated.vue
@@ -4,7 +4,8 @@ import FixedBanner from '@shell/components/FixedBanner';
 
 export default {
   mixins:     [Brand],
-  components: { FixedBanner }
+  components: { FixedBanner },
+  middleware: ['unauthenticated'],
 };
 </script>
 

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -13,7 +13,7 @@ import { get } from '@shell/utils/object';
 import { AFTER_LOGIN_ROUTE } from '@shell/store/prefs';
 import { NAME as VIRTUAL } from '@shell/config/product/harvester';
 import { BACK_TO } from '@shell/config/local-storage';
-import { setFavIcon } from '@shell/utils/favicon';
+import { setFavIcon, haveSetFavIcon } from '@shell/utils/favicon';
 
 const getPackageFromRoute = (route) => {
   if (!route?.meta) {
@@ -108,7 +108,9 @@ export default async function({
     });
 
     // Set the favicon - use custom one from store if set
-    setFavIcon(store);
+    if (!haveSetFavIcon()) {
+      setFavIcon(store);
+    }
 
     const res = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);
     const plSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.PL);

--- a/shell/middleware/unauthenticated.js
+++ b/shell/middleware/unauthenticated.js
@@ -1,0 +1,22 @@
+import { setFavIcon, haveSetFavIcon } from '@shell/utils/favicon';
+import { MANAGEMENT } from '@shell/config/types';
+import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
+
+export default async function({ store }) {
+  if (haveSetFavIcon()) {
+    return;
+  }
+
+  try {
+    // Load settings, which will either be just the public ones if not logged in, or all if you are
+    await store.dispatch('management/findAll', {
+      type: MANAGEMENT.SETTING,
+      opt:  {
+        load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
+      }
+    });
+
+    // Set the favicon - use custom one from store if set
+    setFavIcon(store);
+  } catch (e) {}
+}

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -6,9 +6,12 @@ import { createCssVars } from '@shell/utils/color';
 
 export default {
   async fetch() {
-    if ( this.$store.getters['management/canList'](CATALOG.APP) ) {
-      this.apps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP });
-    }
+    // For the login page, the schemas won't be loaded - we don't need the apps in this case
+    try {
+      if (this.$store.getters['management/canList'](CATALOG.APP)) {
+        this.apps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP });
+      }
+    } catch (e) {}
   },
 
   data() {

--- a/shell/pages/c/_cluster/settings/brand.vue
+++ b/shell/pages/c/_cluster/settings/brand.vue
@@ -307,7 +307,7 @@ export default {
               @selected="updateLogo($event, 'uiFavicon')"
             />
           </div>
-          <SimpleBox v-if="uiFavicon" class="theme-light">
+          <SimpleBox v-if="uiFavicon">
             <label class="text-muted">{{ t('branding.favicon.preview') }}</label>
             <img class="logo-preview" :src="uiFavicon" />
           </SimpleBox>

--- a/shell/utils/favicon.js
+++ b/shell/utils/favicon.js
@@ -1,13 +1,21 @@
 import { SETTING } from '@shell/config/settings';
 import { MANAGEMENT } from '@shell/config/types';
 
+let favIconSet = false;
+
+export function haveSetFavIcon() {
+  return favIconSet;
+}
+
 export function setFavIcon(store) {
   const app = store.app;
   const res = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FAVICON);
+
   const link = findIconLink(app.head.link);
 
   if (link) {
     link.href = res?.value || defaultFavIcon;
+    favIconSet = true;
   }
 }
 


### PR DESCRIPTION
Follow-on fixes for adding custom fav icon.

- Don't force light theme in the settings page
- Ensure the icon is set for all page layouts - previously this was only for those that included the `authenticated` middleware