### PR TITLE
Update yarn.lock for updating rancher icons

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14515,9 +14515,9 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-rancher-icons@rancher/icons#v2.0.3:
-  version "2.0.3"
-  resolved "https://codeload.github.com/rancher/icons/tar.gz/1c5a0af4020ee01d42babc004597904d5c4423b8"
+rancher-icons@rancher/icons#v2.0.6:
+  version "2.0.6"
+  resolved "https://codeload.github.com/rancher/icons/tar.gz/43d0c2ff064df877748f81879a9f60f3fa99047e"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Rancher icons was updated in package.json for the 2.0.6 version that has the extension icon, but this was not reflected in the package.lock file