### PR TITLE
Add rancher dashboard version to "About" page

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:ci": "jest --collectCoverage",
     "nuxt": "./node_modules/.bin/nuxt",
     "dev": "./node_modules/.bin/nuxt dev",
-    "mem-dev": "node --max-old-space-size=8192 ./node_modules/.bin/nuxt dev",
+    "mem-dev": "source ./scripts/version && node --max-old-space-size=8192 ./node_modules/.bin/nuxt dev",
     "docker-dev": "docker run --rm --name dashboard-dev -p 8005:8005 -e API=$API -v $(pwd):/src -v dashboard_node:/src/node_modules rancher/dashboard:dev",
     "docker:local:start": "docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=password -e CATTLE_PASSWORD_MIN_LENGTH=3 --name cypress --privileged rancher/rancher:v2.7-head",
     "docker:local:stop": "docker kill cypress || docker rm cypress || true",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest --watch",
     "test:ci": "jest --collectCoverage",
     "nuxt": "./node_modules/.bin/nuxt",
-    "dev": "./node_modules/.bin/nuxt dev",
+    "dev": "source ./scripts/version && ./node_modules/.bin/nuxt dev",
     "mem-dev": "source ./scripts/version && node --max-old-space-size=8192 ./node_modules/.bin/nuxt dev",
     "docker-dev": "docker run --rm --name dashboard-dev -p 8005:8005 -e API=$API -v $(pwd):/src -v dashboard_node:/src/node_modules rancher/dashboard:dev",
     "docker:local:start": "docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=password -e CATTLE_PASSWORD_MIN_LENGTH=3 --name cypress --privileged rancher/rancher:v2.7-head",

--- a/scripts/version
+++ b/scripts/version
@@ -12,8 +12,10 @@ GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 LAST_TAG=${GIT_TAG:-'v0.0.0'}
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    export DASHBOARD_VERSION=$GIT_TAG
     VERSION=$GIT_TAG
 else
+    export DASHBOARD_VERSION="${COMMIT_BRANCH}-${COMMIT}"
     VERSION="${COMMIT}${DIRTY}"
 fi
 

--- a/scripts/version
+++ b/scripts/version
@@ -15,7 +15,7 @@ if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     export DASHBOARD_VERSION=$GIT_TAG
     VERSION=$GIT_TAG
 else
-    export DASHBOARD_VERSION="${COMMIT_BRANCH}-${COMMIT}"
+    export DASHBOARD_VERSION="${COMMIT_BRANCH} ${COMMIT}"
     VERSION="${COMMIT}${DIRTY}"
 fi
 

--- a/scripts/version
+++ b/scripts/version
@@ -12,10 +12,14 @@ GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
 LAST_TAG=${GIT_TAG:-'v0.0.0'}
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    # human readable version used on rancher dashboard about page
     export DASHBOARD_VERSION=$GIT_TAG
+    # computer readable version
     VERSION=$GIT_TAG
 else
+    # human readable version used on rancher dashboard about page
     export DASHBOARD_VERSION="${COMMIT_BRANCH} ${COMMIT}"
+    # computer readable version
     VERSION="${COMMIT}${DIRTY}"
 fi
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -16,6 +16,7 @@ generic:
   create: Create
   created: Created
   customize: Customize
+  dashboard: Dashboard
   default: Default
   disabled: Disabled
   done: Done

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -14,10 +14,6 @@ import { SETTING } from '@shell/config/settings';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
 import { isRancherPrime } from '@shell/config/version';
 
