### PR TITLE
Fix storybook build

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
 const NM_REGEX  = /node_modules\/(.*)/
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   "stories": [
@@ -86,6 +87,9 @@ module.exports = {
 
     // Cheat for importing ~shell/assets
     config.resolve.modules.push(baseFolder);
+
+    config.resolve.plugins = config.resolve.plugins || [];
+    config.resolve.plugins.push(new TsconfigPathsPlugin({}));
 
     return config;
   },  

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -17,6 +17,7 @@
     "@storybook/addon-a11y": "^6.3.8",
     "@storybook/vue": "^6.3.8",
     "storybook-dark-mode": "^1.0.8",
-    "storybook-auto-events": "^0.1.1"
+    "storybook-auto-events": "^0.1.1",
+    "tsconfig-paths-webpack-plugin": "^4.0.0"
   }
 }


### PR DESCRIPTION
Storybook build is broken.

This PR fixes this by adding the `tsconfig-paths-webpack-plugin` to address issues with paths for the rancher components library that meant it was not getting transpiled correctly.