### PR TITLE
Prefer non-istio image when showing main image for a workload

### DIFF
--- a/shell/components/formatter/PodImages.vue
+++ b/shell/components/formatter/PodImages.vue
@@ -1,6 +1,10 @@
 <script>
 import { mapGetters } from 'vuex';
 
+// For the main image hat we show, use these to ignore istio proxy images so that
+// we are more likely to show the important main iamge and not the istio sidecar
+const IGNORE_IMAGES = ['istio/proxy', 'gcr.io/istio-release/proxy', 'mirrored-istio-proxy'];
+
 export default {
   props: {
     value: {
@@ -38,6 +42,12 @@ export default {
       }
 
       return null;
+    },
+    mainImage() {
+      const images = this.images;
+      const filter = images.filter(image => !IGNORE_IMAGES.find(i => image.includes(i)));
+
+      return filter.length > 0 ? filter[0] : images[0];
     }
   }
 
@@ -46,7 +56,7 @@ export default {
 
 <template>
   <span>
-    <span>{{ images[0] }}</span><br>
+    <span>{{ mainImage }}</span><br>
     <span
       v-if="images.length-1>0"
       v-tooltip.bottom="imageLabels"


### PR DESCRIPTION
Fixes #6293 

This PR tries to avoid showing the istio sidecar container image for a pod as the main image - so that it is more likely that the user sees the main pod rather than the istio one.

To test, you don't need to install Istio:

- Create a deployment with two containers, the first should use the image `istio/proxy` and the second `nginx`
- Before this PR you'll see that the istio image is shown as the main image
- After this PR you should see nginx as the main image show
- Verify that hovering over the image name still shows the list of all images
- Change the image of the first container to 'gcr.io/istio-release/proxy' and then 'rancher/mirrored-istio-proxy' and after doing so, verify that nginx is still shown as the main image

<img width="1380" alt="image" src="https://user-images.githubusercontent.com/1955897/185428144-6b6562d2-e9bf-4e82-93cf-87085e589b83.png">

