### PR TITLE
e2e tests for extensions

### DIFF
--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -1,0 +1,230 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+
+export default class ExtensionsPo extends PagePo {
+  static url: string = '/c/local/uiplugins'
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(ExtensionsPo.url);
+  }
+
+  constructor() {
+    super(ExtensionsPo.url);
+  }
+
+  // screen title
+  title(): Cypress.Chainable<string> {
+    return this.self().getId('extensions-page-title').invoke('text');
+  }
+
+  // install rancher-plugin-examples
+  installRancherPluginExamples() {
+    // we should be on the extensions page
+    this.title().should('contain', 'Extensions');
+
+    // go to app repos
+    this.extensionMenuToggle();
+
+    this.manageReposClick();
+
+    // create a new clusterrepo
+    this.createNewClusterRepoClick();
+
+    // fill the form
+    this.selectRadioOptionGitRepo(2);
+    this.enterClusterRepoName('rancher-plugin-examples');
+    this.enterGitRepoName('https://github.com/rancher/ui-plugin-examples');
+    this.enterGitBranchName('main');
+
+    // save it
+    return this.saveNewClusterRepoClick();
+  }
+
+  // extension card
+  extensionCard(extensionName: string) {
+    return this.self().getId(`extension-card-${ extensionName }`);
+  }
+
+  extensionCardClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).click();
+  }
+
+  extensionCardInstallClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-install-btn-${ extensionName }`).click();
+  }
+
+  extensionCardUpdateClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-update-btn-${ extensionName }`).click();
+  }
+
+  extensionCardRollbackClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-rollback-btn-${ extensionName }`).click();
+  }
+
+  extensionCardUninstallClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-uninstall-btn-${ extensionName }`).click();
+  }
+
+  // extension install modal
+  extensionInstallModal() {
+    return this.self().get('[data-modal="installPluginDialog"]');
+  }
+
+  installModalSelectVersionClick(optionIndex: number): Cypress.Chainable {
+    this.extensionInstallModal().getId('install-ext-modal-select-version').click();
+
+    return this.self().get(`.vs__dropdown-menu .vs__dropdown-option:nth-child(${ optionIndex })`).click();
+  }
+
+  installModalCancelClick(): Cypress.Chainable {
+    return this.extensionInstallModal().getId('install-ext-modal-cancel-btn').click();
+  }
+
+  installModalInstallClick(): Cypress.Chainable {
+    return this.extensionInstallModal().getId('install-ext-modal-install-btn').click();
+  }
+
+  // extension uninstall modal
+  extensionUninstallModal() {
+    return this.self().get('[data-modal="uninstallPluginDialog"]');
+  }
+
+  uninstallModalCancelClick(): Cypress.Chainable {
+    return this.extensionUninstallModal().getId('uninstall-ext-modal-cancel-btn').click();
+  }
+
+  uninstallModaluninstallClick(): Cypress.Chainable {
+    return this.extensionUninstallModal().getId('uninstall-ext-modal-uninstall-btn').click();
+  }
+
+  // extension details
+  extensionDetails() {
+    return this.self().getId('extension-details');
+  }
+
+  extensionDetailsBgClick(): Cypress.Chainable {
+    return this.self().getId('extension-details-bg').click();
+  }
+
+  extensionDetailsTitle(): Cypress.Chainable<string> {
+    return this.extensionDetails().getId('extension-details-title').invoke('text');
+  }
+
+  extensionDetailsCloseClick(): Cypress.Chainable {
+    return this.extensionDetails().getId('extension-details-close').click();
+  }
+
+  // extension tabs
+  extensionTabs() {
+    return this.self().getId('extension-tabs');
+  }
+
+  extensionTabInstalledClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(1) a').click();
+  }
+
+  extensionTabAvailableClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(2) a').click();
+  }
+
+  extensionTabUpdatesClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(3) a').click();
+  }
+
+  extensionTabAllClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(4) a').click();
+  }
+
+  // extension reload banner
+  extensionReloadBanner() {
+    return this.self().getId('extension-reload-banner');
+  }
+
+  extensionReloadClick(): Cypress.Chainable {
+    return this.extensionReloadBanner().getId('extension-reload-banner-reload-btn').click();
+  }
+
+  // extension menu
+  private extensionMenu() {
+    return this.self().getId('extensions-page-menu');
+  }
+
+  extensionMenuToggle(): Cypress.Chainable {
+    return this.extensionMenu().click();
+  }
+
+  manageReposClick(): Cypress.Chainable {
+    return this.self().getId('action-menu-0-item').click();
+  }
+
+  // this will only appear with developer mode enabled
+  // developerLoadClick(): Cypress.Chainable {
+  //   return this.self().getId('action-menu-2-item').click();
+  // }
+
+  disableExtensionsClick(): Cypress.Chainable {
+    return this.self().getId('action-menu-2-item').click();
+  }
+
+  // disable extensions OVERALL modal
+  disableExtensionModal() {
+    return this.self().getId('disable-ext-modal');
+  }
+
+  removeRancherExtRepoCheckboxClick(): Cypress.Chainable {
+    return this.self().getId('disable-ext-modal-remove-repo').click();
+  }
+
+  disableExtensionModalCancelClick(): Cypress.Chainable {
+    return this.disableExtensionModal().get('.dialog-buttons button:first-child').click();
+  }
+
+  disableExtensionModalDisableClick(): Cypress.Chainable {
+    return this.disableExtensionModal().get('.dialog-buttons button:last-child').click();
+  }
+
+  // enable extensions OVERALL modal
+  enableExtensionModal() {
+    return this.self().get('[data-modal="confirm-uiplugins-setup"]');
+  }
+
+  enableExtensionModalCancelClick(): Cypress.Chainable {
+    return this.enableExtensionModal().get('.dialog-buttons button:first-child').click();
+  }
+
+  enableExtensionModalEnableClick(): Cypress.Chainable {
+    return this.enableExtensionModal().get('.dialog-buttons button:last-child').click();
+  }
+
+  // install operator
+  installOperatorBtn() {
+    return this.self().getId('extension-enable-operator');
+  }
+
+  installOperatorBtnClick(): Cypress.Chainable {
+    return this.installOperatorBtn().click();
+  }
+
+  // add a new repo (Extension Examples)
+  createNewClusterRepoClick(): Cypress.Chainable {
+    return this.self().getId('masthead-create').click();
+  }
+
+  enterClusterRepoName(name: string) {
+    return cy.get('[data-testid="name-ns-description-name"] input').type(name);
+  }
+
+  enterGitRepoName(name: string) {
+    return cy.get('[data-testid="clusterrepo-git-repo-input"]').type(name);
+  }
+
+  enterGitBranchName(name: string) {
+    return cy.get('[data-testid="clusterrepo-git-branch-input"]').type(name);
+  }
+
+  selectRadioOptionGitRepo(index: Number): Cypress.Chainable {
+    return this.self().get(`[data-testid="clusterrepo-radio-input"] .radio-group > div:nth-child(${ index }) .labeling label`).click();
+  }
+
+  saveNewClusterRepoClick(): Cypress.Chainable {
+    return this.self().getId('action-button-async-button').click();
+  }
+}

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -15,6 +15,25 @@ export default class ExtensionsPo extends PagePo {
     return this.self().getId('extensions-page-title').invoke('text');
   }
 
+  // install extensions operator
+  installExtensionsOperatorIfNeeded(attempt = 0) {
+    // this will make sure we wait for the page to render first content
+    // so that the attemps aren't on a blank page
+    this.title();
+
+    if (attempt > 20) {
+      return;
+    }
+    if (Cypress.$('[data-testid="extension-enable-operator"]').length > 0) {
+      cy.get('[data-testid="extension-enable-operator"]').click();
+      this.enableExtensionModalEnableClick();
+    } else {
+      cy.wait(250).then(() => { // eslint-disable-line
+        this.installExtensionsOperatorIfNeeded(++attempt); // next attempt
+      });
+    }
+  }
+
   // install rancher-plugin-examples
   installRancherPluginExamples() {
     // we should be on the extensions page

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -6,14 +6,18 @@ describe('Extensions page', () => {
   before(() => {
     cy.login();
 
-    // install the rancher plugin examples
     ExtensionsPo.goTo();
     const extensionsPo = new ExtensionsPo();
 
+    // install extensions operator if it's not installed
+    extensionsPo.installExtensionsOperatorIfNeeded();
+
+    // install the rancher plugin examples
     extensionsPo.installRancherPluginExamples();
   });
 
   beforeEach(() => {
+    cy.login();
     ExtensionsPo.goTo();
   });
 
@@ -80,14 +84,6 @@ describe('Extensions page', () => {
   //   extensionsPo.extensionCardInstallClick(extensionName);
   //   extensionsPo.extensionInstallModal().should('be.visible');
 
-  //   // let's just make sure dialog disappears when we cancel
-  //   extensionsPo.installModalCancelClick();
-  //   extensionsPo.extensionInstallModal().should('not.exist');
-
-  //   // all good, let's install it then
-  //   extensionsPo.extensionCardInstallClick(extensionName);
-  //   extensionsPo.extensionInstallModal().should('be.visible');
-
   //   // select version and click install
   //   extensionsPo.installModalSelectVersionClick(2);
   //   extensionsPo.installModalInstallClick();
@@ -147,14 +143,6 @@ describe('Extensions page', () => {
   //   extensionsPo.extensionTabInstalledClick();
 
   //   // click on uninstall button on card
-  //   extensionsPo.extensionCardUninstallClick(extensionName);
-  //   extensionsPo.extensionUninstallModal().should('be.visible');
-
-  //   // let's just make sure dialog disappears when we cancel
-  //   extensionsPo.uninstallModalCancelClick();
-  //   extensionsPo.extensionUninstallModal().should('not.exist');
-
-  //   // all good, let's uninstall it then
   //   extensionsPo.extensionCardUninstallClick(extensionName);
   //   extensionsPo.extensionUninstallModal().should('be.visible');
   //   extensionsPo.uninstallModaluninstallClick();

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -21,139 +21,139 @@ describe('Extensions page', () => {
     ExtensionsPo.goTo();
   });
 
-  // it('Should disable and enable extension support', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should disable and enable extension support', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   // open menu and click on disable extension support
-  //   extensionsPo.extensionMenuToggle();
-  //   extensionsPo.disableExtensionsClick();
+    // open menu and click on disable extension support
+    extensionsPo.extensionMenuToggle();
+    extensionsPo.disableExtensionsClick();
 
-  //   // on the modal, keep the extensions repo and click disable
-  //   extensionsPo.removeRancherExtRepoCheckboxClick();
-  //   extensionsPo.disableExtensionModalDisableClick();
+    // on the modal, keep the extensions repo and click disable
+    extensionsPo.removeRancherExtRepoCheckboxClick();
+    extensionsPo.disableExtensionModalDisableClick();
 
-  //   // let's wait for the install button to become visible and re-install
-  //   // the extensions operator
-  //   extensionsPo.installOperatorBtn().should('be.visible');
-  //   extensionsPo.installOperatorBtnClick();
-  //   extensionsPo.enableExtensionModalEnableClick();
+    // let's wait for the install button to become visible and re-install
+    // the extensions operator
+    extensionsPo.installOperatorBtn().should('be.visible');
+    extensionsPo.installOperatorBtnClick();
+    extensionsPo.enableExtensionModalEnableClick();
 
-  //   // wait for operation to finish and refresh...
-  //   extensionsPo.extensionTabs().should('be.visible');
-  //   ExtensionsPo.goTo();
+    // wait for operation to finish and refresh...
+    extensionsPo.extensionTabs().should('be.visible');
+    ExtensionsPo.goTo();
 
-  //   // let's make sure all went good
-  //   extensionsPo.extensionTabAvailableClick();
-  //   extensionsPo.extensionCard(extensionName).should('be.visible');
-  // });
+    // let's make sure all went good
+    extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionCard(extensionName).should('be.visible');
+  });
 
-  // it('Should toogle the extension details', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should toogle the extension details', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionTabAvailableClick();
 
-  //   // we should be on the extensions page
-  //   extensionsPo.title().should('contain', 'Extensions');
+    // we should be on the extensions page
+    extensionsPo.title().should('contain', 'Extensions');
 
-  //   // show extension details
-  //   extensionsPo.extensionCardClick(extensionName);
+    // show extension details
+    extensionsPo.extensionCardClick(extensionName);
 
-  //   // after card click, we should get the info slide in panel
-  //   extensionsPo.extensionDetails().should('be.visible');
-  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+    // after card click, we should get the info slide in panel
+    extensionsPo.extensionDetails().should('be.visible');
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
 
-  //   // close the details on the cross icon X
-  //   extensionsPo.extensionDetailsCloseClick();
-  //   extensionsPo.extensionDetails().should('not.be.visible');
+    // close the details on the cross icon X
+    extensionsPo.extensionDetailsCloseClick();
+    extensionsPo.extensionDetails().should('not.be.visible');
 
-  //   // show extension details again...
-  //   extensionsPo.extensionCardClick(extensionName);
-  //   extensionsPo.extensionDetails().should('be.visible');
+    // show extension details again...
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetails().should('be.visible');
 
-  //   // clicking outside the details tab should also close it
-  //   extensionsPo.extensionDetailsBgClick();
-  //   extensionsPo.extensionDetails().should('not.be.visible');
-  // });
+    // clicking outside the details tab should also close it
+    extensionsPo.extensionDetailsBgClick();
+    extensionsPo.extensionDetails().should('not.be.visible');
+  });
 
-  // it('Should install an extension', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should install an extension', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionTabAvailableClick();
 
-  //   // click on install button on card
-  //   extensionsPo.extensionCardInstallClick(extensionName);
-  //   extensionsPo.extensionInstallModal().should('be.visible');
+    // click on install button on card
+    extensionsPo.extensionCardInstallClick(extensionName);
+    extensionsPo.extensionInstallModal().should('be.visible');
 
-  //   // select version and click install
-  //   extensionsPo.installModalSelectVersionClick(2);
-  //   extensionsPo.installModalInstallClick();
+    // select version and click install
+    extensionsPo.installModalSelectVersionClick(2);
+    extensionsPo.installModalInstallClick();
 
-  //   // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // make sure extension card is in the installed tab
-  //   extensionsPo.extensionTabInstalledClick();
-  //   extensionsPo.extensionCardClick(extensionName);
-  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-  //   extensionsPo.extensionDetailsCloseClick();
-  // });
+    // make sure extension card is in the installed tab
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+    extensionsPo.extensionDetailsCloseClick();
+  });
 
-  // it('Should update an extension version', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should update an extension version', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionTabInstalledClick();
 
-  //   // click on update button on card
-  //   extensionsPo.extensionCardUpdateClick(extensionName);
-  //   extensionsPo.installModalInstallClick();
+    // click on update button on card
+    extensionsPo.extensionCardUpdateClick(extensionName);
+    extensionsPo.installModalInstallClick();
 
-  //   // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // make sure extension card is not available anymore on the updates tab
-  //   // since we installed the latest version
-  //   extensionsPo.extensionTabUpdatesClick();
-  //   extensionsPo.extensionCard(extensionName).should('not.exist');
-  // });
+    // make sure extension card is not available anymore on the updates tab
+    // since we installed the latest version
+    extensionsPo.extensionTabUpdatesClick();
+    extensionsPo.extensionCard(extensionName).should('not.exist');
+  });
 
-  // it('Should rollback an extension version', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should rollback an extension version', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionTabInstalledClick();
 
-  //   // click on the rollback button on card
-  //   // this will rollback to the immediate previous version
-  //   extensionsPo.extensionCardRollbackClick(extensionName);
-  //   extensionsPo.installModalInstallClick();
+    // click on the rollback button on card
+    // this will rollback to the immediate previous version
+    extensionsPo.extensionCardRollbackClick(extensionName);
+    extensionsPo.installModalInstallClick();
 
-  //   // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // make sure extension card is on the updates tab
-  //   extensionsPo.extensionTabUpdatesClick();
-  //   extensionsPo.extensionCard(extensionName).should('be.visible');
-  // });
+    // make sure extension card is on the updates tab
+    extensionsPo.extensionTabUpdatesClick();
+    extensionsPo.extensionCard(extensionName).should('be.visible');
+  });
 
-  // it('Should uninstall an extension', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should uninstall an extension', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionTabInstalledClick();
 
-  //   // click on uninstall button on card
-  //   extensionsPo.extensionCardUninstallClick(extensionName);
-  //   extensionsPo.extensionUninstallModal().should('be.visible');
-  //   extensionsPo.uninstallModaluninstallClick();
+    // click on uninstall button on card
+    extensionsPo.extensionCardUninstallClick(extensionName);
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
 
