### PR TITLE
Fix azuread endpoint initial option after rancher upgrade

### DIFF
--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -176,10 +176,13 @@ export default {
     },
 
     setInitialEndpoint(endpoint) {
-      const endpointKey = Object.keys(ENDPOINT_MAPPING).find(key => ENDPOINT_MAPPING[key].graphEndpoint === endpoint);
+      const newEndpointKey = Object.keys(ENDPOINT_MAPPING).find(key => ENDPOINT_MAPPING[key].graphEndpoint === endpoint);
+      const oldEndpointKey = Object.keys(OLD_ENDPOINTS).find(key => OLD_ENDPOINTS[key].graphEndpoint === endpoint);
 
-      if ( endpointKey ) {
-        this.endpoint = endpointKey;
+      if ( newEndpointKey ) {
+        this.endpoint = newEndpointKey;
+      } else if ( oldEndpointKey ) {
+        this.endpoint = oldEndpointKey;
       } else {
         this.endpoint = 'custom';
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6428
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
When setting the initial endpoint option we were not checking for an endpoint that has been deprecated.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
This is a simple fix by adding a check for the `graphEndpoint` in the config to match one of the old endpoints ( e.g. `https://graph.windows.net/` ).

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Steps to test are in the referenced issue
