### PR TITLE
Availability zones are in order

### DIFF
--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -363,7 +363,9 @@ export default {
       });
 
       if (data.length > 0) {
-        return data[0].AvailabilityZones;
+        return data[0].AvailabilityZones.sort((a, b) => {
+          return a - b;
+        });
       }
 
       return [];


### PR DESCRIPTION
This PR addresses the RKE2 portion of https://github.com/rancher/dashboard/issues/7877

The AZs should always be in order now:

<img width="1250" alt="Screenshot 2023-01-13 at 2 41 14 PM" src="https://user-images.githubusercontent.com/20599230/212424668-d38b56fe-1d5d-40fc-8d12-8a102546fe3d.png">