-  //   // // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // // make sure extension card is in the available tab
-  //   extensionsPo.extensionTabAvailableClick();
-  //   extensionsPo.extensionCardClick(extensionName);
-  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-  // });
+    // // make sure extension card is in the available tab
+    extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  });
 });

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -1,0 +1,171 @@
+import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
+
+const extensionName = 'homepage';
+
+describe('Extensions page', () => {
+  before(() => {
+    cy.login();
+
+    // install the rancher plugin examples
+    ExtensionsPo.goTo();
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.installRancherPluginExamples();
+  });
+
+  beforeEach(() => {
+    ExtensionsPo.goTo();
+  });
+
+  // it('Should disable and enable extension support', () => {
+  //   const extensionsPo = new ExtensionsPo();
+
+  //   // open menu and click on disable extension support
+  //   extensionsPo.extensionMenuToggle();
+  //   extensionsPo.disableExtensionsClick();
+
+  //   // on the modal, keep the extensions repo and click disable
+  //   extensionsPo.removeRancherExtRepoCheckboxClick();
+  //   extensionsPo.disableExtensionModalDisableClick();
+
+  //   // let's wait for the install button to become visible and re-install
+  //   // the extensions operator
+  //   extensionsPo.installOperatorBtn().should('be.visible');
+  //   extensionsPo.installOperatorBtnClick();
+  //   extensionsPo.enableExtensionModalEnableClick();
+
+  //   // wait for operation to finish and refresh...
+  //   extensionsPo.extensionTabs().should('be.visible');
+  //   ExtensionsPo.goTo();
+
+  //   // let's make sure all went good
+  //   extensionsPo.extensionTabAvailableClick();
+  //   extensionsPo.extensionCard(extensionName).should('be.visible');
+  // });
+
+  // it('Should toogle the extension details', () => {
+  //   const extensionsPo = new ExtensionsPo();
+
+  //   extensionsPo.extensionTabAvailableClick();
+
+  //   // we should be on the extensions page
+  //   extensionsPo.title().should('contain', 'Extensions');
+
+  //   // show extension details
+  //   extensionsPo.extensionCardClick(extensionName);
+
+  //   // after card click, we should get the info slide in panel
+  //   extensionsPo.extensionDetails().should('be.visible');
+  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+
+  //   // close the details on the cross icon X
+  //   extensionsPo.extensionDetailsCloseClick();
+  //   extensionsPo.extensionDetails().should('not.be.visible');
+
+  //   // show extension details again...
+  //   extensionsPo.extensionCardClick(extensionName);
+  //   extensionsPo.extensionDetails().should('be.visible');
+
+  //   // clicking outside the details tab should also close it
+  //   extensionsPo.extensionDetailsBgClick();
+  //   extensionsPo.extensionDetails().should('not.be.visible');
+  // });
+
+  // it('Should install an extension', () => {
+  //   const extensionsPo = new ExtensionsPo();
+
+  //   extensionsPo.extensionTabAvailableClick();
+
+  //   // click on install button on card
+  //   extensionsPo.extensionCardInstallClick(extensionName);
+  //   extensionsPo.extensionInstallModal().should('be.visible');
+
+  //   // let's just make sure dialog disappears when we cancel
+  //   extensionsPo.installModalCancelClick();
+  //   extensionsPo.extensionInstallModal().should('not.exist');
+
+  //   // all good, let's install it then
+  //   extensionsPo.extensionCardInstallClick(extensionName);
+  //   extensionsPo.extensionInstallModal().should('be.visible');
+
+  //   // select version and click install
+  //   extensionsPo.installModalSelectVersionClick(2);
+  //   extensionsPo.installModalInstallClick();
+
+  //   // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
+
+  //   // make sure extension card is in the installed tab
+  //   extensionsPo.extensionTabInstalledClick();
+  //   extensionsPo.extensionCardClick(extensionName);
+  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  //   extensionsPo.extensionDetailsCloseClick();
+  // });
+
+  // it('Should update an extension version', () => {
+  //   const extensionsPo = new ExtensionsPo();
+
+  //   extensionsPo.extensionTabInstalledClick();
+
+  //   // click on update button on card
+  //   extensionsPo.extensionCardUpdateClick(extensionName);
+  //   extensionsPo.installModalInstallClick();
+
+  //   // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
+
+  //   // make sure extension card is not available anymore on the updates tab
+  //   // since we installed the latest version
+  //   extensionsPo.extensionTabUpdatesClick();
+  //   extensionsPo.extensionCard(extensionName).should('not.exist');
+  // });
+
+  // it('Should rollback an extension version', () => {
+  //   const extensionsPo = new ExtensionsPo();
+
+  //   extensionsPo.extensionTabInstalledClick();
+
+  //   // click on the rollback button on card
+  //   // this will rollback to the immediate previous version
+  //   extensionsPo.extensionCardRollbackClick(extensionName);
+  //   extensionsPo.installModalInstallClick();
+
+  //   // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
+
+  //   // make sure extension card is on the updates tab
+  //   extensionsPo.extensionTabUpdatesClick();
+  //   extensionsPo.extensionCard(extensionName).should('be.visible');
+  // });
+
+  // it('Should uninstall an extension', () => {
+  //   const extensionsPo = new ExtensionsPo();
+
+  //   extensionsPo.extensionTabInstalledClick();
+
+  //   // click on uninstall button on card
+  //   extensionsPo.extensionCardUninstallClick(extensionName);
+  //   extensionsPo.extensionUninstallModal().should('be.visible');
+
+  //   // let's just make sure dialog disappears when we cancel
+  //   extensionsPo.uninstallModalCancelClick();
+  //   extensionsPo.extensionUninstallModal().should('not.exist');
+
+  //   // all good, let's uninstall it then
+  //   extensionsPo.extensionCardUninstallClick(extensionName);
+  //   extensionsPo.extensionUninstallModal().should('be.visible');
+  //   extensionsPo.uninstallModaluninstallClick();
+
+  //   // // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
+
+  //   // // make sure extension card is in the available tab
+  //   extensionsPo.extensionTabAvailableClick();
+  //   extensionsPo.extensionCardClick(extensionName);
+  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  // });
+});

--- a/pkg/test-features/BannerComponent.vue
+++ b/pkg/test-features/BannerComponent.vue
@@ -1,0 +1,25 @@
+<script>
+import Banner from '@components/Banner/Banner.vue';
+
+export default {
+  name:       'BannerComponent',
+  components: { Banner },
+  data() {
+    return { key: 'asdasd' };
+  }
+};
+</script>
+
+<template>
+  <div>
+    <Banner
+      color="info"
+    >
+      Just a sample banner
+    </Banner>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/pkg/test-features/MastheadDetailsComponent.vue
+++ b/pkg/test-features/MastheadDetailsComponent.vue
@@ -1,0 +1,19 @@
+<script>
+export default {
+  name: 'MastheadDetailsComponent',
+  data() {
+    return { key: 'asdasd' };
+  }
+};
+</script>
+
+<template>
+  <div>
+    <p><span>Some key1: some label1</span></p>
+    <p><span>Some key2: some label2</span></p>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/pkg/test-features/MastheadDetailsComponent.vue
+++ b/pkg/test-features/MastheadDetailsComponent.vue
@@ -9,6 +9,8 @@ export default {
 
 <template>
   <div>
+    <br>
+    <h4>This is a user defined component!</h4>
     <p><span>Some key1: some label1</span></p>
     <p><span>Some key2: some label2</span></p>
   </div>

--- a/pkg/test-features/MyTabComponent.vue
+++ b/pkg/test-features/MyTabComponent.vue
@@ -1,0 +1,18 @@
+<script>
+export default {
+  name: 'MyDemoComponent',
+  data() {
+    return { key: 'asdasd' };
+  }
+};
+</script>
+
+<template>
+  <div>
+    <h1>THIS IS A DEMO COMPONENT</h1>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/pkg/test-features/babel.config.js
+++ b/pkg/test-features/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./.shell/pkg/babel.config.js');

--- a/pkg/test-features/index.ts
+++ b/pkg/test-features/index.ts
@@ -1,0 +1,126 @@
+import { importTypes } from '@rancher/auto-import';
+import {
+  IPlugin,
+  UI_CONFIG_HEADER_ACTION,
+  UI_CONFIG_TAB,
+  UI_CONFIG_TABLE_ACTION,
+  UI_CONFIG_DETAILS_MASTHEAD,
+  UI_CONFIG_DETAIL_TOP,
+  UI_CONFIG_RESOURCE_LIST,
+} from '@shell/core/types';
+import { isMac } from '@shell/utils/platform';
+
+// Init the package
+export default function(plugin: IPlugin) {
+  // Auto-import model, detail, edit from the folders
+  importTypes(plugin);
+
+  // Provide plugin metadata from package.json
+  plugin.metadata = require('./package.json');
+
+  // Load a product
+  // plugin.addProduct(require('./product'));
+
+  // header menu action global - example
+  plugin.addUIAction(UI_CONFIG_HEADER_ACTION, {}, {
+    tooltipKey: 'generic.customize',
+    tooltip:    'Test Action1',
+    shortcutLabel() {
+      return isMac ? '(\u2318-M)' : '(Ctrl+M)';
+    },
+    shortcutKey: { windows: ['ctrl', 'm'], mac: ['meta', 'm'] },
+    icon:        'icon-pipeline',
+    enabled() {
+      return true;
+    },
+    clicked() {
+      console.log('action executed 1', this.$route); // eslint-disable-line no-console
+    }
+  });
+
+  // header menu action per route name - example
+  plugin.addUIAction(UI_CONFIG_HEADER_ACTION, { name: 'c-cluster-explorer' }, {
+    tooltipKey: 'generic.comingSoon',
+    tooltip:    'Test Action2',
+    shortcutLabel() {
+      return isMac ? '(\u2318-B)' : '(Ctrl+B)';
+    },
+    shortcutKey: { windows: ['ctrl', 'b'], mac: ['meta', 'b'] },
+    icon:        'icon-spinner',
+    enabled() {
+      return true;
+    },
+    clicked() {
+      console.log('action executed 2', this); // eslint-disable-line no-console
+    }
+  });
+
+  // tab in resourceTabs per resource - example
+  plugin.addUIAction(UI_CONFIG_TAB, { resource: 'pod' }, {
+    name:       'some-name',
+    labelKey:   'generic.comingSoon',
+    label:      'some-label',
+    weight:     -5,
+    showHeader: true,
+    tooltip:    'this is a tooltip message',
+    badge:      3,
+    component:  () => import('./MyTabComponent.vue')
+  });
+
+  // action in table per resource - example
+  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, { divider: true });
+
+  // action in table per resource - example
+  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, {
+    action:  'some-extension-action',
+    label:   'some-extension-action',
+    icon:    'icon-pipeline',
+    enabled: true,
+    clicked() {
+      console.log('table action executed1', this); // eslint-disable-line no-console
+    }
+  });
+
+  // action in table per resource - example
+  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, {
+    action:   'some-bulkable-action',
+    label:    'some-bulkable-action',
+    labelKey: 'generic.comingSoon',
+    icon:     'icon-pipeline',
+    bulkable: true,
+    enabled:  true,
+    clicked() {
+      console.log('table action executed2', this); // eslint-disable-line no-console
+    },
+    bulkAction(args: any) {
+      console.log('bulk table action executed', this, args); // eslint-disable-line no-console
+    }
+  });
+
+  // information in Details Masthead - example
+  plugin.addUIAction(UI_CONFIG_DETAILS_MASTHEAD,
+    {
+      resource: 'catalog.cattle.io.clusterrepo',
+      name:     'c-cluster-product-resource-id'
+    },
+    { component: () => import('./MastheadDetailsComponent.vue') });
+
+  // information in Details Masthead - example
+  plugin.addUIAction(UI_CONFIG_DETAILS_MASTHEAD,
+    {
+      resource: 'catalog.cattle.io.clusterrepo',
+      name:     'c-cluster-product-resource-id',
+      query:    { as: 'config' }
+    },
+    { component: () => import('./MastheadDetailsComponent.vue') });
+
+  // information in DetailTop - example
+  plugin.addUIAction(UI_CONFIG_DETAIL_TOP,
+    { resource: 'catalog.cattle.io.clusterrepo' },
+    { component: () => import('./MastheadDetailsComponent.vue') });
+
+  // information in ResourceList - example
+  plugin.addUIAction(UI_CONFIG_RESOURCE_LIST,
+    { resource: 'catalog.cattle.io.app' },
+    { component: () => import('./BannerComponent.vue') });
+}

--- a/pkg/test-features/index.ts
+++ b/pkg/test-features/index.ts
@@ -1,18 +1,6 @@
 import { importTypes } from '@rancher/auto-import';
-import {
-  IPlugin,
-  UI_CONFIG_HEADER_ACTION,
-  UI_CONFIG_TAB,
-  UI_CONFIG_TABLE_ACTION,
-  UI_CONFIG_DETAILS_MASTHEAD,
-  UI_CONFIG_DETAIL_TOP,
-  UI_CONFIG_RESOURCE_LIST,
-  UI_CONFIG_GLOBAL_SETTING,
-  UI_CONFIG_CLUSTER_DASHBOARD_CARD,
-  UI_CONFIG_TABLE_COL,
-} from '@shell/core/types';
+import { IPlugin } from '@shell/core/types';
 import { isMac } from '@shell/utils/platform';
