### PR TITLE
fix styling of visible cols in advanced filtering

### DIFF
--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -348,7 +348,7 @@ export default {
         }
       }
       .table-options-container {
-        width: 320px;
+        width: 350px;
         border: 1px solid var(--primary);
         background-color: var(--body-bg);
         padding: 20px;
@@ -369,11 +369,10 @@ export default {
           list-style: none;
           margin: 0;
           padding: 0;
-          display: flex;
-          flex-wrap: wrap;
+          max-height: 200px;
+          overflow-y: auto;
 
           li {
-            flex: 1 1 136px;
             margin: 0;
             padding: 0;
 
@@ -486,12 +485,10 @@ export default {
     }
   </style>
   <style lang="scss">
+    .table-options-checkbox .checkbox-custom {
+      min-width: 14px;
+    }
     .table-options-checkbox .checkbox-label {
       color: var(--body-text);
-      text-overflow: ellipsis;
-      width: 100px;
-      display: inline-block;
-      white-space: nowrap;
-      overflow: hidden;
     }
   </style>


### PR DESCRIPTION
Fixes rancher/elemental-ui#71 

- fix styling of visible cols in advanced filtering

Before:
![Screenshot 2023-01-31 at 10 20 48](https://user-images.githubusercontent.com/97888974/215734478-cab24fed-a571-4f5b-84af-2c5f76234f58.png)

After:
![Screenshot 2023-01-31 at 10 17 28](https://user-images.githubusercontent.com/97888974/215734554-59765579-8449-47e0-81bf-3c8494a7d7f4.png)


To test:
- Check the inventory of machines in Elemental as it's where the advanced filtering is activated