### PR TITLE
Ensure that we show empty machine pools

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -28,9 +28,31 @@ import Socket, {
   EVENT_CONNECT_ERROR
 } from '@shell/utils/socket';
 import { get } from '@shell/utils/object';
+import CapiMachineDeployment from '@shell/models/cluster.x-k8s.io.machinedeployment';
 
 let lastId = 1;
 const ansiup = new AnsiUp();
+
+/**
+ * Machine Deployment has a reference to the 'template' used to create that deployment
+ * For an empty machine pool, we (obviously) don't get any machine deployments for that pool.
+ *
+ * This class allows us to fake a machine deployment - when created, we set additional properties (_cluster etc)
+ * and use these in the getters.
+ **/
+class EmptyCapiMachineDeployment extends CapiMachineDeployment {
+  get inClusterSpec() {
+    return this._clusterSpec;
+  }
+
+  get cluster() {
+    return this._cluster;
+  }
+
+  get template() {
+    return this._template;
+  }
+}
 
 export default {
   components: {
@@ -123,6 +145,7 @@ export default {
     this.haveNodes = !!fetchTwoRes.allNodes;
     this.allNodePools = fetchTwoRes.allNodePools || [];
     this.haveNodePools = !!fetchTwoRes.allNodePools;
+    this.machineTemplates = fetchTwoRes.mdtt || [];
   },
 
   created() {
@@ -204,15 +227,48 @@ export default {
     },
 
     fakeMachines() {
+      // When we scale up, the quantity will change to N+1 - so from 0 to 1, the quantity changes,
+      // but it takes tiem for the machine to appear, so the pool is empty, but if we just go off on a non-zero quqntity
+      // then the pool would be hidden - so we find empty pool by checking the machines
+      const emptyPools = this.value.spec.rkeConfig.machinePools.filter((mp) => {
+        const machinePrefix = `${ this.value.name }-${ mp.name }`;
+        const machines = this.value.machines.filter((machine) => {
+          return machine.spec?.infrastructureRef?.name.startsWith(machinePrefix);
+        });
+
+        return machines.length === 0;
+      });
+
       // When a deployment has no machines it's not shown.... so add a fake machine to it
       // This is a catch all scenario seen in older node pool world but not deployments
-      const emptyDeployments = this.allMachineDeployments.filter(x => x.spec.clusterName === this.value.metadata.name && x.spec.replicas === 0);
+      return emptyPools.map((mp) => {
+        const pool = new EmptyCapiMachineDeployment(
+          {
+            metadata: {
+              name:      `${ this.value.nameDisplay }-${ mp.name }`,
+              namespace: this.value.namespace,
+            },
+            spec: {}
+          },
+          {
+            getters:     this.$store.getters,
+            rootGetters: this.$root.$store.getters,
+          }
+        );
 
-      return emptyDeployments.map(d => ({
-        poolId:       d.id,
-        mainRowKey: 'isFake',
-        pool:       d,
-      }));
+        const templateNamePrefix = `${ pool.metadata.name }-`;
+
+        // All of these properties are needed to ensure the pool displays correctly and that we can scale up and down
+        pool._template = this.machineTemplates.find(t => t.metadata.name.startsWith(templateNamePrefix));
+        pool._cluster = this.value;
+        pool._clusterSpec = mp;
+
+        return {
+          poolId:     pool.id,
+          mainRowKey: 'isFake',
+          pool,
+        };
+      });
     },
 
     machines() {

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -230,7 +230,7 @@ export default {
       // When we scale up, the quantity will change to N+1 - so from 0 to 1, the quantity changes,
       // but it takes tiem for the machine to appear, so the pool is empty, but if we just go off on a non-zero quqntity
       // then the pool would be hidden - so we find empty pool by checking the machines
-      const emptyPools = this.value.spec.rkeConfig.machinePools.filter((mp) => {
+      const emptyPools = (this.value.spec.rkeConfig?.machinePools || []).filter((mp) => {
         const machinePrefix = `${ this.value.name }-${ mp.name }`;
         const machines = this.value.machines.filter((machine) => {
           return machine.spec?.infrastructureRef?.name.startsWith(machinePrefix);
@@ -241,9 +241,10 @@ export default {
 
       // When a deployment has no machines it's not shown.... so add a fake machine to it
       // This is a catch all scenario seen in older node pool world but not deployments
-      return emptyPools.map((mp) => {
+      return emptyPools.map((mp, i) => {
         const pool = new EmptyCapiMachineDeployment(
           {
+            id:       i,
             metadata: {
               name:      `${ this.value.nameDisplay }-${ mp.name }`,
               namespace: this.value.namespace,

--- a/shell/models/cluster.x-k8s.io.machine.js
+++ b/shell/models/cluster.x-k8s.io.machine.js
@@ -239,7 +239,7 @@ export default class CapiMachine extends SteveModel {
   }
 
   get isRunning() {
-    return this.status.phase === 'Running';
+    return this.status?.phase === 'Running';
   }
 
   get ipaddress() {


### PR DESCRIPTION
Fixes #5773

For RKE2, when you scale down a machine pool, there are no machine deployments in that pool, so we don't show the machine pool.

This PR fixes this - fakeMachines has been updated to work correctly when there are no machine deployments in a pool

To test:

- Bring up an RKE2 cluster with 2 machine pools.
- In the 2nd pool, scale down the pool to 0
- Verify that the pool is still shown as empty
- Verify that you scan scale the pool back to 1

Note: There is a slight issue when scaling that the pool ordering changes briefly - I think this is minor and we can live with this.
