### PR TITLE
Fix for 'Description' field for Rancher roles not editable or 'viewable'

### DIFF
--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { get } from '@shell/utils/object';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { NORMAN } from '@shell/config/types';
-import SteveModel from '@shell/plugins/steve/steve-class';
+import SteveDescriptionModel from '@shell/plugins/steve/steve-description-class';
 import Role from './rbac.authorization.k8s.io.role';
 
 export const CATTLE_API_GROUP = '.cattle.io';
@@ -55,7 +55,7 @@ export const VERBS = [
   'watch',
 ];
 
-export default class RoleTemplate extends SteveModel {
+export default class RoleTemplate extends SteveDescriptionModel {
   get availableActions() {
     const out = super._availableActions;
 

--- a/shell/plugins/steve/steve-description-class.js
+++ b/shell/plugins/steve/steve-description-class.js
@@ -1,0 +1,32 @@
+import SteveModel from './steve-class';
+
+/**
+ * SteveModel that supports the description being in the root 'description' property.
+ */
+export default class SteveDescriptionModel extends SteveModel {
+  // Preserve description
+  constructor(data, ctx, rehydrateNamespace = null, setClone = false) {
+    const _description = data.description;
+
+    super(data, ctx, rehydrateNamespace, setClone);
+    this.description = _description;
+  }
+
+  get description() {
+    return this._description;
+  }
+
+  set description(value) {
+    this._description = value;
+  }
+
+  // Ensure when we clone that we preserve the desription
+  toJSON() {
+    const data = super.toJSON();
+
+    data.description = this.description;
+    delete data._description;
+
+    return data;
+  }
+}


### PR DESCRIPTION
Fixes #6585

Resources that have a `description` stored at the top level of the resource object and that use the Steve model don't work - this PR adds a new Model that supports this pattern and uses it for the role template resource.

To Test:

- Create a new Role Template and set a description
- Reload the dashboard in the browser
- Click on the name of the new role template in the list and verify that the description is shown in the detail masthead
- From the action menu, edit the config and verify that the description is populated
- Change the description and save the resource
- View the resource again and verify that the description is correct
- Refresh the browser and verify that the description is still correct