### PR TITLE
allow cloning roles; fix unlabeled multi-select style

### DIFF
--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -605,12 +605,12 @@ export default {
             <template #column-headers>
               <div class="column-headers row">
                 <div :class="ruleClass">
-                  <label class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.verbs') }}
+                  <span class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.verbs') }}
                     <span class="required">*</span>
-                  </label>
+                  </span>
                 </div>
                 <div :class="ruleClass">
-                  <label class="text-label">
+                  <span class="text-label">
                     {{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.resources') }}
                     <i
                       v-tooltip="t('rbac.roletemplate.tabs.grantResources.resourceOptionInfo')"
@@ -620,21 +620,21 @@ export default {
                       v-if="isNamespaced"
                       class="required"
                     >*</span>
-                  </label>
+                  </span>
                 </div>
                 <div :class="ruleClass">
-                  <label class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.apiGroups') }}
+                  <span class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.apiGroups') }}
                     <span
                       v-if="isNamespaced"
                       class="required"
                     >*</span>
-                  </label>
+                  </span>
                 </div>
                 <div
                   v-if="!isNamespaced"
                   :class="ruleClass"
                 >
-                  <label class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.nonResourceUrls') }}</label>
+                  <span class="text-label">{{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.nonResourceUrls') }}</span>
                 </div>
               </div>
             </template>
@@ -737,6 +737,7 @@ export default {
   ::v-deep {
     .column-headers {
       margin-right: 75px;
+      margin-bottom: 5px;
     }
 
     .box {

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -4,14 +4,13 @@ import CruResource from '@shell/components/CruResource';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { RadioGroup } from '@components/Form/Radio';
 import Select from '@shell/components/form/Select';
-import { LabeledInput } from '@components/Form/LabeledInput';
 import ArrayList from '@shell/components/form/ArrayList';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
 import { ucFirst } from '@shell/utils/string';
 import SortableTable from '@shell/components/SortableTable';
-import { _DETAIL } from '@shell/config/query-params';
+import { _CLONE, _DETAIL } from '@shell/config/query-params';
 import { SCOPED_RESOURCES } from '@shell/config/roles';
 
 import { SUBTYPE_MAPPING, VERBS } from '@shell/models/management.cattle.io.roletemplate';
@@ -52,7 +51,6 @@ export default {
   components: {
     ArrayList,
     CruResource,
-    LabeledInput,
     RadioGroup,
     Select,
     NameNsDescription,
@@ -89,6 +87,10 @@ export default {
       });
       this.templateOptions = Object.values(this.keyedTemplateOptions);
     }
+    if (this.realMode === _CLONE) {
+      this.value.displayName = '';
+      this.value.builtin = false;
+    }
   },
 
   data() {
@@ -112,7 +114,6 @@ export default {
 
   created() {
     this.$set(this.value, 'rules', this.value.rules || []);
-
     this.value.rules.forEach((rule) => {
       if (rule.verbs[0] === '*') {
         this.$set(rule, 'verbs', [...VERBS]);
@@ -665,23 +666,23 @@ export default {
                   />
                 </div>
                 <div :class="ruleClass">
-                  <LabeledInput
+                  <input
                     :value="getRule('apiGroups', props.row.value)"
                     :disabled="isBuiltin"
                     :mode="mode"
                     @input="setRule('apiGroups', props.row.value, $event)"
-                  />
+                  >
                 </div>
                 <div
                   v-if="!isNamespaced"
                   :class="ruleClass"
                 >
-                  <LabeledInput
+                  <input
                     :value="getRule('nonResourceURLs', props.row.value)"
                     :disabled="isBuiltin"
                     :mode="mode"
                     @input="setRule('nonResourceURLs', props.row.value, $event)"
-                  />
+                  >
                 </div>
               </div>
             </template>

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -268,6 +268,10 @@ export default {
       }
     }
 
+    & .vs--multiple ::v-deep .vs__selected-options .vs__selected {
+      width: auto;
+    }
+
     ::v-deep .labeled-tooltip.error .status-icon {
       top: 7px;
       right: 2px;

--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -1,10 +1,11 @@
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { SCHEMA, NORMAN } from '@shell/config/types';
-import { CATTLE_API_GROUP, SUBTYPE_MAPPING } from '@shell/models/management.cattle.io.roletemplate';
+import { CATTLE_API_GROUP, SUBTYPE_MAPPING, CREATE_VERBS } from '@shell/models/management.cattle.io.roletemplate';
 import { uniq } from '@shell/utils/array';
 import { get } from '@shell/utils/object';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import Role from './rbac.authorization.k8s.io.role';
+import { AS, MODE, _CLONE, _UNFLAG } from '@shell/config/query-params';
 
 const BASE = 'user-base';
 const USER = 'user';
@@ -111,6 +112,26 @@ export default class GlobalRole extends SteveModel {
 
       return norman;
     })();
+  }
+
+  get canCreate() {
+    const schema = this.$getters['schemaFor'](this.type);
+
+    return schema?.resourceMethods.find(verb => CREATE_VERBS.has(verb));
+  }
+
+  goToClone(moreQuery = {}) {
+    const location = this.detailLocation;
+
+    location.query = {
+      ...location.query,
+      [MODE]:      _CLONE,
+      [AS]:        _UNFLAG,
+      roleContext: GLOBAL,
+      ...moreQuery
+    };
+
+    this.currentRouter().push(location);
   }
 
   async save() {

--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -4,7 +4,7 @@ import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { NORMAN } from '@shell/config/types';
 import SteveDescriptionModel from '@shell/plugins/steve/steve-description-class';
 import Role from './rbac.authorization.k8s.io.role';
-import { AS, MODE, _CLONE, _UNFLAG } from '~/shell/config/query-params';
+import { AS, MODE, _CLONE, _UNFLAG } from '@shell/config/query-params';
 
 export const CATTLE_API_GROUP = '.cattle.io';
 

--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -4,6 +4,7 @@ import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { NORMAN } from '@shell/config/types';
 import SteveDescriptionModel from '@shell/plugins/steve/steve-description-class';
 import Role from './rbac.authorization.k8s.io.role';
+import { AS, MODE, _CLONE, _UNFLAG } from '~/shell/config/query-params';
 
 export const CATTLE_API_GROUP = '.cattle.io';
 
@@ -54,6 +55,8 @@ export const VERBS = [
   'update',
   'watch',
 ];
+
+export const CREATE_VERBS = new Set(['PUT', 'blocked-PUT']);
 
 export default class RoleTemplate extends SteveDescriptionModel {
   get customValidationRules() {
@@ -157,6 +160,26 @@ export default class RoleTemplate extends SteveDescriptionModel {
 
       return norman;
     })();
+  }
+
+  get canCreate() {
+    const schema = this.$getters['schemaFor'](this.type);
+
+    return schema?.resourceMethods.find(verb => CREATE_VERBS.has(verb));
+  }
+
+  goToClone(moreQuery = {}) {
+    const location = this.detailLocation;
+
+    location.query = {
+      ...location.query,
+      [MODE]:      _CLONE,
+      [AS]:        _UNFLAG,
+      roleContext: this.subtype,
+      ...moreQuery
+    };
+
+    this.currentRouter().push(location);
   }
 
   async save() {

--- a/shell/pages/c/_cluster/auth/roles/index.vue
+++ b/shell/pages/c/_cluster/auth/roles/index.vue
@@ -4,7 +4,7 @@ import Tabbed from '@shell/components/Tabbed';
 import { MANAGEMENT } from '@shell/config/types';
 import ResourceTable from '@shell/components/ResourceTable';
 import Loading from '@shell/components/Loading';
-import { SUBTYPE_MAPPING } from '@shell/models/management.cattle.io.roletemplate';
+import { SUBTYPE_MAPPING, CREATE_VERBS } from '@shell/models/management.cattle.io.roletemplate';
 import { NAME } from '@shell/config/product/auth';
 import { BLANK_CLUSTER } from '@shell/store';
 
@@ -26,8 +26,6 @@ const createRoleTemplate = {
     resource: MANAGEMENT.ROLE_TEMPLATE,
   }
 };
-
-const createVerbs = new Set(['PUT', 'blocked-PUT']);
 
 export default {
   name: 'Roles',
@@ -57,7 +55,7 @@ export default {
       tabs: {
         [GLOBAL]: {
           canFetch:       globalRoleSchema?.collectionMethods.find(verb => verb === 'GET'),
-          canCreate:      globalRoleSchema?.resourceMethods.find(verb => createVerbs.has(verb)),
+          canCreate:      globalRoleSchema?.resourceMethods.find(verb => CREATE_VERBS.has(verb)),
           weight:         3,
           labelKey:       SUBTYPE_MAPPING.GLOBAL.labelKey,
           schema:         globalRoleSchema,
@@ -68,7 +66,7 @@ export default {
         },
         [CLUSTER]: {
           canFetch:       roleTemplatesSchema?.collectionMethods.find(verb => verb === 'GET'),
-          canCreate:      roleTemplatesSchema?.resourceMethods.find(verb => createVerbs.has(verb)),
+          canCreate:      roleTemplatesSchema?.resourceMethods.find(verb => CREATE_VERBS.has(verb)),
           labelKey:       SUBTYPE_MAPPING.CLUSTER.labelKey,
           weight:         2,
           schema:         roleTemplatesSchema,
@@ -80,7 +78,7 @@ export default {
         },
         [PROJECT]: {
           canFetch:       roleTemplatesSchema?.collectionMethods.find(verb => verb === 'GET'),
-          canCreate:      roleTemplatesSchema?.resourceMethods.find(verb => createVerbs.has(verb)),
+          canCreate:      roleTemplatesSchema?.resourceMethods.find(verb => CREATE_VERBS.has(verb)),
           labelKey:       SUBTYPE_MAPPING.NAMESPACE.labelKey,
           weight:         1,
           schema:         roleTemplatesSchema,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6956 #7204
This PR adds the ability to clone global/cluster/namespace roles and fixes a couple style issues in the role form:
![Screen Shot 2022-10-21 at 9 07 49 AM](https://user-images.githubusercontent.com/42977925/197242422-4eeaed09-90a0-4fd1-89c7-2b5020c98bbb.png)
![Screen Shot 2022-10-21 at 9 07 55 AM](https://user-images.githubusercontent.com/42977925/197242426-dce0de58-76e8-4b0c-b21f-7b60d6f7d18b.png)
