### PR TITLE
Disabling clusters in the top level menu if the cluster is in an error state

### DIFF
--- a/shell/components/formatter/ClusterLink.vue
+++ b/shell/components/formatter/ClusterLink.vue
@@ -25,12 +25,8 @@ export default {
       return this.row?.detailLocation;
     },
 
-    clusterHasIssues() {
-      return this.row.status?.conditions?.some(condition => condition.error === true);
-    },
-
     statusErrorConditions() {
-      if (this.clusterHasIssues) {
+      if (this.row.hasError) {
         return this.row?.status.conditions.filter(condition => condition.error === true);
       }
 
@@ -38,7 +34,7 @@ export default {
     },
 
     formattedConditions() {
-      if (this.clusterHasIssues) {
+      if (this.row.hasError) {
         const filteredConditions = this.statusErrorConditions;
         const formattedTooltip = [];
 
@@ -69,7 +65,7 @@ export default {
       class="template-upgrade-icon icon-alert icon"
     />
     <i
-      v-if="clusterHasIssues"
+      v-if="row.hasError"
       v-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
       class="conditions-alert-icon icon-error icon-lg"
     />

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -65,9 +65,10 @@ export default {
     clusters() {
       const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
       let kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all), this.$store);
+      let pClusters = null;
 
       if (this.hasProvCluster) {
-        const pClusters = this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
+        pClusters = this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
         const available = pClusters.reduce((p, c) => {
           p[c.mgmt] = true;
 
@@ -81,10 +82,12 @@ export default {
       }
 
       return kubeClusters.map((x) => {
+        const pCluster = pClusters?.find(c => c.mgmt.id === x.id);
+
         return {
           id:              x.id,
           label:           x.nameDisplay,
-          ready:           x.isReady,
+          ready:           x.isReady && !pCluster?.hasError,
           osLogo:          x.providerOsLogo,
           providerNavLogo: x.providerMenuLogo,
           badge:           x.badge,
@@ -166,7 +169,7 @@ export default {
   watch: {
     $route() {
       this.shown = false;
-    },
+    }
   },
 
   mounted() {

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -149,7 +149,7 @@ export default {
       <template #cell:explorer="{row}">
         <span v-if="row.mgmt && row.mgmt.isHarvester"></span>
         <n-link
-          v-else-if="row.mgmt && row.mgmt.isReady"
+          v-else-if="row.mgmt && row.mgmt.isReady && !row.hasError"
           data-testid="cluster-manager-list-explore-management"
           class="btn btn-sm role-secondary"
           :to="{name: 'c-cluster', params: {cluster: row.mgmt.id}}"

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -766,4 +766,8 @@ export default class ProvCluster extends SteveModel {
       await this.$dispatch('ws.resource.remove', { data: this });
     }
   }
+
+  get hasError() {
+    return this.status?.conditions?.some(condition => condition.error === true);
+  }
 }

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -311,7 +311,7 @@ export default {
                 <template #col:name="{row}">
                   <td>
                     <span v-if="row.mgmt">
-                      <n-link v-if="row.mgmt.isReady" :to="{ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }}">
+                      <n-link v-if="row.mgmt.isReady && !row.hasError" :to="{ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }}">
                         {{ row.nameDisplay }}
                       </n-link>
                       <span v-else>{{ row.nameDisplay }}</span>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#7036
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This should be isolated to the top level menu where the clusters are listed


### Areas or cases that should be tested
Broken and healthy clusters
A simpler way to reproduce:
- Create a cluster with a single node
- Edit yaml of cluster
- Change `cloudCredentialSecretName: cattle-global-data:cc-4twkpo` to be a secret that doesn't exist.

### Areas which could experience regressions
This should be isolated only to the top level menu where the clusters are listed

### Screenshot/Video
![image](https://user-images.githubusercontent.com/55104481/193684979-20eafc2e-cfb1-4068-948c-10dd2ec472e8.png)
![image](https://user-images.githubusercontent.com/55104481/193865675-3644e9af-061f-42f4-b433-ba22c266fed7.png)
![image](https://user-images.githubusercontent.com/55104481/193865732-0cd0a3d5-4d97-4dcf-b025-37d51e364faa.png)
