### PR TITLE
If Azure storage type StandardSSD_LRS is selected, show managed disks warning

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1344,6 +1344,7 @@ cluster:
         label: SSH Username
       storageType:
         label: Storage Type
+        warning: StandardSSD_LRS requires managed disks. Please select Use Managed Disks or select another storage type.
       subnet:
         label: Subnet
       subnetPrefix:

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -449,8 +449,6 @@ export default {
             :label="t('cluster.machineConfig.azure.storageType.warning')"
           />
         </div>
-      </div>
-      <div class="row mt-20">
         <div class="col span-6">
           <Checkbox
             v-model="value.managedDisks"
@@ -458,16 +456,17 @@ export default {
             :label="t('cluster.machineConfig.azure.managedDisks.label')"
             :disabled="disabled"
           />
+        </div>
+      </div>
+      <div class="row mt-20">
+        <div class="col span-6">
           <LabeledInput
             v-model="value.diskSize"
             :mode="mode"
-            class="mt-10"
             :label="t('cluster.machineConfig.azure.managedDisksSize.label')"
             :disabled="disabled"
           />
         </div>
-      </div>
-      <div class="row mt-20">
         <div class="col span-6">
           <LabeledInput
             v-model="value.sshUser"

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -443,6 +443,11 @@ export default {
             option-key="value"
             option-label="name"
           />
+          <Banner
+            v-if="value.storageType === 'StandardSSD_LRS' && !value.managedDisks"
+            color="error"
+            :label="t('cluster.machineConfig.azure.storageType.warning')"
+          />
         </div>
       </div>
       <div class="row mt-20">


### PR DESCRIPTION
Addresses https://github.com/rancher/dashboard/issues/7744

The StandardSSD_LRS storage option requires managed disks to work. So if StandardSSD_LRS is selected, and managed disks are not selected, there should now be an error message:


<img width="932" alt="Screenshot 2022-12-16 at 1 21 56 PM" src="https://user-images.githubusercontent.com/20599230/208183079-ac43e8d3-9eea-422b-aaaf-a681d1604334.png">

If managed disks are enabled, the error message disappears:


<img width="934" alt="Screenshot 2022-12-16 at 1 22 02 PM" src="https://user-images.githubusercontent.com/20599230/208183143-29d6d67e-2fb1-4139-8d90-5dcf0dccdc7b.png">
