### PR TITLE
Minor plugin tweaks

### DIFF
--- a/shell/assets/styles/global/_button.scss
+++ b/shell/assets/styles/global/_button.scss
@@ -139,6 +139,7 @@ fieldset[disabled] .btn {
   color: var(--disabled-text) !important;
   &:not(.role-link){
     background-color: var(--disabled-bg) !important;
+    border-color: var(--disabled-bg) !important;
   }
 }
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3677,6 +3677,7 @@ plugins:
   descriptions:
     experimental: This Extension is marked as experimental
     third-party: This Extension is provided by a Third-Party
+    built-in: This Extension is built-in
   error:
     title: Error loading extension
     message: Could not load extension code

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3708,6 +3708,7 @@ plugins:
     updates: No updates available for installed Extensions
   loadError: An error occurred loading the code for this extension
   helmError: "An error occurred installing the extension via Helm"
+  manageRepos: Manage Repositories
   tabs:
     all: All
     available: Available

--- a/shell/config/product/settings.js
+++ b/shell/config/product/settings.js
@@ -26,6 +26,7 @@ export function init(store) {
     removable:           false,
     showClusterSwitcher: false,
     category:            'configuration',
+    weight:              100,
   });
 
   virtualType({

--- a/shell/config/product/uiplugins.js
+++ b/shell/config/product/uiplugins.js
@@ -13,5 +13,6 @@ export function init(store) {
     removable:           false,
     showClusterSwitcher: false,
     category:            'configuration',
+    weight:              50,
   });
 }

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -34,6 +34,7 @@ export const UI_PLUGIN_CHART_ANNOTATIONS = {
   RANCHER_VERSION:    'catalog.cattle.io/rancher-version',
   EXTENSIONS_VERSION: 'catalog.cattle.io/ui-extenstions-version',
   EXTENSIONS_HOST:    'catalog.cattle.io/ui-extenstions-host',
+  DISPLAY_NAME:       'catalog.cattle.io/display-name',
 };
 
 // Plugin Metadata properties
