### PR TITLE
Add check for azuread endpoint type

### DIFF
--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -76,6 +76,8 @@ export default {
   data() {
     return {
       endpoint:          'standard',
+      oldEndpoint:        false,
+
       // Storing the applicationSecret is necessary because norman doesn't support returning secrets and when we
       // override the steve authconfig with a norman config the applicationSecret is lost
       applicationSecret: this.value.applicationSecret
@@ -147,9 +149,6 @@ export default {
       handler() {
         this.model.accessMode = this.model.accessMode || 'unrestricted';
         this.model.rancherUrl = this.model.rancherUrl || this.replyUrl;
-        if (this.endpoint !== 'custom') {
-          this.setEndpoints(this.endpoint);
-        }
 
         if (this.model.applicationSecret) {
           this.$set(this, 'applicationSecret', this.model.applicationSecret);
@@ -162,11 +161,13 @@ export default {
   methods: {
     setEndpoints(endpoint) {
       if (this.editConfig || !this.model.enabled) {
-        Object.keys(ENDPOINT_MAPPING[endpoint]).forEach((key) => {
+        const endpointType = this.oldEndpoint && endpoint !== 'custom' ? OLD_ENDPOINTS : ENDPOINT_MAPPING;
+
+        Object.keys(endpointType[endpoint]).forEach((key) => {
           this.$set(
             this.model,
             key,
-            ENDPOINT_MAPPING[endpoint][key].replace(
+            endpointType[endpoint][key].replace(
               TENANT_ID_TOKEN,
               this.model.tenantId
             )
@@ -176,10 +177,14 @@ export default {
     },
 
     setInitialEndpoint(endpoint) {
-      const endpointKey = Object.keys(ENDPOINT_MAPPING).find(key => ENDPOINT_MAPPING[key].graphEndpoint === endpoint);
+      const newEndpointKey = Object.keys(ENDPOINT_MAPPING).find(key => ENDPOINT_MAPPING[key].graphEndpoint === endpoint);
+      const oldEndpointKey = Object.keys(OLD_ENDPOINTS).find(key => OLD_ENDPOINTS[key].graphEndpoint === endpoint);
 
-      if ( endpointKey ) {
-        this.endpoint = endpointKey;
+      if ( newEndpointKey ) {
+        this.endpoint = newEndpointKey;
+      } else if ( oldEndpointKey ) {
+        this.endpoint = oldEndpointKey;
+        this.oldEndpoint = true;
       } else {
         this.endpoint = 'custom';
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6868 - Fixes #6428 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
If the azuread auth has been configured prior to 2.6.7 and the endpoints have not been updated, the deprecated endpoints ( e.g. `https://graph.windows.net/` ) should be respected when editing the config. Also, when setting the initial endpoint option we were not checking for the old endpoints, thus setting the endpoint radio option to `custom`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Added a check for a `graphEndpoint` in the config to match one of the old endpoints. When `setEndpoints` is called it use the appropriate endpoint map to update the model.
Also removed the unnecessary call to `setEndpoints` when the model as this was causing the endpoint to be reset to the new set of endpoints regardless of the original value.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Editing the config of an existing azuread auth after upgrading to `v2.6-head`
- Creating a new azuread auth
