### PR TITLE
Increase debounce time for table filter box

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -326,7 +326,7 @@ export default {
   watch: {
     eventualSearchQuery: debounce(function(q) {
       this.searchQuery = q;
-    }, 100),
+    }, 200),
   },
 
   computed: {


### PR DESCRIPTION
Increase debounce time for the search filter box on the sortable table.

100ms is too small, so we don't actually debounce.