### PR TITLE
[2.6 backport] improve performance of pod logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "vue-select": "^3.18.3",
     "vue-server-renderer": "2.6.14",
     "vue-shortkey": "^3.1.7",
+    "vue-virtual-scroll-list": "^2.3.4",
     "vue2-transitions": "^0.3.0",
     "vuedraggable": "^2.24.3",
     "vuex": "^3.6.2",

--- a/shell/components/LogItem.vue
+++ b/shell/components/LogItem.vue
@@ -1,0 +1,69 @@
+<script>
+import day from 'dayjs';
+import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
+import { escapeHtml } from '@shell/utils/string';
+
+export default {
+  props: {
+    source: {
+      type:    Object,
+      default: () => {}
+    }
+  },
+
+  computed: {
+    timeFormatStr() {
+      const dateFormat = escapeHtml( this.$store.getters['prefs/get'](DATE_FORMAT));
+      const timeFormat = escapeHtml( this.$store.getters['prefs/get'](TIME_FORMAT));
+
+      return `${ dateFormat } ${ timeFormat }`;
+    },
+  },
+
+  methods: {
+    format(time) {
+      if ( !time ) {
+        return '';
+      }
+
+      return day(time).format(this.timeFormatStr);
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="line">
+    <span class="time">{{ format(source.time) }}</span>
+    <span
+      class="msg"
+      v-html="source.msg"
+    />
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.line {
+  font-family: Menlo,Consolas,monospace;
+  color: var(--logs-text);
+  display:flex;
+}
+
+.time {
+  white-space: nowrap;
+  display: none;
+  width: 0;
+  padding-right: 15px;
+  user-select: none;
+}
+
+.msg {
+  white-space: pre;
+
+  .highlight {
+    color: var(--logs-highlight);
+    background-color: var(--logs-highlight-bg);
+  }
+}
+
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -21652,6 +21652,11 @@ vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
 
+vue-virtual-scroll-list@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/vue-virtual-scroll-list/-/vue-virtual-scroll-list-2.3.4.tgz#0d08c2d26299d8609018b8c04f5e3ca608fbe2d6"
+  integrity sha512-a9bmmIhAdnKcp8NG0C9ZQ+pW9nAOrDv5SHqJfbbEpXxVVERCtbIgGeBnkwrGgmoILBoFz/WANIZgA22G44F0Yw==
+
 vue2-transitions@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/vue2-transitions/-/vue2-transitions-0.3.0.tgz#765fc0d743103fcfe2d10f431697d8873a075c17"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8135 
<!-- Define findings related to the feature or bug issue. -->
Backport of https://github.com/rancher/dashboard/pull/7511

### Testing
1. Create the deployment listed below
2. Go to the detail view for the deployment
3. For the pod listed, click kebab menu->view logs
4. Allow the logs to stream in for ~15-20min 
5. Watch the memory tab in browser dev tools and verify that memory use is <1gb

```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    workload.user.cattle.io/workloadselector: apps.deployment-default-test-logs
  name: test-logs
  namespace: default
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      workload.user.cattle.io/workloadselector: apps.deployment-default-test-logs
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      labels:
        workload.user.cattle.io/workloadselector: apps.deployment-default-test-logs
    spec:
      affinity: {}
      containers:
      - args:
        - 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep .001; done'
        command:
        - /bin/sh
        - -c
        image: busybox
        imagePullPolicy: Always
        name: fast
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      - args:
        - 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 1; done'
        command:
        - /bin/sh
        - -c
        image: busybox
        imagePullPolicy: Always
        name: slower
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      - args:
        - 'i=0; while true; do echo "$i: $(date)"; i=$((i+1)); sleep 10; done'
        command:
        - /bin/sh
        - -c
        image: busybox
        imagePullPolicy: Always
        name: sloooow
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
 ```