### PR TITLE
Add manage button to home page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1269,6 +1269,7 @@ cluster:
   explore: Explore
   exploreHarvester: Explore
   importAction: Import Existing
+  manageAction: Manage
   kubernetesVersion:
     label: Kubernetes Version
     experimental: experimental

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -176,7 +176,7 @@ export default {
       >
         <n-link
           :to="importLocation"
-          class="btn role-primary"
+          class="btn role-primary mr-10"
           data-testid="cluster-manager-list-import"
         >
           {{ t('cluster.importAction') }}

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -363,21 +363,21 @@ export default {
                     <n-link
                       v-if="canManageClusters"
                       :to="manageLocation"
-                      class="btn role-secondary"
+                      class="btn btn-sm role-secondary"
                     >
                       {{ t('cluster.manageAction') }}
                     </n-link>
                     <n-link
                       v-if="canCreateCluster"
                       :to="importLocation"
-                      class="btn role-primary"
+                      class="btn btn-sm role-primary"
                     >
                       {{ t('cluster.importAction') }}
                     </n-link>
                     <n-link
                       v-if="canCreateCluster"
                       :to="createLocation"
-                      class="btn role-primary"
+                      class="btn btn-sm role-primary"
                     >
                       {{ t('generic.create') }}
                     </n-link>
@@ -519,9 +519,15 @@ export default {
 </style>
 <style lang="scss">
 .home-page {
-  .search > INPUT {
-    background-color: transparent;
-    padding: 8px;
+  .search {
+    align-items: center;
+    display: flex;
+
+    > INPUT {
+      background-color: transparent;
+      height: 30px;
+      padding: 8px;
+    }
   }
 
   h2 {

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -79,10 +79,28 @@ export default {
       return this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
     },
 
+    // User can go to Cluster Management if they can see the cluster schema
+    canManageClusters() {
+      const schema = this.$store.getters['management/schemaFor'](CAPI.RANCHER_CLUSTER);
+
+      return !!schema;
+    },
+
     canCreateCluster() {
       const schema = this.$store.getters['management/schemaFor'](CAPI.RANCHER_CLUSTER);
 
       return !!schema?.collectionMethods.find(x => x.toLowerCase() === 'post');
+    },
+
+    manageLocation() {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          product:  MANAGER,
+          cluster:  BLANK_CLUSTER,
+          resource: CAPI.RANCHER_CLUSTER
+        },
+      };
     },
 
     createLocation() {
@@ -338,17 +356,26 @@ export default {
                   </div>
                 </template>
                 <template
-                  v-if="canCreateCluster"
+                  v-if="canCreateCluster || canManageClusters"
                   #header-middle
                 >
                   <div class="table-heading">
                     <n-link
+                      v-if="canManageClusters"
+                      :to="manageLocation"
+                      class="btn role-secondary"
+                    >
+                      {{ t('cluster.manageAction') }}
+                    </n-link>
+                    <n-link
+                      v-if="canCreateCluster"
                       :to="importLocation"
                       class="btn role-primary"
                     >
                       {{ t('cluster.importAction') }}
                     </n-link>
                     <n-link
+                      v-if="canCreateCluster"
                       :to="createLocation"
                       class="btn role-primary"
                     >
@@ -453,7 +480,7 @@ export default {
     height: 39px;
 
     & > a {
-      margin-left: 5px;
+      margin-left: 10px;
     }
   }
   .panel:not(:first-child) {
@@ -472,6 +499,7 @@ export default {
     display: contents;
     white-space: nowrap;
   }
+
   .list-cluster-name {
     align-items: center;
     display: flex;
@@ -479,6 +507,13 @@ export default {
     .conditions-alert-icon {
       color: var(--error);
       margin-left: 4px;
+    }
+  }
+
+  // Hide the side-panel showing links when the screen is small
+  @media screen and (max-width: 996px) {
+    .side-panel {
+      display: none;
     }
   }
 </style>


### PR DESCRIPTION
Fixes #7547

This PR adds a manage button to the home page - this reduces the clicks required to go to Cluster Management from there:

![image](https://user-images.githubusercontent.com/1955897/203938776-bbaf21e5-ebc4-4e0b-9d86-cc7ec7d7fe0d.png)

It also adds responsiveness, so when the screen is smaller, we hide the doc links panel:

![image](https://user-images.githubusercontent.com/1955897/203864470-473929e5-8749-4012-9259-89ed135b6e90.png)

Lastly, on the Cluster Management page, this PR fixes the spacing between the "Import Existing" and "Create" buttons:

![image](https://user-images.githubusercontent.com/1955897/203865329-2282d012-849d-4863-a4ed-419007747c7c.png)
