### PR TITLE
Fixes #5903

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4853,6 +4853,7 @@ user:
   list:
     errorRefreshingGroupMemberships: Error refreshing group memberships
 validation:
+  noUpperCase: 'Alphanumeric characters in "{key}" must be lowercase'
   arrayLength:
     between: '"{key}" should contain between {min} and {max} {max, plural, =1 {item} other {items}}'
     exactly: '"{key}" should contain {count, plural, =1 {# item} other {# items}}'

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -75,6 +75,8 @@ export default function(t: (key: string, options?: any) => string, opt: {display
 
   const required: Validator = (val: any) => !val && val !== false ? t('validation.required', { key: displayKey }) : undefined;
 
+  const noUpperCase: Validator = (val = '') => val.toLowerCase() !== val ? t('validation.noUpperCase', { key: displayKey }) : undefined;
+
   const cronSchedule: Validator = (val: string) => {
     try {
       cronstrue.toString(val);
@@ -371,6 +373,7 @@ export default function(t: (key: string, options?: any) => string, opt: {display
   };
 
   return {
+    noUpperCase,
     required,
     cronSchedule,
     isHttps,


### PR DESCRIPTION
Add in form validation on "name" field when creating and editing backups. Checks if name conforms to dnsLabel and noUpperCase validation.

### Summary
Fixes #5903 
should provide live user feedback to user if the "name" field in the rancher-backup form is out of spec.
* If the field contains upper-case letters
* If the field contains invalid characters such as "_"

### Occurred changes and/or fixed issues
Standard implementation of form-validation