### PR TITLE
Fix unique user count on bound user role deletion

### DIFF
--- a/shell/promptRemove/mixin/roleDeletionCheck.js
+++ b/shell/promptRemove/mixin/roleDeletionCheck.js
@@ -41,7 +41,7 @@ export default {
       let resourceToCheck;
       let propToMatch;
       let numberOfRolesWithBinds = 0;
-      let numberUniqueUsersWithBinds = 0;
+      const uniqueUsersWithBinds = new Set();
 
       this.info = this.t('rbac.globalRoles.waiting', { count: rolesToRemove.length });
 
@@ -75,14 +75,14 @@ export default {
 
               if (uniqueUsers.length) {
                 numberOfRolesWithBinds++;
-                numberUniqueUsersWithBinds += uniqueUsers.length;
+                uniqueUsers.forEach(user => uniqueUsersWithBinds.add(user));
               }
             }
           });
 
-          if (numberOfRolesWithBinds && numberUniqueUsersWithBinds) {
+          if (numberOfRolesWithBinds && uniqueUsersWithBinds.size) {
             this.info = '';
-            this.warning = this.t('rbac.globalRoles.usersBound', { count: numberUniqueUsersWithBinds });
+            this.warning = this.t('rbac.globalRoles.usersBound', { count: uniqueUsersWithBinds.size });
           } else {
             this.info = this.t('rbac.globalRoles.notBound', null, true);
           }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7046
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The count of unique users bound to multiple roles would stack regardless if they were unique. This changes the number of unique users to a set, which will remove the duplicate user names from the count.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Converted the `numberUniqueUsersWithBinds` variable to a Set, adding the unique users from each role checked, then returning the size of the set as the user count.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Removing multiple cluster member roles that are bound to multiple users
- The same should be done with project roles

### Screenshot/Video

https://user-images.githubusercontent.com/40806497/193354591-9013c073-83e8-4cb5-829b-2ad77bbe0eac.mp4


