### PR TITLE
Added info about how table headers are populated

### DIFF
--- a/docusaurus/docs/code-base-works/sortable-table.md
+++ b/docusaurus/docs/code-base-works/sortable-table.md
@@ -18,3 +18,13 @@ When the user scrolls the page and other columns become visible, Sortable Table 
 
 Typically a delayed component would initally not render itself at all - or render a simple indicator that the content has not loaded. When its
 `startDelayedLoading` method is called, it will then render its full content, fetching data as needed etc,
+
+
+### Table header
+
+There are two ways table headers are populated:
+
+- Customize header: You can create a customized header for the sortable table by defining it in `explore.js`. Read more [how to create custom table headers](/code-base-works/customising-how-k8s-resources-are-presented#customising-tables) for each type.
+
+- Header coming from Schema: If table data is coming from Schema, headers are dynamically populated by the Schema data. For the Internationalization make sure to add table headers locale key in translations YAML files.
+

--- a/docusaurus/docs/code-base-works/sortable-table.md
+++ b/docusaurus/docs/code-base-works/sortable-table.md
@@ -24,7 +24,7 @@ Typically a delayed component would initally not render itself at all - or rende
 
 There are two ways table headers are populated:
 
-- Customize header: You can create a customized header for the sortable table by defining it in `explore.js`. Read more [how to create custom table headers](/code-base-works/customising-how-k8s-resources-are-presented#customising-tables) for each type.
+- Custom header: You can create a customized header for the sortable table by defining it in the appropriate configuration file under shell/config/product folder. Read more [how to create custom table headers](/code-base-works/customising-how-k8s-resources-are-presented#customising-tables) for each type.
 
 - Header coming from Schema: If table data is coming from Schema, headers are dynamically populated by the Schema data. For the Internationalization make sure to add table headers locale key in translations YAML files.
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7283

<!-- Define findings related to the feature or bug issue. -->
Added some info in the sortable-table page about the table header

### How to test

- Start docusaurus
- Go to page http://localhost:3000/dashboard/code-base-works/sortable-table

It should have info about how table headers are populated