### PR TITLE
Fix locked project roles

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2945,6 +2945,7 @@ members:
     custom:
       label: Custom
       description: Choose individual roles for this user.
+      lockedRole: This role is locked.
   localClusterWarning: "Caution: This is the cluster that Rancher is using as a data store. Only administrators should be given write access to this cluster. Users with write access to this cluster can use it to grant themselves access to any part of this installation."
   noRolesAssigned: There are no users assigned to this project.
 

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -279,7 +279,7 @@ export default {
             <i
               v-if="permission.locked"
               v-tooltip="permission.tooltip"
-              class="icon icon-lock icon-lg"
+              class="icon icon-lock icon-fw"
             />
           </div>
         </div>

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -180,8 +180,8 @@ export default {
         const lockedExist = this.roleTemplates.find(roleTemplateItem => roleTemplateItem.displayName === customPermissionsItem.label);
 
         if (lockedExist.locked) {
-          customPermissionsItem['locked'] = true
-          customPermissionsItem['tooltip'] = 'This cluster role is locked.';
+          customPermissionsItem['locked'] = true;
+          customPermissionsItem['tooltip'] = 'This role is locked.';
         }
       });
 
@@ -266,15 +266,22 @@ export default {
           class="custom-permissions ml-20 mt-10"
           :class="{'two-column': useTwoColumnsForCustom}"
         >
-          <Checkbox
+          <div
             v-for="permission in customPermissionsUpdate"
             :key="permission.key"
-            v-model="permission.value"
-            :disabled="permission.locked"
-            :tooltip="permission.tooltip"
-            class="mb-5"
-            :label="permission.label"
-          />
+          >
+            <Checkbox
+              v-model="permission.value"
+              :disabled="permission.locked"
+              class="mb-5"
+              :label="permission.label"
+            />
+            <i
+              v-if="permission.locked"
+              v-tooltip="permission.tooltip"
+              class="icon icon-lock icon-lg"
+            />
+          </div>
         </div>
       </template>
     </Card>
@@ -296,6 +303,9 @@ label.radio {
   grid-template-columns: 1fr 1fr 1fr;
   &.two-column {
     grid-template-columns: 1fr 1fr;
+  }
+  ::v-deep .checkbox-label {
+    margin-right: 0;
   }
 }
 </style>

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -176,16 +176,16 @@ export default {
       }, { root: true });
     },
     customPermissionsUpdate() {
-      this.customPermissions.map((customPermissionsItem) => {
+      return this.customPermissions.reduce((acc, customPermissionsItem) => {
         const lockedExist = this.roleTemplates.find(roleTemplateItem => roleTemplateItem.displayName === customPermissionsItem.label);
 
         if (lockedExist.locked) {
           customPermissionsItem['locked'] = true;
-          customPermissionsItem['tooltip'] = 'This role is locked.';
+          customPermissionsItem['tooltip'] = this.t('members.clusterPermissions.custom.lockedRole');
         }
-      });
 
-      return this.customPermissions;
+        return [...acc, customPermissionsItem];
+      }, []);
     }
   },
 

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -175,7 +175,20 @@ export default {
         opt:  { url: `/v3/principals/${ principalId }` }
       }, { root: true });
     },
+    customPermissionsUpdate() {
+      this.customPermissions.map((customPermissionsItem) => {
+        const lockedExist = this.roleTemplates.find(roleTemplateItem => roleTemplateItem.displayName === customPermissionsItem.label);
+
+        if (lockedExist.locked) {
+          customPermissionsItem['locked'] = true
+          customPermissionsItem['tooltip'] = 'This cluster role is locked.';
+        }
+      });
+
+      return this.customPermissions;
+    }
   },
+
   watch: {
     roleTemplateIds() {
       this.updateBindings();
@@ -208,7 +221,7 @@ export default {
         this.$emit('input', bindings);
       }
     }
-  }
+  },
 };
 </script>
 <template>
@@ -254,9 +267,11 @@ export default {
           :class="{'two-column': useTwoColumnsForCustom}"
         >
           <Checkbox
-            v-for="permission in customPermissions"
+            v-for="permission in customPermissionsUpdate"
             :key="permission.key"
             v-model="permission.value"
+            :disabled="permission.locked"
+            :tooltip="permission.tooltip"
             class="mb-5"
             :label="permission.label"
           />

--- a/shell/components/form/ProjectMemberEditor.vue
+++ b/shell/components/form/ProjectMemberEditor.vue
@@ -188,6 +188,18 @@ export default {
           value:       'custom'
         }
       ];
