### PR TITLE
Plugins: Move formatter cache loading out of Sortable Table

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -22,16 +22,8 @@ import actions from './actions';
 
 // Its quicker to render if we directly supply the components for the formatters
 // rather than just the name of a global component - so create a map of the formatter comoponents
-const FORMATTERS = {};
-
-const components = require.context('@shell/components/formatter', false, /[A-Z]\w+\.(vue)$/);
-
-components.keys().forEach((fileName) => {
-  const componentConfig = components(fileName);
-  const componentName = fileName.split('/').pop().split('.')[0];
-
-  FORMATTERS[componentName] = componentConfig.default || componentConfig;
-});
+// NOTE: This is populated by a plugin (formatters.js) to avoid issues with plugins
+export const FORMATTERS = {};
 
 export const COLUMN_BREAKPOINTS = {
   /**

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -580,6 +580,7 @@ export default function(dir, _appConfig) {
       path.join(NUXT_SHELL, 'plugins/back-button'),
       { src: path.join(NUXT_SHELL, 'plugins/plugin'), ssr: false },
       { src: path.join(NUXT_SHELL, 'plugins/codemirror-loader'), ssr: false },
+      { src: path.join(NUXT_SHELL, 'plugins/formatters'), ssr: false }, // Populate formatters cache for sorted table
     ],
 
     // Proxy: https://github.com/nuxt-community/proxy-module#options

--- a/shell/plugins/formatters.js
+++ b/shell/plugins/formatters.js
@@ -1,0 +1,15 @@
+// This registers all of the built-in formatters into the SortableTable cache
+
+// We do it here to keep it away from plugins
+// It was in SortableTable itself, but this causes plugins to pull in all formatters and their dependencies
+
+import { FORMATTERS } from '@shell/components/SortableTable';
+
+const components = require.context('@shell/components/formatter', false, /[A-Z]\w+\.(vue)$/);
+
+components.keys().forEach((fileName) => {
+  const componentConfig = components(fileName);
+  const componentName = fileName.split('/').pop().split('.')[0];
+
+  FORMATTERS[componentName] = componentConfig.default || componentConfig;
+});


### PR DESCRIPTION
Reduces size of plugin packages significantly.

Advis, if a plug-in uses sortable table, it pulls in all formatters.

This PR moved the formatted cache initialisation to a plug-in that runs once.