### PR TITLE
Fix the url used to fetch the embedded harvester plugin

### DIFF
--- a/shell/models/harvesterhci.io.management.cluster.js
+++ b/shell/models/harvesterhci.io.management.cluster.js
@@ -79,11 +79,11 @@ export default class HciCluster extends ProvCluster {
     const pkgName = `${ HARVESTER_NAME }-1.0.3`;
 
     if (uiOfflinePreferred === 'true') {
-      // Embedded (aka give me the version of the embedded plugin that was in the last release)
-      const embeddedPath = `dashboard/${ pkgName }/${ pkgName }.umd.min.js`;
+      // Embedded (aka give me the embedded plugin that was in the last rancher release)
+      const embeddedPath = `${ pkgName }/${ pkgName }.umd.min.js`;
 
       return {
-        pkgUrl: process.env.dev ? `${ process.env.api }/${ embeddedPath }` : embeddedPath,
+        pkgUrl: process.env.dev ? `${ process.env.api }/dashboard/${ embeddedPath }` : embeddedPath,
         pkgName
       };
     }


### PR DESCRIPTION
- Use case supports legacy harvester cluster use case where it does not have it's own plugin
- Bug discovered by @WuJun2016 during 2.6.9 release testing
- ![image](https://user-images.githubusercontent.com/18697775/191247409-3d104716-c1e9-4191-b87b-4a61d0244076.png)


