### PR TITLE
ResourceTable, allow Enter event to be propagated

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -150,6 +150,20 @@ export default {
     }
   },
 
+  mounted() {
+    /**
+     * v-shortkey prevents the event's propagation:
+     * https://github.com/fgr-araujo/vue-shortkey/blob/55d802ea305cadcc2ea970b55a3b8b86c7b44c05/src/index.js#L156-L157
+     *
+     * 'Enter' key press is handled via event listener in order to allow the event propagation
+     */
+    window.addEventListener('keyup', this.handleEnterKeyPress);
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('keyup', this.handleEnterKeyPress);
+  },
+
   data() {
     const options = this.$store.getters[`type-map/optionsFor`](this.schema);
     const listGroups = options?.listGroups || [];
@@ -387,8 +401,11 @@ export default {
 
     handleActionButtonClick(event) {
       this.$emit('clickedActionButton', event);
-    }
+    },
 
+    handleEnterKeyPress(event) {
+      this.keyAction('detail');
+    }
   }
 };
 </script>
@@ -460,11 +477,6 @@ export default {
     </template>
 
     <template #shortkeys>
-      <button
-        v-shortkey.once="['enter']"
-        class="hide detail"
-        @shortkey="keyAction('detail')"
-      />
       <button
         v-shortkey.once="['e']"
         class="hide"


### PR DESCRIPTION
Signed-off-by: Francesco Torchia <francesco.torchia@suse.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7048
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
`Enter` shortcut is implemented in `SortableTable` component using the `v-shortkey` library.
Having a quick look to the library code, the event propagation is blocked.

This means when users navigate in a tab where the table is used, for example `Jobs` view, the event is captured by the table's shortcuts and it is not propagated to the Namespace's filter on the top.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Go to any tab with SortableTable inside, for example `Jobs` and try to use the Enter shortcut to select a namespace.


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->