### PR TITLE
add disable auth provider prompt modal

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4044,8 +4044,7 @@ promptRemove:
     other { and <b>{count} others</b>.}
     }
   attemptingToRemove: "You are attempting to delete the {type}"
-  attemptingToRemoveAuthConfig: "You are attempting to disable this {type}. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. Are you sure you want to proceed?"
-  attemptingToRemoveAuthConfigNew: "You are attempting to disable this Auth Provider. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. Are you sure you want to proceed?"
+  attemptingToRemoveAuthConfig: "You are attempting to disable this Auth Provider. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. <br><br> Are you sure you want to proceed?"
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
   confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4044,6 +4044,8 @@ promptRemove:
     other { and <b>{count} others</b>.}
     }
   attemptingToRemove: "You are attempting to delete the {type}"
+  attemptingToRemoveAuthConfig: "You are attempting to disable this {type}. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. Are you sure you want to proceed?"
+  attemptingToRemoveAuthConfigNew: "You are attempting to disable this Auth Provider. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. Are you sure you want to proceed?"
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
   confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"

--- a/shell/components/DisableAuthProviderModal.vue
+++ b/shell/components/DisableAuthProviderModal.vue
@@ -1,0 +1,122 @@
+<script>
+import { Card } from '@components/Card';
+import AsyncButton from '@shell/components/AsyncButton';
+export default {
+  name: 'PromptRemove',
+
+  components: {
+    Card,
+    // Checkbox,
+    AsyncButton
+  },
+  props: {
+    /**
+     * Inherited global identifier prefix for tests
+     * Define a term based on the parent component to avoid conflicts on multiple components
+     */
+    componentTestid: {
+      type:    String,
+      default: 'disable-auth-provider'
+    }
+  },
+  data() {
+    // const { resource } = this.$route.params;
+
+    return {};
+  },
+  computed: {},
+
+  watch: {},
+
+  methods: {
+    show() {
+      this.$modal.show('disableAuthProviderModal');
+    },
+    close() {
+      this.$modal.hide('disableAuthProviderModal');
+    },
+    disable() {
+      this.$modal.hide('disableAuthProviderModal');
+      this.$emit('disable');
+    },
+  }
+};
+</script>
+
+<template>
+  <modal
+    class="remove-modal"
+    name="disableAuthProviderModal"
+    :width="400"
+    height="auto"
+    styles="max-height: 100vh;"
+    @closed="close"
+  >
+    <Card
+      class="disable-auth-provider"
+      :show-highlight-border="false"
+    >
+      <h4
+        slot="title"
+        class="text-default-text"
+      >
+        {{ t('promptRemove.title') }}
+      </h4>
+      <div slot="body">
+        <div class="mb-10">
+          <!-- <p v-html="t('promptRemove.attemptingToRemoveAuthConfig', { type }, true)" /> -->
+          <p v-html="t('promptRemove.attemptingToRemoveAuthConfigNew', null, true)" />
+        </div>
+      </div>
+      <template #actions>
+        <button
+          class="btn role-secondary"
+          @click="close"
+        >
+          {{ t('generic.cancel') }}
+        </button>
+        <div class="spacer" />
+        <AsyncButton
+          mode="delete"
+          class="btn bg-error ml-10"
+          :disabled="deleteDisabled"
+          :data-testid="componentTestid + '-confirm-button'"
+          @click="disable"
+        />
+      </template>
+    </Card>
+  </modal>
+</template>
+
+<style lang='scss'>
+  .disable-auth-provider {
+    &.card-container {
+      box-shadow: none;
+    }
+    #confirm {
+      width: 90%;
+      margin-left: 3px;
+    }
+
+    .remove-modal {
+        border-radius: var(--border-radius);
+        overflow: scroll;
+        max-height: 100vh;
+        & ::-webkit-scrollbar-corner {
+          background: rgba(0,0,0,0);
+        }
+    }
+
+    .actions {
+      text-align: right;
+    }
+
+    .card-actions {
+      display: flex;
+
+      .spacer {
+        flex: 1;
+      }
+    }
+  }
+</style>

--- a/shell/components/DisableAuthProviderModal.vue
+++ b/shell/components/DisableAuthProviderModal.vue
@@ -1,15 +1,10 @@
 <script>
 import { Card } from '@components/Card';
