### PR TITLE
Fix all events link

### DIFF
--- a/shell/components/CommunityLinks.vue
+++ b/shell/components/CommunityLinks.vue
@@ -63,12 +63,12 @@ export default {
       }
 
       // Custom links set from settings
-      if (this.uiCustomLinks?.value) {
+      if (!!this.uiCustomLinks?.value) {
         try {
           const customLinks = JSON.parse(this.uiCustomLinks.value);
 
           if (Array.isArray(customLinks)) {
-            return JSON.parse(this.uiCustomLinks.value).reduce((prev, curr) => {
+            return customLinks.reduce((prev, curr) => {
               prev[curr.key] = curr.value;
 
               return prev;

--- a/shell/components/CommunityLinks.vue
+++ b/shell/components/CommunityLinks.vue
@@ -63,12 +63,20 @@ export default {
       }
 
       // Custom links set from settings
-      if (this.uiCustomLinks) {
-        return JSON.parse(this.uiCustomLinks.value).reduce((prev, curr) => {
-          prev[curr.key] = curr.value;
+      if (this.uiCustomLinks?.value) {
+        try {
+          const customLinks = JSON.parse(this.uiCustomLinks.value);
 
-          return prev;
-        }, {});
+          if (Array.isArray(customLinks)) {
+            return JSON.parse(this.uiCustomLinks.value).reduce((prev, curr) => {
+              prev[curr.key] = curr.value;
+
+              return prev;
+            }, {});
+          }
+        } catch (e) {
+          console.error('Could not parse custom links setting', e); // eslint-disable-line no-console
+        }
       }
 
       // Fallback

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -348,6 +348,16 @@ export default {
 
     hasDescription() {
       return !!this.currentCluster?.spec?.description;
+    },
+
+    allEventsLink() {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          product:  'explorer',
+          resource: 'event',
+        }
+      };
     }
   },
 
@@ -487,7 +497,7 @@ export default {
       <Tabbed @changed="tabChange">
         <Tab name="cluster-events" :label="t('clusterIndexPage.sections.events.label')" :weight="2">
           <span class="events-table-link">
-            <n-link :to="{name: 'c-cluster-explorer-event'}">
+            <n-link :to="allEventsLink">
               <span>{{ t('glance.eventsTable') }}</span>
             </n-link>
           </span>


### PR DESCRIPTION
Fixes #5816 

Addresses 2 problems when clicking on the 'Show all events' link on the cluster dashboard page.

- Error parsing community links when it is set to `{}` - which can happen
- Error on the link used for the event resource page