### PR TITLE
Add tags to Azure machine pool config

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1354,6 +1354,8 @@ cluster:
       vnet:
         label: Virtual Network
         placeholder: '[resourcegroup:]name'
+      tags:
+        label: Tags
     digitalocean:
       sizeLabel: |-
         {plan, select,

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -11,6 +11,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import ArrayList from '@shell/components/form/ArrayList';
 import { randomStr } from '@shell/utils/string';
 import { addParam, addParams } from '@shell/utils/url';
+import KeyValue from '@shell/components/form/KeyValue';
 
 export const azureEnvironments = [
   { value: 'AzurePublicCloud' },
@@ -58,6 +59,7 @@ const defaultConfig = {
     '10251/tcp',
     '10252/tcp',
   ],
+  tags: null
 };
 
 const storageTypes = [
@@ -88,6 +90,7 @@ export default {
     ArrayList,
     Banner,
     Checkbox,
+    KeyValue,
     LabeledInput,
     LabeledSelect,
     Loading,
@@ -116,6 +119,7 @@ export default {
 
   async fetch() {
     this.errors = [];
+    this.initTags();
 
     try {
       const {
@@ -185,6 +189,35 @@ export default {
     stringify,
     setLocation(location) {
       this.value.location = location?.name;
+    },
+    initTags() {
+      const parts = (this.value.tags || '').split(/,/);
+      const out = {};
+
+      let i = 0;
+
+      while ( i + 1 < parts.length ) {
+        const key = `${ parts[i] }`.trim();
+        const value = `${ parts[i + 1] }`.trim();
+
+        if ( key ) {
+          out[key] = value;
+        }
+
+        i += 2;
+      }
+
+      this.tags = out;
+    },
+
+    updateTags(tags) {
+      const ary = [];
+
+      for ( const k in tags ) {
+        ary.push(k, tags[k]);
+      }
+
+      this.$set(this.value, 'tags', ary.join(','));
     },
   },
 };
@@ -446,6 +479,22 @@ export default {
             :show-protip="true"
             :protip="t('cluster.machineConfig.azure.openPort.help')"
             :disabled="disabled"
+          />
+        </div>
+      </div>
+
+      <div class="row mt-20">
+        <div class="col span-12">
+          <h3><t k="cluster.machineConfig.azure.tags.label" /></h3>
+          <KeyValue
+            :value="tags"
+            :mode="mode"
+            :read-allowed="false"
+            :label="t('cluster.machineConfig.amazonEc2.tagTitle')"
+            :add-label="t('labels.addTag')"
+            :initial-empty-row="true"
+            :disabled="disabled"
+            @input="updateTags"
           />
         </div>
       </div>


### PR DESCRIPTION
This PR addresses the RKE2/K3s machine pool part of https://github.com/rancher/dashboard/issues/7164 by adding a new input for tags in the form for Azure machine pools, under advanced options:

<img width="1181" alt="Screen Shot 2022-10-27 at 3 53 03 PM" src="https://user-images.githubusercontent.com/20599230/198413268-c8819b14-1374-49d4-a453-2c336260eed0.png">

To test this PR, I made sure the tags were persisted when creating or editing an Azure cluster.

