### PR TITLE
In SortableTable, do filtering before sorting

### DIFF
--- a/shell/components/SortableTable/filtering.js
+++ b/shell/components/SortableTable/filtering.js
@@ -38,7 +38,10 @@ export default {
         out = this.previousResult.slice();
       } else {
         this.previousResult = null;
-        out = (this.arrangedRows || []).slice();
+        // We filter the rows before they are sorted
+        // so that we don't have to sort rows that will
+        // get filtered out anyway.
+        out = (this.rows || []).slice();
       }
 
       this.previousFilter = searchText;

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -40,7 +40,10 @@ export default {
         }
       }
 
-      const out = sortBy(this.rows, this.sortFields, this.descending);
+      // When sorting, we start with the text-filtered rows
+      // so that we don't have to sort rows that will
+      // get filtered out anyway.
+      const out = sortBy(this.filteredRows, this.sortFields, this.descending);
 
       if ( key ) {
         this.cacheKey = key;


### PR DESCRIPTION
I noticed that SortableTable does both sorting and filtering, but it sorts before it filters. I thought it would be more performant to do the filtering before the sorting so that we don't have to sort items that will be filtered out immediately afterward.

In my local testing it improved the speed of navigating between the Deployments list page and other workload pages. I tried text search as well and if anything it seems less laggy.


Edit: converted to draft because I just realized it broke the ability to sort workloads by name.

## Notes for further improvements
The full flow of data through SortableTable is like this:

1. The workload list page fetches rows.
2. The workload list loops over rows and filters them using `(!*this*.allTypes || row.showAsWorkload)` (For Deployments, nothing is filtered out.) This filtering is redone every 5 seconds.
3. The workload list passes rows into ResourceTable through the `rows` prop.
4. Then ResourceTable:
	1. filters the rows to show only the workloads that are in active namespaces.
5. Then SortableTable does this (this is how it was before my PR):
	1. Sorts the rows and creates `arrangedRows`, a computed property.
	2. Filters rows in `arrangedRows` based on text searches, yielding the `filteredRows` computed property.
	3. Paging.js breaks the filtered rows into a separate page of rows, yielding the `pagedRows` computed property.
	4. grouping.js loops over the single-page result from `groupedRows` to format rows into groups.

There might be more opportunities in there to reduce the number of loops.