### PR TITLE
Fix broken extensions check

### DIFF
--- a/shell/creators/app/app.package.json
+++ b/shell/creators/app/app.package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {},
   "resolutions": {
-    "**/webpack": "4"
+    "**/webpack": "4",
+    "@types/node": "^16"
   }  
 }


### PR DESCRIPTION
`@types/node` got bumped today - this gets picked up by the extensions build which breaks it.

This PR pins it do the v6 node types.