### PR TITLE
Prompt node pool

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7,6 +7,7 @@ generic:
   and: ' and '
   back: Back
   cancel: Cancel
+  confirm: Confirm
   clear: Clear
   clearAll: Clear All
   close: Close
@@ -4125,7 +4126,7 @@ promptRemove:
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"
   willDeleteAssociatedNamespaces: "This will also delete all namespaces in the project: "
   confirmRelatedResource: "Deleting the {type} will remove all the resources on this particular {type} and this is not revertable, are you sure you want to continue deleting {names}?"
-  promptConfirmation: "Don't prompt again for confirmation when scaling down"
+  promptConfirmation: "Do not prompt again for confirmation when scaling down."
 
 promptRemoveApp:
   removeCrd: "Delete the CRD associated with this app"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3942,6 +3942,9 @@ prefs:
     'true': Include Prerelease Versions
     'false': Show Releases Only
     label: Helm Charts
+  confirmationSetting:
+    title: Confirmation Setting
+    scalingDownPrompt: Enable confirmation prompt for scaling down node pool.
 
 principal:
   loading: Loading&hellip;

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4125,6 +4125,7 @@ promptRemove:
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"
   willDeleteAssociatedNamespaces: "This will also delete all namespaces in the project: "
   confirmRelatedResource: "Deleting the {type} will remove all the resources on this particular {type} and this is not revertable, are you sure you want to continue deleting {names}?"
+  promptConfirmation: "Don't prompt again for confirmation when scaling down"
 
 promptRemoveApp:
   removeCrd: "Delete the CRD associated with this app"

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -693,7 +693,7 @@ export default {
                     :disabled="!group.ref.canScaleDownPool()"
                     type="button"
                     class="btn btn-sm role-secondary"
-                    @click="group.ref.scalePool(-1)"
+                    @click="group.ref.toggleScaleDownModal()"
                   >
                     <i class="icon icon-sm icon-minus" />
                   </button>

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -180,9 +180,7 @@ export default {
     }
   },
 
