### PR TITLE
Add info banner for rke2 cni and network policy conflict

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1650,7 +1650,7 @@ cluster:
       label: Default Pod Security Policy
     enableNetworkPolicy:
       label: Project Network Isolation
-      warning: Per default the ingress controller will not be able to route requests to pods on other nodes.
+      warning: Per default, the ingress controller will not be able to route requests to pods on other nodes.
     workNode:
       label: Worker Nodes
     controlPlaneConcurrency:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1650,6 +1650,7 @@ cluster:
       label: Default Pod Security Policy
     enableNetworkPolicy:
       label: Project Network Isolation
+      warning: Per default the ingress controller will not be able to route requests to pods on other nodes.
     workNode:
       label: Worker Nodes
     controlPlaneConcurrency:

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1788,6 +1788,12 @@ export default {
             </div>
           </div>
 
+          <div v-if="serverConfig.cni === 'cilium' && value.spec.enableNetworkPolicy" class="row">
+            <div class="col span-12">
+              <Banner color="info" :label="t('cluster.rke2.enableNetworkPolicy.warning')" />
+            </div>
+          </div>
+
           <div class="spacer" />
 
           <div v-if="serverArgs.disable" class="row">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5105 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This adds an info banner in the rke2 cluster configuration under the `Project network isolation` checkbox when the Container Network is `cilium` and the Project network isolation checkbox is enabled. The info will read "Per default the ingress controller will not be able to route requests to pods on other nodes."

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Creating/editing an rke2 cluster

### Screenshot/Video
![banner](https://user-images.githubusercontent.com/40806497/191259905-7f47ee65-2195-4132-8618-d9fa8bca8e2d.png)
