### PR TITLE
Bug fix and Improvements to Carousel

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -800,6 +800,7 @@ catalog:
     windowsIncompatible: Linux only
     versionWindowsIncompatible: Linux only version
     header: Charts
+    featuredCharts: Featured Charts
     noCharts: 'There are no charts available, have you added any repos?'
     noWindows: Your repos do not contain any charts capable of being deployed on a cluster with Windows nodes.
     noWindowsAndLinux: Your repos do not contain any charts capable of being deployed on a cluster with both Windows and Linux worker nodes.

--- a/shell/components/Carousel.vue
+++ b/shell/components/Carousel.vue
@@ -1,6 +1,9 @@
 <script>
 import { get } from '@shell/utils/object';
 import { BadgeState } from '@components/BadgeState';
+import { mapGetters } from 'vuex';
+
+const carouselSeenStorageKey = `carousel-seen`;
 
 export default {
   components: { BadgeState },
@@ -31,16 +34,18 @@ export default {
       default: 'noopener noreferrer nofollow'
     },
   },
+
   data() {
     return {
-      slider:          this.sliders,
-      activeItemId:    0,
-      autoScroll:      true
+      slider:                  this.sliders,
+      activeItemId:            0,
+      autoScroll:              true,
+      autoScrollSlideInterval: null,
     };
   },
 
   computed: {
-
+    ...mapGetters(['clusterId']),
     trackStyle() {
       const sliderItem = this.activeItemId * 100 / this.slider.length;
       const width = 60 * this.slider.length;
@@ -77,9 +82,6 @@ export default {
       this.slidePosition();
     },
 
-    timer() {
-      setInterval(this.autoScrollSlide, 2000);
-    },
     autoScrollSlide() {
       if (this.activeItemId < this.slider.length && this.autoScroll ) {
         this.activeItemId++;
@@ -103,9 +105,23 @@ export default {
     }
   },
 
+  beforeDestroy() {
+    if (this.autoScrollSlideInterval) {
+      clearInterval(this.autoScrollSlideInterval);
+    }
+  },
+
   mounted() {
-    this.timer();
-  }
+    const lastSeenCluster = sessionStorage.getItem(carouselSeenStorageKey);
+
+    if (lastSeenCluster !== this.clusterId) {
+      // Session storage lasts until tab/window closed (retained on refresh)
+      sessionStorage.setItem(carouselSeenStorageKey, this.clusterId);
+
+      this.autoScrollSlideInterval = setInterval(this.autoScrollSlide, 5000);
+    }
+  },
+
 };
 
 </script>

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -353,7 +353,7 @@ export default {
       </div>
     </header>
     <div v-if="showCarousel">
-      <h3>Featured Charts</h3>
+      <h3>{{ t('catalog.charts.featuredCharts') }}</h3>
       <Carousel
         :sliders="getFeaturedCharts"
         @clicked="(row) => selectChart(row)"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7241
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Ensure scroll timer is cleared when we leave the page (#7241)
- Don't scroll on return to charts page of same cluster
  - The scroll will only be enabled if 
    - Charts page has not been visited since the tab was opened
    - User previously visited the Charts page of another cluster
 - This works on sessionStorage, so is persisted over tab refresh
- Increase time spent on each carousel section from 2 to 5 seconds
- l10n for header