### PR TITLE
Change the default value for 'Allow Privilege Escalation' in container security context

### DIFF
--- a/shell/components/form/Security.vue
+++ b/shell/components/form/Security.vue
@@ -63,10 +63,10 @@ export default {
 
     const {
       capabilities = {},
-      runAsRoot = true,
+      runAsNonRoot = false,
       readOnlyRootFilesystem = false,
       privileged = false,
-      allowPrivilegeEscalation = true,
+      allowPrivilegeEscalation = false,
       runAsUser
     } = this.value;
     const {
@@ -78,7 +78,7 @@ export default {
       privileged,
       allowPrivilegeEscalation,
       allCapabilities,
-      runAsRoot,
+      runAsNonRoot,
       readOnlyRootFilesystem,
       add,
       drop,
@@ -105,7 +105,7 @@ export default {
   methods: {
     update() {
       const securityContext = {
-        runAsRoot:                this.runAsRoot,
+        runAsNonRoot:             this.runAsNonRoot,
         readOnlyRootFilesystem:   this.readOnlyRootFilesystem,
         capabilities:             { add: this.add, drop: this.drop },
         privileged:               this.privileged,
@@ -115,6 +115,7 @@ export default {
 
       this.$emit('input', securityContext);
     }
+
   }
 };
 </script>
@@ -164,13 +165,13 @@ export default {
           class="col span-6"
         >
           <RadioGroup
+            v-model="runAsNonRoot"
             name="runasNonRoot"
             :label="t('workload.container.security.runAsNonRoot.label')"
-            :value="!runAsRoot"
             :options="[false, true]"
             :labels="[t('workload.container.security.runAsNonRoot.false'), t('workload.container.security.runAsNonRoot.true')]"
             :mode="mode"
-            @input="e=>{runAsRoot = !e; update()}"
+            @input="update"
           />
         </div>
         <div

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -47,6 +47,7 @@ import { BEFORE_SAVE_HOOKS } from '@shell/mixins/child-hook';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import formRulesGenerator from '@shell/utils/validators/formRules';
 import { TYPES as SECRET_TYPES } from '@shell/models/secret';
+import { defaultContainer } from '@shell/models/workload';
 
 const TAB_WEIGHT_MAP = {
   general:              99,
@@ -871,9 +872,9 @@ export default {
         nameNumber++;
       }
       const container = {
-        imagePullPolicy: 'Always',
-        name:            `container-${ nameNumber }`,
-        active:          true
+        ...defaultContainer,
+        name:   `container-${ nameNumber }`,
+        active: true
       };
 
       this.podTemplateSpec.containers.push(container);

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -7,6 +7,16 @@ import { convertSelectorObj, matching, matches } from '@shell/utils/selector';
 import { SEPARATOR } from '@shell/components/DetailTop';
 import WorkloadService from '@shell/models/workload.service';
 
+export const defaultContainer = {
+  imagePullPolicy: 'Always',
+  name:            'container-0',
+  securityContext: {
+    runAsNonRoot:             false,
+    readOnlyRootFilesystem:   false,
+    privileged:               false,
+    allowPrivilegeEscalation: false,
+  }
+};
 export default class Workload extends WorkloadService {
   // remove clone as yaml/edit as yaml until API supported
   get _availableActions() {
@@ -98,7 +108,9 @@ export default class Workload extends WorkloadService {
       if (!spec.template) {
         spec.template = {
           spec: {
-            restartPolicy: this.type === WORKLOAD_TYPES.JOB ? 'Never' : 'Always', containers: [{ imagePullPolicy: 'Always', name: 'container-0' }], initContainers: []
+            restartPolicy:  this.type === WORKLOAD_TYPES.JOB ? 'Never' : 'Always',
+            containers:     [{ ...defaultContainer }],
+            initContainers: []
           }
         };
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7165 

The ask was to change the default for `allowPrivilegeEscalation` but the ticket also mentions that these securityContext defaults are only set when a value on the tab is changed. We can avoid that by setting them when the container is initialized. I also noticed we were trying to set `runAsRoot` when the correct field is `runAsNonRoot` https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core