### PR TITLE
add tooltip to fleet cluster labels editor title with appropriate copy

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2356,6 +2356,7 @@ labels:
   addAnnotation: Add Annotation
   labels:
     title: Labels
+    fleetClusterTooltip: Label changes are made to the Management Cluster and synchronized to the Fleet Cluster
   annotations:
     title: Annotations
 

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -28,6 +28,16 @@ export default {
     defaultSectionClass: {
       type:    String,
       default: '',
+    },
+
+    labelTitleTooltip: {
+      type:    String,
+      default: '',
+    },
+
+    annotationTitleTooltip: {
+      type:    String,
+      default: '',
     }
   },
 
@@ -51,6 +61,7 @@ export default {
         :add-label="t('labels.addLabel')"
         :mode="mode"
         :title="t('labels.labels.title')"
+        :title-protip="labelTitleTooltip"
         :read-allowed="false"
         :value-can-be-empty="true"
         @input="value.setLabels($event)"
@@ -64,6 +75,7 @@ export default {
         :add-label="t('labels.addAnnotation')"
         :mode="mode"
         :title="t('labels.annotations.title')"
+        :title-protip="annotationTitleTooltip"
         :read-allowed="false"
         :value-can-be-empty="true"
         @input="value.setAnnotations($event)"

--- a/shell/edit/fleet.cattle.io.cluster.vue
+++ b/shell/edit/fleet.cattle.io.cluster.vue
@@ -88,6 +88,7 @@ export default {
       :value="normanCluster"
       :mode="mode"
       :display-side-by-side="false"
+      :label-title-tooltip="t('labels.labels.fleetClusterTooltip')"
     />
   </CruResource>
 </template>


### PR DESCRIPTION
Addresses Github issue: [#6014](https://github.com/rancher/dashboard/issues/6014)

From the interpretation of the issue, the client is trying to reverse-engineer the API used for Rancher to automate some 
tasks, so the goal here is to provide additional information in the form of a tooltip so that the user knows how the relationship between Fleet Clusters and Management Clusters work.

- Add tooltip to fleet cluster labels editor title with appropriate copy

<img width="736" alt="Screenshot 2022-07-13 at 11 19 05" src="https://user-images.githubusercontent.com/97888974/178712337-76b8419d-3bbe-4178-8477-c0030db9a074.png">
