### PR TITLE
fix disable growl notification and default to true

### DIFF
--- a/shell/config/settings.js
+++ b/shell/config/settings.js
@@ -104,7 +104,7 @@ export const DEFAULT_PERF_SETTING = {
     enabled:   false,
     threshold: 1500,
   },
-  disableWebsocketNotification: false
+  disableWebsocketNotification: true
 };
 
 export const fetchOrCreateSetting = async(store, id, val, save = true) => {

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -404,10 +404,10 @@ export const actions = {
     const tries = event?.detail?.tries; // have to pull it off of the event because the socket's tries is already reset to 0
     const t = rootGetters['i18n/t'];
     const perfSetting = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);
-    let disableGrowl = false;
+    let disableGrowl = true;
 
     if ( perfSetting?.value ) {
-      disableGrowl = JSON.parse(perfSetting.value).disableWebsocketNotification || false;
+      disableGrowl = JSON.parse(perfSetting.value).disableWebsocketNotification !== false;
     }
 
     this.$socket = socket;
@@ -467,7 +467,11 @@ export const actions = {
 
     // determine if websocket notifications are disabled
     const perfSetting = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);
-    let disableGrowl = false;
+    let disableGrowl = true;
+
+    if ( perfSetting?.value ) {
+      disableGrowl = JSON.parse(perfSetting.value).disableWebsocketNotification !== false;
+    }
 
     if (!disableGrowl) {
       const dateFormat = escapeHtml( rootGetters['prefs/get'](DATE_FORMAT));
@@ -479,10 +483,6 @@ export const actions = {
       const tries = state?.socket?.tries;
 
       const t = rootGetters['i18n/t'];
-
-      if ( perfSetting?.value ) {
-        disableGrowl = JSON.parse(perfSetting.value).disableWebsocketNotification || false;
-      }
 
       const growlErr = rootGetters['growl/find']({ key: 'url', val: url });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6960


### Areas or cases that should be tested
* disconnect and reconnect growls should be disabled if the user has never touched performance prefs
* disconnect and reconnect growls should be disabled if the user turns them off
* disconnect and reconnect growls should be shown if the user has turned them on
