### PR TITLE
Improve presentation of add Member dialog

### DIFF
--- a/pkg/rancher-components/src/components/Card/Card.vue
+++ b/pkg/rancher-components/src/components/Card/Card.vue
@@ -45,13 +45,17 @@ export default Vue.extend({
     showActions: {
       type:    Boolean,
       default: true
-    }
+    },
+    sticky: {
+      type:    Boolean,
+      default: false,
+    },    
   }
 });
 </script>
 
 <template>
-  <div class="card-container" :class="{'highlight-border': showHighlightBorder}">
+  <div class="card-container" :class="{'highlight-border': showHighlightBorder, 'card-sticky': sticky}">
     <div class="card-wrap">
       <div class="card-title">
         <slot name="title">
@@ -115,6 +119,31 @@ export default Vue.extend({
      }
     .flex-right {
       margin-left: auto;
+    }
+   }
+
+  // Sticky mode will stick header and footer to top and bottom with content in the middle scrolling
+   &.card-sticky {
+      // display: flex;
+      // flex-direction: column;
+      overflow: hidden;
+
+    .card-wrap {
+      display: flex;
+      flex-direction: column;
+
+      .card-body {
+        justify-content: flex-start;
+        overflow: scroll;
+      }
+
+      > * {
+        flex: 0;
+      }
+
+      .card-body {
+        flex: 1;
+      }
     }
    }
  }

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -42,7 +42,7 @@ export default {
     stickyProps() {
       const isSticky = !!this.modalData?.modalSticky;
 
-      return !isSticky ? '' : ';display: flex; flex-direction: column;';
+      return !isSticky ? '' : 'display: flex; flex-direction: column; ';
     }
   },
 

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -38,6 +38,11 @@ export default {
     cssProps() {
       // this computed property lets us generate a scss var that we can use in the style
       return `--prompt-modal-width: ${ this.modalWidth }`;
+    },
+    stickyProps() {
+      const isSticky = !!this.modalData?.modalSticky;
+
+      return !isSticky ? '' : ';display: flex; flex-direction: column;';
     }
   },
 
@@ -78,7 +83,7 @@ export default {
   <modal
     class="promptModal-modal"
     name="promptModal"
-    :styles="`background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 95vh; ${cssProps}`"
+    :styles="`background-color: var(--nav-bg); border-radius: var(--border-radius); ${stickyProps} max-height: 95vh; ${cssProps}`"
     height="auto"
     :scrollable="true"
     @closed="close()"

--- a/shell/components/dialog/AddProjectMemberDialog.vue
+++ b/shell/components/dialog/AddProjectMemberDialog.vue
@@ -76,7 +76,7 @@ export default {
 </script>
 
 <template>
-  <Card class="prompt-rotate" :show-highlight-border="false">
+  <Card class="prompt-rotate" :show-highlight-border="false" :sticky="true">
     <h4 slot="title" class="text-default-text" v-html="t('addProjectMemberDialog.title')" />
 
     <div slot="body" class="pl-10 pr-10">

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -48,6 +48,11 @@ export default {
       type:     Function,
       default:  null,
     },
+
+    modalSticky: {
+      type:    Boolean,
+      default: false,
+    }
   },
 
   async fetch() {
@@ -132,7 +137,11 @@ export default {
 
   methods: {
     addMember() {
-      this.$store.dispatch('cluster/promptModal', { component: this.addMemberDialogName, resources: [this.onAddMember] });
+      this.$store.dispatch('cluster/promptModal', {
+        component:   this.addMemberDialogName,
+        resources:   [this.onAddMember],
+        modalSticky: this.modalSticky
+      });
     },
 
     onAddMember(bindings) {

--- a/shell/components/form/Members/ProjectMembershipEditor.vue
+++ b/shell/components/form/Members/ProjectMembershipEditor.vue
@@ -54,6 +54,7 @@ export default {
   <MembershipEditor
     ref="editor"
     add-member-dialog-name="AddProjectMemberDialog"
+    :modal-sticky="true"
     :default-binding-handler="defaultBindingHandler"
     :type="NORMAN.PROJECT_ROLE_TEMPLATE_BINDING"
     :mode="mode"


### PR DESCRIPTION
Fixes #6499 

This PR:

- Adds 'sticky' property so that a dialog can support content where header and footer are sticky
- Wires this into add members dialog

Result:

![image](https://user-images.githubusercontent.com/1955897/181015100-61f22d13-754d-41dd-aa53-9c8ff68eeb41.png)

To Test:

- Create a few project roles
- Go to the local cluster -> Cluster -> Projects/Namespaces.
- Choose a project and from the three dots, choose 'Edit Config'. Click 'Add' beneath members.
- Shrink the height of the browser window
- Verify that the middle content of the dialog scrolls - as shown above
