### PR TITLE
Namespace filters aren't applied to the API call if force namespace off.

### DIFF
--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -140,8 +140,12 @@ export default {
      *
      * This covers case 1
      */
-    namespaceFilter(neu) {
-      if (neu && !this.hasFetch) {
+    namespaceFilter(neu, old) {
+      if (
+        (neu || old) && // if neu or old have a value
+        neu !== old && // and there's a difference between them
+        !this.hasFetch // and there's a fetch passed into the component
+      ) {
         this.$fetchType(this.resource);
       }
     }

--- a/shell/mixins/resource-fetch-namespaced.js
+++ b/shell/mixins/resource-fetch-namespaced.js
@@ -24,7 +24,8 @@ export default {
      * Returns the namespace that requests should be filtered by
      */
     namespaceFilter() {
-      return this.__namespaceRequired ? this.__singleNamespaceFilter : '';
+      // If there's only a single namespace selected then we don't even need to check if it's required.
+      return this.isSingleNamespace || this.__namespaceRequired ? this.__singleNamespaceFilter : '';
     },
 
     /**
@@ -77,8 +78,11 @@ export default {
       immediate: true,
     },
 
-    async namespaceFilter(neu) {
-      if (neu) {
+    async namespaceFilter(neu, old) {
+      if (
+        (neu || old) & // if neu or old have a value
+        neu !== old // and there's a difference between them
+      ) {
         // When a NS filter is required and the user selects a different one, kick off a new set of API requests
         //
         // ResourceList has two modes


### PR DESCRIPTION
If the option to force namespace filters above a threshold is not enabled, using a single namespace filter should still filter API requests as needed.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
resource-fetch-namespaced.js not checks if only a single namespace is picked when determining what to pass to __singleNamespaceFilter. nameSpaceFilter watch on the mixin and on the resourcelist now also perform a comparison of neu to old to see if the value has changed. previously, if the new value was false (the filter was cleared) and new API request would not be triggered even though it should be.

### Technical notes summary

resource-fetch-namespaced.js not checks if only a single namespace is picked when determining what to pass to __singleNamespaceFilter. nameSpaceFilter watch on the mixin and on the resourcelist now also perform a comparison of neu to old to see if the value has changed. previously, if the new value was false (the filter was cleared) and new API request would not be triggered even though it should be.

### Areas or cases that should be tested
Load namespaced list page with a single namespace filter already in the namespace filter - API request should include a namespace filter
Load namespaced list page with multiple namespace filters already in the namespace filter - API request should not include a namespace filter and the table filtering should filter instead
Go from one namespace filter to none - new API request with no namespace filter
Go from no or multiple namespace filters to just one - No new API request since resources are already in the store
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
Chrome