### PR TITLE
Correct syntax error in E2E script statement

### DIFF
--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 ID="$(echo ${TEST_RUN_ID:-`date +%s`} | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
-command="CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' cy2 run --browser chrome --record --key rancher-dashboard --parallel --ci-build-id ${ID}"
-
 echo "$ID"
-echo "$command"
-eval "$command"
+
+CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' cy2 run --browser chrome --record --key rancher-dashboard --parallel --ci-build-id "$ID"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7056
For some reasons the bash script does not work on master only. It is unclear why Docker logs is then collected while using evals command, therefore is simply reverted.

This issue does not seems to happen in any fork as well.

### Occurred changes and/or fixed issues
Reverted use of eval in bash.

### Technical notes summary


### Areas or cases that should be tested
GH Actions.

### Areas which could experience regressions
-

### Screenshot/Video

E2E Test passing correctly on the fork using the previous command: https://github.com/cnotv/dashboard/actions/runs/3160200703