+    },
+    customPermissionsUpdate() {
+      this.customPermissions.map((customPermissionsItem) => {
+        const lockedExist = this.roleTemplates.find(roleTemplateItem => roleTemplateItem.displayName === customPermissionsItem.label);
+
+        if (lockedExist.locked) {
+          customPermissionsItem['locked'] = true
+          customPermissionsItem['tooltip'] = 'This project role is locked.';
+        }
+      });
+
+      return this.customPermissions;
     }
   },
   watch: {
@@ -278,9 +290,11 @@ export default {
           :class="{'two-column': useTwoColumnsForCustom}"
         >
           <Checkbox
-            v-for="permission in customPermissions"
+            v-for="permission in customPermissionsUpdate"
             :key="permission.key"
             v-model="permission.value"
+            :disabled="permission.locked"
+            :tooltip="permission.tooltip"
             class="mb-5"
             :label="permission.label"
           />

--- a/shell/components/form/ProjectMemberEditor.vue
+++ b/shell/components/form/ProjectMemberEditor.vue
@@ -195,7 +195,7 @@ export default {
 
         if (lockedExist.locked) {
           customPermissionsItem['locked'] = true
-          customPermissionsItem['tooltip'] = 'This project role is locked.';
+          customPermissionsItem['tooltip'] = 'This role is locked.';
         }
       });
 
@@ -289,15 +289,22 @@ export default {
           class="custom-permissions ml-20 mt-10"
           :class="{'two-column': useTwoColumnsForCustom}"
         >
-          <Checkbox
+          <div
             v-for="permission in customPermissionsUpdate"
             :key="permission.key"
-            v-model="permission.value"
-            :disabled="permission.locked"
-            :tooltip="permission.tooltip"
-            class="mb-5"
-            :label="permission.label"
-          />
+          >
+            <Checkbox
+              v-model="permission.value"
+              :disabled="permission.locked"
+              class="mb-5"
+              :label="permission.label"
+            />
+            <i
+              v-if="permission.locked"
+              v-tooltip="permission.tooltip"
+              class="icon icon-lock icon-lg"
+            />
+          </div>
         </div>
       </template>
     </Card>
@@ -319,6 +326,10 @@ label.radio {
   grid-template-columns: 1fr 1fr 1fr;
   &.two-column {
     grid-template-columns: 1fr 1fr;
+  }
+
+  ::v-deep .checkbox-label {
+    margin-right: 0;
   }
 }
 </style>

--- a/shell/components/form/ProjectMemberEditor.vue
+++ b/shell/components/form/ProjectMemberEditor.vue
@@ -190,16 +190,16 @@ export default {
       ];
     },
     customPermissionsUpdate() {
-      this.customPermissions.map((customPermissionsItem) => {
+      return this.customPermissions.reduce((acc, customPermissionsItem) => {
         const lockedExist = this.roleTemplates.find(roleTemplateItem => roleTemplateItem.displayName === customPermissionsItem.label);
 
         if (lockedExist.locked) {
           customPermissionsItem['locked'] = true;
-          customPermissionsItem['tooltip'] = 'This role is locked.';
+          customPermissionsItem['tooltip'] = this.t('members.clusterPermissions.custom.lockedRole');
         }
-      });
 
-      return this.customPermissions;
+        return [...acc, customPermissionsItem];
+      }, []);
     }
   },
   watch: {

--- a/shell/components/form/ProjectMemberEditor.vue
+++ b/shell/components/form/ProjectMemberEditor.vue
@@ -194,7 +194,7 @@ export default {
         const lockedExist = this.roleTemplates.find(roleTemplateItem => roleTemplateItem.displayName === customPermissionsItem.label);
 
         if (lockedExist.locked) {
-          customPermissionsItem['locked'] = true
+          customPermissionsItem['locked'] = true;
           customPermissionsItem['tooltip'] = 'This role is locked.';
         }
       });
@@ -302,7 +302,7 @@ export default {
             <i
               v-if="permission.locked"
               v-tooltip="permission.tooltip"
-              class="icon icon-lock icon-lg"
+              class="icon icon-lock icon-fw"
             />
           </div>
         </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5952
<!-- Define findings related to the feature or bug issue. -->
User should not be able to use Disabled/Locked Project Roles after the upgrade

### How to test
- Go to users and auth, > roles and cluster roles.
- Pick a role e.g. `Manage Cluster Backups` and select Edit Config from the action menu for it. Set 'Locked` to yes
- Go to the Cluster and Project Members and click Add > custom you'll get a list of custom roles
-  `Manage Cluster Backups` should be disabled 

![Screenshot 2023-01-23 at 16 06 23](https://user-images.githubusercontent.com/18264463/214073819-0f1cf344-0670-4a9e-9f83-636e0d083cd8.png)
