### PR TITLE
FIx bug where deleting project on its own did not work

### DIFF
--- a/shell/promptRemove/management.cattle.io.project.vue
+++ b/shell/promptRemove/management.cattle.io.project.vue
@@ -79,6 +79,9 @@ export default {
       if (this.deleteProjectNamespaces) {
         return Promise.all(this.filteredNamespaces.map(n => n.remove())).then(() => false);
       }
+
+      // Return false so that the main promptRemoval will continue to remove the project
+      return false;
     },
   },
 };


### PR DESCRIPTION
Fixes bug where you can't delete a project without deleting the namespaces in it - dialog stays open with the button greyed out.

Addresses re-opened #5624