### PR TITLE
Fix issue where brand is not set on authenticated pages

### DIFF
--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -3,6 +3,7 @@ import { getVendor } from '@shell/config/private-label';
 import { SETTING } from '@shell/config/settings';
 import { findBy } from '@shell/utils/array';
 import { createCssVars } from '@shell/utils/color';
+import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 
 export default {
   async fetch() {
@@ -13,7 +14,15 @@ export default {
       }
     } catch (e) {}
 
-    this.globalSettings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.SETTING });
+    // Ensure we read the settings even when we are not authenticated
+    try {
+      this.globalSettings = await this.$store.dispatch('management/findAll', {
+        type: MANAGEMENT.SETTING,
+        opt:  {
+          load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
+        }
+      });
+    } catch (e) {}
   },
 
   data() {


### PR DESCRIPTION
Fixes #7305 

When not authenticated, call to fetch settings failed - this PR changes this to use the same pattern elsewhere that ensures this can read the settings that an unauthenticated user is allowed to retrieve.