### PR TITLE
Fix stale management cluster resources

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -30,6 +30,7 @@ import Socket, {
 import { get } from '@shell/utils/object';
 import CapiMachineDeployment from '@shell/models/cluster.x-k8s.io.machinedeployment';
 import { isAlternate } from '@shell/utils/platform';
+import { defaultTableSortGenerationFn } from '@shell/components/ResourceTable.vue';
 
 let lastId = 1;
 const ansiup = new AnsiUp();
@@ -638,6 +639,26 @@ export default {
         return day(time).format(this.dateTimeFormatStr);
       }
     },
+
+    machineSortGenerationFn() {
+      // The sort generation function creates a unique value and is used to create a key including sort details.
+      // The unique key determines if the list is redrawn or a cached version is shown.
+      // Because we ensure the 'not in a pool' group is there via a row, and timing issues, the unqiue key doesn't change
+      // after a machine is added/removed... so the list won't update... so we need to inject a string to ensure the key is fresh
+      const base = defaultTableSortGenerationFn(this.machineSchema, this.$store);
+
+      return base + (!!this.fakeMachines.length ? '-fake' : '');
+    },
+
+    nodeSortGenerationFn() {
+      // The sort generation function creates a unique value and is used to create a key including sort details.
+      // The unique key determines if the list is redrawn or a cached version is shown.
+      // Because we ensure the 'not in a pool' group is there via a row, and timing issues, the unqiue key doesn't change
+      // after a machine is added/removed... so the list won't update... so we need to inject a string to ensure the key is fresh
+      const base = defaultTableSortGenerationFn(this.mgmtNodeSchema, this.$store);
+
+      return base + (!!this.fakeNodes.length ? '-fake' : '');
+    },
   }
 };
 </script>
