### PR TITLE
Fix empty API Group when edit as yaml for role

### DIFF
--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -146,16 +146,12 @@ export function cleanUp(obj) {
     const val = obj[key];
 
     if ( Array.isArray(val) ) {
-      obj[key] = compact(val.map((each) => {
-        if (each) {
-          const cleaned = cleanUp(each);
-
-          if (!isEmpty(cleaned)) {
-            return cleaned;
-          }
+      obj[key] = val.map((each) => {
+        if (each !== null && each !== undefined) {
+          return cleanUp(each);
         }
-      }));
-      if (compact(obj[key]).length === 0) {
+      });
+      if (obj[key].length === 0) {
         delete obj[key];
       }
     } else if (typeof val === 'undefined' || val === null) {


### PR DESCRIPTION
Fixes #6223 

This PR fixes some over-zealous code in the cleanup function.

To reproduce:

- Go to a cluster, click on the 'search' icon, and go to 'ClusterRole'
- Find a cluster role (e.g. admin) and click 'Edit Config'
- Click 'Edit as YAML'
- Verify that you see :
```
 - apiGroups:
      - ''
 ```

The problem is when you switch to 'Edit as YAML' from the from, we clone the resource and run it through the `cleanup` function. This was removing empty values - it was going through Arrays and removing falseys - this seems problematic, as a. valid array like this:

```
test:
 - false
```

would be removed.

This PR removes the cleaning up of arrays like this - we no longer remove falsey values and we don't cleanup the values themselves.