### PR TITLE
Manual Refresh Performance Option

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -411,16 +411,14 @@ export default {
       immediate: true
     },
 
-    isManualRefreshLoading: {
+    // this is the flag that indicates that manual refresh data has been loaded
+    // and we should update the deferred cols
+    manualRefreshLoadingFinished: {
       handler(neu, old) {
-        this.currentPhase = neu ? ASYNC_BUTTON_STATES.WAITING : ASYNC_BUTTON_STATES.ACTION;
-
-        // setTimeout is needed so that this is pushed further back on the JS computing queue
-        // because nextTick isn't enough to capture the DOM update for the manual refresh only scenario
-        if (old && !neu) {
-          this.manualRefreshTimer = setTimeout(() => {
-            this.watcherUpdateLiveAndDelayed(neu, old);
-          }, 2000);
+        // this is merely to update the manual refresh button status
+        this.currentPhase = !neu ? ASYNC_BUTTON_STATES.WAITING : ASYNC_BUTTON_STATES.ACTION;
+        if (neu && neu !== old) {
+          this.$nextTick(() => this.updateLiveAndDelayed());
         }
       },
       immediate: true
@@ -440,6 +438,10 @@ export default {
 
     initalLoad() {
       return !!(!this.loading && !this._didinit && this.rows?.length);
+    },
+
+    manualRefreshLoadingFinished() {
+      return !!(!this.loading && this._didinit && this.rows?.length && !this.isManualRefreshLoading);
     },
 
     fullColspan() {

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -420,7 +420,7 @@ export default {
         if (old && !neu) {
           this.manualRefreshTimer = setTimeout(() => {
             this.watcherUpdateLiveAndDelayed(neu, old);
-          }, 1000);
+          }, 2000);
         }
       },
       immediate: true

--- a/shell/list/fleet.cattle.io.bundle.vue
+++ b/shell/list/fleet.cattle.io.bundle.vue
@@ -30,8 +30,8 @@ export default {
   },
 
   async fetch() {
-    await this.$fetchType(FLEET.BUNDLE);
-    this.allFleet = await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER });
+    await this.$fetchType(this.resource);
+    this.allFleet = await this.$fetchType(FLEET.CLUSTER);
   },
 
   data() {

--- a/shell/list/fleet.cattle.io.cluster.vue
+++ b/shell/list/fleet.cattle.io.cluster.vue
@@ -25,9 +25,11 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('management/findAll', { type: FLEET.WORKSPACE });
-    this.allMgmt = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
-    await this.$fetchType(FLEET.CLUSTER);
+    this.$initializeFetchData(this.resource);
+
+    this.$fetchType(FLEET.WORKSPACE);
+    await this.$fetchType(this.resource);
+    this.allMgmt = await this.$fetchType(MANAGEMENT.CLUSTER);
   },
 
   data() {

--- a/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
+++ b/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
@@ -25,8 +25,8 @@ export default {
   },
 
   async fetch() {
-    await this.$fetchType(FLEET.TOKEN);
-    this.allFleet = await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER });
+    await this.$fetchType(this.resource);
+    this.allFleet = await this.$fetchType(FLEET.CLUSTER);
   },
 
   data() {

--- a/shell/list/fleet.cattle.io.gitrepo.vue
+++ b/shell/list/fleet.cattle.io.gitrepo.vue
@@ -39,11 +39,10 @@ export default {
   },
 
   async fetch() {
-    const store = this.$store;
+    this.$initializeFetchData(this.resource);
 
-    await store.dispatch('management/findAll', { type: FLEET.CLUSTER });
-    await store.dispatch('management/findAll', { type: FLEET.CLUSTER_GROUP });
-
+    this.$fetchType(FLEET.CLUSTER);
+    this.$fetchType(FLEET.CLUSTER_GROUP);
     await this.$fetchType(this.resource);
   }
 };

--- a/shell/list/logging.banzaicloud.io.clusterflow.vue
+++ b/shell/list/logging.banzaicloud.io.clusterflow.vue
@@ -25,7 +25,9 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('cluster/findAll', { type: LOGGING.CLUSTER_OUTPUT });
+    this.$initializeFetchData(this.resource);
+    this.$fetchType(LOGGING.CLUSTER_OUTPUT);
+
     await this.$fetchType(this.resource);
   }
 };

