### PR TITLE
Can use RKE1 cluster scoped registry for Helm chart installs

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -768,7 +768,7 @@ catalog:
   chart:
     registry:
       label: Container Registry
-      tooltip: Container images are pulled from the Cluster Container or, failing that, the System Container Registry Setting. To change this default behavior enter or update the registry here
+      tooltip: Container images are pulled from the Cluster Container Registry or, failing that, the System Container Registry Setting. To change this default behavior enter or update the registry here
       custom:
         checkBoxLabel: Container Registry for Rancher System Container Images
         inputLabel: Container Registry

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -432,7 +432,12 @@ export default class MgmtCluster extends HybridModel {
   }
 
   get provClusterId() {
-    const verb = this.isLocal ? 'to' : 'from';
+    const isRKE1 = !!this.spec?.rancherKubernetesEngineConfig;
+    // Note: RKE1 provisioning cluster IDs are in a different format. For example,
+    // RKE2 cluster IDs include the name - fleet-default/cluster-name - whereas an RKE1
+    // cluster has the less human readable management cluster ID in it: fleet-default/c-khk48
+
+    const verb = this.isLocal || isRKE1 ? 'to' : 'from';
     const from = `${ verb }Type`;
     const id = `${ verb }Id`;
 

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -799,6 +799,19 @@ export default {
             return clusterRegistry;
           }
         }
+        if (provCluster.isRke1) {
+          // For RKE1 clusters, the cluster scoped private registry is on the management
+          // cluster, not the provisioning cluster.
+          const rke1Registries = mgmCluster.spec.rancherKubernetesEngineConfig.privateRegistries;
+
+          if (rke1Registries.length > 0) {
+            const defaultRegistry = rke1Registries.find((registry) => {
+              return registry.isDefault;
+            });
+
+            return defaultRegistry.url;
+          }
+        }
       }
     },
 

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -804,7 +804,7 @@ export default {
           // cluster, not the provisioning cluster.
           const rke1Registries = mgmCluster.spec.rancherKubernetesEngineConfig.privateRegistries;
 
-          if (rke1Registries.length > 0) {
+          if (rke1Registries?.length > 0) {
             const defaultRegistry = rke1Registries.find((registry) => {
               return registry.isDefault;
             });


### PR DESCRIPTION
Fixes #7233, https://github.com/rancher/dashboard/issues/7232

# QA Template

## Root cause
Last week, we changed the Helm chart install page so that it would check for the existence of a cluster scoped private registry, then add that value into the values.yaml. https://github.com/rancher/dashboard/issues/6910 However, this only worked for K3s/RKE2.

Some additional code still needed to be written for RKE1 because the cluster registry needed to be taken from the cluster management resource for RKE1, as opposed to the provisioning cluster resource for RKE2.
 
## What was fixed, or what changes have occurred
- Fixed a bug in the `provClusterId` getter on the management cluster model in which it returned undefined for RKE1 clusters. (Because RKE1 clusters are not created with CAPI resources, they don't have the same relationship to CAPI resources as RKE2/K3s.)
- The Helm chart install page now gets the cluster registry from the management cluster resource if it's an RKE1 cluster.
 
## Areas or cases that should be tested

1. Should create two RKE1 clusters, one that has a cluster-level private registry when the cluster is first created, and one that does not. 
2. Then make sure that when a Rancher Helm chart app is installed, such as alerting drivers or CIS benchmark,
  - For the RKE1 cluster with the cluster scoped registry, images are pulled from that cluster registry
  - For the RKE1 cluster without the cluster scoped registry, see that the images are pulled from the global registry
  - If you select the checkbox for a custom registry on the Helm chart install page and enter a value there, the images should be pulled from that registry
 
## What areas could experience regressions?
I don't expect behavior to change for RKE2/K3s, but if it did change, it would be in the same areas that were affected when the feature was added for RKE2/K3s https://github.com/rancher/dashboard/issues/6910#issuecomment-1266143075
 