### PR TITLE
Improve user profile page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3648,7 +3648,7 @@ prefs:
     ember: Cluster Manager
   displaySettings: 
     title: Display Settings
-    detail: Change the way information is displayed in {vendor}.
+    detail: Change the way information is displayed in the UI.
   clusterToShow:
     label: Number of clusters to show in side menu
     value: |-

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3646,7 +3646,9 @@ prefs:
     label: Login Landing Page
     vue: Cluster Explorer
     ember: Cluster Manager
-  formatting: Formatting
+  formatting: 
+    title: Display Settings
+    detail: Change the way information is displayed in
   clusterToShow:
     label: Number of clusters to show in side menu
     value: |-

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3646,9 +3646,9 @@ prefs:
     label: Login Landing Page
     vue: Cluster Explorer
     ember: Cluster Manager
-  formatting: 
+  displaySettings: 
     title: Display Settings
-    detail: Change the way information is displayed in
+    detail: Change the way information is displayed in {vendor}.
   clusterToShow:
     label: Number of clusters to show in side menu
     value: |-

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -11,6 +11,7 @@ import {
 } from '@shell/store/prefs';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
+import { getVendor } from '@shell/config/private-label';
 
 export default {
   layout:     'plain',
@@ -29,6 +30,10 @@ export default {
     menuMaxClusters: mapPref(MENU_MAX_CLUSTERS),
 
     ...mapGetters(['isSingleProduct']),
+
+    product() {
+      return getVendor();
+    },
 
     theme: {
       get() {
@@ -159,8 +164,11 @@ export default {
       <LandingPagePreference />
     </div>
     <hr />
-    <h4 v-t="'prefs.formatting'" />
-    <div class="row">
+    <h4 v-t="'prefs.formatting.title'" />
+    <p class="set-landing-leadin">
+      {{ t('prefs.formatting.detail', {product}) }}
+    </p>
+    <div class="row mt-20">
       <div class="col span-4">
         <LabeledSelect
           v-model="dateFormat"
@@ -175,7 +183,9 @@ export default {
           :options="timeOptions"
         />
       </div>
+    </div>
 
+    <div class="row mt-20">
       <div class="col span-4">
         <LabeledSelect
           v-model.number="perPage"
@@ -186,9 +196,6 @@ export default {
           placeholder="Select a row count"
         />
       </div>
-    </div>
-
-    <div class="row mt-20">
       <div class="col span-4">
         <LabeledSelect
           v-model.number="menuMaxClusters"

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -11,7 +11,7 @@ import {
 } from '@shell/store/prefs';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
-import { getVendor } from '@shell/config/private-label';
+import { getProduct } from '@shell/config/private-label';
 
 export default {
   layout:     'plain',
@@ -32,7 +32,7 @@ export default {
     ...mapGetters(['isSingleProduct']),
 
     product() {
-      return getVendor();
+      return getProduct();
     },
 
     theme: {
@@ -164,9 +164,9 @@ export default {
       <LandingPagePreference />
     </div>
     <hr />
-    <h4 v-t="'prefs.formatting.title'" />
+    <h4 v-t="'prefs.displaySettings.title'" />
     <p class="set-landing-leadin">
-      {{ t('prefs.formatting.detail', {product}) }}
+      {{ t('prefs.displaySettings.detail', {product}) }}
     </p>
     <div class="row mt-20">
       <div class="col span-4">

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -209,7 +209,7 @@ export default {
         <h4 v-t="'prefs.advanced'" />
         <Checkbox v-model="dev" :label="t('prefs.dev.label', {}, true)" />
         <p class="wrap-text">
-          {{ t('prefs.advancedTooltip', {}, raw=true) }}
+          {{ t('prefs.advancedTooltip') }}
         </p>
         <br>
         <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-10" />

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -11,7 +11,6 @@ import {
 } from '@shell/store/prefs';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
-import { getProduct } from '@shell/config/private-label';
 
 export default {
   layout:     'plain',
@@ -30,10 +29,6 @@ export default {
     menuMaxClusters: mapPref(MENU_MAX_CLUSTERS),
 
     ...mapGetters(['isSingleProduct']),
-
-    product() {
-      return getProduct();
-    },
 
     theme: {
       get() {
@@ -166,7 +161,7 @@ export default {
     <hr />
     <h4 v-t="'prefs.displaySettings.title'" />
     <p class="set-landing-leadin">
-      {{ t('prefs.displaySettings.detail', {product}) }}
+      {{ t('prefs.displaySettings.detail', {}, raw=true) }}
     </p>
     <div class="row mt-20">
       <div class="col span-4">


### PR DESCRIPTION
### Summary
Fixes #6672

Updated the 'Formatting' Section with new changes on the User preference page.

### Areas or cases that should be tested
Go to the user preference page :
> It should have a `Display Settings` section 
>  `Table Rows per Page` and `Number of clusters to show in side menu` selector should be on the same row