### PR TITLE
Bug fix for can not edit cloud credential description

### DIFF
--- a/shell/edit/cloudcredential.vue
+++ b/shell/edit/cloudcredential.vue
@@ -260,7 +260,13 @@ export default {
       @select-type="selectType"
       @error="e=>errors = e"
     >
-      <NameNsDescription v-model="value" name-key="_name" :mode="mode" :namespaced="false" />
+      <NameNsDescription
+        v-model="value"
+        name-key="_name"
+        description-key="description"
+        :mode="mode"
+        :namespaced="false"
+      />
       <keep-alive>
         <component
           :is="cloudComponent"


### PR DESCRIPTION
Fixes #6584 

Simple fix for bug above.

The Cloud Credential is a Norman resource, so we need to se4t the description key for the NSNameDescription component.

To Test:

- Create a Digital Ocean Cloud Credential with a description
- Edit the credential and change the description (note you need to provide the token again)
- Verify that the new description shows in the list 