### PR TITLE
Fix snapshot location for rke1 clusters being empty

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1676,6 +1676,9 @@ cluster:
       }
     groupLabel: Location
     failed: "Snapshot from {time} failed"
+    rke1:
+      local: local
+      s3: s3
   tabs:
     ace: Authorized Endpoint
     addons: Add-On Config

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -397,7 +397,7 @@ export default {
     },
 
     snapshotsGroupBy() {
-      return `$['metadata']['annotations']['etcdsnapshot.rke.io/storage']`;
+      return 'backupLocation';
     }
   },
 

--- a/shell/models/etcdbackup.js
+++ b/shell/models/etcdbackup.js
@@ -37,4 +37,8 @@ export default class Rke1EtcdBackup extends NormanModel {
   get nameDisplay() {
     return this.name;
   }
+
+  get backupLocation() {
+    return !!this.backupConfig.s3BackupConfig ? this.t('cluster.snapshot.rke1.s3') : this.t('cluster.snapshot.rke1.local');
+  }
 }

--- a/shell/models/rke.cattle.io.etcdsnapshot.js
+++ b/shell/models/rke.cattle.io.etcdsnapshot.js
@@ -66,4 +66,9 @@ export default class EtcdBackup extends NormanModel {
 
     return trans || error ? fileMessage || ucFirst(message) : '';
   }
+
+  get backupLocation() {
+    return this.metadata?.annotations?.['etcdsnapshot.rke.io/storage'];
+  }
+ 
 }

--- a/shell/models/rke.cattle.io.etcdsnapshot.js
+++ b/shell/models/rke.cattle.io.etcdsnapshot.js
@@ -70,5 +70,4 @@ export default class EtcdBackup extends NormanModel {
   get backupLocation() {
     return this.metadata?.annotations?.['etcdsnapshot.rke.io/storage'];
   }
- 
 }


### PR DESCRIPTION
Fixes #5706 

Note the age column problem mentioned in that issue has already been fixed.

For an RKE1 cluster, the snapshots list shows an empty location - this is shown in the group tab (Location: ) with the table: 

![image](https://user-images.githubusercontent.com/1955897/177947656-417c8bec-e2c2-456b-afc7-c0fbf24ff5ba.png)

How it looks now:

![Screenshot 2022-07-07 at 20 43 48](https://user-images.githubusercontent.com/1955897/177945471-9b5389aa-17f4-4d09-bcbd-7b7a0a0e669b.png)

and still works for RKE2 clusters:

![Screenshot 2022-07-07 at 20 37 40](https://user-images.githubusercontent.com/1955897/177945514-a1e55284-2376-4591-a481-4acf8d7f7de6.png)

For an RKE1 cluster, we determine the location from the presence of an object in `backupConfig.s3BackupConfig` - there are only two possible backup locations: s3 or local.

For RKE2, there is an annotation on the snapshot indicating s3 or local for the location.

This PR moves the logic for the group label (used to group by location) into the models for the RKE1 and RKE2 snapshots. The cluster detail view now uses this property on the model to group by.

To Test:

- Spin up RKE1 and RKE2 clusters and create a snapshot in both
- Verify that the snapshots tab for both show 'Location: local' in the group name for the snapshot list
- Spin up RKE1 and RKE2 clusters, configure s3 as the backup location and create a snapshot in both
- Verify that the snapshots tab for both show 'Location: s3' in the group name for the snapshot list
