### PR TITLE
Reset user preferences on E2E start or requests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -59,6 +59,7 @@ Cypress.Commands.add('getId', (id: string) => {
 /**
  * Override user preferences to default values, allowing to pass custom preferences for a deterministic scenario
  */
+// eslint-disable-next-line no-undef
 Cypress.Commands.add('userPreferences', (preferences: Partial<UserPreferences> = {}) => {
   return cy.intercept('/v1/userpreferences', (req) => {
     req.reply({

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -55,3 +55,32 @@ Cypress.Commands.add('byLabel', (label) => {
 Cypress.Commands.add('getId', (id: string) => {
   return cy.get(`[data-testid="${ id }"]`);
 });
+
+/**
+ * Override user preferences to default values, allowing to pass custom preferences for a deterministic scenario
+ */
+Cypress.Commands.add('userPreferences', (preferences: Partial<UserPreferences> = {}) => {
+  return cy.intercept('/v1/userpreferences', (req) => {
+    req.reply({
+      statusCode: 201,
+      body:       {
+        data:    [{
+          data: {
+            'after-login-route': '\"home\"',
+            cluster:             'local',
+            'group-by':          'none',
+            'home-page-cards':   '',
+            'last-namespace':    'default',
+            'last-visited':      '',
+            'ns-by-cluster':     '',
+            provisioner:         '',
+            'read-whatsnew':     '',
+            'seen-whatsnew':     '2.x.x',
+            theme:               '',
+            ...preferences,
+          },
+        }]
+      },
+    });
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -8,6 +8,7 @@ declare global {
       login(username?: string, password?: string, cacheSession?: boolean): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       getId(id: string,): Chainable<Element>;
+      userPreferences(preferences?: Partial<UserPreferences>): Chainable<null>;
     }
   }
 }

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -8,6 +8,7 @@ declare global {
       login(username?: string, password?: string, cacheSession?: boolean): Chainable<Element>;
       byLabel(label: string,): Chainable<Element>;
       getId(id: string,): Chainable<Element>;
+      // eslint-disable-next-line no-undef
       userPreferences(preferences?: Partial<UserPreferences>): Chainable<null>;
     }
   }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "types": ["cypress"]
   },
-  "include": ["./**/*.ts"]
+  "include": ["./**/*.ts", "../types/*.ts"]
 }

--- a/types/userPreferences.d.ts
+++ b/types/userPreferences.d.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-unused-vars
+interface UserPreferences {
+  'after-login-route': string,
+  cluster: string,
+  'group-by': string,
+  'home-page-cards': string,
+  'last-namespace': string,
+  'last-visited': string,
+  'ns-by-cluster': string,
+  provisioner: string,
+  'read-whatsnew': string,
+  'seen-whatsnew': string,
+  theme: string,
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6300
As in issue description.

### Occurred changes and/or fixed issues
None.

### Created issues

- #6537

### Technical notes summary
- Added `userPreferences` command to reset or override values
- Added UserPreferences interfaces with the keys, not values as are unknown
- Added global types folder to Cypress tsconfig.json, for distributed types

### Areas or cases that should be tested

Add `cy.userPreferences({ theme: '\"ui-dark\"' });` to test changes in the UI, based on this configuration. E.g. theme.

### Areas which could experience regressions
None.

### Screenshot/Video
