### PR TITLE
move harvester service add on translations back into shell

### DIFF
--- a/pkg/harvester/l10n/en-us.yaml
+++ b/pkg/harvester/l10n/en-us.yaml
@@ -748,25 +748,6 @@ harvester:
   projectNamespace:
     label: Projects/Namespaces
 
-  service:
-    title: Add-on Config
-    ipam:
-      label: IPAM
-    healthCheckPort:
-      label: Health Check Port
-    healthCheckSuccessThreshold:
-      label: Health Check Success Threshold
-      description: If the number of times the prober continuously detects an address successfully reaches the success threshold, then the backend server can start to forward traffic.
-    healthCheckFailureThreshold:
-      label: Health Check Failure Threshold
-      description: The backend server will stop forwarding traffic if the number of health check failures reaches the failure threshold.
-    healthCheckPeriod:
-      label: Health Check Period
-    healthCheckTimeout:
-      label: Health Check Timeout
-    healthCheckEnabled:
-      label: Health Check
-
   vip:
     namespace:
       label: Namespace

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4335,6 +4335,24 @@ servicesPage:
     placeholder: e.g. my.database.example.com
     input:
       label: DNS Name
+  harvester:
+    title: Add-on Config
+    ipam:
+      label: IPAM
+    healthCheckPort:
+      label: Health Check Port
+    healthCheckSuccessThreshold:
+      label: Health Check Success Threshold
+      description: If the number of times the prober continuously detects an address successfully reaches the success threshold, then the backend server can start to forward traffic.
+    healthCheckFailureThreshold:
+      label: Health Check Failure Threshold
+      description: The backend server will stop forwarding traffic if the number of health check failures reaches the failure threshold.
+    healthCheckPeriod:
+      label: Health Check Period
+    healthCheckTimeout:
+      label: Health Check Timeout
+    healthCheckEnabled:
+      label: Health Check
   ips:
     define: Service Ports
     clusterIpHelpText: The Cluster IP address must be within the CIDR range configured for the API server.

--- a/shell/components/HarvesterServiceAddOnConfig.vue
+++ b/shell/components/HarvesterServiceAddOnConfig.vue
@@ -100,7 +100,7 @@ export default {
       const errors = [];
 
       if (this.healthCheckEnabled && !this.healthcheckPort) {
-        errors.push(this.t('validation.required', { key: this.t('harvester.service.healthCheckPort.label') }, true));
+        errors.push(this.t('validation.required', { key: this.t('servicesPage.harvester.healthCheckPort.label') }, true));
       }
 
       if (errors.length > 0) {
@@ -131,7 +131,7 @@ export default {
           v-model="ipam"
           :mode="mode"
           :options="ipamOptions"
-          :label="t('harvester.service.ipam.label')"
+          :label="t('servicesPage.harvester.ipam.label')"
           :disabled="mode === 'edit'"
         />
       </div>
@@ -143,7 +143,7 @@ export default {
           v-model="healthCheckEnabled"
           :mode="mode"
           name="healthCheckEnabled"
-          :label="t('harvester.service.healthCheckEnabled.label')"
+          :label="t('servicesPage.harvester.healthCheckEnabled.label')"
           :labels="[t('generic.disabled'),t('generic.enabled')]"
           :options="[false, true]"
         />
@@ -157,7 +157,7 @@ export default {
             :mode="mode"
             :options="portOptions"
             required
-            :label="t('harvester.service.healthCheckPort.label')"
+            :label="t('servicesPage.harvester.healthCheckPort.label')"
           />
         </div>
         <div class="col span-6">
@@ -165,8 +165,8 @@ export default {
             v-model="healthCheckSuccessThreshold"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckSuccessThreshold.label')"
-            :tooltip="t('harvester.service.healthCheckSuccessThreshold.description')"
+            :label="t('servicesPage.harvester.healthCheckSuccessThreshold.label')"
+            :tooltip="t('servicesPage.harvester.healthCheckSuccessThreshold.description')"
           />
         </div>
       </div>
@@ -176,8 +176,8 @@ export default {
             v-model="healthCheckFailureThreshold"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckFailureThreshold.label')"
-            :tooltip="t('harvester.service.healthCheckFailureThreshold.description')"
+            :label="t('servicesPage.harvester.healthCheckFailureThreshold.label')"
+            :tooltip="t('servicesPage.harvester.healthCheckFailureThreshold.description')"
           />
         </div>
         <div class="col span-6">
@@ -185,7 +185,7 @@ export default {
             v-model="healthCheckPeriod"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckPeriod.label')"
+            :label="t('servicesPage.harvester.healthCheckPeriod.label')"
           />
         </div>
       </div>
@@ -195,7 +195,7 @@ export default {
             v-model="healthCheckTimeout"
             :mode="mode"
             type="number"
-            :label="t('harvester.service.healthCheckTimeout.label')"
+            :label="t('servicesPage.harvester.healthCheckTimeout.label')"
           />
         </div>
       </div>

--- a/shell/components/form/WorkloadPorts.vue
+++ b/shell/components/form/WorkloadPorts.vue
@@ -366,7 +366,7 @@ export default {
             v-model="row._ipam"
             :mode="mode"
             :options="ipamOptions"
-            :label="t('harvester.service.ipam.label')"
+            :label="t('servicesPage.harvester.ipam.label')"
             :disabled="mode === 'edit'"
             @input="queueUpdate"
           />
@@ -376,7 +376,7 @@ export default {
             v-model="rows[ipamIndex]._ipam"
             :mode="mode"
             :options="ipamOptions"
-            :label="t('harvester.service.ipam.label')"
+            :label="t('servicesPage.harvester.ipam.label')"
             :disabled="true"
             @input="queueUpdate"
           />

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -453,7 +453,7 @@ export default {
       <Tab
         v-if="showHarvesterAddOnConfig"
         name="add-on-config"
-        :label="t('harvester.service.title')"
+        :label="t('servicesPage.harvester.title')"
         :weight="-1"
       >
         <HarvesterServiceAddOnConfig


### PR DESCRIPTION
This fixes a problem with the harvester-specific section of loadbalancers: https://github.com/harvester/harvester/issues/2929

There is a harvester component still in `shell` that adds some UI when creating loadbalancers in an rke2 cluster provisioned with harvester. There's also a related bit in workload creation port config (which can create services) During the pluginization process, we accidentally moved the translations for this component into the harvester pkg; they need to stay in `shell` where the component is used.

The easiest way to test this is to alter the service edit component's `showHarvesterAddOnConfig` computed prop and WorkloadPort's `showIpam` computed prop to always return `true`.


![Screen Shot 2022-10-13 at 10 34 46 AM](https://user-images.githubusercontent.com/42977925/195666608-14e1f30e-81d0-42bb-9640-85c647e11a7b.png)
![Screen Shot 2022-10-13 at 10 35 13 AM](https://user-images.githubusercontent.com/42977925/195666610-8995ac95-fe72-4daf-adcc-9e4fce48544b.png)

forwardport: https://github.com/rancher/dashboard/pull/7189
