### PR TITLE
UI 2.6.x 'events' view is confusing and 'hidden' by default

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2067,6 +2067,7 @@ glance:
   installMonitoring: Install Monitoring
   v1MonitoringInstalled: V1 Monitoring Installed
   clusterInfo: Cluster Information
+  eventsTable: Full events list
 
 clusterBadge:
   addLabel: Add Cluster Badge

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -58,6 +58,7 @@ export function init(store) {
     'namespaces',
     NODE,
     VIRTUAL_TYPES.CLUSTER_MEMBERS,
+    EVENT,
   ], 'cluster');
   basicType([
     SERVICE,
@@ -142,6 +143,7 @@ export function init(store) {
   configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: true });
 
   configureType(EVENT, { limit: 500 });
+  weightType(EVENT, -1, true);
 
   // Allow Pods to be grouped by node
   configureType(POD, {

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -446,6 +446,11 @@ export default {
     <div class="mt-30">
       <Tabbed @changed="tabChange">
         <Tab name="cluster-events" :label="t('clusterIndexPage.sections.events.label')" :weight="2">
+          <span class="events-table-link">
+            <n-link :to="{name: 'c-cluster-explorer-event'}">
+              <span>{{ t('glance.eventsTable') }}</span>
+            </n-link>
+          </span>
           <EventsTable />
         </Tab>
         <Tab v-if="hasMonitoring" name="cluster-alerts" :label="t('clusterIndexPage.sections.alerts.label')" :weight="1">
@@ -546,6 +551,12 @@ export default {
   &:focus {
     outline: 0;
   }
+}
+
+.events-table-link {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
 }
 
 .k8s-component-status {


### PR DESCRIPTION
Fixes #5816 

- add `event` resource type on cluster tab in side menu 
- add link to events list on the events overview in cluster dashboard

**Screenshots**
![edited](https://user-images.githubusercontent.com/97888974/191219086-91a3b16d-c1c5-4490-b0c8-063391dfbef4.png)
