### PR TITLE
Allow configuring system image registry only for charts that support it

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -95,9 +95,11 @@ export default {
     this.errors = [];
 
     // If the chart doesn't contain system `systemDefaultRegistry` properties there's no point applying them
-    this.clusterRegistry = await this.getClusterRegistry();
-    this.globalRegistry = await this.getGlobalRegistry();
-    this.defaultRegistrySetting = this.clusterRegistry || this.globalRegistry;
+    if (this.showCustomRegistry) {
+      this.clusterRegistry = await this.getClusterRegistry();
+      this.globalRegistry = await this.getGlobalRegistry();
+      this.defaultRegistrySetting = this.clusterRegistry || this.globalRegistry;
+    }
 
     this.serverUrlSetting = await this.$store.dispatch('management/find', {
       type: MANAGEMENT.SETTING,
@@ -282,13 +284,20 @@ export default {
       */
       this.chartValues = merge(merge({}, this.versionInfo?.values || {}), userValues);
 
-      const existingRegistry = this.chartValues?.global?.systemDefaultRegistry || this.chartValues?.global?.cattle?.systemDefaultRegistry;
+      if (this.showCustomRegistry) {
+        /**
+         * The input to configure the registry should never be
+         * shown for third-party charts, which don't have Rancher
+         * global values.
+         */
+        const existingRegistry = this.chartValues?.global?.systemDefaultRegistry || this.chartValues?.global?.cattle?.systemDefaultRegistry;
 
-      delete this.chartValues?.global?.systemDefaultRegistry;
-      delete this.chartValues?.global?.cattle?.systemDefaultRegistry;
+        delete this.chartValues?.global?.systemDefaultRegistry;
+        delete this.chartValues?.global?.cattle?.systemDefaultRegistry;
 
-      this.customRegistrySetting = existingRegistry || this.defaultRegistrySetting;
-      this.showCustomRegistryInput = !!this.customRegistrySetting;
+        this.customRegistrySetting = existingRegistry || this.defaultRegistrySetting;
+        this.showCustomRegistryInput = !!this.customRegistrySetting;
+      }
 
       /* Serializes an object as a YAML document */
       this.valuesYaml = saferDump(this.chartValues);
@@ -664,6 +673,22 @@ export default {
       return null;
     },
 
+    /**
+     * Check if the chart contains `systemDefaultRegistry` properties.
+     * If not we shouldn't apply the setting, because if the option
+     * is exposed for third-party Helm charts, it confuses users because
+     * it shows a private registry setting that is never used
+     * by the chart they are installing. If not hidden, the setting
+     * does nothing, and if the user changes it, it will look like
+     * there is a bug in the UI when it doesn't work, because UI is
+     * exposing a feature that the chart does not have.
+     */
+    showCustomRegistry() {
+      const global = this.versionInfo?.values?.global || {};
+
+      return global.systemDefaultRegistry !== undefined || global.cattle?.systemDefaultRegistry !== undefined;
+    },
+
   },
 
   watch: {
@@ -980,8 +1005,11 @@ export default {
 
       setIfNotSet(cattle, 'clusterId', cluster?.id);
       setIfNotSet(cattle, 'clusterName', cluster?.nameDisplay);
-      set(cattle, 'systemDefaultRegistry', this.customRegistrySetting);
-      set(global, 'systemDefaultRegistry', this.customRegistrySetting);
+
+      if (this.showCustomRegistry) {
+        set(cattle, 'systemDefaultRegistry', this.customRegistrySetting);
+        set(global, 'systemDefaultRegistry', this.customRegistrySetting);
+      }
 
       setIfNotSet(global, 'cattle.systemProjectId', systemProjectId);
       setIfNotSet(cattle, 'url', serverUrl);
@@ -1421,6 +1449,7 @@ export default {
           />
 
           <Checkbox
+            v-if="showCustomRegistry"
             v-model="showCustomRegistryInput"
             class="mb-20"
             :label="t('catalog.chart.registry.custom.checkBoxLabel')"


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/7766 by conditionally showing the option to configure a private registry for Rancher system images based on the presence of `global.cattle.systemDefaultRegistry` in a chart's `values.yaml`

## Context

These changes are mostly reversing the changes from this PR https://github.com/rancher/dashboard/pull/7273 , which is no longer needed because the NeuVector chart has been updated to use the `global.cattle.systemDefaultRegistry` value for pulling Rancher system images. In pre-Rancher-2.7.0 releases of the NeuVector chart, it used to be possible to configure the value at `registry` in the values.yaml, but that value is no longer used in the template. In the latest chart version released with Rancher v2.7.0, the NeuVector Helm chart template now uses the `global.cattle.systemDefaultRegistry` exclusively for pulling images if it is set. See the NeuVector chart template here: https://github.com/rancher/charts/blob/release-v2.7/charts/neuvector/101.0.1%2Bup2.2.4/templates/_helpers.tpl#L36)

Older versions of the NeuVector Helm chart allowed a registry to be configured in the Container Images section of the questions.yaml. That input has also been removed from the questions.yaml in the latest NeuVector chart as of v2.7.0, so users will no longer see two registry inputs, which would be confusing, as Izaac had noted in the past (https://github.com/rancher/dashboard/issues/7260#issuecomment-1291424754).

Note: the original `registry` value still remains in the `values.yaml` for the NeuVector chart along with `global.cattle.systemDefaultRegistry` but I believe this should not be changed because based on the folder structure of the NeuVector chart, it appears that the same values file is being shared by templates for multiple chart versions.

## Known Issue

The alerting drivers chart could not be installed in v2.7-head, but that issue is tracked here. https://github.com/rancher/rancher/issues/39848

## Testing

I verified the following in my local setup:

- The `global.cattle.systemDefaultRegistry` value is present in the Helm chart values of all 20 official Rancher charts available from Cluster Explorer.
- The custom registry input is available for the official Rancher charts.
- The custom registry input is hidden for third-party charts.