### PR TITLE
Add containerStatus lastState information to Pod detail page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5116,6 +5116,7 @@ workload:
       sysctls: Sysctls
       sysctlsKey: Name
     standard: Standard Container
+    terminationState: "Last state: Terminated with {lsExitCode}: {lsDescription}, started: {lsStartedAt}, finished: {lsFinishedAt}"
     titles:
       container: Container
       command: Command
@@ -6705,7 +6706,7 @@ notifications:
   menuLabel: 'Custom Notifications'
   loginError:
     header: Login Failed Banner
-    showCheckboxLabel: Show custom login error 
+    showCheckboxLabel: Show custom login error
     messageLabel: Text to display
 resourceQuota:
   label: Resource Quotas

--- a/shell/detail/pod.vue
+++ b/shell/detail/pod.vue
@@ -12,6 +12,9 @@ import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@shell/utils/grafana';
 import Loading from '@shell/components/Loading';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import day from 'dayjs';
+import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
+import { escapeHtml } from '@shell/utils/string';
 
 const POD_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-pod-containers-1/rancher-pod-containers?orgId=1';
 const POD_METRICS_SUMMARY_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-pod-1/rancher-pod?orgId=1';
@@ -79,8 +82,8 @@ export default {
           const lsReason = ls.reason || '';
           const lsMessage = ls.message || '';
           const lsExitCode = ls.exitCode || '';
-          const lsStartedAt = ls.startedAt || '';
-          const lsFinishedAt = ls.finishedAt || '';
+          const lsStartedAt = this.dateTimeFormat(ls.startedAt);
+          const lsFinishedAt = this.dateTimeFormat(ls.finishedAt);
           const lsShowBracket = ls.reason && ls.message;
           const lsDescription = `${ lsReason }${ lsShowBracket ? ' (' : '' }${ lsMessage }${ lsShowBracket ? ')' : '' }`;
 
@@ -195,6 +198,13 @@ export default {
       } else {
         return `${ this.v1MonitoringContainerBaseUrl }/${ this.metricsID }`;
       }
+    },
+
+    dateTimeFormatString() {
+      const dateFormat = escapeHtml( this.$store.getters['prefs/get'](DATE_FORMAT));
+      const timeFormat = escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
+
+      return `${ dateFormat } ${ timeFormat }`;
     }
   },
 
@@ -205,6 +215,10 @@ export default {
       this.metricsID = id;
       this.selection = c;
     },
+
+    dateTimeFormat(value) {
+      return value ? day(value).format(this.dateTimeFormatString) : '';
+    }
   }
 };
 </script>

--- a/shell/detail/pod.vue
+++ b/shell/detail/pod.vue
@@ -60,12 +60,34 @@ export default {
       return (containers || []).map((container) => {
         const status = findBy(statuses, 'name', container.name);
         const state = status?.state || {};
+        const descriptions = [];
 
         // There can be only one member of a `ContainerState`
         const s = Object.values(state)[0] || {};
         const reason = s.reason || '';
         const message = s.message || '';
         const showBracket = s.reason && s.message;
+        const description = `${ reason }${ showBracket ? ' (' : '' }${ message }${ showBracket ? ')' : '' }`;
+
+        if (description) {
+          descriptions.push(description);
+        }
+
+        // add lastState to show termination reason
+        if (status?.lastState?.terminated) {
+          const ls = status?.lastState?.terminated;
+          const lsReason = ls.reason || '';
+          const lsMessage = ls.message || '';
+          const lsExitCode = ls.exitCode || '';
+          const lsStartedAt = ls.startedAt || '';
+          const lsFinishedAt = ls.finishedAt || '';
+          const lsShowBracket = ls.reason && ls.message;
+          const lsDescription = `${ lsReason }${ lsShowBracket ? ' (' : '' }${ lsMessage }${ lsShowBracket ? ')' : '' }`;
+
+          descriptions.push(this.t('workload.container.terminationState', {
+            lsDescription, lsExitCode, lsStartedAt, lsFinishedAt
+          }));
+        }
 
         return {
           ...container,
@@ -76,7 +98,7 @@ export default {
           readyIcon:        status?.ready ? 'icon-checkmark icon-2x text-success ml-5' : 'icon-x icon-2x text-error ml-5',
           availableActions: this.value.containerActions,
           stateObj:         status, // Required if there's a description
-          stateDescription: `${ reason }${ showBracket ? ' (' : '' }${ message }${ showBracket ? ')' : '' }`, // Required to display the description
+          stateDescription: descriptions.join(' | '), // Required to display the description
           initIcon:         this.value.containerIsInit(container) ? 'icon-checkmark icon-2x text-success ml-5' : 'icon-minus icon-2x text-muted ml-5',
 
           // Call openShell here so that opening the shell


### PR DESCRIPTION
### Summary
Add containerStatus lastState information to Pod detail page

The containerStatus object (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#containerstatus-v1-core) also contains a lastState field which gives you details about the container's last termination condition.

If there's a lastState in the containerStatus, this should also be displayed in the container list.

This is especially useful when you need to debug why a container restarted, because it gives you the exit code, potential error message and reason as well as the time when the container terminated.

Fixes #6189

### Occurred changes and/or fixed issues
If there is a `containerStatus.lastState` for a container, this information will be added to the containers stateDescription field.

### Technical notes summary
In order to test, you need check a pod that has restarts.

If you need one for testing, this is an example deployment, where the pod exits after 10s and will be restarted by Kubernetes:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: crashing-test-pod
spec:
  selector:
    matchLabels:
      app: crashing-test-pod
  template:
    metadata:
      labels: 
        app: crashing-test-pod
    spec:      
      containers:
        - command:
            - bash
            - -c
            - "echo test; sleep 10; exit 1;"
          image: ubuntu
          name: crashing-test-container
```


### Areas or cases that should be tested
Pod detail pages, where a list of containers in a pod is displayed

### Areas which could experience regressions
Pod detail pages

### Screenshot/Video
Example with only lastState:
![Bildschirmfoto 2022-06-16 um 15 27 58](https://user-images.githubusercontent.com/243056/174081224-6ad1b110-4807-4a4b-98aa-73ec27be6d46.png)

Example with both error state and last state:
![Bildschirmfoto 2022-06-16 um 15 46 09](https://user-images.githubusercontent.com/243056/174084194-2944f2ee-d993-4071-86b9-dee9707854d6.png)


