### PR TITLE
Add accelerated networking and availability zones to RKE2/K3s machine pools

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1301,6 +1301,10 @@ cluster:
     azure:
       availabilitySet:
         label: Availability Set (unmanaged)
+        description: Availability sets are used to protect applications from hardware failures within an Azure data center. Each machine pool can have an availability set or an availability zone, but not both.
+      availabilityZone:
+        label: Availability Zone
+        description: Availability zones protect applications from complete Azure data center failures. Each machine pool can have an availability set or an availability zone, but not both.
       dns:
         help: A unique DNS label for the public IP address.
         label: DNS Label

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1347,6 +1347,12 @@ cluster:
       size:
         label: VM Size
         tooltip: When accelerated networking is enabled, not all sizes are available.
+        supportsAcceleratedNetworking: Sizes that Support Accelerated Networking
+        doesNotSupportAcceleratedNetworking: Sizes Without Accelerated Networking
+        availabilityWarning: The selected VM size is not available in the selected region.
+        regionDoesNotSupportAzs: Availability zones are not supported in the selected region. Please select a different region or use an availability set instead.
+        regionSupportsAzsButNotThisSize: The selected region does not support availability zones for the selected VM size. Please select a different region or VM size.
+        selectedSizeAcceleratedNetworkingWarning: The selected VM size does not support accelerated networking. Please select another VM size or disable accelerated networking.
       sshUser:
         label: SSH Username
       storageType:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1299,12 +1299,14 @@ cluster:
           other {{storageSize, number} {storageUnit} {storageType}}
         }
     azure:
+      acceleratedNetworking:
+        label: Accelerated Networking
       availabilitySet:
         label: Availability Set (unmanaged)
-        description: Availability sets are used to protect applications from hardware failures within an Azure data center. Each machine pool can have an availability set or an availability zone, but not both.
+        description: Availability sets are used to protect applications from hardware failures within an Azure data center.
       availabilityZone:
         label: Availability Zone
-        description: Availability zones protect applications from complete Azure data center failures. Each machine pool can have an availability set or an availability zone, but not both.
+        description: Availability zones protect applications from complete Azure data center failures.
       dns:
         help: A unique DNS label for the public IP address.
         label: DNS Label
@@ -1344,6 +1346,7 @@ cluster:
         label: Resource Group
       size:
         label: VM Size
