### PR TITLE
[2.5] fix annotation path in azuread warning banner

### DIFF
--- a/components/auth/AzureWarning.vue
+++ b/components/auth/AzureWarning.vue
@@ -35,7 +35,7 @@ export default {
       const endpoint = this.authConfig?.graphEndpoint;
 
       return (
-        get(this.authConfig, `annotations."${ AZURE_MIGRATED }"`) !== 'true' &&
+        get(this.authConfig, `_annotations."${ AZURE_MIGRATED }"`) !== 'true' &&
         this.authConfig.enabled
       );
     }


### PR DESCRIPTION
#6516 - I thought I saw this issue in Ember yesterday but can't repro so I guess I was mistaken. Anyway the issue here is that norman annotations are mapped to _annotations:
https://github.com/rancher/dashboard/blob/a2755a358159343aa78c0c96b3325cce7ccb3873/plugins/steve/resource-proxy.js#L113-L116