@@ -681,6 +702,7 @@ export default {
           :group-by="value.isCustom ? null : 'poolId'"
           group-ref="pool"
           :group-sort="['pool.nameDisplay']"
+          :sort-generation-fn="machineSortGenerationFn"
         >
           <template #main-row:isFake="{fullColspan}">
             <tr class="main-row">
@@ -765,6 +787,7 @@ export default {
           :group-by="value.isCustom ? null : 'spec.nodePoolName'"
           group-ref="pool"
           :group-sort="['pool.nameDisplay']"
+          :sort-generation-fn="nodeSortGenerationFn"
         >
           <template #main-row:isFake="{fullColspan}">
             <tr class="main-row">

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -457,9 +457,9 @@ export default class ProvCluster extends SteveModel {
         return names.join('<br>');
       } else {
         const names = this.machines.filter((machine) => {
-          return machine.status.conditions.find(c => c.error && c.type === 'NodeHealthy');
+          return machine.status?.conditions?.find(c => c.error && c.type === 'NodeHealthy');
         }).map((machine) => {
-          if (machine.status.nodeRef?.name) {
+          if (machine.status?.nodeRef?.name) {
             return this.t('cluster.availabilityWarnings.node', { name: machine.status.nodeRef.name });
           }
 

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -314,7 +314,8 @@ export default {
       dispatch('watch', {
         type,
         revision:  out.revision,
-        namespace: opt.watchNamespace
+        namespace: opt.watchNamespace,
+        force:     opt.forceWatch === true,
       });
     }
 
@@ -377,7 +378,8 @@ export default {
       dispatch('watch', {
         type,
         selector,
-        revision: res.revision
+        revision: res.revision,
+        force:    opt.forceWatch === true,
       });
     }
 

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -705,7 +705,9 @@ const defaultActions = {
    * - Steve tells us that the resource is no longer watched
    *
    */
-  'ws.resource.stop'({ getters, commit, dispatch }, msg) {
+  'ws.resource.stop'({
+    state, getters, commit, dispatch
+  }, msg) {
     const type = msg.resourceType;
     const obj = {
       type,
@@ -714,7 +716,7 @@ const defaultActions = {
       selector:  msg.selector
     };
 
-    // console.warn(`Resource stop: [${ getters.storeName }]`, msg); // eslint-disable-line no-console
+    state.debugSocket && console.info(`Resource Stop [${ getters.storeName }]`, type, msg); // eslint-disable-line no-console
 
     // If we're trying to watch this event, attempt to re-watch
     if ( getters['schemaFor'](type) && getters['watchStarted'](obj) ) {
@@ -759,6 +761,7 @@ const defaultActions = {
   },
 
   'ws.resource.create'(ctx, msg) {
+    ctx.state.debugSocket && console.info(`Resource Create [${ ctx.getters.storeName }]`, msg.resourceType, msg); // eslint-disable-line no-console
     queueChange(ctx, msg, true, 'Create');
   },
 
@@ -808,6 +811,8 @@ const defaultActions = {
   'ws.resource.remove'(ctx, msg) {
     const data = msg.data;
     const type = data.type;
+
+    ctx.state.debugSocket && console.info(`Resource Remove [${ ctx.getters.storeName }]`, type, msg); // eslint-disable-line no-console
 
     if (type === SCHEMA) {
       const worker = (this.$workers || {})[ctx.getters.storeName];

--- a/shell/utils/socket.js
+++ b/shell/utils/socket.js
@@ -26,6 +26,7 @@ export const EVENT_DISCONNECT_ERROR = 'disconnect_error';
 
 export const NO_WATCH = 'NO_WATCH';
 export const NO_SCHEMA = 'NO_SCHEMA';
+export const REVISION_TOO_OLD = 'TOO_OLD';
 
 export default class Socket extends EventTarget {
   url;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7819
Fixes #7815
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
There's a number of 'stale' screen content when creating an RKE2 DO cluster, adding/removing machine pools (deployments) and scaling up/down a pool (deployment). Stale content covers

- Cluster overall State
- Freshly created pool does not show new machine
- Machine from a removed pool remained
- Pool's Machine summary bar graph not updating
- Pool scaled down still shows removed machine
- Created cluster shows empty pools without deployments

The only consistent way to reproduce any of these, is to scale down the last remaining machine in a second pool (deleted machine stays in second pool) and from the same cluster state edit the cluster to have one in the second pool and nav quickly to the cluster detail page (new machine does not show in pool two). For the others, it's just about getting lucky/unlucky when creating/editing/removing clusters and pools, and scaling pools.

From what I can tell there's three causes

1. We don't receive the relevant resource.create, resource.change, resource.remove message
    - Probably missed due to the lag between resource.stop and re-subscribing
2. We do receive the relevant resource.create, resource.change, resource.remove message
    - Mystery vue reactivity issue
3. There are errors in shell/models/provisioning.cattle.io.cluster.js get unavailableMachines
    - Sometimes the machine we iterate over does not contain a status or status.condition
    - Must be 'crap in' somewhere

Fixes 
1. Missing socket messages - https://github.com/rancher/dashboard/commit/e73c55c78267a82c74564df227ae82e63b4365bb
    - This is all about reducing the time between the backend telling us to `resource.stop` a resource sub and us trying to start it again.
    - resource.stop caused by a number of things, more detail in commit message
    - new fix means we don't wait 5 seconds and re-sub straight away with whatever revision we have in the store
      - if the revision isn't `too old` (stop probably came from change of permision) it should mean we get all required resource change messages promptly
      - if the revision is `too old` (stop probably came from 30 min socket death) it means we'll re-fetch entire state and re-watch from that revision
    - these changes were possible given the backend now gives us the correct too old message
3. UI doesn't update following socket messages - https://github.com/rancher/dashboard/commit/6ce6632e1357f29948a30fff7922a3474e326637
    - I think this is machine/node list issue where we were adding/removing a fake entry to ensure a pool group was shown... this didn't change the footprint of the list (real one removed --> fake one added, fake one removed --> real one added) so a cached, stale set of rows was shown
4. shell/models/provisioning.cattle.io.cluster.js get unavailableMachines - https://github.com/rancher/dashboard/commit/90ccf3f7e183d413e95e4ec59ba3ef2cbc140740
    -  Make these null safe

### Technical notes summary
Workings out - https://github.com/rancher/rancher/issues/40558#issuecomment-1434462942

### Areas or cases that should be tested
- RKE1/RKE2 Cluster Create
  - Single node, multiple nodes/groups
- RKE1/RKE2 Pool Scaling
  - Up / Down in a pool, including to zero left
- RKE1/RKE2 Pool Create/Delete

### Areas which could experience regressions
- Anywhere that cluster information in cluster management or the home page is shown
  - The initial data should be fine, but anything that changes afterwards
- This includes a partial revert of the fix for https://github.com/rancher/dashboard/issues/5997. 
  - We now fall back on the _potential_ dodgy revision
    - If it's good there's no problem. If it's not we will re-fetch the entire lot (which we were doing pre-2.7.0(
    - This fix is better ensuring info is kept up to date on screen, rather than potentially making additional socket start that will fail

