### PR TITLE
Fix initial display of table bulk actions

### DIFF
--- a/shell/components/SortableTable/actions.js
+++ b/shell/components/SortableTable/actions.js
@@ -13,6 +13,8 @@ export default {
       bulkActionAvailabilityClass: 'action-availability',
 
       hiddenActions: [],
+
+      updateHiddenBulkActions: debounce(this.protectedUpdateHiddenBulkActions, 10)
     };
   },
 
@@ -79,7 +81,7 @@ export default {
     /**
      * Determine if any actions wrap over to a new line, if so group them into a dropdown instead
      */
-    updateHiddenBulkActions: debounce(function() {
+    protectedUpdateHiddenBulkActions() {
       if (!this.$refs.container) {
         return;
       }
@@ -146,6 +148,6 @@ export default {
       if (!showActionsDropdown) {
         actionsDropdown.style.display = 'none';
       }
-    }, 10)
+    }
   }
 };

--- a/shell/components/SortableTable/selection.js
+++ b/shell/components/SortableTable/selection.js
@@ -547,14 +547,14 @@ function _add(map, act, incrementCounts = true) {
     obj.allEnabled = false;
   }
 
-  if ( act.enabled === false ) {
+  if ( !act.enabled ) {
     obj.allEnabled = false;
   } else {
     obj.anyEnabled = true;
   }
 
   if ( incrementCounts ) {
-    obj.available = (obj.available || 0) + (act.enabled === false ? 0 : 1 );
+    obj.available = (obj.available || 0) + (!act.enabled ? 0 : 1 );
     obj.total = (obj.total || 0) + 1;
   }
 


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7421


### Occurred changes and/or fixed issues
Issue 1
- When there are multiple instances of the table the bulk actions weren't initially visible
- Caused by the `debounce` definition shared between different instances of the table 

Takeaway - `debounce` should not be used on Vue component methods (but created as part of the `data` method)

Issue 2
- K3s cluster nodes list would initially show 'delete' action and then magically disappear
- Caused by mgmt node model canDelete returning undefined instead of false (due to missing norman node which is letter there)
- The check to then show the actions only checked for `false` rather than a falsey
- Once the norman node was supplied undefined became false, so was correctly excluded
- This would affect anywhere canDelete/canUpdate returns an undefined instead of false (happens a lot around nodes, pools and machines)

Takeaway - We need typescript

### Areas or cases that should be tested
- Cluster Machine Pool page (rke2 and other types of clusters)

### Screenshot/Video
- See issue