### PR TITLE
Fix for cloning namespace in a project

### DIFF
--- a/shell/models/namespace.js
+++ b/shell/models/namespace.js
@@ -210,4 +210,17 @@ export default class Namespace extends SteveModel {
   set resourceQuota(value) {
     Vue.set(this.metadata.annotations, RESOURCE_QUOTA, JSON.stringify(value));
   }
+
+  // Preserve the project label - ensures we preserve project when cloning a namespace
+  cleanForNew() {
+    const project = this.metadata?.labels?.[PROJECT];
+
+    super.cleanForNew();
+
+    if (project) {
+      this.metadata = this.metadata || {};
+      this.metadata.labels = this.metadata.labels || {};
+      this.metadata.labels[PROJECT] = project;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #7231 

The label that indicates the project for a namespace was not being preserved when cloning - this PR fixes this, so cloning a namespace will ensure the clone is in the same project as the one being cloned.