### PR TITLE
Add name and readOnly fields to the Volume types

### DIFF
--- a/shell/edit/workload/storage/awsElasticBlockStore.vue
+++ b/shell/edit/workload/storage/awsElasticBlockStore.vue
@@ -1,9 +1,11 @@
 <script>
 import { LabeledInput } from '@components/Form/LabeledInput';
+import { Checkbox } from '@components/Form/Checkbox';
+
 import { mapGetters } from 'vuex';
 
 export default {
-  components: { LabeledInput },
+  components: { LabeledInput, Checkbox },
   props:      {
     // volumeAttributes object
     value: {
@@ -24,6 +26,23 @@ export default {
 
 <template>
   <div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.name"
+          :required="true"
+          :mode="mode"
+          :label="t('workload.storage.volumeName')"
+        />
+      </div>
+      <div class="col span-6">
+        <Checkbox
+          v-model="value.awsElasticBlockStore.readOnly"
+          :mode="mode"
+          :label="t('workload.storage.readOnly')"
+        />
+      </div>
+    </div>
     <div class="row mb-10">
       <div class="col span-6">
         <LabeledInput

--- a/shell/edit/workload/storage/azureDisk.vue
+++ b/shell/edit/workload/storage/azureDisk.vue
@@ -1,10 +1,13 @@
 <script>
+import { mapGetters } from 'vuex';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
-import { mapGetters } from 'vuex';
+import { Checkbox } from '@components/Form/Checkbox';
 
 export default {
-  components: { LabeledInput, RadioGroup },
+  components: {
+    LabeledInput, RadioGroup, Checkbox
+  },
   props:      {
     // volumeAttributes object
     value: {
@@ -31,6 +34,23 @@ export default {
 
 <template>
   <div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.name"
+          :required="true"
+          :mode="mode"
+          :label="t('workload.storage.volumeName')"
+        />
+      </div>
+      <div class="col span-6">
+        <Checkbox
+          v-model="value.azureDisk.readOnly"
+          :mode="mode"
+          :label="t('workload.storage.readOnly')"
+        />
+      </div>
+    </div>
     <div class="row mb-10">
       <div class="col span-6">
         <LabeledInput

--- a/shell/edit/workload/storage/azureFile.vue
+++ b/shell/edit/workload/storage/azureFile.vue
@@ -1,9 +1,10 @@
 <script>
-import { LabeledInput } from '@components/Form/LabeledInput';
 import { mapGetters } from 'vuex';
+import { Checkbox } from '@components/Form/Checkbox';
+import { LabeledInput } from '@components/Form/LabeledInput';
 
 export default {
-  components: { LabeledInput },
+  components: { LabeledInput, Checkbox },
 
   props:      {
     value: {
@@ -25,6 +26,23 @@ export default {
 
 <template>
   <div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.name"
+          :required="true"
+          :mode="mode"
+          :label="t('workload.storage.volumeName')"
+        />
+      </div>
+      <div class="col span-6">
+        <Checkbox
+          v-model="value.azureFile.readOnly"
+          :mode="mode"
+          :label="t('workload.storage.readOnly')"
+        />
+      </div>
+    </div>
     <div class="row mb-10">
       <div class="col span-6">
         <LabeledInput

--- a/shell/edit/workload/storage/csi/index.vue
+++ b/shell/edit/workload/storage/csi/index.vue
@@ -1,9 +1,11 @@
 <script>
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { Checkbox } from '@components/Form/Checkbox';
+
 import { mapGetters } from 'vuex';
 
 export default {
-  components: { LabeledSelect },
+  components: { LabeledSelect, Checkbox },
 
   props:      {
     podSpec: {
@@ -45,6 +47,23 @@ export default {
 <template>
   <div>
     <div>
+      <div class="row mb-10">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.name"
+            :required="true"
+            :mode="mode"
+            :label="t('workload.storage.volumeName')"
+          />
+        </div>
+        <div class="col span-6">
+          <Checkbox
+            v-model="value.csi.readOnly"
+            :mode="mode"
+            :label="t('workload.storage.readOnly')"
+          />
+        </div>
+      </div>
       <div class="row mb-10">
         <div class="col span-6">
           <LabeledSelect

--- a/shell/edit/workload/storage/csi/index.vue
+++ b/shell/edit/workload/storage/csi/index.vue
@@ -1,11 +1,14 @@
 <script>
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { Checkbox } from '@components/Form/Checkbox';
+import { LabeledInput } from '@components/Form/LabeledInput';
 
 import { mapGetters } from 'vuex';
 
 export default {
-  components: { LabeledSelect, Checkbox },
+  components: {
+    LabeledSelect, Checkbox, LabeledInput
+  },
 
   props:      {
     podSpec: {

--- a/shell/edit/workload/storage/gcePersistentDisk.vue
+++ b/shell/edit/workload/storage/gcePersistentDisk.vue
@@ -1,9 +1,10 @@
 <script>
-import { LabeledInput } from '@components/Form/LabeledInput';
 import { mapGetters } from 'vuex';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { Checkbox } from '@components/Form/Checkbox';
 
 export default {
-  components: { LabeledInput },
+  components: { LabeledInput, Checkbox },
 
   props:      {
     value: {
@@ -25,6 +26,23 @@ export default {
 
 <template>
   <div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.name"
+          :required="true"
+          :mode="mode"
+          :label="t('workload.storage.volumeName')"
+        />
+      </div>
+      <div class="col span-6">
+        <Checkbox
+          v-model="value.gcePersistentDisk.readOnly"
+          :mode="mode"
+          :label="t('workload.storage.readOnly')"
+        />
+      </div>
+    </div>
     <div class="row mb-10">
       <div class="col span-6">
         <LabeledInput

--- a/shell/edit/workload/storage/vsphereVolume.vue
+++ b/shell/edit/workload/storage/vsphereVolume.vue
@@ -1,6 +1,6 @@
 <script>
-import { LabeledInput } from '@components/Form/LabeledInput';
 import { mapGetters } from 'vuex';
+import { LabeledInput } from '@components/Form/LabeledInput';
 
 export default {
   components: { LabeledInput },
@@ -25,6 +25,16 @@ export default {
 
 <template>
   <div>
+    <div class="row mb-10">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.name"
+          :required="true"
+          :mode="mode"
+          :label="t('workload.storage.volumeName')"
+        />
+      </div>
+    </div>
     <div class="row mb-10">
       <div class="col span-6">
         <LabeledInput


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7021 - Allow user to change the volume name when creating a workload

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Following new fields were added based on the API https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#volume-v1-core

| Volume Type                             | Name               | readOnly |
| -------------                    | -------------      | ------------- |
| AWSElasticBlockStoreVolumeSource | :heavy_check_mark: | :heavy_check_mark: 
| AzureDiskVolumeSource            | :heavy_check_mark: | :heavy_check_mark: 
| AzureFileVolumeSource            | :heavy_check_mark: | :heavy_check_mark: 
| CSIVolumeSource                  | :heavy_check_mark: | :heavy_check_mark: 
| GCEPersistentDiskVolumeSource    | :heavy_check_mark: | :heavy_check_mark: 
| VsphereVirtualDiskVolumeSource   | :heavy_check_mark: | -

### Areas or cases that should be tested
1. Amazon EBS disk
2. Azure disk
3. Azure file
4. CSI
5. Google persistent disk
6. VMWare vSphere volume

### Areas which could experience regressions
1. Go to the deployments list
2. Go to a deployment. In the Pod tab, click **Storage > Add Volume > Open EBS Disk**
3. Add name
4. Select readonly
5. Inspect the YAML
6. Create the deployment

### Screenshot/Video

Create

https://user-images.githubusercontent.com/1387263/192630331-96b48b0c-02b4-49e6-83a7-cd903b4ae3c8.mov

View

https://user-images.githubusercontent.com/1387263/192630376-83ac1093-cd56-4679-8711-b3437efa504c.mov

