### PR TITLE
HARVESTER: Cluster field is not really *required* when creating RKE2/K3s Harvester

### DIFF
--- a/shell/cloud-credential/harvester.vue
+++ b/shell/cloud-credential/harvester.vue
@@ -78,7 +78,28 @@ export default {
       this.$nuxt.$loading.finish();
 
       this.value.setData('kubeconfigContent', kubeconfigContent);
-    }
+    },
+
+    'value.decodedData.clusterId': {
+      handler() {
+        this.emitValidation();
+      },
+      immediate: true,
+    },
+
+    isImportCluster: {
+      handler() {
+        this.emitValidation();
+      },
+      immediate: true,
+    },
+
+    'value.decodedData.kubeconfigContent': {
+      handler() {
+        this.emitValidation();
+      },
+      immediate: true,
+    },
   },
 
   methods: {
@@ -102,7 +123,15 @@ export default {
         return true;
       }
     },
-  }
+
+    emitValidation() {
+      if (this.test() === true) {
+        this.$emit('validationChanged', true);
+      } else {
+        this.$emit('validationChanged', false);
+      }
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes Cluster field is not really *required* when creating RKE2/K3s Harvester
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3165

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/18737885/207531276-eefee8e1-0d55-4f8d-998a-53f008126a1b.png)
