### PR TITLE
Fix workspace filtering

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -17,11 +17,19 @@ export const defaultTableSortGenerationFn = (schema, $store) => {
   }
 
   const resource = schema.id;
+  let sortKey = resource;
+
   const inStore = $store.getters['currentStore'](resource);
   const generation = $store.getters[`${ inStore }/currentGeneration`]?.(resource);
 
   if ( generation ) {
-    return `${ resource }/${ generation }`;
+    sortKey += `/${ generation }`;
+  }
+
+  const nsFilterKey = $store.getters['activeNamespaceCacheKey'];
+
+  if ( nsFilterKey ) {
+    return `${ sortKey }/${ nsFilterKey }`;
   }
 };
 

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -195,7 +195,7 @@ export default {
         return this.rows || [];
       }
 
-      const includedNamespaces = this.$store.getters['activeNamespaceCache']();
+      const includedNamespaces = this.$store.getters['activeNamespaceCache'];
 
       // Shouldn't happen, but does for resources like management.cattle.io.preference
       if (!this.rows) {

--- a/shell/components/nav/Jump.vue
+++ b/shell/components/nav/Jump.vue
@@ -37,7 +37,7 @@ export default {
       let namespaces = null;
 
       if ( !isAllNamespaces ) {
-        namespaces = Object.keys(this.$store.getters['activeNamespaceCache']());
+        namespaces = Object.keys(this.$store.getters['activeNamespaceCache']);
       }
 
       const allTypes = this.$store.getters['type-map/allTypes'](product) || {};

--- a/shell/components/nav/WorkspaceSwitcher.vue
+++ b/shell/components/nav/WorkspaceSwitcher.vue
@@ -16,7 +16,7 @@ export default {
 
       set(value) {
         if (value !== this.value) {
-          this.$store.commit('updateWorkspace', { value });
+          this.$store.commit('updateWorkspace', { value, getters: this.$store.getters });
           this.$store.dispatch('prefs/set', { key: WORKSPACE, value });
         }
       },

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -70,7 +70,7 @@ export default {
     afterLoginRoute: mapPref(AFTER_LOGIN_ROUTE),
 
     namespaces() {
-      return this.$store.getters['activeNamespaceCache']();
+      return this.$store.getters['activeNamespaceCache'];
     },
 
     dev:            mapPref(DEV),

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -10,10 +10,11 @@ import { applyProducts } from '@shell/store/type-map';
 import { findBy } from '@shell/utils/array';
 import { ClusterNotFoundError } from '@shell/utils/error';
 import { get } from '@shell/utils/object';
-import { AFTER_LOGIN_ROUTE } from '@shell/store/prefs';
+import { AFTER_LOGIN_ROUTE, WORKSPACE } from '@shell/store/prefs';
 import { NAME as VIRTUAL } from '@shell/config/product/harvester';
 import { BACK_TO } from '@shell/config/local-storage';
 import { setFavIcon, haveSetFavIcon } from '@shell/utils/favicon';
+import { NAME as FLEET_NAME } from '@shell/config/product/fleet.js';
 
 const getPackageFromRoute = (route) => {
   if (!route?.meta) {
@@ -27,7 +28,7 @@ const getPackageFromRoute = (route) => {
 
 let beforeEachSetup = false;
 
-function setProduct(store, to) {
+function getProduct(to) {
   let product = to.params?.product;
 
   if ( !product ) {
@@ -37,6 +38,12 @@ function setProduct(store, to) {
       product = match[1];
     }
   }
+
+  return product;
+}
+
+function setProduct(store, to) {
+  let product = getProduct(to);
 
   if ( !product ) {
     product = EXPLORER;
@@ -245,6 +252,7 @@ export default async function({
     beforeEachSetup = true;
 
     store.app.router.beforeEach((to, from, next) => {
+      // NOTE - This beforeEach runs AFTER this middleware. So anything in this middleware that requires it must set it manually
       setProduct(store, to);
       next();
     });
@@ -266,10 +274,10 @@ export default async function({
     let clusterId = get(route, 'params.cluster');
 
     const pkg = getPackageFromRoute(route);
-    const product = route?.params?.product;
+    const product = getProduct(route);
 
     const oldPkg = getPackageFromRoute(from);
-    const oldProduct = from?.params?.product;
+    const oldProduct = getProduct(from);
 
     // Leave an old pkg where we weren't before?
     const oldPkgPlugin = oldPkg ? Object.values($plugin.getPlugins()).find(p => p.name === oldPkg) : null;
@@ -303,6 +311,17 @@ export default async function({
         product,
         oldProduct,
         oldIsExt: !!oldPkg
+      });
+    }
+
+    // Ensure that the activeNamespaceCache is updated given the change of context either from or to a place where it uses workspaces
+    // When fleet moves to it's own package this should be moved to pkg onEnter/onLeave
+    if ((oldProduct === FLEET_NAME || product === FLEET_NAME) && oldProduct !== product) {
+      // See note above for store.app.router.beforeEach, need to setProduct manually, for the moment do this in a targeted way
+      setProduct(store, route);
+      store.commit('updateWorkspace', {
+        value:   store.getters['prefs/get'](WORKSPACE),
+        getters: store.getters
       });
     }
 

--- a/shell/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/shell/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -122,7 +122,7 @@ export default {
     },
     groupPreference: mapPref(GROUP_RESOURCES),
     activeProjects() {
-      const namespaceFilters = this.$store.getters['activeNamespaceFilters']();
+      const namespaceFilters = this.$store.getters['activeNamespaceFilters'];
       const activeProjectFilters = this.getActiveProjects(namespaceFilters);
 
       if (namespaceFilters.includes(NAMESPACE_FILTER_ALL_ORPHANS) && Object.keys(activeProjectFilters).length === 0) {
@@ -146,7 +146,7 @@ export default {
     },
     activeNamespaces() {
       // Apply namespace filters from the top nav.
-      const activeNamespaces = this.$store.getters['activeNamespaceCache']();
+      const activeNamespaces = this.$store.getters['activeNamespaceCache'];
 
       return this.namespaces.filter((namespaceData) => {
         return !!activeNamespaces[namespaceData.metadata.name];

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -82,7 +82,7 @@ export default {
     },
 
     namespaces() {
-      return this.$store.getters['activeNamespaceCache']();
+      return this.$store.getters['activeNamespaceCache'];
     },
 
     rancherCatalog() {

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -99,7 +99,7 @@ export default {
   },
   methods: {
     setWorkspaceFilterAndLinkToGitRepo(value) {
-      this.$store.commit('updateWorkspace', { value });
+      this.$store.commit('updateWorkspace', { value, getters: this.$store.getters } );
       this.$store.dispatch('prefs/set', { key: WORKSPACE, value });
 
       this.$router.push({

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -128,25 +128,38 @@ const getActiveNamespaces = (state, getters) => {
   return out;
 };
 
+const updateActiveNamespaceCache = (state, getters) => {
+  state.activeNamespaceCache = getActiveNamespaces(state, getters);
+
+  // This is going to run a lot, so keep it optimised
+  let cacheKey = '';
+
+  for (const key in state.activeNamespaceCache) {
+    cacheKey += key + state.activeNamespaceCache[key];
+  }
+  state.activeNamespaceCacheKey = cacheKey;
+};
+
 export const state = () => {
   return {
-    managementReady:      false,
-    clusterReady:         false,
-    isMultiCluster:       false,
-    isRancher:            false,
-    namespaceFilters:     [],
-    activeNamespaceCache: {}, // Used to efficiently check if a resource should be displayed
-    allNamespaces:        null,
-    allWorkspaces:        null,
-    clusterId:            null,
-    productId:            null,
-    workspace:            null,
-    error:                null,
-    cameFromError:        false,
-    pageActions:          [],
-    serverVersion:        null,
-    systemNamespaces:     [],
-    isSingleProduct:      undefined,
+    managementReady:         false,
+    clusterReady:            false,
+    isMultiCluster:          false,
+    isRancher:               false,
+    namespaceFilters:        [],
+    activeNamespaceCache:    {}, // Used to efficiently check if a resource should be displayed
+    activeNamespaceCacheKey: '', // Fingerprint of activeNamespaceCache
+    allNamespaces:           null,
+    allWorkspaces:           null,
+    clusterId:               null,
+    productId:               null,
+    workspace:               null,
+    error:                   null,
+    cameFromError:           false,
+    pageActions:             [],
+    serverVersion:           null,
+    systemNamespaces:        [],
+    isSingleProduct:         undefined,
   };
 };
 
@@ -330,6 +343,10 @@ export const getters = {
     return state.activeNamespaceCache;
   },
 
+  activeNamespaceCacheKey(state) {
+    return state.activeNamespaceCacheKey;
+  },
+
   activeNamespaceFilters(state) {
     return state.namespaceFilters;
   },
@@ -489,7 +506,7 @@ export const mutations = {
 
     // Create map that can be used to efficiently check if a
     // resource should be displayed
-    state.activeNamespaceCache = getActiveNamespaces(state, getters);
+    updateActiveNamespaceCache(state, getters);
   },
 
   pageActions(state, pageActions) {
@@ -512,7 +529,7 @@ export const mutations = {
 
     state.workspace = value;
 
-    state.activeNamespaceCache = getActiveNamespaces(state, getters);
+    updateActiveNamespaceCache(state, getters);
   },
 
   clusterId(state, neu) {

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -327,15 +327,11 @@ export const getters = {
     // updateNamespaces mutation. We use this map to filter workloads
     // as we don't want to recompute the active namespaces
     // for each workload in a list.
-    return () => {
-      return state.activeNamespaceCache;
-    };
+    return state.activeNamespaceCache;
   },
 
   activeNamespaceFilters(state) {
-    return () => {
-      return state.namespaceFilters;
-    };
+    return state.namespaceFilters;
   },
 
   namespaces(state, getters) {
@@ -354,7 +350,7 @@ export const getters = {
     }
 
     const inStore = product.inStore;
-    const filteredMap = getters['activeNamespaceCache']();
+    const filteredMap = getters['activeNamespaceCache'];
     const isAll = getters['isAllNamespaces'];
     const all = getters[`${ inStore }/all`](NAMESPACE).map(x => x.id);
     let out;
@@ -500,7 +496,7 @@ export const mutations = {
     state.pageActions = pageActions;
   },
 
-  updateWorkspace(state, { value, all }) {
+  updateWorkspace(state, { value, all, getters }) {
     if ( all ) {
       state.allWorkspaces = all;
 
@@ -515,6 +511,8 @@ export const mutations = {
     }
 
     state.workspace = value;
+
+    state.activeNamespaceCache = getActiveNamespaces(state, getters);
   },
 
   clusterId(state, neu) {
@@ -650,6 +648,7 @@ export const actions = {
       commit('updateWorkspace', {
         value: getters['prefs/get'](WORKSPACE),
         all:   res.workspaces,
+        getters
       });
     }
 


### PR DESCRIPTION
Part 1
- This was broken by https://github.com/rancher/dashboard/pull/6261
- The `activeNamespaceCache` depends on the product (fleet requires workspaces, everything else namespaces)
- This needs updating when going to or from fleet

Part 2
- When changing the filter (workspace or namespace) switching between selections that contain the same number of results/rows wouldn't change the rows. 
- This is more obvious on the fleet/workspace world where the filter switches between two values, rather than the explorer/namespace filter which toggles values on or off  (making it unlikely to go from one state to another with the same amount of rows)
- The fix is to ensure the lists take into account the ns filter, alongside things like row count, sort settings, etc)

NOTE - On `head` (but not `ui-dashboard-index` `latest`) refreshing on the explorer pods page does not show the correct namespace filtered pods - see https://github.com/rancher/dashboard/issues/6525

Small tidyup for `activeNamespaceCache` and `activeNamespaceFilters` getters
