### PR TITLE
add logic around limiting extensions to a specific ui-version

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3879,6 +3879,7 @@ podDisruptionBudget:
 
 # Rancher Extensions
 plugins:
+  incompatibleDisclaimer: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ rancherVersion })."
   labels:
     builtin: Built-in
     experimental: Experimental
@@ -3912,6 +3913,7 @@ plugins:
     detail: Detail
     versions: Versions
     versionError: Could not load version information
+    requiresVersion: "Requires Rancher {version}"
   empty:
     all: Extensions are neither installed nor available
     available: No Extensions available

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -33,6 +33,7 @@ export const UI_PLUGINS_REPO_BRANCH = 'main';
 export const UI_PLUGIN_CHART_ANNOTATIONS = {
   RANCHER_VERSION:    'catalog.cattle.io/rancher-version',
   EXTENSIONS_VERSION: 'catalog.cattle.io/ui-extensions-version',
+  UI_VERSION:         'catalog.cattle.io/ui-version',
   EXTENSIONS_HOST:    'catalog.cattle.io/ui-extensions-host',
   DISPLAY_NAME:       'catalog.cattle.io/display-name',
 };
@@ -127,4 +128,29 @@ export function isSupportedChartVersion(chartVersion, rancherVersion) {
   }
 
   return true;
+}
+
+export function isChartVersionAvailableForInstall(version, dashboardVersion, returnObj = false) {
+  const requiredUiVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.UI_VERSION];
+  const versionObj = { ...version };
+
+  versionObj.isCompatibleWithUi = true;
+
+  if (requiredUiVersion && !semver.satisfies(dashboardVersion, requiredUiVersion)) {
+    if (!returnObj) {
+      return false;
+    }
+    versionObj.isCompatibleWithUi = false;
+    versionObj.requiredUiVersion = requiredUiVersion;
+  }
+
+  if (returnObj) {
+    return versionObj;
+  }
+
+  return true;
+}
+
+export function isChartVersionHigher(versionA, versionB) {
+  return semver.gt(versionA, versionB);
 }

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -130,13 +130,13 @@ export function isSupportedChartVersion(chartVersion, rancherVersion) {
   return true;
 }
 
