### PR TITLE
Add support for Pod Security Admission in the Clusters and Workloads

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1732,7 +1732,7 @@ cluster:
       header: Security
     defaultPodSecurityPolicyTemplateName:
       label: Default Pod Security Policy
-    defaultPodSecurityAdmissionConfigurationTemplateId:
+    defaultPodSecurityAdmissionConfigurationTemplateName:
       label: Default Pod Security Admission
       option: RKE2 Default
     enableNetworkPolicy:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1563,6 +1563,7 @@ cluster:
     rke2-k3-reprovisioning: 'Making changes to cluster configuration may result in nodes reprovisioning. For more information see the <a target="blank" href="{docsBase}/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/" target="_blank" rel="noopener nofollow">documentation</a>.'
     desiredNodeGroupWarning: There are 0 nodes available to run the cluster agent. The cluster will not become active until at least one node is available.
     invalidPsps: You have one or more PodSecurityPolicy resource(s) in this cluster. Pod Security Policies are not available in Kubernetes v1.25.
+    haveArgInfo: Configuration information is not available for the selected Kubernetes version.  The options available in this screen will be limited, you may want to use the YAML editor.
 
   rkeTemplateUpgrade: Template revision {name} available for upgrade
 
@@ -1731,8 +1732,9 @@ cluster:
       header: Security
     defaultPodSecurityPolicyTemplateName:
       label: Default Pod Security Policy
-    defaultPodSecurityAdmissionTemplateName:
+    defaultPodSecurityAdmissionConfigurationTemplateId:
       label: Default Pod Security Admission
+      option: RKE2 Default
     enableNetworkPolicy:
       label: Project Network Isolation
       warning: Per default, the ingress controller will not be able to route requests to pods on other nodes.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1732,9 +1732,12 @@ cluster:
       header: Security
     defaultPodSecurityPolicyTemplateName:
       label: Default Pod Security Policy
+      option: (None)
     defaultPodSecurityAdmissionConfigurationTemplateName:
       label: Default Pod Security Admission
-      option: RKE2 Default
+      option: (None)
+    cisProfile:
+      option: (None)
     enableNetworkPolicy:
       label: Project Network Isolation
       warning: Per default, the ingress controller will not be able to route requests to pods on other nodes.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1732,7 +1732,7 @@ cluster:
       header: Security
     defaultPodSecurityPolicyTemplateName:
       label: Default Pod Security Policy
-      option: (None)
+      option: RKE Default
     defaultPodSecurityAdmissionConfigurationTemplateName:
       label: Default Pod Security Admission
       option: (None)

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -75,6 +75,14 @@ export default {
       default: () => []
     },
 
+    /**
+     * Set of maps to convert error messages to something more user friendly and apply icons
+     */
+    errorsMap: {
+      type:    Object,
+      default: null
+    },
+
     // Is the edit as yaml button allowed
     canYaml: {
       type:    Boolean,
@@ -152,7 +160,7 @@ export default {
         4: '18px',
         5: '16px',
         6: '14px'
-      }
+      },
     };
   },
 
@@ -224,6 +232,19 @@ export default {
      */
     hasErrors() {
       return this.errors?.length && Array.isArray(this.errors);
+    },
+
+    /**
+     * Replace returned string with new picked value and icon
+     */
+    mappedErrors() {
+      return !this.errors ? {} : this.errorsMap || this.errors.reduce((acc, error) => ({
+        ...acc,
+        [error]: {
+          message: error,
+          icon:    null
+        }
+      }), {});
     },
   },
 
