### PR TITLE
when using pv to make pvc set storageClassName if present on pv

### DIFF
--- a/shell/edit/persistentvolumeclaim.vue
+++ b/shell/edit/persistentvolumeclaim.vue
@@ -145,12 +145,16 @@ export default {
       set(value) {
         const persistentVolume = this.persistentVolumes.find(pv => pv.metadata.name === value);
 
+        this.$set(this.value.spec, 'storageClassName', '');
+
         if (persistentVolume) {
           this.$set(this.value.spec.resources.requests, 'storage', persistentVolume.spec.capacity?.storage);
+          if (persistentVolume.spec?.storageClassName) {
+            this.$set(this.value.spec, 'storageClassName', persistentVolume.spec?.storageClassName );
+          }
         }
 
         this.$set(this.value.spec, 'volumeName', value);
-        this.$set(this.value.spec, 'storageClassName', '');
       }
     },
     storageAmountMode() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7332 

When a PV is assigned to a storage class (has `spec.storageClassName` set) PVC's created from that PV also need `spec.storageClassName` set.


### Areas or cases that should be tested
A note about the repro step [here](https://github.com/rancher/dashboard/issues/7332#issuecomment-1302586528) : when creating your PV you need to go to the customize tab and choose 'longhorn' in the 'assign to storage class' dropdown, not just select 'longhorn' as the volume plugin (I made this mistake initially)
