### PR TITLE
Shows fetched value for the default builder

### DIFF
--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -67,7 +67,7 @@ interface FileWithRelativePath extends File {
    readonly webkitRelativePath: string;
 }
 
-const DEFAULT_BUILD_PACK = 'paketobuildpacks/builder:full';
+const DEFAULT_BUILD_PACK = 'paketobuildpacks/builder:test';
 
 // Data, Methods, Computed, Props
 export default Vue.extend<Data, any, any, any>({
@@ -98,9 +98,11 @@ export default Vue.extend<Data, any, any, any>({
   async created() {
     const res = await this.$store.dispatch(`epinio/request`, { opt: { url: `/api/v1/info` } });
 
-    this.defaultBuilderImage = res.default_builder_image;
     if (res.default_builder_image) {
+      this.defaultBuilderImage = res.default_builder_image;
       this.builderImage.value = res.default_builder_image;
+    } else {
+      this.builderImage.value = DEFAULT_BUILD_PACK;
     }
   },
   data() {

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -95,10 +95,18 @@ export default Vue.extend<Data, any, any, any>({
       required: true
     },
   },
+  async created() {
+    const res = await this.$store.dispatch(`epinio/request`, { opt: { url: `/api/v1/info` } });
 
+    this.defaultBuilderImage = res.default_builder_image;
+    if (res.default_builder_image) {
+      this.builderImage.value = res.default_builder_image;
+    }
+  },
   data() {
     return {
-      open: false,
+      open:                false,
+      defaultBuilderImage: undefined,
 
       archive: {
         tarball:             this.source?.archive.tarball || '',
@@ -120,7 +128,7 @@ export default Vue.extend<Data, any, any, any>({
 
       builderImage: {
         value:   this.source?.builderImage?.value || DEFAULT_BUILD_PACK,
-        default: this.source?.builderImage?.default !== undefined ? this.source.builderImage.default : true,
+        default: this.defaultBuilderImage !== undefined ? this.source.builderImage.default : true,
       },
 
       appChart: this.source?.appChart,
@@ -265,7 +273,7 @@ export default Vue.extend<Data, any, any, any>({
 
     onImageType(defaultImage: boolean) {
       if (defaultImage) {
-        this.builderImage.value = DEFAULT_BUILD_PACK;
+        this.builderImage.value = this.defaultBuilderImage;
       }
 
       this.builderImage.default = defaultImage;
@@ -456,7 +464,7 @@ export default Vue.extend<Data, any, any, any>({
     <template v-else-if="type === APPLICATION_SOURCE_TYPE.GIT_HUB">
       <GithubPicker @githubData="githubData" />
     </template>
-    <Collapse :open.sync="open" :title="'Advanced Settings'" class="mt-30 mb-30 source">
+    <Collapse v-if="defaultBuilderImage" :open.sync="open" :title="'Advanced Settings'" class="mt-30 mb-30 source">
       <template>
         <LabeledSelect
           v-model="appChart"

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -67,7 +67,7 @@ interface FileWithRelativePath extends File {
    readonly webkitRelativePath: string;
 }
 
-const DEFAULT_BUILD_PACK = 'paketobuildpacks/builder:test';
+const DEFAULT_BUILD_PACK = 'paketobuildpacks/builder:full';
 
 // Data, Methods, Computed, Props
 export default Vue.extend<Data, any, any, any>({

--- a/pkg/epinio/types.ts
+++ b/pkg/epinio/types.ts
@@ -135,3 +135,10 @@ export interface EpinioServiceResource {
 }
 
 export type EpinioService = EpinioServiceResource & EpinioServiceModel & EpinioMetaProperty;
+
+export interface EpinioInfo {
+  default_builder_image: string, // eslint-disable-line camelcase
+  kube_version: string, // eslint-disable-line camelcase
+  platform: string, // eslint-disable-line camelcase
+  version: string, // eslint-disable-line camelcase
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/epinio/ui/issues/154
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
1. We now fetch the default paketo packager from the `/info` endpoint instead of hardcoding it.
2. There was an issue where if you manually set another package, it would not respect it and it will use the default value.


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. From the UI, create a new Application from git (`https://github.com/scures/epinio-sample-app` and `master` branch is a good example). 
2. In advance settings for the paketo image, select custom and type `paketobuildpacks/builder:tiny`
3. Follow the rest of the steps.

This app won't deploy with the tiny version, it's fine. We need to validate that the package used for the build was actually the `builder:tiny` and not `builder:full`. To do so, one handy command would be:
`kubectl  get apps.application.epinio.io -n {{NAMESPACE}} {{APP_NAME}} -o yaml`
The outcome should look as:

```
spec:
  // .......
  builderimage: paketobuildpacks/builder:tiny
  // .......
```