### PR TITLE
Show browse-featured-toggle button when there is featured chart data

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -345,7 +345,7 @@ export default {
           {{ t('catalog.charts.header') }}
         </h1>
       </div>
-      <div class="actions-container">
+      <div v-if="getFeaturedCharts.length > 0" class="actions-container">
         <ButtonGroup
           v-model="chartMode"
           :options="chartOptions"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7121
<!-- Define findings related to the feature or bug issue. -->
On the charts page Show `Browse/Featured` toggle buttons should be visible only when there is data for featured charts.


### How to test

- To test you can add a new repository with this HTTP URL: https://nwmac.github.io/rancher-charts

- Go to page:  https://192.168.1.11:8005/c/local/apps/charts
Select newly added charts in the dropdown and It should show `Browse/Featured` toggle buttons for the test-charts.


