### PR TITLE
Include oprhaned `POD`s in Workload list

### DIFF
--- a/shell/components/formatter/WorkloadHealthScale.vue
+++ b/shell/components/formatter/WorkloadHealthScale.vue
@@ -2,10 +2,11 @@
 import Vue from 'vue';
 import ProgressBarMulti from '@shell/components/ProgressBarMulti';
 import PlusMinus from '@shell/components/form/PlusMinus';
-import { SCALABLE_WORKLOAD_TYPES } from '@shell/config/types';
+import { POD, SCALABLE_WORKLOAD_TYPES } from '@shell/config/types';
 import { ucFirst } from '@shell/utils/string';
 
 const SCALABLE_TYPES = Object.values(SCALABLE_WORKLOAD_TYPES);
+const INVALID_TYPES = [POD];
 
 export default {
   components: { PlusMinus, ProgressBarMulti },
@@ -45,6 +46,10 @@ export default {
 
     canScale() {
       return !!SCALABLE_TYPES.includes(this.row.type) && this.row.canUpdate;
+    },
+
+    canShow() {
+      return !INVALID_TYPES.includes(this.row.type);
     },
 
     parts() {
@@ -162,8 +167,9 @@ export default {
 </script>
 
 <template>
+  <div v-if="!canShow" />
   <div
-    v-if="loading"
+    v-else-if="loading"
     class="hs-popover__loader"
   >
     <i class="icon icon-spinner" />

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -92,6 +92,11 @@ const {
 
 export const SCALABLE_WORKLOAD_TYPES = scalableWorkloads;
 
+export const LIST_WORKLOAD_TYPES = {
+  ...WORKLOAD_TYPES,
+  POD
+};
+
 export const METRIC = {
   NODE: 'metrics.k8s.io.nodemetrics',
   POD:  'metrics.k8s.io.podmetrics',

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -11,6 +11,7 @@ import {
   SERVICE_ACCOUNT,
   CAPI,
   POD,
+  LIST_WORKLOAD_TYPES,
 } from '@shell/config/types';
 import Tab from '@shell/components/Tabbed/Tab';
 import CreateEditView from '@shell/mixins/create-edit-view';
@@ -490,21 +491,19 @@ export default {
       return this.$store.getters['cluster/schemaFor'](this.type);
     },
 
-    workloadTypes() {
-      return omitBy(WORKLOAD_TYPES, (type) => {
+    // array of id, label, description, initials for type selection step
+    workloadSubTypes() {
+      const workloadTypes = omitBy(LIST_WORKLOAD_TYPES, (type) => {
         return (
           type === WORKLOAD_TYPES.REPLICA_SET ||
           type === WORKLOAD_TYPES.REPLICATION_CONTROLLER
         );
       });
-    },
 
-    // array of id, label, description, initials for type selection step
-    workloadSubTypes() {
       const out = [];
 
-      for (const prop in this.workloadTypes) {
-        const type = this.workloadTypes[prop];
+      for (const prop in workloadTypes) {
+        const type = workloadTypes[prop];
         const subtype = {
           id:          type,
           description: `workload.typeDescriptions.'${ type }'`,

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -1,6 +1,8 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
-import { WORKLOAD_TYPES, SCHEMA, NODE, POD } from '@shell/config/types';
+import {
+  WORKLOAD_TYPES, SCHEMA, NODE, POD, LIST_WORKLOAD_TYPES
+} from '@shell/config/types';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 
 const schema = {
@@ -16,7 +18,7 @@ const schema = {
 const $loadingResources = ($route, $store) => {
   const allowedResources = [];
 
-  Object.values(WORKLOAD_TYPES).forEach((type) => {
+  Object.values(LIST_WORKLOAD_TYPES).forEach((type) => {
     // You may not have RBAC to see some of the types
     if ($store.getters['cluster/schemaFor'](type) ) {
       allowedResources.push(type);
@@ -134,8 +136,8 @@ export default {
       } else {
         const type = this.$route.params.resource;
 
-        if (type === WORKLOAD_TYPES.JOB) {
-          // Ignore job (we're fetching this anyway, plus they contain their own state)
+        if (type === WORKLOAD_TYPES.JOB || type === POD) {
+          // Ignore job and pods (we're fetching this anyway, plus they contain their own state)
           return;
         }
 

--- a/shell/models/pod.js
+++ b/shell/models/pod.js
@@ -129,6 +129,10 @@ export default class Pod extends WorkloadService {
     return workloads[0];
   }
 
+  get ownedByWorkload() {
+    return !!this.workloadRef;
+  }
+
   get details() {
     const out = [
       {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/7506
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Show pods that aren't owned by another workload in the workload list
- Allow user to create PODS from the workload list

### Technical notes summary
- This is done in a very targeted way 
  - Only replaces `WORKLOAD_TYPES` in two specific places
  - This should avoid issues where `WORKLOAD_TYPES` is used in other contexts

### Areas or cases that should be tested
- Both Workloads List and Workloads --> Pods Lists
  - Create/Edit
  - `Health` column should not show for non-pod workloads (and vice-versa)

<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
- Other area's that show lists of workload like resources (for example deployment detail page Pods list)

### Screenshot/Video

> Note that the pod for the deployment is not shown

![image](https://user-images.githubusercontent.com/18697775/218526430-f97ef843-cdec-4405-9534-ea1b643a4209.png)
