### PR TITLE
Don't change zube status for draft PRs

### DIFF
--- a/.github/workflows/scripts/pr.js
+++ b/.github/workflows/scripts/pr.js
@@ -199,6 +199,8 @@ async function processOpenOrEditAction() {
         console.log("+ This PR does not fix any issues");
     }
 
+    console.log(JSON.stringify(body, null, 2));
+
     const milestones = {};
 
     for (i of issues) {

--- a/.github/workflows/scripts/pr.js
+++ b/.github/workflows/scripts/pr.js
@@ -191,7 +191,8 @@ async function processOpenOrEditAction() {
     console.log('Processing Opened/Edited PR #' + event.pull_request.number + ' : ' + event.pull_request.title);
     console.log('======');
 
-    const body = event.pull_request.body;
+    const pr = event.pull_request;
+    const body = pr.body;
     const issues = getReferencedIssues(body);
     if (issues.length > 0) {
         console.log('+ This PR fixes issues: #' + issues.join(', '));
@@ -207,7 +208,10 @@ async function processOpenOrEditAction() {
       console.log('')
       console.log('Processing Issue #' + i + ' - ' + iss.title);
 
-      if (hasLabel(iss, BACKEND_BLOCKED_LABEL)) {
+
+      if (pr.draft) {
+        console.log('    Issue will not be moved to In Review (Draft PR)');
+      } else if (hasLabel(iss, BACKEND_BLOCKED_LABEL)) {
         console.log('    Issue will not be moved to In Review (Backend Blocked)');
       } else {
         if (!hasLabel(iss, IN_REVIEW_LABEL)) {

--- a/.github/workflows/scripts/pr.js
+++ b/.github/workflows/scripts/pr.js
@@ -199,8 +199,6 @@ async function processOpenOrEditAction() {
         console.log("+ This PR does not fix any issues");
     }
 
-    console.log(JSON.stringify(body, null, 2));
-
     const milestones = {};
 
     for (i of issues) {
@@ -244,7 +242,7 @@ async function processOpenOrEditAction() {
 }
 
 // Debugging
-// console.log(JSON.stringify(event, null, 2));
+console.log(JSON.stringify(event, null, 2));
 
 // Look at the action
 if (event.action === 'opened' || event.action === 'reopened') {

--- a/.github/workflows/scripts/pr.js
+++ b/.github/workflows/scripts/pr.js
@@ -208,7 +208,6 @@ async function processOpenOrEditAction() {
       console.log('')
       console.log('Processing Issue #' + i + ' - ' + iss.title);
 
-
       if (pr.draft) {
         console.log('    Issue will not be moved to In Review (Draft PR)');
       } else if (hasLabel(iss, BACKEND_BLOCKED_LABEL)) {
@@ -246,7 +245,7 @@ async function processOpenOrEditAction() {
 }
 
 // Debugging
-console.log(JSON.stringify(event, null, 2));
+// console.log(JSON.stringify(event, null, 2));
 
 // Look at the action
 if (event.action === 'opened' || event.action === 'reopened') {


### PR DESCRIPTION
Fixes #7167 

Updates PR script to not change Zube status of draft PRs.