### PR TITLE
Fixed local string for cluster-membership page

### DIFF
--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -248,7 +248,7 @@ export function init(store) {
   });
 
   virtualType({
-    label:      store.getters['i18n/t']('members.clusterAndProject'),
+    labelKey:   'members.clusterAndProject',
     group:      'cluster',
     namespaced: false,
     name:       VIRTUAL_TYPES.CLUSTER_MEMBERS,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7786
<!-- Define findings related to the feature or bug issue. -->
Fixed localization bug for ‘EXPLORE CLUSTER’ menu in the sidebar 


### To test
- Open the 'Preferences' and change the language to '简体中文'(Chinese)
- Navigate to the ‘EXPLORE CLUSTER’
- It should show all sidebar menus in the Chinese language

![Screenshot 2022-12-22 at 13 55 21](https://user-images.githubusercontent.com/18264463/209139633-66298c52-d4d8-4758-b67b-0becb1251850.png)
