### PR TITLE
Remove jquery from ActionMenu.vue, FileDiff.vue

### DIFF
--- a/shell/components/ActionMenu.vue
+++ b/shell/components/ActionMenu.vue
@@ -1,6 +1,5 @@
 <script>
 import { mapGetters } from 'vuex';
-import $ from 'jquery';
 import { AUTO, CENTER, fitOnScreen } from '@shell/utils/position';
 import { isAlternate } from '@shell/utils/platform';
 import IconOrSvg from '@shell/components/IconOrSvg';
@@ -149,7 +148,7 @@ export default {
 
     updateStyle() {
       if ( this.phase === SHOW && !this.useCustomTargetElement) {
-        const menu = $('.menu', this.$el)[0];
+        const menu = this.$el.querySelector('.menu');
         const event = this.targetEvent;
         const elem = this.targetElem;
 
@@ -169,7 +168,7 @@ export default {
       }
 
       if ( this.open && this.useCustomTargetElement) {
-        const menu = $('.menu', this.$el)[0];
+        const menu = this.$el.querySelector('.menu');
         const elem = this.customTargetElement;
 
         // If the action menu state is controlled with

--- a/shell/components/FileDiff.vue
+++ b/shell/components/FileDiff.vue
@@ -1,7 +1,6 @@
 <script>
 import { Diff2Html } from 'diff2html';
 import { createPatch } from 'diff';
-import $ from 'jquery';
 
 export default {
   props: {
@@ -74,21 +73,21 @@ export default {
         return;
       }
 
-      const container = $(this.$refs.root);
+      const container = this.$refs.root;
 
-      if ( !container || !container.length ) {
+      if ( !container ) {
         return;
       }
 
-      const offset = container.offset();
+      const offset = container.getBoundingClientRect();
 
       if ( !offset ) {
         return;
       }
 
-      const desired = $(window).innerHeight() - offset.top - this.footerSpace;
+      const desired = window.innerHeight - offset.top - this.footerSpace;
 
-      container.css('height', `${ Math.max(0, desired) }px`);
+      container.style.height = `${ Math.max(0, desired) }px`;
     },
   },
 };


### PR DESCRIPTION
Signed-off-by: Francesco Torchia [francesco.torchia@suse.com](mailto:francesco.torchia@suse.com)

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to #5070
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
`ActionMenu` in each row of our SortableTables
file diff function in `edit yaml` views