### PR TITLE
Remove some legacy v1 tools

### DIFF
--- a/shell/config/product/legacy.js
+++ b/shell/config/product/legacy.js
@@ -47,16 +47,6 @@ export function init(store) {
   });
 
   virtualType({
-    labelKey:       'legacy.cis-scans',
-    name:           'v1-cis-scans',
-    group:          'Root',
-    namespaced:     true,
-    weight:         111,
-    route:          { name: 'c-cluster-legacy-pages-page', params: { page: 'cis' } },
-    exact:          true
-  });
-
-  virtualType({
     ifHave:     IF_HAVE.PROJECT,
     labelKey:   'legacy.project.label',
     namespaced: true,
@@ -82,7 +72,6 @@ export function init(store) {
     'v1-alerts',
     'v1-catalogs',
     'v1-notifiers',
-    'v1-cis-scans',
     'v1-project-overview'
   ]);
 
@@ -123,44 +112,11 @@ export function init(store) {
 
   virtualType({
     ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.logging',
-    namespaced: true,
-    name:       'project-logging',
-    weight:     105,
-    route:      { name: 'c-cluster-legacy-project-page', params: { page: 'logging' } },
-    exact:      true,
-    overview:   false,
-  });
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
     labelKey:   'legacy.monitoring',
     namespaced: true,
     name:       'project-monitoring',
     weight:     105,
     route:      { name: 'c-cluster-legacy-project-page', params: { page: 'monitoring' } },
-    exact:      true,
-    overview:   false,
-  });
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.istio',
-    namespaced: true,
-    name:       'project-istio',
-    weight:     105,
-    route:      { name: 'c-cluster-legacy-project-page', params: { page: 'istio' } },
-    exact:      true,
-    overview:   false,
-  });
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.pipelines',
-    namespaced: true,
-    name:       'project-pipelines',
-    weight:     104,
-    route:      { name: 'c-cluster-legacy-project-pipelines' },
     exact:      true,
     overview:   false,
   });
@@ -192,10 +148,7 @@ export function init(store) {
     'project-alerts',
     'project-catalogs',
     'project-config-maps',
-    'project-logging',
-    'project-istio',
     'project-monitoring',
-    'project-pipelines',
     'project-secrets',
   ], 'Project');
 }

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -127,7 +127,7 @@ export default {
         charts = sortBy(charts, ['certifiedSort', 'chartNameDisplay']);
       }
 
-      const chartsWithApps = charts.map((chart) => {
+      let chartsWithApps = charts.map((chart) => {
         return {
           chart,
           app: this.installedAppForChart[chart.id],
@@ -136,9 +136,9 @@ export default {
 
       // V1 Legacy support
       if (this.legacyEnabled) {
-        this.checkLegacyApp(chartsWithApps, this.v1Apps, 'v1-monitoring', 'rancher-monitoring', 'cluster-monitoring');
-        this.checkLegacyApp(chartsWithApps, this.v1Apps, 'v1-istio', 'rancher-istio', 'cluster-istio');
-        this.checkLegacyApp(chartsWithApps, this.v1Apps, 'v1-logging', 'rancher-logging', 'rancher-logging');
+        chartsWithApps = this.checkLegacyApp(chartsWithApps, this.v1Apps, 'v1-monitoring', 'rancher-monitoring', 'cluster-monitoring', false);
+        chartsWithApps = this.checkLegacyApp(chartsWithApps, this.v1Apps, 'v1-istio', 'rancher-istio', 'cluster-istio', true);
+        chartsWithApps = this.checkLegacyApp(chartsWithApps, this.v1Apps, 'v1-logging', 'rancher-logging', 'rancher-logging', true);
       }
 
       return chartsWithApps;
@@ -231,7 +231,7 @@ export default {
       return versions;
     },
 
-    checkLegacyApp(chartsWithApps, v1Apps, v1ChartName, v2ChartName, v1AppName) {
+    checkLegacyApp(chartsWithApps, v1Apps, v1ChartName, v2ChartName, v1AppName, showOnlyIfInstalled) {
       const v1 = chartsWithApps.find(a => a.chart.chartName === v1ChartName);
       const v2 = chartsWithApps.find(a => a.chart.chartName === v2ChartName);
 
@@ -251,6 +251,9 @@ export default {
               v1.app.upgradeAvailable = latest;
             }
           }
+        } else if (showOnlyIfInstalled) {
+          // Remove the v1 chart if it is not already installed for charts which we no longer support
+          chartsWithApps = chartsWithApps.filter(c => c !== v1);
         }
 
         if (v2) {
@@ -262,6 +265,8 @@ export default {
           }
         }
       }
+
+      return chartsWithApps;
     }
   }
 };


### PR DESCRIPTION
Fixes #6864
Fixes #6876
Fixes #6874
Fixes #6872

This PR removes some of the deprecated v1 tools which are no longer being supported - specifically:

In the 'legacy' section of the side-nav when exploring a cluster:

1. CIS Scans
2. Project => Istio
3. Project => Logging
4. Project => Pipelines

Additionally, the Istio and Logging v1 tools shown in the 'Cluster Tools' section will only now appear IF they are already installed - they will no longer be installable from the new UI - the can still be managed if already installed, so that the user can remove them in order to upgrade to v2.