### PR TITLE
Remove v1 tools from getting started document

### DIFF
--- a/shell/content/docs/en-us/getting-started.md
+++ b/shell/content/docs/en-us/getting-started.md
@@ -73,11 +73,6 @@ As of version 2.6, Cluster Manager is no longer provided as a separate UI. The d
       <td colspan="3">Global</td>
     </tr>
     <tr>
-      <td>Apps</td>
-      <td>Global → Apps</td>
-      <td>Menu → Multi-cluster Apps → Apps</td>
-    </tr>
-    <tr>
       <td>Settings</td>
       <td>Global → Settings</td>
       <td>Menu → Global Settings</td>
@@ -100,7 +95,7 @@ As of version 2.6, Cluster Manager is no longer provided as a separate UI. The d
     <tr>
       <td>Pod Security Policies</td>
       <td>Global → Security → Pod Security Policies</td>
-      <td>Menu → Cluster Management → Advanced → Pod Security Policies</td>
+      <td>Menu → Cluster Management → Pod Security Policies</td>
     </tr>
     <!-- -->
     <tr class="table-group">
@@ -137,24 +132,9 @@ As of version 2.6, Cluster Manager is no longer provided as a separate UI. The d
       <td>Menu → (Cluster) → Legacy -> Notifiers</td>
     </tr>
     <tr>
-      <td>Logging (V1)</td>
-      <td>(Cluster) → Tools → Logging</td>
-      <td>Menu → (Cluster) → Cluster Tools -> Logging (Legacy)</td>
-    </tr>
-    <tr>
       <td>Monitoring (V1)</td>
       <td>(Cluster) → Tools → Monitoring</td>
       <td>Menu → (Cluster) → Cluster Tools -> Monitoring (Legacy)</td>
-    </tr>
-    <tr>
-      <td>Istio (V1)</td>
-      <td>(Cluster) → Tools → Istio</td>
-      <td>Menu → (Cluster) → Cluster Tools -> Istio (Legacy)</td>
-    </tr>
-    <tr>
-      <td>CIS Scans (V1)</td>
-      <td>(Cluster) → Tools → CIS Scans</td>
-      <td>Menu → (Cluster) → Legacy -> CIS Scans</td>
     </tr>
     <tr class="table-group">
       <td colspan="3">V1 Monitoring</td>
@@ -211,11 +191,6 @@ As of version 2.6, Cluster Manager is no longer provided as a separate UI. The d
       <td>Monitoring</td>
       <td>(Cluster) → (Project) → Tools → Monitoring</td>
       <td>Menu → (Cluster) → Legacy → Project → (Project) → Monitoring</td>
-    </tr>
-    <tr>
-      <td>Pipeline</td>
-      <td>(Cluster) → (Project) → Tools → Pipeline</td>
-      <td>Menu → (Cluster) → Legacy → Project → (Project) → Pipelines → Configuration</td>
     </tr>
     <tr class="table-group">
       <td colspan="3">Other</td>

--- a/shell/pages/docs/_doc.vue
+++ b/shell/pages/docs/_doc.vue
@@ -301,10 +301,12 @@ export default {
 
       thead > tr > th {
         background-color: var(--sortable-table-header-bg);
+        line-height: 1.75em;
       }
 
       tbody > tr.table-group > td {
-        background-color: var(--sortable-table-selected-bg);
+        background-color: var(--sortable-table-header-bg);
+        font-weight: bold;
       }
 
       thead, tbody {


### PR DESCRIPTION
Fixes #7086 

- Update getting started page
- Fix styling issues on the table to better show the groups in the table