### PR TITLE
Update parsing for nodeTimeout durations

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -64,11 +64,17 @@ export default {
 
   data() {
     const parseDuration = (duration) => {
-      // The back end stores the timeout in Duration format, for example, "10m".
-      // Here we convert that string to an integer.
-      const numberString = duration.split('m')[0];
+      // The back end stores the timeout in Duration format, for example, "10m30s".
+      // Here we convert that string to an integer and return the duration as seconds.
+      const splitStr = duration.split(/[m,s]/).filter(s => s);
+      const minutes = parseInt(splitStr[0], 10);
+      const seconds = parseInt(splitStr[1], 10);
 
-      return parseInt(numberString, 10);
+      if ( isNaN(seconds) ) {
+        return minutes;
+      }
+
+      return seconds + minutes * 60;
     };
 
     return {

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -1,5 +1,4 @@
 <script>
-
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { Checkbox } from '@components/Form/Checkbox';
 import { _EDIT } from '@shell/config/query-params';
@@ -64,17 +63,40 @@ export default {
 
   data() {
     const parseDuration = (duration) => {
-      // The back end stores the timeout in Duration format, for example, "10m30s".
+      // The back end stores the timeout in Duration format, for example, "42d31h10m30s".
       // Here we convert that string to an integer and return the duration as seconds.
-      const splitStr = duration.split(/[m,s]/).filter(s => s);
-      const minutes = parseInt(splitStr[0], 10);
-      const seconds = parseInt(splitStr[1], 10);
+      const splitStr = duration.split(/([a-z])/);
 
-      if ( isNaN(seconds) ) {
-        return minutes;
-      }
+      const durationsAsSeconds = splitStr.reduce((old, neu, idx) => {
+        const parsed = parseInt(neu);
 
-      return seconds + minutes * 60;
+        if ( isNaN(parsed) ) {
+          return old;
+        }
+
+        const interval = splitStr[(idx + 1)];
+
+        switch (interval) {
+        case 'd':
+          old.push(parsed * 24 * 60 * 60);
+          break;
+        case 'h':
+          old.push(parsed * 60 * 60);
+          break;
+        case 'm':
+          old.push(parsed * 60);
+          break;
+        case 's':
+          old.push(parsed);
+          break;
+        default:
+          break;
+        }
+
+        return old;
+      }, []);
+
+      return durationsAsSeconds.reduce((old, neu) => old + neu);
     };
 
     return {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6275
<!-- Define findings related to the feature or bug issue. -->
When a cluster has been defined with an `unhealthyNodeTimeout` greater than `1m` prior to this version, the value would appear as seconds (i.e. `1 seconds`).

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added some logic to the `parseDuration` method to return the full amount of Duration time in seconds.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Creating/Editing clusters with a different `unhealthyNodeTimeout` duration.