### PR TITLE
Add support for nested dynamic components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,3 +18,4 @@ shell/assets/fonts
 assets/fonts
 shell/pkg/import.js
 pkg/rancher-components/
+shell/rancher-components/

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -164,6 +164,16 @@ export class Plugin implements IPlugin {
   }
 
   public register(type: string, name: string, fn: Function) {
+    const nparts = name.split('/');
+
+    // Support components in a sub-folder - component_name/index.vue (and ignore other componnets in that folder)
+    if (nparts.length === 2) {
+      if (nparts[1] !== 'index') {
+        return;
+      }
+      name = nparts[0];
+    }
+
     // Accumulate l10n resources rather than replace
     if (type === 'l10n') {
       if (!this.l10n[name]) {


### PR DESCRIPTION
Fixes #6148

Updated .eslintignore to exclude rancher components folder that exists when the shell package is published

Updated register method to take into account component with index.vue in a folder.