### PR TITLE
Add a warning alert when migrating to 1.25 if they have PSPs. 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
     "overcommit",
     "prepending",
     "protip",
+    "PSPS",
     "pvcs",
     "shortkey",
     "testid",

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1619,7 +1619,7 @@ cluster:
     os: 'You are attemping to add a {newOS} worker node to a cluster with one or more {existingOS} worker nodes: some installed apps may need to be upgraded or removed.'
     rke2-k3-reprovisioning: 'Making changes to cluster configuration may result in nodes reprovisioning. For more information see the <a target="blank" href="{docsBase}/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/" target="_blank" rel="noopener nofollow">documentation</a>.'
     desiredNodeGroupWarning: There are 0 nodes available to run the cluster agent. The cluster will not become active until at least one node is available.
-    invalidPsps: You have one or more PodSecurityPolicy resource(s) in this cluster. Pod Security Policies are not available in Kubernetes v1.25.
+    invalidPsps: You have one or more PodSecurityPolicy resource(s) in this cluster. Pod Security Policies are not available in Kubernetes v1.25 and will be automatically removed.
     haveArgInfo: Configuration information is not available for the selected Kubernetes version.  The options available in this screen will be limited, you may want to use the YAML editor.
     deprecatedPsp: Pod Security Policies are deprecated as of Kubernetes v1.21, and have been removed in Kubernetes v1.25.
     removedPsp: Pod Security Policies have been removed in Kubernetes v1.25, use PodSecurity Admission instead.

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -54,6 +54,7 @@ export const NETWORK_POLICY = 'networking.k8s.io.networkpolicy';
 export const POD = 'pod';
 export const POD_DISRUPTION_BUDGET = 'policy.poddisruptionbudget';
 export const PSP = 'policy.podsecuritypolicy';
+export const PSPS = 'policy.podsecuritypolicies';
 export const PV = 'persistentvolume';
 export const PVC = 'persistentvolumeclaim';
 export const RESOURCE_QUOTA = 'resourcequota';

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -131,7 +131,9 @@ export default {
   },
 
   async fetch() {
-    this.hasPsp = await this.checkPsp();
+    if (this.mode !== _CREATE) {
+      this.hasPsp = await this.checkPsp();
+    }
 
     if ( !this.rke2Versions ) {
       const hash = {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2183,7 +2183,7 @@ export default {
             {{ t('cluster.rke2.security.header') }}
           </h3>
           <Banner
-            v-if="isEdit && hasPsps"
+            v-if="isEdit && !needsPSP && hasPsps"
             color="warning"
             :label="t('cluster.banner.invalidPsps')"
           />

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -131,7 +131,7 @@ export default {
   },
 
   async fetch() {
-    this.hasPsp = this.checkPsp();
+    this.hasPsp = await this.checkPsp();
 
     if ( !this.rke2Versions ) {
       const hash = {
@@ -321,7 +321,7 @@ export default {
       harvesterVersion:      '',
       cisOverride:           false,
       cisPsaChangeBanner:    false,
-      hasPsp
+      hasPsp:                false,
     };
   },
 
@@ -1854,7 +1854,18 @@ export default {
     /**
      * Check if current cluster has PSP enabled
      */
-    checkPsp() {
+    async checkPsp() {
+      const clusterId = this.value.mgmtClusterId;
+      const url = `/k8s/clusters/${ clusterId }/v1`;
+
+      try {
+        const mything = await this.$store.dispatch('cluster/request', { url: `${ url }/policy.podsecuritypolicies` });
+
+        console.log(mything);
+      } catch (error) {
+
+      }
+
       const count = this.$store.getters[`cluster/all`](COUNT);
       const clusterCounts = count?.[0]?.counts;
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -131,9 +131,7 @@ export default {
 
   async fetch() {
     // Check presence of PSP in RKE2, which is where we show the templates
-    if (this.mode !== _CREATE && !this.isK3s) {
-      this.psps = await this.checkPsps();
-    }
+    this.psps = await this.checkPsps();
 
     if ( !this.rke2Versions ) {
       const hash = {
@@ -1862,15 +1860,18 @@ export default {
 
     /**
      * Check if current cluster has PSP enabled
+     * Consider exclusively RKE2 provisioned clusters in edit mode
      */
     checkPsps() {
-      const clusterId = this.value.mgmtClusterId;
-      const url = `/k8s/clusters/${ clusterId }/v1/${ PSPS }`;
+      if (this.mode !== _CREATE && !this.isK3s && this.value.state !== 'reconciling') {
+        const clusterId = this.value.mgmtClusterId;
+        const url = `/k8s/clusters/${ clusterId }/v1/${ PSPS }`;
 
-      try {
-        return this.$store.dispatch('cluster/request', { url } );
-      } catch (error) {
-        // PSP may not exists for this cluster and an error is returned without need to handle
+        try {
+          return this.$store.dispatch('cluster/request', { url });
+        } catch (error) {
+          // PSP may not exists for this cluster and an error is returned without need to handle
+        }
       }
     },
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -984,19 +984,6 @@ export default {
         return false;
       }
     },
-
-    displayInvalidPspsBanner() {
-      const version = VERSION.parse(this.value.spec.kubernetesVersion);
-
-      const major = parseInt(version?.[0] || 0);
-      const minor = parseInt(version?.[1] || 0);
-
-      if (major === 1 && minor >= 25) {
-        return this.allPSPs?.length > 0;
-      }
-
-      return false;
-    }
   },
 
   watch: {
@@ -2196,7 +2183,7 @@ export default {
             {{ t('cluster.rke2.security.header') }}
           </h3>
           <Banner
-            v-if="isEdit && displayInvalidPspsBanner && hasPsps"
+            v-if="isEdit && hasPsps"
             color="warning"
             :label="t('cluster.banner.invalidPsps')"
           />

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -272,7 +272,7 @@ export default class ProvCluster extends SteveModel {
   }
 
   get mgmtClusterId() {
-    return this.mgmt?.id || this.id.replace(`${ this.metadata.namespace }/`, '');
+    return this.mgmt?.id || this.id?.replace(`${ this.metadata.namespace }/`, '');
   }
 
   get mgmt() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7553
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Added requirement to have PSPs enabled for the current management cluster
- Check is done only for RKE2, editing mode of provisioned clusters (no `reconciling`)

### Technical notes summary
- Added PSPS type
- Corrected with optional chaining for provisioned cluster model while retrieving `mgmtClusterId`

### Areas or cases that should be tested
- Create and complete provisioning of RKE2 cluster with version 1.23.x or 1.24.x
- PSP will be created within the cluster, you can explore it and search Pod Security Policies to ensure it
- Edit cluster configuration and select higher K8S version 1.25.x
- A banner will appear communicating the removal of PSPs

Note: It is NOT possible to create a cluster RKE2 without PSPs from the UI.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://user-images.githubusercontent.com/5009481/220956862-de3414ca-aeca-4fdf-aac6-45af5924c715.mov

