### PR TITLE
Nested tabs should not contain padding

### DIFF
--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -40,6 +40,12 @@ export default {
       default: false,
     },
 
+    // Remove padding and box-shadow
+    flat: {
+      type:    Boolean,
+      default: false,
+    },
+
     tabsOnly: {
       type:    Boolean,
       default: false,
@@ -257,7 +263,13 @@ export default {
       </ul>
       <slot name="tab-row-extras" />
     </ul>
-    <div :class="{ 'tab-container': !!tabs.length || !!sideTabs, 'no-content': noContent }">
+    <div
+      :class="{
+        'tab-container': !!tabs.length || !!sideTabs,
+        'no-content': noContent,
+        'tab-container--flat': !!flat,
+      }"
+    >
       <slot />
     </div>
   </div>
@@ -350,6 +362,12 @@ export default {
   &.no-content {
     padding: 0 0 3px 0;
   }
+
+  // Example case: Tabbed component within a tabbed component
+  &--flat {
+    box-shadow: unset;
+    padding: 0;
+  }
 }
 
 .tabs-only {
@@ -373,11 +391,6 @@ export default {
 
   .tab-container {
     padding: 20px;
-  }
-
-  // Tabbed component within a tabbed component
-  .tab-container & {
-    box-shadow: unset;
   }
 
   & .tabs {
@@ -451,7 +464,9 @@ export default {
     }
   }
 
-  & .tab-container {
+  &
+
+  .tab-container {
     width: calc(100% - #{$sideways-tabs-width});
     flex-grow: 1;
     background-color: var(--body-bg);

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -92,7 +92,7 @@ export default {
           />
         </div>
       </div>
-      <Tabbed class="deployment-tabs" :show-tabs-add-remove="true" :default-tab="defaultTab" @changed="changed">
+      <Tabbed class="deployment-tabs" :show-tabs-add-remove="true" :default-tab="defaultTab" :flat="true" @changed="changed">
         <Tab
           v-for="(tab, i) in allContainers"
           :key="i"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7124
As in issue.

### Occurred changes and/or fixed issues
Removed unnecessary padding.

### Technical notes summary
Added prop to the `Tabbed` component and pointed class for active property.

### Areas or cases that should be tested
- `NetworkPolicy`, `/c/local/explorer/networking.k8s.io.networkpolicy
- `Workload` creation

### Areas which could experience regressions
Based on what defined in the issue, no other view has nested tabs cases.

### Screenshot/Video
<img width="731" alt="Screenshot 2022-10-10 at 17 38 53" src="https://user-images.githubusercontent.com/5009481/194904925-cc8cff7a-f7fc-48de-802b-e1b56184cc4c.png">
<img width="584" alt="Screenshot 2022-10-10 at 17 39 32" src="https://user-images.githubusercontent.com/5009481/194904931-05dc8d99-d513-4784-a3c7-984047199b37.png">
