### PR TITLE
[2.6 backport] Fix Changing a Container Name highlights the Deployment tab when creating a Deployment

### DIFF
--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -94,7 +94,7 @@ export default {
       <Tabbed class="deployment-tabs" :show-tabs-add-remove="true" :default-tab="defaultTab" :flat="true" @changed="changed">
         <Tab
           v-for="(tab, i) in allContainers"
-          :key="i+tab.name"
+          :key="i"
           :label="tab.name"
           :name="tab.name"
           :weight="tab.weight"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7505

I think this fix makes sense: if the tab is keyed off the container name, every time the container name is changed the tab is re-rendered, its `active` property is re-set to `null`, the `Tabbed` component detects that tabs have changed, looks for a tab with `active === true`, doesn't find one, and defaults to the first tab (deployment labels). 

Do you remember what happned here @Shavindra ? The introduction of this bug in 2.6 and resolution in 2.7 is less unclear to me, which is why this PR isn't just a cherry-pick of a fix from 2.7... The bug was introduced by [this PR, 6841 ](https://github.com/rancher/dashboard/pull/6841/commits/eb0c53e9417bbf21eadc5c94a8bf5b848ea176f8) which claimed to fix [this issue, 6837](https://github.com/rancher/dashboard/issues/6837), but I can't reproduce that issue after reverting the tab key change from the PR. The other changes from that PR were...overwritten? Removed? By some other PR in 2.6 and re-added along with the fix for the tab key in 2.7 [here](https://github.com/rancher/dashboard/pull/7105/commits/27d79f02b06b75d732acc12d6e227b622eebf658). tl;dr I'm confused by the git history around this but form behavior seems ok with this PR. 