### PR TITLE
Feature/7875 workload edit warning

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2197,6 +2197,9 @@ growl:
   reconnected:
     message: "The connection to {url} was restored on attempt #{tries}."
     title: Websocket Reconnected
+  podSecurity:
+    message: "The creation of this Pod would violate existing restricted policies for the adopted Namespace"
+    title: PodSecurity violation
 
 hpa:
   detail:

--- a/shell/models/pod.js
+++ b/shell/models/pod.js
@@ -181,6 +181,20 @@ export default class Pod extends WorkloadService {
     return 0;
   }
 
+  processSaveResponse(res) {
+    if (res._headers && res._headers.warning) {
+      const warnings = res._headers.warning.split('299') || [];
+      const hasPsaWarnings = warnings.filter(warning => warning.includes('violate PodSecurity')).length;
+
+      if (hasPsaWarnings) {
+        this.$dispatch('growl/warning', {
+          title:   this.$rootGetters['i18n/t']('growl.podSecurity.title'),
+          message: this.$rootGetters['i18n/t']('growl.podSecurity.message'),
+        }, { root: true });
+      }
+    }
+  }
+
   save() {
     const prev = { ...this };
 

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1075,6 +1075,12 @@ export default class Resource {
     return this._save(...arguments);
   }
 
+  /**
+   * Allow to handle the response of the save request
+   * @param {*} res Full request response
+   */
+  processSaveResponse(res) { }
+
   async _save(opt = {}) {
     delete this.__rehydrate;
     delete this.__clone;
@@ -1150,6 +1156,9 @@ export default class Resource {
 
     try {
       const res = await this.$dispatch('request', { opt, type: this.type } );
+
+      // Allow to process response independently from the related models
+      this.processSaveResponse(res);
 
       // Steve sometimes returns Table responses instead of the resource you just saved.. ignore
       if ( res && res.kind !== 'Table') {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7875
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Added warning growl on PodSecurity violations with `warn:restricted`

### Technical notes summary
- Extended resource model with empty method `processSaveResponse()` to expose the response of the resource requests and allow manipulation; this has been discussed already with @nwmac FYI and peace of mind
- Integrated logic for method `processSaveResponse()`, allowing to parse header warnings and trigger growl if any

### Areas or cases that should be tested
Pod creation with Namespace using PSA.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/212361757-aa0517ab-246e-44ae-9e19-df54f1c20644.mov

https://user-images.githubusercontent.com/5009481/212361785-bcc65cc3-84b0-497e-a39d-ae3853df3bdb.mov
