### PR TITLE
Update the name for BadgeState type export

### DIFF
--- a/pkg/rancher-components/types/index.d.ts
+++ b/pkg/rancher-components/types/index.d.ts
@@ -1,6 +1,6 @@
 import { VueConstructor } from 'vue'
 
-export const Badge: VueConstructor
+export const BadgeState: VueConstructor
 export const Banner: VueConstructor
 export const Card: VueConstructor
 export const Checkbox: VueConstructor

--- a/pkg/rancher-components/types/index.d.ts
+++ b/pkg/rancher-components/types/index.d.ts
@@ -1,11 +1,11 @@
-import { VueConstructor } from 'vue'
+import { VueConstructor } from 'vue';
 
-export const BadgeState: VueConstructor
-export const Banner: VueConstructor
-export const Card: VueConstructor
-export const Checkbox: VueConstructor
-export const LabeledInput: VueConstructor
-export const LabeledTooltip: VueConstructor
-export const RadioButton: VueConstructor
-export const RadioGroup: VueConstructor
-export const TextAreaAutoGrow: VueConstructor
+export const BadgeState: VueConstructor;
+export const Banner: VueConstructor;
+export const Card: VueConstructor;
+export const Checkbox: VueConstructor;
+export const LabeledInput: VueConstructor;
+export const LabeledTooltip: VueConstructor;
+export const RadioButton: VueConstructor;
+export const RadioGroup: VueConstructor;
+export const TextAreaAutoGrow: VueConstructor;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the name of the `BadgeState` so that it accurately reflects the source. Doing this will fix an issue where tsc will display an error when attempting to import `import { BadgeState } from '@rancher/components';`

```
import BadgeState
Module '"@rancher/components"' has no exported member 'BadgeState'.
```

Fixes #6655 