### PR TITLE
get docs base url version from getVersionInfo

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3089,7 +3089,7 @@ monitoring:
       stepTitle: Uninstall V1
       stepSubtext: Uninstall Previous Monitoring
       warning1: V1 Monitoring is currently deployed. This needs to be uninstalled before V2 monitoring can be installed.
-      warning2: <a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
+      warning2: <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
       promptDescription: <div class="mt-20 mb-20">You are attempting to uninstall V1 Monitoring. Please ensure you have read the migration steps.</div>
       success1: V1 monitoring successfully uninstalled.
       success2: Press Next to continue
@@ -6958,13 +6958,13 @@ embedding:
 v1ClusterTools:
   monitoring:
     label: Monitoring (Legacy)
-    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">Learn more</a> about the migration steps to V2 Monitoring.'
+    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">Learn more</a> about the migration steps to V2 Monitoring.'
   logging:
     label: Logging (Legacy)
-    description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">Learn more</a> about migrating to V2 Logging.'
+    description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">Learn more</a> about migrating to V2 Logging.'
   istio:
     label: Istio (Legacy)
-    description: 'Legacy V1 Istio. Istio v1.5 has been deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/pages-for-subheaders/istio#migrate-from-previous-istio-version">Learn more</a> about migrating to the latest version.'
+    description: 'Legacy V1 Istio. Istio v1.5 has been deprecated since Rancher 2.5.0. <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/pages-for-subheaders/istio#migrate-from-previous-istio-version">Learn more</a> about migrating to the latest version.'
 
 legacy:
   alerts: Alerts

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3089,7 +3089,7 @@ monitoring:
       stepTitle: Uninstall V1
       stepSubtext: Uninstall Previous Monitoring
       warning1: V1 Monitoring is currently deployed. This needs to be uninstalled before V2 monitoring can be installed.
-      warning2: <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
+      warning2: <a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
       promptDescription: <div class="mt-20 mb-20">You are attempting to uninstall V1 Monitoring. Please ensure you have read the migration steps.</div>
       success1: V1 monitoring successfully uninstalled.
       success2: Press Next to continue
@@ -6958,13 +6958,13 @@ embedding:
 v1ClusterTools:
   monitoring:
     label: Monitoring (Legacy)
-    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">Learn more</a> about the migration steps to V2 Monitoring.'
+    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">Learn more</a> about the migration steps to V2 Monitoring.'
   logging:
     label: Logging (Legacy)
-    description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">Learn more</a> about migrating to V2 Logging.'
+    description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">Learn more</a> about migrating to V2 Logging.'
   istio:
     label: Istio (Legacy)
-    description: 'Legacy V1 Istio. Istio v1.5 has been deprecated since Rancher 2.5.0. <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/pages-for-subheaders/istio#migrate-from-previous-istio-version">Learn more</a> about migrating to the latest version.'
+    description: 'Legacy V1 Istio. Istio v1.5 has been deprecated since Rancher 2.5.0. <a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/pages-for-subheaders/istio#migrate-from-previous-istio-version">Learn more</a> about migrating to the latest version.'
 
 legacy:
   alerts: Alerts

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -416,7 +416,7 @@ authConfig:
           5: 'Upload the downloaded JSON file in the OAuth credentials box.'
       3:
         title: 'Create Service Account credentials'
-        introduction: 'Follow <a href="{docsBase}/admin-settings/authentication/google/#3-creating-service-account-credentials" target="_blank" rel="noopener noreferrer nofollow">this</a> guide to:'
+        introduction: 'Follow <a href="{docsBase}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-google-oauth#3-creating-service-account-credentials" target="_blank" rel="noopener noreferrer nofollow">this</a> guide to:'
         body:
           1: Create a service account.
           2: Generate a key for the service account.
@@ -1011,7 +1011,7 @@ cis:
   alertNeeded: |-
     Alerting must be enabled within the CIS chart values.yaml.
     This requires that the <a tabindex="0" href="{link}">{vendor} Monitoring and Alerting app</a> is installed
-    and the Receivers and Routes are <a target="_blank" rel='noopener noreferrer nofollow' href='{docsBase}/monitoring-alerting/configuration/#alertmanager-configuration/'> configured to send out alerts.</a>
+    and the Receivers and Routes are <a target="_blank" rel='noopener noreferrer nofollow' href='{docsBase}/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/alertmanager'> configured to send out alerts.</a>
   alertOnComplete: Alert on scan completion
   alertOnFailure: Alert on scan failure
   benchmarkVersion: Benchmark Version
