### PR TITLE
Improve performance of NamespaceFilter when there are thousands of entries

### DIFF
--- a/shell/components/__tests__/NamespaceFilter.test.ts
+++ b/shell/components/__tests__/NamespaceFilter.test.ts
@@ -157,7 +157,7 @@ describe('component: NamespaceFilter', () => {
         directives: { shortkey: () => jest.fn() }
       });
 
-      wrapper.vm.cachedFiltered = [
+      (wrapper.vm as any).cachedFiltered = [
         {
           kind:  'namespace',
           label: `default-${ text }`,
@@ -199,7 +199,7 @@ describe('component: NamespaceFilter', () => {
         directives: { shortkey: () => jest.fn() }
       });
 
-      wrapper.vm.cachedFiltered = [
+      (wrapper.vm as any).cachedFiltered = [
         {
           label:     text,
           key,

--- a/shell/components/__tests__/NamespaceFilter.test.ts
+++ b/shell/components/__tests__/NamespaceFilter.test.ts
@@ -25,7 +25,7 @@ describe('component: NamespaceFilter', () => {
           options:  () => [],
           value:    () => [],
         },
-        mocks:      { $store: { getters: { 'i18n/t': () => text } } },
+        mocks:      { $store: { getters: { 'i18n/t': () => text, namespaceFilterMode: () => undefined } } },
         directives: { shortkey: () => jest.fn() }
       });
       const element = wrapper.find(`[data-testid="namespaces-values-none"]`).element.textContent;
@@ -60,7 +60,8 @@ describe('component: NamespaceFilter', () => {
           options:  () => [],
           value:    () => [{ label: text }],
         },
-        directives: { shortkey: () => jest.fn() }
+        directives: { shortkey: () => jest.fn() },
+        mocks:      { $store: { getters: { 'i18n/t': () => text, namespaceFilterMode: () => undefined } } },
       });
 
       const element = wrapper.find(`[data-testid="namespaces-value-0"]`).element.textContent;
@@ -92,8 +93,9 @@ describe('component: NamespaceFilter', () => {
         mocks: {
           $store: {
             getters: {
-              'i18n/t':    () => text,
-              'prefs/get': () => preferences
+              'i18n/t':            () => text,
+              'prefs/get':         () => preferences,
+              namespaceFilterMode: () => undefined,
             },
           }
         },
@@ -114,6 +116,7 @@ describe('component: NamespaceFilter', () => {
           options:  () => [],
           value:    () => [],
         },
+        mocks:      { $store: { getters: { 'i18n/t': () => '', namespaceFilterMode: () => undefined } } },
         directives: { shortkey: () => jest.fn() }
       });
       const dropdown = wrapper.find(`[data-testid="namespaces-dropdown"]`);
@@ -132,7 +135,7 @@ describe('component: NamespaceFilter', () => {
           options:  () => [],
           value:    () => [],
         },
-        mocks:      { $store: { getters: { 'i18n/t': () => text } } },
+        mocks:      { $store: { getters: { 'i18n/t': () => text, namespaceFilterMode: () => undefined } } },
         directives: { shortkey: () => jest.fn() }
       });
       const dropdown = wrapper.find(`[data-testid="namespaces-dropdown"]`);
@@ -147,18 +150,20 @@ describe('component: NamespaceFilter', () => {
       const text = 'my option';
       const wrapper = mount(NamespaceFilter, {
         computed: {
-          filtered: () => [
-            {
-              kind:  'namespace',
-              label: `default-${ text }`,
-            },
-          ],
           options: () => [],
           value:   () => [],
         },
-        mocks:      { $store: { getters: { 'i18n/t': () => text } } },
+        mocks:      { $store: { getters: { 'i18n/t': () => text, namespaceFilterMode: () => undefined } } },
         directives: { shortkey: () => jest.fn() }
       });
+
+      wrapper.vm.cachedFiltered = [
+        {
+          kind:  'namespace',
+          label: `default-${ text }`,
+        },
+      ];
+
       const dropdown = wrapper.find(`[data-testid="namespaces-dropdown"]`);
 
       await dropdown.trigger('click');
@@ -180,28 +185,30 @@ describe('component: NamespaceFilter', () => {
       jest.spyOn(NamespaceFilter.computed.value, 'get').mockReturnValue([]);
       const wrapper = mount(NamespaceFilter, {
         computed: {
-          filtered: () => [
-            {
-              label:     text,
-              key,
-              elementId: text,
-              id:        text,
-              kind:      'namespace',
-              enabled:   true,
-            },
-          ],
-          options:        () => [],
-          currentProduct: () => undefined,
-          key:            () => key,
+          options:             () => [],
+          currentProduct:      () => undefined,
+          namespaceFilterMode: () => undefined,
+          key:                 () => key,
         },
         mocks: {
           $store: {
-            getters:  { 'i18n/t': () => text },
+            getters:  { 'i18n/t': () => text, namespaceFilterMode: () => undefined },
             dispatch: action
           }
         },
         directives: { shortkey: () => jest.fn() }
       });
+
+      wrapper.vm.cachedFiltered = [
+        {
+          label:     text,
+          key,
+          elementId: text,
+          id:        text,
+          kind:      'namespace',
+          enabled:   true,
+        },
+      ];
 
       await wrapper.find(`[data-testid="namespaces-dropdown"]`).trigger('click');
       await wrapper.find(`[data-testid="namespaces-option-0"]`).trigger('click');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "cypress",
     "./cypress.config.ts",
     "docusaurus",
-    "script/standalone"
+    "script/standalone",
+    "**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7775
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- When there are thousands of entries certain actions (drop down opened, selection changed, etc) take a long time to complete (upwards of 5 seconds)
- This is caused by churn of the filtered and options computed properties causing multiple renders for each action.
- To break this multiple-render per cycle behaviour detach `filtered` from the value used in `v-for`.
- This knocks off 2/3 of the time taken for the actions. 

### Technical notes summary
- This is a lo-bar fix to address in the 2.7.next1 timeframe. In the future we should consider
  - only rendering what's in view 
  - not including whole model in options

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
- Cluster Explorer view - Namespace Filter (opening, listing projects/namespaces, selecting projects/namespaces)

### Screenshot/Video
Process - Open up NS filter and change from user to system namespaces
**Before Change**
Open NS filter - ~3 seconds
Change selection - ~3 seconds
![image](https://user-images.githubusercontent.com/18697775/209125396-b88d5587-db51-4d34-8110-a172a072cf12.png)


**After Change**
Open NS filter - ~0.7 seconds
Change selection - ~1 second
![image](https://user-images.githubusercontent.com/18697775/209125046-d91e5570-bf5e-4c11-99d5-1f838259d82a.png)

