### PR TITLE
'View in API' preference is not obvious

### DIFF
--- a/pkg/harvester/list/harvesterhci.io.setting.vue
+++ b/pkg/harvester/list/harvesterhci.io.setting.vue
@@ -2,7 +2,7 @@
 import { mapGetters } from 'vuex';
 import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
-import { DEV } from '@shell/store/prefs';
+import { VIEW_IN_API } from '@shell/store/prefs';
 import { MANAGEMENT } from '@shell/config/types';
 import { HCI } from '../types';
 import { allHash } from '@shell/utils/promise';
@@ -12,7 +12,7 @@ export default {
   components: { Banner, Loading },
 
   async fetch() {
-    const isDev = this.$store.getters['prefs/get'](DEV);
+    const isDev = this.$store.getters['prefs/get'](VIEW_IN_API);
     const isSingleProduct = !!this.$store.getters['isSingleProduct'];
 
     const hash = { harvesterSettings: this.$store.dispatch('harvester/findAll', { type: HCI.SETTING }) };

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3675,16 +3675,12 @@ prefs:
     vim: 'Vim'
   advFeatures:
     title: Advanced Features
-    viewInApi: Enables 'View in API' option
-    allNamespaces: This setting reveals namespaces that are managed by Rancher and are not meant to be manually edited or deleted
-    themeShortcut: Enables keyboard shortcut to toggle light or dark theme (shift+T)
-    noLocaleShortcut: Enables keyboard shortcut to toggle locales (shift+L)
-  advanced: Advanced
-  advancedTooltip: Enables 'View in API' option and keyboard shortcut to toggle light or dark theme (shift+t). This setting also reveals namespaces that are managed by Rancher and are not meant to be manually edited or deleted.
-  dev:
-    label: Enable Developer Tools & Features
+    viewInApi: Enable "View in API"
+    allNamespaces: Show system Namespaces managed by Rancher (not intended for editing or deletion)
+    themeShortcut: Enable Dark/Light Theme keyboard shortcut toggle (shift+T)
+    noLocaleShortcut: Enable Language Selection keyboard shortcut toggle (shift+L)
   hideDesc:
-    label: Hide All Type Description Boxes
+    label: Hide All Type Descriptions
   helm:
     'true': Include Prerelease Versions
     'false': Show Releases Only

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3673,6 +3673,14 @@ prefs:
     sublime: 'Normal human'
     emacs: 'Emacs'
     vim: 'Vim'
+  features:
+    title: Features
+    allNamespaces: This setting reveals namespaces that are managed by Rancher and are not meant to be manually edited or deleted
+    themeShortcut: Enables keyboard shortcut to toggle light or dark theme (shift+T)
+    noLocaleShortcut: Enables keyboard shortcut to toggle locales (shift+L)
+  devTools:
+    title: Developer Tools
+    viewInApi: Enables 'View in API' option
   advanced: Advanced
   advancedTooltip: Enables 'View in API' option and keyboard shortcut to toggle light or dark theme (shift+t). This setting also reveals namespaces that are managed by Rancher and are not meant to be manually edited or deleted.
   dev:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3673,14 +3673,12 @@ prefs:
     sublime: 'Normal human'
     emacs: 'Emacs'
     vim: 'Vim'
-  features:
-    title: Features
+  advFeatures:
+    title: Advanced Features
+    viewInApi: Enables 'View in API' option
     allNamespaces: This setting reveals namespaces that are managed by Rancher and are not meant to be manually edited or deleted
     themeShortcut: Enables keyboard shortcut to toggle light or dark theme (shift+T)
     noLocaleShortcut: Enables keyboard shortcut to toggle locales (shift+L)
-  devTools:
-    title: Developer Tools
-    viewInApi: Enables 'View in API' option
   advanced: Advanced
   advancedTooltip: Enables 'View in API' option and keyboard shortcut to toggle light or dark theme (shift+t). This setting also reveals namespaces that are managed by Rancher and are not meant to be manually edited or deleted.
   dev:

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -7,7 +7,7 @@ import { MANAGEMENT, NAMESPACE, VIRTUAL_TYPES } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import { PROJECT_ID } from '@shell/config/query-params';
 import Masthead from '@shell/components/ResourceList/Masthead';
-import { mapPref, GROUP_RESOURCES, DEV } from '@shell/store/prefs';
+import { mapPref, GROUP_RESOURCES, ALL_NAMESPACES } from '@shell/store/prefs';
 import MoveModal from '@shell/components/MoveModal';
 import { defaultTableSortGenerationFn } from '@shell/components/ResourceTable.vue';
 import { NAMESPACE_FILTER_ALL_ORPHANS } from '@shell/utils/namespace-filter';
@@ -184,8 +184,8 @@ export default {
       return this.groupPreference === 'none' ? this.rows : this.rowsWithFakeNamespaces;
     },
     rows() {
-      if (this.$store.getters['prefs/get'](DEV)) {
-        // If developer tools are turned on in the user preferences,
+      if (this.$store.getters['prefs/get'](ALL_NAMESPACES)) {
+        // If all namespaces options are turned on in the user preferences,
         // return all namespaces including system namespaces and RBAC
         // management namespaces.
         return this.activeNamespaces;

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -1,6 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
-import { NAMESPACE_FILTERS, DEV } from '@shell/store/prefs';
+import { NAMESPACE_FILTERS, ALL_NAMESPACES } from '@shell/store/prefs';
 import { NAMESPACE, MANAGEMENT } from '@shell/config/types';
 import { sortBy } from '@shell/utils/sort';
 import { isArray, addObjects, findBy, filterBy } from '@shell/utils/array';
@@ -322,8 +322,8 @@ export default {
 
   methods: {
     filterNamespaces(namespaces) {
-      if (this.$store.getters['prefs/get'](DEV)) {
-        // If developer tools are turned on in the user preferences,
+      if (this.$store.getters['prefs/get'](ALL_NAMESPACES)) {
+        // If all namespaces options are turned on in the user preferences,
         // return all namespaces including system namespaces and RBAC
         // management namespaces.
         return namespaces;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -4,7 +4,7 @@ import ClusterProviderIcon from '@shell/components/ClusterProviderIcon';
 import { mapGetters } from 'vuex';
 import $ from 'jquery';
 import { CAPI, MANAGEMENT } from '@shell/config/types';
-import { mapPref, DEV, MENU_MAX_CLUSTERS } from '@shell/store/prefs';
+import { mapPref, MENU_MAX_CLUSTERS } from '@shell/store/prefs';
 import { sortBy } from '@shell/utils/sort';
 import { ucFirst } from '@shell/utils/string';
 import { KEY } from '@shell/utils/platform';
@@ -102,8 +102,6 @@ export default {
 
       return sorted;
     },
-
-    dev: mapPref(DEV),
 
     maxClustersToShow: mapPref(MENU_MAX_CLUSTERS),
 

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -1,7 +1,13 @@
 <script>
 import debounce from 'lodash/debounce';
 import { mapState, mapGetters } from 'vuex';
-import { mapPref, DEV, FAVORITE_TYPES, AFTER_LOGIN_ROUTE } from '@shell/store/prefs';
+import {
+  mapPref,
+  FAVORITE_TYPES,
+  AFTER_LOGIN_ROUTE,
+  NO_LOCALE_SHORTCUT,
+  THEME_SHORTCUT
+} from '@shell/store/prefs';
 import ActionMenu from '@shell/components/ActionMenu';
 import GrowlManager from '@shell/components/GrowlManager';
 import WindowManager from '@shell/components/nav/WindowManager';
@@ -78,8 +84,9 @@ export default {
       return this.$store.getters['activeNamespaceCache'];
     },
 
-    dev:            mapPref(DEV),
-    favoriteTypes:  mapPref(FAVORITE_TYPES),
+    themeShortcut:    mapPref(THEME_SHORTCUT),
+    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT),
+    favoriteTypes:    mapPref(FAVORITE_TYPES),
 
     pageActions() {
       const pageActions = [];
@@ -647,8 +654,8 @@ export default {
         <PromptRestore />
         <AssignTo />
         <PromptModal />
-        <button v-if="dev" v-shortkey.once="['shift','l']" class="hide" @shortkey="toggleNoneLocale()" />
-        <button v-if="dev" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
+        <button v-if="noLocaleShortcut" v-shortkey.once="['shift','l']" class="hide" @shortkey="toggleNoneLocale()" />
+        <button v-if="themeShortcut" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
         <button v-shortkey.once="['f8']" class="hide" @shortkey="wheresMyDebugger()" />
         <button v-shortkey.once="['`']" class="hide" @shortkey="toggleShell" />
       </main>

--- a/shell/layouts/home.vue
+++ b/shell/layouts/home.vue
@@ -3,7 +3,7 @@ import Header from '@shell/components/nav/Header';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
-import { mapPref, THEME_SHORTCUT } from '@shell/store/prefs';
+import { mapPref, THEME_SHORTCUT, NO_LOCALE_SHORTCUT } from '@shell/store/prefs';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
@@ -31,13 +31,17 @@ export default {
   },
 
   computed: {
-    themeShortcut: mapPref(THEME_SHORTCUT),
+    themeShortcut:    mapPref(THEME_SHORTCUT),
+    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT),
     ...mapState(['managementReady']),
   },
 
   methods: {
     toggleTheme() {
       this.$store.dispatch('prefs/toggleTheme');
+    },
+    toggleNoneLocale() {
+      this.$store.dispatch('i18n/toggleNone');
     },
   }
 
@@ -60,6 +64,7 @@ export default {
     <FixedBanner :footer="true" />
     <GrowlManager />
     <button v-if="themeShortcut" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
+    <button v-if="noLocaleShortcut" v-shortkey.once="['shift','l']" class="hide" @shortkey="toggleNoneLocale()" />
   </div>
 </template>
 

--- a/shell/layouts/home.vue
+++ b/shell/layouts/home.vue
@@ -3,7 +3,7 @@ import Header from '@shell/components/nav/Header';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
-import { mapPref, DEV } from '@shell/store/prefs';
+import { mapPref, THEME_SHORTCUT } from '@shell/store/prefs';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
@@ -31,7 +31,7 @@ export default {
   },
 
   computed: {
-    dev: mapPref(DEV),
+    themeShortcut: mapPref(THEME_SHORTCUT),
     ...mapState(['managementReady']),
   },
 
@@ -59,7 +59,7 @@ export default {
     </div>
     <FixedBanner :footer="true" />
     <GrowlManager />
-    <button v-if="dev" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
+    <button v-if="themeShortcut" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
   </div>
 </template>
 

--- a/shell/layouts/plain.vue
+++ b/shell/layouts/plain.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapPref, THEME_SHORTCUT } from '@shell/store/prefs';
+import { mapPref, THEME_SHORTCUT, NO_LOCALE_SHORTCUT } from '@shell/store/prefs';
 import ActionMenu from '@shell/components/ActionMenu';
 import Header from '@shell/components/nav/Header';
 import PromptRemove from '@shell/components/PromptRemove';
@@ -37,12 +37,18 @@ export default {
     };
   },
 
-  computed: { themeShortcut: mapPref(THEME_SHORTCUT) },
+  computed: {
+    themeShortcut:    mapPref(THEME_SHORTCUT),
+    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT)
+  },
 
   methods: {
     toggleTheme() {
       this.$store.dispatch('prefs/toggleTheme');
-    }
+    },
+    toggleNoneLocale() {
+      this.$store.dispatch('i18n/toggleNone');
+    },
   }
 };
 </script>
@@ -63,6 +69,7 @@ export default {
         <PromptRemove />
         <AssignTo />
         <button v-if="themeShortcut" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
+        <button v-if="noLocaleShortcut" v-shortkey.once="['shift','l']" class="hide" @shortkey="toggleNoneLocale()" />
       </main>
     </div>
 

--- a/shell/layouts/plain.vue
+++ b/shell/layouts/plain.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapPref, DEV } from '@shell/store/prefs';
+import { mapPref, THEME_SHORTCUT } from '@shell/store/prefs';
 import ActionMenu from '@shell/components/ActionMenu';
 import Header from '@shell/components/nav/Header';
 import PromptRemove from '@shell/components/PromptRemove';
@@ -37,7 +37,7 @@ export default {
     };
   },
 
-  computed: { dev: mapPref(DEV) },
+  computed: { themeShortcut: mapPref(THEME_SHORTCUT) },
 
   methods: {
     toggleTheme() {
@@ -62,7 +62,7 @@ export default {
         <ActionMenu />
         <PromptRemove />
         <AssignTo />
-        <button v-if="dev" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
+        <button v-if="themeShortcut" v-shortkey.once="['shift','t']" class="hide" @shortkey="toggleTheme()" />
       </main>
     </div>
 

--- a/shell/list/management.cattle.io.setting.vue
+++ b/shell/list/management.cattle.io.setting.vue
@@ -4,13 +4,13 @@ import { MANAGEMENT } from '@shell/config/types';
 import { ALLOWED_SETTINGS } from '@shell/config/settings';
 import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
-import { DEV } from '@shell/store/prefs';
+import { VIEW_IN_API } from '@shell/store/prefs';
 
 export default {
   components: { Banner, Loading },
 
   async fetch() {
-    const isDev = this.$store.getters['prefs/get'](DEV);
+    const viewInApi = this.$store.getters['prefs/get'](VIEW_IN_API);
     const rows = await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.SETTING });
     const t = this.$store.getters['i18n/t'];
     // Map settings from array to object keyed by id
@@ -51,7 +51,7 @@ export default {
       }
       // There are only 2 actions that can be enabled - Edit Setting or View in API
       // If neither is available for this setting then we hide the action menu button
-      s.hasActions = (!s.readOnly || isDev) && setting.availableActions?.length;
+      s.hasActions = (!s.readOnly || viewInApi) && setting.availableActions?.length;
       settings.push(s);
     }
 

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -149,31 +149,33 @@ export default {
 <template>
   <div>
     <BackLink :link="backLink" />
-    <h1 v-t="'prefs.title'" />
-
-    <h4 v-t="'prefs.language'" />
-    <div class="row">
-      <div class="col span-4">
-        <LocaleSelector />
+    <h1 v-t="'prefs.title'" class="mb-20" />
+    <!-- Language -->
+    <div class="mt-10 mb-10">
+      <h4 v-t="'prefs.language'" />
+      <div class="row">
+        <div class="col span-4">
+          <LocaleSelector />
+        </div>
       </div>
     </div>
-    <hr />
     <!-- Theme -->
-    <h4 v-t="'prefs.theme.label'" class="mt-20" />
-    <div>
+    <div class="mt-10 mb-10">
+      <hr />
+      <h4 v-t="'prefs.theme.label'" />
       <ButtonGroup v-model="theme" :options="themeOptions" />
-    </div>
-    <div class="mt-10">
-      <t k="prefs.theme.autoDetail" :pm="pm" :am="am" />
+      <div class="mt-10">
+        <t k="prefs.theme.autoDetail" :pm="pm" :am="am" />
+      </div>
     </div>
     <!-- Login landing page -->
-    <div v-if="!isSingleProduct">
+    <div v-if="!isSingleProduct" class="mt-10 mb-10">
       <hr />
       <h4 v-t="'prefs.landing.label'" />
       <LandingPagePreference />
     </div>
     <!-- Display Settings -->
-    <div>
+    <div class="mt-10 mb-10">
       <hr />
       <h4 v-t="'prefs.displaySettings.title'" />
       <p class="set-landing-leadin">
@@ -220,7 +222,7 @@ export default {
       </div>
     </div>
     <!-- Advanced Features -->
-    <div class="col adv-features">
+    <div class="col adv-features mt-10 mb-10">
       <hr />
       <h4 v-t="'prefs.advFeatures.title'" />
       <Checkbox v-model="viewInApi" :label="t('prefs.advFeatures.viewInApi', {}, true)" class="mt-10" />
@@ -234,13 +236,13 @@ export default {
       <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-20" />
     </div>
     <!-- YAML editor key mapping -->
-    <div class="col">
+    <div class="col mt-10 mb-10">
       <hr />
       <h4 v-t="'prefs.keymap.label'" />
       <ButtonGroup v-model="keymap" :options="keymapOptions" />
     </div>
     <!-- Helm Charts -->
-    <div v-if="!isSingleProduct" class="col mb-40">
+    <div v-if="!isSingleProduct" class="col mt-10 mb-40">
       <hr />
       <h4 v-t="'prefs.helm.label'" />
       <ButtonGroup v-model="showPreRelease" :options="helmOptions" />

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -166,12 +166,6 @@ export default {
     <div class="mt-10">
       <t k="prefs.theme.autoDetail" :pm="pm" :am="am" />
     </div>
-    <!-- Developer Tools -->
-    <div class="col dev-tools">
-      <hr />
-      <h4 v-t="'prefs.devTools.title'" />
-      <Checkbox v-model="viewInApi" :label="t('prefs.devTools.viewInApi', {}, true)" class="mt-10" />
-    </div>
     <!-- Login landing page -->
     <div v-if="!isSingleProduct">
       <hr />
@@ -225,15 +219,17 @@ export default {
         </div>
       </div>
     </div>
-    <!-- Features -->
-    <div class="col features">
+    <!-- Advanced Features -->
+    <div class="col adv-features">
       <hr />
-      <h4 v-t="'prefs.features.title'" />
-      <Checkbox v-model="allNamespaces" :label="t('prefs.features.allNamespaces', {}, true)" class="mt-10" />
+      <h4 v-t="'prefs.advFeatures.title'" />
+      <Checkbox v-model="viewInApi" :label="t('prefs.advFeatures.viewInApi', {}, true)" class="mt-10" />
       <br />
-      <Checkbox v-model="themeShortcut" :label="t('prefs.features.themeShortcut', {}, true)" class="mt-20" />
+      <Checkbox v-model="allNamespaces" :label="t('prefs.advFeatures.allNamespaces', {}, true)" class="mt-20" />
       <br />
-      <Checkbox v-model="noLocaleShortcut" :label="t('prefs.features.noLocaleShortcut', {}, true)" class="mt-20" />
+      <Checkbox v-model="themeShortcut" :label="t('prefs.advFeatures.themeShortcut', {}, true)" class="mt-20" />
+      <br />
+      <Checkbox v-model="noLocaleShortcut" :label="t('prefs.advFeatures.noLocaleShortcut', {}, true)" class="mt-20" />
       <br />
       <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-20" />
     </div>

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -7,7 +7,8 @@ import ButtonGroup from '@shell/components/ButtonGroup';
 import { Checkbox } from '@components/Form/Checkbox';
 import LandingPagePreference from '@shell/components/LandingPagePreference';
 import {
-  mapPref, THEME, KEYMAP, DEV, DATE_FORMAT, TIME_FORMAT, ROWS_PER_PAGE, HIDE_DESC, SHOW_PRE_RELEASE, MENU_MAX_CLUSTERS
+  mapPref, THEME, KEYMAP, DATE_FORMAT, TIME_FORMAT, ROWS_PER_PAGE, HIDE_DESC, SHOW_PRE_RELEASE, MENU_MAX_CLUSTERS,
+  VIEW_IN_API, ALL_NAMESPACES, NO_LOCALE_SHORTCUT, THEME_SHORTCUT
 } from '@shell/store/prefs';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
@@ -20,14 +21,17 @@ export default {
   },
   mixins:     [BackRoute],
   computed:   {
-    keymap:          mapPref(KEYMAP),
-    dev:             mapPref(DEV),
-    dateFormat:      mapPref(DATE_FORMAT),
-    timeFormat:      mapPref(TIME_FORMAT),
-    perPage:         mapPref(ROWS_PER_PAGE),
-    hideDesc:        mapPref(HIDE_DESC),
-    showPreRelease:  mapPref(SHOW_PRE_RELEASE),
-    menuMaxClusters: mapPref(MENU_MAX_CLUSTERS),
+    keymap:           mapPref(KEYMAP),
+    viewInApi:        mapPref(VIEW_IN_API),
+    allNamespaces:    mapPref(ALL_NAMESPACES),
+    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT),
+    themeShortcut:    mapPref(THEME_SHORTCUT),
+    dateFormat:       mapPref(DATE_FORMAT),
+    timeFormat:       mapPref(TIME_FORMAT),
+    perPage:          mapPref(ROWS_PER_PAGE),
+    hideDesc:         mapPref(HIDE_DESC),
+    showPreRelease:   mapPref(SHOW_PRE_RELEASE),
+    menuMaxClusters:  mapPref(MENU_MAX_CLUSTERS),
 
     ...mapGetters(['isSingleProduct']),
 
@@ -154,92 +158,96 @@ export default {
       </div>
     </div>
     <hr />
-    <h4 v-t="'prefs.theme.label'" />
+    <!-- Theme -->
+    <h4 v-t="'prefs.theme.label'" class="mt-20" />
     <div>
       <ButtonGroup v-model="theme" :options="themeOptions" />
     </div>
     <div class="mt-10">
       <t k="prefs.theme.autoDetail" :pm="pm" :am="am" />
     </div>
+    <!-- Developer Tools -->
+    <div class="col dev-tools">
+      <hr />
+      <h4 v-t="'prefs.devTools.title'" />
+      <Checkbox v-model="viewInApi" :label="t('prefs.devTools.viewInApi', {}, true)" class="mt-10" />
+    </div>
+    <!-- Login landing page -->
     <div v-if="!isSingleProduct">
       <hr />
       <h4 v-t="'prefs.landing.label'" />
       <LandingPagePreference />
     </div>
-    <hr />
-    <h4 v-t="'prefs.displaySettings.title'" />
-    <p class="set-landing-leadin">
-      {{ t('prefs.displaySettings.detail', {}, raw=true) }}
-    </p>
-    <div class="row mt-20">
-      <div class="col span-4">
-        <LabeledSelect
-          v-model="dateFormat"
-          :label="t('prefs.dateFormat.label')"
-          :options="dateOptions"
-        />
-      </div>
-      <div class="col span-4">
-        <LabeledSelect
-          v-model="timeFormat"
-          :label="t('prefs.timeFormat.label')"
-          :options="timeOptions"
-        />
-      </div>
-    </div>
-
-    <div class="row mt-20">
-      <div class="col span-4">
-        <LabeledSelect
-          v-model.number="perPage"
-          :label="t('prefs.perPage.label')"
-          :options="perPageOptions"
-          option-key="value"
-          option-label="label"
-          placeholder="Select a row count"
-        />
-      </div>
-      <div class="col span-4">
-        <LabeledSelect
-          v-model.number="menuMaxClusters"
-          :label="t('prefs.clusterToShow.label')"
-          :options="menuClusterOptions"
-          option-key="value"
-          option-label="label"
-          placeholder="Select a row count"
-        />
-      </div>
-    </div>
-
-    <hr />
-    <div class="row">
-      <div class="col prefs-advanced">
-        <h4 v-t="'prefs.advanced'" />
-        <Checkbox v-model="dev" :label="t('prefs.dev.label', {}, true)" />
-        <p class="wrap-text">
-          {{ t('prefs.advancedTooltip') }}
-        </p>
-        <br>
-        <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-10" />
-      </div>
-    </div>
-
-    <hr />
-    <div class="row">
-      <div class="col span-12">
-        <h4 v-t="'prefs.keymap.label'" />
-        <ButtonGroup v-model="keymap" :options="keymapOptions" />
-      </div>
-    </div>
-
-    <div v-if="!isSingleProduct">
+    <!-- Display Settings -->
+    <div>
       <hr />
-      <div class="row mb-20">
-        <div class="col span-12">
-          <h4 v-t="'prefs.helm.label'" />
-          <ButtonGroup v-model="showPreRelease" :options="helmOptions" />
+      <h4 v-t="'prefs.displaySettings.title'" />
+      <p class="set-landing-leadin">
+        {{ t('prefs.displaySettings.detail', {}, raw=true) }}
+      </p>
+      <div class="row mt-20">
+        <div class="col span-4">
+          <LabeledSelect
+            v-model="dateFormat"
+            :label="t('prefs.dateFormat.label')"
+            :options="dateOptions"
+          />
+        </div>
+        <div class="col span-4">
+          <LabeledSelect
+            v-model="timeFormat"
+            :label="t('prefs.timeFormat.label')"
+            :options="timeOptions"
+          />
         </div>
       </div>
+
+      <div class="row mt-20">
+        <div class="col span-4">
+          <LabeledSelect
+            v-model.number="perPage"
+            :label="t('prefs.perPage.label')"
+            :options="perPageOptions"
+            option-key="value"
+            option-label="label"
+            placeholder="Select a row count"
+          />
+        </div>
+        <div class="col span-4">
+          <LabeledSelect
+            v-model.number="menuMaxClusters"
+            :label="t('prefs.clusterToShow.label')"
+            :options="menuClusterOptions"
+            option-key="value"
+            option-label="label"
+            placeholder="Select a row count"
+          />
+        </div>
+      </div>
+    </div>
+    <!-- Features -->
+    <div class="col features">
+      <hr />
+      <h4 v-t="'prefs.features.title'" />
+      <Checkbox v-model="allNamespaces" :label="t('prefs.features.allNamespaces', {}, true)" class="mt-10" />
+      <br />
+      <Checkbox v-model="themeShortcut" :label="t('prefs.features.themeShortcut', {}, true)" class="mt-20" />
+      <br />
+      <Checkbox v-model="noLocaleShortcut" :label="t('prefs.features.noLocaleShortcut', {}, true)" class="mt-20" />
+      <br />
+      <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-20" />
+    </div>
+    <!-- YAML editor key mapping -->
+    <div class="col">
+      <hr />
+      <h4 v-t="'prefs.keymap.label'" />
+      <ButtonGroup v-model="keymap" :options="keymapOptions" />
+    </div>
+    <!-- Helm Charts -->
+    <div v-if="!isSingleProduct" class="col mb-40">
+      <hr />
+      <h4 v-t="'prefs.helm.label'" />
+      <ButtonGroup v-model="showPreRelease" :options="helmOptions" />
     </div>
   </div>
 </template>

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -9,7 +9,7 @@ import {
   AS,
   MODE
 } from '@shell/config/query-params';
-import { DEV } from '@shell/store/prefs';
+import { VIEW_IN_API } from '@shell/store/prefs';
 import { addObject, addObjects, findBy, removeAt } from '@shell/utils/array';
 import CustomValidators from '@shell/utils/custom-validators';
 import { downloadFile, generateZip } from '@shell/utils/download';
@@ -966,7 +966,7 @@ export default class Resource {
   }
 
   get canViewInApi() {
-    return this.hasLink('self') && this.$rootGetters['prefs/get'](DEV);
+    return this.hasLink('self') && this.$rootGetters['prefs/get'](VIEW_IN_API);
   }
 
   get canYaml() {

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -91,7 +91,13 @@ export const TIME_FORMAT = create('time-format', 'h:mm:ss a', {
 });
 
 export const TIME_ZONE = create('time-zone', 'local');
+// DEV will be deprecated on v2.7.0, but is needed so that we can grab the value for the new settings that derived from it
+// such as: VIEW_IN_API, ALL_NAMESPACES, NO_LOCALE_SHORTCUT, THEME_SHORTCUT
 export const DEV = create('dev', false, { parseJSON });
+export const VIEW_IN_API = create('view-in-api', mapPref(DEV) || false, { parseJSON });
+export const ALL_NAMESPACES = create('all-namespaces', mapPref(DEV) || false, { parseJSON });
+export const NO_LOCALE_SHORTCUT = create('no-locale-shortcut', mapPref(DEV) || false, { parseJSON });
+export const THEME_SHORTCUT = create('theme-shortcut', mapPref(DEV) || false, { parseJSON });
 export const LAST_VISITED = create('last-visited', 'home', { parseJSON });
 export const SEEN_WHATS_NEW = create('seen-whatsnew', '', { parseJSON });
 export const READ_WHATS_NEW = create('read-whatsnew', '', { parseJSON });

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -15,6 +15,7 @@ export const create = function(name, def, opt = {}) {
   const asCookie = opt.asCookie === true;
   const asUserPreference = opt.asUserPreference !== false;
   const options = opt.options;
+  const inheritFrom = opt.inheritFrom;
 
   definitions[name] = {
     def,
@@ -22,6 +23,7 @@ export const create = function(name, def, opt = {}) {
     parseJSON,
     asCookie,
     asUserPreference,
+    inheritFrom, // if value is not defined on server, we can default it to another pref
     mangleRead:  opt.mangleRead, // Alter the value read from the API (to match old Rancher expectations)
     mangleWrite: opt.mangleWrite, // Alter the value written back to the API (ditto)
   };
@@ -94,10 +96,10 @@ export const TIME_ZONE = create('time-zone', 'local');
 // DEV will be deprecated on v2.7.0, but is needed so that we can grab the value for the new settings that derived from it
 // such as: VIEW_IN_API, ALL_NAMESPACES, NO_LOCALE_SHORTCUT, THEME_SHORTCUT
 export const DEV = create('dev', false, { parseJSON });
-export const VIEW_IN_API = create('view-in-api', mapPref(DEV) || false, { parseJSON });
-export const ALL_NAMESPACES = create('all-namespaces', mapPref(DEV) || false, { parseJSON });
-export const NO_LOCALE_SHORTCUT = create('no-locale-shortcut', mapPref(DEV) || false, { parseJSON });
-export const THEME_SHORTCUT = create('theme-shortcut', mapPref(DEV) || false, { parseJSON });
+export const VIEW_IN_API = create('view-in-api', false, { parseJSON, inheritFrom: DEV });
+export const ALL_NAMESPACES = create('all-namespaces', false, { parseJSON, inheritFrom: DEV });
+export const NO_LOCALE_SHORTCUT = create('no-locale-shortcut', false, { parseJSON, inheritFrom: DEV });
+export const THEME_SHORTCUT = create('theme-shortcut', false, { parseJSON, inheritFrom: DEV });
 export const LAST_VISITED = create('last-visited', 'home', { parseJSON });
 export const SEEN_WHATS_NEW = create('seen-whatsnew', '', { parseJSON });
 export const READ_WHATS_NEW = create('read-whatsnew', '', { parseJSON });
@@ -436,6 +438,10 @@ export const actions = {
     for (const key in definitions) {
       const definition = definitions[key];
       let value = clone(server.data[key]);
+
+      if (value === undefined && definition.inheritFrom) {
+        value = clone(server.data[definition.inheritFrom]);
+      }
 
       if ( value === undefined || key === ignoreKey) {
         continue;

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -122,7 +122,7 @@
 // )
 import { AGE, NAME, NAMESPACE as NAMESPACE_COL, STATE } from '@shell/config/table-headers';
 import { COUNT, SCHEMA, MANAGEMENT, NAMESPACE } from '@shell/config/types';
-import { DEV, EXPANDED_GROUPS, FAVORITE_TYPES } from '@shell/store/prefs';
+import { VIEW_IN_API, EXPANDED_GROUPS, FAVORITE_TYPES } from '@shell/store/prefs';
 import {
   addObject, findBy, insertAt, isArray, removeObject, filterBy
 } from '@shell/utils/array';
@@ -802,7 +802,7 @@ export const getters = {
       const module = findBy(state.products, 'name', product).inStore;
       const schemas = rootGetters[`${ module }/all`](SCHEMA);
       const counts = rootGetters[`${ module }/all`](COUNT)?.[0]?.counts || {};
-      const isDev = rootGetters['prefs/get'](DEV);
+      const isDev = rootGetters['prefs/get'](VIEW_IN_API);
       const isBasic = mode === BASIC;
 
       const out = {};
@@ -1215,7 +1215,7 @@ export const getters = {
   activeProducts(state, getters, rootState, rootGetters) {
     const knownTypes = {};
     const knownGroups = {};
-    const isDev = rootGetters['prefs/get'](DEV);
+    const isDev = rootGetters['prefs/get'](VIEW_IN_API);
 
     if ( state.schemaGeneration < 0 ) {
       // This does nothing, but makes activeProducts depend on schemaGeneration


### PR DESCRIPTION
Fixes #6289 

- splitting up user preferences belonging to `DEV` key and updating references throughout rancher 
- update user preferences page to individually control each one of them

**Before**
<img width="788" alt="Screenshot 2022-09-23 at 12 29 23" src="https://user-images.githubusercontent.com/97888974/191951268-842d1df0-75c6-416d-b1ca-412b18372ee5.png">

**After**
<img width="788" alt="Screenshot 2022-09-23 at 12 29 26" src="https://user-images.githubusercontent.com/97888974/191951292-ac8cde8e-b705-41b1-a289-9824d7369aed.png">

