### PR TITLE
List of projects/namespaces respects filters in top nav

### DIFF
--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -253,6 +253,12 @@ export const getters = {
     return BOTH;
   },
 
+  activeNamespaceFilters(state) {
+    return () => {
+      return state.namespaceFilters;
+    };
+  },
+
   namespaces(state, getters) {
     return () => {
       const out = {};


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5088 by making it so that you select projects or namespaces in the top nav of Cluster Explorer, the projects/namespaces list view is updated accordingly. This should avoid a disconcerting experience for users who don't want to see things that are outside of their active filters.

Example of filtering by a namespace:

<img width="1517" alt="Screen Shot 2022-07-11 at 11 18 42 PM" src="https://user-images.githubusercontent.com/20599230/178422089-a540c017-d375-407d-8ba8-eb6b15635ade.png">


Example of filtering by a project:

<img width="1521" alt="Screen Shot 2022-07-11 at 11 18 50 PM" src="https://user-images.githubusercontent.com/20599230/178422103-ab643505-79aa-4871-87d7-812109194d2a.png">


## What was fixed, or what changes have occurred
Added filters to the Projects/Namespaces list view
 
## Areas or cases that should be tested
Should try all the namespace/project filtering options in the top nav and make sure they work as expected.
 
## What areas could experience regressions?
I would expect that the Projects/Namespaces page is the only page that could be affected.

Note: There is a related design issue about reminding users that filters are being applied, but that can be addressed in a separate PR. https://github.com/rancher/dashboard/issues/6321