### PR TITLE
remove secondary data config from the data prop

### DIFF
--- a/shell/edit/persistentvolume/index.vue
+++ b/shell/edit/persistentvolume/index.vue
@@ -80,34 +80,13 @@ export default {
     const plugin = (foundPlugin || VOLUME_PLUGINS[0]).value;
 
     return {
-      secondaryResourceData: {
-        namespace: null,
-        data:      {
-          [STORAGE_CLASS]: {
-            applyTo: [
-              {
-                var:         'storageClassOptions',
-                parsingFunc: (data) => {
-                  const storageClassOptions = data.map(s => ({
-                    label: s.metadata.name,
-                    value: s.metadata.name
-                  }));
-
-                  storageClassOptions.unshift(this.NONE_OPTION);
-
-                  return storageClassOptions;
-                }
-              }
-            ]
-          },
-        }
-      },
-      storageClassOptions: [],
-      currentClaim:        null,
+      secondaryResourceData: this.secondaryResourceDataConfig(),
+      storageClassOptions:   [],
+      currentClaim:          null,
       plugin,
       NONE_OPTION,
       NODE,
-      initialNodeAffinity: clone(this.value.spec.nodeAffinity),
+      initialNodeAffinity:   clone(this.value.spec.nodeAffinity),
     };
   },
 
