### PR TITLE
Enforce Namespace Filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "nuxt": "2.15.8",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "rancher-icons": "rancher/icons#v2.0.9",
+    "rancher-icons": "rancher/icons#v2.0.13",
     "require-extension-hooks": "0.3.3",
     "require-extension-hooks-babel": "1.0.0",
     "require-extension-hooks-vue": "3.0.0",

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4285,7 +4285,7 @@ resourceList:
     create: Create
     createFromYaml: Create from YAML
     createResource: "Create {resourceName}"
-  nsFiltering: "There are too many {resource}.<br>Please filter them by selecting a single Namespace."
+  nsFiltering: "There are too many {resource}.<br>Please filter them by selecting a Namespace above."
 resourceLoadingIndicator:
   loading: Loading
 
@@ -6319,10 +6319,10 @@ performance:
   nsFiltering:
     label: Require Namespace Filtering
     description: When there are too many resources to show in a list, require the user to select a single namespace and only fetch resources from within it.
-    checkboxLabel: Enable Require Namespace Filtering
+    checkboxLabel: Enable Required Namespace Filtering
     count:
       inputLabel: Resource Threshold
-      description: You can configure a threshold above which filtering by a namespace is required
+      description: The threshold above which filtering by a namespace is required
 
 banner:
   label: Fixed Banners

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4285,6 +4285,7 @@ resourceList:
     create: Create
     createFromYaml: Create from YAML
     createResource: "Create {resourceName}"
+  nsFiltering: "There are a lot of {resource}.<br>Please filter them by selecting a single Namespace."
 resourceLoadingIndicator:
   loading: Loading
 
@@ -6273,6 +6274,7 @@ featureFlags:
 performance:
   label: UI Performance Settings
   settingName: Performance
+  experimental: This setting is experimental and may be removed or updated in future versions.
   incrementalLoad:
     label: Incremental Loading
     setting: You can configure the threshold above which incremental loading will be used.
@@ -6281,7 +6283,6 @@ performance:
     checkboxLabel: Enable incremental loading
     inputLabel: Resource Threshold
   manualRefresh:
-    banner: This setting is experimental and may be removed or updated in future versions.
     label: Manual Refresh
     setting: You can configure a threshold above which manual refresh will be enabled.
     buttonTooltip: Refresh list
@@ -6297,7 +6298,6 @@ performance:
   gc:
     label: Resource Garbage Collection
     description: The UI will cache kuberentes resources locally to avoid having to re-fetch them. In some cases this can lead to a large amount of data stored in the browser. Enable this setting to periodically remove them.
-    banner: This setting is experimental and may be removed or updated in future versions.
     checkboxLabel: Enable Garbage Collection
     whenRun:
       description: Update when garbage collection runs
@@ -6316,7 +6316,13 @@ performance:
       count:
         description: Resource types must exceed this amount to be considered for garbage collection.
         inputLabel: Resource Count
-
+  nsFiltering:
+    label: Force Namespace Filtering
+    description: When there are too many resources to show in a list, force the user to select a single namespace and only fetch resources within it.
+    checkboxLabel: Enable Forced Namespace Filtering
+    count:
+      inputLabel: Resource Threshold
+      description: You can configure a threshold above which filtering by a namespace is required
 
 banner:
   label: Fixed Banners

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4286,6 +4286,7 @@ resourceList:
     createFromYaml: Create from YAML
     createResource: "Create {resourceName}"
   nsFiltering: "There are too many {resource}.<br>Please filter them by selecting a Namespace above."
+  nsFilterToolTip: "There are too many resources, filtering is restricted to a single {mode}."
 resourceLoadingIndicator:
   loading: Loading
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4285,7 +4285,7 @@ resourceList:
     create: Create
     createFromYaml: Create from YAML
     createResource: "Create {resourceName}"
-  nsFiltering: "There are a lot of {resource}.<br>Please filter them by selecting a single Namespace."
+  nsFiltering: "There are too many {resource}.<br>Please filter them by selecting a single Namespace."
 resourceLoadingIndicator:
   loading: Loading
 
@@ -6317,9 +6317,9 @@ performance:
         description: Resource types must exceed this amount to be considered for garbage collection.
         inputLabel: Resource Count
   nsFiltering:
-    label: Force Namespace Filtering
-    description: When there are too many resources to show in a list, force the user to select a single namespace and only fetch resources within it.
-    checkboxLabel: Enable Forced Namespace Filtering
+    label: Require Namespace Filtering
+    description: When there are too many resources to show in a list, require the user to select a single namespace and only fetch resources from within it.
+    checkboxLabel: Enable Require Namespace Filtering
     count:
       inputLabel: Resource Threshold
       description: You can configure a threshold above which filtering by a namespace is required

--- a/shell/components/ResourceList/Masthead.vue
+++ b/shell/components/ResourceList/Masthead.vue
@@ -65,6 +65,11 @@ export default {
       default: false
     },
 
