### PR TITLE
Refactors sockets and moves reconnect logic and error handling into it.

### DIFF
--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -522,10 +522,7 @@ export default {
     };
 
     if (getters['schemaFor'](type) && getters['watchStarted'](obj)) {
-      // Set that we don't want to watch this type
-      // Otherwise, the dispatch to unwatch below will just cause a re-watch when we
-      // detect the stop message from the backend over the web socket
-      commit('setWatchStopped', obj);
+      // the socket's send method called in the "watch" action here will pick up the "stop" in obj and automatically unwatch the resource
       dispatch('watch', obj); // Ask the backend to stop watching the type
       // Make sure anything in the pending queue for the type is removed, since we've now removed the type
       commit('clearFromQueue', type);

--- a/shell/plugins/steve/index.js
+++ b/shell/plugins/steve/index.js
@@ -25,7 +25,6 @@ export function SteveFactory(namespace, baseUrl) {
         pendingFrames:    [],
         deferredRequests: {},
         started:          [],
-        inError:          {},
         podsByNamespace:  {}, // Cache of pods by namespace
       };
     },

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -1,13 +1,12 @@
 import { addObject, removeObject } from '@shell/utils/array';
 import { NAMESPACE, POD, SCHEMA } from '@shell/config/types';
 import {
-  forgetType,
+  forgetType as dashboardStoreForgetAll,
   resetStore,
   loadAll,
   load,
   remove
 } from '@shell/plugins/dashboard-store/mutations';
-import { keyForSubscribe } from '@shell/plugins/steve/subscribe';
 import { perfLoadAll } from '@shell/plugins/steve/performanceTesting';
 import Vue from 'vue';
 
