### PR TITLE
Ensure Feature Flag table description column consumes space rather than name

### DIFF
--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -870,7 +870,6 @@ export const FEATURE_DESCRIPTION = {
   value:         'status.description',
   align:         'left',
   sort:          ['status.description'],
-  width:         300,
   formatter:     'Translate',
   formatterOpts: { prefix: 'featureFlags.description' },
 };


### PR DESCRIPTION
### Summary
- the feature flag names are small compared to the description
- ensure that the description consumes the horizontal width rather than the name

### Screenshot/Video

## Before
![image](https://user-images.githubusercontent.com/18697775/189400654-6ff42bec-e051-4dad-941b-2c3af598a1ed.png)

## After
![image](https://user-images.githubusercontent.com/18697775/189400605-8d8cd200-0508-4fe4-b82b-4ce712901a32.png)

