### PR TITLE
fix roletemplatebinding models

### DIFF
--- a/shell/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/shell/models/management.cattle.io.clusterroletemplatebinding.js
@@ -46,11 +46,11 @@ export default class CRTB extends HybridModel {
   }
 
   get roleDisplay() {
-    return this.roleTemplate.nameDisplay;
+    return this.roleTemplate?.nameDisplay;
   }
 
   get roleDescription() {
-    return this.roleTemplate.description;
+    return this.roleTemplate?.description;
   }
 
   get roleTemplate() {

--- a/shell/models/projectroletemplatebinding.js
+++ b/shell/models/projectroletemplatebinding.js
@@ -7,11 +7,11 @@ export default class PRTB extends NormanModel {
   }
 
   get roleDisplay() {
-    return this.roleTemplate.nameDisplay;
+    return this.roleTemplate?.nameDisplay;
   }
 
   get roleDescription() {
-    return this.roleTemplate.description;
+    return this.roleTemplate?.description;
   }
 
   get roleTemplate() {


### PR DESCRIPTION
Fixes #6442 

This seems to be a pretty straightforward fix: If a `roleTemplate` is deleted some template binding getters throw an error. There's a harvester resource in the screenshotted stack trace but I looked through cluster/project role template/role template binding code and couldn't find any harvester references, so I think these getters are all that need to be fixed here.