### PR TITLE
[Backport for 2.6.x] Fix: Open shell from workload pages may pick wrong pod

### DIFF
--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -612,8 +612,10 @@ export default class Workload extends WorkloadService {
 
   async matchingPods() {
     const all = await this.$dispatch('findAll', { type: POD });
+    const allInNamespace = all.filter(pod => pod.metadata.namespace === this.metadata.namespace);
+
     const selector = convertSelectorObj(this.spec.selector);
 
-    return matching(all, selector);
+    return matching(allInNamespace, selector);
   }
 }


### PR DESCRIPTION
Backport https://github.com/rancher/dashboard/pull/6981
Original issue https://github.com/rancher/dashboard/issues/6982

Fixes https://github.com/rancher/dashboard/issues/7274