### PR TITLE
Grabs and sets the version from the API endpoint

### DIFF
--- a/pkg/epinio/index.ts
+++ b/pkg/epinio/index.ts
@@ -3,9 +3,21 @@ import { IPlugin, OnNavToPackage, OnNavAwayFromPackage } from '@shell/core/types
 import epinioStore from './store/epinio-store';
 import epinioMgmtStore from './store/epinio-mgmt-store';
 import epinioRoutes from './routing/epinio-routing';
+import { MANAGEMENT } from '@shell/config/types';
 
 const onEnter: OnNavToPackage = async(store, config) => {
   await store.dispatch(`${ epinioMgmtStore.config.namespace }/loadManagement`);
+
+  const serverVersionSettings = store.getters['management/byId'](MANAGEMENT.SETTING, 'server-version');
+  const res = await store.dispatch(`epinio/request`, { opt: { url: `/api/v1/info` } });
+
+  await store.dispatch('management/load', {
+    data: {
+      ...serverVersionSettings,
+      type:    MANAGEMENT.SETTING,
+      value: res.version
+    }
+  });
 };
 const onLeave: OnNavAwayFromPackage = async(store, config) => {
   // The dashboard retains the previous cluster info until another cluster is loaded, this helps when returning to the same cluster.


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/epinio/ui/issues/145
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We fetch the version from the `/api/v1/info`. We do all this in `onEnter` so it should stay for the session duration. 

> For the future, we might want to have it as part of the  `epinio/rancher/v1/userpreferences` settings (?)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/88777903/204287815-aa9d871f-e399-4e5d-8fda-ffb8cd514338.png)
