### PR TITLE
fix pods usage in nodes to only account for running pods

### DIFF
--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -201,7 +201,9 @@ export default class ClusterNode extends SteveModel {
   }
 
   get podConsumed() {
-    return this.pods.length;
+    const runningPods = this.pods.filter(pod => pod.state === 'running');
+
+    return runningPods.length || 0;
   }
 
   get podRequests() {


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/7504

- fix pods usage in nodes to only account for running pods

**Screenshots**

_Before_
<img width="1759" alt="Screenshot 2022-12-12 at 15 28 41" src="https://user-images.githubusercontent.com/97888974/207106795-1e190b55-f8c5-43ca-877c-8c6d29a99018.png">
<img width="1715" alt="Screenshot 2022-12-12 at 15 28 38" src="https://user-images.githubusercontent.com/97888974/207106803-69b55be8-59f3-4029-811a-41ad2e2d5382.png">


_After_
<img width="1759" alt="Screenshot 2022-12-12 at 16 57 58" src="https://user-images.githubusercontent.com/97888974/207106856-01d08da3-217e-4993-ae78-e0b5a7e576d9.png">

NOTE:
There are differences between the CPU and MEM usage for nodes on both interfaces which can be explained by:
cpu usage => https://github.com/rancher/dashboard/blob/master/shell/models/cluster/node.js#L160-L162
mem usage => https://github.com/rancher/dashboard/blob/master/shell/models/cluster/node.js#L176-L178