### PR TITLE
Project/namespace list updates when project is added or removed

### DIFF
--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -85,7 +85,8 @@ export default class Project extends HybridModel {
     const norman = await this.norman;
 
     await norman.remove(...arguments);
-    this.$dispatch('management/remove', this, { root: true });
+    await this.$dispatch('management/remove', this, { root: true });
+    await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
   }
 
   get norman() {

--- a/shell/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/shell/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -76,7 +76,13 @@ export default {
     clusterProjects() {
       const clusterId = this.$store.getters['currentCluster'].id;
 
-      return this.projects.filter(project => project.spec.clusterName === clusterId);
+      // Get the list of projects from the store so that the list
+      // is updated if a new project is created or removed.
+      const projectsInAllClusters = this.$store.getters['management/all'](MANAGEMENT.PROJECT);
+
+      const clustersInProjects = projectsInAllClusters.filter(project => project.spec.clusterName === clusterId);
+
+      return clustersInProjects;
     },
     projectsWithoutNamespaces() {
       return this.activeProjects.filter((project) => {
@@ -117,13 +123,19 @@ export default {
     groupPreference: mapPref(GROUP_RESOURCES),
     activeProjects() {
       const namespaceFilters = this.$store.getters['activeNamespaceFilters']();
-      const activeProjects = this.getActiveProjects(namespaceFilters);
+      const activeProjectFilters = this.getActiveProjects(namespaceFilters);
+
+      // If the user is not filtering by any projects, return
+      // all projects in the cluster.
+      if (Object.keys(activeProjectFilters).length === 0) {
+        return this.clusterProjects;
+      }
 
       // Filter out projects that are not selected in the top nav.
       return this.clusterProjects.filter((projectData) => {
         const projectId = projectData.id.split('/')[1];
 
-        return !!activeProjects[projectId];
+        return !!activeProjectFilters[projectId];
       });
     },
     activeNamespaces() {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6353 and https://github.com/rancher/dashboard/issues/6350 by making it so that the project/namespace list in cluster is updated when you create and delete projects.

To test this PR, I went to cluster explorer in the local cluster, added and deleted projects, and added and deleted namespaces. Based on this comment https://github.com/rancher/dashboard/issues/6353#issuecomment-1183188092 I also confirmed that empty projects are also shown.