### PR TITLE
Fix blank chart install page

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -94,13 +94,11 @@ export default {
 
     this.errors = [];
 
-    console.error(this.showCustomRegistry);
-
     // If the chart doesn't contain system `systemDefaultRegistry` properties there's no point applying them
     if (this.showCustomRegistry) {
       this.clusterRegistry = await this.getClusterRegistry();
       this.globalRegistry = await this.getGlobalRegistry();
-      // this.defaultRegistrySetting = this.clusterRegistry || this.globalRegistry;
+      this.defaultRegistrySetting = this.clusterRegistry || this.globalRegistry;
     }
 
     this.serverUrlSetting = await this.$store.dispatch('management/find', {

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -94,11 +94,13 @@ export default {
 
     this.errors = [];
 
+    console.error(this.showCustomRegistry);
+
     // If the chart doesn't contain system `systemDefaultRegistry` properties there's no point applying them
     if (this.showCustomRegistry) {
       this.clusterRegistry = await this.getClusterRegistry();
       this.globalRegistry = await this.getGlobalRegistry();
-      this.defaultRegistrySetting = this.clusterRegistry || this.globalRegistry;
+      // this.defaultRegistrySetting = this.clusterRegistry || this.globalRegistry;
     }
 
     this.serverUrlSetting = await this.$store.dispatch('management/find', {
@@ -792,7 +794,7 @@ export default {
 
       if (hasPermissionToSeeProvCluster) {
         const mgmCluster = this.$store.getters['currentCluster'];
-        const provCluster = mgmCluster ? await this.$store.dispatch('management/find', {
+        const provCluster = mgmCluster?.provClusterId ? await this.$store.dispatch('management/find', {
           type: CAPI.RANCHER_CLUSTER,
           id:   mgmCluster.provClusterId
         }) : {};


### PR DESCRIPTION
Fixes #7808 
Fixes #7833 

These two issues are caused by the same underlying problem.

For some imported clusters, there is no `provClusterId` property, which causes the code to fail during the `fetch` method, which is why we get a blank screen.

I have observed the 2 issues on a system and verified that this fix addresses them.

I have been unable to create my own test system which exhibits the error behaviour.

The system I saw had an Azure AKS cluster that had been imported as a generic cluster.