### PR TITLE
do not assume ec2 vpc obj have Tags

### DIFF
--- a/shell/machine-config/amazonec2.vue
+++ b/shell/machine-config/amazonec2.vue
@@ -212,7 +212,7 @@ export default {
       const subnetsByVpc = {};
 
       for ( const obj of this.vpcInfo.Vpcs ) {
-        const name = obj.Tags.find(t => t.Key === 'Name')?.Value;
+        const name = obj.Tags && obj.Tags?.length ? obj.Tags.find(t => t.Key === 'Name')?.Value : null;
 
         vpcs.push({
           label:     name || obj.VpcId,
@@ -237,7 +237,7 @@ export default {
           subnetsByVpc[obj.VpcId] = entry;
         }
 
-        const name = obj.Tags.find(t => t.Key === 'Name')?.Value;
+        const name = obj.Tags && obj.Tags?.length ? obj.Tags.find(t => t.Key === 'Name')?.Value : null;
 
         entry.push({
           label:     name || obj.SubnetId,
@@ -474,6 +474,7 @@ export default {
               :disabled="disabled"
               :placeholder="t('cluster.machineConfig.amazonEc2.selectedNetwork.placeholder')"
               :label="t('cluster.machineConfig.amazonEc2.selectedNetwork.label')"
+              option-key="value"
               @input="updateNetwork($event)"
             >
               <template v-slot:option="opt">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6566

I didn't see this bug until I switched the machine pool's zone from us-west-1 to us-east-2. Using the fallback for un-named vpcs already in place, `SubnetId`, caused duplicate key errors. Setting `optionKey` on the select resolves this without otherwise altering functionality.