### PR TITLE
do not attempt to conditionally render the recent events tab off the presence of events

### DIFF
--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -58,11 +58,6 @@ export default {
     needRelated: {
       type:    Boolean,
       default: true
-    },
-
-    alwaysShowEvents: {
-      type:    Boolean,
-      default: false
     }
   },
 
@@ -92,7 +87,7 @@ export default {
       return false;
     },
     showEvents() {
-      return this.isView && this.needEvents && this.hasEvents && (this.events.length || this.alwaysShowEvents);
+      return this.isView && this.needEvents && this.hasEvents;
     },
     showRelated() {
       return this.isView && this.needRelated;

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -373,7 +373,6 @@ export default {
     </div>
     <ResourceTabs
       :value="value"
-      :always-show-events="true"
     >
       <Tab
         v-if="isCronJob"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7374 

Richard summarized this well in the original issue:

> Think this is a regression brought in by #6683 and applies to ALL resources where we don't force the visibility of events. We gated the visibility of the events tab on if we have events OR we're manually forcing it. If we're not forcing it we fetch the events when we visit the tab (which we can't do because it's never visible).

We can't conditionally render the Events tab off the presence of events if we do not retrieve events until we visit the Events tab. The change in this PR means that every resource detail view will have a 'recent events' tab now regardless of whether there are recent events, but I think our only other option would be to revert the performance-improving event loading change.