@@ -41,6 +42,7 @@ export const UI_PLUGIN_METADATA = {
   RANCHER_VERSION:    'rancherVersion',
   EXTENSION_VERSION:  'extVersion',
   EXTENSIONS_HOST:    'host',
+  DISPLAY_NAME:       'displayName',
 };
 
 export function isUIPlugin(chart) {
@@ -53,6 +55,17 @@ export function uiPluginHasAnnotation(chart, name, value) {
   return !!chart?.versions.find((v) => {
     return v.annotations && v.annotations[name] === value;
   });
+}
+
+/**
+ * Get value of the annotation from teh latest version for a chart
+ */
+export function uiPluginAnnotation(chart, name) {
+  if (chart?.versions?.length > 0) {
+    return chart.versions[0].annotations?.[name];
+  }
+
+  return undefined;
 }
 
 // Should we load a plugin, based on the metadata returned by the backend?

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -194,6 +194,7 @@ export default {
           id:   operationId
         });
       } catch (e) {
+        console.log(e);
         this.$store.dispatch('growl/error', {
           title:   this.t('plugins.error.generic'),
           message: e.message ? e.message : e,

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -159,7 +159,9 @@ export default {
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
 
       if (isRancherImage && defaultRegistry) {
-        chart.values.global = { cattle: { systemDefaultRegistry: defaultRegistry } };
+        chart.values.global = chart.values.global || {};
+        chart.values.global.cattle = chart.values.global.cattle || {};
+        chart.values.global.cattle.systemDefaultRegistry = defaultRegistry;
       }
 
       // Pass in the system default registry property if set - only if the image is in the rancher org

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -155,6 +155,13 @@ export default {
         values: {}
       };
 
+      // Pass in the system default registry property if set
+      const defaultRegistry = this.defaultRegistrySetting?.value || '';
+
+      if (defaultRegistry) {
+        chart.values.global = { cattle: { systemDefaultRegistry: defaultRegistry } };
+      }
+
       // Pass in the system default registry property if set - only if the image is in the rancher org
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
 

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -164,15 +164,6 @@ export default {
         chart.values.global.cattle.systemDefaultRegistry = defaultRegistry;
       }
 
-      // Pass in the system default registry property if set - only if the image is in the rancher org
-      const defaultRegistry = this.defaultRegistrySetting?.value || '';
-
-      if (isRancherImage && defaultRegistry) {
-        chart.values.global = chart.values.global || {};
-        chart.values.global.cattle = chart.values.global.cattle || {};
-        chart.values.global.cattle.systemDefaultRegistry = defaultRegistry;
-      }
-
       const input = {
         charts:    [chart],
         // timeout:   this.cmdOptions.timeout > 0 ? `${ this.cmdOptions.timeout }s` : null,

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -208,7 +208,7 @@ export default {
   >
     <div v-if="plugin" class="plugin-install-dialog">
       <h4 class="mt-10">
-        {{ t(`plugins.${ mode }.title`, { name: plugin.name }) }}
+        {{ t(`plugins.${ mode }.title`, { name: plugin.label }) }}
       </h4>
       <div class="custom mt-10">
         <div class="dialog-panel">

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -194,7 +194,6 @@ export default {
           id:   operationId
         });
       } catch (e) {
-        console.log(e);
         this.$store.dispatch('growl/error', {
           title:   this.t('plugins.error.generic'),
           message: e.message ? e.message : e,

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -155,10 +155,10 @@ export default {
         values: {}
       };
 
-      // Pass in the system default registry property if set
+      // Pass in the system default registry property if set - only if the image is in the rancher org
       const defaultRegistry = this.defaultRegistrySetting?.value || '';
 
-      if (defaultRegistry) {
+      if (isRancherImage && defaultRegistry) {
         chart.values.global = { cattle: { systemDefaultRegistry: defaultRegistry } };
       }
 

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -117,8 +117,11 @@ export default {
         </div>
         <div>
           <Banner v-if="info.error" color="error" :label="info.error" class="mt-10" />
-          <Banner v-if="!info.certified" color="warning" :label="t('plugins.descriptions.third-party')" class="mt-10" />
-          <Banner v-if="info.experimental" color="warning" :label="t('plugins.descriptions.experimental')" class="mt-10" />
+          <Banner v-if="info.builtin" color="warning" :label="t('plugins.descriptions.built-in')" class="mt-10" />
+          <template v-else>
+            <Banner v-if="!info.certified" color="warning" :label="t('plugins.descriptions.third-party')" class="mt-10" />
+            <Banner v-if="info.experimental" color="warning" :label="t('plugins.descriptions.experimental')" class="mt-10" />
+          </template>
         </div>
 
         <h3 v-if="info.versions.length">

--- a/shell/pages/c/_cluster/uiplugins/UninstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/UninstallDialog.vue
@@ -69,7 +69,7 @@ export default {
   >
     <div v-if="plugin" class="plugin-install-dialog">
       <h4 class="mt-10">
-        {{ t('plugins.uninstall.title', { name: plugin.name }) }}
+        {{ t('plugins.uninstall.title', { name: plugin.label }) }}
       </h4>
       <div class="mt-10 dialog-panel">
         <div class="dialog-info">

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -22,6 +22,8 @@ import { isUIPlugin, uiPluginHasAnnotation, isSupportedChartVersion, UI_PLUGIN_N
 
 const MAX_DESCRIPTION_LENGTH = 200;
 
+const MAX_DESCRIPTION_LENGTH = 200;
+
 export default {
   components: {
     ActionMenu,

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -200,6 +200,7 @@ export default {
           const item = {
             name:           p.name,
             description:    p.metadata?.description,
+            icon:           p.metadata?.icon,
             id:             p.id,
             versions:       [],
             displayVersion: p.metadata?.version || '-',
@@ -319,11 +320,11 @@ export default {
 
     plugins(neu, old) {
       const installed = this.$store.getters['uiplugins/plugins'];
-
+      const shouldHaveLoaded = (installed || []).filter(p => !this.uiErrors[p.name] && !p.builtin);
       let changes = 0;
 
       // Did the user remove an extension
-      if (neu?.length < installed.length) {
+      if (neu?.length < shouldHaveLoaded.length) {
         changes++;
       }
 
@@ -331,7 +332,9 @@ export default {
         const existing = installed.find(p => !p.removed && p.name === plugin.name && p.version === plugin.version);
 
         if (!existing && plugin.isCached) {
-          changes++;
+          if (!this.uiErrors[plugin.name]) {
+            changes++;
+          }
 
           this.updatePluginInstallStatus(plugin.name, false);
         }
@@ -533,9 +536,6 @@ export default {
                 {{ plugin.name }}
               </div>
               <div>{{ plugin.description }}</div>
-              <div v-if="plugin.builtin" class="plugin-builtin">
-                {{ t('plugins.labels.builtin') }}
-              </div>
               <div class="plugin-version">
                 <span v-if="plugin.installing === 'uninstall'" class="plugin-installing">
                   -
@@ -545,7 +545,12 @@ export default {
                   <span v-if="plugin.upgrade" v-tooltip="t('plugins.upgradeAvailable')"> -> {{ plugin.upgrade }}</span>
                 </span>
               </div>
-              <div class="plugin-badges">
+              <div v-if="plugin.builtin" class="plugin-badges">
+                <div class="plugin-builtin">
+                  {{ t('plugins.labels.builtin') }}
+                </div>
+              </div>
+              <div v-else class="plugin-badges">
                 <div v-if="!plugin.certified" v-tooltip="t('plugins.descriptions.third-party')">
                   {{ t('plugins.labels.third-party') }}
                 </div>

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -22,8 +22,6 @@ import { isUIPlugin, uiPluginHasAnnotation, isSupportedChartVersion, UI_PLUGIN_N
 
 const MAX_DESCRIPTION_LENGTH = 200;
 
-const MAX_DESCRIPTION_LENGTH = 200;
-
 export default {
   components: {
     ActionMenu,


### PR DESCRIPTION
A few minor tweaks:

- Fixed presentation of the 'reload required' for plugins that are in error or are built-in
- Fixed annoying blue border on the disabled button - seen on the cancel button on the plugin uninstall dialog
- Improved the presentation of 'built-in' metadata for a built-in plugin
- Changed order of configuration items, so Extensions is in the middle
- Show icon from package metadata for plugins without a corresponding chart
- Added 'Manage Repositories' to the action menu to make it easier to get to this page from extensions
- Added support for the display name override to give plugins a custom title