### PR TITLE
Display provisioned IOPs for GP3 volumes

### DIFF
--- a/shell/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/aws-ebs.vue
+++ b/shell/edit/storage.k8s.io.storageclass/provisioners/kubernetes.io/aws-ebs.vue
@@ -114,7 +114,7 @@ export default {
           :options="volumeTypeOptions"
         />
         <UnitInput
-          v-if="value.parameters.type === 'io1'"
+          v-if="value.parameters.type === 'io1' || value.parameters.type === 'gp3'"
           v-model="iopsPerGB"
           class="mt-10"
           :label="t('storageClass.aws-ebs.volumeType.provisionedIops.label')"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
See https://github.com/rancher/dashboard/pull/6243, GP3 should show the Provisioned IOPs field.

### Screencapture
From AWS console create volume UI:
<img width="624" alt="image" src="https://user-images.githubusercontent.com/468462/176552971-8d8d0833-6e89-48bb-bc4d-e88f6907ddec.png">
