### PR TITLE
Use correct taints flag in RKE2 custom cluster registration command

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -71,7 +71,7 @@ export default {
         const e = sanitizeValue(t.effect);
 
         if ( k && v && e ) {
-          out.push(`--taint ${ k }=${ v }:${ e }`);
+          out.push(`--taints ${ k }=${ v }:${ e }`);
         }
       }
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/6827 and https://github.com/rancher/rancher/issues/36131#issuecomment-1245216251 by correcting the flag for adding taints to a custom cluster registration command.

To test this PR,

1. In cluster management, I went to Clusters and clicked Create
2. Made sure the toggle for K3s/RKE2 was selected
3. Clicked **Custom** under **Use existing nodes and create a cluster using RKE2/K3s**
4. Entered a name for the cluster and clicked Create
5. Still in cluster management, in the cluster detail page, on the Registration tab, I clicked **Show Advanced**.
6. Clicked Add Taint. Added two taints that way.

<img width="1248" alt="Screen Shot 2022-09-13 at 12 26 57 PM" src="https://user-images.githubusercontent.com/20599230/190015841-8b295dd9-3627-4544-b4e3-853017242033.png">

7. Confirmed that in the cluster registration command below, each taint was included in the command with the `--taints` flag:
<img width="922" alt="Screen Shot 2022-09-13 at 12 27 15 PM" src="https://user-images.githubusercontent.com/20599230/190015886-75b053d5-0303-4d94-abac-1ce4db98d0d1.png">

Note: The steps to test don't match the steps to repro the issue as described in the issue description on https://github.com/rancher/rancher/issues/36131. The original issue and internal ticket mention Docker, RKE1 and EC2, but after reading Harrison's comments and repro steps, it sounds like the issue doesn't have to do with any of that. The bug is really around only custom clusters, and has to do with the RKE2/K3s registration command, and doesn't have to do with any specific cloud provider.