### PR TITLE
Fix lint issue in Checkbox

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -6,7 +6,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 export default Vue.extend({
   name: 'Checkbox',
-  
+
   props: {
     /**
      * The checkbox value.


### PR DESCRIPTION
Our own lint does not complain, but GitHub complains on PRs:

![image](https://user-images.githubusercontent.com/1955897/220901446-44e5d266-c624-4131-80b8-571dd1bac75d.png)

This PR removes the trailing space.