### PR TITLE
Fix project/namespace --> cluster manager blank page bug

### DIFF
--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -5,8 +5,7 @@ import Masthead from './Masthead';
 import ResourceLoadingIndicator from './ResourceLoadingIndicator';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import IconMessage from '@shell/components/IconMessage.vue';
-
-export const ResourceListComponentName = 'ResourceList';
+import { ResourceListComponentName } from './resource-list.config';
 
 export default {
   name: ResourceListComponentName,

--- a/shell/components/ResourceList/resource-list.config.js
+++ b/shell/components/ResourceList/resource-list.config.js
@@ -1,0 +1,7 @@
+/**
+ * Component name of the `ResourceList`
+ *
+ * This needs to be a in separate file to avoid circular dependency of
+ * index.vue --> resource-fetch mixin --> resource-fetch-namespaced mixin --> index.vue
+ */
+export const ResourceListComponentName = 'ResourceList';

--- a/shell/mixins/resource-fetch-namespaced.js
+++ b/shell/mixins/resource-fetch-namespaced.js
@@ -1,5 +1,6 @@
 import { mapGetters } from 'vuex';
-import { ResourceListComponentName } from '../components/ResourceList';
+import { ResourceListComponentName } from '../components/ResourceList/resource-list.config';
+
 /**
  * Companion mixin used with `resource-fetch` for `ResourceList` to determine if the user needs to filter the list by a single namespace
  */


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7801

### Occurred changes and/or fixed issues
- Move ResourceList name out of ResourceList component

### Technical notes summary
- bug caused by circular dependency of index.vue --> resource-fetch mixin --> resource-fetch-namespaced mixin --> index.vue
- not sure why the works on most pages... but bugs out for this one... but the fix makes sense
