### PR TITLE
Feature/6633 min password again

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5362,6 +5362,8 @@ validation:
   noType: No type to validate
   number:
     requiredInt: '"{key}" must be integer'
+    isPositive: '"{key}" must be positive'
+    isOctal: '"{key}" must have no leading zeros'
     between: '"{key}" should be between {min} and {max}'
     exactly: '"{key}" should be exactly {val}'
     max: '"{key}" should be at most {val}'

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -56,7 +56,7 @@ export const SETTING = {
   AUTH_USER_SESSION_TTL_MINUTES:        'auth-user-session-ttl-minutes',
   AUTH_USER_INFO_RESYNC_CRON:           'auth-user-info-resync-cron',
   AUTH_LOCAL_VALIDATE_DESC:             'auth-password-requirements-description',
-  CATTLE_PASSWORD_MIN_LENGTH:           'password-min-length',
+  PASSWORD_MIN_LENGTH:                  'password-min-length', // CATTLE_PASSWORD_MIN_LENGTH
   CLUSTER_TEMPLATE_ENFORCEMENT:         'cluster-template-enforcement',
   UI_INDEX:                             'ui-index',
   UI_DASHBOARD_INDEX:                   'ui-dashboard-index',
@@ -88,10 +88,10 @@ export const SETTING = {
 
 // These are the settings that are allowed to be edited via the UI
 export const ALLOWED_SETTINGS: GlobalSetting = {
-  [SETTING.CA_CERTS]:                   { kind: 'multiline', readOnly: true },
-  [SETTING.ENGINE_URL]:                 {},
-  [SETTING.ENGINE_ISO_URL]:             {},
-  [SETTING.CATTLE_PASSWORD_MIN_LENGTH]: {
+  [SETTING.CA_CERTS]:            { kind: 'multiline', readOnly: true },
+  [SETTING.ENGINE_URL]:          {},
+  [SETTING.ENGINE_ISO_URL]:      {},
+  [SETTING.PASSWORD_MIN_LENGTH]: {
     kind:    'integer',
     ruleSet: [
       {

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -98,6 +98,10 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
         name: 'betweenValues',
         key:  'Password',
         arg:  [2, 256]
+      },
+      {
+        name: 'isInteger',
+        key:  'Password',
       }
     ],
   },

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -4,7 +4,7 @@ import { GC_DEFAULTS } from '../utils/gc/gc-types';
 interface GlobalSettingRuleset {
   name: string,
   key?: string | number,
-  arg?: string | number | (string | number)[]
+  factoryArg?: string | number | (string | number)[]
 }
 
 interface GlobalSetting {
@@ -95,9 +95,9 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
     kind:    'integer',
     ruleSet: [
       {
-        name: 'betweenValues',
-        key:  'Password',
-        arg:  [2, 256]
+        name:       'betweenValues',
+        key:        'Password',
+        factoryArg: [2, 256]
       },
       {
         name: 'isInteger',

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -102,6 +102,14 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
       {
         name: 'isInteger',
         key:  'Password',
+      },
+      {
+        name: 'isPositive',
+        key:  'Password',
+      },
+      {
+        name: 'isOctal',
+        key:  'Password',
       }
     ],
   },

--- a/shell/edit/__tests__/management.cattle.io.setting.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.setting.test.ts
@@ -65,7 +65,7 @@ describe('management.cattle.io.setting should', () => {
       });
       const expectation = [{
         path:  'value',
-        rules: ['betweenValues', 'isInteger']
+        rules: ['betweenValues', 'isInteger', 'isPositive', 'isOctal']
       }];
 
       expect(wrapper.vm.$data['fvFormRuleSets']).toStrictEqual(expectation);
@@ -76,7 +76,7 @@ describe('management.cattle.io.setting should', () => {
         propsData: { value: { id, value: '' } },
         ...requiredSetup()
       });
-      const expectation = ['betweenValues', 'isInteger'];
+      const expectation = ['betweenValues', 'isInteger', 'isPositive', 'isOctal'];
 
       // Avoid integration tests with mixin as it returns the whole function
       const rules = Object.keys((wrapper.vm as any)['fvExtraRules']);

--- a/shell/edit/__tests__/management.cattle.io.setting.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.setting.test.ts
@@ -32,7 +32,7 @@ describe('management.cattle.io.setting should', () => {
   });
 
   describe('using predefined generic rule', () => {
-    const id = SETTING.CATTLE_PASSWORD_MIN_LENGTH;
+    const id = SETTING.PASSWORD_MIN_LENGTH;
 
     describe('validate input with provided settings', () => {
       it('allowing to save if pass', () => {

--- a/shell/edit/__tests__/management.cattle.io.setting.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.setting.test.ts
@@ -65,7 +65,7 @@ describe('management.cattle.io.setting should', () => {
       });
       const expectation = [{
         path:  'value',
-        rules: ['betweenValues']
+        rules: ['betweenValues', 'isInteger']
       }];
 
       expect(wrapper.vm.$data['fvFormRuleSets']).toStrictEqual(expectation);
@@ -76,7 +76,7 @@ describe('management.cattle.io.setting should', () => {
         propsData: { value: { id, value: '' } },
         ...requiredSetup()
       });
-      const expectation = ['betweenValues'];
+      const expectation = ['betweenValues', 'isInteger'];
 
       // Avoid integration tests with mixin as it returns the whole function
       const rules = Object.keys((wrapper.vm as any)['fvExtraRules']);

--- a/shell/edit/management.cattle.io.setting.vue
+++ b/shell/edit/management.cattle.io.setting.vue
@@ -57,8 +57,13 @@ export default {
       // We map the setting rulesets to use values to define validation from factory
       return this.setting?.ruleSet ? mapValues(
         keyBy(this.setting.ruleSet, 'name'),
+        // arg is present only in case of ValidatorFactory
         ({ key, name, arg }) => {
-          return formRulesGenerator(t, key ? { key } : {})[name](arg);
+          // eslint-disable-next-line multiline-ternary
+          return arg
+            // eslint-disable-next-line multiline-ternary
+            ? formRulesGenerator(t, key ? { key } : {})[name](arg) // ValidatorFactory
+            : formRulesGenerator(t, key ? { key } : {})[name]; // Validator
         }) : {};
     }
   },

--- a/shell/edit/management.cattle.io.setting.vue
+++ b/shell/edit/management.cattle.io.setting.vue
@@ -57,13 +57,11 @@ export default {
       // We map the setting rulesets to use values to define validation from factory
       return this.setting?.ruleSet ? mapValues(
         keyBy(this.setting.ruleSet, 'name'),
-        // arg is present only in case of ValidatorFactory
-        ({ key, name, arg }) => {
-          // eslint-disable-next-line multiline-ternary
-          return arg
-            // eslint-disable-next-line multiline-ternary
-            ? formRulesGenerator(t, key ? { key } : {})[name](arg) // ValidatorFactory
-            : formRulesGenerator(t, key ? { key } : {})[name]; // Validator
+        // The validation is curried and may require the factory argument for the ValidatorFactory
+        ({ key, name, factoryArg }) => {
+          const rule = formRulesGenerator(t, key ? { key } : {})[name];
+
+          return factoryArg ? rule(factoryArg) : rule;
         }) : {};
     }
   },

--- a/shell/models/management.cattle.io.setting.js
+++ b/shell/models/management.cattle.io.setting.js
@@ -12,7 +12,7 @@ export default class Setting extends HybridModel {
     let out = super._availableActions;
 
     // Some settings are not editable
-    if ( settingMetadata?.readOnly || this.fromEnv ) {
+    if ( settingMetadata?.readOnly ) {
       toFilter.push('goToEdit');
     }
 

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -1058,6 +1058,9 @@ describe('formRules', () => {
   describe.each([
     ['requiredInt', [2, 2.2], ['e']],
     ['isInteger', ['2', 2], [2.2, 'e']],
+    ['isPositive', ['0', 1], [-1]],
+    ['isOctal', ['0', 0], ['01']],
+
   ])('given validator %p', (rule, correctValues, wrongValues) => {
     it.each(wrongValues as [])('should return error for value %p', (wrong) => {
       const formRuleResult = (formRules as any)[rule](wrong);

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -1059,7 +1059,7 @@ describe('formRules', () => {
     ['requiredInt', [2, 2.2], ['e']],
     ['isInteger', ['2', 2], [2.2, 'e']],
     ['isPositive', ['0', 1], [-1]],
-    ['isOctal', ['0', 0], ['01']],
+    ['isOctal', ['0', 0, 10], ['01']],
 
   ])('given validator %p', (rule, correctValues, wrongValues) => {
     it.each(wrongValues as [])('should return error for value %p', (wrong) => {

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -1041,15 +1041,32 @@ describe('formRules', () => {
     ['minLength', 2, ['test'], ['x']],
     ['maxLength', 10, ['x'], ['wrong value']],
     ['betweenLengths', [2, 10], ['test'], ['x', 'wrong value']],
-  ])('%p with parameter %p should', (rule, argument, correctValues, wrongValues) => {
-    it.each(wrongValues as [])('return error for value %p', (wrong) => {
+  ])('given factory validator %p with parameter %p', (rule, argument, correctValues, wrongValues) => {
+    it.each(wrongValues as [])('should return error for value %p', (wrong) => {
       const formRuleResult = (formRules as any)[rule](argument)(wrong);
 
       expect(formRuleResult).not.toBeUndefined();
     });
 
-    it.each(correctValues as [])('return valid for value %p', (correct) => {
+    it.each(correctValues as [])('should return valid for value %p', (correct) => {
       const formRuleResult = (formRules as any)[rule](argument)(correct);
+
+      expect(formRuleResult).toBeUndefined();
+    });
+  });
+
+  describe.each([
+    ['requiredInt', [2, 2.2], ['e']],
+    ['isInteger', [2], [2.2, 'e']],
+  ])('given validator %p', (rule, correctValues, wrongValues) => {
+    it.each(wrongValues as [])('should return error for value %p', (wrong) => {
+      const formRuleResult = (formRules as any)[rule](wrong);
+
+      expect(formRuleResult).not.toBeUndefined();
+    });
+
+    it.each(correctValues as [])('should return valid for value %p', (correct) => {
+      const formRuleResult = (formRules as any)[rule](correct);
 
       expect(formRuleResult).toBeUndefined();
     });

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -1057,7 +1057,7 @@ describe('formRules', () => {
 
   describe.each([
     ['requiredInt', [2, 2.2], ['e']],
-    ['isInteger', [2], [2.2, 'e']],
+    ['isInteger', ['2', 2], [2.2, 'e']],
   ])('given validator %p', (rule, correctValues, wrongValues) => {
     it.each(wrongValues as [])('should return error for value %p', (wrong) => {
       const formRuleResult = (formRules as any)[rule](wrong);

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -83,6 +83,8 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions) {
 
   const requiredInt: Validator = (val: string) => isNaN(parseInt(val, 10)) ? t('validation.number.requiredInt', { key }) : undefined;
 
+  const isInteger: Validator = (val: string) => !Number.isInteger(val) ? t('validation.number.requiredInt', { key }) : undefined;
+
   const portNumber: Validator = (val: string) => parseInt(val, 10) < 1 || parseInt(val, 10) > 65535 ? t('validation.number.between', {
     key, min: '1', max: '65535'
   }) : undefined;
@@ -470,6 +472,7 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions) {
     portNumber,
     required,
     requiredInt,
+    isInteger,
     roleTemplateRules,
     ruleGroups,
     servicePort,

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -83,7 +83,7 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions) {
 
   const requiredInt: Validator = (val: string) => isNaN(parseInt(val, 10)) ? t('validation.number.requiredInt', { key }) : undefined;
 
-  const isInteger: Validator = (val: string) => !Number.isInteger(val) ? t('validation.number.requiredInt', { key }) : undefined;
+  const isInteger: Validator = (val: string) => !Number.isInteger(+val) ? t('validation.number.requiredInt', { key }) : undefined;
 
   const portNumber: Validator = (val: string) => parseInt(val, 10) < 1 || parseInt(val, 10) > 65535 ? t('validation.number.between', {
     key, min: '1', max: '65535'

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -83,7 +83,14 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions) {
 
   const requiredInt: Validator = (val: string) => isNaN(parseInt(val, 10)) ? t('validation.number.requiredInt', { key }) : undefined;
 
-  const isInteger: Validator = (val: string) => !Number.isInteger(+val) ? t('validation.number.requiredInt', { key }) : undefined;
+  const isInteger: Validator = (val: string | number) => !Number.isInteger(+val) ? t('validation.number.requiredInt', { key }) : undefined;
+  const isPositive: Validator = (val: string | number) => +val < 0 ? t('validation.number.isPositive', { key }) : undefined;
+  const isOctal: Validator = (val: string | number) => {
+    const valueString = `${ val }`;
+    const singleDigit = valueString.length !== 1 || (valueString.length > 1 && valueString[0] === '0');
+
+    return singleDigit ? t('validation.number.isOctal', { key }) : undefined;
+  };
 
   const portNumber: Validator = (val: string) => parseInt(val, 10) < 1 || parseInt(val, 10) > 65535 ? t('validation.number.between', {
     key, min: '1', max: '65535'
@@ -473,6 +480,8 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions) {
     required,
     requiredInt,
     isInteger,
+    isPositive,
+    isOctal,
     roleTemplateRules,
     ruleGroups,
     servicePort,

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -84,12 +84,14 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions) {
   const requiredInt: Validator = (val: string) => isNaN(parseInt(val, 10)) ? t('validation.number.requiredInt', { key }) : undefined;
 
   const isInteger: Validator = (val: string | number) => !Number.isInteger(+val) ? t('validation.number.requiredInt', { key }) : undefined;
+
   const isPositive: Validator = (val: string | number) => +val < 0 ? t('validation.number.isPositive', { key }) : undefined;
+
   const isOctal: Validator = (val: string | number) => {
     const valueString = `${ val }`;
-    const singleDigit = valueString.length !== 1 || (valueString.length > 1 && valueString[0] === '0');
+    const isValid = valueString.match(/(^0+)(.+)/);
 
-    return singleDigit ? t('validation.number.isOctal', { key }) : undefined;
+    return isValid ? t('validation.number.isOctal', { key }) : undefined;
   };
 
   const portNumber: Validator = (val: string) => parseInt(val, 10) < 1 || parseInt(val, 10) > 65535 ? t('validation.number.between', {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6633

This is the third PR we have for this issue ([1](https://github.com/rancher/dashboard/pull/6801), [2](https://github.com/rancher/dashboard/pull/6897)). In this case we are adding to the validation to the password to be an integer or string parsed to integer as value ([QA comment](https://github.com/rancher/dashboard/issues/6633#issuecomment-1318936432)).

### Occurred changes and/or fixed issues
- Added validation for integers exclusively for min-password changes

### Technical notes summary
- Changed setting key `CATTLE_PASSWORD_MIN_LENGTH` to `PASSWORD_MIN_LENGTH`, to match server returned value
- Allowed editing settings from environment variables; this is due server configuration have been changed for this case
- Added validation functions to settings configuration
- Added validation tests for validation utils
- Extended settings configuration with new rule

### Areas or cases that should be tested
Validation of min password in global settings `/c/local/settings/management.cattle.io.setting`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/212734222-cd1bd884-38ea-44fb-9267-acbdb13b8880.mov

