### PR TITLE
The inner of the loading spinner uses different color than body.

### DIFF
--- a/shell/static/loading-indicator.html
+++ b/shell/static/loading-indicator.html
@@ -13,7 +13,7 @@
 
 .initial-load-spinner {
   animation: initial-load-animate 1s infinite linear;
-  background-color: #fff;
+  background-color: transparent;
   box-sizing: border-box;
   border: 5px solid #008ACF;
   border-radius: 50%;


### PR DESCRIPTION
Fixes: https://github.com/rancher/dashboard/issues/7805

Signed-off-by: Volker Theile <vtheile@suse.com>