-import { MANAGEMENT } from '@shell/config/types';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -36,7 +24,7 @@ export default function(plugin: IPlugin) {
    * @param {function} enabled - whether the action/button is enabled or not
    * @param {function} clicked - function performed when action/button is clicked
    */
-  plugin.addUIAction(UI_CONFIG_HEADER_ACTION, {}, {
+  plugin.addHeaderAction( {}, {
     tooltipKey: 'generic.customize',
     tooltip:    'Test Action1',
     shortcutLabel() {
@@ -53,7 +41,7 @@ export default function(plugin: IPlugin) {
   });
 
   // HEADER ACTION (button)
-  plugin.addUIAction(UI_CONFIG_HEADER_ACTION, { name: 'c-cluster-explorer' }, {
+  plugin.addHeaderAction( { product: 'explorer' }, {
     tooltipKey: 'generic.comingSoon',
     tooltip:    'Test Action2',
     shortcutLabel() {
@@ -78,22 +66,20 @@ export default function(plugin: IPlugin) {
    * @param {int} weight - defines the order on which the tabs are displayed
    * @param {boolean} showHeader - whether the tab header is displayed or not
    * @param {string} tooltip - tooltip message (on tab header)
-   * @param {int} badge - badge count indicator to be displayed on tab (on top)
    * @param {function} component - component to be displayed as tab content
    */
-  plugin.addUIAction(UI_CONFIG_TAB, { resource: 'pod' }, {
+  plugin.addTab( { resource: 'pod' }, {
     name:       'some-name',
     labelKey:   'generic.comingSoon',
     label:      'some-label',
     weight:     -5,
     showHeader: true,
     tooltip:    'this is a tooltip message',
-    badge:      3,
     component:  () => import('./MyTabComponent.vue')
   });
 
   // TABLE ACTIONS - divider
-  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, { divider: true }); // renders a divider instead of an actual action
+  plugin.addTableAction( { resource: 'catalog.cattle.io.clusterrepo' }, { divider: true }); // renders a divider instead of an actual action
 
   // TABLE ACTIONS
   /**
@@ -108,7 +94,7 @@ export default function(plugin: IPlugin) {
    * @param {boolean} bulkable - whether the action/button is bulkable (can be performed on multiple list items)
    * @param {function} bulkAction - function performed when bulklable action/button is clicked (only bulkable mode)
    */
-  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, {
+  plugin.addTableAction( { resource: 'catalog.cattle.io.clusterrepo' }, {
     action:   'some-extension-action',
     label:    'some-extension-action',
     labelKey: 'generic.customize',
@@ -120,7 +106,7 @@ export default function(plugin: IPlugin) {
   });
 
   // TABLE ACTIONS
-  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, {
+  plugin.addTableAction( { resource: 'catalog.cattle.io.clusterrepo' }, {
     action:   'some-bulkable-action',
     label:    'some-bulkable-action',
     labelKey: 'generic.comingSoon',
@@ -140,28 +126,26 @@ export default function(plugin: IPlugin) {
    * Config options
    * @param {function} component - component to be displayed on details view masthead
    */
-  plugin.addUIAction(UI_CONFIG_DETAILS_MASTHEAD,
-    {
-      resource: 'catalog.cattle.io.clusterrepo',
-      name:     'c-cluster-product-resource-id'
-    },
+  plugin.addToDetailsMasthead(
+    { resource: 'catalog.cattle.io.clusterrepo' },
     { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
 
   // DETAILS VIEW MASTHEAD DATA
-  plugin.addUIAction(UI_CONFIG_DETAILS_MASTHEAD,
-    {
-      resource: 'catalog.cattle.io.clusterrepo',
-      name:     'c-cluster-product-resource-id',
-      query:    { as: 'config' }
-    },
+  plugin.addToDetailsMasthead(
+    { resource: 'catalog.cattle.io.clusterrepo', mode: 'config' },
     { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
+
+  // DETAILS VIEW MASTHEAD DATA
+  plugin.addToDetailsMasthead(
+    { resource: 'catalog.cattle.io.clusterrepo', mode: 'edit' },
+    { component: () => import('./BannerComponent.vue') }); // component to be rendered
 
   // DETAILS VIEW "DetailTop" DATA
   /**
    * Config options
    * @param {function} component - component to be displayed on details view "detailsTop" area
    */
-  plugin.addUIAction(UI_CONFIG_DETAIL_TOP,
+  plugin.addToDetailTop(
     { resource: 'catalog.cattle.io.clusterrepo' },
     { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
 
@@ -170,33 +154,9 @@ export default function(plugin: IPlugin) {
    * Config options
    * @param {function} component - component to be displayed before a list view (ResourceList component)
    */
-  plugin.addUIAction(UI_CONFIG_RESOURCE_LIST,
+  plugin.addToListView(
     { resource: 'catalog.cattle.io.app' },
     { component: () => import('./BannerComponent.vue') }); // component to be rendered
-
-  // GLOBAL SETTINGS PAGE (not working yet...)
-  plugin.addUIAction(UI_CONFIG_GLOBAL_SETTING, {}, {
-    virtualType: {
-      ifHaveType: MANAGEMENT.SETTING,
-      labelKey:   'generic.comingSoon',
-      name:       'dummy',
-      namespaced: false,
-      weight:     91,
-      icon:       'folder',
-      route:      { name: 'c-cluster-settings-dummy' }
-    },
-    basicType:     true,
-    configureType: {
-      type:    MANAGEMENT.SETTING,
-      options: {
-        isCreatable: false,
-        isRemovable: false,
-        showAge:     false,
-        showState:   false,
-        canYaml:     false,
-      }
-    }
-  });
 
   // CLUSTER DASHBOARD CARD
   /**
@@ -205,76 +165,64 @@ export default function(plugin: IPlugin) {
    * @param {string} labelKey - same as "label" but allows for translation. Will superseed "label"
    * @param {function} component - component to be displayed inside card
    */
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
+  plugin.addClusterDashboardCard( { cluster: 'local' }, {
     label:     'some-label',
     labelKey:  'generic.comingSoon',
     component: () => import('./MastheadDetailsComponent.vue')
   });
 
   // CLUSTER DASHBOARD CARD
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
+  plugin.addClusterDashboardCard( { cluster: 'local' }, {
     label:     'some-label1',
     labelKey:  'generic.comingSoon',
     component: () => import('./MastheadDetailsComponent.vue')
   });
 
   // CLUSTER DASHBOARD CARD
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
+  plugin.addClusterDashboardCard( { cluster: 'local' }, {
     label:     'some-label2',
     labelKey:  'generic.comingSoon',
     component: () => import('./MastheadDetailsComponent.vue')
   });
 
   // CLUSTER DASHBOARD CARD
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
+  plugin.addClusterDashboardCard( { cluster: 'local' }, {
     label:     'some-label3',
     labelKey:  'generic.comingSoon',
     component: () => import('./MastheadDetailsComponent.vue')
   });
 
   // ADD A COL TO A TABLE
+  // NOTE: this will only work for a locationConfig bound to a resource. Ex: { resource: 'configmap' }
   /**
    * Config options
-   * @param {string} type - resource type to apply the col to (required)
-   * @param {object} classProp - defines a new prop for a given resource in it's class/model
-   * @param {object} config - col configuration object (required)
+   * @param {string} name - label for col
+   * @param {string} labelKey - Same as "name" but allows for translation. Will superseed "name"
+   * @param {string} value - // col prop to obtain the value from
+   * @param {function} getValue - same as "value", but it can be a function. Will superseed "value"
+   * @param {number} width - col width (optional)
    */
-  plugin.addUIAction(UI_CONFIG_TABLE_COL, { resource: 'configmap' }, {
-    type:      'configmap',
-    classProp: {
-      propName: 'some-prop',
-      value:    (data: any) => {
-        return `${ data.id }-some-string`;
-      }
+  plugin.addTableCol( { resource: 'configmap' }, {
+    name:     'some-prop-col',
+    labelKey: 'generic.comingSoon',
+    getValue: (row: any) => {
+      return `${ row.id }-some-string`;
     },
-    config: {
-      // A USER DEFINED PROP! check "classProp" above
-      name:     'some-prop-col',
-      labelKey: 'generic.comingSoon',
-      getValue: (row: any) => row.extensionProps['some-prop'],
 
-      // SIMPLE STATE EXAMPLE
-      // name:      'state', // label for col
-      // labelKey:  'tableHeaders.state', // Same as "name" but allows for translation. Will superseed "name"
-      // sort:      ['stateSort', 'nameSort'], // prop(s) to be bound to the table sorting
-      // search:    ['stateSort', 'nameSort'], // prop(s) to be bound to the table search
-      // value:     'stateDisplay', // col prop to obtain the value from
-      // getValue:  (row: any) => row.stateDisplay, // same as "value", but it can be a function. Will superseed "value"
-      // width:     100, // col width
-      // default:   'unknown', // col default value
-      // formatter: 'BadgeStateFormatter', // col formatter if needed
-
-      // OTHER OPTIONS
-      // formatterOpts: { reference: 'claim.detailLocation' }, // passing options to formatter
-      // canBeVariable: true, // col can have variable with
-      // dashIfEmpty:   true, // display dash if there's no value for this prop
-      // width:         120, // col width
-      // align:         'center', // col alignment
-      // liveUpdates:   true,
-      // breakpoint:    COLUMN_BREAKPOINTS.DESKTOP,
-      // maxPageSize:   25, // Hide this column when the page size is bigger than 25
-      // skipSelect:    true,
-      // delayLoading:  true, // col data will only load after data is loaded or scroll is done
-    }
+    // OTHER OPTIONS
+    // width:     100, // col width
+    // sort:      ['stateSort', 'nameSort'], // prop(s) to be bound to the table sorting
+    // search:    ['stateSort', 'nameSort'], // prop(s) to be bound to the table search
+    // default:   'unknown', // col default value
+    // formatter: 'BadgeStateFormatter', // col formatter if needed
+    // formatterOpts: { reference: 'claim.detailLocation' }, // passing options to formatter
+    // canBeVariable: true, // col can have variable with
+    // dashIfEmpty:   true, // display dash if there's no value for this prop
+    // align:         'center', // col alignment
+    // liveUpdates:   true,
+    // breakpoint:    COLUMN_BREAKPOINTS.DESKTOP,
+    // maxPageSize:   25, // Hide this column when the page size is bigger than 25
+    // skipSelect:    true,
+    // delayLoading:  true, // col data will only load after data is loaded or scroll is done
   });
 }

--- a/pkg/test-features/index.ts
+++ b/pkg/test-features/index.ts
@@ -9,6 +9,7 @@ import {
   UI_CONFIG_RESOURCE_LIST,
   UI_CONFIG_GLOBAL_SETTING,
   UI_CONFIG_CLUSTER_DASHBOARD_CARD,
+  UI_CONFIG_TABLE_COL,
 } from '@shell/core/types';
 import { isMac } from '@shell/utils/platform';
 import { MANAGEMENT } from '@shell/config/types';
@@ -24,7 +25,7 @@ export default function(plugin: IPlugin) {
   // Load a product
   // plugin.addProduct(require('./product'));
 
-  // header menu action global - example
+  // HEADER ACTION (button)
   plugin.addUIAction(UI_CONFIG_HEADER_ACTION, {}, {
     tooltipKey: 'generic.customize',
     tooltip:    'Test Action1',
@@ -33,7 +34,7 @@ export default function(plugin: IPlugin) {
     },
     shortcutKey: { windows: ['ctrl', 'm'], mac: ['meta', 'm'] },
     icon:        'icon-pipeline',
-    enabled() {
+    enabled(ctx: any) {
       return true;
     },
     clicked() {
@@ -41,7 +42,7 @@ export default function(plugin: IPlugin) {
     }
   });
 
-  // header menu action per route name - example
+  // HEADER ACTION (button)
   plugin.addUIAction(UI_CONFIG_HEADER_ACTION, { name: 'c-cluster-explorer' }, {
     tooltipKey: 'generic.comingSoon',
     tooltip:    'Test Action2',
@@ -50,7 +51,7 @@ export default function(plugin: IPlugin) {
     },
     shortcutKey: { windows: ['ctrl', 'b'], mac: ['meta', 'b'] },
     icon:        'icon-spinner',
-    enabled() {
+    enabled(ctx: any) {
       return true;
     },
     clicked() {
@@ -58,7 +59,7 @@ export default function(plugin: IPlugin) {
     }
   });
 
-  // tab in resourceTabs per resource - example
+  // ADDS TAB TO "ResourceTabs" COMPONENT
   plugin.addUIAction(UI_CONFIG_TAB, { resource: 'pod' }, {
     name:       'some-name',
     labelKey:   'generic.comingSoon',
@@ -70,21 +71,22 @@ export default function(plugin: IPlugin) {
     component:  () => import('./MyTabComponent.vue')
   });
 
-  // action in table per resource - example
-  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, { divider: true });
+  // TABLE ACTIONS - divider
+  plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, { divider: true }); // renders a divider instead of an actual action
 
-  // action in table per resource - example
+  // TABLE ACTIONS
   plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, {
-    action:  'some-extension-action',
-    label:   'some-extension-action',
-    icon:    'icon-pipeline',
-    enabled: true,
+    action:   'some-extension-action',
+    label:    'some-extension-action',
+    labelKey: 'generic.customize',
+    icon:     'icon-pipeline',
+    enabled:  true,
     clicked() {
       console.log('table action executed1', this); // eslint-disable-line no-console
     }
   });
 
-  // action in table per resource - example
+  // TABLE ACTIONS
   plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, {
     action:   'some-bulkable-action',
     label:    'some-bulkable-action',
@@ -100,34 +102,34 @@ export default function(plugin: IPlugin) {
     }
   });
 
-  // information in Details Masthead - example
+  // DETAILS VIEW MASTHEAD DATA
   plugin.addUIAction(UI_CONFIG_DETAILS_MASTHEAD,
     {
       resource: 'catalog.cattle.io.clusterrepo',
       name:     'c-cluster-product-resource-id'
     },
-    { component: () => import('./MastheadDetailsComponent.vue') });
+    { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
 
-  // information in Details Masthead - example
+  // DETAILS VIEW MASTHEAD DATA
   plugin.addUIAction(UI_CONFIG_DETAILS_MASTHEAD,
     {
       resource: 'catalog.cattle.io.clusterrepo',
       name:     'c-cluster-product-resource-id',
       query:    { as: 'config' }
     },
-    { component: () => import('./MastheadDetailsComponent.vue') });
+    { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
 
-  // information in DetailTop - example
+  // DETAILS VIEW "DetailTop" DATA
   plugin.addUIAction(UI_CONFIG_DETAIL_TOP,
     { resource: 'catalog.cattle.io.clusterrepo' },
-    { component: () => import('./MastheadDetailsComponent.vue') });
+    { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
 
-  // information in ResourceList - example
+  // DATA ABOVE LIST VIEW
   plugin.addUIAction(UI_CONFIG_RESOURCE_LIST,
     { resource: 'catalog.cattle.io.app' },
-    { component: () => import('./BannerComponent.vue') });
+    { component: () => import('./BannerComponent.vue') }); // component to be rendered
 
-  // setting up a Global Settings page
+  // GLOBAL SETTINGS PAGE (not working yet...)
   plugin.addUIAction(UI_CONFIG_GLOBAL_SETTING, {}, {
     virtualType: {
       ifHaveType: MANAGEMENT.SETTING,
@@ -151,28 +153,71 @@ export default function(plugin: IPlugin) {
     }
   });
 
-  // adds cards to the cluster dashboard screen
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
-    label:     'some-label',
-    labelKey:  'generic.comingSoon',
-    component: () => import('./MastheadDetailsComponent.vue')
+  // CLUSTER DASHBOARD CARD
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
+    label:     'some-label', // title for card
+    labelKey:  'generic.comingSoon', // Same as "label" but allows for translation. Will superseed "label"
+    component: () => import('./MastheadDetailsComponent.vue') // component to be rendered
   });
 
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
+  // CLUSTER DASHBOARD CARD
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
     label:     'some-label1',
     labelKey:  'generic.comingSoon',
     component: () => import('./MastheadDetailsComponent.vue')
   });
 
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
+  // CLUSTER DASHBOARD CARD
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
     label:     'some-label2',
     labelKey:  'generic.comingSoon',
     component: () => import('./MastheadDetailsComponent.vue')
   });
 
-  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
+  // CLUSTER DASHBOARD CARD
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
     label:     'some-label3',
     labelKey:  'generic.comingSoon',
     component: () => import('./MastheadDetailsComponent.vue')
+  });
+
+  // ADD A COL TO A TABLE
+  plugin.addUIAction(UI_CONFIG_TABLE_COL, { resource: 'configmap' }, {
+    type:      'configmap', // resource type to apply the col to (required)
+    classProp: { // defining a custom prop which can later be applied as a col (optional)
+      propName: 'some-prop',
+      value:    (data: any) => {
+        return `${ data.id }-some-string`;
+      }
+    },
+    config: { // col configuration (required)
+      // A USER DEFINED PROP! check "classProp" above
+      name:     'some-prop-col',
+      labelKey: 'generic.comingSoon',
+      getValue: (row: any) => row.extensionProps['some-prop'],
+
+      // SIMPLE STATE EXAMPLE
+      // name:      'state', // label for col
+      // labelKey:  'tableHeaders.state', // Same as "name" but allows for translation. Will superseed "name"
+      // sort:      ['stateSort', 'nameSort'], // prop(s) to be bound to the table sorting
+      // search:    ['stateSort', 'nameSort'], // prop(s) to be bound to the table search
+      // value:     'stateDisplay', // col prop to obtain the value from
+      // getValue:  (row: any) => row.stateDisplay, // same as "value", but it can be a function. Will superseed "value"
+      // width:     100, // col width
+      // default:   'unknown', // col default value
+      // formatter: 'BadgeStateFormatter', // col formatter if needed
+
+      // OTHER OPTIONS
+      // formatterOpts: { reference: 'claim.detailLocation' }, // passing options to formatter
+      // canBeVariable: true, // col can have variable with
+      // dashIfEmpty:   true, // display dash if there's no value for this prop
+      // width:         120, // col width
+      // align:         'center', // col alignment
+      // liveUpdates:   true,
+      // breakpoint:    COLUMN_BREAKPOINTS.DESKTOP,
+      // maxPageSize:   25, // Hide this column when the page size is bigger than 25
+      // skipSelect:    true,
+      // delayLoading:  true, // col data will only load after data is loaded or scroll is done
+    }
   });
 }

--- a/pkg/test-features/index.ts
+++ b/pkg/test-features/index.ts
@@ -7,8 +7,10 @@ import {
   UI_CONFIG_DETAILS_MASTHEAD,
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
+  UI_CONFIG_GLOBAL_SETTING,
 } from '@shell/core/types';
 import { isMac } from '@shell/utils/platform';
+import { MANAGEMENT } from '@shell/config/types';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -123,4 +125,28 @@ export default function(plugin: IPlugin) {
   plugin.addUIAction(UI_CONFIG_RESOURCE_LIST,
     { resource: 'catalog.cattle.io.app' },
     { component: () => import('./BannerComponent.vue') });
+
+  // setting up a Global Settings page
+  plugin.addUIAction(UI_CONFIG_GLOBAL_SETTING, {}, {
+    virtualType: {
+      ifHaveType: MANAGEMENT.SETTING,
+      labelKey:   'generic.comingSoon',
+      name:       'dummy',
+      namespaced: false,
+      weight:     91,
+      icon:       'folder',
+      route:      { name: 'c-cluster-settings-dummy' }
+    },
+    basicType:     true,
+    configureType: {
+      type:    MANAGEMENT.SETTING,
+      options: {
+        isCreatable: false,
+        isRemovable: false,
+        showAge:     false,
+        showState:   false,
+        canYaml:     false,
+      }
+    }
+  });
 }

--- a/pkg/test-features/index.ts
+++ b/pkg/test-features/index.ts
@@ -26,6 +26,16 @@ export default function(plugin: IPlugin) {
   // plugin.addProduct(require('./product'));
 
   // HEADER ACTION (button)
+  /**
+   * Config options
+   * @param {string} tooltip - text for tooltip of button
+   * @param {string} tooltipKey - same as "tooltip" but allows for translation. Will superseed "tooltip"
+   * @param {function} shortcutLabel - adds shortcut label to tooltip
+   * @param {object} shortcutKey - shortcut key binding
+   * @param {string} icon - icon name (based on rancher icons)
+   * @param {function} enabled - whether the action/button is enabled or not
+   * @param {function} clicked - function performed when action/button is clicked
+   */
   plugin.addUIAction(UI_CONFIG_HEADER_ACTION, {}, {
     tooltipKey: 'generic.customize',
     tooltip:    'Test Action1',
@@ -60,6 +70,17 @@ export default function(plugin: IPlugin) {
   });
 
   // ADDS TAB TO "ResourceTabs" COMPONENT
+  /**
+   * Config options
+   * @param {string} name - query param name used in url when tab is active/clicked
+   * @param {string} label - text for tab label
+   * @param {string} labelKey - same as "label" but allows for translation. Will superseed "label"
+   * @param {int} weight - defines the order on which the tabs are displayed
+   * @param {boolean} showHeader - whether the tab header is displayed or not
+   * @param {string} tooltip - tooltip message (on tab header)
+   * @param {int} badge - badge count indicator to be displayed on tab (on top)
+   * @param {function} component - component to be displayed as tab content
+   */
   plugin.addUIAction(UI_CONFIG_TAB, { resource: 'pod' }, {
     name:       'some-name',
     labelKey:   'generic.comingSoon',
@@ -75,6 +96,18 @@ export default function(plugin: IPlugin) {
   plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, { divider: true }); // renders a divider instead of an actual action
 
   // TABLE ACTIONS
+  /**
+   * Config options
+   * @param {string} action - action name
+   * @param {string} label - action label
+   * @param {string} labelKey - same as "label" but allows for translation. Will superseed "label"
+   * @param {string} icon - icon name (based on rancher icons)
+   * @param {boolean} enabled - whether the action/button is enabled or not
+   * @param {function} clicked - function performed when action/button is clicked (non-bulkable mode)
+   * @param {boolean} divider - shows a line separator (divider) in actions menu
+   * @param {boolean} bulkable - whether the action/button is bulkable (can be performed on multiple list items)
+   * @param {function} bulkAction - function performed when bulklable action/button is clicked (only bulkable mode)
+   */
   plugin.addUIAction(UI_CONFIG_TABLE_ACTION, { resource: 'catalog.cattle.io.clusterrepo' }, {
     action:   'some-extension-action',
     label:    'some-extension-action',
@@ -103,6 +136,10 @@ export default function(plugin: IPlugin) {
   });
 
   // DETAILS VIEW MASTHEAD DATA
+  /**
+   * Config options
+   * @param {function} component - component to be displayed on details view masthead
+   */
   plugin.addUIAction(UI_CONFIG_DETAILS_MASTHEAD,
     {
       resource: 'catalog.cattle.io.clusterrepo',
@@ -120,11 +157,19 @@ export default function(plugin: IPlugin) {
     { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
 
   // DETAILS VIEW "DetailTop" DATA
+  /**
+   * Config options
+   * @param {function} component - component to be displayed on details view "detailsTop" area
+   */
   plugin.addUIAction(UI_CONFIG_DETAIL_TOP,
     { resource: 'catalog.cattle.io.clusterrepo' },
     { component: () => import('./MastheadDetailsComponent.vue') }); // component to be rendered
 
   // DATA ABOVE LIST VIEW
+  /**
+   * Config options
+   * @param {function} component - component to be displayed before a list view (ResourceList component)
+   */
   plugin.addUIAction(UI_CONFIG_RESOURCE_LIST,
     { resource: 'catalog.cattle.io.app' },
     { component: () => import('./BannerComponent.vue') }); // component to be rendered
@@ -154,10 +199,16 @@ export default function(plugin: IPlugin) {
   });
 
   // CLUSTER DASHBOARD CARD
+  /**
+   * Config options
+   * @param {string} label - card title
+   * @param {string} labelKey - same as "label" but allows for translation. Will superseed "label"
+   * @param {function} component - component to be displayed inside card
+   */
   plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, { cluster: 'local' }, {
-    label:     'some-label', // title for card
-    labelKey:  'generic.comingSoon', // Same as "label" but allows for translation. Will superseed "label"
-    component: () => import('./MastheadDetailsComponent.vue') // component to be rendered
+    label:     'some-label',
+    labelKey:  'generic.comingSoon',
+    component: () => import('./MastheadDetailsComponent.vue')
   });
 
   // CLUSTER DASHBOARD CARD
@@ -182,15 +233,21 @@ export default function(plugin: IPlugin) {
   });
 
   // ADD A COL TO A TABLE
+  /**
+   * Config options
+   * @param {string} type - resource type to apply the col to (required)
+   * @param {object} classProp - defines a new prop for a given resource in it's class/model
+   * @param {object} config - col configuration object (required)
+   */
   plugin.addUIAction(UI_CONFIG_TABLE_COL, { resource: 'configmap' }, {
-    type:      'configmap', // resource type to apply the col to (required)
-    classProp: { // defining a custom prop which can later be applied as a col (optional)
+    type:      'configmap',
+    classProp: {
       propName: 'some-prop',
       value:    (data: any) => {
         return `${ data.id }-some-string`;
       }
     },
-    config: { // col configuration (required)
+    config: {
       // A USER DEFINED PROP! check "classProp" above
       name:     'some-prop-col',
       labelKey: 'generic.comingSoon',

--- a/pkg/test-features/index.ts
+++ b/pkg/test-features/index.ts
@@ -8,6 +8,7 @@ import {
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
   UI_CONFIG_GLOBAL_SETTING,
+  UI_CONFIG_CLUSTER_DASHBOARD_CARD,
 } from '@shell/core/types';
 import { isMac } from '@shell/utils/platform';
 import { MANAGEMENT } from '@shell/config/types';
@@ -148,5 +149,30 @@ export default function(plugin: IPlugin) {
         canYaml:     false,
       }
     }
+  });
+
+  // adds cards to the cluster dashboard screen
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
+    label:     'some-label',
+    labelKey:  'generic.comingSoon',
+    component: () => import('./MastheadDetailsComponent.vue')
+  });
+
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
+    label:     'some-label1',
+    labelKey:  'generic.comingSoon',
+    component: () => import('./MastheadDetailsComponent.vue')
+  });
+
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
+    label:     'some-label2',
+    labelKey:  'generic.comingSoon',
+    component: () => import('./MastheadDetailsComponent.vue')
+  });
+
+  plugin.addUIAction(UI_CONFIG_CLUSTER_DASHBOARD_CARD, {}, {
+    label:     'some-label3',
+    labelKey:  'generic.comingSoon',
+    component: () => import('./MastheadDetailsComponent.vue')
   });
 }

--- a/pkg/test-features/l10n/en-us.yaml
+++ b/pkg/test-features/l10n/en-us.yaml
@@ -1,0 +1,3 @@
+testLabel:
+  first: First Label
+  second: Second Label

--- a/pkg/test-features/package.json
+++ b/pkg/test-features/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-features",
+  "description": "test-features plugin",
+  "version": "0.1.0",
+  "private": false,
+  "rancher": true,
+  "scripts": {
+    "dev": "./node_modules/.bin/nuxt dev",
+    "nuxt": "./node_modules/.bin/nuxt"
+  },
+  "engines": {
+    "node": ">=12"
+  },
+  "devDependencies": {
+    "@vue/cli-plugin-babel": "~4.5.0",
+    "@vue/cli-service": "~4.5.0",
+    "@vue/cli-plugin-typescript": "^4.5.15"
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "not dead"
+  ]
+}

--- a/pkg/test-features/pages/c/_cluster/settings/dummy.vue
+++ b/pkg/test-features/pages/c/_cluster/settings/dummy.vue
@@ -1,0 +1,13 @@
+<script>
+export default { name: 'Dummy' };
+</script>
+
+<template>
+  <div>
+    <h1>DUMMY PAGE!</h1>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/pkg/test-features/tsconfig.json
+++ b/pkg/test-features/tsconfig.json
@@ -1,0 +1,54 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "jsx": "preserve",
+    "importHelpers": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "preserveSymlinks": true,
+    "typeRoots": [
+      "../../node_modules",
+      "../../shell/types"
+    ],
+    "types": [
+      "node",
+      "webpack-env",
+      "@types/node",
+      "@types/jest",
+      "@types/lodash",
+      "@nuxt/types",
+      "rancher",
+      "shell"
+    ],
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "scripthost"
+    ],
+    "paths": {
+      "@shell/*": [
+        "../../shell/*"
+      ],
+      "@components/*": [
+        "@rancher/components/*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.d.ts",
+    "**/*.tsx",
+    "**/*.vue"
+  ],
+  "exclude": [
+    "../../node_modules"
+  ]
+}

--- a/pkg/test-features/vue.config.js
+++ b/pkg/test-features/vue.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./.shell/pkg/vue.config')(__dirname);

--- a/shell/assets/styles/global/_gauges.scss
+++ b/shell/assets/styles/global/_gauges.scss
@@ -31,7 +31,7 @@
 
 .resource-gauges {
   display: grid;
-  grid-column-gap: 10px;
+  grid-column-gap: 15px;
   grid-row-gap: 15px;
   margin-top: 25px;
 

--- a/shell/assets/styles/global/_layout.scss
+++ b/shell/assets/styles/global/_layout.scss
@@ -40,6 +40,10 @@
     margin-left: 8px;
     align-self: center;
     text-align: right;
+
+    &.align-start {
+      align-self: start;
+    }
   }
 
   .role-multi-action {

--- a/shell/components/ActionMenu.vue
+++ b/shell/components/ActionMenu.vue
@@ -3,8 +3,6 @@ import { mapGetters } from 'vuex';
 import $ from 'jquery';
 import { AUTO, CENTER, fitOnScreen } from '@shell/utils/position';
 import { isAlternate } from '@shell/utils/platform';
-import { UI_CONFIG_TABLE_ACTION } from '@shell/core/types';
-import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 const HIDDEN = 'hide';
 const CALC = 'calculate';
@@ -109,19 +107,6 @@ export default {
 
       return this.options;
     },
-
-    extensionMenuActions() {
-      const extensionMenuActions = [];
-      const actions = this.$plugin.getUIConfig(UI_CONFIG_TABLE_ACTION);
-
-      actions.forEach((action) => {
-        if (checkExtensionRouteBinding(this.$route, action.locationConfig)) {
-          extensionMenuActions.push(action);
-        }
-      });
-
-      return extensionMenuActions;
-    },
   },
 
   watch: {
@@ -217,7 +202,14 @@ export default {
         return;
       }
 
-      if (this.useCustomTargetElement) {
+      // this will come from extensions...
+      if (action.clicked) {
+        const fn = action.clicked;
+
+        if (fn && action.enabled) {
+          fn.apply(this, [event]);
+        }
+      } else if (this.useCustomTargetElement) {
         // If the state of this component is controlled
         // by props instead of Vuex, we assume you wouldn't want
         // the mutation to have a dependency on Vuex either.
@@ -242,14 +234,6 @@ export default {
       }
 
       this.hide();
-    },
-
-    handleExtensionAction(action, event) {
-      const fn = action.clicked;
-
-      if (fn && action.enabled()) {
-        fn.apply(this, [event]);
-      }
     },
 
     hasOptions(options) {
@@ -277,22 +261,6 @@ export default {
         :class="{divider: opt.divider}"
         :data-testid="componentTestid + '-' + i + '-item'"
         @click="execute(opt, $event)"
-      >
-        <i
-          v-if="opt.icon"
-          :class="{icon: true, [opt.icon]: true}"
-        />
-        <span v-html="opt.label" />
-      </li>
-
-      <!-- Extension menu actions -->
-      <li
-        v-for="(opt, i) in extensionMenuActions"
-        :key="`${opt.label}${i}`"
-        :disabled="opt.enabled ? !opt.enabled() : false"
-        :class="{divider: opt.divider}"
-        :data-testid="extensionComponentTestid + '-' + i + '-item'"
-        @click="handleExtensionAction(opt, $event)"
       >
         <i
           v-if="opt.icon"

--- a/shell/components/ActionMenu.vue
+++ b/shell/components/ActionMenu.vue
@@ -71,14 +71,6 @@ export default {
     componentTestid: {
       type:    String,
       default: 'action-menu'
-    },
-    /**
-     * Inherited global identifier prefix for tests
-     * Define a term based on the parent component to avoid conflicts on multiple components
-     */
-    extensionComponentTestid: {
-      type:    String,
-      default: 'extension-action-menu'
     }
   },
 

--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -3,6 +3,8 @@ import Tag from '@shell/components/Tag';
 import isEmpty from 'lodash/isEmpty';
 import DetailText from '@shell/components/DetailText';
 import { _VIEW } from '@shell/config/query-params';
+import { UI_CONFIG_DETAIL_TOP } from '@shell/core/types';
+import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 export const SEPARATOR = { separator: true };
 
@@ -155,6 +157,19 @@ export default {
 
       return false;
     },
+
+    extensionDetailTop() {
+      const extensionDetailTop = [];
+      const actions = this.$plugin.getUIConfig(UI_CONFIG_DETAIL_TOP);
+
+      actions.forEach((action) => {
+        if (checkExtensionRouteBinding(this.$route, action.locationConfig)) {
+          extensionDetailTop.push(action);
+        }
+      });
+
+      return extensionDetailTop;
+    },
   },
   methods: {
     toggleLabels() {
@@ -283,6 +298,19 @@ export default {
           class="annotation"
           :value="val"
           :label="key"
+        />
+      </div>
+    </div>
+
+    <!-- Extensions Detail Top -->
+    <div v-if="extensionDetailTop">
+      <div
+        v-for="item, i in extensionDetailTop"
+        :key="`extensionDetailTop${i}`"
+      >
+        <component
+          :is="item.component"
+          :resource="value"
         />
       </div>
     </div>

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -10,6 +10,8 @@ import { HIDE_SENSITIVE } from '@shell/store/prefs';
 import {
   AS, _DETAIL, _CONFIG, _YAML, MODE, _CREATE, _EDIT, _VIEW, _UNFLAG, _GRAPH
 } from '@shell/config/query-params';
+import { UI_CONFIG_DETAILS_MASTHEAD } from '@shell/core/types';
+import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 /**
  * Resource Detail Masthead component.
@@ -362,6 +364,19 @@ export default {
 
       return parent?.location;
     },
+
+    extensionDetailsMasthead() {
+      const extensionDetailsMasthead = [];
+      const actions = this.$plugin.getUIConfig(UI_CONFIG_DETAILS_MASTHEAD);
+
+      actions.forEach((action) => {
+        if (checkExtensionRouteBinding(this.$route, action.locationConfig)) {
+          extensionDetailsMasthead.push(action);
+        }
+      });
+
+      return extensionDetailsMasthead;
+    },
   },
 
   methods: {
@@ -433,6 +448,21 @@ export default {
             :value="value.creationTimestamp"
           /></span>
           <span v-if="value.showPodRestarts">{{ t("resourceDetail.masthead.restartCount") }}:<span class="live-data"> {{ value.restartCount }}</span></span>
+        </div>
+        <!-- Extension Masthead Details -->
+        <div
+          v-if="extensionDetailsMasthead.length"
+        >
+          <div
+            v-for="item, i in extensionDetailsMasthead"
+            :key="`extensionDetailsMasthead${i}`"
+            class="subheader"
+          >
+            <component
+              :is="item.component"
+              :resource="value"
+            />
+          </div>
         </div>
       </div>
       <slot name="right">

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -466,7 +466,7 @@ export default {
         </div>
       </div>
       <slot name="right">
-        <div class="actions-container">
+        <div class="actions-container align-start">
           <div class="actions">
             <button
               v-if="detailsAction && currentView === DETAIL_VIEW && isView"

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -6,6 +6,8 @@ import ResourceLoadingIndicator from './ResourceLoadingIndicator';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import IconMessage from '@shell/components/IconMessage.vue';
 import { ResourceListComponentName } from './resource-list.config';
+import { UI_CONFIG_RESOURCE_LIST } from '@shell/core/types';
+import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 export default {
   name: ResourceListComponentName,
@@ -127,7 +129,20 @@ export default {
 
     showIncrementalLoadingIndicator() {
       return this.perfConfig?.incrementalLoading?.enabled;
-    }
+    },
+
+    extensionResourceList() {
+      const extensionResourceList = [];
+      const actions = this.$plugin.getUIConfig(UI_CONFIG_RESOURCE_LIST);
+
+      actions.forEach((action) => {
+        if (checkExtensionRouteBinding(this.$route, action.locationConfig)) {
+          extensionResourceList.push(action);
+        }
+      });
+
+      return extensionResourceList;
+    },
   },
 
   watch: {
@@ -191,6 +206,19 @@ export default {
         <slot name="extraActions" />
       </template>
     </Masthead>
+    <!-- Extensions Detail Top -->
+    <div v-if="extensionResourceList">
+      <div
+        v-for="item, i in extensionResourceList"
+        :key="`extensionResourceList${i}`"
+      >
+        <component
+          :is="item.component"
+          :resource="resource"
+        />
+      </div>
+    </div>
+
     <div v-if="hasListComponent">
       <component
         :is="listComponent"

--- a/shell/components/Tabbed/Tab.vue
+++ b/shell/components/Tabbed/Tab.vue
@@ -99,7 +99,7 @@ export default {
       class="tab-header"
     >
       <h2>
-        {{ label }}
+        {{ labelDisplay }}
         <i
           v-if="tooltip"
           v-tooltip="tooltip"

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -11,6 +11,8 @@ import { EVENT } from '@shell/config/types';
 import SortableTable from '@shell/components/SortableTable';
 import { _VIEW } from '@shell/config/query-params';
 import RelatedResources from '@shell/components/RelatedResources';
+import { UI_CONFIG_TAB } from '@shell/core/types';
+import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 export default {
 
@@ -77,6 +79,19 @@ export default {
   },
 
   computed: {
+    extensionTabs() {
+      const extensionTabs = [];
+      const actions = this.$plugin.getUIConfig(UI_CONFIG_TAB);
+
+      actions.forEach((action) => {
+        if (checkExtensionRouteBinding(this.$route, action.locationConfig)) {
+          extensionTabs.push(action);
+        }
+      });
+
+      return extensionTabs;
+    },
+
     showConditions() {
       const inStore = this.$store.getters['currentStore'](this.value.type);
 
@@ -219,6 +234,26 @@ export default {
         :ignore-types="[value.type]"
         :value="value"
         direction="to"
+      />
+    </Tab>
+
+    <!-- Extension tabs -->
+    <Tab
+      v-for="tab, i in extensionTabs"
+      :key="`${tab.name}${i}`"
+      :name="tab.name"
+      :label="tab.label"
+      :label-key="tab.labelKey"
+      :weight="tab.weight"
+      :tooltip="tab.tooltip"
+      :show-header="tab.showHeader"
+      :display-alert-icon="tab.displayAlertIcon"
+      :error="tab.error"
+      :badge="tab.badge"
+    >
+      <component
+        :is="tab.component"
+        :resource="value"
       />
     </Tab>
   </Tabbed>

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -165,17 +165,17 @@ export default {
       };
     },
 
-    extensionActions() {
-      const extensionActions = [];
+    extensionHeaderActions() {
+      const extensionHeaderActions = [];
       const actions = this.$plugin.getUIConfig(UI_CONFIG_HEADER_ACTION);
 
       actions.forEach((action) => {
         if (checkExtensionRouteBinding(this.$route, action.locationConfig)) {
-          extensionActions.push(action);
+          extensionHeaderActions.push(action);
         }
       });
 
-      return extensionActions;
+      return extensionHeaderActions;
     },
 
   },
@@ -308,7 +308,7 @@ export default {
     handleExtensionAction(action, event) {
       const fn = action.clicked;
 
-      if (fn) {
+      if (fn && action.enabled()) {
         fn.apply(this, [event]);
       }
     },
@@ -538,11 +538,11 @@ export default {
 
       <!-- Extension header actions -->
       <div
-        v-if="extensionActions.length"
+        v-if="extensionHeaderActions.length"
         class="header-buttons"
       >
         <button
-          v-for="action, i in extensionActions"
+          v-for="action, i in extensionHeaderActions"
           :key="`${action.label}${i}`"
           v-tooltip="handleExtensionTooltip(action)"
           v-shortkey="action.shortcutKey"

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -165,6 +165,10 @@ export default {
       };
     },
 
+    ctx() {
+      return this;
+    },
+
     extensionHeaderActions() {
       const extensionHeaderActions = [];
       const actions = this.$plugin.getUIConfig(UI_CONFIG_HEADER_ACTION);
@@ -546,7 +550,7 @@ export default {
           :key="`${action.label}${i}`"
           v-tooltip="handleExtensionTooltip(action)"
           v-shortkey="action.shortcutKey"
-          :disabled="action.enabled ? !action.enabled() : false"
+          :disabled="action.enabled ? !action.enabled(ctx) : false"
           type="button"
           class="btn header-btn role-tertiary"
           @shortkey="handleExtensionAction(action, $event)"

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -16,6 +16,7 @@ import TopLevelMenu from './TopLevelMenu';
 import Jump from './Jump';
 import { allHash } from '@shell/utils/promise';
 import { UI_CONFIG_HEADER_ACTION } from '@shell/core/types';
+import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 const PAGE_HEADER_ACTION = 'page-action';
 
@@ -164,26 +165,17 @@ export default {
       };
     },
 
-    productAction() {
-      const product = this.currentProduct?.name || '';
-
-      if (product === 'explorer') {
-        if (!this.$route.name.startsWith('c-')) {
-          return '';
-        }
-      }
-
-      return product;
-    },
-
     extensionActions() {
-      const globalActions = this.$plugin.getUIConfig(UI_CONFIG_HEADER_ACTION, 'global');
-      const productActions = this.productAction.length ? this.$plugin.getUIConfig(UI_CONFIG_HEADER_ACTION, `${ this.productAction }`) : [];
+      const extensionActions = [];
+      const actions = this.$plugin.getUIConfig(UI_CONFIG_HEADER_ACTION);
 
-      return [
-        ...productActions,
-        ...globalActions,
-      ];
+      actions.forEach((action) => {
+        if (checkExtensionRouteBinding(this.$route, action.locationConfig)) {
+          extensionActions.push(action);
+        }
+      });
+
+      return extensionActions;
     },
 
   },
@@ -313,8 +305,8 @@ export default {
       });
     },
 
-    invokeExtensionAction(action, event) {
-      const fn = action.execute;
+    handleExtensionAction(action, event) {
+      const fn = action.clicked;
 
       if (fn) {
         fn.apply(this, [event]);
@@ -557,8 +549,8 @@ export default {
           :disabled="action.enabled ? !action.enabled() : false"
           type="button"
           class="btn header-btn role-tertiary"
-          @shortkey="invokeExtensionAction(action, $event)"
-          @click="invokeExtensionAction(action, $event)"
+          @shortkey="handleExtensionAction(action, $event)"
+          @click="handleExtensionAction(action, $event)"
         >
           <i
             class="icon icon-lg"

--- a/shell/config/product/settings.js
+++ b/shell/config/product/settings.js
@@ -6,7 +6,6 @@ import {
   RESTART,
   NAME_UNLINKED,
 } from '@shell/config/table-headers';
-import { UI_CONFIG_GLOBAL_SETTING } from '@shell/core/types';
 
 export const NAME = 'settings';
 
@@ -20,17 +19,6 @@ export function init(store) {
     hideBulkActions,
   } = DSL(store, NAME);
 
-  const extensionSettings = store.getters['uiplugins/uiConfig'][UI_CONFIG_GLOBAL_SETTING];
-
-  const basicTypeArray = [
-    'settings',
-    'features',
-    'brand',
-    'banners',
-    'performance',
-    'links'
-  ];
-
   product({
     ifHaveType:          new RegExp(`${ MANAGEMENT.SETTING }|${ MANAGEMENT.FEATURE }`, 'i'),
     inStore:             'management',
@@ -40,31 +28,6 @@ export function init(store) {
     category:            'configuration',
     weight:              100,
   });
-
-  // handle extension-defined settings
-  if (extensionSettings.length) {
-    extensionSettings.forEach((setting) => {
-      if (setting.virtualType) {
-        virtualType(setting.virtualType);
-      }
-
-      if (setting.basicType) {
-        basicTypeArray.push(setting.virtualType.name);
-      }
-
-      if (setting.configureType && setting.configureType.type && setting.configureType.options) {
-        configureType(setting.configureType.type, setting.configureType.options);
-      }
-
-      if (setting.headers && setting.headers.type && setting.headers.options) {
-        headers(setting.headers.type, setting.headers.options);
-      }
-
-      if (setting.hideBulkActions && setting.hideBulkActions.type) {
-        hideBulkActions(setting.hideBulkActions.type, setting.hideBulkActions.value);
-      }
-    });
-  }
 
   virtualType({
     ifHaveType: MANAGEMENT.SETTING,
@@ -138,7 +101,14 @@ export function init(store) {
     route:      { name: 'c-cluster-settings-links' }
   });
 
-  basicType(basicTypeArray);
+  basicType([
+    'settings',
+    'features',
+    'brand',
+    'banners',
+    'performance',
+    'links'
+  ]);
 
   configureType(MANAGEMENT.SETTING, {
     isCreatable: false,

--- a/shell/config/product/settings.js
+++ b/shell/config/product/settings.js
@@ -6,6 +6,7 @@ import {
   RESTART,
   NAME_UNLINKED,
 } from '@shell/config/table-headers';
+import { UI_CONFIG_GLOBAL_SETTING } from '@shell/core/types';
 
 export const NAME = 'settings';
 
@@ -19,6 +20,17 @@ export function init(store) {
     hideBulkActions,
   } = DSL(store, NAME);
 
+  const extensionSettings = store.getters['uiplugins/uiConfig'][UI_CONFIG_GLOBAL_SETTING];
+
+  const basicTypeArray = [
+    'settings',
+    'features',
+    'brand',
+    'banners',
+    'performance',
+    'links'
+  ];
+
   product({
     ifHaveType:          new RegExp(`${ MANAGEMENT.SETTING }|${ MANAGEMENT.FEATURE }`, 'i'),
     inStore:             'management',
@@ -28,6 +40,31 @@ export function init(store) {
     category:            'configuration',
     weight:              100,
   });
+
+  // handle extension-defined settings
+  if (extensionSettings.length) {
+    extensionSettings.forEach((setting) => {
+      if (setting.virtualType) {
+        virtualType(setting.virtualType);
+      }
+
+      if (setting.basicType) {
+        basicTypeArray.push(setting.virtualType.name);
+      }
+
+      if (setting.configureType && setting.configureType.type && setting.configureType.options) {
+        configureType(setting.configureType.type, setting.configureType.options);
+      }
+
+      if (setting.headers && setting.headers.type && setting.headers.options) {
+        headers(setting.headers.type, setting.headers.options);
+      }
+
+      if (setting.hideBulkActions && setting.hideBulkActions.type) {
+        hideBulkActions(setting.hideBulkActions.type, setting.hideBulkActions.value);
+      }
+    });
+  }
 
   virtualType({
     ifHaveType: MANAGEMENT.SETTING,
@@ -101,14 +138,7 @@ export function init(store) {
     route:      { name: 'c-cluster-settings-links' }
   });
 
-  basicType([
-    'settings',
-    'features',
-    'brand',
-    'banners',
-    'performance',
-    'links'
-  ]);
+  basicType(basicTypeArray);
 
   configureType(MANAGEMENT.SETTING, {
     isCreatable: false,

--- a/shell/core/helpers.js
+++ b/shell/core/helpers.js
@@ -1,6 +1,7 @@
-export function checkExtensionRouteBinding({ name, params }, locationConfig) {
+export function checkExtensionRouteBinding({
+  name, params, path, query
+}, locationConfig) {
   // console.log('name && params', name, params);
-  // console.log('locationConfig', locationConfig);
 
   // if no configuration is passed, consider it as global
   if (!Object.keys(locationConfig).length) {
@@ -8,7 +9,11 @@ export function checkExtensionRouteBinding({ name, params }, locationConfig) {
   }
 
   // matches route "name" pattern (if only the "name" is provided)
-  if (Object.keys(locationConfig).length === 1 && locationConfig.name && name.includes(locationConfig.name)) {
+  if (Object.keys(locationConfig).length === 1 && locationConfig.name && name === locationConfig.name) {
+    return true;
+  }
+  // matches route "path" pattern (if only the "path" is provided)
+  if (Object.keys(locationConfig).length === 1 && locationConfig.path && path === locationConfig.path) {
     return true;
   }
 
@@ -24,6 +29,7 @@ export function checkExtensionRouteBinding({ name, params }, locationConfig) {
   let res = false;
 
   paramsToCheck.forEach((param) => {
+    // handle "product" in a separate way...
     if (param === 'product') {
       if (locationConfig[param] === 'explorer' && !name.startsWith('c-')) {
         res = false;
@@ -32,11 +38,39 @@ export function checkExtensionRouteBinding({ name, params }, locationConfig) {
       if (locationConfig[param] === params[param]) {
         res = true;
       }
+    // handle multiple locationConfig definitions at the same time "param" + "name" + "query"
     } else if (locationConfig[param] && locationConfig[param] === params[param]) {
-      if (locationConfig.name && name.includes(locationConfig.name)) {
-        res = true;
+      // check "name"
+      if (locationConfig.name && name === locationConfig.name) {
+        // check "query"
+        if (query && Object.keys(query).length && locationConfig.query && Object.keys(locationConfig.query).length) {
+          let matching = true;
+
+          Object.keys(locationConfig.query).forEach((key) => {
+            if (!query[key] || query[key] !== locationConfig.query[key]) {
+              matching = false;
+            }
+          });
+
+          matching ? res = true : res = false;
+        } else {
+          res = true;
+        }
       } else if (!locationConfig.name) {
-        res = true;
+        // check "query"
+        if (query && Object.keys(query).length && locationConfig.query && Object.keys(locationConfig.query).length) {
+          let matching = true;
+
+          Object.keys(locationConfig.query).forEach((key) => {
+            if (!query[key] || query[key] !== locationConfig.query[key]) {
+              matching = false;
+            }
+          });
+
+          matching ? res = true : res = false;
+        } else {
+          res = true;
+        }
       }
     }
   });

--- a/shell/core/helpers.js
+++ b/shell/core/helpers.js
@@ -1,0 +1,48 @@
+export function checkExtensionRouteBinding({ name, params }, locationConfig) {
+  console.log('name', name);
+  console.log('params', params);
+  console.log('locationConfig', locationConfig);
+
+  // if no configuration is passed, consider it as global
+  if (!Object.keys(locationConfig).length) {
+    return true;
+  }
+
+  // matches route "name" pattern
+  if (locationConfig.name && name.includes(locationConfig.name)) {
+    return true;
+  }
+
+  // matches "product" param on route
+  if (locationConfig.product) {
+    if (locationConfig.product === 'explorer' && !name.startsWith('c-')) {
+      return false;
+    }
+
+    if (locationConfig.product === params.product) {
+      return true;
+    }
+  }
+
+  // matches "resource" param on route
+  if (locationConfig.resource && locationConfig.resource === params.resource) {
+    return true;
+  }
+
+  // matches "namespace" param on route
+  if (locationConfig.namespace && locationConfig.namespace === params.namespace) {
+    return true;
+  }
+
+  // matches "cluster" param on route
+  if (locationConfig.cluster && locationConfig.cluster === params.cluster) {
+    return true;
+  }
+
+  // matches "id" param on route
+  if (locationConfig.id && locationConfig.id === params.id) {
+    return true;
+  }
+
+  return false;
+}

--- a/shell/core/helpers.js
+++ b/shell/core/helpers.js
@@ -35,7 +35,7 @@ export function checkExtensionRouteBinding({
         res = false;
       }
 
-      if (locationConfig[param] === params[param]) {
+      if (locationConfig[param] && params[param] && locationConfig[param] === params[param]) {
         res = true;
       }
     // handle multiple locationConfig definitions at the same time "param" + "name" + "query"

--- a/shell/core/helpers.js
+++ b/shell/core/helpers.js
@@ -1,6 +1,6 @@
 export function checkExtensionRouteBinding({ name, params }, locationConfig) {
-  console.log('name && params', name, params);
-  console.log('locationConfig', locationConfig);
+  // console.log('name && params', name, params);
+  // console.log('locationConfig', locationConfig);
 
   // if no configuration is passed, consider it as global
   if (!Object.keys(locationConfig).length) {

--- a/shell/core/helpers.js
+++ b/shell/core/helpers.js
@@ -1,6 +1,5 @@
 export function checkExtensionRouteBinding({ name, params }, locationConfig) {
-  console.log('name', name);
-  console.log('params', params);
+  console.log('name && params', name, params);
   console.log('locationConfig', locationConfig);
 
   // if no configuration is passed, consider it as global
@@ -8,41 +7,39 @@ export function checkExtensionRouteBinding({ name, params }, locationConfig) {
     return true;
   }
 
-  // matches route "name" pattern
-  if (locationConfig.name && name.includes(locationConfig.name)) {
+  // matches route "name" pattern (if only the "name" is provided)
+  if (Object.keys(locationConfig).length === 1 && locationConfig.name && name.includes(locationConfig.name)) {
     return true;
   }
 
-  // matches "product" param on route
-  if (locationConfig.product) {
-    if (locationConfig.product === 'explorer' && !name.startsWith('c-')) {
-      return false;
+  // "params" to be checked based on the locationConfig
+  const paramsToCheck = [
+    'product',
+    'resource',
+    'namespace',
+    'cluster',
+    'id'
+  ];
+
+  let res = false;
+
+  paramsToCheck.forEach((param) => {
+    if (param === 'product') {
+      if (locationConfig[param] === 'explorer' && !name.startsWith('c-')) {
+        res = false;
+      }
+
+      if (locationConfig[param] === params[param]) {
+        res = true;
+      }
+    } else if (locationConfig[param] && locationConfig[param] === params[param]) {
+      if (locationConfig.name && name.includes(locationConfig.name)) {
+        res = true;
+      } else if (!locationConfig.name) {
+        res = true;
+      }
     }
+  });
 
-    if (locationConfig.product === params.product) {
-      return true;
-    }
-  }
-
-  // matches "resource" param on route
-  if (locationConfig.resource && locationConfig.resource === params.resource) {
-    return true;
-  }
-
-  // matches "namespace" param on route
-  if (locationConfig.namespace && locationConfig.namespace === params.namespace) {
-    return true;
-  }
-
-  // matches "cluster" param on route
-  if (locationConfig.cluster && locationConfig.cluster === params.cluster) {
-    return true;
-  }
-
-  // matches "id" param on route
-  if (locationConfig.id && locationConfig.id === params.id) {
-    return true;
-  }
-
-  return false;
+  return res;
 }

--- a/shell/core/helpers.js
+++ b/shell/core/helpers.js
@@ -1,19 +1,8 @@
-export function checkExtensionRouteBinding({
-  name, params, path, query
-}, locationConfig) {
+export function checkExtensionRouteBinding({ name, params, query }, locationConfig) {
   // console.log('name && params', name, params);
 
   // if no configuration is passed, consider it as global
   if (!Object.keys(locationConfig).length) {
-    return true;
-  }
-
-  // matches route "name" pattern (if only the "name" is provided)
-  if (Object.keys(locationConfig).length === 1 && locationConfig.name && name === locationConfig.name) {
-    return true;
-  }
-  // matches route "path" pattern (if only the "path" is provided)
-  if (Object.keys(locationConfig).length === 1 && locationConfig.path && path === locationConfig.path) {
     return true;
   }
 
@@ -23,57 +12,52 @@ export function checkExtensionRouteBinding({
     'resource',
     'namespace',
     'cluster',
-    'id'
+    'id',
+    'mode'
   ];
 
   let res = false;
 
-  paramsToCheck.forEach((param) => {
-    // handle "product" in a separate way...
-    if (param === 'product') {
-      if (locationConfig[param] === 'explorer' && !name.startsWith('c-')) {
-        res = false;
-      }
+  for (let i = 0; i < paramsToCheck.length; i++) {
+    const param = paramsToCheck[i];
 
-      if (locationConfig[param] && params[param] && locationConfig[param] === params[param]) {
+    if (locationConfig[param]) {
+      // handle "product" in a separate way...
+      if (param === 'product') {
+        if (locationConfig[param] === 'home' && !name.startsWith('c-')) {
+          res = true;
+        } else if (locationConfig[param] === 'explorer' && name.startsWith('c-')) {
+          res = true;
+        } else if (locationConfig[param] === params[param]) {
+          res = true;
+        } else {
+          res = false;
+          break;
+        }
+        // also handle "mode" in a separate way because it mainly depends on query params
+      } else if (param === 'mode') {
+        if (locationConfig[param] === 'edit' && query.mode && query.mode === 'edit') {
+          res = true;
+        } else if (locationConfig[param] === 'config' && query.as && query.as === 'config') {
+          res = true;
+        } else if (locationConfig[param] === 'detail' && name.includes('-id')) {
+          res = true;
+        } else if (locationConfig[param] === 'list' && !name.includes('-id')) {
+          res = true;
+        } else {
+          res = false;
+          break;
+        }
+      } else if (locationConfig[param] === params[param]) {
         res = true;
+      } else {
+        res = false;
+        break;
       }
-    // handle multiple locationConfig definitions at the same time "param" + "name" + "query"
-    } else if (locationConfig[param] && locationConfig[param] === params[param]) {
-      // check "name"
-      if (locationConfig.name && name === locationConfig.name) {
-        // check "query"
-        if (query && Object.keys(query).length && locationConfig.query && Object.keys(locationConfig.query).length) {
-          let matching = true;
-
-          Object.keys(locationConfig.query).forEach((key) => {
-            if (!query[key] || query[key] !== locationConfig.query[key]) {
-              matching = false;
-            }
-          });
-
-          matching ? res = true : res = false;
-        } else {
-          res = true;
-        }
-      } else if (!locationConfig.name) {
-        // check "query"
-        if (query && Object.keys(query).length && locationConfig.query && Object.keys(locationConfig.query).length) {
-          let matching = true;
-
-          Object.keys(locationConfig.query).forEach((key) => {
-            if (!query[key] || query[key] !== locationConfig.query[key]) {
-              matching = false;
-            }
-          });
-
-          matching ? res = true : res = false;
-        } else {
-          res = true;
-        }
-      }
+    } else {
+      continue;
     }
-  });
+  }
 
   return res;
 }

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -1,6 +1,12 @@
 import { RouteConfig } from 'vue-router';
 import { DSL as STORE_DSL } from '@shell/store/type-map';
-import { CoreStoreInit, IPlugin } from './types';
+import {
+  CoreStoreInit,
+  IAction,
+  IPlugin,
+  UI_CONFIG_HEADER_ACTION,
+  UI_CONFIG_TAB
+} from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
 import {
   PluginRouteConfig, RegisterStore, UnregisterStore, CoreStoreSpecifics, CoreStoreConfig, OnNavToPackage, OnNavAwayFromPackage, OnLogOut
@@ -19,6 +25,11 @@ export class Plugin implements IPlugin {
   public onEnter: OnNavToPackage = () => Promise.resolve();
   public onLeave: OnNavAwayFromPackage = () => Promise.resolve();
   public _onLogOut: OnLogOut = () => Promise.resolve();
+
+  public uiConfig: { [key: string]: { [key: string]: any[] } } = {
+    [UI_CONFIG_HEADER_ACTION]: {},
+    [UI_CONFIG_TAB]:           {},
+  };
 
   // Plugin metadata (plugin package.json)
   public _metadata: any = {};
@@ -106,6 +117,17 @@ export class Plugin implements IPlugin {
     };
 
     this.routes.push({ parent, route });
+  }
+
+  addUIAction(type: string, location: string, action: IAction): void {
+    this.uiConfig[type][location] = this.uiConfig[type][location] || [];
+    this.uiConfig[type][location].push(action);
+  }
+
+  // Note: we can factor these two to use a common method for adding to the UI configuration
+  addTab(location: string, tab: any): void {
+    this.uiConfig[UI_CONFIG_TAB][location] = this.uiConfig[UI_CONFIG_TAB][location] || [];
+    this.uiConfig[UI_CONFIG_TAB][location].push(tab);
   }
 
   setHomePage(component: any) {

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -5,7 +5,11 @@ import {
   IAction,
   IPlugin,
   UI_CONFIG_HEADER_ACTION,
-  UI_CONFIG_TAB
+  UI_CONFIG_TAB,
+  UI_CONFIG_TABLE_ACTION,
+  UI_CONFIG_DETAILS_MASTHEAD,
+  UI_CONFIG_DETAIL_TOP,
+  UI_CONFIG_RESOURCE_LIST,
 } from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
 import {
@@ -27,8 +31,12 @@ export class Plugin implements IPlugin {
   public _onLogOut: OnLogOut = () => Promise.resolve();
 
   public uiConfig: { [key: string]: any[] } = {
-    [UI_CONFIG_HEADER_ACTION]: [],
-    [UI_CONFIG_TAB]:           [],
+    [UI_CONFIG_HEADER_ACTION]:    [],
+    [UI_CONFIG_TAB]:              [],
+    [UI_CONFIG_TABLE_ACTION]:     [],
+    [UI_CONFIG_DETAILS_MASTHEAD]: [],
+    [UI_CONFIG_DETAIL_TOP]:       [],
+    [UI_CONFIG_RESOURCE_LIST]:    [],
   };
 
   // Plugin metadata (plugin package.json)

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -11,6 +11,7 @@ import {
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
   UI_CONFIG_GLOBAL_SETTING,
+  UI_CONFIG_CLUSTER_DASHBOARD_CARD,
 } from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
 import {
@@ -32,13 +33,14 @@ export class Plugin implements IPlugin {
   public _onLogOut: OnLogOut = () => Promise.resolve();
 
   public uiConfig: { [key: string]: any[] } = {
-    [UI_CONFIG_HEADER_ACTION]:    [],
-    [UI_CONFIG_TAB]:              [],
-    [UI_CONFIG_TABLE_ACTION]:     [],
-    [UI_CONFIG_DETAILS_MASTHEAD]: [],
-    [UI_CONFIG_DETAIL_TOP]:       [],
-    [UI_CONFIG_RESOURCE_LIST]:    [],
-    [UI_CONFIG_GLOBAL_SETTING]:   [],
+    [UI_CONFIG_HEADER_ACTION]:          [],
+    [UI_CONFIG_TAB]:                    [],
+    [UI_CONFIG_TABLE_ACTION]:           [],
+    [UI_CONFIG_DETAILS_MASTHEAD]:       [],
+    [UI_CONFIG_DETAIL_TOP]:             [],
+    [UI_CONFIG_RESOURCE_LIST]:          [],
+    [UI_CONFIG_GLOBAL_SETTING]:         [],
+    [UI_CONFIG_CLUSTER_DASHBOARD_CARD]: [],
   };
 
   // Plugin metadata (plugin package.json)

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -12,6 +12,7 @@ import {
   UI_CONFIG_RESOURCE_LIST,
   UI_CONFIG_GLOBAL_SETTING,
   UI_CONFIG_CLUSTER_DASHBOARD_CARD,
+  UI_CONFIG_TABLE_COL,
 } from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
 import {
@@ -41,6 +42,7 @@ export class Plugin implements IPlugin {
     [UI_CONFIG_RESOURCE_LIST]:          [],
     [UI_CONFIG_GLOBAL_SETTING]:         [],
     [UI_CONFIG_CLUSTER_DASHBOARD_CARD]: [],
+    [UI_CONFIG_TABLE_COL]:              [],
   };
 
   // Plugin metadata (plugin package.json)

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -10,6 +10,7 @@ import {
   UI_CONFIG_DETAILS_MASTHEAD,
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
+  UI_CONFIG_GLOBAL_SETTING,
 } from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
 import {
@@ -37,6 +38,7 @@ export class Plugin implements IPlugin {
     [UI_CONFIG_DETAILS_MASTHEAD]: [],
     [UI_CONFIG_DETAIL_TOP]:       [],
     [UI_CONFIG_RESOURCE_LIST]:    [],
+    [UI_CONFIG_GLOBAL_SETTING]:   [],
   };
 
   // Plugin metadata (plugin package.json)

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -4,13 +4,13 @@ import {
   CoreStoreInit,
   IAction,
   IPlugin,
+  LocationConfig,
   UI_CONFIG_HEADER_ACTION,
   UI_CONFIG_TAB,
   UI_CONFIG_TABLE_ACTION,
   UI_CONFIG_DETAILS_MASTHEAD,
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
-  UI_CONFIG_GLOBAL_SETTING,
   UI_CONFIG_CLUSTER_DASHBOARD_CARD,
   UI_CONFIG_TABLE_COL,
 } from './types';
@@ -40,7 +40,6 @@ export class Plugin implements IPlugin {
     [UI_CONFIG_DETAILS_MASTHEAD]:       [],
     [UI_CONFIG_DETAIL_TOP]:             [],
     [UI_CONFIG_RESOURCE_LIST]:          [],
-    [UI_CONFIG_GLOBAL_SETTING]:         [],
     [UI_CONFIG_CLUSTER_DASHBOARD_CARD]: [],
     [UI_CONFIG_TABLE_COL]:              [],
   };
@@ -133,10 +132,68 @@ export class Plugin implements IPlugin {
     this.routes.push({ parent, route });
   }
 
-  // add extension UI action
-  addUIAction(type: string, locationConfig: object, action: IAction): void {
-    this.uiConfig[type] = this.uiConfig[type] || [];
-    this.uiConfig[type].push({ ...action, locationConfig });
+  /**
+   * Adds an action/button to Header component
+   */
+  addHeaderAction(locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_HEADER_ACTION] = this.uiConfig[UI_CONFIG_HEADER_ACTION] || [];
+    this.uiConfig[UI_CONFIG_HEADER_ACTION].push({ ...action, locationConfig });
+  }
+
+  /**
+   * Adds a tab to the ResourceTabs component
+   */
+  addTab(locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_TAB] = this.uiConfig[UI_CONFIG_TAB] || [];
+    this.uiConfig[UI_CONFIG_TAB].push({ ...action, locationConfig });
+  }
+
+  /**
+   * Adds an action to the SortableTable component
+   */
+  addTableAction(locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_TABLE_ACTION] = this.uiConfig[UI_CONFIG_TABLE_ACTION] || [];
+    this.uiConfig[UI_CONFIG_TABLE_ACTION].push({ ...action, locationConfig });
+  }
+
+  /**
+   * Adds a component to the Details Masthead component
+   */
+  addToDetailsMasthead( locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_DETAILS_MASTHEAD] = this.uiConfig[UI_CONFIG_DETAILS_MASTHEAD] || [];
+    this.uiConfig[UI_CONFIG_DETAILS_MASTHEAD].push({ ...action, locationConfig });
+  }
+
+  /**
+   * Adds a component to the DetailTop component
+   */
+  addToDetailTop( locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_DETAIL_TOP] = this.uiConfig[UI_CONFIG_DETAIL_TOP] || [];
+    this.uiConfig[UI_CONFIG_DETAIL_TOP].push({ ...action, locationConfig });
+  }
+
+  /**
+   * Adds a component to the list view page
+   */
+  addToListView( locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_RESOURCE_LIST] = this.uiConfig[UI_CONFIG_RESOURCE_LIST] || [];
+    this.uiConfig[UI_CONFIG_RESOURCE_LIST].push({ ...action, locationConfig });
+  }
+
+  /**
+   * Adds a card to the cluster dashboard view
+   */
+  addClusterDashboardCard( locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_CLUSTER_DASHBOARD_CARD] = this.uiConfig[UI_CONFIG_CLUSTER_DASHBOARD_CARD] || [];
+    this.uiConfig[UI_CONFIG_CLUSTER_DASHBOARD_CARD].push({ ...action, locationConfig });
+  }
+
+  /**
+   * Adds a new column to the SortableTable  component
+   */
+  addTableCol(locationConfig: LocationConfig, action: IAction): void {
+    this.uiConfig[UI_CONFIG_TABLE_COL] = this.uiConfig[UI_CONFIG_TABLE_COL] || [];
+    this.uiConfig[UI_CONFIG_TABLE_COL].push({ ...action, locationConfig });
   }
 
   setHomePage(component: any) {

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -26,9 +26,9 @@ export class Plugin implements IPlugin {
   public onLeave: OnNavAwayFromPackage = () => Promise.resolve();
   public _onLogOut: OnLogOut = () => Promise.resolve();
 
-  public uiConfig: { [key: string]: { [key: string]: any[] } } = {
-    [UI_CONFIG_HEADER_ACTION]: {},
-    [UI_CONFIG_TAB]:           {},
+  public uiConfig: { [key: string]: any[] } = {
+    [UI_CONFIG_HEADER_ACTION]: [],
+    [UI_CONFIG_TAB]:           [],
   };
 
   // Plugin metadata (plugin package.json)
@@ -119,15 +119,10 @@ export class Plugin implements IPlugin {
     this.routes.push({ parent, route });
   }
 
-  addUIAction(type: string, location: string, action: IAction): void {
-    this.uiConfig[type][location] = this.uiConfig[type][location] || [];
-    this.uiConfig[type][location].push(action);
-  }
-
-  // Note: we can factor these two to use a common method for adding to the UI configuration
-  addTab(location: string, tab: any): void {
-    this.uiConfig[UI_CONFIG_TAB][location] = this.uiConfig[UI_CONFIG_TAB][location] || [];
-    this.uiConfig[UI_CONFIG_TAB][location].push(tab);
+  // add extension UI action
+  addUIAction(type: string, locationConfig: object, action: IAction): void {
+    this.uiConfig[type] = this.uiConfig[type] || [];
+    this.uiConfig[type].push({ ...action, locationConfig });
   }
 
   setHomePage(component: any) {

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -7,6 +7,9 @@ import {
   UI_CONFIG_HEADER_ACTION,
   UI_CONFIG_TAB,
   UI_CONFIG_TABLE_ACTION,
+  UI_CONFIG_DETAILS_MASTHEAD,
+  UI_CONFIG_DETAIL_TOP,
+  UI_CONFIG_RESOURCE_LIST,
 } from './types';
 
 const MODEL_TYPE = 'models';
@@ -27,9 +30,12 @@ export default function({
   const pluginRoutes = new PluginRoutes(app.router);
 
   const uiConfig = {
-    [UI_CONFIG_HEADER_ACTION]: [],
-    [UI_CONFIG_TAB]:           [],
-    [UI_CONFIG_TABLE_ACTION]:  [],
+    [UI_CONFIG_HEADER_ACTION]:    [],
+    [UI_CONFIG_TAB]:              [],
+    [UI_CONFIG_TABLE_ACTION]:     [],
+    [UI_CONFIG_DETAILS_MASTHEAD]: [],
+    [UI_CONFIG_DETAIL_TOP]:       [],
+    [UI_CONFIG_RESOURCE_LIST]:    [],
   };
 
   inject('plugin', {

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -23,8 +23,8 @@ export default function({
   const pluginRoutes = new PluginRoutes(app.router);
 
   const uiConfig = {
-    [UI_CONFIG_HEADER_ACTION]: {},
-    [UI_CONFIG_TAB]:           {},
+    [UI_CONFIG_HEADER_ACTION]: [],
+    [UI_CONFIG_TAB]:           [],
   };
 
   inject('plugin', {
@@ -259,11 +259,12 @@ export default function({
 
       // UI Configuration - copy UI config from a plugin into the global uiConfig object
       Object.keys(plugin.uiConfig).forEach((type) => {
-        Object.keys(plugin.uiConfig[type]).forEach((location) => {
-          uiConfig[type][location] = uiConfig[type][location] || [];
-          uiConfig[type][location].push(...plugin.uiConfig[type][location]);
+        plugin.uiConfig[type].forEach((action) => {
+          uiConfig[type].push(action);
         });
       });
+
+      console.log('uiConfig', uiConfig[UI_CONFIG_HEADER_ACTION]);
 
       // l10n
       Object.keys(plugin.l10n).forEach((name) => {
@@ -351,10 +352,8 @@ export default function({
     /**
      * Return the UI configuration for the given type and location
      */
-    getUIConfig(typeName, location) {
-      const uc = uiConfig[typeName] || {};
-
-      return uc[location] || [];
+    getUIConfig(typeName) {
+      return uiConfig[typeName] || {};
     },
 
     /**

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -10,7 +10,6 @@ import {
   UI_CONFIG_DETAILS_MASTHEAD,
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
-  UI_CONFIG_GLOBAL_SETTING,
   UI_CONFIG_CLUSTER_DASHBOARD_CARD,
   UI_CONFIG_TABLE_COL,
 } from './types';
@@ -39,7 +38,6 @@ export default function({
     [UI_CONFIG_DETAILS_MASTHEAD]:       [],
     [UI_CONFIG_DETAIL_TOP]:             [],
     [UI_CONFIG_RESOURCE_LIST]:          [],
-    [UI_CONFIG_GLOBAL_SETTING]:         [],
     [UI_CONFIG_CLUSTER_DASHBOARD_CARD]: [],
     [UI_CONFIG_TABLE_COL]:              [],
   };
@@ -280,9 +278,6 @@ export default function({
           uiConfig[type].push(action);
         });
       });
-
-      // Add the global plugin to the store
-      store.dispatch('uiplugins/addPluginsUiConfig', uiConfig);
 
       console.log('UICONFIG GLOBAL OBJECT', uiConfig); // eslint-disable-line no-console
 

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -11,6 +11,7 @@ import {
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
   UI_CONFIG_GLOBAL_SETTING,
+  UI_CONFIG_CLUSTER_DASHBOARD_CARD,
 } from './types';
 
 const MODEL_TYPE = 'models';
@@ -31,13 +32,14 @@ export default function({
   const pluginRoutes = new PluginRoutes(app.router);
 
   const uiConfig = {
-    [UI_CONFIG_HEADER_ACTION]:    [],
-    [UI_CONFIG_TAB]:              [],
-    [UI_CONFIG_TABLE_ACTION]:     [],
-    [UI_CONFIG_DETAILS_MASTHEAD]: [],
-    [UI_CONFIG_DETAIL_TOP]:       [],
-    [UI_CONFIG_RESOURCE_LIST]:    [],
-    [UI_CONFIG_GLOBAL_SETTING]:   [],
+    [UI_CONFIG_HEADER_ACTION]:          [],
+    [UI_CONFIG_TAB]:                    [],
+    [UI_CONFIG_TABLE_ACTION]:           [],
+    [UI_CONFIG_DETAILS_MASTHEAD]:       [],
+    [UI_CONFIG_DETAIL_TOP]:             [],
+    [UI_CONFIG_RESOURCE_LIST]:          [],
+    [UI_CONFIG_GLOBAL_SETTING]:         [],
+    [UI_CONFIG_CLUSTER_DASHBOARD_CARD]: [],
   };
 
   inject('plugin', {

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -3,7 +3,11 @@ import { clearModelCache } from '@shell/plugins/dashboard-store/model-loader';
 import { Plugin } from './plugin';
 import { PluginRoutes } from './plugin-routes';
 import { UI_PLUGIN_BASE_URL } from '@shell/config/uiplugins';
-import { UI_CONFIG_HEADER_ACTION, UI_CONFIG_TAB } from './types';
+import {
+  UI_CONFIG_HEADER_ACTION,
+  UI_CONFIG_TAB,
+  UI_CONFIG_TABLE_ACTION,
+} from './types';
 
 const MODEL_TYPE = 'models';
 
@@ -25,6 +29,7 @@ export default function({
   const uiConfig = {
     [UI_CONFIG_HEADER_ACTION]: [],
     [UI_CONFIG_TAB]:           [],
+    [UI_CONFIG_TABLE_ACTION]:  [],
   };
 
   inject('plugin', {
@@ -264,7 +269,7 @@ export default function({
         });
       });
 
-      console.log('uiConfig', uiConfig[UI_CONFIG_HEADER_ACTION]);
+      console.log('uiConfig GLOBAL OBJECT', uiConfig);
 
       // l10n
       Object.keys(plugin.l10n).forEach((name) => {

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -269,7 +269,10 @@ export default function({
         });
       });
 
-      console.log('uiConfig GLOBAL OBJECT', uiConfig);
+      // Add the global plugin to the store
+      store.dispatch('uiplugins/addPluginsUiConfig', uiConfig);
+
+      console.log('UICONFIG GLOBAL OBJECT', uiConfig);
 
       // l10n
       Object.keys(plugin.l10n).forEach((name) => {

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -3,6 +3,7 @@ import { clearModelCache } from '@shell/plugins/dashboard-store/model-loader';
 import { Plugin } from './plugin';
 import { PluginRoutes } from './plugin-routes';
 import { UI_PLUGIN_BASE_URL } from '@shell/config/uiplugins';
+import { UI_CONFIG_HEADER_ACTION, UI_CONFIG_TAB } from './types';
 
 const MODEL_TYPE = 'models';
 
@@ -20,6 +21,11 @@ export default function({
   const plugins = {};
 
   const pluginRoutes = new PluginRoutes(app.router);
+
+  const uiConfig = {
+    [UI_CONFIG_HEADER_ACTION]: {},
+    [UI_CONFIG_TAB]:           {},
+  };
 
   inject('plugin', {
     // Plugins should not use these - but we will pass them in for now as a 2nd argument
@@ -251,6 +257,14 @@ export default function({
         });
       });
 
+      // UI Configuration - copy UI config from a plugin into the global uiConfig object
+      Object.keys(plugin.uiConfig).forEach((type) => {
+        Object.keys(plugin.uiConfig[type]).forEach((location) => {
+          uiConfig[type][location] = uiConfig[type][location] || [];
+          uiConfig[type][location].push(...plugin.uiConfig[type][location]);
+        });
+      });
+
       // l10n
       Object.keys(plugin.l10n).forEach((name) => {
         plugin.l10n[name].forEach((fn) => {
@@ -332,6 +346,22 @@ export default function({
 
     getValidator(name) {
       return validators[name];
+    },
+
+    /**
+     * Return the UI configuration for the given type and location
+     */
+    getUIConfig(typeName, location) {
+      const uc = uiConfig[typeName] || {};
+
+      return uc[location] || [];
+    },
+
+    /**
+     * Returns all UI Configuration (useful for debugging)
+     */
+    getAllUIConfig() {
+      return uiConfig;
     },
 
     // Timestamp that a UI package was last loaded

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -282,7 +282,7 @@ export default function({
       // Add the global plugin to the store
       store.dispatch('uiplugins/addPluginsUiConfig', uiConfig);
 
-      console.log('UICONFIG GLOBAL OBJECT', uiConfig);
+      console.log('UICONFIG GLOBAL OBJECT', uiConfig); // eslint-disable-line no-console
 
       // l10n
       Object.keys(plugin.l10n).forEach((name) => {

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -10,6 +10,7 @@ import {
   UI_CONFIG_DETAILS_MASTHEAD,
   UI_CONFIG_DETAIL_TOP,
   UI_CONFIG_RESOURCE_LIST,
+  UI_CONFIG_GLOBAL_SETTING,
 } from './types';
 
 const MODEL_TYPE = 'models';
@@ -36,6 +37,7 @@ export default function({
     [UI_CONFIG_DETAILS_MASTHEAD]: [],
     [UI_CONFIG_DETAIL_TOP]:       [],
     [UI_CONFIG_RESOURCE_LIST]:    [],
+    [UI_CONFIG_GLOBAL_SETTING]:   [],
   };
 
   inject('plugin', {

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -12,6 +12,7 @@ import {
   UI_CONFIG_RESOURCE_LIST,
   UI_CONFIG_GLOBAL_SETTING,
   UI_CONFIG_CLUSTER_DASHBOARD_CARD,
+  UI_CONFIG_TABLE_COL,
 } from './types';
 
 const MODEL_TYPE = 'models';
@@ -40,6 +41,7 @@ export default function({
     [UI_CONFIG_RESOURCE_LIST]:          [],
     [UI_CONFIG_GLOBAL_SETTING]:         [],
     [UI_CONFIG_CLUSTER_DASHBOARD_CARD]: [],
+    [UI_CONFIG_TABLE_COL]:              [],
   };
 
   inject('plugin', {

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -43,6 +43,7 @@ export const UI_CONFIG_DETAIL_TOP = 'detail-top';
 export const UI_CONFIG_RESOURCE_LIST = 'resource-list';
 export const UI_CONFIG_GLOBAL_SETTING = 'global-setting';
 export const UI_CONFIG_CLUSTER_DASHBOARD_CARD = 'cluster-dashboard-card';
+export const UI_CONFIG_TABLE_COL = 'table-col';
 
 export type IAction = any;
 

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -41,11 +41,19 @@ export const UI_CONFIG_TABLE_ACTION = 'table-action';
 export const UI_CONFIG_DETAILS_MASTHEAD = 'details-masthead';
 export const UI_CONFIG_DETAIL_TOP = 'detail-top';
 export const UI_CONFIG_RESOURCE_LIST = 'resource-list';
-export const UI_CONFIG_GLOBAL_SETTING = 'global-setting';
 export const UI_CONFIG_CLUSTER_DASHBOARD_CARD = 'cluster-dashboard-card';
 export const UI_CONFIG_TABLE_COL = 'table-col';
 
 export type IAction = any;
+
+export type LocationConfig = {
+  product?: string,
+  resource?: string,
+  namespace?: string,
+  cluster?: string,
+  id?: string,
+  mode?: string
+};
 
 /**
  * Interface for a Dashboard plugin
@@ -86,9 +94,44 @@ export interface IPlugin {
   addRoute(parent: string, route: RouteConfig): void;
 
   /**
-   * Adds a UI action for an extension to a particular area of the UI
+   * Adds an action/button to Header component
    */
-  addUIAction(type: string, locationConfig: object, action: IAction): void;
+   addHeaderAction(locationConfig: LocationConfig, action: IAction): void;
+
+  /**
+   * Adds a tab to the ResourceTabs component
+   */
+   addTab( locationConfig: LocationConfig, action: IAction): void;
+
+  /**
+   * Adds an action to the SortableTable component
+   */
+   addTableAction( locationConfig: LocationConfig, action: IAction): void;
+
+  /**
+   * Adds a component to the Details Masthead component
+   */
+   addToDetailsMasthead( locationConfig: LocationConfig, action: IAction): void;
+
+  /**
+   * Adds a component to the DetailTop component
+   */
+  addToDetailTop( locationConfig: LocationConfig, action: IAction): void;
+
+  /**
+   * Adds a component to the list view page
+   */
+   addToListView( locationConfig: LocationConfig, action: IAction): void;
+
+  /**
+   * Adds a card to the cluster dashboard view
+   */
+   addClusterDashboardCard( locationConfig: LocationConfig, action: IAction): void;
+
+  /**
+   * Adds a new column to the SortableTable  component
+   */
+   addTableCol(locationConfig: LocationConfig, action: IAction): void;
 
   /**
    * Set the component to use for the landing home page

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -41,6 +41,7 @@ export const UI_CONFIG_TABLE_ACTION = 'table-action';
 export const UI_CONFIG_DETAILS_MASTHEAD = 'details-masthead';
 export const UI_CONFIG_DETAIL_TOP = 'detail-top';
 export const UI_CONFIG_RESOURCE_LIST = 'resource-list';
+export const UI_CONFIG_GLOBAL_SETTING = 'global-setting';
 
 export type IAction = any;
 

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -37,6 +37,7 @@ export type OnLogOut = (store: any) => Promise<void>;
 
 export const UI_CONFIG_HEADER_ACTION = 'header-action';
 export const UI_CONFIG_TAB = 'tab';
+export const UI_CONFIG_TABLE_ACTION = 'table-action';
 
 export type IAction = any;
 

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -35,6 +35,11 @@ export type OnNavToPackage = (store: any, config: OnEnterLeavePackageConfig) => 
 export type OnNavAwayFromPackage = (store: any, config: OnEnterLeavePackageConfig) => Promise<void>;
 export type OnLogOut = (store: any) => Promise<void>;
 
+export const UI_CONFIG_HEADER_ACTION = 'header-action';
+export const UI_CONFIG_TAB = 'tab';
+
+export type IAction = any;
+
 /**
  * Interface for a Dashboard plugin
  */
@@ -72,6 +77,11 @@ export interface IPlugin {
    */
   addRoute(route: RouteConfig): void;
   addRoute(parent: string, route: RouteConfig): void;
+
+  /**
+   * Adds a UI action for an extension to a particular area of the UI
+   */
+  addUIAction(type: string, location: string, action: IAction): void;
 
   /**
    * Set the component to use for the landing home page

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -42,6 +42,7 @@ export const UI_CONFIG_DETAILS_MASTHEAD = 'details-masthead';
 export const UI_CONFIG_DETAIL_TOP = 'detail-top';
 export const UI_CONFIG_RESOURCE_LIST = 'resource-list';
 export const UI_CONFIG_GLOBAL_SETTING = 'global-setting';
+export const UI_CONFIG_CLUSTER_DASHBOARD_CARD = 'cluster-dashboard-card';
 
 export type IAction = any;
 

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -38,6 +38,9 @@ export type OnLogOut = (store: any) => Promise<void>;
 export const UI_CONFIG_HEADER_ACTION = 'header-action';
 export const UI_CONFIG_TAB = 'tab';
 export const UI_CONFIG_TABLE_ACTION = 'table-action';
+export const UI_CONFIG_DETAILS_MASTHEAD = 'details-masthead';
+export const UI_CONFIG_DETAIL_TOP = 'detail-top';
+export const UI_CONFIG_RESOURCE_LIST = 'resource-list';
 
 export type IAction = any;
 

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -81,7 +81,7 @@ export interface IPlugin {
   /**
    * Adds a UI action for an extension to a particular area of the UI
    */
-  addUIAction(type: string, location: string, action: IAction): void;
+  addUIAction(type: string, locationConfig: object, action: IAction): void;
 
   /**
    * Set the component to use for the landing home page

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -59,6 +59,7 @@ export default {
           :options="[false, true]"
           :labels="[t('catalog.repo.target.http'), t('catalog.repo.target.git')]"
           :mode="mode"
+          data-testid="clusterrepo-radio-input"
         />
       </div>
     </div>
@@ -74,6 +75,7 @@ export default {
           :label="t('catalog.repo.gitRepo.label')"
           :placeholder="t('catalog.repo.gitRepo.placeholder', null, true)"
           :mode="mode"
+          data-testid="clusterrepo-git-repo-input"
         />
       </div>
       <div class="col span-6">
@@ -83,6 +85,7 @@ export default {
           :label="t('catalog.repo.gitBranch.label')"
           :placeholder="t('catalog.repo.gitBranch.placeholder', null, true)"
           :mode="mode"
+          data-testid="clusterrepo-git-branch-input"
         />
       </div>
     </div>

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -42,6 +42,7 @@ import EventsTable from './EventsTable';
 import { fetchClusterResources } from './explorer-utils';
 import SimpleBox from '@shell/components/SimpleBox';
 import { UI_CONFIG_CLUSTER_DASHBOARD_CARD } from '@shell/core/types';
+import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 export const RESOURCES = [NAMESPACE, INGRESS, PV, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.DAEMON_SET, SERVICE];
 
@@ -147,15 +148,20 @@ export default {
     ...monitoringStatus(),
 
     extensionCards() {
+      const extensionCards = [];
       const cards = this.$plugin.getUIConfig(UI_CONFIG_CLUSTER_DASHBOARD_CARD);
 
       cards.forEach((card, i) => {
-        if (card.labelKey) {
-          cards[i].label = this.t(card.labelKey);
+        if (checkExtensionRouteBinding(this.$route, card.locationConfig)) {
+          if (card.labelKey) {
+            cards[i].label = this.t(card.labelKey);
+          }
+
+          extensionCards.push(card);
         }
       });
 
-      return cards;
+      return extensionCards;
     },
 
     displayPspDeprecationBanner() {

--- a/shell/pages/c/_cluster/uiplugins/DeveloperInstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/DeveloperInstallDialog.vue
@@ -181,12 +181,14 @@ export default {
         <div class="dialog-buttons mt-20">
           <button
             class="btn role-secondary"
+            data-testid="dev-install-ext-modal-cancel-btn"
             @click="closeDialog()"
           >
             {{ t('generic.cancel') }}
           </button>
           <AsyncButton
             mode="load"
+            data-testid="dev-install-ext-modal-install-btn"
             @click="loadPlugin"
           />
         </div>

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -243,6 +243,7 @@ export default {
             label-key="plugins.install.version"
             :options="versionOptions"
             class="version-selector mt-10"
+            data-testid="install-ext-modal-select-version"
           />
           <div v-else>
             {{ t('plugins.install.version') }} {{ version }}
@@ -252,12 +253,14 @@ export default {
           <button
             :disabled="busy"
             class="btn role-secondary"
+            data-testid="install-ext-modal-cancel-btn"
             @click="closeDialog(false)"
           >
             {{ t('generic.cancel') }}
           </button>
           <AsyncButton
             :mode="buttonMode"
+            data-testid="install-ext-modal-install-btn"
             @click="install"
           />
         </div>

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -113,10 +113,12 @@ export default {
     <div
       v-if="showSlideIn"
       class="glass"
+      data-testid="extension-details-bg"
       @click="hide()"
     />
     <div
       class="slideIn"
+      data-testid="extension-details"
       :class="{'hide': false, 'slideIn__show': showSlideIn}"
     >
       <div
@@ -142,7 +144,10 @@ export default {
             >
           </div>
           <div class="plugin-title">
-            <h2 class="slideIn__header">
+            <h2
+              class="slideIn__header"
+              data-testid="extension-details-title"
+            >
               {{ info.name }}
             </h2>
             <p class="plugin-description">
@@ -153,6 +158,7 @@ export default {
             <div class="slideIn__header__buttons">
               <div
                 class="slideIn__header__button"
+                data-testid="extension-details-close"
                 @click="showSlideIn = false"
               >
                 <i class="icon icon-close" />

--- a/shell/pages/c/_cluster/uiplugins/RemoveUIPlugins.vue
+++ b/shell/pages/c/_cluster/uiplugins/RemoveUIPlugins.vue
@@ -107,6 +107,7 @@ export default {
     name="confirm-uiplugins-remove"
     :title="t('plugins.setup.remove.title')"
     mode="disable"
+    data-testid="disable-ext-modal"
     @okay="doRemove"
   >
     <template>
@@ -121,6 +122,7 @@ export default {
           v-model="removeRepo"
           :primary="true"
           label-key="plugins.setup.remove.registry.title"
+          data-testid="disable-ext-modal-remove-repo"
         />
         <div class="checkbox-info">
           {{ t('plugins.setup.remove.registry.prompt') }}

--- a/shell/pages/c/_cluster/uiplugins/SetupUIPlugins.vue
+++ b/shell/pages/c/_cluster/uiplugins/SetupUIPlugins.vue
@@ -214,6 +214,7 @@ export default {
               :manual="true"
               :current-phase="buttonState"
               class="enable-plugin-support"
+              data-testid="extension-enable-operator"
               @click="enable"
             />
           </div>

--- a/shell/pages/c/_cluster/uiplugins/UninstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/UninstallDialog.vue
@@ -84,12 +84,14 @@ export default {
           <button
             :disabled="busy"
             class="btn role-secondary"
+            data-testid="uninstall-ext-modal-cancel-btn"
             @click="closeDialog(false)"
           >
             {{ t('generic.cancel') }}
           </button>
           <AsyncButton
             mode="uninstall"
+            data-testid="uninstall-ext-modal-uninstall-btn"
             @click="uninstall()"
           />
         </div>

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -492,10 +492,13 @@ export default {
 <template>
   <div class="plugins">
     <div class="plugin-header">
-      <h2>{{ t('plugins.title') }}</h2>
+      <h2 data-testid="extensions-page-title">
+        {{ t('plugins.title') }}
+      </h2>
       <div
         v-if="reloadRequired"
         class="plugin-reload-banner mr-20"
+        data-testid="extension-reload-banner"
       >
         <i class="icon icon-checkmark mr-10" />
         <span>
@@ -503,6 +506,7 @@ export default {
         </span>
         <button
           class="ml-10 btn btn-sm role-primary"
+          data-testid="extension-reload-banner-reload-btn"
           @click="reload()"
         >
           {{ t('generic.reload') }}
@@ -514,6 +518,7 @@ export default {
         aria-haspopup="true"
         type="button"
         class="btn actions role-secondary"
+        data-testid="extensions-page-menu"
         @click="setMenu"
       >
         <i class="icon icon-actions" />
@@ -555,15 +560,18 @@ export default {
       <Tabbed
         ref="tabs"
         :tabs-only="true"
+        data-testid="extension-tabs"
         @changed="filterChanged"
       >
         <Tab
           name="installed"
+          data-testid="extension-tab-installed"
           label-key="plugins.tabs.installed"
           :weight="20"
         />
         <Tab
           name="available"
+          data-testid="extension-tab-available"
           label-key="plugins.tabs.available"
           :weight="19"
         />
@@ -606,6 +614,7 @@ export default {
             v-for="plugin in list"
             :key="plugin.name"
             class="plugin"
+            :data-testid="`extension-card-${plugin.name}`"
             @click="showPluginDetail(plugin)"
           >
             <div
@@ -709,6 +718,7 @@ export default {
                   <button
                     v-if="!plugin.builtin"
                     class="btn role-secondary"
+                    :data-testid="`extension-card-uninstall-btn-${plugin.name}`"
                     @click="showUninstallDialog(plugin, $event)"
                   >
                     {{ t('plugins.uninstall.label') }}
@@ -716,6 +726,7 @@ export default {
                   <button
                     v-if="plugin.upgrade"
                     class="btn role-secondary"
+                    :data-testid="`extension-card-update-btn-${plugin.name}`"
                     @click="showInstallDialog(plugin, 'update', $event)"
                   >
                     {{ t('plugins.update.label') }}
@@ -723,6 +734,7 @@ export default {
                   <button
                     v-if="!plugin.upgrade && plugin.versions.length > 1"
                     class="btn role-secondary"
+                    :data-testid="`extension-card-rollback-btn-${plugin.name}`"
                     @click="showInstallDialog(plugin, 'rollback', $event)"
                   >
                     {{ t('plugins.rollback.label') }}
@@ -734,6 +746,7 @@ export default {
                 >
                   <button
                     class="btn role-secondary"
+                    :data-testid="`extension-card-install-btn-${plugin.name}`"
                     @click="showInstallDialog(plugin, 'install', $event)"
                   >
                     {{ t('plugins.install.label') }}

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -894,6 +894,10 @@ export default class Resource {
 
     actions.forEach((action) => {
       if (checkExtensionRouteBinding(currentRoute, action.locationConfig)) {
+        if (action.labelKey) {
+          action.label = this.t(action.labelKey);
+        }
+
         extensionMenuActions.push(action);
       }
     });

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -36,7 +36,7 @@ import Vue from 'vue';
 
 import { normalizeType } from './normalize';
 
-import { UI_CONFIG_TABLE_ACTION, UI_CONFIG_TABLE_COL } from '@shell/core/types';
+import { UI_CONFIG_TABLE_ACTION } from '@shell/core/types';
 import { checkExtensionRouteBinding } from '@shell/core/helpers';
 
 const STRING_LIKE_TYPES = [
@@ -552,31 +552,6 @@ export default class Resource {
         writable:     true
       });
     }
-
-    // adds user defined props on the extensions
-    if (data.type !== 'schema') {
-      const extensionCols = ctx.rootGetters['uiplugins/uiConfig'][UI_CONFIG_TABLE_COL];
-
-      if (extensionCols.length) {
-        const applicableCols = extensionCols.filter(col => (col.type === data.type) && col.classProp);
-
-        if (applicableCols.length) {
-          this.extensionProps = {};
-          Object.defineProperty(this, 'extensionProps', {
-            value:        {},
-            enumerable:   false,
-            configurable: false,
-            writable:     false
-          });
-
-          applicableCols.forEach((col) => {
-            if (col.classProp.propName && col.classProp.value) {
-              this.extensionProps[col.classProp.propName] = col.classProp.value(data);
-            }
-          });
-        }
-      }
-    }
   }
 
   get '$getters'() {
@@ -914,7 +889,8 @@ export default class Resource {
   get _availableActions() {
     // get menu actions available by plugins configuration
     const extensionMenuActions = [];
-    const actions = this.$rootGetters['uiplugins/uiConfig'][UI_CONFIG_TABLE_ACTION];
+
+    const actions = this.$rootState.$plugin.getUIConfig(UI_CONFIG_TABLE_ACTION);
     const currentRoute = this.currentRouter().app._route;
 
     actions.forEach((action) => {
@@ -1125,11 +1101,6 @@ export default class Resource {
   async _save(opt = {}) {
     delete this.__rehydrate;
     delete this.__clone;
-
-    // delete the extension defined "extensionProps" prop
-    if (this.extensionProps) {
-      delete this.extensionProps;
-    }
 
     const forNew = !this.id;
 

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -36,6 +36,9 @@ import Vue from 'vue';
 
 import { normalizeType } from './normalize';
 
+import { UI_CONFIG_TABLE_ACTION } from '@shell/core/types';
+import { checkExtensionRouteBinding } from '@shell/core/helpers';
+
 const STRING_LIKE_TYPES = [
   'string',
   'date',
@@ -884,7 +887,18 @@ export default class Resource {
 
   // You can add custom actions by overriding your own availableActions (and probably reading super._availableActions)
   get _availableActions() {
-    const all = [
+    // get menu actions available by plugins configuration
+    const extensionMenuActions = [];
+    const actions = this.$rootGetters['uiplugins/uiConfig'][UI_CONFIG_TABLE_ACTION];
+    const currentRoute = this.currentRouter().app._route;
+
+    actions.forEach((action) => {
+      if (checkExtensionRouteBinding(currentRoute, action.locationConfig)) {
+        extensionMenuActions.push(action);
+      }
+    });
+
+    let all = [
       { divider: true },
       {
         action:  this.canUpdate ? 'goToEdit' : 'goToViewConfig',
@@ -931,6 +945,10 @@ export default class Resource {
         weight:     -10, // Delete always goes last
       },
     ];
+
+    if (extensionMenuActions.length) {
+      all = all.concat(extensionMenuActions);
+    }
 
     return all;
   }

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -223,12 +223,12 @@ export function DSL(store, product, module = 'type-map') {
     },
 
     headers(type, headers) {
-      const extensionCols = store.getters['uiplugins/uiConfig'][UI_CONFIG_TABLE_COL];
+      const extensionCols = store.$plugin.getUIConfig(UI_CONFIG_TABLE_COL);
 
       // adding extension defined cols to the correct header config
       extensionCols.forEach((col) => {
-        if (type === col.type) {
-          headers = headers.concat(col.config);
+        if (col.locationConfig.resource && type === col.locationConfig.resource) {
+          headers = headers.concat(col);
         }
       });
 

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -147,6 +147,8 @@ import { sortBy } from '@shell/utils/sort';
 import { haveV1Monitoring, haveV2Monitoring } from '@shell/utils/monitoring';
 import { NEU_VECTOR_NAMESPACE } from '@shell/config/product/neuvector';
 
+import { UI_CONFIG_TABLE_COL } from '@shell/core/types';
+
 export const NAMESPACED = 'namespaced';
 export const CLUSTER_LEVEL = 'cluster';
 export const BOTH = 'both';
@@ -221,6 +223,15 @@ export function DSL(store, product, module = 'type-map') {
     },
 
     headers(type, headers) {
+      const extensionCols = store.getters['uiplugins/uiConfig'][UI_CONFIG_TABLE_COL];
+
+      // adding extension defined cols to the correct header config
+      extensionCols.forEach((col) => {
+        if (type === col.type) {
+          headers = headers.concat(col.config);
+        }
+      });
+
       headers.forEach((header) => {
         // If on the client, then use the value getter if there is one
         if (header.getValue) {

--- a/shell/store/uiplugins.ts
+++ b/shell/store/uiplugins.ts
@@ -7,7 +7,6 @@ import { Plugin } from '@shell/core/plugin';
 
 interface UIPluginState {
   plugins: Plugin[],
-  uiConfig: any,
   errors: any,
 }
 
@@ -18,17 +17,12 @@ interface LoadError {
 
 export const state = function(): UIPluginState {
   return {
-    uiConfig: null,
-    plugins:  [],
-    errors:   {},
+    plugins: [],
+    errors:  {},
   };
 };
 
 export const getters = {
-  uiConfig: (state: any) => {
-    return state.uiConfig;
-  },
-
   plugins: (state: any) => {
     return state.plugins;
   },
@@ -41,10 +35,6 @@ export const getters = {
 export const mutations = {
   setError(state: UIPluginState, error: LoadError) {
     state.errors[error.name] = error.error;
-  },
-
-  addPluginsUiConfig(state: UIPluginState, uiConfig: any) {
-    state.uiConfig = uiConfig;
   },
 
   addPlugin(state: UIPluginState, plugin: Plugin) {
@@ -64,10 +54,6 @@ export const mutations = {
 export const actions = {
   setError( { commit }: any, error: LoadError ) {
     commit('setError', error);
-  },
-
-  addPluginsUiConfig({ commit }: any, uiConfig: any) {
-    commit('addPluginsUiConfig', uiConfig);
   },
 
   addPlugin({ commit }: any, plugin: Plugin) {

--- a/shell/store/uiplugins.ts
+++ b/shell/store/uiplugins.ts
@@ -7,6 +7,7 @@ import { Plugin } from '@shell/core/plugin';
 
 interface UIPluginState {
   plugins: Plugin[],
+  uiConfig: any,
   errors: any,
 }
 
@@ -17,12 +18,17 @@ interface LoadError {
 
 export const state = function(): UIPluginState {
   return {
-    plugins: [],
-    errors:  {},
+    uiConfig: null,
+    plugins:  [],
+    errors:   {},
   };
 };
 
 export const getters = {
+  uiConfig: (state: any) => {
+    return state.uiConfig;
+  },
+
   plugins: (state: any) => {
     return state.plugins;
   },
@@ -35,6 +41,10 @@ export const getters = {
 export const mutations = {
   setError(state: UIPluginState, error: LoadError) {
     state.errors[error.name] = error.error;
+  },
+
+  addPluginsUiConfig(state: UIPluginState, uiConfig: any) {
+    state.uiConfig = uiConfig;
   },
 
   addPlugin(state: UIPluginState, plugin: Plugin) {
@@ -54,6 +64,10 @@ export const mutations = {
 export const actions = {
   setError( { commit }: any, error: LoadError ) {
     commit('setError', error);
+  },
+
+  addPluginsUiConfig({ commit }: any, uiConfig: any) {
+    commit('addPluginsUiConfig', uiConfig);
   },
 
   addPlugin({ commit }: any, plugin: Plugin) {


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/8119

Add e2e tests to cover basic functionalities of extensions:
- enable/disable extensions in general
- clicking on extension card toggles details side-panel
- install an extension
- upgrade an extension
- rollback an extension
- uninstall an extension

**NOTE: this needs a rebase with PR https://github.com/rancher/dashboard/pull/7777 in order to eliminate most of the changes. For now it needs the code from that PR because of the `data-testid` that was added there**