### PR TITLE
provide interface to edit node name (custom name) for RKE1 nodes

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2661,6 +2661,9 @@ login:
   remember:
     label: Remember Username
 
+managementNode:
+  customName: Custom Name
+
 members:
   clusterMembers: Cluster Members
   createActionLabel: Add

--- a/shell/edit/management.cattle.io.node.vue
+++ b/shell/edit/management.cattle.io.node.vue
@@ -35,20 +35,21 @@ export default {
 
         saveCb(true);
 
-        // navigate back to the area we came from
-        this.$router.go(-1);
+        this.done();
       } catch (error) {
         this.errors.push(error);
         saveCb(false);
       }
     },
-    overrideCancel() {
-      this.$router.go(-1);
-    },
   },
   mounted() {
     this.name = this.value.spec.displayName;
-  }
+  },
+  computed: {
+    doneLocationOverride() {
+      return this.value.doneOverride;
+    },
+  },
 };
 </script>
 
@@ -59,9 +60,7 @@ export default {
     :resource="value"
     :mode="mode"
     :errors="errors"
-    :cancel-event="true"
     @finish="save"
-    @cancel="overrideCancel"
   >
     <LabeledInput
       v-model="name"

--- a/shell/edit/management.cattle.io.node.vue
+++ b/shell/edit/management.cattle.io.node.vue
@@ -1,0 +1,72 @@
+<script>
+import createEditView from '@shell/mixins/create-edit-view';
+import CruResource from '@shell/components/CruResource';
+import Loading from '@shell/components/Loading';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { NORMAN } from '@shell/config/types';
+export default {
+  components: {
+    CruResource,
+    Loading,
+    LabeledInput
+  },
+  mixins: [createEditView],
+  props:  {
+    value: {
+      type:     Object,
+      required: true,
+    },
+  },
+  async fetch() {
+    // we need this to populate the NORMAN node... getNorman
+    await this.$store.dispatch('rancher/findAll', { type: NORMAN.NODE });
+  },
+  data() {
+    return {
+      name:    '',
+      loading: true
+    };
+  },
+  methods: {
+    async save(saveCb) {
+      try {
+        this.value.norman.name = this.name;
+        await this.value.norman.save();
+
+        saveCb(true);
+
+        // navigate back to the area we came from
+        this.$router.go(-1);
+      } catch (error) {
+        this.errors.push(error);
+        saveCb(false);
+      }
+    },
+    overrideCancel() {
+      this.$router.go(-1);
+    },
+  },
+  mounted() {
+    this.name = this.value.spec.displayName;
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="!value" />
+  <CruResource
+    v-else
+    :resource="value"
+    :mode="mode"
+    :errors="errors"
+    :cancel-event="true"
+    @finish="save"
+    @cancel="overrideCancel"
+  >
+    <LabeledInput
+      v-model="name"
+      :label="t('managementNode.customName')"
+      :mode="mode"
+    />
+  </CruResource>
+</template>

--- a/shell/models/management.cattle.io.node.js
+++ b/shell/models/management.cattle.io.node.js
@@ -89,7 +89,7 @@ export default class MgmtNode extends HybridModel {
   }
 
   get canUpdate() {
-    return this.norman?.hasLink('update');
+    return this.hasLink('update') && this.norman?.hasLink('update');
   }
 
   remove() {

--- a/shell/models/management.cattle.io.node.js
+++ b/shell/models/management.cattle.io.node.js
@@ -113,18 +113,11 @@ export default class MgmtNode extends HybridModel {
   }
 
   get provisioningCluster() {
-    return this.$getters['all'](CAPI.RANCHER_CLUSTER).find(c => c.name === this.namespace);
+    return this.$getters['all'](CAPI.RANCHER_CLUSTER).find(c => c.mgmtClusterId === this.mgmtClusterId);
   }
 
   get doneOverride() {
-    return {
-      name:   'c-cluster-product-resource-namespace-id',
-      params: {
-        resource:  CAPI.RANCHER_CLUSTER,
-        namespace: this.provisioningCluster?.namespace,
-        id:        this.namespace
-      }
-    };
+    return this.provisioningCluster?.detailLocation;
   }
 
   get canClone() {


### PR DESCRIPTION
Addresses Github issue: [#5951](https://github.com/rancher/dashboard/issues/5951)

- provide interface to edit node name (custom name) for RKE1 nodes

**Screenshots**
<img width="798" alt="Screenshot 2022-07-14 at 15 25 55" src="https://user-images.githubusercontent.com/97888974/179012023-2108aba2-1b1c-4c8b-89d4-9771c53e736b.png">
<img width="798" alt="Screenshot 2022-07-14 at 15 27 11" src="https://user-images.githubusercontent.com/97888974/179012028-f71cbd91-ffb8-4141-a7b6-2dfbfc177c1a.png">
<img width="798" alt="Screenshot 2022-07-14 at 15 26 02" src="https://user-images.githubusercontent.com/97888974/179012040-e606984c-d6f6-4cef-8c26-2742c6fc06dc.png">

