### PR TITLE
Ensure path is shown when listing ingress rules

### DIFF
--- a/shell/models/networking.k8s.io.ingress.js
+++ b/shell/models/networking.k8s.io.ingress.js
@@ -14,10 +14,9 @@ function isTlsHost(spec, host) {
   return tlsHosts(spec).includes(host);
 }
 
-export function ingressFullPath(resource, rule) {
+export function ingressFullPath(resource, rule, path = {}) {
   const spec = resource.spec;
   const hostValue = rule.host || '';
-  const path = rule?.http?.paths || [];
   const pathValue = path.path || '';
   let protocol = '';
 
@@ -73,7 +72,7 @@ export default class Ingress extends SteveModel {
 
   createPathForListPage(workloads, rule, path, certificates) {
     const serviceName = get(path?.backend, this.serviceNamePath);
-    const fullPath = this.fullPath(rule);
+    const fullPath = this.fullPath(rule, path);
 
     return {
       // isUrl thinks urls which contain '*' are valid so I'm adding an additional check for '*'
@@ -88,8 +87,8 @@ export default class Ingress extends SteveModel {
     };
   }
 
-  fullPath(rule) {
-    return ingressFullPath(this, rule);
+  fullPath(rule, path) {
+    return ingressFullPath(this, rule, path);
   }
 
   certLink(cert, certificates = []) {


### PR DESCRIPTION
- Fixes https://github.com/rancher/dashboard/issues/6198
- Regression brought in by changes to `shell/models/networking.k8s.io.ingress.js` in https://github.com/richard-cox/dashboard/commit/50aed3eb9ebc1b1204979956dd74d408451e4ff3#diff-7a50af77ca2d43ff68be7e5f06102af2f4468473e27874480c2325a1fe1faa81R7
- Breaking change included splitting out path calculation into separate function
- function got the path totally wrong

For 'before' screenshots see issues

'After' screenshots
![image](https://user-images.githubusercontent.com/18697775/174583028-21ce2030-8d55-428d-b6b7-e290da28f84f.png)

![image](https://user-images.githubusercontent.com/18697775/174583119-da61f0c0-3783-4864-aed9-0a6250e049e0.png)

