### PR TITLE
Sockets subscribe with namespaces and other filters and also unsubscribe

### DIFF
--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -131,8 +131,8 @@ export default {
 
       const schema = this.$store.getters[`${ currStore }/schemaFor`](type);
 
-      if (schema?.attributes?.namespaced) {
-        opt.namespaced = this.namespaceFilter;
+      if (schema?.attributes?.namespaced) { // Is this specific resource namespaced (could be primary or secondary resource)?
+        opt.namespaced = this.namespaceFilter; // namespaceFilter will only be populated if applicable for primary resource
       }
 
       return this.$store.dispatch(`${ currStore }/findAll`, {

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -152,7 +152,7 @@ export default {
       const args = {
         type,
         revision:  '',
-        namespace: opt.watchNamespace
+        namespace: opt.watchNamespace || opt.namespaced
       };
 
       if (opt.watch !== false ) {
@@ -310,11 +310,13 @@ export default {
       }
     }
 
+    // ToDo: SM if we start a "bigger" watch (such as watch without a namespace vs a watch with a namespace), we should stop the stop the "smaller" watch so we don't have duplicate events coming back
     if ( opt.watch !== false ) {
       dispatch('watch', {
         type,
         revision:  out.revision,
-        namespace: opt.watchNamespace,
+        namespace: opt.watchNamespace || opt.namespaced, // it could be either apparently
+        // ToDo: SM namespaced is sometimes a boolean and sometimes a string, I don't see it as especially broken but we should refactor that in the future
         force:     opt.forceWatch === true,
       });
     }
@@ -539,8 +541,10 @@ export default {
 
   // Forget a type in the store
   // Remove all entries for that type and stop watching it
-  forgetType({ commit, getters, dispatch }, type) {
-    dispatch('unwatch', type);
+  forgetType({ commit, dispatch, state }, type) {
+    state.started
+      .filter(entry => entry.type === type)
+      .forEach(entry => dispatch('unwatch', entry));
 
     commit('forgetType', type);
   },

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -148,10 +148,13 @@ export default {
       commit('registerType', type);
     }
 
+    // No need to request the resources if we have them already
     if ( opt.force !== true && (getters['haveAll'](type) || getters['haveAllNamespace'](type, opt.namespaced))) {
       const args = {
         type,
         revision:  '',
+        // watchNamespace - used sometimes when we haven't fetched the results of a single namespace
+        // namespaced - used when we have fetched the result of a single namespace (see https://github.com/rancher/dashboard/pull/7329/files)
         namespace: opt.watchNamespace || opt.namespaced
       };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7919 
Namespaces can be fed into subscriptions using either `watchNamespace` or the `namespaced` watch option, also the `unwatch` action didn't accept `id`, `namespace`, or `selector` filter parameters so it wasn't possible to unwatch subscriptions that had those criteria.

### Occurred changes and/or fixed issues
when the `watch` action is dispatched in findall now we pass in the namespace as either the `watchNamespace` or the `namespaced` option. The other major change here is that we now can unsubscribe with specific filter options so that when the `namespace` option changes we will unwatch any watches using a different namespace.

### Technical notes summary
We should be able to test this by observing socket messages and responses in browser dev tools and if Vue dev tools are available it should be observable that the "started" property in the various stores drop watches that aren't active anymore.

### Areas or cases that should be tested
Switching Namespaces with the performance option to force namespaces above a threshold (with the list being tested being above the threshold) should be tested
Using Chrome

### Areas which could experience regressions
It is possible that some changes through a websocket that we'd expect might not be caught properly because it's been improperly unwatched. Not sure of an easy way to test that holistically but this change should only unwatch when the namespace is different so potential regressions would be limited.