### PR TITLE
Only label imported clusters as imported

### DIFF
--- a/shell/components/formatter/ClusterProvider.vue
+++ b/shell/components/formatter/ClusterProvider.vue
@@ -5,6 +5,15 @@ export default {
       type:     Object,
       required: true
     },
+  },
+  data(props) {
+    return {
+      // The isImported getter on the provisioning cluster
+      // model doesn't work for imported K3s clusters, in
+      // which case it returns 'k3s' instead of 'imported.'
+      // This is the workaround.
+      isImported: props.row.mgmt.providerForEmberParam === 'import'
+    };
   }
 };
 </script>
@@ -17,7 +26,7 @@ export default {
     <template v-else-if="row.isCustom">
       {{ t('cluster.provider.custom') }}
     </template>
-    <template v-else>
+    <template v-else-if="isImported">
       {{ t('cluster.provider.imported') }}
     </template>
     <div class="text-muted">

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -80,6 +80,7 @@ export default class MgmtCluster extends HybridModel {
   }
 
   get provisioner() {
+    // For imported K3s clusters, this.status.driver is 'k3s.'
     return this.status?.driver ? this.status.driver : 'imported';
   }
 
@@ -99,11 +100,9 @@ export default class MgmtCluster extends HybridModel {
     return this.spec?.clusterTemplateRevisionName;
   }
 
-  get emberEditPath() {
+  get providerForEmberParam() {
     // Ember wants one word called provider to tell what component to show, but has much indirect mapping to figure out what it is.
     let provider;
-    let clusterTemplateRevision;
-
     // Provisioner is the "<something>Config" in the model
     const provisioner = KONTAINER_TO_DRIVER[(this.provisioner || '').toLowerCase()] || this.provisioner;
 
@@ -114,13 +113,6 @@ export default class MgmtCluster extends HybridModel {
       } else {
         provider = 'custom';
       }
-
-      // If the RKE1 cluster is created from an RKE template, we need
-      // to get the template version to pass into the Ember UI for
-      // the iFramed edit cluster form
-      if (this.rkeTemplateVersion) {
-        clusterTemplateRevision = this.rkeTemplateVersion;
-      }
     } else if ( this.driver ) {
       provider = this.driver;
     } else if ( provisioner && provisioner.endsWith('v2') ) {
@@ -128,6 +120,20 @@ export default class MgmtCluster extends HybridModel {
     } else {
       provider = 'import';
     }
+
+    return provider;
+  }
+
+  get emberEditPath() {
+    let clusterTemplateRevision;
+
+    // If the RKE1 cluster is created from an RKE template, we need
+    // to get the template version to pass into the Ember UI for
+    // the iFramed edit cluster form
+    if (this.rkeTemplateVersion) {
+      clusterTemplateRevision = this.rkeTemplateVersion;
+    }
+    const provider = this.providerForEmberParam;
 
     // Avoid passing falsy values as query parameters
     const qp = { };

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -200,6 +200,8 @@ export default class ProvCluster extends SteveModel {
   }
 
   get isImported() {
+    // As of Rancher v2.6.7, this returns false for imported K3s clusters,
+    // in which this.provisioner is `k3s`.
     return this.provisioner === 'imported';
   }
 
@@ -220,6 +222,8 @@ export default class ProvCluster extends SteveModel {
   }
 
   get isImportedK3s() {
+    // As of Rancher v2.6.7, this returns false for imported K3s clusters,
+    // in which this.provisioner is `k3s`.
     return this.isImported && this.mgmt?.status?.provider === 'k3s';
   }
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6352 by making it so that the **Provider** column in the list of clusters labels ONLY imported clusters as imported, while hosted Kubernetes clusters do not get a label in that column:
<img width="1039" alt="Screen Shot 2022-07-18 at 8 44 52 PM" src="https://user-images.githubusercontent.com/20599230/179660703-e64dd58a-5bd7-44ca-85f8-1d0a9c0953d4.png">
 
Previously, the imported label was added by default. I changed it so that now we check to see if the cluster is imported before adding the label.

Normally I would have used the `isImported` getter on the provisioning cluster model to check if a cluster is imported. However, the `isImported` getter is broken - it returns `k3s` instead of `import` as the provisioner for an imported K3s cluster. I was afraid to fix the getter because I thought that changing its output could introduce bugs close to the 2.6.7 release, so I used a workaround. The workaround was that since the provider was correctly identified in the code that decides query params for iFramed ember forms, I decided to take the code that decides the provider from there and break it out as a new getter. This new getter is used in this PR to decide if the cluster is imported.