### PR TITLE
Project & Cluster Members: Move loading indicators to tables

### DIFF
--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -1,7 +1,6 @@
 <script>
 import { MANAGEMENT, NORMAN, VIRTUAL_TYPES } from '@shell/config/types';
 import ResourceTable from '@shell/components/ResourceTable';
-import Loading from '@shell/components/Loading';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { AGE, ROLE, STATE, PRINCIPAL } from '@shell/config/table-headers';
 import { canViewClusterPermissionsEditor } from '@shell/components/form/Members/ClusterPermissionsEditor.vue';
@@ -17,7 +16,6 @@ export default {
 
   components: {
     Banner,
-    Loading,
     Masthead,
     ResourceTable
   },
@@ -96,8 +94,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending || !currentCluster" />
-  <div v-else>
+  <div>
     <Masthead
       :schema="schema"
       :resource="resource"
@@ -116,6 +113,7 @@ export default {
       :rows="filteredClusterRoleTemplateBindings"
       :groupable="false"
       :namespaced="false"
+      :loading="$fetchState.pending || !currentCluster"
       sub-search="subSearch"
       :sub-fields="['nameDisplay']"
     />

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -4,7 +4,6 @@ import ResourceTable from '@shell/components/ResourceTable';
 import { STATE, AGE, NAME } from '@shell/config/table-headers';
 import { uniq } from '@shell/utils/array';
 import { MANAGEMENT, NAMESPACE, VIRTUAL_TYPES } from '@shell/config/types';
-import Loading from '@shell/components/Loading';
 import { PROJECT_ID } from '@shell/config/query-params';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { mapPref, GROUP_RESOURCES, DEV } from '@shell/store/prefs';
@@ -15,7 +14,7 @@ import { NAMESPACE_FILTER_ALL_ORPHANS } from '@shell/utils/namespace-filter';
 export default {
   name:       'ListProjectNamespace',
   components: {
-    Loading, Masthead, MoveModal, ResourceTable
+    Masthead, MoveModal, ResourceTable
   },
 
   props: {
@@ -302,8 +301,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending || !currentCluster" />
-  <div v-else class="project-namespaces">
+  <div class="project-namespaces">
     <Masthead
       :schema="projectSchema"
       :type-display="t('projectNamespaces.label')"
@@ -321,6 +319,7 @@ export default {
       :rows="filteredRows"
       :groupable="true"
       :sort-generation-fn="sortGenerationFn"
+      :loading="$fetchState.pending || !currentCluster"
       group-tooltip="resourceTable.groupBy.project"
       key-field="_key"
       v-on="$listeners"


### PR DESCRIPTION
Fixes #6976 

Small fix - but makes these 2 pages appear to load more quickly - user is not blocked from interacting with the UI for the data to load - so can use create etc. 