### PR TITLE
Add developer debug panel for watches and types info

### DIFF
--- a/shell/components/DebugPanel.vue
+++ b/shell/components/DebugPanel.vue
@@ -1,0 +1,148 @@
+<script>
+export default {
+  props: {
+    content: {
+      type:    String,
+      default: ''
+    }
+  },
+
+  data() {
+    return { visible: false };
+  },
+
+  computed: {
+    info() {
+      const info = this.$store.getters['cluster/debugInfo']();
+
+      return info;
+    }
+  },
+
+  methods: {
+    close() {
+      this.visible = false;
+
+      const el = document.getElementById(this.content);
+
+      el.style.width = '';
+    },
+
+    open() {
+      this.visible = true;
+
+      const el = document.getElementById(this.content);
+
+      el.style.width = 'calc(100% - 300px)';
+    }
+  }
+};
+</script>
+
+<template>
+  <div v-if="visible" class="debug-panel" :class="{visible: visible}">
+    <div class="header">
+      <div>DEBUG PANEL</div>
+      <div class="close" @click="close()">
+        <i class="icon icon-close" />
+      </div>
+    </div>
+
+    <div class="header list">
+      <div>Watches</div>
+      <div>{{ info.watches.length }}</div>
+    </div>
+
+    <div v-for="(type, i) in info.watches" :key="i" class="list-item">
+      {{ type }}
+    </div>
+
+    <div class="header list">
+      <div>Types</div>
+      <div>{{ info.types.length }}</div>
+    </div>
+
+    <table>
+      <tr v-for="type in info.types" :key="type.name">
+        <td class="wrap">
+          {{ type.name }}
+        </td>
+        <td class="right">
+          {{ type.count }}
+        </td>
+      </tr>
+    </table>
+
+    <button
+      v-shortkey="{windows: ['ctrl', 'i'], mac: ['meta', 'i']}"
+      class="hide"
+      @shortkey="close()"
+    />
+  </div>
+
+  <button
+    v-else
+    v-shortkey="{windows: ['ctrl', 'i'], mac: ['meta', 'i']}"
+    class="hide"
+    @shortkey="open()"
+  />
+</template>
+
+<style lang="scss" scoped>
+  TABLE {
+    width: 100%;
+    padding: 10px;
+  }
+
+  TD.wrap {
+    word-break: break-all;
+  }
+
+  TD.right {
+    text-align: right;
+  }
+
+  .list-item {
+    padding: 0 10px;
+    line-height: 20px;
+  }
+
+  .debug-panel {
+    border-left: 1px solid var(--border);
+    position: absolute;
+    width: 300px;
+    right: 0;
+    height: 100%;
+
+    .header {
+      align-items: center;
+      display: flex;
+      padding: 5px 10px;
+
+      &.list {
+        border-top: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        margin: 5px 0;
+        padding: 5px 10px;
+      }
+
+      > :first-child {
+        flex: 1;
+      }
+
+      .close {
+        cursor: pointer;
+
+        > i {
+          font-size: 20px;
+          width: 20x;
+          height: 20px;
+        }
+
+        &:hover {
+          color: var(--link);
+        }
+      }
+    }
+  }
+</style>

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -15,6 +15,7 @@ import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
+import DebugPanel from '@shell/components/DebugPanel';
 import {
   COUNT, SCHEMA, MANAGEMENT, UI, CATALOG, HCI
 } from '@shell/config/types';
@@ -46,7 +47,8 @@ export default {
     WindowManager,
     FixedBanner,
     AwsComplianceBanner,
-    AzureWarning
+    AzureWarning,
+    DebugPanel
   },
 
   mixins: [PageHeaderActions, Brand, BrowserTabVisibility],
@@ -75,6 +77,10 @@ export default {
 
     dev:            mapPref(DEV),
     favoriteTypes:  mapPref(FAVORITE_TYPES),
+
+    devEnv() {
+      return process.env.dev;
+    },
 
     pageActions() {
       const pageActions = [];
@@ -544,7 +550,7 @@ export default {
     <FixedBanner :header="true" />
     <AwsComplianceBanner v-if="managementReady" />
     <AzureWarning v-if="managementReady" />
-    <div v-if="managementReady" class="dashboard-content">
+    <div v-if="managementReady" id="dashboard-content" class="dashboard-content">
       <Header />
       <nav v-if="clusterReady" class="side-nav">
         <div class="nav">
@@ -637,6 +643,7 @@ export default {
     </div>
     <FixedBanner :footer="true" />
     <GrowlManager />
+    <DebugPanel v-if="devEnv && managementReady" content="dashboard-content" />
   </div>
 </template>
 <style lang="scss" scoped>

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -110,4 +110,22 @@ export default {
     return map?.list || [];
   },
 
+  debugInfo: state => () => {
+    const watches = state.started.map(w => w.type);
+    const types = [];
+
+    Object.keys(state.types).forEach((t) => {
+      const info = state.types[t];
+
+      types.push({
+        name:  t,
+        count: info.list.length
+      });
+    });
+
+    return {
+      watches,
+      types
+    };
+  }
 };


### PR DESCRIPTION
When run in development environment, adds a keyboard shortcut that (CTRL+i, META+i) that shows/hides a panel showing the active watchers and type info from the store.

Useful for debugging performance issues.