### PR TITLE
Adjusts timing, messaging, control, etc of websocket growls.

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2096,9 +2096,15 @@ graphOptions:
 
 growl:
   clearAll: Clear All Notifications
-  disconnected: 
-    message: "The connection to {url} closed unexpectedly {time}. Retrying..."
+  disconnectError: 
+    message: "The connection to {url} closed unexpectedly at {time}. Disconnected after {tries} reconnect attempts. Check your network connection and reload the page"
     title: Websocket Disconnected 
+  connectError: 
+    message: "The connection to {url} closed unexpectedly at {time}. Reconnect attempt #{tries}."
+    title: Websocket Reconnecting 
+  reconnected: 
+    message: "The connection to {url} was restored on attempt #{tries}."
+    title: Websocket Reconnected
 
 hpa:
   detail:


### PR DESCRIPTION
### Summary
Fixes #6785
Some sockets close quickly, given that we growl on every socket closing, this can lead to flooding the UI with growl notifications. Growl notifications were added to the dashboard because if a websocket cannot connect, that's something a user should know about.

### Occurred changes and/or fixed issues
* We don't consider ourselves actually disconnected until the reconnect attempts have failed.
* We only attempt to reconnect 3 times before declaring the socket disconnected and telling the user to reload the page (maybe later, I'll figure out how to add a "try again" button to the growl to bump the maxTries and attempt to connect again.
* Subscribe.js doesn't have any setTimeouts for displaying growls, all the timing is handled by when we dispatch the events in socket.js, keeping the timeline in my head was driving me crazy so I had to centralize it.
* We don't even notify the user unless the 1st reconnect attempt has failed since sockets closing and reconnecting is part of their normal lifecycle.
* If there's been more than 1 attempt to reconnect and the 2nd or 3rd attempt was successful then we clear all the growls and instead tell them that we've reconnected.
* Given that the growls effectively escalate the same issue, we always remove the old growl before dispatching the new one so we don't flood the screen.

### Areas or cases that should be tested
I still don't have a great way to test this. Ideally, one could send socket connections through a proxy that you could arbitrarily disconnect and reconnect to cover all test cases.

### Areas which could experience regressions
The app is now a lot more careful about sending growl notifications about sockets, we'll want to make sure that they do show up when they're supposed to still.