### PR TITLE
Stop cluster config from jumping up and down when navigating between tabs

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1759,7 +1759,10 @@ export default {
       </template>
 
       <h2 v-t="'cluster.tabs.cluster'" />
-      <Tabbed :side-tabs="true">
+      <Tabbed
+        :side-tabs="true"
+        class="min-height"
+      >
         <Tab
           name="basic"
           label-key="cluster.tabs.basic"
@@ -2411,6 +2414,9 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  .min-height {
+    min-height: 40em;
+  }
   .patch-version {
     margin-top: 5px;
   }


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/6631

This PR adds a minimum height to the RKE2/K3s cluster config form to stop it from wiggling when tabs are clicked.
<img width="1461" alt="Screenshot 2022-11-07 at 6 30 35 PM" src="https://user-images.githubusercontent.com/20599230/200451722-65edff80-30b7-4514-a9ac-06eca9f899e7.png">
