### PR TITLE
Improve util socket logging

### DIFF
--- a/shell/utils/socket.js
+++ b/shell/utils/socket.js
@@ -338,12 +338,20 @@ export default class Socket extends EventTarget {
     }
   }
 
+  /**
+   * `console.log` the provided summary statement, with default information to identify the socket and the provided props
+   */
   _log(summary, props) {
     this._baseLog(summary, {
       state: this.state, id: this.socket?.sockId || 0, ...props
     });
   }
 
+  /**
+   * `console.log` the provided summary statement and props
+   *
+   * This does not contain information to identify the socket and can be used in scenarios where it's not known or default
+   */
   _baseLog(summary, props) {
     const message = [summary];
     const values = Object.entries(props || {});

--- a/shell/utils/socket.js
+++ b/shell/utils/socket.js
@@ -87,7 +87,7 @@ export default class Socket extends EventTarget {
     const id = sockId++;
     const url = addParam(this.url, 'sockId', id);
 
-    console.log(`Socket connecting (id=${ id }, url=${ `${ url.replace(/\?.*/, '') }...` })`); // eslint-disable-line no-console
+    this._baseLog('connecting', { id, url: url.replace(/\?.*/, '') });
 
     let socket;
 
@@ -208,7 +208,7 @@ export default class Socket extends EventTarget {
       socket.onmessage = null;
       socket.close();
     } catch (e) {
-      this._log('Socket exception', e);
+      this._log('exception', { e: e.toString() });
       // Continue anyway...
     }
 
@@ -256,7 +256,7 @@ export default class Socket extends EventTarget {
 
     if ( timeout && this.state === STATE_CONNECTED) {
       this.frameTimer = setTimeout(() => {
-        this._log('Socket watchdog expired after', timeout, 'closing');
+        this._log(`watchdog expired after${ timeout }. Closing`);
         this._close();
         this.dispatchEvent(new CustomEvent(EVENT_FRAME_TIMEOUT));
       }, timeout);
@@ -268,8 +268,13 @@ export default class Socket extends EventTarget {
     this._log('error');
   }
 
-  _closed() {
-    console.log(`Socket ${ this.closingId } closed`); // eslint-disable-line no-console
+  _closed(event) {
+    const { code, reason, wasClean } = event;
+
+    this._baseLog('closed', {
+      id: this.closingId || this.socket?.sockId || 'unknown', code, reason, clean: wasClean
+    });
+
     this.closingId = 0;
     this.socket = null;
     clearTimeout(this.reconnectTimer);
@@ -333,13 +338,29 @@ export default class Socket extends EventTarget {
     }
   }
 
-  _log(...args) {
-    const message = JSON.parse(JSON.stringify([...args]));
+  _log(summary, props) {
+    this._baseLog(summary, {
+      state: this.state, id: this.socket?.sockId || 0, ...props
+    });
+  }
 
-    message.unshift('Socket');
+  _baseLog(summary, props) {
+    const message = [summary];
+    const values = Object.entries(props || {});
 
-    message.push(`(state=${ this.state }, id=${ this.socket ? this.socket.sockId : 0 })`);
+    message.unshift('Socket ');
 
-    console.log(message.join(' ')); // eslint-disable-line no-console
+    if (values.length) {
+      message.push(' (');
+      values.forEach(([key, value], index) => {
+        if (index !== 0) {
+          message.push(`, `);
+        }
+        message.push(`${ key }=${ value }`);
+      });
+      message.push(')');
+    }
+
+    console.log(message.join('')); // eslint-disable-line no-console
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Improve util/socket.js logging

### Occurred changes and/or fixed issues
- Ensure error exceptions are logged (`JSON.stringify(new Error('dsf'))` returns empty object)
- Ensure details of closed sockets are printed (code, reason, wasClean)
- Use a base level logging method to ensure consistent output
  - used where we might not know some basic info like socket id
- Use a top level logging method to add common socket info

### Areas or cases that should be tested
- Basic socket events (connect, disconnect, etc)
- I've tested the core ones connecting, opened, closing, closed, error, exception (mocked in screenshot below)

### Screenshot/Video
![image](https://user-images.githubusercontent.com/18697775/206763451-3b880066-91e3-4d94-8f12-7cad37836b11.png)