### PR TITLE
Enable embedding of legacy harvester plugin

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -228,7 +228,7 @@ steps:
   pull: default
   image: node:14
   environment:
-    DISABLED_EMBED_PKG: https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3/harvester-1.0.3.tar.gz
+    EMBED_PKG: https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3.tar.gz
   commands:
   - ./scripts/build-embedded
 
@@ -273,7 +273,7 @@ steps:
   pull: default
   image: node:14
   environment:
-    DISABLED_EMBED_PKG: https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3/harvester-1.0.3.tar.gz
+    EMBED_PKG: https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3.tar.gz
   commands:
   - ./scripts/build-embedded
 
@@ -309,7 +309,7 @@ steps:
   pull: default
   image: node:14
   environment:
-    DISABLED_EMBED_PKG: https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3/harvester-1.0.3.tar.gz
+    EMBED_PKG: https://releases.rancher.com/harvester-ui/plugin/harvester-1.0.3.tar.gz
   commands:
   - ./scripts/build-embedded
 

--- a/scripts/build-embedded
+++ b/scripts/build-embedded
@@ -26,7 +26,9 @@ NUXT_ENV_commit=${COMMIT} NUXT_ENV_version=${VERSION} OUTPUT_DIR=$OUTPUT_DIR ROU
 if [ -v EMBED_PKG ]; then
     echo "Build and embed plugin from: $EMBED_PKG"
     PKG_FILE_NAME=${EMBED_PKG##*/}
-    PKG_NAME=$(cut -d "-" -f1 <<< "$PKG_FILE_NAME")
+    echo PKG_FILE_NAME: $PKG_FILE_NAME
+
+    PKG_NAME="${PKG_FILE_NAME/.tar.gz/""}"
     echo "Plugin name: '$PKG_NAME'"
 
     # Fetch file, unpack and move to dist


### PR DESCRIPTION
- The harvester plugin to support legacy harvester clusters is now available
- Update the env var to ensure it's included in the dashboard
