### PR TITLE
Remove box shadow for nested tabs

### DIFF
--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -365,8 +365,11 @@ export default {
 
   // Example case: Tabbed component within a tabbed component
   &--flat {
-    box-shadow: unset;
     padding: 0;
+
+    .side-tabs {
+      box-shadow: unset;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7124

### Occurred changes and/or fixed issues
Removed box shadow previously defined in child element.

### Technical notes summary
/

### Areas or cases that should be tested
/

### Areas which could experience regressions
/

### Screenshot/Video
![Screenshot 2022-10-11 at 16 57 16](https://user-images.githubusercontent.com/5009481/195128061-e0d3a402-f5b0-4667-abe7-96e4a556a380.png)
![Screenshot 2022-10-11 at 16 58 23](https://user-images.githubusercontent.com/5009481/195128067-44509981-4705-4f6c-8239-3f80fe90f9d9.png)
