### PR TITLE
Added port input in receiver email form

### DIFF
--- a/shell/config/product/monitoring.js
+++ b/shell/config/product/monitoring.js
@@ -79,7 +79,8 @@ export function init(store) {
           to:            { type: 'string' },
           send_resolved: { type: 'boolean' },
           from:          { type: 'string' },
-          smarthost:     { type: 'string' },
+          host:          { type: 'string' },
+          port:          { type: 'string' },
           require_tls:   { type: 'boolean' },
           auth_username: { type: 'string' },
           auth_password: { type: 'string' }

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -48,7 +48,6 @@ export default {
       for (let i = 0; i < this.value.spec.email_configs.length; i++) {
         if (this.value.spec.email_configs[i].smarthost) {
           const hostPort = this.value.spec.email_configs[i].smarthost.split(':');
-
           this.$set(this.value.spec.email_configs[i], 'host', hostPort[0] || '');
           this.$set(this.value.spec.email_configs[i], 'port', hostPort[1] || '');
           delete this.value.spec.email_configs[i]['smarthost'];
@@ -167,7 +166,8 @@ export default {
       if (this.value.spec.email_configs.length > 0) {
         this.value.spec.email_configs.forEach((email) => {
           if (email['port'] || email['host']) {
-            email.smarthost = email.port ? `${ email.host }:${ email.port }` : `${ email.host }`;
+            const hostValue =  email.host ? `${ email.host }` : '';
+            email.smarthost = email.port ? `${ hostValue }:${ email.port }` : `${ hostValue }`;
             delete email['port'];
             delete email['host'];
           }

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -165,28 +165,19 @@ export default {
 
     createSmarthost() {
       if (this.value.spec.email_configs.length > 0) {
-        for (let i = 0; i < this.value.spec.email_configs.length; i++) {
-          if (this.value.spec.email_configs[i]['port'] || this.value.spec.email_configs[i]['host']) {
-            this.value.spec.email_configs[i].smarthost = `${ this.value.spec.email_configs[i].host }:${ this.value.spec.email_configs[i].port }`;
+        this.value.spec.email_configs.forEach((email) => {
+          if (email['port'] || email['host']) {
+            email.smarthost = `${ email.host }:${ email.port }`;
+            delete email['port'];
+            delete email['host'];
           }
-        }
-      }
-    },
-    deletePortHost() {
-      if (this.value.spec.email_configs.length > 0) {
-        for (let i = 0; i < this.value.spec.email_configs.length; i++) {
-          if (this.value.spec.email_configs[i]['port'] || this.value.spec.email_configs[i]['host']) {
-            delete this.value.spec.email_configs[i]['port'];
-            delete this.value.spec.email_configs[i]['host'];
-          }
-        }
+        });
       }
     }
   },
 
   created() {
     this.registerBeforeHook(this.createSmarthost, 'create-smarthost');
-    this.registerAfterHook(this.deletePortHost, 'delete-port-host');
   },
 };
 </script>

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -48,6 +48,7 @@ export default {
       for (let i = 0; i < this.value.spec.email_configs.length; i++) {
         if (this.value.spec.email_configs[i].smarthost) {
           const hostPort = this.value.spec.email_configs[i].smarthost.split(':');
+
           this.$set(this.value.spec.email_configs[i], 'host', hostPort[0] || '');
           this.$set(this.value.spec.email_configs[i], 'port', hostPort[1] || '');
           delete this.value.spec.email_configs[i]['smarthost'];
@@ -166,7 +167,8 @@ export default {
       if (this.value.spec.email_configs.length > 0) {
         this.value.spec.email_configs.forEach((email) => {
           if (email['port'] || email['host']) {
-            const hostValue =  email.host ? `${ email.host }` : '';
+            const hostValue = email.host ? `${ email.host }` : '';
+
             email.smarthost = email.port ? `${ hostValue }:${ email.port }` : `${ hostValue }`;
             delete email['port'];
             delete email['host'];

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -48,6 +48,7 @@ export default {
       for (let i = 0; i < this.value.spec.email_configs.length; i++) {
         if (this.value.spec.email_configs[i].smarthost) {
           const hostPort = this.value.spec.email_configs[i].smarthost.split(':');
+
           this.$set(this.value.spec.email_configs[i], 'host', hostPort[0] || '');
           this.$set(this.value.spec.email_configs[i], 'port', hostPort[1] || '');
           delete this.value.spec.email_configs[i]['smarthost'];

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -167,7 +167,7 @@ export default {
       if (this.value.spec.email_configs.length > 0) {
         this.value.spec.email_configs.forEach((email) => {
           if (email['port'] || email['host']) {
-            email.smarthost = `${ email.host }:${ email.port }`;
+            email.smarthost = email.port ? `${ email.host }:${ email.port }` : `${ email.host }`;
             delete email['port'];
             delete email['host'];
           }

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -161,8 +161,33 @@ export default {
 
     createAddOptions(receiverType) {
       return receiverType.addOptions.map();
+    },
+
+    createSmarthost() {
+      if (this.value.spec.email_configs.length > 0) {
+        for (let i = 0; i < this.value.spec.email_configs.length; i++) {
+          if (this.value.spec.email_configs[i]['port'] || this.value.spec.email_configs[i]['host']) {
+            this.value.spec.email_configs[i].smarthost = `${ this.value.spec.email_configs[i].host }:${ this.value.spec.email_configs[i].port }`;
+          }
+        }
+      }
+    },
+    deletePortHost() {
+      if (this.value.spec.email_configs.length > 0) {
+        for (let i = 0; i < this.value.spec.email_configs.length; i++) {
+          if (this.value.spec.email_configs[i]['port'] || this.value.spec.email_configs[i]['host']) {
+            delete this.value.spec.email_configs[i]['port'];
+            delete this.value.spec.email_configs[i]['host'];
+          }
+        }
+      }
     }
-  }
+  },
+
+  created() {
+    this.registerBeforeHook(this.createSmarthost, 'create-smarthost');
+    this.registerAfterHook(this.deletePortHost, 'delete-port-host');
+  },
 };
 </script>
 

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -20,6 +20,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 import jsyaml from 'js-yaml';
 import { RECEIVERS_TYPES } from '@shell/models/monitoring.coreos.com.receiver';
 import ButtonDropdown from '@shell/components/ButtonDropdown';
+import { _EDIT, _VIEW } from 'config/query-params';
 
 export default {
   components: {
@@ -42,6 +43,17 @@ export default {
 
   data() {
     this.$set(this.value, 'spec', this.value.spec || {});
+    console.log('this.mode', this.mode);
+    if (this.mode === _EDIT || this.mode === _VIEW) {
+      for (let i = 0; i < this.value.spec.email_configs.length; i++) {
+        if (this.value.spec.email_configs[i].smarthost) {
+          const hostPort = this.value.spec.email_configs[i].smarthost.split(':');
+          this.$set(this.value.spec.email_configs[i], 'host', hostPort[0] || '');
+          this.$set(this.value.spec.email_configs[i], 'port', hostPort[1] || '');
+          delete this.value.spec.email_configs[i]['smarthost'];
+        }
+      }
+    }
 
     RECEIVERS_TYPES.forEach((receiverType) => {
       this.$set(this.value.spec, receiverType.key, this.value.spec[receiverType.key] || []);

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -20,7 +20,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 import jsyaml from 'js-yaml';
 import { RECEIVERS_TYPES } from '@shell/models/monitoring.coreos.com.receiver';
 import ButtonDropdown from '@shell/components/ButtonDropdown';
-import { _EDIT, _VIEW } from 'config/query-params';
+import { _EDIT, _VIEW } from '@shell/config/query-params';
 
 export default {
   components: {
@@ -43,7 +43,7 @@ export default {
 
   data() {
     this.$set(this.value, 'spec', this.value.spec || {});
-    console.log('this.mode', this.mode);
+
     if (this.mode === _EDIT || this.mode === _VIEW) {
       for (let i = 0; i < this.value.spec.email_configs.length; i++) {
         if (this.value.spec.email_configs[i].smarthost) {

--- a/shell/edit/monitoring.coreos.com.receiver/types/email.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/email.vue
@@ -73,15 +73,23 @@ export default {
       </div>
     </div>
     <div class="row mb-20">
-      <div class="col span-6">
+      <div class="col span-4">
         <LabeledInput
-          v-model="value.smarthost"
+          v-model="value.host"
           :mode="mode"
           label="Host"
-          placeholder="e.g. 192.168.1.121:587"
+          placeholder="e.g. 192.168.1.121"
         />
       </div>
-      <div class="col span-6">
+      <div class="col span-4">
+        <LabeledInput
+          v-model="value.port"
+          :mode="mode"
+          label="Port"
+          placeholder="e.g. 80"
+        />
+      </div>
+      <div class="col span-4">
         <Checkbox
           v-model="value.require_tls"
           :mode="mode"

--- a/shell/models/monitoring.coreos.com.receiver.js
+++ b/shell/models/monitoring.coreos.com.receiver.js
@@ -72,17 +72,6 @@ export default class Receiver extends SteveModel {
       return Promise.reject(errors);
     }
 
-    if (this.spec.email_configs.length > 0) {
-      for (let i = 0; i < this.spec.email_configs.length; i++) {
-        if (this.spec.email_configs[i]['port'] || this.spec.email_configs[i]['host']) {
-          this.spec.email_configs[i].smarthost = `${ this.spec.email_configs[i].host }:${ this.spec.email_configs[i].port }`;
-
-          delete this.spec.email_configs[i]['port'];
-          delete this.spec.email_configs[i]['host'];
-        }
-      }
-    }
-
     await this.updateReceivers((currentReceivers) => {
       const existingReceiver = currentReceivers.find(r => r.name === this.spec?.name);
 

--- a/shell/models/monitoring.coreos.com.receiver.js
+++ b/shell/models/monitoring.coreos.com.receiver.js
@@ -72,6 +72,17 @@ export default class Receiver extends SteveModel {
       return Promise.reject(errors);
     }
 
+    if (this.spec.email_configs.length > 0) {
+      for (let i = 0; i < this.spec.email_configs.length; i++) {
+        if (this.spec.email_configs[i]['port'] || this.spec.email_configs[i]['host']) {
+          this.spec.email_configs[i].smarthost = `${ this.spec.email_configs[i].host }:${ this.spec.email_configs[i].port }`;
+
+          delete this.spec.email_configs[i]['port'];
+          delete this.spec.email_configs[i]['host'];
+        }
+      }
+    }
+
     await this.updateReceivers((currentReceivers) => {
       const existingReceiver = currentReceivers.find(r => r.name === this.spec?.name);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5453
<!-- Define findings related to the feature or bug issue. -->
Added port input in receiver email form


### How to test
- Goto > cluster > monitoring > route-receiver
- Click on `Create` > select Email tab > click on `Add email`, form should have a Port field

![Screenshot 2023-01-25 at 12 05 43](https://user-images.githubusercontent.com/18264463/214567268-53bcff65-f3ad-46c9-b0cf-9fe252118e65.png)

