### PR TITLE
Script to create standalone build for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ dist-pkg
 
 # Plugins - temporary
 shell/rancher-components
+
+# standalone script
+scripts/standalone/ui
+scripts/standalone/cert

--- a/scripts/standalone/dashboard
+++ b/scripts/standalone/dashboard
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./node ./index.js

--- a/scripts/standalone/index.js
+++ b/scripts/standalone/index.js
@@ -1,0 +1,159 @@
+const fs = require('fs');
+const https = require('https');
+const path = require('path');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+const express = require('express');
+
+const base = path.resolve(__dirname, '.');
+const dist = path.resolve(base, 'ui');
+
+const options = {
+  key:  fs.readFileSync(path.resolve(base, 'cert/server.key')),
+  cert: fs.readFileSync(path.resolve(base, 'cert/server.crt'))
+};
+
+const mimeTypes = {
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.html': 'text/html'
+};
+
+let api = process.env.API || 'http://localhost:8989';
+
+if ( !api.startsWith('http') ) {
+  api = `https://${ api }`;
+}
+
+let PORT = process.env.PORT || '5443';
+
+PORT = parseInt(PORT, 10)
+
+if (isNaN(PORT)) {
+  console.log('Invalid port')
+  process.exit(1);
+}
+
+const dev = (process.env.NODE_ENV !== 'production');
+const devPorts = dev || process.env.DEV_PORTS === 'true';
+
+const proxy = {
+  '/k8s':          proxyWsOpts(api), // Straight to a remote cluster (/k8s/clusters/<id>/)
+  '/pp':           proxyWsOpts(api), // For (epinio) standalone API
+  '/api':          proxyWsOpts(api), // Management k8s API
+  '/apis':         proxyWsOpts(api), // Management k8s API
+  '/v1':           proxyWsOpts(api), // Management Steve API
+  '/v3':           proxyWsOpts(api), // Rancher API
+  '/v3-public':    proxyOpts(api), // Rancher Unauthed API
+  '/api-ui':       proxyOpts(api), // Browser API UI
+  '/meta':         proxyMetaOpts(api), // Browser API UI
+  '/v1-*':         proxyOpts(api), // SAML, KDM, etc
+  // These are for Ember embedding
+  '/c/*/edit':     proxyOpts('https://127.0.0.1:8000'), // Can't proxy all of /c because that's used by Vue too
+  '/k/':           proxyOpts('https://127.0.0.1:8000'),
+  '/g/':           proxyOpts('https://127.0.0.1:8000'),
+  '/n/':           proxyOpts('https://127.0.0.1:8000'),
+  '/p/':           proxyOpts('https://127.0.0.1:8000'),
+  '/assets':       proxyOpts('https://127.0.0.1:8000'),
+  '/translations': proxyOpts('https://127.0.0.1:8000'),
+  '/engines-dist': proxyOpts('https://127.0.0.1:8000'),
+  // Plugin dev
+  '/verdaccio/':   proxyOpts('http://127.0.0.1:4873/-'),
+};
+
+const proxies = {};
+
+const app = express();
+
+for (const [key, value] of Object.entries(proxy)) {
+  const config = createProxyMiddleware(value);
+
+  proxies[key] = config;
+  app.use(key, config);
+}
+
+app.use(express.static(dist));
+
+const server = https.createServer(options, app);
+const appServer = server.listen(PORT);
+
+console.log('Running Dashboard web server on port ' + PORT);
+
+// Just proxy web sockets for v1 and v3 endpoints
+appServer.on('upgrade', function(a, b, c, d) {
+  if (a.url.startsWith('/v1')) {
+    return proxies['/v1'].upgrade(a, b, c, d);
+  } else {
+    return proxies['/v3'].upgrade(a, b, c, d);
+  }
+});
+
+// ===============================================================================================
+// Functions for the request proxying used in dev
+// ===============================================================================================
+
+function proxyMetaOpts(target) {
+  return {
+    target,
+    followRedirects: true,
+    secure:          !dev,
+    ws:           false,
+    changeOrigin: true,    
+    onProxyReq,
+    onProxyReqWs,
+    onError,
+    onProxyRes,
+  };
+}
+
+function proxyOpts(target) {
+  return {
+    target,
+    secure: !devPorts,
+    ws:           false,
+    changeOrigin: true,    
+    onProxyReq,
+    onProxyReqWs,
+    onError,
+    onProxyRes,
+  };
+}
+
+function onProxyRes(proxyRes, req, res) {
+  if (devPorts) {
+    proxyRes.headers['X-Frame-Options'] = 'ALLOWALL';
+  }
+}
+
+function proxyWsOpts(target) {
+  return {
+    ...proxyOpts(target),
+    ws:           false,
+    changeOrigin: true,
+    secure:       false,
+  };
+}
+
+function onProxyReq(proxyReq, req) {
+  if (!(proxyReq._currentRequest && proxyReq._currentRequest._headerSent)) {
+    proxyReq.setHeader('x-api-host', req.headers['host']);
+    proxyReq.setHeader('x-forwarded-proto', 'https');
+    // console.log(proxyReq.getHeaders());
+  }
+}
+
+function onProxyReqWs(proxyReq, req, socket, options, head) {
+  req.headers.origin = options.target.href;
+  proxyReq.setHeader('origin', options.target.href + '/');
+  proxyReq.setHeader('x-api-host', req.headers['host']);
+  proxyReq.setHeader('x-forwarded-proto', 'https');
+
+  socket.on('error', (err) => {
+    console.error('Proxy WS Error:', err); // eslint-disable-line no-console
+  });
+}
+
+function onError(err, req, res) {
+  res.statusCode = 598;
+  console.error('Proxy Error:', err); // eslint-disable-line no-console
+  res.write(JSON.stringify(err));
+}

