### PR TITLE
LabeledSelect: Displayed label does not update with options

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -152,7 +152,10 @@ export default {
       const isOutdated = !this.options.find(opt => option[this.optionLabel] === opt[this.optionLabel]);
 
       if (isOutdated) {
-        return this.options.find(opt => option[this.optionKey] === opt[this.optionKey])?.[this.optionLabel];
+        const option = this.options.find(opt => option[this.optionKey] === opt[this.optionKey]);
+        const label = get(option, this.optionLabel);
+
+        return this.localizedLabel ? this.$store.getters['i18n/t'](label) || label : label;
       }
 
       if (this.$attrs['get-option-label']) {

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -149,10 +149,10 @@ export default {
       }
 
       // Force to update the option label if prop has been changed
-      const isOutdated = !this.options.find(({ label }) => option.label === label);
+      const isOutdated = !this.options.find(opt => option[this.optionLabel] === opt[this.optionLabel]);
 
       if (isOutdated) {
-        return this.options.find(({ value }) => option.value === value)?.label;
+        return this.options.find(opt => option[this.optionKey] === opt[this.optionKey])?.[this.optionLabel];
       }
 
       if (this.$attrs['get-option-label']) {

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -1,7 +1,6 @@
 <script>
 import CompactInput from '@shell/mixins/compact-input';
 import LabeledFormElement from '@shell/mixins/labeled-form-element';
-import { findBy } from '@shell/utils/array';
 import { get } from '@shell/utils/object';
 import { LabeledTooltip } from '@components/LabeledTooltip';
 import VueSelectOverrides from '@shell/mixins/vue-select-overrides';
@@ -105,16 +104,6 @@ export default {
     hasLabel() {
       return this.isCompact ? false : !!this.label || !!this.labelKey || !!this.$slots.label;
     },
-
-    currentLabel() {
-      const entry = findBy(this.options || [], 'value', this.value);
-
-      if (entry) {
-        return entry.label;
-      }
-
-      return this.getOptionLabel(this.value);
-    },
   },
 
   methods: {
@@ -157,6 +146,13 @@ export default {
     getOptionLabel(option) {
       if (!option) {
         return;
+      }
+
+      // Force to update the option label if prop has been changed
+      const isOutdated = !this.options.find(({ label }) => option.label === label);
+
+      if (isOutdated) {
+        return this.options.find(({ value }) => option.value === value)?.label;
       }
 
       if (this.$attrs['get-option-label']) {

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+
+describe('component: LabeledSelect', () => {
+  it('should automatically pick option for given value', () => {
+    const label = 'Foo';
+    const value = 'foo';
+    const wrapper = mount(LabeledSelect, {
+      propsData: {
+        value,
+        options: [
+          { label, value },
+        ],
+      }
+    });
+
+    // Component is from a library and class is not going to be changed
+    expect(wrapper.find('.vs__selected').text()).toBe(label);
+  });
+
+  it('should update the displayed label if options are changed', async() => {
+    const newLabel = 'Baz';
+    const oldLabel = 'Foo';
+    const value = 'foo';
+    const wrapper = mount(LabeledSelect, {
+      propsData: {
+        value,
+        options: [
+          { label: oldLabel, value },
+        ],
+      }
+    });
+
+    await wrapper.setProps({
+      options: [
+        { label: newLabel, value },
+      ]
+    });
+
+    // Component is from a library and class is not going to be changed
+    expect(wrapper.find('.vs__selected').text()).toBe(newLabel);
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8149
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
As in issue description.

To reproduce create/extend in the UI something like:

```ts
// ...
data: () {
  return {
    // ...
    toggleLabel:           false,
    myValue:               '',
  }
},


computed: {
  // ...

  myOptions() {
    return this.toggleLabel 
      ? [{ label: 'Old Label', value: '' }] 
      : [{ label: 'New Label', value: '' }];
  },
}
// ...
``` 

```html
      <LabeledSelect
        v-model="myValue"
        :options="myOptions"
      />
      <Checkbox
        v-model="toggleLabel"
        label="Toggle my label"
      />
```


### Technical notes summary
- Added unit tests for ensuring label updates
- Forced displayed label to match existing options with the same value

### Areas or cases that should be tested
Any dropdown as we have no story nor tests.

### Areas which could experience regressions
Any dropdown as we have no story nor tests.

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/218513012-fa6f3a03-8f89-4fee-80d5-7951aa01da7d.mov

