### PR TITLE
Fix storybook publish error

### DIFF
--- a/.github/workflows/scripts/publish-storybook
+++ b/.github/workflows/scripts/publish-storybook
@@ -8,7 +8,7 @@ if [ -z "${STORYBOOK_TOKEN}" ]; then
   exit 1
 fi
 
-if [ ! -d "${DIR}/storybook-static" ]; then
+if [ ! -d "storybook-static" ]; then
   echo "Storybook has not been built"
   exit 1
 fi


### PR DESCRIPTION
The Storybook publish task is broken at the moment - it references the `DIR` env var which is not set, so it thinks that the Storybook has not been built.

This PR fixes this - the script runs in the top-level folder by default, so we can just remove the `DIR` env var.