### PR TITLE
In RKE2 cluster edit form, avoid showing YAML in form mode

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -619,7 +619,7 @@ export default {
       </template>
       <!------ YAML ------>
       <section
-        v-else
+        v-else-if="showYaml"
         class="cru-resource-yaml-container resource-container cru__content"
       >
         <ResourceYaml


### PR DESCRIPTION
This PR addresses this bug https://github.com/rancher/dashboard/issues/7876 by only rendering the `ResourceYaml` component if `showYaml` is true.

I followed these steps both to reproduce the bug and to test that it was fixed:

1. Went to list of clusters in Cluster Management
2. Clicked Create
3. Clicked Azure
4. Clicked Edit as YAML
5. Changed `spec.rkeConfig.etcd.snapshotRetention` from 5 to 6
6. Clicked Back to Form
7. Clicked OK

Confirmed that this error is no longer seen:
<img width="1400" alt="Screenshot 2023-01-13 at 5 59 07 PM" src="https://user-images.githubusercontent.com/20599230/212500344-b84662c1-f16d-4588-96fb-4066aae21b02.png">
