### PR TITLE
delay showing and removing socket disconnects

### DIFF
--- a/shell/utils/socket.js
+++ b/shell/utils/socket.js
@@ -174,6 +174,10 @@ export default class Socket extends EventTarget {
     }
   }
 
+  isConnected() {
+    return this.state === STATE_CONNECTED;
+  }
+
   setAutoReconnect(autoReconnect) {
     this.autoReconnect = autoReconnect;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5093 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
The socket disconnect notification wont be dispatched until the socket is disconnected for 10 seconds. Notifications wont be removed until they have been visible for at least 3 seconds. These numbers are arbitrary; we can be even more conservative about sending growls if they still seem excessive.


### Areas or cases that should be tested
I tested this by upgrading my rancher instance and watching both the locally-running and its actual ui side by side.
