### PR TITLE
Fixed close icon color on hover in Banner component

### DIFF
--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -224,6 +224,7 @@ $icon-size: 24px;
       text-align: center;
 
       .closer-icon {
+        --link: #fff;
         opacity: 0.7;
 
         &:hover {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Close icon on hover is invisible because the color is equal to banner background color
Fixes #
Fixed close icon color on hover in Banner component for primary variant

### Screenshot/Video
Before: 
![before](https://i.imgur.com/gEnJnis.png)

After:
![after](https://i.imgur.com/Cjqn7ht.png)