### PR TITLE
Selection for PSA is cleared after changing the RKE2/K3S cluster version

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1806,7 +1806,6 @@ export default {
         }
 
         this.previousKubernetesVersion = value;
-        set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateName', '');
       }
     },
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -280,7 +280,6 @@ export default {
 
     // Store the initial PSP template name, so we can set it back if needed
     const lastDefaultPodSecurityPolicyTemplateName = this.value.spec.defaultPodSecurityPolicyTemplateName;
-    const lastDefaultPodSecurityAdmissionTemplateName = this.value.spec.defaultPodSecurityAdmissionTemplateName;
     const previousKubernetesVersion = this.value.spec.kubernetesVersion;
 
     return {
@@ -314,7 +313,6 @@ export default {
       }],
       harvesterVersionRange: {},
       lastDefaultPodSecurityPolicyTemplateName,
-      lastDefaultPodSecurityAdmissionTemplateName,
       previousKubernetesVersion,
     };
   },
@@ -1810,13 +1808,6 @@ export default {
     },
 
     /**
-     * Keep last PSA value
-     */
-    handlePsaChange(value) {
-      this.lastDefaultPodSecurityAdmissionTemplateName = value;
-    },
-
-    /**
      * Keep last PSP value
      */
     handlePspChange(value) {
@@ -2105,7 +2096,6 @@ export default {
                 data-testid="rke2-custom-edit-psa"
                 :options="psaOptions"
                 :label="t('cluster.rke2.defaultPodSecurityAdmissionConfigurationTemplateName.label')"
-                @input="handlePsaChange($event)"
               />
             </div>
           </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1795,11 +1795,8 @@ export default {
 
         // Reset PSA if not RKE2
         if (!value.includes('rke2')) {
-          set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateName', '');
           set(this.value.spec, 'defaultPodSecurityPolicyTemplateName', '');
         } else {
-          set(this.value.spec, 'defaultPodSecurityAdmissionConfigurationTemplateName', this.lastDefaultPodSecurityAdmissionTemplateName);
-
           // Reset PSP if it's legacy due k8s version 1.25+
           if (major === 1 && minor >= 25) {
             set(this.value.spec, 'defaultPodSecurityPolicyTemplateName', '');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8068
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
As request

### Technical notes summary
@nwmac 
- Reset PSP ~and PSA~ if K3
- Restore ~PSA if RKE2 and also PSP if k8s version above or equal 1.25~ PSP if RKE2 and k8s version above or equal 1.25

Note: Please mind requirement in https://github.com/rancher/dashboard/issues/8061

### Areas or cases that should be tested
Cluster creation as in issue definition.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/217036968-2cf0ff47-e22f-4b96-9c32-ba777399d448.mov

