### PR TITLE
Cluster explorer no longer crashes

### DIFF
--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -260,7 +260,7 @@ export default {
         const prefs = this.$store.getters['prefs/get'](NAMESPACE_FILTERS);
 
         const prefDefault = this.currentProduct?.customNamespaceFilter ? [] : [ALL_USER];
-        const values = prefs ? prefs[this.key] : prefDefault;
+        const values = prefs && prefs[this.key] ? prefs[this.key] : prefDefault;
         const options = this.options;
 
         // Remove values that are not valid options


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/7495

If a preferences object exists, the code checks that object for the namespace filtering preference for the active cluster. But sometimes, the user does not have any preexisting preferences for the cluster, in which case the UI crashes. This fix makes it so the default is used if the user has no preference set for namespace filtering for the active cluster.