--- a/scripts/standalone/index.js
+++ b/scripts/standalone/index.js
@@ -79,11 +79,15 @@ const appServer = server.listen(PORT);
 console.log('Running Dashboard web server on port ' + PORT);
 
 // Just proxy web sockets for v1 and v3 endpoints
-appServer.on('upgrade', function(a, b, c, d) {
-  if (a.url.startsWith('/v1')) {
-    return proxies['/v1'].upgrade(a, b, c, d);
+appServer.on('upgrade', function(req, socket, head) {
+  if (req.url.startsWith('/v1')) {
+    return proxies['/v1'].upgrade(req, socket, head);
+  } else if (req.url.startsWith('/v3')) {
+    return proxies['/v3'].upgrade(req, socket, head);
+  } else if (req.url.startsWith('/k8s/')) {
+    return proxies['/k8s'].upgrade(req, socket, head);
   } else {
-    return proxies['/v3'].upgrade(a, b, c, d);
+    console.log('Unknown Web socket upgrade request for ' + req.url);
   }
 });
 

--- a/scripts/standalone/index.js
+++ b/scripts/standalone/index.js
@@ -12,12 +12,6 @@ const options = {
   cert: fs.readFileSync(path.resolve(base, 'cert/server.crt'))
 };
 
-const mimeTypes = {
-  '.svg': 'image/svg+xml',
-  '.png': 'image/png',
-  '.html': 'text/html'
-};
-
 let api = process.env.API || 'http://localhost:8989';
 
 if ( !api.startsWith('http') ) {
@@ -26,10 +20,10 @@ if ( !api.startsWith('http') ) {
 
 let PORT = process.env.PORT || '5443';
 
-PORT = parseInt(PORT, 10)
+PORT = parseInt(PORT, 10);
 
 if (isNaN(PORT)) {
-  console.log('Invalid port')
+  console.log('Invalid port');
   process.exit(1);
 }
 
@@ -76,10 +70,10 @@ app.use(express.static(dist));
 const server = https.createServer(options, app);
 const appServer = server.listen(PORT);
 
-console.log('Running Dashboard web server on port ' + PORT);
+console.log(`Running Dashboard web server on port ${ PORT }`);
 
 // Just proxy web sockets for v1 and v3 endpoints
-appServer.on('upgrade', function(req, socket, head) {
+appServer.on('upgrade', (req, socket, head) => {
   if (req.url.startsWith('/v1')) {
     return proxies['/v1'].upgrade(req, socket, head);
   } else if (req.url.startsWith('/v3')) {
@@ -87,7 +81,7 @@ appServer.on('upgrade', function(req, socket, head) {
   } else if (req.url.startsWith('/k8s/')) {
     return proxies['/k8s'].upgrade(req, socket, head);
   } else {
-    console.log('Unknown Web socket upgrade request for ' + req.url);
+    console.log(`Unknown Web socket upgrade request for ${ req.url }`);
   }
 });
 
@@ -100,8 +94,8 @@ function proxyMetaOpts(target) {
     target,
     followRedirects: true,
     secure:          !dev,
-    ws:           false,
-    changeOrigin: true,    
+    ws:              false,
+    changeOrigin:    true,
     onProxyReq,
     onProxyReqWs,
     onError,
@@ -112,9 +106,9 @@ function proxyMetaOpts(target) {
 function proxyOpts(target) {
   return {
     target,
-    secure: !devPorts,
+    secure:       !devPorts,
     ws:           false,
-    changeOrigin: true,    
+    changeOrigin: true,
     onProxyReq,
     onProxyReqWs,
     onError,
@@ -147,7 +141,7 @@ function onProxyReq(proxyReq, req) {
 
 function onProxyReqWs(proxyReq, req, socket, options, head) {
   req.headers.origin = options.target.href;
-  proxyReq.setHeader('origin', options.target.href + '/');
+  proxyReq.setHeader('origin', `${ options.target.href }/`);
   proxyReq.setHeader('x-api-host', req.headers['host']);
   proxyReq.setHeader('x-forwarded-proto', 'https');
 

--- a/scripts/standalone/package.json
+++ b/scripts/standalone/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "standalone",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.1",
+    "http-proxy-middleware": "^2.0.6"
+  }
+}

--- a/scripts/standalone/package.sh
+++ b/scripts/standalone/package.sh
@@ -31,7 +31,7 @@ fi
 
 rm -rf ui
 mkdir -p ui
-cp -R ${DIR}/dist/ ./ui/
+cp -R ${DIR}/dist/* ./ui
 
 EXE=$(which node)
 

--- a/scripts/standalone/package.sh
+++ b/scripts/standalone/package.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+DIR=$(cd $(dirname $0)/../..; pwd)
+
+# clean
+if [ $1 == "-c" ]; then
+  echo "Cleaning .."
+  rm -f dashboard.tar.gz
+  rm -f dashboard.tar
+  rm -f node
+  rm -rf ui
+  rm -rf cert
+  rm -rf node_modules
+  exit 0
+fi
+
+mkdir -p cert
+cp ${DIR}/shell/server/server.* ./cert
+
+if [ ! -d "${DIR}/dist/" ]; then
+  pushd ${DIR}
+  yarn install
+  yarn build
+  popd
+fi
+
+if [ ! -d "node_modules" ]; then
+  yarn install --no-lockfile
+fi
+
+rm -rf ui
+mkdir -p ui
+cp -R ${DIR}/dist/ ./ui/
+
+EXE=$(which node)
+
+cp $EXE .
+
+rm -rf dashboard.tar
+tar --exclude=package.* --exclude *.tar -cvf dashboard.tar .
+gzip dashboard.tar

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -681,6 +681,9 @@ export default function(dir, _appConfig) {
     proxyReq.setHeader('x-forwarded-proto', 'https');
     // console.log(proxyReq.getHeaders());
 
+    console.log('onProxy');
+    console.log(proxyReq.getHeaders());
+
     socket.on('error', (err) => {
       console.error('Proxy WS Error:', err); // eslint-disable-line no-console
     });

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -681,9 +681,6 @@ export default function(dir, _appConfig) {
     proxyReq.setHeader('x-forwarded-proto', 'https');
     // console.log(proxyReq.getHeaders());
 
-    console.log('onProxy');
-    console.log(proxyReq.getHeaders());
-
     socket.on('error', (err) => {
       console.error('Proxy WS Error:', err); // eslint-disable-line no-console
     });


### PR DESCRIPTION
This PR adds a script in `shell/scripts/standalone/package.sh` - this when run from its parent folder will generate `dashboard.tar.gz` - a standalone package which can then be installed on a machine and browsed to test out the latest UI against an existing backend.

You need to run this on the same target platform as you intend to run it on (e.g. linux etc).

This bundles in the node executable as well from the host machine.