### PR TITLE
Adds most common architecture for macOS & linux

### DIFF
--- a/pkg/epinio/pages/about.vue
+++ b/pkg/epinio/pages/about.vue
@@ -27,8 +27,8 @@ export default {
       const gitUrl = `https://github.com/epinio/epinio/releases/download`;
 
       return [
-        this.createOSOption('about.os.mac', 'icon-apple', `${ gitUrl }/${ this.version?.displayVersion }/${ this.appName.toLowerCase() }-darwin-arm64`, null),
-        this.createOSOption('about.os.linux', 'icon-linux', `${ gitUrl }/${ this.version?.displayVersion }/${ this.appName.toLowerCase() }-linux-arm64`, this.downloadLinuxImages),
+        this.createOSOption('about.os.mac', 'icon-apple', `${ gitUrl }/${ this.version?.displayVersion }/${ this.appName.toLowerCase() }-darwin-x86_64`, null),
+        this.createOSOption('about.os.linux', 'icon-linux', `${ gitUrl }/${ this.version?.displayVersion }/${ this.appName.toLowerCase() }-linux-x86_64`, this.downloadLinuxImages),
         this.createOSOption('about.os.windows', 'icon-windows', `${ gitUrl }/${ this.version?.displayVersion }/${ this.appName.toLowerCase() }-windows-x86_64.zip`)
       ];
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/epinio/ui/issues/166


Changes the download packages for MacOS & Linux to the `x86_64` instead of `arm64`