### PR TITLE
Display node IPs in cluster management list view -  #2957

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4622,6 +4622,7 @@ tableHeaders:
   clusterFlow: Cluster Flow
   clusterOutput: Cluster Output
   clusters: Clusters
+  clusterIPList: Node IPs
   clustersReady: Clusters Ready
   clusterGroups: Cluster Groups
   commit: Commit

--- a/shell/components/fleet/FleetClusters.vue
+++ b/shell/components/fleet/FleetClusters.vue
@@ -4,6 +4,8 @@ import { STATE, NAME, AGE, FLEET_SUMMARY } from '@shell/config/table-headers';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
 
 export default {
+  name: 'FleetClusters',
+
   components: { ResourceTable },
 
   props: {

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -1,4 +1,4 @@
-import { AGE, NAME as NAME_COL, STATE } from '@shell/config/table-headers';
+import { AGE, CLUSTER_NODE_IPS, NAME as NAME_COL, STATE } from '@shell/config/table-headers';
 import {
   CAPI,
   CATALOG,
@@ -157,6 +157,7 @@ export function init(store) {
       formatter: 'ClusterProvider',
     },
     MACHINE_SUMMARY,
+    CLUSTER_NODE_IPS,
     AGE,
     {
       name:  'explorer',

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -926,3 +926,9 @@ export const IP_ADDRESS = {
   value:         'ipaddress',
   labelKey:      'tableHeaders.ipaddress',
 };
+
+export const CLUSTER_NODE_IPS = {
+  name:          'ipaddress',
+  value:         'ipaddress',
+  labelKey:      'tableHeaders.clusterIPList',
+};

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -133,8 +133,10 @@ export default {
         </n-link>
       </template>
     </Masthead>
-
     <ResourceTable :schema="schema" :rows="rows" :namespaced="false" :loading="$fetchState.pending">
+      <template #cell:ipaddress="{row}">
+        <span v-for="(ip,i) in row.ipaddress" :key="i">{{ ip }}</br></span>
+      </template>
       <template #cell:summary="{row}">
         <span v-if="!row.stateParts.length">{{ row.nodes.length }}</span>
       </template>

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -1,4 +1,6 @@
-import { CAPI, MANAGEMENT, NORMAN, SNAPSHOT } from '@shell/config/types';
+import {
+  ADDRESSES, CAPI, MANAGEMENT, NORMAN, SNAPSHOT
+} from '@shell/config/types';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { findBy } from '@shell/utils/array';
 import { get, set } from '@shell/utils/object';
@@ -634,6 +636,12 @@ export default class ProvCluster extends SteveModel {
 
   get canClone() {
     return false;
+  }
+
+  get ipaddress() {
+    return this.nodes.map((node) => {
+      return node.status.internalNodeStatus?.addresses?.find(({ type }) => type === ADDRESSES.INTERNAL_IP)?.address || '';
+    });
   }
 
   async remove(opt = {}) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  #2957 - Display nodes' IPs to be displayed from the cluster management --> cluster page


### Technical notes summary

- add getter `get ipaddress` to  `shell/models/provisioning.cattle.io.cluster.js`
- Update the list view `shell/list/provisioning.cattle.io.cluster.vue` to display the nodes' IPs

### Areas or cases that should be tested
1. From the navigation Global apps > Cluster Management
2. List view should show list of all the IP addresses of the the nodes associated with a cluster

### Areas which could experience regressions

### Screenshot/Video
![image](https://user-images.githubusercontent.com/1387263/178894444-525c2d01-efe3-421a-bb3d-0ea472f988cf.png)
