### PR TITLE
Add global setting to disable websocket notification growls

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6780,24 +6780,27 @@ featureFlags:
 performance:
   label: UI Performance Settings
   settingName: Performance
-  description: |-
-    Performance settings allow the behavior of the UI to be configured when dealing with many resources in a cluster. These settings only apply to the following resources: Pods, Deployments, Cron Jobs, Daemon Sets, Jobs, Stateful Sets, Replica Sets, Replication Controllers, Workloads and Secrets.
-  banner: These settings are experimental and may be removed or updated in future versions
   incrementalLoad:
     label: Incremental Loading
     setting: You can configure the threshold above which incremental loading will be used.
     description: |-
-      When enabled, resources will appear more quickly, but it may take slightly longer to load the entire set of resources.
+      When enabled, resources will appear more quickly, but it may take slightly longer to load the entire set of resources. This setting only applies to the following resources: Pods, Deployments, Cron Jobs, Daemon Sets, Jobs, Stateful Sets, Replica Sets, Replication Controllers, Workloads and Secrets.
     checkboxLabel: Enable incremental loading
     inputLabel: Resource Threshold
   manualRefresh:
+    banner: This setting is experimental and may be removed or updated in future versions.
     label: Manual Refresh
     setting: You can configure a threshold above which manual refresh will be enabled.
     buttonTooltip: Refresh list
     description: |-
-      When enabled list data will not auto-update but instead the user must manually trigger a list-view refresh.
+      When enabled, list data will not auto-update but instead the user must manually trigger a list-view refresh. This setting only applies to the following resources: Pods, Deployments, Cron Jobs, Daemon Sets, Jobs, Stateful Sets, Replica Sets, Replication Controllers, Workloads and Secrets.
     checkboxLabel: Enable manual refresh of data for lists
     inputLabel: Resource Threshold
