### PR TITLE
Fix windows builds by using posix path for all dirs in nuxt.config

### DIFF
--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -326,12 +326,12 @@ export default function(dir, _appConfig) {
     ],
 
     dir: {
-      assets:     path.join(SHELL, 'assets'),
-      layouts:    path.join(SHELL, 'layouts'),
-      middleware: path.join(SHELL, 'middleware'),
-      pages:      path.join(SHELL, 'pages'),
-      static:     path.join(SHELL, 'static'),
-      store:      path.join(SHELL, 'store'),
+      assets:     path.posix.join(SHELL, 'assets'),
+      layouts:    path.posix.join(SHELL, 'layouts'),
+      middleware: path.posix.join(SHELL, 'middleware'),
+      pages:      path.posix.join(SHELL, 'pages'),
+      static:     path.posix.join(SHELL, 'static'),
+      store:      path.posix.join(SHELL, 'store'),
     },
 
     watchers: { webpack: { ignore: watcherIgnores } },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This attempts to produce consistent results when working with `dir` paths on Windows, Linux, and macOS by using `path.posix` for all values specified for `dir`. 

The Nuxt documentation doesn't specify much regarding formatting for `dir` values but I was able to identify an issue with imports repeating (e.g. `require('..\\shell\\store\\shell\\store\\index.js')`) in the generated Nuxt output when `dir` has paths specified in the Windows-style. Always deferring to the posix-style resolves this issue allows for building Dashboard on Windows.



Signed-off-by: Phillip Rak <rak.phillip@gmail.com>