### PR TITLE
Fix issue with project name not editable

### DIFF
--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -152,7 +152,7 @@ export default {
               type: MANAGEMENT.PROJECT,
               id:   this.value.id,
               opt:  { force: true }
-             });
+            });
           }
 
           // // we allow users with permissions for projectroletemplatebindings to be able to manage members on projects

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -146,6 +146,13 @@ export default {
         } else if (this.mode === _EDIT) {
           if (this.canEditProject) {
             await this.value.save(true);
+
+            // We updated the Norman resource - re-fetch the Steve resource so we know it is definitely updated in the store
+            await this.$store.dispatch('management/find', {
+              type: MANAGEMENT.PROJECT,
+              id:   this.value.id,
+              opt:  { force: true }
+             });
           }
 
           // // we allow users with permissions for projectroletemplatebindings to be able to manage members on projects

--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -163,6 +163,7 @@ export default class Project extends HybridModel {
       normanProject.setLabels(this.metadata.labels);
       normanProject.setResourceQuotas(clearedResourceQuotas);
       normanProject.description = this.spec.description;
+      normanProject.name = this.spec.displayName;
       normanProject.containerDefaultResourceLimit = this.spec.containerDefaultResourceLimit;
 
       return normanProject;


### PR DESCRIPTION
Fixes #7179 

Original fix did not set the name, so I don't know how that every worked or was tested? @Shavindra 

This PR:

- Ensures the name is updated
- Forces a fetch of the updated resource, to avoid an issue where we update the Norman resource and when you return to the list page, the name does not reflect the change made - we force a fetch of the corresponding Steve resource