### PR TITLE
re-add lost cluster.explore translation

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1282,7 +1282,7 @@ cluster:
     commandInstructionsInsecure: 'If you get a &quot;certificate signed by unknown authority&quot; error, your {vendor} installation has a self-signed or untrusted SSL certificate.  Run the command below instead to bypass the certificate verification:'
     clusterRoleBindingInstructions: 'If you get permission errors creating some of the resources, your user may not have the <code>cluster-admin</code> role.  Use this command to apply it:'
     clusterRoleBindingCommand: 'kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user <your username from your kubeconfig>'
-  exploreHarvester: Explore
+  explore: Explore
   importAction: Import Existing
   manageAction: Manage
   kubernetesVersion:

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -197,7 +197,7 @@ export default {
           class="btn btn-sm role-secondary"
           :to="{name: 'c-cluster', params: {cluster: row.mgmt.id}}"
         >
-          {{ t('cluster.exploreHarvester') }}
+          {{ t('cluster.explore') }}
         </n-link>
         <button
           v-else


### PR DESCRIPTION
Fixes #7763

We lost the `cluster.explore` translation string recently. Interestingly, the disabled button shown while a cluster is not ready was referencing a different key than the n-link used when the cluster can be explored. I opted to remove the `exploreHarvester` version because it's misleading when it is only applied to non-harvester clusters.