### PR TITLE
Improve UX for cluster scoped private registry config

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1606,12 +1606,10 @@ cluster:
       searchPlaceholder: Start typing to search
       noResults: No results found
   privateRegistry:
-    systemDefaultRegistry:
-      label: Registry hostname for Rancher System Container Images
-    mode:
-      public: Use default global registry for Rancher System Container Images
-      private: Use specified private registry for Rancher System Container Images
-      advanced: Configure advanced containerd mirroring and registry authentication options
+    label: Enable cluster scoped container registry for Rancher system container images
+    description: "If enabled, Rancher will pull container images from this registry during cluster provisioning. By default, Rancher will also use this registry when installing Rancher's official Helm chart apps. If the cluster scoped registry is disabled, system images are pulled from the System Default Registry in the global settings."
+    docsLinkRke2: "For help configuring private registry mirrors, see the RKE2 <a href=\"https://docs.rke2.io/install/containerd_registry_configuration/\" target=\"_blank\">documentation.</a>"
+    docsLinkK3s: "For help configuring private registry mirrors, see the K3s <a href=\"https://docs.k3s.io/installation/private-registry\" target=\"_blank\">documentation.</a>"
   provider:
     aliyunecs: Aliyun ECS
     aliyunkubernetescontainerservice: Alibaba ACK
@@ -6178,13 +6176,15 @@ keyValue:
 
 registryMirror:
   header: Mirrors
-  toolTip: 'Mirrors can be used to redirect requests for images from one registry to actually come from a list of endpoints you specify instead.  For example you could point docker.io to always talk to your internal registry and instead of ever going to the actual DockerHub on the internet.'
+  toolTip: 'Mirrors can be used to redirect requests for images from one registry to come from a list of endpoints you specify instead.  For example docker.io could redirect to your internal registry instead of ever going to DockerHub.'
   addLabel: Add Mirror
+  description: Mirrors define the names and endpoints for private registries. The endpoints are tried one by one, and the first working one is used.
 
 registryConfig:
   header: Registry Authentication
   toolTip: 'When an image needs to be pulled from the given registry hostname, this information will be used to verify the identity of the registry and authenticate to it.'
   addLabel: Add Registry
+  description: "The configs section defines the TLS and credential configuration for each mirror."
 
 ##############################
 ### Advanced Settings

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6184,7 +6184,7 @@ registryConfig:
   header: Registry Authentication
   toolTip: 'When an image needs to be pulled from the given registry hostname, this information will be used to verify the identity of the registry and authenticate to it.'
   addLabel: Add Registry
-  description: "The configs section defines the TLS and credential configuration for each mirror."
+  description: "Define the TLS and credential configuration for each registry hostname and mirror."
 
 ##############################
 ### Advanced Settings

--- a/shell/components/AdvancedSection.vue
+++ b/shell/components/AdvancedSection.vue
@@ -5,10 +5,17 @@ export default {
       type:     String,
       required: true,
     },
+    isOpenByDefault: {
+      // It may be useful to keep the advanced options open
+      // if the form is in edit mode and it has non-default
+      // advanced options configured.
+      type:    Boolean,
+      default: false
+    }
   },
 
