### PR TITLE
Fixes for building epinio pkg & hot load of existing plugin

### DIFF
--- a/pkg/epinio/tsconfig.json
+++ b/pkg/epinio/tsconfig.json
@@ -48,6 +48,9 @@
       "@components/*": [
         "../../pkg/rancher-components/*"
       ],
+      "@shell/mixins/*": [
+        "../../shell/mixins/*"
+      ],
       "@pkg/*": [
         "./*"
       ]

--- a/shell/creators/pkg/tsconfig.json
+++ b/shell/creators/pkg/tsconfig.json
@@ -38,7 +38,22 @@
       ],
       "@shell/store/*": [
         "../../node_modules/@rancher/shell/store/*"
-      ]
+      ],
+      "@shell/plugins/*": [
+        "../../node_modules/@rancher/shell/plugins/*"
+      ],
+      "@shell/utils/*": [
+        "../../node_modules/@rancher/shell/utils/*"
+      ],
+      "@shell/models/*": [
+        "../../node_modules/@rancher/shell/models/*"
+      ],
+      "@shell/mixins/*": [
+        "../../node_modules/@rancher/shell/mixins/*"
+      ],
+      "@pkg/*": [
+        "./*"
+      ],
     }
   },
   "include": [

--- a/shell/pkg/vue.config.js
+++ b/shell/pkg/vue.config.js
@@ -41,6 +41,7 @@ module.exports = function(dir) {
       config.resolve.alias['~shell'] = path.join(dir, '.shell');
       // This should be udpated once we move to rancher-components as a dependency
       config.resolve.alias['@components'] = COMPONENTS_DIR;
+      // config.resolve.alias['@components'] = path.join(maindir, 'pkg', 'rancher-components', 'src', 'components'); TODO: RC
       config.resolve.alias['./node_modules'] = path.join(maindir, 'node_modules');
       config.resolve.alias['@pkg'] = dir;
       config.resolve.alias['~pkg'] = dir;


### PR DESCRIPTION
- Fix build of epinio pkg. Includes
  - some core dashboard component import updates
  - lint fixes
  - creator pkg updates 
  - pkg vue.config fix for rancher-components
- Ensure correct components loaded when a new version of a plugin is loaded
  - The route matcher was never updated with new route-->component values
  - This was due to `this.router.options.routes` not containing the result of `router.add`
  - See https://github.com/vuejs/vue-router/issues/2280
