### PR TITLE
Closes apps logs on namespace removal

### DIFF
--- a/pkg/epinio/models/applications.js
+++ b/pkg/epinio/models/applications.js
@@ -536,21 +536,25 @@ export default class EpinioApplicationModel extends EpinioMetaResource {
     }, { root: true });
   }
 
-  async remove(opt = {} ) {
+  closeWindows() {
     // Closes appShell & appLogs on app Remove.
     this.$dispatch('wm/close', this.appShellId, { root: true });
     this.$dispatch('wm/close', this.appLogId, { root: true });
 
     // Closes all builds logs on app Remove.
-    const allTabs = await this.$rootGetters['wm/allTabs'];
+    const allTabs = this.$rootGetters['wm/allTabs'];
 
     if ( allTabs.length > 0 ) {
-      allTabs.map((e) => {
+      allTabs.forEach((e) => {
         if (e.id.startsWith(this.stagingLog)) {
           this.$dispatch('wm/close', e.id, { root: true });
         }
       });
     }
+  }
+
+  async remove(opt = {} ) {
+    this.closeWindows();
 
     await super.remove();
   }

--- a/pkg/epinio/models/namespaces.js
+++ b/pkg/epinio/models/namespaces.js
@@ -1,3 +1,4 @@
+import { EPINIO_TYPES } from '~/pkg/epinio/types';
 import EpinioMetaResource from './epinio-namespaced-resource';
 
 export default class EpinioNamespace extends EpinioMetaResource {
@@ -63,20 +64,15 @@ export default class EpinioNamespace extends EpinioMetaResource {
   }
 
   async remove() {
-    if (this.apps && this.apps.length) {
-      const allTabs = await this.$rootGetters['wm/allTabs'];
+    const allTabs = this.$rootGetters['wm/allTabs'];
 
-      this.apps.map((e) => {
-        if ( allTabs.length > 0 ) {
-          allTabs.map((el) => {
-            if (el.id.startsWith(`epinio-${ this.id }/${ e }-logs-`)) {
-              this.$dispatch('wm/close', el.id, { root: true });
-            }
-          });
+    if (this.apps?.length && allTabs?.length) {
+      this.apps.forEach((e) => {
+        const app = this.$getters['byId'](EPINIO_TYPES.APP, `${ this.name }/${ e }`);
+
+        if (!!app && app.meta.namespace === this.name) {
+          app.closeWindows();
         }
-
-        this.$dispatch('wm/close', `epinio-${ this.id }/${ e }-app-logs`, { root: true });
-        this.$dispatch('wm/close', `epinio-${ this.id }/${ e }-app-shell`, { root: true });
       });
     }
     await super.remove();

--- a/shell/components/form/GithubPicker.vue
+++ b/shell/components/form/GithubPicker.vue
@@ -47,7 +47,7 @@ export default {
         width:        220,
         label:       this.t('githubPicker.tableHeaders.date.label'),
         value:       'date',
-        sort:        'date',
+        sort:        'date:desc',
         formatter:   'Date',
         defaultSort: true,
       },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes [#135  ](https://github.com/epinio/ui/issues/135) on namespaces.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It was missing the functionality to close the logs of an application when a namespace was removed, this should do it.
Not sure about the place of the code and I have the feeling I overcomplicated it a bit, but it works. Let me know @richard-cox 