### PR TITLE
Namespace results are consistent in top nav and Projects/namespace page

### DIFF
--- a/shell/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/shell/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -150,19 +150,9 @@ export default {
       return this.groupPreference === 'none' ? this.rows : this.rowsWithFakeNamespaces;
     },
     rows() {
-      if (this.$store.getters['prefs/get'](DEV)) {
-        return this.activeNamespaces;
-      }
-
-      const isVirtualCluster = this.$store.getters['isVirtualCluster'];
-      const isVirtualProduct = this.$store.getters['currentProduct'].name === HARVESTER;
-
-      return this.activeNamespaces.filter((namespace) => {
-        const isSettingSystemNamespace = this.$store.getters['systemNamespaces'].includes(namespace.metadata.name);
-        const systemNS = namespace.isSystem || namespace.isFleetManaged || isSettingSystemNamespace;
-
-        return isVirtualCluster && isVirtualProduct ? (!systemNS && !namespace.isObscure) : !namespace.isObscure;
-      });
+      // These rows are not filtered in order to stay consistent
+      // with the namespaces available in the top nav of Cluster Explorer.
+      return this.activeNamespaces;
     },
 
     showMockNotInProjectGroup() {

--- a/shell/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/shell/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -125,9 +125,9 @@ export default {
       const namespaceFilters = this.$store.getters['activeNamespaceFilters']();
       const activeProjectFilters = this.getActiveProjects(namespaceFilters);
 
-      // If the user is not filtering by any projects, return
+      // If the user is not filtering by any projects or namespaces, return
       // all projects in the cluster.
-      if (Object.keys(activeProjectFilters).length === 0) {
+      if (!this.userIsFilteringForSpecificNamespaceOrProject()) {
         return this.clusterProjects;
       }
 


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/5088

This PR addresses feedback from QA that the namespace list was inconsistent between the top nav and the Projects/Namespaces page in Cluster Explorer. https://github.com/rancher/dashboard/issues/5088#issuecomment-1184915725 It changes the table to match the top nav instead of the other way around because Nancy explained that the top nav is more accurate: https://github.com/rancher/dashboard/issues/5088#issuecomment-1184933250

To test this PR, I filtered the top nav to show "Not in a project" namespaces and confirmed that the list items to choose from in the top nav matched the results in the tables.

This PR also:
- Fixes an undocumented bug in which, if you filter by a specific namespace, you would see empty projects on the page. For example, if you filtered by `default` you would see the Default project with only the default namespace in it, and an empty System project. This PR makes it so that if you filter by a certain namespace, only the project containing that namespace is shown.
- Makes it so that if you filter by "Not in a Project," you don't see empty projects.