### PR TITLE
Add text to help with Services and Ingresses

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4621,7 +4621,7 @@ serviceTypes:
   nodeport: Node Port
 
 servicesPage:
-  serviceListDescription: Services allow you to define a logical set of Pods that can be accessed with single IP address and port.
+  serviceListDescription: Services allow you to define a logical set of Pods that can be accessed with a single IP address and port.
   targetPorts: The Service will send requests to this port, and the selected Pods are expected to listen on this port.
   listeningPorts: The Service is exposed on this port.
   anyNode: Any Node

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5627,7 +5627,7 @@ workload:
     ports:
       expose: Networking
       description: 'Define a Service to expose the container, or define a non-functional, named port so that humans will know where the app within the container is expected to run.'
-      detailedDescription: If ClusterIP, LoadBalancer or NodePort is selected, a Service is automatically created that will select the Pods in this workload using labels.
+      detailedDescription: If ClusterIP, LoadBalancer, or NodePort is selected, a Service is automatically created that will select the Pods in this workload using labels.
       toolTip: 'For help exposing workloads on Kubernetes, see the official Kubernetes documentation on Services. You can also manually create a Service to expose Pods by selecting their labels, and you can use an Ingress to map HTTP routes to Services.'
       createService: Service Type
       noCreateService: Do not create a service

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2322,6 +2322,7 @@ import:
     }
 
 ingress:
+  description: Ingresses route incoming traffic from the internet to Services within the cluster based on the hostname and path specified in the request. You can expose multiple Services on the same external IP address and port.
   certificates:
     addCertificate: Add Certificate
     addHost: Add Host
@@ -2374,6 +2375,7 @@ ingress:
       placeholder: e.g. example.com
     target:
       label: Target Service
+      tooltip: If none of the Services in this dropdown select the Pods that you need to expose, you will need to create a Service that selects those Pods first.
       doesntExist: The selected service does not exist
     title: Rules
   rulesAndCertificates:
@@ -4619,6 +4621,9 @@ serviceTypes:
   nodeport: Node Port
 
 servicesPage:
+  serviceListDescription: Services allow you to define a logical set of Pods that can be accessed with single IP address and port.
+  targetPorts: The Service will send requests to this port, and the selected Pods are expected to listen on this port.
+  listeningPorts: The Service is exposed on this port.
   anyNode: Any Node
   labelsAnnotations:
     label: Labels & Annotations
@@ -4681,6 +4686,7 @@ servicesPage:
     helpText: ""
     label: Selectors
     matchingPods:
