### PR TITLE
[2.5]backport azuread endpoint migration

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -324,6 +324,14 @@ authConfig:
     graphEndpoint: Graph Endpoint
     tokenEndpoint: Token Endpoint
     authEndpoint: Auth Endpoint
+    reply:
+      info: 'Azure AD requires a whitelisted URL for your Rancher server before beginning this setup. Please ensure that the following URL is set in the Reply URL section of your Azure Portal. Please note that it may take up to 5 minutes for the whitelisted URL to propagate.'
+      label: Reply URL
+    updateEndpoint:
+      banner:
+        message: 'Azure AD Authentication must be updated: it is using the Azure Graph API, which will be deprecated at the end of 2022.'
+        linkText: 'Update it here.'
+      button: Update Endpoint
   stateBanner:
     disabled: '{provider} is currently disabled.'
     enabled: '{provider} is currently enabled.'

--- a/components/auth/AuthBanner.vue
+++ b/components/auth/AuthBanner.vue
@@ -41,6 +41,7 @@ export default {
       <div class="text">
         {{ t('authConfig.stateBanner.enabled', tArgs) }}
       </div>
+      <slot name="actions" />
       <button type="button" class="btn-sm role-primary" @click="edit">
         {{ t('action.edit') }}
       </button>

--- a/components/auth/AzureWarning.vue
+++ b/components/auth/AzureWarning.vue
@@ -1,0 +1,67 @@
+<script>
+// This component will become redundant in 2023, see https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview
+import { NORMAN, MANAGEMENT } from '@/config/types';
+import { get } from '@/utils/object';
+import { AZURE_MIGRATED } from '@/config/labels-annotations';
+export default {
+  async fetch() {
+    // Check for access to steve authConfigs because everyone can load the norman auth config schema
+    if (
+      this.$store.getters['isRancher'] &&
+      this.$store.getters['management/schemaFor'](MANAGEMENT.AUTH_CONFIG)
+    ) {
+      this.authConfig = await this.$store.dispatch('rancher/find', {
+        type: NORMAN.AUTH_CONFIG,
+        id:   'azuread',
+        opt:  { url: `/v3/${ NORMAN.AUTH_CONFIG }/azuread` }
+      });
+    }
+  },
+  data() {
+    const backToRancher = this.$store.getters['backToRancherGlobalLink'];
+
+    return {
+      authConfig:      null,
+      authConfigLink: `${ backToRancher }/security/authentication`
+    };
+  },
+  computed: {
+    showWarning() {
+      if (!this.authConfig) {
+        return false;
+      }
+      // force re-compute if the authConfig is updated in another window
+      // eslint-disable-next-line no-unused-vars
+      const endpoint = this.authConfig?.graphEndpoint;
+
+      return (
+        get(this.authConfig, `annotations."${ AZURE_MIGRATED }"`) !== 'true' &&
+        this.authConfig.enabled
+      );
+    }
+  },
+};
+</script>
+
+<template>
+  <div v-if="showWarning" id="azure-warn" class="banner">
+    <p>
+      {{ t('authConfig.azuread.updateEndpoint.banner.message') }}
+      <a target="_blank" rel="noopener noreferrer nofollow" :href="authConfigLink">
+        {{ t('authConfig.azuread.updateEndpoint.banner.linkText') }}
+      </a>
+    </p>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+#azure-warn {
+  background-color: var(--warning);
+  color: var(--warning-text);
+  line-height: 2em;
+  width: 100%;
+  > p {
+    text-align: center;
+  }
+}
+</style>

--- a/config/labels-annotations.js
+++ b/config/labels-annotations.js
@@ -9,6 +9,7 @@ export const CONTAINER_DEFAULT_RESOURCE_LIMIT = 'field.cattle.io/containerDefaul
 export const CATTLE_PUBLIC_ENDPOINTS = 'field.cattle.io/publicEndpoints';
 export const TARGET_WORKLOADS = 'field.cattle.io/targetWorkloadIds';
 export const UI_MANAGED = 'management.cattle.io/ui-managed';
+export const AZURE_MIGRATED = 'auth.cattle.io/azuread-endpoint-migrated';
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,7 +15,7 @@ import { BASIC, FAVORITE, USED } from '@/store/type-map';
 import { addObjects, replaceWith, clear } from '@/utils/array';
 import { NAME as EXPLORER } from '@/config/product/explorer';
 import isEqual from 'lodash/isEqual';
