### PR TITLE
Change side-nav cluster order to sort by name

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -101,7 +101,7 @@ export default {
 
       const out = search ? this.clusters.filter(item => item.label.toLowerCase().includes(search)) : this.clusters;
 
-      const sorted = sortBy(out, ['ready:desc', 'label']);
+      const sorted = sortBy(out, ['name:desc', 'label']);
 
       return sorted;
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6708 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The cluster order on the mgmt and home pages sort clusters by name, this will change the order within the side-nav to change the sorting from `ready` status to `name`. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The order for listed clusters on the mgmt and home page are sorted by name which is from the backend. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Steps to test are in the referenced issue

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Side nav**
![side](https://user-images.githubusercontent.com/40806497/191265060-6317b8a4-d560-4f38-b2e7-57555084d19f.png)

**Home page**
![home](https://user-images.githubusercontent.com/40806497/191265093-5eda434e-298b-491a-aec1-3b79a73805f1.png)

**Cluster management page**
![mgmt](https://user-images.githubusercontent.com/40806497/191265154-289bf9df-078d-4aaf-b2e7-8d3a7cd901db.png)