-import AsyncButton from '@shell/components/AsyncButton';
 export default {
   name: 'PromptRemove',
 
-  components: {
-    Card,
-    // Checkbox,
-    AsyncButton
-  },
-  props: {
+  components: { Card },
+  props:      {
     /**
      * Inherited global identifier prefix for tests
      * Define a term based on the parent component to avoid conflicts on multiple components
@@ -18,11 +13,6 @@ export default {
       type:    String,
       default: 'disable-auth-provider'
     }
-  },
-  data() {
-    // const { resource } = this.$route.params;
-
-    return {};
   },
   computed: {},
 
@@ -64,8 +54,7 @@ export default {
       </h4>
       <div slot="body">
         <div class="mb-10">
-          <!-- <p v-html="t('promptRemove.attemptingToRemoveAuthConfig', { type }, true)" /> -->
-          <p v-html="t('promptRemove.attemptingToRemoveAuthConfigNew', null, true)" />
+          <p v-html="t('promptRemove.attemptingToRemoveAuthConfig', null, true)" />
         </div>
       </div>
       <template #actions>
@@ -76,13 +65,13 @@ export default {
           {{ t('generic.cancel') }}
         </button>
         <div class="spacer" />
-        <AsyncButton
-          mode="delete"
-          class="btn bg-error ml-10"
-          :disabled="deleteDisabled"
+        <button
+          class="btn role-primary bg-error ml-10"
           :data-testid="componentTestid + '-confirm-button'"
           @click="disable"
-        />
+        >
+          {{ t('generic.disable') }}
+        </button>
       </template>
     </Card>
   </modal>

--- a/shell/components/DisableAuthProviderModal.vue
+++ b/shell/components/DisableAuthProviderModal.vue
@@ -1,8 +1,7 @@
 <script>
 import { Card } from '@components/Card';
 export default {
-  name: 'PromptRemove',
-
+  name:       'PromptRemove',
   components: { Card },
   props:      {
     /**
@@ -14,10 +13,6 @@ export default {
       default: 'disable-auth-provider'
     }
   },
-  computed: {},
-
-  watch: {},
-
   methods: {
     show() {
       this.$modal.show('disableAuthProviderModal');

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -2,11 +2,13 @@
 <script>
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
+import DisableAuthProviderModal from '@shell/components/DisableAuthProviderModal';
 
 export default {
   components: {
     AsyncButton,
-    Banner
+    Banner,
+    DisableAuthProviderModal
   },
 
   props: {
@@ -30,6 +32,12 @@ export default {
   computed: {
     values() {
       return Object.entries(this.table);
+    }
+  },
+
+  methods: {
+    showDisableModal() {
+      this.$refs.disableAuthProviderModal.show();
     }
   },
 };
@@ -57,7 +65,7 @@ export default {
         mode="disable"
         size="sm"
         action-color="bg-error"
-        @click="disable"
+        @click="showDisableModal"
       />
     </Banner>
 
@@ -67,6 +75,10 @@ export default {
     >
       <slot name="rows" />
     </table>
+    <DisableAuthProviderModal
+      ref="disableAuthProviderModal"
+      @disable="disable"
+    />
   </div>
 </template>
 

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -1,12 +1,10 @@
 
 <script>
 import { Banner } from '@components/Banner';
-import AsyncButton from '@shell/components/AsyncButton';
 import DisableAuthProviderModal from '@shell/components/DisableAuthProviderModal';
 
 export default {
   components: {
-    AsyncButton,
     Banner,
     DisableAuthProviderModal
   },
@@ -60,13 +58,13 @@ export default {
       >
         {{ t('action.edit') }}
       </button>
-      <AsyncButton
-        class="ml-10"
-        mode="disable"
-        size="sm"
-        action-color="bg-error"
+      <button
+        type="button"
+        class="ml-10 btn-sm role-primary bg-error"
         @click="showDisableModal"
-      />
+      >
+        {{ t('generic.disable') }}
+      </button>
     </Banner>
 
     <table

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -238,10 +238,6 @@ export default {
       }
     },
 
-    showDisableModal() {
-      this.$refs.disableAuthProviderModal.show();
-    },
-
     async reloadModel() {
       this.originalModel = await this.$store.dispatch('rancher/find', {
         type: NORMAN.AUTH_CONFIG,

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -238,9 +238,8 @@ export default {
       }
     },
 
-    showDisableModal(btnCb) {
+    showDisableModal() {
       this.$refs.disableAuthProviderModal.show();
-      btnCb(false);
     },
 
     async reloadModel() {

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -214,7 +214,7 @@ export default {
       }
     },
 
-    async disable(btnCb) {
+    async disable() {
       try {
         if (this.model.hasAction('disable')) {
           await this.model.doAction('disable');
@@ -233,11 +233,14 @@ export default {
           opt:  { url: '/v3/principals', force: true }
         });
         this.showLdap = false;
-        btnCb(true);
       } catch (err) {
         this.errors = [err];
-        btnCb(false);
       }
+    },
+
+    showDisableModal(btnCb) {
+      this.$refs.disableAuthProviderModal.show();
+      btnCb(false);
     },
 
     async reloadModel() {


### PR DESCRIPTION
Fixes #7525 

- add disable auth provider prompt modal

**Screenshots**
![Screenshot 2022-12-16 at 15 33 44](https://user-images.githubusercontent.com/97888974/208134321-372ec3fb-7b54-4fd9-9118-6ab89d6f533a.png)
![Screenshot 2022-12-16 at 15 33 53](https://user-images.githubusercontent.com/97888974/208134340-bd077c7a-2f48-4c5f-a138-826471e28cca.png)

**Test**
- Go to `Users & Authentication` -> `Auth Provider`
- Provision an `Auth Provider` such as `OpenLDAP` (https://confluence.suse.com/display/CU/Setting+up+an+OpenLDAP+Auth+Provider+on+Rancher+Dashboard+for+testing)
- After `OpenLDAP` is active, press `disable`
- Modal should appear and work as expected (copy is according #7525 )