### PR TITLE
Monitoring Installation: Remove Prometheus storage volumeMode

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2790,7 +2790,6 @@ monitoring:
         existing: Enable With Existing PVC
         statefulset: Enable with StatefulSet Template
         template: Enable with PVC Template
-      volumeMode: Volume Mode
       volumeName: Volume Name
     title: Configure Grafana
   hostNetwork:
@@ -2853,7 +2852,6 @@ monitoring:
       selector: Selector
       selectorWarning: 'If you are using a dynamic provisioner (e.g. Longhorn), no Selectors should be specified since a PVC with a non-empty selector can''t have a PV dynamically provisioned for it.'
       size: Size
-      volumeMode: Volume Mode
       volumeName: Volume Name
     title: Configure Prometheus
     warningInstalled: |
@@ -2942,10 +2940,6 @@ monitoring:
     prometheus: Prometheus
     projectMetrics: Project Metrics
   v1Warning: 'Monitoring is currently deployed from Cluster Manager. If you are migrating from an older version of {vendor} with monitoring enabled, please disable monitoring in Cluster Manager before attempting to install the new {vendor} Monitoring chart in Cluster Explorer.'
-  volume:
-    modes:
-      block: Block
-      file: Filesystem
 
 monitoringReceiver:
   addButton: Add {type}

--- a/shell/chart/monitoring/prometheus/index.vue
+++ b/shell/chart/monitoring/prometheus/index.vue
@@ -59,16 +59,6 @@ export default {
 
   data() {
     return {
-      volumeModes: [
-        {
-          id:    'Filesystem',
-          label: 'monitoring.volume.modes.file',
-        },
-        {
-          id:    'Block',
-          label: 'monitoring.volume.modes.block',
-        },
-      ],
       enablePersistentStorage: !!this.value?.prometheus?.prometheusSpec?.storageSpec?.volumeClaimTemplate?.spec,
       warnUser:                false,
     };
@@ -165,7 +155,6 @@ export default {
               accessModes: ['ReadWriteOnce'],
               resources:   { requests: { storage: '50Gi' } },
               selector:    { matchExpressions: [], matchLabels: {} },
-              volumeMode:  'Filesystem',
             }
           }
         );
@@ -334,16 +323,6 @@ export default {
               :mode="mode"
               :multiple="true"
               :options="accessModes"
-              :reduce="({id})=> id"
-            />
-          </div>
-          <div class="col span-6">
-            <LabeledSelect
-              v-model="value.prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.volumeMode"
-              :label="t('monitoring.prometheus.storage.volumeMode')"
-              :localized-label="true"
-              :mode="mode"
-              :options="volumeModes"
               :reduce="({id})=> id"
             />
           </div>


### PR DESCRIPTION
### Summary

Monitoring Installation: Remove Prometheus storage volumeMode form field

Prometheus needs a formatted filesystem for its persistent volume. Setting the volumeMode to anything else but `Filesystem` (default) does not work.

Fixes #6600

### Occurred changes and/or fixed issues
Form field is removed.

### Technical notes summary
The default value in the monitoring helm chart and in Kubernetes for the volumMode is `Filesystem`. The form field is also not present for the Grafana volume configuration.

### Areas or cases that should be tested
Monitoring installation and upgrades/reconfiguration, with a persistent volume configured for Prometheus.

I tested installing and upgrading Monitoring with out the field, and the installation succeeds and Prometheus gets a correctly configured persistent volume.

### Screenshot/Video
After the removal:
![Bildschirmfoto 2022-08-04 um 14 24 21](https://user-images.githubusercontent.com/243056/182850516-1061aa74-aa4d-4a0f-8991-dc2fb7742d1e.png)

