### PR TITLE
Allow user to select deprecated K8s patch versions

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1199,6 +1199,9 @@ cluster:
   kubernetesVersion:
     label: Kubernetes Version
     experimental: experimental
+    deprecated: deprecated
+    deprecatedPatches: Show deprecated Kubernetes patch versions
+    deprecatedPatchWarning: We recommend using the latest patch version for each minor Kubernetes version. Deprecated patch versions can be useful for migration purposes.
   toolsTip: Use the new Cluster Tools to manage and install Monitoring, Logging and other tools
   legacyWarning: The legacy feature flag is enabled and not all legacy features are supported in Kubernetes 1.21+.
   log:

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -286,28 +286,29 @@ export default {
     }
 
     return {
-      loadedOnce:              false,
-      lastIdx:                 0,
-      allPSPs:                 null,
-      nodeComponent:           null,
-      credentialId:            null,
-      credential:              null,
-      machinePools:            null,
-      rke2Versions:            null,
-      k3sVersions:             null,
-      defaultRke2:             '',
-      defaultK3s:              '',
-      s3Backup:                false,
-      versionInfo:             {},
-      membershipUpdate:        {},
-      systemRegistry:          null,
-      registryHost:            null,
-      registryMode:            null,
-      registrySecret:          null,
-      userChartValues:         {},
-      userChartValuesTemp:     {},
-      addonsRev:               0,
-      clusterIsAlreadyCreated: !!this.value.id
+      loadedOnce:                  false,
+      lastIdx:                     0,
+      allPSPs:                     null,
+      nodeComponent:               null,
+      credentialId:                null,
+      credential:                  null,
+      machinePools:                null,
+      rke2Versions:                null,
+      k3sVersions:                 null,
+      defaultRke2:                 '',
+      defaultK3s:                  '',
+      s3Backup:                    false,
+      versionInfo:                 {},
+      membershipUpdate:            {},
+      showDeprecatedPatchVersions: false,
+      systemRegistry:              null,
+      registryHost:                null,
+      registryMode:                null,
+      registrySecret:              null,
+      userChartValues:             {},
+      userChartValuesTemp:         {},
+      addonsRev:                   0,
+      clusterIsAlreadyCreated:     !!this.value.id
     };
   },
 
@@ -385,10 +386,20 @@ export default {
       const cur = this.liveValue?.spec?.kubernetesVersion || '';
       const existingRke2 = this.mode === _EDIT && cur.includes('rke2');
       const existingK3s = this.mode === _EDIT && cur.includes('k3s');
-      const rke2 = this.filterAndMap(this.rke2Versions, (existingRke2 ? cur : null), cur, this.defaultRke2);
-      const k3s = this.filterAndMap(this.k3sVersions, (existingK3s ? cur : null), cur, this.defaultK3s);
-      const showRke2 = rke2.length && !existingK3s;
-      const showK3s = k3s.length && !existingRke2;
+
+      let allValidRke2Versions = this.getAllOptionsAfterMinVersion(this.rke2Versions, (existingRke2 ? cur : null), this.defaultRke2);
+      let allValidK3sVersions = this.getAllOptionsAfterMinVersion(this.k3sVersions, (existingK3s ? cur : null), this.defaultK3s);
+
+      if (!this.showDeprecatedPatchVersions) {
+        // Normally, we only want to show the most recent patch version
+        // for each Kubernetes minor version. However, if the user
+        // opts in to showing deprecated versions, we don't filter them.
+        allValidRke2Versions = this.filterOutDeprecatedPatchVersions(allValidRke2Versions, cur);
+        allValidK3sVersions = this.filterOutDeprecatedPatchVersions(allValidK3sVersions, cur);
+      }
+
+      const showRke2 = allValidRke2Versions.length && !existingK3s;
+      const showK3s = allValidK3sVersions.length && !existingRke2;
       const out = [];
 
       if ( showRke2 ) {
@@ -396,7 +407,7 @@ export default {
           out.push({ kind: 'group', label: this.t('cluster.provider.rke2') });
         }
 
-        out.push(...rke2);
+        out.push(...allValidRke2Versions);
       }
 
       if ( showK3s ) {
@@ -408,7 +419,7 @@ export default {
           });
         }
 
