### PR TITLE
Correctly shows bound services in applications view

### DIFF
--- a/pkg/epinio/pages/c/_cluster/applications/index.vue
+++ b/pkg/epinio/pages/c/_cluster/applications/index.vue
@@ -62,11 +62,8 @@ export default {
       if (services.length) {
         const serviceBounds = [];
 
-        // We iterate over all services.
         services.map((service) => {
-          // now we have the service, as redis, for instance
           if (service.boundapps && service.boundapps.includes(theAppName)) {
-            // in the service, we have some bounded apps, check if the app we are looking for is bounded
             serviceBounds.push(service.meta.name);
           }
         });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/epinio/ui/issues/156


Follow the steps at https://github.com/epinio/ui/issues/156 to reproduce. 
Now an app with a single bounded service should show only that one and not all available services.

> Note: Binding apps to services from UI won't work before merging  https://github.com/rancher/dashboard/pull/6865, you can use epinio-cli for it.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/88777903/190195192-e9ffbb94-c40c-4887-8a47-a2e0a5a5e272.png)
