### PR TITLE
Fixed link alignment in home page whats new section

### DIFF
--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -162,8 +162,6 @@ $icon-size: 24px;
     line-height: 20px;
     width: 100%;
     border-left: solid $left-border-size transparent;
-    align-items: center;
-    flex-direction: row;
     display: flex;
 
     .primary & {

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -162,6 +162,9 @@ $icon-size: 24px;
     line-height: 20px;
     width: 100%;
     border-left: solid $left-border-size transparent;
+    align-items: center;
+    flex-direction: row;
+    display: flex;
 
     .primary & {
       background: var(--primary);

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -301,7 +301,9 @@ export default {
             data-testid="changelog-banner"
             color="info whats-new"
           >
-            <div>{{ t('landing.seeWhatsNew') }}</div>
+            <div class="message">
+              {{ t('landing.seeWhatsNew') }}
+            </div>
             <a
               class="hand"
               @click.prevent.stop="showWhatsNew"
@@ -322,7 +324,9 @@ export default {
                 :closable="true"
                 @close="closeSetLoginBanner()"
               >
-                <div>{{ t('landing.landingPrefs.title') }}</div>
+                <div class="message">
+                  {{ t('landing.landingPrefs.title') }}
+                </div>
                 <a
                   class="hand mr-20"
                   @click.prevent.stop="showUserPrefs"
@@ -457,20 +461,10 @@ export default {
       margin-left: 1.75%;
     }
   }
-
-  .banner.info.whats-new, .banner.set-login-page {
-    border: 0;
-    margin-top: 0;
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    > div {
-      flex: 1;
-    }
-    > a {
-      align-self: flex-end;
-    }
+  .banner.set-login-page .message, .whats-new .message  {
+    flex: 1;
   }
+
   .banner.set-login-page {
     border: 1px solid var(--border);
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7794
<!-- Define findings related to the feature or bug issue. -->
Fixed `What's new in 2.7` and `Preferences` hyperlinks alignment


### How to test

Go to the home page:
`What's new in 2.7` and `Preferences` hyperlinks should be aligned to the right side.

![Screenshot 2023-01-10 at 14 13 06](https://user-images.githubusercontent.com/18264463/211560989-aa650357-e59a-4494-bc33-9cf23a8b01d7.png)
