### PR TITLE
fix advanced filtering issue 

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "nuxt": "2.15.8",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "rancher-icons": "rancher/icons#v2.0.6",
+    "rancher-icons": "rancher/icons#v2.0.8",
     "require-extension-hooks": "0.3.3",
     "require-extension-hooks-babel": "1.0.0",
     "require-extension-hooks-vue": "3.0.0",

--- a/shell/components/SortableTable/filtering.js
+++ b/shell/components/SortableTable/filtering.js
@@ -216,7 +216,9 @@ function matches(fields, token, item) {
     }
 
     // some items might not even have metadata.labels or metadata.labels.something... ignore those items. Nothing to filter by
-    if (field.includes(LABEL_IDENTIFIER) && (!item.metadata.labels || !item.metadata.labels[field.replace(LABEL_IDENTIFIER, '')])) {
+    if (typeof field !== 'function' &&
+    field.includes(LABEL_IDENTIFIER) &&
+    (!item.metadata.labels || !item.metadata.labels[field.replace(LABEL_IDENTIFIER, '')])) {
       continue;
     }
 

--- a/shell/components/SortableTable/filtering.js
+++ b/shell/components/SortableTable/filtering.js
@@ -215,6 +215,11 @@ function matches(fields, token, item) {
       continue;
     }
 
+    // some items might not even have metadata.labels or metadata.labels.something... ignore those items. Nothing to filter by
+    if (field.includes(LABEL_IDENTIFIER) && (!item.metadata.labels || !item.metadata.labels[field.replace(LABEL_IDENTIFIER, '')])) {
+      continue;
+    }
+
     let modifier;
     let val;
 

--- a/shell/package.json
+++ b/shell/package.json
@@ -113,7 +113,7 @@
     "nyc": "15.1.0",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "rancher-icons": "rancher/icons#v2.0.3",
+    "rancher-icons": "rancher/icons#v2.0.8",
     "require-extension-hooks": "0.3.3",
     "require-extension-hooks-babel": "1.0.0",
     "require-extension-hooks-vue": "3.0.0",


### PR DESCRIPTION
Fixes #7452 

- fix advanced filtering issue where we were trying to search for a specific value in all cols (including labels) and some items to be searched don't even have `metadata.labels`
- bump rancher icons version

**QA Testing**
**NOTE: This is dependent on republishing the `elemental-ui` extension! will move to testing once it's published.**

- Test on `rancher/dashboard`, `OS management` (elemental) product
- Add the `elemental-ui` repo to `Apps/repositories` so that `elemental-ui` extension becomes available to install
<img width="1935" alt="Screenshot 2022-11-07 at 11 40 48" src="https://user-images.githubusercontent.com/97888974/200301644-86a715a5-6267-4486-b976-ccab9b129c8d.png">

- Install the `elemental-ui` on `extensions` in `rancher/dashboard`

- Install `elemental-operator`

Go to Local cluster -> open kubectl shell -> install helm chart:
```
helm install --create-namespace -n cattle-elemental-system elemental-operator \
             oci://registry.opensuse.org/isv/rancher/elemental/charts/elemental/elemental-operator
```

- Update `elemental-operator`

On the same kubectl shell run:
```
helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator oci://registry.opensuse.org/isv/rancher/elemental/stable/charts/elemental/elemental-operator
```

- Enter side-menu entry `OS Management`

- Go to `Machine Inventories` list view and create a few items of this resource type

- Make sure advanced filtering is working as expected