-  data( { $cookies } ) {
-    const scalePoolPrompt = $cookies.get('scalePoolPrompt');
-
+  data() {
     return {
 
       allMachines:           [],
@@ -206,8 +204,7 @@ export default {
       logSocket: null,
       logs:      [],
 
-      showWindowsWarning:  false,
-      showScalePoolPrompt: scalePoolPrompt
+      showWindowsWarning: false
     };
   },
 
@@ -696,7 +693,7 @@ export default {
                     :disabled="!group.ref.canScaleDownPool()"
                     type="button"
                     class="btn btn-sm role-secondary"
-                    @click="group.ref.toggleScaleDownModal($event, showScalePoolPrompt)"
+                    @click="group.ref.toggleScaleDownModal($event)"
                   >
                     <i class="icon icon-sm icon-minus" />
                   </button>

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -180,7 +180,9 @@ export default {
     }
   },
 
-  data() {
+  data( { $cookies } ) {
+    const scalePoolPrompt = $cookies.get('scalePoolPrompt');
+
     return {
 
       allMachines:           [],
@@ -204,7 +206,8 @@ export default {
       logSocket: null,
       logs:      [],
 
-      showWindowsWarning: false
+      showWindowsWarning:  false,
+      showScalePoolPrompt: scalePoolPrompt
     };
   },
 
@@ -693,7 +696,7 @@ export default {
                     :disabled="!group.ref.canScaleDownPool()"
                     type="button"
                     class="btn btn-sm role-secondary"
-                    @click="group.ref.toggleScaleDownModal()"
+                    @click="group.ref.toggleScaleDownModal($event, showScalePoolPrompt)"
                   >
                     <i class="icon icon-sm icon-minus" />
                   </button>

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -24,7 +24,9 @@ export default {
   },
   computed: {
     machinenName() {
-      return this.resources[0].id.split('/')[1];
+      const name = this.resources.length > 0 ? this.resources[0].id.split('/')[1] : '';
+
+      return name;
     },
     protip() {
       return this.t('promptRemove.protip', { alternateLabel });

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -30,9 +30,11 @@ export default {
       return this.t('promptRemove.protip', { alternateLabel });
     },
   },
-  mounted() {
+  created() {
     const showScalePoolPrompt = this.$cookies.get('scalePoolPrompt');
 
+    // Check for showScalePoolPrompt cookies
+    // If undefined set cookies and update promt checkbox
     if ( showScalePoolPrompt === undefined ) {
       this.promptConfirmation = true;
       this.$cookies.set('scalePoolPrompt', true);
@@ -46,17 +48,15 @@ export default {
       this.$emit('close');
     },
 
-    update(e) {
-      if (this.promptConfirmation) {
-        this.$cookies.set('scalePoolPrompt', true);
-      } else {
-        this.$cookies.set('scalePoolPrompt', false);
-      }
+    update() {
+      this.$cookies.set('scalePoolPrompt', !!this.promptConfirmation);
     },
 
     remove() {
       // Delete pool
-      this.resources[0].scalePool(-1);
+      if (this.resources.length > 0 ) {
+        this.resources[0].scalePool(-1);
+      }
       this.close();
     }
   }
@@ -86,7 +86,7 @@ export default {
           v-model="promptConfirmation"
           :label="t('promptRemove.promptConfirmation')"
           class="mt-10"
-          @input="update($event)"
+          @input="update()"
         />
       </div>
       <div class="text-info mt-20">

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -1,0 +1,171 @@
+<script>
+import { Card } from '@components/Card';
+import { alternateLabel } from '@shell/utils/platform';
+import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
+import { exceptionToErrorsArray } from '@shell/utils/error';
+import { CAPI } from '@shell/config/types';
+import { Checkbox } from '@components/Form/Checkbox';
+
+export default {
+  components: { Card, Checkbox },
+
+  props: {
+    resources: {
+      type:     Array,
+      required: true
+    }
+  },
+
+  data() {
+    const allToDelete = Array.isArray(this.resources) ? this.resources : [this.resources];
+
+    return {
+      allToDelete,
+      type: this.$store.getters['type-map/labelFor'](allToDelete[0].schema, allToDelete.length),
+      promptConfirmation: false
+    };
+  },
+  computed: {
+    machinenName() {
+      return this.resources[0].id.split('/')[1];
+    },
+    protip() {
+      return this.t('promptRemove.protip', { alternateLabel });
+    },
+  },
+  mounted() {
+    const scalePoolPrompcsrf = this.$cookies.get('scalePoolPromp');
+    this.promptConfirmation = scalePoolPrompcsrf;
+  },
+
+  methods: {
+    scalePool(delta, save = true, depth = 0) {
+      console.log(delta);
+      // This is used in different places with different scaling rules, so don't check if we can/cannot scale
+      if (!this.resources[0].inClusterSpec) {
+        return;
+      }
+
+      if (delta === -1) {
+        console.log('machine -1');
+
+        return;
+      }
+
+      const initialValue = this.resources[0].cluster.toJSON();
+
+      this.resources[0].inClusterSpec.quantity += delta;
+
+      if ( !save ) {
+        return;
+      }
+      const value = this.resources[0].cluster;
+      const liveModel = this.resources[0].$rootGetters['management/byId'](CAPI.RANCHER_CLUSTER, this.resources[0].cluster.id);
+
+      if ( this.resources[0].scaleTimer ) {
+        clearTimeout(this.resources[0].scaleTimer);
+      }
+
+      this.resources[0].scaleTimer = setTimeout(() => {
+        this.resources[0].cluster.save().catch((err) => {
+          let errors = exceptionToErrorsArray(err);
+
+          if ( err.status === 409 && depth < 2 ) {
+            const conflicts = handleConflict(initialValue, value, liveModel, this.resources[0].$rootGetters, this.resources[0].$store);
+
+            if ( conflicts === false ) {
+              // It was automatically figured out, save again
+              // (pass in the delta again as `this.inClusterSpec.quantity` would have reset from the re-fetch done in `save`)
+              return this.scalePool(delta, true, depth + 1);
+            } else {
+              errors = conflicts;
+            }
+          }
+
+          this.$dispatch('growl/fromError', {
+            title: 'Error scaling pool',
+            err:   errors
+          }, { root: true });
+        });
+      }, 1000);
+    },
+
+    close() {
+      this.$emit('close');
+    },
+
+    update(e) {
+      console.log('clicked');
+      
+      console.log('clicked ---- ' + e);
+      if (this.promptConfirmation) {
+        console.log('true ---- set to false');
+        this.$cookies.set('scalePoolPromp', true);
+      } else {
+        console.log('false ---- set to true');
+        this.$cookies.set('scalePoolPromp', false);
+      }
+    },
+
+    remove() {
+      // Delete pool
+      this.scalePool(-1);
+      this.close();
+    }
+  }
+};
+</script>
+
+<template>
+  <Card
+    class="prompt-remove"
+    :show-highlight-border="false"
+  >
+    <h4
+      slot="title"
+      class="text-default-text"
+    >
+      {{ t('promptForceRemove.modalTitle') }}
+    </h4>
+    <div
+      slot="body"
+      class="pl-10 pr-10"
+    >
+      <div>
+        {{ t('promptRemove.attemptingToRemove', { type }) }} <b>{{ machinenName }}</b>
+      </div>
+      <div>
+        <Checkbox
+          v-model="promptConfirmation"
+          :label="t('promptRemove.promptConfirmation')"
+          class="mt-10"
+          @input="update($event)"
+        />
+      </div>
+      <div class="text-info mt-20">
+        {{ protip }}
+      </div>
+    </div>
+    <template #actions>
+      <button
+        class="btn role-secondary mr-10"
+        @click="close"
+      >
+        {{ t('generic.cancel') }}
+      </button>
+      <div class="spacer" />
+      <button
+        class="btn role-secondary mr-10"
+        @click="remove"
+      >
+        Confirm
+      </button>
+    </template>
+  </Card>
+</template>
+
+<style lang='scss' scoped>
+  .actions {
+    text-align: right;
+  }
+</style>

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -2,6 +2,7 @@
 import { Card } from '@components/Card';
 import { alternateLabel } from '@shell/utils/platform';
 import { Checkbox } from '@components/Form/Checkbox';
+import { SCALE_POOL_PROMPT } from '@shell/store/prefs';
 
 export default {
   components: { Card, Checkbox },
@@ -33,13 +34,13 @@ export default {
     },
   },
   created() {
-    const showScalePoolPrompt = this.$cookies.get('scalePoolPrompt');
+    const showScalePoolPrompt = this.$store.getters['prefs/get'](SCALE_POOL_PROMPT);
 
-    // Check for showScalePoolPrompt cookies
-    // If undefined set cookies and update promt checkbox
-    if ( showScalePoolPrompt === undefined ) {
+    // Check for showScalePoolPrompt pref
+    // If it is not set, set it to true and update promt checkbox
+    if ( showScalePoolPrompt === '' ) {
       this.promptConfirmation = true;
-      this.$cookies.set('scalePoolPrompt', true);
+      this.$store.dispatch('prefs/set', { key: SCALE_POOL_PROMPT, value: true });
     } else {
       this.promptConfirmation = showScalePoolPrompt;
     }
@@ -51,7 +52,7 @@ export default {
     },
 
     update() {
-      this.$cookies.set('scalePoolPrompt', !!this.promptConfirmation);
+      this.$store.dispatch('prefs/set', { key: SCALE_POOL_PROMPT, value: !!this.promptConfirmation });
     },
 
     remove() {

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -1,9 +1,6 @@
 <script>
 import { Card } from '@components/Card';
 import { alternateLabel } from '@shell/utils/platform';
-import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
-import { exceptionToErrorsArray } from '@shell/utils/error';
-import { CAPI } from '@shell/config/types';
 import { Checkbox } from '@components/Form/Checkbox';
 
 export default {
@@ -21,8 +18,8 @@ export default {
 
     return {
       allToDelete,
-      type: this.$store.getters['type-map/labelFor'](allToDelete[0].schema, allToDelete.length),
-      promptConfirmation: false
+      type:               this.$store.getters['type-map/labelFor'](allToDelete[0].schema, allToDelete.length),
+      promptConfirmation: true
     };
   },
   computed: {
@@ -34,82 +31,32 @@ export default {
     },
   },
   mounted() {
-    const scalePoolPrompcsrf = this.$cookies.get('scalePoolPromp');
-    this.promptConfirmation = scalePoolPrompcsrf;
+    const showScalePoolPrompt = this.$cookies.get('scalePoolPrompt');
+
+    if ( showScalePoolPrompt === undefined ) {
+      this.promptConfirmation = true;
+      this.$cookies.set('scalePoolPrompt', true);
+    } else {
+      this.promptConfirmation = showScalePoolPrompt;
+    }
   },
 
   methods: {
-    scalePool(delta, save = true, depth = 0) {
-      console.log(delta);
-      // This is used in different places with different scaling rules, so don't check if we can/cannot scale
-      if (!this.resources[0].inClusterSpec) {
-        return;
-      }
-
-      if (delta === -1) {
-        console.log('machine -1');
-
-        return;
-      }
-
-      const initialValue = this.resources[0].cluster.toJSON();
-
-      this.resources[0].inClusterSpec.quantity += delta;
-
-      if ( !save ) {
-        return;
-      }
-      const value = this.resources[0].cluster;
-      const liveModel = this.resources[0].$rootGetters['management/byId'](CAPI.RANCHER_CLUSTER, this.resources[0].cluster.id);
-
-      if ( this.resources[0].scaleTimer ) {
-        clearTimeout(this.resources[0].scaleTimer);
-      }
-
-      this.resources[0].scaleTimer = setTimeout(() => {
-        this.resources[0].cluster.save().catch((err) => {
-          let errors = exceptionToErrorsArray(err);
-
-          if ( err.status === 409 && depth < 2 ) {
-            const conflicts = handleConflict(initialValue, value, liveModel, this.resources[0].$rootGetters, this.resources[0].$store);
-
-            if ( conflicts === false ) {
-              // It was automatically figured out, save again
-              // (pass in the delta again as `this.inClusterSpec.quantity` would have reset from the re-fetch done in `save`)
-              return this.scalePool(delta, true, depth + 1);
-            } else {
-              errors = conflicts;
-            }
-          }
-
-          this.$dispatch('growl/fromError', {
-            title: 'Error scaling pool',
-            err:   errors
-          }, { root: true });
-        });
-      }, 1000);
-    },
-
     close() {
       this.$emit('close');
     },
 
     update(e) {
-      console.log('clicked');
-      
-      console.log('clicked ---- ' + e);
       if (this.promptConfirmation) {
-        console.log('true ---- set to false');
-        this.$cookies.set('scalePoolPromp', true);
+        this.$cookies.set('scalePoolPrompt', true);
       } else {
-        console.log('false ---- set to true');
-        this.$cookies.set('scalePoolPromp', false);
+        this.$cookies.set('scalePoolPrompt', false);
       }
     },
 
     remove() {
       // Delete pool
-      this.scalePool(-1);
+      this.resources[0].scalePool(-1);
       this.close();
     }
   }
@@ -155,10 +102,10 @@ export default {
       </button>
       <div class="spacer" />
       <button
-        class="btn role-secondary mr-10"
+        class="btn bg-error ml-10 btn role-primary"
         @click="remove"
       >
-        Confirm
+        {{ t('generic.confirm') }}
       </button>
     </template>
   </Card>

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -108,7 +108,7 @@ export default class CapiMachineDeployment extends SteveModel {
       this.$dispatch('promptModal', {
         component:  'ScalePoolDownDialog',
         resources,
-        modalWidth: '750px'
+        modalWidth: '450px'
       });
     } else {
       // User held alt key, so don't prompt

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -102,8 +102,10 @@ export default class CapiMachineDeployment extends SteveModel {
   }
 
   toggleScaleDownModal( event, showScalePoolPrompt, resources = this ) {
+    // Check if the user held alt key when an action is clicked.
     const alt = isAlternate(event);
 
+    // Prompt if showScalePoolPrompt cookies not store and user did not held alt key
     if (!alt && !showScalePoolPrompt) {
       this.$dispatch('promptModal', {
         component:  'ScalePoolDownDialog',

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -7,6 +7,7 @@ import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
 import { MACHINE_ROLES } from '@shell/config/labels-annotations';
 import { notOnlyOfRole } from '@shell/models/cluster.x-k8s.io.machine';
 import { isAlternate } from '@shell/utils/platform';
+import { SCALE_POOL_PROMPT } from '@shell/store/prefs';
 
 export default class CapiMachineDeployment extends SteveModel {
   get cluster() {
@@ -101,11 +102,12 @@ export default class CapiMachineDeployment extends SteveModel {
     return machinePools.find(pool => pool.machineConfigRef.name === machineConfigName);
   }
 
-  toggleScaleDownModal( event, showScalePoolPrompt, resources = this ) {
+  toggleScaleDownModal( event, resources = this ) {
     // Check if the user held alt key when an action is clicked.
     const alt = isAlternate(event);
+    const showScalePoolPrompt = this.$rootGetters['prefs/get'](SCALE_POOL_PROMPT);
 
-    // Prompt if showScalePoolPrompt cookies not store and user did not held alt key
+    // Prompt if showScalePoolPrompt pref not store and user did not held alt key
     if (!alt && !showScalePoolPrompt) {
       this.$dispatch('promptModal', {
         component:  'ScalePoolDownDialog',

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -100,13 +100,29 @@ export default class CapiMachineDeployment extends SteveModel {
     return machinePools.find(pool => pool.machineConfigRef.name === machineConfigName);
   }
 
+  toggleScaleDownModal(resources = this) {
+    console.log(resources);
+    this.$dispatch('promptModal', {
+      component:  'ScalePoolDownDialog',
+      resources,
+      modalWidth: '750px'
+    });
+  }
+
   scalePool(delta, save = true, depth = 0) {
+    console.log(delta);
     // This is used in different places with different scaling rules, so don't check if we can/cannot scale
     if (!this.inClusterSpec) {
       return;
     }
 
     const initialValue = this.cluster.toJSON();
+
+    if (delta === -1) {
+      console.log('machine -1');
+
+      return;
+    }
 
     this.inClusterSpec.quantity += delta;
 

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -9,7 +9,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import LandingPagePreference from '@shell/components/LandingPagePreference';
 import {
   mapPref, THEME, KEYMAP, DATE_FORMAT, TIME_FORMAT, ROWS_PER_PAGE, HIDE_DESC, SHOW_PRE_RELEASE, MENU_MAX_CLUSTERS,
-  VIEW_IN_API, ALL_NAMESPACES, THEME_SHORTCUT, PLUGIN_DEVELOPER
+  VIEW_IN_API, ALL_NAMESPACES, THEME_SHORTCUT, PLUGIN_DEVELOPER, SCALE_POOL_PROMPT
 } from '@shell/store/prefs';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
@@ -25,17 +25,18 @@ export default {
     return { admin: isAdminUser(this.$store.getters) };
   },
   computed: {
-    keymap:          mapPref(KEYMAP),
-    viewInApi:       mapPref(VIEW_IN_API),
-    allNamespaces:   mapPref(ALL_NAMESPACES),
-    themeShortcut:   mapPref(THEME_SHORTCUT),
-    dateFormat:      mapPref(DATE_FORMAT),
-    timeFormat:      mapPref(TIME_FORMAT),
-    perPage:         mapPref(ROWS_PER_PAGE),
-    hideDesc:        mapPref(HIDE_DESC),
-    showPreRelease:  mapPref(SHOW_PRE_RELEASE),
-    menuMaxClusters: mapPref(MENU_MAX_CLUSTERS),
-    pluginDeveloper: mapPref(PLUGIN_DEVELOPER),
+    keymap:            mapPref(KEYMAP),
+    viewInApi:         mapPref(VIEW_IN_API),
+    allNamespaces:     mapPref(ALL_NAMESPACES),
+    themeShortcut:     mapPref(THEME_SHORTCUT),
+    dateFormat:        mapPref(DATE_FORMAT),
+    timeFormat:        mapPref(TIME_FORMAT),
+    perPage:           mapPref(ROWS_PER_PAGE),
+    hideDesc:          mapPref(HIDE_DESC),
+    showPreRelease:    mapPref(SHOW_PRE_RELEASE),
+    menuMaxClusters:   mapPref(MENU_MAX_CLUSTERS),
+    pluginDeveloper:   mapPref(PLUGIN_DEVELOPER),
+    scalingDownPrompt: mapPref(SCALE_POOL_PROMPT),
 
     ...mapGetters(['isSingleProduct']),
 
@@ -237,6 +238,16 @@ export default {
           />
         </div>
       </div>
+    </div>
+    <!-- Confirmation setting -->
+    <div class="col adv-features mt-10 mb-10">
+      <hr>
+      <h4 v-t="'prefs.confirmationSetting.title'" />
+      <Checkbox
+        v-model="scalingDownPrompt"
+        :label="t('prefs.confirmationSetting.scalingDownPrompt')"
+        class="mt-10"
+      />
     </div>
     <!-- Advanced Features -->
     <div class="col adv-features mt-10 mb-10">

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -120,8 +120,8 @@ export const PSP_DEPRECATION_BANNER = create('hide-psp-deprecation-banner', fals
 // Maximum number of clusters to show in the slide-in menu
 export const MENU_MAX_CLUSTERS = create('menu-max-clusters', 4, { options: [2, 3, 4, 5, 6, 7, 8, 9, 10], parseJSON });
 
-// Prompt for confirm node deletion when scaling down node pool in GUI
-export const SCALE_POOL_PROMPT = create('scalePoolPrompt', '', { parseJSON });
+// Prompt for confirm when scaling down node pool in GUI and save the pref
+export const SCALE_POOL_PROMPT = create('scale-pool-prompt', '', { parseJSON });
 // --------------------
 
 const cookiePrefix = 'R_';

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -120,6 +120,8 @@ export const PSP_DEPRECATION_BANNER = create('hide-psp-deprecation-banner', fals
 // Maximum number of clusters to show in the slide-in menu
 export const MENU_MAX_CLUSTERS = create('menu-max-clusters', 4, { options: [2, 3, 4, 5, 6, 7, 8, 9, 10], parseJSON });
 
+// Prompt for confirm node deletion when scaling down node pool in GUI
+export const SCALE_POOL_PROMPT = create('scalePoolPrompt', '', { parseJSON });
 // --------------------
 
 const cookiePrefix = 'R_';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6961
<!-- Define findings related to the feature or bug issue. -->
Added a confirmation dialog when the user pressed the minus icon on a cluster detail page 


### How to test
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2022-12-20 at 16 06 13](https://user-images.githubusercontent.com/18264463/208700128-c68d0470-6a58-4fbd-a41a-36ca8a920fc0.png)

![Screenshot 2022-12-20 at 16 13 37](https://user-images.githubusercontent.com/18264463/208700636-f549eda9-d8a3-41c8-82dd-0a2d2554eed4.png)


Go to Cluster Management -> [cluster] 
- When the user clicks on the minus icon, it should show a confirmation dialog.
- The dialog should also show a checkbox below the first line and it should be checked by default we need to remember this (only within the user's browser session ) 
- If the checkbox is checked by default, the next time when the user scales it down, the confirmation dialog will NOT prompt again.
- If the checkbox is not checked, the confirmation dialog will prompt again.
- Added confirmation prompt setting in pref page

![Screenshot 2023-01-11 at 13 34 50](https://user-images.githubusercontent.com/18264463/211807716-a15db2c4-8524-4be1-8663-493908d95ac3.png)

