### PR TITLE
Fix generic prompt and prompt remove plugin overrides

### DIFF
--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -32,8 +32,8 @@ export default {
       return this.modalData?.modalWidth || '600px';
     },
     component() {
-      // Looks for a dialog component by looking up @shell/dialog/${name}.
-      return importDialog(this.modalData?.component);
+      // Looks for a dialog component by looking up in plugins and @shell/dialog/${name}.
+      return this.$store.getters['type-map/importDialog'](this.modalData?.component);
     },
     cssProps() {
       // this computed property lets us generate a scss var that we can use in the style

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -1,7 +1,6 @@
 <script>
 import { mapState } from 'vuex';
 import { isArray } from '@shell/utils/array';
-import { importDialog } from '@shell/utils/dynamic-importer';
 
 /**
  * @name PromptModal

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -1089,24 +1089,11 @@ export const getters = {
     };
   },
 
-  hasCustomPromptRemove(state, getters) {
-    return (rawType) => {
-      const type = getters.componentFor(rawType);
+  hasCustomPromptRemove(state, getters, rootState) {
+    return (rawType, subType) => {
+      const key = getters.componentFor(rawType, subType);
 
-      const cache = state.cache.promptRemove;
-
-      if ( cache[type] !== undefined ) {
-        return cache[type];
-      }
-
-      try {
-        require.resolve(`@shell/promptRemove/${ type }`);
-        cache[type] = true;
-      } catch (e) {
-        cache[type] = false;
-      }
-
-      return cache[type];
+      return hasCustom(state, rootState, 'promptRemove', key, () => require.resolve(`@shell/promptRemove/${ key }`));
     };
   },
 
@@ -1148,11 +1135,9 @@ export const getters = {
     };
   },
 
-  importCustomPromptRemove(state, getters) {
-    return (rawType) => {
-      const type = getters.componentFor(rawType);
-
-      return importCustomPromptRemove(type);
+  importCustomPromptRemove(state, getters, rootState) {
+    return (rawType, subType) => {
+      return loadExtension(rootState, 'promptRemove', getters.componentFor(rawType, subType), importCustomPromptRemove);
     };
   },
 

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -131,8 +131,7 @@ import {
   ensureRegex, escapeHtml, escapeRegex, ucFirst, pluralize
 } from '@shell/utils/string';
 import {
-  importList, importDetail, importEdit, listProducts, loadProduct, importCustomPromptRemove, resolveList, resolveEdit, resolveWindowComponent, importWindowComponent, resolveDetail
-
+  importList, importDetail, importEdit, listProducts, loadProduct, importCustomPromptRemove, resolveList, resolveEdit, resolveWindowComponent, importWindowComponent, resolveDetail, importDialog
 } from '@shell/utils/dynamic-importer';
 
 import { NAME as EXPLORER } from '@shell/config/product/explorer';
@@ -1122,6 +1121,12 @@ export const getters = {
   importComponent(state, getters) {
     return (path) => {
       return importEdit(path);
+    };
+  },
+
+  importDialog(state, getters, rootState) {
+    return (rawType, subType) => {
+      return loadExtension(rootState, 'dialog', getters.componentFor(rawType, subType), importDialog);
     };
   },
 


### PR DESCRIPTION
### Occurred changes and/or fixed issues
Fixes plugin overrides for 
- generic prompts (`dialog`s)
- remove prompts (`promptRemove`s)

Relates to https://github.com/rancher/dashboard/pull/6815

### Technical notes summary
This fixes 
- `pkg/harvester/dialog` (for instance enabling maintenance mode of a harvester host)
- `pkg/harvester/promptRemove` (for instance custom modal when deleting a harvester vm)