### PR TITLE
Performance: Unwatch some resource types on cluster dashboard and nodes pages

### DIFF
--- a/shell/list/node.vue
+++ b/shell/list/node.vue
@@ -70,6 +70,13 @@ export default {
     };
   },
 
+  beforeDestroy() {
+    // Stop watching pods, nodes and node metrics
+    this.$store.dispatch('cluster/forgetType', POD);
+    this.$store.dispatch('cluster/forgetType', NODE);
+    this.$store.dispatch('cluster/forgetType', METRIC.NODE);
+  },
+
   computed: {
     hasWindowsNodes() {
       return (this.kubeNodes || []).some(node => node.status.nodeInfo.operatingSystem === 'windows');

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -12,6 +12,7 @@ import {
   STATE,
 } from '@shell/config/table-headers';
 import {
+  EVENT,
   NAMESPACE,
   INGRESS,
   MANAGEMENT,
@@ -123,6 +124,13 @@ export default {
       ETCD_METRICS_SUMMARY_URL,
       clusterCounts
     };
+  },
+
+  beforeDestroy() {
+    // Remove the data and stop watching events and nodes
+    // Events in particular can lead to change messages having to be processed when we are no longer interested in events
+    this.$store.dispatch('cluster/forgetType', EVENT);
+    this.$store.dispatch('cluster/forgetType', NODE);
   },
 
   computed: {

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -383,6 +383,25 @@ export default {
     return classify(ctx, resource.toJSON(), true);
   },
 
+  // Forget a type in the store
+  // Remove all entries for that type and stop watching it
+  forgetType({ commit, getters, dispatch }, type) {
+    const obj = {
+      type,
+      stop: true, // Stops the watch on a type
+    };
+
+    if (getters['schemaFor'](type) && getters['watchStarted'](obj)) {
+      // Set that we don't want to watch this type
+      // Otherwise, the dispatch to unwatch below will just cause a re-watch when we
+      // detect the stop message from the backend over the web socket
+      commit('setWatchStopped', obj);
+      dispatch('watch', obj); // Ask the backend to stop watching the type
+    }
+
+    commit('forgetType', type);
+  },
+
   promptRemove({ commit, state }, resources ) {
     commit('action-menu/togglePromptRemove', resources, { root: true });
   },

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -397,6 +397,8 @@ export default {
       // detect the stop message from the backend over the web socket
       commit('setWatchStopped', obj);
       dispatch('watch', obj); // Ask the backend to stop watching the type
+      // Make sure anything in the pending queue for the type is removed, since we've now removed the type
+      commit('clearFromQueue', type);
     }
 
     commit('forgetType', type);

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -68,6 +68,13 @@ export default {
     state.podsByNamespace = {};
   },
 
+  clearFromQueue(state, type) {
+    // Remove anything in the queue that is a resource update for the given type
+    state.queue = state.queue.filter((item) => {
+      return item.body?.type !== type;
+    });
+  },
+
   loadMulti(state, { data, ctx }) {
     for (const entry of data) {
       const resource = load(state, { data: entry, ctx });


### PR DESCRIPTION
Fixes #6431

This PR exposes forgetType as an action and adds in un-watching of the type as well.

It wires this into the cluster dashboard and nodes page, un-watching Steve types that are used in those pages.

In particular, the cluster dashboard page watches events - which can be changing quite regularly, so if you then change to another page, we still get event messages, even though  we're not showing them anywhere.

On the nodes page, we fetch pods, which can also be changing a lot. These will now also be un-watched. Other pages do use pods, so the downside is that if you are looking at deployments and go to nodes, when you go back, the pods will have to re-load - but this should not block the page, just the time taken for certain columns to have the pod data to be able to update.

Reducing the number of types being actively watched seems like a good thing to do - less load on the backend and less load on the frontend, which has to process the web socket messages for those updates and add then to the store.

To test:

- Open up the browser dev tools, go to networking, show web sockets only and select web socket 1 (or whichever is the Steve web scoket)
- Go to the cluster dashboard page for a cluster (local or downstream)
- Verify that the events table shows data correctly
- In dev tools, verify that you see messages to watch events and nodes - they look like `{ "resourceType": "event", "resourceVersion": "<NUMBER>"}`
- Go to the projects/namespaces view
- In dev tools, verify that you see messages to un-watch events and nodes - they look like `{ "resourceType": "event", "resourceVersion": "<NUMBER>", "stop": true}`
 - Go back to the cluster dashboard page and verify that the events table loads correctly
 - Repeat the above for the nodes table, checking that the `node` and `pod` resource types are correctly un-watched