### PR TITLE
For certain roles hide concept of namespace outside of groups

### DIFF
--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -186,16 +186,20 @@ export default {
       description = metadata?.annotations?.[DESCRIPTION];
     }
 
+    const inStore = this.$store.getters['currentStore']();
+    const nsSchema = this.$store.getters[`${ inStore }/schemaFor`](NAMESPACE);
+
     return {
       namespace,
       name,
       description,
-      createNamespace: false
+      createNamespace: false,
+      nsSchema
     };
   },
 
   computed: {
-    ...mapGetters(['isVirtualCluster']),
+    ...mapGetters(['isVirtualCluster', 'currentCluster']),
     namespaceReallyDisabled() {
       return (
         !!this.forceNamespace || this.namespaceDisabled || this.mode === _EDIT
@@ -240,18 +244,22 @@ export default {
         });
       }
 
-      return [
-        {
+      const out = [];
+
+      if (this.canCreateNamespace) {
+        out.push({
           label: this.t('namespace.createNamespace'),
           value: ''
-        },
-        {
-          label:    'divider',
-          disabled: true,
-          kind:     'divider'
-        },
-        ...sortedByLabel
-      ];
+        });
+      }
+      out.push({
+        label:    'divider',
+        disabled: true,
+        kind:     'divider'
+      },
+      ...sortedByLabel);
+
+      return out;
     },
 
     isView() {
@@ -270,6 +278,11 @@ export default {
 
       return `span-${ span }`;
     },
+
+    canCreateNamespace() {
+      // Check if user can push to namespaces... and as the ns is outside of a project restrict to admins and cluster owners
+      return (this.nsSchema?.collectionMethods || []).includes('POST') && this.currentCluster.canUpdate;
+    }
   },
 
   watch: {

--- a/shell/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/shell/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -10,6 +10,7 @@ import { mapPref, GROUP_RESOURCES, DEV } from '@shell/store/prefs';
 import MoveModal from '@shell/components/MoveModal';
 import { defaultTableSortGenerationFn } from '@shell/components/ResourceTable.vue';
 import { NAMESPACE_FILTER_ALL_ORPHANS } from '@shell/utils/namespace-filter';
+import { mapGetters } from 'vuex';
 
 export default {
   name:       'ListNamespace',
@@ -48,6 +49,7 @@ export default {
   },
 
   computed: {
+    ...mapGetters(['currentCluster']),
 
     isNamespaceCreatable() {
       return (this.schema?.collectionMethods || []).includes('POST');
@@ -199,6 +201,10 @@ export default {
     },
 
     showMockNotInProjectGroup() {
+      if (!this.currentCluster.canUpdate) {
+        return false;
+      }
+
       const someNamespacesAreNotInProject = !this.rows.some(row => !row.project);
 
       // Hide the "Not in a Project" group if the user is filtering


### PR DESCRIPTION
### Summary
Fixes #6594

### Occurred changes and/or fixed issues
Users who have no overarching view of the cluster (non-rancher admins, non-cluster owners)
- shouldn't see namespaces outside of their projects
- shouldn't be able to create namespaces outside of their projects (specifically not in a project)

### Technical notes summary
The original issue talks about project owners and members. However those can be tricky to work due to cross over with rancher admins and cluster owners (they can use feature but may or may not have any of the project roles). 

So to make it simpler i thought this should be restricted to rancher admins and cluster owners. To determine this though global and cluster roles have to be fetched, with are resource hungry. Given this will be used in many places opted for something simpler.

In the end choice if the user can `update` the management cluster. That gives a good indication on if they can view and manage namespaces outside of projects.

### Areas or cases that should be tested
The following area's should be validated whilst rancher admins, cluster owners and project members
- Project/Namespace list
  - only rancher admins and cluster owners should be able to see and create namespaces outside of projects
- Anywhere that uses the NameNsDescription component, for example the Create Deployment pages
  - only rancher admins and cluster owners should be able to create namespaces when selecting a namespace for the deployment
