### PR TITLE
Can pull Helm chart app images from cluster registry or custom registry

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -767,10 +767,10 @@ catalog:
   chart:
     registry:
       label: Container Registry
-      tooltip: By default, container images are pulled from the Cluster Container Registry in the cluster configuration, and the Global Container Registry is used as a fallback. To use images from a non-default registry, enter a custom container registry here.
+      tooltip: Container images are pulled from the Cluster Container or, failing that, the System Container Registry Setting. To change this default behaviour enter or update the registry here
       custom:
-        checkBoxLabel: Use Custom Container Registry for {vendor} System Container Images
-        inputLabel: Custom Container Registry
+        checkBoxLabel: Container Registry for {vendor} System Container Images
+        inputLabel: Container Registry
         placeholder: Registry domain and ports, ex. registry.io:5000
     header:
       charts: Charts

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -767,9 +767,9 @@ catalog:
   chart:
     registry:
       label: Container Registry
-      tooltip: Container images are pulled from the Cluster Container or, failing that, the System Container Registry Setting. To change this default behaviour enter or update the registry here
+      tooltip: Container images are pulled from the Cluster Container or, failing that, the System Container Registry Setting. To change this default behavior enter or update the registry here
       custom:
-        checkBoxLabel: Container Registry for {vendor} System Container Images
+        checkBoxLabel: Container Registry for Rancher System Container Images
         inputLabel: Container Registry
         placeholder: Registry domain and ports, ex. registry.io:5000
     header:
@@ -1586,10 +1586,10 @@ cluster:
       noResults: No results found
   privateRegistry:
     systemDefaultRegistry:
-      label: Registry hostname for {vendor} System Container Images
+      label: Registry hostname for Rancher System Container Images
     mode:
-      public: Use default global registry for {vendor} System Container Images
-      private: Use specified private registry for {vendor} System Container Images
+      public: Use default global registry for Rancher System Container Images
+      private: Use specified private registry for Rancher System Container Images
       advanced: Configure advanced containerd mirroring and registry authentication options
   provider:
     aliyunecs: Aliyun ECS

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -752,8 +752,6 @@ backupRestoreOperator:
     useDefault: Use the default storage location configured during installation
   targetBackup: Target Backup
 
-
-
 catalog:
   app:
     managed: Managed
@@ -767,6 +765,13 @@ catalog:
         busy: The related resources will appear when {app} is fully installed.
       values: Values YAML
   chart:
+    registry:
+      label: Container Registry
+      tooltip: By default, container images are pulled from the Cluster Container Registry in the cluster configuration, and the Global Container Registry is used as a fallback. To use images from a non-default registry, enter a custom container registry here.
+      custom:
+        checkBoxLabel: Use Custom Container Registry for Rancher system images
+        inputLabel: Custom Container Registry
+        placeholder: Registry domain and ports, ex. registry.io:5000
     header:
       charts: Charts
     info:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -769,7 +769,7 @@ catalog:
       label: Container Registry
       tooltip: By default, container images are pulled from the Cluster Container Registry in the cluster configuration, and the Global Container Registry is used as a fallback. To use images from a non-default registry, enter a custom container registry here.
       custom:
-        checkBoxLabel: Use Custom Container Registry for Rancher system images
+        checkBoxLabel: Use Custom Container Registry for {vendor} System Container Images
         inputLabel: Custom Container Registry
         placeholder: Registry domain and ports, ex. registry.io:5000
     header:

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import { CATALOG, CLUSTER_BADGE } from '@shell/config/labels-annotations';
-import { NODE, FLEET, MANAGEMENT } from '@shell/config/types';
+import { NODE, FLEET, MANAGEMENT, CAPI } from '@shell/config/types';
 import { insertAt } from '@shell/utils/array';
 import { downloadFile } from '@shell/utils/download';
 import { parseSi } from '@shell/utils/units';
