### PR TITLE
Re-initialize default values when new kubernetes version is selected

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/ACE.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/ACE.vue
@@ -4,6 +4,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import FileSelector, { createOnSelected } from '@shell/components/form/FileSelector';
 import { set } from '@shell/utils/object';
 import isEmpty from 'lodash/isEmpty';
+import { _CREATE } from '@shell/config/query-params';
 
 export default {
   components: {
@@ -23,7 +24,7 @@ export default {
   },
 
   data() {
-    if ( isEmpty(this.value?.spec?.localClusterAuthEndpoint) ) {
+    if ( isEmpty(this.value?.spec?.localClusterAuthEndpoint) && this.mode === _CREATE ) {
       set(this.value, 'spec.localClusterAuthEndpoint', {
         enabled: false,
         caCerts: '',

--- a/shell/edit/provisioning.cattle.io.cluster/DrainOptions.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/DrainOptions.vue
@@ -10,7 +10,6 @@ const DEFAULTS = {
   force:                           false, // Show; true = Delete standalone pods, false = fail if there are any
   gracePeriod:                     -1, // Show; Pod shut down time, negative value uses pod default
   ignoreDaemonSets:                true, // Hide; true = work, false = never work because there's always daemonSets
-  ignoreErrors:                    false, // Hide; profit?
   skipWaitForDeleteTimeoutSeconds: 0, // Hide; If the pod deletion time is older than this > 0, don't wait, for some reason
   timeout:                         120, // Show; Give up after this many seconds
 };

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -902,7 +902,9 @@ export default {
 
       // Allow time for addonNames to update... then fetch any missing addons
       this.$nextTick(() => this.initAddons());
-      this.initServerAgentArgs();
+      if (this.mode === _CREATE) {
+        this.initServerAgentArgs();
+      }
     },
 
     showCni(neu) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1096,10 +1096,6 @@ export default {
           entry.config = await entry.config.save();
         }
 
-        if ( !entry.pool.hostnamePrefix ) {
-          entry.pool.hostnamePrefix = `${ prefix }-`;
-        }
-
         finalPools.push(entry.pool);
       }
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -202,26 +202,6 @@ export default {
       set(this.value.spec, 'kubernetesVersion', this.defaultVersion);
     }
 
-    for ( const k in this.serverArgs ) {
-      if ( this.serverConfig[k] === undefined ) {
-        const def = this.serverArgs[k].default;
-
-        set(this.serverConfig, k, (def !== undefined ? def : undefined));
-      }
-    }
-
-    for ( const k in this.agentArgs ) {
-      if ( this.agentConfig[k] === undefined ) {
-        const def = this.agentArgs[k].default;
-
-        set(this.agentConfig, k, (def !== undefined ? def : undefined));
-      }
-    }
-
-    if ( !this.serverConfig.profile ) {
-      set(this.serverConfig, 'profile', null);
-    }
-
     if ( this.rkeConfig.etcd?.s3?.bucket ) {
       this.s3Backup = true;
     }
@@ -922,6 +902,7 @@ export default {
 
       // Allow time for addonNames to update... then fetch any missing addons
       this.$nextTick(() => this.initAddons());
+      this.initServerAgentArgs();
     },
 
     showCni(neu) {
@@ -1385,6 +1366,28 @@ export default {
       const key = this.chartVersionKey(name);
 
       return merge({}, defaultChartValue?.values || {}, this.userChartValues[key] || {});
+    },
+
+    initServerAgentArgs() {
+      for ( const k in this.serverArgs ) {
+        if ( this.serverConfig[k] === undefined ) {
+          const def = this.serverArgs[k].default;
+
+          set(this.serverConfig, k, (def !== undefined ? def : undefined));
+        }
+      }
+
+      for ( const k in this.agentArgs ) {
+        if ( this.agentConfig[k] === undefined ) {
+          const def = this.agentArgs[k].default;
+
+          set(this.agentConfig, k, (def !== undefined ? def : undefined));
+        }
+      }
+
+      if ( !this.serverConfig.profile ) {
+        set(this.serverConfig, 'profile', null);
+      }
     },
 
     chartVersionKey(name) {


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6881 
There are two underlying problems causing extra fields to be added when editing rke2 and k3s clusters. One is that we're using rke2 default values in `machineGlobalConfig` and `agentConfig` when creating k3s clusters, then overriding with the correct k3s defaults on edit. The other problem is that the UI is trying to set default values for a handful of fields that don't appear to exist.


### Occurred changes and/or fixed issues
This PR updates the `machineGlobalConfig` and `agentConfig` logic to re-run every time a different kubernetes version is selected, so when a user selects a k3s release, their cluster spec will be populated with correct defaults. 

`hostNamePrefix` and `ignoreErrors` defaults have been removed. afaict `localClusterAuthEndpoint` doesn't need defaults explicitly set by the UI.



