### PR TITLE
Can select secrets for receivers in AlertmanagerConfig

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -270,7 +270,7 @@ export default {
       @search:focus="onFocus"
       @search="onSearch"
       @open="onOpen"
-      @option:selecting="$emit('selecting', $event)"
+      @option:selected="$emit('selecting', $event)"
     >
       <template #option="option">
         <template v-if="option.kind === 'group'">


### PR DESCRIPTION
Addresses a bug which caused https://github.com/rancher/dashboard/issues/5875 to be reopened by QA.

The TL;DR was that after https://github.com/rancher/dashboard/issues/5875 was reviewed and merged, I made another change https://github.com/rancher/dashboard/pull/5999 that broke the secret selector for the AlertmanagerConfig receivers. This PR fixes that.

The more detailed reason for this PR is that the original event listener that I had, which is `option:selecting`, never actually worked:

```
@option:selecting="$emit('input', $event)"
```
I just thought it worked because the `input` event was being emitted by something else anyway. So when I started listening for an event with a different name in this PR https://github.com/rancher/dashboard/pull/5999, the event that I wanted was not emitted anymore. But since I changed it from `@option:selecting` to `@option:selected`, now the event is actually emitted.