### PR TITLE
allow plugins to register models in subfolders

### DIFF
--- a/pkg/harvester/models/harvester/configmap.js
+++ b/pkg/harvester/models/harvester/configmap.js
@@ -1,7 +1,7 @@
 import { clone } from '@shell/utils/object';
 import { HCI } from '@shell/config/types';
-import HarvesterResource from './harvester';
-import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
+import HarvesterResource from '../harvester';
+import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 
 // FIXME: Harvester Request for team to validate navigation (list, create, etc) for this resource type
 export default class HciConfigMap extends HarvesterResource {

--- a/pkg/harvester/models/harvester/k8s.cni.cncf.io.networkattachmentdefinition.js
+++ b/pkg/harvester/models/harvester/k8s.cni.cncf.io.networkattachmentdefinition.js
@@ -1,7 +1,7 @@
 import { clone } from '@shell/utils/object';
 import { HCI } from '@shell/config/types';
 import NetworkAttachmentDef from '@shell/models/k8s.cni.cncf.io.networkattachmentdefinition';
-import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
+import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 
 // FIXME: Harvester Request for team to validate navigation (list, create, etc) for this resource type
 export default class HarvesterNetworkAttachmentDef extends NetworkAttachmentDef {

--- a/pkg/harvester/models/harvester/management.cattle.io.managedchart.js
+++ b/pkg/harvester/models/harvester/management.cattle.io.managedchart.js
@@ -1,7 +1,7 @@
 import isEqual from 'lodash/isEqual';
 import { HCI } from '@shell/config/types';
 import { clone } from '@shell/utils/object';
-import HarvesterResource from './harvester';
+import HarvesterResource from '../harvester';
 
 // FIXME: Harvester Request for team to validate navigation (list, create, etc) for this resource type
 export default class HciManagedChart extends HarvesterResource {

--- a/pkg/harvester/models/harvester/management.cattle.io.setting.js
+++ b/pkg/harvester/models/harvester/management.cattle.io.setting.js
@@ -1,7 +1,7 @@
 import { HCI } from '@shell/config/types';
 import { clone } from '@shell/utils/object';
-import HarvesterResource from './harvester';
-import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
+import HarvesterResource from '../harvester';
+import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 
 export default class HciSetting extends HarvesterResource {
   get detailLocation() {

--- a/pkg/harvester/models/harvester/node.js
+++ b/pkg/harvester/models/harvester/node.js
@@ -8,8 +8,8 @@ import {
   stateDisplay
 } from '@shell/plugins/dashboard-store/resource-class';
 import { parseSi } from '@shell/utils/units';
-import HarvesterResource from './harvester';
-import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
+import HarvesterResource from '../harvester';
+import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 
 const ALLOW_SYSTEM_LABEL_KEYS = [
   'topology.kubernetes.io/zone',

--- a/pkg/harvester/models/harvester/persistentvolumeclaim.js
+++ b/pkg/harvester/models/harvester/persistentvolumeclaim.js
@@ -9,8 +9,8 @@ import {
 import { findBy } from '@shell/utils/array';
 import { get, clone } from '@shell/utils/object';
 import { colorForState } from '@shell/plugins/dashboard-store/resource-class';
-import HarvesterResource from './harvester';
-import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../config/harvester';
+import HarvesterResource from '../harvester';
+import { PRODUCT_NAME as HARVESTER_PRODUCT } from '../../config/harvester';
 
 // FIXME: Harvester Request for team to validate navigation (list, create, etc) for this resource type
 export default class HciPv extends HarvesterResource {

--- a/pkg/harvester/models/harvester/pod.js
+++ b/pkg/harvester/models/harvester/pod.js
@@ -2,7 +2,7 @@ import includes from 'lodash/includes';
 import { findBy } from '@shell/utils/array';
 import { get } from '@shell/utils/object';
 import { NODE } from '@shell/config/types';
-import HarvesterResource from './harvester';
+import HarvesterResource from '../harvester';
 
 const POD_STATUS_NOT_SCHEDULABLE = 'POD_NOT_SCHEDULABLE';
 

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -178,7 +178,8 @@ export class Plugin implements IPlugin {
     const nparts = name.split('/');
 
     // Support components in a sub-folder - component_name/index.vue (and ignore other componnets in that folder)
-    if (nparts.length === 2) {
+    // Allow store-scoped models via sub-folder - pkgname/models/storename/type will be registered as storename/type to avoid overwriting shell/models/type
+    if (nparts.length === 2 && type !== 'models') {
       if (nparts[1] !== 'index') {
         return;
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6797 
Harvester models were superseding shell models of the same name.

### Occurred changes and/or fixed issues
This PR fixes the issue by 1) moving duplicated harvester models into a subfolder with the name of the store they're used in ('harvester') and 2) allowing the dynamic registration of models in subfolders. 

### Technical notes summary
When classifying a new object, the harvester store will first look for a model registered as 'harvester/type' and fall back to one registered as 'type':
https://github.com/rancher/dashboard/blob/16e1c2e29d35a27e4448d3cfc2713688b7bf5d21/shell/plugins/dashboard-store/model-loader.js#L51-L68

### Areas or cases that should be tested
Clicking detail links for the moved harvester types in both their harvester ui view and the explorer view should be enough to determine if the correct model is being used. (harvester types overwrite the stevemodel detail route)

