### PR TITLE
do not attempt to filter by namespace for any unnamespaced resource

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -199,7 +199,8 @@ export default {
       const isVirtualProduct = this.$store.getters['currentProduct'].name === HARVESTER;
 
       // If the resources isn't namespaced or we want ALL of them, there's nothing to do.
-      if ( (!this.isNamespaced || isAll) && !isVirtualProduct) {
+      // If this is a harvester list, 'all' must still be filtered
+      if ( !this.isNamespaced || (isAll && !isVirtualProduct)) {
         return this.rows || [];
       }
 


### PR DESCRIPTION
fixes #6596 
If this is not true, resource table filters its rows wrt the namespace filter (and calculates active namespaces to do so):
`if ( (!this.isNamespaced || isAll) && !isVirtualProduct)` 

The logic here is a little off. We don't want to attempt to filter by ns if the resource is not namespaced, regardless of whether it's a harvester resource or not. "Why does this cause an infinite loop in the project/namespace list specifically?" You may ask. Good question. I think this is because the project/namespace list component also retrieves namespaces via getter and these two calls are causing each other to re-calculate. Regardless, that `if` block is wrong and fixing it fixes the bug.