### PR TITLE
Bump shell package version

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes PRs failing the plugin gate check.

Will need to fix a different way, but this will unblock things for now.