### PR TITLE
Add explore button to cluster detail view

### DIFF
--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -125,6 +125,10 @@ export default {
       return null;
     },
 
+    detailsAction() {
+      return this.value?.detailsAction;
+    },
+
     shouldHifenize() {
       return (this.mode === 'view' || this.mode === 'edit') && this.resourceSubtype?.length && this.value?.nameDisplay?.length;
     },
@@ -368,6 +372,18 @@ export default {
 
     toggleSensitiveData(e) {
       this.$store.dispatch('prefs/set', { key: HIDE_SENSITIVE, value: !!e });
+    },
+
+    invokeDetailsAction() {
+      const action = this.detailsAction;
+
+      if (action) {
+        const fn = this.value[action.action];
+
+        if (fn) {
+          fn.apply(this.value, []);
+        }
+      }
     }
   }
 };
@@ -418,6 +434,15 @@ export default {
       <slot name="right">
         <div class="actions-container">
           <div class="actions">
+            <button
+              v-if="detailsAction"
+              type="button"
+              class="btn role-primary actions mr-10"
+              :disabled="!detailsAction.enabled"
+              @click="invokeDetailsAction"
+            >
+              {{ detailsAction.label }}
+            </button>
             <ButtonGroup
               v-if="showSensitiveToggle"
               :value="!!hideSensitiveData"

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -54,7 +54,7 @@ export function init(store) {
     name:       'pod-security-policies',
     group:      'Root',
     namespaced: false,
-    weight:     0,
+    weight:     5,
     icon:       'folder',
     route:      { name: 'c-cluster-manager-pages-page', params: { cluster: 'local', page: 'pod-security-policies' } },
     exact:      true
@@ -64,7 +64,6 @@ export function init(store) {
     CAPI.RANCHER_CLUSTER,
     'cloud-credentials',
     'drivers',
-    'pod-security-policies',
   ]);
 
   configureType(CAPI.RANCHER_CLUSTER, {
@@ -125,6 +124,7 @@ export function init(store) {
     CAPI.MACHINE_SET,
     CAPI.MACHINE,
     CATALOG.CLUSTER_REPO,
+    'pod-security-policies',
   ], 'advanced');
 
   weightGroup('advanced', -1, true);

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -71,6 +71,17 @@ export default class ProvCluster extends SteveModel {
     return super.creationTimestamp;
   }
 
+  // Models can specify a single action that will be shown as a button in the details masthead
+  get detailsAction() {
+    const canExplore = this.mgmt?.isReady && !this.hasError;
+
+    return {
+      action:  'explore',
+      label:   this.$rootGetters['i18n/t']('cluster.explore'),
+      enabled: canExplore,
+    };
+  }
+
   get _availableActions() {
     const out = super._availableActions;
     const isLocal = this.mgmt?.isLocal;
@@ -163,6 +174,15 @@ export default class ProvCluster extends SteveModel {
     const out = this.$rootGetters['rancher/byId'](NORMAN.CLUSTER, name);
 
     return out;
+  }
+
+  explore() {
+    const location = {
+      name:   'c-cluster',
+      params: { cluster: this.mgmt.id }
+    };
+
+    this.currentRouter().push(location);
   }
 
   goToViewYaml() {


### PR DESCRIPTION
Fixes #7694

This PR:

- Extends the detail masthead to support a single action that can be provided by the resource model to be shown as a button in the detail masthead
- Updates the cluster model to provide an action to be shown in the masthead which will take the user to the cluster

![image](https://user-images.githubusercontent.com/1955897/207351533-1b54b36d-2829-4f87-9290-c7f2d2b176fd.png)
