### PR TITLE
Home page not load in safari: positive lookhead unsupported

### DIFF
--- a/shell/edit/workload/__tests__/index.test.ts
+++ b/shell/edit/workload/__tests__/index.test.ts
@@ -1,0 +1,98 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Workload from '@shell/edit/workload/index.vue';
+
+jest.mock('@shell/models/secret', () => ({ onmessage: jest.fn() }));
+
+describe('component: Workload', () => {
+  it.each([
+    [
+      `pods \"test\" is forbidden: violates PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"container-0\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"container-0\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (container \"container-0\" must not set securityContext.runAsNonRoot=false), seccompProfile (pod or container \"container-0\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")`,
+      `Pod "test" Security Policy Violation "restricted:latest"`
+    ]
+  ])('should map error message into object', (oldMessage, newMessage) => {
+    const mockedValidationMixin = {
+      methods: {
+        fvFormIsValid:                jest.fn(),
+        type:                         jest.fn(),
+        fvUnreportedValidationErrors: jest.fn(),
+        fvGetAndReportPathRules:      jest.fn(),
+      }
+    };
+    const mockedCREMixin = {};
+    const mockedWorkloadMixin = {
+      methods: {
+        doneRoute:                   jest.fn(),
+        workloadSubTypes:            jest.fn(),
+        applyHooks:                  jest.fn(),
+        save:                        jest.fn(),
+        selectType:                  jest.fn(),
+        isCronJob:                   jest.fn(),
+        spec:                        jest.fn(),
+        isReplicable:                jest.fn(),
+        isStatefulSet:               jest.fn(),
+        headlessServices:            jest.fn(),
+        defaultTab:                  jest.fn(),
+        allContainers:               jest.fn(),
+        isPod:                       jest.fn(),
+        tabWeightMap:                jest.fn(),
+        podLabels:                   jest.fn(),
+        podTemplateSpec:             jest.fn(),
+        isLoadingSecondaryResources: jest.fn(),
+        allNodes:                    jest.fn(),
+        allNodeObjects:              jest.fn(),
+        clearPvcFormState:           jest.fn(),
+        savePvcHookName:             jest.fn(),
+        namespacedConfigMaps:        jest.fn(),
+        podAnnotations:              jest.fn(),
+        isJob:                       jest.fn(),
+        podFsGroup:                  jest.fn(),
+        namespacedSecrets:           jest.fn(),
+        registerBeforeHook:          jest.fn(),
+        pvcs:                        jest.fn(),
+        // tabWeightMap:     jest.fn(),
+      }
+    };
+    const localVue = createLocalVue();
+    const MockedWorkload = { ...Workload, mixins: [mockedValidationMixin, mockedCREMixin, mockedWorkloadMixin] };
+    const wrapper = shallowMount(MockedWorkload, {
+      localVue,
+      propsData: {
+        value:         { metadata: {}, spec: { template: {} } },
+        params:        {},
+        fvFormIsValid: {}
+      },
+      mocks: {
+        $route:      { params: {}, query: {} },
+        $router:     { applyQuery: jest.fn() },
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            'cluster/schemaFor': jest.fn(),
+            'type-map/labelFor': jest.fn(),
+            'i18n/t':            jest.fn(),
+          },
+        },
+      },
+      stubs: {
+        Tab:                 true,
+        LabeledInput:        true,
+        VolumeClaimTemplate: true,
+        Networking:          true,
+        Job:                 true,
+        NodeScheduling:      true,
+        PodAffinity:         true,
+        Tolerations:         true,
+        Storage:             true,
+        Tabbed:              true,
+        LabeledSelect:       true,
+        NameNsDescription:   true,
+        CruResource:         true,
+        KeyValue:            true
+      }
+    });
+
+    const result = (wrapper.vm as any).mapError(oldMessage).message;
+
+    expect(result).toStrictEqual(newMessage);
+  });
+});

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -38,12 +38,12 @@ export default {
     mapError(error) {
       switch (true) {
       case error.includes('violates PodSecurity'): {
-        const match = error.match(/(?<=\")(.*?)(?=\")/gi);
+        const match = error.match(/\"(.*?)\"/gi);
         const name = match[0];
-        const policy = match[2];
+        const policy = match[1];
 
         return {
-          message: `Pod "${ name }" Security Policy Violation "${ policy }"`,
+          message: `Pod ${ name } Security Policy Violation ${ policy }`,
           icon:    'icon-pod_security'
         };
       }
@@ -57,7 +57,7 @@ export default {
      * Map all the error texts to a message and icon object
      */
     getErrorsMap(errors) {
-      return !errors ? {} : errors.reduce((acc, error) => ({
+      return !errors || !Array.isArray(errors) ? {} : errors.reduce((acc, error) => ({
         ...acc,
         [error]: this.mapError(error) || {
           message: error,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8023
As mentioned in the issue, it's not possible to load the page with current regular expression, as positive lookbehind is not supported in Safari.

### Occurred changes and/or fixed issues
Changed regular expression.

### Technical notes summary
Created very cumbersome sized unit test for the mapping method.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

![Screenshot 2023-01-25 at 17 15 43](https://user-images.githubusercontent.com/5009481/214616510-970638a9-bf50-4d02-818e-cdfbba8e6123.png)
