### PR TITLE
Add cluster ID label to new alerting rules & recording rules

### DIFF
--- a/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -1,6 +1,5 @@
 <script>
 import has from 'lodash/has';
-
 import { Banner } from '@components/Banner';
 import { removeAt } from '@shell/utils/array';
 import { _VIEW } from '@shell/config/query-params';
@@ -34,8 +33,9 @@ export default {
       expr:   '',
       for:    '0s',
       labels: {
-        severity:  'none',
-        namespace: 'default'
+        severity:   'none',
+        namespace:  'default',
+        cluster_id: this.$store.getters['clusterId']
       },
     };
 
@@ -91,7 +91,15 @@ export default {
 
       switch (ruleType) {
       case 'record':
-        value.push({ record: '', expr: '' });
+        value.push({
+          record: '',
+          expr:   '',
+          labels: {
+            severity:   'none',
+            namespace:  'default',
+            cluster_id: this.$store.getters['clusterId']
+          },
+        });
         break;
       case 'alert':
         value.push(this.defaultAlert);


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/7513 by adding the cluster ID to the default labels for new PrometheusRules. It applies to both Recording Rules and Alerting Rules within the PrometheusRule form.

The default alerting rule fields now include cluster ID in the labels:

<img width="1174" alt="Screenshot 2023-01-17 at 1 49 11 AM" src="https://user-images.githubusercontent.com/20599230/212858138-a51dd49e-05c4-4189-bc45-7ad2bef34a1e.png">

To test this PR,

1. I installed monitoring on a downstream cluster.
2. Went to the form to create a Prometheus rule
3. Within that form, clicked Add Record
4. Confirmed that the cluster ID label was there by default for the new rule
5. Deleted the recording rule
6. Clicked Add Alert
7. Confirmed that the cluster ID label was there by default for the new rule
