### PR TITLE
Plugin in explorer scoped

### DIFF
--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -325,6 +325,7 @@ export default async function({
           id:     clusterId,
           oldPkg: oldPkgPlugin,
           newPkg: newPkgPlugin,
+          product,
           oldProduct,
         })]);
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -629,7 +629,7 @@ export const actions = {
   async loadCluster({
     state, commit, dispatch, getters
   }, {
-    id, oldProduct, oldPkg, newPkg
+    id, product, oldProduct, oldPkg, newPkg
   }) {
     const sameCluster = state.clusterId && state.clusterId === id;
     const samePackage = oldPkg?.name === newPkg?.name;
@@ -654,9 +654,13 @@ export const actions = {
       s => getters[`${ s.storeName }/isClusterStore`]
     )?.storeName;
 
+    const productConfig = state['type-map']?.products?.find(p => p.name === product);
+    const forgetCurrentCluster = ((state.clusterId && id) || !samePackage) && !productConfig?.inExplorer;
+
     // Should we leave/forget the current cluster? Only if we're going from an existing cluster to a new cluster, or the package has changed
     // (latter catches cases like nav from explorer cluster A to epinio cluster A)
-    if ( (state.clusterId && id) || !samePackage) {
+    // AND if the product not scoped to the explorer - a case for products that only exist within the explorer (i.e. Kubewarden)
+    if ( forgetCurrentCluster ) {
       // Clear the old cluster state out if switching to a new one.
       // If there is not an id then stay connected to the old one behind the scenes,
       // so that the nav and header stay the same when going to things like prefs

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -37,6 +37,7 @@
 //   ifHaveType,              -- Show this product only if the given type exists in the store [inStore], This can also be specified as an object { type: TYPE, store: 'management' } if the type isn't in the current [inStore]
 //   ifHaveVerb,              -- In combination with ifHaveTYpe, show it only if the type also has this collectionMethod
 //   inStore,                 -- Which store to look at for if* above and the left-nav, defaults to "cluster"
+//   inExplorer,              -- Determines if the product is to be scoped to the explorer
 //   public,                  -- If true, show to all users.  If false, only show when the Developer Tools pref is on (default true)
 //   category,                -- Group to show the product in for the nav hamburger menu
 //   typeStoreMap,            -- An object mapping types to the store that should be used to retrieve information about the type

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -179,6 +179,7 @@ export function DSL(store, product, module = 'type-map') {
         name:                product,
         weight:              1,
         inStore:             'cluster',
+        inExplorer:          false,
         removable:           true,
         showClusterSwitcher: true,
         showNamespaceFilter: false,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
<!-- Define findings related to the feature or bug issue. -->
This fixes an issue of unsubscribing and resetting the cluster for products that only exist within the explorer for a given cluster.
 
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
While a package is strictly scoped to the explorer of a cluster and not accessible from management, any navigation to/from the package would cause the [cluster subscription to be unsubscribed and reset](https://github.com/rancher/dashboard/blob/7145f349ffcc5210aeeab653964814a7c84140e3/shell/store/index.js#L659-L683). This resulted in a timing issue that would cause the cluster to be undefined before the package is loaded.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
To fix this issue I added `inExplorer` to the `product` object of DSL to determine if the product is to be scoped to the explorer. If this prop is true, any navigation to/from the product will bypass the `cluster/unsubscribe` dispatch.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Installed packages/products.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
This should not create a regression as the `inExplorer` prop defaults to `false`, only when it is explicitly set to `true` within a product's config will this be relevant.