### PR TITLE
Remove node ip from cluster's list & UX tweaks to cluster list/detail pages

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4623,7 +4623,6 @@ tableHeaders:
   clusterFlow: Cluster Flow
   clusterOutput: Cluster Output
   clusters: Clusters
-  clusterIPList: Node IPs
   clustersReady: Clusters Ready
   clusterGroups: Cluster Groups
   commit: Commit

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -233,7 +233,7 @@ export default {
           @click.prevent="select(tab.name, $event)"
         >
           <span>{{ tab.labelDisplay }}</span>
-          <i v-if="hasIcon(tab)" v-tooltip="t('validation.tab')" class="conditions-alert-icon icon-warning icon-lg" />
+          <i v-if="hasIcon(tab)" v-tooltip="t('validation.tab')" class="conditions-alert-icon icon-error icon-lg" />
         </a>
       </li>
       <li v-if="sideTabs && !sortedTabs.length" class="tab disabled">
@@ -307,7 +307,7 @@ export default {
 
       .conditions-alert-icon {
         color: var(--error);
-        padding-left: 10px;
+        padding-left: 4px;
       }
 
       &:last-child {

--- a/shell/components/fleet/FleetClusters.vue
+++ b/shell/components/fleet/FleetClusters.vue
@@ -4,8 +4,6 @@ import { STATE, NAME, AGE, FLEET_SUMMARY } from '@shell/config/table-headers';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
 
 export default {
-  name: 'FleetClusters',
-
   components: { ResourceTable },
 
   props: {

--- a/shell/components/formatter/ClusterLink.vue
+++ b/shell/components/formatter/ClusterLink.vue
@@ -58,7 +58,7 @@ export default {
 
 </script>
 <template>
-  <span>
+  <span class="cluster-link">
     <n-link v-if="to" :to="to">
       {{ value }}
     </n-link>
@@ -72,9 +72,13 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  .cluster-link {
+    display: flex;
+    align-items: center;
+  }
   .conditions-alert-icon {
     color: var(--error);
-    padding-left: 2px;
+    margin-left: 4px;
   }
   ::v-deep {
     .labeled-tooltip, .status-icon {

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -1,4 +1,4 @@
-import { AGE, CLUSTER_NODE_IPS, NAME as NAME_COL, STATE } from '@shell/config/table-headers';
+import { AGE, NAME as NAME_COL, STATE } from '@shell/config/table-headers';
 import {
   CAPI,
   CATALOG,
@@ -157,7 +157,6 @@ export function init(store) {
       formatter: 'ClusterProvider',
     },
     MACHINE_SUMMARY,
-    CLUSTER_NODE_IPS,
     AGE,
     {
       name:  'explorer',

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -926,9 +926,3 @@ export const IP_ADDRESS = {
   value:         'ipaddress',
   labelKey:      'tableHeaders.ipaddress',
 };
-
-export const CLUSTER_NODE_IPS = {
-  name:          'ipaddress',
-  value:         'ipaddress',
-  labelKey:      'tableHeaders.clusterIPList',
-};

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -140,10 +140,10 @@ export default {
       </template>
       <template #cell:explorer="{row}">
         <span v-if="row.mgmt && row.mgmt.isHarvester"></span>
-        <n-link v-else-if="row.mgmt && row.mgmt.isReady" class="btn btn-sm role-primary" :to="{name: 'c-cluster', params: {cluster: row.mgmt.id}}">
+        <n-link v-else-if="row.mgmt && row.mgmt.isReady" class="btn btn-sm role-secondary" :to="{name: 'c-cluster', params: {cluster: row.mgmt.id}}">
           Explore
         </n-link>
-        <button v-else :disabled="true" class="btn btn-sm role-primary">
+        <button v-else :disabled="true" class="btn btn-sm role-secondary">
           Explore
         </button>
       </template>

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -133,10 +133,8 @@ export default {
         </n-link>
       </template>
     </Masthead>
+
     <ResourceTable :schema="schema" :rows="rows" :namespaced="false" :loading="$fetchState.pending">
-      <template #cell:ipaddress="{row}">
-        <span v-for="(ip,i) in row.ipaddress" :key="i">{{ ip }}</br></span>
-      </template>
       <template #cell:summary="{row}">
         <span v-if="!row.stateParts.length">{{ row.nodes.length }}</span>
       </template>

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -1,6 +1,4 @@
-import {
-  ADDRESSES, CAPI, MANAGEMENT, NORMAN, SNAPSHOT
-} from '@shell/config/types';
+import { CAPI, MANAGEMENT, NORMAN, SNAPSHOT } from '@shell/config/types';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { findBy } from '@shell/utils/array';
 import { get, set } from '@shell/utils/object';
@@ -640,12 +638,6 @@ export default class ProvCluster extends SteveModel {
 
   get canClone() {
     return false;
-  }
-
-  get ipaddress() {
-    return this.nodes.map((node) => {
-      return node.status.internalNodeStatus?.addresses?.find(({ type }) => type === ADDRESSES.INTERNAL_IP)?.address || '';
-    });
   }
 
   async remove(opt = {}) {


### PR DESCRIPTION
- Fixes #2957 (reverts https://github.com/rancher/dashboard/pull/6320 following discussions between QA and UX)
- Following discussions with UX also make improvements to cluster list and condition warnings
  - Cluster list - Make `Explore` button role-secondary
  - Cluster list - Better vertical alignment of cluster list conditions fail icon
  - Cluster list & detail - Align spacing and icon type of cluster list and detail condition icons

Before
![image](https://user-images.githubusercontent.com/18697775/179201085-b0701d68-092d-40fb-9050-d41d80f093e6.png)

![image](https://user-images.githubusercontent.com/18697775/179201181-0ff2b6a4-c14f-4f45-a6bc-822d61c6fdad.png)


After
![image](https://user-images.githubusercontent.com/18697775/179200775-7b73c52c-59c0-4dcb-9a87-c60c8476ca8b.png)

![image](https://user-images.githubusercontent.com/18697775/179200841-17341cfd-b2f5-4984-ac89-a985d1708de6.png)
