### PR TITLE
Cancel XHR when environment is desktop

### DIFF
--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -116,8 +116,23 @@ export default {
       }
     }
 
+    function newCancelToken(cancelToken, timeout = 0) {
+      const source = cancelToken.source();
+
+      if (timeout) {
+        setTimeout(() => source.cancel('Operation cancelled by user'), timeout);
+      }
+
+      return source.token;
+    }
+
     function makeRequest(that, opt) {
-      return that.$axios(opt).then((res) => {
+      return that.$axios(
+        {
+          ...opt,
+          cancelToken: newCancelToken(that.$axios.CancelToken, that.$config.rancherEnv === 'desktop' ? 5000 : 0)
+        }
+      ).then((res) => {
         let out;
 
         if ( opt.responseType ) {


### PR DESCRIPTION
This allows for cancelling XHR objects when the environment is `desktop`. 

We need a strategy for cancelling XHR via axios. Without one, we end up with a scenario where the UI gets blocked because the connection will never timeout in the absence of a backend. While Dashboard is not designed to allow for rendering any content without a backend, this at least enables us to create a customized template for Rancher Desktop to use.  

I opted to use the deprecated `CancelToken` approach because we won't be able to make use of `AbortController` until we update node for Rancher Dashboard. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before
Always renders spinner, never progresses beyond registration of nuxt plugins

https://user-images.githubusercontent.com/835961/210877410-fede6c2a-c0d5-48df-a969-c8ca99d2d56e.mp4

#### After
Renders homepage, albeit with no content whatsoever

https://user-images.githubusercontent.com/835961/210877547-b6eec900-bea7-4d40-911d-91a4fcb44518.mp4

Signed-off-by: Phillip Rak <rak.phillip@gmail.com>
