### PR TITLE
re-add header tag global style to accommodate pre-existing extensions

### DIFF
--- a/shell/assets/styles/global/_layout.scss
+++ b/shell/assets/styles/global/_layout.scss
@@ -11,7 +11,7 @@
   }
 }
 
-.header-layout {
+HEADER {
   display: grid;
   grid-template-areas:
     'type-banner type-banner'

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -399,7 +399,7 @@ export default {
 
 <template>
   <div class="masthead">
-    <header class="header-layout">
+    <header>
       <div class="title">
         <div class="primaryheader">
           <h1>

--- a/shell/components/ResourceList/Masthead.vue
+++ b/shell/components/ResourceList/Masthead.vue
@@ -168,7 +168,7 @@ export default {
 </script>
 
 <template>
-  <header class="header-layout">
+  <header>
     <slot name="typeDescription">
       <TypeDescription :resource="resource" />
     </slot>

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -340,7 +340,7 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else>
-    <header class="header-layout">
+    <header>
       <div class="title">
         <h1 class="m-0">
           {{ t('catalog.charts.header') }}

--- a/shell/pages/c/_cluster/auth/group.principal/assign-edit.vue
+++ b/shell/pages/c/_cluster/auth/group.principal/assign-edit.vue
@@ -78,7 +78,7 @@ export default {
   <div>
     <div>
       <div class="masthead">
-        <header class="header-layout">
+        <header>
           <div class="title">
             <h1 class="m-0">
               {{ t('authGroups.assignEdit.assignTitle') }}

--- a/shell/pages/c/_cluster/auth/roles/index.vue
+++ b/shell/pages/c/_cluster/auth/roles/index.vue
@@ -156,7 +156,7 @@ export default {
 <template>
   <Loading v-if="!globalRoles || !roleTemplates" />
   <div v-else>
-    <header class="header-layout">
+    <header>
       <div class="title">
         <h1 class="m-0">
           {{ t('rbac.roletemplate.label') }}

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -400,7 +400,7 @@ export default {
 
 <template>
   <section class="dashboard">
-    <header class="header-layout">
+    <header>
       <div class="title">
         <h1>
           <t k="clusterIndexPage.header" />

--- a/shell/pages/c/_cluster/longhorn/index.vue
+++ b/shell/pages/c/_cluster/longhorn/index.vue
@@ -39,7 +39,7 @@ export default {
 
 <template>
   <section>
-    <header class="header-layout row">
+    <header class="row">
       <div class="col span-12">
         <h1>
           <t k="longhorn.overview.title" />

--- a/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
+++ b/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
@@ -226,7 +226,7 @@ export default {
 
 <template>
   <div>
-    <header class="header-layout header">
+    <header class="header">
       <div class="title">
         <div class="primaryheader">
           <h1>

--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -140,7 +140,7 @@ export default {
 
 <template>
   <section>
-    <header class="header-layout row">
+    <header class="row">
       <div class="col span-12">
         <h1>
           <t k="monitoring.overview.title" />

--- a/shell/pages/c/_cluster/neuvector/index.vue
+++ b/shell/pages/c/_cluster/neuvector/index.vue
@@ -37,7 +37,7 @@ export default {
 
 <template>
   <section>
-    <header class="header-layout row">
+    <header class="row">
       <div class="col span-12">
         <h1>
           <t k="neuvector.overview.title" />

--- a/shell/pages/rio/mesh.vue
+++ b/shell/pages/rio/mesh.vue
@@ -408,7 +408,7 @@ export default {
 </script>
 <template>
   <div class="mesh">
-    <header class="header-layout">
+    <header>
       <h1>App Mesh</h1>
     </header>
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7942 and re-opens https://github.com/rancher/dashboard/issues/7341 ... #7942 is a high priority for Harvester and #7341 is a tech debt issue so I think this is a fair trade.

Components in pre-existing Harvester extensions don't have the `header-layout` class and consequently the styles formerly applied to header tags are lost within those extensions. I think https://github.com/rancher/dashboard/issues/7341, the request to remove global styling of tags, will be more tricky to resolve with this limitation in mind. Honestly I can't think of a good solution and am open to suggestions. The only thing I thought of was using a selector like `HEADER:not([class])` in `__layout.scss` which would let us use header tags without those styles applied by adding any class, but it feels pretty hacky.