@@ -70,8 +69,14 @@ export default {
   },
 
   forgetType(state, type) {
-    if ( forgetType(state, type) ) {
-      delete state.inError[keyForSubscribe({ type })];
+    if ( dashboardStoreForgetAll(state, type) ) {
+      Object.keys(state?.socket?.watches || {})
+        .filter((watchKey) => {
+          return state.socket.watches[watchKey].resourceType === type;
+        })
+        .forEach((watchKey) => {
+          state.socket.unwatch(watchKey);
+        });
     }
   },
 

--- a/shell/utils/resourceWatcher.js
+++ b/shell/utils/resourceWatcher.js
@@ -1,0 +1,272 @@
+import Socket from '@shell/utils/socket';
+import { addParam } from '@shell/utils/url';
+import { keyForSubscribe } from '~/shell/plugins/steve/subscribe';
+
+const INSECURE = 'ws://';
+const SECURE = 'wss://';
+
+const STATE_DISCONNECTED = 'disconnected';
+const STATE_CONNECTING = 'connecting';
+const STATE_CONNECTED = 'connected';
+
+export const EVENT_CONNECTING = STATE_CONNECTING;
+export const EVENT_CONNECTED = STATE_CONNECTED;
+export const EVENT_DISCONNECTED = STATE_DISCONNECTED;
+export const EVENT_MESSAGE = 'message';
+export const EVENT_FRAME_TIMEOUT = 'frame_timeout';
+export const EVENT_CONNECT_ERROR = 'connect_error';
+export const EVENT_DISCONNECT_ERROR = 'disconnect_error';
+
+export const NO_WATCH = 'NO_WATCH';
+export const NO_SCHEMA = 'NO_SCHEMA';
+
+export const WATCHSTATUSES = {
+  PENDING:    'pending', // created but not requested of the socket yet
+  REQUESTED:  'requested', // requested but not confirmed by the socket yet
+  WATCHING:   'watching', // confirmed as active by the socket
+  REFRESHING: 'refreshing', // temporarily stopped while we make a full request to the API, will be rewatched afterwards
+  STOPPED:    'stopped', // temporarily stopped via message from the socket, a watch should immediately be triggered but the maintenance cycle will pick it up if that doesn't happen.
+  CANCELLED:  'cancelled', // has been flagged to send a stop request to the socket
+  REMOVED:    'removed' // stop request has been sent to the socket or it's been stopped by the socket itself and is now awaiting cleanup by the maintenanceInterval
+};
+
+export default class ResourceWatcher extends Socket {
+  watches = {};
+  maintenanceInterval;
+
+  constructor(url, autoReconnect = true, frameTimeout = null, protocol = null, maxTries = null) {
+    super(url, autoReconnect, frameTimeout, protocol, maxTries);
+
+    this.maintenanceInterval = setInterval(() => {
+      // Every 1 second we:
+      if (this.baseUrl) {
+        this.syncWatches();
+      }
+    }, 1000);
+  }
+
+  setUrl(url) {
+    this.baseUrl = self.location.origin + url.replace('subscribe', '');
+    if ( !url.match(/wss?:\/\//) ) {
+      url = self.location.origin.replace(/^http/, 'ws') + url;
+    }
+
+    if ( self.location.protocol === 'https:' && url.startsWith(INSECURE) ) {
+      url = SECURE + url.substr(INSECURE.length);
+    }
+
+    this.url = url;
+  }
+
+  // refactoring this to use new specific methods for subscribing and unsubscribing to resource collections which will make recovering stopped subscriptions a little bit easier.
+  send(data) {
+    // we're going to use these values from the data we're sending to determine if we're subscribing or unsubscribing
+    if (data.resourceType) {
+      const {
+        resourceType, namespace, id, selector, resourceVersion, resourceVersionTime = Date.now(), stop = false
+      } = JSON.parse(data);
+
+      const watchObject = {
+        resourceType,
+        id,
+        namespace,
+        selector
+      };
+      const watchKey = keyForSubscribe(watchObject);
+
+      if (!this.watches?.[watchKey]) {
+        this.watches[watchKey] = {
+          ...watchObject,
+          status: WATCHSTATUSES.PENDING,
+          resourceVersion,
+          resourceVersionTime
+        };
+      }
+
+      if (!stop && resourceVersion) {
+        this.watch(watchKey, resourceVersion, resourceVersionTime, {
+          resourceType, id, namespace, selector
+        });
+      } else if (stop) {
+        this.unwatch(watchKey);
+      }
+
+      return true;
+    }
+
+    // keeping this primarily for websockets used for consoles
+    if ( this.socket && this.state === STATE_CONNECTED ) {
+      this.socket.send(data);
+
+      return true;
+    }
+
+    return false;
+  }
+
+  async watch(watchKey, providedResourceVersion, providedResourceVersionTime = Date.now(), providedKeyParts = {}) {
+    const {
+      PENDING, REQUESTED, WATCHING, REFRESHING
+    } = WATCHSTATUSES;
+    const {
+      resourceType: providedResourceType,
+      id: providedId,
+      namespace: providedNamespace,
+      selector: providedSelector
+    } = providedKeyParts;
+    const resourceType = providedResourceType || this.watches?.[watchKey]?.resourceType;
+    const id = providedId || this.watches?.[watchKey]?.id;
+    const namespace = providedNamespace || this.watches?.[watchKey]?.namespace;
+    const selector = providedSelector || this.watches?.[watchKey]?.selector;
+    const resourceStatus = this.watches?.[watchKey]?.status;
+    const resourceUrl = this.baseUrl + resourceType;
+    const limitedResourceUrl = addParam(resourceUrl, 'limit', 1);
+    const opt = {
+      method:  'get',
+      headers: { accept: 'application/json' }
+    };
+    const watchObject = {
+      resourceType,
+      id,
+      namespace,
+      selector
+    };
+
+    let resourceVersionTime = providedResourceVersionTime || this.watches?.[watchKey]?.resourceVersionTime;
+    let resourceVersion = providedResourceVersion || this.watches?.[watchKey]?.resourceVersion;
+
+    if (!resourceVersion || Date.now() - resourceVersionTime > 300000) { // 300000ms is 5minutes
+      await fetch(limitedResourceUrl, opt)
+        .then((res) => {
+          if (!res.ok) {
+            this.watches[watchKey].error = res.json();
+            console.warn(`Resource error retrieving resourceVersion`, resourceType, ':', res.json()); // eslint-disable-line no-console
+          }
+
+          return res.json();
+        })
+        .then((res) => {
+          resourceVersionTime = Date.now();
+          resourceVersion = res.revision;
+        });
+    }
+
+    if (![PENDING, REQUESTED, WATCHING, REFRESHING].includes(resourceStatus)) {
+      this.watches[watchKey] = {
+        ...watchObject,
+        status: WATCHSTATUSES.PENDING,
+        resourceVersion,
+        resourceVersionTime
+      };
+    }
+  }
+
+  unwatch(watchKey) {
+    if (this.watches?.[watchKey]) {
+      this.watches[watchKey] = { ...this.watches[watchKey], status: WATCHSTATUSES.CANCELLED };
+    }
+  }
+
+  syncWatches() {
+    const watchesArray = Object.values(this.watches); // convert to array
+    const {
+      PENDING, REQUESTED, WATCHING, REFRESHING, REMOVED, CANCELLED
+    } = WATCHSTATUSES;
+
+    if (this.isConnected()) {
+      watchesArray
+        .forEach((watch) => {
+          const {
+            resourceType, id, namespace, selector, resourceVersion, status
+          } = watch;
+          const watchObject = {
+            resourceType,
+            id,
+            namespace,
+            selector
+          };
+          const watchKey = keyForSubscribe(watchObject);
+
+          if (status === PENDING) {
+            this.socket.send(JSON.stringify({
+              ...watchObject,
+              resourceVersion
+            }));
+            this.watches[watchKey].status = REQUESTED;
+          } else if (watch.status === CANCELLED) {
+            this.socket.send(JSON.stringify({
+              ...watchObject,
+              stop: true
+            }));
+            this.watches[watchKey].status = REMOVED;
+          }
+        });
+
+      // get rid of all of the removed watches
+      watchesArray
+        .filter(watch => watch.status === REMOVED)
+        .forEach((watch) => {
+          delete this.watches[keyForSubscribe(watch)];
+        });
+    } else if (this.isConnecting()) {
+      watchesArray
+        .forEach((watch) => {
+          const { status } = watch;
+          const watchKey = keyForSubscribe(watch);
+
+          if ([PENDING, REQUESTED, WATCHING, REFRESHING].includes(status)) {
+            this.watch(watchKey);
+          } else {
+            this.watch[watchKey].status = REMOVED;
+          }
+        });
+    }
+  }
+
+  isConnecting() {
+    return this.state === STATE_CONNECTING;
+  }
+
+  _onmessage(event) {
+    const {
+      REQUESTED, WATCHING, STOPPED, CANCELLED, REMOVED
+    } = WATCHSTATUSES;
+
+    const {
+      name: eventName, resourceType, id, namespace, selector, data
+    } = event.data;
+    const watchKey = keyForSubscribe({
+      resourceType,
+      id,
+      namespace,
+      selector
+    });
+
+    this._resetWatchdog();
+    this.tries = 0;
+    this.framesReceived++;
+
+    if (eventName === 'resource.start' && this.watches?.[watchKey]?.status === REQUESTED) {
+      this.watches[watchKey].status = WATCHING;
+    } else if (eventName === 'resource.stop' && this.watches?.[watchKey] && ![CANCELLED, REMOVED].includes(this.watches?.[watchKey]?.status)) {
+      this.watches[watchKey].status = STOPPED;
+      delete this.watches[watchKey].resourceVersion;
+      delete this.watches[watchKey].resourceVersionTime;
+      this.watch(watchKey);
+    } else if (eventName === 'resource.error') {
+      const err = data?.error?.toLowerCase();
+
+      if ( this.watches[watchKey] && err.includes('watch not allowed') ) {
+        this.watches[watchKey].error = { type: resourceType, reason: NO_WATCH };
+        this.unwatch(watchKey);
+      } else if ( this.watches[watchKey] && err.includes('failed to find schema') ) {
+        this.watches[watchKey].error = { type: resourceType, reason: NO_SCHEMA };
+        this.unwatch(watchKey);
+      } else if ( err.includes('too old') ) {
+        this.watch(watchKey);
+      }
+    }
+
+    this.dispatchEvent(new CustomEvent(EVENT_MESSAGE, { detail: event }));
+  }
+}


### PR DESCRIPTION
### Summary
Fixes #5997
Socket subscriptions did not maintain adequate information about their current state to self-heal from an error state. Most notably, there was no information as to which resourceVersion or the age of the resourceVersion being stored in vuex that would allow for a quick recovery if a subscription (watch) was stopped. Subscriptions (watches) were tracked in a store key "started" which didn't adequately describe what was being stored, and a subscription's (watch's) error state was being kept in the key "inError" which also doesn't adequately describe that the key is for use only for subscriptions (watches).

A resourceVersion remains valid to use to resubscribe only if it is less than 5 minutes old, these resourceVersions are not necessarily sequential so they can't be guessed. Current logic was to use the latest resourceVersion from a single resource in a collection rather than the collection resourceVersion, causing issues creating the new subscription (watch).

### Occurred changes and/or fixed issues
Websocket subscriptions for resources are referred to as "watches" in the [Kubernetes API Concepts documentation](https://kubernetes.io/docs/reference/using-api/api-concepts/) so they are referred to as such in code and in this description from here on out.

Moves logic for maintaining resource watches into the socket object itself and extends it so that the socket maintains those subscriptions by itself to consolidate logic and location of socket relevant values.

### Technical notes summary
A lot of code removed from `shell/plugins/steve/subscribe.js` and replaced in `shell/utils/socket.js` which should hopefully make sockets more modular (this lays a decent amount of groundwork for advanced webworkers as well). Changes outside of these files should be relatively minimal and there shouldn't be much in the way of user impact aside from more stable websocket watches.

### Areas or cases that should be tested
* High socket traffic
* Watches the receive frequent "resource.stop" messages should resubscribe by themselves
* Switching between clusters should work properly
* resource.error messages should be handled gracefully, if an error uses the word "too old" then that watch should stop (if not already) and rewatch.

### Areas which could experience regressions
This is a major change to sockets and watches so those should be thoroughly tested