### PR TITLE
Issue template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a bug with Rancher Dashboard
-title: "[BUG]"
+title: "<bug title: summarize bug in one line>"
 labels: kind/bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest a new feature or enhancement for Rancher Dashboard
-title: "[FEATURE]"
+title: "<bug title: summarize feature in one line>"
 labels: 'kind/enhancement'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest a new feature or enhancement for Rancher Dashboard
-title: "<bug title: summarize feature in one line>"
+title: "<feature title: summarize feature in one line>"
 labels: 'kind/enhancement'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: Question on Rancher Dashboard UI
-title: "[QUESTION]"
+title: "<bug title: summarize question in one line>"
 labels: kind/question
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: Question on Rancher Dashboard UI
-title: "<bug title: summarize question in one line>"
+title: "<question title: summarize question in one line>"
 labels: kind/question
 assignees: ''
 


### PR DESCRIPTION
Update issue templates to hopefully make it clearer that issue titles don't need to keep `[BUG]` etc at the start - just enter a clear title.