-        out.push(...k3s);
+        out.push(...allValidK3sVersions);
       }
 
       if ( cur ) {
@@ -745,7 +756,7 @@ export default {
       const first = all[0]?.value;
       const preferred = all.find(x => x.value === this.defaultRke2)?.value;
 
-      const rke2 = this.filterAndMap(this.rke2Versions, null);
+      const rke2 = this.getAllOptionsAfterMinVersion(this.rke2Versions, null);
       const showRke2 = rke2.length;
       let out;
 
@@ -1407,7 +1418,7 @@ export default {
       }
     },
 
-    filterAndMap(versions, minVersion, currentVersion, defaultVersion) {
+    getAllOptionsAfterMinVersion(versions, minVersion, defaultVersion) {
       const out = (versions || []).filter(obj => !!obj.serverArgs).map((obj) => {
         let disabled = false;
         let experimental = false;
@@ -1430,11 +1441,49 @@ export default {
           disabled,
         };
       });
-
       const sorted = sortBy(out, 'sort:desc');
+
+      const mostRecentPatchVersions = this.getMostRecentPatchVersions(sorted);
+
+      const sortedWithDeprecatedLabel = sorted.map((optionData) => {
+        const majorMinor = `${ semver.major(optionData.value) }.${ semver.minor(optionData.value) }`;
+
+        if (mostRecentPatchVersions[majorMinor] === optionData.value) {
+          return optionData;
+        }
+
+        return {
+          ...optionData,
+          label: `${ optionData.label } (${ this.t('cluster.kubernetesVersion.deprecated') })`
+        };
+      });
+
+      return sortedWithDeprecatedLabel;
+    },
+
+    getMostRecentPatchVersions(sortedVersions) {
+      // Get the most recent patch version for each Kubernetes minor version.
       const versionMap = {};
 
-      return sorted.filter((version) => {
+      sortedVersions.forEach((version) => {
+        const majorMinor = `${ semver.major(version.value) }.${ semver.minor(version.value) }`;
+
+        if (!versionMap[majorMinor]) {
+          // Because we start with a sorted list of versions, we know the
+          // highest patch version is first in the list, so we only keep the
+          // first of each minor version in the list.
+          versionMap[majorMinor] = version.value;
+        }
+      });
+
+      return versionMap;
+    },
+
+    filterOutDeprecatedPatchVersions(allVersions, currentVersion) {
+      // Get the most recent patch version for each Kubernetes minor version.
+      const mostRecentPatchVersions = this.getMostRecentPatchVersions(allVersions);
+
+      const filteredVersions = allVersions.filter((version) => {
         // Always show pre-releases
         if (semver.prerelease(version.value)) {
           return true;
@@ -1443,14 +1492,14 @@ export default {
         const majorMinor = `${ semver.major(version.value) }.${ semver.minor(version.value) }`;
 
         // Always show current version, else show if we haven't shown anything for this major.minor version yet
-        if (version === currentVersion || !versionMap[majorMinor]) {
-          versionMap[majorMinor] = true;
-
+        if (version === currentVersion || mostRecentPatchVersions[majorMinor] === version.value) {
           return true;
         }
 
         return false;
       });
+
+      return filteredVersions;
     },
 
     generateYaml() {
@@ -1601,6 +1650,12 @@ export default {
                 :mode="mode"
                 :options="versionOptions"
                 label-key="cluster.kubernetesVersion.label"
+              />
+              <Checkbox
+                v-model="showDeprecatedPatchVersions"
+                :label="t('cluster.kubernetesVersion.deprecatedPatches')"
+                :tooltip="t('cluster.kubernetesVersion.deprecatedPatchWarning')"
+                class="patch-version"
               />
               <div v-if="showK3sTechPreviewWarning" class="k3s-tech-preview-info">
                 {{ t('cluster.k3s.techPreview') }}
@@ -2093,5 +2148,8 @@ export default {
   .k3s-tech-preview-info {
     color: var(--error);
     padding-top: 10px;
+  }
+  .patch-version {
+    margin-top: 5px;
   }
 </style>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6376 by allowing a user to reveal deprecated Kubernetes patch versions when provisioning RKE2/K3s clusters, which can be useful when migrating from another Kubernetes distro.

When you go to provision an RKE2/K3s cluster, the default Kubernetes version dropdown menu is unchanged:
<img width="1273" alt="Screen Shot 2022-07-19 at 5 11 31 PM" src="https://user-images.githubusercontent.com/20599230/179869921-b71665ed-1cee-417a-bf3f-ff8e26042215.png">

Below the dropdown, there is a new checkbox to reveal deprecated patch versions:
<img width="888" alt="Screen Shot 2022-07-19 at 5 11 37 PM" src="https://user-images.githubusercontent.com/20599230/179870005-30b27ccd-ac87-4dd9-af0a-c0ca2384f9fb.png">

There is a tooltip that explains that the deprecated versions are a bad idea unless you are migrating:
<img width="1030" alt="Screen Shot 2022-07-19 at 5 11 43 PM" src="https://user-images.githubusercontent.com/20599230/179870077-69af4eb0-1255-4396-8b07-a62ca21c0d43.png">

When the box is checked, all but the most recent minor versions are marked as deprecated:
<img width="1007" alt="Screen Shot 2022-07-19 at 5 12 17 PM" src="https://user-images.githubusercontent.com/20599230/179870142-2a62c242-5591-4789-93be-07c5d2c9906d.png">

I confirmed that I could successfully provision a v1.21.12 cluster, whereas our supported version is v1.21.14:
<img width="1021" alt="Screen Shot 2022-07-19 at 5 21 00 PM" src="https://user-images.githubusercontent.com/20599230/179870190-100f6834-8fef-463f-bdaa-7b4dae024827.png">

