### PR TITLE
Fleet: Fix empty workspace filter on first login

### DIFF
--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -4,7 +4,7 @@ import {
   SETUP, TIMED_OUT, UPGRADED, _FLAGGED, _UNFLAG
 } from '@shell/config/query-params';
 import { SETTING } from '@shell/config/settings';
-import { MANAGEMENT, NORMAN } from '@shell/config/types';
+import { MANAGEMENT, NORMAN, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { applyProducts } from '@shell/store/type-map';
 import { findBy } from '@shell/utils/array';
@@ -320,7 +320,7 @@ export default async function({
       // See note above for store.app.router.beforeEach, need to setProduct manually, for the moment do this in a targeted way
       setProduct(store, route);
       store.commit('updateWorkspace', {
-        value:   store.getters['prefs/get'](WORKSPACE),
+        value:   store.getters['prefs/get'](WORKSPACE) || DEFAULT_WORKSPACE,
         getters: store.getters
       });
     }


### PR DESCRIPTION
Fixes #6572 

- fix issue when on first login we were setting an empty value to `state.workspace` because user doesn't have an prefs set at that point in time

How to test:
- spin up a new system (rancher backend + rancher dashboard on head)
- enter `continuous delivery` (Fleet) right after first login
- make sure `workspace` filter has a first value set (defaults to `fleet-default` workspace)

**Before**
<img width="1752" alt="Screenshot 2022-08-03 at 09 43 11" src="https://user-images.githubusercontent.com/97888974/182567535-ed4016be-2ab0-4789-9de0-93dd715f1d4e.png">


**After**
<img width="1752" alt="Screenshot 2022-08-03 at 09 43 42" src="https://user-images.githubusercontent.com/97888974/182567498-fa58e022-8420-4a83-bcd2-fbfd7cc6ce9e.png">
