### PR TITLE
prevent creation of ns outside of projects for certain roles

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3845,6 +3845,7 @@ promptRemove:
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
   confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"
+  willDeleteAssociatedNamespaces: "This will also delete all namespaces in the project: "
 
 promptRemoveApp:
   removeCrd: "Delete the CRD associated with this app"

--- a/shell/pages/c/_cluster/_product/projectsnamespaces.vue
+++ b/shell/pages/c/_cluster/_product/projectsnamespaces.vue
@@ -200,8 +200,12 @@ export default {
       });
     },
 
+    canSeeProjectlessNamespaces() {
+      return this.currentCluster.canUpdate;
+    },
+
     showMockNotInProjectGroup() {
-      if (!this.currentCluster.canUpdate) {
+      if (!this.canSeeProjectlessNamespaces) {
         return false;
       }
 
@@ -212,6 +216,10 @@ export default {
       const usingSpecificFilter = this.userIsFilteringForSpecificNamespaceOrProject();
 
       return !usingSpecificFilter && someNamespacesAreNotInProject;
+    },
+
+    notInProjectKey() {
+      return this.$store.getters['i18n/t']('resourceTable.groupLabel.notInAProject');
     }
   },
   methods: {
@@ -325,7 +333,7 @@ export default {
           </div>
           <div class="right">
             <n-link
-              v-if="isNamespaceCreatable"
+              v-if="isNamespaceCreatable && (canSeeProjectlessNamespaces || group.group.key !== notInProjectKey)"
               class="create-namespace btn btn-sm role-secondary mr-5"
               :to="createNamespaceLocation(group.group)"
             >


### PR DESCRIPTION
fixes #6594 
#6599 is incomplete; users who shouldn't be able to see namespaces outside projects can still create them with a little chicanery: 

https://user-images.githubusercontent.com/42977925/183220653-05030b58-5ca9-4bf0-9d9a-c6cb3cbbf3ba.mov


With this PR: 

https://user-images.githubusercontent.com/42977925/183220913-a68fda15-7695-4a28-b474-b8cd3e669800.mov

 This PR aims to resolve that by:

-  forcing users who can't see project-less namespaces to delete their namespaces with project deletion
- hiding the 'create namespace' button on the 'Not in a Project' group if the user shouldn't be able to create ns outside of projects.

I wasn't able to reproduce that creation error-but-it-actually-worked bug in the first vid.