### PR TITLE
Metadata.name on workload types should allow "." character now

### DIFF
--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -218,7 +218,7 @@ export default class Workload extends WorkloadService {
         path:           'metadata.name',
         required:       true,
         translationKey: 'generic.name',
-        type:           'dnsLabel',
+        type:           'subDomain',
       },
       {
         nullable:       false,


### PR DESCRIPTION
### Summary
Fixes #6906 
API allows the "." to be included in "metadata.name" for all workload types so form validation should allow it. Looking at the kubernetes spec for these resource types, name should be a valid subdomain so this is now using that validator.

### Occurred changes and/or fixed issues
Name field in workload type forms should allow "." character now and also enforce any other subdomain rules.

### Technical notes summary
Just switched up one well-tested validator for another according to spec.

### Areas or cases that should be tested
Create one of each type of workload resource with a period in it, notice that the form allows this.

### Areas which could experience regressions
None, this change is minimal and fairly targeted.