### PR TITLE
Add gke hosted provider to token creation

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -93,7 +93,7 @@ export default {
       fetchOne.snapshots = this.$store.dispatch('management/findAll', { type: SNAPSHOT });
     }
 
-    if ( this.value.isImported || this.value.isCustom || this.value.isAKS || this.value.isEKS ) {
+    if ( this.value.isImported || this.value.isCustom || this.value.isHostedKubernetesProvider ) {
       fetchOne.clusterToken = this.value.getOrCreateToken();
     }
 
@@ -322,7 +322,7 @@ export default {
     },
 
     showEksNodeGroupWarning() {
-      if ( this.value.isEKS ) {
+      if ( this.value.provisioner === 'EKS' ) {
         const desiredTotal = this.value.eksNodeGroups.filter(g => g.desiredSize === 0);
 
         if ( desiredTotal.length === this.value.eksNodeGroups.length ) {
@@ -451,7 +451,7 @@ export default {
         return true;
       }
 
-      if ( ( this.value.isAKS || this.value.isEKS ) && !this.isClusterReady ) {
+      if ( this.value.isHostedKubernetesProvider && !this.isClusterReady ) {
         return true;
       }
 

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -197,12 +197,10 @@ export default class ProvCluster extends SteveModel {
     return super.canEditYaml;
   }
 
-  get isAKS() {
-    return this.provisioner === 'AKS';
-  }
+  get isHostedKubernetesProvider() {
+    const providers = ['AKS', 'EKS', 'GKE'];
 
-  get isEKS() {
-    return this.provisioner === 'EKS';
+    return providers.includes(this.provisioner);
   }
 
   get isImported() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6838 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Similar to https://github.com/rancher/dashboard/issues/6036 where the cluster token was not being generated for a GKE hosted cluster, which would result in the registration tab not showing.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Reworked how we were determining if a cluster was from a hosted k8s provider into one method (`isHostedKuberenetesProvider`). Also changed the conditional in `showEksNodeGroupWarning` to check directly for `this.value.provisioner === 'EKS'` since I merged the original `isEKS` into the new method.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Creating a GKE cluster with a private endpoint


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![gke-private](https://user-images.githubusercontent.com/40806497/192813842-b3a88883-1381-4807-b41f-18c488fa7428.png)
