### PR TITLE
fix filter namespace

### DIFF
--- a/pkg/harvester/store/harvester-store/actions.ts
+++ b/pkg/harvester/store/harvester-store/actions.ts
@@ -100,7 +100,6 @@ export default {
     commit('updateNamespaces', {
       filters: filters || [ALL_USER],
       all:     res.virtualNamespaces,
-      ...getters
     }, { root: true });
   },
 };

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -81,7 +81,13 @@ const getActiveNamespaces = (state, getters) => {
     return out;
   }
 
-  const namespaces = getters[`${ inStore }/all`](NAMESPACE);
+  let namespaces = [];
+
+  if (Array.isArray(state.allNamespaces) && state.allNamespaces.length > 0) {
+    namespaces = state.allNamespaces;
+  } else {
+    namespaces = getters[`${ inStore }/all`](NAMESPACE);
+  }
 
   const filters = state.namespaceFilters.filter(x => !!x && !`${ x }`.startsWith(NAMESPACED_PREFIX));
   const includeAll = getters.isAllNamespaces;
@@ -850,7 +856,6 @@ export const actions = {
     commit('updateNamespaces', {
       filters: filters || [ALL_USER],
       all:     res.namespaces,
-      ...getters
     });
 
     commit('clusterReady', true);
@@ -868,7 +873,7 @@ export const actions = {
         [key]: ids
       }
     });
-    commit('updateNamespaces', { filters: ids, ...getters });
+    commit('updateNamespaces', { filters: ids });
   },
 
   setNamespaceFilterMode({ commit }, mode) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
1. There is no parameter to receive `getters` in mutations (`updateNamespaces`).  I think it may be unnecessary.
2. In `getActiveNamespaces`, I wonder if we should filter based on `allNamespaces`.    


Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->