### PR TITLE
Ensure roles that inherit from many many other roles can be edited

### DIFF
--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -80,11 +80,14 @@ export default {
     // users to freely type in resources that are not shown in the list.
 
     if (this.value.subtype === CLUSTER || this.value.subtype === NAMESPACE) {
-      this.templateOptions = (await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }))
-        .map(option => ({
-          label: option.nameDisplay,
-          value: option.id
-        }));
+      (await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE })).forEach((template) => {
+        // Ensure we have quick access to a specific template. This allows unselected drop downs to show the correct value
+        this.keyedTemplateOptions[template.id] = {
+          label: template.nameDisplay,
+          value: template.id
+        };
+      });
+      this.templateOptions = Object.values(this.keyedTemplateOptions);
     }
   },
 
@@ -97,11 +100,13 @@ export default {
         resources:       [],
         verbs:           []
       },
-      verbOptions:       VERBS,
-      templateOptions:   [],
-      resources:         this.value.resources,
-      scopedResources:   SCOPED_RESOURCES,
-      defaultValue:      false,
+      verbOptions:          VERBS,
+      templateOptions:      [],
+      keyedTemplateOptions: {},
+      resources:            this.value.resources,
+      scopedResources:      SCOPED_RESOURCES,
+      defaultValue:         false,
+      selectFocused:        null,
     };
   },
 
@@ -682,10 +687,12 @@ export default {
                     :taggable="false"
                     :disabled="isBuiltin"
                     :searchable="true"
-                    :options="templateOptions"
+                    :options="selectFocused === props.i ? templateOptions : [keyedTemplateOptions[props.row.value]]"
                     option-key="value"
                     option-label="label"
                     :mode="mode"
+                    @on-focus="selectFocused = props.i"
+                    @on-blur="selectFocused = null"
                   />
                 </div>
               </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6885
For roles that inherit from 1000s of roles the general view/edit experience is impeded 
- Getting to the detail/edit page of the role is a bit sluggish
- Viewing the 'inherit from' tab in edit view is sluggish
- Leaving the page after viewing `inherit from` tab causes dashboard to hang

### Occurred changes and/or fixed issues
- Root issue addressed in this commit is performance of the inherit from tab, specifically the tab hang one
- On a system with a cluster role that inherits from 1100 other roles
  - Tab shows one drop down for every role it inherits (1100)
  - Each drop down contains 1100 entries
  - Each slot that shows the drop down is passed 1100 roles as well
- To Address
  - Fix the primary issue of 1000s of selects with 1000s of entries
  - Reduce this to 1000s selects with 1 entry.... except when the user clicks on it

### Technical notes summary
I have an instance as described in the issue