### PR TITLE
Set container to be the default tab in workload screens.

### DIFF
--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -148,7 +148,6 @@ export default {
   },
 
   data() {
-    let defaultTab;
     let type = this.$route.params.resource;
     const createSidecar = !!this.$route.query.sidecar;
     const isInitContainer = !!this.$route.query.init;

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -165,16 +165,10 @@ export default {
           name:            `container-0`,
         }];
 
-        defaultTab = 'container-0';
-
         const podSpec = { template: { spec: { containers: podContainers, initContainers: [] } } };
 
         this.$set(this.value, 'spec', podSpec);
       }
-    }
-
-    if (this.mode === _CREATE) {
-      defaultTab = 'container-0';
     }
 
     if ((this.mode === _EDIT || this.mode === _VIEW ) && this.value.type === 'pod' ) {
@@ -214,7 +208,6 @@ export default {
           imagePullPolicy: 'Always',
           name:            `container-${ allContainers.length }`,
         });
-        defaultTab = 'container-0';
 
         containers = podTemplateSpec.initContainers;
       }
@@ -223,8 +216,6 @@ export default {
           imagePullPolicy: 'Always',
           name:            `container-${ allContainers.length }`,
         };
-
-        defaultTab = 'container-0';
 
         containers.push(container);
       } else {
@@ -261,7 +252,6 @@ export default {
         path: 'image', rootObject: this.container, rules: ['required'], translationKey: 'workload.container.image'
       }],
       fvReportedValidationPaths: ['spec'],
-      defaultTab
 
     };
   },
@@ -269,6 +259,14 @@ export default {
   computed: {
     tabErrors() {
       return { general: this.fvGetPathErrors(['image'])?.length > 0 };
+    },
+
+    defaultTab() {
+      if (!!this.$route.query.sidecar || this.$route.query.init || this.mode === _CREATE) {
+        return 'container-0';
+      }
+
+      return this.allContainers.length ? this.allContainers[0].name : '';
     },
 
     isEdit() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6644 - On workload screens make container tab default tab

### Areas or cases that should be tested
1. Navigate to Cluster Explorer > Cluster > Workload > Deployment
2. Click on Create 
3. When the screen loads it should have `container-0` already selected
4. If a workload is already created, going to `view` or `edit` should highlight the first container regardless of the name given

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->