### PR TITLE
Update alias for ProjectMembershipEditor import

### DIFF
--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -9,7 +9,7 @@ import Tabbed from '@shell/components/Tabbed/index.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 import SortableTable from '@shell/components/SortableTable';
 import { mapGetters } from 'vuex';
-import { canViewProjectMembershipEditor } from '~/shell/components/form/Members/ProjectMembershipEditor.vue';
+import { canViewProjectMembershipEditor } from '@shell/components/form/Members/ProjectMembershipEditor.vue';
 import { allHash } from '@shell/utils/promise';
 
 /**


### PR DESCRIPTION
Signed-off-by: Phillip Rak <rak.phillip@gmail.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This updates the import for the `ProjectMembershipEditor.vue` import to make use of the `@shell` alias.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

We want to use the `@shell` alias to

- Maintain consistency with other imports throughout our app
- Allow linking `@rancher/shell` without errors (e.g. `Module not found: Error: Can't resolve '~/shell/components/form/Members/ProjectMembershipEditor.vue' in '/home/phillip/Development/rancher-desktop/node_modules/@rancher/shell/components'`)