### PR TITLE
add enable psp checkbox to custom chart uis

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -5,6 +5,8 @@ import { addObject, removeObject } from '@shell/utils/array';
 import cloneDeep from 'lodash/cloneDeep';
 
 export default Vue.extend({
+  name: 'Checkbox',
+  
   props: {
     /**
      * The checkbox value.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -819,6 +819,8 @@ catalog:
       clusterToolExists: This chart has a fixed namespace and name. A matching <a href="{url}">application</a> has been found and any changes will be made to it.
     banner:
       legacy: 'PSP Removal: Before upgrading a cluster to Kubernetes 1.25+, please ensure you review your Helm applications for Pod Security Policies and update them accordingly'
+    enablePSP: Enable Pod Security Policies
+    global: Global
   charts:
     all: All
     categories:
@@ -2421,7 +2423,7 @@ istio:
       label: Jaeger
       description: Monitor and Troubleshoot microservices-based distributed systems.
     disabled: '{app} is not installed'
-  cni: Enabled CNI
+  cni: Enable CNI
   customOverlayFile:
     label: Custom Overlay File
     tip: 'The <a target="_blank" rel="noopener noreferrer nofollow" href="https://istio.io/latest/docs/setup/additional-setup/customize-installation/#patching-the-output-manifest">overlay file</a> allows for additional configuration on top of the base {vendor} Istio installation. You can utilize the <a href="https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/" target="_blank" rel="noopener noreferrer nofollow" >IstioOperator API</a> to make changes and additions for all components and apply those changes via this overlay YAML file.'
@@ -2572,20 +2574,20 @@ istio:
         label: Subject Alternative Names
         placeholder: e.g. example.com
         add: Add Subject Alternative Name
-  egressGateway: Enabled Egress Gateway
-  ingressGateway: Enabled Ingress Gateway
-  istiodRemote: Enabled istiodRemote
-  kiali: Enabled Kiali
-  pilot: Enabled Pilot
-  policy: Enabled Policy
+  egressGateway: Enable Egress Gateway
+  ingressGateway: Enable Ingress Gateway
+  istiodRemote: Enable istiodRemote
+  kiali: Enable Kiali
+  pilot: Enable Pilot
+  policy: Enable Policy
   poweredBy: Powered by <a target="_blank" rel="noopener noreferrer nofollow" href='https://istio.io/latest/'>Istio</a>
-  telemetry: Enabled Telemetry
+  telemetry: Enable Telemetry
   titles:
     components: Components
     customAnswers: Custom Answers
     advanced: Advanced Settings
     description: Description
-  tracing: Enabled Jaeger Tracing (limited)
+  tracing: Enable Jaeger Tracing (limited)
   v1Warning: Please uninstall the current Istio version in the <code>istio-system</code> namespace before attempting to install this version.
 
 labels:

--- a/shell/chart/gatekeeper.vue
+++ b/shell/chart/gatekeeper.vue
@@ -1,8 +1,9 @@
 <script>
 import UnitInput from '@shell/components/form/UnitInput';
+import ChartPsp from '@shell/components/ChartPsp';
 
 export default {
-  components: { UnitInput },
+  components: { UnitInput, ChartPsp },
   props:      {
     value: {
       type:    Object,
@@ -31,6 +32,11 @@ export default {
           label="Constraint violations limit"
           suffix="Violations"
         />
+      </div>
+    </div>
+    <div class="row mt-10">
+      <div class="col span-6">
+        <ChartPsp :value="value" />
       </div>
     </div>
   </div>

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -7,6 +7,7 @@ import { mapGetters } from 'vuex';
 import FileSelector from '@shell/components/form/FileSelector';
 import Tab from '@shell/components/Tabbed/Tab';
 import { Banner } from '@components/Banner';
+import ChartPsp from '@shell/components/ChartPsp';
 
 const defaultOverlayFile = `#apiVersion: install.istio.io/v1alpha1
 #kind: IstioOperator
@@ -54,11 +55,9 @@ export default {
     Checkbox,
     FileSelector,
     YamlEditor,
-    Tab,
-    Banner
+    Banner,
+    ChartPsp
   },
-
-  hasTabs: true,
 
   props: {
     value: {
@@ -131,116 +130,117 @@ export default {
 
 <template>
   <div>
-    <Tab
-      name="components"
-      :label="t('istio.titles.components') "
-    >
-      <div class="row">
-        <div
-          v-if="value.cni"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.cni.enabled"
-            :label="t('istio.cni')"
-            @input="update"
-          />
-        </div>
-        <div
-          v-if="value.ingressGateways"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.ingressGateways.enabled"
-            :label="t('istio.ingressGateway')"
-          />
-        </div>
-        <div
-          v-if="value.egressGateways"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.egressGateways.enabled"
-            :label="t('istio.egressGateway')"
-          />
-        </div>
+    <h3>
+      {{ t('catalog.chart.global') }}
+    </h3>
+    <div class="row mb-20">
+      <div class="col">
+        <ChartPsp :value="value" />
       </div>
-      <div class="row">
-        <div
-          v-if="value.pilot"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.pilot.enabled"
-            :label="t('istio.pilot')"
-          />
-        </div>
-        <div
-          v-if="value.policy"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.policy.enabled"
-            :label="t('istio.policy')"
-          />
-        </div>
-        <div
-          v-if="value.telemetry"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.telemetry.enabled"
-            :label="t('istio.telemetry')"
-          />
-        </div>
+    </div>
+    <h3>
+      {{ t('istio.titles.components') }}
+    </h3>
+    <div class="row">
+      <div
+        v-if="value.cni"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.cni.enabled"
+          :label="t('istio.cni')"
+          @input="update"
+        />
       </div>
-      <div class="row">
-        <div
-          v-if="value.kiali"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.kiali.enabled"
-            :label="t('istio.kiali')"
-          />
-        </div>
-        <div
-          v-if="value.tracing"
-          class="col span-4"
-        >
-          <Checkbox
-            v-model="value.tracing.enabled"
-            :label="t('istio.tracing')"
-          />
-        </div>
-        <div class="col span-4" />
+      <div
+        v-if="value.ingressGateways"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.ingressGateways.enabled"
+          :label="t('istio.ingressGateway')"
+        />
       </div>
-    </Tab>
+      <div
+        v-if="value.egressGateways"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.egressGateways.enabled"
+          :label="t('istio.egressGateway')"
+        />
+      </div>
+    </div>
+    <div class="row">
+      <div
+        v-if="value.pilot"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.pilot.enabled"
+          :label="t('istio.pilot')"
+        />
+      </div>
+      <div
+        v-if="value.policy"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.policy.enabled"
+          :label="t('istio.policy')"
+        />
+      </div>
+      <div
+        v-if="value.telemetry"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.telemetry.enabled"
+          :label="t('istio.telemetry')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div
+        v-if="value.kiali"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.kiali.enabled"
+          :label="t('istio.kiali')"
+        />
+      </div>
+      <div
+        v-if="value.tracing"
+        class="col span-4"
+      >
+        <Checkbox
+          v-model="value.tracing.enabled"
+          :label="t('istio.tracing')"
+        />
+      </div>
+      <div class="col span-4" />
+    </div>
 
-    <Tab
-      :label="t('istio.customOverlayFile.label')"
-      name="overlay"
-      @active="$refs['yaml-editor'].refresh()"
-    >
-      <div class="custom-overlay">
-        <Banner color="info">
-          <span
-            v-html="t('istio.customOverlayFile.tip', {}, true)"
-          />
-        </Banner>
-        <YamlEditor
-          ref="yaml-editor"
-          class="yaml-editor mb-10"
-          :value="overlayFile"
-          @onInput="valuesChanged"
+    <h3>{{ t('istio.customOverlayFile.label') }}</h3>
+    <div class="custom-overlay">
+      <Banner color="info">
+        <span
+          v-html="t('istio.customOverlayFile.tip', {}, true)"
         />
-        <FileSelector
-          class="role-primary  btn-sm"
-          :label="t('generic.readFromFile')"
-          @selected="onFileSelected"
-        />
-      </div>
-    </Tab>
+      </Banner>
+      <YamlEditor
+        ref="yaml-editor"
+        class="yaml-editor mb-10"
+        :value="overlayFile"
+        @onInput="valuesChanged"
+      />
+      <FileSelector
+        class="role-primary  btn-sm"
+        :label="t('generic.readFromFile')"
+        @selected="onFileSelected"
+      />
+    </div>
   </div>
 </template>
 

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -5,7 +5,6 @@ import { Checkbox } from '@components/Form/Checkbox';
 import YamlEditor from '@shell/components/YamlEditor';
 import { mapGetters } from 'vuex';
 import FileSelector from '@shell/components/form/FileSelector';
-import Tab from '@shell/components/Tabbed/Tab';
 import { Banner } from '@components/Banner';
 import ChartPsp from '@shell/components/ChartPsp';
 

--- a/shell/chart/logging/index.vue
+++ b/shell/chart/logging/index.vue
@@ -2,10 +2,13 @@
 import { mapGetters } from 'vuex';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { Checkbox } from '@components/Form/Checkbox';
+import ChartPsp from '@shell/components/ChartPsp';
 
 export default {
-  components: { Checkbox, LabeledInput },
-  props:      {
+  components: {
+    Checkbox, LabeledInput, ChartPsp
+  },
+  props: {
     value: {
       type:    Object,
       default: () => {
@@ -72,12 +75,17 @@ export default {
         />
       </div>
     </div>
-    <div class="row">
+    <div class="row mb-20">
       <div class="col span-6">
         <Checkbox
           v-model="value.additionalLoggingSources[provider].enabled"
           :label="t('logging.install.enableAdditionalLoggingSources')"
         />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <ChartPsp :value="value" />
       </div>
     </div>
   </div>

--- a/shell/chart/monitoring/index.vue
+++ b/shell/chart/monitoring/index.vue
@@ -12,6 +12,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import Loading from '@shell/components/Loading';
 import Prometheus from '@shell/chart/monitoring/prometheus';
 import Tab from '@shell/components/Tabbed/Tab';
+import ChartPsp from '@shell/components/ChartPsp';
 
 import { allHash } from '@shell/utils/promise';
 import { STORAGE_CLASS, PVC, SECRET, WORKLOAD_TYPES } from '@shell/config/types';
@@ -26,6 +27,7 @@ export default {
     Loading,
     Prometheus,
     Tab,
+    ChartPsp
   },
 
   hasTabs: true,
@@ -207,11 +209,13 @@ export default {
     >
       <div>
         <div class="row mb-20">
-          <ClusterSelector
-            :value="value"
-            :mode="mode"
-            @onClusterTypeChanged="clusterType = $event"
-          />
+          <div class="col span-6">
+            <ClusterSelector
+              :value="value"
+              :mode="mode"
+              @onClusterTypeChanged="clusterType = $event"
+            />
+          </div>
         </div>
         <div
           v-if="clusterType.group === 'managed'"
@@ -255,6 +259,11 @@ export default {
               :hover-tooltip="true"
               :mode="mode"
             />
+          </div>
+        </div>
+        <div class="row mt-20">
+          <div class="col span-6">
+            <ChartPsp :value="value" />
           </div>
         </div>
       </div>

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -10,6 +10,7 @@ import { allHash } from '@shell/utils/promise';
 import { STORAGE_CLASS, SECRET, PV } from '@shell/config/types';
 import { mapGetters } from 'vuex';
 import { STORAGE } from '@shell/config/labels-annotations';
+import ChartPsp from '@shell/components/ChartPsp';
 
 export default {
   components: {
@@ -18,7 +19,8 @@ export default {
     S3,
     LabeledInput,
     LabeledSelect,
-    Banner
+    Banner,
+    ChartPsp
   },
 
   hasTabs: true,
@@ -165,6 +167,11 @@ export default {
       label="Chart Options"
       name="chartOptions"
     >
+      <div class="row">
+        <div class="col">
+          <ChartPsp :value="value" />
+        </div>
+      </div>
       <Banner
         color="info"
         :label="t('backupRestoreOperator.deployment.storage.tip')"

--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -21,7 +21,7 @@ export default {
       this.$set(this.value.global, 'cattle', { psp: { enabled: false } });
     }
     if (!this.value.global.cattle.psp) {
-      this.$set(this.value.global, 'psp', { enabled: false });
+      this.$set(this.value.global.cattle, 'psp', { enabled: false });
     }
   },
   computed: { ...mapGetters({ t: 'i18n/t' }) }

--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -1,5 +1,5 @@
 <script>
-import { Checkbox } from '@components/form/Checkbox';
+import { Checkbox } from '@components/Form/Checkbox';
 import { mapGetters } from 'vuex';
 
 export default {

--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -1,0 +1,37 @@
+<script>
+import { Checkbox } from '@components/form/Checkbox';
+import { mapGetters } from 'vuex';
+
+export default {
+  components: { Checkbox },
+  props:      {
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+    mode: {
+      type:    String,
+      default: 'edit'
+    }
+  },
+  created() {
+    if (!this.value.global.cattle) {
+      this.$set(this.value.global, 'cattle', { psp: { enabled: false } });
+    }
+    if (!this.value.global.cattle.psp) {
+      this.$set(this.value.global, 'psp', { enabled: false });
+    }
+  },
+  computed: { ...mapGetters({ t: 'i18n/t' }) }
+};
+</script>
+
+<template>
+  <Checkbox
+    v-model="value.global.cattle.psp.enabled"
+    :mode="mode"
+    :label="t('catalog.chart.enablePSP')"
+  />
+</template>

--- a/shell/components/__tests__/ChartPsp.test.ts
+++ b/shell/components/__tests__/ChartPsp.test.ts
@@ -1,0 +1,32 @@
+import { shallowMount, mount } from '@vue/test-utils';
+import ChartPsp from '@shell/components/ChartPsp.vue';
+
+describe('component: ChartPsp', () => {
+  it.each([[
+    { global: { cattle: { psp: { enabled: true } } } }, true
+  ], [{ global: { cattle: { psp: { enabled: false } } } }, false]])('should render checkbox referencing value.global.cattle.psp.enabled', (chartValue, checkboxValue) => {
+    const wrapper = shallowMount(ChartPsp, { propsData: { value: chartValue } });
+
+    expect(wrapper.findComponent({ name: 'Checkbox' }).props().value).toBe(checkboxValue);
+  });
+
+  it('should update value.global.cattle.psp.enabled when checkbox is toggled', async() => {
+    const chartValues = { global: {} } as any;
+    const wrapper = mount(ChartPsp, { propsData: { value: chartValues } });
+
+    await wrapper.find('.checkbox-container').trigger('click');
+
+    expect(chartValues.global.cattle.psp.enabled).toBe(true);
+
+    await wrapper.find('.checkbox-container').trigger('click');
+    expect(chartValues.global.cattle.psp.enabled).toBe(false);
+  });
+
+  it('should define cattle.psp.enabled and set to false if not present in value.global', () => {
+    const chartValues = { global: {} } as any;
+
+    shallowMount(ChartPsp, { propsData: { value: chartValues } });
+
+    expect(chartValues.global.cattle.psp.enabled).toBe(false);
+  });
+});

--- a/shell/components/__tests__/ChartPsp.test.ts
+++ b/shell/components/__tests__/ChartPsp.test.ts
@@ -22,11 +22,12 @@ describe('component: ChartPsp', () => {
     expect(chartValues.global.cattle.psp.enabled).toBe(false);
   });
 
-  it('should define cattle.psp.enabled and set to false if not present in value.global', () => {
-    const chartValues = { global: {} } as any;
-
+  it.each([
+    [{ global: {} } as any, false],
+    [{ global: { cattle: {} } } as any, false],
+  ])('should define cattle.psp.enabled and set to false if not present in value.global', (chartValues, expected) => {
     shallowMount(ChartPsp, { propsData: { value: chartValues } });
 
-    expect(chartValues.global.cattle.psp.enabled).toBe(false);
+    expect(chartValues.global.cattle.psp.enabled).toBe(expected);
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8053 

This PR adds a component to toggle `<chartvalues>.global.cattle.psp.enabled`, and define it if missing from chart values. It also removes the alerting-drivers custom UI since that app is using a questions.yaml now. 

The big diff from the istio component is because I remove the tabs; there wasn't enough content to justify them.