### PR TITLE
[backport v2.6.9] NetworkPolicy PolicyRules checkbox and buttons overlap

### DIFF
--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -35,6 +35,12 @@ export default {
       default: true,
     },
 
+    // Remove padding and box-shadow
+    flat: {
+      type:    Boolean,
+      default: false,
+    },
+
     noContent: {
       type:    Boolean,
       default: false,
@@ -251,7 +257,13 @@ export default {
       </ul>
       <slot name="tab-row-extras" />
     </ul>
-    <div :class="{ 'tab-container': !!tabs.length || !!sideTabs, 'no-content': noContent }">
+    <div
+      :class="{
+        'tab-container': !!tabs.length || !!sideTabs,
+        'no-content': noContent,
+        'tab-container--flat': !!flat,
+      }"
+    >
       <slot />
     </div>
   </div>
@@ -335,6 +347,15 @@ export default {
   &.no-content {
     padding: 0 0 3px 0;
   }
+
+  // Example case: Tabbed component within a tabbed component
+  &--flat {
+    padding: 0;
+
+    .side-tabs {
+      box-shadow: unset;
+    }
+  }
 }
 
 .side-tabs {
@@ -345,12 +366,6 @@ export default {
 
   .tab-container {
     padding: 20px;
-  }
-
-  // Tabbed component within a tabbed component
-  .tab-container & {
-    margin: -20px;
-    box-shadow: unset;
   }
 
   & .tabs {

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -91,7 +91,7 @@ export default {
           />
         </div>
       </div>
-      <Tabbed class="deployment-tabs" :show-tabs-add-remove="true" :default-tab="defaultTab" @changed="changed">
+      <Tabbed class="deployment-tabs" :show-tabs-add-remove="true" :default-tab="defaultTab" :flat="true" @changed="changed">
         <Tab
           v-for="(tab, i) in allContainers"
           :key="i+tab.name"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7115 
As in issue.

### Occurred changes and/or fixed issues
Removed unnecessary padding and margin.

### Technical notes summary
Added prop to the `Tabbed` component and pointed class for active property.

### Areas or cases that should be tested
- `NetworkPolicy`, `/c/local/explorer/networking.k8s.io.networkpolicy
- `Workload` creation

### Areas which could experience regressions
Based on what defined in the issue, no other view has nested tabs cases.

### Screenshot/Video
<img width="731" alt="Screenshot 2022-10-10 at 17 38 53" src="https://user-images.githubusercontent.com/5009481/194904925-cc8cff7a-f7fc-48de-802b-e1b56184cc4c.png">

<img width="584" alt="Screenshot 2022-10-10 at 17 39 32" src="https://user-images.githubusercontent.com/5009481/194904931-05dc8d99-d513-4784-a3c7-984047199b37.png">

![Screenshot 2022-10-06 at 16 35 41](https://user-images.githubusercontent.com/5009481/194342573-e77734d2-fd59-40f5-97db-ab90e1869dac.png)

![Screenshot 2022-10-06 at 16 35 44](https://user-images.githubusercontent.com/5009481/194342579-4dd18aad-d815-4829-b54e-eec92fefbf82.png)

![Screenshot 2022-10-06 at 16 37 57](https://user-images.githubusercontent.com/5009481/194342588-8d2eac89-752a-487b-82a6-b7049875baa0.png)

![Screenshot 2022-10-11 at 16 57 16](https://user-images.githubusercontent.com/5009481/195126769-54545462-3951-417a-9109-104862428c14.png)
![Screenshot 2022-10-11 at 16 58 23](https://user-images.githubusercontent.com/5009481/195126779-0b6b86ee-35df-46de-8f5d-b1d16903b55b.png)
