### PR TITLE
Fix application of branding, color and theme from settings

### DIFF
--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -12,16 +12,15 @@ export default {
         this.apps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP });
       }
     } catch (e) {}
+
+    this.globalSettings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.SETTING });
   },
 
   data() {
-    return { apps: [] };
+    return { apps: [], globalSettings: [] };
   },
 
   computed: {
-    globalSettings() {
-      return this.$store.getters['management/all'](MANAGEMENT.SETTING);
-    },
 
     brand() {
       const setting = findBy(this.globalSettings, 'id', SETTING.BRAND);


### PR DESCRIPTION
### Summary
Fixes #6704
### Occurred changes and/or fixed issues
- `mixins/brand.js` handle the application of some settings in watchers on them
- The watchers weren't triggering as they never changed from the initial value
- Caused by https://github.com/rancher/dashboard/commit/771f168a5b33f970f47bcefb272cfa199b3d10be
- Revert to the initial way. This may break epinio but that can be fixed later on

### Areas or cases that should be tested
Global Settings / Banners (all features)
Global Settings / Branding (all features)
Burger Menu --> Support --> Add a Sub ID  (custom colours should be removed, suse green colours should then be used by UI)
Note - Importantly the settings should apply after refreshing the browser