@@ -1560,7 +1560,7 @@ cluster:
   banner:
     warning: 'This cluster contains a machineSelectorConfig which this form does not fully support; use the YAML editor to manage the full configuration.'
     os: 'You are attemping to add a {newOS} worker node to a cluster with one or more {existingOS} worker nodes: some installed apps may need to be upgraded or removed.'
-    rke2-k3-reprovisioning: 'Making changes to cluster configuration may result in nodes reprovisioning. For more information see the <a target="blank" href="{docsBase}/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/" target="_blank" rel="noopener nofollow">documentation</a>.'
+    rke2-k3-reprovisioning: 'Making changes to cluster configuration may result in nodes reprovisioning. For more information see the <a target="blank" href="{docsBase}/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences" target="_blank" rel="noopener nofollow">documentation</a>.'
     desiredNodeGroupWarning: There are 0 nodes available to run the cluster agent. The cluster will not become active until at least one node is available.
 
   rkeTemplateUpgrade: Template revision {name} available for upgrade
@@ -3032,7 +3032,7 @@ monitoring:
       keyFilePath:
         label: Key File Path
         placeholder: e.g. ./key-file.pfx
-      secretsBanner: The file paths below must be referenced in <pre class="inline-block m-0 p-0 vertical-middle">alertmanager.alertmanagerSpec.secrets</pre> when deploying the Monitoring chart. For more information see our <a href="{docsBase}/monitoring-alerting/" target="_blank" rel="noopener noreferrer nofollow">documentation</a>.
+      secretsBanner: The file paths below must be referenced in <pre class="inline-block m-0 p-0 vertical-middle">alertmanager.alertmanagerSpec.secrets</pre> when deploying the Monitoring chart. For more information see our <a href="{docsBase}/pages-for-subheaders/monitoring-v2-configuration" target="_blank" rel="noopener noreferrer nofollow">documentation</a>.
   projectMonitoring:
     detail:
       error: "Unable to fetch Dashboard values with status: "
@@ -3089,7 +3089,7 @@ monitoring:
       stepTitle: Uninstall V1
       stepSubtext: Uninstall Previous Monitoring
       warning1: V1 Monitoring is currently deployed. This needs to be uninstalled before V2 monitoring can be installed.
-      warning2: <a target="blank" href="{docsBase}/monitoring-alerting/guides/migrating/" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
+      warning2: <a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>Learn more</a> about the migration steps to V2 Monitoring.
       promptDescription: <div class="mt-20 mb-20">You are attempting to uninstall V1 Monitoring. Please ensure you have read the migration steps.</div>
       success1: V1 monitoring successfully uninstalled.
       success2: Press Next to continue
@@ -6958,13 +6958,13 @@ embedding:
 v1ClusterTools:
   monitoring:
     label: Monitoring (Legacy)
-    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/monitoring-alerting/guides/migrating/">Learn more</a> about the migration steps to V2 Monitoring.'
+    description: 'Legacy V1 monitoring. V1 Monitoring is deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">Learn more</a> about the migration steps to V2 Monitoring.'
   logging:
     label: Logging (Legacy)
-    description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/logging/migrating/">Learn more</a> about migrating to V2 Logging.'
+    description: 'Legacy V1 logging. V1 Logging is deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">Learn more</a> about migrating to V2 Logging.'
   istio:
     label: Istio (Legacy)
-    description: 'Legacy V1 Istio. Istio v1.5 has been deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/istio/#migrate-from-previous-istio-version">Learn more</a> about migrating to the latest version.'
+    description: 'Legacy V1 Istio. Istio v1.5 has been deprecated since Rancher 2.5.0. <a target="blank" href="{docsBase}/pages-for-subheaders/istio#migrate-from-previous-istio-version">Learn more</a> about migrating to the latest version.'
 
 legacy:
   alerts: Alerts

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -407,7 +407,7 @@ authConfig:
           5: '在 OAuth 凭证框中，上传下载的 JSON 文件。'
       3:
         title: '创建 Service Account 凭证'
-        introduction: '参照本<a href="{docsBase}/admin-settings/authentication/google/#3-creating-service-account-credentials" target="_blank" rel="noopener noreferrer nofollow">指南</a>：'
+        introduction: '参照本<a href="{docsBase}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-google-oauth#3-creating-service-account-credentials" target="_blank" rel="noopener noreferrer nofollow">指南</a>：'
         body:
           1: 创建一个 Service Account。
           2: 为这个 Service Account 生成密钥。
