### PR TITLE
When adding alerting rule, provide a default namespace label

### DIFF
--- a/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -28,6 +28,24 @@ export default {
     },
   },
 
+  data(props) {
+    const defaultAlert = {
+      alert:  '',
+      expr:   '',
+      for:    '0s',
+      labels: {
+        severity:  'none',
+        namespace: 'default'
+      },
+    };
+
+    if (!this.value.rules) {
+      this.value['rules'] = [defaultAlert];
+    }
+
+    return { defaultAlert };
+  },
+
   computed: {
     recordingRules() {
       const { value: rules } = this;
@@ -76,12 +94,7 @@ export default {
         value.push({ record: '', expr: '' });
         break;
       case 'alert':
-        value.push({
-          alert:  '',
-          expr:   '',
-          for:    '0s',
-          labels: { severity: 'none' },
-        });
+        value.push(this.defaultAlert);
         break;
       default:
         break;


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6478 by modifying the default values for a new alerting rule so that it now creates a new label for `namespace=default`.

To test this PR,

1. I installed monitoring.
2. In the side nav of Cluster Explorer, I went to **Monitoring > Advanced > PrometheusRules**.
3. Clicked **Add Alert**.
4. Confirmed that in the form that appears, a default `namespace=default` label is there.
<img width="950" alt="Screen Shot 2022-07-27 at 12 16 59 PM" src="https://user-images.githubusercontent.com/20599230/181355114-3a7bf481-01e1-4da3-a1fc-e8710526fed6.png">
5. Created the resource and confirmed the YAML was saved properly:

```yaml
spec:
  groups:
    - name: rancher-qa
      rules:
        - alert: rancher-qa
          expr: vector(1)
          for: 0s
          labels:
            namespace: default
            severity: none
```
6. Confirmed the saved value renders correctly in the detail view
<img width="1045" alt="Screen Shot 2022-07-27 at 12 18 31 PM" src="https://user-images.githubusercontent.com/20599230/181355260-cbd9a941-0e49-44b9-998d-b070613a53c3.png">

