### PR TITLE
[2.7.x] HARVESTER: Remove External Harvester Cloud Credentials Support

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1217,7 +1217,6 @@ cluster:
           More info on roles can be found <a href="https://cloud.google.com/kubernetes-engine/docs/how-to/iam-integration" target="_blank" rel="noopener noreferrer nofollow">here</a>.
     harvester:
       import: Imported Harvester
-      external: External Harvester (Experimental)
       namespace: Namespace
       cpu: CPUs
       memory: Memory

--- a/shell/cloud-credential/harvester.vue
+++ b/shell/cloud-credential/harvester.vue
@@ -1,19 +1,13 @@
 <script>
 import CreateEditView from '@shell/mixins/create-edit-view';
-import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
-import { RadioGroup } from '@components/Form/Radio';
 
 import { get, set } from '@shell/utils/object';
 import { MANAGEMENT, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
 
-const IMPORTED = 'imported';
-
 export default {
-  components: {
-    LabeledInput, LabeledSelect, RadioGroup
-  },
-  mixins: [CreateEditView],
+  components: { LabeledSelect },
+  mixins:     [CreateEditView],
 
   async fetch() {
     this.clusters = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
@@ -22,16 +16,11 @@ export default {
   data() {
     this.$emit('validationChanged', true);
 
-    if (!this.value.decodedData.clusterType) {
-      this.value.setData('clusterType', IMPORTED);
-    }
-
     const cluster = get(this.value, 'harvestercredentialConfig.clusterId') || '';
 
     return {
       clusters: [],
       cluster,
-      IMPORTED,
     };
   },
 
@@ -44,22 +33,9 @@ export default {
         };
       });
     },
-
-    isImportCluster() {
-      return this.value.decodedData.clusterType === IMPORTED;
-    }
   },
 
   watch: {
-    'value.decodedData.clusterType': {
-      handler(neu) {
-        if (this.isCreate) {
-          this.value.setData('kubeconfigContent', '');
-          this.cluster = '';
-        }
-      },
-    },
-
     async cluster(neu) {
       if (!neu) {
         return;
@@ -86,14 +62,6 @@ export default {
       },
       immediate: true,
     },
-
-    isImportCluster: {
-      handler() {
-        this.emitValidation();
-      },
-      immediate: true,
-    },
-
     'value.decodedData.kubeconfigContent': {
       handler() {
         this.emitValidation();
@@ -106,17 +74,9 @@ export default {
     test() {
       const t = this.$store.getters['i18n/t'];
 
-      if (!this.cluster && this.isImportCluster) {
+      if (!this.cluster) {
         const cluster = t('cluster.credential.harvester.cluster');
         const errors = [t('validation.required', { key: cluster })];
-
-        return { errors };
-      }
-
-      if (!this.value.decodedData.kubeconfigContent) {
-        const kubeconfigContent = t('cluster.credential.harvester.kubeconfigContent.label');
-
-        const errors = [t('validation.required', { key: kubeconfigContent })];
 
         return { errors };
       } else {
@@ -138,20 +98,7 @@ export default {
 <template>
   <div>
     <div class="row mb-10">
-      <RadioGroup
-        v-model="value.decodedData.clusterType"
-        :mode="mode"
-        :disabled="isEdit"
-        name="clusterType"
-        :labels="[t('cluster.credential.harvester.import'),t('cluster.credential.harvester.external')]"
-        :options="[IMPORTED, 'external']"
-        @input="value.setData('clusterType', $event);"
-      />
-    </div>
-
-    <div class="row mb-10">
       <div
-        v-if="isImportCluster"
         class="col span-6"
       >
         <LabeledSelect
@@ -161,19 +108,6 @@ export default {
           :options="clusterOptions"
           :required="true"
           :label="t('cluster.credential.harvester.cluster')"
-        />
-      </div>
-
-      <div class="col span-6">
-        <LabeledInput
-          v-if="!isImportCluster"
-          :value="value.decodedData.kubeconfigContent"
-          label-key="cluster.credential.harvester.kubeconfigContent.label"
-          :required="true"
-          type="multiline"
-          :min-height="160"
-          :mode="mode"
-          @input="value.setData('kubeconfigContent', $event);"
         />
       </div>
     </div>

--- a/shell/machine-config/harvester.vue
+++ b/shell/machine-config/harvester.vue
@@ -96,12 +96,7 @@ export default {
 
       const url = `/k8s/clusters/${ clusterId }/v1`;
 
-      const isImportCluster =
-        this.credential.decodedData.clusterType === 'imported';
-
-      this.isImportCluster = isImportCluster;
-
-      if (clusterId && isImportCluster) {
+      if (clusterId) {
         const res = await allHashSettled({
           namespaces: this.$store.dispatch('cluster/request', { url: `${ url }/${ NAMESPACE }s` }),
           images:     this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` }),
@@ -244,7 +239,6 @@ export default {
 
     return {
       credential:         null,
-      isImportCluster:    false,
       vmAffinity,
       userData,
       networkData,
@@ -413,7 +407,7 @@ export default {
         const clusterId = get(this.credential, 'decodedData.clusterId');
         const url = `/k8s/clusters/${ clusterId }/v1`;
 
-        if (url && this.isImportCluster) {
+        if (url) {
           const res = await this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` });
 
           this.images = res?.data;
@@ -504,7 +498,6 @@ export default {
 
         <div class="col span-6">
           <LabeledSelect
-            v-if="isImportCluster"
             v-model="value.vmNamespace"
             :mode="mode"
             :options="namespaceOptions"
@@ -516,23 +509,10 @@ export default {
               t('cluster.harvester.machinePool.namespace.placeholder')
             "
           />
-
-          <LabeledInput
-            v-else
-            v-model="value.vmNamespace"
-            label-key="cluster.credential.harvester.namespace"
-            :required="true"
-            :mode="mode"
-            :disabled="namespaceDisabled"
-            :placeholder="
-              t('cluster.harvester.machinePool.namespace.placeholder')
-            "
-          />
         </div>
       </div>
 
       <div
-        v-if="isImportCluster"
         class="row mt-20"
       >
         <div class="col span-6">
@@ -560,33 +540,6 @@ export default {
             :placeholder="
               t('cluster.harvester.machinePool.network.placeholder')
             "
-          />
-        </div>
-      </div>
-
-      <div
-        v-else
-        class="row mt-20"
-      >
-        <div class="col span-6">
-          <LabeledInput
-            v-model="value.imageName"
-            :mode="mode"
-            :required="true"
-            :placeholder="t('cluster.credential.harvester.placeholder')"
-            :disabled="disabledEdit"
-            label-key="cluster.credential.harvester.image"
-          />
-        </div>
-
-        <div class="col span-6">
-          <LabeledInput
-            v-model="value.networkName"
-            :mode="mode"
-            :required="true"
-            :placeholder="t('cluster.credential.harvester.placeholder')"
-            :disabled="disabledEdit"
-            label-key="cluster.credential.harvester.network"
           />
         </div>
       </div>
@@ -633,7 +586,7 @@ export default {
         </h3>
         <div>
           <LabeledSelect
-            v-if="isImportCluster && isCreate"
+            v-if="isCreate"
             v-model="userData"
             class="mb-10"
             :options="userDataOptions"
@@ -656,7 +609,7 @@ export default {
         <h3>{{ t('cluster.credential.harvester.networkData.title') }}</h3>
         <div>
           <LabeledSelect
-            v-if="isImportCluster && isCreate"
+            v-if="isCreate"
             v-model="networkData"
             class="mb-10"
             :options="networkDataOptions"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Remove External Harvester Cloud Credentials Support
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3319

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Remove `clusterType` radio button
- Remove `kubeconfig content` textarea

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Cluster Management -> Cloud Credentials
- Cluster Management -> Create Harvester -> Machine Pools


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/18737885/210354376-584a726c-37cd-4a13-be34-1ede31865f9c.png)
