### PR TITLE
Add description to advanced developer preference

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -237,9 +237,10 @@ $fontColor: var(--input-label);
   flex-direction: column;
   &-description {
     color: $fontColor;
-    font-size: 11px;
-    margin-left: 20px;
+    font-size: 14px;
+    margin-left: 19px;
     margin-top: 5px;
+    opacity: 0.8;
   }
 }
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3560,6 +3560,7 @@ prefs:
     emacs: 'Emacs'
     vim: 'Vim'
   advanced: Advanced
+  advancedTooltip: Enables 'View in API' option and keyboard shortcut to toggle light or dark theme (shift+t)
   dev:
     label: Enable Developer Tools & Features
   hideDesc:

--- a/shell/layouts/plain.vue
+++ b/shell/layouts/plain.vue
@@ -35,9 +35,7 @@ export default {
     };
   },
 
-  computed: {
-    dev: mapPref(DEV)
-  },
+  computed: { dev: mapPref(DEV) },
 
   methods: {
     toggleTheme() {

--- a/shell/layouts/plain.vue
+++ b/shell/layouts/plain.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapPref, DEV } from '@shell/store/prefs';
 import ActionMenu from '@shell/components/ActionMenu';
 import Header from '@shell/components/nav/Header';
 import PromptRemove from '@shell/components/PromptRemove';
@@ -34,6 +35,15 @@ export default {
     };
   },
 
+  computed: {
+    dev: mapPref(DEV)
+  },
+
+  methods: {
+    toggleTheme() {
+      this.$store.dispatch('prefs/toggleTheme');
+    }
+  }
 };
 </script>
 
@@ -51,6 +61,7 @@ export default {
         <ActionMenu />
         <PromptRemove />
         <AssignTo />
+        <button v-if="dev" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
       </main>
     </div>
 

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -203,14 +203,19 @@ export default {
 
     <hr />
     <div class="row">
-      <div class="col span-8">
+      <div class="col prefs-advanced">
+        <h4 v-t="'prefs.advanced'" />
+        <Checkbox v-model="dev" :description="t('prefs.advancedTooltip', {}, raw=true)" :label="t('prefs.dev.label', {}, true)" />
+        <br>
+        <Checkbox v-if="!isSingleVirtualCluster" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-10" />
+      </div>
+    </div>
+
+    <hr />
+    <div class="row">
+      <div class="col span-12">
         <h4 v-t="'prefs.keymap.label'" />
         <ButtonGroup v-model="keymap" :options="keymapOptions" />
-      </div>
-      <div class="col span-4">
-        <h4 v-t="'prefs.advanced'" />
-        <Checkbox v-model="dev" :label="t('prefs.dev.label', {}, true)" />
-        <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" />
       </div>
     </div>
 


### PR DESCRIPTION
This PR fixes https://github.com/rancher/dashboard/issues/5370 by adding an additional description to the 'enable developer tools & features' user preference.

Also:

- Updated the font size of the checkbox description, so that it is readable
- Updated margin of checkbox description, so it aligns with the label
- Added ability to toggle theme with the keyboard shortcut on the prefs page - since the description describes this shortcut, which previously did not work on that screen (plain layout)

![image](https://user-images.githubusercontent.com/1955897/177528123-395fcf54-67a1-46ad-ad17-dd4042cf77c4.png)
