### PR TITLE
Remove icons from the user drop down menu

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -492,13 +492,13 @@ export default {
                 </div>
               </li>
               <nuxt-link v-if="showPreferencesLink" tag="li" :to="{name: 'prefs'}" class="user-menu-item">
-                <a>{{ t('nav.userMenu.preferences') }} <i class="icon icon-fw icon-gear" /></a>
+                <a>{{ t('nav.userMenu.preferences') }}</a>
               </nuxt-link>
               <nuxt-link v-if="showAccountAndApiKeyLink" tag="li" :to="{name: 'account'}" class="user-menu-item">
-                <a>{{ t('nav.userMenu.accountAndKeys', {}, true) }} <i class="icon icon-fw icon-user" /></a>
+                <a>{{ t('nav.userMenu.accountAndKeys', {}, true) }}</a>
               </nuxt-link>
               <nuxt-link v-if="authEnabled" tag="li" :to="{name: 'auth-logout', query: { [LOGGED_OUT]: true }}" class="user-menu-item">
-                <a @blur="showMenu(false)">{{ t('nav.userMenu.logOut') }} <i class="icon icon-fw icon-close" /></a>
+                <a @blur="showMenu(false)">{{ t('nav.userMenu.logOut') }}</a>
               </nuxt-link>
             </ul>
           </template>


### PR DESCRIPTION
Fixes #6204 

Removed the icons - they don't add any value.

Here's how it looks now:

![image](https://user-images.githubusercontent.com/1955897/177580915-5b5f069c-2631-4474-90f2-11385ee75a83.png)