@@ -1009,7 +1009,7 @@ cis:
   alertNeeded: |-
     必须在 CIS Chart values.yaml 中开启告警。
     这要求<a tabindex="0" href="{link}"> {vendor} 的 Monitoring 与 Alerting 应用</a>已经安装
-    ，而且接收器和路由<a target="_blank" rel='noopener noreferrer nofollow' href='{docsBase}/monitoring-alerting/configuration/#alertmanager-configuration/'>已配置告警发送</a>。
+    ，而且接收器和路由<a target="_blank" rel='noopener noreferrer nofollow' href='{docsBase}/how-to-guides/advanced-user-guides/monitoring-v2-configuration-guides/advanced-configuration/alertmanager'>已配置告警发送</a>。
   alertOnComplete: 扫描完成告警
   alertOnFailure: 扫描失败告警
   benchmarkVersion: Benchmark 版本
@@ -1559,7 +1559,7 @@ cluster:
   banner:
     warning: '此集群包含此表单不完全支持的 machineSelectorConfig。使用 YAML 编辑器管理完整配置。'
     os: '你正在将 {newOS} worker 节点添加到具有一个或多个 {existingOS} worker 节点的集群。你可能需要升级或删除某些已安装的应用。'
-    rke2-k3-reprovisioning: '更改集群配置可能导致节点重新配置。详情请参见 <a target="blank" href="{docsBase}/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/" target="_blank" rel="noopener nofollow">文档</a>。'
+    rke2-k3-reprovisioning: '更改集群配置可能导致节点重新配置。详情请参见 <a target="blank" href="{docsBase}/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences" target="_blank" rel="noopener nofollow">文档</a>。'
     desiredNodeGroupWarning: 没有可用于运行 Cluster Agent 的节点。要让集群变为 Active 状态，至少需要有 1 个可用的节点。
 
   rkeTemplateUpgrade: 模板修订版 {name} 可用于升级
@@ -3034,7 +3034,7 @@ monitoring:
       keyFilePath:
         label: 密钥文件路径
         placeholder: 例如：./key-file.pfx
-      secretsBanner: 部署 Monitoring Chart 时，必须在<<pre class="inline-block m-0 p-0 vertical-middle">alertmanager.alertmanagerSpec.secrets</pre>中引用以下文件路径。详情请查看<a href="{docsBase}/monitoring-alerting/" target="_blank" rel="noopener noreferrer nofollow">官方文档</a>。
+      secretsBanner: 部署 Monitoring Chart 时，必须在<<pre class="inline-block m-0 p-0 vertical-middle">alertmanager.alertmanagerSpec.secrets</pre>中引用以下文件路径。详情请查看<a href="{docsBase}/pages-for-subheaders/monitoring-v2-configuration" target="_blank" rel="noopener noreferrer nofollow">官方文档</a>。
   projectMonitoring:
     detail:
       error: "无法获取具有状态的仪表板值： "
@@ -3091,7 +3091,7 @@ monitoring:
       stepTitle: 卸载 V1
       stepSubtext: 卸载旧版 Monitoring
       warning1: 已部署 Monitoring V1。你需要先卸载 Monitoring V1 才能安装 Monitoring V2。
-      warning2: <a target="blank" href="{docsBase}/monitoring-alerting/guides/migrating/" target='_blank' rel='noopener nofollow'>了解迁移到 Monitoring V2 的步骤</a>。
+      warning2: <a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>了解迁移到 Monitoring V2 的步骤</a>。
       promptDescription: <div class="mt-20 mb-20">你正在尝试卸载 Monitoring V1。请确保你已阅读迁移步骤。</div>
       success1:  Monitoring V1 已成功卸载。
       success2: 点击下一步继续
@@ -6715,13 +6715,13 @@ embedding:
 v1ClusterTools:
   monitoring:
     label: Monitoring（旧版）
-    description: '旧版 Monitoring V1。自 Rancher 2.5.0 起，我们已弃用 Monitoring V1。了解<a target="blank" href="{docsBase}/monitoring-alerting/guides/migrating/">迁移到 Monitoring V2 的步骤</a>。'
+    description: '旧版 Monitoring V1。自 Rancher 2.5.0 起，我们已弃用 Monitoring V1。了解<a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">迁移到 Monitoring V2 的步骤</a>。'
   logging:
     label: Logging（旧版）
