### PR TITLE
StringList - Commit changes when losing focus

### DIFF
--- a/pkg/rancher-components/src/components/StringList/StringList.vue
+++ b/pkg/rancher-components/src/components/StringList/StringList.vue
@@ -129,7 +129,7 @@ export default Vue.extend({
     },
 
     onSelect(item: string) {
-      if (this.isCreateItem || this.editedItem === item) {
+      if (this.readonly || this.isCreateItem || this.editedItem === item) {
         return;
       }
       this.selected = item;
@@ -251,6 +251,9 @@ export default Vue.extend({
      * Show/Hide the input line to create new item
      */
     toggleCreateMode(show: boolean) {
+      if (this.readonly) {
+        return;
+      }
       if (show) {
         this.value = '';
 
@@ -269,6 +272,9 @@ export default Vue.extend({
      * Show/Hide the in-line editing to edit an existing item
      */
     toggleEditMode(show: boolean, item?: string) {
+      if (this.readonly) {
+        return;
+      }
       if (show) {
         this.toggleCreateMode(false);
         this.value = this.editedItem;

--- a/pkg/rancher-components/src/components/StringList/StringList.vue
+++ b/pkg/rancher-components/src/components/StringList/StringList.vue
@@ -87,7 +87,7 @@ export default Vue.extend({
     return {
       value:             null as string | null,
       selected:          null as string | null,
-      isEditItem:        null as string | null,
+      editedItem:        null as string | null,
       isCreateItem:      false,
       errors:            { duplicate: false } as Record<Error, boolean>
     };
@@ -100,7 +100,7 @@ export default Vue.extend({
      */
     errorMessagesArray(): string[] {
       return (Object.keys(this.errors) as Error[])
-        .filter(f => !!(this.errors)[f])
+        .filter(f => this.errors[f] && this.errorMessages[f])
         .map(k => this.errorMessages[k]);
     },
   },
@@ -129,7 +129,7 @@ export default Vue.extend({
     },
 
     onSelect(item: string) {
-      if (this.isCreateItem || this.isEditItem === item) {
+      if (this.isCreateItem || this.editedItem === item) {
         return;
       }
       this.selected = item;
@@ -160,7 +160,7 @@ export default Vue.extend({
     },
 
     onClickEmptyBody() {
-      if (!this.isCreateItem && !this.isEditItem) {
+      if (!this.isCreateItem && !this.editedItem) {
         this.toggleCreateMode(true);
       }
     },
@@ -176,7 +176,7 @@ export default Vue.extend({
 
         return;
       }
-      if (this.isEditItem) {
+      if (this.editedItem) {
         this.toggleEditMode(false);
 
         return;
@@ -229,6 +229,7 @@ export default Vue.extend({
      */
     toggleError(type: Error, val: boolean, refId?: string) {
       this.errors[type] = val;
+
       if (refId) {
         this.toggleErrorClass(refId, val);
       }
@@ -270,16 +271,16 @@ export default Vue.extend({
     toggleEditMode(show: boolean, item?: string) {
       if (show) {
         this.toggleCreateMode(false);
-        this.value = this.isEditItem;
+        this.value = this.editedItem;
 
-        this.isEditItem = item || '';
+        this.editedItem = item || '';
         this.setFocus(INPUT.edit);
       } else {
         this.value = null;
         this.toggleError('duplicate', false);
         this.onSelectLeave();
 
-        this.isEditItem = null;
+        this.editedItem = null;
       }
     },
 
@@ -387,13 +388,13 @@ export default Vue.extend({
         @blur="onSelectLeave(item)"
       >
         <span
-          v-if="!isEditItem || isEditItem !== item"
+          v-if="!editedItem || editedItem !== item"
           class="label static"
         >
           {{ item }}
         </span>
         <LabeledInput
-          v-if="isEditItem && isEditItem === item"
+          v-if="editedItem && editedItem === item"
           ref="item-edit"
           class="edit-input static"
           :value="value != null ? value : item"
@@ -428,7 +429,7 @@ export default Vue.extend({
       >
         <button
           class="btn btn-sm role-tertiary remove-button"
-          :disabled="!selected && !isCreateItem && !isEditItem"
+          :disabled="!selected && !isCreateItem && !editedItem"
           @mousedown.prevent="onClickMinusButton"
         >
           <span class="icon icon-minus icon-sm" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes [#3369](https://github.com/rancher-sandbox/rancher-desktop/issues/3369)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Fixes #7392
Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/3373 (duplicate)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The list of items editing has changed (both create and edit mode):

- Items are saved when losing focus or when pressing Enter key.
- when there is a duplicate and focus is lost, input field is closed and the item is not saved.
- when there is a duplicate and Enter key is pressed, nothing happens.
- a new event `errors` is emitted when there is an error. We have only a `duplicate` error for the moment.
- duplicate error messages are displayed during user's typing.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
StringList