### PR TITLE
Allow kubeconfig to be downloaded/copied when cluster is not ready

### DIFF
--- a/cypress/e2e/po/components/action-menu.po.ts
+++ b/cypress/e2e/po/components/action-menu.po.ts
@@ -8,4 +8,8 @@ export default class ActionMenuPo extends ComponentPo {
   clickMenuItem(index: number) {
     return this.self().find('li').eq(index).click();
   }
+
+  getMenuItem(name: string) {
+    return this.self().get('li > span').contains(name);
+  }
 }

--- a/cypress/e2e/tests/pages/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/cluster-manager.spec.ts
@@ -21,7 +21,7 @@ const clusterNamePartial = `${ runPrefix }-create`;
 const rke2CustomName = `${ clusterNamePartial }-rke2-custom`;
 const importGenericName = `${ clusterNamePartial }-import-generic`;
 
-const downloadsFolder = Cypress.config('downloadsFolder')
+const downloadsFolder = Cypress.config('downloadsFolder');
 
 describe('Cluster Manager', () => {
   const clusterList = new ClusterManagerListPagePo();

--- a/cypress/e2e/tests/pages/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/cluster-manager.spec.ts
@@ -87,7 +87,7 @@ describe('Cluster Manager', () => {
 
         const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
-        cy.readFile(downloadedFilename).then(buffer => {
+        cy.readFile(downloadedFilename).then((buffer) => {
           // This will throw an exception which will fail the test if not valid yaml
           const obj = jsyaml.load(buffer);
 

--- a/cypress/e2e/tests/pages/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/cluster-manager.spec.ts
@@ -7,6 +7,8 @@ import ClusterManagerEditRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioni
 import ClusterManagerImportGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.generic.po';
 import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
+import * as path from 'path';
+import * as jsyaml from 'js-yaml';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
 const runTimestamp = +new Date();
@@ -18,6 +20,8 @@ const clusterRequestBase = `${ baseUrl }/v1/provisioning.cattle.io.clusters/flee
 const clusterNamePartial = `${ runPrefix }-create`;
 const rke2CustomName = `${ clusterNamePartial }-rke2-custom`;
 const importGenericName = `${ clusterNamePartial }-import-generic`;
+
+const downloadsFolder = Cypress.config('downloadsFolder')
 
 describe('Cluster Manager', () => {
   const clusterList = new ClusterManagerListPagePo();
@@ -54,7 +58,7 @@ describe('Cluster Manager', () => {
         cy.intercept('PUT', `${ clusterRequestBase }/${ rke2CustomName }`).as('saveRequest');
 
         clusterList.goTo();
-        clusterList.list().actionMenu(rke2CustomName).clickMenuItem(0);
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
         editCreatedClusterPage.waitForPage('mode=edit', 'basic');
         editCreatedClusterPage.nameNsDescription().description().set(rke2CustomName);
@@ -62,7 +66,7 @@ describe('Cluster Manager', () => {
 
         cy.wait('@saveRequest').then(() => {
           clusterList.goTo();
-          clusterList.list().actionMenu(rke2CustomName).clickMenuItem(0);
+          clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
           editCreatedClusterPage.waitForPage('mode=edit', 'basic');
           editCreatedClusterPage.nameNsDescription().description().self().should('have.value', rke2CustomName);
@@ -71,17 +75,35 @@ describe('Cluster Manager', () => {
 
       it('can view cluster YAML editor', () => {
         clusterList.goTo();
-        clusterList.list().actionMenu(rke2CustomName).clickMenuItem(1);
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit YAML').click();
 
         editCreatedClusterPage.waitForPage('mode=edit&as=yaml');
         editCreatedClusterPage.resourceDetail().resourceYaml().checkVisible();
+      });
+
+      it('can download KubeConfig', () => {
+        clusterList.goTo();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
+
+        const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
+
+        cy.readFile(downloadedFilename).then(buffer => {
+          // This will throw an exception which will fail the test if not valid yaml
+          const obj = jsyaml.load(buffer);
+
+          // Basic checks on the downloaded YAML
+          expect(obj.clusters.length).to.equal(1);
+          expect(obj.clusters[0].name).to.equal(rke2CustomName);
+          expect(obj.apiVersion).to.equal('v1');
+          expect(obj.kind).to.equal('Config');
+        });
       });
 
       it('can delete cluster', () => {
         cy.intercept('DELETE', `${ clusterRequestBase }/${ rke2CustomName }`).as('deleteRequest');
 
         clusterList.goTo();
-        clusterList.list().actionMenu(rke2CustomName).clickMenuItem(4);
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
 
         const promptRemove = new PromptRemove();
 
@@ -118,7 +140,7 @@ describe('Cluster Manager', () => {
 
       it('can navigate to cluster edit page', () => {
         clusterList.goTo();
-        clusterList.list().actionMenu(importGenericName).clickMenuItem(0);
+        clusterList.list().actionMenu(importGenericName).getMenuItem('Edit Config').click();
 
         editImportedClusterPage.waitForPage('mode=edit');
       });

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -114,12 +114,12 @@ export default class ProvCluster extends SteveModel {
         label:      this.$rootGetters['i18n/t']('nav.kubeconfig.download'),
         icon:       'icon icon-download',
         bulkable:   true,
-        enabled:    this.mgmt?.hasAction('generateKubeconfig') && ready,
+        enabled:    this.mgmt?.hasAction('generateKubeconfig'),
       }, {
         action:   'copyKubeConfig',
         label:    this.t('cluster.copyConfig'),
         bulkable: false,
-        enabled:  this.mgmt?.hasAction('generateKubeconfig') && ready,
+        enabled:  this.mgmt?.hasAction('generateKubeconfig'),
         icon:     'icon icon-copy',
       }, {
         action:     'snapshotAction',


### PR DESCRIPTION
Fixes #7080

The check for enabling the download and copy for kubeconfig was checking the cluster was ready - we should allow the user to download/copy it if the action to generate it is available.