### PR TITLE
Fix mismatching tab name when ssh'ing into a node

### DIFF
--- a/shell/models/cluster.x-k8s.io.machine.js
+++ b/shell/models/cluster.x-k8s.io.machine.js
@@ -98,10 +98,12 @@ export default class CapiMachine extends SteveModel {
     return false;
   }
 
-  openSsh() {
+  openSsh(name) {
+    const label = name || this.nameDisplay;
+
     this.$dispatch('wm/open', {
       id:        `${ this.id }-ssh`,
-      label:     this.nameDisplay,
+      label,
       icon:      'terminal',
       component: 'MachineSsh',
       attrs:     { machine: this, pod: {} }

--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -76,7 +76,8 @@ export default class ClusterNode extends SteveModel {
   }
 
   openSsh() {
-    this.provisionedMachine.openSsh();
+    // Pass in the name of the node, so we display that rather than the name of the provisioned machine
+    this.provisionedMachine.openSsh(this.nameDisplay);
   }
 
   downloadKeys() {


### PR DESCRIPTION
Fixes #7854 

Before this PR, when you SSH into a node, the tab name for the terminal does not match the node name (it is the machine name), for example:

 
![image](https://user-images.githubusercontent.com/1955897/212278107-6b626967-1b01-471b-974d-c118dd832dec.png)

This PR fixes this by passing the node name down to the function that opens the shell window. Now they match:

![image](https://user-images.githubusercontent.com/1955897/212278209-7b8ace76-212d-48ae-90bb-42f855b608bd.png)
