### PR TITLE
Login errors not being displayed for LDAP Active Directory login

### DIFF
--- a/shell/components/auth/login/ldap.vue
+++ b/shell/components/auth/login/ldap.vue
@@ -34,6 +34,9 @@ export default {
         this.$router.replace('/');
       } catch (err) {
         this.err = err;
+
+        // emit error to parent so that it can displayed on the error Banner
+        this.$emit('error', err);
         buttonCb(false);
       }
     },

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -225,6 +225,10 @@ export default {
       }
     },
 
+    handleProviderError(err) {
+      this.err = err;
+    },
+
     async loginLocal(buttonCb) {
       try {
         await this.$store.dispatch('auth/login', {
@@ -383,6 +387,7 @@ export default {
             :name="name"
             :open="!showLocal"
             @showInputs="showLocal = false"
+            @error="handleProviderError"
           />
         </div>
         <template v-if="hasLocal">


### PR DESCRIPTION
Fixes #7292 

- fix issue where LDAP Active Directory login errors aren't being displayed on the UI

**Testing**
[Create a new OpenLDAP Auth Provider](https://confluence.suse.com/display/CU/Setting+up+an+OpenLDAP+Auth+Provider+on+Rancher+Dashboard+for+testing)

try to login with user and pass defined on the above link (to reproduce the fix, just get the username or pass wrong)