### PR TITLE
Make `ToggleSwitch` state react to changes from parent

### DIFF
--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -36,7 +36,7 @@ describe('ToggleSwitch.vue', () => {
     expect(toggleInput.checked).toBe(true);
   });
 
-  it('emits an input event with default values when clicked', async () => {
+  it('emits an input event with a true value', async () => {
     const wrapper = shallowMount(ToggleSwitch);
 
     (wrapper.vm as any).toggle(true);
@@ -47,25 +47,35 @@ describe('ToggleSwitch.vue', () => {
     expect(wrapper.emitted().input?.length).toBe(1);
     expect(wrapper.emitted().input?.[0][0]).toBe(true);
 
+  });
+
+  it('emits an input event with a false value', async () => {
+    const wrapper = shallowMount(
+      ToggleSwitch,
+      {
+        propsData: {
+          value: true
+        }
+      }
+    );
+
     (wrapper.vm as any).toggle(false);
 
     await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted('input')).toBeTruthy();
-    expect(wrapper.emitted().input?.length).toBe(2);
-    expect(wrapper.emitted().input?.[1][0]).toBe(false);
-  });
+    expect(wrapper.emitted().input?.length).toBe(1);
+    expect(wrapper.emitted().input?.[0][0]).toBe(false);
+  })
 
-  it('emits an input event with custom values when clicked', async () => {
+  it('emits an input event with a custom onValue', async () => {
     const onValue = 'THE TRUTH';
-    const offValue = 'NOT THE TRUTH';
 
     const wrapper = shallowMount(
       ToggleSwitch,
       {
         propsData: {
           onValue,
-          offValue,
         }
       });
 
@@ -76,13 +86,26 @@ describe('ToggleSwitch.vue', () => {
     expect(wrapper.emitted().input).toBeTruthy()
     expect(wrapper.emitted().input?.length).toBe(1);
     expect(wrapper.emitted().input?.[0][0]).toBe(onValue);
+  });
+
+  it('emits an input event with a custom offValue', async () => {
+    const offValue = 'NOT THE TRUTH';
+
+    const wrapper = shallowMount(
+      ToggleSwitch,
+      {
+        propsData: {
+          value: true,
+          offValue,
+        }
+      });
 
     (wrapper.vm as any).toggle(false);
 
     await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted('input')).toBeTruthy();
-    expect(wrapper.emitted().input?.length).toBe(2);
-    expect(wrapper.emitted().input?.[1][0]).toBe(offValue);
-  });
+    expect(wrapper.emitted().input?.length).toBe(1);
+    expect(wrapper.emitted().input?.[0][0]).toBe(offValue);
+  })
 });

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -10,7 +10,7 @@ describe('ToggleSwitch.vue', () => {
     expect(toggleInput.checked).toBeFalsy();
   });
 
-  it('renders truthy', () => {
+  it('renders a true value', () => {
     const wrapper = shallowMount(
       ToggleSwitch,
       {
@@ -21,7 +21,7 @@ describe('ToggleSwitch.vue', () => {
 
     const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
 
-    expect(toggleInput.checked).toBeTruthy();
+    expect(toggleInput.checked).toBe(true);
   });
 
   it('updates from falsy to truthy when props change', async () => {
@@ -29,11 +29,11 @@ describe('ToggleSwitch.vue', () => {
   
     const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
 
-    expect(toggleInput.checked).toBeFalsy();
+    expect(toggleInput.checked).toBe(false);
 
     await wrapper.setProps({ value: true });
   
-    expect(toggleInput.checked).toBeTruthy();
+    expect(toggleInput.checked).toBe(true);
   });
 
   it('emits an input event with default values when clicked', async () => {

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -1,0 +1,89 @@
+import { shallowMount, ThisTypedShallowMountOptions } from '@vue/test-utils';
+import { ToggleSwitch } from './index';
+
+const createWrapper = (options?: ThisTypedShallowMountOptions<Vue> | undefined) => shallowMount(ToggleSwitch, options);
+
+describe('ToggleSwitch.vue', () => {
+  it('renders falsy by default', () => {
+    const wrapper = createWrapper();
+
+    const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
+
+    expect(toggleInput.checked).toBeFalsy();
+  });
+
+  it('renders truthy', () => {
+    const wrapper = createWrapper(
+      {
+        propsData: {
+          value: true
+        }
+      });
+
+    const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
+
+    expect(toggleInput.checked).toBeTruthy();
+  });
+
+  it('updates from falsy to truthy when props change', async () => {
+    const wrapper = createWrapper();
+  
+    const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
+
+    expect(toggleInput.checked).toBeFalsy();
+
+    await wrapper.setProps({ value: true });
+  
+    expect(toggleInput.checked).toBeTruthy();
+  });
+
+  it('emits an input event with default values when clicked', async () => {
+    const wrapper = createWrapper();
+
+    (wrapper.vm as any).toggle(true);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted().input).toBeTruthy()
+    expect(wrapper.emitted().input?.length).toBe(1);
+    expect(wrapper.emitted().input?.[0][0]).toBe(true);
+
+    (wrapper.vm as any).toggle(false);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('input')).toBeTruthy();
+    expect(wrapper.emitted().input?.length).toBe(2);
+    expect(wrapper.emitted().input?.[1][0]).toBe(false);
+  });
+
+  it('emits an input event with custom values when clicked', async () => {
+    const onValue = 'THE TRUTH';
+    const offValue = 'NOT THE TRUTH';
+
+    const wrapper = createWrapper(
+      {
+        propsData: {
+          onValue,
+          offValue,
+        }
+      });
+
+    (wrapper.vm as any).toggle(true);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted().input).toBeTruthy()
+    expect(wrapper.emitted().input?.length).toBe(1);
+    expect(wrapper.emitted().input?.[0][0]).toBe(onValue);
+
+    (wrapper.vm as any).toggle(false);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('input')).toBeTruthy();
+    expect(wrapper.emitted().input?.length).toBe(2);
+    expect(wrapper.emitted().input?.[1][0]).toBe(offValue);
+  });
+});
+

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -43,7 +43,6 @@ describe('ToggleSwitch.vue', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted().input).toBeTruthy()
     expect(wrapper.emitted().input?.length).toBe(1);
     expect(wrapper.emitted().input?.[0][0]).toBe(true);
 
@@ -63,7 +62,6 @@ describe('ToggleSwitch.vue', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('input')).toBeTruthy();
     expect(wrapper.emitted().input?.length).toBe(1);
     expect(wrapper.emitted().input?.[0][0]).toBe(false);
   })
@@ -83,7 +81,6 @@ describe('ToggleSwitch.vue', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted().input).toBeTruthy()
     expect(wrapper.emitted().input?.length).toBe(1);
     expect(wrapper.emitted().input?.[0][0]).toBe(onValue);
   });
@@ -104,7 +101,6 @@ describe('ToggleSwitch.vue', () => {
 
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('input')).toBeTruthy();
     expect(wrapper.emitted().input?.length).toBe(1);
     expect(wrapper.emitted().input?.[0][0]).toBe(offValue);
   })

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -86,4 +86,3 @@ describe('ToggleSwitch.vue', () => {
     expect(wrapper.emitted().input?.[1][0]).toBe(offValue);
   });
 });
