### PR TITLE
Registry mirrors

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6667,6 +6667,19 @@ registryMirror:
   toolTip: 'Mirrors can be used to redirect requests for images from one registry to come from a list of endpoints you specify instead.  For example docker.io could redirect to your internal registry instead of ever going to DockerHub.'
   addLabel: Add Mirror
   description: Mirrors define the names and endpoints for private registries. The endpoints are tried one by one, and the first working one is used.
+  hostnameLabel: Registry Hostname
+  hostnamePlaceholder: e.g. docker.io or *
+  endpointsLabel: Mirror Endpoints
+  endpointsPlaceholder: e.g. a.registry.com:5000, b.registry.com:5000
+
+registryMirrorRewrite:
+  header: Rewrites
+  toolTip: 'Each mirror can have a set of rewrites. Rewrites can change the tag of an image based on a regular expression.'
+  addLabel: Add Rewrite Config
+  keyLabel: Rewrite pattern
+  keyPlaceholder: e.g. ^rancher/(.*)
+  valueLabel: Rewrite replacement
+  valuePlaceholder: e.g. mirrorproject/rancher-images/$1
 
 registryConfig:
   header: Registry Authentication

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -37,7 +37,9 @@ export default {
   },
 
   created() {
-    set(this.value, 'spec.rkeConfig.registries.mirrors', {});
+    if (!this.value.spec.rkeConfig?.registries?.mirrors) {
+      set(this.value, 'spec.rkeConfig.registries.mirrors', {});
+    }
   },
 
   computed: {


### PR DESCRIPTION
### Summary
This adds form field to configure registry mirror rewrites in the RKE2 cluster provisioning form.

Fixes #7939

The second issue fixes also an issue that the mirror settings are being removed when the cluster is edited without touching the mirroring configuration.

### Technical notes summary
The backend already supports the rewrites field: https://github.com/rancher/rancher/blob/release/v2.7/pkg/apis/rke.cattle.io/v1/registries.go#L4-L15.

The feature is documented here https://docs.rke2.io/install/containerd_registry_configuration#rewrites.

### Areas or cases that should be tested
Creating and editing clusters with registry mirrors and registry mirror rewrites.

### Areas which could experience regressions
Creating and editing clusters with registry mirrors and registry mirror rewrites.

### Screenshot/Video
<img width="587" alt="Bildschirm­foto 2023-01-17 um 14 37 54" src="https://user-images.githubusercontent.com/243056/212945961-62c6566b-3126-47fb-8931-a87963f6175b.png">
