### PR TITLE
Performance: Cache Pod selector results for workload list items

### DIFF
--- a/shell/components/formatter/PodsUsage.vue
+++ b/shell/components/formatter/PodsUsage.vue
@@ -1,5 +1,4 @@
 <script>
-import { POD } from '@shell/config/types';
 export default {
   name:  'PodsUsage',
   props: {

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -45,6 +45,14 @@ export default {
         const resource = await this.$store.dispatch('cluster/findAll', { type });
 
         resources = [resource];
+
+        if (type !== POD) {
+          // Build Pod selector cache so that when we look up which Pods
+          // are managed by a workload, we don't have to loop over all Pods
+          // in the cluster for each workload list item. We will just
+          // do it once.
+          this.$store.dispatch('cluster/buildPodSelectorCache', { workloads: resources[0] });
+        }
       }
     }
 
@@ -110,6 +118,7 @@ export default {
         }
       }
     }
+
   },
 
   typeDisplay() {

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -29,6 +29,10 @@ function registerType(state, type) {
   return cache;
 }
 
+function loadPodSelectorCache(state, podSelectorCache) {
+  state.podSelectorCache = podSelectorCache;
+}
+
 function load(state, { data, ctx, existing }) {
   const { getters } = ctx;
   let type = normalizeType(data.type);
@@ -164,6 +168,7 @@ export function loadAll(state, { type, data, ctx }) {
 
 export default {
   registerType,
+  loadPodSelectorCache,
   load,
 
   applyConfig(state, config) {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -101,5 +101,11 @@ export default {
     const typeSuperClass = Object.getPrototypeOf(Object.getPrototypeOf(existing))?.constructor;
 
     return typeSuperClass === HybridModel ? cleanHybridResources(data) : data;
-  }
+  },
+
+  podSelectorCache(state) {
+    return (workloadName) => {
+      return state.podSelectorCache[workloadName];
+    };
+  },
 };

--- a/shell/plugins/steve/index.js
+++ b/shell/plugins/steve/index.js
@@ -26,6 +26,7 @@ function SteveFactory(namespace, baseUrl) {
         deferredRequests: {},
         started:          [],
         inError:          {},
+        podSelectorCache: {}, // Used to efficiently check which Pods correspond to a workload
       };
     },
 


### PR DESCRIPTION
Currently the workload list page takes a long time to load because for each workload in the list, the UI loops over all pods in the cluster (potentially thousands) to get the pod restart count and health metrics for each workload.

It should't get merged until after https://github.com/rancher/dashboard/pull/6261/ because it has a dependency on it.

This PR improves the performance of the workload list view by adding a `podSelectorCache` to the Vuex store. It creates a cache of the workloads' Pod selector lookups so that each workload in the list does not have to loop over the entire list of Pods. It builds the cache based on owner references from the Pod itself instead of looping over all workloads to see if the Pod would match. This decreases the complexity from O(workloads * pods) to just O(pods) so the page loads faster. 

The disadvantage of this method is that, although the owner reference method would field the same results 99 percent of the time, it could be inaccurate. In other words, it could yield a different result than the workload selector. In the future, Steve may be enhanced to hold the pod data in memory and return it along with the workload list. However, to make the workload page able to load for large cluster, this PR just adds a tooltip that explains how the number was calculated.