### PR TITLE
Removed btn-sm class to make button size nomal

### DIFF
--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -296,13 +296,13 @@ export default {
                   <div class="table-heading">
                     <n-link
                       :to="importLocation"
-                      class="btn btn-sm role-primary"
+                      class="btn role-primary"
                     >
                       {{ t('cluster.importAction') }}
                     </n-link>
                     <n-link
                       :to="createLocation"
-                      class="btn btn-sm role-primary"
+                      class="btn role-primary"
                     >
                       {{ t('generic.create') }}
                     </n-link>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7042

<!-- Define findings related to the feature or bug issue. -->
The buttons on the home page should have the same height, width, margin, and padding as buttons on other pages.
- Removed `btn-sm` class to fix this issue
