### PR TITLE
HARVESTER: Fix Harvester v1.1.1 cluster members page is unavailable

### DIFF
--- a/shell/models/clusterroletemplatebinding.js
+++ b/shell/models/clusterroletemplatebinding.js
@@ -21,4 +21,8 @@ export default class CRTB extends NormanModel {
   get clusterroletemplatebinding() {
     return this.$rootGetters[`management/byId`](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, this.id?.replace(':', '/'));
   }
+
+  get steve() {
+    return this.$rootGetters[`management/byId`](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, this.id?.replace(':', '/'));
+  }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix Harvester v1.1.1 cluster members page is unavailable
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/rancher/rancher/issues/40663
- https://github.com/harvester/harvester/issues/3515

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The root cause is [here](https://github.com/rancher/dashboard/pull/7245/files#diff-dd84197114a85e2c4f6c8f3af7938f1c603d9d82162f7aa6595c76a0437fc400), `steve` change to `clusterroletemplatebinding`, that makes v1.1.1 Harvester cannot obtain cluster RTB as expected. 

For v1.1.1 Harvester is 
```
    const steveBindings = await Promise.all(
      clusterRoleTemplateBindings.map(b => b.steve)
    );
 ```
 
 For v2.7-head Rancher is
 ```
     clusterRoleTemplateBindings() {
      return this.normanClusterRoleTemplateBindings.map(b => b.clusterroletemplatebinding) ;
    },
 ```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->