### PR TITLE
Ensure HPA cannot be associated with workloads owned by others

### DIFF
--- a/shell/detail/namespace.vue
+++ b/shell/detail/namespace.vue
@@ -156,7 +156,7 @@ export default {
     workloadRows() {
       const params = this.$route.params;
       const { id } = params;
-      const rows = flatten(compact(this.allWorkloads)).filter(row => row.showAsWorkload);
+      const rows = flatten(compact(this.allWorkloads)).filter(row => !row.ownedByWorkload);
       const namespacedRows = filter(rows, ({ metadata: { namespace } }) => namespace === id);
 
       return namespacedRows;

--- a/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -70,7 +70,10 @@ export default {
         Object.values(SCALABLE_WORKLOAD_TYPES)
           .flatMap(type => this.$store.getters['cluster/all'](type))
           .filter(
-            wl => wl.metadata.namespace === this.value.metadata.namespace
+            // Filter out anything that has an owner, which should probably be the one with the HPA
+            // For example ReplicaSets can be associated with a HPA (https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#replicaset-as-a-horizontal-pod-autoscaler-target)
+            // but wouldn't make sense if it's owned by a deployment
+            wl => wl.metadata.namespace === this.value.metadata.namespace && !wl.ownedByWorkload
           )
       );
     },

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -85,7 +85,7 @@ export default {
         }
 
         for ( const row of typeRows ) {
-          if (!this.allTypes || row.showAsWorkload) {
+          if (!this.allTypes || !row.ownedByWorkload) {
             out.push(row);
           }
         }

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -499,7 +499,7 @@ export default class Workload extends WorkloadService {
     return ports;
   }
 
-  get showAsWorkload() {
+  get ownedByWorkload() {
     const types = Object.values(WORKLOAD_TYPES);
 
     if (this.metadata?.ownerReferences) {
@@ -507,12 +507,12 @@ export default class Workload extends WorkloadService {
         const have = (`${ owner.apiVersion.replace(/\/.*/, '') }.${ owner.kind }`).toLowerCase();
 
         if ( types.includes(have) ) {
-          return false;
+          return true;
         }
       }
     }
 
-    return true;
+    return false;
   }
 
   get isFromNorman() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #2372
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- This ensures ReplicaSets with owners are hidden
- For example ReplicaSets can be associated with a HPA (https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#replicaset-as-a-horizontal-pod-autoscaler-target) but wouldn't make sense if it's owned by a deployment

### Technical notes summary
- If the HPA has an invalid entry we still show it to the user but won't let them set it in the form (they're ofc free to enter whatever via YAML)
