### PR TITLE
[Epinio] Fix Namespace Filter

### DIFF
--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -73,7 +73,7 @@ const getActiveNamespaces = (state, getters) => {
   }
 
   const inStore = product?.inStore;
-  const clusterId = getters['currentCluster']?.id;
+  const clusterId = getters['clusterId'];
 
   if ( !clusterId || !inStore ) {
     updateActiveNamespaceCache(state, out);
@@ -137,7 +137,7 @@ const updateActiveNamespaceCache = (state, activeNamespaceCache) => {
   let cacheKey = '';
 
   for (const key in activeNamespaceCache) {
-    // I though array.join would be faster than string concatenation, but in places like this where the array must first be constructed it's
+    // I thought array.join would be faster than string concatenation, but in places like this where the array must first be constructed it's
     // slower.
     cacheKey += key + activeNamespaceCache[key];
   }
@@ -473,7 +473,9 @@ export const mutations = {
     state.clusterReady = ready;
   },
 
-  updateNamespaces(state, { filters, all }) {
+  updateNamespaces(state, getters) {
+    const { filters, all } = getters;
+
     state.namespaceFilters = filters.filter(x => !!x);
 
     if ( all ) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/epinio/ui/issues/164
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Both issues revolve around `getActiveNamespaces`
1) the getter of currentCluster will always be undefined in epinio (it has no current prov cluster, but it does have a clusterId), this was blocking updating the ns cache
2) getter passed in was incorrect when called by updateNamespaces, brought in by bad merge https://github.com/rancher/dashboard/commit/b3f13843dda3450d218
   - spent a lot of time working out why this wasn't causing issues in master, but given where/when it's called it doesn't currently make any different. once upon a time if the cache stuff was fully used it probably would have broken switching between clusters

Note  - This will be merged in to `master` in the 2.7.1 timeframe