### PR TITLE
Add StandardSSD as a storage option for Azure cluster provisioning

### DIFF
--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -81,6 +81,10 @@ const storageTypes = [
     name:  'Premium LRS',
     value: 'Premium_LRS',
   },
+  {
+    name:  'Standard SSD LRS',
+    value: 'StandardSSD_LRS'
+  }
 ];
 
 export default {


### PR DESCRIPTION
This PR partly addresses https://github.com/rancher/dashboard/issues/7177 by adding StandardSSD to Azure storage options.


Edit: Changed the PR to a draft because based on this comment (https://github.com/rancher/ui/pull/4905#issuecomment-1287075886) it needs these changes:

- when StandardSSD_LRS is selected, the managed disk dropdown becomes disabled and its value becomes enabled
- managed disk dropdown has tooltip that says StandardSSD_LRS requires managed disk to be enabled



To test this PR,

1. Went to Cluster Management > Clusters
2. Clicked Create
3. Selected RKE2/K3s and Azure
4. In the Machine Pools section, clicked Show Advanced
5. For Storage Type, selected Standard SSD LRS, the new storage option

<img width="765" alt="Screen Shot 2022-10-20 at 4 50 50 PM" src="https://user-images.githubusercontent.com/20599230/197085989-862159cf-880f-4e50-82f4-7838394c826e.png">

6. Added a name for the cluster
7. Clicked Create
8. Confirmed that the cluster came up successfully



