### PR TITLE
Extensions: Don't show version when installing

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3766,7 +3766,9 @@ plugins:
       registry:
         title: Remove the Rancher Extensions Repository
         prompt: The Rancher Extensions Repository provides extensions published by Rancher
-
+      crd:
+        title: Remove the Rancher Extensions Custom Resource Definition
+        prompt: There are one or more extensions installed - removing the CRD will require you to manually reinstall these extensions if you subsequently re-enable extensions support.
 prefs:
   title: Preferences
   theme:

--- a/shell/pages/c/_cluster/uiplugins/RemoveUIPlugins.vue
+++ b/shell/pages/c/_cluster/uiplugins/RemoveUIPlugins.vue
@@ -7,6 +7,7 @@ import {
   UI_PLUGIN_CHARTS,
   UI_PLUGINS_REPO_NAME,
   UI_PLUGINS_REPO_URL,
+  UI_PLUGIN_OPERATOR_CRD_CHART_NAME,
 } from '@shell/config/uiplugins';
 
 export default {
@@ -21,13 +22,23 @@ export default {
 
       this.defaultRepo = repos.find(r => r.name === UI_PLUGINS_REPO_NAME && r.spec.gitRepo === UI_PLUGINS_REPO_URL);
     }
+
+    if (this.$store.getters['management/schemaFor'](UI_PLUGIN)) {
+      const plugins = await this.$store.dispatch('management/findAll', { type: UI_PLUGIN });
+
+      // Are there any plugins installed?
+      this.hasPluginsInstalled = (plugins || {}).length > 0;
+      this.removeCRD = !this.hasPluginsInstalled;
+    }
   },
 
   data() {
     return {
-      errors:      [],
-      defaultRepo: undefined,
-      removeRepo:  false,
+      errors:              [],
+      defaultRepo:         undefined,
+      removeRepo:          false,
+      removeCRD:           true,
+      hasPluginsInstalled: false,
     };
   },
 
@@ -42,8 +53,8 @@ export default {
         return found.remove();
       }
 
-      // TODO - Return rejected promise - error
-      return null;
+      // Return rejected promise - could not find the required chart
+      return Promise.reject(new Error(`Could not find chart §{ name }`));
     },
 
     showDialog() {
@@ -55,7 +66,12 @@ export default {
       this.errors = [];
 
       // Remove the charts in the reverse order that we install them in
-      const uninstall = [...UI_PLUGIN_CHARTS].reverse();
+      let uninstall = [...UI_PLUGIN_CHARTS].reverse();
+
+      if (!this.removeCRD) {
+        // User does not want to uninstall the CRD, so remove the chart
+        uninstall = uninstall.filter(chart => chart !== UI_PLUGIN_OPERATOR_CRD_CHART_NAME);
+      }
 
       for (let i = 0; i < uninstall.length; i++) {
         const chart = uninstall[i];
@@ -101,6 +117,12 @@ export default {
         <Checkbox v-model="removeRepo" :primary="true" label-key="plugins.setup.remove.registry.title" />
         <div class="checkbox-info">
           {{ t('plugins.setup.remove.registry.prompt') }}
+        </div>
+      </div>
+      <div v-if="hasPluginsInstalled" class="mt-20">
+        <Checkbox v-model="removeCRD" :primary="true" label-key="plugins.setup.remove.crd.title" />
+        <div class="checkbox-info">
+          {{ t('plugins.setup.remove.crd.prompt') }}
         </div>
       </div>
     </template>

--- a/shell/pages/c/_cluster/uiplugins/RemoveUIPlugins.vue
+++ b/shell/pages/c/_cluster/uiplugins/RemoveUIPlugins.vue
@@ -27,7 +27,7 @@ export default {
       const plugins = await this.$store.dispatch('management/findAll', { type: UI_PLUGIN });
 
       // Are there any plugins installed?
-      this.hasPluginsInstalled = (plugins || {}).length > 0;
+      this.hasPluginsInstalled = (plugins || []).length > 0;
       this.removeCRD = !this.hasPluginsInstalled;
     }
   },

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -567,7 +567,7 @@ export default {
               </div>
               <div>{{ plugin.description }}</div>
               <div class="plugin-version">
-                <span v-if="plugin.installing === 'uninstall'" class="plugin-installing">
+                <span v-if="plugin.installing" class="plugin-installing">
                   -
                 </span>
                 <span v-else>


### PR DESCRIPTION
Fixes #7239

A couple of updates:

- Don't show version number when installing - we don't know the version until install has completed
- Allow the user not to uninstall the plugin CRD