### PR TITLE
Remove override for chart container registry when it matches the global container registry

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -673,13 +673,6 @@ export default {
       return global.systemDefaultRegistry !== undefined || global.cattle?.systemDefaultRegistry !== undefined;
     },
 
-    /**
-     * True if we should apply/save the custom registry value. This should be false if matching the global registry
-     * (we shouldn't save the global registry to avoid issues on upgrade where we might confused it with a custom one)
-     */
-    applyCustomRegistry() {
-      return this.customRegistrySetting !== this.globalRegistry;
-    }
   },
 
   watch: {
@@ -997,12 +990,8 @@ export default {
       setIfNotSet(cattle, 'clusterId', cluster?.id);
       setIfNotSet(cattle, 'clusterName', cluster?.nameDisplay);
       if (this.showCustomRegistry) {
-        // If this is the current global registry leave it blank. This avoids the scenario on upgrade where a previous global registry that's
-        // been updated is confused with a custom user registry
-        const registry = this.applyCustomRegistry ? this.customRegistrySetting : '';
-
-        set(cattle, 'systemDefaultRegistry', registry);
-        set(global, 'systemDefaultRegistry', registry);
+        set(cattle, 'systemDefaultRegistry', this.customRegistrySetting);
+        set(global, 'systemDefaultRegistry', this.customRegistrySetting);
       }
 
       setIfNotSet(global, 'cattle.systemProjectId', systemProjectId);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/7246
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Partial implementation brought in by https://github.com/rancher/dashboard/issues/6910
- However that assumed an empty string meant the global registry was used when in fact it falls back on docker.io
- So always pass through the registry if one exists (cluster > global)

### Areas or cases that should be tested
- Installing a helm app in a downstream cluster with neither global or cluster registry
- Installing a helm app in a downstream cluster with a global registry

