### PR TITLE
Avoid spurious console.error

### DIFF
--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -306,8 +306,13 @@ const sharedActions = {
     }
 
     // If socket is in error don't try to watch.... unless we `force` it
-    if ( !stop && !force && !getters.canWatch(params) ) {
-      console.error(`Aborting Watch Request [${ getters.storeName }] (socket probably in error)`, JSON.stringify(params)); // eslint-disable-line no-console
+    const inError = getters.inError(params);
+
+    if ( !stop && !force && inError ) {
+      // REVISION_TOO_OLD is a temporary state and will be handled when `resyncWatch` completes
+      if (inError !== REVISION_TOO_OLD) {
+        console.error(`Aborting Watch Request [${ getters.storeName }]. Watcher in error (${ inError })`, JSON.stringify(params)); // eslint-disable-line no-console
+      }
 
       return;
     }
@@ -897,8 +902,8 @@ const defaultMutations = {
  * Getters that cover cases 1 & 2 (see file description)
  */
 const defaultGetters = {
-  canWatch: state => (obj) => {
-    return !state.inError[keyForSubscribe(obj)];
+  inError: state => (obj) => {
+    return state.inError[keyForSubscribe(obj)];
   },
 
   watchStarted: state => (obj) => {


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- when we receive a `too old` socket watch error we kick off a resync which will watch with a valid revision
- we'll get a resource.stop event following the previous error. socket is in error though so we correctly abort
- the error for this was misleading
- Connected to https://github.com/rancher/dashboard/pull/8224

### Areas or cases that should be tested
Can be trigger with a fake revision on cluster list in subscription's `watch`
```
    if (!trigger && type === 'management.cattle.io.fleetworkspace') {
      trigger = true;
      revision = 1;
    }
```
