### PR TITLE
xterm, align theme properties to version 5.x

### DIFF
--- a/pkg/epinio/windowComponents/ApplicationShell.vue
+++ b/pkg/epinio/windowComponents/ApplicationShell.vue
@@ -90,10 +90,10 @@ export default {
 
       const terminal = new xterm.Terminal({
         theme: {
-          background: docStyle.getPropertyValue('--terminal-bg').trim(),
-          cursor:     docStyle.getPropertyValue('--terminal-cursor').trim(),
-          selection:  docStyle.getPropertyValue('--terminal-selection').trim(),
-          foreground: docStyle.getPropertyValue('--terminal-text').trim(),
+          background:          docStyle.getPropertyValue('--terminal-bg').trim(),
+          foreground:          docStyle.getPropertyValue('--terminal-text').trim(),
+          cursor:              docStyle.getPropertyValue('--terminal-cursor').trim(),
+          selectionBackground: docStyle.getPropertyValue('--terminal-selection').trim(),
         },
         ...this.xtermConfig,
       });

--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -158,10 +158,10 @@ export default {
 
       const terminal = new xterm.Terminal({
         theme: {
-          background: docStyle.getPropertyValue('--terminal-bg').trim(),
-          cursor:     docStyle.getPropertyValue('--terminal-cursor').trim(),
-          selection:  docStyle.getPropertyValue('--terminal-selection').trim(),
-          foreground: docStyle.getPropertyValue('--terminal-text').trim(),
+          background:          docStyle.getPropertyValue('--terminal-bg').trim(),
+          foreground:          docStyle.getPropertyValue('--terminal-text').trim(),
+          cursor:              docStyle.getPropertyValue('--terminal-cursor').trim(),
+          selectionBackground: docStyle.getPropertyValue('--terminal-selection').trim(),
         },
         ...this.xtermConfig,
       });


### PR DESCRIPTION
Signed-off-by: Francesco Torchia <francesco.torchia@suse.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7820
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
dark & light mode, selection background restored to `rgba(#3D98D3, 0.5)`

![image](https://user-images.githubusercontent.com/26394656/210397855-1285f606-c2fd-4362-a40a-84c804268277.png)

![image](https://user-images.githubusercontent.com/26394656/210398045-eb122492-bd97-4949-b61f-719880a15b30.png)
