### PR TITLE
Performance: Fix issues with live and delayed columns

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -314,8 +314,6 @@ export default {
 
     this._onScroll = this.onScroll.bind(this);
     $main.on('scroll', this._onScroll);
-
-    this.updateLiveAndDelayed();
   },
 
   beforeDestroy() {
@@ -329,10 +327,6 @@ export default {
 
     $main.off('scroll', this._onScroll);
   },
-
-  // updated() {
-  //   this.updateLiveAndDelayed();
-  // },
 
   watch: {
     eventualSearchQuery: debounce(function(q) {
@@ -349,7 +343,7 @@ export default {
     initalLoad(neu, old) {
       if (neu && !old) {
         this._didinit = true;
-        this.updateLiveAndDelayed();
+        this.$nextTick(() => this.updateLiveAndDelayed());
       }
     }
   },

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -335,7 +335,7 @@ export default {
 
     page(neu, old) {
       if (neu !== old) {
-        this.updateLiveAndDelayed();
+        this.$nextTick(() => this.updateLiveAndDelayed());
       }
     },
 

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -330,14 +330,28 @@ export default {
     $main.off('scroll', this._onScroll);
   },
 
-  updated() {
-    this.updateLiveAndDelayed();
-  },
+  // updated() {
+  //   this.updateLiveAndDelayed();
+  // },
 
   watch: {
     eventualSearchQuery: debounce(function(q) {
       this.searchQuery = q;
     }, 200),
+
+    page(neu, old) {
+      if (neu !== old) {
+        this.updateLiveAndDelayed();
+      }
+    },
+
+    pagedRows() {
+      // Ensure we update live and delayed columns on first load
+      if (!this.loading && !this._didinit && this.rows?.length) {
+        this._didinit = true;
+        this.updateLiveAndDelayed();
+      }
+    }
   },
 
   computed: {
@@ -558,6 +572,8 @@ export default {
     },
 
     updateDelayedColumns() {
+      clearTimeout(this._delayedColumnsTimer);
+
       if (!this.$refs.column || this.pagedRows.length === 0) {
         return;
       }
@@ -590,6 +606,8 @@ export default {
     },
 
     updateLiveColumns() {
+      clearTimeout(this._liveColumnsTimer);
+
       if (!this.$refs.column || !this.hasLiveColumns || this.pagedRows.length === 0) {
         return;
       }

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -345,9 +345,9 @@ export default {
       }
     },
 
-    pagedRows() {
-      // Ensure we update live and delayed columns on first load
-      if (!this.loading && !this._didinit && this.rows?.length) {
+    // Ensure we update live and delayed columns on first load
+    initalLoad(neu, old) {
+      if (neu && !old) {
         this._didinit = true;
         this.updateLiveAndDelayed();
       }
@@ -355,6 +355,10 @@ export default {
   },
 
   computed: {
+    initalLoad() {
+      return !this.loading && !this._didinit && this.rows?.length;
+    },
+
     fullColspan() {
       let span = 0;
 

--- a/shell/components/formatter/LivePodRestarts.vue
+++ b/shell/components/formatter/LivePodRestarts.vue
@@ -1,0 +1,47 @@
+<script>
+export default {
+  props: {
+    row: {
+      type:     Object,
+      required: true
+    },
+    col: {
+      type:     Object,
+      required: true
+    },
+  },
+
+  data() {
+    return { loading: true, restarts: 0 };
+  },
+
+  methods:  {
+    startDelayedLoading() {
+      this.loading = false;
+    },
+
+    liveUpdate() {
+      if (this.loading) {
+        return;
+      }
+
+      this.restarts = this.row?.restartCount;
+
+      return 5;
+    }
+  }
+};
+</script>
+
+<template>
+  <i v-if="loading" class="icon icon-spinner delayed-loader" />
+  <span v-else>{{ restarts }}</span>
+</template>
+
+<style lang="scss" scoped>
+  .delayed-loader {
+    font-size: 16px;
+    height: 16px;
+    width: 16px;
+  }
+</style>

--- a/shell/components/formatter/WorkloadHealthScale.vue
+++ b/shell/components/formatter/WorkloadHealthScale.vue
@@ -33,7 +33,8 @@ export default {
     return {
       disabled: false,
       expanded: false,
-      loading:  true
+      loading:  true,
+      cParts:   [],
     };
   },
 
@@ -47,18 +48,28 @@ export default {
     },
 
     parts() {
-      return Object.entries(this.row.jobGauges || this.row.podGauges || [])
+      return this.cParts;
+    },
+  },
+
+  methods:  {
+    liveUpdate() {
+      if (this.loading) {
+        return 5;
+      }
+
+      this.cParts = Object.entries(this.row.jobGauges || this.row.podGauges || [])
         .map(([name, value]) => ({
           color: `bg-${ value.color }`,
           value: value.count || 0,
           label: ucFirst(name)
         })).filter(x => x.value > 0);
-    },
-  },
 
-  methods:  {
+      return 5;
+    },
     startDelayedLoading() {
       this.loading = false;
+      this.liveUpdate();
     },
 
     onClickOutside(event) {

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -274,12 +274,13 @@ export const POD_IMAGES = {
 export const POD_RESTARTS = {
   name:         'pod_restarts',
   labelKey:     'tableHeaders.podRestarts',
-  formatter:    'DelayedValue',
+  formatter:    'LivePodRestarts',
   delayLoading: true,
   value:        'restartCount',
   getValue:     row => row.restartCount,
   // This column is expensive to compute, so don't make it searchable
   search:       false,
+  liveUpdates:  true
 };
 
 export const ENDPOINTS = {
@@ -658,6 +659,7 @@ export const WORKLOAD_HEALTH_SCALE = {
   delayLoading: true,
   // This column is expensive to compute, so don't make it searchable
   search:       false,
+  liveUpdates:  true,
 };
 
 export const FLEET_SUMMARY = {


### PR DESCRIPTION
Addresses #6457

This PR improves performance of the workload view significantly.

Currently, the live and delayed columns update almost every second on a system where there is activity.

This PR changes the restarts and workload health columns to be live columns that only update every 5 seconds.

It also fixes an issue in the way these are updated - the `updated` lifecycle hook was being used, but this is triggered when anything on the component changes, which leads to the live and delayed columns updating a lot. We now do an initial trigger and then trigger when the page is changed by the user.

To Test:

Verify that the on the workload page, the Restart Count and Health columns still show and update correctly as you change pages and enter the page. Also check that you can add new deployments, scale then up/down and that these columns still show the correct data.

To test the performance aspect, you need a cluster with a couple of thousand pods and deployments, with about 100 or so pods that are set to crash - then verify that the deployment and workload page shows the correct data and is responsive.