### PR TITLE
Fix: Also show RKE1/RKE2 toggle on cluster creation screen if all node drivers are deactivated

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -205,10 +205,6 @@ export default {
 
     rke2Enabled: mapFeature(RKE2_FEATURE),
 
-    showRkeToggle() {
-      return this.rke2Enabled && !this.isImport;
-    },
-
     provisioner: {
       get() {
         // This can incorrectly return rke1 instead
@@ -352,9 +348,29 @@ export default {
 
       return sortBy(Object.values(out), 'sort');
     },
+
+    firstNodeDriverItem() {
+      return this.groupedSubTypes.findIndex(obj => [_RKE1, _RKE2].includes(obj.name));
+    },
+
+    firstCustomClusterItem() {
+      return this.groupedSubTypes.findIndex(obj => ['custom', 'custom1', 'custom2'].includes(obj.name));
+    },
   },
 
   methods: {
+    showRkeToggle(i) {
+      if (this.isImport || !this.rke2Enabled) {
+        return false;
+      }
+
+      if (this.firstNodeDriverItem >= 0) {
+        return i === this.firstNodeDriverItem;
+      }
+
+      return i === this.firstCustomClusterItem;
+    },
+
     loadStylesheet(url, id) {
       if ( !id ) {
         console.error('loadStylesheet called without an id'); // eslint-disable-line no-console
@@ -469,7 +485,7 @@ export default {
       >
         <h4>
           <div
-            v-if="showRkeToggle && [_RKE1,_RKE2].includes(obj.name)"
+            v-if="showRkeToggle(i)"
             class="grouped-type"
           >
             <ToggleSwitch


### PR DESCRIPTION
### Summary
This fixes the cluster creation page to also show a RKE1/RKE2 toggle if all node drivers are deactivated.

Fixes #7705

### Occurred changes and/or fixed issues
This changes the `v-if` to decide if the toggle is shown on one of the headlines, to either show it at the 2nd item (node driver clusters or custom clusters) or at the 1st item (custom clusters, if both all node drivers and cluster drivers are deactivated).

### Areas or cases that should be tested
Cluster creation screen with different variants of having cluster or node drivers activated. The toggle should always be visible.

### Areas which could experience regressions
Cluster creation screen.

### Screenshot/Video
![Bildschirm­foto 2022-12-14 um 17 23 47](https://user-images.githubusercontent.com/243056/207651675-90d11263-1fe4-4d0c-81c5-7bbe05a221c9.png)
![Bildschirm­foto 2022-12-14 um 17 23 38](https://user-images.githubusercontent.com/243056/207651678-bcab88a3-d01f-432e-889e-6f7c262db855.png)
![Bildschirm­foto 2022-12-14 um 17 23 30](https://user-images.githubusercontent.com/243056/207651681-f2a7a08e-476d-432e-8e99-739c52da0da3.png)
![Bildschirm­foto 2022-12-14 um 17 23 18](https://user-images.githubusercontent.com/243056/207651684-b10a5143-3555-4c82-97ca-a2eaf729c496.png)

