### PR TITLE
Disassociate the steve worker creator from the steve store

### DIFF
--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -630,6 +630,7 @@ export default function(dir, _appConfig) {
       { src: path.join(NUXT_SHELL, 'plugins/codemirror-loader'), ssr: false },
       { src: path.join(NUXT_SHELL, 'plugins/formatters'), ssr: false }, // Populate formatters cache for sorted table
       { src: path.join(NUXT_SHELL, 'plugins/version'), ssr: false }, // Makes a fetch to the backend to get version metadata
+      { src: path.join(NUXT_SHELL, 'plugins/steve-create-worker'), ssr: false }, // Add steve web worker creator to the store, to break the import chain
     ],
 
     // Proxy: https://github.com/nuxt-community/proxy-module#options

--- a/shell/plugins/steve-create-worker.js
+++ b/shell/plugins/steve-create-worker.js
@@ -1,0 +1,14 @@
+import createWorker from './steve/worker/index.js';
+
+/**
+ * Link the steve worker creator to the store
+ *
+ * This is done to allow disassociate (no import chain) access to the steve worker file.
+ * Without this third party plugins (in given scenarios / harvester) will fail to build
+ * due to missing web worker specific build config
+ *
+ * Note - When rancher/steve store is spun out in to a extension this also needs to move out
+ */
+export default function({ store }) {
+  store.steveCreateWorker = createWorker;
+}

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -29,8 +29,6 @@ import { escapeHtml } from '@shell/utils/string';
 import { keyForSubscribe } from '@shell/plugins/steve/resourceWatcher';
 import { waitFor } from '@shell/utils/async';
 
-// eslint-disable-next-line
-import storeWorker from './worker/index.js';
 import { BLANK_CLUSTER } from '@shell/store/index.js';
 
 // minimum length of time a disconnect notification is shown
@@ -97,7 +95,7 @@ export async function createWorker(store, ctx) {
 
   if (!store.$workers[storeName]) {
     const workerMode = advancedWorker ? 'advanced' : 'basic';
-    const worker = storeWorker(workerMode);
+    const worker = store.steveCreateWorker(workerMode);
 
     store.$workers[storeName] = worker;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes - Alt fix for https://github.com/rancher/dashboard/pull/8064

### Occurred changes and/or fixed issues
- `yarn build-pkg harvester` fails due to import of web workers
- import fails due to the build process missing web worker build config
- Fix is to disassociate the import chain for the web worker creator 
  - Assign the steve worker creator to the store via plugin
  - On the downside this means rancher/steve specific stuff is applied at a more global level

### Areas or cases that should be tested
- Web socket updates work correctly when advanced worker setting is enabled and not enabled
- When enabled the cluster socket should be 'advanced' 
  - ![image](https://user-images.githubusercontent.com/18697775/218754690-3420fb91-43b6-4435-8d1c-4e9d7c68897b.png)

