### PR TITLE
Two Select Principal Fixes

### DIFF
--- a/shell/components/auth/SelectPrincipal.vue
+++ b/shell/components/auth/SelectPrincipal.vue
@@ -95,6 +95,11 @@ export default {
 
   methods: {
     add(id) {
+      if (!id) {
+        // Ignore attempts to select an invalid principal
+        return;
+      }
+
       this.$emit('add', id);
       if (!this.retainSelection) {
         this.newValue = '';

--- a/shell/list/group.principal.vue
+++ b/shell/list/group.principal.vue
@@ -126,6 +126,7 @@ export default {
           :waiting-label="t('authGroups.actions.refresh')"
           :success-label="t('authGroups.actions.refresh')"
           :error-label="t('authGroups.actions.refresh')"
+          :class="{'mr-5': canCreateGlobalRoleBinding}"
           @click="refreshGroupMemberships"
         />
         <n-link

--- a/shell/pages/c/_cluster/auth/group.principal/assign-edit.vue
+++ b/shell/pages/c/_cluster/auth/group.principal/assign-edit.vue
@@ -87,7 +87,7 @@ export default {
         </header>
       </div>
 
-      <form>
+      <form onsubmit="return false;">
         <SelectPrincipal :retain-selection="true" class="mb-20" :show-my-group-types="['group']" :search-group-types="'group'" @add="setPrincipal" />
 
         <GlobalRoleBindings


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #3182


### Occurred changes and/or fixed issues
- Ensure invalid principals aren't selected on press of `return`
  - Most evident on `Users & Authentication` --> `Auth Provider` (after enabling a provider like github and changing from the default value for `Configure who should be able to login and use Rancher - see issue for screenshots)
- On `Users & Authentication` --> `Groups` --> `Create` page ensure page doesn't reload on press of `return`

Also fixed spacing of `Refresh Group Memberships` and `Assign Global Roles` buttons on `Groups` page

### Technical notes summary
- Principals can be tested by configuring the github auth provider (they map to github groups)

### Areas or cases that should be tested
- `Users & Authentication` --> `Groups` --> `Create`

### Areas which could experience regressions
- Anywhere groups can be assigned to roles (cluster members, project members, global roles and auth provider config from above)

