### PR TITLE
Fix description not working for user resources

### DIFF
--- a/shell/edit/management.cattle.io.user.vue
+++ b/shell/edit/management.cattle.io.user.vue
@@ -167,7 +167,13 @@ export default {
       normanUser._name = this.form.displayName;
       normanUser.mustChangePassword = this.form.password.userChangeOnLogin;
 
-      return normanUser.save();
+      await normanUser.save();
+
+      return await this.$store.dispatch('management/find', {
+        type: MANAGEMENT.USER,
+        id:   this.value.id,
+        opt:  { force: true }
+      });
     },
 
     async updateRoles(userId) {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -130,6 +130,12 @@ export default {
 
       return data;
     }
+
+    // If the existing model has a cleanResource method, use it
+    if (existing?.cleanResource && typeof existing.cleanResource === 'function') {
+      return existing.cleanResource(data);
+    }
+
     const typeSuperClass = Object.getPrototypeOf(Object.getPrototypeOf(existing))?.constructor;
 
     return typeSuperClass === HybridModel ? cleanHybridResources(data) : data;


### PR DESCRIPTION
Fixes #7839 

This is similar to other Norman-style resources where the description was lost (e.g. Role) - see https://github.com/rancher/dashboard/pull/7738 and https://github.com/rancher/dashboard/pull/6676.

This is slightly different as User inherits form HybridModel, so we can't use the extra class that was created - the changes are applied here to the user model.

Also note, that because the user model inherits from HybridModel, we need to add a hook to allow it NOT to clean the description field.