### PR TITLE
Fix project monitor create button visibility

### DIFF
--- a/shell/list/helm.cattle.io.projecthelmchart.vue
+++ b/shell/list/helm.cattle.io.projecthelmchart.vue
@@ -72,7 +72,7 @@ export default {
       :show-incremental-loading-indicator="incrementalLoadingIndicator"
       :load-resources="loadResources"
       :load-indeterminate="loadIndeterminate"
-      is-creatable
+      :is-creatable="canCreateProjectHelmChart"
     />
     <Banner color="info" :label="t('monitoring.projectMonitoring.list.banner')" />
     <!-- ToDo: figure out how to get this centered in the empty space -->


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6042 , not the first customer issue quoted (confirmed fixed already) but specifically [SURE-4692](https://github.com/rancher/dashboard/issues/6042#issuecomment-1142588601)

Project members appear to have the ability enable project monitoring (create a `projecthelmchart`) but they do not. This PR makes that 'create' button dependent on the `projecthelmchart` schema methods including `POST`.