### PR TITLE
Improve handling of steve socket watch timeout

### DIFF
--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -544,6 +544,9 @@ export const actions = {
     }
   },
 
+  /**
+   * Steve only event
+   */
   'ws.resource.start'({ state, getters, commit }, msg) {
     state.debugSocket && console.info(`Resource start: [${ getters.storeName }]`, msg); // eslint-disable-line no-console
     commit('setWatchStarted', {
@@ -568,6 +571,13 @@ export const actions = {
     }
   },
 
+  /**
+   * Steve only event
+   *
+   * Steve only seems to send out `resource.stop` messages for two reasons
+   * - We have requested that the resource watch should be stopped and we receive this event as confirmation
+   * - Steve tells us that the resource is no longer watched
+   */
   'ws.resource.stop'({ getters, commit, dispatch }, msg) {
     const type = msg.resourceType;
     const obj = {
@@ -579,15 +589,46 @@ export const actions = {
 
     // console.warn(`Resource stop: [${ getters.storeName }]`, msg); // eslint-disable-line no-console
 
+    // If we're trying to watch this event, attempt to re-watch
     if ( getters['schemaFor'](type) && getters['watchStarted'](obj) ) {
       // Try reconnecting once
 
       commit('setWatchStopped', obj);
 
+      // In summary, we need to re-watch but with a reliable `revision` (to avoid `too old` message kicking off a full re-fetch of all
+      // resources). To get a reliable `revision` go out and fetch the latest for that resource type, in theory our local cache should be
+      // up to date with that revision.
+      // Optimisation - Some v1 resource types don't have revisions (either at the collection or resource level), so avoid trying to fetch
+      // latest for those types
+      // Note - In theory `0`, `-1` or `null` revisions will watch for latest, however steve will send the current state of each resource
+      // via a `resource.created` event
+
+      const revision = getters.nextResourceVersion(type, obj.id);
+
+      let pLatestRevision;
+
+      if (revision) {
+        // Attempt to fetch the latest revision at the time the resource watch was stopped, in theory our local cache should be up to
+        // date with this
+        const opt = { limit: 1 };
+
+        opt.url = getters.urlFor(type, null, opt);
+        pLatestRevision = dispatch('request', { opt, type } )
+          .then(res => res.revision)
+          .catch((err) => {
+            // For some reason we can't fetch a reasonable revision, so force a re-fetch
+            console.warn(`Resource error retrieving resourceVersion, forcing re-fetch`, type, ':', err); // eslint-disable-line no-console
+            dispatch('resyncWatch', msg);
+            throw err;
+          });
+      } else {
+        pLatestRevision = Promise.resolve(null); // Null to ensure we don't go through `nextResourceVersion` again
+      }
+
       setTimeout(() => {
         // Delay a bit so that immediate start/error/stop causes
         // only a slow infinite loop instead of a tight one.
-        dispatch('watch', obj);
+        pLatestRevision.then(revision => dispatch('watch', { ...obj, revision }));
       }, 5000);
     }
   },
@@ -766,7 +807,7 @@ export const getters = {
         return null;
       }
 
-      revision = cache.revision;
+      revision = cache.revision; // This is always zero.....
 
       for ( const obj of cache.list ) {
         if ( obj && obj.metadata ) {


### PR DESCRIPTION
- Steve socket times out watches every 30 minues and we get a `resource.stop` event
- Previously we attempted to re-watch with a dodgy revision causing a `too old` error and the dashboard then fetching all resources for that type
- Avoid this by tracking latest revision which we should be up to date with

### Summary
Fixes #5997

### Occurred changes and/or fixed issues
Problem - Every 30 minutes...
  - Rancher `/v1` socket will stop watching a resource type and send a `resource.stop` socket message to the dashboard. 
  - The dashboard will then try to re-watch the resource from a specific revision. It gets this from a dodgy source, so this can SOMETIMES be invalid (too old)

There's been a BE fix already
 - Previously the BE failed to send the `too old` error, just the `resource.stop`. This would lead to the dashboard attempting the same again. Cycle continued ad nauseam. 
  - This has now been fixed (too old message is sent)

There's FE fixes in this PR
  - When dashboard receives a `too old` socket error message for a resource it re-fetches all of the resource type and re-watches from there that revision. This is super safe but also does not scale well
  - The fix is to avoid the `too old` message by watching from the latest revision when the `resource.stop` is received
  - The latest revision is found by fetching a collection and extracting it's revision. This isn't that quick, but the alternative is to send an empty revision in the watch request and that has repercussions (if it's not set, is set to -1 or 0 then steve will use the latest BUT k8s will send a resource created message for each resource ---> costly). 
  - We optimise the flow by ensuring that if a type does not contain a revision we won't try to fetch the latest revision

Notes

- This only affects the steve / `v1` socket
- The Rancher CATTLE_WATCH_TIMEOUT_SECONDS env var can be supplied at install time to reduce the 30 minute wait time (recommend 300 seconds) on the `v1` socket

### Technical notes summary
References
- PRs on the journy of discovery
  - https://github.com/rancher/dashboard/pull/7620
  - https://github.com/Sean-McQ/dashboard/pull/2
  - Where the setTimeout first came from - https://github.com/rancher/dashboard/commit/dad04cb9e38dd2f97d28dc04b6176fec56c7041f#diff-42632b5ed3c30e60abade8a67748b16d45e0778091713dd71a46d4bbe9211d2c
  - Where the setTimeout was updated from 1s to 5s - https://github.com/rancher/dashboard/pull/1534/files#diff-42632b5ed3c30e60abade8a67748b16d45e0778091713dd71a46d4bbe9211d2c

### Areas or cases that should be tested
We need to confirm that once the steve / v1 socket re-opens we continue to receive updates. This can be done by...
- Set up Rancher with CATTLE_WATCH_TIMEOUT_SECONDS=300
- Navigate to Cluster Management (note the clusters shown)
- Open browser dev tools and refresh page
- In browser dev tools `Network` --> `WS` tab there should be an entry for `v1`. Ensure that there are messages there (probably finishing with some `ping`s)
- Wait over 300 seconds (5 minutes)
- There should be `resource.stop` messages for the `v1` socket
- In another browser create an imported cluster
- In the original browser the imported cluster should automatically appear

### Areas which could experience regressions
Everywhere that watches v1 resources (management store, so things like users, principals, cluster management style resources, etc)