### PR TITLE
HARVESTER: Fix kubernetesVersionExtension is '' on the create Harvester storage class page

### DIFF
--- a/shell/components/SingleClusterInfo.vue
+++ b/shell/components/SingleClusterInfo.vue
@@ -118,11 +118,11 @@ export default {
         class="glance-item"
       >
         <label>{{ t('glance.version') }}: </label>
+        <span>{{ clusterDetail.kubernetesVersionBase }}</span>
         <span
           v-if="clusterDetail.kubernetesVersionExtension"
-          style="font-size: 0.5em"
+          style="font-size: 0.75em"
         >{{ clusterDetail.kubernetesVersionExtension }}</span>
-        <span>{{ clusterDetail.kubernetesVersionBase }}</span>
       </div>
       <div class="glance-item">
         <label>{{ t('glance.created') }}: </label>

--- a/shell/edit/storage.k8s.io.storageclass/provisioners/driver.harvesterhci.io.vue
+++ b/shell/edit/storage.k8s.io.storageclass/provisioners/driver.harvesterhci.io.vue
@@ -46,7 +46,7 @@ export default {
 
     isSatisfiesVersion() {
       const kubernetesVersion = this.currentCluster.kubernetesVersion || '';
-      const kubernetesVersionExtension = this.currentCluster.kubernetesVersion.replace(/^.*([+-])/, '$1');
+      const kubernetesVersionExtension = this.currentCluster.kubernetesVersionExtension;
 
       if (kubernetesVersionExtension.startsWith('+rke2')) {
         const charts = ((this.rke2Versions?.data || []).find(v => v.id === kubernetesVersion) || {}).charts;

--- a/shell/edit/storage.k8s.io.storageclass/provisioners/driver.harvesterhci.io.vue
+++ b/shell/edit/storage.k8s.io.storageclass/provisioners/driver.harvesterhci.io.vue
@@ -45,10 +45,10 @@ export default {
     ...mapGetters(['currentCluster']),
 
     isSatisfiesVersion() {
-      const kubernetesVersion = this.currentCluster.kubernetesVersion;
-      const kubernetesVersionExtension = this.currentCluster.kubernetesVersionExtension;
+      const kubernetesVersion = this.currentCluster.kubernetesVersion || '';
+      const kubernetesVersionExtension = this.currentCluster.kubernetesVersion.replace(/^.*([+-])/, '$1');
 
-      if (kubernetesVersionExtension.startsWith('rke2')) {
+      if (kubernetesVersionExtension.startsWith('+rke2')) {
         const charts = ((this.rke2Versions?.data || []).find(v => v.id === kubernetesVersion) || {}).charts;
         let csiVersion = charts?.['harvester-csi-driver']?.version || '';
 

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -196,7 +196,7 @@ export default class MgmtCluster extends HybridModel {
   }
 
   get kubernetesVersionExtension() {
-    if ( this.kubernetesVersion.match(/[+-]]/) ) {
+    if ( this.kubernetesVersion.match(/[+-]/) ) {
       return this.kubernetesVersion.replace(/^.*([+-])/, '$1');
     }
 

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -444,11 +444,11 @@ export default {
       </div>
       <div>
         <label>{{ t('glance.version') }}: </label>
+        <span>{{ currentCluster.kubernetesVersionBase }}</span>
         <span
           v-if="currentCluster.kubernetesVersionExtension"
-          style="font-size: 0.5em"
+          style="font-size: 0.75em"
         >{{ currentCluster.kubernetesVersionExtension }}</span>
-        <span>{{ currentCluster.kubernetesVersionBase }}</span>
       </div>
       <div>
         <label>{{ t('glance.created') }}: </label>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix kubernetesVersionExtension is '' on the create Harvester storage class page
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3052

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The kubernetesVersionExtension in `/models/management.cattle.io.cluster.js` always returns `''`. Considering there have some styles depending on kubernetesVersionExtension. I just fix the issue on the create Harvester storage class page.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->