### PR TITLE
remove the user preference for language toggle

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3683,7 +3683,6 @@ prefs:
     viewInApi: Enable "View in API"
     allNamespaces: Show system Namespaces managed by Rancher (not intended for editing or deletion)
     themeShortcut: Enable Dark/Light Theme keyboard shortcut toggle (shift+T)
-    noLocaleShortcut: Enable Language Selection keyboard shortcut toggle (shift+L)
   hideDesc:
     label: Hide All Type Descriptions
   helm:

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -5,7 +5,6 @@ import {
   mapPref,
   FAVORITE_TYPES,
   AFTER_LOGIN_ROUTE,
-  NO_LOCALE_SHORTCUT,
   THEME_SHORTCUT
 } from '@shell/store/prefs';
 import ActionMenu from '@shell/components/ActionMenu';
@@ -61,9 +60,10 @@ export default {
   // Note - This will not run on route change
   data() {
     return {
-      groups:                        [],
-      gettingGroups:                 false,
-      wantNavSync:                   false,
+      noLocaleShortcut: process.env.dev || false,
+      groups:           [],
+      gettingGroups:    false,
+      wantNavSync:      false,
     };
   },
 
@@ -85,7 +85,6 @@ export default {
     },
 
     themeShortcut:    mapPref(THEME_SHORTCUT),
-    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT),
     favoriteTypes:    mapPref(FAVORITE_TYPES),
 
     pageActions() {

--- a/shell/layouts/home.vue
+++ b/shell/layouts/home.vue
@@ -3,7 +3,7 @@ import Header from '@shell/components/nav/Header';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
-import { mapPref, THEME_SHORTCUT, NO_LOCALE_SHORTCUT } from '@shell/store/prefs';
+import { mapPref, THEME_SHORTCUT } from '@shell/store/prefs';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
@@ -26,13 +26,13 @@ export default {
   data() {
     return {
       // Assume home pages have routes where the name is the key to use for string lookup
-      name: this.$route.name
+      name:             this.$route.name,
+      noLocaleShortcut: process.env.dev || false
     };
   },
 
   computed: {
-    themeShortcut:    mapPref(THEME_SHORTCUT),
-    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT),
+    themeShortcut: mapPref(THEME_SHORTCUT),
     ...mapState(['managementReady']),
   },
 

--- a/shell/layouts/plain.vue
+++ b/shell/layouts/plain.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapPref, THEME_SHORTCUT, NO_LOCALE_SHORTCUT } from '@shell/store/prefs';
+import { mapPref, THEME_SHORTCUT } from '@shell/store/prefs';
 import ActionMenu from '@shell/components/ActionMenu';
 import Header from '@shell/components/nav/Header';
 import PromptRemove from '@shell/components/PromptRemove';
@@ -33,14 +33,12 @@ export default {
   data() {
     return {
       // Assume home pages have routes where the name is the key to use for string lookup
-      name: this.$route.name,
+      name:             this.$route.name,
+      noLocaleShortcut: process.env.dev || false,
     };
   },
 
-  computed: {
-    themeShortcut:    mapPref(THEME_SHORTCUT),
-    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT)
-  },
+  computed: { themeShortcut: mapPref(THEME_SHORTCUT) },
 
   methods: {
     toggleTheme() {

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -8,7 +8,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import LandingPagePreference from '@shell/components/LandingPagePreference';
 import {
   mapPref, THEME, KEYMAP, DATE_FORMAT, TIME_FORMAT, ROWS_PER_PAGE, HIDE_DESC, SHOW_PRE_RELEASE, MENU_MAX_CLUSTERS,
-  VIEW_IN_API, ALL_NAMESPACES, NO_LOCALE_SHORTCUT, THEME_SHORTCUT
+  VIEW_IN_API, ALL_NAMESPACES, THEME_SHORTCUT
 } from '@shell/store/prefs';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
@@ -24,7 +24,6 @@ export default {
     keymap:           mapPref(KEYMAP),
     viewInApi:        mapPref(VIEW_IN_API),
     allNamespaces:    mapPref(ALL_NAMESPACES),
-    noLocaleShortcut: mapPref(NO_LOCALE_SHORTCUT),
     themeShortcut:    mapPref(THEME_SHORTCUT),
     dateFormat:       mapPref(DATE_FORMAT),
     timeFormat:       mapPref(TIME_FORMAT),
@@ -230,8 +229,6 @@ export default {
       <Checkbox v-model="allNamespaces" :label="t('prefs.advFeatures.allNamespaces', {}, true)" class="mt-20" />
       <br />
       <Checkbox v-model="themeShortcut" :label="t('prefs.advFeatures.themeShortcut', {}, true)" class="mt-20" />
-      <br />
-      <Checkbox v-model="noLocaleShortcut" :label="t('prefs.advFeatures.noLocaleShortcut', {}, true)" class="mt-20" />
       <br />
       <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-20" />
     </div>

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -94,11 +94,10 @@ export const TIME_FORMAT = create('time-format', 'h:mm:ss a', {
 
 export const TIME_ZONE = create('time-zone', 'local');
 // DEV will be deprecated on v2.7.0, but is needed so that we can grab the value for the new settings that derived from it
-// such as: VIEW_IN_API, ALL_NAMESPACES, NO_LOCALE_SHORTCUT, THEME_SHORTCUT
+// such as: VIEW_IN_API, ALL_NAMESPACES, THEME_SHORTCUT
 export const DEV = create('dev', false, { parseJSON });
 export const VIEW_IN_API = create('view-in-api', false, { parseJSON, inheritFrom: DEV });
 export const ALL_NAMESPACES = create('all-namespaces', false, { parseJSON, inheritFrom: DEV });
-export const NO_LOCALE_SHORTCUT = create('no-locale-shortcut', false, { parseJSON, inheritFrom: DEV });
 export const THEME_SHORTCUT = create('theme-shortcut', false, { parseJSON, inheritFrom: DEV });
 export const LAST_VISITED = create('last-visited', 'home', { parseJSON });
 export const SEEN_WHATS_NEW = create('seen-whatsnew', '', { parseJSON });


### PR DESCRIPTION
- Removed the user preference `Enable Language Selection keyboard shortcut toggle (shift+L)` as it's only meant to be used by developers and gate it to be available on DEV builds only, as agreed with @nwmac 

**Test**
- Go to user preferences and check if option is no longer there
- make sure shortcut `SHIFT+L` still works on DEV builds

**Screenshots**
<img width="771" alt="Screenshot 2022-09-27 at 15 51 39" src="https://user-images.githubusercontent.com/97888974/192560695-a9a8929f-cd41-4ddb-ad8b-e9333aefece6.png">
