### PR TITLE
Web worker - fix for revision being lost for schema updates

### DIFF
--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -36,11 +36,13 @@ export function createWorker(store, ctx) {
   }
 
   const workerActions = {
-    load: (resource) => {
-      queueChange(ctx, resource, true, 'Change');
+    load: (msg) => {
+      queueChange(ctx, msg, true, 'Change');
     },
     destroyWorker: () => {
-      delete this.$workers[storeName];
+      if (this.$workers[storeName]) {
+        delete this.$workers[storeName];
+      }
     }
   };
 
@@ -620,7 +622,7 @@ export const actions = {
       const worker = (this.$workers || {})[ctx.getters.storeName];
 
       if (worker) {
-        worker.postMessage({ updateSchema: data });
+        worker.postMessage({ updateSchema: msg });
 
         // No further processing - let the web worker check the schema updates
         return;

--- a/shell/plugins/steve/web-worker.steve-sub-worker.js
+++ b/shell/plugins/steve/web-worker.steve-sub-worker.js
@@ -32,19 +32,14 @@ function hashObj(obj) {
 }
 
 function flush() {
-  state.queue.forEach((schema) => {
+  state.queue.forEach((msg) => {
+    const schema = msg.data;
     const hash = hashObj(schema);
     const existing = state.schemas[schema.id];
 
     if (!existing || (existing && existing !== hash)) {
       // console.log(`${ schema.id } CHANGED  ${ hash } > ${ existing }`);
       state.schemas[schema.id] = hash;
-
-      const msg = {
-        data:          schema,
-        resourceType:  SCHEMA,
-        type:          'resource.change'
-      };
 
       load(msg);
     }
@@ -120,15 +115,15 @@ const workerActions = {
   },
 
   // Called when schema is updated
-  updateSchema: (schema) => {
+  updateSchema: (msg) => {
     // Add the schema to the queue to be checked to see if the schema really changed
-    state.queue.push(schema);
+    state.queue.push(msg);
   },
 
   // Remove the cached schema
   removeSchema: (id) => {
     // Remove anything in the queue related to the schema - we don't want to send any pending updates later for a schema that has been removed
-    state.queue = state.queue.filter(schema => schema.id !== id);
+    state.queue = state.queue.filter(schema => schema.data?.id !== id);
 
     // Delete the schema from the map, so if it comes back we don't ignore it if the hash is the same
     delete state.schemas[id];


### PR DESCRIPTION
The web worker for schemas and counts added in 2.6.7 loses the revision for schema updates.

This PR fixes that.