### PR TITLE
Handle rests of the state when moving between steps

### DIFF
--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -31,8 +31,8 @@ interface GitUrl {
 
 type GithubAPIData = {
   repos: any[],
-      branches: any[],
-      commits: any[]
+  branches: any[],
+  commits: any[]
 }
 export interface GitHub {
   usernameOrOrg?: string,

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -29,10 +29,18 @@ interface GitUrl {
   branch: string
 }
 
-interface GitHub {
+type GithubAPIData = {
+  repos: any[],
+      branches: any[],
+      commits: any[]
+}
+export interface GitHub {
   usernameOrOrg?: string,
-  url: string
+  repo: string,
   commit: string,
+  branch: string,
+  url: string,
+  sourceData: GithubAPIData
 }
 
 interface BuilderImage {
@@ -122,8 +130,15 @@ export default Vue.extend<Data, any, any, any>({
 
       github: {
         usernameOrOrg: this.source?.github.usernameOrOrg || '',
-        url:           this.source?.github.url || '',
+        repo:           this.source?.github.repo || '',
         commit:        this.source?.github.commit || '',
+        branch:        this.source?.github.branch || '',
+        url:           this.source?.github.url || '',
+        sourceData:    this.source?.github.sourceData || {
+          repos:    [],
+          branches: [],
+          commits:  []
+        }
       },
 
       builderImage: {
@@ -153,11 +168,12 @@ export default Vue.extend<Data, any, any, any>({
       APPLICATION_SOURCE_TYPE
     };
   },
-
   mounted() {
     if (!this.appChart) {
       Vue.set(this, 'appChart', this.appCharts[0].value);
     }
+
+    this.$emit('valid', false);
     this.update();
   },
 
@@ -280,20 +296,30 @@ export default Vue.extend<Data, any, any, any>({
 
       this.update();
     },
-    githubData({ repo, selectedAccOrOrg, commit }: {
-      commit: string,
+    githubData({
+      repo, selectedAccOrOrg, branch, commitSha, sourceData
+    }: {
+      commitSha: string,
       selectedAccOrOrg: string,
       repo: string,
+      branch: string,
+      sourceData: GithubAPIData
     }) {
-      const url = `https://github.com/${ selectedAccOrOrg }/${ repo }`;
+      if (!!selectedAccOrOrg && !!repo && !!commitSha && !!branch) {
+        const url = `https://github.com/${ selectedAccOrOrg }/${ repo }`;
 
-      if (url.length && selectedAccOrOrg.length) {
         this.github.usernameOrOrg = selectedAccOrOrg;
         this.github.url = url;
-        this.github.commit = commit;
+        this.github.commit = commitSha;
+        this.github.branch = branch;
+        this.github.repo = repo;
+        this.github.sourceData = sourceData;
 
         this.update();
         this.$emit('valid', true);
+      } else {
+        this.update();
+        this.$emit('valid', false);
       }
     }
   },
@@ -463,7 +489,9 @@ export default Vue.extend<Data, any, any, any>({
       </div>
     </template>
     <template v-else-if="type === APPLICATION_SOURCE_TYPE.GIT_HUB">
-      <GithubPicker @githubData="githubData" />
+      <KeepAlive>
+        <GithubPicker :selection="source.github" @githubData="githubData" />
+      </KeepAlive>
     </template>
     <Collapse :open.sync="open" :title="'Advanced Settings'" class="mt-30 mb-30 source">
       <template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  https://github.com/epinio/ui/issues/153
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Small state resets when navigating between steps.
The issue was,  once we send data with `$emit('githubData')`, the state & step inside parent component `AppSource` will be valid. to fix this, when we reset an input field we also emit the event with the current `githubData` so the parent component can re-validate the step.  Added the revalidation for when the `GithubPicker` is mounted (so its resets on the `back` button) and for each input event for each step in the Picker.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The mentioned issue explains how to reproduce it, now it should be fixed.

