### PR TITLE
Ensure local cluster kube node's can determine their cluster id

### DIFF
--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -7,7 +7,7 @@ import { parseSi } from '@shell/utils/units';
 import findLast from 'lodash/findLast';
 
 import SteveModel from '@shell/plugins/steve/steve-class';
-import { LOCAL } from '~/shell/config/query-params';
+import { LOCAL } from '@shell/config/query-params';
 
 export default class ClusterNode extends SteveModel {
   get _availableActions() {

--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -7,6 +7,7 @@ import { parseSi } from '@shell/utils/units';
 import findLast from 'lodash/findLast';
 
 import SteveModel from '@shell/plugins/steve/steve-class';
+import { LOCAL } from '~/shell/config/query-params';
 
 export default class ClusterNode extends SteveModel {
   get _availableActions() {
@@ -254,10 +255,20 @@ export default class ClusterNode extends SteveModel {
     }));
   }
 
+  /**
+   *Find the node's cluster id from it's url
+   */
   get clusterId() {
     const parts = this.links.self.split('/');
 
-    return parts[parts.length - 4];
+    // Local cluster url links omit `/k8s/clusters/<cluster id>`
+    // `/v1/nodes` vs `k8s/clusters/c-m-274kcrc4/v1/nodes`
+    // Be safe when determining this, so work back through the url from a known point
+    if (parts.length > 6 && parts[parts.length - 6] === 'k8s' && parts[parts.length - 5] === 'clusters') {
+      return parts[parts.length - 4];
+    }
+
+    return LOCAL;
   }
 
   get normanNodeId() {


### PR DESCRIPTION
### Summary
Fixes #6641

### Occurred changes and/or fixed issues
- We determine the cluster id via the node's `self` link
- Normally this is something like `k8s/clusters/c-m-274kcrc4/v1/nodes/nodeid`. However for the local cluster this is only `v1/nodes/nodeid`
- This meant that for local cluster nodes it's norman and mgmt nodes were unavailable
- From what i can this only affected it's ability to
  - determine it's role (though this had a working fallback)
  - determine if some actions were shown (and also execute them)
 
### Areas or cases that should be tested
As per issue. Note - I think only worker nodes can be cordoned, drained, etc, so Rancher would need to be installed on a RKE multi-node environment with at least one worker node

### Areas which could experience regressions
- upstream/downstream cluster kube node page
- cluster management cluster's Machine Pools list