### PR TITLE
Errors are not displaying when standard user attempts to create a project with non-default Pod Security Policy

### DIFF
--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -74,7 +74,7 @@ export default class Project extends HybridModel {
 
     const newValue = await norman.save({ replace: forceReplaceOnReq });
 
-    newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
+    await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
 
     await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
 


### PR DESCRIPTION
This is a rework of PR: https://github.com/rancher/dashboard/pull/6166

Fixes https://github.com/rancher/dashboard/issues/5964

Update save logic to catch promise errors and pass to CRU form if found

To test:

- Create RKE Cluster
- Create new user (member)
- Enable Pod Security Policy at cluster level
- Add new user to cluster and project
- Log in as new user
- Create new project in cluster and select a pod security policy (eg Restricted)
- Error message should display as banner at top of page