### PR TITLE
do not set driver type using isCustom on create

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -6,7 +6,7 @@ import SelectIconGrid from '@shell/components/SelectIconGrid';
 import EmberPage from '@shell/components/EmberPage';
 import ToggleSwitch from '@shell/components/form/ToggleSwitch';
 import {
-  CHART, FROM_CLUSTER, SUB_TYPE, _EDIT, _IMPORT, _CONFIG
+  CHART, FROM_CLUSTER, SUB_TYPE, _EDIT, _IMPORT, _CONFIG, _VIEW
 } from '@shell/config/query-params';
 import { mapGetters } from 'vuex';
 import { sortBy } from '@shell/utils/sort';
@@ -156,7 +156,7 @@ export default {
       if (this.value) {
         // For custom RKE2 clusters, don't load an Ember page.
         // It should be the dashboard.
-        if ( this.value.isRke2 && ((this.value.isCustom && this.mode === _EDIT) || (this.value.isCustom && this.as === _CONFIG) || (this.subType || '').toLowerCase() === 'custom')) {
+        if ( this.value.isRke2 && ((this.value.isCustom && this.mode === _EDIT) || (this.value.isCustom && this.as === _CONFIG && this.mode === _VIEW) || (this.subType || '').toLowerCase() === 'custom')) {
           // For admins, this.value.isCustom is used to check if it is a custom cluster.
           // For cluster owners, this.subtype is used.
           this.selectType('custom', false);


### PR DESCRIPTION
Fix related to changes here: https://github.com/rancher/dashboard/pull/6467
On create, `value.isCustom` is briefly true because no `machinePools` have been added to the spec. This causes `this.selectType('custom', false);` to be called, preventing any custom driver components from rendering.