### PR TITLE
fix issue with "compare changes"

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -522,6 +522,10 @@ export default {
       return this.formYamlOption === VALUES_STATE.YAML || ( !this.valuesComponent && !this.hasQuestions );
     },
 
+    showingYamlDiff() {
+      return this.formYamlOption === VALUES_STATE.DIFF;
+    },
+
     formYamlOptions() {
       const options = [];
 
@@ -1062,7 +1066,7 @@ export default {
 
       const errors = [];
 
-      if ( this.showingYaml ) {
+      if ( this.showingYaml || this.showingYamlDiff ) {
         const { errors: yamlErrors } = this.applyYamlToValues();
 
         errors.push(...yamlErrors);


### PR DESCRIPTION
Fixes #7502 

- fix issue with "compare changes" not setting YAML changes on the payload sent to the server after editing the app YAML

**To test**
- install `rancher-alerting-drivers`app from app/marketplace
- go to `apps` side-menu
- edit the `rancher-alerting-drivers`app
- edit via YAML
- click on `compare changes` tab/button (make sure changes are there)
- hit `Update` to save (make sure you were on the `compare changes` tab/button before hitting the save)

Check on Network the payload sent and payload received to make sure changes are there OR edit the app again and check if changes persisted