### PR TITLE
Remove registration warning banner for custom clusters

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -709,7 +709,7 @@ export default {
       </Tab>
 
       <Tab v-if="showRegistration" name="registration" :label="t('cluster.tabs.registration')" :weight="2">
-        <Banner color="warning" :label="t('cluster.import.warningBanner')" />
+        <Banner v-if="!value.isCustom" color="warning" :label="t('cluster.import.warningBanner')" />
         <CustomCommand v-if="value.isCustom" :cluster-token="clusterToken" :cluster="value" @copied-windows="hasWindowsMachine ? null : showWindowsWarning = true" />
         <template v-else>
           <h4 v-html="t('cluster.import.commandInstructions', null, true)" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7171 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This removes the registration warning banner for custom rke and k3s clusters. Works for both rke1 and rke2.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
_rke2_
![no-banner](https://user-images.githubusercontent.com/40806497/195595798-e025cb6d-8b45-422a-86df-4a75b25712cf.png)

_rke1_
![rke-custom](https://user-images.githubusercontent.com/40806497/195595856-f0426664-5f91-4bad-afa1-6dbb6f30bea9.png)

