### PR TITLE
Set pod forceDelete false by default - #5549.

### DIFF
--- a/shell/promptRemove/pod.vue
+++ b/shell/promptRemove/pod.vue
@@ -36,7 +36,7 @@ export default {
   data() {
     return {
       errors:      [],
-      forceDelete: true
+      forceDelete: false
     };
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5549 - https://github.com/rancher/dashboard/issues/5549#issuecomment-1181195338

<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
#### Single cluster deletion
1. Navigate to `Cluster Explorer > Cluster > Deployments > Pod >`
2. Select three dots on the right and select `Delete`
3. Select the force deletion and submit
4. Delete request should have payload `{"gracePeriod":0,"force":true}` 
5. If unticked there should not be a payload

#### Multiple cluster deletion
1. Navigate to `Cluster Explorer > Cluster > Deployments > Pod >`
2. From checkboxes on the left select multiple pods and select `Delete`
3. Select the force deletion and submit
4. All Delete requests should have payload `{"gracePeriod":0,"force":true}` 
5. If unticked there should not be a payload

### Screenshot/Video
<img width="800" alt="image" src="https://user-images.githubusercontent.com/1387263/178459173-46204ce7-37e9-4290-b640-cfba2163ed5d.png">