### PR TITLE
Retry project creation after 409 error

### DIFF
--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -72,9 +72,22 @@ export default class Project extends HybridModel {
   async save(forceReplaceOnReq) {
     const norman = await this.norman;
 
+    // PUT requests to Norman have trouble with nested objects due to the
+    // merging strategy performed on the backend. Whenever a field is
+    // removed, the resource should be replaced instead of merged,
+    // and the PUT request should have a query param _replace=true.
     const newValue = await norman.save({ replace: forceReplaceOnReq });
 
-    await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
+    try {
+      await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
+    } catch (err) {
+      if (err.status === 409) {
+        // The backend updates each new project soon after it is created,
+        // so there is a chance of a resource conflict error. If that happens,
+        // retry the action.
+        await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
+      }
+    }
 
     await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6377 by changing the order of what happens when we save a new project. If we fetch projects before updating the podsecuritytemplate, we avoid a version conflict.

I also removed the `forceReplaceOnReq` variable because it was always undefined and a search revealed that it was not being passed in by anything.

To test the PR, I created a bunch of projects, waited until I saw the 409 error in the console, and confirmed that the project was successfully created with no errors in the UI.