### PR TITLE
Fix error response to return message string

### DIFF
--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -278,7 +278,7 @@ export default {
         await this.refreshSpoofedTypes(spoofedTypes);
         this.done();
       } catch (err) {
-        this.error = err;
+        this.error = err.message ? err.message : err;
         btnCB(false);
       }
     },

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -266,7 +266,7 @@ export default {
         await this.refreshSpoofedTypes(spoofedTypes);
         this.done();
       } catch (err) {
-        this.error = err;
+        this.error = err.message || err;
         btnCB(false);
       }
     },
@@ -278,7 +278,7 @@ export default {
         await this.refreshSpoofedTypes(spoofedTypes);
         this.done();
       } catch (err) {
-        this.error = err.message ? err.message : err;
+        this.error = err.message || err;
         btnCB(false);
       }
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7138 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This fixes the error message when deleting cloud credentials that are in use to return the `error.message` rather than the entire error object.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![error](https://user-images.githubusercontent.com/40806497/195134400-54e44ab6-c909-4de7-9436-a8fb02ec705d.png)

