### PR TITLE
Add check for 403 to project creation action

### DIFF
--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -102,9 +102,9 @@ export default class Project extends HybridModel {
     try {
       await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
     } catch (err) {
-      if (err.status === 409) {
+      if ( err.status === 409 || err.status === 403 ) {
         // The backend updates each new project soon after it is created,
-        // so there is a chance of a resource conflict error. If that happens,
+        // so there is a chance of a resource conflict or forbidden error. If that happens,
         // retry the action.
         await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
       } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6861 
<!-- Define findings related to the feature or bug issue. -->
This issue was difficult to duplicate as the errors were inconsistent, in some instances the action `setpodsecuritypolicytemplate` would cause a `403` error to be returned, but not always. [This comment](https://github.com/rancher/dashboard/issues/6377#issuecomment-1185369752) led me to believe this was a case of the backend not updating correctly or quickly enough which may cause this error to appear. 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
I added an additional check for the `403` error alongside the conditional for a `409` error. This allows the action to be called once more, which if the user is truly able to will allow for the project to be created and fixes the error from being thrown.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Steps to test are in the referenced issue.
