### PR TITLE
[2.5] fix issue with force-reloading norman objects

### DIFF
--- a/plugins/steve/mutations.js
+++ b/plugins/steve/mutations.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { addObject, addObjects, clear, removeObject } from '@/utils/array';
 import { SCHEMA } from '@/config/types';
 import { normalizeType, KEY_FIELD_FOR } from './normalize';
-import { proxyFor } from './resource-proxy';
+import { proxyFor, remapSpecialKeys } from './resource-proxy';
 
 function registerType(state, type) {
   let cache = state.types[type];
@@ -67,6 +67,8 @@ function load(state, { data, ctx, existing }) {
 
     if ( entry ) {
       // There's already an entry in the store, update it
+      // remap norman keys that are overridden by resource-instance properties
+      remapSpecialKeys(data);
       replace(entry, data);
       // console.log('### Mutation Updated', type, id);
     } else {


### PR DESCRIPTION
Fixes #6516  
https://github.com/rancher/dashboard/issues/6516#issuecomment-1200473823

The AzureAD upgrade warning banner re-appears when a user visits the auth provider detail page. When the config view for a specific auth prover is loaded the authConfig mixin will always send an api request for the norman config object by using the `force` option.

If a resource being loaded from a network request is already in the store, the steve plugin `load` mutation overwrites the existing object in the store key by key. Because this overwrite data is never run through `proxyFor`, `remapSpecialKeys` is not called on it, and the norman keys that intersect with resource-class methods are not properly remapped. In this case, `value.annotations` needs to be mapped to `value._annotations`. 

As far as I can tell, the lack of remapping is only an issue if `force` is used to fetch a norman resource already in the store. I think this is a safe change (no re-mapping of something that shouldn't have been)  because `remapSpecialKeys` is called every time a resource is proxified initially, so `entry` in the context of this change is always something that was run through `remapSpecialKeys` itself. 