### PR TITLE
Remove message saying K3s provisioning is in tech preview

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1733,7 +1733,6 @@ cluster:
         false: Only available inside the cluster
         true: Exposed to the public interface
   k3s:
-    techPreview: K3s provisioning is in Tech Preview
     systemService:
       coredns: 'CoreDNS'
       local-storage: 'Local Storage'

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -327,12 +327,6 @@ export default {
       return this.value.agentConfig;
     },
 
-    showK3sTechPreviewWarning() {
-      const selectedVersion = this.value?.spec?.kubernetesVersion || 'none';
-
-      return !!this.k3sVersions.find(v => v.version === selectedVersion);
-    },
-
     // kubeletConfigs() {
     //   return this.value.spec.rkeConfig.machineSelectorConfig.filter(x => !!x.machineLabelSelector);
     // },
@@ -1773,9 +1767,6 @@ export default {
                 :tooltip="t('cluster.kubernetesVersion.deprecatedPatchWarning')"
                 class="patch-version"
               />
-              <div v-if="showK3sTechPreviewWarning" class="k3s-tech-preview-info">
-                {{ t('cluster.k3s.techPreview') }}
-              </div>
             </div>
             <div v-if="showCloudProvider" class="col span-6">
               <LabeledSelect


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/7334
<img width="859" alt="Screenshot 2022-11-04 at 12 34 04 PM" src="https://user-images.githubusercontent.com/20599230/200060648-c6ffa78a-0680-4e05-9998-bfa64f95ca04.png">

To test this PR, I went to provision a RKE2/K3s cluster, then selected a K3s Kubernetes version. Confirmed the tech preview was gone.