### PR TITLE
Add more details to auth secret dropdown

### DIFF
--- a/shell/components/form/SelectOrCreateAuthSecret.vue
+++ b/shell/components/form/SelectOrCreateAuthSecret.vue
@@ -211,7 +211,7 @@ export default {
           return true;
         }).map((x) => {
           return {
-            label: `${ x.metadata.name } (${ x.subTypeDisplay })`,
+            label: `${ x.metadata.name } (${ x.subTypeDisplay }: ${ x.dataPreview })`,
             group: x.metadata.namespace,
             value: x.id,
           };


### PR DESCRIPTION
### Summary
This PR adds additional details to the auth secret drop down, used for example in the git repo ui of continuous delivery
This makes it easier to pick the right secret if there are multiple ones. 

Fixes #6239

### Occurred changes and/or fixed issues
Adds additional, already existing `dataPreview` details to the `SelectOrCreateAuthSecret` component. The `dataPreview` are already displayed as a column in the secrets list.

### Areas or cases that should be tested
The component is used in

* Git Repo creation
* RKE2 Cluster creation, etcd S3 backup configuration
* RKE2 Cluster creation, private registry configuration
* RKE2 Cluster creation, advanced registry configuration
* Marketplace repository creation

### Areas which could experience regressions
Areas see above. There should be no regression, because the PR only changes the content of a label.

### Screenshot/Video
Screenshot example before
<img width="950" alt="Bildschirmfoto 2022-06-28 um 14 26 10" src="https://user-images.githubusercontent.com/243056/176180853-4b800454-1397-46ff-beba-c1d463ce707c.png">

Screenshot examples after in the places where the component is used
<img width="891" alt="Bildschirmfoto 2022-06-28 um 14 25 43" src="https://user-images.githubusercontent.com/243056/176180879-0854a515-fc29-4d36-80e1-73b8f36a6d18.png">
<img width="1022" alt="Bildschirmfoto 2022-06-28 um 14 29 32" src="https://user-images.githubusercontent.com/243056/176180885-45fd2f9b-f9ee-490b-8150-60e007787fc6.png">
<img width="798" alt="Bildschirmfoto 2022-06-28 um 14 34 08" src="https://user-images.githubusercontent.com/243056/176180890-b4c3d719-495b-4a20-a53d-f871844920ab.png">
<img width="878" alt="Bildschirmfoto 2022-06-28 um 14 34 58" src="https://user-images.githubusercontent.com/243056/176180894-128efbb6-ca0b-4fea-a449-d4f09b6df63d.png">
<img width="915" alt="Bildschirmfoto 2022-06-28 um 14 35 10" src="https://user-images.githubusercontent.com/243056/176180897-85a2d3bf-47c0-4f86-b161-9dfa3a554a59.png">
<img width="817" alt="Bildschirmfoto 2022-06-28 um 14 36 01" src="https://user-images.githubusercontent.com/243056/176180899-1e0c0cf6-00c2-43e2-87e8-3703d00ac4c8.png">

