### PR TITLE
Show if there is an updated RKE Template available for a cluster

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1494,6 +1494,7 @@ cluster:
     machineProvider: Machine Provider
     machinePools: Machine Pools
     machines: Machines
+    rkeTemplate: RKE Template
 
   machinePool:
     name:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1486,6 +1486,8 @@ cluster:
     os: 'You are attemping to add a {newOS} worker node to a cluster with one or more {existingOS} worker nodes: some installed apps may need to be upgraded or removed.'
     rke2-k3-reprovisioning: 'Making changes to cluster configuration may result in nodes reprovisioning. For more information see the <a target="blank" href="{docsBase}/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/" target="_blank" rel="noopener nofollow">documentation</a>.'
 
+  rkeTemplateUpgrade: Template revision {name} available for upgrade
+
   detail:
     provisioner: Provisioner
     kubernetesVersion: Kubernetes Version

--- a/shell/components/formatter/ClusterLink.vue
+++ b/shell/components/formatter/ClusterLink.vue
@@ -64,6 +64,11 @@ export default {
     </n-link>
     <span v-else>{{ value }}</span>
     <i
+      v-if="row.rkeTemplateUpgrade"
+      v-tooltip="t('cluster.rkeTemplateUpgrade', { name: row.rkeTemplateUpgrade })"
+      class="template-upgrade-icon icon-alert icon"
+    />
+    <i
       v-if="clusterHasIssues"
       v-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
       class="conditions-alert-icon icon-error icon-lg"
@@ -92,5 +97,13 @@ export default {
   }
   .mytooltip ul {
     outline: 1px dashed red;
+  }
+  .template-upgrade-icon {
+    border: 1px solid var(--warning);
+    border-radius: 50%;
+    color: var(--warning);
+    margin-left: 4px;
+    font-size: 14px;
+    padding: 2px;
   }
 </style>

--- a/shell/components/formatter/RKETemplateName.vue
+++ b/shell/components/formatter/RKETemplateName.vue
@@ -1,0 +1,37 @@
+<script>
+export default {
+  props: {
+    value: {
+      type:     Object,
+      required: true
+    },
+  }
+};
+</script>
+
+<template>
+  <div class="rke-template">
+    <span>{{ value.displayName }}</span>
+    <i
+      v-if="value.upgrade"
+      v-tooltip="t('cluster.rkeTemplateUpgrade', { name: value.upgrade })"
+      class="template-upgrade-icon icon-alert icon"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .rke-template {
+    align-items: center;
+    display: inline-flex;
+
+    .template-upgrade-icon {
+      border: 1px solid var(--warning);
+      border-radius: 50%;
+      color: var(--warning);
+      margin-left: 4px;
+      font-size: 14px;
+      padding: 2px;
+    }
+  }
+</style>

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -170,6 +170,7 @@ export const MANAGEMENT = {
   MANAGED_CHART:                 'management.cattle.io.managedchart',
   USER_NOTIFICATION:             'management.cattle.io.rancherusernotification',
   GLOBAL_DNS_PROVIDER:           'management.cattle.io.globaldnsprovider',
+  RKE_TEMPLATE:                  'management.cattle.io.clustertemplate',
   RKE_TEMPLATE_REVISION:         'management.cattle.io.clustertemplaterevision',
 };
 

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -169,7 +169,8 @@ export const MANAGEMENT = {
   POD_SECURITY_POLICY_TEMPLATE:  'management.cattle.io.podsecuritypolicytemplate',
   MANAGED_CHART:                 'management.cattle.io.managedchart',
   USER_NOTIFICATION:             'management.cattle.io.rancherusernotification',
-  GLOBAL_DNS_PROVIDER:           'management.cattle.io.globaldnsprovider'
+  GLOBAL_DNS_PROVIDER:           'management.cattle.io.globaldnsprovider',
+  RKE_TEMPLATE_REVISION:         'management.cattle.io.clustertemplaterevision',
 };
 
 export const CAPI = {

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -146,6 +146,16 @@ export default {
     this.allNodePools = fetchTwoRes.allNodePools || [];
     this.haveNodePools = !!fetchTwoRes.allNodePools;
     this.machineTemplates = fetchTwoRes.mdtt || [];
+
+    // Fetch RKE template revisions so we can show when an updated template is available
+    // This request does not need to be blocking
+    if ( this.$store.getters['management/canList'](MANAGEMENT.RKE_TEMPLATE) ) {
+      this.$store.dispatch('management/findAll', { type: MANAGEMENT.RKE_TEMPLATE });
+    }
+
+    if ( this.$store.getters['management/canList'](MANAGEMENT.RKE_TEMPLATE_REVISION) ) {
+      this.$store.dispatch('management/findAll', { type: MANAGEMENT.RKE_TEMPLATE_REVISION });
+    }
   },
 
   created() {

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -41,6 +41,12 @@ export default {
       hash.machineDeployments = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE_DEPLOYMENT });
     }
 
+    // Fetch RKE template revisions so we can show when an updated template is available
+    // This request does not need to be blocking
+    if ( this.$store.getters['management/canList'](MANAGEMENT.RKE_TEMPLATE_REVISION) ) {
+      this.$store.dispatch('management/findAll', { type: MANAGEMENT.RKE_TEMPLATE_REVISION });
+    }
+
     const res = await allHash(hash);
 
     this.mgmtClusters = res.mgmtClusters;

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -36,6 +36,17 @@ export default class ProvCluster extends SteveModel {
       },
     ].filter(x => !!x.content);
 
