### PR TITLE
Create `diagnostic` page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -239,7 +239,7 @@ about:
     title: CLI Downloads
   diagnostic:
     title: Diagnostics
-    checkboxTooltip: Supplement diagnostics data with response times for the top 10 resources of each cluster. These may take a while to complete
+    checkboxTooltip: Supplement diagnostics data with response times for the top 10 resources. These may take a while to complete
     checkboxLabel: Make additional requests
     systemInformation: 
       subtitle: System Information

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -238,9 +238,9 @@ about:
   downloadCLI:
     title: CLI Downloads
   diagnostic:
-    title: Diagnostic
-    checkboxTooltip: Get the response times when fetching data from the server for the top 10 highest count resources when downloading the diagnostic data. It may take a while
-    checkboxLabel: Include response times
+    title: Diagnostics
+    checkboxTooltip: Supplement diagnostics data with response times for the top 10 resources of each cluster. These may take a while to complete
+    checkboxLabel: Make additional requests
     systemInformation: 
       subtitle: System Information
       os: OS
@@ -255,7 +255,7 @@ about:
     logs: 
       subtitle: Latest Logs
     resourceCounts: 
-      subtitle: Resource Counts Per Cluster
+      subtitle: Resource Counts
 
 accountAndKeys:
   title: Account and API Keys

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -237,6 +237,8 @@ about:
     title: Image Lists
   downloadCLI:
     title: CLI Downloads
+  diagnostic:
+    title: Diagnostic
 
 accountAndKeys:
   title: Account and API Keys

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -239,6 +239,23 @@ about:
     title: CLI Downloads
   diagnostic:
     title: Diagnostic
+    checkboxTooltip: Get the response times when fetching data from the server for the top 10 highest count resources when downloading the diagnostic data. It may take a while
+    checkboxLabel: Include response times
+    systemInformation: 
+      subtitle: System Information
+      os: OS
+      browserUserAgent: Browser User Agent
+      browserLanguage: Browser Language
+      cookieEnabled: Cookies Enabled 
+      deviceMemory: Device Memory 
+      hardwareConcurrency: Hardware Concurrency 
+      memJsHeapLimit: Memory JS Heap Size limit 
+      memTotalJsHeapSize: Memory Total JS Heap Size 
+      memUsedJsHeapSize: Memory Used JS Heap Size 
+    logs: 
+      subtitle: Latest Logs
+    resourceCounts: 
+      subtitle: Resource Counts Per Cluster
 
 accountAndKeys:
   title: Account and API Keys
@@ -547,6 +564,10 @@ asyncButton:
     action:  Deactivate
     waiting: Deactivating&hellip;
     success: Deactivated
