### PR TITLE
Fix two navigation issues

### DIFF
--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -172,6 +172,10 @@ export default {
       return { name: `c-cluster-${ product }-support` };
     },
 
+    unmatchedRoute() {
+      return !this.$route?.matched?.length;
+    }
+
   },
 
   watch: {
@@ -621,13 +625,13 @@ export default {
         <button v-shortkey.once="['f8']" class="hide" @shortkey="wheresMyDebugger()" />
         <button v-shortkey.once="['`']" class="hide" @shortkey="toggleShell" />
       </main>
+      <!-- Ensure there's an outlet to show the error (404) page -->
+      <main v-else-if="unmatchedRoute">
+        <nuxt class="outlet" />
+      </main>
       <div class="wm">
         <WindowManager />
       </div>
-      <main v-if="!clusterId">
-        <!-- Always ensure there's an outlet to cover 404 cases get directed to error page -->
-        <nuxt class="outlet" />
-      </main>
     </div>
     <FixedBanner :footer="true" />
     <GrowlManager />

--- a/shell/list/management.cattle.io.setting.vue
+++ b/shell/list/management.cattle.io.setting.vue
@@ -12,6 +12,7 @@ export default {
   async fetch() {
     const isDev = this.$store.getters['prefs/get'](DEV);
     const rows = await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.SETTING });
+
     const t = this.$store.getters['i18n/t'];
     // Map settings from array to object keyed by id
     const settingsMap = rows.reduce((res, s) => {
@@ -27,7 +28,7 @@ export default {
       const setting = settingsMap[id];
 
       if ( !setting ) {
-        return;
+        continue;
       }
 
       const readonly = !!ALLOWED_SETTINGS[id].readOnly;

--- a/shell/list/management.cattle.io.setting.vue
+++ b/shell/list/management.cattle.io.setting.vue
@@ -12,7 +12,6 @@ export default {
   async fetch() {
     const isDev = this.$store.getters['prefs/get'](DEV);
     const rows = await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.SETTING });
-
     const t = this.$store.getters['i18n/t'];
     // Map settings from array to object keyed by id
     const settingsMap = rows.reduce((res, s) => {


### PR DESCRIPTION
Fix cluster to cluster nav issue
- the outlet was showing prematurely
- now we only show the backup outlet for 404 errors if there's a 404 situation

Fix settings page when there are unknown resource setting
- https://github.com/rancher/dashboard/pull/6351 added additional `ALLOWED_SETTINGS` to the UI
- in older systems this resource setting does not exist
- the settings page `fetch` would return early if it encounters settings that do not exist, leaving the `settings` array un-initialised
- fix is to `continue` instead of `return`