### PR TITLE
Set protect-kernel-defaults to false when Worker CIS Profile is selected

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1047,6 +1047,7 @@ cis:
   testID: Test ID
   testsSkipped: Tests Skipped
   testsToSkip: Tests to Skip
+  workerProfile: CIS Worker Profile
 
 cluster:
   addonChart:

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1644,6 +1644,18 @@ export default {
         this.initRegistry();
       }
     },
+    updateCisProfile() {
+      // If the user selects any Worker CIS Profile,
+      // protect-kernel-defaults should be set to false
+      // in the RKE2 worker/agent config.
+      const selectedCisProfile = this.agentConfig?.profile;
+
+      if (selectedCisProfile) {
+        set(this.agentConfig, 'protect-kernel-defaults', true);
+      } else {
+        set(this.agentConfig, 'protect-kernel-defaults', false);
+      }
+    }
   },
 };
 </script>
@@ -1915,7 +1927,8 @@ export default {
                 v-model="agentConfig.profile"
                 :mode="mode"
                 :options="profileOptions"
-                label="Worker CIS Profile"
+                :label="t('cis.workerProfile')"
+                @input="updateCisProfile"
               />
             </div>
           </div>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/7331
## QA Template

## What was fixed, or what changes have occurred
In the create/edit form for RKE2 custom clusters, when the user selects any Worker CIS Profile in the dropdown menu, the value "protect kernel defaults" is now set to `true` in the cluster YAML.

If the user selects "None" for the Worker CIS Profile, the "protect kernel defaults" should still be `false` in the cluster YAML.
 
## Areas or cases that should be tested
This only affects custom RKE2 clusters.

### Test that the default behavior is unchanged for clusters without a CIS profile selected
1. Go to the cluster list in Cluster Management
2. Click Create
3. Click RKE2 and Custom
4. In the cluster create form, click Edit as YAML
5. Confirm that in YAML, by default,`spec.rkeConfig.machineSelectorConfig[0].config["protect-kernel-defaults"]` is `false`

### Test that selecting a CIS profile sets "protect-kernel-defaults" to true
1. Go back to the cluster create/edit form
2. Click **Worker CIS Profile > cis-1.5** (or 1.6)
3. Click Edit as YAML
4. Confirm that `spec.rkeConfig.machineSelectorConfig[0].config["protect-kernel-defaults"]` is `true`
 
### Test that setting the CIS profile to "None" sets "protect-kernel-defaults" to false
1. Go back to the cluster create/edit form
2. Set **Worker CIS Profile** to None
3. Click **Edit as YAML**
4. Confirm that `spec.rkeConfig.machineSelectorConfig[0].config["protect-kernel-defaults"]` is `false`