@@ -175,6 +154,30 @@ export default {
   },
 
   methods: {
+    secondaryResourceDataConfig() {
+      return {
+        namespace: null,
+        data:      {
+          [STORAGE_CLASS]: {
+            applyTo: [
+              {
+                var:         'storageClassOptions',
+                parsingFunc: (data) => {
+                  const storageClassOptions = data.map(s => ({
+                    label: s.metadata.name,
+                    value: s.metadata.name
+                  }));
+
+                  storageClassOptions.unshift(this.NONE_OPTION);
+
+                  return storageClassOptions;
+                }
+              }
+            ]
+          },
+        }
+      };
+    },
     checkboxSetter(key, value) {
       if (value) {
         this.value.spec.accessModes.push(key);

--- a/shell/edit/persistentvolume/index.vue
+++ b/shell/edit/persistentvolume/index.vue
@@ -16,7 +16,7 @@ import UnitInput from '@shell/components/form/UnitInput';
 import { NODE, PVC, STORAGE_CLASS } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import { LONGHORN_PLUGIN, VOLUME_PLUGINS } from '@shell/models/persistentvolume';
-import { _CREATE, _VIEW, _EDIT } from '@shell/config/query-params';
+import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { clone } from '@shell/utils/object';
 import InfoBox from '@shell/components/InfoBox';
 import { mapFeature, UNSUPPORTED_STORAGE_DRIVERS } from '@shell/store/features';
@@ -44,7 +44,7 @@ export default {
   mixins: [CreateEditView, ResourceManager],
 
   fetch() {
-    if (this.mode === _EDIT) {
+    if (this.mode !== _CREATE) {
       this.secondaryResourceData.namespace = this.value?.spec?.claimRef?.namespace || null;
 
       this.secondaryResourceData.data[PVC] = {

--- a/shell/edit/persistentvolumeclaim.vue
+++ b/shell/edit/persistentvolumeclaim.vue
@@ -77,31 +77,7 @@ export default {
     const defaultTab = this.$route.query[FOCUS] || null;
 
     return {
-      secondaryResourceData: {
-        namespace: this.value?.metadata?.namespace || null,
-        data:      {
-          [PV]: {
-            applyTo: [
-              { var: 'persistentVolumes' },
-              {
-                var:         'persistentVolumeOptions',
-                parsingFunc: (data) => {
-                  return data
-                    .map((s) => {
-                      const status = s.status.phase === 'Available' ? '' : ` (${ s.status.phase })`;
-
-                      return {
-                        label: `${ s.metadata.name }${ status }`,
-                        value: s.metadata.name
-                      };
-                    })
-                    .sort((l, r) => l.label.localeCompare(r.label));
-                }
-              }
-            ]
-          },
-        }
-      },
+      secondaryResourceData:   this.secondaryResourceDataConfig(),
       sourceOptions,
       source:                  this.value.spec.volumeName ? sourceOptions[1].value : sourceOptions[0].value,
       immutableMode:           this.realMode === _CREATE ? _CREATE : _VIEW,
@@ -178,6 +154,33 @@ export default {
     }
   },
   methods: {
+    secondaryResourceDataConfig() {
+      return {
+        namespace: this.value?.metadata?.namespace || null,
+        data:      {
+          [PV]: {
+            applyTo: [
+              { var: 'persistentVolumes' },
+              {
+                var:         'persistentVolumeOptions',
+                parsingFunc: (data) => {
+                  return data
+                    .map((s) => {
+                      const status = s.status.phase === 'Available' ? '' : ` (${ s.status.phase })`;
+
+                      return {
+                        label: `${ s.metadata.name }${ status }`,
+                        value: s.metadata.name
+                      };
+                    })
+                    .sort((l, r) => l.label.localeCompare(r.label));
+                }
+              }
+            ]
+          },
+        }
+      };
+    },
     checkboxSetter(key, value) {
       if (value) {
         this.value.spec.accessModes.push(key);

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -209,47 +209,7 @@ export default {
     this.selectContainer(container);
 
     return {
-      secondaryResourceData: {
-        namespace: this.value?.metadata?.namespace || null,
-        data:      {
-          [CONFIG_MAP]:      { applyTo: [{ var: 'namespacedConfigMaps' }] },
-          [PVC]:             { applyTo: [{ var: 'pvcs' }] },
-          [SERVICE_ACCOUNT]: { applyTo: [{ var: 'namespacedServiceNames' }] },
-          [SECRET]:          {
-            applyTo: [
-              { var: 'namespacedSecrets' },
-              {
-                var:         'imagePullNamespacedSecrets',
-                parsingFunc: (data) => {
-                  return data.filter(secret => (secret._type === SECRET_TYPES.DOCKER || secret._type === SECRET_TYPES.DOCKER_JSON));
-                }
-              }
-            ]
-          },
-          [NODE]: {
-            applyTo: [
-              { var: 'allNodeObjects' },
-              {
-                var:         'allNodes',
-                parsingFunc: (data) => {
-                  return data.map(node => node.id);
-                }
-              }
-            ]
-          },
-          [SERVICE]: {
-            applyTo: [
-              { var: 'allServices' },
-              {
-                var:         'headlessServices',
-                parsingFunc: (data) => {
-                  return data.filter(service => service.spec.clusterIP === 'None');
-                }
-              }
-            ]
-          },
-        }
-      },
+      secondaryResourceData:      this.secondaryResourceDataConfig(),
       namespacedConfigMaps:       [],
       allNodes:                   null,
       allNodeObjects:             [],
@@ -604,6 +564,49 @@ export default {
   },
 
   methods: {
+    secondaryResourceDataConfig() {
+      return {
+        namespace: this.value?.metadata?.namespace || null,
+        data:      {
+          [CONFIG_MAP]:      { applyTo: [{ var: 'namespacedConfigMaps' }] },
+          [PVC]:             { applyTo: [{ var: 'pvcs' }] },
+          [SERVICE_ACCOUNT]: { applyTo: [{ var: 'namespacedServiceNames' }] },
+          [SECRET]:          {
+            applyTo: [
+              { var: 'namespacedSecrets' },
+              {
+                var:         'imagePullNamespacedSecrets',
+                parsingFunc: (data) => {
+                  return data.filter(secret => (secret._type === SECRET_TYPES.DOCKER || secret._type === SECRET_TYPES.DOCKER_JSON));
+                }
+              }
+            ]
+          },
+          [NODE]: {
+            applyTo: [
+              { var: 'allNodeObjects' },
+              {
+                var:         'allNodes',
+                parsingFunc: (data) => {
+                  return data.map(node => node.id);
+                }
+              }
+            ]
+          },
+          [SERVICE]: {
+            applyTo: [
+              { var: 'allServices' },
+              {
+                var:         'headlessServices',
+                parsingFunc: (data) => {
+                  return data.filter(service => service.spec.clusterIP === 'None');
+                }
+              }
+            ]
+          },
+        }
+      };
+    },
     addContainerBtn() {
       this.selectContainer({ name: 'Add Container', __add: true });
     },


### PR DESCRIPTION
Fixes #7109 

- remove secondary data config from the data prop so that we don't have a huge config hindering code readability

@richard-cox I don't know how to improve this further, since moving it to a method. It cannot be a `const` because it needs to access `this` values. Wasn't able to create a custom method and access it from the mixin, also. If you have a further idea, please let me know. 🙏 

**QA testing**
No major changes were done, just moving stuff around to improve code readability. Generally just check if `PV`, `PVC` and `Workloads` `create` + `edit` views are working properly and loading data to select inputs.
