### PR TITLE
Add hosted k8s provider to provClusterId condition

### DIFF
--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -247,6 +247,12 @@ export default class MgmtCluster extends HybridModel {
     return isHarvesterCluster(this);
   }
 
+  get isHostedKubernetesProvider() {
+    const providers = ['AKS', 'EKS', 'GKE'];
+
+    return providers.includes(this.provisioner);
+  }
+
   get providerLogo() {
     const provider = this.status?.provider || 'kubernetes';
     // Only interested in the part before the period
@@ -437,7 +443,7 @@ export default class MgmtCluster extends HybridModel {
     // RKE2 cluster IDs include the name - fleet-default/cluster-name - whereas an RKE1
     // cluster has the less human readable management cluster ID in it: fleet-default/c-khk48
 
-    const verb = this.isLocal || isRKE1 ? 'to' : 'from';
+    const verb = this.isLocal || isRKE1 || this.isHostedKubernetesProvider ? 'to' : 'from';
     const from = `${ verb }Type`;
     const id = `${ verb }Id`;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7442 
<!-- Define findings related to the feature or bug issue. -->
The issue effects `AKS`, `GKE`, and `EKS` clusters which prevents the installation of any chart from within that cluster, the main cause was not being able to determine the correct Cluster ID. This PR adds the hosted kubernetes providers to determine the related cluster ID.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a method to determine if the cluster is from a hosted kubernetes provider, and based off of this the Cluster ID can be found.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Installing charts on AKS, EKS, and GKE clusters
- Installing charts on rke1 clusters

___Note:___ Can provide a testing environment if needed.