### PR TITLE
Extensions test script: ensure build fails when one of the build steps fails

### DIFF
--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -91,6 +91,10 @@ ${SHELL_DIR}/scripts/publish-shell.sh
 yarn build:lib
 yarn publish:lib
 
+# We pipe into cat for cleaner logging - we need to set pipefail
+# to ensure the build fails in these cases
+set -o pipefail
+
 if [ "${SKIP_STANDALONE}" == "false" ]; then
   DIR=$(mktemp -d)
   pushd $DIR > /dev/null


### PR DESCRIPTION
Fixes #8179 

To improve logging, we pipe the output of some commands into `cat`. Unfortunately, this means if the command fails, the error does not cause the script to fail - we do `set -e` which does this, but this does not catch the errors lost in the pipe.

To fix this, we need to add:

```
set -o pipefail
```

so that errors in the pipe fail the script via `set -e`.

This PR fixes this.
