### PR TITLE
Allow wildcards in ingress hostnames

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/index.vue
+++ b/shell/edit/networking.k8s.io.ingress/index.vue
@@ -65,7 +65,7 @@ export default {
           path: 'metadata.name', rules: ['required', 'hostname'], translationKey: 'nameNsDescription.name.label'
         },
         {
-          path: 'spec.rules.host', rules: ['hostname'], translationKey: 'ingress.rules.requestHost.label'
+          path: 'spec.rules.host', rules: ['wildcardHostname'], translationKey: 'ingress.rules.requestHost.label'
         },
         {
           path: 'spec.rules.http.paths.path', rules: ['absolutePath'], translationKey: 'ingress.rules.path.label'
@@ -83,7 +83,7 @@ export default {
         {
           path: 'spec.defaultBackend.service.port.number', rules: ['required', 'requiredInt', 'portNumber'], translationKey: 'ingress.defaultBackend.port.label'
         },
-        { path: 'spec.tls.hosts', rules: ['required', 'hostname'] }
+        { path: 'spec.tls.hosts', rules: ['required', 'wildcardHostname'] }
       ],
       fvReportedValidationPaths: ['spec.rules.http.paths.backend.service.port.number', 'spec.rules.http.paths.path', 'spec.rules.http.paths.backend.service.name']
     };

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -906,6 +906,114 @@ describe('formRules', () => {
     expect(formRuleResult).toStrictEqual(expectedResult);
   });
 
+  // this rule is pretty much identical to the standard hostname, but also allows for wildcards
+  it('"wildcardHostname" : returns undefined when value is valid hostname', () => {
+    const testValue = 'www.url.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"wildcardHostname" : returns expected message when value starts with a dot', () => {
+    const testValue = '.hostname';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.startDot', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when value starts is too long for a hostname', () => {
+    const testValue = 'There.are.many.variations.of.passages.of.Lorem.Ipsum.available.but.the.majority.have.suffered.alteration.in.some.form.by.injected.humour.or.randomised.words.which.dont.look.even.slightly.believable.If.you.are.going.to.use.a.passage.of.Lorem.Ipsum.you.need';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.hostname.tooLong', key: 'testDisplayKey', max: 253
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when value contains invalid characters', () => {
+    const testValue = 'www.host*name.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars', key: 'testDisplayKey', count: 1, chars: '"*"'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when value contains a space character', () => {
+    const testValue = 'www.host name.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars', key: 'testDisplayKey', count: 1, chars: 'Space'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when hostname label starts with a dash', () => {
+    const testValue = 'www.-hostname.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.startHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when hostname label ends with a dash', () => {
+    const testValue = 'www.hostname-.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.hostname.endHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when hostname label contains a double-dash at the third character position', () => {
+    const testValue = 'www.ho--stname.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.dns.doubleHyphen', key: 'testDisplayKey' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when hostname label is too long', () => {
+    const testValue = 'www.0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.dns.hostname.tooLongLabel', key: 'testDisplayKey', max: 63
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when wildcard character is not the first part', () => {
+    const testValue = 'www.*.hostname.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars', key: 'testDisplayKey', count: 1, chars: '"*"'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns expected message when wildcard character is at the beginning but not its own part', () => {
+    const testValue = '*hostname.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+
+    const expectedResult = JSON.stringify({
+      message: 'validation.chars', key: 'testDisplayKey', count: 1, chars: '"*"'
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"wildcardHostname" : returns valid when wildcard character is the first part', () => {
+    const testValue = '*.hostname.com';
+    const formRuleResult = formRules.wildcardHostname(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
   it('"absolutePath" : return expected message when path doesn\'t begin with a "/"', () => {
     const formRuleResult = formRules.absolutePath('absolute_path');
     const expectedResult = JSON.stringify({ message: 'validation.path', key: 'testDisplayKey' });

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -204,6 +204,13 @@ export default function(t: (key: string, options?: any) => string, opt: {display
     }
   };
 
+  const wildcardHostname: Validator = (val: string) => {
+    // allow wildcard in first part of hostname
+    val = val ? val.replace(/^\*\./, '') : val;
+
+    return hostname(val);
+  };
+
   const externalName: Validator = (val: string) => {
     if (isEmpty(val)) {
       return t('validation.service.externalName.none');
@@ -442,6 +449,7 @@ export default function(t: (key: string, options?: any) => string, opt: {display
     hostname,
     testRule,
     subDomain,
-    absolutePath
+    absolutePath,
+    wildcardHostname,
   };
 }


### PR DESCRIPTION
### Summary
Wildcards like `*.example.com` are allowed in ingress hostnames since Kubernetes 1.18: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#support-for-hostname-wildcards.

Fixes #6957

### Occurred changes and/or fixed issues
This adds a new validation rule `wildcardHostname` including tests, which extends the `hostname` rule to also allow a wildcard in the first part of the hostname:

* `*.foo.example.com` is valid
* `foo.*.example.com` is not valid
* `foo.*example.com` is not valid
* `*foo.example.com` is not valid

### Technical notes summary
Allowing wildcards was added in https://github.com/kubernetes/kubernetes/pull/29204.

### Areas or cases that should be tested
Creating and editing ingresses.

### Areas which could experience regressions
The hostname and tls hostname fields.

### Screenshot/Video

Working validations:

<img width="1506" alt="Bildschirmfoto 2022-09-28 um 07 36 58" src="https://user-images.githubusercontent.com/243056/192697956-f3565c10-aa82-4f4a-9339-384dd75545e6.png">
<img width="942" alt="Bildschirmfoto 2022-09-28 um 07 36 49" src="https://user-images.githubusercontent.com/243056/192697961-f03c4853-341f-4f01-9579-21c6b7b720a2.png">

