### PR TITLE
Incorrectly referencing workers when destroying workers

### DIFF
--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -40,7 +40,9 @@ export function createWorker(store, ctx) {
       queueChange(ctx, resource, true, 'Change');
     },
     destroyWorker: () => {
-      delete this.$workers[storeName];
+      if (store.$workers) {
+        delete store.$workers[storeName];
+      }
     }
   };
 


### PR DESCRIPTION
Summary
Fixes #7065 
Issue relating to e2e test failing on destroyWorker.