### PR TITLE
Fix update of side nav given changes to counts and schemas

### DIFF
--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -98,7 +98,7 @@ export default {
     },
 
     allSchemas() {
-      const managementReady = this.$store.getters['managementReady'];
+      const managementReady = this.managementReady;
       const product = this.$store.getters['currentProduct'];
 
       if ( !managementReady || !product ) {
@@ -117,7 +117,7 @@ export default {
     },
 
     counts() {
-      const managementReady = this.$store.getters['managementReady'];
+      const managementReady = this.managementReady;
       const product = this.$store.getters['currentProduct'];
 
       if ( !managementReady || !product ) {
@@ -179,20 +179,28 @@ export default {
   },
 
   watch: {
-    counts() {
-      this.queueUpdate();
+    counts(a, b) {
+      if ( a !== b ) {
+        this.queueUpdate();
+      }
     },
 
-    allSchemas() {
-      this.queueUpdate();
+    allSchemas(a, b) {
+      if ( a !== b ) {
+        this.queueUpdate();
+      }
     },
 
-    allNavLinks() {
-      this.queueUpdate();
+    allNavLinks(a, b) {
+      if ( a !== b ) {
+        this.queueUpdate();
+      }
     },
 
-    favoriteTypes() {
-      this.queueUpdate();
+    favoriteTypes(a, b) {
+      if ( !isEqual(a, b) ) {
+        this.queueUpdate();
+      }
     },
 
     locale(a, b) {


### PR DESCRIPTION
### Summary
Fixes #6719

### Occurred changes and/or fixed issues
- BUG
  - there is no getter for `managementReady` so it was always undefined
  - this means both computed properties for counts and schemas always returned an empty object/array
  - when the getter returns the empty objects/arrays the watchers ALWAYS fired which then updated the side nav
  - HOWEVER - it seems vue fails to trigger changes to computed properties which contains getters that were never hit (aka we never called the getters to fetch counts/schemas... so changes to them didn't trigger updates to the computed property). 
- FIX
  - Ensure we get the correct `managementReady`... so the computed properties both return the correct count/schema and trigger when that value changes
  - HOWEVER - this means we'll trigger the side nav update more. So guard against some of the simpler issues (watches fire even if `old === new`, so gate on that... both count/schema shouldn't change much given `web-worker.steve-sub-worker.js`)

### Areas or cases that should be tested
- Counts of resources shown in the side nav should automatically update given
  - creating/deleting resources within that browser
  - creating/deleting resource in another browser
- Same as above, but for schemas (for instance installing/uninstalling the CIS Benchmark app should show/remove the `CIS Benchmark` side nav menu item
