### PR TITLE
Only show none locale when dev pref is set and running in dev

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -113,7 +113,7 @@ export default {
     },
 
     showNone() {
-      return this.dev;
+      return !!process.env.dev && this.dev;
     },
 
     multiClusterApps() {


### PR DESCRIPTION
It is confusing for users who enable the developer preference to then see the `None` locale in the locale chooser:

![image](https://user-images.githubusercontent.com/1955897/175522584-8979bdd8-acc5-44b6-9f56-867d4cf42e7d.png)

This PR updates so that we only show the None locale if you're running as a developer with `yarn dev` - it won't appear in a production build.