### PR TITLE
Add unit tests for Namespace filtering in resources

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
     "prepending",
     "protip",
     "pvcs",
+    "shortkey",
     "testid",
     "tolerations",
     "userpreferences",

--- a/docusaurus/docs/testing/unit-test.md
+++ b/docusaurus/docs/testing/unit-test.md
@@ -23,6 +23,17 @@ It is possible to use debugging tools within Jest via VSCode. To do so, open the
 
 On top of the recommendation provided by the [Vue documentation](https://vuejs.org/guide/scaling-up/testing.html), it is also encouraged to follow these patterns to create readable and aimed tests.
 
+## Jest global configuration
+
+Some of the global configuration for Jest can be found in the `jest.setup.js` file, mainly to avoid repetitions. This will include:
+
+- Global Vue mounted
+  - Components
+  - Modules
+  - Directives
+  - Getters (e.g., i18n/t)
+- Global hooks, e.g. `afterEach()` with mocks resets
+
 ### Describe and test/it statement
 
 To clearly state the scope of the test, it's convenient to define in the first `describe` always define with a noun the name of the function, method, or component being tested. Multiple assertions may be grouped together under a common statement in `describe` block, as it helps to avoid repetition and ensure a set of tests to be included. Each `test`/`it` block should then start with a verb related to what is the expectation.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -10,12 +10,6 @@ Vue.config.productionTip = false;
 Vue.use(VTooltip).use(VModal);
 Vue.component('v-select', vSelect);
 
-config.mocks['$store'] = { getters: { 'i18n/t': jest.fn() } };
-config.directives = { t };
-
-// Overrides some components
-// config.stubs['my-component'] = { template: "<div></div> "};
-
 /**
  * Global configuration for Jest tests
  */
@@ -28,6 +22,13 @@ beforeAll(() => {
 beforeEach(() => {
   // jest.resetModules(); // Use this function inside your test if you need to remove any cache stored
   // jest.clearAllMocks(); // Use this function inside your test if you need to reset mocks
+  jest.restoreAllMocks(); // Use this function inside your test if you need to reset mocks and restore existing functionality
+
+  config.mocks['$store'] = { getters: { 'i18n/t': jest.fn() } };
+  config.directives = { t };
+
+  // Overrides some components
+  // config.stubs['my-component'] = { template: "<div></div> "};
 });
 
 /**

--- a/shell/components/__tests__/NamespaceFilter.test.ts
+++ b/shell/components/__tests__/NamespaceFilter.test.ts
@@ -1,0 +1,213 @@
+import { mount } from '@vue/test-utils';
+import NamespaceFilter from '@shell/components/nav/NamespaceFilter.vue';
+
+describe('component: NamespaceFilter', () => {
+  describe('given namespace select input', () => {
+    it('should be visible', () => {
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [],
+          options:  () => [],
+          value:    () => [],
+        },
+        directives: { shortkey: () => jest.fn() }
+      });
+      const filter = wrapper.find(`[data-testid="namespaces-filter"]`);
+
+      expect(filter).toBeDefined();
+    });
+
+    it('should display no namespace selection', () => {
+      const text = 'none';
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [],
+          options:  () => [],
+          value:    () => [],
+        },
+        mocks:      { $store: { getters: { 'i18n/t': () => text } } },
+        directives: { shortkey: () => jest.fn() }
+      });
+      const element = wrapper.find(`[data-testid="namespaces-values-none"]`).element.textContent;
+
+      expect(element).toContain(text);
+    });
+
+    it('should display the default namespace', () => {
+      const text = 'special namespace';
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [],
+          options:  () => [],
+          value:    () => ([{
+            label: text,
+            kind:  'special',
+          }]),
+        },
+        directives: { shortkey: () => jest.fn() }
+      });
+
+      const element = wrapper.find(`[data-testid="namespaces-values-label"]`).element.textContent;
+
+      expect(element).toContain(text);
+    });
+
+    it('should display the selected namespace', () => {
+      const text = 'current namespace';
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [],
+          options:  () => [],
+          value:    () => [{ label: text }],
+        },
+        directives: { shortkey: () => jest.fn() }
+      });
+
+      const element = wrapper.find(`[data-testid="namespaces-value-0"]`).element.textContent;
+
+      expect(element).toContain(text);
+    });
+
+    it('should display the selected namespace from user preferences if options are available', () => {
+      const text = 'my preference';
+      const key = 'local';
+      const preferences = {
+        [key]: [
+          `ns://${ text }`
+        ]
+      };
+
+      jest.spyOn(NamespaceFilter.computed.value, 'set');
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered:       () => [],
+          options:  () => [{
+            id:    `ns://${ text }`,
+            kind:  'namespace',
+            label: text
+          }],
+          currentProduct: () => undefined,
+          key:            () => key,
+        },
+        mocks: {
+          $store: {
+            getters: {
+              'i18n/t':    () => text,
+              'prefs/get': () => preferences
+            },
+          }
+        },
+        directives: { shortkey: () => jest.fn() }
+      });
+
+      const element = wrapper.find(`[data-testid="namespaces-value-0"]`).element.textContent;
+
+      expect(element).toContain(text);
+    });
+  });
+
+  describe('given namespace menu options', () => {
+    it('should be opened and displayed on click', async() => {
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [],
+          options:  () => [],
+          value:    () => [],
+        },
+        directives: { shortkey: () => jest.fn() }
+      });
+      const dropdown = wrapper.find(`[data-testid="namespaces-dropdown"]`);
+
+      await dropdown.trigger('click');
+      const menu = wrapper.find(`[data-testid="namespaces-menu"]`);
+
+      expect(menu).toBeDefined();
+    });
+
+    it('should contain no options', async() => {
+      const text = 'no options';
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [],
+          options:  () => [],
+          value:    () => [],
+        },
+        mocks:      { $store: { getters: { 'i18n/t': () => text } } },
+        directives: { shortkey: () => jest.fn() }
+      });
+      const dropdown = wrapper.find(`[data-testid="namespaces-dropdown"]`);
+
+      await dropdown.trigger('click');
+      const option = wrapper.find(`[data-testid="namespaces-option-none"]`).element.textContent;
+
+      expect(option).toContain(text);
+    });
+
+    it('should contain an option', async() => {
+      const text = 'my option';
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [
+            {
+              kind:      'namespace',
+              label:     `default-${ text }`,
+            },
+          ],
+          options:  () => [],
+          value:    () => [],
+        },
+        mocks:      { $store: { getters: { 'i18n/t': () => text } } },
+        directives: { shortkey: () => jest.fn() }
+      });
+      const dropdown = wrapper.find(`[data-testid="namespaces-dropdown"]`);
+
+      await dropdown.trigger('click');
+      const option = wrapper.find(`[data-testid="namespaces-option-0"]`).element.textContent;
+
+      expect(option).toContain(text);
+    });
+
+    it('should set the option as user preference', async() => {
+      const text = 'my option';
+      const key = 'my key';
+      const value = {
+        ids: [text],
+        key
+      };
+      const actionName = 'switchNamespaces';
+      const action = jest.fn();
+
+      jest.spyOn(NamespaceFilter.computed.value, 'get').mockReturnValue([]);
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [
+            {
+              label:     text,
+              key,
+              elementId: text,
+              id:        text,
+              kind:      'namespace',
+            },
+          ],
+          options:        () => [],
+          currentProduct: () => undefined,
+          key:            () => key,
+        },
+        mocks: {
+          $store: {
+            getters:  { 'i18n/t': () => text },
+            dispatch: action
+          }
+        },
+        directives: { shortkey: () => jest.fn() }
+      });
+
+      await wrapper.find(`[data-testid="namespaces-dropdown"]`).trigger('click');
+      await wrapper.find(`[data-testid="namespaces-option-0"]`).trigger('click');
+
+      expect(action).toHaveBeenCalledWith(actionName, value);
+    });
+
+    it.todo('should generate the options based on the Rancher resources');
+  });
+});

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -87,7 +87,8 @@ export default {
       const t = this.$store.getters['i18n/t'];
       let out = [];
 
-      if (this.currentProduct.customNamespaceFilter) {
+      // TODO: Add return info
+      if (this.currentProduct?.customNamespaceFilter && this.currentProduct?.inStore) {
         // Sometimes the component can show before the 'currentProduct' has caught up, so access the product via the getter rather
         // than caching it in the `fetch`
         return this.$store.getters[`${ this.currentProduct.inStore }/namespaceFilterOptions`]({
@@ -96,6 +97,7 @@ export default {
         });
       }
 
+      // TODO: Add return info
       if (!this.currentProduct?.hideSystemResources) {
         out = [
           {
@@ -129,6 +131,11 @@ export default {
       }
 
       const inStore = this.$store.getters['currentStore'](NAMESPACE);
+
+      if (!inStore) {
+        return out;
+      }
+
       let namespaces = sortBy(
         this.$store.getters[`${ inStore }/all`](NAMESPACE),
         ['nameDisplay']
@@ -249,9 +256,11 @@ export default {
 
     value: {
       get() {
+        // Use last picked filter from user preferences
         const prefs = this.$store.getters['prefs/get'](NAMESPACE_FILTERS);
-        const prefDefault = this.currentProduct.customNamespaceFilter ? [] : [ALL_USER];
-        const values = prefs[this.key] || prefDefault;
+
+        const prefDefault = this.currentProduct?.customNamespaceFilter ? [] : [ALL_USER];
+        const values = prefs ? prefs[this.key] : prefDefault;
         const options = this.options;
 
         // Remove values that are not valid options
@@ -291,7 +300,7 @@ export default {
         // If there was something selected and you remove it, go back to user by default
         // Unless it was user or all
         if (neu.length === 0 && !hadUser && !hadAll) {
-          ids = this.currentProduct.customNamespaceFilter ? [] : [ALL_USER];
+          ids = this.currentProduct?.customNamespaceFilter ? [] : [ALL_USER];
         } else {
           ids = neu.map(x => x.id);
         }
@@ -553,6 +562,7 @@ export default {
 <template>
   <div
     class="ns-filter"
+    data-testid="namespaces-filter"
     tabindex="0"
     @focus="open()"
   >
@@ -561,16 +571,19 @@ export default {
       class="ns-glass"
       @click="close()"
     />
-    <!-- Dropdown control -->
+
+    <!-- Select Dropdown control -->
     <div
       ref="dropdown"
       class="ns-dropdown"
+      data-testid="namespaces-dropdown"
       :class="{ 'ns-open': isOpen }"
       @click="toggle()"
     >
       <div
         v-if="value.length === 0"
         ref="values"
+        data-testid="namespaces-values-none"
         class="ns-values"
       >
         {{ t('nav.ns.all') }}
@@ -578,6 +591,7 @@ export default {
       <div
         v-else-if="isSingleSpecial"
         ref="values"
+        data-testid="namespaces-values-label"
         class="ns-values"
       >
         {{ value[0].label }}
@@ -586,28 +600,33 @@ export default {
         v-else
         ref="values"
         v-tooltip="tooltip"
+        data-testid="namespaces-values"
         class="ns-values"
       >
         <div
           v-if="total"
           ref="total"
+          data-testid="namespaces-values-total"
           class="ns-value ns-abs"
         >
           {{ t('namespaceFilter.selected.label', { total }) }}
         </div>
         <div
-          v-for="ns in value"
+          v-for="(ns, j) in value"
           ref="value"
           :key="ns.id"
+          :data-testid="`namespaces-value-${j}`"
           class="ns-value"
         >
           <div>{{ ns.label }}</div>
           <i
             class="icon icon-close"
+            :data-testid="`namespaces-values-close-${j}`"
             @click="removeOption(ns, $event)"
           />
         </div>
       </div>
+      <!-- Inform user if more namespaces are selected -->
       <div
         v-if="hidden > 0"
         ref="more"
@@ -630,9 +649,12 @@ export default {
       class="hide"
       @shortkey="open()"
     />
+
+    <!-- Dropdown menu -->
     <div
       v-if="isOpen"
       class="ns-dropdown-menu"
+      data-testid="namespaces-menu"
     >
       <div class="ns-controls">
         <div class="ns-input">
@@ -663,12 +685,13 @@ export default {
         role="list"
       >
         <div
-          v-for="opt in filtered"
+          v-for="(opt, i) in filtered"
           :id="opt.elementId"
           :key="opt.id"
           tabindex="0"
           class="ns-option"
           :class="{'ns-selected': opt.selected}"
+          :data-testid="`namespaces-option-${i}`"
           @click="selectOption(opt)"
           @mouseover="mouseOver($event)"
           @keydown="itemKeyHandler($event, opt)"
@@ -695,6 +718,7 @@ export default {
         <div
           v-if="filtered.length === 0"
           class="ns-none"
+          data-testid="namespaces-option-none"
         >
           {{ t('namespaceFilter.noMatchingOptions') }}
         </div>

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -264,13 +264,13 @@ export default {
         const options = this.options;
 
         // Remove values that are not valid options
-        const out = values
+        const filters = values
           .map((value) => {
             return findBy(options, 'id', value);
           })
           .filter(x => !!x);
 
-        return out;
+        return filters;
       },
 
       set(neu) {
@@ -580,6 +580,7 @@ export default {
       :class="{ 'ns-open': isOpen }"
       @click="toggle()"
     >
+      <!-- No filters found or available -->
       <div
         v-if="value.length === 0"
         ref="values"
@@ -588,6 +589,8 @@ export default {
       >
         {{ t('nav.ns.all') }}
       </div>
+
+      <!-- Filtered by set with custom label E.g. "All namespaces" -->
       <div
         v-else-if="isSingleSpecial"
         ref="values"
@@ -596,6 +599,8 @@ export default {
       >
         {{ value[0].label }}
       </div>
+
+      <!-- All the selected namespaces -->
       <div
         v-else
         ref="values"
@@ -626,6 +631,7 @@ export default {
           />
         </div>
       </div>
+
       <!-- Inform user if more namespaces are selected -->
       <div
         v-if="hidden > 0"

--- a/shell/list/__tests__/workload.test.ts
+++ b/shell/list/__tests__/workload.test.ts
@@ -45,9 +45,6 @@ describe('component: workload', () => {
     expect(wrapper.vm.schema).toStrictEqual(schema);
   });
 
+  // TODO - #7473: Further tests may be defined within one of the table components
   it.todo('should display the list of workloads');
-
-  it.each([
-    'deployment',
-  ])('should filter the workloads for %p', (type) => { });
 });

--- a/shell/list/__tests__/workload.test.ts
+++ b/shell/list/__tests__/workload.test.ts
@@ -1,0 +1,53 @@
+import { shallowMount } from '@vue/test-utils';
+import Workload from '@shell/list/workload.vue';
+import ResourceFetch from '@shell/mixins/resource-fetch';
+import ResourceTable from '@shell/components/ResourceTable.vue';
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+
+describe('component: workload', () => {
+  it('should load the schema for the workload', () => {
+    const resource = 'workload';
+    const schema = {
+      id:         resource,
+      type:       'schema',
+      attributes: {
+        kind:       'Workload',
+        namespaced: true,
+      },
+      metadata: { name: resource },
+    };
+
+    const wrapper = shallowMount(Workload as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      components: { ResourceTable },
+      mixins:     [ResourceFetch],
+      mocks:      {
+        $store: {
+          getters: {
+            currentStore:                  () => jest.fn(),
+            namespaces:                    () => jest.fn(),
+            'management/byId':             () => jest.fn(),
+            'resource-fetch/refreshFlag':  () => jest.fn(),
+            'type-map/hideBulkActionsFor': () => jest.fn(),
+            'type-map/labelFor':           () => jest.fn(),
+            'type-map/optionsFor':         () => jest.fn(),
+            'type-map/headersFor':         () => jest.fn(),
+            'prefs/get':                   () => resource,
+          }
+        },
+        $fetchState: {
+          pending: false, error: true, timestamp: Date.now()
+        },
+        $route: { params: { resource } },
+      }
+    });
+
+    expect(wrapper.vm.schema).toStrictEqual(schema);
+  });
+
+  it.todo('should display the list of workloads');
+
+  it.each([
+    'deployment',
+  ])('should filter the workloads for %p', (type) => { });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7391
These tests are aimed to ensure the functionalities of the namespace filter an part of the Workload fetching data capabilities.

### Occurred changes and/or fixed issues
- Prevented issues in `NamespaceFilter` component in case of missing props or data, e.g. `currentProduct`
- Added `data-testid` attributes for selecting component.

### Technical notes summary
- Added  [jest.restoreAllMocks()](https://jestjs.io/docs/jest-object#jestrestoreallmocks) globally for jest setup
- Added information related on global configuration for the unit tests in the documentation

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->