### PR TITLE
Performance: Don't block nodes table on fetching pods

### DIFF
--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -214,7 +214,7 @@ export const PODS = {
   labelKey:  'tableHeaders.pods',
   sort:      'podConsumed',
   search:    false,
-  value:     'podConsumedUsage',
+  value:     row => row.podConsumedUsage,
   formatter: 'PercentageBar',
   width:     120,
 };

--- a/shell/list/node.vue
+++ b/shell/list/node.vue
@@ -54,8 +54,8 @@ export default {
     }
 
     if (this.canViewPods) {
-      // Used for running pods metrics
-      hash.pods = this.$store.dispatch('cluster/findAll', { type: POD });
+      // Used for running pods metrics - we don't need to block on this to show the list of nodes
+      this.$store.dispatch('cluster/findAll', { type: POD });
     }
 
     const res = await allHash(hash);


### PR DESCRIPTION
Fixes #6403

This PR improves the performance of the Nodes list by not waiting for pods to load before showing the node detail.

Once pods load, the pods usage column will update.

On systems with large number of pods, the user had to wait until all of the pods loaded before they could view the nodes.
