### PR TITLE
RKE2 Cluster provisioning on Harvester: Make image form field editable

### DIFF
--- a/shell/machine-config/harvester.vue
+++ b/shell/machine-config/harvester.vue
@@ -470,7 +470,7 @@ export default {
             :options="imageOptions"
             :required="true"
             :searchable="true"
-            :disabled="disabledEdit"
+            :disabled="disabled"
             label-key="cluster.credential.harvester.image"
             :placeholder="t('cluster.harvester.machinePool.image.placeholder')"
             @on-open="onOpen"


### PR DESCRIPTION
### Summary
Fixes #6764

### Occurred changes and/or fixed issues
The image form field of a harvester machine pool is now editable.

### Areas or cases that should be tested
Editing the image of an RKE2 cluster that was provisioned from Rancher on Harvester.
