### PR TITLE
Add support for formatters in plugins

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -485,9 +485,19 @@ export default {
               formatted = value.join(', ');
             }
 
-            if (c.formatter && FORMATTERS[c.formatter]) {
-              component = FORMATTERS[c.formatter];
-              needRef = true;
+            if (c.formatter) {
+              if (FORMATTERS[c.formatter]) {
+                component = FORMATTERS[c.formatter];
+                needRef = true;
+              } else {
+                // Check if we have a formatter from a plugin
+                const pluginFormatter = this.$plugin?.getDynamic('formatters', c.formatter);
+
+                if (pluginFormatter) {
+                  component = pluginFormatter;
+                  needRef = true;
+                }
+              }
             }
 
             rowData.columns.push({

--- a/shell/pkg/auto-import.js
+++ b/shell/pkg/auto-import.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const contextFolders = ['chart', 'cloud-credential', 'content', 'detail', 'edit', 'list', 'machine-config', 'models', 'promptRemove', 'l10n', 'windowComponents'];
+const contextFolders = ['chart', 'cloud-credential', 'content', 'detail', 'edit', 'list', 'machine-config', 'models', 'promptRemove', 'l10n', 'windowComponents', 'formatters'];
 const contextMap = contextFolders.reduce((map, obj) => {
   map[obj] = true;
 


### PR DESCRIPTION
Fixes #6147 

Adds support for a `formatters` folder.

SortableTable will look for formatters provided by plugins in this way - also avoids having to make formatters global components.

You can test by creating a plugin, creating a `formatters` folder and copying an existing formatter there (rename it) and then updating a list for a resource type to use this new formatter name.