+    // RKE Template details
+    const rkeTemplate = this.rkeTemplate;
+
+    if (rkeTemplate) {
+      out.push({
+        label:     this.t('cluster.detail.rkeTemplate'),
+        formatter: 'RKETemplateName',
+        content:   rkeTemplate,
+      });
+    }
+
     if (!this.machineProvider) {
       out.splice(1, 1);
 
@@ -590,6 +601,34 @@ export default class ProvCluster extends SteveModel {
     }
 
     return this._stateObj;
+  }
+
+  get rkeTemplate() {
+    if (!this.isRke1 || !this.mgmt) {
+      // Not an RKE! cluster or no management cluster available
+      return false;
+    }
+
+    if (!this.mgmt.spec?.clusterTemplateRevisionName) {
+      // Cluster does not use an RKE template
+      return false;
+    }
+
+    const clusterTemplateName = this.mgmt.spec.clusterTemplateName.replace(':', '/');
+    const clusterTemplateRevisionName = this.mgmt.spec.clusterTemplateRevisionName.replace(':', '/');
+    const template = this.$rootGetters['management/all'](MANAGEMENT.RKE_TEMPLATE).find(t => t.id === clusterTemplateName);
+    const revision = this.$rootGetters['management/all'](MANAGEMENT.RKE_TEMPLATE_REVISION).find(t => t.spec.enabled && t.id === clusterTemplateRevisionName);
+
+    if (!template || !revision) {
+      return false;
+    }
+
+    return {
+      displayName: `${ template.spec?.displayName }/${ revision.spec?.displayName }`,
+      upgrade:     this.rkeTemplateUpgrade,
+      template,
+      revision,
+    };
   }
 
   get rkeTemplateUpgrade() {


### PR DESCRIPTION
Fixes #6580

This PR fixes a gap between the old and new UIs - when an RKE1 cluster has been created from an RKE template, if the template has been updated, we now show this on the cluster list page:

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/1955897/185101890-8338d07f-a057-41bd-aba5-9796f2018abb.png">

Additionally, we also show the template name and version and the upgrade icon on the detail page, just as we do in the Ember UI:

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/1955897/185101980-5a60b764-b95b-4fad-9275-db6a0328ae9a.png">

To test:

- Create an RKE1 Template
- Create a 1-node RKE1 cluster from this template
- Go to the cluster list page and validate that there is no upgrade icon
- Go to the cluster details page and validate that there is not an upgrade icon 
- Add a new version to the RKE Template
- Go to the cluster list page and validate that there is an upgrade icon
- Go to the cluster details page and validate that there is an upgrade icon 
- Edit the cluster and update it to the latest template version
- Go to the cluster list page and validate that there is no upgrade icon
- Go to the cluster details page and validate that there is not an upgrade icon
- 