### PR TITLE
Unit tests: Collect coverage for unit tests and components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,9 +26,10 @@ module.exports = {
   snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],
   collectCoverage:     false,
   collectCoverageFrom: [
-    '<rootDir>/components/**/*.vue',
+    '<rootDir>/shell/components/**/*.vue',
+    "<rootDir>/shell/utils/**/*",
     // '<rootDir>/pages/*.vue',
-    '!<rootDir>/components/RancherProviderIcon.vue',
+    // '!<rootDir>/components/RancherProviderIcon.vue',
   ],
   modulePathIgnorePatterns: ['<rootDir>/cypress/'],
   coverageDirectory:        '<rootDir>/coverage',

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
   collectCoverage:     false,
   collectCoverageFrom: [
     '<rootDir>/shell/components/**/*.vue',
-    "<rootDir>/shell/utils/**/*",
+    '<rootDir>/shell/utils/**/*',
     // '<rootDir>/pages/*.vue',
     // '!<rootDir>/components/RancherProviderIcon.vue',
   ],


### PR DESCRIPTION
Fixes coverage reports for unit tests.

- Corrects the folder for components (was not updated when plugins changes made)
- Adds utils folder, so that these tests are included in coverage report