### PR TITLE
Renamed Worker CIS Profile to CIS Profile

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1065,7 +1065,7 @@ cis:
   testID: Test ID
   testsSkipped: Tests Skipped
   testsToSkip: Tests to Skip
-  workerProfile: CIS Worker Profile
+  workerProfile: CIS Profile
 
 cluster:
   addonChart:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7950
<!-- Define findings related to the feature or bug issue. -->
Renamed `Worker CIS Profile` to `CIS Profile`

### How to test
- Navigate to Add Cluster -> RKE2 -> Custom
- Check 'Worker CIS Profile' dropdown under the Security section should be `CIS Profile`