-    description: '旧版 Logging V1。自 Rancher 2.5.0 起，我们已弃用 Logging V1。了解<a target="blank" href="{docsBase}/logging/migrating/">迁移到 Logging V2 的步骤</a>。'
+    description: '旧版 Logging V1。自 Rancher 2.5.0 起，我们已弃用 Logging V1。了解<a target="blank" href="{docsBase}/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">迁移到 Logging V2 的步骤</a>。'
   istio:
     label: Istio（旧版）
-    description: '旧版 Istio V1。自 Rancher 2.5.0 起，我们已弃用 Istio V1.5。了解<a target="blank" href="{docsBase}/istio/#migrate-from-previous-istio-version">迁移到最新版本</a> 的更多信息。'
+    description: '旧版 Istio V1。自 Rancher 2.5.0 起，我们已弃用 Istio V1.5。了解<a target="blank" href="{docsBase}/pages-for-subheaders/istio#migrate-from-previous-istio-version">迁移到最新版本</a> 的更多信息。'
 
 legacy:
   alerts: 告警

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -3091,7 +3091,7 @@ monitoring:
       stepTitle: 卸载 V1
       stepSubtext: 卸载旧版 Monitoring
       warning1: 已部署 Monitoring V1。你需要先卸载 Monitoring V1 才能安装 Monitoring V2。
-      warning2: <a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>了解迁移到 Monitoring V2 的步骤</a>。
+      warning2: <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>了解迁移到 Monitoring V2 的步骤</a>。
       promptDescription: <div class="mt-20 mb-20">你正在尝试卸载 Monitoring V1。请确保你已阅读迁移步骤。</div>
       success1:  Monitoring V1 已成功卸载。
       success2: 点击下一步继续
@@ -6715,13 +6715,13 @@ embedding:
 v1ClusterTools:
   monitoring:
     label: Monitoring（旧版）
-    description: '旧版 Monitoring V1。自 Rancher 2.5.0 起，我们已弃用 Monitoring V1。了解<a target="blank" href="{docsBase}/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">迁移到 Monitoring V2 的步骤</a>。'
+    description: '旧版 Monitoring V1。自 Rancher 2.5.0 起，我们已弃用 Monitoring V1。了解<a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">迁移到 Monitoring V2 的步骤</a>。'
   logging:
     label: Logging（旧版）
-    description: '旧版 Logging V1。自 Rancher 2.5.0 起，我们已弃用 Logging V1。了解<a target="blank" href="{docsBase}/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">迁移到 Logging V2 的步骤</a>。'
+    description: '旧版 Logging V1。自 Rancher 2.5.0 起，我们已弃用 Logging V1。了解<a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">迁移到 Logging V2 的步骤</a>。'
   istio:
     label: Istio（旧版）
-    description: '旧版 Istio V1。自 Rancher 2.5.0 起，我们已弃用 Istio V1.5。了解<a target="blank" href="{docsBase}/pages-for-subheaders/istio#migrate-from-previous-istio-version">迁移到最新版本</a> 的更多信息。'
+    description: '旧版 Istio V1。自 Rancher 2.5.0 起，我们已弃用 Istio V1.5。了解<a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/pages-for-subheaders/istio#migrate-from-previous-istio-version">迁移到最新版本</a> 的更多信息。'
 
 legacy:
   alerts: 告警

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -3091,7 +3091,7 @@ monitoring:
       stepTitle: 卸载 V1
       stepSubtext: 卸载旧版 Monitoring
       warning1: 已部署 Monitoring V1。你需要先卸载 Monitoring V1 才能安装 Monitoring V2。
-      warning2: <a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>了解迁移到 Monitoring V2 的步骤</a>。
+      warning2: <a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2" target='_blank' rel='noopener nofollow'>了解迁移到 Monitoring V2 的步骤</a>。
       promptDescription: <div class="mt-20 mb-20">你正在尝试卸载 Monitoring V1。请确保你已阅读迁移步骤。</div>
       success1:  Monitoring V1 已成功卸载。
       success2: 点击下一步继续
@@ -6715,13 +6715,13 @@ embedding:
 v1ClusterTools:
   monitoring:
     label: Monitoring（旧版）
