### PR TITLE
Update @rancher/components github action 

### DIFF
--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -8,16 +8,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
+        scope: '@rancher'
 
     - name: Install
       run: yarn install --frozen-lockfile

--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -2,7 +2,7 @@
   "name": "@rancher/components",
   "repository": "git://github.com:rancher/dashboard.git",
   "license": "Apache-2.0",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "module": "./main.js",
   "main": "./dist/@rancher/components.umd.min.js",
   "files": [


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes an issue with npm authenticating before publishing @rancher/components by updating the github action to more closely resemble examples provided by github docs. 

I have tested this release in my fork and it appears to be working so I've bumped the version number so that we could test in the `rancher/dashboard` repo after merging.

* https://github.com/rancher/dashboard/runs/7959900154?check_suite_focus=true
* https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages