### PR TITLE
HARVESTER: Fix Harvester add member error

### DIFF
--- a/shell/models/clusterroletemplatebinding.js
+++ b/shell/models/clusterroletemplatebinding.js
@@ -23,6 +23,9 @@ export default class CRTB extends NormanModel {
   }
 
   get steve() {
-    return this.$rootGetters[`management/byId`](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, this.id?.replace(':', '/'));
+    return this.$dispatch(`management/find`, {
+      type: MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
+      id:   this.id?.replace(':', '/')
+    }, { root: true });
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix Harvester add cluster member error
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3515

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The PR [8244](https://github.com/rancher/dashboard/pull/8244) only fixed the error on the cluster member list page, there is still an error when adding cluster members. I update `get steve() {}` to use `dispatch` instead of `getter` because the plugin is using `Promise.all` to get the list of roles.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->