### PR TITLE
defaults to stable release if the build is a custom/internal build

### DIFF
--- a/pkg/epinio/index.ts
+++ b/pkg/epinio/index.ts
@@ -5,17 +5,22 @@ import epinioMgmtStore from './store/epinio-mgmt-store';
 import epinioRoutes from './routing/epinio-routing';
 import { MANAGEMENT } from '@shell/config/types';
 
+const semanticVersionRegex = /v(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.\d+)/;
+
 const onEnter: OnNavToPackage = async(store, config) => {
   await store.dispatch(`${ epinioMgmtStore.config.namespace }/loadManagement`);
 
   const serverVersionSettings = store.getters['management/byId'](MANAGEMENT.SETTING, 'server-version');
   const res = await store.dispatch(`epinio/request`, { opt: { url: `/api/v1/info` } });
 
+  // If the version is a custom build, set it to 1.5.1
+  const version = !res.version.match(semanticVersionRegex) ? 'v1.5.1' : res.version;
+
   await store.dispatch('management/load', {
     data: {
       ...serverVersionSettings,
       type:  MANAGEMENT.SETTING,
-      value: res.version
+      value: version
     }
   });
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/epinio/ui/issues/145
<!-- Define findings related to the feature or bug issue. -->

There was an issue with the tests failing because they couldn't download the files from git given that was an internal build of the Epinio BE.

This PR introduces a check for a matching semantic release versioning and defaults to `v1.5.1` when it detects a custom build.
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Small test:
![image](https://user-images.githubusercontent.com/88777903/206653108-69e73664-c889-49a2-b1e9-6c0b4174d9c6.png)