-export function isChartVersionAvailableForInstall(version, dashboardVersion, returnObj = false) {
+export function isChartVersionAvailableForInstall(version, rancherVersion, returnObj = false) {
   const requiredUiVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.UI_VERSION];
   const versionObj = { ...version };
 
   versionObj.isCompatibleWithUi = true;
 
-  if (requiredUiVersion && !semver.satisfies(dashboardVersion, requiredUiVersion)) {
+  if (requiredUiVersion && !semver.satisfies(rancherVersion, requiredUiVersion)) {
     if (!returnObj) {
       return false;
     }

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -36,7 +36,7 @@ export default {
 
   computed: {
     showVersionSelector() {
-      return this.plugin?.versions.length > 1;
+      return this.versionOptions?.length > 1;
     },
 
     versionOptions() {
@@ -44,8 +44,8 @@ export default {
         return [];
       }
 
-      // Don't allow update/rollback to curent version
-      const versions = this.plugin.versions.filter((v) => {
+      // Don't allow update/rollback to current version
+      const versions = this.plugin.installableVersions.filter((v) => {
         if (this.currentVersion) {
           return v.version !== this.currentVersion;
         }
@@ -78,12 +78,12 @@ export default {
         this.currentVersion = plugin.displayVersion;
 
         // Update to latest version, so take the first version
-        if (plugin.versions.length > 0) {
-          this.version = plugin.versions[0].version;
+        if (plugin.installableVersions.length > 0) {
+          this.version = plugin.installableVersions[0].version;
         }
       } else if (mode === 'rollback') {
         // Find the newest version once we remove the current version
-        const versionNames = plugin.versions.filter(v => v.version !== plugin.displayVersion);
+        const versionNames = plugin.installableVersions.filter(v => v.version !== plugin.displayVersion);
 
         this.currentVersion = plugin.displayVersion;
 
@@ -93,10 +93,10 @@ export default {
       }
 
       // Make sure we have the version available
-      const versionChart = plugin.versions?.find(v => v.version === this.version);
+      const versionChart = plugin.installableVersions?.find(v => v.version === this.version);
 
       if (!versionChart) {
-        this.version = plugin.versions[0].version;
+        this.version = plugin.installableVersions[0].version;
       }
 
       this.busy = false;

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -63,16 +63,18 @@ export default {
     },
 
     async loadPluginVersionInfo(version) {
-      this.versionError = false;
-      this.versionInfo = undefined;
-
       const versionName = version || this.info.displayVersion;
+
+      const isVersionNotCompatibleWithUi = this.info.versions?.find(v => v.version === versionName && !v.isCompatibleWithUi);
+
+      if (!this.info.chart || isVersionNotCompatibleWithUi) {
+        return;
+      }
 
       this.infoVersion = versionName;
 
-      if (!this.info.chart) {
-        return;
-      }
+      this.versionError = false;
+      this.versionInfo = undefined;
 
       try {
         this.versionInfo = await this.$store.dispatch('catalog/getVersionInfo', {
@@ -204,8 +206,9 @@ export default {
             :key="v.version"
           >
             <a
+              v-tooltip="v.requiredUiVersion ? t('plugins.info.requiresVersion', { version: v.requiredUiVersion }) : ''"
               class="version-link"
-              :class="{'version-active': v.version === infoVersion}"
+              :class="{'version-active': v.version === infoVersion, 'disabled': !v.isCompatibleWithUi}"
               @click="loadPluginVersionInfo(v.version)"
             >
               {{ v.version }}
@@ -354,6 +357,14 @@ export default {
         &.version-active {
           color: var(--link-text);
           background: var(--link);
+        }
+
+        &.disabled {
+          cursor: not-allowed;
+          color: var(--disabled-text) !important;
+          background-color: var(--disabled-bg) !important;
+          border-color: var(--disabled-bg) !important;
+          text-decoration: none !important;
         }
 
         &.version-builtin {

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -23,6 +23,8 @@ import {
   uiPluginAnnotation,
   uiPluginHasAnnotation,
   isSupportedChartVersion,
+  isChartVersionAvailableForInstall,
+  isChartVersionHigher,
   UI_PLUGIN_NAMESPACE,
   UI_PLUGIN_CHART_ANNOTATIONS
 } from '@shell/config/uiplugins';
@@ -183,27 +185,36 @@ export default {
         // Label can be overridden by chart annotation
         const label = uiPluginAnnotation(UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME) || chart.chartNameDisplay;
         const item = {
-          name:           chart.chartNameDisplay,
+          name:         chart.chartNameDisplay,
           label,
-          description:    chart.chartDescription,
-          id:             chart.id,
-          versions:       [],
-          displayVersion: chart.versions?.length > 0 ? chart.versions[0].version : '',
-          installed:      false,
-          builtin:        false,
-          experimental:   uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.EXPERIMENTAL, 'true'),
-          certified:      uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.CERTIFIED, CATALOG_ANNOTATIONS._RANCHER),
+          description:  chart.chartDescription,
+          id:           chart.id,
+          versions:     [],
+          installed:    false,
+          builtin:      false,
+          experimental: uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.EXPERIMENTAL, 'true'),
+          certified:    uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.CERTIFIED, CATALOG_ANNOTATIONS._RANCHER),
         };
 
-        this.latest = chart.versions[0];
         item.versions = [...chart.versions];
         item.chart = chart;
 
-        // Filter the versions, leaving only those that are compatible with this Rancher
-        item.versions = item.versions.filter(version => isSupportedChartVersion(version));
+        // Filter the versions available to install (plugins-api version and current dashboard version)
+        item.installableVersions = item.versions.filter(version => isSupportedChartVersion(version) && isChartVersionAvailableForInstall(version, this.$config.dashboardVersion));
 
-        if (this.latest) {
-          item.icon = chart.icon || this.latest.annotations['catalog.cattle.io/ui-icon'];
+        // add prop to version object if version is compatible with the current dashboard version
+        item.versions = item.versions.map(version => isChartVersionAvailableForInstall(version, this.$config.dashboardVersion, true));
+
+        const latestCompatible = item.installableVersions?.[0];
+        const latestNotCompatible = item.versions.find(version => !version.isCompatibleWithUi);
+
+        if (latestCompatible) {
+          item.displayVersion = latestCompatible.version;
+          item.icon = chart.icon || latestCompatible.annotations['catalog.cattle.io/ui-icon'];
+        }
+
+        if (latestNotCompatible && isChartVersionHigher(latestNotCompatible.version, item.installableVersions?.[0].version)) {
+          item.incompatibleDisclaimer = this.t('plugins.incompatibleDisclaimer', { version: latestNotCompatible.version, rancherVersion: latestNotCompatible.requiredUiVersion }, true);
         }
 
         if (this.installing[item.name]) {
@@ -253,8 +264,8 @@ export default {
           chart.installing = this.installing[chart.name];
 
           // Check for upgrade
-          if (chart.versions.length && p.version !== chart.versions[0].version) {
-            chart.upgrade = chart.versions[0].version;
+          if (chart.installableVersions.length && p.version !== chart.installableVersions[0].version) {
+            chart.upgrade = chart.installableVersions[0].version;
           }
         } else {
           // No chart, so add a card for the plugin based on its Custom resource being present
@@ -619,6 +630,7 @@ export default {
             :data-testid="`extension-card-${plugin.name}`"
             @click="showPluginDetail(plugin)"
           >
+            <!-- plugin icon -->
             <div
               class="plugin-icon"
               :class="applyDarkModeBg"
@@ -636,7 +648,9 @@ export default {
                 class="icon plugin-icon-img"
               >
             </div>
+            <!-- plugin card -->
             <div class="plugin-metadata">
+              <!-- plugin basic info -->
               <div class="plugin-name">
                 {{ plugin.label }}
               </div>
@@ -654,8 +668,13 @@ export default {
                     v-if="plugin.upgrade"
                     v-tooltip="t('plugins.upgradeAvailable')"
                   > -> {{ plugin.upgrade }}</span>
+                  <p
+                    v-if="plugin.incompatibleDisclaimer"
+                    class="incompatible"
+                  >{{ plugin.incompatibleDisclaimer }}</p>
                 </span>
               </div>
+              <!-- plugin badges -->
               <div
                 v-if="plugin.builtin"
                 class="plugin-badges"
@@ -682,6 +701,7 @@ export default {
                 </div>
               </div>
               <div class="plugin-spacer" />
+              <!-- plugin badges -->
               <div class="plugin-actions">
                 <template v-if="plugin.error">
                   <div
@@ -691,6 +711,7 @@ export default {
                     <i class="icon icon-warning" />
                   </div>
                 </template>
+                <!-- plugin status -->
                 <div
                   v-if="plugin.helmError"
                   v-tooltip="t('plugins.helmError')"
@@ -713,6 +734,7 @@ export default {
                     {{ t('plugins.labels.uninstalling') }}
                   </div>
                 </div>
+                <!-- plugin buttons -->
                 <div
                   v-else-if="plugin.installed"
                   class="plugin-buttons"
@@ -734,7 +756,7 @@ export default {
                     {{ t('plugins.update.label') }}
                   </button>
                   <button
-                    v-if="!plugin.upgrade && plugin.versions.length > 1"
+                    v-if="!plugin.upgrade && plugin.installableVersions && plugin.installableVersions.length > 1"
                     class="btn role-secondary"
                     :data-testid="`extension-card-rollback-btn-${plugin.name}`"
                     @click="showInstallDialog(plugin, 'rollback', $event)"
@@ -941,6 +963,11 @@ export default {
         font-size: 16px;
         height: 16px;
         width: 16px;
+      }
+
+      .incompatible {
+        margin: 10px 0;
+        font-weight: bold;
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/rancher/elemental-ui/issues/78

- add logic around limiting extensions to a specific ui-version

### To Test
- Provision a Rancher instance `2.7.1` (needs to be a final cut/version in order for semver comparison to work properly)
- Add my fork of `rancher-ui-examples` to `catalog.cattle.io.clusterrepo`, which has some use-cases specific to this PR:

**GitHub url:** https://github.com/aalves08/ui-plugin-examples
**Branch:** main

the extension `homepage` has the following changes (5 versions):
**0.0.5** -> added label `catalog.cattle.io/ui-version: '>= 2.7.3'` to chart `index.yaml`
**0.0.4** -> added label `catalog.cattle.io/ui-version: '>= 2.7.0'` to chart `index.yaml`
**0.0.3** -> added label `catalog.cattle.io/ui-version: '>= 2.7.3'` to chart `index.yaml`
**0.0.2** -> unchanged
**0.0.1** -> unchanged

the extension `homepage-two` has the following changes (4 versions):
**0.0.4** -> unchanged
**0.0.3** -> added label `catalog.cattle.io/ui-version: '>= 2.7.3'` to chart `index.yaml`
**0.0.2** -> unchanged
**0.0.1** -> unchanged

- Check if disclaimer appears on extension `homepage` card
- Check if slide in info panel shows disabled versions (hover on disabled version should show tooltip)
- Check if `install`, `update` and `rollback` select's shows correct options

### Screenshot/Video
![Screenshot 2023-02-17 at 14 52 48](https://user-images.githubusercontent.com/97888974/219692343-ee0d20eb-53ef-43ae-a18b-d29ce49bf816.png)
![Screenshot 2023-02-17 at 14 53 11](https://user-images.githubusercontent.com/97888974/219692369-7b921b1b-06dd-45df-9968-5dd088bdd796.png)
![Screenshot 2023-02-17 at 14 52 53](https://user-images.githubusercontent.com/97888974/219692358-73819935-556c-4b8d-bd52-88d76432d822.png)
![Screenshot 2023-02-17 at 14 52 59](https://user-images.githubusercontent.com/97888974/219692364-53dbeaa2-919d-43d7-a25d-f520c49463cc.png)