+      description: Selector keys and values are intended to match labels and values on existing Pods.
       matchesSome: |-
         {matched, plural,
           =0 {Matches 0 of {total, number} pods. If no selector is created, manual endpoints must be made.}
@@ -4690,23 +4696,23 @@ servicesPage:
   serviceTypes:
     clusterIp:
       abbrv: IP
-      description: Exposes the service on a cluster-internal IP. Choosing this value makes the service only reachable from within the cluster. This is the default type.
+      description: Expose a set of Pods to other Pods within the cluster. This type of Service is only reachable from within the cluster. This is the default type.
       label: Cluster IP
     externalName:
       abbrv: EN
-      description: "Maps the service to the contents of the `externalName` field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up."
+      description: Create a Service that uses a DNS name instead of selectors. This is an advanced use case.
       label: External Name
     headless:
       abbrv: H
-      description: Neither a cluster IP or load balancer is defined. These are used to interface with other service discovery mechanisms outside of Kubernetes implementation. A cluster IP is not allocated and kube-proxy does not handle these services.
+      description: Create a Service without a cluster IP or load balancer. This is an advanced use case.
       label: Headless
     loadBalancer:
       abbrv: LB
-      description: Exposes the service externally using a cloud provider's load balancer.
+      description: Create a load balancer in the underlying infrastructure (e.g. a cloud provider's load balancer) and assign a public IP address to the service. Allows external clients to access the service using the public IP address and the port specified in the service definition.
       label: Load Balancer
     nodePort:
       abbrv: NP
-      description: "Exposes the service on each node's IP at a static port (the `NodePort`). You'll be able to contact this type of service, from outside the cluster, by requesting `&lt;NodeIP&gt;:&lt;NodePort&gt;`."
+      description: "Expose the service on each node's IP at a static port."
       label: Node Port
   typeOpts:
     label: Service Type
@@ -5619,6 +5625,10 @@ workload:
     noPorts: There are no ports configured.
     noServiceAccess: You do not have permission to create or manage services
     ports:
+      expose: Networking
+      description: 'Define a Service to expose the container, or define a non-functional, named port so that humans will know where the app within the container is expected to run.'
+      detailedDescription: If ClusterIP, LoadBalancer or NodePort is selected, a Service is automatically created that will select the Pods in this workload using labels.
+      toolTip: 'For help exposing workloads on Kubernetes, see the official Kubernetes documentation on Services. You can also manually create a Service to expose Pods by selecting their labels, and you can use an Ingress to map HTTP routes to Services.'
       createService: Service Type
       noCreateService: Do not create a service
       containerPort: Private Container Port
@@ -6680,7 +6690,7 @@ unit:
       other { days }
     }
 workloadPorts:
-  addPort: Add Port
+  addPort: Add Port or Service
   remove: Remove
   addHost: Add Host
 

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -136,6 +136,11 @@ export default {
     componentTestid: {
       type:    String,
       default: 'form'
+    },
+
+    description: {
+      type:    String,
+      default: ''
     }
   },
 
@@ -379,6 +384,12 @@ export default {
 <template>
   <section class="cru">
     <slot name="noticeBanner" />
+    <p
+      v-if="description"
+      class="description"
+    >
+      {{ description }}
+    </p>
     <form
       :is="(isView? 'div' : 'form')"
       class="create-resource-container cru__form"
@@ -824,6 +835,11 @@ form.create-resource-container .cru {
     background-color: var(--header-bg);
     margin: 10px 0;
   }
+}
+
+.description {
+  margin-bottom: 15px;
+  margin-top: 5px;
 }
 
 </style>

--- a/shell/components/form/ServicePorts.vue
+++ b/shell/components/form/ServicePorts.vue
@@ -136,6 +136,10 @@ export default {
         </span>
         <span class="port">
           <t k="servicePorts.rules.listening.label" />
+          <i
+            v-tooltip="t('servicesPage.listeningPorts')"
+            class="icon icon-info flex"
+          />
           <span class="text-error">*</span>
         </span>
         <span
@@ -146,6 +150,10 @@ export default {
         </span>
         <span class="target-port">
           <t k="servicePorts.rules.target.label" />
+          <i
+            v-tooltip="t('servicesPage.targetPorts')"
+            class="icon icon-info flex"
+          />
           <span class="text-error">*</span>
 
         </span>

--- a/shell/components/form/WorkloadPorts.vue
+++ b/shell/components/form/WorkloadPorts.vue
@@ -259,6 +259,12 @@ export default {
 
 <template>
   <div :style="{'width':'100%'}">
+    <p
+      v-if="rows.length > 0"
+      class="padded"
+    >
+      {{ t('workload.container.ports.detailedDescription') }}
+    </p>
     <div
       v-for="(row, idx) in rows"
       :key="idx"

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -66,7 +66,11 @@ export default {
       return isValueAnOption ? null : 'warning';
     },
     serviceTargetTooltip() {
-      return this.serviceTargetStatus === 'warning' ? this.t('ingress.rules.target.doesntExist') : null;
+      if (this.serviceTargetStatus === 'warning' ) {
+        return this.t('ingress.rules.target.doesntExist');
+      }
+
+      return this.t('ingress.rules.target.tooltip');
     },
   },
   created() {

--- a/shell/edit/networking.k8s.io.ingress/index.vue
+++ b/shell/edit/networking.k8s.io.ingress/index.vue
@@ -198,6 +198,7 @@ export default {
     :subtypes="[]"
     :validation-passed="fvFormIsValid"
     :errors="fvUnreportedValidationErrors"
+    :description="t('ingress.description')"
     @error="e=>errors = e"
     @finish="save"
     @cancel="done"

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -328,6 +328,7 @@ export default {
     :validation-passed="fvFormIsValid"
     :errors="fvUnreportedValidationErrors"
     :apply-hooks="applyHooks"
+    :description="t('servicesPage.serviceListDescription')"
     @error="(e) => (errors = e)"
     @finish="save"
     @cancel="done"
@@ -385,6 +386,7 @@ export default {
         name="selectors"
         :label="t('servicesPage.selectors.label')"
       >
+        <p>{{ t('servicesPage.selectors.matchingPods.description') }}</p>
         <div class="row">
           <div class="col span-12">
             <Banner :color="(matchingPods.none ? 'warning' : 'success')">

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -244,7 +244,16 @@ export default {
               </div>
               <div class="spacer" />
               <div>
-                <h3>{{ t('workload.container.titles.ports') }}</h3>
+                <h3>
+                  {{ t('workload.container.ports.expose') }}
+                  <i
+                    v-tooltip="t('workload.container.ports.toolTip')"
+                    class="icon icon-info"
+                  />
+                </h3>
+                <p class="padded">
+                  {{ t('workload.container.ports.description') }}
+                </p>
                 <div class="row">
                   <WorkloadPorts
                     v-model="allContainers[i].ports"
@@ -565,9 +574,7 @@ export default {
               type="button"
               class="btn-sm role-link"
               @click="addContainerBtn"
-            >
-              <i class="icon icon-plus" /> {{ t('workload.container.addContainer') }}
-            </button>
+            />
           </li>
         </template>
       </Tabbed>
@@ -634,5 +641,8 @@ export default {
     border-bottom: 1px solid var(--border);
     margin-bottom: 10px;
   }
+}
+.padded {
+  padding-bottom: 10px;
 }
 </style>


### PR DESCRIPTION
This PR addresses https://github.com/rancher/dashboard/issues/5441 by adding some explanatory descriptions and tooltips around services and ingresses.



# Workload Create/Edit Form

In the Ports section,

  - Change "Ports" to "Networking" because that section can create a Service in addition to defining a port.
  - Add a tooltip that says "For help exposing workloads on Kubernetes, see the official Kubernetes documentation on Services. You can also manually create a Service to expose Pods by selecting their labels, and you can use an Ingress to map HTTP routes to Services."
  - Add a description that says "Define a Service to expose the container, or define a non-functional, named port so that humans will know where the app within the container is expected to run." (If a port is defined, it updates the YAML on the workload being created. If one of the Service types is selected, it creates a Service that selects the workload using automatically created labels.)
  - Change button from "Add Port" to "Add Port or Service".
  - If the "Add Port or Service" button is clicked, more explanatory text appears: "If ClusterIP, LoadBalancer or NodePort is selected, a Service is automatically created that will select the Pods in this workload using labels."

## Workload create/edit form: Before
<img width="1119" alt="Screen Shot 2023-01-21 at 10 55 38 PM" src="https://user-images.githubusercontent.com/20599230/213902742-f8900d85-3bc1-4292-83a1-f396045105c7.png">


## Workload create/edit form: After
<img width="1284" alt="Screen Shot 2023-01-21 at 10 55 46 PM" src="https://user-images.githubusercontent.com/20599230/213902740-120381e4-ad96-4410-962e-75082a1605ca.png">

After clicking the button to add a port or service:

<img width="1354" alt="Screen Shot 2023-01-21 at 10 56 43 PM" src="https://user-images.githubusercontent.com/20599230/213902763-0d5e6705-56aa-4b5a-bf00-a2667ff14f04.png">


# Service Create/Edit Form

  - A description says what a Service is. "Services allow you to define a logical set of Pods that can be accessed with single IP address and port."
  - On the Selector tab, explain that "Selector keys and values are intended to match labels and values on existing Pods."
  - Add a tooltip to target port: "The Service will send requests to this port, and the selected Pods are expected to listen on this port."
  - Add a tooltip to listening port: "The Service is exposed on this port."

## Service create/edit form: before
<img width="1281" alt="Screen Shot 2023-01-21 at 10 57 33 PM" src="https://user-images.githubusercontent.com/20599230/213902794-26596709-53b2-4a93-a691-f965ea13a5c4.png">

## Service create/edit form: after
<img width="1289" alt="Screen Shot 2023-01-21 at 10 58 19 PM" src="https://user-images.githubusercontent.com/20599230/213902810-3b16e15f-ef1c-40a7-91b9-96fea3aa34f6.png">


# Ingress Create/Edit Form

- A description says what an Ingress is. "Ingresses route incoming traffic from the internet to Services within the cluster based on the hostname and path specified in the request. You can expose multiple Services on the same external IP address and port."
- In the Rules tab, the target service dropdown has a tooltip: "If none of the Services in this dropdown select the Pods that you need to expose, you will need to create a Service that selects those Pods first."

## Ingress create/edit form: before

<img width="1273" alt="Screen Shot 2023-01-21 at 10 59 07 PM" src="https://user-images.githubusercontent.com/20599230/213902835-88ecc186-ffd0-410e-95cf-21345f65d874.png">

## Ingress create/edit form: after
<img width="1276" alt="Screen Shot 2023-01-21 at 11 00 02 PM" src="https://user-images.githubusercontent.com/20599230/213902859-eef46274-bac1-4851-b1d7-6fe270a6910f.png">

# Services Overview
I changed the descriptions of the different types of services attempting to make it clearer. Now it indicates which options are for advanced use cases.

## Service descriptions - Before
<img width="1348" alt="Screen Shot 2023-01-21 at 11 00 34 PM" src="https://user-images.githubusercontent.com/20599230/213902905-7d0309ff-7022-485b-8f84-00a7f0c33b2e.png">

## Service descriptions - After

<img width="1337" alt="Screen Shot 2023-01-21 at 11 01 44 PM" src="https://user-images.githubusercontent.com/20599230/213902935-31332a85-7cc5-47e3-b332-daf04024d173.png">

