### PR TITLE
Adds a default return to home when no route history

### DIFF
--- a/shell/components/BackLink.vue
+++ b/shell/components/BackLink.vue
@@ -12,6 +12,9 @@ export default {
   <nuxt-link v-if="link && link.name" :to="link" class="back-link">
     <i class="icon icon-chevron-left" /> {{ t('generic.back') }}
   </nuxt-link>
+  <nuxt-link v-else to="/" class="back-link">
+    <i class="icon icon-chevron-left" /> {{ t('nav.home') }}
+  </nuxt-link>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/epinio/ui/issues/159
<!-- Define findings related to the feature or bug issue. -->



### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The current `back-button` component works when a route history is presented (from where you landed there)
If none is found, it would not render.
With the change, we have a generic return to Home (`/`) button.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Normal scenario:
1. Click on the `dev` link at the bottom of the footer.
2. You should see the `< Back` button at the top of the new page.

![image](https://user-images.githubusercontent.com/88777903/192525393-61000abc-ca08-4799-9c8f-2487cb0ee5f4.png)


No history scenario:
1. Refresh the page
2. You should see the `< Home` button at the top of the new page.

![image](https://user-images.githubusercontent.com/88777903/192525446-e3c08ba3-7fa4-405d-ab3a-745786ab1c19.png)
