### PR TITLE
Service detail page: Show loadbalancer ip or hostname from the service status

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4219,6 +4219,8 @@ servicesPage:
       label: Cluster IP
       placeholder: e.g. 10.43.xxx.xxx
     label: IP Addresses
+    loadBalancer:
+      label: Load Balancer
     loadBalancerIp:
       label: Load Balancer IP
       placeholder: e.g. 192.0.xxx.xxx

--- a/shell/models/service.js
+++ b/shell/models/service.js
@@ -98,11 +98,17 @@ export default class extends SteveModel {
       });
     }
 
-    if (loadBalancerIP && this.serviceType === 'LoadBalancer') {
-      out.push({
-        label:   this.t('servicesPage.ips.loadBalancerIp.label'),
-        content: loadBalancerIP
-      });
+    if (this.serviceType === 'LoadBalancer') {
+      const statusIps = this.status.loadBalancer?.ingress?.map(ingress => ingress.hostname || ingress.ip).join(', ');
+
+      const loadbalancerInfo = loadBalancerIP || statusIps || '';
+
+      if (loadbalancerInfo) {
+        out.push({
+          label:   this.t('servicesPage.ips.loadBalancer.label'),
+          content: loadbalancerInfo
+        });
+      }
     }
 
     if (externalName) {


### PR DESCRIPTION
### Summary
Service detail page: Show loadbalancer ip or hostname from the service status, if the spec field is empty

Fixes #6245

### Occurred changes and/or fixed issues
Currently the external IP is only shown, if it was defined in the Service spec. In most cases the external IP or hostname of a LoadBalancer Service is automatically assigned by the cloud provider though. In that case `spec.loadBalancerIP` is empty. But you can see the assigned information in `status.loadBalancer.ingress`.

This PR shows the information from the status if the spec field is empty.

### Technical notes summary
A lot of cloud providers assign a IP address to a load balancer service (e.g. AKS), but some assign a hostname (e.g. EKS).

### Areas or cases that should be tested
Service detail page for services of type LoadBalancer, e.g. in an AKS, EKS or GKE cluster.

### Areas which could experience regressions
Service detail page.

### Screenshot/Video
Example on AKS
<img width="770" alt="Bildschirmfoto 2022-06-29 um 12 02 42" src="https://user-images.githubusercontent.com/243056/176413216-6283fafb-6143-4211-bbf9-7d2934e75d34.png">


Example on EKS
<img width="1228" alt="Bildschirmfoto 2022-06-29 um 12 05 26" src="https://user-images.githubusercontent.com/243056/176413207-e8ecbcb6-ddf7-4801-9769-8947dfe9bdd6.png">

