### PR TITLE
Fix: Service selector preview does not consider namespace

### DIFF
--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -198,7 +198,8 @@ export default {
   },
 
   watch: {
-    'value.spec.selector': 'updateMatchingPods',
+    'value.metadata.namespace': 'updateMatchingPods',
+    'value.spec.selector':      'updateMatchingPods',
     'value.spec.sessionAffinity'(val) {
       if (val === 'ClientIP') {
         this.value.spec.sessionAffinityConfig = { clientIP: { timeoutSeconds: null } };
@@ -240,21 +241,22 @@ export default {
 
   methods: {
     updateMatchingPods: throttle(function() {
-      const { allPods, value: { spec: { selector = { } } } } = this;
+      const { value: { spec: { selector = { } } } } = this;
+      const allInNamespace = this.allPods.filter(pod => pod.metadata.namespace === this.value?.metadata?.namespace);
 
       if (isEmpty(selector)) {
         this.matchingPods = {
           matched: 0,
-          total:   allPods.length,
+          total:   allInNamespace.length,
           none:    true,
           sample:  null,
         };
       } else {
-        const match = matching(allPods, selector);
+        const match = matching(allInNamespace, selector);
 
         this.matchingPods = {
           matched: match.length,
-          total:   allPods.length,
+          total:   allInNamespace.length,
           none:    match.length === 0,
           sample:  match[0] ? match[0].nameDisplay : null,
         };


### PR DESCRIPTION
### Summary
This fixes the selector preview box on the service create and edit form to only show selected pods from the same namespace

Fixes https://github.com/rancher/dashboard/issues/6984

### Occurred changes and/or fixed issues
The matching function was missing a filter to only show pods of the namespace of the service and to update itself when the namespace changes.

### Areas or cases that should be tested
Preview box when creating or editing services

### Screenshot/Video
With this deployment:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  namespace: default
spec:
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - image: nginx
        name: container-0
```

Before the patch, there is no namespace filter:

<img width="1127" alt="Bildschirmfoto 2022-09-23 um 16 26 44" src="https://user-images.githubusercontent.com/243056/191985550-81778b6c-83f2-4b06-bf03-6650cb4b26ae.png">


After, the namespace filtering now works correctly:

<img width="1129" alt="Bildschirmfoto 2022-09-23 um 16 28 16" src="https://user-images.githubusercontent.com/243056/191985426-db0c8f05-8d74-43f7-804b-58b6c95f450a.png">
<img width="1138" alt="Bildschirmfoto 2022-09-23 um 16 28 23" src="https://user-images.githubusercontent.com/243056/191985418-e55c0ae5-c376-4113-b421-ebc3ea6ff1be.png">
