### PR TITLE
remove tech preview message from k3s kubernetes version dropdown

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -391,11 +391,7 @@ export default {
 
       if ( showK3s ) {
         if ( showRke2 ) {
-          out.push({
-            kind:  'group',
-            label: this.t('cluster.provider.k3s'),
-            badge: this.t('generic.techPreview')
-          });
+          out.push({ kind: 'group', label: this.t('cluster.provider.k3s') });
         }
 
         out.push(...allValidK3sVersions);
@@ -2259,10 +2255,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .k3s-tech-preview-info {
-    color: var(--error);
-    padding-top: 10px;
-  }
   .patch-version {
     margin-top: 5px;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7334 
<!-- Define findings related to the feature or bug issue. -->
there was still text for `tech preview` in the dropdown section of kubernetes version selection. 

### Areas or cases that should be tested
This was found through QA, by grepping for `tech preview` in the code base and observing what was still tech preview for k3s. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->