### PR TITLE
improve PSP removal banner

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2455,6 +2455,7 @@ landing:
     title: Getting Started
     body: Take a look at the the quick getting started guide. For Cluster Manager users, learn more about where you can find your favorite features in the Dashboard UI.
   support: Support
+  psps: PSPs
   deprecatedPsp: Pod Security Policies are deprecated as of Kubernetes v1.21, and have been removed in Kubernetes v1.25. You have one or more PodSecurityPolicy resource(s) in this cluster.
   community:
     title: Community Support

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -25,7 +25,7 @@ import {
   CATALOG,
   POD,
 } from '@shell/config/types';
-import { mapPref, CLUSTER_TOOLS_TIP } from '@shell/store/prefs';
+import { mapPref, CLUSTER_TOOLS_TIP, PSP_DEPRECATION_BANNER } from '@shell/store/prefs';
 import { haveV1Monitoring, monitoringStatus } from '@shell/utils/monitoring';
 import Tabbed from '@shell/components/Tabbed';
 import Tab from '@shell/components/Tabbed/Tab';
@@ -173,7 +173,8 @@ export default {
       return this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
     },
 
-    hideClusterToolsTip: mapPref(CLUSTER_TOOLS_TIP),
+    hideClusterToolsTip:      mapPref(CLUSTER_TOOLS_TIP),
+    hidePspDeprecationBanner: mapPref(PSP_DEPRECATION_BANNER),
 
     hasV1Monitoring() {
       return haveV1Monitoring(this.$store.getters);
@@ -402,8 +403,10 @@ export default {
       </div>
     </header>
     <Banner
-      v-if="displayPspDeprecationBanner"
+      v-if="displayPspDeprecationBanner && !hidePspDeprecationBanner"
+      :closable="true"
       color="warning"
+      @close="hidePspDeprecationBanner = true"
     >
       <t k="landing.deprecatedPsp" :raw="true" />
     </Banner>
@@ -432,6 +435,14 @@ export default {
         <label>{{ t('glance.created') }}: </label>
         <span><LiveDate :value="currentCluster.metadata.creationTimestamp" :add-suffix="true" :show-tooltip="true" /></span>
       </div>
+      <p
+        v-if="displayPspDeprecationBanner && hidePspDeprecationBanner"
+        v-tooltip="t('landing.deprecatedPsp')"
+        class="alt-psp-deprecation-info"
+      >
+        <span>{{ t('landing.psps') }}</span>
+        <i class="icon icon-warning" />
+      </p>
       <div :style="{'flex':1}" />
       <div v-if="!monitoringStatus.v2 && !monitoringStatus.v1">
         <n-link :to="{name: 'c-cluster-explorer-tools'}" class="monitoring-install">
@@ -566,6 +577,16 @@ export default {
 
 .cluster-tools-tip {
   margin-top: 0;
+}
+
+.alt-psp-deprecation-info {
+  display: flex;
+  align-items: center;
+  color: var(--warning);
+
+  span {
+    margin-right: 4px;
+  }
 }
 
 .monitoring-install {

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -113,6 +113,9 @@ export const PROVISIONER = create('provisioner', _RKE1, { options: [_RKE1, _RKE2
 // Promo for Cluster Tools feature on Cluster Dashboard page
 export const CLUSTER_TOOLS_TIP = create('hide-cluster-tools-tip', false, { parseJSON });
 
+// Promo for Pod Security Policies (PSPs) being deprecated on kube version 1.25 on Cluster Dashboard page
+export const PSP_DEPRECATION_BANNER = create('hide-psp-deprecation-banner', false, { parseJSON });
+
 // Maximum number of clusters to show in the slide-in menu
 export const MENU_MAX_CLUSTERS = create('menu-max-clusters', 4, { options: [2, 3, 4, 5, 6, 7, 8, 9, 10], parseJSON });
 


### PR DESCRIPTION
Fixes rancher/dashboard#7012 

- improve PSP (pod security policies) removal banner by adding a dismiss action and a smaller indication of the warning with a hoverable tooltip message

**How to test**
- Have a cluster with kube version >= 1.21 and <1.25 with `Pod Security Policies`
- Enter cluster explorer and make sure banner displays
- click to dismiss banner
- make sure banner doesn't appear again
- check that new smaller warning indication now appears for that cluster on the same cluster explorer page

### Screenshot/Video
<img width="735" alt="Screenshot 2022-09-27 at 12 00 39" src="https://user-images.githubusercontent.com/97888974/192532184-55e7a8bc-8f9d-4715-9ba9-2680d8c7e71c.png">
