### PR TITLE
Fix service shows pods from other namespaces

### DIFF
--- a/shell/models/service.js
+++ b/shell/models/service.js
@@ -136,7 +136,11 @@ export default class extends SteveModel {
       let pods = [];
 
       if (podRelationship) {
-        pods = await this.$dispatch('cluster/findMatching', { type: POD, selector: podRelationship.selector }, { root: true });
+        pods = await this.$dispatch('cluster/findMatching', {
+          type:      POD,
+          selector:  podRelationship.selector,
+          namespace: this.namespace
+        }, { root: true });
       }
 
       return pods;

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -319,7 +319,12 @@ export default {
     return all;
   },
 
-  async findMatching(ctx, { type, selector, opt }) {
+  async findMatching(ctx, {
+    type,
+    selector,
+    opt,
+    namespace
+  }) {
     const {
       getters, commit, dispatch, rootGetters
     } = ctx;
@@ -332,7 +337,7 @@ export default {
       commit('registerType', type);
     }
     if ( opt.force !== true && getters['haveSelector'](type, selector) ) {
-      return getters.matching( type, selector );
+      return getters.matching( type, selector, namespace );
     }
 
     const typeOptions = rootGetters['type-map/optionsFor'](type);
@@ -366,7 +371,7 @@ export default {
       });
     }
 
-    return getters.matching( type, selector );
+    return getters.matching( type, selector, namespace );
   },
 
   // opt:

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -25,8 +25,13 @@ export default {
     return state.types[type].list;
   },
 
-  matching: (state, getters) => (type, selector) => {
-    const all = getters['all'](type);
+  matching: (state, getters) => (type, selector, namespace) => {
+    let all = getters['all'](type);
+
+    // Filter first by namespace if one is provided, since this is efficient
+    if (namespace) {
+      all = all.filter(obj => obj.namespace === namespace);
+    }
 
     return all.filter((obj) => {
       return matches(obj, selector);


### PR DESCRIPTION
Fixes #6619 

PR ensures we filter the pods by namespace.

Steps to test are in the linked issue.

Before: Service shows pods from other namespace
After: Services shows pods only form the namespace it is in