### PR TITLE
Ensure that the helm install getClusterRegistry process handles missing machineSelectorConfig

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -799,7 +799,7 @@ export default {
         }) : {};
 
         if (provCluster.isRke2) { // isRke2 returns true for both RKE2 and K3s clusters.
-          const agentConfig = provCluster.spec.rkeConfig.machineSelectorConfig.find(x => !x.machineLabelSelector).config;
+          const agentConfig = provCluster.spec?.rkeConfig?.machineSelectorConfig?.find(x => !x.machineLabelSelector).config;
 
           // If a cluster scoped registry exists,
           // it should be used by default.
@@ -812,7 +812,7 @@ export default {
         if (provCluster.isRke1) {
           // For RKE1 clusters, the cluster scoped private registry is on the management
           // cluster, not the provisioning cluster.
-          const rke1Registries = mgmCluster.spec.rancherKubernetesEngineConfig.privateRegistries;
+          const rke1Registries = mgmCluster.spec?.rancherKubernetesEngineConfig?.privateRegistries;
 
           if (rke1Registries?.length > 0) {
             const defaultRegistry = rke1Registries.find((registry) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8241
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- issue caused by the prov cluster missing a spec.rkeConfig.machineSelectorConfig causing helm install getClusterRegistry to silently fail
- solution is to make helm install getClusterRegistry even more hardended to strange scenarios
- Note there were other issues caused by the same function that have the same outcome, that PR was https://github.com/rancher/dashboard/pull/7952

### Areas or cases that should be tested
- the provisioning cluster spec.rkeConfig.machineSelectorConfig MUST be `null`
- the chart MUST be one from rancher (we optimised in 2.7.2 to avoid the function for non-rancher charts)
- try to install the chart
