### PR TITLE
Increase Cypress timeout

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,6 @@
     "tests/setup/**/*.spec.ts",
     "tests/pages/**/*.spec.ts",
     "tests/navigation/**/*.spec.ts"
-  ]
+  ],
+  "defaultCommandTimeout": 60000
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6264
Solve timeout related fails on E2E in CI.

### Occurred changes and/or fixed issues
Increased default timeout in Cypress config.

### Technical notes summary
As quick solution to unblock current [failing test ](https://github.com/rancher/dashboard/actions/workflows/e2e.yaml)in [other PR](https://github.com/rancher/dashboard/pulls), the timeout is increased.
Issue will be tackled down with https://github.com/rancher/dashboard/issues/5966

Most of the complained errors are now related to [slow authentication process](https://github.com/rancher/dashboard/runs/7177526759?check_suite_focus=true) which is not related to #5966.

### Areas or cases that should be tested
-

### Areas which could experience regressions
-

### Screenshot/Video
CI process.