### PR TITLE
Show VMs that support AN first

### DIFF
--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -313,11 +313,10 @@ export default {
       // }
 
       const out = [
-        { kind: 'group', label: this.t('cluster.machineConfig.azure.size.doesNotSupportAcceleratedNetworking') },
-        ...this.vmsWithoutAcceleratedNetworking,
         { kind: 'group', label: this.t('cluster.machineConfig.azure.size.supportsAcceleratedNetworking') },
         ...this.vmsWithAcceleratedNetworking,
-
+        { kind: 'group', label: this.t('cluster.machineConfig.azure.size.doesNotSupportAcceleratedNetworking') },
+        ...this.vmsWithoutAcceleratedNetworking,
       ];
 
       if (!this.selectedVmSizeExistsInSelectedRegion) {


### PR DESCRIPTION
This PR addresses the RKE2 portion of this issue https://github.com/rancher/dashboard/issues/7878

The VMs that do support AN now appear first in the dropdown:

<img width="490" alt="Screenshot 2023-01-13 at 2 52 17 PM" src="https://user-images.githubusercontent.com/20599230/212425916-7ca7fc7c-3657-42ec-8b6d-f13bbbc18399.png">
