### PR TITLE
Fix RBAC issues with PVC creation

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3593,6 +3593,9 @@ persistentVolumeClaim:
     storageClass: Storage Class
     requestStorage: Request Storage
     persistentVolume: Persistent Volume
+    tooltips:
+      noStorageClass: You don't have permission to list Storage Classes, enter a name manually
+      noPersistentVolume: You don't have permission to list Persistent Volumes, enter a name manually
   customize:
     label: Customize
     accessModes:

--- a/shell/edit/persistentvolumeclaim.vue
+++ b/shell/edit/persistentvolumeclaim.vue
@@ -5,6 +5,7 @@ import CruResource from '@shell/components/CruResource';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Tab from '@shell/components/Tabbed/Tab';
 import { RadioGroup } from '@components/Form/Radio';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import UnitInput from '@shell/components/form/UnitInput';
 import uniq from 'lodash/uniq';
@@ -24,6 +25,7 @@ export default {
     Banner,
     Checkbox,
     CruResource,
+    LabeledInput,
     LabeledSelect,
     Labels,
     NameNsDescription,
@@ -38,7 +40,9 @@ export default {
   async fetch() {
     const storageClasses = await this.$store.dispatch('cluster/findAll', { type: STORAGE_CLASS });
 
-    this.persistentVolumes = await this.$store.dispatch('cluster/findAll', { type: PV });
+    if (this.$store.getters['management/canList'](PV)) {
+      this.persistentVolumes = await this.$store.dispatch('cluster/findAll', { type: PV });
+    }
 
     this.storageClassOptions = storageClasses.map(s => s.name).sort();
     this.storageClassOptions.unshift(this.t('persistentVolumeClaim.useDefault'));
@@ -55,6 +59,8 @@ export default {
     this.$set(this.value.spec, 'storageClassName', this.value.spec.storageClassName || this.storageClassOptions[0]);
   },
   data() {
+    const canListPersistentVolumes = this.$store.getters['management/canList'](PV);
+    const canListStorageClasses = this.$store.getters['management/canList'](STORAGE_CLASS);
     const sourceOptions = [
       {
         label: this.t('persistentVolumeClaim.source.options.new'),
@@ -65,6 +71,7 @@ export default {
         value: 'existing'
       }
     ];
+
     const defaultAccessModes = ['ReadWriteOnce'];
 
     this.$set(this.value, 'spec', this.value.spec || {});
@@ -85,6 +92,8 @@ export default {
       persistentVolumes:       [],
       storageClassOptions:     [],
       defaultTab,
+      canListPersistentVolumes,
+      canListStorageClasses,
     };
   },
   computed: {
@@ -216,15 +225,36 @@ export default {
           <div class="col span-6">
             <div class="row">
               <div v-if="source === 'new'" class="col span-12">
-                <LabeledSelect v-model="value.spec.storageClassName" :options="storageClassOptions" :label="t('persistentVolumeClaim.volumeClaim.storageClass')" :mode="immutableMode" />
+                <LabeledSelect
+                  v-if="canListStorageClasses"
+                  v-model="value.spec.storageClassName"
+                  :options="storageClassOptions"
+                  :label="t('persistentVolumeClaim.volumeClaim.storageClass')"
+                  :mode="immutableMode"
+                />
+                <LabeledInput
+                  v-else
+                  v-model="value.spec.storageClassName"
+                  :label="t('persistentVolumeClaim.volumeClaim.storageClass')"
+                  :mode="immutableMode"
+                  :tooltip="t('persistentVolumeClaim.volumeClaim.tooltips.noStorageClass')"
+                />
               </div>
               <div v-else class="col span-12">
                 <LabeledSelect
+                  v-if="canListPersistentVolumes"
                   v-model="persistentVolume"
                   :options="persistentVolumeOptions"
                   :label="t('persistentVolumeClaim.volumeClaim.persistentVolume')"
                   :selectable="isPersistentVolumeSelectable"
                   :mode="immutableMode"
+                />
+                <LabeledInput
+                  v-else
+                  v-model="persistentVolume"
+                  :label="t('persistentVolumeClaim.volumeClaim.persistentVolume')"
+                  :mode="immutableMode"
+                  :tooltip="t('persistentVolumeClaim.volumeClaim.tooltips.noPersistentVolume')"
                 />
               </div>
             </div>


### PR DESCRIPTION
Fixes #6444

This PR fixes the above issue.

The problem is that we don't check if the user has permission to list storage classes or persistent volumes and this causes the fetch code path to break.

This PR updates this to check permissions and to use input boxes rather than select components - the user still has permission to create a PVC, so we don't block, we just aren't able to show them the existing options.

It also adds a tooltip explaining this.

Issue #6444 was about persistent volumes, but the bug was also there if the user did not have permission to list storage classes - this PR fixes both.

The linked issue describes steps to reproduce, but to test:

- As Admin, create a new Standard User
- Create a new Cluster Role named 'Custom Storage' and add Verbs '*' and Resource 'persistentvolumeclaims'
- Add the new user as a Cluster Member and give them the 'Custom Storage' Role
- Log in as the new user
- Validate that when you go to Create a PVC, both the options show input boxes and not select options and that they both show a tooltip
- As Admin, edit the 'Custom Storage' and give the user permissions to list storage classes.
- Login as the user
- Validate that when creating a PVC, the storage class option now lists the storage classes (since the user now has access to do so)
- Repeat the above for persistent volumes

How it looks:

<img width="942" alt="image" src="https://user-images.githubusercontent.com/1955897/185100218-a8593477-a251-4cbd-b375-35fe98fd2c21.png">

<img width="942" alt="image" src="https://user-images.githubusercontent.com/1955897/185100310-874df0b4-04ac-4167-8114-4f2fb7fbb4dd.png">
