### PR TITLE
Fix storybook rancher logo

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const webpack = require('webpack');
 const NM_REGEX  = /node_modules\/(.*)/
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   "stories": [
@@ -86,6 +87,9 @@ module.exports = {
 
     // Cheat for importing ~shell/assets
     config.resolve.modules.push(baseFolder);
+
+    config.resolve.plugins = config.resolve.plugins || [];
+    config.resolve.plugins.push(new TsconfigPathsPlugin({}));
 
     return config;
   },  

--- a/.storybook/package.json
+++ b/.storybook/package.json
@@ -17,6 +17,7 @@
     "@storybook/addon-a11y": "^6.3.8",
     "@storybook/vue": "^6.3.8",
     "storybook-dark-mode": "^1.0.8",
-    "storybook-auto-events": "^0.1.1"
+    "storybook-auto-events": "^0.1.1",
+    "tsconfig-paths-webpack-plugin": "^4.0.0"
   }
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -61,12 +61,12 @@ export const parameters = {
     dark: {
       ...themes.dark,
       brandTitle: 'Rancher Storybook',
-      brandImage: '/dark/rancher-logo.svg'
+      brandImage: 'dark/rancher-logo.svg'
     },
     light: {
       ...themes.normal,
       brandTitle: 'Rancher Storybook',
-      brandImage: '/rancher-logo.svg'
+      brandImage: 'rancher-logo.svg'
     },
     darkClass: 'theme-dark',
     lightClass: 'theme-light',


### PR DESCRIPTION
Logo is broken when published:

![image](https://user-images.githubusercontent.com/1955897/205028332-dcd7040e-ae41-4bfd-81f8-05041a7960b2.png)

This PR fixes this by using a relative link for the image rather than an absolute one.
