### PR TITLE
Change machine config unhealthyNodeTimeoutInteger (autoReplace) unit to seconds

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1545,7 +1545,7 @@ cluster:
     autoReplace:
       label: Auto Replace
       toolTip: If greater than 0, nodes that are unreachable for this duration will be automatically deleted and replaced.
-      unit: "Minutes"
+      unit: "Seconds"
   managementTimeout: The cluster to become available. It's possible the cluster was created. We suggest checking the clusters page before trying to create another.
   memberRoles:
     removeMessage: 'Note: Removing a user will not remove their project permissions'

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -210,7 +210,7 @@ export default {
             :mode="mode"
             :output-modifier="true"
             :base-unit="t('cluster.machinePool.autoReplace.unit')"
-            @input="value.pool.unhealthyNodeTimeout = `${unhealthyNodeTimeoutInteger}m`"
+            @input="value.pool.unhealthyNodeTimeout = `${unhealthyNodeTimeoutInteger}s`"
           />
         </div>
         <div class="col span-4">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6275 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This changes the placeholder and input unit for the autoReplace field for an rke2 machine config.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
rke2 creating/upgrading should be tested.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
***Input***
![auto-replace](https://user-images.githubusercontent.com/40806497/187443656-20a59a21-ae55-403a-95b7-4d7b85897710.png)


***yaml***
![autoreplaceyaml](https://user-images.githubusercontent.com/40806497/187443770-9fa0433a-4bf9-4a45-94d3-29a40106d300.png)


