### PR TITLE
Performance: Add support for Incremental loading

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -102,7 +102,15 @@ export default Vue.extend({
     description: {
       type:    String,
       default: null
-    }
+    },
+
+    /**
+     * Primary checkbox displays label so that it stands out more
+     */
+    primary: {
+      type:    Boolean,
+      default: false
+    },    
   },
 
   computed: {
@@ -214,7 +222,7 @@ export default Vue.extend({
       />
       <span
         v-if="$slots.label || label || labelKey || tooltipKey || tooltip"
-        class="checkbox-label"
+        class="checkbox-label" :class="{ 'checkbox-primary': primary }"
       >
         <slot name="label">
           <t v-if="labelKey" :k="labelKey" :raw="true" />
@@ -262,6 +270,11 @@ $fontColor: var(--input-label);
     color: var(--input-label);
     display: inline-flex;
     margin: 0px 10px 0px 5px;
+
+    &.checkbox-primary {
+      color: inherit;
+      font-weight: 600;
+    }
   }
 
   .checkbox-info {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6757,8 +6757,8 @@ performance:
     setting: You can configure a threshold, below which, the default behvaiour will apply and above which, incremental loading will be used.
     description: |-
       When loading lists of resources, incremental loading initially fetches a small set of resources and then incrementally
-      fetches the remaining resources by making addtional questes for a page until all resources are retrieved. When enabled, resources will
-      appear more quickly, but it may take slightly longer to load the entire set of resources, compared to the default behaviour of loading
+      fetches the remaining resources by making additional requests for a page until all resources are retrieved. When enabled, resources will
+      appear more quickly, but it may take slightly longer to load the entire set of resources, compared to the default behavior of loading
       all resources in one request. This applies to the main Kubernetes resources retrieved by the UI.
 
 banner:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6746,6 +6746,21 @@ featureFlags:
     title: Waiting for Restart
     wait: This may take a few moments
 
+performance:
+  label: UI Performance Settings
+  settingName: Performance
+  description: |-
+    Performance settings allow the behaviour of the UI to be configured when dealing with many resources in a cluster
+  banner: These settings are experimental and may be removed or updated in future versions
+  incrementalLoad:
+    label: Incremental loading
+    setting: You can configure a threshold, below which, the default behvaiour will apply and above which, incremental loading will be used.
+    description: |-
+      When loading lists of resources, incremental loading initially fetches a small set of resources and then incrementally
+      fetches the remaining resources by making addtional questes for a page until all resources are retrieved. When enabled, resources will
+      appear more quickly, but it may take slightly longer to load the entire set of resources, compared to the default behaviour of loading
+      all resources in one request. This applies to the main Kubernetes resources retrieved by the UI.
+
 banner:
   label: Fixed Banners
   settingName: Banners

--- a/shell/components/ResourceList/Masthead.vue
+++ b/shell/components/ResourceList/Masthead.vue
@@ -146,6 +146,7 @@ export default {
       <h1 class="m-0">
         {{ _typeDisplay }} <Favorite v-if="isExplorer" :resource="favoriteResource || resource" />
       </h1>
+      <slot name="header"></slot>
     </div>
     <div class="actions-container">
       <slot name="actions">
@@ -174,3 +175,14 @@ export default {
     </div>
   </header>
 </template>
+
+<style lang="scss" scoped>
+  .title {
+    align-items: center;
+    display: flex;
+
+    h1 {
+      margin: 0;
+    }
+  }
+</style>

--- a/shell/components/ResourceList/ResourceLoadingIndicator.vue
+++ b/shell/components/ResourceList/ResourceLoadingIndicator.vue
@@ -45,6 +45,7 @@ export default {
       return 0;
     },
 
+    // Have we loaded all resources for the types that are needed
     haveAll() {
       return this.resources.reduce((acc, r) => {
         return acc && this.$store.getters[`${ this.inStore }/haveAll`](r);
@@ -69,6 +70,7 @@ export default {
       }, 0);
     },
 
+    // Width style to enable the progress bar style presentation
     width() {
       const progress = Math.ceil(100 * (this.count / this.total));
 
@@ -108,7 +110,7 @@ export default {
       top: 0;
 
       background-color: var(--link);
-      color: #fff;
+      color: var(--link-text);
       overflow: hidden;
       white-space: nowrap;
     }

--- a/shell/components/ResourceList/ResourceLoadingIndicator.vue
+++ b/shell/components/ResourceList/ResourceLoadingIndicator.vue
@@ -1,0 +1,112 @@
+<script>
+import { COUNT } from '@shell/config/types';
+
+/**
+ * Loading Indicator for resources - used when we are loading resources incrementally, by page
+ */
+export default {
+
+  name: 'ResourceLoadingIndicator',
+
+  props: {
+    resource: {
+      type:     String,
+      required: true,
+    },
+    indeterminate: {
+      type:    Boolean,
+      default: false,
+    },
+  },
+
+  data() {
+    const inStore = this.$store.getters['currentStore'](this.resource);
+
+    return { inStore };
+  },
+
+  computed: {
+    haveAll() {
+      return this.$store.getters[`${ this.inStore }/haveAll`](this.resource);
+    },
+
+    total() {
+      const clusterCounts = this.$store.getters[`${ this.inStore }/all`](COUNT);
+
+      return clusterCounts?.[0]?.counts?.[this.resource]?.summary?.count;
+    },
+
+    count() {
+      const existingData = this.$store.getters[`${ this.inStore }/all`](this.resource) || [];
+
+      return (existingData || []).length;
+    },
+
+    width() {
+      const progress = Math.ceil(100 * (this.count / this.total));
+
+      return `${ progress }%`;
+    }
+  },
+};
+</script>
+
+<template>
+  <div v-if="count && !haveAll" class="ml-10 resource-loading-indicator">
+    <div class="inner">
+      <div class="resource-loader">
+        <div class="rl-bg">
+          <i class="icon icon-spinner icon-spin" /><span>Loading {{ count }}<span v-if="!indeterminate"> / {{ total }}</span></span>
+        </div>
+      </div>
+      <div class="resource-loader" :style="{width}">
+        <div class="rl-fg">
+          <i class="icon icon-spinner icon-spin" /><span>Loading {{ count }}<span v-if="!indeterminate"> / {{ total }}</span></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .resource-loading-indicator {
+    border: 1px solid var(--link);
+    border-radius: 10px;
+    position: relative;
+    width: min-content;
+    overflow: hidden;
+
+    .resource-loader:last-child {
+      position: absolute;
+      top: 0;
+
+      background-color: var(--link);
+      color: #fff;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .resource-loader:first-child {
+      background-color: var(--border);
+    }
+
+    .resource-loader {
+      padding: 1px 10px;
+      width: max-content;
+
+      .rl-fg, .rl-bg {
+        align-content: center;
+        display: flex;
+
+        > i {
+          font-size: 18px;
+          line-height: 18px;
+        }
+
+        > span {
+          margin-left: 5px;
+        }
+      }
+    }
+  }
+</style>

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -39,6 +39,8 @@ export default {
         hasFetch = true;
       }
 
+      // If the custom component supports it, ask it what resources it loads, so we can
+      // use the incremental loading indicator when enabled
       if (component?.$loadingResources) {
         const { loadResources, loadIndeterminate } = component?.$loadingResources(this.$route, resource);
 
@@ -83,7 +85,6 @@ export default {
       // Provided by fetch later
       rows:              [],
       customTypeDisplay: null,
-      wantLoadIndicator: false,
       loadResources:     [resource],
       loadIndeterminate: false,
     };

--- a/shell/config/product/settings.js
+++ b/shell/config/product/settings.js
@@ -80,11 +80,22 @@ export function init(store) {
     route:          { name: 'c-cluster-settings-banners' }
   });
 
+  virtualType({
+    ifHaveType:     MANAGEMENT.SETTING,
+    labelKey:       'performance.settingName',
+    name:           'performance',
+    namespaced:     false,
+    weight:         97,
+    icon:           'folder',
+    route:          { name: 'c-cluster-settings-performance' }
+  });
+
   basicType([
     'settings',
     'features',
     'brand',
-    'banners'
+    'banners',
+    'performance'
   ]);
 
   configureType(MANAGEMENT.SETTING, {

--- a/shell/config/settings.js
+++ b/shell/config/settings.js
@@ -51,6 +51,7 @@ export const SETTING = {
   LINK_COLOR:                           'ui-link-color',
   COMMUNITY_LINKS:                      'ui-community-links',
   FAVICON:                              'ui-favicon',
+  UI_PERFORNMANCE:                      'ui-performance',
   /**
    * Allow the backend to force a light/dark theme. Used in non-rancher world and results in the theme used
    * both pre and post log in. If not present defaults to the usual process

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -1,6 +1,7 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
 import { WORKLOAD_TYPES, SCHEMA, NODE, POD } from '@shell/config/types';
+import PageFetchMixin from '@shell/mixins/paged-fetch';
 
 const schema = {
   id:         'workload',
@@ -15,6 +16,7 @@ const schema = {
 export default {
   name:       'ListWorkload',
   components: { ResourceTable },
+  mixins:     [PageFetchMixin],
 
   async fetch() {
     try {
@@ -36,13 +38,13 @@ export default {
           return null;
         }
 
-        return this.$store.dispatch('cluster/findAll', { type });
+        return this.$fetchType(type);
       }));
     } else {
       const type = this.$route.params.resource;
 
       if ( this.$store.getters['cluster/schemaFor'](type) ) {
-        const resource = await this.$store.dispatch('cluster/findAll', { type });
+        const resource = await this.$fetchType(type);
 
         resources = [resource];
       }

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -91,6 +91,16 @@ export default {
     },
   },
 
+  // All of the resources that we will load that we need for the loading indicator
+  $loadingResources(route) {
+    const allTypes = route.params.resource === schema.id;
+
+    return {
+      loadResources:     allTypes ? Object.values(WORKLOAD_TYPES) : [route.params.resource],
+      loadIndeterminate: allTypes,
+    };
+  },
+
   methods: {
     loadHeathResources() {
       // Fetch these in the background to populate workload health
@@ -128,5 +138,10 @@ export default {
 </script>
 
 <template>
-  <ResourceTable :loading="$fetchState.pending" :schema="schema" :rows="rows" :overflow-y="true" />
+  <ResourceTable
+    :loading="$fetchState.pending"
+    :schema="schema"
+    :rows="rows"
+    :overflow-y="true"
+  />
 </template>

--- a/shell/mixins/paged-fetch.js
+++ b/shell/mixins/paged-fetch.js
@@ -20,14 +20,23 @@ export default {
     return { fetchedResourceType: [], perfConfig };
   },
 
+  beforeDestroy() {
+    const inStore = this.$store.getters['currentStore'](COUNT);
+
+    this.fetchedResourceType.forEach((type) => {
+      this.$store.dispatch(`${ inStore }/incrementLoadCounter`, type);
+    });
+  },
+
   methods: {
     /**
      * Fetch all resources for a given type, taking into consideraton the incremental loading configuration
      */
     $fetchType(type) {
       const inStore = this.$store.getters['currentStore'](COUNT);
-
       const { incremental } = this.$getTypeFetchMetadata(type);
+
+      this.fetchedResourceType.push(type);
 
       return this.$store.dispatch(`${ inStore }/findAll`, { type, opt: { incremental } });
     },

--- a/shell/mixins/paged-fetch.js
+++ b/shell/mixins/paged-fetch.js
@@ -27,28 +27,38 @@ export default {
     $fetchType(type) {
       const inStore = this.$store.getters['currentStore'](COUNT);
 
-      let incremental = 0;
-
-      if (this.perfConfig?.incrementalLoading?.enabled) {
-        const config = this.$getTypeFetchMetadata(type);
-
-        const threshold = parseInt(this.perfConfig?.incrementalLoading?.threshold || '0', 10);
-
-        if (threshold > 0 && config.total > threshold) {
-          incremental = Math.ceil(config.total / PAGES);
-        }
-      }
+      const { incremental } = this.$getTypeFetchMetadata(type);
 
       return this.$store.dispatch(`${ inStore }/findAll`, { type, opt: { incremental } });
     },
 
     $getTypeFetchMetadata(type) {
-      const inStore = this.$store.getters['currentStore'](COUNT);
-      const clusterCounts = this.$store.getters[`${ inStore }/all`](COUNT)?.[0]?.counts;
-      const summary = clusterCounts?.[type]?.summary || {};
-      // const total = summary.count || 0;
+      if (this.perfConfig?.incrementalLoading?.enabled) {
+        const inStore = this.$store.getters['currentStore'](COUNT);
+        const clusterCounts = this.$store.getters[`${ inStore }/all`](COUNT)?.[0]?.counts;
+        const summary = clusterCounts?.[type]?.summary || {};
+        const threshold = parseInt(this.perfConfig?.incrementalLoading?.threshold || '0', 10);
+        const total = summary.count || 0;
+        let incremental = 0;
 
-      return { total: summary.count || 0 };
+        if (threshold > 0 && total > threshold) {
+          incremental = Math.ceil(total / PAGES);
+        }
+
+        return {
+          enabled: true,
+          total,
+          incremental,
+          threshold,
+        };
+      }
+
+      return {
+        enabled:     false,
+        incremental: 0,
+        total:       0,
+        threshold:   0
+      };
     }
   },
 };

--- a/shell/mixins/paged-fetch.js
+++ b/shell/mixins/paged-fetch.js
@@ -1,0 +1,54 @@
+import { COUNT, MANAGEMENT } from '@shell/config/types';
+import { SETTING } from '@shell/config/settings';
+
+// Number of pages to fetch when loading incrementally
+const PAGES = 4;
+
+export default {
+  data() {
+    const perfSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORNMANCE);
+    let perfConfig = {};
+
+    if (perfSetting && perfSetting.value) {
+      try {
+        perfConfig = JSON.parse(perfSetting.value);
+      } catch (e) {
+        console.warn('ui-performance setting contains invalid data'); // eslint-disable-line no-console
+      }
+    }
+
+    return { fetchedResourceType: [], perfConfig };
+  },
+
+  methods: {
+    /**
+     * Fetch all resources for a given type, taking into consideraton the incremental loading configuration
+     */
+    $fetchType(type) {
+      const inStore = this.$store.getters['currentStore'](COUNT);
+
+      let incremental = 0;
+
+      if (this.perfConfig?.incrementalLoading?.enabled) {
+        const config = this.$getTypeFetchMetadata(type);
+
+        const threshold = parseInt(this.perfConfig?.incrementalLoading?.threshold || '0', 10);
+
+        if (threshold > 0 && config.total > threshold) {
+          incremental = Math.ceil(config.total / PAGES);
+        }
+      }
+
+      return this.$store.dispatch(`${ inStore }/findAll`, { type, opt: { incremental } });
+    },
+
+    $getTypeFetchMetadata(type) {
+      const inStore = this.$store.getters['currentStore'](COUNT);
+      const clusterCounts = this.$store.getters[`${ inStore }/all`](COUNT)?.[0]?.counts;
+      const summary = clusterCounts?.[type]?.summary || {};
+      // const total = summary.count || 0;
+
+      return { total: summary.count || 0 };
+    }
+  },
+};

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -1,5 +1,4 @@
 import { findBy, insertAt } from '@shell/utils/array';
-import { matches } from '@shell/utils/selector';
 import {
   TARGET_WORKLOADS, TIMESTAMP, UI_MANAGED, HCI as HCI_LABELS_ANNOTATIONS, CATTLE_PUBLIC_ENDPOINTS
 } from '@shell/config/labels-annotations';

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -1,4 +1,5 @@
 import { findBy, insertAt } from '@shell/utils/array';
+import { matches } from '@shell/utils/selector';
 import {
   TARGET_WORKLOADS, TIMESTAMP, UI_MANAGED, HCI as HCI_LABELS_ANNOTATIONS, CATTLE_PUBLIC_ENDPOINTS
 } from '@shell/config/labels-annotations';

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -1,0 +1,151 @@
+<script>
+import { Checkbox } from '@components/Form/Checkbox';
+import Loading from '@shell/components/Loading';
+import AsyncButton from '@shell/components/AsyncButton';
+import { Banner } from '@components/Banner';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { MANAGEMENT } from '@shell/config/types';
+import { SETTING } from '@shell/config/settings';
+import { _EDIT, _VIEW } from '@shell/config/query-params';
+
+const DEFAULT_PERF_SETTING = {
+  incrementalLoading: {
+    enabled:   false,
+    threshold: 2500,
+  }
+};
+
+export default {
+  layout: 'authenticated',
+
+  components: {
+    Checkbox,
+    Loading,
+    AsyncButton,
+    Banner,
+    LabeledInput,
+  },
+
+  async fetch() {
+    try {
+      this.uiPerfSetting = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.UI_PERFORNMANCE });
+    } catch (e) {
+      this.uiPerfSetting = await this.$store.dispatch('management/create', { type: MANAGEMENT.SETTING }, { root: true });
+
+      // Setting does not exist - create a new one
+      this.uiPerfSetting.value = JSON.parse(JSON.stringify(DEFAULT_PERF_SETTING));
+      this.uiPerfSetting.metadata = { name: SETTING.UI_PERFORNMANCE };
+    }
+
+    const sValue = this.uiPerfSetting?.value || JSON.stringify(DEFAULT_PERF_SETTING);
+
+    this.value = JSON.parse(sValue);
+  },
+
+  data() {
+    return {
+      uiPerfSetting: DEFAULT_PERF_SETTING,
+      bannerVal:     {},
+      value:         {},
+      errors:        [],
+    };
+  },
+
+  computed: {
+    mode() {
+      const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
+
+      return schema?.resourceMethods?.includes('PUT') ? _EDIT : _VIEW;
+    },
+  },
+
+  watch: {
+    uiBannerSetting(neu) {
+      if (neu?.value && neu.value !== '') {
+        try {
+          const parsedBanner = JSON.parse(neu.value);
+
+          this.bannerVal = this.checkOrUpdateLegacyUIBannerSetting(parsedBanner);
+        } catch {}
+      }
+    }
+  },
+
+  methods: {
+    async save(btnCB) {
+      this.uiPerfSetting.value = JSON.stringify(this.value);
+
+      this.errors = [];
+
+      try {
+        await Promise.all([
+          this.uiPerfSetting.save()
+        ]);
+        btnCB(true);
+      } catch (err) {
+        this.errors.push(err);
+        btnCB(false);
+      }
+    },
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
+    <h1 class="mb-20">
+      {{ t('performance.label') }}
+    </h1>
+    <div>
+      <label class="text-label">
+        {{ t(`performance.description`, {}, true) }}
+      </label>
+
+      <Banner color="error" label-key="performance.banner" />
+
+      <!-- Incremental Loading -->
+      <div class="ui-perf-setting">
+        <h2>{{ t('performance.incrementalLoad.label') }}</h2>
+        <p>{{ t('performance.incrementalLoad.description') }}</p>
+        <Checkbox v-model="value.incrementalLoading.enabled" label="Enable incremental loading" :primary="true" />
+        <div class="ml-20">
+          <p :class="{ 'text-muted': !value.incrementalLoading.enabled }">
+            {{ t('performance.incrementalLoad.setting') }}
+          </p>
+          <LabeledInput v-model="value.incrementalLoading.threshold" label="Resource Threshold" :disabled="!value.incrementalLoading.enabled" class="input" />
+        </div>
+      </div>
+    </div>
+    <template v-for="err in errors">
+      <Banner :key="err" color="error" :label="err" />
+    </template>
+    <div v-if="mode === 'edit'">
+      <AsyncButton class="pull-right mt-20" mode="apply" @click="save" />
+    </div>
+  </div>
+</template>
+
+<style scoped lang='scss'>
+.overlay {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: var(--overlay-bg);
+  z-index: 1;
+}
+  .ui-perf-setting {
+    P {
+      line-height: 1.25;
+      margin-bottom: 10px;
+    }
+  }
+
+  .input {
+    max-width: 25%;
+
+  }
+
+</style>

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -284,6 +284,9 @@ export default {
     return state.config.isClusterStore;
   },
 
+  // Increment the load counter for a resource type
+  // This is used for incremental loading do detect when a page changes occur of the a reload happend
+  // While a previous incremental loading operation is still in progress
   loadCounter: (state, getters) => (type) => {
     type = getters.normalizeType(type);
 

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -282,6 +282,15 @@ export default {
 
   isClusterStore: (state) => {
     return state.config.isClusterStore;
-  }
+  },
 
+  loadCounter: (state, getters) => (type) => {
+    type = getters.normalizeType(type);
+
+    if (!!state.types[type]) {
+      return state.types[type].loadCounter;
+    }
+
+    return 0;
+  }
 };

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -252,12 +252,11 @@ export default {
     });
   },
 
+  // Add a set of resources to the store for a given type
+  // Don't mark the 'haveAll' field - this is used for incremental loading
   loadAdd(state, { type, data: allLatest, ctx }) {
     const { getters } = ctx;
-    // const allLatest = await dispatch('findAll', { type, opt: { force: true, load, _NONE } });
-    // const allExisting = getters.all({type});
     const keyField = getters.keyFieldForType(type);
-    // const cache = state.types[type];
 
     allLatest.forEach((entry) => {
       const existing = state.types[type].map.get(entry[keyField]);

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -14,6 +14,7 @@ function registerType(state, type) {
       haveSelector: {},
       revision:     0, // The highest known resourceVersion from the server for this type
       generation:   0, // Updated every time something is loaded for this type
+      loadCounter:  0, // Used to cancel incremental loads if the page changes during load
     };
 
     // Not enumerable so they don't get sent back to the client for SSR
@@ -297,4 +298,12 @@ export default {
   },
 
   forgetType,
+
+  incrementLoadCounter(state, type) {
+    const typeData = state.types[type];
+
+    if (typeData) {
+      typeData.loadCounter++;
+    }
+  }
 };

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -155,7 +155,12 @@ export function remove(state, obj, getters) {
   }
 }
 
-export function loadAll(state, { type, data, ctx }) {
+export function loadAll(state, {
+  type,
+  data,
+  ctx,
+  skipHaveAll
+}) {
   const { getters } = ctx;
 
   if (!data) {
@@ -184,7 +189,10 @@ export function loadAll(state, { type, data, ctx }) {
     cache.map.set(proxies[i][keyField], proxies[i]);
   }
 
-  cache.haveAll = true;
+  // Allow requester to skip setting that everything has loaded
+  if (!skipHaveAll) {
+    cache.haveAll = true;
+  }
 
   return proxies;
 }
@@ -243,6 +251,22 @@ export default {
     });
   },
 
+  loadAdd(state, { type, data: allLatest, ctx }) {
+    const { getters } = ctx;
+    // const allLatest = await dispatch('findAll', { type, opt: { force: true, load, _NONE } });
+    // const allExisting = getters.all({type});
+    const keyField = getters.keyFieldForType(type);
+    // const cache = state.types[type];
+
+    allLatest.forEach((entry) => {
+      const existing = state.types[type].map.get(entry[keyField]);
+
+      load(state, {
+        data: entry, ctx, existing
+      });
+    });
+  },
+
   forgetAll(state, { type }) {
     const cache = registerType(state, type);
 
@@ -255,6 +279,12 @@ export default {
     const cache = registerType(state, type);
 
     cache.generation++;
+    cache.haveAll = true;
+  },
+
+  setHaveAll(state, { type }) {
+    const cache = registerType(state, type);
+
     cache.haveAll = true;
   },
 

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -27,14 +27,19 @@ function registerNamespace(state, namespace) {
 }
 
 export default {
-  loadAll(state, { type, data, ctx }) {
+  loadAll(state, {
+    type,
+    data,
+    ctx,
+    skipHaveAll
+  }) {
     // Performance testing in dev and when env var is set
     if (process.env.dev && !!process.env.perfTest) {
       data = perfLoadAll(type, data);
     }
 
     const proxies = loadAll(state, {
-      type, data, ctx
+      type, data, ctx, skipHaveAll
     });
 
     // If we loaded a set of pods, then update the podsByNamespace cache


### PR DESCRIPTION
Fixes: #6540

This PR adds support for incremental loading:

- Adds a new 'Performance' section to Global Settings that allows this feature to be enabled and configured

![image](https://user-images.githubusercontent.com/1955897/181452237-8da44a6b-ff80-4404-911c-4c01519760fd.png)

- When enabled it changes the fetch behaviour for anything that uses ResourceList and for the Workloads views to first fetch an initial page of 100 results and then to fetch the results in 4 pages, incremental loading and making available the data to the user
- Adds a loading indicator to show progress:
- 
![image](https://user-images.githubusercontent.com/1955897/181451272-1c773055-d2db-42a5-b432-d96f6245b889.png)

- Changes the presentation of the loading indicator depending on whether we know how may results we are expecting (Workloads view is a case of where we do not)