### PR TITLE
Hide auto-created RBAC namespaces

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3632,7 +3632,7 @@ prefs:
     emacs: 'Emacs'
     vim: 'Vim'
   advanced: Advanced
-  advancedTooltip: Enables 'View in API' option and keyboard shortcut to toggle light or dark theme (shift+t)
+  advancedTooltip: Enables 'View in API' option and keyboard shortcut to toggle light or dark theme (shift+t). This setting also reveals namespaces that are managed by Rancher and are not meant to be manually edited or deleted.
   dev:
     label: Enable Developer Tools & Features
   hideDesc:

--- a/shell/models/namespace.js
+++ b/shell/models/namespace.js
@@ -12,7 +12,15 @@ import Vue from 'vue';
 
 const OBSCURE_NAMESPACE_PREFIX = [
   'c-', // cluster namespace
-  'p-', // project namespace
+
+  // Project namespace. When a user creates a project, Rancher creates
+  // namespaces in the local cluster with the 'p-' prefix which are
+  // used to manage RBAC for the project. If these namespaces are deleted,
+  // role bindings can be lost and Rancher may need to be restored from
+  // backup. Therefore we hide these namespaces unless the developer setting
+  // is turned on from the user preferences.
+  'p-',
+
   'user-', // user namespace
   'local', // local namespace
 ];

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -205,7 +205,10 @@ export default {
     <div class="row">
       <div class="col prefs-advanced">
         <h4 v-t="'prefs.advanced'" />
-        <Checkbox v-model="dev" :description="t('prefs.advancedTooltip', {}, raw=true)" :label="t('prefs.dev.label', {}, true)" />
+        <Checkbox v-model="dev" :label="t('prefs.dev.label', {}, true)" />
+        <p class="wrap-text">
+          {{ t('prefs.advancedTooltip', {}, raw=true) }}
+        </p>
         <br>
         <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-10" />
       </div>
@@ -234,5 +237,10 @@ export default {
 <style lang="scss" scoped>
   hr {
     margin: 20px 0;
+  }
+  .wrap-text {
+    overflow-wrap: break-word;
+    max-width: 80vw;
+    color: var(--input-label);
   }
 </style>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6465 by hiding auto-created RBAC namespaces starting with `p-`. After this change, you should only be able to see the namespaces beginning with `p-` by going to the user preferences and turning on the developer tools.

I've updated the description of the developer tools to explain that it changes what namespaces you see:
<img width="886" alt="Screen Shot 2022-07-23 at 4 08 44 PM" src="https://user-images.githubusercontent.com/20599230/180625846-81a27ba1-edc8-4973-bad8-1e6be3f3bde1.png">

This PR updates the namespace filtering logic in the top nav to make it consistent with the list view. The top nav now also shows the RBAC namespaces based on the user preference set in the developer tools.

With the developer tools turned off:

<img width="474" alt="Screen Shot 2022-07-23 at 4 34 14 PM" src="https://user-images.githubusercontent.com/20599230/180626186-88ac6a98-847d-4dfd-a101-a32910c782dd.png">

With the developer tools turned on:
<img width="396" alt="Screen Shot 2022-07-23 at 4 23 32 PM" src="https://user-images.githubusercontent.com/20599230/180626188-f8638e59-5b51-42bd-95d8-79c3229927e4.png">


To test this PR,

1. I created a project and namespace in a downstream cluster
2. Got the project ID from the project's YAML
3. Went to the user preferences and turned on the developer tools
4. Went to the local cluster in Cluster Explorer and filtered by "Not in a Project"
5. Confirmed that Rancher had automatically created a namespace with the new project ID, and it was listed under "Not in a Project"
6. Went to the user preferences and turned off the developer tools
7. Went back to "Not in a Project" and confirmed that the RBAC namespaces are hidden

Note: Didn't hide system namespaces because we still want to see the contents of the system project.