### PR TITLE
delay showing and removing socket disconnects

### DIFF
--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -61,11 +61,6 @@ export default class ProvCluster extends SteveModel {
   }
 
   get _availableActions() {
-    // No actions for Harvester clusters
-    if (this.isHarvester) {
-      return [];
-    }
-
     const out = super._availableActions;
     const isLocal = this.mgmt?.isLocal;
 

--- a/shell/utils/socket.js
+++ b/shell/utils/socket.js
@@ -174,6 +174,10 @@ export default class Socket extends EventTarget {
     }
   }
 
+  isConnected() {
+    return this.state === STATE_CONNECTED;
+  }
+
   setAutoReconnect(autoReconnect) {
     this.autoReconnect = autoReconnect;
   }


### PR DESCRIPTION
Fixes #5093 
This PR is aimed at eliminating cases where the websocket disconnect notification flashes on and off. With this PR the notification wont be dispatched until the socket is disconnected for 10 seconds. Notifications wont be removed until they have been visible for at least 3 seconds. Both numbers are arbitrary and can be adjusted as needed until we feel there are no more obnoxious growls.

I tested this by upgrading my rancher instance and watching both the locally-running UI and actual UI.