### PR TITLE
add subdomain validator to prov cluster metadata.name

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4891,6 +4891,8 @@ validation:
       tooLong: '"{key}" cannot be longer than {max} characters'
       tooLongLabel: '"{key}" cannot contain a section longer than {max} characters'
     label:
+      endDot: '"{key}" cannot end with a dot'
+      startDot: '"{key}" cannot start with a dot'
       emptyLabel: '"{key}" cannot be empty'
       endHyphen: '"{key}" cannot end with a hyphen'
       startHyphen: '"{key}" cannot start with a hyphen'

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -6,6 +6,7 @@ import merge from 'lodash/merge';
 import { mapGetters } from 'vuex';
 
 import CreateEditView from '@shell/mixins/create-edit-view';
+import FormValidation from '@shell/mixins/form-validation';
 
 import {
   CAPI,
@@ -101,7 +102,7 @@ export default {
     YamlEditor,
   },
 
-  mixins: [CreateEditView],
+  mixins: [CreateEditView, FormValidation],
 
   props: {
     mode: {
@@ -308,7 +309,10 @@ export default {
       userChartValues:             {},
       userChartValuesTemp:         {},
       addonsRev:                   0,
-      clusterIsAlreadyCreated:     !!this.value.id
+      clusterIsAlreadyCreated:     !!this.value.id,
+      fvFormRuleSets:              [{
+        path: 'metadata.name', rules: ['subDomain'], translationKey: 'nameNsDescription.name.label'
+      }]
     };
   },
 
@@ -1538,7 +1542,7 @@ export default {
     v-else
     ref="cruresource"
     :mode="mode"
-    :validation-passed="validationPassed()"
+    :validation-passed="validationPassed() && fvFormIsValid"
     :resource="value"
     :errors="errors"
     :cancel-event="true"
@@ -1549,7 +1553,7 @@ export default {
     @done="done"
     @finish="saveOverride"
     @cancel="cancel"
-    @error="e=>errors = e"
+    @error="fvUnreportedValidationErrors"
   >
     <Banner
       v-if="isEdit"
@@ -1576,6 +1580,7 @@ export default {
         name-placeholder="cluster.name.placeholder"
         description-label="cluster.description.label"
         description-placeholder="cluster.description.placeholder"
+        :rules="{name:fvGetAndReportPathRules('metadata.name')}"
       />
 
       <Banner v-if="appsOSWarning" color="error">

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -39,8 +39,7 @@ export default function(t: (key: string, options?: any) => string, opt: {display
   // utility validators these validators only get used by other validators
   const startDot: ValidatorFactory = (label: string): Validator => (val: string) => val?.slice(0, 1) === '.' ? t(`validation.dns.${ label }.startDot`, { key: displayKey }) : undefined;
 
-  // this one should technically be used for restricted hostnames but it doesn't look like the existing code will ever call validateHostName with restricted set to true.
-  // const endDot = label => val => val?.slice(-1) === '.' ? t(`validation.dns.${ label }.endDot`, { key: displayKey }) : undefined;
+  const endDot = (label: any) => (val: string) => val?.slice(-1) === '.' ? t(`validation.dns.${ label }.endDot`, { key: displayKey }) : undefined;
 
   const startNumber: ValidatorFactory = (label: string): Validator => (val: string) => val?.slice(0, 1)?.match(/[0-9]/) ? t(`validation.dns.${ label }.startNumber`, { key: displayKey }) : undefined;
 
@@ -373,6 +372,18 @@ export default function(t: (key: string, options?: any) => string, opt: {display
     }
   };
 
+  const subDomain: Validator = (val) => {
+    const matchedChars = val?.match(/[^a-z0-9.-]/g);
+
+    if (matchedChars) {
+      return t('validation.chars', {
+        key: displayKey, count: matchedChars.length, chars: matchedChars.map((char: string) => char === ' ' ? 'Space' : `"${ char }"`).join(', ')
+      });
+    }
+
+    return runValidators(val, [startHyphen('label'), endHyphen('label'), startDot('label'), endDot('label'), required]);
+  };
+
   return {
     noUpperCase,
     required,
@@ -396,6 +407,7 @@ export default function(t: (key: string, options?: any) => string, opt: {display
     dnsLabelIanaServiceName,
     dnsLabelRestricted,
     hostname,
-    testRule
+    testRule,
+    subDomain
   };
 }


### PR DESCRIPTION
#5927 - this came through from Harvester but appears to apply to provisioning.cattle.io.clusters generally. The error returned for a DO rke2 cluster is `Cluster.provisioning.cattle.io "BAD" is invalid: metadata.name: Invalid value: "BAD": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`