### PR TITLE
Rollback options are timestamped in format from user preferences

### DIFF
--- a/shell/dialog/RollbackWorkloadDialog.vue
+++ b/shell/dialog/RollbackWorkloadDialog.vue
@@ -10,6 +10,8 @@ import { WORKLOAD_TYPES } from '@shell/config/types';
 import { diffFrom } from '@shell/utils/time';
 import { mapGetters } from 'vuex';
 import { ACTIVELY_REMOVE, NEVER_ADD } from '@shell/utils/create-yaml';
+import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
+import { escapeHtml } from '@shell/utils/string';
 
 const HIDE = [
   'metadata.labels.pod-template-hash',
@@ -99,7 +101,13 @@ export default {
     },
     sanitizedSelectedRevision() {
       return this.sanitizeYaml(this.selectedRevision);
-    }
+    },
+    timeFormatStr() {
+      const dateFormat = escapeHtml( this.$store.getters['prefs/get'](DATE_FORMAT));
+      const timeFormat = escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
+
+      return `${ dateFormat }, ${ timeFormat }`;
+    },
   },
   fetch() {
     // Fetch revisions of the current workload
@@ -161,14 +169,18 @@ export default {
       const isCurrentRevision = revisionNumber === this.currentRevisionNumber;
       const now = day();
       const createdDate = day(revision.metadata.creationTimestamp);
-      const revisionAge = diffFrom(createdDate, now, this.t);
-      const units = this.t(revisionAge.unitsKey, { count: revisionAge.label });
+      const createdDateFormatted = createdDate.format(this.timeFormatStr);
+
+      const revisionAgeObject = diffFrom(createdDate, now, this.t);
+      const revisionAge = `${ createdDateFormatted }, ${ revisionAgeObject.label }`;
+      const units = this.t(revisionAgeObject.unitsKey, { count: revisionAgeObject.label });
       const currentLabel = this.t('promptRollback.currentLabel');
+
       const optionLabel = this.t('promptRollback.revisionOption', {
         revisionNumber,
-        revisionAge:    revisionAge.label,
+        revisionAge,
         units,
-        currentLabel:   isCurrentRevision ? currentLabel : ''
+        currentLabel: isCurrentRevision ? currentLabel : ''
       });
 
       return {


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/6022

This PR adds the exact time of the revision creation to the dropdown menu for rolling back a workload.

To test this PR,

1. I created a Deployment
2. Went to Edit Config on the Deployment, changed the image pull policy, saved, and changed it back to create new revisions of the workload
3. From the Deployment list view, I went to the new Deployment and clicked **⋮ > Rollback**
4. Confirmed that the timestamp of each workload was in the format in the user preferences

<img width="868" alt="Screenshot 2022-11-08 at 6 47 22 PM" src="https://user-images.githubusercontent.com/20599230/200718294-12c47fb4-27a5-40a3-8b3a-c26aae2b683e.png">


6. Went to the user preferences
7. Changed the time format
8. Went back to rollback the workload again
9. Confirmed that the timestamps were updated to the new format in the user preferences 
<img width="814" alt="Screenshot 2022-11-08 at 6 48 04 PM" src="https://user-images.githubusercontent.com/20599230/200718357-c5526a2b-badf-4d2f-860b-3f410aa84b43.png">

