### PR TITLE
Edit actions for builtin roletemplates and global roles

### DIFF
--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -24,7 +24,7 @@ export default class GlobalRole extends SteveModel {
       }
     });
 
-    if ( editActions ) {
+    if ( editActions.length > 0 ) {
       editActions.forEach((a) => {
         a.enabled = !this.builtin;
       });

--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -14,6 +14,25 @@ const SPECIAL = [BASE, ADMIN, USER];
 const GLOBAL = SUBTYPE_MAPPING.GLOBAL.key;
 
 export default class GlobalRole extends SteveModel {
+  get availableActions() {
+    const out = super._availableActions;
+
+    const toFilter = ['goToEdit', 'promptRemove'];
+    const editActions = out.filter((a) => {
+      if ( toFilter.includes(a.action) ) {
+        return a;
+      }
+    });
+
+    if ( editActions ) {
+      editActions.forEach((a) => {
+        a.enabled = !this.builtin;
+      });
+    }
+
+    return out;
+  }
+
   get customValidationRules() {
     return Role.customValidationRules();
   }

--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -66,7 +66,7 @@ export default class RoleTemplate extends SteveModel {
       }
     });
 
-    if ( editActions ) {
+    if ( editActions.length > 0 ) {
       editActions.forEach((a) => {
         a.enabled = !this.builtin;
       });

--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -56,6 +56,25 @@ export const VERBS = [
 ];
 
 export default class RoleTemplate extends SteveModel {
+  get availableActions() {
+    const out = super._availableActions;
+
+    const toFilter = ['goToEdit', 'promptRemove'];
+    const editActions = out.filter((a) => {
+      if ( toFilter.includes(a.action) ) {
+        return a;
+      }
+    });
+
+    if ( editActions ) {
+      editActions.forEach((a) => {
+        a.enabled = !this.builtin;
+      });
+    }
+
+    return out;
+  }
+
   get customValidationRules() {
     return Role.customValidationRules();
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6212
<!-- Define findings related to the feature or bug issue. -->

The main issue of not being able to update roles was actually due to the role being `builtin`, as in this is a Rancher specific role that ***cannot*** be updated or deleted. In the old UI we actually prevent the user from being able to update or delete a role by disabling the inputs.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Instead of disabling all of the inputs, a quick fix here would be to disable the actions for editing/deleting from the resource itself.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
If the role has `builtin: true` we will disable the `goToEdit` and `promptRemove` actions. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
You should be able to create a role and still have the ability to edit/delete.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
_`builtin` role has no edit/delete action_
![removedaction](https://user-images.githubusercontent.com/40806497/180080287-adedf7ee-606e-48c3-859a-5c634bdb05b9.png)

_The old UI for reference_
![oldui](https://user-images.githubusercontent.com/40806497/180080452-6c4d2415-74dc-4151-9952-a10dec140fd0.png)


