### PR TITLE
add k3s provisioning as GA in 2.7.0

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2482,7 +2482,7 @@ landing:
     cpuUsed: CPU Used
     memoryUsed: Memory Used
   seeWhatsNew: Learn more about the improvements and new capabilities in this version.
-  whatsNewLink: "What's new in 2.6"
+  whatsNewLink: "What's new in 2.7"
   learnMore: Learn More
   support: Support
   psps: PSPs

--- a/shell/content/docs/en-us/whats-new.md
+++ b/shell/content/docs/en-us/whats-new.md
@@ -13,6 +13,10 @@ installed by administrators. Extensions are provided as Helm charts. A new top-l
 
 - Authentication for OCI-based registries is now supported. Note that the structure of the fleet.yaml is the same and the credentials are provided as a Kubernetes secret, which is described in the Private Helm Repo box in the Repo Structure docs.
 
+### k3s provisioning is GA
+
+- You can now provision clusters that use k3s. 
+
 ---
 title: What's New in 2.6
 ---


### PR DESCRIPTION
Signed-off-by: Gary A Korhonen <gkorhonen@suse.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7361 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
What's New for 2.7.0 now includes mention of k3s provisioning being GA

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Load What's New and ensure that k3s provisioning as GA appears.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->