### PR TITLE
add workspace as a filter to fleet clusters list

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -7,6 +7,7 @@ import SortableTable from '@shell/components/SortableTable';
 import { NAMESPACE } from '@shell/config/table-headers';
 import { findBy } from '@shell/utils/array';
 import { NAME as HARVESTER } from '@shell/config/product/harvester';
+import { NAME as FLEET_NAME } from '@shell/config/product/fleet';
 
 // Default group-by in the case the group stored in the preference does not apply
 const DEFAULT_GROUP = 'namespace';
@@ -126,6 +127,8 @@ export default {
 
   computed: {
     ...mapGetters(['isVirtualCluster']),
+    ...mapGetters(['workspace']),
+    ...mapGetters(['productId']),
     isNamespaced() {
       if ( this.namespaced !== null ) {
         return this.namespaced;
@@ -190,12 +193,24 @@ export default {
       const isAll = this.$store.getters['isAllNamespaces'];
       const isVirtualProduct = this.$store.getters['currentProduct'].name === HARVESTER;
 
+      console.log('*** filtered triggered ***', this.isNamespaced, isAll);
+
       // If the resources isn't namespaced or we want ALL of them, there's nothing to do.
       if ( (!this.isNamespaced || isAll) && !isVirtualProduct) {
         return this.rows || [];
       }
 
-      const includedNamespaces = this.$store.getters['activeNamespaceCache']();
+      let includedNamespaces = this.$store.getters['activeNamespaceCache']();
+
+      if (this.productId === FLEET_NAME) {
+        const workspaceSelected = {};
+
+        workspaceSelected[this.workspace] = true;
+
+        includedNamespaces = Object.assign({}, workspaceSelected);
+      }
+
+      console.log('*** includedNamespaces ***', includedNamespaces);
 
       // Shouldn't happen, but does for resources like management.cattle.io.preference
       if (!this.rows) {

--- a/shell/list/fleet.cattle.io.cluster.vue
+++ b/shell/list/fleet.cattle.io.cluster.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex';
 import FleetClusters from '@shell/components/fleet/FleetClusters';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
@@ -32,6 +33,7 @@ export default {
   },
 
   computed: {
+    ...mapGetters(['workspace']),
     allClusters() {
       const out = this.allFleet.slice();
 
@@ -50,12 +52,16 @@ export default {
       return out;
     },
 
-    rows() {
-      return this.fleetClusters.filter(c => !isHarvesterCluster(c));
-    },
-
     fleetClusters() {
       return this.allClusters.filter(c => c.type === FLEET.CLUSTER);
+    },
+
+    workspaceClusters() {
+      return this.fleetClusters.filter(c => c.metadata?.namespace === this.workspace);
+    },
+
+    rows() {
+      return this.workspaceClusters.filter(c => !isHarvesterCluster(c));
     },
 
     hiddenHarvesterCount() {

--- a/shell/list/fleet.cattle.io.cluster.vue
+++ b/shell/list/fleet.cattle.io.cluster.vue
@@ -1,5 +1,4 @@
 <script>
-import { mapGetters } from 'vuex';
 import FleetClusters from '@shell/components/fleet/FleetClusters';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
@@ -33,7 +32,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['workspace']),
     allClusters() {
       const out = this.allFleet.slice();
 
@@ -52,16 +50,12 @@ export default {
       return out;
     },
 
+    rows() {
+      return this.fleetClusters.filter(c => !isHarvesterCluster(c));
+    },
+
     fleetClusters() {
       return this.allClusters.filter(c => c.type === FLEET.CLUSTER);
-    },
-
-    workspaceClusters() {
-      return this.fleetClusters.filter(c => c.metadata?.namespace === this.workspace);
-    },
-
-    rows() {
-      return this.workspaceClusters.filter(c => !isHarvesterCluster(c));
     },
 
     hiddenHarvesterCount() {


### PR DESCRIPTION
Addresses issue [6363](https://github.com/rancher/dashboard/issues/6363#issuecomment-1192906662) 

- add workspace as a filter to fleet clusters list so that list view becomes reactive to workspace change on header

@jameson-mcghee 
