### PR TITLE
Fix pod priority class name field

### DIFF
--- a/shell/edit/workload/types/Deployment.vue
+++ b/shell/edit/workload/types/Deployment.vue
@@ -249,7 +249,7 @@ export default {
                       <LabeledInput v-model.number="podTemplateSpec.priority" :mode="mode" :label="t('workload.scheduling.priority.priority')" />
                     </div>
                     <div class="col span-6">
-                      <LabeledInput v-model="podTemplateSpec.priorityClassname" :mode="mode" :label="t('workload.scheduling.priority.className')" />
+                      <LabeledInput v-model="podTemplateSpec.priorityClassName" :mode="mode" :label="t('workload.scheduling.priority.className')" />
                     </div>
                   </div>
                 </div>

--- a/shell/edit/workload/types/Generic.vue
+++ b/shell/edit/workload/types/Generic.vue
@@ -196,7 +196,7 @@ export default {
                   <LabeledInput v-model.number="podTemplateSpec.priority" :mode="mode" :label="t('workload.scheduling.priority.priority')" />
                 </div>
                 <div class="col span-6">
-                  <LabeledInput v-model="podTemplateSpec.priorityClassname" :mode="mode" :label="t('workload.scheduling.priority.className')" />
+                  <LabeledInput v-model="podTemplateSpec.priorityClassName" :mode="mode" :label="t('workload.scheduling.priority.className')" />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixes #6443 

Simple fix - the case of the `priorityClassName` was incorrect.

To test:

- Create a new deployment
- Edit the deployment, go to pod and resources and enter a name in the Priority Class Name field
- Validate that this field is stored by editing the deployment again
  