### PR TITLE
Improve initial load of Home and Cluster Dashboard pages

### DIFF
--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -531,8 +531,8 @@ export default {
 <template>
   <div class="dashboard-root">
     <FixedBanner :header="true" />
-    <AwsComplianceBanner />
-    <AzureWarning />
+    <AwsComplianceBanner v-if="managementReady" />
+    <AzureWarning v-if="managementReady" />
     <div v-if="managementReady" class="dashboard-content">
       <Header />
       <nav v-if="clusterReady" class="side-nav">

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -15,7 +15,6 @@ import { NAME as VIRTUAL } from '@shell/config/product/harvester';
 import { BACK_TO } from '@shell/config/local-storage';
 import { setFavIcon, haveSetFavIcon } from '@shell/utils/favicon';
 import { NAME as FLEET_NAME } from '@shell/config/product/fleet.js';
-import { allHash } from '@shell/utils/promise';
 
 const getPackageFromRoute = (route) => {
   if (!route?.meta) {
@@ -190,19 +189,8 @@ export default async function({
   }
 
   if ( store.getters['auth/enabled'] !== false && !store.getters['auth/loggedIn'] ) {
-    const hash = { userMe: store.dispatch('auth/getUser') };
-    const fromHeader = store.getters['auth/fromHeader'];
-
-    const fromHeaderNone = fromHeader === 'none' ;
-    const fromHeaderFalse = fromHeader === 'false';
-    const fromHeaderTrue = fromHeader === 'true';
-    const fromHeaderOther = !fromHeaderNone && !fromHeaderFalse && !fromHeaderTrue;
-
-    if (fromHeaderTrue || fromHeaderOther) {
-      hash.principalMe = findMe(store);
-    }
-
-    const res = await allHash(hash);
+    // `await` so we have one successfully request whilst possibly logged in (ensures fromHeader is populated from `x-api-cattle-auth`)
+    await store.dispatch('auth/getUser');
 
     const v3User = store.getters['auth/v3User'] || {};
 
@@ -211,19 +199,20 @@ export default async function({
     }
 
     // In newer versions the API calls return the auth state instead of having to make a new call all the time.
+    const fromHeader = store.getters['auth/fromHeader'];
 
-    if ( fromHeaderNone ) {
+    if ( fromHeader === 'none' ) {
       noAuth();
-    } else if ( fromHeaderTrue ) {
-      const me = res.principalMe;
+    } else if ( fromHeader === 'true' ) {
+      const me = await findMe(store);
 
       isLoggedIn(me);
-    } else if ( fromHeaderFalse ) {
+    } else if ( fromHeader === 'false' ) {
       notLoggedIn();
-    } else if (fromHeaderOther) {
+    } else {
       // Older versions look at principals and see what happens
       try {
-        const me = res.principalMe;
+        const me = await findMe(store);
 
         isLoggedIn(me);
       } catch (e) {

--- a/shell/pages/c/_cluster/explorer/EventsTable.vue
+++ b/shell/pages/c/_cluster/explorer/EventsTable.vue
@@ -50,12 +50,8 @@ export default {
 </script>
 
 <template>
-  <div v-if="$fetchState.pending" class="events-loading">
-    <i class="icon icon-spin icon-spinner icon-lg" />
-    <div v-html="t('generic.loading', {}, true)" />
-  </div>
   <SortableTable
-    v-else
+    :loading="$fetchState.pending"
     :rows="events"
     :headers="eventHeaders"
     key-field="id"
@@ -76,13 +72,3 @@ export default {
     </template>
   </SortableTable>
 </template>
-<style lang="scss" scoped>
-  .events-loading {
-    align-items: center;
-    display: flex;
-
-    > i {
-      margin-right: 5px;
-    }
-  }
-</style>

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -75,11 +75,31 @@ export default {
   mixins: [metricPoller],
 
   fetch() {
-    setPromiseResult(fetchClusterResources(this.$store, NODE), this, 'nodes', `Load ${ NODE }`);
+    setPromiseResult(
+      fetchClusterResources(this.$store, NODE),
+      this,
+      'nodes',
+      `Load ${ NODE }`
+    );
 
-    setPromiseResult(allDashboardsExist(this.$store, this.currentCluster.id, [CLUSTER_METRICS_DETAIL_URL, CLUSTER_METRICS_SUMMARY_URL]), this, 'showClusterMetrics', `Determine cluster metrics`);
-    setPromiseResult(allDashboardsExist(this.$store, this.currentCluster.id, [K8S_METRICS_DETAIL_URL, K8S_METRICS_SUMMARY_URL]), this, 'showK8sMetrics', `Determine k8s metrics`);
-    setPromiseResult(allDashboardsExist(this.$store, this.currentCluster.id, [ETCD_METRICS_DETAIL_URL, ETCD_METRICS_SUMMARY_URL]), this, 'showEtcdMetrics', `Determine etcd metrics`);
+    setPromiseResult(
+      allDashboardsExist(this.$store, this.currentCluster.id, [CLUSTER_METRICS_DETAIL_URL, CLUSTER_METRICS_SUMMARY_URL]),
+      this,
+      'showClusterMetrics',
+      `Determine cluster metrics`
+    );
+    setPromiseResult(
+      allDashboardsExist(this.$store, this.currentCluster.id, [K8S_METRICS_DETAIL_URL, K8S_METRICS_SUMMARY_URL]),
+      this,
+      'showK8sMetrics',
+      `Determine k8s metrics`
+    );
+    setPromiseResult(
+      allDashboardsExist(this.$store, this.currentCluster.id, [ETCD_METRICS_DETAIL_URL, ETCD_METRICS_SUMMARY_URL]),
+      this,
+      'showEtcdMetrics',
+      `Determine etcd metrics`
+    );
 
     if (this.currentCluster.isLocal) {
       setPromiseResult(this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE }), this, 'mgmtNodes', `Load ${ MANAGEMENT.NODE }`);
@@ -116,7 +136,7 @@ export default {
   },
 
   beforeDestroy() {
-    // Remove the data and stop watching events and nodes
+    // Remove the data and stop watching resources that were fetched in this page
     // Events in particular can lead to change messages having to be processed when we are no longer interested in events
     this.$store.dispatch('cluster/forgetType', EVENT);
     this.$store.dispatch('cluster/forgetType', NODE);

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -75,12 +75,7 @@ export default {
   mixins: [metricPoller],
 
   fetch() {
-    setPromiseResult(
-      fetchClusterResources(this.$store, NODE),
-      this,
-      'nodes',
-      `Load ${ NODE }`
-    );
+    fetchClusterResources(this.$store, NODE);
 
     setPromiseResult(
       allDashboardsExist(this.$store, this.currentCluster.id, [CLUSTER_METRICS_DETAIL_URL, CLUSTER_METRICS_SUMMARY_URL]),
@@ -102,7 +97,7 @@ export default {
     );
 
     if (this.currentCluster.isLocal) {
-      setPromiseResult(this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE }), this, 'mgmtNodes', `Load ${ MANAGEMENT.NODE }`);
+      this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
     }
   },
 
@@ -119,8 +114,6 @@ export default {
       constraints:         [],
       events:              [],
       nodeMetrics:         [],
-      nodes:               [],
-      mgmtNodes:          [],
       showClusterMetrics: false,
       showK8sMetrics:     false,
       showEtcdMetrics:    false,
@@ -148,6 +141,14 @@ export default {
   computed: {
     ...mapGetters(['currentCluster']),
     ...monitoringStatus(),
+
+    nodes() {
+      return this.$store.getters['cluster/all'](NODE);
+    },
+
+    mgmtNodes() {
+      return this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
+    },
 
     hideClusterToolsTip: mapPref(CLUSTER_TOOLS_TIP),
 

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -42,8 +42,18 @@ export default {
   mixins: [PageHeaderActions],
 
   fetch() {
-    setPromiseResult(this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }), this, 'provClusters', 'Failed to load prov clusters');
-    setPromiseResult(this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }), this, 'mgmtClusters', 'Failed to load mgmt clusters');
+    setPromiseResult(
+      this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
+      this,
+      'provClusters',
+      'Load prov clusters'
+    );
+    setPromiseResult(
+      this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
+      this,
+      'mgmtClusters',
+      'Load mgmt clusters'
+    );
   },
 
   data() {

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -21,7 +21,6 @@ import { mapFeature, MULTI_CLUSTER } from '@shell/store/features';
 import { SETTING } from '@shell/config/settings';
 import { BLANK_CLUSTER } from '@shell/store';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
-import { setPromiseResult } from '@shell/utils/promise';
 
 import { RESET_CARDS_ACTION, SET_LOGIN_ACTION } from '@shell/config/page-actions';
 
@@ -42,18 +41,8 @@ export default {
   mixins: [PageHeaderActions],
 
   fetch() {
-    setPromiseResult(
-      this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
-      this,
-      'provClusters',
-      'Load prov clusters'
-    );
-    setPromiseResult(
-      this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
-      this,
-      'mgmtClusters',
-      'Load mgmt clusters'
-    );
+    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
+    this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
   },
 
   data() {
@@ -72,7 +61,7 @@ export default {
     ];
 
     return {
-      HIDE_HOME_PAGE_CARDS, mgmtClusters: null, provClusters: null, fullVersion, pageActions, vendor: getVendor(),
+      HIDE_HOME_PAGE_CARDS, fullVersion, pageActions, vendor: getVendor(),
     };
   },
 
@@ -80,6 +69,10 @@ export default {
     ...mapState(['managementReady']),
     ...mapGetters(['currentCluster']),
     mcm: mapFeature(MULTI_CLUSTER),
+
+    provClusters() {
+      return this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
+    },
 
     canCreateCluster() {
       const schema = this.$store.getters['management/schemaFor'](CAPI.RANCHER_CLUSTER);

--- a/shell/utils/promise.js
+++ b/shell/utils/promise.js
@@ -93,3 +93,13 @@ export function deferred(name) {
 
   return out;
 }
+
+export function setPromiseResult(promise, that, key, label) {
+  promise
+    .then((res) => {
+      that[key] = res;
+    })
+    .catch((e) => {
+      console.warn('Failed to: ', label, e); // eslint-disable-line no-console
+    });
+}

--- a/shell/utils/promise.js
+++ b/shell/utils/promise.js
@@ -94,10 +94,20 @@ export function deferred(name) {
   return out;
 }
 
-export function setPromiseResult(promise, that, key, label) {
+/**
+ * Apply the result of a promise to a given object's property
+ *
+ * This is a non-blocking method
+ *
+ * @param promise Promise to fetch result for
+ * @param obj Object to set result of promise to
+ * @param key Property in object to set result to
+ * @param label Description of what promise is trying to  do
+ */
+export function setPromiseResult(promise, obj, key, label) {
   promise
     .then((res) => {
-      that[key] = res;
+      obj[key] = res;
     })
     .catch((e) => {
       console.warn('Failed to: ', label, e); // eslint-disable-line no-console


### PR DESCRIPTION
### Summary
Fixes #6504

This improves first load experience of the dashboard's home and cluster dashboard pages. On fast systems there won't be much difference, but on slow rancher instances, slow clusters and/or slow host machines this PR should speed up the time the pages show. Content that was blocking these pages should either show a loading indicator or show eventual (some areas are conditional, not just waiting to be loaded).

### Occurred changes and/or fixed issues
Home Page
- Don't block whole page on loading of mgmt and prov clusters
- Use table `loading` indicator when clusters are loading
- Use correct cluster count (with harv cluster filter)

Cluster Dashboard
- EventsTable - use standard table loading indicator
- Don't block on fetch at all (or show page loading indicator)
  - Remove fetch for nodeTemplates and rke1NodePools. I went through a lot of code and don't think these are needed
  - Reminaing calls for Node and Metrics can happen at the same time
- Forget additional resource types when leaving page
- Optimise fetch of management nodes

~Pre-Page optimisations~
~- Authentication Mixin~
~- if applicable, fetch `principal` 'me' same time as `user` 'me'~

Other tweaks
- Don't show AwsComplianceBanner or AzureWarning until management store ready

Note - Rancher v2 monitoring graphs on the cluster dashboard page won't show when running dashboard locally, but i created https://releases.rancher.com/dashboard/richard-cox-2-dev/index.html to test and all looks good.

### Areas or cases that should be tested
- Home Page
  - Cards show correctly
  - Multiple clusters show correct in clusters list (imported and created)
- Cluster Dashboard Page
The below should work for imported and created (rke1 and rke2) cluster types
  - header detail (provider, etc) shows correctly
  - counts (resources, nodes, deployments) shows correctly
 - Events table shows correctly
 - When v1 or v2 monitoring is enabled the additional content show correctly
   - v2 monitoring - Alerts table. 3 x metrics tabs 
   - v1 monitoring - Haven't ever seen this


### Areas which could experience regressions
- Rancher setup flow

### Screenshot/Video
Home Page
![image](https://user-images.githubusercontent.com/18697775/181069973-beda1a39-094f-4d7b-8ba9-3bc268e8993d.png)


Cluster Dashboard Page
![image](https://user-images.githubusercontent.com/18697775/181070077-f302daad-c7f7-4cd9-a2b0-f69e6fe90348.png)


