### PR TITLE
update url for namespaced requests for secondary data

### DIFF
--- a/shell/edit/workload/storage/persistentVolumeClaim/index.vue
+++ b/shell/edit/workload/storage/persistentVolumeClaim/index.vue
@@ -87,7 +87,7 @@ export default {
 
   watch: {
     namespace(neu) {
-      this.__newPvc.metadata.namespace = neu;
+      this.value.__newPvc.metadata.namespace = neu;
     },
 
     'value.__newPvc.metadata.name'(neu) {

--- a/shell/mixins/resource-manager.js
+++ b/shell/mixins/resource-manager.js
@@ -56,29 +56,11 @@ export default {
           const status = hash[type].status;
           // if it's namespaced, we get the data on 'items' prop, for non-namespaced it's  'data' prop...
           const requestData = hash[type].value.items || hash[type].value.data || hash[type].value;
-          const schema = this.$store.getters['cluster/schemaFor'](type);
 
           if (status === 'fulfilled' && resourceData.data[type] && resourceData.data[type].applyTo?.length) {
             for (let y = 0; y < resourceData.data[type].applyTo.length; y++) {
               const apply = resourceData.data[type].applyTo[y];
               let resources = requestData;
-
-              if (schema?.attributes?.namespaced) {
-                // The resources returned when requesting namespaced types do not contain id, type and links properties.
-                // This isn't perfect, or universally applicable, but will work for the current set of use cases
-                // To make this more generic
-                // - id param = this.$store.getters['cluster/keyFieldForType'](type)
-                // - id value = new dashboard-store getter, overwritten by steve store getter
-                requestData.forEach((item) => {
-                  // if there's already a prop type, don't overwrite it without storing it first...
-                  // only do this operation once in multiple apply's because the requestData is the same!
-                  if (item.type && !item._type) {
-                    item._type = item.type;
-                  }
-                  item.type = type;
-                  item.id = `${ item.metadata.namespace }/${ item.metadata.name }`;
-                });
-              }
 
               if (apply.classify) {
                 resources = await this.$store.dispatch('cluster/createMany', requestData);

--- a/shell/mixins/resource-manager.js
+++ b/shell/mixins/resource-manager.js
@@ -35,11 +35,7 @@ export default {
           let url = schema.links.collection;
 
           if (schema?.attributes?.namespaced && namespace) {
-            const parts = url.split('/');
-
-            parts.splice(parts.length - 2, 0, `api`);
-            parts.splice(parts.length - 1, 0, `namespaces/${ namespace }`);
-            url = parts.join('/');
+            url = `${ url }/${ namespace }`;
           } else if (onlyNamespaced) {
             // Type isn't namespaced and we've been requested to only fetch namespaced types
             return;


### PR DESCRIPTION
Fixes #7255 

- update url for namespaced requests for secondary data

NOTE: I have checked the original PR for changes/adaptations for k8s api data format and I cannot seem to find any changes to be reverted here. The ones I found are related to the fact that we don't `classify` the data by default, which, imo, we shouldn't. 🙏 

Original PR here: https://github.com/rancher/dashboard/pull/6860/files