### PR TITLE
Show a loading indicator when the harvester plugin loads slowly

### DIFF
--- a/shell/list/harvesterhci.io.management.cluster.vue
+++ b/shell/list/harvesterhci.io.management.cluster.vue
@@ -84,14 +84,19 @@ export default {
 
   methods: {
     async goToCluster(row) {
+      const timeout = setTimeout(() => {
+        // Don't show loading indicator for quickly fetched plugins
+        this.navigating = row.id;
+      }, 1000);
+
       try {
-        setTimeout(() => {
-          // Don't show loading indicator for quickly fetched plugins
-          this.navigating = row.id;
-        }, 1000);
         await row.goToCluster();
+
+        clearTimeout(timeout);
+        this.navigating = false;
       } catch {
-        // The error handling is carried out within goToCluster
+        // The error handling is carried out within goToCluster, but just in case something happens before the promise chain can catch it...
+        clearTimeout(timeout);
         this.navigating = false;
       }
     }

--- a/shell/list/harvesterhci.io.management.cluster.vue
+++ b/shell/list/harvesterhci.io.management.cluster.vue
@@ -41,6 +41,7 @@ export default {
     const resource = CAPI.RANCHER_CLUSTER;
 
     return {
+      navigating:   false,
       VIRTUAL,
       hciDashboard: HCI.DASHBOARD,
       resource,
@@ -79,6 +80,21 @@ export default {
     typeDisplay() {
       return this.t(`typeLabel."${ HCI.CLUSTER }"`, { count: this.row?.length || 0 });
     },
+  },
+
+  methods: {
+    async goToCluster(row) {
+      try {
+        setTimeout(() => {
+          // Don't show loading indicator for quickly fetched plugins
+          this.navigating = row.id;
+        }, 1000);
+        await row.goToCluster();
+      } catch {
+        // The error handling is carried out within goToCluster
+        this.navigating = false;
+      }
+    }
   }
 };
 </script>
@@ -115,11 +131,12 @@ export default {
     >
       <template #col:name="{row}">
         <td>
-          <span>
-            <a v-if="row.isReady" class="link" @click="row.goToCluster()">{{ row.nameDisplay }}</a>
+          <span class="cluster-link">
+            <a v-if="row.isReady" class="link" :disabled="navigating" @click="goToCluster(row)">{{ row.nameDisplay }}</a>
             <span v-else>
               {{ row.nameDisplay }}
             </span>
+            <i class="icon icon-spinner icon-spin ml-5" :class="{'navigating': navigating === row.id}" />
           </span>
         </td>
       </template>
@@ -152,6 +169,20 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  .cluster-link {
+    display: flex;
+    align-items: center;
+
+    .icon {
+      // Use visibility to avoid the columns re-adjusting when the icon is shown
+      visibility: hidden;
+
+      &.navigating {
+        visibility: visible;
+      }
+    }
+
+  }
   .no-clusters {
     text-align: center;
   }


### PR DESCRIPTION
- clicking on a harvester cluster name will make a http request for `ui-info` and then depending on result inject script in to the dom
- these can take some time, the user is left on the cluster list page with no visual indication anything is happening
- to provide this, and prevent multiple clicks, when waiting show a loading indicator and disable all cluster links