### PR TITLE
Hide the windows command from k3s cluster

### DIFF
--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -679,6 +679,10 @@ export default class ProvCluster extends SteveModel {
   }
 
   get supportsWindows() {
+    if (this.isK3s || this.isImportedK3s) {
+      return false;
+    }
+
     if ( this.isRke1 ) {
       return this.mgmt?.spec?.windowsPreferedCluster || false;
     }


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#7126


### Technical notes summary
It looks like we determine the provisioner is k3s in a couple different ways.

### Areas or cases that should be tested
Anywhere that requires windows support to be show or used could be affected but it's unlikely.

### Areas which could experience regressions
Anywhere that requires windows support to be show or used could be affected but it's unlikely.

### Screenshot/Video
![image](https://user-images.githubusercontent.com/55104481/194951854-b04db9dc-42f4-4318-97e4-f3a058de2513.png)