### PR TITLE
Fix broken link to plugins documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ During the transition to the new folder structured in 2.6.5 required by the plug
 - Run the script `./scripts/rejig -d` to move folders to their old location and update imports again
   Use this to convert newer branches to the old format (possibly useful for branches)
 
-For more information on plugins see [Plugins](./docs/developer/PLUGINS.md).
+For more information on plugins see [Plugins](./docusaurus/docs/guide/plugins.md).
 
 ## Running for Development
 This is what you probably want to get started.


### PR DESCRIPTION
This updates the path to the plugins page in `README.md`

It looks like 11cd95d5b3591be33de4acec5b61af70bea1c04d changed the location but didn't update this link alongside the change.