@@ -373,8 +394,8 @@ export default {
           v-for="(err, i) in errors"
           :key="i"
           color="error"
-          :label="stringify(err)"
-          :stacked="true"
+          :label="stringify(mappedErrors[err].message)"
+          :icon="mappedErrors[err].icon"
           :closable="true"
           @close="closeError(i)"
         />

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -174,6 +174,7 @@ export const MANAGEMENT = {
   GLOBAL_ROLE:                   'management.cattle.io.globalrole',
   GLOBAL_ROLE_BINDING:           'management.cattle.io.globalrolebinding',
   POD_SECURITY_POLICY_TEMPLATE:  'management.cattle.io.podsecuritypolicytemplate',
+  PSA:                           'management.cattle.io.podsecurityadmissionconfigurationtemplate',
   MANAGED_CHART:                 'management.cattle.io.managedchart',
   USER_NOTIFICATION:             'management.cattle.io.rancherusernotification',
   GLOBAL_DNS_PROVIDER:           'management.cattle.io.globaldnsprovider',

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -2,7 +2,11 @@ import { mount } from '@vue/test-utils';
 import rke2 from '@shell/edit/provisioning.cattle.io.cluster/rke2.vue';
 
 describe('component: rke2', () => {
-  it('should display PSA option', () => {
+  it.each([
+    'v1.25.0+rke2r1',
+    'v1.24.0+rke2r1',
+    'v1.23.0+rke2r1',
+  ])('should display PSA option', () => {
     const label = 'whatever';
     const option = { label, value: label };
     const wrapper = mount(rke2, {

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -14,10 +14,10 @@ describe('component: rke2', () => {
         mode:  'create',
         value: {
           spec: {
-            rkeConfig:                                          { etcd: { disableSnapshots: false } },
-            chartValues:                                        {},
-            defaultPodSecurityAdmissionConfigurationTemplateId: label,
-            kubernetesVersion:                                  'v1.25.0+rke2r1'
+            rkeConfig:                                            { etcd: { disableSnapshots: false } },
+            chartValues:                                          {},
+            defaultPodSecurityAdmissionConfigurationTemplateName: label,
+            kubernetesVersion:                                    'v1.25.0+rke2r1'
           }
         },
         provider: 'whatever',

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -1,0 +1,89 @@
+import { mount } from '@vue/test-utils';
+import rke2 from '@shell/edit/provisioning.cattle.io.cluster/rke2.vue';
+
+describe('component: rke2', () => {
+  it('should display PSA option', () => {
+    const label = 'whatever';
+    const option = { label, value: label };
+    const wrapper = mount(rke2, {
+      propsData: {
+        mode:  'create',
+        value: {
+          spec: {
+            rkeConfig:                                          { etcd: { disableSnapshots: false } },
+            chartValues:                                        {},
+            defaultPodSecurityAdmissionConfigurationTemplateId: label,
+            kubernetesVersion:                                  'v1.25.0+rke2r1'
+          }
+        },
+        provider: 'whatever',
+        resource: {}
+      },
+      computed: {
+        showForm() {
+          return true;
+        },
+        hasMachinePools() {
+          return false;
+        },
+        showk8s21LegacyWarning() {
+          return false;
+        },
+      },
+      mocks: {
+        $fetchState: { pending: false },
+        $route:      {
+          name:  'anything',
+          query: { AS: 'yaml' },
+        },
+        $store: {
+          getters: {
+            currentStore:           () => 'current_store',
+            'management/schemaFor': jest.fn(),
+            'current_store/all':    jest.fn(),
+            'i18n/t':               jest.fn(),
+            'i18n/withFallback':    jest.fn(),
+          },
+          dispatch: {
+            'management/find':    jest.fn(),
+            'management/findAll': () => ([option]),
+          }
+        },
+      },
+      stubs: {
+        CruResource:              { template: '<div><slot></slot></div>' }, // Required to render the slot content
+        Banner:                   true,
+        LabeledSelect:            true,
+        ACE:                      true,
+        AgentEnv:                 true,
+        ArrayList:                true,
+        ArrayListGrouped:         true,
+        BadgeState:               true,
+        Checkbox:                 true,
+        ClusterMembershipEditor:  true,
+        DrainOptions:             true,
+        LabeledInput:             true,
+        Labels:                   true,
+        Loading:                  true,
+        MachinePool:              true,
+        MatchExpressions:         true,
+        NameNsDescription:        true,
+        Questions:                true,
+        RadioGroup:               true,
+        RegistryConfigs:          true,
+        RegistryMirrors:          true,
+        S3Config:                 true,
+        SelectCredential:         true,
+        SelectOrCreateAuthSecret: true,
+        Tab:                      true,
+        Tabbed:                   true,
+        UnitInput:                true,
+        YamlEditor:               true,
+      }
+    });
+
+    const select = wrapper.find('[data-testid="rke2-custom-edit-psa"]');
+
+    expect((select.vm as unknown as any).options[0].label).toBe(`${ label } (Current)`);
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -75,6 +75,8 @@ const ADVANCED = 'advanced';
 const HARVESTER = 'harvester';
 const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
 
+const noneOption = { label: '(None)', value: '' };
+
 export default {
   components: {
     ACE,
@@ -458,7 +460,7 @@ export default {
         return { label: x, value: x };
       });
 
-      out.unshift({ label: '(None)', value: '' });
+      out.unshift(noneOption);
 
       return out;
     },
@@ -468,7 +470,7 @@ export default {
         return null;
       }
 
-      const out = [{ label: 'RKE2 Default', value: '' }];
+      const out = [noneOption];
 
       if ( this.allPSPs ) {
         for ( const pspt of this.allPSPs ) {
@@ -495,7 +497,7 @@ export default {
       if ( !this.needsPSA ) {
         return [];
       }
-      const out = [{ label: this.t(`cluster.rke2.defaultPodSecurityAdmissionConfigurationTemplateId.option`), value: '' }];
+      const out = [noneOption];
 
       if ( this.allPSAs ) {
         for ( const psa of this.allPSAs ) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2022,7 +2022,7 @@ export default {
           </h3>
 
           <div
-            v-if="psaOptions && needsPSA"
+            v-if="needsPSA"
             class="row mb-10"
           >
             <div class="col span-6">

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -281,7 +281,7 @@ export default {
       loadedOnce:                      false,
       lastIdx:                         0,
       allPSPs:                         null,
-      allPSAs:                         null,
+      allPSAs:                         [],
       nodeComponent:                   null,
       credentialId:                    null,
       credential:                      null,
@@ -344,7 +344,7 @@ export default {
       const release = this.value?.spec?.kubernetesVersion || '';
       const isRKE2 = release.includes('rke2');
       const version = release.match(/\d+/g);
-      const needsPSA = version ? version[0] > +1 || version[1] >= +25 : false;
+      const needsPSA = version && version.length ? version[0] > +1 || version[1] >= +25 : false;
 
       return isRKE2 && needsPSA;
     },
@@ -487,7 +487,7 @@ export default {
      */
     psaOptions() {
       if ( !this.needsPSA ) {
-        return null;
+        return [];
       }
       const out = [{ label: this.t(`cluster.rke2.defaultPodSecurityAdmissionConfigurationTemplateId.option`), value: '' }];
 
@@ -1989,7 +1989,7 @@ export default {
               <LabeledSelect
                 v-if="pspOptions && !needsPSA"
                 v-model="value.spec.defaultPodSecurityPolicyTemplateName"
-                data-testid="rke2-custom-edit-psa"
+                data-testid="rke2-custom-edit-psp"
                 :mode="mode"
                 :options="pspOptions"
                 :label="t('cluster.rke2.defaultPodSecurityPolicyTemplateName.label')"
@@ -2000,6 +2000,7 @@ export default {
                 v-if="psaOptions && needsPSA"
                 v-model="value.spec.defaultPodSecurityAdmissionConfigurationTemplateId"
                 :mode="mode"
+                data-testid="rke2-custom-edit-psa"
                 :options="psaOptions"
                 :label="t('cluster.rke2.defaultPodSecurityAdmissionConfigurationTemplateId.label')"
               />

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -236,7 +236,6 @@ export default {
       set(this.value.spec, 'defaultPodSecurityPolicyTemplateName', '');
     }
 
-    // TODO: Check if conditionally required to set empty value
     if ( this.value.spec.defaultPodSecurityAdmissionConfigurationTemplateId === undefined ) {
       set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateId', '');
     }
@@ -419,14 +418,6 @@ export default {
           out.push({ kind: 'group', label: this.t('cluster.provider.k3s') });
         }
 
-        // TODO: Remove this after fetching real value
-        out.push({
-          label:      'v1.25.7+rke2r1',
-          value:      'v1.25.7+rke2r1',
-          serverArgs: {},
-          agentArgs:  {}
-        });
-
         out.push(...allValidK3sVersions);
       }
 
@@ -499,7 +490,6 @@ export default {
           });
         }
       }
-      // TODO: Check if spec key is correct
       const cur = this.value.spec.defaultPodSecurityAdmissionConfigurationTemplateId;
 
       if ( cur && !out.find(x => x.value === cur) ) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -239,8 +239,8 @@ export default {
       set(this.value.spec, 'defaultPodSecurityPolicyTemplateName', '');
     }
 
-    if ( this.value.spec.defaultPodSecurityAdmissionConfigurationTemplateId === undefined ) {
-      set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateId', '');
+    if ( this.value.spec.defaultPodSecurityAdmissionConfigurationTemplateName === undefined ) {
+      set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateName', '');
     }
 
     await this.initAddons();
@@ -507,7 +507,7 @@ export default {
           });
         }
       }
-      const cur = this.value.spec.defaultPodSecurityAdmissionConfigurationTemplateId;
+      const cur = this.value.spec.defaultPodSecurityAdmissionConfigurationTemplateName;
 
       if ( cur && !out.find(x => x.value === cur) ) {
         out.unshift({ label: `${ cur } (Current)`, value: cur });
@@ -1739,7 +1739,7 @@ export default {
      */
     handleKubernetesChange(value) {
       if (value) {
-        set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateId', '');
+        set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateName', '');
         set(this.value.spec, 'defaultPodSecurityPolicyTemplateName', '');
       }
     },
@@ -1758,7 +1758,7 @@ export default {
      */
     handlePspChange(value) {
       if (value) {
-        set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateId', '');
+        set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateName', '');
       }
     },
 
@@ -2028,11 +2028,11 @@ export default {
             <div class="col span-6">
               <!-- PSA template selector -->
               <LabeledSelect
-                v-model="value.spec.defaultPodSecurityAdmissionConfigurationTemplateId"
+                v-model="value.spec.defaultPodSecurityAdmissionConfigurationTemplateName"
                 :mode="mode"
                 data-testid="rke2-custom-edit-psa"
                 :options="psaOptions"
-                :label="t('cluster.rke2.defaultPodSecurityAdmissionConfigurationTemplateId.label')"
+                :label="t('cluster.rke2.defaultPodSecurityAdmissionConfigurationTemplateName.label')"
                 @input="handlePsaChange($event)"
               />
             </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -75,8 +75,6 @@ const ADVANCED = 'advanced';
 const HARVESTER = 'harvester';
 const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
 
-const noneOption = { label: '(None)', value: '' };
-
 export default {
   components: {
     ACE,
@@ -460,7 +458,10 @@ export default {
         return { label: x, value: x };
       });
 
-      out.unshift(noneOption);
+      out.unshift({
+        label: this.$store.getters['i18n/t']('cluster.rke2.cisProfile.option'),
+        value: ''
+      });
 
       return out;
     },
@@ -470,7 +471,10 @@ export default {
         return null;
       }
 
-      const out = [noneOption];
+      const out = [{
+        label: this.$store.getters['i18n/t']('cluster.rke2.defaultPodSecurityPolicyTemplateName.option'),
+        value: ''
+      }];
 
       if ( this.allPSPs ) {
         for ( const pspt of this.allPSPs ) {
@@ -497,7 +501,10 @@ export default {
       if ( !this.needsPSA ) {
         return [];
       }
-      const out = [noneOption];
+      const out = [{
+        label: this.$store.getters['i18n/t']('cluster.rke2.defaultPodSecurityAdmissionConfigurationTemplateName.option'),
+        value: ''
+      }];
 
       if ( this.allPSAs ) {
         for ( const psa of this.allPSAs ) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1794,7 +1794,7 @@ export default {
         v-if="isEdit"
         color="warning"
       >
-        <span v-html="t('cluster.banner.rke2-k3-reprovisioning', true)" />
+        <span v-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
       </Banner>
       <Banner
         v-if="isEdit && displayInvalidPspsBanner"

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -36,7 +36,9 @@ export default {
     mapError(error) {
       switch (true) {
       case error.includes('violates PodSecurity'): {
-        const [name, _, policy] = error.match(/(?<=\")(.*?)(?=\")/gi);
+        const match = error.match(/(?<=\")(.*?)(?=\")/gi);
+        const name = match[0];
+        const policy = match[2];
 
         return {
           message: `Pod "${ name }" Security Policy Violation "${ policy }"`,

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -28,6 +28,38 @@ export default {
       if ( container ) {
         this.selectContainer(container);
       }
+    },
+
+    /**
+     * Find error exceptions to be mapped for each case
+     */
+    mapError(error) {
+      switch (true) {
+      case error.includes('violates PodSecurity'): {
+        const [name, _, policy] = error.match(/(?<=\")(.*?)(?=\")/gi);
+
+        return {
+          message: `Pod "${ name }" Security Policy Violation "${ policy }"`,
+          icon:    'icon-pod_security'
+        };
+      }
+
+      default:
+        break;
+      }
+    },
+
+    /**
+     * Map all the error texts to a message and icon object
+     */
+    getErrorsMap(errors) {
+      return !errors ? {} : errors.reduce((acc, error) => ({
+        ...acc,
+        [error]: this.mapError(error) || {
+          message: error,
+          icon:    null
+        }
+      }), {});
     }
   }
 };
@@ -49,6 +81,7 @@ export default {
       :subtypes="workloadSubTypes"
       :apply-hooks="applyHooks"
       :value="value"
+      :errors-map="getErrorsMap(fvUnreportedValidationErrors)"
       @finish="save"
       @select-type="selectType"
       @error="e=>errors = e"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7628,
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Navigation
  - Hidden PSP resource link in cluster manager
  - Added PSA resource link in cluster manager
- RKE2 cluster editor
  - Added dropdown for PSA for k8s 1.23+
  - Hidden PSP dropdown for k8s 1.25+
  - ~Replaced the label `RKE Default` with `(None)`~ Used `(None)` if no PSA is selected
  - Corrected reprovisioning banner hyperlink
- Workloads
  - Added Banner with icon for PSA errors, removed stacked view to balance with case lacking it

### Technical notes summary
- RKE2 cluster editor
  - Retrieved PSA templates and added in the select input
  - Added initial tests for RKE2 cluster editor
  - Added comments for each tab due collapse view
  - Added `haveArgInfo` i18n text
- Workloads
  - Extended `CruResource` component to map errors into objects with messages and icons
  - Added PSA RegEx computation to replace message and add icon to existing message

### Areas or cases that should be tested
- Cluster creation for k8s 1.23.x, 1.24.x, 1.25.x with PSP and PSA
- Errors in Pod creation with namespace restriction
- Navigation

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

Cluster creation

https://user-images.githubusercontent.com/5009481/212337024-f487134a-8cbc-4efc-8c83-cf06e0a204b0.mov

Pod error banner

https://user-images.githubusercontent.com/5009481/212338223-f2ae67f6-39d7-492d-a980-ffc9d21ffdc4.mov

Switch to YAML

https://user-images.githubusercontent.com/5009481/212339519-f3d583c9-f3f6-4502-9f9e-41dfb25c316b.mov

