### PR TITLE
fix issue detected on advanced filtering where searching for a text w…

### DIFF
--- a/shell/components/SortableTable/filtering.js
+++ b/shell/components/SortableTable/filtering.js
@@ -254,7 +254,7 @@ function matches(fields, token, item) {
     }
 
     if ( !modifier ) {
-      if ( val.includes(token) ) {
+      if ( val.includes((`${ token }`).toLowerCase()) ) {
         return true;
       }
     } else if ( modifier === 'exact' ) {


### PR DESCRIPTION
Fixes https://github.com/rancher/elemental-ui/issues/68

- fix issue detected on advanced filtering where searching for a text with an uppercase yelded no results (should be case insensitive)

To reproduce - only works with Elemental extension:
- Create a couple of machine inventories
- On one of those machine inventories, edit it and create a label with some uppercase value:

```
labels:
  some-label: SomeLabelValue
```
- Go the machine inventories list and apply an advanced filter on all cols with the value `SomeLabelValue`
- It should filter the value correctly
