### PR TITLE
Add retry option for E2E tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -26,7 +26,8 @@ const baseUrl = (process.env.TEST_BASE_URL || 'https://localhost:8005').replace(
 export default defineConfig({
   projectId:              process.env.TEST_PROJECT_ID,
   defaultCommandTimeout:  60000,
-  trashAssetsBeforeRuns:  true,
+  trashAssetsBeforeRuns: true,
+  retries:               2,
   env:                    {
     baseUrl,
     coverage:             false,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7281
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Added [`retry`](https://docs.cypress.io/guides/guides/test-retries) option in the Cypress config.

### Technical notes summary
The retry will generate multiple attempts to a total of 3, if any error occurs, which can be inspected separately and will have separated screenshots.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
Retrying 3 times with a long waiting time in case of error may eventually have a very length test, in case everything fails.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->