### PR TITLE
Window Manager, fix bottom actions layout

### DIFF
--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -463,7 +463,7 @@ export default {
             />
           </template>
         </Select>
-        <div class="log-action ml-5">
+        <div class="log-action log-action-group ml-5">
           <button
             class="btn bg-primary wm-btn"
             :disabled="isFollowing"
@@ -503,7 +503,7 @@ export default {
           </div>
         </div>
 
-        <div class="log-action ml-5">
+        <div class="log-action log-action-group ml-5">
           <v-popover
             trigger="click"
             placement="top"
@@ -543,7 +543,7 @@ export default {
           </v-popover>
         </div>
 
-        <div class="log-action ml-5">
+        <div class="log-action log-action-group ml-5">
           <input
             v-model="search"
             class="input-sm"
@@ -654,10 +654,23 @@ export default {
     }
   }
 
+  .log-action-group {
+    display: flex;
+    gap: 3px;
+
+    .input-sm {
+      min-width: 180px;
+    }
+  }
+
   .log-previous {
     align-items: center;
     display: flex;
+    min-width: 175px;
     height: 30px;
+    text-overflow : ellipsis;
+    overflow      : hidden;
+    white-space   : nowrap;
   }
 
   .status {

--- a/shell/components/nav/WindowManager/Window.vue
+++ b/shell/components/nav/WindowManager/Window.vue
@@ -93,6 +93,8 @@ export default {
     vertical-align: middle;
     // line-height: $title-height - 4px;
     padding: 10px;
+    overflow-x: auto;
+    overflow-y: hidden;
   }
 
   .body {


### PR DESCRIPTION
Signed-off-by: Francesco Torchia <francesco.torchia@suse.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #4733
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Terminal Windows where bottom actions are displayed, example: Job's logs

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![terminal-window-2022-11-9](https://user-images.githubusercontent.com/26394656/206736606-cafd16ac-f159-4489-976e-3701945b38bd.gif)

