### PR TITLE
[Epinio] Allow app logs to re-supply socket url on re-connect

### DIFF
--- a/pkg/epinio/windowComponents/ApplicationLogs.vue
+++ b/pkg/epinio/windowComponents/ApplicationLogs.vue
@@ -150,6 +150,10 @@ export default {
       const url = await this.getSocketUrl();
 
       this.socket = new Socket(url, true, 0);
+      this.socket.setAutoReconnectUrl(async() => {
+        return await this.getSocketUrl();
+      });
+
       this.socket.addEventListener(EVENT_CONNECTED, (e) => {
         this.isOpen = true;
       });


### PR DESCRIPTION
- epinio uses a token in url for auth
- on socket re-connect we need to re-fetch the token
- partially addresses https://github.com/epinio/ui/issues/148 (specifically https://github.com/epinio/ui/issues/148#issuecomment-1209223473)
