### PR TITLE
Add logging output forms for OpenSearch and Redis

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2695,6 +2695,8 @@ logging:
       configuration: Configuration
   outputProviders:
     elasticsearch: Elasticsearch
+    opensearch: OpenSearch
+    redis: Redis
     splunkHec: Splunk
     kafka: Kafka
     forward: Fluentd

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2556,6 +2556,15 @@ logging:
     clientKeyPass: Client Key Pass from Secret
     verifySsl: Verify SSL
     sslVersion: SSL Version
+  redis:
+    host: Host
+    port: Port
+    dbNumber: Redis database number
+    ttl: TTL for each key
+    password: Password from Secret
+    format:
+      title: Format
+      type: Type
   gelf:
     host: Host
     port: Port

--- a/shell/edit/logging.banzaicloud.io.output/providers/opensearch.vue
+++ b/shell/edit/logging.banzaicloud.io.output/providers/opensearch.vue
@@ -192,15 +192,6 @@ export default {
       </div>
     </div>
     <div class="row mb-10">
-      <div class="col span-6">
-        <LabeledSelect
-          v-model="value.ssl_version"
-          :mode="mode"
-          :disabled="disabled"
-          :options="sslVersions"
-          :label="t('logging.elasticsearch.sslVersion')"
-        />
-      </div>
       <div class="col span-6 vertically-center">
         <Checkbox
           v-model="value.ssl_verify"

--- a/shell/edit/logging.banzaicloud.io.output/providers/opensearch.vue
+++ b/shell/edit/logging.banzaicloud.io.output/providers/opensearch.vue
@@ -1,0 +1,222 @@
+<script>
+import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import SecretSelector from '@shell/components/form/SecretSelector';
+import { Checkbox } from '@components/Form/Checkbox';
+import { _CREATE } from '@shell/config/query-params';
+import { updatePort, protocol, sslVersions } from './utils';
+
+export default {
+  components: {
+    LabeledInput, LabeledSelect, SecretSelector, Checkbox
+  },
+  props: {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+    namespace: {
+      type:     String,
+      required: true
+    }
+  },
+  data() {
+    if (this.mode === _CREATE) {
+      // Set default values only if no values are already
+      // present. This allows changes to default values to persist
+      // after navigating to YAML and back.
+
+      // Require SSL verification by default
+      if (typeof this.value.ssl_verify === 'undefined') {
+        this.$set(this.value, 'ssl_verify', true);
+      }
+
+      // Use the SSL version TLSv1_2 by default to match Ember
+      if (typeof this.value.ssl_version === 'undefined') {
+        this.$set(this.value, 'ssl_version', sslVersions[0]);
+      }
+    }
+
+    return { protocolOptions: protocol, sslVersions };
+  },
+  computed: {
+    port: {
+      get() {
+        return this.value.port;
+      },
+      set(port) {
+        updatePort(value => this.$set(this.value, 'port', value), port);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="opensearch">
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.target') }}</h3>
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-2">
+        <LabeledSelect
+          v-model="value.scheme"
+          :mode="mode"
+          :disabled="disabled"
+          class="scheme"
+          :options="protocolOptions"
+          :label="t('logging.elasticsearch.scheme')"
+        />
+      </div>
+      <div class="col span-8">
+        <LabeledInput
+          v-model="value.host"
+          :mode="mode"
+          :disabled="disabled"
+          class="host"
+          :label="t('logging.elasticsearch.host')"
+        />
+      </div>
+      <div class="col span-2">
+        <LabeledInput
+          v-model.number="port"
+          :mode="mode"
+          :disabled="disabled"
+          class="port"
+          type="number"
+          min="1"
+          max="65535"
+          :label="t('logging.elasticsearch.port')"
+        />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.index_name"
+          :mode="mode"
+          :disabled="disabled"
+          :label="t('logging.elasticsearch.indexName')"
+        />
+      </div>
+    </div>
+    <div class="spacer" />
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.access') }}</h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.user"
+          :mode="mode"
+          :disabled="disabled"
+          :label="t('logging.elasticsearch.user')"
+        />
+      </div>
+      <div class="col span-6">
+        <SecretSelector
+          v-model="value.password"
+          :secret-name-label="t('logging.elasticsearch.password')"
+          :mode="mode"
+          :namespace="namespace"
+          :disabled="disabled"
+          :show-key-selector="true"
+        />
+      </div>
+    </div>
+    <div class="spacer" />
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.certificate') }}</h3>
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <SecretSelector
+          v-model="value.ca_file"
+          mount-key="mountFrom"
+          :mode="mode"
+          :namespace="namespace"
+          :disabled="disabled"
+          :secret-name-label="t('logging.elasticsearch.caFile.label')"
+          :show-key-selector="true"
+        />
+      </div>
+      <div class="col span-6">
+        <SecretSelector
+          v-model="value.client_cert"
+          mount-key="mountFrom"
+          :mode="mode"
+          :namespace="namespace"
+          :disabled="disabled"
+          :secret-name-label="t('logging.elasticsearch.clientCert.label')"
+          :show-key-selector="true"
+        />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <SecretSelector
+          v-model="value.client_key"
+          mount-key="mountFrom"
+          :mode="mode"
+          :namespace="namespace"
+          :disabled="disabled"
+          :secret-name-label="t('logging.elasticsearch.clientKey.label')"
+          :show-key-selector="true"
+        />
+      </div>
+      <div class="col span-6">
+        <SecretSelector
+          v-model="value.client_key_pass"
+          :mode="mode"
+          :namespace="namespace"
+          :disabled="disabled"
+          :secret-name-label="t('logging.elasticsearch.clientKeyPass')"
+          :show-key-selector="true"
+        />
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.ssl_version"
+          :mode="mode"
+          :disabled="disabled"
+          :options="sslVersions"
+          :label="t('logging.elasticsearch.sslVersion')"
+        />
+      </div>
+      <div class="col span-6 vertically-center">
+        <Checkbox
+          v-model="value.ssl_verify"
+          :label="t('logging.elasticsearch.verifySsl')"
+          :disabled="disabled"
+          :mode="mode"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+<style>
+.row {
+  margin-bottom: 5px;
+}
+.vertically-center {
+  padding: 20px 0;
+}
+</style>

--- a/shell/edit/logging.banzaicloud.io.output/providers/redis.vue
+++ b/shell/edit/logging.banzaicloud.io.output/providers/redis.vue
@@ -1,0 +1,142 @@
+<script>
+import { LabeledInput } from '@components/Form/LabeledInput';
+import SecretSelector from '@shell/components/form/SecretSelector';
+import { updatePort } from './utils';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+
+export default {
+  components: {
+    LabeledInput, LabeledSelect, SecretSelector
+  },
+  props: {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+    namespace: {
+      type:     String,
+      required: true
+    }
+  },
+  data() {
+    const formatTypeOptions = ['json', 'out_file', 'ltsv', 'csv', 'msgpack', 'hash', 'single_value'];
+
+    this.$set(this.value, 'format', this.value.format || { type: formatTypeOptions[0] });
+
+    return { formatTypeOptions };
+  },
+  computed: {
+    port: {
+      get() {
+        return this.value.port;
+      },
+      set(port) {
+        updatePort(value => this.$set(this.value, 'port', value), port);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="opensearch">
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.target') }}</h3>
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-8">
+        <LabeledInput
+          v-model="value.host"
+          :mode="mode"
+          :disabled="disabled"
+          class="host"
+          :label="t('logging.redis.host')"
+        />
+      </div>
+      <div class="col span-2">
+        <LabeledInput
+          v-model.number="port"
+          :mode="mode"
+          :disabled="disabled"
+          class="port"
+          type="number"
+          min="1"
+          max="65535"
+          :label="t('logging.redis.port')"
+        />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <LabeledInput
+          v-model.number="value.db_number"
+          :mode="mode"
+          :disabled="disabled"
+          type="number"
+          :label="t('logging.redis.dbNumber')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model.number="value.ttl"
+          :mode="mode"
+          :disabled="disabled"
+          type="number"
+          :label="t('logging.redis.ttl')"
+        />
+      </div>
+    </div>
+    <div class="spacer" />
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.redis.format.title') }}</h3>
+      </div>
+    </div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.format.type"
+          :options="formatTypeOptions"
+          :mode="mode"
+          :disabled="disabled"
+          :label="t('logging.redis.format.type')"
+        />
+      </div>
+    </div>
+    <div class="spacer" />
+    <div class="row">
+      <div class="col span-6">
+        <h3>{{ t('logging.output.sections.access') }}</h3>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <SecretSelector
+          v-model="value.password"
+          :secret-name-label="t('logging.elasticsearch.password')"
+          :mode="mode"
+          :namespace="namespace"
+          :disabled="disabled"
+          :show-key-selector="true"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+<style>
+.row {
+  margin-bottom: 5px;
+}
+</style>

--- a/shell/models/logging.banzaicloud.io.output.js
+++ b/shell/models/logging.banzaicloud.io.output.js
@@ -77,6 +77,18 @@ export const PROVIDERS = [
     default:  { },
   },
   {
+    name:     'opensearch',
+    labelKey: 'logging.outputProviders.opensearch',
+    default:  {},
+  },
+  {
+    name:     'redis',
+    labelKey: 'logging.outputProviders.redis',
+    default:  {
+      port: 6379, db_number: 0, ttl: 0
+    },
+  },
+  {
     name:     'splunkHec',
     labelKey: 'logging.outputProviders.splunkHec',
     default:  {},


### PR DESCRIPTION
### Summary
This adds the new OpenSearch and Redis output plugins to the logging ClusterOutput and Output forms.

Fixes #6701
Fixes #6702

### Technical notes summary
The output plugins are available starting with rancher-logging 100.1.3+up3.17.7 in Rancher 2.6.7.

References for the output plugins:
https://banzaicloud.com/docs/one-eye/logging-operator/configuration/plugins/outputs/opensearch/
https://banzaicloud.com/docs/one-eye/logging-operator/configuration/plugins/outputs/redis/

### Areas or cases that should be tested
Output and ClusterOutput forms

### Screenshot/Video

![Bildschirmfoto 2022-08-18 um 14 51 54](https://user-images.githubusercontent.com/243056/185636393-3d2f0b11-d6d2-4775-8125-abe49b1c3a06.png)
![Bildschirmfoto 2022-08-18 um 15 24 31](https://user-images.githubusercontent.com/243056/185636399-eb77ec81-3e7d-43de-89db-98f0c1d3569b.png)
