### PR TITLE
Fix secondary style small button height

### DIFF
--- a/shell/assets/styles/global/_button.scss
+++ b/shell/assets/styles/global/_button.scss
@@ -95,7 +95,11 @@ button,
   }
 
   &.btn-sm {
-    line-height: $btn-sm-height;
+    line-height: $btn-sm-height - 2px;
+
+    &:focus, &.focused {
+      border: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #7727 

Addresses minor issue with the height and style of small buttons with secondary styling:

Before:

![image](https://user-images.githubusercontent.com/1955897/208071899-e9cd82e2-a393-423f-97f5-b0966345d965.png)


After PR:

![image](https://user-images.githubusercontent.com/1955897/208072153-13cb5b23-c9a3-44ff-9de5-6282087e58a0.png)
