### PR TITLE
Workaround for backend issue where ws.resource.error is sent as ws.resource.change

### DIFF
--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -641,6 +641,12 @@ export const actions = {
     const data = msg.data;
     const type = data.type;
 
+    // Work-around for ws.error messages being sent as change events
+    // These have no id (or other metadata) which breaks lots if they are processed as change events
+    if (data.message && !data.id) {
+      return;
+    }
+
     // Web worker can process schemas to check that they are actually changing and
     // only load updates if the schema did actually change
     if (type === SCHEMA) {


### PR DESCRIPTION
Workaround for a backend issue where we are sent `ws.resource.error` messages as `ws.resource.change` - we try and process these and this breaks the UI in many places.

This was picked up from our e2e tests - one of the breakages was that deleting a cluster would not then cause the list to update.

The workaround is to check for an id and ignore them if not present.

We should revert this when the backend fixes this issue.