### PR TITLE
Minor log styling fix

### DIFF
--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -602,7 +602,7 @@ export default {
     }
 
     .msg {
-      white-space: nowrap;
+      white-space: pre;
 
       .highlight {
         color: var(--logs-highlight);
@@ -611,7 +611,7 @@ export default {
     }
 
     &.wrap-lines .msg {
-      white-space: normal;
+      white-space: pre-wrap;
     }
   }
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/4950 by making a minor CSS fix.

To test this PR,

1. I created a Deployment named `test` of a sample application that has the same Spring Boot logs as the original issue. I used this container image that I found by googling: `springio/gs-spring-boot-docker:latest`
2. Go to the Deployment detail page for `test`
3. On the Pods tab, go to a pod and click the *⋮ > View Logs*
4. Confirm that the "Spring Boot" is formatted properly

Before:

<img width="962" alt="Screenshot 2022-11-07 at 7 16 28 PM" src="https://user-images.githubusercontent.com/20599230/200458832-03b42eea-0c06-4cc8-89b1-941fe397976b.png">

After:

<img width="936" alt="Screenshot 2022-11-07 at 7 18 48 PM" src="https://user-images.githubusercontent.com/20599230/200458946-e5e29830-524a-4b83-b78b-829ac969e465.png">
