### PR TITLE
Add script to update docker image

### DIFF
--- a/docusaurus/docs/getting-started/development_environment.md
+++ b/docusaurus/docs/getting-started/development_environment.md
@@ -131,4 +131,15 @@ A common mistake is to accidentally work from the wrong Rancher version. Because
 
 ### Upgrading Rancher with Docker
 
-If you want to use a more long-lived Rancher instance, you may need to upgrade Rancher without just killing the container running in Docker. In that case, you can follow these docs to upgrade Rancher with Docker: https://rancher.com/docs/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-upgrades/
+If you want to use a more long-lived Rancher instance, you may need to upgrade Rancher without just killing the container running in Docker. In that case, you can run the script `./scripts/update-docker-image`, or you can follow [these docs](https://rancher.com/docs/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-upgrades/) to upgrade Rancher with Docker.
+
+If using the script, you will need to provide 2 arguments:
+
+- A container name to be updated
+- An image tag for which to update the container with (e.g. `v2.7-head`)
+
+For instance:
+
+```console
+./scripts/update-docker-image my-rancher-instance v2.7-head
+```

--- a/scripts/update-docker-image
+++ b/scripts/update-docker-image
@@ -14,7 +14,7 @@ RESET="\033[0m"
 usage() {
   echo -e "Usage: \n$0 <name> <tag>"
   echo "  <name>    Specify the container name you wish to update"
-  echo "  <tag>     Specify which container image to use when updating your container"
+  echo "  <tag>     Specify which container image to use when updating your container (e.g. v2.7-head)"
   exit 1
 }
 
@@ -46,11 +46,12 @@ docker create \
   --volumes-from ${CONTAINER_NAME} \
   --name ${CONTAINER_NAME}-${DATE}-data ${OLD_IMAGE}
 
-echo -e "${CYAN}Creating backup${RESET}"
+echo -e "${CYAN}Creating backup...${RESET}"
 docker run \
   --volumes-from ${CONTAINER_NAME}-${DATE}-data \
   -v "$PWD:/backup" \
-  --rm busybox tar zcvf /backup/${DATE}-data-backup.tar.gz /var/lib/rancher
+  --rm busybox tar zcvf /backup/${DATE}-data-backup.tar.gz /var/lib/rancher \
+  >./${CONTAINER_NAME}-${DATE}-backup.log 2>&1
 
 docker pull rancher/rancher:${TAG}
 

--- a/scripts/update-docker-image
+++ b/scripts/update-docker-image
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+# options
+CONTAINER_NAME=$1
+TAG=$2
+
+DATE=`date +%F`
+
+CYAN="\033[96m"
+BOLD="\033[1m"
+RESET="\033[0m"
+
+usage() {
+  echo -e "Usage: \n$0 <name> <tag>"
+  echo "  <name>    Specify the container name you wish to update"
+  echo "  <tag>     Specify which container image to use when updating your container"
+  exit 1
+}
+
+if [ $# -eq 0 ];
+then
+    echo "No arguments were provided..."
+    usage
+    exit 0
+else
+
+while getopts ":h" opt; do
+  case $opt in
+    h | *)
+      usage
+      exit 0
+      ;;
+  esac
+done
+
+shift "$((OPTIND-1))"
+
+OLD_IMAGE=`docker ps --filter "name=${CONTAINER_NAME}" --format "{{.Image}}"`
+
+echo -e "${CYAN}${BOLD}Updating Rancher instance ${CONTAINER_NAME} to ${TAG}${RESET}"
+
+docker stop ${CONTAINER_NAME}
+
+docker create \
+  --volumes-from ${CONTAINER_NAME} \
+  --name ${CONTAINER_NAME}-${DATE}-data ${OLD_IMAGE}
+
+echo -e "${CYAN}Creating backup${RESET}"
+docker run \
+  --volumes-from ${CONTAINER_NAME}-${DATE}-data \
+  -v "$PWD:/backup" \
+  --rm busybox tar zcvf /backup/${DATE}-data-backup.tar.gz /var/lib/rancher
+
+docker pull rancher/rancher:${TAG}
+
+echo -e "${CYAN}Running Rancher version: ${TAG}${RESET}"
+docker run -d \
+  --volumes-from ${CONTAINER_NAME}-${DATE}-data \
+  --restart unless-stopped \
+  --privileged \
+  -p 80:80 \
+  -p 443:443 \
+  rancher/rancher:${TAG}
+
+echo -e "${CYAN}${BOLD}Rancher instance updated${RESET}"
+
+fi


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6602
<!-- Define findings related to the feature or bug issue. -->

This script will update a running instance of Rancher in Docker to a specified image and will create a backup of the original image.

The script needs 2 arguments:
- A container name to be updated
- An image tag for which to update the container with  

### To Test
Run the script:
```console
./scripts/update-docker-image <container-name> <image-tag>
```