-    description: '旧版 Monitoring V1。自 Rancher 2.5.0 起，我们已弃用 Monitoring V1。了解<a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">迁移到 Monitoring V2 的步骤</a>。'
+    description: '旧版 Monitoring V1。自 Rancher 2.5.0 起，我们已弃用 Monitoring V1。了解<a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/how-to-guides/advanced-user-guides/monitoring-alerting-guides/migrate-to-rancher-v2.5+-monitoring#migrating-from-monitoring-v1-to-monitoring-v2">迁移到 Monitoring V2 的步骤</a>。'
   logging:
     label: Logging（旧版）
-    description: '旧版 Logging V1。自 Rancher 2.5.0 起，我们已弃用 Logging V1。了解<a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">迁移到 Logging V2 的步骤</a>。'
+    description: '旧版 Logging V1。自 Rancher 2.5.0 起，我们已弃用 Logging V1。了解<a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/integrations-in-rancher/logging/migrate-to-rancher-v2.5+-logging">迁移到 Logging V2 的步骤</a>。'
   istio:
     label: Istio（旧版）
-    description: '旧版 Istio V1。自 Rancher 2.5.0 起，我们已弃用 Istio V1.5。了解<a target="blank" href="https://docs.ranchermanager.rancher.io/v2.6/pages-for-subheaders/istio#migrate-from-previous-istio-version">迁移到最新版本</a> 的更多信息。'
+    description: '旧版 Istio V1。自 Rancher 2.5.0 起，我们已弃用 Istio V1.5。了解<a target="blank" href="https://ranchermanager.docs.rancher.com/v2.6/pages-for-subheaders/istio#migrate-from-previous-istio-version">迁移到最新版本</a> 的更多信息。'
 
 legacy:
   alerts: 告警

--- a/shell/chart/monitoring/steps/uninstall-v1.vue
+++ b/shell/chart/monitoring/steps/uninstall-v1.vue
@@ -3,6 +3,7 @@
 import { haveV1Monitoring, haveV1MonitoringWorkloads } from '@shell/utils/monitoring';
 import AsyncButton from '@shell/components/AsyncButton';
 import IconMessage from '@shell/components/IconMessage';
