### PR TITLE
Fix global role description

### DIFF
--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -146,6 +146,13 @@ export default {
         } else if (this.mode === _EDIT) {
           if (this.canEditProject) {
             await this.value.save(true);
+
+            // We updated the Norman resource - re-fetch the Steve resource so we know it is definitely updated in the store
+            await this.$store.dispatch('management/find', {
+              type: MANAGEMENT.PROJECT,
+              id:   this.value.id,
+              opt:  { force: true }
+            });
           }
 
           // // we allow users with permissions for projectroletemplatebindings to be able to manage members on projects

--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -3,7 +3,7 @@ import { SCHEMA, NORMAN } from '@shell/config/types';
 import { CATTLE_API_GROUP, SUBTYPE_MAPPING, CREATE_VERBS } from '@shell/models/management.cattle.io.roletemplate';
 import { uniq } from '@shell/utils/array';
 import { get } from '@shell/utils/object';
-import SteveModel from '@shell/plugins/steve/steve-class';
+import SteveDescriptionModel from '@shell/plugins/steve/steve-description-class';
 import Role from './rbac.authorization.k8s.io.role';
 import { AS, MODE, _CLONE, _UNFLAG } from '@shell/config/query-params';
 
@@ -14,7 +14,7 @@ const SPECIAL = [BASE, ADMIN, USER];
 
 const GLOBAL = SUBTYPE_MAPPING.GLOBAL.key;
 
-export default class GlobalRole extends SteveModel {
+export default class GlobalRole extends SteveDescriptionModel {
   get customValidationRules() {
     return Role.customValidationRules();
   }

--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -163,6 +163,7 @@ export default class Project extends HybridModel {
       normanProject.setLabels(this.metadata.labels);
       normanProject.setResourceQuotas(clearedResourceQuotas);
       normanProject.description = this.spec.description;
+      normanProject.name = this.spec.displayName;
       normanProject.containerDefaultResourceLimit = this.spec.containerDefaultResourceLimit;
 
       return normanProject;


### PR DESCRIPTION
Fixes #7635 

Need to use the different base model that respects the description field for the cases like this where description is on the top-level object.

Applies fix from: https://github.com/rancher/dashboard/pull/6676/files to global roles