### PR TITLE
On Cluster creates, sets rke2/k3s as default

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -213,8 +213,8 @@ export default {
       get() {
         // This can incorrectly return rke1 instead
         // of rke2 for cluster owners.
-        if ( !this.rke2Enabled ) {
-          return _RKE1;
+        if ( this.rke2Enabled ) {
+          return _RKE2;
         }
 
         return this.preferredProvisioner;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/7395#issuecomment-1346837440
<!-- Define findings related to the feature or bug issue. -->


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

As per issues, we expect to have the RKE2/K3S as default in the Cluster Creations

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://user-images.githubusercontent.com/88777903/207261973-8bd3d04e-a3ea-40bc-a1d0-6e05d47c8f22.mp4

