### PR TITLE
PSA minor changes

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6223,6 +6223,11 @@ typeLabel:
       one { Workspace }
       other { Workspaces }
     }
+  management.cattle.io.podsecurityadmissionconfigurationtemplate: |-
+    {count, plural,
+      one { Pod Security Admission }
+      other { Pod Security Admissions }
+    }
   policy.poddisruptionbudget: |-
     {count, plural,
       one { Pod Disruption Budget }

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3942,10 +3942,20 @@ plugins:
         title: Remove the Rancher Extensions Custom Resource Definition
         prompt: There are one or more extensions installed - removing the CRD will require you to manually reinstall these extensions if you subsequently re-enable extensions support.
 podSecurityAdmission:
-  label: Pod Security Admission
+  name: Pod Security Admission
   description: Define the admission control mode you want to use for the pod security
   banner: 
     modifications: 'Note: Modifying a Pod Security Admission Configuration Template will not affect any downstream cluster that references it until there is a cluster update'
+  labels:
+    enforce: Enforce
+    audit: Audit
+    warn: Warn
+    usernames: Usernames
+    runtimeClasses: RuntimeClasses
+    namespaces: Namespaces
+    privileged: privileged
+    baseline: baseline
+    restricted: restricted
   version:
     placeholder: 'Version (default: latest)'
   exemptions: 

--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -90,7 +90,7 @@ export default {
     },
 
     labels() {
-      if (this.showAllLabels || !this.showFilteredSystemLabels) {
+      if (!this.showFilteredSystemLabels) {
         return this.value?.labels || {};
       }
 
@@ -249,6 +249,7 @@ export default {
             v-tooltip="prop ? `${key} : ${prop}` : key"
           >
             <span>{{ internalTooltips[key] ? internalTooltips[key] : key }}</span>
+            <span v-if="showAllLabels">: {{ key }}</span>
           </span>
           <span v-else>{{ prop ? `${key} : ${prop}` : key }}</span>
         </Tag>

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -235,13 +235,17 @@ export default {
     }
   },
   methods: {
-    getPSA(row) {
+    /**
+     * Get PSA HTML to be displayed in the tooltips
+     */
+    getPsaTooltip(row) {
       const dictionary = row.psaTooltipsDescription;
       const list = Object.values(dictionary)
         .sort()
         .map(text => `<li>${ text }</li>`).join('');
+      const title = `<p>${ this.t('podSecurityAdmission.name') }: </p>`;
 
-      return `<ul class="psa-tooltip">${ list }</ul>`;
+      return `${ title }<ul class="psa-tooltip">${ list }</ul>`;
     },
 
     userIsFilteringForSpecificNamespaceOrProject() {
@@ -409,7 +413,7 @@ export default {
           </span>
           <i
             v-if="row.hasSystemLabels"
-            v-tooltip="getPSA(row)"
+            v-tooltip="getPsaTooltip(row)"
             class="icon icon-lock ml-5"
           />
         </div>

--- a/shell/components/PodSecurityAdmission.vue
+++ b/shell/components/PodSecurityAdmission.vue
@@ -186,7 +186,7 @@ export default Vue.extend({
 <template>
   <div class="psa">
     <!-- PSA -->
-    <p class="helper-text mb-30">
+    <p class="mb-30">
       <t k="podSecurityAdmission.description" />
     </p>
 
@@ -237,7 +237,7 @@ export default Vue.extend({
           <t k="podSecurityAdmission.exemptions.title" />
         </h3>
       </slot>
-      <p class="helper-text mb-30">
+      <p class="mb-30">
         <t k="podSecurityAdmission.exemptions.description" />
       </p>
 

--- a/shell/components/PodSecurityAdmission.vue
+++ b/shell/components/PodSecurityAdmission.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Vue from 'vue';
-import { _VIEW } from '@shell/config/query-params';
+import { _VIEW, _CREATE } from '@shell/config/query-params';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
@@ -113,6 +113,12 @@ export default Vue.extend({
     };
 
     this.psaExemptionsControls = this.getPsaExemptions();
+
+    // Emit initial value on creation if labels always active, as default predefined values are required
+    if (this.mode === _CREATE && this.labelsAlwaysActive) {
+      this.updateLabels();
+      this.updateExemptions();
+    }
   },
 
   methods: {
@@ -134,6 +140,9 @@ export default Vue.extend({
       this.$emit('updateLabels', labels);
     },
 
+    /**
+     * Emit active exemptions in required format
+     */
     updateExemptions(): void {
       const exemptions = PSADimensions.reduce((acc, dimension) => {
         const value = this.psaExemptionsControls[dimension].value.split(',').map(value => value.trim());

--- a/shell/components/PodSecurityAdmission.vue
+++ b/shell/components/PodSecurityAdmission.vue
@@ -78,7 +78,10 @@ export default Vue.extend({
       // Generate PSA form controls
       psaControls:           toDictionary(PSAModes, getPsaControl) as Record<PSAMode, PSAControl>,
       psaExemptionsControls: toDictionary(PSADimensions, getExemptionControl) as Record<PSADimension, PSAExemptionControl>,
-      options:               PSALevels,
+      options:               PSALevels.map(level => ({
+        value: level,
+        label: this.t(`podSecurityAdmission.labels.${ level }`)
+      })),
     };
   },
 
@@ -197,6 +200,7 @@ export default Vue.extend({
           v-model="psaControl.active"
           :data-testid="componentTestid + '--psaControl-' + i + '-active'"
           :label="level"
+          :label-key="`podSecurityAdmission.labels.${ level }`"
           :disabled="isView"
           @input="updateLabels()"
         />
@@ -247,6 +251,7 @@ export default Vue.extend({
             v-model="psaExemptionsControl.active"
             :data-testid="componentTestid + '--psaExemptionsControl-' + i + '-active'"
             :label="dimension"
+            :label-key="`podSecurityAdmission.labels.${ dimension }`"
             :disabled="isView"
             @input="updateExemptions()"
           />

--- a/shell/components/__tests__/PodSecurityAdmission.test.ts
+++ b/shell/components/__tests__/PodSecurityAdmission.test.ts
@@ -204,6 +204,104 @@ describe('component: PodSecurityAdmission', () => {
         });
       });
     });
+
+    describe.each(['level', 'version'])('should keep always %p enabled', (inputId) => {
+      it('given labelsAlwaysActive true and no labels', () => {
+        const wrapper = mount(PodSecurityAdmission, {
+          propsData: {
+            mode:               'create',
+            labelsAlwaysActive: true,
+            labels:             {}
+          },
+        });
+
+        const input = wrapper.find(`[data-testid="pod-security-admission--psaControl-0-${ inputId }"]`).find('input').element as HTMLInputElement;
+
+        expect(input.disabled).toBe(false);
+      });
+
+      it('given existing values', () => {
+        const wrapper = mount(PodSecurityAdmission, {
+          propsData: {
+            mode:   'create',
+            labels: {
+              [`enforce`]:         'baseline',
+              [`enforce-version`]: '123'
+            }
+          },
+        });
+
+        const input = wrapper.find(`[data-testid="pod-security-admission--psaControl-0-${ inputId }"]`).find('input').element as HTMLInputElement;
+
+        expect(input.disabled).toBe(false);
+      });
+    });
+
+    describe.each(['level', 'version'])('should keep always %p disabled', (inputId) => {
+      it('given labelsAlwaysActive false and no labels', () => {
+        const wrapper = mount(PodSecurityAdmission, {
+          propsData: {
+            mode:               'create',
+            labelsAlwaysActive: false,
+            labels:             {}
+          },
+        });
+
+        const input = wrapper.find(`[data-testid="pod-security-admission--psaControl-0-${ inputId }"]`).find('input').element as HTMLInputElement;
+
+        expect(input.disabled).toBe(true);
+      });
+
+      it('given disabled active status', () => {
+        const wrapper = mount(PodSecurityAdmission, {
+          propsData: { mode: 'create' },
+          data:      () => ({
+            psaControls: {
+              enforce: {
+                active:  false,
+                level:   '',
+                version: ''
+              }
+            }
+          }),
+        });
+
+        const input = wrapper.find(`[data-testid="pod-security-admission--psaControl-0-${ inputId }"]`).find('input').element as HTMLInputElement;
+
+        expect(input.disabled).toBe(true);
+      });
+
+      it('given view mode and provided labels', () => {
+        const wrapper = mount(PodSecurityAdmission, {
+          propsData: {
+            mode:   'view',
+            labels: {
+              [`enforce`]:         'baseline',
+              [`enforce-version`]: '123'
+            }
+          },
+        });
+
+        const input = wrapper.find(`[data-testid="pod-security-admission--psaControl-0-${ inputId }"]`).find('input').element as HTMLInputElement;
+
+        expect(input.disabled).toBe(true);
+      });
+    });
+
+    it.each([
+      [true, false],
+    ])('should display the checkbox %p', (value) => {
+      const wrapper = mount(PodSecurityAdmission, {
+        propsData: {
+          mode:               'create',
+          labelsAlwaysActive: value
+        }
+      });
+
+      const input = wrapper.find(`[data-testid="pod-security-admission--psaControl-0-active"]`).element as HTMLInputElement;
+
+      expect(!input).toBe(value);
+    });
   });
 
   describe('handling exemptions', () => {

--- a/shell/components/__tests__/PodSecurityAdmission.test.ts
+++ b/shell/components/__tests__/PodSecurityAdmission.test.ts
@@ -2,13 +2,31 @@ import { mount } from '@vue/test-utils';
 import PodSecurityAdmission from '@shell/components/PodSecurityAdmission.vue';
 
 describe('component: PodSecurityAdmission', () => {
+  it.each([
+    ['updateLabels', {
+      audit:             'privileged',
+      'audit-version':   'latest',
+      enforce:           'privileged',
+      'enforce-version': 'latest',
+      warn:              'privileged',
+      'warn-version':    'latest',
+    }],
+    ['updateExemptions', {
+      namespaces: [], runtimeClasses: [], usernames: []
+    }]
+  ])('should emit %p and exemptions on creation if labels always active', (emission, value) => {
+    const wrapper = mount(PodSecurityAdmission, { propsData: { mode: 'create', labelsAlwaysActive: true } });
+
+    expect(wrapper.emitted(emission)![0][0]).toStrictEqual(value);
+  });
+
   describe('handling labels', () => {
     it.each([
       ['true', 'active'],
       ['', 'level'],
       ['', 'version'],
     ])('should display default value %p for input %p', (value, inputId) => {
-      const wrapper = mount(PodSecurityAdmission, { propsData: { mode: 'create' } });
+      const wrapper = mount(PodSecurityAdmission, { propsData: { mode: 'edit' } });
 
       const input = wrapper.find(`[data-testid="pod-security-admission--psaControl-0-${ inputId }"]`).find('input').element as HTMLInputElement;
 
@@ -44,7 +62,7 @@ describe('component: PodSecurityAdmission', () => {
 
         const wrapper = mount(PodSecurityAdmission, {
           propsData: {
-            mode:         'create',
+            mode:         'edit',
             labels,
             labelsPrefix: prefix
           }
@@ -65,7 +83,7 @@ describe('component: PodSecurityAdmission', () => {
 
         const wrapper = mount(PodSecurityAdmission, {
           propsData: {
-            mode:         'create',
+            mode:         'edit',
             labels,
             labelsPrefix: prefix
           }
@@ -88,7 +106,7 @@ describe('component: PodSecurityAdmission', () => {
 
         const wrapper = mount(PodSecurityAdmission, {
           propsData: {
-            mode:         'create',
+            mode:         'edit',
             labels,
             labelsPrefix: prefix
           }
@@ -108,7 +126,7 @@ describe('component: PodSecurityAdmission', () => {
           };
           const wrapper = mount(PodSecurityAdmission, {
             propsData: {
-              mode:         'create',
+              mode:         'edit',
               labels:       {},
               labelsPrefix: prefix
             },
@@ -141,7 +159,7 @@ describe('component: PodSecurityAdmission', () => {
           };
           const wrapper = mount(PodSecurityAdmission, {
             propsData: {
-              mode:         'create',
+              mode:         'edit',
               labels,
               labelsPrefix: prefix
             },
@@ -177,7 +195,7 @@ describe('component: PodSecurityAdmission', () => {
         it('should assign default version and level if missing', () => {
           const wrapper = mount(PodSecurityAdmission, {
             propsData: {
-              mode:         'create',
+              mode:         'edit',
               labels:       {},
               labelsPrefix: prefix
             },
@@ -209,7 +227,7 @@ describe('component: PodSecurityAdmission', () => {
       it('given labelsAlwaysActive true and no labels', () => {
         const wrapper = mount(PodSecurityAdmission, {
           propsData: {
-            mode:               'create',
+            mode:               'edit',
             labelsAlwaysActive: true,
             labels:             {}
           },
@@ -223,7 +241,7 @@ describe('component: PodSecurityAdmission', () => {
       it('given existing values', () => {
         const wrapper = mount(PodSecurityAdmission, {
           propsData: {
-            mode:   'create',
+            mode:   'edit',
             labels: {
               [`enforce`]:         'baseline',
               [`enforce-version`]: '123'
@@ -241,7 +259,7 @@ describe('component: PodSecurityAdmission', () => {
       it('given labelsAlwaysActive false and no labels', () => {
         const wrapper = mount(PodSecurityAdmission, {
           propsData: {
-            mode:               'create',
+            mode:               'edit',
             labelsAlwaysActive: false,
             labels:             {}
           },
@@ -254,7 +272,7 @@ describe('component: PodSecurityAdmission', () => {
 
       it('given disabled active status', () => {
         const wrapper = mount(PodSecurityAdmission, {
-          propsData: { mode: 'create' },
+          propsData: { mode: 'edit' },
           data:      () => ({
             psaControls: {
               enforce: {
@@ -293,7 +311,7 @@ describe('component: PodSecurityAdmission', () => {
     ])('should display the checkbox %p', (value) => {
       const wrapper = mount(PodSecurityAdmission, {
         propsData: {
-          mode:               'create',
+          mode:               'edit',
           labelsAlwaysActive: value
         }
       });
@@ -326,7 +344,7 @@ describe('component: PodSecurityAdmission', () => {
 
       const wrapper = mount(PodSecurityAdmission, {
         propsData: {
-          mode: 'create',
+          mode: 'edit',
           exemptions,
         }
       });
@@ -341,7 +359,7 @@ describe('component: PodSecurityAdmission', () => {
       const exemptions = { usernames: [value] };
       const wrapper = mount(PodSecurityAdmission, {
         propsData: {
-          mode: 'create',
+          mode: 'edit',
           exemptions
         }
       });
@@ -364,7 +382,7 @@ describe('component: PodSecurityAdmission', () => {
         };
         const wrapper = mount(PodSecurityAdmission, {
           propsData: {
-            mode: 'create',
+            mode: 'edit',
             exemptions
           },
         });

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -75,7 +75,7 @@ export default {
           :on-label="t('labels.labels.show')"
         />
       </div>
-      <p class="helper-text mt-10 mb-10">
+      <p class="mt-10 mb-10">
         <t k="labels.labels.description" />
       </p>
       <div :class="sectionClass">

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -3,7 +3,8 @@ import {
   CAPI,
   CATALOG,
   NORMAN,
-  HCI
+  HCI,
+  MANAGEMENT
 } from '@shell/config/types';
 import { MULTI_CLUSTER } from '@shell/store/features';
 import { DSL } from '@shell/store/type-map';
@@ -65,7 +66,6 @@ export function init(store) {
     'cloud-credentials',
     'drivers',
     'pod-security-policies',
-    'management.cattle.io.podsecurityadmissionconfigurationtemplate'
   ]);
 
   configureType(CAPI.RANCHER_CLUSTER, {
@@ -120,6 +120,7 @@ export function init(store) {
   weightType(CAPI.MACHINE_SET, 2, true);
   weightType(CAPI.MACHINE, 1, true);
   weightType(CATALOG.CLUSTER_REPO, 0, true);
+  weightType(MANAGEMENT.PSA, 5, true);
 
   basicType([
     CAPI.MACHINE_DEPLOYMENT,
@@ -127,6 +128,7 @@ export function init(store) {
     CAPI.MACHINE,
     CATALOG.CLUSTER_REPO,
     'pod-security-policies',
+    MANAGEMENT.PSA
   ], 'advanced');
 
   weightGroup('advanced', -1, true);

--- a/shell/edit/management.cattle.io.podsecurityadmissionconfigurationtemplate.vue
+++ b/shell/edit/management.cattle.io.podsecurityadmissionconfigurationtemplate.vue
@@ -97,6 +97,7 @@ export default (Vue as VueConstructor<Vue & InstanceType<typeof CreateEditView>>
     />
     <PodSecurityAdmission
       :labels="defaults"
+      :labels-always-active="true"
       :exemptions="exemptions"
       :mode="mode"
       @updateLabels="setDefaults($event)"

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -238,8 +238,8 @@ export default {
       </Tab>
       <Tab
         name="pod-security-admission"
-        label-key="podSecurityAdmission.label"
-        :label="t('podSecurityAdmission.label')"
+        label-key="podSecurityAdmission.name"
+        :label="t('podSecurityAdmission.name')"
       >
         <PodSecurityAdmission
           :labels="value.labels"

--- a/shell/models/pod.js
+++ b/shell/models/pod.js
@@ -190,6 +190,7 @@ export default class Pod extends WorkloadService {
         this.$dispatch('growl/warning', {
           title:   this.$rootGetters['i18n/t']('growl.podSecurity.title'),
           message: this.$rootGetters['i18n/t']('growl.podSecurity.message'),
+          timeout: 5000,
         }, { root: true });
       }
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7999
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- PSA position is now under Advance with a new name
- PSA edit/list is not added as i18n term and shortened
- PSA form labels are now i18n and capitalized
- Restored original text size in PSA Edit descriptions
- Replaced checkboxes for PSA template edit, while kept in the Namespace tab, updating related logic
- Added tooltip title in Namespace list resource which contain PSA labels
- Updated detail page label to toggle between concise and verbose version
- Increased growl timeout to 5 seconds on Pod creation with warn/restricted

### Technical notes summary
Updated and added tests related to PSA:
- Creation in case of no checkboxes
- Input disabled

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

Namespace details

https://user-images.githubusercontent.com/5009481/214538184-d7cbd9ab-ceb1-439c-9894-65656984d292.mov

PSA form and sidebar

https://user-images.githubusercontent.com/5009481/214541837-8d3fbdf6-f16e-4f98-8ac1-b5fb79500431.mov

PSA form creation cases with and without edit

https://user-images.githubusercontent.com/5009481/214557362-70e8743d-ca27-4673-829e-141a1c9427be.mov

Pod growl

https://user-images.githubusercontent.com/5009481/214541876-a67cc23d-883c-492b-8c24-5cd827a84fa4.mov

