### PR TITLE
Fix namespace detail page when a namespace filter is applied

### DIFF
--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -69,6 +69,10 @@ export default {
 
     afterLoginRoute: mapPref(AFTER_LOGIN_ROUTE),
 
+    namespaces() {
+      return this.$store.getters['activeNamespaceCache'];
+    },
+
     dev:            mapPref(DEV),
     favoriteTypes:  mapPref(FAVORITE_TYPES),
 
@@ -212,6 +216,13 @@ export default {
     },
 
     namespaceMode(a, b) {
+      if ( !isEqual(a, b) ) {
+        // Immediately update because you'll see it come in later
+        this.getGroups();
+      }
+    },
+
+    namespaces(a, b) {
       if ( !isEqual(a, b) ) {
         // Immediately update because you'll see it come in later
         this.getGroups();

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -138,15 +138,20 @@ const getActiveNamespaces = (state, getters) => {
 };
 
 const updateActiveNamespaceCache = (state, activeNamespaceCache) => {
-  state.activeNamespaceCache = activeNamespaceCache;
-
   // This is going to run a lot, so keep it optimised
   let cacheKey = '';
 
-  for (const key in state.activeNamespaceCache) {
-    cacheKey += key + state.activeNamespaceCache[key];
+  for (const key in activeNamespaceCache) {
+    // I though array.join would be faster than string concatenation, but in places like this where the array must first be constructed it's
+    // slower.
+    cacheKey += key + activeNamespaceCache[key];
   }
-  state.activeNamespaceCacheKey = cacheKey;
+
+  // Only update `activeNamespaceCache` if there have been changes. This reduces a lot of churn
+  if (state.activeNamespaceCacheKey !== cacheKey) {
+    state.activeNamespaceCacheKey = cacheKey;
+    state.activeNamespaceCache = activeNamespaceCache;
+  }
 };
 
 export const state = () => {


### PR DESCRIPTION
- fixes #6609
- Caused by `filteredRows` running causing `getActiveNamespaces` to run.. which in tern triggers other table's `filteredRows`, etc
- Fix is to only update `activeNamespaceCache` if there were actual changes
- Tested
  - ns detail page
  - project/namespaces list
  - fleet resources
  - fleet resources where there are only 1 entry in two workspaces

This also fixes an issue where the resource counts in the side nav bar failed to update. This fix is dependent on changes in this PR