@@ -429,5 +429,13 @@ export default class MgmtCluster extends HybridModel {
 
   get nodes() {
     return this.$getters['all'](MANAGEMENT.NODE).filter(node => node.id.startsWith(this.id));
+  }
+
+  get provClusterId() {
+    const verb = this.isLocal ? 'to' : 'from';
+    const from = `${ verb }Type`;
+    const id = `${ verb }Id`;
+
+    return this.metadata.relationships.find(r => r[from] === CAPI.RANCHER_CLUSTER)?.[id];
   }
 }

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1227,7 +1227,7 @@ export default {
           version:     dependency.version,
           releaseName: dependency.annotations[CATALOG_ANNOTATIONS.RELEASE_NAME] || dependency.name,
           projectId:   this.project,
-          values:      values.global,
+          values:      this.addGlobalValuesTo({ global: values.global }),
           annotations: {
             ...migratedAnnotations,
             [CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE]: dependency.repoType,

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -294,10 +294,12 @@ export default {
         /* For an new app, start empty. */
         userValues = {};
       }
+
       /*
         Remove global values if they are identical to
         the currently available information about the cluster
         and Rancher settings.
+
         Immediately before the Helm chart is installed or
         upgraded, the global values are re-added.
       */
@@ -338,6 +340,7 @@ export default {
     /* Look for annotation to say this app is a legacy migrated app (we look in either place for now) */
     this.migratedApp = (this.existing?.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.MIGRATED] === 'true');
   },
+
   data() {
     /* Helm CLI options that are not persisted on the back end,
     but are used for the final install/upgrade operation. */
@@ -927,49 +930,6 @@ export default {
       }
     },
 
-    removeGlobalValuesFrom(values) {
-      if ( !values ) {
-        return;
-      }
-      const cluster = this.$store.getters['currentCluster'];
-      const defaultRegistry = this.defaultRegistrySetting?.value || '';
-      const serverUrl = this.serverUrlSetting?.value || '';
-      const isWindows = (cluster.workerOSs || []).includes(WINDOWS);
-      const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
-      const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
-
-      if ( values.global?.cattle ) {
-        deleteIfEqual(values.global.cattle, 'clusterId', cluster?.id);
-        deleteIfEqual(values.global.cattle, 'clusterName', cluster?.nameDisplay);
-        deleteIfEqual(values.global.cattle, 'systemDefaultRegistry', defaultRegistry);
-        deleteIfEqual(values.global.cattle, 'url', serverUrl);
-        deleteIfEqual(values.global.cattle, 'rkePathPrefix', pathPrefix);
-        deleteIfEqual(values.global.cattle, 'rkeWindowsPathPrefix', windowsPathPrefix);
-        if ( isWindows ) {
-          deleteIfEqual(values.global.cattle.windows, 'enabled', true);
-        }
-      }
-      if ( values.global?.cattle?.windows && !Object.keys(values.global.cattle.windows).length ) {
-        delete values.global.cattle.windows;
-      }
-      if ( values.global?.cattle && !Object.keys(values.global.cattle).length ) {
-        delete values.global.cattle;
-      }
-      if ( values.global ) {
-        deleteIfEqual(values.global, 'systemDefaultRegistry', defaultRegistry);
-      }
-      if ( !Object.keys(values.global || {}).length ) {
-        delete values.global;
-      }
-
-      return values;
-      function deleteIfEqual(obj, key, val) {
-        if ( get(obj, key) === val ) {
-          delete obj[key];
-        }
-      }
-    },
-
     addGlobalValuesTo(values) {
       let global = values.global;
 
@@ -1012,6 +972,56 @@ export default {
       function setIfNotSet(obj, key, val) {
         if ( typeof get(obj, key) === 'undefined' ) {
           set(obj, key, val);
+        }
+      }
+    },
+
+    removeGlobalValuesFrom(values) {
+      if ( !values ) {
+        return;
+      }
+
+      const cluster = this.$store.getters['currentCluster'];
+      const defaultRegistry = this.defaultRegistrySetting?.value || '';
+      const serverUrl = this.serverUrlSetting?.value || '';
+      const isWindows = (cluster.workerOSs || []).includes(WINDOWS);
+      const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
+      const windowsPathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
+
+      if ( values.global?.cattle ) {
+        deleteIfEqual(values.global.cattle, 'clusterId', cluster?.id);
+        deleteIfEqual(values.global.cattle, 'clusterName', cluster?.nameDisplay);
+        deleteIfEqual(values.global.cattle, 'systemDefaultRegistry', defaultRegistry);
+        deleteIfEqual(values.global.cattle, 'url', serverUrl);
+        deleteIfEqual(values.global.cattle, 'rkePathPrefix', pathPrefix);
+        deleteIfEqual(values.global.cattle, 'rkeWindowsPathPrefix', windowsPathPrefix);
+
+        if ( isWindows ) {
+          deleteIfEqual(values.global.cattle.windows, 'enabled', true);
+        }
+      }
+
+      if ( values.global?.cattle?.windows && !Object.keys(values.global.cattle.windows).length ) {
+        delete values.global.cattle.windows;
+      }
+
+      if ( values.global?.cattle && !Object.keys(values.global.cattle).length ) {
+        delete values.global.cattle;
+      }
+
+      if ( values.global ) {
+        deleteIfEqual(values.global, 'systemDefaultRegistry', defaultRegistry);
+      }
+
+      if ( !Object.keys(values.global || {}).length ) {
+        delete values.global;
+      }
+
+      return values;
+
+      function deleteIfEqual(obj, key, val) {
+        if ( get(obj, key) === val ) {
+          delete obj[key];
         }
       }
     },
@@ -1174,7 +1184,6 @@ export default {
         charts that may not be CRD charts but are also meant to be installed at
         the same time.
       */
-
       for ( const dependency of more ) {
         const globalValues = values.global;
 
@@ -1603,7 +1612,7 @@ export default {
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
   $title-height: 50px;
   $padding: 5px;
   $slideout-width: 35%;

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -297,7 +297,7 @@ export default {
     }
 
     if (this.showCustomRegistry) {
-      const existingRegistry = this.chartValues.global.systemDefaultRegistry || this.chartValues.global.cattle.systemDefaultRegistry;
+      const existingRegistry = this.chartValues?.global?.systemDefaultRegistry || this.chartValues?.global?.cattle?.systemDefaultRegistry;
 
       this.customRegistrySetting = existingRegistry || this.defaultRegistrySetting;
       this.showCustomRegistryInput = this.applyCustomRegistry;
@@ -349,7 +349,6 @@ export default {
       valuesYaml:             '',
       project:                null,
       migratedApp:            false,
-      clusterData:            null,
       defaultCmdOpts,
       customCmdOpts:          { ...defaultCmdOpts },
 
@@ -780,16 +779,14 @@ export default {
       const hasPermissionToSeeProvCluster = this.$store.getters[`management/schemaFor`](CAPI.RANCHER_CLUSTER);
 
       if (hasPermissionToSeeProvCluster) {
-        const clusterName = this.$store.getters['currentCluster'].spec.displayName;
-        const clusterResourceId = `fleet-default/${ clusterName }`;
-
-        this.clusterData = await this.$store.dispatch('management/find', {
+        const mgmCluster = this.$store.getters['currentCluster'];
+        const provCluster = await this.$store.dispatch('management/find', {
           type: CAPI.RANCHER_CLUSTER,
-          id:   clusterResourceId
+          id:   mgmCluster.provClusterId
         });
 
-        if (this.clusterData.isRke2) { // isRke2 returns true for both RKE2 and K3s clusters.
-          const agentConfig = this.clusterData.spec.rkeConfig.machineSelectorConfig.find(x => !x.machineLabelSelector).config;
+        if (provCluster.isRke2) { // isRke2 returns true for both RKE2 and K3s clusters.
+          const agentConfig = provCluster.spec.rkeConfig.machineSelectorConfig.find(x => !x.machineLabelSelector).config;
 
           // If a cluster scoped registry exists,
           // it should be used by default.

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -284,6 +284,16 @@ export default {
       */
       this.chartValues = merge(merge({}, this.versionInfo?.values || {}), userValues);
 
+      if (this.showCustomRegistry) {
+        const existingRegistry = this.chartValues?.global?.systemDefaultRegistry || this.chartValues?.global?.cattle?.systemDefaultRegistry;
+
+        delete this.chartValues?.global?.systemDefaultRegistry;
+        delete this.chartValues?.global?.cattle?.systemDefaultRegistry;
+
+        this.customRegistrySetting = existingRegistry || this.defaultRegistrySetting;
+        this.showCustomRegistryInput = !!this.customRegistrySetting;
+      }
+
       /* Serializes an object as a YAML document */
       this.valuesYaml = saferDump(this.chartValues);
 
@@ -294,13 +304,6 @@ export default {
 
       this.loadedVersionValues = this.versionInfo?.values || {};
       this.loadedVersion = this.version?.key;
-    }
-
-    if (this.showCustomRegistry) {
-      const existingRegistry = this.chartValues?.global?.systemDefaultRegistry || this.chartValues?.global?.cattle?.systemDefaultRegistry;
-
-      this.customRegistrySetting = existingRegistry || this.defaultRegistrySetting;
-      this.showCustomRegistryInput = this.applyCustomRegistry;
     }
 
     /* Check if chart exists and if required values exist */
@@ -1013,7 +1016,6 @@ export default {
       }
 
       const cluster = this.$store.getters['currentCluster'];
-      const defaultRegistry = this.defaultRegistrySetting?.value || '';
       const serverUrl = this.serverUrlSetting?.value || '';
       const isWindows = (cluster.workerOSs || []).includes(WINDOWS);
       const pathPrefix = cluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
@@ -1022,7 +1024,6 @@ export default {
       if ( values.global?.cattle ) {
         deleteIfEqual(values.global.cattle, 'clusterId', cluster?.id);
         deleteIfEqual(values.global.cattle, 'clusterName', cluster?.nameDisplay);
-        deleteIfEqual(values.global.cattle, 'systemDefaultRegistry', defaultRegistry);
         deleteIfEqual(values.global.cattle, 'url', serverUrl);
         deleteIfEqual(values.global.cattle, 'rkePathPrefix', pathPrefix);
         deleteIfEqual(values.global.cattle, 'rkeWindowsPathPrefix', windowsPathPrefix);
@@ -1038,10 +1039,6 @@ export default {
 
       if ( values.global?.cattle && !Object.keys(values.global.cattle).length ) {
         delete values.global.cattle;
-      }
-
-      if ( values.global ) {
-        deleteIfEqual(values.global, 'systemDefaultRegistry', defaultRegistry);
       }
 
       if ( !Object.keys(values.global || {}).length ) {


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/6910

To test:

1. Provision two downstream RKE2 clusters, one with a private registry in the cluster config and one without.
2. In the cluster that has a registry, install a helm chart with the default settings. (I used Rancher alerting drivers) Confirm that the cluster registry from the cluster config is used in the values.yaml under `values.global.cattle.systemDefaultRegistry`. 
3. In the cluster that does not have a registry, install a helm chart with the default settings. The `values.global.cattle.systemDefaultRegistry` should be an empty string because the global default registry in the settings is also an empty string.
4. In the global settings of Rancher, change `system-default-registry` to a different string. It can be any string.
5. In the cluster that does not have a registry, install or upgrade a chart and confirm that the systemDefaultRegistry now reflects the new default registry from the global settings. Note: This is where I got stuck - the new default setting is not sent in the network request.


I have not tested the following yet, but this is what I intend to test:
6. In any cluster, install or upgrade a chart. In the first page of the helm chart install workflow, select the new checkbox that says "Use Custom Container Registry for Rancher system images"
7. Enter a custom registry
8. Confirm that the new registry is in the `values.global.cattle.systemDefaultRegistry` in the values.yaml
