### PR TITLE
Fix undefined currentCluster for cluster templates

### DIFF
--- a/shell/models/chart.js
+++ b/shell/models/chart.js
@@ -10,7 +10,7 @@ export default class Chart extends SteveModel {
     let version;
     const chartVersions = this.versions;
     const currentCluster = this.$rootGetters['currentCluster'];
-    const workerOSs = currentCluster.workerOSs;
+    const workerOSs = currentCluster?.workerOSs;
     const compatibleVersions = compatibleVersionsFor(this, workerOSs);
 
     if (compatibleVersions.length) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6195 
<!-- Define findings related to the feature or bug issue. -->
If the `currentCluster` was not already in the store a custom cluster template could not be loaded.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This was a simple fix with a conditional added to return `null` rather than `undefined` for the `currentCluster`, which will allow the cluster template to be loaded with a "blank" cluster in it's place.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Added an optional chaining operator to return `null` for the `currentCluster.workerOSs` property.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Steps to test are in the issue listed above

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://user-images.githubusercontent.com/40806497/187704268-72ceeb62-5aab-44ed-8c82-b9397f8b2167.mp4

