### PR TITLE
Move PSPs to advanced section

### DIFF
--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -54,7 +54,7 @@ export function init(store) {
     name:       'pod-security-policies',
     group:      'Root',
     namespaced: false,
-    weight:     0,
+    weight:     5,
     icon:       'folder',
     route:      { name: 'c-cluster-manager-pages-page', params: { cluster: 'local', page: 'pod-security-policies' } },
     exact:      true
@@ -64,7 +64,6 @@ export function init(store) {
     CAPI.RANCHER_CLUSTER,
     'cloud-credentials',
     'drivers',
-    'pod-security-policies',
   ]);
 
   configureType(CAPI.RANCHER_CLUSTER, {
@@ -125,6 +124,7 @@ export function init(store) {
     CAPI.MACHINE_SET,
     CAPI.MACHINE,
     CATALOG.CLUSTER_REPO,
+    'pod-security-policies',
   ], 'advanced');
 
   weightGroup('advanced', -1, true);


### PR DESCRIPTION
Fixes #7621 

Move PSP to the advanced section, since they are deprecated and now removed in 1.25 (obviously nav only shows if the schema is present)

Now looks like this:

<img width="236" alt="image" src="https://user-images.githubusercontent.com/1955897/207291826-5d40cea6-df82-4587-aed7-4136b83c15b7.png">
