### PR TITLE
Standalone script - allow refresh on dynamic pages

### DIFF
--- a/scripts/standalone/index.js
+++ b/scripts/standalone/index.js
@@ -67,6 +67,20 @@ for (const [key, value] of Object.entries(proxy)) {
 
 app.use(express.static(dist));
 
+// Catch reload on a dyanmic page
+// Check that the requestor will accept html and send them the index file
+app.use('*', (req, res, next) => {
+  const accept = req.headers.accept || '';
+  const acceptArray = accept.split(',');
+  const html = acceptArray.find(h => h.trim() === 'text/html');
+
+  if (html) {
+    return res.sendFile(path.join(dist, 'index.html'));
+  }
+
+  next();
+});
+
 const server = https.createServer(options, app);
 const appServer = server.listen(PORT);
 

--- a/scripts/standalone/index.js
+++ b/scripts/standalone/index.js
@@ -67,7 +67,7 @@ for (const [key, value] of Object.entries(proxy)) {
 
 app.use(express.static(dist));
 
-// Catch reload on a dyanmic page
+// Catch reload on a dynamic page
 // Check that the requestor will accept html and send them the index file
 app.use('*', (req, res, next) => {
   const accept = req.headers.accept || '';

--- a/scripts/standalone/package.sh
+++ b/scripts/standalone/package.sh
@@ -4,7 +4,7 @@ set -e
 DIR=$(cd $(dirname $0)/../..; pwd)
 
 # clean
-if [ $1 == "-c" ]; then
+if [ "$1" == "-c" ]; then
   echo "Cleaning .."
   rm -f dashboard.tar.gz
   rm -f dashboard.tar


### PR DESCRIPTION
Fixes the standalone script so that you can refresh on a dynamic route.

Also fixes a small bug in the publish script that leads to an error message.