### PR TITLE
[Epinio] Redirects to the correct route after removing an application

### DIFF
--- a/.github/workflows/check-plugins.yaml
+++ b/.github/workflows/check-plugins.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - epinio-dev
 
 jobs:
   validate:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
       branches:
         - master
         - 'release-*'
+        - epinio-dev
   workflow_dispatch:
     environment:
       description: 'Environment to run tests against'

--- a/pkg/epinio/models/applications.js
+++ b/pkg/epinio/models/applications.js
@@ -3,6 +3,7 @@ import { formatSi } from '@shell/utils/units';
 import { classify } from '@shell/plugins/dashboard-store/classify';
 import EpinioMetaResource from './epinio-namespaced-resource';
 import { downloadFile } from '@shell/utils/download';
+import { createEpinioRoute } from '../utils/custom-routing';
 
 // See https://github.com/epinio/epinio/blob/00684bc36780a37ab90091498e5c700337015a96/pkg/api/core/v1/models/app.go#L11
 const STATES = {
@@ -337,6 +338,10 @@ export default class EpinioApplicationModel extends EpinioMetaResource {
    */
   get routes() {
     return this.configuration?.routes || [];
+  }
+
+  get doneLocationRemove() {
+    return createEpinioRoute(`c-cluster-applications`, {}) ;
   }
 
   // ------------------------------------------------------------------

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -90,6 +90,11 @@ export default {
       if (this.toRemove.length > 1) {
         return null;
       }
+
+      if (this.toRemove[0].doneLocationRemove) {
+        return this.toRemove[0].doneLocationRemove;
+      }
+
       const currentRoute = this.toRemove[0].currentRoute();
       const out = {};
       const params = { ...currentRoute.params };
@@ -214,6 +219,7 @@ export default {
         // doneLocation will recompute to undefined when delete request completes
         this.cachedDoneLocation = { ...this.doneLocation };
       }
+
       if (this.hasCustomRemove && this.$refs?.customPrompt?.remove) {
         let handled = this.$refs.customPrompt.remove(btnCB);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/epinio/ui/issues/134
<!-- Define findings related to the feature or bug issue. -->


### Technical notes summary
Added a new method to `EpinioApplicationModel` to be used on `PromptRemove` component.

### Areas or cases that should be tested
1. Create a new APP under https://localhost:8005/epinio/c/default/applications/createapp
2. Open the interactive menu (3 dots, top right) and click Delete
3. Confirm the action

Expected behavior:
- You should get redirected to  https://localhost:8005/epinio/c/default/applications & the create button should take you to the Create App wizard. 