### PR TITLE
fix azuread update btn

### DIFF
--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -113,7 +113,7 @@ export default {
 
     needsUpdate() {
       return (
-        get(this.value, `metadata.annotations."${ AZURE_MIGRATED }"`) !== 'true'
+        get(this.model, `annotations."${ AZURE_MIGRATED }"`) !== 'true'
       );
     },
 
@@ -151,7 +151,8 @@ export default {
           this.$set(this, 'applicationSecret', this.model.applicationSecret);
         }
       }
-    }
+    },
+
   },
 
   methods: {


### PR DESCRIPTION
### Summary
Fixes  #6236

The migration annotation lives on the norman authconfig object, which is `model` not `value` in the azuread edit component - https://github.com/rancher/dashboard/blob/master/shell/mixins/auth-config.js#L83-L87
