### PR TITLE
Render the correct form for imported RKE2 clusters

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -6,7 +6,7 @@ import SelectIconGrid from '@shell/components/SelectIconGrid';
 import EmberPage from '@shell/components/EmberPage';
 import ToggleSwitch from '@shell/components/form/ToggleSwitch';
 import {
-  CHART, FROM_CLUSTER, SUB_TYPE, _EDIT, _IMPORT
+  CHART, FROM_CLUSTER, SUB_TYPE, _EDIT, _IMPORT, _CONFIG
 } from '@shell/config/query-params';
 import { mapGetters } from 'vuex';
 import { sortBy } from '@shell/utils/sort';
@@ -156,7 +156,7 @@ export default {
       if (this.value) {
         // For custom RKE2 clusters, don't load an Ember page.
         // It should be the dashboard.
-        if ( this.value.isRke2 && ((this.value.isCustom && this.mode === _EDIT) || (this.subType || '').toLowerCase() === 'custom')) {
+        if ( this.value.isRke2 && ((this.value.isCustom && this.mode === _EDIT) || (this.value.isCustom && this.as === _CONFIG) || (this.subType || '').toLowerCase() === 'custom')) {
           // For admins, this.value.isCustom is used to check if it is a custom cluster.
           // For cluster owners, this.subtype is used.
           this.selectType('custom', false);


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5922 by updating the conditional logic that renders the read-only config form for custom K3s/RKE2 clusters.

The route of this read-only form is `rancherServerUrl/c/c-m-4brtk95v/manager/provisioning.cattle.io.cluster/fleet-default/catherine-test-custom?as=config`. This PR makes it so that now we render the custom cluster form using the `as=config` query param.

Previously, you could still get to the correct form by going to the context menu and clicking Edit Config. This PR only affects the Config view that you can get to from the cluster detail page in Cluster Management:
<img width="1100" alt="Screen Shot 2022-07-23 at 1 39 25 PM" src="https://user-images.githubusercontent.com/20599230/180622266-d6a1a818-1ff2-4a6f-89db-5a4f546f697c.png">

When the Config button is clicked, it now shows the correct config form in read-only mode:

<img width="1164" alt="Screen Shot 2022-07-23 at 1 43 58 PM" src="https://user-images.githubusercontent.com/20599230/180622289-a11d561b-636e-4cbe-a5cd-d7c7824f9a68.png">

