### PR TITLE
Adding a windows deprecation banner to the registration command of rke1 clusters

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1038,6 +1038,7 @@ cluster:
       windowsDetail: Run this command in PowerShell on each of the existing Windows machines you want to register. Windows nodes can only be workers.
       windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
       windowsWarning: Workload pods, including some deployed by Rancher charts, will be scheduled on both Linux and Windows nodes by default. Edit NodeSelector in the chart to direct them to be placed onto a compatible node.
+      windowsDeprecatedForRKE1: Windows support is being deprecated for RKE1. We suggest migrating to RKE2.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."
   credential:
     banner:

--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -213,6 +213,11 @@ function sanitizeValue(v) {
       <template v-if="cluster.supportsWindows">
         <hr class="mt-20 mb-20" />
         <h4 v-t="'cluster.custom.registrationCommand.windowsDetail'" />
+        <Banner
+          v-if="cluster.isRke1"
+          color="warning"
+          :label="t('cluster.custom.registrationCommand.windowsDeprecatedForRKE1')"
+        />
         <template v-if="readyForWindows">
           <CopyCode
             id="copiedWindows"


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/5995#issuecomment-1206817132

### To Test
- Create an RKE1 custom cluser
- Select these options to make it a windows cluster 
![image](https://user-images.githubusercontent.com/55104481/183519826-fd35fcbf-9d69-4ed8-96cc-3fc1982039d0.png)
- View the Cluster Mangement detail view of the cluster to see the message

### Screenshot/Video
Windows rke1:
![image](https://user-images.githubusercontent.com/55104481/183519564-d690c588-bc1b-4d61-ac77-77aec561b38d.png)

Not-windows rke1:
![image](https://user-images.githubusercontent.com/55104481/183519632-37b020f0-73d6-4054-bc36-d26839a0236d.png)
