### PR TITLE
Add node inactive warning indicator

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1533,6 +1533,10 @@ cluster:
 
   rkeTemplateUpgrade: Template revision {name} available for upgrade
 
+  availabilityWarnings:
+    node: Node {name} is inactive
+    machine: Machine {name} is inactive
+
   detail:
     provisioner: Provisioner
     kubernetesVersion: Kubernetes Version

--- a/shell/components/formatter/ClusterLink.vue
+++ b/shell/components/formatter/ClusterLink.vue
@@ -63,6 +63,11 @@ export default {
     </n-link>
     <span v-else>{{ value }}</span>
     <i
+      v-if="row.unavailableMachines"
+      v-tooltip="row.unavailableMachines"
+      class="conditions-alert-icon icon-alert icon"
+    />
+    <i
       v-if="row.rkeTemplateUpgrade"
       v-tooltip="t('cluster.rkeTemplateUpgrade', { name: row.rkeTemplateUpgrade })"
       class="template-upgrade-icon icon-alert icon"

--- a/shell/config/home-links.js
+++ b/shell/config/home-links.js
@@ -48,7 +48,10 @@ export async function fetchLinks(store, hasSupport, isSupportPage, t) {
   try {
     const uiLinksSetting = await store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.UI_CUSTOM_LINKS });
 
-    uiLinks = JSON.parse(uiLinksSetting.value);
+    // Don't try and parse empty string
+    if (uiLinksSetting.value) {
+      uiLinks = JSON.parse(uiLinksSetting.value);
+    }
   } catch (e) {
     console.warn('Could not parse custom link settings', e); // eslint-disable-line no-console
   }

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -48,6 +48,10 @@ export default {
       hash.etcdSnapshots = this.$store.dispatch('management/findAll', { type: SNAPSHOT });
     }
 
+    if ( this.$store.getters['management/canList'](CAPI.MACHINE) ) {
+      hash.capiMachines = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE });
+    }
+
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE) ) {
       hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
     }


### PR DESCRIPTION
Fixes #7544 

Adds parity with Cluster Manager UI.

Adds non-active indicator to Cluster list on management list and home page.

Home Page:

![image](https://user-images.githubusercontent.com/1955897/203949434-45dff127-00e5-4500-929d-d1908d8acaf5.png)

Cluster Management Cluster List:

![image](https://user-images.githubusercontent.com/1955897/203949589-bcc435fa-2dba-4bff-be65-c6cd51fcdeb9.png)

Works for both RKE1 and RKE2.

This PR also fixes minor issue on home page where we tried to parse empty string as JSON for the home page links which leads to a browser console warning. A check is now added.

**To Test:**

**RKE1:**

- Create an RKE1 Cluster (e.g. in DO) with two node pools. 2nd pool should just have one worker node.
- Wait for cluster to be ready
- Stop docker on the 2nd node.(e.g. in DO, use the web console to get a terminal on the machine and run `systemctl stop docker`
- Wait 30 seconds or so
- Go to both the Cluster Management cluster list and home pages and check that that the warning icon appears and that when you hover on ti, the tooltip shows which node is not active

**RKE2:**

- Create an RKE2 Cluster (e.g. in DO) with two node pools. 2nd pool should just have two worker node.
- Wait for cluster to be ready
- Stop  RKE2 services on one of the nodes in the 2nd pool. (e.g. in DO, set up a firewall that has no outbound access and add the droplet for the node to this firewall - this prevents that node communicating back to Rancher)
- Wait 30 seconds or so
- Go to both the Cluster Management cluster list and home pages and check that that the warning icon appears and that when you hover on ti, the tooltip shows which node is not active











