### PR TITLE
Performance: Don't allow column definiton changes in sortable table

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -301,7 +301,7 @@ export default {
       eventualSearchQuery: '',
       actionOfInterest:    null,
       loadingDelay:        false,
-      tableHeaders:        this.headers || [],      
+      tableHeaders:        this.headers || [],
     };
   },
 
@@ -351,7 +351,7 @@ export default {
       if (neuNames !== oldNames) {
         this.tableHeaders = neu;
       }
-    },    
+    },
   },
 
   computed: {

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -301,6 +301,7 @@ export default {
       eventualSearchQuery: '',
       actionOfInterest:    null,
       loadingDelay:        false,
+      tableHeaders:        this.headers || [],      
     };
   },
 
@@ -338,6 +339,19 @@ export default {
     eventualSearchQuery: debounce(function(q) {
       this.searchQuery = q;
     }, 200),
+
+    // Workaround for headers changing, when they haven't really
+    // Caused by resource.change messages for the schema which results in table headers being updated, when they have not changed
+    // We just check the names are the same - we don't allow definitoons to be changed during table display
+    headers(neu) {
+      const neuNames = neu.map(o => o.name).join(',');
+      const oldNames = this.tableHeaders.map(o => o.name).join(',');
+
+      // Only update headers if we think they actually changed - otherwise a bunch of stuff recomputes which affects performance
+      if (neuNames !== oldNames) {
+        this.tableHeaders = neu;
+      }
+    },    
   },
 
   computed: {
@@ -382,6 +396,10 @@ export default {
     },
 
     columns() {
+      if (!this.tableHeaders) {
+        return [];
+      }
+
       // Filter out any columns that are too heavy to show for large page sizes
       const out = this.headers.slice().filter(c => !c.maxPageSize || (c.maxPageSize && c.maxPageSize >= this.perPage));
 

--- a/shell/components/SortableTable/selection.js
+++ b/shell/components/SortableTable/selection.js
@@ -52,7 +52,7 @@ export default {
       let selected = this.selectedRows;
 
       // Nothing is selected
-      if ( !this.selectedRows.length ) {
+      if ( !this.selectedRows?.length ) {
         // and there are no rows
         if ( !allRows ) {
           return [];

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -52,14 +52,15 @@ export default {
   },
 
   data() {
+    const headers = this.tableHeaders || [];
     let sortBy = null;
 
     this._defaultSortBy = this.defaultSortBy;
 
     // Try to find a reasonable default sort
     if ( !this._defaultSortBy ) {
-      const markedColumn = this.headers.find(x => !!x.defaultSort);
-      const nameColumn = this.headers.find( x => x.name === 'name');
+      const markedColumn = headers.find(x => !!x.defaultSort);
+      const nameColumn = headers.find( x => x.name === 'name');
 
       if ( markedColumn ) {
         this._defaultSortBy = markedColumn.name;
@@ -68,7 +69,7 @@ export default {
         this._defaultSortBy = nameColumn.name;
       } else {
         // The first column that isn't state
-        const first = this.headers.filter( x => x.name !== 'state' )[0];
+        const first = headers.filter( x => x.name !== 'state' )[0];
 
         if ( first ) {
           this._defaultSortBy = first.name;
@@ -80,7 +81,7 @@ export default {
     }
 
     // If the sort column doesn't exist or isn't specified, use default
-    if ( !sortBy || !this.headers.find(x => x.name === sortBy ) ) {
+    if ( !sortBy || !headers.find(x => x.name === sortBy ) ) {
       sortBy = this._defaultSortBy;
     }
 


### PR DESCRIPTION
This PR makes a small improvement to the sortable table.

On my large cluster, schema updates occur quite frequently, which causes the headers computed to re-evaluate.

This PR watches the headers and only updates a new `tableHeaders` property when the actual set of columns changes (checks names). This means is a column definition changes while viewing a table, this will be not be reflected - but we do not expect this to happen and currently this does not happen.