### PR TITLE
HARVESTER: Fix can not load Harvester plugin on Harvester cluster page

### DIFF
--- a/shell/plugins/steve/worker/web-worker.advanced.js
+++ b/shell/plugins/steve/worker/web-worker.advanced.js
@@ -300,3 +300,5 @@ onmessage = (e) => {
     }
   });
 }; // bind everything to the worker's onmessage handler via the workerActions
+
+export default {};

--- a/shell/plugins/steve/worker/web-worker.basic.js
+++ b/shell/plugins/steve/worker/web-worker.basic.js
@@ -95,3 +95,5 @@ const workerActions = {
 };
 
 onmessage = workerActions.onmessage; // bind everything to the worker's onmessage handler via the workerAction
+
+export default {};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix "export 'default' was not found when building plugins
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Reproduce Steps:
1. Run `yarn build-pkg harvester && yarn serve-pkgs` under rancher/dashboard repo.
2. The terminal will throw two warrings: `"export 'default' (imported as 'advancedWorkerConstructor') was not found in '@shell/plugins/steve/worker/web-worker.advanced.js'` and `"export 'default' (imported as 'basicWorkerConstructor') was not found in '@shell/plugins/steve/worker/web-worker.basic.js'`
3. Login to the Rancher and import a Harvester cluster
4. Go to the Global setting. Set `ui-dashboard-index` to `https://releases.rancher.com/dashboard/latest/index.html`. Set `ui-offline-preferred` to `Remote`.
5. Login to the Harvester UI, and go to settings. Set `ui-plugin-index` to `http://127.0.0.1:4500/harvester-1.1.0/harvester-1.1.0.umd.min.js`. Set `ui-source` to `External `
6. Open the Rancher UI and try to go to the imported Harvester cluster

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Fix "export 'default' was not found when building plugins

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://user-images.githubusercontent.com/18737885/215271958-cda57c50-075c-4639-8553-94d77bcc50b7.png)

