### PR TITLE
Prevent side nav auto-collapse

### DIFF
--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -258,11 +258,6 @@ export default {
         }
       }
     },
-
-    $route(a, b) {
-      this.$nextTick(() => this.syncNav());
-    },
-
   },
 
   async created() {
@@ -271,11 +266,6 @@ export default {
     this.getGroups();
 
     await this.$store.dispatch('prefs/setLastVisited', this.$route);
-  },
-
-  mounted() {
-    // Sync the navigation tree on fresh load
-    this.$nextTick(() => this.syncNav());
   },
 
   methods: {
@@ -303,12 +293,6 @@ export default {
         name:   this.$route.name,
         params: this.$route.params
       };
-    },
-
-    collapseAll() {
-      this.$refs.groups.forEach((grp) => {
-        grp.isExpanded = false;
-      });
     },
 
     getGroups() {
@@ -468,14 +452,6 @@ export default {
       this.$store.dispatch('prefs/toggleTheme');
     },
 
-    groupSelected(selected) {
-      this.$refs.groups.forEach((grp) => {
-        if (grp.canCollapse) {
-          grp.isExpanded = (grp.group.name === selected.name);
-        }
-      });
-    },
-
     wheresMyDebugger() {
       // vue-shortkey is preventing F8 from passing through to the browser... this works for now.
       // eslint-disable-next-line no-debugger
@@ -499,37 +475,6 @@ export default {
       }
 
       cluster.openShell();
-    },
-
-    syncNav() {
-      const refs = this.$refs.groups;
-
-      if (refs) {
-        // Only expand one group - so after the first has been expanded, no more will
-        // This prevents the 'More Resources' group being expanded in addition to the normal group
-        let canExpand = true;
-        const expanded = refs.filter(grp => grp.isExpanded)[0];
-
-        if (expanded && expanded.hasActiveRoute()) {
-          this.$nextTick(() => expanded.syncNav());
-
-          return;
-        }
-        refs.forEach((grp) => {
-          if (!grp.group.isRoot) {
-            grp.isExpanded = false;
-            if (canExpand) {
-              const isActive = grp.hasActiveRoute();
-
-              if (isActive) {
-                grp.isExpanded = true;
-                canExpand = false;
-                this.$nextTick(() => grp.syncNav());
-              }
-            }
-          }
-        });
-      }
     },
 
     switchLocale(locale) {
@@ -557,8 +502,6 @@ export default {
               :group="g"
               :can-collapse="!g.isRoot"
               :show-header="!g.isRoot"
-              @selected="groupSelected($event)"
-              @expand="groupSelected($event)"
             />
           </template>
         </div>


### PR DESCRIPTION
This PR fixes https://github.com/rancher/dashboard/issues/6658 and partly addresses https://github.com/rancher/dashboard/issues/4431#issuecomment-1060228669

Changes in this PR:

- Side nav in Cluster Explorer no longer auto-collapses as you navigate
- You can now have more than one group expanded in the side nav

Reasons for the change:

- We got customer feedback that the auto-collapse is disconcerting (https://github.com/rancher/dashboard/issues/4431#issuecomment-1064318705)
- There is an accessibility guideline that says we should avoid rearranging content in a way that users would not expect

Screenshot of multiple groups expanded:

<img width="519" alt="Screen Shot 2022-08-15 at 2 15 08 PM" src="https://user-images.githubusercontent.com/20599230/184719798-58a9c462-9aa1-4fda-b4e3-a920820a3980.png">

To test this PR, I went to Cluster Explorer and:

- Confirmed that when a nav group is clicked, it expands
- When an expanded group is clicked, it collapses
- When collapsing a group that is actively selected, it is still marked as active/highlighted
- Changing between different nav items does not auto-collapse nav items

Note: I think the auto-collapse may have originally been intended to prevent an issue with the nav becoming too long for the page, but we no longer have this problem due to the scroll bar on the nav section