### PR TITLE
Add additional namespaces match field to logging ClusterFlow page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2522,13 +2522,39 @@ logging:
       doesntExistTooltip: This cluster output doesn't exist
       label: Cluster Outputs
     matches:
+      banner: Configure which container logs will be pulled from
+      unsupportedConfig: This resource contains a match configuration that the form editor does not support. Please use YAML edit.
       label: Matches
       addSelect: Add Include Rule
       addExclude: Add Exclude Rule
+      pods:
+        title:
+          include: Include Pods
+          exclude: Exclude Pods
+        keyLabel: Pod Label Key
+        valueLabel: Pod Label Value
+        addLabel: Add Pod
+      nodes:
+        title:
+          include: Limit to specific nodes
+          exclude: Exclude specific nodes
+        placeholder: "Default: Any node"
+      containerNames:
+        title:
+          include: Limit to specific container names
+          exclude: Exclude specific container names
+        placeholder: "Default: Any container"
+      namespaces:
+        title:
+          include: Limit to specific namespaces
+          exclude: Exclude specific namespaces
+        placeholder: "Default: Any namespace"
+
     filters:
       label: Filters
     outputs:
       doesntExistTooltip: This output doesn't exist
+      sameNamespaceError: Output must reside in same namespace as the flow.
       label: Outputs
   install:
     k3sContainerEngine: K3S Container Engine

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -275,9 +275,10 @@ export default {
 
     ::v-deep .vs__selected-options {
       display: flex;
+      margin: 3px;
 
       .vs__selected {
-          width: 100%;
+          width: initial;
       }
     }
 

--- a/shell/edit/logging-flow/Match.vue
+++ b/shell/edit/logging-flow/Match.vue
@@ -27,6 +27,16 @@ export default {
       type:    Array,
       default: () => [],
     },
+
+    namespaces: {
+      type:    Array,
+      default: () => [],
+    },
+
+    isClusterFlow: {
+      type:    Boolean,
+      default: false
+    }
   },
 
   methods: {
@@ -90,6 +100,27 @@ export default {
           :close-on-select="false"
           placement="top"
         />
+      </div>
+    </div>
+    <div v-if="isClusterFlow">
+      <div class="spacer"></div>
+      <h3>
+        Limit to specific namespaces
+      </h3>
+      <div class="row">
+        <div class="col span-12">
+          <Select
+            v-model="value.namespaces"
+            class="lg"
+            :options="namespaces"
+            placeholder="Default: Any namespace"
+            :multiple="true"
+            :taggable="true"
+            :clearable="true"
+            :close-on-select="false"
+            placement="top"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/shell/edit/logging-flow/Match.vue
+++ b/shell/edit/logging-flow/Match.vue
@@ -53,19 +53,19 @@ export default {
   <div>
     <KeyValue
       v-model="value.labels"
-      :title="value.select ? 'Include Pods' : 'Exclude Pods'"
+      :title="value.select ? t('logging.flow.matches.pods.title.include') : t('logging.flow.matches.pods.title.exclude')"
       :mode="mode"
       :initial-empty-row="true"
       :read-allowed="false"
       :title-add="true"
       protip=""
-      key-label="Pod Label Key"
-      value-label="Pod Label Value"
-      add-label="Add Pod"
+      :key-label="t('logging.flow.matches.pods.keyLabel')"
+      :value-label="t('logging.flow.matches.pods.valueLabel')"
+      :add-label="t('logging.flow.matches.pods.addLabel')"
     />
     <div class="spacer" />
     <h3>
-      Limit to specific nodes
+      {{ value.select ? t('logging.flow.matches.nodes.title.include') : t('logging.flow.matches.nodes.title.exclude') }}
     </h3>
     <div class="row">
       <div class="col span-12">
@@ -73,7 +73,7 @@ export default {
           v-model="value.hosts"
           class="lg"
           :options="nodes"
-          placeholder="Default: Any node"
+          :placeholder="t('logging.flow.matches.nodes.placeholder')"
           :multiple="true"
           :searchable="true"
           :taggable="true"
@@ -85,7 +85,7 @@ export default {
     </div>
     <div class="spacer" />
     <h3>
-      Limit to specific container names
+      {{ value.select ? t('logging.flow.matches.containerNames.title.include') : t('logging.flow.matches.containerNames.title.exclude') }}
     </h3>
     <div class="row">
       <div class="col span-12">
@@ -93,7 +93,7 @@ export default {
           v-model="value.container_names"
           class="lg"
           :options="containers"
-          placeholder="Default: Any container"
+          :placeholder="t('logging.flow.matches.containerNames.placeholder')"
           :multiple="true"
           :taggable="true"
           :clearable="true"
@@ -103,9 +103,9 @@ export default {
       </div>
     </div>
     <div v-if="isClusterFlow">
-      <div class="spacer"></div>
+      <div class="spacer" />
       <h3>
-        Limit to specific namespaces
+        {{ value.select ? t('logging.flow.matches.namespaces.title.include') : t('logging.flow.matches.namespaces.title.exclude') }}
       </h3>
       <div class="row">
         <div class="col span-12">
@@ -113,7 +113,7 @@ export default {
             v-model="value.namespaces"
             class="lg"
             :options="namespaces"
-            placeholder="Default: Any namespace"
+            :placeholder="t('logging.flow.matches.namespaces.placeholder')"
             :multiple="true"
             :taggable="true"
             :clearable="true"

--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -6,7 +6,9 @@ import Loading from '@shell/components/Loading';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Tabbed from '@shell/components/Tabbed';
 import Tab from '@shell/components/Tabbed/Tab';
-import { LOGGING, NODE, POD, SCHEMA } from '@shell/config/types';
+import {
+  LOGGING, NAMESPACE, NODE, POD, SCHEMA
+} from '@shell/config/types';
 import jsyaml from 'js-yaml';
 import { createYaml } from '@shell/utils/create-yaml';
 import YamlEditor, { EDITOR_MODES } from '@shell/components/YamlEditor';
@@ -51,6 +53,7 @@ export default {
   async fetch() {
     const hasAccessToClusterOutputs = this.$store.getters[`cluster/schemaFor`](LOGGING.CLUSTER_OUTPUT);
     const hasAccessToOutputs = this.$store.getters[`cluster/schemaFor`](LOGGING.OUTPUT);
+    const hasAccessToNamespaces = this.$store.getters[`cluster/schemaFor`](NAMESPACE);
     const hasAccessToNodes = this.$store.getters[`cluster/schemaFor`](NODE);
     const hasAccessToPods = this.$store.getters[`cluster/schemaFor`](POD);
     const isFlow = this.value.type === LOGGING.FLOW;
@@ -62,6 +65,7 @@ export default {
     const hash = await allHash({
       allOutputs:        getAllOrDefault(LOGGING.OUTPUT, isFlow && hasAccessToOutputs),
       allClusterOutputs: getAllOrDefault(LOGGING.CLUSTER_OUTPUT, hasAccessToClusterOutputs),
+      allNamespaces:     getAllOrDefault(NAMESPACE, hasAccessToNamespaces),
       allNodes:          getAllOrDefault(NODE, hasAccessToNodes),
       allPods:           getAllOrDefault(POD, hasAccessToPods),
     });
@@ -113,6 +117,7 @@ export default {
       matches,
       allOutputs:         null,
       allClusterOutputs:  null,
+      allNamespaces:      null,
       allNodes:           null,
       allPods:            null,
       filtersYaml,
@@ -164,6 +169,22 @@ export default {
         .map((clusterOutput) => {
           return { label: clusterOutput.metadata.name, value: clusterOutput.metadata.name };
         });
+    },
+
+    namespaceChoices() {
+      if (!this.allNamespaces) {
+        // Handle the case where the user doesn't have permission
+        // to see namespaces
+        return [];
+      }
+      const out = this.allNamespaces.map((namespace) => {
+        return {
+          label: namespace.nameDisplay,
+          value: namespace.metadata.name
+        };
+      });
+
+      return out;
     },
 
     nodeChoices() {
@@ -362,8 +383,10 @@ export default {
               class="rule mb-20"
               :value="props.row.value"
               :mode="mode"
+              :namespaces="namespaceChoices"
               :nodes="nodeChoices"
               :containers="containerChoices"
+              :is-cluster-flow="value.type === LOGGING.CLUSTER_FLOW"
               @remove="e=>removeMatch(props.row.i)"
               @input="e=>updateMatch(e,props.row.i)"
             />

--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -370,7 +370,7 @@ export default {
         <Banner
           color="info"
           class="mt-0"
-          label="Configure which container logs will be pulled from"
+          :label="t('logging.flow.matches.banner')"
         />
         <ArrayListGrouped
           v-model="matches"
@@ -417,7 +417,7 @@ export default {
       >
         <Banner
           v-if="value.type !== LOGGING.CLUSTER_FLOW"
-          label="Output must reside in same namespace as the flow."
+          :label="t('logging.flow.outputs.sameNamespaceError')"
           color="info"
         />
         <LabeledSelect
@@ -480,7 +480,7 @@ export default {
   </CruResource>
   <Banner
     v-else
-    label="This resource contains a match configuration that the form editor does not support.  Please use YAML edit."
+    :label="t('logging.flow.matches.unsupportedConfig')"
     color="error"
   />
 </template>

--- a/shell/models/logging.banzaicloud.io.flow.js
+++ b/shell/models/logging.banzaicloud.io.flow.js
@@ -20,6 +20,10 @@ export function matchRuleIsPopulated(rule) {
     return true;
   }
 
+  if ( rule.namespaces?.length ) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
### Summary
This adds an additional namespaces selector to the match section of the logging ClusterFlow form.

See also https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/clusterflow_types/#clusterselect-namespaces

Fixes #6687

### Occurred changes and/or fixed issues
The additional field is only added for ClusterFlows and not for namespaces Flows. Flows don't have a namespaces selector.

### Technical notes summary
There was also a small styling issue in the Select fields on this page, which I fixed as well. Before:
![Bildschirmfoto 2022-08-18 um 12 14 20](https://user-images.githubusercontent.com/243056/185376190-62c1b1d1-03b7-4425-bd2a-a75fd8d7c283.png)

### Areas or cases that should be tested
Creating and editing ClusterFlows.

### Areas which could experience regressions
Creating and editing namespaced Flows.

### Screenshot/Video
![Bildschirmfoto 2022-08-18 um 12 13 45](https://user-images.githubusercontent.com/243056/185376155-448bcb6f-bf73-4fde-a3e5-afba342c4ee7.png)

