### PR TITLE
Fix rendering issues on Helm Install page

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1349,13 +1349,15 @@ export default {
             color="info"
             class="description"
           >
-            <span>{{ step1Description }}</span>
-            <span
-              v-if="namespaceNewAllowed"
-              class="mt-10"
-            >
-              {{ t('catalog.install.steps.basics.nsCreationDescription', {}, true) }}
-            </span>
+            <div>
+              <span>{{ step1Description }}</span>
+              <span
+                v-if="namespaceNewAllowed"
+                class="mt-10"
+              >
+                {{ t('catalog.install.steps.basics.nsCreationDescription', {}, true) }}
+              </span>
+            </div>
           </Banner>
           <div
             v-if="requires.length || warnings.length"
@@ -1474,10 +1476,11 @@ export default {
 &nbsp;
           </div>
           <Banner
-            v-if="isNamespaceNew"
+            v-if="isNamespaceNew && value.metadata.namespace.length"
             color="info"
-            v-html="t('catalog.install.steps.basics.createNamespace', {namespace: value.metadata.namespace}, true) "
-          />
+          >
+            <div v-html="t('catalog.install.steps.basics.createNamespace', {namespace: value.metadata.namespace}, true) " />
+          </Banner>
         </div>
       </template>
       <template #clusterTplVersion>


### PR DESCRIPTION
Fixes #7977 

This PR:

- Fixes the top banner overlap rendering
- Fixes namespace banner at the bottom when creating a new namespace
- Only shows new namespace banner when the namespace has contents

After this PR:

![image](https://user-images.githubusercontent.com/1955897/214150638-114169b4-fd66-4d5a-8596-714819934897.png)

Before this PR, top banner is not rendered correctly:

![image](https://user-images.githubusercontent.com/1955897/214150884-1366af46-97ff-474a-8c11-ad94806d70b9.png)

Before this PR, when selecting 'Create a new namespace', the banner would show for an empty namespace:

![image](https://user-images.githubusercontent.com/1955897/214150972-9ccf36b4-6ff4-4faf-b625-59b7c7080685.png)

