### PR TITLE
Remove the legacy docker secret type from creation screen

### DIFF
--- a/shell/config/secret.js
+++ b/shell/config/secret.js
@@ -1,7 +1,6 @@
 export const SECRET_TYPES = {
   OPAQUE:           'Opaque',
   SERVICE_ACCT:     'kubernetes.io/service-account-token',
-  DOCKER:           'kubernetes.io/dockercfg',
   DOCKER_JSON:      'kubernetes.io/dockerconfigjson',
   BASIC:            'kubernetes.io/basic-auth',
   SSH:              'kubernetes.io/ssh-auth',


### PR DESCRIPTION
Fixes #6913

Remove the legacy docker secret type from the dropdown:

![image](https://user-images.githubusercontent.com/1955897/212966344-bb7c0d70-f8ef-4cb5-a0ac-f9d3457c7f3b.png)
