### PR TITLE
fix azuread banner link

### DIFF
--- a/shell/components/auth/AzureWarning.vue
+++ b/shell/components/auth/AzureWarning.vue
@@ -3,6 +3,7 @@
 import { NORMAN, MANAGEMENT } from '@shell/config/types';
 import { get } from '@shell/utils/object';
 import { AZURE_MIGRATED } from '@shell/config/labels-annotations';
+import { BLANK_CLUSTER } from '@shell/store';
 
 export default {
   async fetch() {
@@ -24,7 +25,10 @@ export default {
       authConfig:      null,
       authConfigRoute: {
         name:   'c-cluster-auth-config-id',
-        params: { id: 'azuread' }
+        params: {
+          cluster: this.$route.params.cluster || BLANK_CLUSTER,
+          id:      'azuread'
+        }
       }
     };
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6752 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
The azuread config view is technically nested within a cluster. Navigating from a page outside a cluster (home, support, and user prefs) requires explicitly defining a cluster param. Previously I had the blank cluster param in all the time; this caused an (obscure) issue when navigating from a product within the explorer.


### Areas or cases that should be tested
* clicking the link from an explorer page
* clicking the link from a product within explorer (cis scans, backups, monitoring, etc)
* clicking the link from a page outside clusters (home, support, user prefs)
