### PR TITLE
fix(RoleDetailEdit): converting resource names to lower case

### DIFF
--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -397,7 +397,7 @@ export default {
           // If we are updating the resources defined in a rule,
           // the event will be an object with the
           // properties apiGroupValue and resourceName.
-          this.$set(rule, 'resources', [event.resourceName]);
+          this.$set(rule, 'resources', [event.resourceName.toLowerCase()]);
           // Automatically fill in the API group of the
           // selected resource.
           this.$set(rule, 'apiGroups', [event.apiGroupValue]);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
<!-- Define findings related to the feature or bug issue. -->
Fix: [After clusterrole/role is created, yaml shows resource item is uppercase](https://github.com/rancher/rancher/issues/38068)

