### PR TITLE
Use display name of cluster for diagnostic page

### DIFF
--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -1,5 +1,5 @@
 <script>
-import { CAPI } from '@shell/config/types';
+import { CAPI, MANAGEMENT } from '@shell/config/types';
 import AsyncButton from '@shell/components/AsyncButton';
 import PromptModal from '@shell/components/PromptModal';
 import { downloadFile } from '@shell/utils/download';
@@ -21,9 +21,12 @@ export default {
     let topTenForResponseTime = [];
 
     clusterForCounts.forEach((cluster, i) => {
+      // Necessary to retrieve the proper display name of the cluster
+      const mgmtCluster = this.$store.getters['management/byId'](MANAGEMENT.CLUSTER, cluster.metadata.name);
+
       finalCounts.push({
         id:             cluster.id,
-        name:           cluster.metadata?.name,
+        name:           mgmtCluster?.spec?.displayName || cluster.metadata?.name,
         namespace:      cluster.metadata?.namespace,
         capiId:         cluster.mgmt?.id,
         counts:         null,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6739 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This adds a step in fetching the clusters to show within the table in-order to retrieve the `displayName` for clusters created by Norman (rke1, gke, ake, eks).

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The `displayName` does not exist on the schema for `capi` clusters, for any legacy clusters the name is shown as the ID.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Viewing legacy clusters from the diagnostic page
