### PR TITLE
Fixes chart filtering when chart has no description

### DIFF
--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -652,7 +652,9 @@ export function filterAndArrangeCharts(charts, {
       const searchTokens = searchQuery.split(/\s*[, ]\s*/).map(x => ensureRegex(x, false));
 
       for ( const token of searchTokens ) {
-        if ( !c.chartNameDisplay.match(token) && (c.chartDescription && !c.chartDescription.match(token)) ) {
+        const chartDescription = c.chartDescription || '';
+
+        if ( !c.chartNameDisplay.match(token) && !chartDescription.match(token) ) {
           return false;
         }
       }


### PR DESCRIPTION
Fixes #6823 

See issue above for steps to reproduce.

Simple fix to ensure we don't match charts that do not have a description.