### PR TITLE
Add loading indicator to clusters list page

### DIFF
--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -134,7 +134,7 @@ export default {
       </template>
     </Masthead>
 
-    <ResourceTable :schema="schema" :rows="rows" :namespaced="false">
+    <ResourceTable :schema="schema" :rows="rows" :namespaced="false" :loading="$fetchState.pending">
       <template #cell:summary="{row}">
         <span v-if="!row.stateParts.length">{{ row.nodes.length }}</span>
       </template>


### PR DESCRIPTION
Adds loading indicator the cluster list page in Cluster Management - currently the table shows 'no rows' message before then showing the clusters - this PR fixes that so that it shows the loading indicator instead of the 'no rows' message.