### PR TITLE
Exclude managed fields from API response

### DIFF
--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -18,6 +18,8 @@ export default {
   async request({ state, dispatch, rootGetters }, pOpt ) {
     const opt = pOpt.opt || pOpt;
 
+    opt.params = { exclude: 'metadata.managedFields' };
+
     const spoofedRes = await handleSpoofedRequest(rootGetters, 'cluster', opt);
 
     if (spoofedRes) {


### PR DESCRIPTION
This PR takes advantage of this performance feature of Steve https://github.com/rancher/rancher/issues/36683 to exclude unneeded fields.

To test this PR, I confirmed the new param was added to resource requests and confirmed managed fields are no longer included in the response.
<img width="1481" alt="Screen Shot 2022-09-20 at 5 53 02 PM" src="https://user-images.githubusercontent.com/20599230/191390623-149b6d08-4a92-4e03-b210-cc0b9a48760f.png">
