### PR TITLE
update package.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14515,9 +14515,9 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-rancher-icons@rancher/icons#v2.0.6:
-  version "2.0.6"
-  resolved "https://codeload.github.com/rancher/icons/tar.gz/43d0c2ff064df877748f81879a9f60f3fa99047e"
+rancher-icons@rancher/icons#v2.0.9:
+  version "2.0.9"
+  resolved "https://codeload.github.com/rancher/icons/tar.gz/09048239918c9eccf49f7770948efef63fb04f24"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
@@ -18061,4 +18061,3 @@ yorkie@^2.0.0:
     is-ci "^1.0.10"
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
-    


### PR DESCRIPTION
Align `package.lock` to new package versions: `"rancher-icons": "rancher/icons#v2.0.9",`

Signed-off-by: Francesco Torchia <francesco.torchia@suse.com>