--- a/shell/list/logging.banzaicloud.io.flow.vue
+++ b/shell/list/logging.banzaicloud.io.flow.vue
@@ -24,12 +24,12 @@ export default {
   },
 
   async fetch() {
-    try {
-      await this.$store.dispatch('cluster/findAll', { type: LOGGING.OUTPUT });
-      await this.$store.dispatch('cluster/findAll', { type: LOGGING.CLUSTER_OUTPUT });
-    } catch (e) {}
+    this.$initializeFetchData(this.resource);
 
-    await this.$fetchType(LOGGING.FLOW);
+    this.$fetchType(LOGGING.OUTPUT);
+    this.$fetchType(LOGGING.CLUSTER_OUTPUT);
+
+    await this.$fetchType(this.resource);
   }
 };
 </script>

--- a/shell/list/monitoring.coreos.com.alertmanagerconfig.vue
+++ b/shell/list/monitoring.coreos.com.alertmanagerconfig.vue
@@ -1,7 +1,6 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
 import { Banner } from '@components/Banner';
-import { MONITORING } from '@shell/config/types';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 export default {
   name:       'ListApps',
@@ -25,12 +24,7 @@ export default {
   },
 
   async fetch() {
-    try {
-      await this.$store.dispatch('cluster/findAll', { type: MONITORING.ALERTMANAGERCONFIG });
-      await this.$fetchType(this.resource);
-    } catch (err) {
-      throw new Error(err);
-    }
+    await this.$fetchType(this.resource);
   }
 };
 </script>

--- a/shell/list/node.vue
+++ b/shell/list/node.vue
@@ -11,7 +11,6 @@ import {
   CAPI,
   MANAGEMENT, METRIC, NODE, NORMAN, POD
 } from '@shell/config/types';
-import { allHash } from '@shell/utils/promise';
 import { get } from '@shell/utils/object';
 import { GROUP_RESOURCES, mapPref } from '@shell/store/prefs';
 import { COLUMN_BREAKPOINTS } from '@shell/components/SortableTable/index.vue';
@@ -41,30 +40,30 @@ export default {
   },
 
   async fetch() {
-    const hash = { kubeNodes: this.$fetchType(NODE) };
+    this.$initializeFetchData(this.resource);
 
     this.canViewPods = this.$store.getters[`cluster/schemaFor`](POD);
 
     if (this.$store.getters[`management/schemaFor`](MANAGEMENT.NODE)) {
       // Required for Drain/Cordon action
-      hash.normanNodes = this.$store.dispatch('rancher/findAll', { type: NORMAN.NODE });
+      this.$fetchType(NORMAN.NODE, [], 'rancher');
     }
 
     if (this.$store.getters[`rancher/schemaFor`](NORMAN.NODE)) {
-      hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
+      this.$fetchType(MANAGEMENT.NODE, [], 'management');
     }
 
     if (this.$store.getters[`management/schemaFor`](CAPI.MACHINE)) {
       // Required for ssh / download key actions
-      hash.machines = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE });
+      this.$fetchType(CAPI.MACHINE, [], 'management');
     }
 
     if (this.canViewPods) {
-      // Used for running pods metrics - we don't need to block on this to show the list of nodes
-      this.$store.dispatch('cluster/findAll', { type: POD });
+      // Used for running pods metrics
+      this.$fetchType(POD);
     }
 
-    await allHash(hash);
+    await this.$fetchType(this.resource);
   },
 
   data() {

--- a/shell/list/persistentvolume.vue
+++ b/shell/list/persistentvolume.vue
@@ -25,11 +25,10 @@ export default {
   },
 
   async fetch() {
-    const inStore = this.$store.getters['currentStore']();
-    const pvcPromise = this.$store.dispatch(`${ inStore }/findAll`, { type: PVC });
+    this.$initializeFetchData(this.resource);
 
+    this.$fetchType(PVC);
     await this.$fetchType(this.resource);
-    await pvcPromise;
   }
 };
 </script>

--- a/shell/list/persistentvolumeclaim.vue
+++ b/shell/list/persistentvolumeclaim.vue
@@ -25,11 +25,9 @@ export default {
   },
 
   async fetch() {
-    const inStore = this.$store.getters['currentStore']();
+    this.$initializeFetchData(this.resource);
 
-    // Fetch storage classes so we can determine if a PVC can be expanded
-    this.$store.dispatch(`${ inStore }/findAll`, { type: STORAGE_CLASS });
-
+    this.$fetchType(STORAGE_CLASS);
     await this.$fetchType(this.resource);
   }
 };

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -2,7 +2,6 @@
 import { Banner } from '@components/Banner';
 import ResourceTable from '@shell/components/ResourceTable';
 import Masthead from '@shell/components/ResourceList/Masthead';
