### PR TITLE
Allow secret type to be set when creating a secret

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4095,6 +4095,7 @@ secret:
   serviceAcct:
     ca: CA Certificate
     token: Token
+  customType: Custom Type
   type: Type
   types:
     'opaque': 'Opaque'
@@ -4126,6 +4127,8 @@ secret:
     's3': 'S3'
   relatedWorkloads: Related Workloads
   typeDescriptions:
+    custom:
+      description: Create a Secret with a custom type
     'kubernetes.io/basic-auth':
       description: 'Authentication with a username and password'
       docLink: https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret

--- a/shell/edit/secret/index.vue
+++ b/shell/edit/secret/index.vue
@@ -3,6 +3,8 @@ import { SECRET_TYPES as TYPES } from '@shell/config/secret';
 import { MANAGEMENT, NAMESPACE, DEFAULT_WORKSPACE } from '@shell/config/types';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
 import CruResource from '@shell/components/CruResource';
 import {
   CLOUD_CREDENTIAL, _CLONE, _CREATE, _EDIT, _FLAGGED
@@ -32,6 +34,8 @@ export default {
   name: 'CruSecret',
 
   components: {
+    LabeledInput,
+    LabeledSelect,
     Loading,
     NameNsDescription,
     CruResource,
@@ -63,14 +67,41 @@ export default {
       this.$set(this.value, 'data', {});
     }
 
+    const secretTypes = [
+      {
+        label: 'Custom',
+        value: 'custom'
+      },
+      {
+        label:    'divider',
+        disabled: true,
+        kind:     'divider'
+      }
+    ];
+
+    Object.values(TYPES).forEach((t) => {
+      secretTypes.push({
+        label: t,
+        value: t
+      });
+    });
+
     return {
       isCloud,
-      nodeDrivers: null,
-
+      nodeDrivers:       null,
+      secretTypes,
+      secretType:        this.value._type,
+      initialSecretType: this.value._type
     };
   },
 
   computed: {
+    isCustomSecretCreate() {
+      return this.mode === _CREATE && this.$route.query.type === 'custom';
+    },
+    showCustomSecretType() {
+      return this.secretType === 'custom';
+    },
     typeKey() {
       if ( this.isCloud ) {
         return 'cloud';
@@ -147,6 +178,13 @@ export default {
             docLink:     this.t(`secret.typeDescriptions.'${ id }'.docLink`)
           });
         }
+
+        out.push({
+          id:          'custom',
+          label:       this.t('secret.customType'),
+          bannerAbbrv: this.initialDisplayFor('custom'),
+          description: this.t('secret.typeDescriptions.custom.description')
+        });
       }
 
       return sortBy(out, 'label');
@@ -237,6 +275,14 @@ export default {
 
       this.$set(this.value, '_type', type);
       this.$emit('set-subtype', this.typeDisplay(type, driver));
+
+      this.secretType = type;
+
+      if (this.mode === _CREATE) {
+        if (type === 'custom') {
+          this.$set(this.value, '_type', '');
+        }
+      }
     },
 
     typeDisplay(type, driver) {
@@ -254,6 +300,12 @@ export default {
 
       return this.$store.getters['i18n/withFallback'](`secret.initials."${ type }"`, null, fallback);
     },
+
+    selectCustomType(type) {
+      if (type !== 'custom') {
+        this.$set(this.value, '_type', type);
+      }
+    }
   },
 };
 </script>
@@ -275,6 +327,34 @@ export default {
       @error="e=>errors = e"
     >
       <NameNsDescription v-model="value" :mode="mode" :namespaced="!isCloud" />
+
+      <div v-if="isCustomSecretCreate" class="row">
+        <div class="col span-3">
+          <LabeledSelect
+            v-model="secretType"
+            :options="secretTypes"
+            :searchable="false"
+            :mode="mode"
+            :multiple="false"
+            :reduce="(e) => e.value"
+            label-key="secret.type"
+            required
+            @input="selectCustomType"
+          />
+        </div>
+
+        <div class="col span-3">
+          <LabeledInput
+            v-if="showCustomSecretType"
+            ref="customType"
+            v-model="value._type"
+            v-focus
+            label-key="secret.customType"
+            :mode="mode"
+            required
+          />
+        </div>
+      </div>
 
       <div class="spacer"></div>
       <component

--- a/shell/edit/secret/index.vue
+++ b/shell/edit/secret/index.vue
@@ -278,10 +278,8 @@ export default {
 
       this.secretType = type;
 
-      if (this.mode === _CREATE) {
-        if (type === 'custom') {
-          this.$set(this.value, '_type', '');
-        }
+      if (this.mode === _CREATE && type === 'custom') {
+        this.$set(this.value, '_type', '');
       }
     },
 


### PR DESCRIPTION
Fixes #6076 

This PR adds support for creating a secret with an arbitrary type.

Note: The type of a secret can only be set when creating the secret - it can not be changed once created.

This PR adds another type to the selector screen presented when creating a secret - Custom Type:

![image](https://user-images.githubusercontent.com/1955897/177723018-f356909b-36ae-4c38-b0a7-de6c8a32caba.png)

When the Custom Type is selected, we now show a drop down and an input box:

![image](https://user-images.githubusercontent.com/1955897/177723246-fddfe34e-df26-40b6-87ba-388e3b9e7aec.png)

This allows the user to enter a custom type name or to select one of the standard types from the drop-down.