### PR TITLE
Extend DetailTop component to have icon and tooltip

### DIFF
--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -22,6 +22,28 @@ export default {
       default: () => {
         return [];
       }
+    },
+
+    /**
+     * Optionally replace key/value and display tooltips for the tab
+     * Dictionary key based
+     */
+    tooltips: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+
+    /**
+     * Optionally display icons next to the tab
+     * Dictionary key based
+     */
+    icons: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
     }
   },
 
@@ -200,7 +222,18 @@ export default {
           v-for="(prop, key) in labels"
           :key="key + prop"
         >
-          {{ key }}<span v-if="prop">: </span>{{ prop }}
+          <i
+            v-if="icons[key]"
+            class="icon"
+            :class="icons[key]"
+          />
+          <span
+            v-if="tooltips[key]"
+            v-tooltip="prop ? `${key} : ${prop}` : key"
+          >
+            <span>{{ tooltips[key] ? tooltips[key] : key }}</span>
+          </span>
+          <span v-else>{{ prop ? `${key} : ${prop}` : key }}</span>
         </Tag>
         <a
           v-if="showFilteredSystemLabels"

--- a/stories/components/DetailTop.stories.mdx
+++ b/stories/components/DetailTop.stories.mdx
@@ -27,7 +27,7 @@ Default view with all the options.
 
 <Canvas>
   <Story
-    name="DetailTop"
+    name="Default"
     args={{
       value: {
         namespaces: [{
@@ -51,7 +51,8 @@ Default view with all the options.
 
 #### Tooltips
 
-Replace value with prettified name and tooltips with actual key/value content.
+Replace the text from the label with a prettified version. This is provided by the tooltip dictionary, using key as reference and may contain any type of information, therefore it may not include any related information.
+The tooltips will then display the actual key/value content.
 
 <Canvas>
   <Story
@@ -67,6 +68,7 @@ Replace value with prettified name and tooltips with actual key/value content.
         labels: {
           'kubernetes.io/metadata.name': 'anyValue',
           'pod-security.kubernetes.io/enforce': 'privileged',
+          'originalKey': 'value displayed in tooltip only',
         }
       },
       icons: {
@@ -74,6 +76,7 @@ Replace value with prettified name and tooltips with actual key/value content.
       },
       tooltips: {
         'pod-security.kubernetes.io/enforce': 'Enforce Privileged (latest)',
+        'originalKey': 'Hover me',
       },
     }}>
     {Template.bind({})}
@@ -93,4 +96,4 @@ Replace value with prettified name and tooltips with actual key/value content.
 
 ### Props table
 
-<ArgsTable of={Banner} />
+<ArgsTable of={DetailTop} />

--- a/stories/components/DetailTop.stories.mdx
+++ b/stories/components/DetailTop.stories.mdx
@@ -1,0 +1,96 @@
+
+import { Canvas, Meta, Story, ArgsTable, Source } from '@storybook/addon-docs';
+import DetailTop from '@shell/components/DetailTop';
+
+<Meta
+  title="Components/DetailTop"
+  component={DetailTop}
+/>
+
+export const Template = (args, { argTypes, events }) => ({
+  components: { DetailTop },
+  props:      Object.keys(argTypes),
+  template:   '<DetailTop v-bind="$props" />',
+})
+
+# DetailTop
+
+Display labels for the current resource.
+
+### Description
+
+This component is strictly bound to the k8s `value` model.
+
+#### Default
+
+Default view with all the options.
+
+<Canvas>
+  <Story
+    name="DetailTop"
+    args={{
+      value: {
+        namespaces: [{
+          medatada: { 
+            name: 'default',
+            detailLocation: 'location'
+          },
+        }],
+        labels: {
+          'kubernetes.io/metadata.name': 'anyValue',
+          'label/with': 'icon',
+        }
+      },
+      icons: {
+        'label/with': 'icon-lock',
+      }
+    }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+#### Tooltips
+
+Replace value with prettified name and tooltips with actual key/value content.
+
+<Canvas>
+  <Story
+    name="Tooltips"
+    args={{
+      value: {
+        namespaces: [{
+          medatada: { 
+            name: 'default',
+            detailLocation: 'location'
+          },
+        }],
+        labels: {
+          'kubernetes.io/metadata.name': 'anyValue',
+          'pod-security.kubernetes.io/enforce': 'privileged',
+        }
+      },
+      icons: {
+        'pod-security.kubernetes.io/enforce': 'icon-pod_security',
+      },
+      tooltips: {
+        'pod-security.kubernetes.io/enforce': 'Enforce Privileged (latest)',
+      },
+    }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Import
+
+<Source
+  language='js'
+  light
+  format={false}
+  code={`
+     import DetailTop from '@shell/components/DetailTop.vue'
+  `}
+/>
+
+### Props table
+
+<ArgsTable of={Banner} />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7597
As defined in the issue.

### Occurred changes and/or fixed issues
- Added icons dictionary, e.g. `{ 'labelKey': 'icon-rancher-icon' }`
- Added tooltips dictionary to replace content, e.g. `{ 'labelKey': 'literaly any type of text' }`

### Technical notes summary
- Created story for the component

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

![Screenshot 2022-12-01 at 15 04 29](https://user-images.githubusercontent.com/5009481/205072929-39512123-ae7e-433d-8e25-49a63bb3f21d.png)
