### PR TITLE
Add a description slot to RadioButton

### DIFF
--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -88,7 +88,14 @@ export default Vue.extend({
     muteLabel(): boolean {
       // Don't mute the label if the mode is view and the button is checked
       return this.disabled && !(this.mode === _VIEW && this.isChecked);
-    }
+    },
+
+    /**
+     * Determines if the description slot is in use.
+     */
+    hasDescriptionSlot(): boolean {
+      return !!this.$slots.description;
+    },
   },
 
   watch: {
@@ -154,6 +161,12 @@ export default Vue.extend({
         <template v-else-if="description">
           {{ description }}
         </template>
+      </div>
+      <div
+        v-else-if="hasDescriptionSlot"
+        class="radio-button-outer-container-description"
+      >
+        <slot name="description" />
       </div>
     </div>
   </label>


### PR DESCRIPTION
### Summary

This change upstreams the inclusion of the description slot for `RadioButton.vue`. 

This slot was a customization used by Rancher Desktop to provide arbitrary content to a radio button's description. For example, using code blocks in the description:

![image](https://user-images.githubusercontent.com/835961/184412747-1fe38028-5a4a-4294-930a-b3d2f4e3227e.png)

`descriptionKey` & `description` props should take priority over the slot in order to preserve backward compatibility. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

We need to look out for regressions in `RadioButton` usage. Performing a search for `RadioButton` should provide a wide array of examples to test. Since this slot is optional, there should be no change to the existing radio button implementations. Any observed change in output is to be considered a regression. 

closes #6649 

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->

<!-- Define findings related to the feature or bug issue. -->
