### PR TITLE
Fix RKE2 Node status in cluster management.

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -630,7 +630,8 @@ export default {
                   {{ group.ref.providerDisplay }} &ndash;  {{ group.ref.providerLocation }} / {{ group.ref.providerSize }} ({{ group.ref.providerName }})
                 </div>
               </div>
-              <div v-if="group.ref" class="right mr-45">
+              <div v-if="group.ref" class="right group-header-buttons">
+                <MachineSummaryGraph :row="poolSummaryInfo[group.ref]" :horizontal="true" class="mr-20" />
                 <template v-if="value.hasLink('update')">
                   <button v-tooltip="t('node.list.scaleDown')" :disabled="!group.ref.canScaleDownPool()" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
                     <i class="icon icon-sm icon-minus" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7082 - Number of nodes not shows for RKE2 clusters

### Technical notes summary
- Component wasn't applied to RKE2 header
 
### Areas or cases that should be tested
- Create RKE1 cluster
- Create RKE 2 cluster
- Navigate to Global Apps > Cluster Management > Click on cluster name
- Node status should now be visible
