### PR TITLE
allow for console.log and console.info to have correct traceability on dev mode

### DIFF
--- a/shell/plugins/console.js
+++ b/shell/plugins/console.js
@@ -1,12 +1,17 @@
 /* eslint-disable no-console */
-export default (context) => {
-  const logTypes = ['log', 'error', 'info', 'warn'];
+export default () => {
+  const logTypes = ['warn', 'error'];
   const MAX_LOGS_STORED = 400;
 
-  console.logLog = console.log.bind(console);
-  console.errorLog = console.error.bind(console);
-  console.infoLog = console.info.bind(console);
+  if (!process.env.dev) {
+    console.logLog = console.log.bind(console);
+    console.infoLog = console.info.bind(console);
+    logTypes.push('log');
+    logTypes.push('info');
+  }
+
   console.warnLog = console.warn.bind(console);
+  console.errorLog = console.error.bind(console);
   console.logs = [];
 
   logTypes.forEach((type) => {


### PR DESCRIPTION
Fixes #6699

- allow for `console.log` and `console.info` to have correct traceability on dev mode