### PR TITLE
e2e tests for Extensions

### DIFF
--- a/cypress/e2e/po/components/action-menu.po.ts
+++ b/cypress/e2e/po/components/action-menu.po.ts
@@ -1,8 +1,8 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class ActionMenuPo extends ComponentPo {
-  constructor() {
-    super(cy.get('main > div > .menu'));
+  constructor(arg:any) {
+    super(arg || cy.get('main > div > .menu'));
   }
 
   clickMenuItem(index: number) {

--- a/cypress/e2e/po/components/component.po.ts
+++ b/cypress/e2e/po/components/component.po.ts
@@ -1,7 +1,14 @@
 import { CypressChainable } from '@/cypress/e2e/po/po.types';
 
+const isVisible = (selector: string) => () => {
+  return cy.get('body').then((body) => {
+    return !!body.find(selector).length;
+  });
+};
+
 export default class ComponentPo {
-  public self: () => CypressChainable
+  public self: () => CypressChainable;
+  public isVisible?: () => Cypress.Chainable<boolean>;
 
   constructor(self: CypressChainable);
   constructor(selector: string, parent?: CypressChainable);// selector should be jquery.Selector
@@ -10,6 +17,10 @@ export default class ComponentPo {
       const [selector, parent] = args as [string, CypressChainable];
 
       this.self = () => (parent || cy).get(selector);
+      if (!parent) {
+        // only works if we can find the element via jquery
+        this.isVisible = isVisible(selector);
+      }
     } else {
       // Note - if the element is removed from screen and shown again this will fail
       const [self] = args as [CypressChainable];

--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -1,0 +1,11 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class LabeledSelectPo extends ComponentPo {
+  toggle() {
+    return this.self().click();
+  }
+
+  clickOption(optionIndex: number) {
+    return this.self().get(`.vs__dropdown-menu .vs__dropdown-option:nth-child(${ optionIndex })`).click();
+  }
+}

--- a/cypress/e2e/po/components/tab.po.ts
+++ b/cypress/e2e/po/components/tab.po.ts
@@ -1,5 +1,0 @@
-import ComponentPo from '@/cypress/e2e/po/components/component.po';
-
-export default class TabPo extends ComponentPo {
-
-}

--- a/cypress/e2e/po/components/tab.po.ts
+++ b/cypress/e2e/po/components/tab.po.ts
@@ -1,0 +1,7 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class TabPo extends ComponentPo {
+  clickNthTab(optionIndex: number) {
+    return this.self().get(`li:nth-child(${ optionIndex }) a`).click();
+  }
+}

--- a/cypress/e2e/po/components/tab.po.ts
+++ b/cypress/e2e/po/components/tab.po.ts
@@ -1,7 +1,5 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class TabPo extends ComponentPo {
-  clickNthTab(optionIndex: number) {
-    return this.self().get(`li:nth-child(${ optionIndex }) a`).click();
-  }
+
 }

--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -1,0 +1,7 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class TabbedPo extends ComponentPo {
+  clickNthTab(optionIndex: number) {
+    return this.self().get(`li:nth-child(${ optionIndex }) a`).click();
+  }
+}

--- a/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po.ts
+++ b/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po.ts
@@ -1,0 +1,54 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
+import RadioGroupInputPo from '~/cypress/e2e/po/components/radio-group-input.po';
+import LabeledInputPo from '~/cypress/e2e/po/components/labeled-input.po';
+import AsyncButtonPo from '~/cypress/e2e/po/components/async-button.po';
+
+/**
+ * Covers core functionality that's common to the dashboard's import or create cluster pages
+ */
+export default class AppClusterRepoEditPo extends PagePo {
+  private static createPath(clusterId: string, type = 'create') {
+    return `/c/${ clusterId }/apps/catalog.cattle.io.clusterrepo/${ type }`;
+  }
+
+  static goTo(clusterId: string, type = 'create'): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(AppClusterRepoEditPo.createPath(clusterId, type));
+  }
+
+  constructor(clusterId: string, type = 'create') {
+    super(AppClusterRepoEditPo.createPath(clusterId, type));
+  }
+
+  resourceDetail() {
+    return new ResourceDetailPo(this.self());
+  }
+
+  // Form
+  nameNsDescription() {
+    return new NameNsDescription(this.self());
+  }
+
+  selectRadioOptionGitRepo(index: number): Cypress.Chainable {
+    const radioButton = new RadioGroupInputPo('[data-testid="clusterrepo-radio-input"]');
+
+    return radioButton.set(index);
+  }
+
+  enterGitRepoName(name: string) {
+    return new LabeledInputPo('[data-testid="clusterrepo-git-repo-input"]').set(name);
+  }
+
+  enterGitBranchName(name: string) {
+    return new LabeledInputPo('[data-testid="clusterrepo-git-branch-input"]').set(name);
+  }
+
+  create() {
+    return this.resourceDetail().createEditView().create();
+  }
+
+  save() {
+    return new AsyncButtonPo('[data-testid="action-button-async-button"]').click();
+  }
+}

--- a/cypress/e2e/po/lists/base-resource-list.po.ts
+++ b/cypress/e2e/po/lists/base-resource-list.po.ts
@@ -1,0 +1,16 @@
+import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import ResourceListMastheadPo from '@/cypress/e2e/po/components/ResourceList/resource-list-masthead.po';
+
+/**
+ * Convenience base class
+ */
+export default class BaseResourceList extends ComponentPo {
+  masthead() {
+    return new ResourceListMastheadPo(this.self());
+  }
+
+  resourceTable() {
+    return new ResourceTablePo(this.self());
+  }
+}

--- a/cypress/e2e/po/lists/catalog.cattle.io.clusterrepo.po.ts
+++ b/cypress/e2e/po/lists/catalog.cattle.io.clusterrepo.po.ts
@@ -1,0 +1,7 @@
+import BaseResourceList from '~/cypress/e2e/po/lists/base-resource-list.po';
+
+/**
+ * List component for catalog.cattle.io.clusterrepo resources
+ */
+export default class AppRepoListPo extends BaseResourceList {
+}

--- a/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
@@ -1,11 +1,9 @@
-import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
-import ComponentPo from '@/cypress/e2e/po/components/component.po';
-import ResourceListMastheadPo from '@/cypress/e2e/po/components/ResourceList/resource-list-masthead.po';
+import BaseResourceList from '~/cypress/e2e/po/lists/base-resource-list.po';
 
 /**
  * List component for provisioning.cattle.io.cluster resources
  */
-export default class ProvClusterListPo extends ComponentPo {
+export default class ProvClusterListPo extends BaseResourceList {
   explore(clusterName: string) {
     return this.resourceTable().sortableTable().rowWithName(clusterName).column(7)
       .find('.btn');
@@ -13,13 +11,5 @@ export default class ProvClusterListPo extends ComponentPo {
 
   actionMenu(clusterName: string) {
     return this.resourceTable().sortableTable().rowActionMenuOpen(clusterName, 8);
-  }
-
-  masthead() {
-    return new ResourceListMastheadPo(this.self());
-  }
-
-  resourceTable() {
-    return new ResourceTablePo(this.self());
   }
 }

--- a/cypress/e2e/po/pages/apps/app-repos.po.ts
+++ b/cypress/e2e/po/pages/apps/app-repos.po.ts
@@ -1,0 +1,35 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import AppRepoListPo from '~/cypress/e2e/po/lists/catalog.cattle.io.clusterrepo.po';
+
+/**
+ * List page for provisioning.cattle.io.cluster resources
+ */
+export default class AppReposListPagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/apps/catalog.cattle.io.clusterrepo`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(AppReposListPagePo.createPath(clusterId));
+  }
+
+  constructor(private clusterId: string) {
+    super(AppReposListPagePo.createPath(clusterId));
+  }
+
+  list(): AppRepoListPo {
+    return new AppRepoListPo('[data-testid="app-cluster-repo-list"]');
+  }
+
+  /**
+   * Convenience method
+   */
+  sortableTable() {
+    return this.list().resourceTable().sortableTable();
+  }
+
+  create() {
+    return this.list().masthead().actions().eq(0)
+      .click();
+  }
+}

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -240,7 +240,8 @@ export default class ExtensionsPo extends PagePo {
   }
 
   enterGitRepoName(name: string) {
-    return new LabeledInputPo(cy.get('[data-testid="clusterrepo-git-repo-input"]')).set(name);
+    // return cy.get('[data-testid="clusterrepo-git-repo-input"]').type(name);
+    return new LabeledInputPo(this.self().get('[data-testid="clusterrepo-git-repo-input"]')).set(name);
   }
 
   enterGitBranchName(name: string) {

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -1,0 +1,249 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+
+export default class ExtensionsPo extends PagePo {
+  static url: string = '/c/local/uiplugins'
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(ExtensionsPo.url);
+  }
+
+  constructor() {
+    super(ExtensionsPo.url);
+  }
+
+  // screen title
+  title(): Cypress.Chainable<string> {
+    return this.self().getId('extensions-page-title').invoke('text');
+  }
+
+  // install extensions operator
+  installExtensionsOperatorIfNeeded(attempt = 0) {
+    // this will make sure we wait for the page to render first content
+    // so that the attemps aren't on a blank page
+    this.title();
+
+    if (attempt > 20) {
+      return;
+    }
+    if (Cypress.$('[data-testid="extension-enable-operator"]').length > 0) {
+      cy.get('[data-testid="extension-enable-operator"]').click();
+      this.enableExtensionModalEnableClick();
+    } else {
+      cy.wait(250).then(() => { // eslint-disable-line
+        this.installExtensionsOperatorIfNeeded(++attempt); // next attempt
+      });
+    }
+  }
+
+  // install rancher-plugin-examples
+  installRancherPluginExamples() {
+    // we should be on the extensions page
+    this.title().should('contain', 'Extensions');
+
+    // go to app repos
+    this.extensionMenuToggle();
+
+    this.manageReposClick();
+
+    // create a new clusterrepo
+    this.createNewClusterRepoClick();
+
+    // fill the form
+    this.selectRadioOptionGitRepo(2);
+    this.enterClusterRepoName('rancher-plugin-examples');
+    this.enterGitRepoName('https://github.com/rancher/ui-plugin-examples');
+    this.enterGitBranchName('main');
+
+    // save it
+    return this.saveNewClusterRepoClick();
+  }
+
+  // extension card
+  extensionCard(extensionName: string) {
+    return this.self().getId(`extension-card-${ extensionName }`);
+  }
+
+  extensionCardClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).click();
+  }
+
+  extensionCardInstallClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-install-btn-${ extensionName }`).click();
+  }
+
+  extensionCardUpdateClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-update-btn-${ extensionName }`).click();
+  }
+
+  extensionCardRollbackClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-rollback-btn-${ extensionName }`).click();
+  }
+
+  extensionCardUninstallClick(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-uninstall-btn-${ extensionName }`).click();
+  }
+
+  // extension install modal
+  extensionInstallModal() {
+    return this.self().get('[data-modal="installPluginDialog"]');
+  }
+
+  installModalSelectVersionClick(optionIndex: number): Cypress.Chainable {
+    this.extensionInstallModal().getId('install-ext-modal-select-version').click();
+
+    return this.self().get(`.vs__dropdown-menu .vs__dropdown-option:nth-child(${ optionIndex })`).click();
+  }
+
+  installModalCancelClick(): Cypress.Chainable {
+    return this.extensionInstallModal().getId('install-ext-modal-cancel-btn').click();
+  }
+
+  installModalInstallClick(): Cypress.Chainable {
+    return this.extensionInstallModal().getId('install-ext-modal-install-btn').click();
+  }
+
+  // extension uninstall modal
+  extensionUninstallModal() {
+    return this.self().get('[data-modal="uninstallPluginDialog"]');
+  }
+
+  uninstallModalCancelClick(): Cypress.Chainable {
+    return this.extensionUninstallModal().getId('uninstall-ext-modal-cancel-btn').click();
+  }
+
+  uninstallModaluninstallClick(): Cypress.Chainable {
+    return this.extensionUninstallModal().getId('uninstall-ext-modal-uninstall-btn').click();
+  }
+
+  // extension details
+  extensionDetails() {
+    return this.self().getId('extension-details');
+  }
+
+  extensionDetailsBgClick(): Cypress.Chainable {
+    return this.self().getId('extension-details-bg').click();
+  }
+
+  extensionDetailsTitle(): Cypress.Chainable<string> {
+    return this.extensionDetails().getId('extension-details-title').invoke('text');
+  }
+
+  extensionDetailsCloseClick(): Cypress.Chainable {
+    return this.extensionDetails().getId('extension-details-close').click();
+  }
+
+  // extension tabs
+  extensionTabs() {
+    return this.self().getId('extension-tabs');
+  }
+
+  extensionTabInstalledClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(1) a').click();
+  }
+
+  extensionTabAvailableClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(2) a').click();
+  }
+
+  extensionTabUpdatesClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(3) a').click();
+  }
+
+  extensionTabAllClick(): Cypress.Chainable {
+    return this.extensionTabs().get('li:nth-child(4) a').click();
+  }
+
+  // extension reload banner
+  extensionReloadBanner() {
+    return this.self().getId('extension-reload-banner');
+  }
+
+  extensionReloadClick(): Cypress.Chainable {
+    return this.extensionReloadBanner().getId('extension-reload-banner-reload-btn').click();
+  }
+
+  // extension menu
+  private extensionMenu() {
+    return this.self().getId('extensions-page-menu');
+  }
+
+  extensionMenuToggle(): Cypress.Chainable {
+    return this.extensionMenu().click();
+  }
+
+  manageReposClick(): Cypress.Chainable {
+    return this.self().getId('action-menu-0-item').click();
+  }
+
+  // this will only appear with developer mode enabled
+  // developerLoadClick(): Cypress.Chainable {
+  //   return this.self().getId('action-menu-2-item').click();
+  // }
+
+  disableExtensionsClick(): Cypress.Chainable {
+    return this.self().getId('action-menu-2-item').click();
+  }
+
+  // disable extensions OVERALL modal
+  disableExtensionModal() {
+    return this.self().getId('disable-ext-modal');
+  }
+
+  removeRancherExtRepoCheckboxClick(): Cypress.Chainable {
+    return this.self().getId('disable-ext-modal-remove-repo').click();
+  }
+
+  disableExtensionModalCancelClick(): Cypress.Chainable {
+    return this.disableExtensionModal().get('.dialog-buttons button:first-child').click();
+  }
+
+  disableExtensionModalDisableClick(): Cypress.Chainable {
+    return this.disableExtensionModal().get('.dialog-buttons button:last-child').click();
+  }
+
+  // enable extensions OVERALL modal
+  enableExtensionModal() {
+    return this.self().get('[data-modal="confirm-uiplugins-setup"]');
+  }
+
+  enableExtensionModalCancelClick(): Cypress.Chainable {
+    return this.enableExtensionModal().get('.dialog-buttons button:first-child').click();
+  }
+
+  enableExtensionModalEnableClick(): Cypress.Chainable {
+    return this.enableExtensionModal().get('.dialog-buttons button:last-child').click();
+  }
+
+  // install operator
+  installOperatorBtn() {
+    return this.self().getId('extension-enable-operator');
+  }
+
+  installOperatorBtnClick(): Cypress.Chainable {
+    return this.installOperatorBtn().click();
+  }
+
+  // add a new repo (Extension Examples)
+  createNewClusterRepoClick(): Cypress.Chainable {
+    return this.self().getId('masthead-create').click();
+  }
+
+  enterClusterRepoName(name: string) {
+    return cy.get('[data-testid="name-ns-description-name"] input').type(name);
+  }
+
+  enterGitRepoName(name: string) {
+    return cy.get('[data-testid="clusterrepo-git-repo-input"]').type(name);
+  }
+
+  enterGitBranchName(name: string) {
+    return cy.get('[data-testid="clusterrepo-git-branch-input"]').type(name);
+  }
+
+  selectRadioOptionGitRepo(index: Number): Cypress.Chainable {
+    return this.self().get(`[data-testid="clusterrepo-radio-input"] .radio-group > div:nth-child(${ index }) .labeling label`).click();
+  }
+
+  saveNewClusterRepoClick(): Cypress.Chainable {
+    return this.self().getId('action-button-async-button').click();
+  }
+}

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -27,7 +27,7 @@ export default class ExtensionsPo extends PagePo {
     // so that the attemps aren't on a blank page
     this.title();
 
-    if (attempt > 20) {
+    if (attempt > 30) {
       return;
     }
     if (Cypress.$('[data-testid="extension-enable-operator"]').length > 0) {

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -4,7 +4,7 @@ import LabeledSelectPo from '~/cypress/e2e/po/components/labeled-select.po';
 import TabPo from '~/cypress/e2e/po/components/tab.po';
 import ActionMenuPo from '~/cypress/e2e/po/components/action-menu.po';
 import NameNsDescriptionPo from '~/cypress/e2e/po/components/name-ns-description.po';
-import LabeledInputPo from '~/cypress/e2e/po/components/labeled-input.po';
+// import LabeledInputPo from '~/cypress/e2e/po/components/labeled-input.po';
 
 export default class ExtensionsPo extends PagePo {
   static url: string = '/c/local/uiplugins'

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -3,7 +3,7 @@ import AsyncButtonPo from '~/cypress/e2e/po/components/async-button.po';
 import LabeledSelectPo from '~/cypress/e2e/po/components/labeled-select.po';
 import TabPo from '~/cypress/e2e/po/components/tab.po';
 import ActionMenuPo from '~/cypress/e2e/po/components/action-menu.po';
-import NameNsDescriptionPo from '~/cypress/e2e/po/components/name-ns-description.po';
+// import NameNsDescriptionPo from '~/cypress/e2e/po/components/name-ns-description.po';
 // import LabeledInputPo from '~/cypress/e2e/po/components/labeled-input.po';
 
 export default class ExtensionsPo extends PagePo {
@@ -236,7 +236,8 @@ export default class ExtensionsPo extends PagePo {
   }
 
   enterClusterRepoName(name: string) {
-    return new NameNsDescriptionPo(this.self()).name().set(name);
+    return cy.get('[data-testid="name-ns-description-name"] input').type(name);
+    // return new NameNsDescriptionPo(this.self()).name().set(name);
   }
 
   enterGitRepoName(name: string) {

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -240,8 +240,8 @@ export default class ExtensionsPo extends PagePo {
   }
 
   enterGitRepoName(name: string) {
-    // return cy.get('[data-testid="clusterrepo-git-repo-input"]').type(name);
-    return new LabeledInputPo(this.self().get('[data-testid="clusterrepo-git-repo-input"]')).set(name);
+    return cy.get('[data-testid="clusterrepo-git-repo-input"]').type(name);
+    // return new LabeledInputPo(this.self().get('[data-testid="clusterrepo-git-repo-input"]')).set(name);
   }
 
   enterGitBranchName(name: string) {

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -1,4 +1,10 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
+import AsyncButtonPo from '~/cypress/e2e/po/components/async-button.po';
+import LabeledSelectPo from '~/cypress/e2e/po/components/labeled-select.po';
+import TabPo from '~/cypress/e2e/po/components/tab.po';
+import ActionMenuPo from '~/cypress/e2e/po/components/action-menu.po';
+import NameNsDescriptionPo from '~/cypress/e2e/po/components/name-ns-description.po';
+import LabeledInputPo from '~/cypress/e2e/po/components/labeled-input.po';
 
 export default class ExtensionsPo extends PagePo {
   static url: string = '/c/local/uiplugins'
@@ -25,7 +31,7 @@ export default class ExtensionsPo extends PagePo {
       return;
     }
     if (Cypress.$('[data-testid="extension-enable-operator"]').length > 0) {
-      cy.get('[data-testid="extension-enable-operator"]').click();
+      new AsyncButtonPo(this.self().find('[data-testid="extension-enable-operator"]')).click();
       this.enableExtensionModalEnableClick();
     } else {
       cy.wait(250).then(() => { // eslint-disable-line
@@ -88,9 +94,11 @@ export default class ExtensionsPo extends PagePo {
   }
 
   installModalSelectVersionClick(optionIndex: number): Cypress.Chainable {
-    this.extensionInstallModal().getId('install-ext-modal-select-version').click();
+    const selectVersion = new LabeledSelectPo(this.extensionInstallModal().getId('install-ext-modal-select-version'));
 
-    return this.self().get(`.vs__dropdown-menu .vs__dropdown-option:nth-child(${ optionIndex })`).click();
+    selectVersion.toggle();
+
+    return selectVersion.clickOption(optionIndex);
   }
 
   installModalCancelClick(): Cypress.Chainable {
@@ -137,19 +145,19 @@ export default class ExtensionsPo extends PagePo {
   }
 
   extensionTabInstalledClick(): Cypress.Chainable {
-    return this.extensionTabs().get('li:nth-child(1) a').click();
+    return new TabPo(this.extensionTabs()).clickNthTab(1);
   }
 
   extensionTabAvailableClick(): Cypress.Chainable {
-    return this.extensionTabs().get('li:nth-child(2) a').click();
+    return new TabPo(this.extensionTabs()).clickNthTab(2);
   }
 
   extensionTabUpdatesClick(): Cypress.Chainable {
-    return this.extensionTabs().get('li:nth-child(3) a').click();
+    return new TabPo(this.extensionTabs()).clickNthTab(3);
   }
 
   extensionTabAllClick(): Cypress.Chainable {
-    return this.extensionTabs().get('li:nth-child(4) a').click();
+    return new TabPo(this.extensionTabs()).clickNthTab(4);
   }
 
   // extension reload banner
@@ -171,7 +179,7 @@ export default class ExtensionsPo extends PagePo {
   }
 
   manageReposClick(): Cypress.Chainable {
-    return this.self().getId('action-menu-0-item').click();
+    return new ActionMenuPo(this.self()).clickMenuItem(0);
   }
 
   // this will only appear with developer mode enabled
@@ -180,7 +188,7 @@ export default class ExtensionsPo extends PagePo {
   // }
 
   disableExtensionsClick(): Cypress.Chainable {
-    return this.self().getId('action-menu-2-item').click();
+    return new ActionMenuPo(this.self()).clickMenuItem(2);
   }
 
   // disable extensions OVERALL modal
@@ -228,11 +236,11 @@ export default class ExtensionsPo extends PagePo {
   }
 
   enterClusterRepoName(name: string) {
-    return cy.get('[data-testid="name-ns-description-name"] input').type(name);
+    return new NameNsDescriptionPo(this.self()).name().set(name);
   }
 
   enterGitRepoName(name: string) {
-    return cy.get('[data-testid="clusterrepo-git-repo-input"]').type(name);
+    return new LabeledInputPo(cy.get('[data-testid="clusterrepo-git-repo-input"]')).set(name);
   }
 
   enterGitBranchName(name: string) {

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -46,113 +46,113 @@ describe('Extensions page', () => {
     extensionsPo.extensionCard(extensionName).should('be.visible');
   });
 
-  it('Should toogle the extension details', () => {
-    const extensionsPo = new ExtensionsPo();
+  // it('Should toogle the extension details', () => {
+  //   const extensionsPo = new ExtensionsPo();
 
-    extensionsPo.extensionTabAvailableClick();
+  //   extensionsPo.extensionTabAvailableClick();
 
-    // we should be on the extensions page
-    extensionsPo.title().should('contain', 'Extensions');
+  //   // we should be on the extensions page
+  //   extensionsPo.title().should('contain', 'Extensions');
 
-    // show extension details
-    extensionsPo.extensionCardClick(extensionName);
+  //   // show extension details
+  //   extensionsPo.extensionCardClick(extensionName);
 
-    // after card click, we should get the info slide in panel
-    extensionsPo.extensionDetails().should('be.visible');
-    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  //   // after card click, we should get the info slide in panel
+  //   extensionsPo.extensionDetails().should('be.visible');
+  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
 
-    // close the details on the cross icon X
-    extensionsPo.extensionDetailsCloseClick();
-    extensionsPo.extensionDetails().should('not.be.visible');
+  //   // close the details on the cross icon X
+  //   extensionsPo.extensionDetailsCloseClick();
+  //   extensionsPo.extensionDetails().should('not.be.visible');
 
-    // show extension details again...
-    extensionsPo.extensionCardClick(extensionName);
-    extensionsPo.extensionDetails().should('be.visible');
+  //   // show extension details again...
+  //   extensionsPo.extensionCardClick(extensionName);
+  //   extensionsPo.extensionDetails().should('be.visible');
 
-    // clicking outside the details tab should also close it
-    extensionsPo.extensionDetailsBgClick();
-    extensionsPo.extensionDetails().should('not.be.visible');
-  });
+  //   // clicking outside the details tab should also close it
+  //   extensionsPo.extensionDetailsBgClick();
+  //   extensionsPo.extensionDetails().should('not.be.visible');
+  // });
 
-  it('Should install an extension', () => {
-    const extensionsPo = new ExtensionsPo();
+  // it('Should install an extension', () => {
+  //   const extensionsPo = new ExtensionsPo();
 
-    extensionsPo.extensionTabAvailableClick();
+  //   extensionsPo.extensionTabAvailableClick();
 
-    // click on install button on card
-    extensionsPo.extensionCardInstallClick(extensionName);
-    extensionsPo.extensionInstallModal().should('be.visible');
+  //   // click on install button on card
+  //   extensionsPo.extensionCardInstallClick(extensionName);
+  //   extensionsPo.extensionInstallModal().should('be.visible');
 
-    // select version and click install
-    extensionsPo.installModalSelectVersionClick(2);
-    extensionsPo.installModalInstallClick();
+  //   // select version and click install
+  //   extensionsPo.installModalSelectVersionClick(2);
+  //   extensionsPo.installModalInstallClick();
 
-    // let's check the extension reload banner and reload the page
-    extensionsPo.extensionReloadBanner().should('be.visible');
-    extensionsPo.extensionReloadClick();
+  //   // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
 
-    // make sure extension card is in the installed tab
-    extensionsPo.extensionTabInstalledClick();
-    extensionsPo.extensionCardClick(extensionName);
-    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-    extensionsPo.extensionDetailsCloseClick();
-  });
+  //   // make sure extension card is in the installed tab
+  //   extensionsPo.extensionTabInstalledClick();
+  //   extensionsPo.extensionCardClick(extensionName);
+  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  //   extensionsPo.extensionDetailsCloseClick();
+  // });
 
-  it('Should update an extension version', () => {
-    const extensionsPo = new ExtensionsPo();
+  // it('Should update an extension version', () => {
+  //   const extensionsPo = new ExtensionsPo();
 
-    extensionsPo.extensionTabInstalledClick();
+  //   extensionsPo.extensionTabInstalledClick();
 
-    // click on update button on card
-    extensionsPo.extensionCardUpdateClick(extensionName);
-    extensionsPo.installModalInstallClick();
+  //   // click on update button on card
+  //   extensionsPo.extensionCardUpdateClick(extensionName);
+  //   extensionsPo.installModalInstallClick();
 
-    // let's check the extension reload banner and reload the page
-    extensionsPo.extensionReloadBanner().should('be.visible');
-    extensionsPo.extensionReloadClick();
+  //   // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
 
-    // make sure extension card is not available anymore on the updates tab
-    // since we installed the latest version
-    extensionsPo.extensionTabUpdatesClick();
-    extensionsPo.extensionCard(extensionName).should('not.exist');
-  });
+  //   // make sure extension card is not available anymore on the updates tab
+  //   // since we installed the latest version
+  //   extensionsPo.extensionTabUpdatesClick();
+  //   extensionsPo.extensionCard(extensionName).should('not.exist');
+  // });
 
-  it('Should rollback an extension version', () => {
-    const extensionsPo = new ExtensionsPo();
+  // it('Should rollback an extension version', () => {
+  //   const extensionsPo = new ExtensionsPo();
 
-    extensionsPo.extensionTabInstalledClick();
+  //   extensionsPo.extensionTabInstalledClick();
 
-    // click on the rollback button on card
-    // this will rollback to the immediate previous version
-    extensionsPo.extensionCardRollbackClick(extensionName);
-    extensionsPo.installModalInstallClick();
+  //   // click on the rollback button on card
+  //   // this will rollback to the immediate previous version
+  //   extensionsPo.extensionCardRollbackClick(extensionName);
+  //   extensionsPo.installModalInstallClick();
 
-    // let's check the extension reload banner and reload the page
-    extensionsPo.extensionReloadBanner().should('be.visible');
-    extensionsPo.extensionReloadClick();
+  //   // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
 
-    // make sure extension card is on the updates tab
-    extensionsPo.extensionTabUpdatesClick();
-    extensionsPo.extensionCard(extensionName).should('be.visible');
-  });
+  //   // make sure extension card is on the updates tab
+  //   extensionsPo.extensionTabUpdatesClick();
+  //   extensionsPo.extensionCard(extensionName).should('be.visible');
+  // });
 
-  it('Should uninstall an extension', () => {
-    const extensionsPo = new ExtensionsPo();
+  // it('Should uninstall an extension', () => {
+  //   const extensionsPo = new ExtensionsPo();
 
-    extensionsPo.extensionTabInstalledClick();
+  //   extensionsPo.extensionTabInstalledClick();
 
-    // click on uninstall button on card
-    extensionsPo.extensionCardUninstallClick(extensionName);
-    extensionsPo.extensionUninstallModal().should('be.visible');
-    extensionsPo.uninstallModaluninstallClick();
+  //   // click on uninstall button on card
+  //   extensionsPo.extensionCardUninstallClick(extensionName);
+  //   extensionsPo.extensionUninstallModal().should('be.visible');
+  //   extensionsPo.uninstallModaluninstallClick();
 
-    // // let's check the extension reload banner and reload the page
-    extensionsPo.extensionReloadBanner().should('be.visible');
-    extensionsPo.extensionReloadClick();
+  //   // // let's check the extension reload banner and reload the page
+  //   extensionsPo.extensionReloadBanner().should('be.visible');
+  //   extensionsPo.extensionReloadClick();
 
-    // // make sure extension card is in the available tab
-    extensionsPo.extensionTabAvailableClick();
-    extensionsPo.extensionCardClick(extensionName);
-    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-  });
+  //   // // make sure extension card is in the available tab
+  //   extensionsPo.extensionTabAvailableClick();
+  //   extensionsPo.extensionCardClick(extensionName);
+  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  // });
 });

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -46,113 +46,113 @@ describe('Extensions page', () => {
     extensionsPo.extensionCard(extensionName).should('be.visible');
   });
 
-  // it('Should toogle the extension details', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should toogle the extension details', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionTabAvailableClick();
 
-  //   // we should be on the extensions page
-  //   extensionsPo.title().should('contain', 'Extensions');
+    // we should be on the extensions page
+    extensionsPo.title().should('contain', 'Extensions');
 
-  //   // show extension details
-  //   extensionsPo.extensionCardClick(extensionName);
+    // show extension details
+    extensionsPo.extensionCardClick(extensionName);
 
-  //   // after card click, we should get the info slide in panel
-  //   extensionsPo.extensionDetails().should('be.visible');
-  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+    // after card click, we should get the info slide in panel
+    extensionsPo.extensionDetails().should('be.visible');
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
 
-  //   // close the details on the cross icon X
-  //   extensionsPo.extensionDetailsCloseClick();
-  //   extensionsPo.extensionDetails().should('not.be.visible');
+    // close the details on the cross icon X
+    extensionsPo.extensionDetailsCloseClick();
+    extensionsPo.extensionDetails().should('not.be.visible');
 
-  //   // show extension details again...
-  //   extensionsPo.extensionCardClick(extensionName);
-  //   extensionsPo.extensionDetails().should('be.visible');
+    // show extension details again...
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetails().should('be.visible');
 
-  //   // clicking outside the details tab should also close it
-  //   extensionsPo.extensionDetailsBgClick();
-  //   extensionsPo.extensionDetails().should('not.be.visible');
-  // });
+    // clicking outside the details tab should also close it
+    extensionsPo.extensionDetailsBgClick();
+    extensionsPo.extensionDetails().should('not.be.visible');
+  });
 
-  // it('Should install an extension', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should install an extension', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionTabAvailableClick();
 
-  //   // click on install button on card
-  //   extensionsPo.extensionCardInstallClick(extensionName);
-  //   extensionsPo.extensionInstallModal().should('be.visible');
+    // click on install button on card
+    extensionsPo.extensionCardInstallClick(extensionName);
+    extensionsPo.extensionInstallModal().should('be.visible');
 
-  //   // select version and click install
-  //   extensionsPo.installModalSelectVersionClick(2);
-  //   extensionsPo.installModalInstallClick();
+    // select version and click install
+    extensionsPo.installModalSelectVersionClick(2);
+    extensionsPo.installModalInstallClick();
 
-  //   // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // make sure extension card is in the installed tab
-  //   extensionsPo.extensionTabInstalledClick();
-  //   extensionsPo.extensionCardClick(extensionName);
-  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-  //   extensionsPo.extensionDetailsCloseClick();
-  // });
+    // make sure extension card is in the installed tab
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+    extensionsPo.extensionDetailsCloseClick();
+  });
 
-  // it('Should update an extension version', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should update an extension version', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionTabInstalledClick();
 
-  //   // click on update button on card
-  //   extensionsPo.extensionCardUpdateClick(extensionName);
-  //   extensionsPo.installModalInstallClick();
+    // click on update button on card
+    extensionsPo.extensionCardUpdateClick(extensionName);
+    extensionsPo.installModalInstallClick();
 
-  //   // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // make sure extension card is not available anymore on the updates tab
-  //   // since we installed the latest version
-  //   extensionsPo.extensionTabUpdatesClick();
-  //   extensionsPo.extensionCard(extensionName).should('not.exist');
-  // });
+    // make sure extension card is not available anymore on the updates tab
+    // since we installed the latest version
+    extensionsPo.extensionTabUpdatesClick();
+    extensionsPo.extensionCard(extensionName).should('not.exist');
+  });
 
-  // it('Should rollback an extension version', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should rollback an extension version', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionTabInstalledClick();
 
-  //   // click on the rollback button on card
-  //   // this will rollback to the immediate previous version
-  //   extensionsPo.extensionCardRollbackClick(extensionName);
-  //   extensionsPo.installModalInstallClick();
+    // click on the rollback button on card
+    // this will rollback to the immediate previous version
+    extensionsPo.extensionCardRollbackClick(extensionName);
+    extensionsPo.installModalInstallClick();
 
-  //   // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // make sure extension card is on the updates tab
-  //   extensionsPo.extensionTabUpdatesClick();
-  //   extensionsPo.extensionCard(extensionName).should('be.visible');
-  // });
+    // make sure extension card is on the updates tab
+    extensionsPo.extensionTabUpdatesClick();
+    extensionsPo.extensionCard(extensionName).should('be.visible');
+  });
 
-  // it('Should uninstall an extension', () => {
-  //   const extensionsPo = new ExtensionsPo();
+  it('Should uninstall an extension', () => {
+    const extensionsPo = new ExtensionsPo();
 
-  //   extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionTabInstalledClick();
 
-  //   // click on uninstall button on card
-  //   extensionsPo.extensionCardUninstallClick(extensionName);
-  //   extensionsPo.extensionUninstallModal().should('be.visible');
-  //   extensionsPo.uninstallModaluninstallClick();
+    // click on uninstall button on card
+    extensionsPo.extensionCardUninstallClick(extensionName);
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
 
-  //   // // let's check the extension reload banner and reload the page
-  //   extensionsPo.extensionReloadBanner().should('be.visible');
-  //   extensionsPo.extensionReloadClick();
+    // // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
 
-  //   // // make sure extension card is in the available tab
-  //   extensionsPo.extensionTabAvailableClick();
-  //   extensionsPo.extensionCardClick(extensionName);
-  //   extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-  // });
+    // // make sure extension card is in the available tab
+    extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  });
 });

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -33,12 +33,12 @@ describe('Extensions page', () => {
 
     // let's wait for the install button to become visible and re-install
     // the extensions operator
-    extensionsPo.installOperatorBtn().should('be.visible');
-    extensionsPo.installOperatorBtnClick();
+    extensionsPo.installOperatorBtn().checkVisible();
+    extensionsPo.installOperatorBtn().click();
     extensionsPo.enableExtensionModalEnableClick();
 
     // wait for operation to finish and refresh...
-    extensionsPo.extensionTabs().should('be.visible');
+    extensionsPo.extensionTabs.checkVisible();
     ExtensionsPo.goTo();
 
     // let's make sure all went good
@@ -46,7 +46,7 @@ describe('Extensions page', () => {
     extensionsPo.extensionCard(extensionName).should('be.visible');
   });
 
-  it('Should toogle the extension details', () => {
+  it('Should toggle the extension details', () => {
     const extensionsPo = new ExtensionsPo();
 
     extensionsPo.extensionTabAvailableClick();

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -1,0 +1,159 @@
+import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
+
+const extensionName = 'homepage';
+
+describe('Extensions page', () => {
+  before(() => {
+    cy.login();
+
+    ExtensionsPo.goTo();
+    const extensionsPo = new ExtensionsPo();
+
+    // install extensions operator if it's not installed
+    extensionsPo.installExtensionsOperatorIfNeeded();
+
+    // install the rancher plugin examples
+    extensionsPo.installRancherPluginExamples();
+  });
+
+  beforeEach(() => {
+    cy.login();
+    ExtensionsPo.goTo();
+  });
+
+  it('Should disable and enable extension support', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    // open menu and click on disable extension support
+    extensionsPo.extensionMenuToggle();
+    extensionsPo.disableExtensionsClick();
+
+    // on the modal, keep the extensions repo and click disable
+    // extensionsPo.removeRancherExtRepoCheckboxClick();
+    extensionsPo.disableExtensionModalDisableClick();
+
+    // let's wait for the install button to become visible and re-install
+    // the extensions operator
+    extensionsPo.installOperatorBtn().should('be.visible');
+    extensionsPo.installOperatorBtnClick();
+    extensionsPo.enableExtensionModalEnableClick();
+
+    // wait for operation to finish and refresh...
+    extensionsPo.extensionTabs().should('be.visible');
+    ExtensionsPo.goTo();
+
+    // let's make sure all went good
+    extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionCard(extensionName).should('be.visible');
+  });
+
+  it('Should toogle the extension details', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.extensionTabAvailableClick();
+
+    // we should be on the extensions page
+    extensionsPo.title().should('contain', 'Extensions');
+
+    // show extension details
+    extensionsPo.extensionCardClick(extensionName);
+
+    // after card click, we should get the info slide in panel
+    extensionsPo.extensionDetails().should('be.visible');
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+
+    // close the details on the cross icon X
+    extensionsPo.extensionDetailsCloseClick();
+    extensionsPo.extensionDetails().should('not.be.visible');
+
+    // show extension details again...
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetails().should('be.visible');
+
+    // clicking outside the details tab should also close it
+    extensionsPo.extensionDetailsBgClick();
+    extensionsPo.extensionDetails().should('not.be.visible');
+  });
+
+  it('Should install an extension', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.extensionTabAvailableClick();
+
+    // click on install button on card
+    extensionsPo.extensionCardInstallClick(extensionName);
+    extensionsPo.extensionInstallModal().should('be.visible');
+
+    // select version and click install
+    extensionsPo.installModalSelectVersionClick(2);
+    extensionsPo.installModalInstallClick();
+
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    // make sure extension card is in the installed tab
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+    extensionsPo.extensionDetailsCloseClick();
+  });
+
+  it('Should update an extension version', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.extensionTabInstalledClick();
+
+    // click on update button on card
+    extensionsPo.extensionCardUpdateClick(extensionName);
+    extensionsPo.installModalInstallClick();
+
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    // make sure extension card is not available anymore on the updates tab
+    // since we installed the latest version
+    extensionsPo.extensionTabUpdatesClick();
+    extensionsPo.extensionCard(extensionName).should('not.exist');
+  });
+
+  it('Should rollback an extension version', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.extensionTabInstalledClick();
+
+    // click on the rollback button on card
+    // this will rollback to the immediate previous version
+    extensionsPo.extensionCardRollbackClick(extensionName);
+    extensionsPo.installModalInstallClick();
+
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    // make sure extension card is on the updates tab
+    extensionsPo.extensionTabUpdatesClick();
+    extensionsPo.extensionCard(extensionName).should('be.visible');
+  });
+
+  it('Should uninstall an extension', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.extensionTabInstalledClick();
+
+    // click on uninstall button on card
+    extensionsPo.extensionCardUninstallClick(extensionName);
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
+
+    // // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    // // make sure extension card is in the available tab
+    extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  });
+});

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -1,6 +1,6 @@
 import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
 
-const extensionName = 'homepage';
+const extensionName = 'clock';
 
 describe('Extensions page', () => {
   before(() => {
@@ -29,7 +29,6 @@ describe('Extensions page', () => {
     extensionsPo.disableExtensionsClick();
 
     // on the modal, keep the extensions repo and click disable
-    // extensionsPo.removeRancherExtRepoCheckboxClick();
     extensionsPo.disableExtensionModalDisableClick();
 
     // let's wait for the install button to become visible and re-install

--- a/shell/list/catalog.cattle.io.clusterrepo.vue
+++ b/shell/list/catalog.cattle.io.clusterrepo.vue
@@ -35,6 +35,7 @@ export default {
       :rows="rows"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+      data-testid="app-cluster-repo-list"
     />
   </div>
 </template>


### PR DESCRIPTION
Fixes #8119 

Create basic test suite of e2e tests for Extensions mechanism:
- enable/disable extensions in general
- clicking on extension card toggles details side-panel
- install an extension
- upgrade an extension
- rollback an extension
- uninstall an extension