-const UNKNOWN = 'unknown';
-const UI_VERSION = process.env.VERSION || UNKNOWN;
-const UI_COMMIT = process.env.COMMIT || UNKNOWN;
-
 export default {
 
   components: { BrandImage, ClusterProviderIcon },
@@ -30,8 +26,6 @@ export default {
       shown:         false,
       displayVersion,
       fullVersion,
-      uiCommit:      UI_COMMIT,
-      uiVersion:     UI_VERSION,
       clusterFilter: '',
       hasProvCluster,
     };
@@ -410,11 +404,11 @@ export default {
           </div>
           <div @click="hide()">
             <nuxt-link
-              v-tooltip="{ content: fullVersion, classes: 'footer-tooltip' }"
               :to="{ name: 'about' }"
               class="version"
-              v-html="displayVersion"
-            />
+            >
+              {{ t('about.title') }}
+            </nuxt-link>
           </div>
         </div>
       </div>

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -22,17 +22,13 @@ export const API_PATH = api;
 
 const dev = (process.env.NODE_ENV !== 'production');
 const devPorts = dev || process.env.DEV_PORTS === 'true';
-const version = process.env.VERSION ||
-  process.env.DRONE_TAG ||
-  process.env.DRONE_VERSION ||
-  require('./package.json').version;
 
+// human readable version used on rancher dashboard about page
 const dashboardVersion = process.env.DASHBOARD_VERSION;
 
 const prime = process.env.PRIME;
 
 const pl = process.env.PL || STANDARD;
-const commit = process.env.COMMIT || 'head';
 const perfTest = (process.env.PERF_TEST === 'true'); // Enable performance testing when in dev
 
 // Allow skipping of eslint check
@@ -253,7 +249,7 @@ export default function(dir, _appConfig) {
   console.log(`Build: ${ dev ? 'Development' : 'Production' }`); // eslint-disable-line no-console
 
   if ( !dev ) {
-    console.log(`Version: ${ version } (${ commit })`); // eslint-disable-line no-console
+    console.log(`Version: ${ dashboardVersion }`); // eslint-disable-line no-console
   }
 
   if ( resourceBase ) {
@@ -292,8 +288,6 @@ export default function(dir, _appConfig) {
 
     // Configuration visible to the client, https://nuxtjs.org/api/configuration-env
     env: {
-      commit,
-      version,
       dev,
       pl,
       perfTest,
@@ -302,6 +296,7 @@ export default function(dir, _appConfig) {
       api
     },
 
+    // vars accessible via this.$config https://nuxtjs.org/docs/configuration-glossary/configuration-runtime-config/
     publicRuntimeConfig: { rancherEnv, dashboardVersion },
 
     buildDir: dev ? '.nuxt' : '.nuxt-prod',

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -27,6 +27,8 @@ const version = process.env.VERSION ||
   process.env.DRONE_VERSION ||
   require('./package.json').version;
 
+const dashboardVersion = process.env.DASHBOARD_VERSION;
+
 const prime = process.env.PRIME;
 
 const pl = process.env.PL || STANDARD;
@@ -300,7 +302,7 @@ export default function(dir, _appConfig) {
       api
     },
 
-    publicRuntimeConfig: { rancherEnv },
+    publicRuntimeConfig: { rancherEnv, dashboardVersion },
 
     buildDir: dev ? '.nuxt' : '.nuxt-prod',
 

--- a/shell/pages/about.vue
+++ b/shell/pages/about.vue
@@ -16,7 +16,8 @@ export default {
   },
   data() {
     return {
-      settings: null,
+      dashboardVersion: this.$config.dashboardVersion,
+      settings:         null,
       SETTING
     };
   },
@@ -120,6 +121,17 @@ export default {
             {{ appName }}
           </a>
         </td><td>{{ rancherVersion.value }}</td>
+      </tr>
+      <tr v-if="dashboardVersion">
+        <td>
+          <a
+            href="https://github.com/rancher/dashboard"
+            target="_blank"
+            rel="nofollow noopener noreferrer"
+          >
+            {{ t("generic.dashboard") }}
+          </a>
+        </td><td>{{ dashboardVersion }}</td>
       </tr>
       <tr v-if="cliVersion">
         <td>


### PR DESCRIPTION
Fixes #4217 

- Add rancher dashboard version to "About" page
- Replace copy of "backend version" link to just "About"
- Remove unused code from `TopLevelMenu` component
