### PR TITLE
E2E Tests: Add logging for env vars

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -29,38 +29,38 @@ const baseUrl = (process.env.TEST_BASE_URL || 'https://localhost:8005').replace(
 const DEFAULT_USERNAME = 'admin';
 
 // Log summary of the environment variables that we have detected (or are going ot use) - we won't show any passwords
-console.log('E2E Test Configuration');
-console.log('');
+console.log('E2E Test Configuration'); // eslint-disable-line no-console
+console.log(''); // eslint-disable-line no-console
 
 if (process.env.TEST_USERNAME) {
-  console.log(`    Username: ${process.env.TEST_USERNAME}`);
+  console.log(`    Username: ${ process.env.TEST_USERNAME }`); // eslint-disable-line no-console
 } else {
-  console.log(`    Username: ${DEFAULT_USERNAME} (TEST_USERNAME not set, using default)`);
+  console.log(`    Username: ${ DEFAULT_USERNAME } (TEST_USERNAME not set, using default)`); // eslint-disable-line no-console
 }
 
 if (process.env.CATTLE_BOOTSTRAP_PASSWORD && process.env.TEST_PASSWORD) {
-  console.log(" ❌ You should not set both CATTLE_BOOTSTRAP_PASSWORD and TEST_PASSWORD - CATTLE_BOOTSTRAP_PASSWORD will be used");
+  console.log(' ❌ You should not set both CATTLE_BOOTSTRAP_PASSWORD and TEST_PASSWORD - CATTLE_BOOTSTRAP_PASSWORD will be used'); // eslint-disable-line no-console
 }
 
 if (!skipSetup && !process.env.CATTLE_BOOTSTRAP_PASSWORD) {
-  console.log(' ❌ You must provide CATTLE_BOOTSTRAP_PASSWORD when running setup tests');
+  console.log(' ❌ You must provide CATTLE_BOOTSTRAP_PASSWORD when running setup tests'); // eslint-disable-line no-console
 }
 
 if (!process.env.CATTLE_BOOTSTRAP_PASSWORD && !process.env.TEST_PASSWORD) {
-  console.log(' ❌ You must provide one of CATTLE_BOOTSTRAP_PASSWORD or TEST_PASSWORD');
+  console.log(' ❌ You must provide one of CATTLE_BOOTSTRAP_PASSWORD or TEST_PASSWORD'); // eslint-disable-line no-console
 }
 
 if (skipSetup && !process.env.TEST_PASSWORD) {
-  console.log(' ❌ You should provide TEST_PASSWORD when running the tests without the setup tests');
+  console.log(' ❌ You should provide TEST_PASSWORD when running the tests without the setup tests'); // eslint-disable-line no-console
 }
 
 if (skipSetup) {
-  console.log(`    Setup tests will NOT be run`);
+  console.log(`    Setup tests will NOT be run`); // eslint-disable-line no-console
 } else {
-  console.log(`    Setup tests will be run`);
+  console.log(`    Setup tests will be run`); // eslint-disable-line no-console
 }
 
-console.log(`    Dashboard URL: ${ baseUrl }`);
+console.log(`    Dashboard URL: ${ baseUrl }`); // eslint-disable-line no-console
 
 export default defineConfig({
   projectId:             process.env.TEST_PROJECT_ID,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'cypress';
 // Required for env vars to be available in cypress
 require('dotenv').config();
 
+const skipSetup = process.env.TEST_SKIP_SETUP === 'true';
+
 /**
  * Filter test spec paths based on env var configuration
  * @returns
@@ -10,7 +12,7 @@ const getSpecPattern = (): string[] => {
   const optionalPaths = [
     {
       path:   'cypress/e2e/tests/setup/**/*.spec.ts',
-      active: process.env.TEST_SKIP_SETUP !== 'true'
+      active: !skipSetup
     }
   ];
   const activePaths = optionalPaths.filter(({ active }) => Boolean(active)).map(({ path }) => path);
@@ -22,6 +24,43 @@ const getSpecPattern = (): string[] => {
   ];
 };
 const baseUrl = (process.env.TEST_BASE_URL || 'https://localhost:8005').replace(/\/$/, '');
+
+// Default user name, if TEST_USERNAME is not provided
+const DEFAULT_USERNAME = 'admin';
+
+// Log summary of the environment variables that we have detected (or are going ot use) - we won't show any passwords
+console.log('E2E Test Configuration');
+console.log('');
+
+if (process.env.TEST_USERNAME) {
+  console.log(`    Username: ${process.env.TEST_USERNAME}`);
+} else {
+  console.log(`    Username: ${DEFAULT_USERNAME} (TEST_USERNAME not set, using default)`);
+}
+
+if (process.env.CATTLE_BOOTSTRAP_PASSWORD && process.env.TEST_PASSWORD) {
+  console.log(" ❌ You should not set both CATTLE_BOOTSTRAP_PASSWORD and TEST_PASSWORD - CATTLE_BOOTSTRAP_PASSWORD will be used");
+}
+
+if (!skipSetup && !process.env.CATTLE_BOOTSTRAP_PASSWORD) {
+  console.log(' ❌ You must provide CATTLE_BOOTSTRAP_PASSWORD when running setup tests');
+}
+
+if (!process.env.CATTLE_BOOTSTRAP_PASSWORD && !process.env.TEST_PASSWORD) {
+  console.log(' ❌ You must provide one of CATTLE_BOOTSTRAP_PASSWORD or TEST_PASSWORD');
+}
+
+if (skipSetup && !process.env.TEST_PASSWORD) {
+  console.log(' ❌ You should provide TEST_PASSWORD when running the tests without the setup tests');
+}
+
+if (skipSetup) {
+  console.log(`    Setup tests will NOT be run`);
+} else {
+  console.log(`    Setup tests will be run`);
+}
+
+console.log(`    Dashboard URL: ${ baseUrl }`);
 
 export default defineConfig({
   projectId:             process.env.TEST_PROJECT_ID,
@@ -45,8 +84,8 @@ export default defineConfig({
         'pkg/rancher-components/src/components/**/*.{vue,ts,js}',
       ]
     },
-    username:          process.env.TEST_USERNAME,
-    password:          process.env.TEST_PASSWORD,
+    username:          process.env.TEST_USERNAME || DEFAULT_USERNAME,
+    password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,
   },
   e2e: {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "start:prod": "DEV_PORTS=true NODE_ENV=production yarn start",
     "generate": "./node_modules/.bin/nuxt generate",
     "dev-debug": "node --inspect ./node_modules/.bin/nuxt",
+    "cy:e2e": "cypress open --e2e --browser chrome",
     "cy:open": "cypress open",
     "cy:run": "cypress run --browser chrome",
     "cy:run:sorry": "./scripts/e2e",


### PR DESCRIPTION
This PR adds logging to the Cypress config file that should notify users when they don't have the env vars set up for E2E tests correctly.

It also adds a convenience `cy:e2e` script that will open Cypress on the e2e tests, to save having to click each time - I'll update the docs for this in a later PR.

It also defaults the username to `admin` - which is what our docs say is the default, but we don't default to this (I think the docs mean that admin is the typical default name, rather than if you don't supply, we'll assume admin).
