### PR TITLE
Allow more retries to finish project creation

### DIFF
--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -99,18 +99,36 @@ export default class Project extends HybridModel {
     // and the PUT request should have a query param _replace=true.
     const newValue = await norman.save({ replace: forceReplaceOnReq });
 
-    try {
-      await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
-    } catch (err) {
-      if ( err.status === 409 || err.status === 403 ) {
-        // The backend updates each new project soon after it is created,
-        // so there is a chance of a resource conflict or forbidden error. If that happens,
-        // retry the action.
+    let retryCount = 0;
+
+    const finishProjectCreation = async() => {
+      try {
         await newValue.doAction('setpodsecuritypolicytemplate', { podSecurityPolicyTemplateId: this.spec.podSecurityPolicyTemplateId || null });
-      } else {
-        throw err;
+      } catch (err) {
+        if ( err.status === 409 || err.status === 403 ) {
+          // The backend updates each new project soon after it is created,
+          // so there is a chance of a 409 resource conflict or forbidden error. If that happens,
+          // retry the action.
+
+          // The 403 permission error can happen due to the user requesting
+          // the project before the project is fully created and the project
+          // permissions are assigned to the user so we allow some
+          // time for that process to complete.
+
+          if (retryCount < 3) {
+            retryCount++;
+            await setTimeout(() => {
+              // Delay for three seconds to avoid another failure due to latency.
+              finishProjectCreation();
+            }, '3000');
+          } else {
+            throw err;
+          }
+        }
       }
-    }
+    };
+
+    await finishProjectCreation();
 
     return newValue;
   }


### PR DESCRIPTION
This PR addresses this reopened issue https://github.com/rancher/dashboard/issues/6464#issuecomment-1378002783

The issue is only intermittently reproducible, and I believe the reason is that it depends on how many users and rolebindings are in your setup. With more users and rolebindings, it takes more time for a user to get permission to see a new project that they just created. So I was able to repro the issue more easily in Anu's setup than in my own setup.

To test this PR, I confirmed that project creation was successful even after it had to retry. I believe that the reason it didn't work before this PR was that it was failing after trying twice and needed to keep trying.
<img width="694" alt="Screenshot 2023-01-13 at 5 44 47 PM" src="https://user-images.githubusercontent.com/20599230/212442442-f8a52e92-5c64-4898-a7ba-c7bf0656e687.png">

