### PR TITLE
Remove unneeded API call to get projects from local cluster

### DIFF
--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -91,8 +91,6 @@ export default class Project extends HybridModel {
       }
     }
 
-    await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
-
     return newValue;
   }
 


### PR DESCRIPTION
I was able to debug https://github.com/rancher/dashboard/issues/6464 after logging into Anu's setup.

The error was caused by the fact that the cluster member did not have permission to list projects using the Steve API:

```
projects.management.cattle.io "p-6rkkp" is forbidden: User "u-w9kcq" cannot get resource "projects" in API group "management.cattle.io" in the namespace "c-6jf6l"
```

The culprit was this line of code, which attempts to refetch all projects immediately after creating a project. It requires admin access to be able to list resources in the local cluster:

```
await this.$dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } }, { root: true });
```
I believe the line is unnecessary because I created several projects as the cluster member and the Projects/namespaces list view was updated every time to show the newly created project.