### PR TITLE
Plugins: Ensure we use a new version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ shell/rancher-components
 # standalone script
 scripts/standalone/ui
 scripts/standalone/cert
+scripts/standalone/node

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -69,6 +69,12 @@ fi
 export YARN_REGISTRY=http://localhost:4873
 export NEXT_TELEMETRY_DISABLED=1
 
+# We need to patch the version number of the shell, otherwise if we are running
+# with the currently published version, things will fail as those versions
+# are already published and Verdaccio will check, since it is a read-through cache
+sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\",/\"version\": \"7.7.7\",/g" ${SHELL_DIR}/package.json
+rm ${SHELL_DIR}/package.json.bak
+
 # Publish shell
 echo "Publishing shell packages to local registry"
 ${SHELL_DIR}/scripts/publish-shell.sh


### PR DESCRIPTION
Fixes issue with plugin test script - if the version number is not updated in the package.json, the test script will attempt to publish to the same version as was already pulled down and cached from npm - this will fail.

This script patches in a new version number to prevent this.