### PR TITLE
Fixed preferences banner top margin

### DIFF
--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -320,7 +320,7 @@ export default {
           >
             <div class="col span-12">
               <Banner
-                color="set-login-page"
+                color="set-login-page mt-0"
                 :closable="true"
                 @close="closeSetLoginBanner()"
               >


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7994
<!-- Define findings related to the feature or bug issue. -->
Fixed Home page card alignment 

### How to test
Go to the home page > The banner to set login preferences and the side links panel should have their tops aligned.

![Screenshot 2023-01-24 at 11 32 40](https://user-images.githubusercontent.com/18264463/214269374-0856a237-05d3-43b5-b700-c3c3da53cbbe.png)