-
+import AzureWarning from '@/components/auth/AzureWarning';
 export default {
 
   components: {
@@ -26,14 +26,15 @@ export default {
     Footer,
     ActionMenu,
     Group,
-    WindowManager
+    WindowManager,
+    AzureWarning
   },
+
+  middleware: ['authenticated'],
 
   data() {
     return { groups: [] };
   },
-
-  middleware: ['authenticated'],
 
   computed: {
     ...mapState(['managementReady', 'clusterReady']),
@@ -233,52 +234,64 @@ export default {
 </script>
 
 <template>
-  <div v-if="managementReady" class="dashboard-root">
-    <Header />
+  <div class="dashboard-root">
+    <AzureWarning />
 
-    <nav v-if="clusterReady">
-      <Jump v-if="showJump" class="m-10" />
-      <div v-else class="mb-20" />
-      <template v-for="(g, idx) in groups">
-        <Group
-          :key="idx"
-          id-prefix=""
-          class="package"
-          :expanded="expanded"
-          :group="g"
-          :can-collapse="!g.isRoot"
-          :show-header="!g.isRoot"
-        >
-          <template #header>
-            <h6>{{ g.label }}</h6>
-          </template>
-        </Group>
-      </template>
-    </nav>
+    <div v-if="managementReady" class="dashboard-content">
+      <Header />
 
-    <main v-if="clusterReady">
-      <nuxt class="outlet" />
-      <Footer />
+      <nav v-if="clusterReady">
+        <Jump v-if="showJump" class="m-10" />
+        <div v-else class="mb-20" />
+        <template v-for="(g, idx) in groups">
+          <Group
+            :key="idx"
+            id-prefix=""
+            class="package"
+            :expanded="expanded"
+            :group="g"
+            :can-collapse="!g.isRoot"
+            :show-header="!g.isRoot"
+          >
+            <template #header>
+              <h6>{{ g.label }}</h6>
+            </template>
+          </Group>
+        </template>
+      </nav>
 
-      <ActionMenu />
-      <PromptRemove />
-      <AssignTo />
-      <button v-if="dev" v-shortkey.once="['shift','l']" class="hide" @shortkey="toggleNoneLocale()" />
-      <button v-if="dev" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
-      <button v-shortkey.once="['f8']" class="hide" @shortkey="wheresMyDebugger()" />
-      <button v-shortkey.once="['`']" class="hide" @shortkey="toggleShell" />
-    </main>
+      <main v-if="clusterReady">
+        <nuxt class="outlet" />
+        <Footer />
 
-    <div class="wm">
-      <WindowManager />
+        <ActionMenu />
+        <PromptRemove />
+        <AssignTo />
+        <button v-if="dev" v-shortkey.once="['shift','l']" class="hide" @shortkey="toggleNoneLocale()" />
+        <button v-if="dev" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
+        <button v-shortkey.once="['f8']" class="hide" @shortkey="wheresMyDebugger()" />
+        <button v-shortkey.once="['`']" class="hide" @shortkey="toggleShell" />
+      </main>
+
+      <div class="wm">
+        <WindowManager />
+      </div>
     </div>
   </div>
 </template>
 
 <style lang="scss">
-  .dashboard-root {
-    display: grid;
+  .dashboard-root{
+    display: flex;
+    flex-direction: column;
     height: 100vh;
+  }
+  .dashboard-content {
+    display: grid;
+    position: relative;
+    flex: 1 1 auto;
+    overflow-y: auto;
+    min-height: 0px;
 
     grid-template-areas:
       "header  header"

--- a/layouts/plain.vue
+++ b/layouts/plain.vue
@@ -1,12 +1,14 @@
 <script>
 import Header from '@/components/nav/Header';
 import Footer from '@/components/nav/Footer';
+import AzureWarning from '@/components/auth/AzureWarning';
 
 export default {
 
   components: {
     Header,
     Footer,
+    AzureWarning
   },
 
   middleware: ['authenticated'],
@@ -25,19 +27,28 @@ export default {
 
 <template>
   <div class="dashboard-root">
-    <Header />
+    <AzureWarning />
 
-    <main>
-      <nuxt class="outlet" />
-      <Footer />
-    </main>
+    <div class="dashboard-content">
+      <Header />
+
+      <main>
+        <nuxt class="outlet" />
+        <Footer />
+      </main>
+    </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
   .dashboard-root {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     height: 100vh;
+  }
+  .dashboard-content {
+    display: grid;
+    flex-grow: 1;
 
     grid-template-areas:
       "header"

--- a/store/auth.js
+++ b/store/auth.js
@@ -142,6 +142,7 @@ export const actions = {
       addObjects(scopes, opt.scopes);
     }
 
+    // this call to removeParam incidentally properly encodes the url and removes duplicate query params, the latter of which cause an error with azure ad
     let url = removeParam(redirectUrl, GITHUB_SCOPE);
 
     const params = {


### PR DESCRIPTION
#6316 - in 2.5 it's possible to set your after-login route to the dashboard, in which case you wouldn't see the warning added in Ember (https://github.com/rancher/ui/pull/4873) so I've ported that over and updated the hardcoded endpoints. Unlike 2.6, I've opted to link out to the ember auth page from the warning banner: dashboard auth (including azuread) had fixes in 2.6 so it would be better for users to re-configure auth through the Ember UI.


Waiting on https://github.com/rancher/rancher/issues/37228

