### PR TITLE
HARVESTER: duplicate receiver name is invalid now

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2984,7 +2984,7 @@ monitoring:
       radio:
         label: Config Secret
     validation:
-      duplicatedReceiverName: 'Duplicate name of receiver'
+      duplicatedReceiverName: A receiver with the name {name} already exists.
     templates:
       keyLabel: File Name
       label: Template Files

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2983,6 +2983,8 @@ monitoring:
       new: Create default config
       radio:
         label: Config Secret
+    validation:
+      duplicatedReceiverName: 'Duplicate name of receiver'
     templates:
       keyLabel: File Name
       label: Template Files

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -154,7 +154,7 @@ export default {
       view:           _VIEW,
       yamlError:      '',
       fvFormRuleSets: [
-        { path: 'name', rules: ['required'] }
+        { path: 'name', rules: ['required', 'duplicateName'] }
       ],
       fvReportedValidationPaths: ['value']
     };
@@ -183,7 +183,19 @@ export default {
     receiverNameDisabled() {
       return this.$route.query.mode === _VIEW;
     },
+    fvExtraRules() {
+      return {
+        duplicateName: () => {
+          const receiversArray = this.alertmanagerConfigResource.spec.receivers;
+          const receiverNamesArray = receiversArray.map(R => R.name);
+          const receiversSet = new Set(receiverNamesArray);
 
+          if (receiversArray.length !== receiversSet.size) {
+            return this.$store.getters['i18n/t']('monitoring.alerting.validation.duplicatedReceiverName', { name: this.value.name });
+          }
+        }
+      };
+    }
   },
 
   watch: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

The receiver with empty name or the receiver with duplicated name is invalid now.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/2798

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->