### PR TITLE
Add PSP Removal banners

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2446,6 +2446,7 @@ landing:
     title: Getting Started
     body: Take a look at the the quick getting started guide. For Cluster Manager users, learn more about where you can find your favorite features in the Dashboard UI.
   support: Support
+  deprecatedPsp: "In Kubernetes v1.25, Pod Security Policies will be removed following it's deprecation in v1.21. They will be removed in favor of Pod Security Admissions, for which you can follow the instructions for migration <a href='https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/' target='_blank' rel='noopener nofollow noreferrer'>here</a>"
   community:
     title: Community Support
     docs: Docs

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2446,7 +2446,7 @@ landing:
     title: Getting Started
     body: Take a look at the the quick getting started guide. For Cluster Manager users, learn more about where you can find your favorite features in the Dashboard UI.
   support: Support
-  deprecatedPsp: "In Kubernetes v1.25, Pod Security Policies will be removed following it's deprecation in v1.21. They will be removed in favor of Pod Security Admissions, for which you can follow the instructions for migration <a href='https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/' target='_blank' rel='noopener nofollow noreferrer'>here</a>"
+  deprecatedPsp: Pod Security Policies are deprecated as of Kubernetes v1.21, and have been removed in Kubernetes v1.25. You have one or more PodSecurityPolicy resource(s) in this cluster.
   community:
     title: Community Support
     docs: Docs

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -140,14 +140,16 @@ export default {
   },
 
   watch: {
-    // logic to be removed once kube version is 1.25 or greater
     // we need to hook up this API call to a watcher because the page logic is based on a getter
-    // as a temporary solution, this seems reasonable, so that we don't disrupt the optimal loading times of the page
+    // this seems reasonable, so that we don't disrupt the optimal loading times of the page
     currentCluster: {
       async handler(neu, old) {
         if (neu && (!old || old.id !== neu.id)) {
-          if (neu.status?.version?.major >= 1 && neu.status?.version?.minor >= 21) {
-            const psps = await this.$store.dispatch('management/request', { url: '/v1/policy.podsecuritypolicies' });
+          const major = neu.status?.version?.major ? parseInt(neu.status?.version?.major) : 0;
+          const minor = neu.status?.version?.minor ? parseInt(neu.status?.version?.minor) : 0;
+
+          if (major === 1 && minor >= 21 && minor < 25) {
+            const psps = await this.$store.dispatch('cluster/request', { url: `/k8s/clusters/${ neu.id }/v1/policy.podsecuritypolicies` });
 
             if (psps && psps.data && psps.data.length) {
               this.displayPspDeprecationBanner = true;

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -111,12 +111,12 @@ export default {
 
     return {
       nodeHeaders,
-      constraints:         [],
-      events:              [],
-      nodeMetrics:         [],
-      showClusterMetrics: false,
-      showK8sMetrics:     false,
-      showEtcdMetrics:    false,
+      constraints:                 [],
+      events:                      [],
+      nodeMetrics:                 [],
+      showClusterMetrics:          false,
+      showK8sMetrics:              false,
+      showEtcdMetrics:             false,
       CLUSTER_METRICS_DETAIL_URL,
       CLUSTER_METRICS_SUMMARY_URL,
       K8S_METRICS_DETAIL_URL,
@@ -124,7 +124,8 @@ export default {
       ETCD_METRICS_DETAIL_URL,
       ETCD_METRICS_SUMMARY_URL,
       clusterCounts,
-      selectedTab:         'cluster-events',
+      selectedTab:                 'cluster-events',
+      displayPspDeprecationBanner: false
     };
   },
 
@@ -136,6 +137,26 @@ export default {
     this.$store.dispatch('cluster/forgetType', ENDPOINTS); // Used by AlertTable to get alerts when v2 monitoring is installed
     this.$store.dispatch('cluster/forgetType', METRIC.NODE);
     this.$store.dispatch('cluster/forgetType', MANAGEMENT.NODE);
+  },
+
+  watch: {
+    // logic to be removed once kube version is 1.25 or greater
+    // we need to hook up this API call to a watcher because the page logic is based on a getter
+    // as a temporary solution, this seems reasonable, so that we don't disrupt the optimal loading times of the page
+    currentCluster: {
+      async handler(neu, old) {
+        if (neu && (!old || old.id !== neu.id)) {
+          if (neu.status?.version?.major >= 1 && neu.status?.version?.minor >= 21) {
+            const psps = await this.$store.dispatch('management/request', { url: '/v1/policy.podsecuritypolicies' });
+
+            if (psps && psps.data && psps.data.length) {
+              this.displayPspDeprecationBanner = true;
+            }
+          }
+        }
+      },
+      immediate: true
+    },
   },
 
   computed: {
@@ -378,6 +399,12 @@ export default {
         </div>
       </div>
     </header>
+    <Banner
+      v-if="displayPspDeprecationBanner"
+      color="warning"
+    >
+      <t k="landing.deprecatedPsp" :raw="true" />
+    </Banner>
     <Banner
       v-if="!hideClusterToolsTip"
       :closable="true"

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -23,7 +23,6 @@ import { BLANK_CLUSTER } from '@shell/store';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
 
 import { RESET_CARDS_ACTION, SET_LOGIN_ACTION } from '@shell/config/page-actions';
-import { allHash } from '~shell/utils/promise';
 
 export default {
   name:       'Home',
@@ -41,14 +40,9 @@ export default {
 
   mixins: [PageHeaderActions],
 
-  async fetch() {
-    const res = await allHash({
-      rancherClusters: this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
-      mgmtClusters:    this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
-      psps:            this.$store.dispatch('management/request', { url: '/v1/policy.podsecuritypolicies' }),
-    });
-
-    this.psps = res.psps?.data || [];
+  fetch() {
+    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
+    this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
   },
 
   data() {
@@ -67,11 +61,7 @@ export default {
     ];
 
     return {
-      HIDE_HOME_PAGE_CARDS,
-      fullVersion,
-      pageActions,
-      vendor: getVendor(),
-      psps:   [],
+      HIDE_HOME_PAGE_CARDS, fullVersion, pageActions, vendor: getVendor(),
     };
   },
 
@@ -82,10 +72,6 @@ export default {
 
     provClusters() {
       return this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
-    },
-
-    hasPodSecurityPolicies() {
-      return this.psps && this.psps.length;
     },
 
     canCreateCluster() {
@@ -305,9 +291,6 @@ export default {
 
       <div class="row">
         <div :class="{'span-9': showSidePanel, 'span-12': !showSidePanel }" class="col">
-          <Banner v-if="hasPodSecurityPolicies" color="warning">
-            <t k="landing.deprecatedPsp" :raw="true" />
-          </Banner>
           <SimpleBox
             id="migration"
             class="panel"

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -23,6 +23,7 @@ import { BLANK_CLUSTER } from '@shell/store';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
 
 import { RESET_CARDS_ACTION, SET_LOGIN_ACTION } from '@shell/config/page-actions';
+import { allHash } from '~shell/utils/promise';
 
 export default {
   name:       'Home',
@@ -40,9 +41,14 @@ export default {
 
   mixins: [PageHeaderActions],
 
-  fetch() {
-    this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
-    this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
+  async fetch() {
+    const res = await allHash({
+      rancherClusters: this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
+      mgmtClusters:    this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
+      psps:            this.$store.dispatch('management/request', { url: '/v1/policy.podsecuritypolicies' }),
+    });
+
+    this.psps = res.psps?.data || [];
   },
 
   data() {
@@ -61,7 +67,11 @@ export default {
     ];
 
     return {
-      HIDE_HOME_PAGE_CARDS, fullVersion, pageActions, vendor: getVendor(),
+      HIDE_HOME_PAGE_CARDS,
+      fullVersion,
+      pageActions,
+      vendor: getVendor(),
+      psps:   [],
     };
   },
 
@@ -72,6 +82,10 @@ export default {
 
     provClusters() {
       return this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
+    },
+
+    hasPodSecurityPolicies() {
+      return this.psps && this.psps.length;
     },
 
     canCreateCluster() {
@@ -291,6 +305,9 @@ export default {
 
       <div class="row">
         <div :class="{'span-9': showSidePanel, 'span-12': !showSidePanel }" class="col">
+          <Banner v-if="hasPodSecurityPolicies" color="warning">
+            <t k="landing.deprecatedPsp" :raw="true" />
+          </Banner>
           <SimpleBox
             id="migration"
             class="panel"


### PR DESCRIPTION
Fixes #6873 

- add deprecation banner for PSPs on cluster dashboard page to be displayed only if the user has any PSPs and if kubernetes version is 1.21 or higher

**Screenshot**
<img width="804" alt="Screenshot 2022-09-21 at 10 58 27" src="https://user-images.githubusercontent.com/97888974/191476968-2a848adb-287b-42c1-a0a1-c6b22de81977.png">


**Test**
- Create a `PodSecurityPolicy`
- Make sure cluster is running kubernetes version 1.21 or higher
- Check if warning Banner appears on the cluster dashboard page