### PR TITLE
Improve spacing/wiggle on Login Page

### DIFF
--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -168,6 +168,10 @@ export default {
       return "kubectl get secret --namespace cattle-system bootstrap-secret -o go-template='{{.data.bootstrapPassword|base64decode}}{{\"\\n\"}}'";
     },
 
+    hasLoginMessage() {
+      return this.errorToDisplay || this.loggedOut || this.timedOut;
+    }
+
   },
 
   created() {
@@ -290,10 +294,13 @@ export default {
         <p class="text-center">
           {{ t('login.howdy') }}
         </p>
-        <h1 class="text-center">
+        <h1 class="text-center login-welcome">
           {{ t('login.welcome', {vendor}) }}
         </h1>
-        <div class="login-messages">
+        <div
+          class="login-messages"
+          :class="{'login-messages--hasContent': hasLoginMessage}"
+        >
           <Banner
             v-if="errorToDisplay"
             :label="errorToDisplay"
@@ -372,7 +379,7 @@ export default {
 
         <div
           v-if="(!hasLocal || (hasLocal && !showLocal)) && providers.length"
-          class="mt-30"
+          :class="{'mt-30': !hasLoginMessage}"
         >
           <component
             :is="providerComponents[idx]"
@@ -388,7 +395,7 @@ export default {
         <template v-if="hasLocal">
           <form
             v-if="showLocal"
-            class="mt-40"
+            :class="{'mt-30': !hasLoginMessage}"
           >
             <div class="span-6 offset-3">
               <div class="mb-20">
@@ -488,6 +495,24 @@ export default {
       height: 100vh;
       margin: 0;
       object-fit: cover;
+    }
+
+    .login-welcome {
+      margin: 0
+    }
+
+    .login-messages {
+      align-items: center;
+
+      .banner {
+        margin: 5px;
+      }
+      h4 {
+        margin: 0;
+      }
+      &--hasContent {
+        min-height: 70px;
+      }
     }
 
     .login-messages, .first-login-message {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #4202

### Occurred changes and/or fixed issues
- After logging out / timeout and then entering bad creds there's now no vertical wiggle
  - I gave a quick look at resolving the wiggle when there's no intial error, but it left too much space to look pleasing
- Improved the general vertical spacing

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
- Local Auth Provider
- Other auth provider (such as Github)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
![image](https://user-images.githubusercontent.com/18697775/200914913-12e82b45-f93e-44c1-adf3-a21cea68a60a.png)

![image](https://user-images.githubusercontent.com/18697775/200914973-20595ef3-2659-497c-82b4-fb664ca70405.png)

![image](https://user-images.githubusercontent.com/18697775/200915037-66f0f3c5-9996-44f2-a1a7-620150186f1b.png)

![image](https://user-images.githubusercontent.com/18697775/200915077-099c8e26-9433-434d-989c-cd7e1efb68a3.png)

![image](https://user-images.githubusercontent.com/18697775/200915660-fb9480c3-12f2-4882-aa9e-bed28b8ff658.png)

![image](https://user-images.githubusercontent.com/18697775/200915717-2e406d63-58a9-4a9b-91b4-835e43d503e1.png)

![image](https://user-images.githubusercontent.com/18697775/200916586-9d5dda58-afaf-4d11-b57c-5c82da0c1416.png)

