### PR TITLE
Istio install : Fix issue where Kiali requires Pilot

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2595,8 +2595,8 @@ istio:
   istiodRemote: Enable istiodRemote
   kiali: Enable Kiali
   pilot: Enable Pilot
+  policy: Enable Policy
   pilotRequired: Pilot must be enabled in order to enable Kiali
-  policy: Enabled Policy
   poweredBy: Powered by <a target="_blank" rel="noopener noreferrer nofollow" href='https://istio.io/latest/'>Istio</a>
   telemetry: Enable Telemetry
   titles:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2595,7 +2595,8 @@ istio:
   istiodRemote: Enable istiodRemote
   kiali: Enable Kiali
   pilot: Enable Pilot
-  policy: Enable Policy
+  pilotRequired: Pilot must be enabled in order to enable Kiali
+  policy: Enabled Policy
   poweredBy: Powered by <a target="_blank" rel="noopener noreferrer nofollow" href='https://istio.io/latest/'>Istio</a>
   telemetry: Enable Telemetry
   titles:

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -74,7 +74,10 @@ export default {
       overlayFile = defaultOverlayFile;
     }
 
-    return { overlayFile };
+    return {
+      overlayFile,
+      showKialiBanner: this.value.kiali?.enabled
+    };
   },
 
   computed: {
@@ -122,6 +125,15 @@ export default {
 
     onFileSelected(value) {
       this.$refs['yaml-editor'].updateValue(value);
+    },
+
+    changeKiali(value) {
+      if (value && this.value.pilot) {
+        this.value.pilot.enabled = true;
+        this.showKialiBanner = true;
+      } else if (!value) {
+        this.showKialiBanner = false;
+      }
     }
   }
 };
@@ -140,7 +152,7 @@ export default {
     <h3>
       {{ t('istio.titles.components') }}
     </h3>
-    <div class="row">
+    <div class="row mb-10">
       <div
         v-if="value.cni"
         class="col span-4"
@@ -170,7 +182,7 @@ export default {
         />
       </div>
     </div>
-    <div class="row">
+      <div class="row mb-10">
       <div
         v-if="value.pilot"
         class="col span-4"
@@ -178,6 +190,7 @@ export default {
         <Checkbox
           v-model="value.pilot.enabled"
           :label="t('istio.pilot')"
+            :disabled="value.kiali && value.kiali.enabled"
         />
       </div>
       <div
@@ -207,6 +220,7 @@ export default {
         <Checkbox
           v-model="value.kiali.enabled"
           :label="t('istio.kiali')"
+            @input="changeKiali"
         />
       </div>
       <div
@@ -219,6 +233,18 @@ export default {
         />
       </div>
       <div class="col span-4" />
+      </div>
+      <div
+        v-if="showKialiBanner"
+        class="row"
+      >
+        <div class="col span-12">
+          <Banner color="info">
+            <span
+              v-html="t('istio.pilotRequired', {}, true)"
+            />
+          </Banner>
+        </div>
     </div>
 
     <h3>{{ t('istio.customOverlayFile.label') }}</h3>

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -190,7 +190,7 @@ export default {
         <Checkbox
           v-model="value.pilot.enabled"
           :label="t('istio.pilot')"
-            :disabled="value.kiali && value.kiali.enabled"
+          :disabled="value.kiali && value.kiali.enabled"
         />
       </div>
       <div

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -220,7 +220,7 @@ export default {
         <Checkbox
           v-model="value.kiali.enabled"
           :label="t('istio.kiali')"
-            @input="changeKiali"
+          @input="changeKiali"
         />
       </div>
       <div
@@ -233,7 +233,6 @@ export default {
         />
       </div>
       <div class="col span-4" />
-      </div>
       <div
         v-if="showKialiBanner"
         class="row"
@@ -245,6 +244,7 @@ export default {
             />
           </Banner>
         </div>
+      </div>
     </div>
 
     <h3>{{ t('istio.customOverlayFile.label') }}</h3>

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -182,7 +182,7 @@ export default {
         />
       </div>
     </div>
-      <div class="row mb-10">
+    <div class="row mb-10">
       <div
         v-if="value.pilot"
         class="col span-4"


### PR DESCRIPTION
Fixes #7970 

This PR updates the Istio install page so that you can't enabled Kiali without enabling Pilot.

It also increases the vertical spacing between checkboxes for better presentation.


![image](https://user-images.githubusercontent.com/1955897/213462195-1804f82c-c558-4de2-b256-2e820a7bbbc9.png)

When Kiali is enabled, pilot will automatically be enabled and the checkbox will be disabled and we will also show a banner - as shown above.