### PR TITLE
Azuread old endpoint config initial radio option

### DIFF
--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -181,11 +181,11 @@ export default {
       const newEndpointKey = this.determineEndpointKeyType(ENDPOINT_MAPPING);
       const oldEndpointKey = Object.keys(OLD_ENDPOINTS).find(key => OLD_ENDPOINTS[key].graphEndpoint === endpoint);
 
-      if ( newEndpointKey ) {
-        this.endpoint = newEndpointKey;
-      } else if ( oldEndpointKey ) {
+      if ( oldEndpointKey ) {
         this.endpoint = oldEndpointKey;
         this.oldEndpoint = true;
+      } else if ( newEndpointKey ) {
+        this.endpoint = newEndpointKey;
       } else {
         this.endpoint = 'custom';
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6428 
<!-- Define findings related to the feature or bug issue. -->

The conditional that would determine if the initial endpoint radio option had the incorrect use case flow. It would choose a `custom` option regardless if the endpoint matched that of the `OLD_ENDPOINT` as it would first check for a `newEndpointKey` that is always returning `custom`.

Switched the conditional around to first check for an `oldEndpointKey`.