### PR TITLE
Add export for DraggableZone

### DIFF
--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -2,7 +2,7 @@
   "name": "@rancher/components",
   "repository": "git://github.com:rancher/dashboard.git",
   "license": "Apache-2.0",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0",
   "module": "./main.js",
   "main": "./dist/@rancher/components.umd.min.js",
   "files": [

--- a/pkg/rancher-components/src/index.ts
+++ b/pkg/rancher-components/src/index.ts
@@ -2,4 +2,5 @@ export { Card } from './components/Card';
 export { BadgeState } from './components/BadgeState';
 export { Banner } from './components/Banner';
 export { StringList } from './components/StringList';
+export { DraggableZone } from './components/Utils/DraggableZone'
 export * from './components/Form';

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -82,14 +82,14 @@ rm ${SHELL_DIR}/package.json.bak
 # We might have bumped the version number but its not published yet, so this will fail
 sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\",/\"version\": \"7.7.7\",/g" ${BASE_DIR}/pkg/rancher-components/package.json
 
-# Publish rancher components
-yarn build:lib
-yarn publish:lib
-
 # Publish shell
 echo "Publishing shell packages to local registry"
 yarn install
 ${SHELL_DIR}/scripts/publish-shell.sh
+
+# Publish rancher components
+yarn build:lib
+yarn publish:lib
 
 if [ "${SKIP_STANDALONE}" == "false" ]; then
   DIR=$(mktemp -d)

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -78,6 +78,14 @@ rm -rf ${BASE_DIR}/pkg/test-pkg
 sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\",/\"version\": \"7.7.7\",/g" ${SHELL_DIR}/package.json
 rm ${SHELL_DIR}/package.json.bak
 
+# Same as above for Rancher Components
+# We might have bumped the version number but its not published yet, so this will fail
+sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\",/\"version\": \"7.7.7\",/g" ${BASE_DIR}/pkg/rancher-components/package.json
+
+# Publish rancher components
+yarn build:lib
+yarn publish:lib
+
 # Publish shell
 echo "Publishing shell packages to local registry"
 yarn install


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This exports `DraggableZone` so that it can be imported via `import { DraggableZone } from '@rancher/components';`.

This also removes that `alpha` flag from published versions of `@rancher/components`

Fixes #7567

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>