### PR TITLE
fix height of applied filters in advanced filtering

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1311,6 +1311,7 @@ export default {
       display: flex;
       align-items: center;
       position: relative;
+      height: 20px;
 
       &:nth-child(4n+1) {
         border-color: var(--success);


### PR DESCRIPTION
- fix height of applied filters in advanced filtering feature

<img width="1457" alt="Screenshot 2022-11-07 at 12 09 33" src="https://user-images.githubusercontent.com/97888974/200307049-34db5e6e-4bf5-4ff3-8824-cd6c5430d461.png">
