### PR TITLE
Remove Pod edit fields that are not editabble from PUT request.

### DIFF
--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -775,7 +775,7 @@ export default {
 
         // Removing `affinity` fixes the issue with setting the `imagePullSecrets`
         // However, this field should not be set. Therefore this is explicitly removed.
-        if (template?.spec?.imagePullSecrets && Object.keys(template?.spec?.imagePullSecrets).length === 0) {
+        if (template?.spec?.imagePullSecrets && template?.spec?.imagePullSecrets.length === 0) {
           delete template.spec.imagePullSecrets;
         }
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#8074 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
When using kubectl shell to create a pod by default `imagePullSecrets` and `affinity` set to `null`. Once set these fields cannot be edited. 

When using UI fields are set to `[]` and `{}`. This create a conflict

### Technical notes summary
- Delete these properties if they are not set

### Areas or cases that should be tested
- Enter Kubectl shell using keyboard command  `` ctrl+`  `` Or using the icon on top navigation
- Create a pod by kubectl: `$ kubectl run nginx-pod --image=nginx`
- Add a Label to the pod via Rancher GUI:
- Cluster Manager -> local cluster -> Workload -> pods -> Edit Config -> 
- Save (there is no need to update any fields. Although this can be tested)
- This should update the POD.