### PR TITLE
Performance: Cache pods by namespace

### DIFF
--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -1,4 +1,5 @@
 import { findBy, insertAt } from '@shell/utils/array';
+import { matches } from '@shell/utils/selector';
 import {
   TARGET_WORKLOADS, TIMESTAMP, UI_MANAGED, HCI as HCI_LABELS_ANNOTATIONS, CATTLE_PUBLIC_ENDPOINTS
 } from '@shell/config/labels-annotations';
@@ -771,7 +772,11 @@ export default class Workload extends SteveModel {
     const podRelationship = relationships.filter(relationship => relationship.toType === POD)[0];
 
     if (podRelationship) {
-      return this.$getters['matching'](POD, podRelationship.selector).filter(pod => pod?.metadata?.namespace === this.metadata.namespace);
+      const pods = this.$getters['podsByNamespace'](this.metadata.namespace);
+
+      return pods.filter((obj) => {
+        return matches(obj, podRelationship.selector);
+      });
     } else {
       return [];
     }

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -1,5 +1,4 @@
 import { findBy, insertAt } from '@shell/utils/array';
-import { matches } from '@shell/utils/selector';
 import {
   TARGET_WORKLOADS, TIMESTAMP, UI_MANAGED, HCI as HCI_LABELS_ANNOTATIONS, CATTLE_PUBLIC_ENDPOINTS
 } from '@shell/config/labels-annotations';
@@ -8,7 +7,7 @@ import { clone, get, set } from '@shell/utils/object';
 import day from 'dayjs';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { shortenedImage } from '@shell/utils/string';
-import { convertSelectorObj, matching } from '@shell/utils/selector';
+import { convertSelectorObj, matching, matches } from '@shell/utils/selector';
 import { SEPARATOR } from '@shell/components/DetailTop';
 
 export default class Workload extends SteveModel {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -101,5 +101,13 @@ export default {
     const typeSuperClass = Object.getPrototypeOf(Object.getPrototypeOf(existing))?.constructor;
 
     return typeSuperClass === HybridModel ? cleanHybridResources(data) : data;
-  }
+  },
+
+  // Return all the pods for a given namespace
+  podsByNamespace: (state) => (namespace) => {
+    const map = state.podsByNamespace[namespace];
+
+    return map?.list || [];
+  },
+
 };

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -104,7 +104,7 @@ export default {
   },
 
   // Return all the pods for a given namespace
-  podsByNamespace: (state) => (namespace) => {
+  podsByNamespace: state => (namespace) => {
     const map = state.podsByNamespace[namespace];
 
     return map?.list || [];

--- a/shell/plugins/steve/index.js
+++ b/shell/plugins/steve/index.js
@@ -26,6 +26,7 @@ function SteveFactory(namespace, baseUrl) {
         deferredRequests: {},
         started:          [],
         inError:          {},
+        podsByNamespace:  {}, // Cache of pods by namespace
       };
     },
 

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -1,6 +1,22 @@
-import { forgetType, resetStore, loadAll } from '@shell/plugins/dashboard-store/mutations';
+import { addObject, removeObject } from '@shell/utils/array';
+import { forgetType, resetStore, loadAll, load, remove } from '@shell/plugins/dashboard-store/mutations';
 import { keyForSubscribe } from '@shell/plugins/steve/subscribe';
 import { perfLoadAll } from '@shell/plugins/steve/performanceTesting';
+
+function registerNamespace(state, namespace) {
+  let cache = state.podsByNamespace[namespace];
+
+  if (!cache) {
+    cache = {
+      list: [],
+      map: new Map()
+    };
+
+    Vue.set(state.podsByNamespace, namespace, cache);
+  }
+
+  return cache;
+}
 
 export default {
   loadAll(state, { type, data, ctx }) {
@@ -9,9 +25,18 @@ export default {
       data = perfLoadAll(type, data);
     }
 
-    return loadAll(state, {
+    const proxies = loadAll(state, {
       type, data, ctx
     });
+
+    // If we loaded a set of pods, then update the posdByNamespace cache
+    if (type == 'pod' && proxies?.length) {
+      proxies.forEach((entry) => {
+        const cache = registerNamespace(state, entry.namespace);
+        addObject(cache.list, entry);
+        cache.map.set(entry.id, entry);
+      });
+    }
   },
 
   forgetType(state, type) {
@@ -23,5 +48,35 @@ export default {
   reset(state) {
     resetStore(state, this.commit);
     this.commit(`${ state.config.namespace }/resetSubscriptions`);
+
+    // Clear the podsByNamespace cache
+    state.podsByNamespace = {};
+  },
+
+  loadMulti(state, { data, ctx }) {
+    for (const entry of data) {
+      const resource = load(state, { data: entry, ctx });
+
+      if (resource.type === 'pod' && resource.metadata) {
+        const cache = registerNamespace(state, resource.namespace);
+
+        addObject(cache.list, resource);
+        cache.map.set(resource.id, resource);
+      }
+    }
+  },
+
+  remove(state, obj) {
+    remove(state, obj, this.getters);
+
+    if (obj && obj.type === 'pod') {
+      const cache = state.podsByNamespace[obj.namespace];
+
+      removeObject(cache.list, obj);
+      cache.map.delete(obj.id);
+    } else if (obj && obj.type === 'namespace') {
+      // Namespace deleted
+      delete state.podsByNamespace[obj.namespace];
+    }
   }
 };

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -1,7 +1,14 @@
 import { addObject, removeObject } from '@shell/utils/array';
-import { forgetType, resetStore, loadAll, load, remove } from '@shell/plugins/dashboard-store/mutations';
+import {
+  forgetType,
+  resetStore,
+  loadAll,
+  load,
+  remove
+} from '@shell/plugins/dashboard-store/mutations';
 import { keyForSubscribe } from '@shell/plugins/steve/subscribe';
 import { perfLoadAll } from '@shell/plugins/steve/performanceTesting';
+import Vue from 'vue';
 
 function registerNamespace(state, namespace) {
   let cache = state.podsByNamespace[namespace];
@@ -9,7 +16,7 @@ function registerNamespace(state, namespace) {
   if (!cache) {
     cache = {
       list: [],
-      map: new Map()
+      map:  new Map()
     };
 
     Vue.set(state.podsByNamespace, namespace, cache);
@@ -30,9 +37,10 @@ export default {
     });
 
     // If we loaded a set of pods, then update the posdByNamespace cache
-    if (type == 'pod' && proxies?.length) {
+    if (type === 'pod' && proxies?.length) {
       proxies.forEach((entry) => {
         const cache = registerNamespace(state, entry.namespace);
+
         addObject(cache.list, entry);
         cache.map.set(entry.id, entry);
       });


### PR DESCRIPTION
Caches the pods in each namespace and uses this in the workload model so that it is only filtering over the number in a given namespace, not the entire list of pods.

Helps to address #6457