### PR TITLE
Fix global role count with standard and admin users

### DIFF
--- a/shell/promptRemove/mixin/roleDeletionCheck.js
+++ b/shell/promptRemove/mixin/roleDeletionCheck.js
@@ -66,12 +66,26 @@ export default {
           method:        'get',
         }, { root: true });
 
+        // We need to fetch the users here in order to get an accurate count when selecting global roles.
+        const users = await this.$store.dispatch('management/request', {
+          url:           `/v1/${ MANAGEMENT.USER }`,
+          method:        'get',
+        }, { root: true });
+
+        const userMap = users.data?.reduce((map, user) => {
+          if ( user.username ) {
+            map[user.id] = user;
+          }
+
+          return map;
+        }, {});
+
         if (request.data && request.data.length) {
           rolesToRemove.forEach((toRemove) => {
             const usedRoles = request.data.filter(item => item[propToMatch] === toRemove.id);
 
             if (usedRoles.length) {
-              const uniqueUsers = [...new Set(usedRoles.map(item => item.userName))];
+              const uniqueUsers = [...new Set(usedRoles.map(item => item.userName).filter(user => userMap[user]))];
 
               if (uniqueUsers.length) {
                 numberOfRolesWithBinds++;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7046 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This fixes the issue of counting Global Roles with the Standard User option.
The Standard User global role binding includes not only the standard users, but also duplicates of the admin accounts. So to fix this we now fetch the users to filter against the count of role bindings found.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Create a few standard users and admin users
- Attempt to delete the Administrator and Standard User global roles
- Notice the count will contain the exact number of actual users  

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

__6 Users__
![6-users](https://user-images.githubusercontent.com/40806497/195612967-78cee214-6019-4fd6-83c4-6591416c7273.png)

__Before - 8 users total__
![before-8-users-bound](https://user-images.githubusercontent.com/40806497/195612477-4f575017-d6ee-442c-840e-ed13b08499ea.png)

__After - 6 users total__
![after-6-users-bound](https://user-images.githubusercontent.com/40806497/195612624-6a166ce0-588d-47d7-91f6-5bb5e788a32b.png)
