### PR TITLE
[Epinio] Limits the files format of the file allowed to be uploaded

### DIFF
--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -94,7 +94,6 @@ export default Vue.extend<Data, any, any, any>({
       archive: {
         tarball:             this.source?.archive.tarball || '',
         fileName:            this.source?.archive.fileName || '',
-        fileType:            this.source?.archive.fileType || '',
       },
 
       container: { url: this.source?.container.url },

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -17,8 +17,7 @@ import { EpinioAppInfo } from './AppInfo.vue';
 
 interface Archive{
   tarball: string,
-  fileName: string,
-  fileType: 'zip' | 'tar' | 'tgz'| 'tbz' | 'txz',
+  fileName: string
 }
 
 interface Container {

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -349,7 +349,7 @@ export default Vue.extend<Data, any, any, any>({
             :label="t('epinio.applications.steps.source.archive.file.button')"
             :mode="mode"
             :raw-data="true"
-            :accept="'.zip, .tar, .tgz, .tbz, .txz'"
+            :accept="'.zip, .tar, .gz, .bz2, .xz'"
             @selected="onFileSelected"
           />
         </div>

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -18,6 +18,7 @@ import { EpinioAppInfo } from './AppInfo.vue';
 interface Archive{
   tarball: string,
   fileName: string,
+  fileType: 'zip' | 'tar' | 'tgz'| 'tbz' | 'txz',
 }
 
 interface Container {
@@ -94,6 +95,7 @@ export default Vue.extend<Data, any, any, any>({
       archive: {
         tarball:             this.source?.archive.tarball || '',
         fileName:            this.source?.archive.fileName || '',
+        fileType:            this.source?.archive.fileType || '',
       },
 
       container: { url: this.source?.container.url },
@@ -349,6 +351,7 @@ export default Vue.extend<Data, any, any, any>({
             :label="t('epinio.applications.steps.source.archive.file.button')"
             :mode="mode"
             :raw-data="true"
+            :accept="'.zip, .tar, .tgz, .tbz, .txz'"
             @selected="onFileSelected"
           />
         </div>

--- a/shell/components/form/FileSelector.vue
+++ b/shell/components/form/FileSelector.vue
@@ -58,6 +58,10 @@ export default {
     rawData: {
       type:    Boolean,
       default:    false
+    },
+    accept: {
+      type:    String,
+      default:    '*'
     }
   },
 
@@ -145,6 +149,7 @@ export default {
       class="hide"
       :multiple="multiple"
       :webkitdirectory="directory"
+      :accept="accept"
       @change="fileChange"
     />
   </button>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/epinio/ui/issues/143

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a new prop to `FileSelector` component, 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Added a new prop called `accept` to `FileSelector` component (default allows all) which takes file formats that we want to allow.

Uses HTML Attribute :accept , supported as Chrome 16 +, Safari 6 +, Firefox 9+ , IE 10 +,  Opera 11 +

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/88777903/181500016-b4d6d81e-6fb6-4ebc-993b-f3f94d282083.png)
