### PR TITLE
Backport: Modal warning disable auth provider

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3873,6 +3873,7 @@ promptRemove:
     other { and <b>{count} others</b>.}
     }
   attemptingToRemove: "You are attempting to delete the {type}"
+  attemptingToRemoveAuthConfig: "You are attempting to disable this Auth Provider. <br><br> Be aware that cluster role template bindings, project role template bindings, global role bindings, users, tokens will be all deleted. <br><br> Are you sure you want to proceed?"
   protip: "Tip: Hold the {alternateLabel} key while clicking delete to bypass this confirmation"
   confirmName: "Enter <b>{nameToMatch}</b> below to confirm:"
   deleteAssociatedNamespaces: "Also delete the namespaces in this project:"

--- a/shell/components/DisableAuthProviderModal.vue
+++ b/shell/components/DisableAuthProviderModal.vue
@@ -1,0 +1,102 @@
+<script>
+import { Card } from '@components/Card';
+export default {
+  name:       'PromptRemove',
+  components: { Card },
+  props:      {
+    /**
+     * Inherited global identifier prefix for tests
+     * Define a term based on the parent component to avoid conflicts on multiple components
+     */
+    componentTestid: {
+      type:    String,
+      default: 'disable-auth-provider'
+    }
+  },
+  methods: {
+    show() {
+      this.$modal.show('disableAuthProviderModal');
+    },
+    close() {
+      this.$modal.hide('disableAuthProviderModal');
+    },
+    disable() {
+      this.$modal.hide('disableAuthProviderModal');
+      this.$emit('disable');
+    },
+  }
+};
+</script>
+
+<template>
+  <modal
+    class="remove-modal"
+    name="disableAuthProviderModal"
+    :width="400"
+    height="auto"
+    styles="max-height: 100vh;"
+    @closed="close"
+  >
+    <Card
+      class="disable-auth-provider"
+      :show-highlight-border="false"
+    >
+      <h4
+        slot="title"
+        class="text-default-text"
+      >
+        {{ t('promptRemove.title') }}
+      </h4>
+      <div slot="body">
+        <div class="mb-10">
+          <p v-html="t('promptRemove.attemptingToRemoveAuthConfig', null, true)" />
+        </div>
+      </div>
+      <template #actions>
+        <button
+          class="btn role-secondary"
+          @click="close"
+        >
+          {{ t('generic.cancel') }}
+        </button>
+        <div class="spacer" />
+        <button
+          class="btn role-primary bg-error ml-10"
+          :data-testid="componentTestid + '-confirm-button'"
+          @click="disable"
+        >
+          {{ t('generic.disable') }}
+        </button>
+      </template>
+    </Card>
+  </modal>
+</template>
+
+<style lang='scss'>
+  .disable-auth-provider {
+    &.card-container {
+      box-shadow: none;
+    }
+    #confirm {
+      width: 90%;
+      margin-left: 3px;
+    }
+    .remove-modal {
+        border-radius: var(--border-radius);
+        overflow: scroll;
+        max-height: 100vh;
+        & ::-webkit-scrollbar-corner {
+          background: rgba(0,0,0,0);
+        }
+    }
+    .actions {
+      text-align: right;
+    }
+    .card-actions {
+      display: flex;
+      .spacer {
+        flex: 1;
+      }
+    }
+  }
+</style>

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -1,12 +1,12 @@
 
 <script>
 import { Banner } from '@components/Banner';
-import AsyncButton from '@shell/components/AsyncButton';
+import DisableAuthProviderModal from '@shell/components/DisableAuthProviderModal';
 
 export default {
   components: {
-    AsyncButton,
-    Banner
+    Banner,
+    DisableAuthProviderModal
   },
 
   props: {
@@ -32,6 +32,11 @@ export default {
       return Object.entries(this.table);
     }
   },
+  methods: {
+    showDisableModal() {
+      this.$refs.disableAuthProviderModal.show();
+    }
+  },
 };
 </script>
 
@@ -45,12 +50,22 @@ export default {
       <button type="button" class="btn-sm role-primary" @click="edit">
         {{ t('action.edit') }}
       </button>
-      <AsyncButton class="ml-10" mode="disable" size="sm" action-color="bg-error" @click="disable" />
+      <button
+        type="button"
+        class="ml-10 btn-sm role-primary bg-error"
+        @click="showDisableModal"
+      >
+        {{ t('generic.disable') }}
+      </button>
     </Banner>
 
     <table v-if="!!$slots.rows" class="values">
       <slot name="rows"></slot>
     </table>
+    <DisableAuthProviderModal
+      ref="disableAuthProviderModal"
+      @disable="disable"
+    />
   </div>
 </template>
 

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -214,7 +214,7 @@ export default {
       }
     },
 
-    async disable(btnCb) {
+    async disable() {
       try {
         if (this.model.hasAction('disable')) {
           await this.model.doAction('disable');
@@ -233,10 +233,8 @@ export default {
           opt:  { url: '/v3/principals', force: true }
         });
         this.showLdap = false;
-        btnCb(true);
       } catch (err) {
         this.errors = [err];
-        btnCb(false);
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8005
<!-- Define findings related to the feature or bug issue. -->
Backport: Show confirmation modal when trying to disable auth provider


### How to test

- Go to Users & Authentication -> Auth Provider
- Provision an Auth Provider such as OpenLDAP 
- After OpenLDAP is active, press disable
- Modal should appear and work as expected (copy is according https://github.com/rancher/dashboard/issues/7525 )