### PR TITLE
Remove uneeded check - add custom check for old endpoints

### DIFF
--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -182,12 +182,10 @@ export default {
       const oldEndpointKey = Object.keys(OLD_ENDPOINTS).find(key => OLD_ENDPOINTS[key].graphEndpoint === endpoint);
 
       if ( oldEndpointKey ) {
-        this.endpoint = oldEndpointKey;
+        this.endpoint = this.determineEndpointKeyType(OLD_ENDPOINTS);
         this.oldEndpoint = true;
-      } else if ( newEndpointKey ) {
-        this.endpoint = newEndpointKey;
       } else {
-        this.endpoint = 'custom';
+        this.endpoint = newEndpointKey;
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6428
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
If the `graphEndpoint` matches the old version (`https://graph.windows.net/`), the conditional will now return the proper endpoint option.

### Testing
A way of testing a custom endpoint while using the standard set of URIs ( e.g. Graph Endpoint: `https://graph.windows.net/`, Token Endpoint: `https://login.microsoftonline.com/${ TENANT_ID_TOKEN }/oauth2/token` ) would be to change the Token or Auth endpoint property in `OLD_ENDPOINTS` to an arbitrary string.