### PR TITLE
Add overflow-wrap to principle member name/loginName

### DIFF
--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -159,6 +159,7 @@ export default {
     .name {
       grid-area: name;
       line-height: math.div($size, 2);
+      overflow-wrap: anywhere;
     }
 
     .description {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5283 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The original pr https://github.com/rancher/dashboard/pull/6831 did not take into account the username/loginName wrapping, only the display name. Added an overflow wrap to fold the text to ensure no overlapping will occur with either the user name or display name.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
`overflow-wrap: anywhere` has been added to the `.name` class which will fold the text when it reaches the end of it's container.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- To test you can add a test user with a long user name **&** display name, then attempt to add the user to a project within a cluster. For example:
user: `long-username-hyz8ql12oa-0b2ewxkh29-vjnzbyqcmd-ohydd9bi3x-7rcje6k5hp-kr9ld7r1si`
display name: `long-displayname-e422ilkhqj-y4rzk02abt-c8m0scwcwl-reliod8oja-hj1jvu31mm-k28d9zppm1`

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Before**
![before](https://user-images.githubusercontent.com/40806497/190657527-bf57cd0e-b314-4984-aa15-e39883ec3138.png)

**After**
![after](https://user-images.githubusercontent.com/40806497/190657574-7582b193-7324-42c6-977a-ce147738eef4.png)
