### PR TITLE
Avoid saving duplicate Helm chart versions

### DIFF
--- a/shell/detail/catalog.cattle.io.app.vue
+++ b/shell/detail/catalog.cattle.io.app.vue
@@ -30,7 +30,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('catalog/load', { force: true });
+    await this.$store.dispatch('catalog/load', { force: true, reset: true });
 
     this.allOperations = await this.$store.dispatch('cluster/findAll', { type: CATALOG.OPERATION });
   },

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -242,7 +242,7 @@ export default {
 
   methods: {
     async fetchChart() {
-      await this.$store.dispatch('catalog/load', { force: true });
+      await this.$store.dispatch('catalog/load', { force: true, reset: true }); // not the problem
 
       if ( this.query.appNamespace && this.query.appName ) {
         // First check the URL query for an app name and namespace.

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -34,7 +34,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('catalog/load', { force: true });
+    await this.$store.dispatch('catalog/load', { force: true, reset: true });
 
     const query = this.$route.query;
 


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/7826

To test it, I did this:

1. Refreshed Rancher to start with a clean store
2. Went to a helm chart app detail page
3. Navigated away from the page
4. Navigated back to the helm chart app detail page
5. Confirmed there were no duplicate chart versions

I opened a related tech debt issue about later improving performance by loading less helm chart data https://github.com/rancher/dashboard/issues/7963 