### PR TITLE
Show both internal and external IP in list of nodes

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4975,6 +4975,7 @@ tableHeaders:
   ingressTarget: Target
   internalExternalIp: External/Internal IP
   ipaddress: IP Address
+  internalIpSameAsExternal: Same as External
   jobs: Jobs
   key: Key
   keys: Data

--- a/shell/components/formatter/InternalExternalIP.vue
+++ b/shell/components/formatter/InternalExternalIP.vue
@@ -11,8 +11,8 @@ export default {
     },
   },
   computed: {
-    showBoth() {
-      return this.row.internalIp !== this.row.externalIp;
+    internalSameAsExternal() {
+      return this.row.internalIp === this.row.externalIp;
     },
     ...mapGetters({ t: 'i18n/t' })
   },
@@ -35,12 +35,15 @@ export default {
       />
     </template>
     <template v-else>
-      {{ t('generic.none') }}
+      -
     </template>
 
-    <template v-if="showBoth">
-      <template v-if="isIp(row.internalIp)">
-        / {{ row.internalIp }} <CopyToClipboard
+    <template>
+      <template v-if="isIp(row.internalIp) && internalSameAsExternal">
+        / {{ t('tableHeaders.internalIpSameAsExternal') }}
+      </template>
+      <template v-else-if="isIp(row.internalIp)">
+        /<CopyToClipboard
           label-as="tooltip"
           :text="row.internalIp"
           class="icon-btn"
@@ -48,7 +51,7 @@ export default {
         />
       </template>
       <template v-else>
-        {{ t('generic.none') }}
+        -
       </template>
     </template>
   </span>

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -23,6 +23,8 @@ export const DOWNLOAD = {
   align:         'right',
 };
 
+// This header is used for nodes in
+// both Cluster Explorer and Cluster Management.
 export const INTERNAL_EXTERNAL_IP = {
   // @TODO this is called internal/external but displays external/internal (╯°□°)╯︵ ┻━┻
   name:      'internal-external-ip',
@@ -934,10 +936,4 @@ export const FLEET_BUNDLE_TYPE = {
   value:    'bundleType',
   sort:     ['bundleType'],
   width:    100,
-};
-
-export const IP_ADDRESS = {
-  name:     'ipaddress',
-  value:    'ipaddress',
-  labelKey: 'tableHeaders.ipaddress',
 };

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -284,7 +284,8 @@ export const VIRTUAL_HARVESTER_PROVIDER = 'harvester';
 
 export const ADDRESSES = {
   HOSTNAME:    'Hostname',
-  INTERNAL_IP: 'InternalIP'
+  INTERNAL_IP: 'InternalIP',
+  EXTERNAL_IP: 'ExternalIP'
 };
 
 export const DEFAULT_WORKSPACE = 'fleet-default';

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -9,7 +9,7 @@ import Tab from '@shell/components/Tabbed/Tab';
 import { allHash } from '@shell/utils/promise';
 import { CAPI, MANAGEMENT, NORMAN, SNAPSHOT } from '@shell/config/types';
 import {
-  STATE, NAME as NAME_COL, AGE, AGE_NORMAN, STATE_NORMAN, ROLES, MACHINE_NODE_OS, MANAGEMENT_NODE_OS, NAME, IP_ADDRESS
+  STATE, NAME as NAME_COL, AGE, AGE_NORMAN, INTERNAL_EXTERNAL_IP, STATE_NORMAN, ROLES, MACHINE_NODE_OS, MANAGEMENT_NODE_OS, NAME,
 } from '@shell/config/table-headers';
 import CustomCommand from '@shell/edit/provisioning.cattle.io.cluster/CustomCommand';
 import AsyncButton from '@shell/components/AsyncButton.vue';
@@ -356,7 +356,7 @@ export default {
           formatterOpts: { reference: 'kubeNodeDetailLocation' },
           dashIfEmpty:   true,
         },
-        IP_ADDRESS,
+        INTERNAL_EXTERNAL_IP,
         MACHINE_NODE_OS,
         ROLES,
         AGE,
@@ -375,7 +375,7 @@ export default {
           formatterOpts: { reference: 'kubeNodeDetailLocation' },
           dashIfEmpty:   true,
         },
-        IP_ADDRESS,
+        INTERNAL_EXTERNAL_IP,
         MANAGEMENT_NODE_OS,
         ROLES,
         AGE

--- a/shell/models/cluster.x-k8s.io.machine.js
+++ b/shell/models/cluster.x-k8s.io.machine.js
@@ -242,7 +242,27 @@ export default class CapiMachine extends SteveModel {
     return this.status?.phase === 'Running';
   }
 
-  get ipaddress() {
-    return this.status?.addresses?.find(({ type }) => type === ADDRESSES.INTERNAL_IP)?.address || '-';
+  get internalIp() {
+    const internal = this.status?.addresses?.find(({ type }) => {
+      return type === ADDRESSES.INTERNAL_IP;
+    });
+
+    if (internal) {
+      return internal.address;
+    }
+
+    return this.t('generic.none');
+  }
+
+  get externalIp() {
+    const external = this.status?.addresses?.find(({ type }) => {
+      return type === ADDRESSES.EXTERNAL_IP;
+    });
+
+    if (external) {
+      return external.address;
+    }
+
+    return this.t('generic.none');
   }
 }


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/6371

This PR changes the "IP Address" column in the list of nodes for a cluster in Cluster Management.

Previously, it only checked for internal IPs. Now it uses the existing table header for showing both internal and external IPs, which matches the UX in Cluster Explorer on the Nodes page.

To test this PR,

1. I provisioned a single-node EC2 cluster
2. Logged into the EC2 console and checked the external IP of the new node
3. Confirmed that the external IP was shown in the list of cluster nodes

Then to make sure I didn't mess up the internal IP display,

1. I provisioned a single-node Digital Ocean cluster, for which an external IP is not available out-of-the-box
2. Confirmed that the internal IP was shown in the list of cluster nodes