### PR TITLE
Backport: Wrong Certificate Information Showing fix

### DIFF
--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -249,12 +249,20 @@ export default class Secret extends SteveModel {
   get certInfo() {
     const pem = base64Decode(this.data['tls.crt']);
     let issuer, notAfter, cn, sans, x;
+    const END_MARKER = '-----END CERTIFICATE-----';
 
     if (pem) {
+      const certs = pem.split(END_MARKER);
+      let first = pem;
+
+      if (certs.length > 1) {
+        first = `${ certs[0] }${ END_MARKER }`;
+      }
+
       try {
         x = new r.X509();
 
-        x.readCertPEM(pem);
+        x.readCertPEM(first);
         const issuerString = x.getIssuerString();
 
         issuer = issuerString.slice(issuerString.indexOf('CN=') + 3);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7956
<!-- Define findings related to the feature or bug issue. -->
[Backport 2.6.x] Fix Wrong Certificate Information Showing

### How to test
Go to local > Storage > Secrets
Click on any TLS Certificate it should show the correct Expires date