### PR TITLE
Set initial endpoint radio group for azuread

### DIFF
--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -67,6 +67,10 @@ export default {
 
   async fetch() {
     await this.reloadModel();
+
+    if ( this.value?.graphEndpoint ) {
+      this.setInitialEndpoint(this.value.graphEndpoint);
+    }
   },
 
   data() {
@@ -168,6 +172,16 @@ export default {
             )
           );
         });
+      }
+    },
+
+    setInitialEndpoint(endpoint) {
+      const endpointKey = Object.keys(ENDPOINT_MAPPING).find(key => ENDPOINT_MAPPING[key].graphEndpoint === endpoint);
+
+      if ( endpointKey ) {
+        this.endpoint = endpointKey;
+      } else {
+        this.endpoint = 'custom';
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6428 
<!-- Define findings related to the feature or bug issue. -->
There was no functionality that set the radio group button to the correct endpoint option, it would always default to `standard`.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a method that will find the appropriate endpoint option depending on the `graphEndpoint`, and if not found it will default to `custom`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Steps to reproduce are in the issue listed
- If no China endpoint is available you can switch the [key names](https://github.com/rancher/dashboard/blob/43d338fac2cc87bf9c0cda6ac5d38fb2c4c7d96d/shell/edit/auth/azuread.vue#L32-L51) in `ENDPOINT_MAPPING` to spoof a different endpoint

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->