### PR TITLE
Provide extra feedback to the user until form-validation can be added

### DIFF
--- a/shell/chart/rancher-alerting-drivers.vue
+++ b/shell/chart/rancher-alerting-drivers.vue
@@ -11,12 +11,26 @@ export default {
         return {};
       }
     }
+  },
+  computed: {
+    mustSelectOne() {
+      if (!this.value.prom2teams.enabled && !this.value.sachet.enabled) {
+        return 'error';
+      }
+
+      return 'info';
+    }
+  },
+  mounted() {
+    if (this.mustSelectOne === 'error') {
+      this.value.sachet.enabled = true;
+    }
   }
 };
 </script>
 <template>
   <div>
-    <Banner color="info">
+    <Banner :color="mustSelectOne">
       {{ t('rancherAlertingDrivers.selectOne') }}
     </Banner>
     <div class="row">


### PR DESCRIPTION
Provide extra feedback to the user until form-validation can be added and also adds in a default value for "Enable SMS" so we're not loading the form in an invalid state.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5924 

### Occurred changes and/or fixed issues
Provide extra feedback to the user until form-validation can be added and also adds in a default value for "Enable SMS" so we're not loading the form in an invalid state.

### Technical notes summary
Greying out the "Install" button will have to be part of a larger effort after technical evaluation. Providing more clear user feedback should prevent the user from installing this chart with invalid values in the interim.

### Areas or cases that should be tested
* Values step should load with "Enable SMS" preselected. When installed without touching the form, payload should include "sachet.enabled" as being true.
* Banner informing the user that they must select at least one of the options in the form should become red if the user deselects both options.