### PR TITLE
Add an example plugin

### DIFF
--- a/.github/workflows/release-rancher-epinio-standalone.yml
+++ b/.github/workflows/release-rancher-epinio-standalone.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install & Build
       run:
-        RANCHER_ENV=epinio EXCLUDES_PKG=rancher-components ./.github/workflows/scripts/build-dashboard.sh
+        RANCHER_ENV=epinio EXCLUDES_PKG=rancher-components,example ./.github/workflows/scripts/build-dashboard.sh
 
     - name: Upload Build
       uses: actions/upload-artifact@v2

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 import config from './shell/nuxt.config';
 
 // Excludes the following plugins if there's no .env file.
-const excludes = process.env.EXCLUDES_PKG || 'epinio, rancher-components';
+const excludes = process.env.EXCLUDES_PKG || 'epinio,rancher-components,example';
 
 export default config(__dirname, {
   excludes: excludes.replace(/\s/g, '').split(','),

--- a/pkg/example/babel.config.js
+++ b/pkg/example/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./.shell/pkg/babel.config.js');

--- a/pkg/example/config/example.ts
+++ b/pkg/example/config/example.ts
@@ -1,0 +1,74 @@
+import {
+  AGE, DESCRIPTION, NAME, SIMPLE_NAME, STATE
+} from '@shell/config/table-headers';
+import { createExampleRoute, rootExampleRoute } from '../utils/custom-routing';
+import { EXAMPLE_PRODUCT_NAME, EXAMPLE_STORE, EXAMPLE_TYPES } from '../types';
+import { MULTI_CLUSTER } from '@shell/store/features';
+
+export function init($plugin: any, store: any) {
+  const {
+    product,
+    basicType,
+    headers,
+    configureType,
+  } = $plugin.DSL(store, $plugin.name);
+
+  product({
+    ifFeature:             MULTI_CLUSTER,
+    category:              EXAMPLE_PRODUCT_NAME,
+    isMultiClusterApp:     true,
+    inStore:               EXAMPLE_STORE,
+    icon:                  'linux',
+    removable:             false,
+    showClusterSwitcher:   false,
+    to:                    rootExampleRoute(),
+    showNamespaceFilter:   false,
+  });
+
+  // Example resource 1
+  configureType(EXAMPLE_TYPES.RESOURCE, {
+    isCreatable:          true,
+    isEditable:           false,
+    isRemovable:          true,
+    showState:            true,
+    canYaml:              false,
+    customRoute:          createExampleRoute('c-cluster-resource', { resource: EXAMPLE_TYPES.RESOURCE }),
+  });
+
+  configureType(EXAMPLE_TYPES.RESOURCE_2, {
+    isCreatable:          false,
+    isEditable:           false,
+    isRemovable:          false,
+    showState:            false,
+    canYaml:              false,
+    customRoute:          createExampleRoute('c-cluster-resource', { resource: EXAMPLE_TYPES.RESOURCE_2 }),
+  });
+
+  // Side Nav
+  basicType([
+    EXAMPLE_TYPES.RESOURCE,
+    EXAMPLE_TYPES.RESOURCE_2
+  ]);
+
+  // Headers
+  headers(EXAMPLE_TYPES.RESOURCE, [
+    STATE,
+    NAME,
+    DESCRIPTION,
+    AGE,
+  ]);
+
+  headers(EXAMPLE_TYPES.RESOURCE_2, [
+    SIMPLE_NAME,
+  ]);
+
+  headers(EXAMPLE_TYPES.CLUSTER, [
+    STATE, {
+      ...NAME,
+      width: 100
+    }, {
+      ...DESCRIPTION,
+      width: null
+    }
+  ]);
+}

--- a/pkg/example/detail/example.resource.vue
+++ b/pkg/example/detail/example.resource.vue
@@ -1,0 +1,83 @@
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import ApplicationCard from '@shell/components/cards/ApplicationCard.vue';
+import Tabbed from '@shell/components/Tabbed/index.vue';
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import { ExampleResource } from '../types';
+
+interface Data {
+}
+
+// Data, Methods, Computed, Props
+export default Vue.extend<Data, any, any, any>({
+  components: {
+    ApplicationCard,
+    Tabbed,
+    Tab,
+  },
+  props: {
+    value: {
+      type:     Object as PropType<ExampleResource>,
+      required: true
+    },
+    initialValue: {
+      type:     Object as PropType<ExampleResource>,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    },
+  },
+
+  data() {
+    return {};
+  },
+
+});
+</script>
+
+<template>
+  <div>
+    <div class="application-details">
+      <ApplicationCard>
+        <!-- Icon slot -->
+        <template v-slot:cardIcon>
+          <i class="icon icon-fw" :class="'icon-linux'"></i>
+        </template>
+
+        <!-- Routes links slot -->
+        <template v-slot:top-left>
+          <h1>This is an example of a custom card</h1>
+        </template>
+
+        <template v-slot:top-right>
+          Top right info
+        </template>
+
+        <!-- Resources count slot -->
+        <template v-slot:resourcesCount>
+          Main Info
+        </template>
+      </ApplicationCard>
+    </div>
+
+    <h3 class="mt-20">
+      {{ t('example.example-resource.detail.tabLabel') }}
+    </h3>
+
+    <div>
+      <Tabbed>
+        <Tab label-key="example.example-resource.detail.tab1.label" name="instances" :weight="3">
+          {{ t('example.example-resource.detail.tab1.description') }}
+        </Tab>
+        <Tab label-key="example.example-resource.detail.tab2.label" name="services" :weight="2">
+          {{ t('example.example-resource.detail.tab2.description') }}
+        </Tab>
+        <Tab label-key="example.example-resource.detail.tab3.label" name="configs" :weight="1">
+          {{ t('example.example-resource.detail.tab3.description') }}
+        </Tab>
+      </Tabbed>
+    </div>
+  </div>
+</template>

--- a/pkg/example/edit/example.resource.vue
+++ b/pkg/example/edit/example.resource.vue
@@ -1,0 +1,72 @@
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import CreateEditView from '@shell/mixins/create-edit-view';
+import CruResource from '@shell/components/CruResource.vue';
+import Loading from '@shell/components/Loading.vue';
+import NameNsDescription from '@shell/components/form/NameNsDescription.vue';
+import { ExampleResource, EXAMPLE_STORE, EXAMPLE_TYPES } from '../types';
+
+export const EPINIO_SERVICE_PARAM = 'service';
+
+interface Data {
+}
+
+// Data, Methods, Computed, Props
+export default Vue.extend<Data, any, any, any>({
+  components: {
+    Loading,
+    CruResource,
+    NameNsDescription,
+  },
+
+  mixins: [CreateEditView],
+
+  props: {
+    value: {
+      type:     Object as PropType<ExampleResource>,
+      required: true
+    },
+    initialValue: {
+      type:     Object as PropType<ExampleResource>,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true
+    },
+  },
+
+  async fetch() {
+    // This is only needed as we mock data (load this page, save a new resource, nav to list and the mock data for list won't contain new resource)
+    await this.$store.dispatch(`${ EXAMPLE_STORE }/findAll`, { type: EXAMPLE_TYPES.RESOURCE });
+  },
+
+  data() {
+    return { errors: [] };
+  },
+
+});
+</script>
+
+<template>
+  <Loading v-if="!value || $fetchState.pending" />
+
+  <CruResource
+    v-else-if="value"
+    :can-yaml="false"
+    :done-route="doneRoute"
+    :mode="mode"
+    :resource="value"
+    :errors="errors"
+    @error="e=>errors = e"
+    @finish="save"
+  >
+    <NameNsDescription
+      name-key="name"
+      description-key="description"
+      :namespaced="false"
+      :value="value"
+      :mode="mode"
+    />
+  </CruResource>
+</template>

--- a/pkg/example/index.ts
+++ b/pkg/example/index.ts
@@ -1,0 +1,45 @@
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin, OnNavToPackage, OnNavAwayFromPackage } from '@shell/core/types';
+import exampleStore from './store/example-store';
+import exampleMgmtStore from './store/example-mgmt-store';
+import exampleRoutes from './routing/example-routing';
+
+// This is an example plugin that has custom product, routes, pages, stores, enter/leave hooks
+// The custom product contains custom resources. To manage them (create, edit, delete, view, list, etc) the plugin contains
+// - detail and edit components
+// - model files for each resources
+// - l10n containing translations
+
+// The plugin is intended to be included/imported to the dashboard and is accessibly via the dashboard side nav
+// When visited the user can select a 'cluster' to manage resources in
+
+const onEnter: OnNavToPackage = async(store, config) => {
+  await store.dispatch(`${ exampleMgmtStore.config.namespace }/loadManagement`);
+};
+const onLeave: OnNavAwayFromPackage = async(store, config) => {
+  // The dashboard retains the previous cluster info until another cluster is loaded, this helps when returning to the same cluster.
+  await store.dispatch(`${ exampleStore.config.namespace }/unsubscribe`);
+  await store.commit(`${ exampleStore.config.namespace }/reset`);
+};
+
+// Init the package
+export default function(plugin: IPlugin) {
+  // Auto-import model, detail, edit from the folders
+  importTypes(plugin);
+
+  // Provide plugin metadata from package.json
+  plugin.metadata = require('./package.json');
+
+  // Load a product
+  plugin.addProduct(require('./config/example'));
+
+  // Add Vuex stores
+  plugin.addDashboardStore(exampleStore.config.namespace, exampleStore.specifics, exampleStore.config);
+  plugin.addDashboardStore(exampleMgmtStore.config.namespace, exampleMgmtStore.specifics, exampleMgmtStore.config);
+
+  // Add Vue Routes
+  plugin.addRoutes(exampleRoutes);
+
+  // Add hooks to Vue navigation world
+  plugin.addNavHooks(onEnter, onLeave);
+}

--- a/pkg/example/l10n/en-us.yaml
+++ b/pkg/example/l10n/en-us.yaml
@@ -1,0 +1,33 @@
+typeLabel:
+  "example.resource": |-
+    {count, plural,
+      one { Resource }
+      other { Resources }
+    }
+  "example.resource.2": |-
+    {count, plural,
+      one { Resource 2 }
+      other { Resources 2}
+    }
+  "example.cluster": |-
+    {count, plural,
+      one { Example Cluster }
+      other { Example Clusters }
+    }
+typeDescription:
+  example.resource: This is an example of an optional description that can be shown for a resource
+product:
+  example: Example Product
+example:
+  example-resource:
+    detail:
+      tabLabel: Example of some tabs
+      tab1: 
+        label: Tab 1 Title
+        description: Tab 1 Content
+      tab2:
+        label: Tab 2 Title
+        description: Tab 2 Content
+      tab3:
+        label: Tab 3 Title
+        description: Tab 3 Content

--- a/pkg/example/list/example.resource.2.vue
+++ b/pkg/example/list/example.resource.2.vue
@@ -1,0 +1,36 @@
+<script>
+import ResourceTable from '@shell/components/ResourceTable';
+import { EXAMPLE_STORE, EXAMPLE_TYPES } from '../types';
+
+export default {
+  components: { ResourceTable },
+  async fetch() {
+    await this.$store.dispatch(`${ EXAMPLE_STORE }/findAll`, { type: EXAMPLE_TYPES.RESOURCE_2 });
+  },
+  props:      {
+    schema: {
+      type:     Object,
+      required: true,
+    },
+  },
+
+  computed: {
+    rows() {
+      return this.$store.getters[`${ EXAMPLE_STORE }/all`](EXAMPLE_TYPES.RESOURCE_2);
+    },
+  }
+};
+</script>
+
+<template>
+  <ResourceTable
+    v-bind="$attrs"
+    :rows="rows"
+    :schema="schema"
+    :loading="$fetchState.pending"
+    :table-actions="false"
+    :row-actions="false"
+    v-on="$listeners"
+  >
+  </ResourceTable>
+</template>

--- a/pkg/example/models/base-example.resource.js
+++ b/pkg/example/models/base-example.resource.js
@@ -1,0 +1,43 @@
+import { createExampleRoute } from '../utils/custom-routing';
+import Resource from '@shell/plugins/dashboard-store/resource-class';
+
+export default class BaseExampleResource extends Resource {
+  get listLocation() {
+    return this.$rootGetters['type-map/optionsFor'](this.type).customRoute || createExampleRoute(`c-cluster-resource`, {
+      cluster:   this.$rootGetters['clusterId'],
+      resource:  this.type,
+    });
+  }
+
+  get parentLocationOverride() {
+    return this.listLocation;
+  }
+
+  get doneRoute() {
+    return this.listLocation.name;
+  }
+
+  get detailLocation() {
+    const id = this.id?.replace(/.*\//, '');
+
+    return createExampleRoute(`c-cluster-resource-id`, {
+      cluster:   this.$rootGetters['clusterId'],
+      resource:  this.type,
+      id,
+    });
+  }
+
+  // ------------------------------------------------------------------
+
+  get canClone() {
+    return false;
+  }
+
+  get canYaml() {
+    return false;
+  }
+
+  get canViewInApi() {
+    return false;
+  }
+}

--- a/pkg/example/models/example.cluster.js
+++ b/pkg/example/models/example.cluster.js
@@ -1,0 +1,7 @@
+import BaseExampleResource from './base-example.resource';
+
+export default class ExampleCluster extends BaseExampleResource {
+  get state() {
+    return this.metadata.state.name;
+  }
+}

--- a/pkg/example/models/example.resource.js
+++ b/pkg/example/models/example.resource.js
@@ -1,0 +1,26 @@
+import BaseExampleResource from './base-example.resource';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+
+export default class ExampleResource extends BaseExampleResource {
+  get links() {
+    return {
+      self:   this.id,
+      create: '',
+      remove: 'thisisrequiredtoshowdeletelinks' // A remove link is required to ensure the delete buttons show
+    };
+  }
+
+  get stateObj() {
+    const transitioning = this.state === STATES_ENUM.IN_PROGRESS;
+
+    return {
+      error:         false,
+      transitioning,
+      message:       transitioning ? 'Custom message for transitional state' : ''
+    };
+  }
+
+  get creationTimestamp() {
+    return this.age;
+  }
+}

--- a/pkg/example/package.json
+++ b/pkg/example/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "example",
+  "description": "Example pkg features for Rancher Manager UI",
+  "version": "0.1.0",
+  "private": false,
+  "rancher": true,
+  "license": "Apache-2.0",
+  "author": "SUSE",  
+  "scripts": {
+    "dev": "./node_modules/.bin/nuxt dev",
+    "nuxt": "./node_modules/.bin/nuxt"
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.5",
+    "@vue/cli-plugin-babel": "~4.5.0",
+    "@vue/cli-plugin-typescript": "^4.5.15",
+    "@vue/cli-service": "~4.5.0"
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "not dead"
+  ]
+}

--- a/pkg/example/pages/c/_cluster/_resource/_id.vue
+++ b/pkg/example/pages/c/_cluster/_resource/_id.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+
+export default {
+  name:        'ExamplePkgResourcedId',
+  components:  { ResourceDetail },
+};
+</script>
+
+<template>
+  <ResourceDetail />
+</template>

--- a/pkg/example/pages/c/_cluster/_resource/create.vue
+++ b/pkg/example/pages/c/_cluster/_resource/create.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+
+export default {
+  name:       'ExamplePkgResourceCreate',
+  components: { ResourceDetail },
+};
+</script>
+
+<template>
+  <ResourceDetail />
+</template>

--- a/pkg/example/pages/c/_cluster/_resource/index.vue
+++ b/pkg/example/pages/c/_cluster/_resource/index.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import ResourceList from '@shell/components/ResourceList/index.vue';
+
+export default {
+  name:       'ExamplePkgResourcedList',
+  components: { ResourceList },
+};
+</script>
+
+<template>
+  <ResourceList />
+</template>

--- a/pkg/example/pages/index.vue
+++ b/pkg/example/pages/index.vue
@@ -1,0 +1,83 @@
+<script lang="ts">
+import Vue from 'vue';
+
+import Loading from '@shell/components/Loading.vue';
+import ResourceTable from '@shell/components/ResourceTable.vue';
+import { EXAMPLE_MGMT_STORE, EXAMPLE_TYPES } from '../types';
+
+// TODO: RC lint
+interface Data {
+  clustersSchema: any;
+  exampleResource: string;
+  clusterResource: string;
+}
+
+// Data, Methods, Computed, Props
+export default Vue.extend<Data, any, any, any>({
+  components: { Loading, ResourceTable },
+
+  layout: 'plain',
+
+  async fetch() {
+    // Note - In production systems this isn't needed, but because we mock data ensure we have a list to avoid fetching and wiping out changes
+    await this.$store.dispatch(`${ EXAMPLE_MGMT_STORE }/findAll`, { type: EXAMPLE_TYPES.CLUSTER });
+  },
+
+  data() {
+    return {
+      clustersSchema:  this.$store.getters[`${ EXAMPLE_MGMT_STORE }/schemaFor`](EXAMPLE_TYPES.CLUSTER),
+      exampleResource: EXAMPLE_TYPES.RESOURCE,
+      clusterResource: EXAMPLE_TYPES.CLUSTER,
+    };
+  },
+
+  computed: {
+    clusters() {
+      return this.$store.getters[`${ EXAMPLE_MGMT_STORE }/all`](EXAMPLE_TYPES.CLUSTER);
+    },
+  },
+
+});
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" mode="main" />
+  <div v-else class="root">
+    <div class="example-table">
+      <h2>{{ t(`typeLabel."${ clusterResource }"`, { count: 2 }) }}</h2>
+      <ResourceTable
+        :rows="clusters"
+        :schema="clustersSchema"
+        :table-actions="false"
+        :row-actions="false"
+      >
+        <template #cell:name="{row}">
+          <n-link v-if="row.metadata.state.name === 'active'" :to="{name: 'example-c-cluster-resource', params: {cluster: row.id, resource: exampleResource}}">
+            {{ row.name }}
+          </n-link>
+          <template v-else>
+            {{ row.name }}
+          </template>
+        </template>
+      </ResourceTable>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+div.root {
+  align-items: center;
+  padding-top: 50px;
+  display: flex;
+
+  .example-table {
+    & > h4 {
+      padding-top: 50px;
+      padding-bottom : 20px;
+    }
+    min-width: 60%;
+  }
+}
+
+</style>

--- a/pkg/example/routing/example-routing.ts
+++ b/pkg/example/routing/example-routing.ts
@@ -1,0 +1,28 @@
+import { RouteConfig } from 'vue-router';
+
+import { EXAMPLE_PRODUCT_NAME } from '../types';
+
+import LandingPage from '../pages/index.vue';
+import ListResource from '../pages/c/_cluster/_resource/index.vue';
+import CreateResource from '../pages/c/_cluster/_resource/create.vue';
+import ViewResource from '../pages/c/_cluster/_resource/_id.vue';
+
+const routes: RouteConfig[] = [{
+  name:      `${ EXAMPLE_PRODUCT_NAME }`,
+  path:      `/:product`,
+  component: LandingPage,
+}, {
+  name:      `${ EXAMPLE_PRODUCT_NAME }-c-cluster-resource`,
+  path:      `/:product/c/:cluster/:resource`,
+  component: ListResource,
+}, {
+  name:      `${ EXAMPLE_PRODUCT_NAME }-c-cluster-resource-create`,
+  path:      `/:product/c/:cluster/:resource/create`,
+  component: CreateResource,
+}, {
+  name:      `${ EXAMPLE_PRODUCT_NAME }-c-cluster-resource-id`,
+  path:      `/:product/c/:cluster/:resource/:id`,
+  component: ViewResource,
+}];
+
+export default routes;

--- a/pkg/example/store/example-mgmt-store/actions.ts
+++ b/pkg/example/store/example-mgmt-store/actions.ts
@@ -1,0 +1,81 @@
+import { exampleMgmtStoreMockRequest } from '../mock-data';
+import { SCHEMA } from '@shell/config/types';
+import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
+import { EXAMPLE_PRODUCT_NAME, EXAMPLE_TYPES } from '../../types';
+
+export default {
+
+  request(ctx: any, { opt }: any) {
+    // This is where custom api requests via $axios should be made
+
+    const data = exampleMgmtStoreMockRequest();
+
+    return responseObject({
+      status: 200,
+      data
+    });
+
+    function responseObject(res: any) {
+      let out = res.data;
+
+      if (typeof out === 'string') {
+        out = {};
+      }
+
+      if ( res.status === 204 || out === null || typeof out === 'string') {
+        out = {};
+      }
+
+      Object.defineProperties(out, {
+        _status:     { value: res.status },
+        _statusText: { value: res.statusText },
+        _headers:    { value: res.headers },
+        _req:        { value: res.request },
+        _url:        { value: opt.url },
+      });
+
+      return out;
+    }
+  },
+
+  async onLogout({ commit }: any) {
+    await commit('reset');
+  },
+
+  loadManagement(ctx: any) {
+    const { state, commit } = ctx;
+
+    if ( state.managementReady) {
+      // Do nothing, it's already loaded
+      return;
+    }
+
+    // Use this to store non-cluster specific schemas. Cluster specific types are stored in the cluster specific store
+
+    // Load management style schemas
+    const res = {
+      data: [{
+        product:           EXAMPLE_PRODUCT_NAME,
+        id:                 EXAMPLE_TYPES.CLUSTER,
+        _id:               normalizeType(EXAMPLE_TYPES.CLUSTER),
+        type:              'schema',
+        links:             { collection: '/api/v1/clusters' },
+        collectionMethods: ['get', 'post'],
+        resourceFields:    { },
+        attributes:        { }
+      }]
+    };
+
+    commit('loadAll', {
+      ctx,
+      type: SCHEMA,
+      data: res.data
+    });
+
+    commit('managementChanged', { ready: true });
+  },
+
+  watch() {
+  },
+
+};

--- a/pkg/example/store/example-mgmt-store/getters.ts
+++ b/pkg/example/store/example-mgmt-store/getters.ts
@@ -1,0 +1,4 @@
+export default {
+  watchStarted: () => () => {
+  }
+};

--- a/pkg/example/store/example-mgmt-store/index.ts
+++ b/pkg/example/store/example-mgmt-store/index.ts
@@ -1,0 +1,30 @@
+import { CoreStoreSpecifics, CoreStoreConfig } from '@shell/core/types';
+
+import { EXAMPLE_MGMT_STORE } from '../../types';
+
+import getters from './getters';
+import mutations from './mutations';
+import actions from './actions';
+
+const exampleMgmtFactory = (): CoreStoreSpecifics => {
+  return {
+    state() {
+      return { managementReady: false };
+    },
+
+    getters: { ...getters },
+
+    mutations: { ...mutations },
+
+    actions: { ...actions },
+  };
+};
+const config: CoreStoreConfig = { namespace: EXAMPLE_MGMT_STORE };
+
+/**
+ * `example-mgmt-store` store contains resources that aren't example 'cluster' specific, for example the list of clusters
+ */
+export default {
+  specifics: exampleMgmtFactory(),
+  config
+};

--- a/pkg/example/store/example-mgmt-store/mutations.ts
+++ b/pkg/example/store/example-mgmt-store/mutations.ts
@@ -1,0 +1,6 @@
+export default {
+  managementChanged(state: any, { ready }: any) {
+    state.managementReady = ready;
+  },
+
+};

--- a/pkg/example/store/example-store/actions.ts
+++ b/pkg/example/store/example-store/actions.ts
@@ -1,0 +1,71 @@
+import { SCHEMA } from '@shell/config/types';
+import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
+import { exampleStoreMockRequest, exampleStoreSchemas } from '../mock-data';
+
+export default {
+
+  remove({ commit }: any, obj: any ) {
+    commit('remove', obj);
+  },
+
+  request(ctx: any, {
+    opt, type, clusterId, growlOnError = false
+  }: any) {
+    // This is where custom api requests via $axios should be made
+    const res = exampleStoreMockRequest(ctx, opt);
+
+    return responseObject(res);
+
+    function responseObject(res: any) {
+      let out = res.data;
+
+      if (typeof out === 'string') {
+        out = {};
+      }
+
+      if ( res.status === 204 || out === null || typeof out === 'string') {
+        out = {};
+      }
+
+      Object.defineProperties(out, {
+        _status:     { value: res.status },
+        _statusText: { value: res.statusText },
+        _headers:    { value: res.headers },
+        _req:        { value: res.request },
+        _url:        { value: opt.url },
+      });
+
+      return out;
+    }
+  },
+
+  async onLogout({ commit, dispatch }: any) {
+    await dispatch(`unsubscribe`);
+    await commit('reset');
+  },
+
+  loadSchemas: ( ctx: any ) => {
+    const { commit } = ctx;
+
+    const res = { data: exampleStoreSchemas() };
+
+    res.data.forEach((schema: any) => {
+      schema._id = normalizeType(schema.id);
+      schema._group = normalizeType(schema.attributes?.group);
+    });
+
+    commit('loadAll', {
+      ctx,
+      type: SCHEMA,
+      data: res.data
+    });
+  },
+
+  loadCluster: ( ctx: any, { id }: any ) => {
+    // If there are any resources to fetch or actions to do when a cluster for this type is visited... this is the place
+  },
+
+  watch() {
+  },
+
+};

--- a/pkg/example/store/example-store/getters.ts
+++ b/pkg/example/store/example-store/getters.ts
@@ -1,0 +1,36 @@
+
+export default {
+
+  urlFor: (state: any, getters: any) => (type: any, id: any, opt: any) => {
+    opt = opt || {};
+    type = getters.normalizeType(type);
+    let url = opt.url;
+
+    if ( !url ) {
+      const schema = getters.schemaFor(type);
+
+      if ( !schema ) {
+        throw new Error(`Unknown schema for type: ${ type }`);
+      }
+
+      url = schema.links.collection;
+
+      if ( id ) {
+        url += `/${ id }`;
+      }
+    }
+
+    url = getters.urlOptions(url, opt);
+
+    return url;
+  },
+
+  urlOptions: () => (url: any, opt: any) => {
+    // Add API specific filter, limit, sort params
+    return url;
+  },
+
+  watchStarted: () => () => {
+  }
+
+};

--- a/pkg/example/store/example-store/index.ts
+++ b/pkg/example/store/example-store/index.ts
@@ -1,0 +1,34 @@
+import { CoreStoreSpecifics, CoreStoreConfig } from '@shell/core/types';
+
+import getters from './getters';
+import mutations from './mutations';
+import actions from './actions';
+
+import { EXAMPLE_STORE } from '../../types';
+
+const exampleStoreFactory = (): CoreStoreSpecifics => {
+  return {
+    state() {
+      return { };
+    },
+
+    getters: { ...getters },
+
+    mutations: { ...mutations },
+
+    actions: { ...actions },
+  };
+};
+const config: CoreStoreConfig = {
+  namespace:      EXAMPLE_STORE,
+  isClusterStore: true,
+};
+
+/**
+ * `example` store is like a `cluster` store...
+ * .. it contains cluster specific resources that should be setup/reset when navigating to/away from an example 'cluster'
+ */
+export default {
+  specifics: exampleStoreFactory(),
+  config
+};

--- a/pkg/example/store/example-store/mutations.ts
+++ b/pkg/example/store/example-store/mutations.ts
@@ -1,0 +1,2 @@
+
+export default {};

--- a/pkg/example/store/mock-data.ts
+++ b/pkg/example/store/mock-data.ts
@@ -1,0 +1,133 @@
+import {
+  ExampleCluster, ExampleResource, ExampleResource2, EXAMPLE_PRODUCT_NAME, EXAMPLE_TYPES
+} from '../types';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+
+const createMockRandomAge = () => {
+  const date = new Date().getTime() - (Math.floor(Math.random() * 10) * 1000 * 60 * 60 * 60);
+
+  return new Date(date).toDateString();
+};
+
+let mockResourceId = 0;
+
+const createMockExampleResource = ():ExampleResource[] => [{
+  id:          (++mockResourceId).toString(),
+  name:        'Resource 1',
+  type:        EXAMPLE_TYPES.RESOURCE,
+  state:       STATES_ENUM.ACTIVE,
+  age:         createMockRandomAge(),
+  description: 'Description for resource 1'
+
+}, {
+  id:          (++mockResourceId).toString(),
+  name:        'Resource 2',
+  type:        EXAMPLE_TYPES.RESOURCE,
+  state:       STATES_ENUM.IN_PROGRESS,
+  age:         createMockRandomAge(),
+  description: 'Description for resource 2'
+}];
+
+const createMockExampleResource2 = ():ExampleResource2[] => [{
+  id:          (++mockResourceId).toString(),
+  name:        'Resource 1',
+  type:        EXAMPLE_TYPES.RESOURCE_2,
+
+}, {
+  id:          (++mockResourceId).toString(),
+  name:        'Resource 2',
+  type:        EXAMPLE_TYPES.RESOURCE_2,
+}];
+
+const makeMockGetRequest = (opt: any) => {
+  const index = opt.url.replace(`/api/v1/${ EXAMPLE_TYPES.RESOURCE }/`, '');
+  const all = opt.url.endsWith(EXAMPLE_TYPES.RESOURCE) ? createMockExampleResource() : createMockExampleResource2();
+
+  const res: { status: number, data: any} = {
+    status: 200,
+    data:   index?.length === 1 ? all.find(r => r.id === index) : all
+  };
+
+  return res;
+};
+
+export const exampleStoreMockRequest = (ctx: any, opt: any) => {
+  const { dispatch, getters } = ctx;
+
+  switch (opt.method) {
+  case 'post':
+    // Hack to allow create/update of example resource
+    return {
+      data: {
+        ...opt.data,
+        id:  (++mockResourceId).toString(),
+        age: createMockRandomAge(),
+      }
+    };
+  case 'delete':
+    // Normally sockets updates will remove this entry from the store, but in this mocked world we need to do it manually
+    dispatch('remove', getters['byId'](EXAMPLE_TYPES.RESOURCE, opt.url));
+
+    return { data: null };
+  default: {
+    const res = makeMockGetRequest(opt);
+
+    if (Array.isArray(res.data)) {
+      // `findAll` expects `{data.data}`
+      res.data = { data: res.data };
+    } else {
+      // `find` action turns this into `{data: data}`
+    }
+
+    return res;
+  }
+  }
+};
+
+export const exampleMgmtStoreMockRequest = ():{ data: ExampleCluster[]} => ({
+  data: [{
+    id:          '1',
+    name:        'Cluster 1',
+    type:        EXAMPLE_TYPES.CLUSTER,
+    description: 'This is the description for cluster 1',
+    metadata:    {
+      state:         {
+        name:          STATES_ENUM.ACTIVE,
+        transitioning: false,
+        error:         false,
+        message:       ''
+      }
+    }
+  }, {
+    id:          '2',
+    name:        'Cluster 2',
+    type:        EXAMPLE_TYPES.CLUSTER,
+    description: 'This is the description for cluster 2',
+    metadata:    {
+      state:       {
+        name:          STATES_ENUM.ERROR,
+        transitioning: false,
+        error:         true,
+        message:       `This is a description for this resource's state`
+      }
+    }
+  }]
+});
+
+export const exampleStoreSchemas = () => [{
+  product:           EXAMPLE_PRODUCT_NAME,
+  id:                 EXAMPLE_TYPES.RESOURCE,
+  type:              'schema',
+  links:             { collection: `/api/v1/${ EXAMPLE_TYPES.RESOURCE }` },
+  collectionMethods: ['get', 'post'],
+  resourceFields:    { },
+  attributes:        { }
+}, {
+  product:           EXAMPLE_PRODUCT_NAME,
+  id:                 EXAMPLE_TYPES.RESOURCE_2,
+  type:              'schema',
+  links:             { collection: `/api/v1/${ EXAMPLE_TYPES.RESOURCE_2 }` },
+  collectionMethods: ['get', 'post'],
+  resourceFields:    { },
+  attributes:        { }
+}];

--- a/pkg/example/tsconfig.json
+++ b/pkg/example/tsconfig.json
@@ -1,0 +1,67 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "jsx": "preserve",
+    "importHelpers": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "preserveSymlinks": true,
+    "types": [
+      "node",
+      "webpack-env"
+    ],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "scripthost"
+    ],
+    "paths": {
+      "@shell/core/*": [
+        "../../shell/core/*"
+      ],
+      "@shell/config/*": [
+        "../../shell/config/*"
+      ],
+      "@shell/store/*": [
+        "../../shell/store/*"
+      ],
+      "@shell/plugins/*": [
+        "../../shell/plugins/*"
+      ],
+      "@shell/utils/*": [
+        "../../shell/utils/*"
+      ],
+      "@shell/models/*": [
+        "../../shell/models/*"
+      ],
+      "@components/*": [
+        "../../pkg/rancher-components/*"
+      ],
+      "@pkg/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.d.ts",
+    "**/*.tsx",
+    "**/*.vue",
+    "../../shell/types/*.d.ts",
+    "../../shell/core/*.ts",
+    "../../shell/config/**/*.js",
+    "**/*.yaml",
+    "../../vue-shim.d.ts",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/pkg/example/types.ts
+++ b/pkg/example/types.ts
@@ -1,0 +1,40 @@
+// Note - The product name needs to match the ..
+// - the name of the package in the plugin's package.json
+// - the name of the folder (if in the dashboard's `pkg` folder)
+// - the main store (in this case EXAMPLE_STORE)
+export const EXAMPLE_PRODUCT_NAME = 'example';
+export const EXAMPLE_STORE = EXAMPLE_PRODUCT_NAME;
+export const EXAMPLE_MGMT_STORE = 'example-mgmt-store';
+
+export const EXAMPLE_TYPES = {
+  RESOURCE:   'example.resource',
+  RESOURCE_2: 'example.resource.2',
+  CLUSTER:    'example.cluster'
+};
+
+export interface RootExampleResource {
+  id: string,
+  name: string,
+  type: string,
+}
+
+export interface ExampleResource extends RootExampleResource{
+  state: string,
+  description: string,
+  age: string,
+}
+
+export interface ExampleResource2 extends RootExampleResource{
+}
+
+export interface ExampleCluster extends RootExampleResource{
+  description: string,
+  metadata: {
+    state: {
+      transitioning: boolean,
+      error: boolean,
+      message: string,
+      name: string,
+    },
+  }
+}

--- a/pkg/example/utils/custom-routing.ts
+++ b/pkg/example/utils/custom-routing.ts
@@ -1,0 +1,14 @@
+import { EXAMPLE_PRODUCT_NAME } from '../types';
+
+export const rootExampleRoute = () => ({
+  name:    EXAMPLE_PRODUCT_NAME,
+  params: { product: EXAMPLE_PRODUCT_NAME }
+});
+
+export const createExampleRoute = (name: string, params: Object) => ({
+  name:   `${ rootExampleRoute().name }-${ name }`,
+  params: {
+    ...rootExampleRoute().params,
+    ...params
+  }
+});

--- a/pkg/example/vue.config.js
+++ b/pkg/example/vue.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./.shell/pkg/vue.config')(__dirname);

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -17,7 +17,17 @@ export interface PackageMetadata {
 
 export type VuexStoreObject = { [key: string]: any }
 export type CoreStoreSpecifics = { state: () => VuexStoreObject, getters: VuexStoreObject, mutations: VuexStoreObject, actions: VuexStoreObject }
-export type CoreStoreConfig = { namespace: string, baseUrl?: string, modelBaseClass?: string, supportsStream?: boolean, isClusterStore?: boolean }
+export type CoreStoreConfig = {
+  namespace: string,
+  baseUrl?: string,
+  modelBaseClass?: string,
+  supportsStream?: boolean,
+  /**
+   * Denotes that this store should be treated as a 'cluster' store
+   * When the user navigates to/away from a route containing a cluster id the dashboard will initialise/reset this store
+   */
+  isClusterStore?: boolean
+}
 export type RegisterStore = () => (store: any) => void
 export type UnregisterStore = (store: any) => void
 


### PR DESCRIPTION
Note - This will probably end up living in a separate repo, but so it's not lost I'm creating a temp PR here
- fixes #6662
- Can be used in dev/e2e world to test the plugin feature set
- It contains
  - custom product, routes, pages, stores, enter/leave hooks, etc
  - custom product contains custom resources. To manage them (create, edit, delete, view, list, etc) the plugin contains
    - detail, list and edit components
    - model files for each resources
    - l10n containing translations