### PR TITLE
fix azure warning banner link

### DIFF
--- a/shell/components/auth/AzureWarning.vue
+++ b/shell/components/auth/AzureWarning.vue
@@ -24,7 +24,7 @@ export default {
       authConfig:      null,
       authConfigRoute: {
         name:   'c-cluster-auth-config-id',
-        params: { id: 'azuread', cluster: '_' }
+        params: { id: 'azuread' }
       }
     };
   },


### PR DESCRIPTION

Fixes #6528 - this bug isn't related to backups specifically. The (unnecessary) blank cluster param in the azuread update link causes `loadCluster` to run and 'reset' the store then trigger a nav re-calculation when schemas are not loaded.