### PR TITLE
Fix banner close icon size

### DIFF
--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
       class="closer"
       @click="$emit('close')"
     >
-      <i class="icon icon-2x icon-close closer-icon" />
+      <i class="icon icon-close closer-icon" />
     </div>
   </div>
 </template>
@@ -125,7 +125,6 @@ export default Vue.extend({
       text-align: center;
 
       .closer-icon {
-        font-size: 22px;
         opacity: 0.7;
 
         &:hover {


### PR DESCRIPTION
Part of #7496 

Fixes banner close icons size - now looks like this:

![image](https://user-images.githubusercontent.com/1955897/203825468-cf42f012-6b1e-4801-b9c3-977ae8bae720.png)

