### PR TITLE
Create wrapper method for console.log

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,9 @@ module.exports = {
     browser: true,
     node:    true
   },
-  globals: { NodeJS: true, Timer: true },
+  globals: {
+    NodeJS: true, Timer: true, debug: 'readonly'
+  },
   plugins: ['jest'],
   extends: [
     'standard',

--- a/pkg/epinio/models/applications.js
+++ b/pkg/epinio/models/applications.js
@@ -343,7 +343,7 @@ export default class EpinioApplicationModel extends EpinioMetaResource {
   // Change/handle changes of the app
 
   trace(text, ...args) {
-    console.log(`### Application: ${ text }`, `${ this.meta.namespace }/${ this.meta.name }`, args.length ? args : '');// eslint-disable-line no-console
+    debug.log(`### Application: ${ text }`, `${ this.meta.namespace }/${ this.meta.name }`, args.length ? args : '');// eslint-disable-line no-console
   }
 
   async create() {

--- a/pkg/epinio/models/configurations.js
+++ b/pkg/epinio/models/configurations.js
@@ -54,7 +54,7 @@ export default class EpinioConfigurationModel extends EpinioNamespacedResource {
   // ------------------------------------------------------------------
 
   trace(text, ...args) {
-    console.log(`### Config: ${ text }`, `${ this.meta.namespace }/${ this.meta.name }`, args);// eslint-disable-line no-console
+    debug.log(`### Config: ${ text }`, `${ this.meta.namespace }/${ this.meta.name }`, args);// eslint-disable-line no-console
   }
 
   async create() {

--- a/pkg/epinio/models/epinio-resource.js
+++ b/pkg/epinio/models/epinio-resource.js
@@ -51,7 +51,7 @@ export default class EpinioResource extends Resource {
     try {
       const res = await this.$dispatch('request', { opt, type: this.type });
 
-      console.log('### Resource Remove', this.type, this.id, res);// eslint-disable-line no-console
+      debug.log('### Resource Remove', this.type, this.id, res);// eslint-disable-line no-console
       this.$dispatch('remove', this);
     } catch (e) {
       throw epinioExceptionToErrorsArray(e);

--- a/shell/components/GlobalRoleBindings.vue
+++ b/shell/components/GlobalRoleBindings.vue
@@ -264,14 +264,14 @@ export default {
       function resourceValidator(resource) {
         const resourcesRequiredForLogin = ['*', 'preferences', 'settings', 'features'];
 
-        // console.log(`resourceValidator status: `, resourcesRequiredForLogin.includes(resource), resource);
+        // debug.log(`resourceValidator status: `, resourcesRequiredForLogin.includes(resource), resource);
         return resourcesRequiredForLogin.includes(resource);
       }
 
       function apiGroupValidator(apiGroup) {
         const apiGroupsRequiredForLogin = ['*', 'management.cattle.io'];
 
-        // console.log(`apiGroupsRequiredForLogin status: `, apiGroupsRequiredForLogin.includes(apiGroup), apiGroup);
+        // debug.log(`apiGroupsRequiredForLogin status: `, apiGroupsRequiredForLogin.includes(apiGroup), apiGroup);
         return apiGroupsRequiredForLogin.includes(apiGroup);
       }
 
@@ -280,11 +280,11 @@ export default {
         const verbsRequiredForLogin = ['*', ...restrictedTarget];
 
         if (isArray(verbs) && verbs.length > 1) {
-          // console.log(`verbsRequiredForLogin status 1: `, restrictedTarget.every(rt => verbs.includes(rt)), verbs);
+          // debug.log(`verbsRequiredForLogin status 1: `, restrictedTarget.every(rt => verbs.includes(rt)), verbs);
           return restrictedTarget.every(rt => verbs.includes(rt));
         }
 
-        // console.log(`verbsRequiredForLogin status 2: `, verbsRequiredForLogin.includes(verbs[0]), verbsRequiredForLogin, verbs);
+        // debug.log(`verbsRequiredForLogin status 2: `, verbsRequiredForLogin.includes(verbs[0]), verbsRequiredForLogin, verbs);
         return verbsRequiredForLogin.includes(verbs[0]);
       }
     },

--- a/shell/components/Questions/index.vue
+++ b/shell/components/Questions/index.vue
@@ -283,7 +283,7 @@ export default {
       try {
         const out = Jexl.evalSync(expr, values);
 
-        // console.log('Eval', expr, '=> ', out);
+        // debug.log('Eval', expr, '=> ', out);
 
         // If the variable contains a hyphen, check if it evaluates to true
         // according to the evaluation logic used in the old UI.

--- a/shell/components/SortableTable/debug.js
+++ b/shell/components/SortableTable/debug.js
@@ -8,23 +8,23 @@
 export default {
   watch: {
     sortFields(neu, old) {
-      console.log('sortFields changed ------------------------------------------------');
-      console.log(neu);
-      console.log(old);
+      debug.log('sortFields changed ------------------------------------------------');
+      debug.log(neu);
+      debug.log(old);
     },
 
     descending(neu, old) {
-      console.log('descending changed ------------------------------------------------');
-      console.log(neu);
-      console.log(old);
+      debug.log('descending changed ------------------------------------------------');
+      debug.log(neu);
+      debug.log(old);
     },
 
     rows(neu, old) {
-      console.log('rows changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('rows changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
 
-      // console.log('Checking rows');
+      // debug.log('Checking rows');
 
       // let diff = 0;
 
@@ -33,84 +33,84 @@ export default {
       //   const b = JSON.stringify(old[i]);
 
       //   if (a !== b) {
-      //     console.log('rows differ ' + i);
+      //     debug.log('rows differ ' + i);
       //     diff++;
       //   }
       // }
 
-      // console.log(diff + ' rows changed');
+      // debug.log(diff + ' rows changed');
     },
 
     pagingDisplay(neu, old) {
-      console.log('pagingDisplay changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('pagingDisplay changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
     },
 
     totalPages(neu, old) {
-      console.log('totalPages changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('totalPages changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
     },
 
     pagedRows(neu, old) {
-      console.log('pagedRows changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('pagedRows changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
     },
 
     arrangedRows(neu, old) {
-      console.log('arrangedRows changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('arrangedRows changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
     },
 
     searchFields(neu, old) {
-      console.log('searchFields changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('searchFields changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
     },
 
     filteredRows(neu, old) {
-      console.log('filteredRows changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('filteredRows changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
     },
 
     groupedRows(neu, old) {
-      console.log('groupedRows changed ------------------------------------------------');
-      console.log(neu.length);
-      console.log(old.length);
+      debug.log('groupedRows changed ------------------------------------------------');
+      debug.log(neu.length);
+      debug.log(old.length);
     },
 
     headers(neu, old) {
-      console.log('headers changed ------------------------------------------------');
-      console.log(neu);
-      console.log(old);
+      debug.log('headers changed ------------------------------------------------');
+      debug.log(neu);
+      debug.log(old);
     },
 
     displayRows(neu, old) {
-      console.log('displayRows changed ------------------------------------------------');
-      console.log(neu);
-      console.log(old);
+      debug.log('displayRows changed ------------------------------------------------');
+      debug.log(neu);
+      debug.log(old);
     },
 
     groupBy(neu, old) {
-      console.log('groupBy changed ------------------------------------------------');
-      console.log(neu);
-      console.log(old);
+      debug.log('groupBy changed ------------------------------------------------');
+      debug.log(neu);
+      debug.log(old);
     },
 
     groupSort(neu, old) {
-      console.log('groupSort changed ------------------------------------------------');
-      console.log(neu);
-      console.log(old);
+      debug.log('groupSort changed ------------------------------------------------');
+      debug.log(neu);
+      debug.log(old);
     },
 
     columns(neu, old) {
-      console.log('columns changed ------------------------------------------------');
-      console.log(neu);
-      console.log(old);
+      debug.log('columns changed ------------------------------------------------');
+      debug.log(neu);
+      debug.log(old);
     },
   }
 };

--- a/shell/components/graph/LinePlot.vue
+++ b/shell/components/graph/LinePlot.vue
@@ -90,7 +90,7 @@ export default {
   methods: {
     animateLine(ref) {
       if (this.interval !== 0) {
-        console.log('animating...'); // eslint-disable-line no-console
+        debug.log('animating...'); // eslint-disable-line no-console
         // calculate px distance to move line
         const distance = this.scaleX([0, 10], 0);
 

--- a/shell/core/plugin-routes.ts
+++ b/shell/core/plugin-routes.ts
@@ -27,7 +27,7 @@ export class PluginRoutes {
     const spaces = Array(indent).join(' ');
 
     r.forEach((s: any) => {
-      console.log(`${ spaces }${ s.name } -> ${ s.path }`); // eslint-disable-line no-console
+      debug.log(`${ spaces }${ s.name } -> ${ s.path }`); // eslint-disable-line no-console
       this.logRoutes(s.children || [], indent + 2);
     });
   }

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -277,6 +277,8 @@ export default {
             addType(id, 'rke2', false);
           });
 
+          debug.log('machineTypes', machineTypes);
+
           addType('custom', 'custom2', false);
         }
       }

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -277,8 +277,6 @@ export default {
             addType(id, 'rke2', false);
           });
 
-          debug.log('machineTypes', machineTypes);
-
           addType('custom', 'custom2', false);
         }
       }

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -376,7 +376,7 @@ export default {
       }
 
       // eslint-disable-next-line no-console
-      console.log(`Global: ${ global }, Kubelet Only: ${ kubeletOnly }, Other: ${ other }`);
+      debug.log(`Global: ${ global }, Kubelet Only: ${ kubeletOnly }, Other: ${ other }`);
 
       return ( global > 1 || other > 0 );
     },

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -566,6 +566,7 @@ export default function(dir, _appConfig) {
       { src: path.join(NUXT_SHELL, 'plugins/nuxt-client-init'), ssr: false },
       path.join(NUXT_SHELL, 'plugins/replaceall'),
       path.join(NUXT_SHELL, 'plugins/back-button'),
+      path.join(NUXT_SHELL, 'plugins/logging'),
       { src: path.join(NUXT_SHELL, 'plugins/plugin'), ssr: false },
       { src: path.join(NUXT_SHELL, 'plugins/codemirror-loader'), ssr: false },
     ],

--- a/shell/pages/rio/mesh.vue
+++ b/shell/pages/rio/mesh.vue
@@ -143,7 +143,7 @@ export default {
     },
 
     displayNodes() {
-      console.log('get displayNodes'); // eslint-disable-line no-console
+      debug.log('get displayNodes'); // eslint-disable-line no-console
       const namespaces = this.namespaces;
 
       const out = this.nodes.filter((x) => {
@@ -154,7 +154,7 @@ export default {
     },
 
     displayEdges() {
-      console.log('get displayEdges'); // eslint-disable-line no-console
+      debug.log('get displayEdges'); // eslint-disable-line no-console
       const namespaces = this.namespaces;
 
       const out = this.edges.filter((x) => {
@@ -171,28 +171,28 @@ export default {
   watch: {
     // Nodes isn't watched, but gets updated at the same time...
     nodes() {
-      console.log('nodes updated'); // eslint-disable-line no-console
+      debug.log('nodes updated'); // eslint-disable-line no-console
       this.updateGraph();
       this.renderGraph();
     },
 
     namespaces() {
-      console.log('namespaces updated'); // eslint-disable-line no-console
+      debug.log('namespaces updated'); // eslint-disable-line no-console
       this.updateGraph();
       this.renderGraph();
     },
 
     edges() {
-      console.log('edges updated'); // eslint-disable-line no-console
+      debug.log('edges updated'); // eslint-disable-line no-console
       this.updateGraph();
       this.renderGraph();
     },
   },
 
   async mounted() {
-    console.log('Mounted'); // eslint-disable-line no-console
+    debug.log('Mounted'); // eslint-disable-line no-console
     this.timer = setInterval(() => {
-      console.log('Timer'); // eslint-disable-line no-console
+      debug.log('Timer'); // eslint-disable-line no-console
       this.refreshData();
     }, INTERVAL);
 
@@ -209,12 +209,12 @@ export default {
 
   methods: {
     async refreshData() {
-      console.log('Refreshing...'); // eslint-disable-line no-console
+      debug.log('Refreshing...'); // eslint-disable-line no-console
       const neu = await loadData(this.$store);
 
       this.nodes = neu.nodes;
       this.edges = neu.edges;
-      console.log('Refreshed'); // eslint-disable-line no-console
+      debug.log('Refreshed'); // eslint-disable-line no-console
     },
 
     async initGraph() {
@@ -281,7 +281,7 @@ export default {
 
     updateGraph() {
       // @TODO diff nodes/edges, remove unexpected and add missing ones
-      console.log('Updating...'); // eslint-disable-line no-console
+      debug.log('Updating...'); // eslint-disable-line no-console
 
       const e = escapeHtml;
       const g = this.graph;
@@ -366,7 +366,7 @@ export default {
     },
 
     renderGraph() {
-      console.log('Rendering...'); // eslint-disable-line no-console
+      debug.log('Rendering...'); // eslint-disable-line no-console
 
       const d3 = this.d3;
       const svg = this.d3.select(this.$refs.mesh);
@@ -388,7 +388,7 @@ export default {
       const dX = (width / 2) - ((graphWidth * scale) / 2);
       const dY = (height / 2) - ((graphHeight * scale) / 2);
 
-      console.log('render'); // eslint-disable-line no-console
+      debug.log('render'); // eslint-disable-line no-console
       if ( this.lastZoom ) {
         svg.call(zoom.transform, d3.zoomIdentity.translate(this.lastZoom.x, this.lastZoom.y).scale(this.lastZoom.k));
       } else {
@@ -401,7 +401,7 @@ export default {
     clicked(event) {
       const path = $(event.target).closest('.edgePath');
 
-      console.log(path); // eslint-disable-line no-console
+      debug.log(path); // eslint-disable-line no-console
     }
   },
 };

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -107,7 +107,7 @@ export default {
 
     const typeOptions = rootGetters['type-map/optionsFor'](type);
 
-    console.log(`Find All: [${ ctx.state.config.namespace }] ${ type }`); // eslint-disable-line no-console
+    debug.log(`Find All: [${ ctx.state.config.namespace }] ${ type }`); // eslint-disable-line no-console
     opt = opt || {};
     opt.url = getters.urlFor(type, null, opt);
     opt.stream = opt.stream !== false && load !== _NONE;
@@ -211,7 +211,7 @@ export default {
     } = ctx;
 
     opt = opt || {};
-    console.log(`Find Matching: [${ ctx.state.config.namespace }] ${ type }`, selector); // eslint-disable-line no-console
+    debug.log(`Find Matching: [${ ctx.state.config.namespace }] ${ type }`, selector); // eslint-disable-line no-console
     type = getters.normalizeType(type);
 
     if ( !getters.typeRegistered(type) ) {
@@ -269,7 +269,7 @@ export default {
 
     type = normalizeType(type);
 
-    console.log(`Find: [${ ctx.state.config.namespace }] ${ type } ${ id }`); // eslint-disable-line no-console
+    debug.log(`Find: [${ ctx.state.config.namespace }] ${ type } ${ id }`); // eslint-disable-line no-console
     let out;
 
     if ( opt.force !== true ) {

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -70,20 +70,20 @@ function load(state, { data, ctx, existing }) {
     entry = replace(existing, data);
     addObject(cache.list, entry);
     cache.map.set(id, entry);
-    // console.log('### Mutation added from existing proxy', type, id);
+    // debug.log('### Mutation added from existing proxy', type, id);
   } else {
     entry = cache.map.get(id);
 
     if ( entry ) {
       // There's already an entry in the store, update it
       replace(entry, data);
-      // console.log('### Mutation Updated', type, id);
+      // debug.log('### Mutation Updated', type, id);
     } else {
       // There's no entry, make a new proxy
       entry = classify(ctx, data);
       addObject(cache.list, entry);
       cache.map.set(id, entry);
-      // console.log('### Mutation', type, id);
+      // debug.log('### Mutation', type, id);
 
       // If there is a limit to the number of resources we can store for this type then
       // remove the first one to keep the list size to that limit
@@ -123,7 +123,7 @@ export function forgetType(state, type) {
 
 export function resetStore(state, commit) {
   // eslint-disable-next-line no-console
-  console.log('Reset store: ', state.config.namespace);
+  debug.log('Reset store: ', state.config.namespace);
 
   for ( const type of Object.keys(state.types) ) {
     commit(`${ state.config.namespace }/forgetType`, type);
@@ -175,7 +175,7 @@ export default {
   },
 
   loadMulti(state, { data, ctx }) {
-    // console.log('### Mutation loadMulti', data?.length);
+    // debug.log('### Mutation loadMulti', data?.length);
     for ( const entry of data ) {
       load(state, { data: entry, ctx });
     }

--- a/shell/plugins/dashboard-store/normalize.js
+++ b/shell/plugins/dashboard-store/normalize.js
@@ -29,9 +29,9 @@ export function handleConflict(initialValueJSON, value, liveValue, rootGetters, 
   const userChange = changeset(orig, user);
   const actualConflicts = changesetConflicts(bgChange, userChange);
 
-  console.log('Background Change', bgChange); // eslint-disable-line no-console
-  console.log('User Change', userChange); // eslint-disable-line no-console
-  console.log('Conflicts', actualConflicts); // eslint-disable-line no-console
+  debug.log('Background Change', bgChange); // eslint-disable-line no-console
+  debug.log('User Change', userChange); // eslint-disable-line no-console
+  debug.log('Conflicts', actualConflicts); // eslint-disable-line no-console
 
   value.metadata.resourceVersion = liveValue.metadata.resourceVersion;
   applyChangeset(value, bgChange);

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -751,7 +751,7 @@ export default class Resource {
   // ------------------------------------------------------------------
 
   waitForTestFn(fn, msg, timeoutMs, intervalMs) {
-    console.log('Starting wait for', msg); // eslint-disable-line no-console
+    debug.log('Starting wait for', msg); // eslint-disable-line no-console
 
     if ( !timeoutMs ) {
       timeoutMs = DEFAULT_WAIT_TMIMEOUT;
@@ -764,12 +764,12 @@ export default class Resource {
     return new Promise((resolve, reject) => {
       // Do a first check immediately
       if ( fn.apply(this) ) {
-        console.log('Wait for', msg, 'done immediately'); // eslint-disable-line no-console
+        debug.log('Wait for', msg, 'done immediately'); // eslint-disable-line no-console
         resolve(this);
       }
 
       const timeout = setTimeout(() => {
-        console.log('Wait for', msg, 'timed out'); // eslint-disable-line no-console
+        debug.log('Wait for', msg, 'timed out'); // eslint-disable-line no-console
         clearInterval(interval);
         clearTimeout(timeout);
         reject(new Error(`Failed waiting for: ${ msg }`));
@@ -777,12 +777,12 @@ export default class Resource {
 
       const interval = setInterval(() => {
         if ( fn.apply(this) ) {
-          console.log('Wait for', msg, 'done'); // eslint-disable-line no-console
+          debug.log('Wait for', msg, 'done'); // eslint-disable-line no-console
           clearInterval(interval);
           clearTimeout(timeout);
           resolve(this);
         } else {
-          console.log('Wait for', msg, 'not done yet'); // eslint-disable-line no-console
+          debug.log('Wait for', msg, 'not done yet'); // eslint-disable-line no-console
         }
       }, intervalMs);
     });

--- a/shell/plugins/logging.js
+++ b/shell/plugins/logging.js
@@ -1,0 +1,37 @@
+function setDebug(isDebug = false) {
+  const timestamp = function() {};
+
+  timestamp.toString = function() {
+    const ts = new Date();
+    const pad = '000';
+    const ms = ts.getMilliseconds().toString();
+    const timestamp = `${ ts.toLocaleTimeString('de-DE') }.${ pad.substring(0, pad.length - ms.length) }${ ms }: `;
+
+    return timestamp;
+  };
+
+  if (isDebug) {
+    window.debug = {
+      log:   window.console.log.bind(window.console, '%s', timestamp),
+      error: window.console.error.bind(window.console, '%s', timestamp),
+      info:  window.console.info.bind(window.console, '%s', timestamp),
+      warn:  window.console.warn.bind(window.console, '%s', timestamp)
+    };
+  } else {
+    const noOp = function() {};
+
+    window.debug = {
+      log:   noOp,
+      error: noOp,
+      warn:  noOp,
+      info:  noOp
+    };
+  }
+}
+
+// this will enable our console.log wrapper function and prevent logs in PROD
+if (process.env.NODE_ENV !== 'production' && (process.client || process.browser)) {
+  setDebug(true);
+} else if (process.client || process.browser) {
+  setDebug(false);
+}

--- a/shell/plugins/lookup.js
+++ b/shell/plugins/lookup.js
@@ -45,6 +45,6 @@ export default (context) => {
     return context.store.dispatch(`${ namespace }/findAll`, { type: realType });
   };
 
-  console.log('# Welcome to warp zone'); // eslint-disable-line no-console
-  console.log("# Try schemaFor('pod'), schemaName('pod'), all('pod'), byId('pod','abc'), await find('pod','abc'), await findAll('pod')"); // eslint-disable-line no-console
+  debug.log('# Welcome to warp zone'); // eslint-disable-line no-console
+  debug.log("# Try schemaFor('pod'), schemaName('pod'), all('pod'), byId('pod','abc'), await find('pod','abc'), await findAll('pod')"); // eslint-disable-line no-console
 };

--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -52,7 +52,7 @@ export default {
 
         waiting.push(later);
 
-        // console.log('Deferred request for', key, waiting.length);
+        // debug.log('Deferred request for', key, waiting.length);
 
         return later.promise;
       } else {
@@ -63,7 +63,7 @@ export default {
     }
 
     if ( opt.stream && state.allowStreaming && state.config.supportsStream && streamingSupported() ) {
-      // console.log('Using Streaming for', opt.url);
+      // debug.log('Using Streaming for', opt.url);
 
       return streamJson(opt.url, opt, opt.onData).then(() => {
         return { finishDeferred: finishDeferred.bind(null, key, 'resolve') };
@@ -71,7 +71,7 @@ export default {
         return onError(err);
       });
     } else {
-      // console.log('NOT Using Streaming for', opt.url);
+      // debug.log('NOT Using Streaming for', opt.url);
     }
 
     let paginatedResult;
@@ -128,7 +128,7 @@ export default {
     function finishDeferred(key, action = 'resolve', res) {
       const waiting = state.deferredRequests[key] || [];
 
-      // console.log('Resolving deferred for', key, waiting.length);
+      // debug.log('Resolving deferred for', key, waiting.length);
 
       while ( waiting.length ) {
         waiting.pop()[action](res);

--- a/shell/plugins/steve/performanceTesting.js
+++ b/shell/plugins/steve/performanceTesting.js
@@ -31,7 +31,7 @@ const DEFAULTS = {
 };
 
 export function perfLoadAll(type, data) {
-  // console.log(`${ type }`);
+  // debug.log(`${ type }`);
   if (data.length === 0) {
     return data;
   }

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -49,7 +49,7 @@ function queueChange({ getters, state }, { data, revision }, load, label) {
     return;
   }
 
-  // console.log(`${ label } Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
+  // debug.log(`${ label } Event [${ state.config.namespace }]`, data.type, data.id); // eslint-disable-line no-console
 
   if ( load ) {
     state.queue.push({

--- a/shell/store/github.js
+++ b/shell/store/github.js
@@ -114,7 +114,7 @@ export const actions = {
     url = proxifyUrl(url);
 
     while ( true ) {
-      console.log('Github Request:', url); // eslint-disable-line no-console
+      debug.log('Github Request:', url); // eslint-disable-line no-console
       const res = await dispatch('rancher/request', { url }, { root: true });
       const links = parseLinkHeader(res._headers['link']);
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -498,11 +498,11 @@ export const mutations = {
   setError(state, { error: obj, locationError }) {
     const err = new ApiError(obj);
 
-    console.log('Loading error', err); // eslint-disable-line no-console
-    console.log('(actual error)', obj); // eslint-disable-line no-console
+    debug.log('Loading error', err); // eslint-disable-line no-console
+    debug.log('(actual error)', obj); // eslint-disable-line no-console
     // Location of error, with description and stack trace
-    console.log('Loading error location', locationError); // eslint-disable-line no-console
-    console.log('Loading original error', obj); // eslint-disable-line no-console
+    debug.log('Loading error location', locationError); // eslint-disable-line no-console
+    debug.log('Loading original error', obj); // eslint-disable-line no-console
 
     state.error = err;
     state.cameFromError = true;
@@ -534,7 +534,7 @@ export const actions = {
       return;
     }
 
-    console.log('Loading management...'); // eslint-disable-line no-console
+    debug.log('Loading management...'); // eslint-disable-line no-console
 
     try {
       await dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL, opt: { url: 'principals' } });
@@ -623,7 +623,7 @@ export const actions = {
       });
     }
 
-    console.log(`Done loading management; isRancher=${ isRancher }; isMultiCluster=${ isMultiCluster }`); // eslint-disable-line no-console
+    debug.log(`Done loading management; isRancher=${ isRancher }; isMultiCluster=${ isMultiCluster }`); // eslint-disable-line no-console
   },
 
   async loadCluster({
@@ -698,7 +698,7 @@ export const actions = {
       return;
     }
 
-    console.log(`Loading ${ isMultiCluster ? 'ECM ' : '' }cluster...`); // eslint-disable-line no-console
+    debug.log(`Loading ${ isMultiCluster ? 'ECM ' : '' }cluster...`); // eslint-disable-line no-console
 
     // If we've entered a new store ensure everything has loaded correctly
     if (newPkgClusterStore) {
@@ -707,7 +707,7 @@ export const actions = {
       await dispatch(`${ newPkgClusterStore }/loadCluster`, { id });
 
       commit('clusterReady', true);
-      console.log('Done loading pkg cluster:', newPkgClusterStore); // eslint-disable-line no-console
+      debug.log('Done loading pkg cluster:', newPkgClusterStore); // eslint-disable-line no-console
 
       // Everything below here is rancher/kube cluster specific
       return;
@@ -791,7 +791,7 @@ export const actions = {
 
     commit('clusterReady', true);
 
-    console.log('Done loading cluster.'); // eslint-disable-line no-console
+    debug.log('Done loading cluster.'); // eslint-disable-line no-console
   },
 
   switchNamespaces({ commit, dispatch, getters }, { ids, key }) {
@@ -845,7 +845,7 @@ export const actions = {
       commit('clusterId', id);
     }
 
-    console.log(`Loading ${ isMultiCluster ? 'ECM ' : '' }cluster...`); // eslint-disable-line no-console
+    debug.log(`Loading ${ isMultiCluster ? 'ECM ' : '' }cluster...`); // eslint-disable-line no-console
 
     // This is a workaround for a timing issue where the mgmt cluster schema may not be available
     // Try and wait until the schema exists before proceeding
@@ -932,7 +932,7 @@ export const actions = {
 
     commit('clusterReady', true);
 
-    console.log('Done loading virtual cluster.'); // eslint-disable-line no-console
+    debug.log('Done loading virtual cluster.'); // eslint-disable-line no-console
   },
 
   async cleanNamespaces({ getters, dispatch }) {

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -173,7 +173,7 @@ export const getters = {
     let theme = getters['get'](THEME);
     const pcs = getters['get'](PREFERS_SCHEME);
 
-    // console.log('Get Theme', theme, pcs);
+    // debug.log('Get Theme', theme, pcs);
 
     // Ember UI uses this prefix
     if ( theme.startsWith('ui-') ) {
@@ -328,7 +328,7 @@ export const actions = {
       setTimeout(() => {
         dispatch('loadTheme');
       }, nextHalfHour);
-      // console.log('Update theme in', nextHalfHour, 'ms');
+      // debug.log('Update theme in', nextHalfHour, 'ms');
 
       if ( watchDark.matches ) {
         changed('dark');
@@ -358,7 +358,7 @@ export const actions = {
     }
 
     function changed(value) {
-      // console.log('Prefers Theme:', value);
+      // debug.log('Prefers Theme:', value);
       dispatch('set', { key: PREFERS_SCHEME, value });
     }
 

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -67,7 +67,7 @@ export function get(obj, path) {
         wrap:        false,
       });
     } catch (e) {
-      console.log('JSON Path error', e, path, obj); // eslint-disable-line no-console
+      debug.log('JSON Path error', e, path, obj); // eslint-disable-line no-console
 
       return '(JSON Path err)';
     }

--- a/shell/utils/position.js
+++ b/shell/utils/position.js
@@ -92,9 +92,9 @@ export function fitOnScreen(contentElem, triggerElemOrEvent, opt, useDefaults) {
     };
   }
 
-  // console.log('screen', screen);
-  // console.log('trigger', trigger);
-  // console.log('content', content);
+  // debug.log('screen', screen);
+  // debug.log('trigger', trigger);
+  // debug.log('content', content);
 
   const style = { position: 'absolute' };
 
@@ -107,7 +107,7 @@ export function fitOnScreen(contentElem, triggerElemOrEvent, opt, useDefaults) {
     bottom: (overlapY ? trigger.top : trigger.bottom ),
   };
 
-  // console.log('origin', originFor);
+  // debug.log('origin', originFor);
 
   const gapIf = {
     left:   screen.right - content.width - originFor.left,
@@ -118,7 +118,7 @@ export function fitOnScreen(contentElem, triggerElemOrEvent, opt, useDefaults) {
     bottom: screen.bottom - content.height - originFor.top,
   };
 
-  // console.log('gapIf', gapIf);
+  // debug.log('gapIf', gapIf);
 
   if ( positionX === CENTER && gapIf.center < 0) {
     positionX = AUTO;
@@ -169,7 +169,7 @@ export function fitOnScreen(contentElem, triggerElemOrEvent, opt, useDefaults) {
     break;
   }
 
-  // console.log(positionX, positionY, style);
+  // debug.log(positionX, positionY, style);
 
   return style;
 }

--- a/shell/utils/promise.js
+++ b/shell/utils/promise.js
@@ -24,7 +24,7 @@ export function allHashSettled(hash) {
 
 export function eachLimit(items, limit, iterator, debug = false) {
   if (debug) {
-    console.log('eachLimit of', items.length, ' items', limit, 'at a time'); // eslint-disable-line no-console
+    debug.log('eachLimit of', items.length, ' items', limit, 'at a time'); // eslint-disable-line no-console
   }
 
   return new Promise((resolve, reject) => {
@@ -41,7 +41,7 @@ export function eachLimit(items, limit, iterator, debug = false) {
 
     function process() {
       if (debug) {
-        console.log(`process, queue=${ queue.getLength() }, pending=${ pending }, failed=${ failed }`); // eslint-disable-line no-console
+        debug.log(`process, queue=${ queue.getLength() }, pending=${ pending }, failed=${ failed }`); // eslint-disable-line no-console
       }
 
       if (failed) {
@@ -56,14 +56,14 @@ export function eachLimit(items, limit, iterator, debug = false) {
         const { item, idx } = queue.dequeue();
 
         if (debug) {
-          console.log('Running', item); // eslint-disable-line no-console
+          debug.log('Running', item); // eslint-disable-line no-console
         }
 
         pending++;
 
         iterator(item, idx).then((res) => {
           if (debug) {
-            console.log('Done', item); // eslint-disable-line no-console
+            debug.log('Done', item); // eslint-disable-line no-console
           }
 
           out[idx] = res;
@@ -72,7 +72,7 @@ export function eachLimit(items, limit, iterator, debug = false) {
           process();
         }).catch((err) => {
           if (debug) {
-            console.log('Failed', err, item); // eslint-disable-line no-console
+            debug.log('Failed', err, item); // eslint-disable-line no-console
           }
 
           failed = true;

--- a/shell/utils/socket.js
+++ b/shell/utils/socket.js
@@ -78,7 +78,7 @@ export default class Socket extends EventTarget {
     const id = sockId++;
     const url = addParam(this.url, 'sockId', id);
 
-    console.log(`Socket connecting (id=${ id }, url=${ `${ url.replace(/\?.*/, '') }...` })`); // eslint-disable-line no-console
+    debug.log(`Socket connecting (id=${ id }, url=${ `${ url.replace(/\?.*/, '') }...` })`); // eslint-disable-line no-console
 
     let socket;
 
@@ -253,7 +253,7 @@ export default class Socket extends EventTarget {
   }
 
   _closed() {
-    console.log(`Socket ${ this.closingId } closed`); // eslint-disable-line no-console
+    debug.log(`Socket ${ this.closingId } closed`); // eslint-disable-line no-console
 
     this.closingId = 0;
     this.socket = null;
@@ -310,6 +310,6 @@ export default class Socket extends EventTarget {
 
     args.push(`(state=${ this.state }, id=${ this.socket ? this.socket.sockId : 0 })`);
 
-    console.log(args.join(' ')); // eslint-disable-line no-console
+    debug.log(args.join(' ')); // eslint-disable-line no-console
   }
 }

--- a/shell/utils/stream.js
+++ b/shell/utils/stream.js
@@ -43,7 +43,7 @@ export function streamJson(url, opt, onData) {
 export function streamingSupported() {
   const supported = typeof TextDecoder !== 'undefined';
 
-  // console.log('Streaming Supported: ', supported);
+  // debug.log('Streaming Supported: ', supported);
 
   return supported;
 }


### PR DESCRIPTION
- wrapping console.log in an auxiliary method in order to prevent logs in PROD

**TODO:**
- change `console.error` to `debug.error`
- change `console.info` to `debug.info`
- change `console.warn` to `debug.warn`
- test on other browsers (Safari, firefox, IE)
- solve `debug` as a properly defined global var in eslint (now return a warning on the terminal - warning  'debug' is not defined  no-undef) 
- Run by Neil/Richard to make sure we don't hit any console.log problems when not in a browser