+        tooltip: When accelerated networking is enabled, not all sizes are available.
       sshUser:
         label: SSH Username
       storageType:

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -183,6 +183,11 @@ export default {
 
   created() {
     if (this.mode === 'create') {
+      for (const key in this.defaultConfig) {
+        if (this.value[key] === undefined) {
+          this.$set(this.value, key, this.defaultConfig[key]);
+        }
+      }
       merge(this.value, this.defaultConfig);
 
       this.value.nsg = `rancher-managed-${ randomStr(8) }`;
@@ -274,7 +279,7 @@ export default {
       </div>
     </div>
     <div class="row mt-20">
-      <div class="col span-6">
+      <div class="col span-4">
         <LabeledInput
           v-model="value.resourceGroup"
           :mode="mode"
@@ -282,11 +287,20 @@ export default {
           :disabled="disabled"
         />
       </div>
-      <div class="col span-6">
+      <div class="col span-4">
         <LabeledInput
           v-model="value.availabilitySet"
           :mode="mode"
           :label="t('cluster.machineConfig.azure.availabilitySet.label')"
+          :disabled="disabled"
+        />
+      </div>
+      <div class="col span-4">
+        <LabeledInput
+          v-model="value.availabilityZone"
+          :mode="mode"
+          :label="t('cluster.machineConfig.azure.availabilityZone.label')"
+          :tooltip="t('cluster.machineConfig.azure.image.help')"
           :disabled="disabled"
         />
       </div>
@@ -366,6 +380,13 @@ export default {
             :disabled="disabled"
           />
         </div>
+      </div>
+      <div class="row mt-20">
+        <Checkbox
+          v-model="value.acceleratedNetworking"
+          :mode="mode"
+          :label="t('cluster.machineConfig.azure.acceleratedNetworking.label')"
+        />
       </div>
       <div class="row mt-20">
         <div class="col span-6">

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -667,6 +667,7 @@ export default {
       <div class="row mt-20">
         <Checkbox
           v-model="value.acceleratedNetworking"
+          :disabled="(!value.acceleratedNetworking && !selectedVmSizeSupportsAN)"
           :mode="mode"
           :label="t('cluster.machineConfig.azure.acceleratedNetworking.label')"
         />
@@ -715,15 +716,6 @@ export default {
             :disabled="!value.usePrivateIp"
           />
         </div>
-      </div>
-      <div class="row mt-20">
-        <Checkbox
-          v-model="value.acceleratedNetworking"
-          :disabled="(!value.acceleratedNetworking && !selectedVmSizeSupportsAN)"
-          :mode="mode"
-          :label="t('cluster.machineConfig.azure.acceleratedNetworking.label')"
-          :tooltip="vmSizeAcceleratedNetworkingWarning"
-        />
       </div>
       <div class="row mt-20">
         <div class="col span-6">

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -14,7 +14,6 @@ import { addParam, addParams } from '@shell/utils/url';
 import KeyValue from '@shell/components/form/KeyValue';
 import { RadioGroup } from '@components/Form/Radio';
 import { _CREATE } from '@shell/config/query-params';
-import { truncate } from 'lodash';
 
 export const azureEnvironments = [
   { value: 'AzurePublicCloud' },

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -165,7 +165,7 @@ export default {
       }
 
       this.vmSizes = await this.$store.dispatch('management/request', {
-        url: addParams('/meta/aksVMSizes', {
+        url: addParams('/meta/aksVMSizesV2', {
           cloudCredentialId: this.credentialId,
           region:            this.value.location
         }),
@@ -359,7 +359,7 @@ export default {
       // VMs are supported in different regions.
       try {
         this.vmSizes = await this.$store.dispatch('management/request', {
-          url: addParams('/meta/aksVMSizes', {
+          url: addParams('/meta/aksVMSizesV2', {
             cloudCredentialId: this.credentialId,
             region:            this.value.location
           }),

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -177,15 +177,23 @@ export default {
   },
 
   data() {
+    let useAvailabilitySet = false;
+
+    if (this.mode === _CREATE) {
+      useAvailabilitySet = true;
+    } else {
+      useAvailabilitySet = !!this.value.availabilitySet;
+    }
+
     return {
       azureEnvironments,
       defaultConfig,
       storageTypes,
-      credential:         null,
-      locationOptions:    [],
-      useAvailabilitySet: !!this.value.availabilitySet,
-      vmSizes:            [],
-      valueCopy:          this.value
+      credential:      null,
+      locationOptions: [],
+      useAvailabilitySet,
+      vmSizes:         [],
+      valueCopy:       this.value
     };
   },
 

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -244,7 +244,7 @@ export default {
       return selectedSizeIsValid;
     },
     vmSizeAcceleratedNetworkingWarning() {
-      if (!this.selectedVmSizeSupportsAN) {
+      if (!this.selectedVmSizeSupportsAN && this.value.acceleratedNetworking) {
         return this.t('cluster.machineConfig.azure.size.selectedSizeAcceleratedNetworkingWarning');
       }
 
@@ -287,7 +287,7 @@ export default {
         return this.t('cluster.machineConfig.azure.size.regionDoesNotSupportAzs');
       }
 
-      if (this.vmsWithAvailabilityZones > 0 && !this.selectedVmSizeHasZones) {
+      if (this.vmsWithAvailabilityZones.length > 0 && !this.selectedVmSizeHasZones) {
         return this.t('cluster.machineConfig.azure.size.regionSupportsAzsButNotThisSize');
       }
 


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7182 and https://github.com/rancher/dashboard/issues/7180

Combining the two options into one PR to avoid merge conflicts

## What was fixed, or what changes have occurred
Summary:
 - Added  accelerated networking (AN) to Azure node options in the Advanced section for RKE2/K3s cluster provisioning
 - Added an Availability Zone option for Azure nodes
	 - You can have an Availability Set or Availability Zone, but not both
	 - The Availability Zone dropdown menu may or may not have any options, depending on the selected region. For example, if you select `westus` as the location, the Availability Zone dropdown should be disabled and you should see a warning because that region doesn't support AZs. If you select `westus2` as the location, the Availability Zone dropdown should have 1, 2 and 3 as options.

### Accelerated Networking
- When AN is enabled, the list of VM sizes should show that the VM sizes that don't support it are disabled.
- When AN is enabled, the VM size dropdown should have a tooltip explaining why some options are disabled.
- If you have AN disabled, then select a VM that does not support AN (such as `BasicA0`), then try enable AN, you should see an error that says the VM size is incompatible with AN. A warning also shows next to the VM size dropdown. The warning goes away if any other non-disabled VM is selected or if AN is turned off.

### Availability Zones
- Can select an AZ for a machine pool
- Warn the user when the selected VM size is not in the selected region
- Warn the user if they have selected availability zones, but that is not supported for the region or VM size

 