### PR TITLE
remove @input event from v-select

### DIFF
--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -223,7 +223,6 @@ export default {
       :selectable="selectable"
       :value="value != null ? value : ''"
       v-on="$listeners"
-      @input="(e) => $emit('input', e)"
       @search:blur="onBlur"
       @search:focus="onFocus"
       @open="resizeHandler"

--- a/shell/components/form/__tests__/MatchExpressions.test.ts
+++ b/shell/components/form/__tests__/MatchExpressions.test.ts
@@ -73,7 +73,6 @@ describe('component: MatchExpressions', () => {
     await wrapper.trigger('keydown.down');
     await wrapper.trigger('keydown.enter');
 
-    // TODO: #6167: Fix issue with Select emitting 2 times
-    expect(wrapper.emitted('input')).toHaveLength(2);
+    expect(wrapper.emitted('input')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes #6167 

- remove `@input` event from `v-select` as event is already sent by default by `v-select`

https://vue-select.org/guide/values.html#event-input
Confirmed via testing on interface and through documentation.

**QA testing**
Generally make sure <Select> component is working properly. Ex: Creating a new role for user (selecting verbs)
