### PR TITLE
Add in form validation to prometheus rule. Fix model validation error.

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4921,6 +4921,7 @@ validation:
       valuesMustBeDefined: Rule [{index}] of {group} {rules} - value must be defined if operator is 'In' or 'NotIn'
   port: A port must be a number between 1 and 65535.
   prometheusRule:
+    noEdit: This Prometheus Rule may not be edited due to invalid characters in name.
     groups:
       required: At least one rule group is required.
       singleAlert: A rule may contain alert rules or recording rules but not both.

--- a/shell/models/monitoring.coreos.com.prometheusrule.js
+++ b/shell/models/monitoring.coreos.com.prometheusrule.js
@@ -1,6 +1,15 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
 
 export default class PrometheusRule extends SteveModel {
+  get _availableActions() {
+    // the user cannot edit PrometheusRules with a "period" in the name because the name cannot be edited after creation and the backend will reject any name with a "period"
+    const out = super._availableActions.filter((action) => {
+      return !this.metadata.name.includes('.') || !['goToEdit', 'goToEditYaml', 'goToClone'].includes(action.action);
+    });
+
+    return out;
+  }
+
   get customValidationRules() {
     return [
       {

--- a/shell/utils/validators/prometheusrule.js
+++ b/shell/utils/validators/prometheusrule.js
@@ -9,7 +9,7 @@ export function ruleGroups(spec, getters, errors, validatorArgs) {
   return errors;
 }
 
-export function groupsAreValid(groups, getters, errors, validatorArgs) {
+export function groupsAreValid(groups = [], getters, errors, validatorArgs) {
   groups.forEach((group, groupIndex) => {
     const readableGroupIndex = groupIndex + 1; // oh that ol zero based array index....
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5820 
Added in form validation for relevant form. This surfaced a bug in the customValidationRules getter in the model which was fixed by adding a default value to the customValidatorFunction. Also removed edit and clone options from action menu for prometheusRules that can't be edited because the helm-created rules have an invalid name that can't be changed.