### PR TITLE
Fix shell package with rancher components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist-pkg
 
 # Others
 .todo
+
+# Plugins - temporary
+shell/rancher-components

--- a/shell/components/form/Footer.vue
+++ b/shell/components/form/Footer.vue
@@ -2,7 +2,7 @@
 import Vue from 'vue';
 import { _VIEW } from '@shell/config/query-params';
 import AsyncButton, { AsyncButtonCallback } from '@shell/components/AsyncButton.vue';
-import Banner from 'pkg/rancher-components/src/components/Banner/Banner.vue';
+import Banner from '@components/Banner/Banner.vue';
 
 export default Vue.extend({
   components: { AsyncButton, Banner },

--- a/shell/creators/pkg/tsconfig.json
+++ b/shell/creators/pkg/tsconfig.json
@@ -40,7 +40,7 @@
     "**/*.tsx",
     "**/*.vue",
     "../../node_modules/@rancher/shell/types/*.d.ts",
-    "../../node_modules/@rancher/shell/core/types.ts",
+    "../../node_modules/@rancher/shell/core/types.ts"
   ],
   "exclude": [
     "node_modules"

--- a/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
+++ b/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
@@ -1,7 +1,7 @@
 <script>
 import CreateEditView from '@shell/mixins/create-edit-view';
 import CruResource from '@shell/components/CruResource';
-import Banner from 'pkg/rancher-components/src/components/Banner/Banner.vue';
+import Banner from '@components/Banner/Banner.vue';
 import { MANAGEMENT } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import ClusterPermissionsEditor from '@shell/components/form/Members/ClusterPermissionsEditor';

--- a/shell/edit/workload/__tests__/Job.test.ts
+++ b/shell/edit/workload/__tests__/Job.test.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 import Job from '@shell/edit/workload/Job.vue';
 import { _EDIT } from '@shell/config/query-params';
-import { WORKLOAD_TYPES } from '~/shell/config/types';
+import { WORKLOAD_TYPES } from '@shell/config/types';
 
 describe('component: Job', () => {
   describe('given CronJob types', () => {

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -21,6 +21,8 @@ export default function(dir, _appConfig) {
   let SHELL = 'node_modules/@rancher/shell';
   let SHELL_ABS = path.join(dir, 'node_modules/@rancher/shell');
   let NUXT_SHELL = '~~node_modules/@rancher/shell';
+  let COMPONENTS_DIR = path.join(SHELL_ABS, 'rancher-components');
+  let typescript = {};
 
   // If we have a local folder named 'shell' then use that rather than the one in node_modules
   // This will be the case in the main dashboard repository.
@@ -28,6 +30,9 @@ export default function(dir, _appConfig) {
     SHELL = './shell';
     SHELL_ABS = path.join(dir, 'shell');
     NUXT_SHELL = '~~/shell';
+    COMPONENTS_DIR = path.join(dir, 'pkg', 'rancher-components', 'src', 'components');
+
+    typescript = { typeCheck: { eslint: { files: './shell/**/*.{ts,js,vue}' } } };
   }
 
   // ===============================================================================================
@@ -306,7 +311,7 @@ export default function(dir, _appConfig) {
       '~shell':      SHELL_ABS,
       '@shell':      SHELL_ABS,
       '@pkg':        path.join(dir, 'pkg'),
-      '@components': path.join(dir, 'pkg', 'rancher-components', 'src', 'components'),
+      '@components': COMPONENTS_DIR,
     },
 
     modulesDir: [
@@ -611,7 +616,8 @@ export default function(dir, _appConfig) {
       ]
     },
 
-    typescript: { typeCheck: { eslint: { files: './shell/**/*.{ts,js,vue}' } } },
+    // Typescript eslint
+    typescript,
 
     ssr: false,
   };

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -40,6 +40,15 @@ function publish() {
 
   echo "Publishing ${NAME} from ${FOLDER}"
   pushd ${FOLDER} > /dev/null
+
+  # Fow now, copy the rancher components into the shell and ship them with it
+  if [ $NAME == 'shell' ]; then
+    echo "Adding Rancher Components"
+    rm -rf ${SHELL_DIR}/rancher-components
+    mkdir -p ${SHELL_DIR}/rancher-components
+    cp -R ${BASE_DIR}/pkg/rancher-components/src/components/ ${SHELL_DIR}/rancher-components
+  fi
+
   yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS}
   RET=$?
   popd > /dev/null


### PR DESCRIPTION
Fixes shell package given recent components changes.

For now, the components are copied into the shell package when published - this ensures when the shell is used as an npm package that it can still compile.