-

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -1,11 +1,9 @@
-import { shallowMount, ThisTypedShallowMountOptions } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { ToggleSwitch } from './index';
-
-const createWrapper = (options?: ThisTypedShallowMountOptions<Vue> | undefined) => shallowMount(ToggleSwitch, options);
 
 describe('ToggleSwitch.vue', () => {
   it('renders falsy by default', () => {
-    const wrapper = createWrapper();
+    const wrapper = shallowMount(ToggleSwitch);
 
     const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
 
@@ -13,7 +11,8 @@ describe('ToggleSwitch.vue', () => {
   });
 
   it('renders truthy', () => {
-    const wrapper = createWrapper(
+    const wrapper = shallowMount(
+      ToggleSwitch,
       {
         propsData: {
           value: true
@@ -26,7 +25,7 @@ describe('ToggleSwitch.vue', () => {
   });
 
   it('updates from falsy to truthy when props change', async () => {
-    const wrapper = createWrapper();
+    const wrapper = shallowMount(ToggleSwitch);
   
     const toggleInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement
 
@@ -38,7 +37,7 @@ describe('ToggleSwitch.vue', () => {
   });
 
   it('emits an input event with default values when clicked', async () => {
-    const wrapper = createWrapper();
+    const wrapper = shallowMount(ToggleSwitch);
 
     (wrapper.vm as any).toggle(true);
 
@@ -61,7 +60,8 @@ describe('ToggleSwitch.vue', () => {
     const onValue = 'THE TRUTH';
     const offValue = 'NOT THE TRUTH';
 
-    const wrapper = createWrapper(
+    const wrapper = shallowMount(
+      ToggleSwitch,
       {
         propsData: {
           onValue,

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
@@ -1,18 +1,19 @@
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+export default Vue.extend({
   props: {
     value: {
-      type:    null,
+      type:    [Boolean, String, Number],
       default: false
     },
 
     offValue: {
-      type:    null,
+      type:    [Boolean, String, Number],
       default: false,
     },
 
     onValue: {
-      type:    null,
+      type:    [Boolean, String, Number],
       default: true,
     },
 
@@ -27,11 +28,11 @@ export default {
     },
   },
   data() {
-    return { state: false };
+    return { state: false as boolean | string | number };
   },
 
   methods: {
-    toggle(neu) {
+    toggle(neu: boolean | string | number) {
       this.state = neu === null ? !this.state : neu;
       this.$emit('input', this.state ? this.onValue : this.offValue);
     }
@@ -45,7 +46,7 @@ export default {
       immediate: true
     }
   }
-};
+});
 </script>
 
 <template>

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
@@ -27,13 +27,22 @@ export default {
     },
   },
   data() {
-    return { state: this.value === this.onValue };
+    return { state: false };
   },
 
   methods: {
     toggle(neu) {
       this.state = neu === null ? !this.state : neu;
       this.$emit('input', this.state ? this.onValue : this.offValue);
+    }
+  },
+
+  watch: {
+    value: {
+      handler() {
+        this.state = this.value === this.onValue;
+      },
+      immediate: true
     }
   }
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds a watch to the `value` prop so that changes will be reflected locally in the `state` data prop when changes come through.

The current behavior subverts expectations by only using the `value` prop to set an initial value. This pattern of managing state internally doesn't align with how I would expect a base component to behave.  

Fixes #6741 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

* Makes `value` prop reactive
* Adds unit tests for `ToggleSwitch`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

`provisioning.cattle.io.cluster` makes use of the toggle switch for switching between RKE and RKE2. Behavior on this page should not regress. 
