### PR TITLE
Alert users when upgrading provisioned k3s cluster from k8s <1.25 to >=1.25 if PSP enabled

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
   "javascript.preferences.importModuleSpecifier": "non-relative",
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "cSpell.words": [
+    "apiserver",
     "autoscroll",
     "cacerts",
     "chainable",

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1775,6 +1775,10 @@ cluster:
       psaChange: PSACT is now set to Rancher default automatically
       cisOverride: Changing this setting may affect cluster security as it overrides default CIS settings
       cisUnsupported: The selected Kubernetes Version no longer supports CIS Profile "{cisProfile}". Please select a supported profile. It's recommended to review RKE2 documentation to evaluate the impact of changing CIS Profile.
+    modal:
+      pspChange:
+        title: Pod Security Policy deprecation
+        body: Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If your cluster has PodSecurityPolicy admission controller enabled via "kube-apiserver-arg.enable-admission-plugins" in Cluster YAML, it has to be MANUALLY removed before proceeding with the upgrade. Additionally, any PSPs that may be present in the cluster will no longer be available/enforced. Proceed?
     snapshots:
       suffix: Snapshots per node
     systemService:

--- a/shell/dialog/AddonConfigConfirmationDialog.vue
+++ b/shell/dialog/AddonConfigConfirmationDialog.vue
@@ -46,7 +46,7 @@ export default {
 
 <template>
   <Card
-    class="addon-config-confirmation"
+    class="prompt-restore"
     :show-highlight-border="false"
   >
     <h4
@@ -66,24 +66,36 @@ export default {
       slot="actions"
       class="bottom"
     >
-      <button
-        type="button"
-        class="btn role-secondary mr-10"
-        @click="close"
-      >
-        {{ t('generic.cancel') }}
-      </button>
-      <AsyncButton
-        mode="continue"
-        @click="apply"
-      />
+      <div class="buttons">
+        <button
+          type="button"
+          class="btn role-secondary mr-10"
+          @click="close"
+        >
+          {{ t('generic.cancel') }}
+        </button>
+        <AsyncButton
+          mode="continue"
+          @click="apply"
+        />
+      </div>
     </div>
   </Card>
 </template>
 <style lang='scss' scoped>
-  ::v-deep .card-actions {
+.prompt-restore {
+  margin: 0;
+}
+
+.bottom {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  .buttons {
     display: flex;
-    flex-direction: row;
-    justify-content: center;
+    justify-content: flex-end;
+    width: 100%;
   }
+}
 </style>

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -26,7 +26,15 @@ export default {
     body: {
       type:    String,
       default: ''
-    }
+    },
+
+    /**
+     * Callback to identify response of the prompt
+     */
+    confirm: {
+      type:    Function,
+      default: () => { }
+    },
   },
   data() {
     return { errors: [] };
@@ -34,13 +42,15 @@ export default {
 
   methods: {
     close() {
-      this.$emit('close');
+      this.confirm(false);
+      this.$emit('close', false);
     },
 
     async apply(buttonDone) {
       try {
         await this.applyAction(buttonDone);
-        this.close();
+        this.confirm(true);
+        this.$emit('close', true);
       } catch (err) {
         console.error(err); // eslint-disable-line
         this.errors = exceptionToErrorsArray(err);

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1332,8 +1332,9 @@ export default {
       }
 
       const isEditVersion = this.isEdit && this.liveValue?.spec?.kubernetesVersion !== this.value?.spec?.kubernetesVersion;
+      const hasPspManuallyAdded = !!this.value.spec.rkeConfig?.machineGlobalConfig?.['kube-apiserver-arg'];
 
-      if (isEditVersion && !this.needsPSP) {
+      if (isEditVersion && !this.needsPSP && hasPspManuallyAdded) {
         if (!await this.showPspConfirmation()) {
           return btnCb('cancelled');
         }

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1317,10 +1317,10 @@ export default {
         this.$store.dispatch('cluster/promptModal', {
           component:      'GenericPrompt',
           componentProps: {
-            title:       this.t('cluster.rke2.modal.pspChange.title'),
-            body:        this.t('cluster.rke2.modal.pspChange.body'),
-            applyMode:   'continue',
-            applyAction: () => resolve(true),
+            title:     this.t('cluster.rke2.modal.pspChange.title'),
+            body:      this.t('cluster.rke2.modal.pspChange.body'),
+            applyMode: 'continue',
+            confirm:   resolve
           },
         });
       });
@@ -1334,9 +1334,7 @@ export default {
       const isEditVersion = this.isEdit && this.liveValue?.spec?.kubernetesVersion !== this.value?.spec?.kubernetesVersion;
 
       if (isEditVersion && !this.needsPSP) {
-        const shouldContinue = await this.showPspConfirmation();
-
-        if (!shouldContinue) {
+        if (!await this.showPspConfirmation()) {
           return btnCb('cancelled');
         }
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8125
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Displayed dialog as indicated in the issue.

### Technical notes summary
- Extended `GeneralPrompt` component to allow use of callback, to make the dialog `async`
- Corrected styling of existing dialog for add-on case due style clashes

### Areas or cases that should be tested
To summarize what is defined in all the comments, these are the steps:
- Start creating a K3S cluster with 1.24.x or 1.23.x
- In the `Advanced` tab add under `Additional API Server Args` the value `enable-admission-plugins=NodeRestriction,PodSecurityPolicy`, as defined in [this comment](https://github.com/rancher/dashboard/issues/8125#issuecomment-1438931325)
- Complete the creation
- Edit and try to update the cluster to version 1.25.x

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://user-images.githubusercontent.com/5009481/220091324-1e977ecd-df40-4bca-acdf-680ebb162cf0.mov

