### PR TITLE
Restore builtin role actions - disable rules for builtin roles

### DIFF
--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -146,7 +146,6 @@ export default {
   },
 
   computed: {
-
     label() {
       return this.t(`rbac.roletemplate.subtypes.${ this.value.subtype }.label`);
     },
@@ -299,6 +298,9 @@ export default {
     },
     isDetail() {
       return this.as === _DETAIL;
+    },
+    isBuiltin() {
+      return this.value.builtin;
     },
     doneLocationOverride() {
       return this.value.listLocation;
@@ -576,6 +578,9 @@ export default {
           <ArrayList
             v-model="value.rules"
             label="Resources"
+            :disabled="isBuiltin"
+            :remove-allowed="!isBuiltin"
+            :add-allowed="!isBuiltin"
             :default-add-value="defaultRule"
             :initial-empty-row="true"
             :show-header="true"
@@ -612,6 +617,7 @@ export default {
                   <Select
                     :value="props.row.value.verbs"
                     class="lg"
+                    :disabled="isBuiltin"
                     :taggable="true"
                     :searchable="true"
                     :options="verbOptions"
@@ -623,6 +629,7 @@ export default {
                 <div :class="ruleClass">
                   <Select
                     :value="getRule('resources', props.row.value)"
+                    :disabled="isBuiltin"
                     :options="resourceOptions"
                     :searchable="true"
                     :taggable="true"
@@ -634,6 +641,7 @@ export default {
                 <div :class="ruleClass">
                   <LabeledInput
                     :value="getRule('apiGroups', props.row.value)"
+                    :disabled="isBuiltin"
                     :mode="mode"
                     @input="setRule('apiGroups', props.row.value, $event)"
                   />
@@ -641,6 +649,7 @@ export default {
                 <div v-if="!isNamespaced" :class="ruleClass">
                   <LabeledInput
                     :value="getRule('nonResourceURLs', props.row.value)"
+                    :disabled="isBuiltin"
                     :mode="mode"
                     @input="setRule('nonResourceURLs', props.row.value, $event)"
                   />
@@ -657,6 +666,9 @@ export default {
         >
           <ArrayList
             v-model="value.roleTemplateNames"
+            :disabled="isBuiltin"
+            :remove-allowed="!isBuiltin"
+            :add-allowed="!isBuiltin"
             label="Resources"
             add-label="Add Resource"
             :mode="mode"
@@ -668,6 +680,7 @@ export default {
                     v-model="props.row.value"
                     class="lg"
                     :taggable="false"
+                    :disabled="isBuiltin"
                     :searchable="true"
                     :options="templateOptions"
                     option-key="value"

--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -14,25 +14,6 @@ const SPECIAL = [BASE, ADMIN, USER];
 const GLOBAL = SUBTYPE_MAPPING.GLOBAL.key;
 
 export default class GlobalRole extends SteveModel {
-  get availableActions() {
-    const out = super._availableActions;
-
-    const toFilter = ['goToEdit', 'promptRemove'];
-    const editActions = out.filter((a) => {
-      if ( toFilter.includes(a.action) ) {
-        return a;
-      }
-    });
-
-    if ( editActions.length > 0 ) {
-      editActions.forEach((a) => {
-        a.enabled = !this.builtin;
-      });
-    }
-
-    return out;
-  }
-
   get customValidationRules() {
     return Role.customValidationRules();
   }

--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -56,25 +56,6 @@ export const VERBS = [
 ];
 
 export default class RoleTemplate extends SteveDescriptionModel {
-  get availableActions() {
-    const out = super._availableActions;
-
-    const toFilter = ['goToEdit', 'promptRemove'];
-    const editActions = out.filter((a) => {
-      if ( toFilter.includes(a.action) ) {
-        return a;
-      }
-    });
-
-    if ( editActions.length > 0 ) {
-      editActions.forEach((a) => {
-        a.enabled = !this.builtin;
-      });
-    }
-
-    return out;
-  }
-
   get customValidationRules() {
     return Role.customValidationRules();
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6737 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This will restore the Edit Config action for all builtin role templates and will instead disable the inputs which govern the rules for those templates. The original PR #6429 removed the ability to edit the config of role templates, which in consequence removed the ability to change the `Locked` and `Default` fields for Global, Cluster, and Project/Namespace Roles that were builtin with Rancher.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Removed the `availableActions` conditional from both `management.cattle.io.globalrole` and `management.cattle.io.roletemplate` models.
Added a computed property to check for `builtin: true` on the resource, and disabling the inputs for rules. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
These Role types should be tested:
1. Global Roles
2. Cluster Roles
3. Project/Namespace Roles

For each Role type, a builtin and non-builtin role should be checked.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://user-images.githubusercontent.com/40806497/187476289-8596cd02-a50d-494c-b605-ebead12b3d42.mp4