+  websocketNotification:
+    label: Websocket Notifications
+    description: |-
+      When checked, websocket notifications will not appear when the UI detects a disconnection.
+    checkboxLabel: Disable websocket notifications
 
 banner:
   label: Fixed Banners

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -16,7 +16,8 @@ const DEFAULT_PERF_SETTING = {
   manualRefresh: {
     enabled:   false,
     threshold: 2500,
-  }
+  },
+  disableWebsocketNotification: false
 };
 
 export default {

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -7,6 +7,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
+
 const DEFAULT_PERF_SETTING = {
   incrementalLoading: {
     enabled:   false,
@@ -27,6 +28,7 @@ export default {
     Banner,
     LabeledInput,
   },
+
   async fetch() {
     try {
       this.uiPerfSetting = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.UI_PERFORMANCE });
@@ -41,6 +43,7 @@ export default {
 
     this.value = JSON.parse(sValue);
   },
+
   data() {
     return {
       uiPerfSetting: DEFAULT_PERF_SETTING,
@@ -49,6 +52,7 @@ export default {
       errors:        [],
     };
   },
+
   computed: {
     mode() {
       const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
@@ -56,10 +60,12 @@ export default {
       return schema?.resourceMethods?.includes('PUT') ? _EDIT : _VIEW;
     },
   },
+
   methods: {
     async save(btnCB) {
       this.uiPerfSetting.value = JSON.stringify(this.value);
       this.errors = [];
+
       try {
         await this.uiPerfSetting.save();
         btnCB(true);
@@ -78,12 +84,19 @@ export default {
       {{ t('performance.label') }}
     </h1>
     <div>
-      <label class="text-label">
-        {{ t(`performance.description`, {}, true) }}
-      </label>
-      <Banner color="error" label-key="performance.banner" />
-      <!-- Incremental Loading -->
       <div class="ui-perf-setting">
+        <!-- Websocket Notifications -->
+        <div class="mt-40">
+          <h2>{{ t('performance.websocketNotification.label') }}</h2>
+          <p>{{ t('performance.websocketNotification.description') }}</p>
+          <Checkbox
+            v-model="value.disableWebsocketNotification"
+            :label="t('performance.websocketNotification.checkboxLabel')"
+            class="mt-10 mb-20"
+            :primary="true"
+          />
+        </div>
+        <!-- Incremental Loading -->
         <div class="mt-40">
           <h2>{{ t('performance.incrementalLoad.label') }}</h2>
           <p>{{ t('performance.incrementalLoad.description') }}</p>
@@ -111,6 +124,7 @@ export default {
         <div class="mt-40">
           <h2 v-t="'performance.manualRefresh.label'" />
           <p>{{ t('performance.manualRefresh.description') }}</p>
+          <Banner color="error" label-key="performance.manualRefresh.banner" />
           <Checkbox
             v-model="value.manualRefresh.enabled"
             :label="t('performance.manualRefresh.checkboxLabel')"

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -459,7 +459,11 @@ export const actions = {
     if (e.type === EVENT_DISCONNECT_ERROR) {
       // determine if websocket notifications are disabled
       const perfSetting = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);
-      const disableGrowl = JSON.parse(perfSetting?.value).disableWebsocketNotification || false;
+      let disableGrowl = false;
+
+      if ( perfSetting?.value ) {
+        disableGrowl = JSON.parse(perfSetting.value).disableWebsocketNotification || false;
+      }
 
       if ( !disableGrowl ) {
         // do not send a growl notification unless the socket stays disconnected for more than MINIMUM_TIME_DISCONNECTED

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -1,6 +1,7 @@
 import { addObject, clear, removeObject } from '@shell/utils/array';
 import { get } from '@shell/utils/object';
-import { COUNT, SCHEMA } from '@shell/config/types';
+import { COUNT, MANAGEMENT, SCHEMA } from '@shell/config/types';
+import { SETTING } from '@shell/config/settings';
 import Socket, {
   EVENT_CONNECTED,
   EVENT_DISCONNECTED,
@@ -456,28 +457,34 @@ export const actions = {
     clearTimeout(state.queueTimer);
     state.queueTimer = null;
     if (e.type === EVENT_DISCONNECT_ERROR) {
-      // do not send a growl notification unless the socket stays disconnected for more than MINIMUM_TIME_DISCONNECTED
-      setTimeout(() => {
-        if (state.socket.isConnected()) {
-          return;
-        }
-        const dateFormat = escapeHtml( rootGetters['prefs/get'](DATE_FORMAT));
-        const timeFormat = escapeHtml( rootGetters['prefs/get'](TIME_FORMAT));
-        const time = e?.srcElement?.disconnectedAt || Date.now();
+      // determine if websocket notifications are disabled
+      const perfSetting = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);
+      const disableGrowl = JSON.parse(perfSetting?.value).disableWebsocketNotification || false;
 
-        const timeFormatted = `${ day(time).format(`${ dateFormat } ${ timeFormat }`) }`;
-        const url = e?.srcElement?.url;
+      if ( !disableGrowl ) {
+        // do not send a growl notification unless the socket stays disconnected for more than MINIMUM_TIME_DISCONNECTED
+        setTimeout(() => {
+          if (state.socket.isConnected()) {
+            return;
+          }
+          const dateFormat = escapeHtml( rootGetters['prefs/get'](DATE_FORMAT));
+          const timeFormat = escapeHtml( rootGetters['prefs/get'](TIME_FORMAT));
+          const time = e?.srcElement?.disconnectedAt || Date.now();
 
-        const t = rootGetters['i18n/t'];
+          const timeFormatted = `${ day(time).format(`${ dateFormat } ${ timeFormat }`) }`;
+          const url = e?.srcElement?.url;
 
-        dispatch('growl/error', {
-          title:         t('growl.disconnected.title'),
-          message:       t('growl.disconnected.message', { url, time: timeFormatted }, { raw: true }),
-          icon:          'error',
-          earliestClose: time + MINIMUM_TIME_NOTIFIED + MINIMUM_TIME_DISCONNECTED,
-          url
-        }, { root: true });
-      }, MINIMUM_TIME_DISCONNECTED);
+          const t = rootGetters['i18n/t'];
+
+          dispatch('growl/error', {
+            title:         t('growl.disconnected.title'),
+            message:       t('growl.disconnected.message', { url, time: timeFormatted }, { raw: true }),
+            icon:          'error',
+            earliestClose: time + MINIMUM_TIME_NOTIFIED + MINIMUM_TIME_DISCONNECTED,
+            url
+          }, { root: true });
+        }, MINIMUM_TIME_DISCONNECTED);
+      }
     } else {
       // if the error is not a disconnect error, the socket never worked: log whether the current browser is safari
       console.error(`WebSocket Connection Error [${ getters.storeName }]`, e.detail); // eslint-disable-line no-console


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6793 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This will add a global setting in the Performance tab to disable the websocket disconnection growls/notifications from appearing.  Also moved the banner and descriptions around within the performance tab.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
For the sake of simplicity, this setting has been added to the json blob value of `/v1/management.cattle.io.settings/ui-performance`. As this is set by an admin, the setting will persist for all users.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
To test you can block any websocket requests made to `v1/subscribe`.

Steps:

- Within the network tab of the browser dev tools - add `wss://<cluster-ip>/k8s/clusters/<cluster-id>/v1/subscribe` to the blocked requests list
![blockedwss](https://user-images.githubusercontent.com/40806497/188733734-459049f2-10ec-477e-945b-90a9aba8128f.png)

- Navigate to your cluster and notice the blocked requests and the "Websocket Disconnected" growl
![enabled](https://user-images.githubusercontent.com/40806497/188733826-4e7892aa-5a6b-4bd5-82fc-66bdf6f804dc.png)

- Then navigate to the Performance tab within the Global Settings page, enable the "Disable websocket notifications" checkbox and hit Apply
![perfsettings](https://user-images.githubusercontent.com/40806497/188734178-daf1db8b-43fd-4c8c-944d-29c8a913d206.png)

- Navigate back to your cluster and within the browser console notice the websocket connection errors and also take note that a growl has not appeared
![console](https://user-images.githubusercontent.com/40806497/188738064-13fbdf26-4a87-4c5d-b694-1516955902b7.png)

