### PR TITLE
Fix Principal member/user name overlap

### DIFF
--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -119,7 +119,7 @@ export default {
       "avatar name"
       "avatar description";
     grid-template-columns: $size auto;
-    grid-template-rows: math.div($size, 2) math.div($size, 2);
+    grid-template-rows: auto math.div($size, 2);
     column-gap: 10px;
 
     &.showLabels {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5283 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This issue can occur regardless of the auth provider. When a display name is larger than the grid column the text will be folded over the element below. I replaced the static sizing on the member name column with `auto`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
To test you can simply add a test user with a long display name, then attempt to add the user to a project within a cluster.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Before**
![before](https://user-images.githubusercontent.com/40806497/189141228-f331ea96-016f-4e97-9d9c-44b9f2bbd8b0.png)

**After**
![after](https://user-images.githubusercontent.com/40806497/189141292-56aa404c-bf86-4019-8f59-ba45855a129d.png)


