### PR TITLE
Add parseInt to nvidiaGpuLimit input conditional

### DIFF
--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -882,7 +882,7 @@ export default {
       }
     },
     nvidiaIsValid(nvidiaGpuLimit) {
-      if (!Number.isInteger(nvidiaGpuLimit)) {
+      if ( !Number.isInteger(parseInt(nvidiaGpuLimit)) ) {
         return false;
       }
       if (nvidiaGpuLimit === undefined) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6454 
<!-- Define findings related to the feature or bug issue. -->
The `nvidia.com/gpu` resource limit was being deleted from the container resources object as the input is a string when fetched from the `podTemplateSpec`.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a method to parse the string as an integer, which will keep the initial functionality and will only pass if the string is indeed a number.  

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Steps to test are in the issue above
- Cluster creation/cloning/editing should be tested

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->