-import { allHash } from '@shell/utils/promise';
 import { CAPI, MANAGEMENT, SNAPSHOT, NORMAN } from '@shell/config/types';
 import { MODE, _IMPORT } from '@shell/config/query-params';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
@@ -33,45 +32,42 @@ export default {
   },
 
   async fetch() {
-    const hash = {
-      rancherClusters: this.$fetchType(CAPI.RANCHER_CLUSTER),
-      normanClusters:  this.$store.dispatch('rancher/findAll', { type: NORMAN.CLUSTER }),
-      mgmtClusters:    this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
-    };
+    this.$initializeFetchData(CAPI.RANCHER_CLUSTER);
+
+    this.$fetchType(NORMAN.CLUSTER, [], 'rancher');
 
     if ( this.$store.getters['management/canList'](SNAPSHOT) ) {
-      hash.etcdSnapshots = this.$store.dispatch('management/findAll', { type: SNAPSHOT });
+      this.$fetchType(SNAPSHOT);
     }
 
     if ( this.$store.getters['management/canList'](CAPI.MACHINE) ) {
-      hash.capiMachines = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE });
+      this.$fetchType(CAPI.MACHINE);
     }
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE) ) {
-      hash.mgmtNodes = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
+      this.$fetchType(MANAGEMENT.NODE);
     }
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE_POOL) ) {
-      hash.mgmtPools = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_POOL });
+      this.$fetchType(MANAGEMENT.NODE_POOL);
     }
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE_TEMPLATE) ) {
-      hash.mgmtTemplates = this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE });
+      this.$fetchType(MANAGEMENT.NODE_TEMPLATE);
     }
 
     if ( this.$store.getters['management/canList'](CAPI.MACHINE_DEPLOYMENT) ) {
-      hash.machineDeployments = this.$store.dispatch('management/findAll', { type: CAPI.MACHINE_DEPLOYMENT });
+      this.$fetchType(CAPI.MACHINE_DEPLOYMENT);
     }
 
     // Fetch RKE template revisions so we can show when an updated template is available
     // This request does not need to be blocking
     if ( this.$store.getters['management/canList'](MANAGEMENT.RKE_TEMPLATE_REVISION) ) {
-      this.$store.dispatch('management/findAll', { type: MANAGEMENT.RKE_TEMPLATE_REVISION });
+      this.$fetchType(MANAGEMENT.RKE_TEMPLATE_REVISION);
     }
 
-    const res = await allHash(hash);
-
-    this.mgmtClusters = res.mgmtClusters;
+    this.mgmtClusters = await this.$fetchType(MANAGEMENT.CLUSTER);
+    await this.$fetchType(CAPI.RANCHER_CLUSTER);
   },
 
   data() {

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -2,6 +2,7 @@
 import { Banner } from '@components/Banner';
 import ResourceTable from '@shell/components/ResourceTable';
 import Masthead from '@shell/components/ResourceList/Masthead';
+import { allHash } from '@shell/utils/promise';
 import { CAPI, MANAGEMENT, SNAPSHOT, NORMAN } from '@shell/config/types';
 import { MODE, _IMPORT } from '@shell/config/query-params';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
@@ -33,31 +34,34 @@ export default {
 
   async fetch() {
     this.$initializeFetchData(CAPI.RANCHER_CLUSTER);
-
-    this.$fetchType(NORMAN.CLUSTER, [], 'rancher');
+    const hash = {
+      rancherClusters: this.$fetchType(CAPI.RANCHER_CLUSTER),
+      normanClusters:  this.$fetchType(NORMAN.CLUSTER, [], 'rancher'),
+      mgmtClusters:    this.$fetchType(MANAGEMENT.CLUSTER),
+    };
 
     if ( this.$store.getters['management/canList'](SNAPSHOT) ) {
-      this.$fetchType(SNAPSHOT);
+      hash.etcdSnapshots = this.$fetchType(SNAPSHOT);
     }
 
     if ( this.$store.getters['management/canList'](CAPI.MACHINE) ) {
-      this.$fetchType(CAPI.MACHINE);
+      hash.capiMachines = this.$fetchType(CAPI.MACHINE);
     }
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE) ) {
-      this.$fetchType(MANAGEMENT.NODE);
+      hash.mgmtNodes = this.$fetchType(MANAGEMENT.NODE);
     }
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE_POOL) ) {
-      this.$fetchType(MANAGEMENT.NODE_POOL);
+      hash.mgmtPools = this.$fetchType(MANAGEMENT.NODE_POOL);
     }
 
     if ( this.$store.getters['management/canList'](MANAGEMENT.NODE_TEMPLATE) ) {
-      this.$fetchType(MANAGEMENT.NODE_TEMPLATE);
+      hash.mgmtTemplates = this.$fetchType(MANAGEMENT.NODE_TEMPLATE);
     }
 
     if ( this.$store.getters['management/canList'](CAPI.MACHINE_DEPLOYMENT) ) {
-      this.$fetchType(CAPI.MACHINE_DEPLOYMENT);
+      hash.machineDeployments = this.$fetchType(CAPI.MACHINE_DEPLOYMENT);
     }
 
     // Fetch RKE template revisions so we can show when an updated template is available
