### PR TITLE
Fixed Escape characters shown on user preferences screen

### DIFF
--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -217,7 +217,7 @@ export default {
         <h4 v-t="'prefs.advanced'" />
         <Checkbox v-model="dev" :label="t('prefs.dev.label', {}, true)" />
         <p class="wrap-text">
-          {{ t('prefs.advancedTooltip') }}
+          {{ t('prefs.advancedTooltip', {}, raw=true) }}
         </p>
         <br>
         <Checkbox v-if="!isSingleProduct" v-model="hideDescriptions" :label="t('prefs.hideDesc.label')" class="mt-10" />


### PR DESCRIPTION
Fixes #6958

### Summary
Fixed escape characters are shown on the user preferences screen
Note: After discussing with [@aalves08](https://github.com/aalves08), I have fixed this issue only for release 2.6.9. He said he will fix this issue for 2.7.0.
### How to test
Go to the user preferences page => Advance section details should not have escape characters.