-  data() {
-    return { show: false };
+  data(props) {
+    return { show: props.isOpenByDefault };
   },
 
   methods: {

--- a/shell/components/form/ArrayListGrouped.vue
+++ b/shell/components/form/ArrayListGrouped.vue
@@ -87,7 +87,7 @@ export default {
         :data-testid="`remove-item-${scope.i}`"
         @click="scope.remove"
       >
-        <i class="icon icon-2x icon-x" />
+        <i class="icon icon-x" />
       </button>
       <span v-else />
     </template>
@@ -113,10 +113,11 @@ export default {
       & > .remove {
         position: absolute;
 
-        padding: 0px;
+        padding: 0;
 
         top: 0;
         right: 0;
+        margin-right: -2.25em;
       }
 
       & > .info-box {

--- a/shell/components/form/ArrayListGrouped.vue
+++ b/shell/components/form/ArrayListGrouped.vue
@@ -21,6 +21,13 @@ export default {
       type:    Boolean,
       default: true,
     },
+    /**
+     * Start with empty row
+     */
+    initialEmptyRow: {
+      type:    Boolean,
+      default: true,
+    },
 
     /**
      * Form mode for the component
@@ -62,7 +69,7 @@ export default {
     v-bind="$attrs"
     :add-allowed="canAdd && !isView"
     :mode="mode"
-    :initial-empty-row="true"
+    :initial-empty-row="initialEmptyRow"
     @input="$emit('input', $event)"
     @add="$emit('add')"
     @remove="$emit('remove', $event)"

--- a/shell/components/form/ArrayListGrouped.vue
+++ b/shell/components/form/ArrayListGrouped.vue
@@ -113,16 +113,15 @@ export default {
       & > .remove {
         position: absolute;
 
-        padding: 0;
-
         top: 0;
         right: 0;
-        margin-right: -2.25em;
       }
 
       & > .info-box {
         margin-bottom: 0;
+        padding-right: 25px;
       }
     }
 }
+
 </style>

--- a/shell/components/form/SelectOrCreateAuthSecret.vue
+++ b/shell/components/form/SelectOrCreateAuthSecret.vue
@@ -1,6 +1,5 @@
 <script>
 import { _EDIT } from '@shell/config/query-params';
-import Loading from '@shell/components/Loading';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { AUTH_TYPE, NORMAN, SECRET } from '@shell/config/types';
@@ -13,7 +12,6 @@ export default {
   name: 'SelectOrCreateAuthSecret',
 
   components: {
-    Loading,
     LabeledInput,
     LabeledSelect,
   },
@@ -131,8 +129,6 @@ export default {
       } else {
         this.allSecrets = await this.$store.dispatch(`${ this.inStore }/findAll`, { type: SECRET });
       }
-    } else {
-      this.allSecrets = [];
     }
 
     if ( this.allowS3 && this.$store.getters['rancher/canList'](NORMAN.CLOUD_CREDENTIAL) ) {
@@ -170,10 +166,10 @@ export default {
     this.update();
   },
 
-  data() {
+  data(props) {
     return {
-      allCloudCreds: null,
-      allSecrets:    null,
+      allCloudCreds: [],
+      allSecrets:    [],
       selected:      null,
 
       publicKey:  '',
@@ -279,11 +275,26 @@ export default {
           disabled: true
         });
       }
+      if ( this.allowNone ) {
+        out.unshift({
+          label: this.t('generic.none'),
+          value: AUTH_TYPE._NONE,
+        });
+      }
+
+      if (this.allowSsh || this.allowS3 || this.allowBasic) {
+        out.unshift({
+          label:    'divider',
+          disabled: true,
+          kind:     'divider'
+        });
+      }
 
       if ( this.allowSsh ) {
         out.unshift({
           label: this.t('selectOrCreateAuthSecret.createSsh'),
           value: AUTH_TYPE._SSH,
+          kind:  'highlighted'
         });
       }
 
@@ -291,6 +302,7 @@ export default {
         out.unshift({
           label: this.t('selectOrCreateAuthSecret.createS3'),
           value: AUTH_TYPE._S3,
+          kind:  'highlighted'
         });
       }
 
@@ -298,13 +310,7 @@ export default {
         out.unshift({
           label: this.t('selectOrCreateAuthSecret.createBasic'),
           value: AUTH_TYPE._BASIC,
-        });
-      }
-
-      if ( this.allowNone ) {
-        out.unshift({
-          label: this.t('generic.none'),
-          value: AUTH_TYPE._NONE,
+          kind:  'highlighted'
         });
       }
 
@@ -455,9 +461,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
   <div
-    v-else
     class="select-or-create-auth-secret"
   >
     <div
@@ -469,21 +473,10 @@ export default {
           v-model="selected"
           :mode="mode"
           :label-key="labelKey"
+          :loading="$fetchState.pending"
           :options="options"
           :selectable="option => !option.disabled"
-        >
-          <template v-slot:option="opt">
-            <template v-if="opt.kind === 'divider'">
-              <hr>
-            </template>
-            <template v-else-if="opt.kind === 'title'">
-              {{ opt.label }}
-            </template>
-            <template v-else>
-              {{ opt.label }}
-            </template>
-          </template>
-        </LabeledSelect>
+        />
       </div>
       <template v-if="selected === _SSH">
         <div :class="moreCols">

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -75,6 +75,10 @@ export default {
     window.z = this;
   },
 
+  // created() {
+  //   set(this.value, 'spec.rkeConfig.registries.configs', {});
+  // },
+
   methods: {
     update() {
       const configs = {};
@@ -91,6 +95,7 @@ export default {
       }
 
       set(this.value, 'spec.rkeConfig.registries.configs', configs);
+      this.$emit('updateConfigs', configs);
     },
 
     wrapRegisterBeforeHook(fn, ...args) {
@@ -127,7 +132,7 @@ export default {
       :default-add-value="defaultAddValue"
       :initial-empty-row="true"
       :mode="mode"
-      @input="update()"
+      @input="update"
     >
       <template #default="{row}">
         <div class="row">

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -118,10 +118,14 @@ export default {
         class="icon icon-info"
       />
     </h3>
+    <p class="mb-20">
+      {{ t('registryConfig.description') }}
+    </p>
     <ArrayListGrouped
       v-model="entries"
       :add-label="t('registryConfig.addLabel')"
       :default-add-value="defaultAddValue"
+      :initial-empty-row="true"
       :mode="mode"
       @input="update()"
     >

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -31,6 +31,10 @@ export default {
     return { entries };
   },
 
+  created() {
+    set(this.value, 'spec.rkeConfig.registries.mirrors', {});
+  },
+
   methods: {
     update(entries) {
       const mirrors = {};
@@ -42,7 +46,6 @@ export default {
 
         mirrors[entry.hostname] = { endpoint: entry.endpoints.split(/\s*,\s*/).map(x => x.trim()) };
       }
-
       set(this.value, 'spec.rkeConfig.registries.mirrors', mirrors);
     },
   }
