### PR TITLE
Added scale down promt confirmation on RKE clusters

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3973,7 +3973,7 @@ prefs:
     label: Helm Charts
   confirmationSetting:
     title: Confirmation Setting
-    scalingDownPrompt: Enable confirmation prompt for scaling down node pool.
+    scalingDownPrompt: Do not ask for confirmation when scaling down node pools.
 
 principal:
   loading: Loading&hellip;

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -501,22 +501,21 @@ export default {
   },
 
   methods: {
-    toggleScaleDownModal( event, resources = this ) {
+    toggleScaleDownModal( event, resources ) {
       // Check if the user held alt key when an action is clicked.
       const alt = isAlternate(event);
       const showScalePoolPrompt = this.$store.getters['prefs/get'](SCALE_POOL_PROMPT);
-      console.log(resources);
 
       // Prompt if showScalePoolPrompt pref not store and user did not held alt key
       if (!alt && !showScalePoolPrompt) {
         this.$store.dispatch('management/promptModal', {
           component:  'ScalePoolDownDialog',
-          resources: resources.allMachineDeployments[0],
+          resources,
           modalWidth: '450px'
         });
       } else {
         // User held alt key, so don't prompt
-        resources.allMachineDeployments[0].scalePool(-1);
+        resources.scalePool(-1);
       }
     },
 
@@ -713,7 +712,7 @@ export default {
                     :disabled="!group.ref.canScaleDownPool()"
                     type="button"
                     class="btn btn-sm role-secondary"
-                    @click="toggleScaleDownModal($event)"
+                    @click="toggleScaleDownModal($event, group.ref)"
                   >
                     <i class="icon icon-sm icon-minus" />
                   </button>
@@ -797,7 +796,7 @@ export default {
                     :disabled="group.ref.spec.quantity < 2"
                     type="button"
                     class="btn btn-sm role-secondary"
-                    @click="group.ref.toggleScaleDownModal($event)"
+                    @click="toggleScaleDownModal($event, group.ref)"
                   >
                     <i class="icon icon-sm icon-minus" />
                   </button>

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -777,7 +777,7 @@ export default {
                     :disabled="group.ref.spec.quantity < 2"
                     type="button"
                     class="btn btn-sm role-secondary"
-                    @click="group.ref.scalePool(-1)"
+                    @click="group.ref.toggleScaleDownModal($event)"
                   >
                     <i class="icon icon-sm icon-minus" />
                   </button>

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -17,7 +17,7 @@ import AnsiUp from 'ansi_up';
 import day from 'dayjs';
 import { addParams } from '@shell/utils/url';
 import { base64Decode } from '@shell/utils/crypto';
-import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
+import { DATE_FORMAT, TIME_FORMAT, SCALE_POOL_PROMPT } from '@shell/store/prefs';
 import { escapeHtml } from '@shell/utils/string';
 import MachineSummaryGraph from '@shell/components/formatter/MachineSummaryGraph';
 import Socket, {
@@ -29,6 +29,7 @@ import Socket, {
 } from '@shell/utils/socket';
 import { get } from '@shell/utils/object';
 import CapiMachineDeployment from '@shell/models/cluster.x-k8s.io.machinedeployment';
+import { isAlternate } from '@shell/utils/platform';
 
 let lastId = 1;
 const ansiup = new AnsiUp();
@@ -500,6 +501,25 @@ export default {
   },
 
   methods: {
+    toggleScaleDownModal( event, resources = this ) {
+      // Check if the user held alt key when an action is clicked.
+      const alt = isAlternate(event);
+      const showScalePoolPrompt = this.$store.getters['prefs/get'](SCALE_POOL_PROMPT);
+      console.log(resources);
+
+      // Prompt if showScalePoolPrompt pref not store and user did not held alt key
+      if (!alt && !showScalePoolPrompt) {
+        this.$store.dispatch('management/promptModal', {
+          component:  'ScalePoolDownDialog',
+          resources: resources.allMachineDeployments[0],
+          modalWidth: '450px'
+        });
+      } else {
+        // User held alt key, so don't prompt
+        resources.allMachineDeployments[0].scalePool(-1);
+      }
+    },
+
     async takeSnapshot(btnCb) {
       try {
         await this.value.takeSnapshot();
@@ -693,7 +713,7 @@ export default {
                     :disabled="!group.ref.canScaleDownPool()"
                     type="button"
                     class="btn btn-sm role-secondary"
-                    @click="group.ref.toggleScaleDownModal($event)"
+                    @click="toggleScaleDownModal($event)"
                   >
                     <i class="icon icon-sm icon-minus" />
                   </button>

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -38,7 +38,7 @@ export default {
 
     // Check for showScalePoolPrompt pref
     // If it is not set, set it to true and update promt checkbox
-    if ( showScalePoolPrompt === '' ) {
+    if ( showScalePoolPrompt === null ) {
       this.promptConfirmation = true;
       this.$store.dispatch('prefs/set', { key: SCALE_POOL_PROMPT, value: true });
     } else {

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -6,8 +6,6 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
 import { MACHINE_ROLES } from '@shell/config/labels-annotations';
 import { notOnlyOfRole } from '@shell/models/cluster.x-k8s.io.machine';
-// import { isAlternate } from '@shell/utils/platform';
-// import { SCALE_POOL_PROMPT } from '@shell/store/prefs';
 
 export default class CapiMachineDeployment extends SteveModel {
   get cluster() {
@@ -102,32 +100,9 @@ export default class CapiMachineDeployment extends SteveModel {
     return machinePools.find(pool => pool.machineConfigRef.name === machineConfigName);
   }
 
-  // toggleScaleDownModal( event, resources = this ) {
-  //   // Check if the user held alt key when an action is clicked.
-  //   const alt = isAlternate(event);
-  //   const showScalePoolPrompt = this.$rootGetters['prefs/get'](SCALE_POOL_PROMPT);
-
-  //   // Prompt if showScalePoolPrompt pref not store and user did not held alt key
-  //   if (!alt && !showScalePoolPrompt) {
-  //     this.$dispatch('promptModal', {
-  //       component:  'ScalePoolDownDialog',
-  //       resources,
-  //       modalWidth: '450px'
-  //     });
-  //   } else {
-  //     // User held alt key, so don't prompt
-  //     this.scalePool(-1);
-  //   }
-  // }
-
   scalePool(delta, save = true, depth = 0) {
     // This is used in different places with different scaling rules, so don't check if we can/cannot scale
     if (!this.inClusterSpec) {
-      return;
-    }
-    if ( delta === -1) {
-      console.log('-1');
-
       return;
     }
 

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -126,6 +126,12 @@ export default class CapiMachineDeployment extends SteveModel {
       return;
     }
 
+    if (delta === -1) {
+      console.log('-1');
+
+      return;
+    }
+
     const initialValue = this.cluster.toJSON();
 
     this.inClusterSpec.quantity += delta;

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -6,8 +6,8 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
 import { MACHINE_ROLES } from '@shell/config/labels-annotations';
 import { notOnlyOfRole } from '@shell/models/cluster.x-k8s.io.machine';
-import { isAlternate } from '@shell/utils/platform';
-import { SCALE_POOL_PROMPT } from '@shell/store/prefs';
+// import { isAlternate } from '@shell/utils/platform';
+// import { SCALE_POOL_PROMPT } from '@shell/store/prefs';
 
 export default class CapiMachineDeployment extends SteveModel {
   get cluster() {
@@ -102,27 +102,32 @@ export default class CapiMachineDeployment extends SteveModel {
     return machinePools.find(pool => pool.machineConfigRef.name === machineConfigName);
   }
 
-  toggleScaleDownModal( event, resources = this ) {
-    // Check if the user held alt key when an action is clicked.
-    const alt = isAlternate(event);
-    const showScalePoolPrompt = this.$rootGetters['prefs/get'](SCALE_POOL_PROMPT);
+  // toggleScaleDownModal( event, resources = this ) {
+  //   // Check if the user held alt key when an action is clicked.
+  //   const alt = isAlternate(event);
+  //   const showScalePoolPrompt = this.$rootGetters['prefs/get'](SCALE_POOL_PROMPT);
 
-    // Prompt if showScalePoolPrompt pref not store and user did not held alt key
-    if (!alt && !showScalePoolPrompt) {
-      this.$dispatch('promptModal', {
-        component:  'ScalePoolDownDialog',
-        resources,
-        modalWidth: '450px'
-      });
-    } else {
-      // User held alt key, so don't prompt
-      this.scalePool(-1);
-    }
-  }
+  //   // Prompt if showScalePoolPrompt pref not store and user did not held alt key
+  //   if (!alt && !showScalePoolPrompt) {
+  //     this.$dispatch('promptModal', {
+  //       component:  'ScalePoolDownDialog',
+  //       resources,
+  //       modalWidth: '450px'
+  //     });
+  //   } else {
+  //     // User held alt key, so don't prompt
+  //     this.scalePool(-1);
+  //   }
+  // }
 
   scalePool(delta, save = true, depth = 0) {
     // This is used in different places with different scaling rules, so don't check if we can/cannot scale
     if (!this.inClusterSpec) {
+      return;
+    }
+    if ( delta === -1) {
+      console.log('-1');
+
       return;
     }
 

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -126,12 +126,6 @@ export default class CapiMachineDeployment extends SteveModel {
       return;
     }
 
-    if (delta === -1) {
-      console.log('-1');
-
-      return;
-    }
-
     const initialValue = this.cluster.toJSON();
 
     this.inClusterSpec.quantity += delta;

--- a/shell/models/management.cattle.io.nodepool.js
+++ b/shell/models/management.cattle.io.nodepool.js
@@ -1,6 +1,8 @@
 import { CAPI, MANAGEMENT, NORMAN } from '@shell/config/types';
 import { sortBy } from '@shell/utils/sort';
 import HybridModel from '@shell/plugins/steve/hybrid-class';
+import { isAlternate } from '@shell/utils/platform';
+import { SCALE_POOL_PROMPT } from '@shell/store/prefs';
 
 export default class MgmtNodePool extends HybridModel {
   get nodeTemplate() {
@@ -47,6 +49,24 @@ export default class MgmtNodePool extends HybridModel {
 
   get scale() {
     return this.norman.quantity;
+  }
+
+  toggleScaleDownModal( event, resources = this ) {
+    // Check if the user held alt key when an action is clicked.
+    const alt = isAlternate(event);
+    const showScalePoolPrompt = this.$rootGetters['prefs/get'](SCALE_POOL_PROMPT);
+
+    // Prompt if showScalePoolPrompt pref not store and user did not held alt key
+    if (!alt && !showScalePoolPrompt) {
+      this.$dispatch('promptModal', {
+        component:  'ScalePoolDownDialog',
+        resources,
+        modalWidth: '450px'
+      });
+    } else {
+      // User held alt key, so don't prompt
+      this.scalePool(-1);
+    }
   }
 
   scalePool(delta) {

--- a/shell/models/management.cattle.io.nodepool.js
+++ b/shell/models/management.cattle.io.nodepool.js
@@ -1,8 +1,6 @@
 import { CAPI, MANAGEMENT, NORMAN } from '@shell/config/types';
 import { sortBy } from '@shell/utils/sort';
 import HybridModel from '@shell/plugins/steve/hybrid-class';
-import { isAlternate } from '@shell/utils/platform';
-import { SCALE_POOL_PROMPT } from '@shell/store/prefs';
 
 export default class MgmtNodePool extends HybridModel {
   get nodeTemplate() {
@@ -49,24 +47,6 @@ export default class MgmtNodePool extends HybridModel {
 
   get scale() {
     return this.norman.quantity;
-  }
-
-  toggleScaleDownModal( event, resources = this ) {
-    // Check if the user held alt key when an action is clicked.
-    const alt = isAlternate(event);
-    const showScalePoolPrompt = this.$rootGetters['prefs/get'](SCALE_POOL_PROMPT);
-
-    // Prompt if showScalePoolPrompt pref not store and user did not held alt key
-    if (!alt && !showScalePoolPrompt) {
-      this.$dispatch('promptModal', {
-        component:  'ScalePoolDownDialog',
-        resources,
-        modalWidth: '450px'
-      });
-    } else {
-      // User held alt key, so don't prompt
-      this.scalePool(-1);
-    }
   }
 
   scalePool(delta) {

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -121,7 +121,7 @@ export const PSP_DEPRECATION_BANNER = create('hide-psp-deprecation-banner', fals
 export const MENU_MAX_CLUSTERS = create('menu-max-clusters', 4, { options: [2, 3, 4, 5, 6, 7, 8, 9, 10], parseJSON });
 
 // Prompt for confirm when scaling down node pool in GUI and save the pref
-export const SCALE_POOL_PROMPT = create('scale-pool-prompt', '', { parseJSON });
+export const SCALE_POOL_PROMPT = create('scale-pool-prompt', null, { parseJSON });
 // --------------------
 
 const cookiePrefix = 'R_';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6961

<!-- Define findings related to the feature or bug issue. -->
- Added confirmation prompt displayed to the user to prevent accidental deletion of nodes - RKE clusters.
- Set the initial state of prompt confirmation from `empty string` to `null` so the pref page will show an unchecked checkbox for prompt confirmation setting,

#### Some below-mentioned issues fixed:
- The code only works for RKE2 clusters and not RKE clusters - you need to wire the confirmation into management.cattle.io.nodepool as well - **Fixed**
- The preference does not work correctly - I think it would be better to change the meaning from Show to Don't show - i.e the preference would be "Don't ask for confirmation when scaling down node pools" - I think the problem is due to the preference defaulting to empty string. Currently, on a fresh system where the preference is new, if you go to preferences, the pref shows checked - if you uncheck it, you will still be asked for confirmation. Alternatively, you can try defaulting it to true rather than an empty string. - **Change the string in `Pref page` and change the default state of `SCALE_POOL_PROMPT` in pref.js from an `empty string` to `null`**

### How to test
- Create an RKE cluster 
- Navigate to the nodes page and click on the minus ("-") button next to a node pool, for the first time it should show a confirmation prompt for node deletion.
- User can change prompt confirmation setting from the `User Pref` page.
 