### PR TITLE
Fix package script and visibility of incremental loading indicator

### DIFF
--- a/scripts/standalone/package.sh
+++ b/scripts/standalone/package.sh
@@ -38,5 +38,5 @@ EXE=$(which node)
 cp $EXE .
 
 rm -rf dashboard.tar
-tar --exclude=package.* --exclude *.tar -cvf dashboard.tar .
+tar --exclude *.tar -cvf dashboard.tar .
 gzip dashboard.tar

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -113,6 +113,10 @@ export default {
 
     loading() {
       return this.hasData ? false : this.$fetchState.pending;
+    },
+
+    showIncrementalLoadingIndicator() {
+      return this.perfConfig?.incrementalLoading?.enabled;
     }
   },
 
@@ -141,6 +145,7 @@ export default {
     >
       <template v-slot:header>
         <ResourceLoadingIndicator
+          v-if="showIncrementalLoadingIndicator"
           :resources="loadResources"
           :indeterminate="loadIndeterminate"
         />

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -48,7 +48,8 @@ export default function(dir, _appConfig) {
   const autoLoadPackages = [];
   const watcherIgnores = [
     /.shell/,
-    /dist-pkg/
+    /dist-pkg/,
+    /scripts\/standalone/
   ];
 
   autoLoad.forEach((pkg) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "cypress",
     "shell/creators",
     "cypress",
-    "./cypress.config.ts"
+    "./cypress.config.ts",
+    "script/standalone"
   ]
 }


### PR DESCRIPTION
Script Changes
- fixed `require` errors
- ensure dashboard ignores output of scripts (useful for local dev)

Dashboard Changes
- only show the resource loading indicator if incremental loading is enabled
