### PR TITLE
Fleet: Error loading Bundle details in fleet

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1856,6 +1856,7 @@ fleet:
       other {# tokens are hidden as they belong to Harvester clusters that can not be used with Continuous Delivery}
       }
   bundles:
+    resources: Resources
     harvester: |-
       {count, plural,
       =1 {1 bundle is hidden as it belongs to a Harvester cluster that can not be used with Continuous Delivery}

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -1,16 +1,14 @@
 <script>
 import { FLEET } from '@shell/config/types';
 import FleetBundleResources from '@shell/components/fleet/FleetBundleResources.vue';
-import Tabbed from '@shell/components/Tabbed';
-import Tab from '@shell/components/Tabbed/Tab';
+import SortableTable from '@shell/components/SortableTable';
 
 export default {
   name: 'FleetBundleDetail',
 
   components: {
-    Tabbed,
-    Tab,
     FleetBundleResources,
+    SortableTable,
   },
   props:      {
     value: {
@@ -27,30 +25,53 @@ export default {
     const { namespace, labels } = this.value.metadata;
     const repoName = `${ namespace }/${ labels['fleet.cattle.io/repo-name'] }`;
 
-    this.repo = await this.$store.dispatch('management/find', { type: FLEET.GIT_REPO, id: repoName });
+    if (this.hasRepoLabel) {
+      this.repo = await this.$store.dispatch('management/find', { type: FLEET.GIT_REPO, id: repoName });
+    }
   },
 
   computed: {
-
-    bundleResources() {
-      const bundleResourceIds = this.bundleResourceIds;
-
-      return this.repo?.status?.resources.filter((resource) => {
-        return bundleResourceIds.includes(resource.name);
-      });
+    hasRepoLabel() {
+      return !!(this.value?.metadata?.labels && this.value?.metadata?.labels['fleet.cattle.io/repo-name']);
     },
+    bundleResources() {
+      if (this.hasRepoLabel) {
+        const bundleResourceIds = this.bundleResourceIds;
 
+        return this.repo?.status?.resources.filter((resource) => {
+          return bundleResourceIds.includes(resource.name);
+        });
+      } else if (this.value?.spec?.resources?.length) {
+        return this.value?.spec?.resources.map((item) => {
+          return {
+            content: item.content,
+            name:    item.name.includes('.') ? item.name.split('.')[0] : item.name
+          };
+        });
+      }
+
+      return [];
+    },
+    resourceHeaders() {
+      return [
+        {
+          name:      'name',
+          value:     'name',
+          sort:      ['name'],
+          labelKey:  'tableHeaders.name',
+        },
+      ];
+    },
+    resourceCount() {
+      return (this.bundleResources && this.bundleResources.length) || this.value?.spec?.resources?.length;
+    },
     bundleResourceIds() {
       if (this.value.status?.resourceKey) {
         return this.value?.status?.resourceKey.map(item => item.name);
       }
 
       return [];
-    },
-
-    repoSchema() {
-      return this.$store.getters['management/schemaFor'](FLEET.GIT_REPO);
-    },
+    }
   }
 };
 
@@ -58,10 +79,41 @@ export default {
 
 <template>
   <div>
-    <Tabbed>
-      <Tab label="Resources" name="resources" :weight="30">
-        <FleetBundleResources :value="bundleResources" />
-      </Tab>
-    </Tabbed>
+    <div class="bundle-title mt-20 mb-20">
+      <h2>{{ t('fleet.bundles.resources') }}</h2>
+      <span>{{ resourceCount }}</span>
+    </div>
+    <FleetBundleResources
+      v-if="hasRepoLabel"
+      :value="bundleResources"
+    />
+    <SortableTable
+      v-else
+      :rows="bundleResources"
+      :headers="resourceHeaders"
+      :table-actions="false"
+      :row-actions="false"
+      key-field="tableKey"
+      default-sort-by="state"
+      :paged="true"
+    />
   </div>
 </template>
+
+<style lang="scss" scoped>
+.bundle-title {
+  display: flex;
+  align-items: center;
+
+  h2 {
+    margin: 0 10px 0 0;
+  }
+
+  span {
+    background-color: var(--success);
+    color: var(--default);
+    padding: 5px 10px;
+    border-radius: 15px;
+  }
+}
+</style>


### PR DESCRIPTION
- change layout of details page for fleet bundle so that it accommodates a list of resources not coming from a 
fleet git repo and therefore prevents the error occurring

Note: chatted to Ken and Neil and we agreed the changes reproduced on the screenshots

**Before**
<img width="775" alt="Screenshot 2022-07-15 at 12 16 28" src="https://user-images.githubusercontent.com/97888974/179213191-c58d2461-7fc6-4013-ac91-e0841821fe1f.png">

**After**
_alternative resource list_
<img width="1508" alt="Screenshot 2022-07-15 at 11 40 11" src="https://user-images.githubusercontent.com/97888974/179212961-b1928a51-ffa5-446e-9268-68622e0739b7.png">

_fleet git repo resource list_
<img width="1508" alt="Screenshot 2022-07-15 at 11 40 15" src="https://user-images.githubusercontent.com/97888974/179212975-260656aa-e9c4-4f3e-9f46-79c626f9beb8.png">

