### PR TITLE
Fix can not cancel from rotate encryption keys dialog

### DIFF
--- a/shell/components/dialog/RotateEncryptionKeyDialog.vue
+++ b/shell/components/dialog/RotateEncryptionKeyDialog.vue
@@ -59,7 +59,7 @@ export default {
 
   methods: {
     close(buttonDone) {
-      if (buttonDone) {
+      if (buttonDone && typeof buttonDone === 'function') {
         buttonDone(true);
       }
       this.$emit('close');


### PR DESCRIPTION
Fixes #6123 

Simple fix - the close method is wired into the cancel button - it has logic to call the buttonDone function - but in the case of the cancel button, the argument that gets passed to the close method is the click event object - the close method then tries to treat that as the buttonDone function.

Updated to check that buttonDone is a function before it is used.

To test:

- Provision an RKE2 cluster
- Go to the cluster management list and from the action menu for the cluster, choose 'Rotate Encryption Keys'
- Verify that pressing the Cancel button in the dialog now closes it