@@ -66,8 +70,9 @@ export default {
       this.$fetchType(MANAGEMENT.RKE_TEMPLATE_REVISION);
     }
 
-    this.mgmtClusters = await this.$fetchType(MANAGEMENT.CLUSTER);
-    await this.$fetchType(CAPI.RANCHER_CLUSTER);
+    const res = await allHash(hash);
+
+    this.mgmtClusters = res.mgmtClusters;
   },
 
   data() {

--- a/shell/list/service.vue
+++ b/shell/list/service.vue
@@ -1,7 +1,6 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
 import { NODE } from '@shell/config/types';
-import { allHash } from '@shell/utils/promise';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 
 export default {
@@ -29,22 +28,14 @@ export default {
   async fetch() {
     const store = this.$store;
     const inStore = store.getters['currentStore']();
-    let hasNodes = false;
 
-    try {
-      const schema = store.getters[`${ inStore }/schemaFor`](NODE);
+    this.$initializeFetchData(this.resource);
 
-      if (schema) {
-        hasNodes = true;
-      }
-    } catch {}
-
-    const hash = { rows: this.$fetchType(this.resource) };
-
-    if (hasNodes) {
-      hash.nodes = store.dispatch(`${ inStore }/findAll`, { type: NODE });
+    if (store.getters[`${ inStore }/schemaFor`](NODE)) {
+      this.$fetchType(NODE);
     }
-    await allHash(hash);
+
+    await this.$fetchType(this.resource);
   }
 };
 </script>

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -44,11 +44,17 @@ export default {
   },
 
   async fetch() {
+    if (this.allTypes && this.loadResources.length) {
+      this.$initializeFetchData(this.loadResources[0], this.loadResources);
+    } else {
+      this.$initializeFetchData(this.$route.params.resource);
+    }
+
     try {
       const schema = this.$store.getters[`cluster/schemaFor`](NODE);
 
       if (schema) {
-        this.$store.dispatch('cluster/findAll', { type: NODE });
+        this.$fetchType(NODE);
       }
     } catch {}
 
@@ -123,8 +129,8 @@ export default {
     loadHeathResources() {
       // Fetch these in the background to populate workload health
       if ( this.allTypes ) {
-        this.$store.dispatch('cluster/findAll', { type: POD, opt: { namespaced: this.namespaceFilter } });
-        this.$store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.JOB, opt: { namespaced: this.namespaceFilter } });
+        this.$fetchType(POD);
+        this.$fetchType(WORKLOAD_TYPES.JOB);
       } else {
         const type = this.$route.params.resource;
 
@@ -134,9 +140,9 @@ export default {
         }
 
         if (type === WORKLOAD_TYPES.CRON_JOB) {
-          this.$store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.JOB, opt: { namespaced: this.namespaceFilter } });
+          this.$fetchType(WORKLOAD_TYPES.JOB);
         } else {
-          this.$store.dispatch('cluster/findAll', { type: POD, opt: { namespaced: this.namespaceFilter } });
+          this.$fetchType(POD);
         }
       }
     }

--- a/shell/mixins/resource-fetch-namespaced.js
+++ b/shell/mixins/resource-fetch-namespaced.js
@@ -62,6 +62,7 @@ export default {
      * Are there too many core list resources to show in the list?
      */
     __areResourcesTooMany() {
+      // __getCountForResources is defined on resource-fetch mixin...
       const count = this.__getCountForResources(this.loadResources);
 
       return count > this.perfConfig.forceNsFilter.threshold;

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -83,7 +83,7 @@ export default {
   methods: {
     // this defines all the flags needed for the mechanism
     // to work. They should be defined based on the main list view
-    // resource that is to be displayed. The sencondary resources
+    // resource that is to be displayed. The secondary resources
     // fetched should follow what was defined (if it is manual and/or incremental)
     $initializeFetchData(type, multipleResources = [], storeType) {
       if (!this.init) {

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -25,13 +25,9 @@ export default {
       perfConfig = DEFAULT_PERF_SETTING;
     }
 
-    const inStore = this.$store.getters['currentStore'](COUNT);
-
     return {
       perfConfig,
       init:                       false,
-      inStore,
-      counts:                     this.$store.getters[`${ inStore }/all`](COUNT)[0].counts,
       multipleResources:          [],
       loadResources:              [this.resource],
       // manual refresh vars
@@ -55,8 +51,8 @@ export default {
       // clear up the store to make sure we aren't storing anything that might interfere with the next rendered list view
       this.$store.dispatch('resource-fetch/clearData');
 
-      this.fetchedResourceType.forEach((type) => {
-        this.$store.dispatch(`${ this.inStore }/incrementLoadCounter`, type);
+      this.fetchedResourceType.forEach((item) => {
+        this.$store.dispatch(`${ item.currStore }/incrementLoadCounter`, item.type);
       });
     }
   },
@@ -64,7 +60,13 @@ export default {
   computed: {
     ...mapGetters({ refreshFlag: 'resource-fetch/refreshFlag' }),
     rows() {
-      return this.$store.getters[`${ this.inStore }/all`](this.resource);
+      const currResource = this.fetchedResourceType.find(item => item.type === this.resource);
+
+      if (currResource) {
+        return this.$store.getters[`${ currResource.currStore }/all`](this.resource);
+      } else {
+        return [];
+      }
     },
     loading() {
       return this.rows.length ? false : this.$fetchState.pending;
@@ -83,9 +85,11 @@ export default {
     // to work. They should be defined based on the main list view
     // resource that is to be displayed. The sencondary resources
     // fetched should follow what was defined (if it is manual and/or incremental)
-    $initializeFetchData(type, multipleResources = []) {
+    $initializeFetchData(type, multipleResources = [], storeType) {
       if (!this.init) {
-        this.__gatherResourceFetchData(type, multipleResources);
+        const currStore = storeType || this.$store.getters['currentStore']();
+
+        this.__gatherResourceFetchData(type, multipleResources, currStore);
 
         // make sure after init that, if we have a manual refresh, we always set the force = true
         if (!this.watch) {
@@ -98,39 +102,51 @@ export default {
       }
     },
     // data fetching for the mechanism
-    $fetchType(type, multipleResources = []) {
-      this.$initializeFetchData(type, multipleResources);
+    $fetchType(type, multipleResources = [], storeType) {
+      const currStore = storeType || this.$store.getters['currentStore']();
 
-      if (!this.fetchedResourceType.includes(type)) {
-        this.fetchedResourceType.push(type);
+      this.$initializeFetchData(type, multipleResources, currStore);
+
+      if (!this.fetchedResourceType.find(item => item.type === type)) {
+        this.fetchedResourceType.push({
+          type,
+          currStore
+        });
       }
 
       const opt = {
-        namespaced:       this.namespaceFilter,
         incremental:      this.incremental,
         watch:            this.watch,
         force:            this.force,
         hasManualRefresh: this.hasManualRefresh
       };
 
-      return this.$store.dispatch(`${ this.inStore }/findAll`, {
+      const schema = this.$store.getters['cluster/schemaFor'](type);
+
+      if (schema?.attributes?.namespaced) {
+        opt.namespaced = this.namespaceFilter;
+      }
+
+      return this.$store.dispatch(`${ currStore }/findAll`, {
         type,
         opt
       });
     },
 
-    __getCountForResources(resourceNames) {
-      return resourceNames.reduce((res, type) => res + this.__getCountForResource(type), 0);
+    __getCountForResources(resourceNames, namespace, storeType) {
+      const currStore = storeType || this.$store.getters['currentStore']();
+
+      return resourceNames.reduce((res, type) => res + this.__getCountForResource(type, namespace, currStore), 0);
     },
 
-    __getCountForResource(resourceName, namespace) {
-      const resourceCounts = this.counts[`${ resourceName }`];
-      const resourceCount = namespace ? resourceCounts?.namespaces[namespace]?.count : resourceCounts?.summary?.count;
+    __getCountForResource(resourceName, namespace, storeType) {
+      const resourceCounts = this.$store.getters[`${ storeType }/all`](COUNT)[0].counts[`${ resourceName }`];
+      const resourceCount = namespace && resourceCounts?.namespaces ? resourceCounts?.namespaces[namespace]?.count : resourceCounts?.summary?.count;
 
       return resourceCount || 0;
     },
 
-    __gatherResourceFetchData(resourceName, multipleResources) {
+    __gatherResourceFetchData(resourceName, multipleResources, currStore) {
       // flag to prevent a first data update being triggered from the requestData watcher
       this.init = true;
 
@@ -156,7 +172,7 @@ export default {
       // get resource counts
       const resourcesForCount = this.multipleResources.length ? this.multipleResources : [resourceName];
 
-      resourceCount = this.__getCountForResources(resourcesForCount);
+      resourceCount = this.__getCountForResources(resourcesForCount, this.namespaceFilter, currStore);
 
       // manual refresh check
       if (manualDataRefreshEnabled && resourceCount >= manualDataRefreshThreshold) {

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -79,7 +79,11 @@ export default {
     }
   },
   methods: {
-    $fetchType(type, multipleResources = []) {
+    // this defines all the flags needed for the mechanism
+    // to work. They should be defined based on the main list view
+    // resource that is to be displayed. The sencondary resources
+    // fetched should follow what was defined (if it is manual and/or incremental)
+    $initializeFetchData(type, multipleResources = []) {
       if (!this.init) {
         this.__gatherResourceFetchData(type, multipleResources);
 
@@ -92,20 +96,26 @@ export default {
           this.hasManualRefresh = true;
         }
       }
+    },
+    // data fetching for the mechanism
+    $fetchType(type, multipleResources = []) {
+      this.$initializeFetchData(type, multipleResources);
 
       if (!this.fetchedResourceType.includes(type)) {
         this.fetchedResourceType.push(type);
       }
 
+      const opt = {
+        namespaced:       this.namespaceFilter,
+        incremental:      this.incremental,
+        watch:            this.watch,
+        force:            this.force,
+        hasManualRefresh: this.hasManualRefresh
+      };
+
       return this.$store.dispatch(`${ this.inStore }/findAll`, {
         type,
-        opt: {
-          namespaced:       this.namespaceFilter,
-          incremental:      this.incremental,
-          watch:            this.watch,
-          force:            this.force,
-          hasManualRefresh: this.hasManualRefresh
-        }
+        opt
       });
     },
 
@@ -153,7 +163,7 @@ export default {
         watch = false;
         isTooManyItemsToAutoUpdate = true;
       }
-      // manual refresh check
+      // incremental loading check
       if (incrementalLoadingEnabled && incrementalLoadingThreshold > 0 && resourceCount >= incrementalLoadingThreshold) {
         incremental = Math.ceil(resourceCount / PAGES);
       }

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -83,6 +83,12 @@ export default {
 
     type = getters.normalizeType(type);
 
+    // if there's no registered type, then register it so
+    // that we don't have issues on 'loadAdd' mutation
+    if ( !getters.typeRegistered(type) ) {
+      commit('registerType', type);
+    }
+
     const loadCount = getters['loadCounter'](type);
 
     try {

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -366,11 +366,7 @@ export default {
     const keyField = getters.keyFieldForType(type);
 
     allLatest.forEach((entry) => {
-      let existing;
-
-      if (state.types && state.types[type]) {
-        existing = state.types[type].map.get(entry[keyField]);
-      }
+      const existing = state.types[type].map.get(entry[keyField]);
 
       load(state, {
         data: entry, ctx, existing

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -366,7 +366,11 @@ export default {
     const keyField = getters.keyFieldForType(type);
 
     allLatest.forEach((entry) => {
-      const existing = state.types[type].map.get(entry[keyField]);
+      let existing;
+
+      if (state.types && state.types[type]) {
+        existing = state.types[type].map.get(entry[keyField]);
+      }
 
       load(state, {
         data: entry, ctx, existing


### PR DESCRIPTION
Fixes #7580 

- Update `resource-fetch` logic to take into consideration the `storeType` for each individual request
- Update `resource-fetch` logic so that we can initialise the mixin data with the main resource (list view resource) before we start actual fetches
- Update all custom list views that load "secondary resources" so that they are manual refreshed if the list view main resource has manual refresh