### PR TITLE
prevent links prefetch on nuxt-link

### DIFF
--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -305,8 +305,9 @@ export default function(dir, _appConfig) {
     },
 
     router: {
-      base:       routerBasePath,
-      middleware: ['i18n'],
+      base:          routerBasePath,
+      middleware:    ['i18n'],
+      prefetchLinks: false
     },
 
     alias: {


### PR DESCRIPTION
Fixes #6697

- prevent links prefetch on `nuxt-link`

I did run some tests to see if content loaded quickly with the prefetch disabled (and comparing with it enabled)  on the home screen and on a local cluster explorer page, but for both I didn't notice any difference