+import { mapGetters } from 'vuex';
 
 function delay(t, v) {
   return new Promise((resolve) => {
@@ -36,6 +37,8 @@ export default {
       hidden:  !this.haveV1Monitoring,
     });
   },
+
+  computed: { ...mapGetters({ rancherDocsBase: 'rancherDocsBase' }) },
 
   methods: {
     uninstall(buttonCb) {
@@ -89,7 +92,7 @@ export default {
           </p>
           <p
             class="mt-10"
-            v-html="t('monitoring.installSteps.uninstallV1.warning2', {}, true)"
+            v-html="t('monitoring.installSteps.uninstallV1.warning2', {docsBase: rancherDocsBase}, true)"
           />
         </template>
       </IconMessage>

--- a/shell/config/home-links.js
+++ b/shell/config/home-links.js
@@ -1,35 +1,6 @@
-import { DOCS_BASE } from '@shell/config/private-label';
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import { allHash } from '@shell/utils/promise';
-
-const DEFAULT_LINKS = [
-  {
-    key:     'docs',
-    value:   DOCS_BASE,
-    enabled: true,
-  },
-  {
-    key:     'forums',
-    value:   'https://forums.rancher.com/',
-    enabled: true,
-  },
-  {
-    key:     'slack',
-    value:   'https://slack.rancher.io/',
-    enabled: true,
-  },
-  {
-    key:     'issues',
-    value:   'https://github.com/rancher/dashboard/issues/new/choose',
-    enabled: true,
-  },
-  {
-    key:     'getStarted',
-    value:   '/docs/getting-started',
-    enabled: true,
-  },
-];
 
 const SUPPORT_LINK = {
   key:      'commercialSupport',
@@ -43,6 +14,33 @@ export const CUSTOM_LINKS_VERSION = 'v1';
 
 // Fetch the settings required for the links, taking into account legacy settings if we have not migrated
 export async function fetchLinks(store, hasSupport, isSupportPage, t) {
+  const DEFAULT_LINKS = [
+    {
+      key:     'docs',
+      value:   store.getters['rancherDocsBase'],
+      enabled: true,
+    },
+    {
+      key:     'forums',
+      value:   'https://forums.rancher.com/',
+      enabled: true,
+    },
+    {
+      key:     'slack',
+      value:   'https://slack.rancher.io/',
+      enabled: true,
+    },
+    {
+      key:     'issues',
+      value:   'https://github.com/rancher/dashboard/issues/new/choose',
+      enabled: true,
+    },
+    {
+      key:     'getStarted',
+      value:   '/docs/getting-started',
+      enabled: true,
+    },
+  ];
   let uiLinks = {};
 
   try {

--- a/shell/config/private-label.js
+++ b/shell/config/private-label.js
@@ -3,7 +3,6 @@ import { SETTING } from './settings';
 export const ANY = 0;
 export const STANDARD = 1;
 export const CUSTOM = 2;
-export const DOCS_BASE = 'https://rancher.com/docs/rancher/v2.7/en';
 
 const STANDARD_VENDOR = 'Rancher';
 const STANDARD_PRODUCT = 'Explorer';

--- a/shell/edit/auth/googleoauth.vue
+++ b/shell/edit/auth/googleoauth.vue
@@ -44,6 +44,7 @@ export default {
         serverUrl: this.serverUrl,
         provider:  this.displayName,
         username:  this.principal.loginName || this.principal.name,
+        docsBase:  this.$store.getters['rancherDocsBase']
       };
     },
 

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -84,7 +84,9 @@ export default {
   },
 
   computed: {
-    ...mapGetters({ currentCluster: 'currentCluster', t: 'i18n/t' }),
+    ...mapGetters({
+      currentCluster: 'currentCluster', t: 'i18n/t', rancherDocsBase: 'rancherDocsBase'
+    }),
 
     canBeScheduled() {
       // check if scan was created and run with an older cis install that doesn't support scheduling/alerting/warn state
@@ -174,7 +176,6 @@ export default {
 
       return !!this.value.spec.scanProfileName;
     }
-
   },
 
   watch: {
@@ -322,7 +323,7 @@ export default {
                 class="mt-0"
                 :color="hasAlertManager ? 'info' : 'warning'"
               >
-                <span v-html="t('cis.alertNeeded', {link: monitoringUrl}, true)" />
+                <span v-html="t('cis.alertNeeded', {link: monitoringUrl, docsBase: rancherDocsBase}, true)" />
               </banner>
               <Checkbox
                 v-model="scanAlertRule.alertOnComplete"

--- a/shell/edit/monitoring.coreos.com.receiver/tls.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/tls.vue
@@ -9,6 +9,7 @@
  */
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { Banner } from '@components/Banner';
+import { mapGetters } from 'vuex';
 
 export default {
   components: { Banner, LabeledInput },
@@ -27,6 +28,7 @@ export default {
 
     return {};
   },
+  computed: { ...mapGetters({ rancherDocsBase: 'rancherDocsBase' }) }
 };
 </script>
 
@@ -37,7 +39,7 @@ export default {
         <h3>{{ t('monitoring.receiver.tls.label') }}</h3>
         <Banner
           color="info"
-          v-html="t('monitoring.receiver.tls.secretsBanner', {}, true)"
+          v-html="t('monitoring.receiver.tls.secretsBanner', {docsBase: rancherDocsBase}, true)"
         />
       </div>
     </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -302,6 +302,7 @@ export default {
   computed: {
     ...mapGetters({ allCharts: 'catalog/charts' }),
     ...mapGetters({ features: 'features/get' }),
+    ...mapGetters({ rancherDocsBase: 'rancherDocsBase' }),
 
     PUBLIC:   () => PUBLIC,
     PRIVATE:  () => PRIVATE,
@@ -1689,7 +1690,7 @@ export default {
       v-if="isEdit"
       color="warning"
     >
-      <span v-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
+      <span v-html="t('cluster.banner.rke2-k3-reprovisioning', {docsBase: rancherDocsBase}, true)" />
     </Banner>
     <SelectCredential
       v-if="needCredential"

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -16,6 +16,7 @@ import { isDevBuild } from '@shell/utils/version';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import Password from '@shell/components/form/Password';
 import { applyProducts } from '@shell/store/type-map';
+import { mapGetters } from 'vuex';
 
 const calcIsFirstLogin = (store) => {
   const firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);
@@ -172,6 +173,7 @@ export default {
   },
 
   computed: {
+    ...mapGetters({ rancherDocsBase: 'rancherDocsBase' }),
     saveEnabled() {
       if ( !this.eula && this.isFirstLogin) {
         return false;
@@ -385,6 +387,7 @@ export default {
                     k="setup.telemetry"
                     :raw="true"
                     :name="productName"
+                    :docs-base="rancherDocsBase"
                   />
                 </template>
               </Checkbox>

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -76,6 +76,7 @@ export default {
     ...mapGetters(['currentCluster']),
     ...mapGetters({ allCharts: 'catalog/charts', loadingErrors: 'catalog/errors' }),
     ...mapGetters({ t: 'i18n/t' }),
+    ...mapGetters({ rancherDocsBase: 'rancherDocsBase' }),
 
     v1Apps() {
       return this.$store.getters['rancher/all'](NORMAN.APP);
@@ -177,7 +178,7 @@ export default {
       return {
         certifiedSort:    1,
         chartNameDisplay: this.t(`v1ClusterTools.${ id }.label`),
-        chartDescription: this.t(`v1ClusterTools.${ id }.description`),
+        chartDescription: this.t(`v1ClusterTools.${ id }.description`, { docsBase: this.rancherDocsBase }),
         id:               `v1-${ id }`,
         chartName:        `v1-${ id }`,
         key:              `v1-${ id }`,

--- a/shell/plugins/axios.js
+++ b/shell/plugins/axios.js
@@ -12,7 +12,7 @@ export default function({
   $axios.onRequest((config) => {
     const csrf = $cookies.get(CSRF, { parseJSON: false });
 
-    if ( csrf ) {
+    if ( csrf && !config.excludeCookies ) {
       config.headers['x-api-csrf'] = csrf;
     }
 

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -615,5 +615,26 @@ export default {
 
   gcResetStore({ state }) {
     garbageCollect.gcResetStore(state);
-  }
+  },
+
+  // the doc url for the latest rancher version does not have a hardcoded version: check if this is the latest major/minor version and set the rancher doc url accordingly
+  async findLatestVersion({ commit, dispatch }) {
+    try {
+      const res = await dispatch('request', {
+        url:                  `https://api.github.com/repos/rancher/rancher/releases/latest`,
+        method:               'GET',
+        headers:              { accept: 'application/json' },
+        redirectUnauthorized: false,
+        withCredentials:      false,
+        excludeCookies:       true
+      });
+
+      const version = res.tag_name;
+
+      commit('setDocsBase', version );
+    } catch {
+      // eslint-disable-next-line no-console
+      console.log('unable to determine latest rancher version...using default documentation versioning');
+    }
+  },
 };

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -334,5 +334,9 @@ export default {
 
   gcIgnoreTypes: () => {
     return {};
+  },
+
+  latestDocsVersion: (state) => {
+    return state.latestDocsVersion;
   }
 };

--- a/shell/plugins/dashboard-store/index.js
+++ b/shell/plugins/dashboard-store/index.js
@@ -11,7 +11,7 @@ export const coreStoreModule = {
   namespaced: true,
 
   state() {
-    return { ...coreStoreState() };
+    return { ...coreStoreState(), latestDocsVersion: '' };
   },
 
   getters: { ...getters },

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -325,4 +325,9 @@ export default {
     }
   },
 
+  setDocsBase(state, version) {
+    const parsedVersion = version.match(/v?[0-9]+\.[0-9]+/)[0];
+
+    state.latestDocsVersion = parsedVersion;
+  }
 };

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -98,8 +98,8 @@ export const getters = {
     } else if ( formatter && formatter.format ) {
       // Inject things like appName so they're always available in any translation
       const moreArgs = {
-        vendor:   getVendor(),
-        appName:  getProduct(),
+        vendor:  getVendor(),
+        appName: getProduct(),
         ...args
       };
 

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -2,7 +2,7 @@ import merge from 'lodash/merge';
 import IntlMessageFormat from 'intl-messageformat';
 import { get } from '@shell/utils/object';
 import en from '@shell/assets/translations/en-us.yaml';
-import { getProduct, getVendor, DOCS_BASE } from '@shell/config/private-label';
+import { getProduct, getVendor } from '@shell/config/private-label';
 import { loadTranslation } from '@shell/utils/dynamic-importer';
 
 const NONE = 'none';
@@ -100,7 +100,6 @@ export const getters = {
       const moreArgs = {
         vendor:   getVendor(),
         appName:  getProduct(),
-        docsBase: DOCS_BASE,
         ...args
       };
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -11,6 +11,7 @@ import { BOTH, CLUSTER_LEVEL, NAMESPACED } from '@shell/store/type-map';
 import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import { TIMED_OUT, LOGGED_OUT, _FLAGGED, UPGRADED } from '@shell/config/query-params';
 import { setBrand, setVendor } from '@shell/config/private-label';
+import { getDocsBase } from '@shell/utils/version';
 import { addParam } from '@shell/utils/url';
 import { SETTING } from '@shell/config/settings';
 import semver from 'semver';
@@ -495,6 +496,10 @@ export const getters = {
     const cluster = getters['currentCluster'];
 
     return cluster?.status?.provider === VIRTUAL_HARVESTER_PROVIDER;
+  },
+
+  rancherDocsBase(state, getters) {
+    return getDocsBase({ getters });
   },
 
   ...gcGetters

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -610,6 +610,7 @@ export const actions = {
     } catch (e) {
       // Maybe not Rancher
     }
+    dispatch('management/findLatestVersion');
 
     let res = await allHashSettled({
       mgmtSubscribe:  dispatch('management/subscribe'),

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -4,7 +4,6 @@ import { MANAGEMENT } from '@shell/config/types';
 import { READ_WHATS_NEW, SEEN_WHATS_NEW } from '@shell/store/prefs';
 
 const DOCS_BASE = 'https://docs.ranchermanager.rancher.io';
-const LATEST_DOCS_VERSION = 'v2.7'; // this is the doc version used when none is specified in the url
 
 export function parse(str) {
   str = `${ str }`;
@@ -104,10 +103,12 @@ export function getVersionInfo(store) {
 export function getDocsBase(store) {
   const version = getVersionInfo(store)?.displayVersion;
 
+  const latestDocsVersion = store.getters['management/latestDocsVersion'] || version;
+
   let docsVersion = '';
 
   // -head and rc builds should just link to the latest docs
-  if (version && (!version.match(/v([0-9]|\.)+$/) || semver.gte(version, semver.coerce(LATEST_DOCS_VERSION)))) {
+  if (version && (!version.match(/v([0-9]|\.)+$/) || semver.gte(version, semver.coerce(latestDocsVersion)))) {
     return DOCS_BASE;
   }
 

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -3,6 +3,10 @@ import semver from 'semver';
 import { MANAGEMENT } from '@shell/config/types';
 import { READ_WHATS_NEW, SEEN_WHATS_NEW } from '@shell/store/prefs';
 
+const DOCS_BASE = 'https://docs.ranchermanager.rancher.io';
+// TODO update once 2.7 docs are available
+const LATEST_DOCS_VERSION = 'v2.6'; // this is the doc version used when none is specified in the url
+
 export function parse(str) {
   str = `${ str }`;
 
@@ -96,6 +100,25 @@ export function getVersionInfo(store) {
     displayVersion,
     fullVersion
   };
+}
+
+export function getDocsBase(store) {
+  const version = getVersionInfo(store)?.displayVersion;
+
+  let docsVersion = '';
+
+  // -head and rc builds should just link to the latest docs
+  if (version && (!version.match(/v([0-9]|\.)+$/) || semver.gte(version, semver.coerce(LATEST_DOCS_VERSION)))) {
+    return DOCS_BASE;
+  }
+
+  // create a doc path with only major and minor version
+  docsVersion = version.match(/v?[0-9]+\.[0-9]+/)[0];
+  if (!docsVersion.startsWith('v')) {
+    docsVersion = `v${ docsVersion }`;
+  }
+
+  return `${ DOCS_BASE }/${ docsVersion }`;
 }
 
 export function seenReleaseNotes(store) {

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -3,7 +3,7 @@ import semver from 'semver';
 import { MANAGEMENT } from '@shell/config/types';
 import { READ_WHATS_NEW, SEEN_WHATS_NEW } from '@shell/store/prefs';
 
-const DOCS_BASE = 'https://docs.ranchermanager.rancher.io';
+const DOCS_BASE = 'https://ranchermanager.docs.rancher.com';
 
 export function parse(str) {
   str = `${ str }`;

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -4,8 +4,7 @@ import { MANAGEMENT } from '@shell/config/types';
 import { READ_WHATS_NEW, SEEN_WHATS_NEW } from '@shell/store/prefs';
 
 const DOCS_BASE = 'https://docs.ranchermanager.rancher.io';
-// TODO update once 2.7 docs are available
-const LATEST_DOCS_VERSION = 'v2.6'; // this is the doc version used when none is specified in the url
+const LATEST_DOCS_VERSION = 'v2.7'; // this is the doc version used when none is specified in the url
 
 export function parse(str) {
   str = `${ str }`;


### PR DESCRIPTION
Fixes #7308 - rather than using the /rancherVersion endpoint suggested in the issue I've used the existing getVersionInfo getter, so this update will work for older cluster versions. 