### PR TITLE
Add k3s clusters to cert rotation options

### DIFF
--- a/shell/dialog/RotateCertificatesDialog.vue
+++ b/shell/dialog/RotateCertificatesDialog.vue
@@ -40,19 +40,25 @@ export default {
 
     serviceOptions() {
       if (this.cluster.isRke2) {
-        return [
+        const options = [
           'admin',
           'api-server',
           'controller-manager',
           'scheduler',
-          'rke2-controller',
-          'rke2-server',
           'cloud-controller',
           'etcd',
           'auth-proxy',
           'kubelet',
           'kube-proxy'
         ];
+
+        if ( this.cluster.isK3s ) {
+          options.push('k3s-controller', 'k3s-server');
+        } else {
+          options.push('rke2-controller', 'rke2-server');
+        }
+
+        return options.sort();
       }
       // For RKE1 clusters, Norman provides the list of service options:
       // type RotateCertificateInput struct {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -230,11 +230,15 @@ export default class ProvCluster extends SteveModel {
   get isImportedK3s() {
     // As of Rancher v2.6.7, this returns false for imported K3s clusters,
     // in which this.provisioner is `k3s`.
-    return this.isImported && this.mgmt?.status?.provider === 'k3s';
+    return this.isImported && this.isK3s;
   }
 
   get isImportedRke2() {
     return this.isImported && this.mgmt?.status?.provider?.startsWith('rke2');
+  }
+
+  get isK3s() {
+    return this.mgmt?.status?.provider === 'k3s';
   }
 
   get isRke2() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6926 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This adds `k3s-controller` and `k3s-server` to rotating individual service options if the provider is `k3s`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Added a method to the `provisioning.cattle.io.cluster` model for determining the `k3s` provider. For the options, `rke2` will be the fallback.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Rotating both `k3s-controller` and `k3s-server` certificates individually.
- The same goes for `rke2` clusters

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**K3s options**
![k3s](https://user-images.githubusercontent.com/40806497/193335894-abb380a0-322b-4d76-8540-a0b63f2a0430.png)

**RKE2 options**
![rke2](https://user-images.githubusercontent.com/40806497/193335927-40103a80-0ea2-412c-9f07-050efc92ca32.png)

**Logs after rotating k3s certs**
![rotation](https://user-images.githubusercontent.com/40806497/193336008-d144b076-e3c6-40d9-8e3b-1be53245109f.png)