@@ -54,6 +57,7 @@ export default {
     key="labels"
     :value="entries"
     :as-map="false"
+    :initial-empty-row="true"
     key-label="Registry Hostname"
     key-name="hostname"
     key-placeholder="e.g. docker.io or *"
@@ -73,6 +77,9 @@ export default {
           class="icon icon-info"
         />
       </h3>
+      <p class="mb-20">
+        {{ t('registryMirror.description') }}
+      </p>
     </template>
   </KeyValue>
 </template>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2221,7 +2221,7 @@ export default {
             <h3>Registry for Rancher System Container Images</h3>
           </div>
           <div class="row">
-            <div class="col span-9">
+            <div class="col span-12">
               <Banner
                 :closable="false"
                 class="cluster-tools-tip"
@@ -2269,9 +2269,9 @@ export default {
               class="row"
             >
               <AdvancedSection
+                class="col span-12 advanced"
                 :is-open-by-default="showCustomRegistryAdvancedInput"
                 :mode="mode"
-                class="advanced"
               >
                 <Banner
                   :closable="false"

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -4,7 +4,6 @@ import throttle from 'lodash/throttle';
 import isArray from 'lodash/isArray';
 import merge from 'lodash/merge';
 import { mapGetters } from 'vuex';
-
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 
@@ -66,6 +65,7 @@ import RegistryConfigs from './RegistryConfigs';
 import RegistryMirrors from './RegistryMirrors';
 import S3Config from './S3Config';
 import SelectCredential from './SelectCredential';
+import AdvancedSection from '@shell/components/AdvancedSection.vue';
 
 const PUBLIC = 'public';
 const PRIVATE = 'private';
@@ -77,6 +77,7 @@ const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
 export default {
   components: {
     ACE,
+    AdvancedSection,
     AgentEnv,
     ArrayList,
     ArrayListGrouped,
@@ -267,30 +268,31 @@ export default {
     }
 
     return {
-      loadedOnce:                  false,
-      lastIdx:                     0,
-      allPSPs:                     null,
-      nodeComponent:               null,
-      credentialId:                null,
-      credential:                  null,
-      machinePools:                null,
-      rke2Versions:                null,
-      k3sVersions:                 null,
-      defaultRke2:                 '',
-      defaultK3s:                  '',
-      s3Backup:                    false,
-      versionInfo:                 {},
-      membershipUpdate:            {},
-      showDeprecatedPatchVersions: false,
-      systemRegistry:              null,
-      registryHost:                null,
-      registryMode:                null,
-      registrySecret:              null,
-      userChartValues:             {},
-      userChartValuesTemp:         {},
-      addonsRev:                   0,
-      clusterIsAlreadyCreated:     !!this.value.id,
-      fvFormRuleSets:              [{
+      loadedOnce:                      false,
+      lastIdx:                         0,
+      allPSPs:                         null,
+      nodeComponent:                   null,
+      credentialId:                    null,
+      credential:                      null,
+      machinePools:                    null,
+      rke2Versions:                    null,
+      k3sVersions:                     null,
+      defaultRke2:                     '',
+      defaultK3s:                      '',
+      s3Backup:                        false,
+      versionInfo:                     {},
+      membershipUpdate:                {},
+      showDeprecatedPatchVersions:     false,
+      systemRegistry:                  null,
+      registryHost:                    null,
+      showCustomRegistryInput:         false,
+      showCustomRegistryAdvancedInput: false,
+      registrySecret:                  null,
+      userChartValues:                 {},
+      userChartValuesTemp:             {},
+      addonsRev:                       0,
+      clusterIsAlreadyCreated:         !!this.value.id,
+      fvFormRuleSets:                  [{
         path: 'metadata.name', rules: ['subDomain'], translationKey: 'nameNsDescription.name.label'
       }],
       harvesterVersionRange: {},
@@ -527,15 +529,6 @@ export default {
 
     showCisProfile() {
       return this.provider === 'custom' && ( this.serverArgs.profile || this.agentArgs.profile );
-    },
-
-    registryOptions() {
-      return [PUBLIC, PRIVATE, ADVANCED].map((opt) => {
-        return {
-          label: this.$store.getters['i18n/withFallback'](`cluster.privateRegistry.mode."${ opt }"`, null, opt),
-          value: opt,
-        };
-      });
     },
 
     needCredential() {
@@ -1393,12 +1386,22 @@ export default {
     },
 
     async initRegistry() {
-      let registryMode = PUBLIC;
-      let registryHost = this.agentConfig?.['system-default-registry'] || '';
+      // Check for an existing cluster scoped registry
+      const clusterRegistry = this.agentConfig?.['system-default-registry'] || '';
+
+      // Check for the global registry
+      this.systemRegistry = (await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.SYSTEM_DEFAULT_REGISTRY })).value || '';
+
+      // The order of precedence is to use the cluster scoped registry
+      // if it exists, then use the global scoped registry as a fallback
+      if (clusterRegistry) {
+        this.registryHost = clusterRegistry;
+      } else {
+        this.registryHost = this.systemRegistry;
+      }
+
       let registrySecret = null;
       let regs = this.rkeConfig.registries;
-
-      this.systemRegistry = (await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.SYSTEM_DEFAULT_REGISTRY })).value || '';
 
       if ( !regs ) {
         regs = {};
@@ -1413,72 +1416,52 @@ export default {
         set(regs, 'mirrors', {});
       }
 
-      if ( registryHost ) {
-        registryMode = PRIVATE;
-      } else if ( this.systemRegistry ) {
-        registryHost = this.systemRegistry;
-        registryMode = PRIVATE;
+      const hostname = Object.keys(regs.configs)[0];
+      const config = regs.configs[hostname];
+
+      if ( config ) {
+        registrySecret = config.authConfigSecretName;
       }
 
-      if ( Object.keys(regs.mirrors || {}).length || Object.keys(regs.configs || {}).length > 1 ) {
-        registryMode = ADVANCED;
-      } else {
-        const hostname = Object.keys(regs.configs)[0];
-        const config = regs.configs[hostname];
+      this.registrySecret = registrySecret;
 
-        if ( config ) {
-          if ( hostname !== registryHost || config.caBundle || config.insecureSkipVerify || config.tlsSecretName ) {
-            registryMode = ADVANCED;
-          } else {
-            registryMode = PRIVATE;
-            registrySecret = config.authConfigSecretName;
-          }
+      const hasMirrorsOrAuthConfig = Object.keys(regs.configs).length > 0 || Object.keys(regs.mirrors).length > 0;
+
+      if (this.registryHost || registrySecret || hasMirrorsOrAuthConfig) {
+        this.showCustomRegistryInput = true;
+
+        if (hasMirrorsOrAuthConfig) {
+          this.showCustomRegistryAdvancedInput = true;
         }
       }
-
-      this.registryHost = registryHost;
-      this.registryMode = registryMode;
-      this.registrySecret = registrySecret;
     },
 
     setRegistryConfig() {
       const hostname = (this.registryHost || '').trim();
 
-      if ( this.registryMode === PUBLIC ) {
-        if ( this.systemRegistry ) {
-          // Empty string overrides the system default to nothing
-          set(this.agentConfig, 'system-default-registry', '');
-        } else {
-          // No need to set anything
-          set(this.agentConfig, 'system-default-registry', undefined);
-        }
-      } else if ( !hostname || hostname === this.systemRegistry ) {
+      if ( this.systemRegistry ) {
+        // Empty string overrides the system default to nothing
+        set(this.agentConfig, 'system-default-registry', '');
+      } else {
+        // No need to set anything
+        set(this.agentConfig, 'system-default-registry', undefined);
+      }
+      if ( !hostname || hostname === this.systemRegistry ) {
         // Undefined removes the key which uses the global setting without hardcoding it into the config
         set(this.agentConfig, 'system-default-registry', undefined);
       } else {
         set(this.agentConfig, 'system-default-registry', hostname);
       }
 
-      if ( this.registryMode === ADVANCED ) {
-        // Leave it alone...
-      } else if ( this.registryMode === PRIVATE ) {
-        set(this.rkeConfig.registries, 'mirrors', {});
-
-        if ( this.registrySecret ) {
-          set(this.rkeConfig.registries, 'configs', {
-            [hostname]: {
-              authConfigSecretName: this.registrySecret,
-              caBundle:             null,
-              insecureSkipVerify:   false,
-              tlsSecretName:        null,
-            }
-          });
-        } else {
-          set(this.rkeConfig.registries, 'configs', {});
-        }
-      } else {
-        set(this.rkeConfig.registries, 'configs', {});
-        set(this.rkeConfig.registries, 'mirrors', {});
+      if ( this.registrySecret ) {
+        set(this.rkeConfig.registries, 'configs', {
+          [hostname]: {
+            authConfigSecretName: this.registrySecret,
+            caBundle:             null,
+            insecureSkipVerify:   false,
+            tlsSecretName:        null,
+          }
+        });
       }
     },
 
@@ -1622,6 +1605,14 @@ export default {
         }
       }
       this.setHarvesterDefaultCloudProvider();
+    },
+    toggleCustomRegistry(e) {
+      if (this.registryHost) {
+        this.registryHost = null;
+        this.registrySecret = null;
+      } else {
+        this.initRegistry();
+      }
     },
   },
 };
@@ -2196,48 +2187,81 @@ export default {
           name="registry"
           label-key="cluster.tabs.registry"
         >
-          <RadioGroup
-            v-model="registryMode"
-            name="registry-mode"
-            :options="registryOptions"
-            :mode="mode"
-          />
-
-          <LabeledInput
-            v-if="registryMode !== PUBLIC"
-            v-model="registryHost"
-            class="mt-20"
-            :mode="mode"
-            :required="true"
-            :label="t('cluster.privateRegistry.systemDefaultRegistry.label')"
-          />
-
-          <SelectOrCreateAuthSecret
-            v-if="registryMode === PRIVATE"
-            v-model="registrySecret"
-            :register-before-hook="registerBeforeHook"
-            :hook-priority="1"
-            :mode="mode"
-            in-store="management"
-            :allow-ssh="false"
-            :allow-rke="true"
-            :vertical="true"
-            :namespace="value.metadata.namespace"
-            generate-name="registryconfig-auth-"
-          />
-          <template v-else-if="registryMode === ADVANCED">
-            <RegistryMirrors
-              v-model="value"
-              class="mt-20"
-              :mode="mode"
+          <div class="row">
+            <h3>Registry for Rancher System Container Images</h3>
+          </div>
+          <div class="row">
+            <div class="col span-9">
+              <Banner
+                :closable="false"
+                class="cluster-tools-tip"
+                color="info"
+                label-key="cluster.privateRegistry.description"
+              />
+            </div>
+          </div>
+          <div class="row">
+            <Checkbox
+              v-model="showCustomRegistryInput"
+              class="mb-20"
+              :label="t('cluster.privateRegistry.label')"
+              @input="toggleCustomRegistry"
             />
-
-            <RegistryConfigs
-              v-model="value"
-              class="mt-20"
-              :mode="mode"
-              :cluster-register-before-hook="registerBeforeHook"
-            />
+          </div>
+          <div
+            v-if="showCustomRegistryInput"
+            class="row"
+          >
+            <div class="col span-6">
+              <LabeledInput
+                v-model="registryHost"
+                label-key="catalog.chart.registry.custom.inputLabel"
+                placeholder-key="catalog.chart.registry.custom.placeholder"
+                :min-height="30"
+              />
+              <SelectOrCreateAuthSecret
+                v-model="registrySecret"
+                :register-before-hook="registerBeforeHook"
+                :hook-priority="1"
+                :mode="mode"
+                in-store="management"
+                :allow-ssh="false"
+                :allow-rke="true"
+                :vertical="true"
+                :namespace="value.metadata.namespace"
+                generate-name="registryconfig-auth-"
+              />
+            </div>
+          </div>
+          <template>
+            <div
+              v-if="showCustomRegistryInput"
+              class="row"
+            >
+              <AdvancedSection
+                :is-open-by-default="showCustomRegistryAdvancedInput"
+                :mode="mode"
+                class="advanced"
+              >
+                <Banner
+                  :closable="false"
+                  class="cluster-tools-tip"
+                  color="info"
+                  :label-key="isK3s ? 'cluster.privateRegistry.docsLinkK3s' : 'cluster.privateRegistry.docsLinkRke2'"
+                />
+                <RegistryMirrors
+                  v-model="value"
+                  class="mt-20"
+                  :mode="mode"
+                />
+                <RegistryConfigs
+                  v-model="value"
+                  class="mt-20"
+                  :mode="mode"
+                  :cluster-register-before-hook="registerBeforeHook"
+                />
+              </AdvancedSection>
+            </div>
           </template>
         </Tab>
 


### PR DESCRIPTION
Addresses these issues:

- https://github.com/rancher/dashboard/issues/6919
- https://github.com/rancher/dashboard/issues/5146
- https://github.com/rancher/dashboard/issues/6875

Previously, we showed private registry options with three radio buttons in the cluster edit form for RKE2/K3s. We got reports that this form was confusing to users:
<img width="941" alt="Screenshot 2022-11-19 at 5 44 57 PM" src="https://user-images.githubusercontent.com/20599230/202877461-1d343ce4-edbc-4864-9b12-4f415b928214.png">

To improve clarity, this PR replaces the radio buttons with a checkbox and explains what the default option is above the checkbox.

If the checkbox is selected, the basic registry config options are displayed. If "Show Advanced" is clicked, the mirroring and advanced auth options are displayed. I have also added more UI text and docs links to help tamp down on the confusion.


Default view: 

<img width="1146" alt="Screenshot 2022-11-19 at 5 33 45 PM" src="https://user-images.githubusercontent.com/20599230/202877063-f7793dae-cf94-4cf6-b265-f53d06a94b76.png">

If cluster registry is enabled:
<img width="1144" alt="Screenshot 2022-11-19 at 5 34 41 PM" src="https://user-images.githubusercontent.com/20599230/202877076-95501447-1aca-48f7-afc9-a95214964a25.png">

If advanced options are expanded (docs link changes to K3s docs if a K3s version is selected):

<img width="874" alt="Screenshot 2022-11-19 at 5 42 39 PM" src="https://user-images.githubusercontent.com/20599230/202877398-9f2677da-b712-4f64-855f-50bd86aa4d1d.png">

