### PR TITLE
Fix stale RKE1 cluster info in clusters list

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -30,6 +30,9 @@ export const defaultTableSortGenerationFn = (schema, $store) => {
   if ( nsFilterKey ) {
     return `${ sortKey }/${ nsFilterKey }`;
   }
+
+  // covers case where we have no current cluster's ns cache
+  return sortKey;
 };
 
 export default {

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1103,6 +1103,11 @@ export default {
             :full-colspan="fullColspan"
             :row="row.row"
             :sub-matches="subMatches"
+            :keyField="keyField"
+            :componentTestid="componentTestid"
+            :i="i"
+            :onRowMouseEnter="onRowMouseEnter"
+            :onRowMouseLeave="onRowMouseLeave"
           >
             <tr
               v-if="row.row.stateDescription"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8237
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- This is a quick fix
- For RKE1 clusters we use the mgmt cluster state instead of row's prov cluster state
- This should all work generically underpinned by using the prov clusters stateObj
- However this does not work, updates sometimes bubble to the prov cluster level and when they do sometimes they even make it to the list. The updates are always received correctly over the socket
- Workaround is to convert the state column and sub row into custom cell and sub row slots
- These update correctly given changes to the mgmt object

Note - I haven't touched the machine summary column, a similar fix might be needed there. I didn't see this testing locally but have in other worlds. Keeping this PR targeted at the specific errors though

### Areas or cases that should be tested
- Clusters list open in browser A, changes made in browser B. Status of clusters in A should be correct
- Changes
  - Create an RKE1 cluster. Edit the cluster to add a pool. Scale the Pool
    - Scaling should show the status text underneath the cluster row 
  - Create an RKE2 cluster. Edit the cluster to add a machine deployment. Scale the deployment
