### PR TITLE
Fix empty advanced tab shown on edit cluster page

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2074,6 +2074,7 @@ export default {
         </Tab>
 
         <Tab
+          v-if="haveArgInfo || agentArgs['protect-kernel-defaults']"
           name="advanced"
           label-key="cluster.tabs.advanced"
           :weight="-1"


### PR DESCRIPTION
Fixes #5866 

Ensures we only show the Advanced tab if it will contain content.

See linked issue for steps to reproduce/validate.