### PR TITLE
Add feedback that kube config has been copied to clipboard

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1042,6 +1042,7 @@ cluster:
     harvester:
       label: Harvester
   copyConfig: Copy KubeConfig to Clipboard
+  copiedConfig: Copied KubeConfig to Clipboard
   custom:
     nodeRole:
       label: Node Role

--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -82,15 +82,17 @@ export default {
   <div class="growl-container" @mouseenter="mouseEnter" @mouseleave="mouseLeave">
     <div class="growl-list">
       <div v-for="growl in stack" :key="growl.id" :class="{'growl': true, ['bg-'+growl.color]: true}">
-        <i class="close hand icon icon-close" @click="close(growl)" />
-        <div class="growl-message">
+        <div class="growl-message" :class="{'growl-center': !growl.message}">
           <div class="icon-container">
             <i :class="{icon: true, ['icon-'+growl.icon]: true}" />
           </div>
           <div class="growl-text">
             <div>{{ growl.title }}</div>
-            <p>{{ growl.message }}</p>
+            <p v-if="growl.message">
+              {{ growl.message }}
+            </p>
           </div>
+          <i class="close hand icon icon-close" @click="close(growl)" />
         </div>
       </div>
     </div>
@@ -127,16 +129,20 @@ export default {
     word-break: break-all;
 
     .close {
-      position: absolute;
-      top: 0;
-      right: 0;
       padding: 5px;
       font-size: 24px;
     }
 
+    .icon-container {
+      align-self: center;
+    }
+
     .growl-message {
       display: flex;
-      align-items: center;
+
+      &.growl-center {
+        align-items: center;
+      }
     }
 
     .growl-text {
@@ -147,7 +153,10 @@ export default {
 
       > div {
         font-size: 16px;
-        margin-bottom: 5px;
+      }
+
+      > P {
+        margin-top: 5px;
       }
     }
 

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -476,8 +476,13 @@ export default class ProvCluster extends SteveModel {
     return this.mgmt?.generateKubeConfig();
   }
 
-  copyKubeConfig() {
-    return this.mgmt?.copyKubeConfig();
+  async copyKubeConfig() {
+    await this.mgmt?.copyKubeConfig();
+
+    this.$dispatch('growl/success', {
+      title:   this.t('cluster.copiedConfig'),
+      timeout: 3000,
+    }, { root: true });
   }
 
   downloadKubeConfig() {


### PR DESCRIPTION
Fixes #6623 

Adds a growl for the copy to clipboard for the kube config from the cluster management list.

This PR also tidies up the notification, so that when it does not have a message, it looks a bit nicer:

![image](https://user-images.githubusercontent.com/1955897/185459064-9cb00c16-0e94-41e2-9a67-8fcbaba119ee.png)

To test:

- Go to the cluster management page
- For any cluster, open the action menu from the three dots on the right
- Choose the 'Copy KubeConfig to Clipboard' option
- Verify that you see a notification like the one in the image above