### PR TITLE
Fix vertical alignment of fail-whale page

### DIFF
--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -95,6 +95,10 @@ export default {
 
 <style lang="scss" scoped>
   .error {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    justify-content: center;
     overflow: hidden;
 
     .row {


### PR DESCRIPTION
Fixes #7099

Changes vertical alignment of fail whale page so that it is vertically centered:

![image](https://user-images.githubusercontent.com/1955897/201662155-5f0cad50-f0e1-4fd9-9e02-f87ef72a4e4e.png)
