### PR TITLE
Fix multi select styling

### DIFF
--- a/pkg/epinio/windowComponents/ApplicationLogs.vue
+++ b/pkg/epinio/windowComponents/ApplicationLogs.vue
@@ -460,6 +460,7 @@ export default {
       display: inline-block;
       min-width: 200px;
       height: 30px;
+      min-height: 30px;
       width: initial;
     }
   }

--- a/pkg/epinio/windowComponents/ApplicationShell.vue
+++ b/pkg/epinio/windowComponents/ApplicationShell.vue
@@ -355,6 +355,7 @@ export default {
     display: inline-block;
     min-width: 200px;
     height: 30px;
+    min-height: 30px;
     width: initial;
   }
 }

--- a/shell/assets/styles/global/_select.scss
+++ b/shell/assets/styles/global/_select.scss
@@ -9,7 +9,7 @@
 }
 
 .unlabeled-select:not(.in-input) {
-  height: $unlabeled-input-height;
+  min-height: $unlabeled-input-height;
 }
 .col {
   > .unlabeled-select:not(.taggable) {
@@ -17,7 +17,7 @@
   }
 }
 .unlabeled-select:not(.in-input) {
-  height: $unlabeled-input-height;
+  min-height: $unlabeled-input-height;
 }
 
 .labeled-select,

--- a/shell/assets/styles/global/_select.scss
+++ b/shell/assets/styles/global/_select.scss
@@ -16,9 +16,6 @@
     padding-top: 5px;
   }
 }
-.unlabeled-select:not(.in-input) {
-  min-height: $unlabeled-input-height;
-}
 
 .labeled-select,
 .unlabeled-select {

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -631,6 +631,7 @@ export default {
       display: inline-block;
       min-width: 200px;
       height: 30px;
+      min-height: 30px;
       width: initial;
     }
   }

--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -441,6 +441,7 @@ export default {
     display: inline-block;
     min-width: 200px;
     height: 30px;
+    min-height: 30px;
     width: initial;
   }
 }


### PR DESCRIPTION
### Summary
Fix multi select styling so that the form field expands if not all items fit into a single line anymore.

Fixes #7842

### Occurred changes and/or fixed issues
Instead of fixing the height of the select form field, the form field now has a `min-height` which allows the field to expand if necessary.

### Areas or cases that should be tested
Create a Logging ClusterFlow and pick a lot of containers or namespaces.

### Areas which could experience regressions
Form fields that use the Select component.

### Screenshot/Video
Before

![Bildschirm­foto 2023-01-05 um 10 53 22](https://user-images.githubusercontent.com/243056/210754536-765f2c53-cccf-40ee-bdf7-c13b47b9c788.png)

After

![Bildschirm­foto 2023-01-05 um 10 54 15](https://user-images.githubusercontent.com/243056/210754566-c1515468-56b6-4259-8384-ea4ff6d756b1.png)
