### PR TITLE
[2.7] adjust socket reconnect logic

### DIFF
--- a/shell/config/settings.js
+++ b/shell/config/settings.js
@@ -135,3 +135,21 @@ export const setSetting = async(store, id, val) => {
 
   return setting;
 };
+
+export const getPerformanceSetting = (rootGetters) => {
+  const perfSetting = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);
+  let perfConfig = {};
+
+  if (perfSetting && perfSetting.value) {
+    try {
+      perfConfig = JSON.parse(perfSetting.value);
+    } catch (e) {
+      console.warn('ui-performance setting contains invalid data'); // eslint-disable-line no-console
+    }
+  }
+
+  // Start with the default and overwrite the values from the setting - ensures we have defaults for newly added options
+  perfConfig = Object.assign(DEFAULT_PERF_SETTING, perfConfig);
+
+  return perfConfig;
+};


### PR DESCRIPTION
…factor performance setting getting logic

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
 fixes #6972, #6992
 
 related 2.6.9 issue: https://github.com/rancher/dashboard/issues/6960

This is partly addressed in a previous PR here https://github.com/rancher/dashboard/pull/6968 but per slack convo w/ Neil we should not be giving up on reconnect attempts if we're not visualizing the failure prominently. (eg when growls are disabled). I snuck in #6972 given that the request stems from code duplication and _not_ tacking it on would just be more code duplication. 