### PR TITLE
Checkbox to accept strings for valueWhenTrue - ec2 httpEndpoint, httpTokens to string values

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
@@ -2,11 +2,11 @@ import { shallowMount } from '@vue/test-utils';
 import { Checkbox } from './index';
 
 describe('Checkbox.vue', () => {
-  it('renders falsy by default', () => {
+  it('is unchecked by default', () => {
     const wrapper = shallowMount(Checkbox);
     const cbInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement;
 
-    expect(cbInput.checked).toBeFalsy();
+    expect(cbInput.checked).toBe(false);
   });
 
   it('renders a true value', () => {
@@ -56,7 +56,7 @@ describe('Checkbox.vue', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted().input?.length).toBe(1);
-    expect(wrapper.emitted().input?.[0][0]).toBeTruthy();
+    expect(wrapper.emitted().input?.[0][0]).toBe(valueWhenTrue);
   });
 
   it('updates from valueWhenTrue to falsy', async () => {
@@ -72,6 +72,6 @@ describe('Checkbox.vue', () => {
     (wrapper.vm as any).clicked(event);
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted().input?.[0][0]).toBeFalsy();
+    expect(wrapper.emitted().input?.[0][0]).toBe(null);
   })
 });

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
@@ -1,0 +1,77 @@
+import { shallowMount } from '@vue/test-utils';
+import { Checkbox } from './index';
+
+describe('Checkbox.vue', () => {
+  it('renders falsy by default', () => {
+    const wrapper = shallowMount(Checkbox);
+    const cbInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement;
+
+    expect(cbInput.checked).toBeFalsy();
+  });
+
+  it('renders a true value', () => {
+    const wrapper = shallowMount(Checkbox, { propsData: { value: true } });
+    const cbInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement;
+
+    expect(cbInput.checked).toBe(true);
+  });
+
+  it('updates from false to true when props change', async () => {
+    const wrapper = shallowMount(Checkbox);
+    const cbInput = wrapper.find('input[type="checkbox"]').element as HTMLInputElement;
+
+    expect(cbInput.checked).toBe(false);
+
+    await wrapper.setProps({ value: true });
+
+    expect(cbInput.checked).toBe(true);
+  });
+
+  it('emits an input event with a true value', async () => {
+    const wrapper = shallowMount(Checkbox);
+    const event = {
+      target: { tagName: 'input', href: null },
+      stopPropagation: () => { },
+      preventDefault: () => { }
+    };
+
+    (wrapper.vm as any).clicked(event);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted().input?.length).toBe(1);
+    expect(wrapper.emitted().input?.[0][0]).toBe(true);
+  });
+
+  it('emits an input event with a custom valueWhenTrue', async () => {
+    const valueWhenTrue = 'BIG IF TRUE';
+    const event = {
+      target: { tagName: 'input', href: null },
+      stopPropagation: () => { },
+      preventDefault: () => { }
+    };
+
+    const wrapper = shallowMount(Checkbox, { propsData: { value: false, valueWhenTrue } });
+
+    (wrapper.vm as any).clicked(event);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted().input?.length).toBe(1);
+    expect(wrapper.emitted().input?.[0][0]).toBeTruthy();
+  });
+
+  it('updates from valueWhenTrue to falsy', async () => {
+    const valueWhenTrue = 'REAL HUGE IF FALSE';
+    const event = {
+      target: { tagName: 'input', href: null },
+      stopPropagation: () => { },
+      preventDefault: () => { }
+    };
+
+    const wrapper = shallowMount(Checkbox, { propsData: { value: valueWhenTrue, valueWhenTrue } });
+
+    (wrapper.vm as any).clicked(event);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted().input?.[0][0]).toBeFalsy();
+  })
+});

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -9,7 +9,7 @@ export default Vue.extend({
      * The checkbox value.
      */
     value: {
-      type:    [Boolean, Array] as PropType<boolean | boolean[]>,
+      type:    [Boolean, Array, String] as PropType<boolean | boolean[] | string>,
       default: false
     },
 
@@ -169,6 +169,12 @@ export default Vue.extend({
           addObject(this.value, this.valueWhenTrue);
         }
         this.$emit('input', this.value);
+      } else if (this.isString(this.valueWhenTrue)) {
+        if (this.isChecked) {
+          this.$emit('input', undefined);
+        } else {
+          this.$emit('input', this.valueWhenTrue);
+        }
       } else {
         this.$emit('input', !this.value);
         this.$el.dispatchEvent(click);
@@ -178,8 +184,12 @@ export default Vue.extend({
     /**
      * Determines if there are multiple values for the checkbox.
      */
-    isMulti(value: boolean | boolean[]): value is boolean[] {
+    isMulti(value: boolean | boolean[] | string): value is boolean[] {
       return Array.isArray(value);
+    },
+
+    isString(value: boolean | number | string): value is boolean {
+      return typeof value === 'string';
     },
 
     /**

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -171,7 +171,7 @@ export default Vue.extend({
         this.$emit('input', this.value);
       } else if (this.isString(this.valueWhenTrue)) {
         if (this.isChecked) {
-          this.$emit('input', undefined);
+          this.$emit('input', null);
         } else {
           this.$emit('input', this.valueWhenTrue);
         }

--- a/shell/machine-config/amazonec2.vue
+++ b/shell/machine-config/amazonec2.vue
@@ -632,6 +632,7 @@ export default {
               <div>
                 <Checkbox
                   v-model="value.httpEndpoint"
+                  value-when-true="enabled"
                   :mode="mode"
                   :disabled="disabled"
                   :label="t('cluster.machineConfig.amazonEc2.httpEndpoint')"
@@ -640,6 +641,7 @@ export default {
               <div>
                 <Checkbox
                   v-model="value.httpTokens"
+                  value-when-true="required"
                   :mode="mode"
                   :disabled="!value.httpEndpoint || disabled"
                   :label="t('cluster.machineConfig.amazonEc2.httpTokens')"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6573 
<!-- Define findings related to the feature or bug issue. -->
This will change the `Checkbox` component to accept strings for the `valueWhenTrue` property, and converts ec2 `httpEndpoint` and `httpTokens` checkboxes to string values.

According to [the spec](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html) of an ec2 instance, `httpEndpoint` can have a value of `enabled` or `disabled`, and `httpTokens` can have a value of `required` or `optional`. In our case, if the checkbox for either is unchecked the value with return to `undefined`.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
In order to supply a string for each value the `Checkbox` component needed some logic to allow this behavior, along with the added `valueWhenTrue` prop.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
`Checkbox` will now accept a string as the value when passed the `valueWhenTrue` prop. If a checkbox is unchecked it will revert the value to `undefined`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Steps for testing are in the issue listed above
- Other areas where the Checkbox component is used

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
There are only two other instances which the `valueWhenTrue` is used:
- https://github.com/rancher/dashboard/blob/master/shell/edit/provisioning.cattle.io.cluster/rke2.vue#L1791
- https://github.com/rancher/dashboard/blob/master/shell/components/GlobalRoleBindings.vue#L317

Where these two files are being used should be tested as well.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->