+    loadNamespace: {
+      type:    String,
+      default: null
+    },
+
     showIncrementalLoadingIndicator: {
       type:    Boolean,
       default: false
@@ -178,6 +183,7 @@ export default {
         v-if="showIncrementalLoadingIndicator"
         :resources="loadResources"
         :indeterminate="loadIndeterminate"
+        :namespace="loadNamespace"
       />
     </div>
     <div class="actions-container">

--- a/shell/components/ResourceList/ResourceLoadingIndicator.vue
+++ b/shell/components/ResourceList/ResourceLoadingIndicator.vue
@@ -16,7 +16,11 @@ export default {
     indeterminate: {
       type:    Boolean,
       default: false,
-    }
+    },
+    namespace: {
+      type:    String,
+      default: undefined
+    },
   },
 
   data() {
@@ -40,6 +44,10 @@ export default {
     // Have we loaded all resources for the types that are needed
     haveAll() {
       return this.resources.reduce((acc, r) => {
+        if (this.namespace) {
+          return acc && this.$store.getters[`${ this.inStore }/haveAllNamespace`](r, this.namespace);
+        }
+
         return acc && this.$store.getters[`${ this.inStore }/haveAll`](r);
       }, true);
     },
@@ -49,7 +57,9 @@ export default {
       const clusterCounts = this.$store.getters[`${ this.inStore }/all`](COUNT);
 
       return this.resources.reduce((acc, r) => {
-        const count = clusterCounts?.[0]?.counts?.[r]?.summary?.count || 0;
+        const resourceCounts = clusterCounts?.[0]?.counts?.[r];
+        const resourceCount = this.namespace ? resourceCounts?.namespaces?.[this.namespace]?.count : resourceCounts?.summary?.count;
+        const count = resourceCount || 0;
 
         return acc + count;
       }, 0);

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -6,8 +6,10 @@ import ResourceLoadingIndicator from './ResourceLoadingIndicator';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import IconMessage from '@shell/components/IconMessage.vue';
 
+export const ResourceListComponentName = 'ResourceList';
+
 export default {
-  name: 'ResourceList',
+  name: ResourceListComponentName,
 
   components: {
     Loading,
@@ -131,15 +133,16 @@ export default {
 
   watch: {
     /**
+     * When a NS filter is required and the user selects a different one, kick off a new set of API requests
+     *
      * ResourceList has two modes
-     * 1) Root component handles API request to fetch resources
+     * 1) ResourceList component handles API request to fetch resources
      * 2) Custom list component handles API request to fetch resources
      *
-     * Case 2 will fetch resources when the component is shown and will use the latest namespace filter
-     * Case 1 requires a manual prod by watching namespaceFilterRequired
+     * This covers case 1
      */
-    namespaceFilterRequired(neu, old) {
-      if (!neu && !this.hasFetch) {
+    namespaceFilter(neu) {
+      if (neu && !this.hasFetch) { //
         this.$fetchType(this.resource);
       }
     }
@@ -165,10 +168,13 @@ export default {
     v-if="namespaceFilterRequired"
     :vertical="true"
     :subtle="false"
-    icon="icon-search"
+    icon="icon-filter_alt"
   >
     <template #message>
-      <span v-html="t('resourceList.nsFiltering', { resource: $store.getters['type-map/labelFor'](schema, 2) || customTypeDisplay }, true)" />
+      <span
+        class="filter"
+        v-html="t('resourceList.nsFiltering', { resource: $store.getters['type-map/labelFor'](schema, 2) || customTypeDisplay }, true)"
+      />
     </template>
   </IconMessage>
   <div v-else>
@@ -205,6 +211,7 @@ export default {
       :adv-filter-hide-labels-as-cols="advFilterHideLabelsAsCols"
       :adv-filter-prevent-filtering-labels="advFilterPreventFilteringLabels"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     />
   </div>
 </template>
@@ -216,6 +223,9 @@ export default {
     H2 {
       position: relative;
       margin: 0 0 20px 0;
+    }
+    .filter{
+      line-height: 45px;
     }
     .right-action {
       position: absolute;

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -142,7 +142,7 @@ export default {
      * This covers case 1
      */
     namespaceFilter(neu) {
-      if (neu && !this.hasFetch) { //
+      if (neu && !this.hasFetch) {
         this.$fetchType(this.resource);
       }
     }

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -232,10 +232,15 @@ export default {
         return [];
       }
 
+      const haveAllNamespace = this.$store.getters['haveAllNamespace'];
+
       return this.rows.filter((row) => {
         if (this.currentProduct?.hideSystemResources && this.isNamespaced) {
           return !!includedNamespaces[row.metadata.namespace] && !row.isSystemResource;
         } else if (!this.isNamespaced) {
+          return true;
+        } else if (haveAllNamespace) {
+          // `rows` only contains resource from a single namespace
           return true;
         } else {
           return !!includedNamespaces[row.metadata.namespace];

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -140,6 +140,13 @@ export default {
     useQueryParamsForSimpleFiltering: {
       type:    Boolean,
       default: false
+    },
+    /**
+     * Manaul force the update of live and delayed cells. Change this number to kick off the update
+     */
+    forceUpdateLiveAndDelayed: {
+      type:    Number,
+      default: 0
     }
   },
 
@@ -411,6 +418,7 @@ export default {
     key-field="_key"
     :sort-generation-fn="safeSortGenerationFn"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     @clickedActionButton="handleActionButtonClick"
     @group-value-change="group = $event"
     v-on="$listeners"

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -304,6 +304,13 @@ export default {
     useQueryParamsForSimpleFiltering: {
       type:    Boolean,
       default: false
+    },
+    /**
+     * Manaul force the update of live and delayed cells. Change this number to kick off the update
+     */
+    forceUpdateLiveAndDelayed: {
+      type:    Number,
+      default: 0
     }
   },
 
@@ -387,6 +394,9 @@ export default {
       this.watcherUpdateLiveAndDelayed(neu, old);
     },
     page(neu, old) {
+      this.watcherUpdateLiveAndDelayed(neu, old);
+    },
+    forceUpdateLiveAndDelayed(neu, old) {
       this.watcherUpdateLiveAndDelayed(neu, old);
     },
 

--- a/shell/components/__tests__/NamespaceFilter.test.ts
+++ b/shell/components/__tests__/NamespaceFilter.test.ts
@@ -187,6 +187,7 @@ describe('component: NamespaceFilter', () => {
               elementId: text,
               id:        text,
               kind:      'namespace',
+              enabled:   true,
             },
           ],
           options:        () => [],

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -445,6 +445,9 @@ export default {
         e.stopPropagation();
         this.up();
       } else if (e.keyCode === KEY.SPACE) {
+        if (this.namespaceFilterMode && !opt.enabled) {
+          return;
+        }
         e.preventDefault();
         e.stopPropagation();
         this.selectOption(opt);
@@ -727,7 +730,16 @@ export default {
           />
         </div>
         <div
-          v-if="!namespaceFilterMode"
+          v-if="namespaceFilterMode"
+          class="ns-singleton-info"
+        >
+          <i
+            v-tooltip="t('resourceList.nsFilterToolTip', { mode: namespaceFilterMode})"
+            class="icon icon-info"
+          />
+        </div>
+        <div
+          v-else
           class="ns-clear"
         >
           <i
@@ -756,7 +768,7 @@ export default {
           :data-testid="`namespaces-option-${i}`"
           @click="opt.enabled && selectOption(opt)"
           @mouseover="opt.enabled && mouseOver($event)"
-          @keydown="opt.enabled && itemKeyHandler($event, opt)"
+          @keydown="itemKeyHandler($event, opt)"
         >
           <div
             v-if="opt.kind === 'divider'"
@@ -819,16 +831,17 @@ export default {
     }
 
     .ns-clear {
-      align-items: center;
-      display: flex;
-      > i {
-        font-size: 24px;
-        padding: 0 5px;
-      }
-
       &:hover {
         color: var(--link);
         cursor: pointer;
+      }
+    }
+
+    .ns-singleton-info, .ns-clear {
+      align-items: center;
+      display: flex;
+      > i {
+        padding-right: 5px;
       }
     }
 

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -137,5 +137,9 @@ export const DEFAULT_PERF_SETTING = {
     threshold: 1500,
   },
   disableWebsocketNotification: true,
-  garbageCollection:            GC_DEFAULTS
+  garbageCollection:            GC_DEFAULTS,
+  forceNsFilter:                      {
+    enabled:   false,
+    threshold: 1500,
+  }
 };

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -138,7 +138,7 @@ export const DEFAULT_PERF_SETTING = {
   },
   disableWebsocketNotification: true,
   garbageCollection:            GC_DEFAULTS,
-  forceNsFilter:                      {
+  forceNsFilter:                {
     enabled:   false,
     threshold: 1500,
   }

--- a/shell/list/__tests__/workload.test.ts
+++ b/shell/list/__tests__/workload.test.ts
@@ -24,7 +24,7 @@ describe('component: workload', () => {
       mocks:      {
         $store: {
           getters: {
-            currentStore:                  () => jest.fn(),
+            currentStore:                  () => 'cluster',
             namespaces:                    () => jest.fn(),
             'management/byId':             () => jest.fn(),
             'resource-fetch/refreshFlag':  () => jest.fn(),
@@ -33,6 +33,8 @@ describe('component: workload', () => {
             'type-map/optionsFor':         () => jest.fn(),
             'type-map/headersFor':         () => jest.fn(),
             'prefs/get':                   () => resource,
+            'cluster/schemaFor':           () => {},
+            'cluster/all':                 () => [{}],
           }
         },
         $fetchState: {

--- a/shell/list/__tests__/workload.test.ts
+++ b/shell/list/__tests__/workload.test.ts
@@ -23,7 +23,8 @@ describe('component: workload', () => {
       mixins:     [ResourceFetch],
       mocks:      {
         $store: {
-          getters: {
+          dispatch: () => jest.fn(),
+          getters:  {
             currentStore:                  () => 'cluster',
             namespaces:                    () => jest.fn(),
             'management/byId':             () => jest.fn(),

--- a/shell/list/catalog.cattle.io.app.vue
+++ b/shell/list/catalog.cattle.io.app.vue
@@ -38,6 +38,7 @@ export default {
     :rows="rows"
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   >
     <template #cell:upgrade="{row}">
       <span

--- a/shell/list/cis.cattle.io.clusterscan.vue
+++ b/shell/list/cis.cattle.io.clusterscan.vue
@@ -66,5 +66,6 @@ export default {
     :headers="headers"
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/list/fleet.cattle.io.bundle.vue
+++ b/shell/list/fleet.cattle.io.bundle.vue
@@ -90,10 +90,8 @@ export default {
 
   // override with relevant info for the loading indicator since this doesn't use it's own masthead
   $loadingResources() {
-    return {
-      loadResources:     [FLEET.BUNDLE],
-      loadIndeterminate: true, // results are filtered so we wouldn't get the correct count on indicator...
-    };
+    // results are filtered so we wouldn't get the correct count on indicator...
+    return { loadIndeterminate: true };
   },
 };
 </script>

--- a/shell/list/fleet.cattle.io.bundle.vue
+++ b/shell/list/fleet.cattle.io.bundle.vue
@@ -109,6 +109,7 @@ export default {
       :rows="bundles"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     >
       <template #cell:deploymentsReady="{row}">
         <span

--- a/shell/list/fleet.cattle.io.cluster.vue
+++ b/shell/list/fleet.cattle.io.cluster.vue
@@ -87,6 +87,7 @@ export default {
       :schema="schema"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     />
   </div>
 </template>

--- a/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
+++ b/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
@@ -67,10 +67,8 @@ export default {
   },
   // override with relevant info for the loading indicator since this doesn't use it's own masthead
   $loadingResources() {
-    return {
-      loadResources:     [FLEET.TOKEN],
-      loadIndeterminate: true, // results are filtered so we wouldn't get the correct count on indicator...
-    };
+    // results are filtered so we wouldn't get the correct count on indicator...
+    return { loadIndeterminate: true };
   },
 };
 </script>

--- a/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
+++ b/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
@@ -86,6 +86,7 @@ export default {
       :rows="tokens"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     />
   </div>
 </template>

--- a/shell/list/fleet.cattle.io.gitrepo.vue
+++ b/shell/list/fleet.cattle.io.gitrepo.vue
@@ -22,11 +22,6 @@ export default {
       required: true,
     },
 
-    loadResources: {
-      type:    Array,
-      default: () => []
-    },
-
     loadIndeterminate: {
       type:    Boolean,
       default: false

--- a/shell/list/fleet.cattle.io.gitrepo.vue
+++ b/shell/list/fleet.cattle.io.gitrepo.vue
@@ -64,6 +64,7 @@ export default {
       :schema="schema"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     />
   </div>
 </template>

--- a/shell/list/helm.cattle.io.projecthelmchart.vue
+++ b/shell/list/helm.cattle.io.projecthelmchart.vue
@@ -16,11 +16,6 @@ export default {
       required: true,
     },
 
-    loadResources: {
-      type:    Array,
-      default: () => []
-    },
-
     loadIndeterminate: {
       type:    Boolean,
       default: false

--- a/shell/list/helm.cattle.io.projecthelmchart.vue
+++ b/shell/list/helm.cattle.io.projecthelmchart.vue
@@ -111,6 +111,7 @@ export default {
         :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
         key-field="_key"
         :groupable="false"
+        :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
       />
     </div>
   </div>

--- a/shell/list/logging.banzaicloud.io.clusterflow.vue
+++ b/shell/list/logging.banzaicloud.io.clusterflow.vue
@@ -37,5 +37,6 @@ export default {
     :rows="rows"
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/list/logging.banzaicloud.io.flow.vue
+++ b/shell/list/logging.banzaicloud.io.flow.vue
@@ -40,5 +40,6 @@ export default {
     :rows="rows"
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/list/management.cattle.io.cluster.vue
+++ b/shell/list/management.cattle.io.cluster.vue
@@ -49,5 +49,6 @@ export default {
     :group-by="$attrs.groupBy"
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/list/management.cattle.io.feature.vue
+++ b/shell/list/management.cattle.io.feature.vue
@@ -89,10 +89,8 @@ export default {
   },
 
   $loadingResources() {
-    return {
-      loadResources:     [MANAGEMENT.FEATURE],
-      loadIndeterminate: true, // results are filtered so we wouldn't get the correct count on indicator...
-    };
+    // results are filtered so we wouldn't get the correct count on indicator...
+    return { loadIndeterminate: true };
   },
 
   watch: {

--- a/shell/list/management.cattle.io.feature.vue
+++ b/shell/list/management.cattle.io.feature.vue
@@ -199,6 +199,7 @@ export default {
       :row-actions="enableRowActions"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     >
       <template
         slot="cell:name"

--- a/shell/list/management.cattle.io.user.vue
+++ b/shell/list/management.cattle.io.user.vue
@@ -1,6 +1,6 @@
 <script>
 import AsyncButton from '@shell/components/AsyncButton';
-import { MANAGEMENT, NORMAN } from '@shell/config/types';
+import { NORMAN } from '@shell/config/types';
 import { NAME } from '@shell/config/product/auth';
 import ResourceTable from '@shell/components/ResourceTable';
 import Masthead from '@shell/components/ResourceList/Masthead';
@@ -17,11 +17,6 @@ export default {
     resource: {
       type:     String,
       required: true,
-    },
-
-    loadResources: {
-      type:    Array,
-      default: () => []
     },
 
     loadIndeterminate: {
@@ -62,10 +57,8 @@ export default {
   },
 
   $loadingResources() {
-    return {
-      loadResources:     [MANAGEMENT.USER],
-      loadIndeterminate: true, // results are filtered so we wouldn't get the correct count on indicator...
-    };
+    // results are filtered so we wouldn't get the correct count on indicator...
+    return { loadIndeterminate: true };
   },
 
   computed: {

--- a/shell/list/management.cattle.io.user.vue
+++ b/shell/list/management.cattle.io.user.vue
@@ -136,6 +136,7 @@ export default {
       :group-by="groupBy"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     />
   </div>
 </template>

--- a/shell/list/monitoring.coreos.com.alertmanagerconfig.vue
+++ b/shell/list/monitoring.coreos.com.alertmanagerconfig.vue
@@ -45,6 +45,7 @@ export default {
       :rows="rows"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     />
   </div>
 

--- a/shell/list/node.vue
+++ b/shell/list/node.vue
@@ -156,6 +156,7 @@ export default {
       :sub-rows="true"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
       v-on="$listeners"
     >
       <template #sub-row="{fullColspan, row, onRowMouseEnter, onRowMouseLeave}">

--- a/shell/list/persistentvolume.vue
+++ b/shell/list/persistentvolume.vue
@@ -42,5 +42,6 @@ export default {
     :group-by="$attrs.groupBy"
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/list/persistentvolumeclaim.vue
+++ b/shell/list/persistentvolumeclaim.vue
@@ -41,5 +41,6 @@ export default {
     :schema="schema"
     :rows="rows"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -16,11 +16,6 @@ export default {
   },
   mixins: [ResourceFetch],
   props:  {
-    loadResources: {
-      type:    Array,
-      default: () => []
-    },
-
     loadIndeterminate: {
       type:    Boolean,
       default: false
@@ -141,10 +136,8 @@ export default {
   },
 
   $loadingResources() {
-    return {
-      loadResources:     [CAPI.RANCHER_CLUSTER],
-      loadIndeterminate: true, // results are filtered so we wouldn't get the correct count on indicator...
-    };
+    // results are filtered so we wouldn't get the correct count on indicator...
+    return { loadIndeterminate: true };
   },
 
   mounted() {

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -184,6 +184,7 @@ export default {
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
       :data-testid="'cluster-list'"
+      :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     >
       <template #cell:summary="{row}">
         <span v-if="!row.stateParts.length">{{ row.nodes.length }}</span>

--- a/shell/list/service.vue
+++ b/shell/list/service.vue
@@ -57,5 +57,6 @@ export default {
     :group-by="$attrs.groupBy"
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -162,5 +162,6 @@ export default {
     :rows="filteredRows"
     :overflow-y="true"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
   />
 </template>

--- a/shell/mixins/resource-fetch-namespaced.js
+++ b/shell/mixins/resource-fetch-namespaced.js
@@ -1,0 +1,66 @@
+import { mapGetters } from 'vuex';
+
+/**
+ * Companion mixin used with `resource-fetch` for `ResourceList` to determine if the user needs to filter the list by a single namespace
+ */
+export default {
+
+  computed: {
+    ...mapGetters(['currentCluster', 'isSingleNamespace']),
+
+    /**
+     * Does the user need to update the filter to supply a single namespace?
+     */
+    namespaceFilterRequired() {
+      return this.__namespaceRequired && !this.__singleNamespaceFilter;
+    },
+
+    /**
+     * Returns the namespace that requests should be filtered by
+     */
+    namespaceFilter() {
+      return this.__namespaceRequired ? this.__singleNamespaceFilter : '';
+    },
+
+    /**
+     * If the Project/Namespace filter from the header contains a single NS... return it
+     */
+    __singleNamespaceFilter() {
+      const ns = this.isSingleNamespace;
+
+      return ns ? ns.replace('ns://', '') : '';
+    },
+
+    /**
+     * Do we need to filter the list by a namespace?
+     */
+    __namespaceRequired() {
+      if (!this.forceNsFilter?.enabled || this.perfConfig.forceNsFilter.threshold === undefined) {
+        return false;
+      }
+
+      return this.__areResourcesNamespaced && this.__areResourcesTooMany;
+    },
+
+    /**
+     * Are all core list resources namespaced?
+     */
+    __areResourcesNamespaced() {
+      return (this.loadResources || []).every((type) => {
+        const schema = this.$store.getters['cluster/schemaFor'](type);
+
+        return schema?.attributes?.namespaced;
+      });
+    },
+
+    /**
+     * Are there too many core list resources to show in the list?
+     */
+    __areResourcesTooMany() {
+      const count = this.__getCountForResources(this.loadResources);
+
+      return count > this.perfConfig.forceNsFilter.threshold;
+    },
+
+  },
+};

--- a/shell/mixins/resource-fetch-namespaced.js
+++ b/shell/mixins/resource-fetch-namespaced.js
@@ -6,7 +6,7 @@ import { mapGetters } from 'vuex';
 export default {
 
   computed: {
-    ...mapGetters(['currentCluster', 'isSingleNamespace']),
+    ...mapGetters(['currentProduct', 'currentCluster', 'isSingleNamespace']),
 
     /**
      * Does the user need to update the filter to supply a single namespace?
@@ -39,7 +39,7 @@ export default {
         return false;
       }
 
-      return this.__areResourcesNamespaced && this.__areResourcesTooMany;
+      return !this.currentProduct.showWorkspaceSwitcher && this.__areResourcesNamespaced && this.__areResourcesTooMany;
     },
 
     /**

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -1,11 +1,15 @@
 import { mapGetters } from 'vuex';
 import { COUNT, MANAGEMENT } from '@shell/config/types';
 import { SETTING, DEFAULT_PERF_SETTING } from '@shell/config/settings';
+import ResourceFetchNamespaced from '@shell/mixins/resource-fetch-namespaced';
 
 // Number of pages to fetch when loading incrementally
 const PAGES = 4;
 
 export default {
+
+  mixins: [ResourceFetchNamespaced],
+
   data() {
     // fetching the settings related to manual refresh from global settings
     const perfSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);
@@ -21,11 +25,15 @@ export default {
       perfConfig = DEFAULT_PERF_SETTING;
     }
 
+    const inStore = this.$store.getters['currentStore'](COUNT);
+
     return {
       perfConfig,
       init:                       false,
-      counts:                     {},
+      inStore,
+      counts:                     this.$store.getters[`${ inStore }/all`](COUNT)[0].counts,
       multipleResources:          [],
+      loadResources:              [this.resource],
       // manual refresh vars
       hasManualRefresh:           false,
       watch:                      true,
@@ -34,6 +42,11 @@ export default {
       // incremental loading vars
       incremental:                0,
       fetchedResourceType:        [],
+      // force ns filtering
+      forceNsFilter:              {
+        ...perfConfig.forceNsFilter,
+        threshold: parseInt(this.perfConfig?.incrementalLoading?.threshold || '0', 10)
+      }
     };
   },
   beforeDestroy() {
@@ -42,10 +55,8 @@ export default {
       // clear up the store to make sure we aren't storing anything that might interfere with the next rendered list view
       this.$store.dispatch('resource-fetch/clearData');
 
-      const inStore = this.$store.getters['currentStore'](COUNT);
-
       this.fetchedResourceType.forEach((type) => {
-        this.$store.dispatch(`${ inStore }/incrementLoadCounter`, type);
+        this.$store.dispatch(`${ this.inStore }/incrementLoadCounter`, type);
       });
     }
   },
@@ -53,9 +64,7 @@ export default {
   computed: {
     ...mapGetters({ refreshFlag: 'resource-fetch/refreshFlag' }),
     rows() {
-      const inStore = this.$store.getters['currentStore'](this.resource);
-
-      return this.$store.getters[`${ inStore }/all`](this.resource);
+      return this.$store.getters[`${ this.inStore }/all`](this.resource);
     },
     loading() {
       return this.rows.length ? false : this.$fetchState.pending;
@@ -71,8 +80,6 @@ export default {
   },
   methods: {
     $fetchType(type, multipleResources = []) {
-      const inStore = this.$store.getters['currentStore'](COUNT);
-
       if (!this.init) {
         this.__gatherResourceFetchData(type, multipleResources);
 
@@ -90,9 +97,10 @@ export default {
         this.fetchedResourceType.push(type);
       }
 
-      return this.$store.dispatch(`${ inStore }/findAll`, {
+      return this.$store.dispatch(`${ this.inStore }/findAll`, {
         type,
         opt: {
+          namespaced:       this.namespaceFilter,
           incremental:      this.incremental,
           watch:            this.watch,
           force:            this.force,
@@ -100,16 +108,19 @@ export default {
         }
       });
     },
-    __getCountForResource(resourceName) {
-      let resourceCount;
 
-      if (this.counts[`${ resourceName }`]) {
-        resourceCount = this.counts[`${ resourceName }`].summary?.count;
-      }
+    __getCountForResources(resourceNames) {
+      return resourceNames.reduce((res, type) => res + this.__getCountForResource(type), 0);
+    },
+
+    __getCountForResource(resourceName, namespace) {
+      const resourceCounts = this.counts[`${ resourceName }`];
+      const resourceCount = namespace ? resourceCounts?.namespaces[namespace]?.count : resourceCounts?.summary?.count;
 
       return resourceCount || 0;
     },
-    __gatherResourceFetchData(type, multipleResources) {
+
+    __gatherResourceFetchData(resourceName, multipleResources) {
       // flag to prevent a first data update being triggered from the requestData watcher
       this.init = true;
 
@@ -123,8 +134,6 @@ export default {
 
       // other vars
       this.multipleResources = multipleResources;
-      const resourceName = type;
-      const inStore = this.$store.getters['currentStore'](resourceName);
       let resourceCount = 0;
 
       // manual refresh vars
@@ -135,17 +144,9 @@ export default {
       let incremental = 0;
 
       // get resource counts
-      if ( this.$store.getters[`${ inStore }/haveAll`](COUNT) ) {
-        this.counts = this.$store.getters[`${ inStore }/all`](COUNT)[0].counts;
+      const resourcesForCount = this.multipleResources.length ? this.multipleResources : [resourceName];
 
-        if (this.multipleResources.length) {
-          this.multipleResources.forEach((item) => {
-            resourceCount = resourceCount + this.__getCountForResource(item);
-          });
-        } else {
-          resourceCount = this.__getCountForResource(resourceName);
-        }
-      }
+      resourceCount = this.__getCountForResources(resourcesForCount);
 
       // manual refresh check
       if (manualDataRefreshEnabled && resourceCount >= manualDataRefreshThreshold) {

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -45,7 +45,7 @@ export default {
       // force ns filtering
       forceNsFilter:              {
         ...perfConfig.forceNsFilter,
-        threshold: parseInt(this.perfConfig?.incrementalLoading?.threshold || '0', 10)
+        threshold: parseInt(perfConfig?.forceNsFilter?.threshold || '0', 10)
       }
     };
   },

--- a/shell/package.json
+++ b/shell/package.json
@@ -113,7 +113,7 @@
     "nyc": "15.1.0",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "rancher-icons": "rancher/icons#v2.0.9",
+    "rancher-icons": "rancher/icons#v2.0.13",
     "require-extension-hooks": "0.3.3",
     "require-extension-hooks-babel": "1.0.0",
     "require-extension-hooks-vue": "3.0.0",

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -133,7 +133,7 @@ export default {
           <p>{{ t('performance.manualRefresh.description') }}</p>
           <Banner
             color="error"
-            label-key="performance.manualRefresh.banner"
+            label-key="performance.experimental"
           />
           <Checkbox
             v-model="value.manualRefresh.enabled"
@@ -163,7 +163,7 @@ export default {
           <p>{{ t('performance.gc.description') }}</p>
           <Banner
             color="error"
-            label-key="performance.gc.banner"
+            label-key="performance.experimental"
           />
           <Checkbox
             v-model="value.garbageCollection.enabled"
@@ -235,6 +235,36 @@ export default {
                 min="0"
               />
             </div>
+          </div>
+        </div>
+        <!-- Force NS filter -->
+        <div class="mt-40">
+          <h2>{{ t('performance.nsFiltering.label') }}</h2>
+          <p>{{ t('performance.nsFiltering.description') }}</p>
+          <Banner
+            color="error"
+            label-key="performance.experimental"
+          />
+          <Checkbox
+            v-model="value.forceNsFilter.enabled"
+            :mode="mode"
+            :label="t('performance.nsFiltering.checkboxLabel')"
+            class="mt-10 mb-20"
+            :primary="true"
+          />
+          <div class="ml-20">
+            <p :class="{ 'text-muted': !value.forceNsFilter.enabled }">
+              {{ t('performance.nsFiltering.count.description') }}
+            </p>
+            <LabeledInput
+              v-model="value.forceNsFilter.threshold"
+              :mode="mode"
+              :label="t('performance.nsFiltering.count.inputLabel')"
+              :disabled="!value.forceNsFilter.enabled"
+              class="input"
+              type="number"
+              min="0"
+            />
           </div>
         </div>
       </div>

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -80,7 +80,7 @@ export default {
 
   // Load a page of data for a given type
   // Used for incremental loading when enabled
-  async loadDataPage(ctx, { type, opt, namespace }) {
+  async loadDataPage(ctx, { type, opt }) {
     const { getters, commit, dispatch } = ctx;
 
     type = getters.normalizeType(type);
@@ -110,16 +110,15 @@ export default {
           opt: {
             ...opt,
             url: res.pagination?.next
-          },
-          namespace
+          }
         });
       } else {
       // We have everything!
         if (opt.hasManualRefresh) {
           dispatch('resource-fetch/updateManualRefreshIsLoading', false, { root: true });
         }
-        if (namespace) {
-          commit('setHaveNamespace', { type, namespace });
+        if (opt.namespaced) {
+          commit('setHaveNamespace', { type, namespace: opt.namespaced });
         } else {
           commit('setHaveAll', { type });
         }
@@ -213,9 +212,7 @@ export default {
         commit('forgetType', type);
       }
 
-      dispatch('loadDataPage', {
-        type, opt: pageFetchOpts, namespace: opt.namespaced
-      });
+      dispatch('loadDataPage', { type, opt: pageFetchOpts });
     }
 
     let streamStarted = false;

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -10,12 +10,13 @@ function registerType(state, type) {
 
   if ( !cache ) {
     cache = {
-      list:         [],
-      haveAll:      false,
-      haveSelector: {},
-      revision:     0, // The highest known resourceVersion from the server for this type
-      generation:   0, // Updated every time something is loaded for this type
-      loadCounter:  0, // Used to cancel incremental loads if the page changes during load
+      list:          [],
+      haveAll:       false,
+      haveSelector:  {},
+      haveNamespace: undefined, // If the cached list only contains resources for a namespace, this will contain the ns name
+      revision:      0, // The highest known resourceVersion from the server for this type
+      generation:    0, // Updated every time something is loaded for this type
+      loadCounter:   0, // Used to cancel incremental loads if the page changes during load
     };
 
     // Not enumerable so they don't get sent back to the client for SSR
@@ -115,6 +116,7 @@ export function forgetType(state, type) {
   if ( cache ) {
     cache.haveAll = false;
     cache.haveSelector = {};
+    cache.haveNamespace = undefined;
     cache.revision = 0;
     cache.generation = 0;
     clear(cache.list);
@@ -167,7 +169,8 @@ export function loadAll(state, {
   type,
   data,
   ctx,
-  skipHaveAll
+  skipHaveAll,
+  namespace
 }) {
   const { getters } = ctx;
 
@@ -199,7 +202,8 @@ export function loadAll(state, {
 
   // Allow requester to skip setting that everything has loaded
   if (!skipHaveAll) {
-    cache.haveAll = true;
+    cache.haveNamespace = namespace;
+    cache.haveAll = !namespace;
   }
 
   return proxies;
@@ -286,6 +290,12 @@ export default {
     const cache = registerType(state, type);
 
     cache.haveAll = true;
+  },
+
+  setHaveNamespace(state, { type, namespace }) {
+    const cache = registerType(state, type);
+
+    cache.haveNamespace = namespace;
   },
 
   loadedAll(state, { type }) {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -6,6 +6,7 @@ import { NAMESPACE, SCHEMA, COUNT, UI } from '@shell/config/types';
 import SteveModel from './steve-class';
 import HybridModel, { cleanHybridResources } from './hybrid-class';
 import NormanModel from './norman-class';
+import { urlFor } from '@shell/plugins/dashboard-store/getters';
 
 export const STEVE_MODEL_TYPES = {
   NORMAN:  'norman',
@@ -63,6 +64,20 @@ export default {
       url += `${ url.includes('?') ? '&' : '?' }order=${ encodeURIComponent(orderBy) }`;
     }
     // End: Sort
+
+    return url;
+  },
+
+  urlFor: (state, getters) => (type, id, opt) => {
+    let url = urlFor(state, getters)(type, id, opt);
+
+    if (opt.namespaced) {
+      const parts = url.split('/');
+
+      url = `${ parts.join('/') }/${ opt.namespaced }`;
+
+      return url;
+    }
 
     return url;
   },

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -31,7 +31,8 @@ export default {
     type,
     data,
     ctx,
-    skipHaveAll
+    skipHaveAll,
+    namespace
   }) {
     // Performance testing in dev and when env var is set
     if (process.env.dev && !!process.env.perfTest) {
@@ -39,7 +40,7 @@ export default {
     }
 
     const proxies = loadAll(state, {
-      type, data, ctx, skipHaveAll
+      type, data, ctx, skipHaveAll, namespace
     });
 
     // If we loaded a set of pods, then update the podsByNamespace cache

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -284,6 +284,34 @@ export const getters = {
     return state.namespaceFilters.filter(x => !`${ x }`.startsWith(NAMESPACED_PREFIX)).length === 0;
   },
 
+  isSingleNamespace(state, getters) {
+    const product = getters['currentProduct'];
+
+    if ( !product ) {
+      return false;
+    }
+
+    if ( product.showWorkspaceSwitcher ) {
+      return false;
+    }
+
+    if ( getters.isAllNamespaces ) {
+      return false;
+    }
+
+    const filters = state.namespaceFilters;
+
+    if ( filters.length !== 1 ) {
+      return false;
+    }
+
+    if (filters[0].startsWith('ns://')) {
+      return filters[0];
+    }
+
+    return false;
+  },
+
   isMultipleNamespaces(state, getters) {
     const product = getters['currentProduct'];
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -169,6 +169,7 @@ export const state = () => {
     serverVersion:           null,
     systemNamespaces:        [],
     isSingleProduct:         undefined,
+    namespaceFilterMode:     null,
   };
 };
 
@@ -203,6 +204,15 @@ export const getters = {
 
   systemNamespaces(state) {
     return state.systemNamespaces;
+  },
+
+  /**
+   * Namespace Filter Mode supplies a resource type to the NamespaceFilter.
+   *
+   * Only one of the resource type is allowed to be selected
+   */
+  namespaceFilterMode(state) {
+    return state.namespaceFilterMode;
   },
 
   currentCluster(state, getters) {
@@ -511,6 +521,10 @@ export const mutations = {
     // Create map that can be used to efficiently check if a
     // resource should be displayed
     getActiveNamespaces(state, getters);
+  },
+
+  setNamespaceFilterMode(state, mode) {
+    state.namespaceFilterMode = mode;
   },
 
   pageActions(state, pageActions) {
@@ -855,6 +869,10 @@ export const actions = {
       }
     });
     commit('updateNamespaces', { filters: ids, ...getters });
+  },
+
+  setNamespaceFilterMode({ commit }, mode) {
+    commit('setNamespaceFilterMode', mode);
   },
 
   async cleanNamespaces({ getters, dispatch }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14515,9 +14515,9 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-rancher-icons@rancher/icons#v2.0.9:
-  version "2.0.9"
-  resolved "https://codeload.github.com/rancher/icons/tar.gz/09048239918c9eccf49f7770948efef63fb04f24"
+rancher-icons@rancher/icons#v2.0.13:
+  version "2.0.13"
+  resolved "https://codeload.github.com/rancher/icons/tar.gz/31a5cbe19edc8c01f7fd8b39f6ff79c81ef68b19"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#6483

### Occurred changes and/or fixed issues
- When there are over a configurable amount of resources to display in a list force the user to select a single namespace and use it to fetch resources related to the list
- Disabled by default, this can be enabled via the usual `Global Settings` --> `Performance` setting as usual

### Technical notes summary
Functional Comments
- Gates for forcing the filter (count, resource type is namespaced, etc) apply only to the resources shown in the list.
  - For example PV's aren't namespaced, so no enforced filtering. However they fetch PVC's which are namespaced
  - Another example, we could have 10 resources to show in the list, but the resource types list component fetches 10000 other resources. The secondary resource count is not taken in to account
- If we're under the threshold and have fetched all resources, if in that session we go over the threshold we won't fetch NS specific resources (because we have them all already)
- If we're over the threshold and have fetched namespaced resources, if in that session we go under the threshold we will fetch all resources
- If we're over the threshold and have fetched namespaced resources, going to a page that needs them all will result in us fetching them all (for instance from `events` list page to `cluster dashboard`)
- Deselecting a namespace and selecting it again should not kick off another http request (unless manual refresh applies to the list)

General PR Comments
- The threshold to enforce the filter is set at 1500 as per manual fresh and incremental loading
- Optimised some code in ResourceList, resource-fetch and $loadingResources

### Areas or cases that should be tested
- Different types of resource lists
  - Workloads (contains resources from different types)
  - Sub-workload types (work with an odd workloads type list
  - Non-workload custom lists (Any list for resources matching file names from `./shell/list/*`
  - Non-workload, non-custom lists (any but those from above, for example `configmap`s or `secret`s
- List performance whilst `Manual Refresh` and `Incremental Loading` performance features are enabled, also with the new `Force Namespace Filtering` enabled

### Areas which could experience regressions
- See above

### Screenshot/Video
![image](https://user-images.githubusercontent.com/18697775/205306636-4f2c18ae-500e-445a-852a-ed23d95c62f1.png)

![image](https://user-images.githubusercontent.com/18697775/205306589-6685e08e-f6ec-44dc-99de-3163407ba42e.png)