### PR TITLE
Remove deprecated v1 multi-cluster apps

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -184,7 +184,7 @@ product:
   settings: Global Settings
   clusterManagement: Cluster Management
   monitoring: Monitoring
-  mcapps: Multi-cluster Apps
+  mcapps: Global Configuration
   neuvector: NeuVector
   harvesterManager: Virtualization Management
   rancher: Rancher
@@ -800,7 +800,8 @@ catalog:
         enableLegacy:
           prompt: You will need to enable Legacy Features to edit this App
           goto: Go to Feature Flag settings
-        navigate: Navigate to {legacyType} Apps
+        navigate: Navigate to Legacy Apps
+        mcmNotSupported: Legacy Multi-cluster Apps can not be managed through this UI
         category:
           legacy: Legacy
           mcm: Multi-cluster

--- a/shell/config/product/multi-cluster-apps.js
+++ b/shell/config/product/multi-cluster-apps.js
@@ -21,17 +21,6 @@ export function init(store) {
   });
 
   virtualType({
-    labelKey:       'legacy.apps',
-    name:           'mc-apps',
-    group:          'Root',
-    namespaced:     false,
-    weight:         112,
-    icon:           'folder',
-    route:          { name: 'c-cluster-mcapps-pages-page', params: { cluster: 'local', page: 'apps' } },
-    exact:          true
-  });
-
-  virtualType({
     labelKey:       'legacy.catalogs',
     name:           'mc-catalogs',
     group:          'Root',
@@ -65,7 +54,6 @@ export function init(store) {
   });
 
   basicType([
-    'mc-apps',
     'mc-catalogs',
     'global-dns-entries',
     'global-dns-providers',

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1533,7 +1533,7 @@ export default {
       </div>
 
       <Banner color="warning" class="description">
-        <span>
+        <span v-if="!mcapp">
           {{ t('catalog.install.error.legacy.label', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true) }}
         </span>
         <template v-if="!legacyEnabled">

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -632,10 +632,6 @@ export default {
       return { name: 'c-cluster-legacy-project' };
     },
 
-    mcmRoute() {
-      return { name: 'c-cluster-mcapps' };
-    },
-
     windowsIncompatible() {
       if (this.chart?.windowsIncompatible) {
         return this.t('catalog.charts.windowsIncompatible');
@@ -1546,9 +1542,12 @@ export default {
             {{ t('catalog.install.error.legacy.enableLegacy.goto') }}
           </nuxt-link>
         </template>
+        <template v-else-if="mcapp">
+            <span v-html="t('catalog.install.error.legacy.mcmNotSupported')" />
+        </template>
         <template v-else>
-          <nuxt-link :to="mcapp ? mcmRoute : legacyAppRoute">
-            <span v-html="t('catalog.install.error.legacy.navigate', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true)" />
+          <nuxt-link :to="legacyAppRoute">
+            <span v-html="t('catalog.install.error.legacy.navigate')" />
           </nuxt-link>
         </template>
       </Banner>

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1543,7 +1543,7 @@ export default {
           </nuxt-link>
         </template>
         <template v-else-if="mcapp">
-            <span v-html="t('catalog.install.error.legacy.mcmNotSupported')" />
+          <span v-html="t('catalog.install.error.legacy.mcmNotSupported')" />
         </template>
         <template v-else>
           <nuxt-link :to="legacyAppRoute">

--- a/shell/pages/c/_cluster/mcapps/index.vue
+++ b/shell/pages/c/_cluster/mcapps/index.vue
@@ -8,7 +8,7 @@ export default {
       params: {
         ...route.params,
         product:  NAME,
-        page:    'apps'
+        page:    'catalogs'
       }
     });
   }


### PR DESCRIPTION
Fixes #6970 

- Renames 'Multi-cluster Apps' in the top-level menu to 'Global Configuration' (since apps are removed)
- Removed Apps from Global Configuration
- Updated the installs screen that used to link to MCM Apps to instead say that they can not be managed through the UI 

Note: For simplicity, I did not rename the product definition, so this stays as `mcapps`.