### PR TITLE
HARVESTER: Fix namespace filter wrong on Harvester page

### DIFF
--- a/shell/components/nav/HarvesterUpgrade.vue
+++ b/shell/components/nav/HarvesterUpgrade.vue
@@ -13,11 +13,21 @@ export default {
   },
 
   async fetch() {
-    await allHash({
-      images:   this.$store.dispatch('harvester/findAll', { type: HCI.IMAGE }),
-      upgrades: this.$store.dispatch('harvester/findAll', { type: HCI.UPGRADE }),
-      nodes:    this.$store.dispatch('harvester/findAll', { type: NODE })
-    });
+    const hash = {};
+
+    if (this.$store.getters['harvester/schemaFor'](HCI.IMAGE)) {
+      hash.images = this.$store.dispatch('harvester/findAll', { type: HCI.IMAGE });
+    }
+
+    if (this.$store.getters['harvester/schemaFor'](HCI.UPGRADE)) {
+      hash.upgrades = this.$store.dispatch('harvester/findAll', { type: HCI.UPGRADE });
+    }
+
+    if (this.$store.getters['harvester/schemaFor'](NODE)) {
+      hash.nodes = this.$store.dispatch('harvester/findAll', { type: NODE });
+    }
+
+    await allHash(hash);
   },
 
   computed: {

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -307,6 +307,7 @@ export default async function({
     }
 
     if (product === VIRTUAL || route.name === `c-cluster-${ VIRTUAL }` || route.name?.startsWith(`c-cluster-${ VIRTUAL }-`)) {
+      setProduct(store, route);
       const res = [
         ...always,
         store.dispatch('loadVirtual', {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes namespace filter wrong on Harvester page
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2578
- https://github.com/harvester/harvester/issues/2587

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- When load harvester store(`loadVirtual`), the product id is `harvesterManager`, thus the store will be 'management', which causes the namespace to be obtained from the management store instead of the harvester store. 

https://github.com/rancher/dashboard/blob/647b917ed34c6cc09eea21a40fd9fb7ffd8ef95d/shell/store/index.js#L82-L84

- Check schema in case of throw console error in `loadVirtual`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->