+  diagnostic:
+    action: Download Data
+    success: Saving
+    waiting: Downloading&hellip;
   done:
     action: Done
     success: Saved

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -563,6 +563,7 @@ export default function(dir, _appConfig) {
       path.join(NUXT_SHELL, 'plugins/trim-whitespace'),
       { src: path.join(NUXT_SHELL, 'plugins/extend-router') },
       { src: path.join(NUXT_SHELL, 'plugins/lookup'), ssr: false },
+      { src: path.join(NUXT_SHELL, 'plugins/console'), ssr: false },
       { src: path.join(NUXT_SHELL, 'plugins/int-number'), ssr: false },
       { src: path.join(NUXT_SHELL, 'plugins/nuxt-client-init'), ssr: false },
       path.join(NUXT_SHELL, 'plugins/replaceall'),

--- a/shell/pages/about.vue
+++ b/shell/pages/about.vue
@@ -90,7 +90,15 @@ export default {
   <Loading v-if="!settings" />
   <div v-else class="about">
     <BackLink :link="backLink" />
-    <h1 v-t="'about.title'" />
+    <div class="title-block mt-20 mb-40">
+      <h1 v-t="'about.title'" />
+      <n-link
+        :to="{ name: 'diagnostic' }"
+        class="btn role-primary"
+      >
+        {{ t('about.diagnostic.title') }}
+      </n-link>
+    </div>
     <h3>{{ t('about.versions.title') }}</h3>
     <table>
       <thead>
@@ -174,6 +182,12 @@ export default {
 
 <style lang="scss" scoped>
 .about {
+  .title-block {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
   table {
     border-collapse: collapse;
     overflow: hidden;

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -155,7 +155,7 @@ export default {
     async downloadData(btnCb) {
       const date = new Date().toLocaleDateString();
       const time = new Date().toLocaleTimeString();
-      const fileName = `rancher-diagnostic-data-${ date }-${ time }`;
+      const fileName = `rancher-diagnostic-data-${ date }-${ time.replaceAll(':', '_') }.json`;
       const data = {
         systemInformation: this.systemInformation,
         logs:              this.latestLogs,
@@ -391,7 +391,8 @@ table {
   list-style: none;
   margin: 0;
   padding: 0;
-  border: 1px solid var(--body-text);;
+  background-color: #FFF;
+  border: 1px solid var(--body-text);
   height: 300px;
   overflow-x: hidden;
   overflow-y: auto;
@@ -404,7 +405,7 @@ table {
     border-bottom: 1px solid #ccc;
 
     &.log {
-      color: var(--body-text);
+      color: #000;
     }
 
     &.warn {

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -47,6 +47,7 @@ export default {
 
         topTenForResponseTime = topTenForResponseTime.concat(sortedCount);
         topTenForResponseTime = sortBy(topTenForResponseTime, 'count:desc');
+        topTenForResponseTime = topTenForResponseTime.splice(0, 10);
 
         topTenForResponseTime.forEach((item, i) => {
           topTenForResponseTime[i].id = finalCounts[index].id;
@@ -56,8 +57,6 @@ export default {
         finalCounts[index].counts = sortedCount;
       }
     });
-
-    topTenForResponseTime = topTenForResponseTime.splice(0, 10);
 
     this.topTenForResponseTime = topTenForResponseTime;
     this.finalCounts = finalCounts;
@@ -154,8 +153,9 @@ export default {
       return `key_${ randomize }_${ data }`;
     },
     async downloadData(btnCb) {
-      const date = new Date().toISOString().split('.')[0];
-      const fileName = `diagnostic-data-${ date }`;
+      const date = new Date().toLocaleDateString();
+      const time = new Date().toLocaleTimeString();
+      const fileName = `rancher-diagnostic-data-${ date }-${ time }`;
       const data = {
         systemInformation: this.systemInformation,
         logs:              this.latestLogs,
@@ -281,7 +281,7 @@ export default {
           :key="generateKey(logEntry.timestamp)"
           :class="logEntry.type"
         >
-          <span class="log-entry-type">{{ logEntry.type }}: </span>
+          <span class="log-entry-type">{{ logEntry.type }} :: </span>
           <span
             v-for="(arg, i) in logEntry.data"
             :key="i"
@@ -391,18 +391,21 @@ table {
   list-style: none;
   margin: 0;
   padding: 0;
-  background-color: #FFF;
-  border: 1px solid #000;
+  border: 1px solid var(--body-text);;
   height: 300px;
   overflow-x: hidden;
   overflow-y: auto;
 
   li {
-    font-family: 'Courier New', monospace;
-    font-size: 13px;
+    font-family: $mono-font;
+    font-size: 12px;
     margin: 0;
     padding: 10px 20px;
     border-bottom: 1px solid #ccc;
+
+    &.log {
+      color: var(--body-text);
+    }
 
     &.warn {
       background-color: LightGoldenRodYellow;
@@ -433,6 +436,7 @@ table {
   table:nth-child(even) {
     th {
       background-color: rgb(239, 239, 239);
+      color: #000;
     }
   }
 }

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -1,0 +1,191 @@
+<script>
+// import Loading from '@shell/components/Loading';
+import BackLink from '@shell/components/BackLink';
+import BackRoute from '@shell/mixins/back-link';
+import { COUNT } from '@shell/config/types';
+// import { getVendor } from '@shell/config/private-label';
+// import { downloadFile } from '@shell/utils/download';
+
+export default {
+  layout:     'plain',
+  components: { BackLink },
+  mixins:     [BackRoute],
+  async fetch() {
+    this.counts = await this.$store.dispatch('management/findAll', { type: COUNT });
+  },
+  data() {
+    return {
+      windowObj:  window,
+      counts:     null,
+      latestLogs: console.logs // eslint-disable-line no-console
+    };
+  },
+  computed: {
+    name() {
+      return this.data;
+    }
+  },
+  methods: {
+    generateKey(data) {
+      const randomize = Math.random() * 10000;
+
+      return `key_${ randomize }_${ data }`;
+    }
+  },
+};
+</script>
+
+<template>
+  <div>
+    <BackLink :link="backLink" />
+    <h1
+      v-t="'about.diagnostic.title'"
+      class="mt-20 mb-40"
+    />
+    <div class="mb-40">
+      <h2 class="mb-20">
+        System information
+      </h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>OS</td>
+            <td>{{ windowObj.navigator.platform }}</td>
+          </tr>
+          <tr>
+            <td>Browser code name</td>
+            <td>{{ windowObj.navigator.appCodeName }}</td>
+          </tr>
+          <tr>
+            <td>Browser name</td>
+            <td>{{ windowObj.navigator.appName }}</td>
+          </tr>
+          <tr>
+            <td>Browser version</td>
+            <td>{{ windowObj.navigator.appVersion }}</td>
+          </tr>
+          <tr>
+            <td>Browser user agent</td>
+            <td>{{ windowObj.navigator.userAgent }}</td>
+          </tr>
+          <tr>
+            <td>Browser language</td>
+            <td>{{ windowObj.navigator.language }}</td>
+          </tr>
+          <tr>
+            <td>Device memory</td>
+            <td>{{ windowObj.navigator.deviceMemory }}</td>
+          </tr>
+          <tr>
+            <td>Memory JS Heap Size limit</td>
+            <td>{{ windowObj.performance.memory.jsHeapSizeLimit }}</td>
+          </tr>
+          <tr>
+            <td>Memory Total JS Heap Size</td>
+            <td>{{ windowObj.performance.memory.totalJSHeapSize }}</td>
+          </tr>
+          <tr>
+            <td>Memory Used JS Heap Size</td>
+            <td>{{ windowObj.performance.memory.usedJSHeapSize }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="mb-40">
+      <h2 class="mb-20">
+        Latest logs
+      </h2>
+      <ul class="logs-container">
+        <li
+          v-for="logEntry in latestLogs"
+          :key="generateKey(logEntry.timestamp)"
+          :class="logEntry.type"
+        >
+          <span class="log-entry-type">{{ logEntry.type }}: </span>
+          <span v-for="(arg, i) in logEntry.data" :key="i">{{ arg }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+table {
+  border-collapse: collapse;
+  overflow: hidden;
+  border-radius: var(--border-radius);
+
+  tr > td:first-of-type {
+    width: 20%;
+  }
+
+  th, td {
+    border: 1px solid var(--border);
+    padding: 8px 5px;
+    min-width: 150px;
+    text-align: left;
+  }
+
+  th {
+    background-color: var(--sortable-table-top-divider);
+    border-bottom: 1px solid var(--sortable-table-top-divider);
+  }
+
+  a {
+    cursor: pointer;
+  }
+
+  .os {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.logs-container {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background-color: #FFF;
+  border: 1px solid #000;
+  height: 300px;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  li {
+    font-family: 'Courier New', monospace;
+    font-size: 13px;
+    margin: 0;
+    padding: 10px 20px;
+    border-bottom: 1px solid #ccc;
+
+    &.warn {
+      background-color: LightGoldenRodYellow;
+      color: SaddleBrown;
+    }
+
+    &.info {
+      background-color: Azure;
+      color: blue;
+    }
+
+    &.error {
+      background-color: MistyRose;
+      color: red;
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    .log-entry-type {
+      font-weight: bold;
+    }
+  }
+}
+</style>

--- a/shell/plugins/console.js
+++ b/shell/plugins/console.js
@@ -1,7 +1,7 @@
-/* eslint-disable */
+/* eslint-disable no-console */
 export default (context) => {
   const logTypes = ['log', 'error', 'info', 'warn'];
-  const MAX_LOGS_STORED = 200;
+  const MAX_LOGS_STORED = 400;
 
   console.logLog = console.log.bind(console);
   console.errorLog = console.error.bind(console);
@@ -14,12 +14,12 @@ export default (context) => {
       const dataLogged = {
         type,
         dateTimeUtc: new Date().toUTCString(),
-        timestamp: Date.now(),
-        data: Array.from(arguments)
-      }
+        timestamp:   Date.now(),
+        data:        Array.from(arguments)
+      };
 
       if (console.logs.length >= MAX_LOGS_STORED) {
-        console.logs.shift()
+        console.logs.shift();
       }
 
       console.logs.push(dataLogged);

--- a/shell/plugins/console.js
+++ b/shell/plugins/console.js
@@ -13,8 +13,7 @@ export default (context) => {
     console[type] = function() {
       const dataLogged = {
         type,
-        date: new Date().toLocaleDateString(),
-        time: new Date().toLocaleTimeString(),
+        dateTimeUtc: new Date().toUTCString(),
         timestamp: Date.now(),
         data: Array.from(arguments)
       }

--- a/shell/plugins/console.js
+++ b/shell/plugins/console.js
@@ -1,0 +1,30 @@
+/* eslint-disable */
+export default (context) => {
+  const logTypes = ['log', 'error', 'info', 'warn'];
+  const MAX_LOGS_STORED = 200;
+
+  console.logLog = console.log.bind(console);
+  console.errorLog = console.error.bind(console);
+  console.infoLog = console.info.bind(console);
+  console.warnLog = console.warn.bind(console);
+  console.logs = [];
+
+  logTypes.forEach((type) => {
+    console[type] = function() {
+      const dataLogged = {
+        type,
+        date: new Date().toLocaleDateString(),
+        time: new Date().toLocaleTimeString(),
+        timestamp: Date.now(),
+        data: Array.from(arguments)
+      }
+
+      if (console.logs.length >= MAX_LOGS_STORED) {
+        console.logs.shift()
+      }
+
+      console.logs.push(dataLogged);
+      console[`${ type }Log`].apply(console, arguments);
+    };
+  });
+};


### PR DESCRIPTION
Fixes #6544 
- Adds `diagnostic` page, accessible via the `about` page

**Screenshots**
_Firefox, Safari_
![Screenshot 2022-08-04 at 17 44 55](https://user-images.githubusercontent.com/97888974/182906971-6571b684-cbc4-4a38-937b-5044d2a91563.png)


_Chrome, Edge_
<img width="788" alt="Screenshot 2022-08-04 at 17 44 52" src="https://user-images.githubusercontent.com/97888974/182906954-b0fe551f-69d0-49e7-900a-31a46dd2f6a7.png">

_Dark mode_
<img width="788" alt="Screenshot 2022-08-05 at 09 42 41" src="https://user-images.githubusercontent.com/97888974/183039159-b7f80a50-bd42-4352-8e1a-26cf38c7233f.png">
