### PR TITLE
clean steve fields from yaml view and download

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -26,7 +26,8 @@ function modeFor(route) {
   }
 }
 
-async function getYaml(model) {
+async function getYaml(store, model) {
+  const inStore = store.getters['currentStore'](model.type);
   let yaml;
   const opt = { headers: { accept: 'application/yaml' } };
 
@@ -34,7 +35,9 @@ async function getYaml(model) {
     yaml = (await model.followLink('view', opt)).data;
   }
 
-  return yaml;
+  const cleanedYaml = await store.dispatch(`${ inStore }/cleanFromSteve`, yaml);
+
+  return cleanedYaml;
 }
 
 export default {
@@ -182,7 +185,7 @@ export default {
       initialModel = await store.dispatch(`${ inStore }/clone`, { resource: liveModel });
 
       if ( as === _YAML ) {
-        yaml = await getYaml(liveModel);
+        yaml = await getYaml(this.$store, liveModel);
       }
 
       if ( as === _GRAPH ) {
@@ -306,7 +309,7 @@ export default {
     // Auto refresh YAML when the model changes
     async 'value.metadata.resourceVersion'(a, b) {
       if ( this.mode === _VIEW && this.as === _YAML && a && b && a !== b) {
-        this.yaml = await getYaml(this.liveModel);
+        this.yaml = await getYaml(this.$store, this.liveModel);
       }
     }
   },

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -35,7 +35,7 @@ async function getYaml(store, model) {
     yaml = (await model.followLink('view', opt)).data;
   }
 
-  const cleanedYaml = await store.dispatch(`${ inStore }/cleanFromSteve`, yaml);
+  const cleanedYaml = await store.dispatch(`${ inStore }/cleanForDownload`, yaml);
 
   return cleanedYaml;
 }

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -577,6 +577,10 @@ export default {
     return resource;
   },
 
+  cleanForDownload(ctx, resource) {
+    return resource;
+  },
+
   // Wait for a schema that is expected to exist that may not have been loaded yet (for instance when loadCluster is still running).
   async waitForSchema({ getters, dispatch }, { type }) {
     let tries = SCHEMA_CHECK_RETRIES;

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1323,7 +1323,7 @@ export default class Resource {
 
   async download() {
     const value = await this.followLink('view', { headers: { accept: 'application/yaml' } });
-    const data = await this.$dispatch('cleanFromSteve', value.data);
+    const data = await this.$dispatch('cleanForDownload', value.data);
 
     downloadFile(`${ this.nameDisplay }.yaml`, data, 'application/yaml');
   }
@@ -1346,7 +1346,7 @@ export default class Resource {
     await eachLimit(items, 10, (item, idx) => {
       return item.followLink('view', { headers: { accept: 'application/yaml' } } ).then(async(data) => {
         const yaml = data.data || data;
-        const cleanedYaml = await this.$dispatch('cleanFromSteve', yaml);
+        const cleanedYaml = await this.$dispatch('cleanForDownload', yaml);
 
         files[`resources/${ names[idx] }`] = cleanedYaml;
       });

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1323,8 +1323,9 @@ export default class Resource {
 
   async download() {
     const value = await this.followLink('view', { headers: { accept: 'application/yaml' } });
+    const data = await this.$dispatch('cleanFromSteve', value.data);
 
-    downloadFile(`${ this.nameDisplay }.yaml`, value.data, 'application/yaml');
+    downloadFile(`${ this.nameDisplay }.yaml`, data, 'application/yaml');
   }
 
   async downloadBulk(items) {
@@ -1343,8 +1344,11 @@ export default class Resource {
     }
 
     await eachLimit(items, 10, (item, idx) => {
-      return item.followLink('view', { headers: { accept: 'application/yaml' } } ).then((data) => {
-        files[`resources/${ names[idx] }`] = data.data || data;
+      return item.followLink('view', { headers: { accept: 'application/yaml' } } ).then(async(data) => {
+        const yaml = data.data || data;
+        const cleanedYaml = await this.$dispatch('cleanFromSteve', yaml);
+
+        files[`resources/${ names[idx] }`] = cleanedYaml;
       });
     });
 

--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -326,7 +326,7 @@ export default {
   },
 
   // remove fields added by steve before showing/downloading yamls
-  cleanFromSteve(ctx, yaml) {
+  cleanForDownload(ctx, yaml) {
     if (!yaml) {
       return;
     }
@@ -337,11 +337,9 @@ export default {
       'actions'
     ];
     const metadataKeys = [
-
       'fields',
       'relationships',
       'state',
-
     ];
     const conditionKeys = [
       'error',

--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -7,6 +7,7 @@ import { streamJson, streamingSupported } from '@shell/utils/stream';
 import isObject from 'lodash/isObject';
 import { classify } from '@shell/plugins/dashboard-store/classify';
 import { NAMESPACE } from '@shell/config/types';
+import jsyaml from 'js-yaml';
 
 export default {
 
@@ -323,6 +324,37 @@ export default {
 
     return resource;
   },
+
+  // remove fields added by steve before showing/downloading yamls
+  cleanFromSteve(ctx, yaml) {
+    if (!yaml) {
+      return;
+    }
+    const rootKeys = [
+      'id',
+      'links',
+      'type',
+      'actions'
+    ];
+    const metadataKeys = [
+
+      'fields',
+      'relationships',
+      'state',
+
+    ];
+    const conditionKeys = [
+      'error',
+      'transitioning',
+    ];
+    const obj = jsyaml.load(yaml);
+
+    dropKeys(obj, rootKeys);
+    dropKeys(obj?.metadata, metadataKeys);
+    (obj?.status?.conditions || []).forEach(condition => dropKeys(condition, conditionKeys));
+
+    return jsyaml.dump(obj);
+  }
 };
 
 const diffRootKeys = [


### PR DESCRIPTION
This PR updates yaml viewing and downloading across the board, so it's worth checking a few different resources. It should also be tested as both an admin and a standard user with access to only downstream clusters. The following actions are potentially impacted:
* view yaml
* edit yaml (note that edit config->as yaml is different)
* download yaml
* download yaml in bulk