### PR TITLE
Fix OPA Gatekeeper constraint inconsistencies

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2160,8 +2160,11 @@ gatekeeperConstraint:
       editAsYaml: Edit as YAML
       title: Parameters
   template: Template
+  enforcement:
+    action: Enforcement Action
   violations:
-    title: Violations
+    title: "Violations: {total}"
+    notAll: Not all are shown - the constraint only includes details for {shown}
 
 gatekeeperIndex:
   poweredBy: OPA Gatekeeper

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -728,8 +728,8 @@ export const CONSTRAINT_VIOLATION_RESOURCE_LINK = {
 export const CONSTRAINT_VIOLATION_TYPE = {
   name:  'Type',
   label: 'Type',
-  value: `constraint.kind`,
-  sort:  `constraint.kind`
+  value: `kind`,
+  sort:  `kind`
 };
 
 export const CONSTRAINT_VIOLATION_MESSAGE = {

--- a/shell/detail/constraints.gatekeeper.sh.constraint.vue
+++ b/shell/detail/constraints.gatekeeper.sh.constraint.vue
@@ -1,20 +1,20 @@
 <script>
 import CreateEditView from '@shell/mixins/create-edit-view';
 import SortableTable from '@shell/components/SortableTable';
+import Banner from '@components/Banner/Banner.vue';
 import { CONSTRAINT_VIOLATION_RESOURCE_LINK, CONSTRAINT_VIOLATION_MESSAGE, CONSTRAINT_VIOLATION_TYPE } from '@shell/config/table-headers';
 
 export default {
-  components: { SortableTable },
+  components: { Banner, SortableTable },
   mixins:     [CreateEditView],
-  data(ctx) {
+  data() {
     return {
       headers: [
         CONSTRAINT_VIOLATION_TYPE,
         CONSTRAINT_VIOLATION_RESOURCE_LINK,
         CONSTRAINT_VIOLATION_MESSAGE
       ],
-      violations: this.value.violations
-        .map((violation, i) => ({ ...violation, id: i }))
+      violations: this.value.violations.map((violation, i) => ({ ...violation, id: i }))
     };
   }
 };
@@ -23,16 +23,26 @@ export default {
   <div>
     <div
       v-if="value.spec.enforcementAction"
-      class="row mt-40"
+      class="row mt-20"
     >
       <div class="col span-12">
-        <h3>Enforcement Action</h3>
+        <h3>
+          {{ t('gatekeeperConstraint.enforcement.action') }}
+        </h3>
         {{ value.spec.enforcementAction }}
       </div>
     </div>
-    <div class="row mt-40">
+    <div class="row mt-20">
       <div class="col span-12">
-        <h3>{{ t('gatekeeperConstraint.violations.title') }}</h3>
+        <h3 class="mb-20">
+          {{ t('gatekeeperConstraint.violations.title', { total: value.totalViolations }) }}
+        </h3>
+        <Banner
+          v-if="value.totalViolations !== value.violations.length"
+          color="info"
+        >
+          {{ t('gatekeeperConstraint.violations.notAll', { shown: value.violations.length }) }}
+        </Banner>
         <SortableTable
           :headers="headers"
           :rows="violations"

--- a/shell/models/constraints.gatekeeper.sh.constraint.js
+++ b/shell/models/constraints.gatekeeper.sh.constraint.js
@@ -50,6 +50,10 @@ export default class GateKeeperConstraint extends SteveModel {
     }, { root: true });
   }
 
+  get totalViolations() {
+    return this.status?.totalViolations || this.violations.length;
+  }
+
   get violations() {
     const violations = this.status?.violations || [];
 

--- a/shell/pages/c/_cluster/gatekeeper/index.vue
+++ b/shell/pages/c/_cluster/gatekeeper/index.vue
@@ -27,7 +27,7 @@ export default {
             }
           }
         },
-        count: constraint.violations.length
+        count: constraint.totalViolations
       }));
   },
   data(ctx) {


### PR DESCRIPTION
Fixes #7853 

This PR Fixes an inconsistency in the OPA Gatekeeper violations view - on one page we show the count being the number of violations listed in the constraint resource, where as on the other we show the total violations form the count.

The correct value to use if from the `totalViolations` property - see: https://open-policy-agent.github.io/gatekeeper/website/docs/audit/#constraint-status - the constraint is limited to a number of violations that it will store detail for (default seems to be 20).


Also:
- Improved padding slightly to reduce it down
- Added a banner when the number shown is not the same as the number with detail
- Pulled out one more hard-coded string
- Fixed a bug where the kind in the constraint violations list was empty
- Added the count of violations to the title, so it is clear how many. there are
- 
Here's how it looks now:
![image](https://user-images.githubusercontent.com/1955897/213664737-feb21848-1c90-4cd9-aa20-4522d648cb17.png)

Before:
![image](https://user-images.githubusercontent.com/1955897/213664934-d8e54fbc-c886-4d38-90e0-16407fc651f4.png)

For the overview, it now looks like this (22 is now shown correctly as the count):

![image](https://user-images.githubusercontent.com/1955897/213665650-2931d856-8d3d-4c68-a8fd-ae1d3d02b1f7.png)


before was like this (count of 20 shown is incorrect):

![image](https://user-images.githubusercontent.com/1955897/213665095-d07d8611-af5c-4156-a45a-8882ce89cd86.png)

![image](https://user-images.githubusercontent.com/1955897/213665019-0acd9a07-9b50-45de-a250-df77960c751b.png)

Easiest way to reproduce:

- Install OPA Gatekeeper into a cluster
- Using the global import yaml in the cluster, import this yaml:
```
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sRequiredLabels
metadata:
  name: all-must-have-owner
spec:
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["Namespace"]
  parameters:
    message: "All namespaces must have an `owner` label that points to your company username"
    labels:
      - key: owner
        allowedRegex: "^[a-zA-Z]+.agilebank.demo$"
```

Go to OPA Gatekeeper and you should see this `all-must-have-owner` constraint and it will have violations for the existing namespaces.