### PR TITLE
Fix cluster pod count on  home page

### DIFF
--- a/shell/components/formatter/PodsUsage.vue
+++ b/shell/components/formatter/PodsUsage.vue
@@ -16,12 +16,14 @@ export default {
   },
   methods: {
     async startDelayedLoading() {
-      if (this.row?.isReady) {
-        const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ this.row?.id }/v1/counts` });
+      const id = this.row?.mgmt?.id;
+
+      if (this.row?.isReady && id) {
+        const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ id }/v1/counts` });
 
         this.loading = false;
         const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
-        const totalPods = this.row?.status?.allocatable?.pods;
+        const totalPods = this.row?.mgmt?.status?.allocatable?.pods;
 
         if (totalPods) {
           this.podsUsage = `${ usedPods }/${ totalPods }`;

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -247,6 +247,10 @@ export default class ProvCluster extends SteveModel {
     return out;
   }
 
+  get isReady() {
+    return !!this.mgmt?.isReady;
+  }
+
   waitForProvisioner(timeout, interval) {
     return this.waitForTestFn(() => {
       return !!this.provisioner;


### PR DESCRIPTION
Fixes #6292 

I broke this when I changed the home page to show provisioning cluster objects not mgmt clusters.

This PR fixes that.