### PR TITLE
Create github action for publishing @rancher/components to npm

### DIFF
--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -39,5 +39,9 @@ jobs:
       with:
         fetch-depth: 1
         persist-credentials: false
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
     - name: Publish to npm
       run: yarn publish:lib

--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -45,3 +45,5 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Publish to npm
       run: yarn publish:lib
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -2,8 +2,8 @@ name: Build and Release Rancher Components
 
 on:
   push:
-    branches:
-      - release/components/*
+    tags:
+        - 'components-v*'
 
 jobs:
   build:

--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -1,0 +1,32 @@
+name: Build and Release Rancher Components
+
+on:
+  push:
+    branches:
+      - release/components/*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16.x'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install
+      run: yarn
+
+    - name: Lint
+      run: yarn lint:lib
+
+    - name: Build
+      run: yarn build:lib
+
+    - name: Unit Test
+      run: yarn test:ci ./pkg/rancher-components

--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -1,4 +1,4 @@
-name: Build and Release Rancher Components
+name: Build and Publish Rancher Components
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install
-      run: yarn
+      run: yarn install --frozen-lockfile
 
     - name: Lint
       run: yarn lint:lib

--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -40,4 +40,4 @@ jobs:
         fetch-depth: 1
         persist-credentials: false
     - name: Publish to npm
-      run: npm publish --dry-run
+      run: yarn publish:lib

--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -31,18 +31,6 @@ jobs:
     - name: Unit Test
       run: yarn test:ci ./pkg/rancher-components
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-        persist-credentials: false
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
     - name: Publish to npm
       run: yarn publish:lib
       env:

--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -30,3 +30,14 @@ jobs:
 
     - name: Unit Test
       run: yarn test:ci ./pkg/rancher-components
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Publish to npm
+      run: npm publish --dry-run

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "install-storybook": "./scripts/storybook-install",
     "remove-storybook": "./scripts/storybook-install -d",
     "remove-storybook-deps": "./scripts/storybook-install -r",
-    "publish:lib": "cd pkg/rancher-components && npm publish --dry-run"
+    "publish:lib": "cd pkg/rancher-components && npm publish"
   },
   "dependencies": {
     "@aws-sdk/client-ec2": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "publish-shell": "./shell/scripts/publish-shell.sh",
     "clean": "./scripts/clean",
     "lint": "./node_modules/.bin/eslint --max-warnings 0 --ext .js,.ts,.vue .",
+    "lint:lib": "cd pkg/rancher-components && yarn lint",
     "lint-l10n": "./node_modules/.bin/yamllint ./shell/assets/translations",
     "test": "jest --watch",
     "test:ci": "jest --collectCoverage",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "build-storybook": "yarn run install-storybook && build-storybook",
     "install-storybook": "./scripts/storybook-install",
     "remove-storybook": "./scripts/storybook-install -d",
-    "remove-storybook-deps": "./scripts/storybook-install -r"
+    "remove-storybook-deps": "./scripts/storybook-install -r",
+    "publish:lib": "cd pkg/rancher-components && npm publish --dry-run"
   },
   "dependencies": {
     "@aws-sdk/client-ec2": "^3.1.0",

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -1,8 +1,6 @@
 
 import { mount } from '@vue/test-utils';
 import { LabeledInput } from './index';
-import Vue from 'vue';
-import Vuex from 'vuex';
 
 describe('component: LabeledInput', () => {
   it('should emit input only once', () => {

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -126,6 +126,8 @@ export default (
       if (this.hasTooltip) {
         return this.tooltipKey ? this.t(this.tooltipKey) : this.tooltip
       }
+
+      return undefined;
     },
 
     /**


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This introduces a github action for publishing @rancher/components to npm. I considered automating this process a little bit by automatically creating release when merging into a release branch, but I decided to walk things back a little bit and keep the release process relatively similar to what we already do today with our other releases. 

For this release, we explicitly choose to only lint, test, and build anything located under `pkg/rancher-components`. I think it might make sense to publish storybook along with releases of the Rancher Component framework, but we already publish changes to storybook on a much more frequent basis than we would with our releases. For this reason, it makes sense to follow up in a separate PR if we think this is needed.

### Areas or cases that should be tested
It might make sense to publish a few alpha releases based off this PR, but I think I think a bulk of the testing will be to publish a few alpha/beta releases with this workflow after merging. 

### Release Workflow

<img width="1490" alt="Untitled" src="https://user-images.githubusercontent.com/835961/182937685-743c1bde-e9dd-456d-8338-f3339ff3582c.png">

closes #5934
<!-- Define findings related to the feature or bug issue. -->


