### PR TITLE
Only set last visited page if needed

### DIFF
--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -470,8 +470,16 @@ export const actions = {
     return server;
   },
 
-  setLastVisited({ state, dispatch }, route) {
+  setLastVisited({ state, dispatch, getters }, route) {
     if (!route) {
+      return;
+    }
+
+    // Only save the last visited page if the user has that set as the login route preference
+    const afterLoginRoutePref = getters['get'](AFTER_LOGIN_ROUTE);
+    const doNotTrackLastVisited = typeof afterLoginRoutePref !== 'string' || afterLoginRoutePref !== 'last-visited';
+
+    if (doNotTrackLastVisited) {
       return;
     }
 


### PR DESCRIPTION
Quick partial fix for: #7202 

With this change, we only update the user pref if the user has their preference set to visited the last area accessed on login.
