### PR TITLE
Registry secrets are not available in the UI when creating a deployment

### DIFF
--- a/shell/mixins/resource-manager.js
+++ b/shell/mixins/resource-manager.js
@@ -74,6 +74,11 @@ export default {
                 // - id param = this.$store.getters['cluster/keyFieldForType'](type)
                 // - id value = new dashboard-store getter, overwritten by steve store getter
                 requestData.forEach((item) => {
+                  // if there's already a prop type, don't overwrite it without storing it first...
+                  // only do this operation once in multiple apply's because the requestData is the same!
+                  if (item.type && !item._type) {
+                    item._type = item.type;
+                  }
                   item.type = type;
                   item.id = `${ item.metadata.namespace }/${ item.metadata.name }`;
                 });


### PR DESCRIPTION
Fixes #7220 

- store `type` prop on requested data before overwriting it for `classify`

https://github.com/rancher/dashboard/blob/master/shell/edit/workload/mixins/workload.js#L221-L226 uses `_type` (which was not found - diferences between steve and k8s API -> here the prop is `type`)  which was being overwritten on the code because of the `classify` operation.

We need to make sure we store this object prop, if it exists, before overwriting it.

Also checked the code where `secondary resource data` is loaded and there is no conflict (at least in terms of the parsing functions) with `type`.