### PR TITLE
Fix pagination with manual refresh

### DIFF
--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -53,7 +53,7 @@ export default {
       const from = this.indexFrom;
       const last = this.filteredRows.length;
 
-      if ( this.page > 1 && from > last ) {
+      if ( this.totalPages > 0 && this.page > 1 && from > last ) {
         this.setPage(this.totalPages);
       }
     }


### PR DESCRIPTION
- run condition to set page if the total pages are at least 1 in order to prevent resetting the current page when there are no results on the list