### PR TITLE
Improve performance of pod logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "vue-select": "3.18.3",
     "vue-server-renderer": "2.6.14",
     "vue-shortkey": "3.1.7",
+    "vue-virtual-scroll-list": "^2.3.4",
     "vue2-transitions": "0.3.0",
     "vuedraggable": "2.24.3",
     "vuex": "3.6.2",

--- a/shell/components/LogItem.vue
+++ b/shell/components/LogItem.vue
@@ -46,6 +46,7 @@ export default {
 .line {
   font-family: Menlo,Consolas,monospace;
   color: var(--logs-text);
+  display:flex;
 }
 
 .time {

--- a/shell/components/LogItem.vue
+++ b/shell/components/LogItem.vue
@@ -23,7 +23,7 @@ export default {
 
 <template>
   <div>
-    <!-- <span v-html="format(source.time)" /> -->
+    <span v-html="format(source.time)" />
     <span v-html="source.msg" />
   </div>
 </template>

--- a/shell/components/LogItem.vue
+++ b/shell/components/LogItem.vue
@@ -1,0 +1,29 @@
+<script>
+import day from 'dayjs';
+
+export default {
+  props: {
+    source: {
+      type:    Object,
+      default: () => {}
+    }
+  },
+
+  methods: {
+    format(time) {
+      if ( !time ) {
+        return '';
+      }
+
+      return day(time).format(this.timeFormatStr);
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <!-- <span v-html="format(source.time)" /> -->
+    <span v-html="source.msg" />
+  </div>
+</template>

--- a/shell/components/LogItem.vue
+++ b/shell/components/LogItem.vue
@@ -1,5 +1,7 @@
 <script>
 import day from 'dayjs';
+import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
+import { escapeHtml } from '@shell/utils/string';
 
 export default {
   props: {
@@ -7,6 +9,15 @@ export default {
       type:    Object,
       default: () => {}
     }
+  },
+
+  computed: {
+    timeFormatStr() {
+      const dateFormat = escapeHtml( this.$store.getters['prefs/get'](DATE_FORMAT));
+      const timeFormat = escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
+
+      return `${ dateFormat } ${ timeFormat }`;
+    },
   },
 
   methods: {
@@ -22,8 +33,36 @@ export default {
 </script>
 
 <template>
-  <div>
-    <span v-html="format(source.time)" />
-    <span v-html="source.msg" />
+  <div class="line">
+    <span class="time">{{ format(source.time) }}</span>
+    <span
+      class="msg"
+      v-html="source.msg"
+    />
   </div>
 </template>
+
+<style lang='scss' scoped>
+.line {
+  font-family: Menlo,Consolas,monospace;
+  color: var(--logs-text);
+}
+
+.time {
+  white-space: nowrap;
+  display: none;
+  width: 0;
+  padding-right: 15px;
+  user-select: none;
+}
+
+.msg {
+  white-space: pre;
+
+  .highlight {
+    color: var(--logs-highlight);
+    background-color: var(--logs-highlight-bg);
+  }
+}
+
+</style>

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -291,12 +291,16 @@ export default {
           }
         }
 
-        this.backlog.push({
+        const parsedLine = {
           id:     lastId++,
           msg:    ansiup.ansi_to_html(msg),
           rawMsg: msg,
           time,
-        });
+        };
+
+        Object.freeze(parsedLine);
+
+        this.backlog.push(parsedLine);
       });
 
       this.socket.connect();

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -3,18 +3,15 @@ import { saveAs } from 'file-saver';
 import AnsiUp from 'ansi_up';
 import { addParams } from '@shell/utils/url';
 import { base64Decode } from '@shell/utils/crypto';
-import {
-  LOGS_RANGE, LOGS_TIME, LOGS_WRAP, DATE_FORMAT, TIME_FORMAT
-} from '@shell/store/prefs';
+import { LOGS_RANGE, LOGS_TIME, LOGS_WRAP } from '@shell/store/prefs';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { Checkbox } from '@components/Form/Checkbox';
 import AsyncButton from '@shell/components/AsyncButton';
 import Select from '@shell/components/form/Select';
 import VirtualList from 'vue-virtual-scroll-list';
 import LogItem from '@shell/components/LogItem';
-import day from 'dayjs';
 
-import { escapeHtml, escapeRegex } from '@shell/utils/string';
+import { escapeRegex } from '@shell/utils/string';
 import { HARVESTER_NAME as VIRTUAL } from '@shell/config/product/harvester-manager';
 
 import Socket, {
@@ -215,17 +212,6 @@ export default {
       }
 
       return out;
-    },
-
-    timeFormatStr() {
-      const dateFormat = escapeHtml( this.$store.getters['prefs/get'](DATE_FORMAT));
-      const timeFormat = escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
-
-      return `${ dateFormat } ${ timeFormat }`;
-    },
-
-    maxLines() {
-      return this.parseRange(this.range)?.tailLines;
     }
   },
 
@@ -327,7 +313,7 @@ export default {
         }
       }
 
-      if ( this.isFollowing) {
+      if ( this.isFollowing ) {
         this.$nextTick(() => {
           this.follow();
         });
@@ -436,14 +422,6 @@ export default {
       this.range = range;
       this.$store.dispatch('prefs/set', { key: LOGS_RANGE, value: this.range });
       this.connect();
-    },
-
-    format(time) {
-      if ( !time ) {
-        return '';
-      }
-
-      return day(time).format(this.timeFormatStr);
     },
 
     cleanup() {
@@ -594,6 +572,14 @@ export default {
           :keeps="200"
           @scroll="updateFollowing"
         />
+        <template v-if="!filtered.length">
+          <div v-if="search">
+            <span class="msg text-muted">{{ t('wm.containerLogs.noMatch') }}</span>
+          </div>
+          <div v-else>
+            <span class="msg text-muted">{{ t('wm.containerLogs.noData') }}</span>
+          </div>
+        </template>
       </div>
     </template>
   </Window>
@@ -613,7 +599,7 @@ export default {
     }
   }
 
-  .logs-container {
+  .logs-container{
     height: 100%;
     overflow: auto;
     padding: 5px;
@@ -625,31 +611,15 @@ export default {
       opacity: 0.25;
     }
 
-    .time {
-      white-space: nowrap;
-      display: none;
-      width: 0;
-      padding-right: 15px;
-      user-select: none;
+    &.wrap-lines ::v-deep  .msg {
+      white-space: pre-wrap;
     }
 
-    &.show-times .time {
+    &.show-times ::v-deep .time {
       display: initial;
       width: auto;
     }
 
-    .msg {
-      white-space: pre;
-
-      .highlight {
-        color: var(--logs-highlight);
-        background-color: var(--logs-highlight-bg);
-      }
-    }
-
-    &.wrap-lines .msg {
-      white-space: pre-wrap;
-    }
   }
 
   .containerPicker {

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -233,6 +233,7 @@ export default {
     container() {
       this.connect();
     },
+
   },
 
   beforeDestroy() {
@@ -345,6 +346,9 @@ export default {
     },
 
     flush() {
+      const virtualList = this.$refs.virtualList;
+      const wasFollowing = virtualList.getScrollSize() - virtualList.getClientSize() === virtualList.getOffset();
+
       if ( this.backlog.length ) {
         this.lines.push(...this.backlog);
         this.backlog = [];
@@ -353,7 +357,7 @@ export default {
         }
       }
 
-      if ( this.isFollowing ) {
+      if ( wasFollowing) {
         this.$nextTick(() => {
           this.follow();
         });
@@ -612,12 +616,14 @@ export default {
         :class="{'logs-container': true, 'open': isOpen, 'closed': !isOpen, 'show-times': timestamps && filtered.length, 'wrap-lines': wrap}"
       >
         <VirtualList
+          v-show="filtered.length"
           ref="virtualList"
           data-key="id"
           :data-sources="filtered"
           :data-component="logItem"
+          direction="vertical"
           class="virtual-list"
-          :keeps="100"
+          :keeps="200"
         />
       </div>
     </template>

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -611,7 +611,7 @@ export default {
       opacity: 0.25;
     }
 
-    &.wrap-lines ::v-deep  .msg {
+    &.wrap-lines ::v-deep .msg {
       white-space: pre-wrap;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17223,6 +17223,11 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue-virtual-scroll-list@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/vue-virtual-scroll-list/-/vue-virtual-scroll-list-2.3.4.tgz#0d08c2d26299d8609018b8c04f5e3ca608fbe2d6"
+  integrity sha512-a9bmmIhAdnKcp8NG0C9ZQ+pW9nAOrDv5SHqJfbbEpXxVVERCtbIgGeBnkwrGgmoILBoFz/WANIZgA22G44F0Yw==
+
 vue2-transitions@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/vue2-transitions/-/vue2-transitions-0.3.0.tgz#765fc0d743103fcfe2d10f431697d8873a075c17"


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7156 


### Occurred changes and/or fixed issues
This PR updates the `ContainerLogs` component to use a virtual list- only the log lines visible on the page (plus a few more for padding) are rendered. The component will also only store the last x lines when that range option is selected, eg if the user has selected "show the last 10,000 lines" the containerlogs component only retains the latest 10,000 lines - previously we retrieved the last 10K then continuously appended new logs. 

### Areas or cases that should be tested
I used chrome's performance monitor to test this, which you can find in the chrome devtool's kebab menu:
![Screen Shot 2022-11-21 at 9 26 36 AM](https://user-images.githubusercontent.com/42977925/203107638-b45ab907-0596-4253-8dee-123848fb591a.png)

* Containers with various log activity should be tested. I used a deployment with 3 containers each logging something in a different interval (pasted below) 
* Various log range options 
* Resizing and moving the container between the bottom and size of the page
* Follow button/scrolling un-follow behavior 
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    workload.user.cattle.io/workloadselector: apps.deployment-default-test-logs
  name: test-logs
  namespace: default
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      workload.user.cattle.io/workloadselector: apps.deployment-default-test-logs
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      labels:
        workload.user.cattle.io/workloadselector: apps.deployment-default-test-logs
    spec:
      affinity: {}
      containers:
      - args:
        - 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep .001; done'
        command:
        - /bin/sh
        - -c
        image: busybox
        imagePullPolicy: Always
        name: fast
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      - args:
        - 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
        command:
        - /bin/sh
        - -c
        image: busybox
        imagePullPolicy: Always
        name: slower
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      - args:
        - 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 10; done'
        command:
        - /bin/sh
        - -c
        image: busybox
        imagePullPolicy: Always
        name: sloooow
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
```

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->