### PR TITLE
performance optimisation for load mutation on dashboard store

### DIFF
--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -51,16 +51,8 @@ export function load(state, { data, ctx, existing }) {
 
   let entry;
 
-  function replace(existing, data) {
-    data = getters.cleanResource(existing, data);
-
-    for ( const k of Object.keys(existing) ) {
-      delete existing[k];
-    }
-
-    for ( const k of Object.keys(data) ) {
-      Vue.set(existing, k, data[k]);
-    }
+  function replace(existing, data, list) {
+    Vue.set(list, list.findIndex(item => item.id === existing.id), data);
 
     return existing;
   }
@@ -68,7 +60,7 @@ export function load(state, { data, ctx, existing }) {
   if ( existing && !existing.id ) {
     // A specific proxy instance to used was passed in (for create -> save),
     // use it instead of making a new proxy
-    entry = replace(existing, data);
+    entry = classify(ctx, data);
     addObject(cache.list, entry);
     cache.map.set(id, entry);
     // console.log('### Mutation added from existing proxy', type, id);
@@ -77,7 +69,9 @@ export function load(state, { data, ctx, existing }) {
 
     if ( entry ) {
       // There's already an entry in the store, update it
-      replace(entry, data);
+      const newData = classify(ctx, data);
+
+      replace(entry, newData, cache.list);
       // console.log('### Mutation Updated', type, id);
     } else {
       // There's no entry, make a new proxy


### PR DESCRIPTION
- performance optimisation for load mutation on dashboard store, where we were applying `Vue.set` to each object property instead of applying it directly to the array

Test case:
- open two browser windows running rancher dashboard and go to `cronjob` list view
- create a new cronjob and make sure it appears on both browser windows
- edit a cronjob and make sure it's updated on both browser windows