### PR TITLE
Fixed issue where willSave() was not detecting if targetPort was number

### DIFF
--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -25,6 +25,7 @@ import { matching } from '@shell/utils/selector';
 import { NAME as HARVESTER } from '@shell/config/product/harvester';
 import { allHash } from '@shell/utils/promise';
 import { isHarvesterSatisfiesVersion } from '@shell/utils/cluster';
+import { Port } from '@shell/utils/validators/formRules';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:     'None',
@@ -292,11 +293,12 @@ export default {
 
     targetPortsStrOrInt(targetPorts = []) {
       const neu = clone(targetPorts);
-      const isNumeric = /^\\d+$/;
 
       neu.forEach((port, idx) => {
-        if (port?.targetPort && isNumeric.test(port.targetPort)) {
-          port.targetPort = parseInt(port.targetPort, 10);
+        const targetPort = new Port(port?.targetPort);
+
+        if (targetPort.isInt) {
+          port.targetPort = targetPort.int;
         }
       });
 

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -18,7 +18,7 @@ type ServicePort = {
   idx: number
 }
 
-class Port {
+export class Port {
   empty: boolean;
   int: number;
   string: string;


### PR DESCRIPTION
### Summary
Fixes #6511 
regex being used to test if string was a valid number was incorrect, refactors to use the same port class that validation uses to determine if a port is an integer or not and correct the payload accordingly.