### PR TITLE
Fix: Open shell from workload pages may pick wrong pod

### DIFF
--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -612,8 +612,10 @@ export default class Workload extends WorkloadService {
 
   async matchingPods() {
     const all = await this.$dispatch('findAll', { type: POD });
+    const allInNamespace = all.filter(pod => pod.metadata.namespace === this.metadata.namespace);
+
     const selector = convertSelectorObj(this.spec.selector);
 
-    return matching(all, selector);
+    return matching(allInNamespace, selector);
   }
 }


### PR DESCRIPTION
### Summary
If a cluster contains two workloads (e.g. deployments) with the same spec.selector, the button to open a container shell from the workload page or list always picks the first pod that matches this selector without taking namespaces into account.

Fixes https://github.com/rancher/dashboard/issues/6982
Fixes https://github.com/rancher/dashboard/issues/6983

### Occurred changes and/or fixed issues
This adds a namespace filter to the function that matches the pod for the workload.

### Areas or cases that should be tested
Opening a shell from a workload (e.g. deployment) page or list

### Screenshot/Video
I added this deployment

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
spec:
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: container-0
```

in the namespaces `default` and `shop`. Note that `spec.selector` is the same for both deployments. In Kubernetes the selector is namespaced and only selects pods from the same namespace.

The deployments create these pods:

<img width="1405" alt="Bildschirmfoto 2022-09-23 um 15 59 41" src="https://user-images.githubusercontent.com/243056/191981701-a927703b-c471-407e-9aa5-aa464b54dce4.png">


Before the patch, when you open a shell for the 2nd deployment (`shop` namespace), the UI opens a shell of the pod of the first deployment (`default` namespace):
<img width="523" alt="Bildschirmfoto 2022-09-23 um 16 01 02" src="https://user-images.githubusercontent.com/243056/191981895-4b5e7017-900d-47cb-8b55-24eb62b632f3.png">

After the patch, the UI picks the pod that matches the namespace of the deployment correctly:
<img width="599" alt="Bildschirmfoto 2022-09-23 um 16 01 57" src="https://user-images.githubusercontent.com/243056/191981979-c8c1f88e-0ed4-41c9-8072-d3defa3d8a4c.png">

