### PR TITLE
Add ClusterScanReports to list of options in RBAC dropdown

### DIFF
--- a/shell/config/roles.ts
+++ b/shell/config/roles.ts
@@ -241,7 +241,8 @@ export const SCOPED_RESOURCES = {
     },
     'cis.cattle.io': {
       resources: [
-        'ClusterScans'
+        'ClusterScans',
+        'ClusterScanReports'
       ]
     },
     'constraints.gatekeeper.sh': {


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/7035 by adding ClusterScanReports to the role creation form in the resource dropdown:

<img width="1099" alt="Screen Shot 2022-10-21 at 10 17 01 AM" src="https://user-images.githubusercontent.com/20599230/197252618-ef03b404-3cde-4758-bc47-fa4d82d620e8.png">

After role creation, the lowercased `clusterscanreports` is in the role yaml:
<img width="612" alt="Screen Shot 2022-10-21 at 10 17 38 AM" src="https://user-images.githubusercontent.com/20599230/197252699-34869c3c-9ce9-4fae-9e74-404e15cde8ef.png">
