### PR TITLE
Persist http response collection revision

### DIFF
--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -53,8 +53,9 @@ export async function loadSchemas(ctx, watch = true) {
 
   commit('loadAll', {
     ctx,
-    type: SCHEMA,
-    data: res.data
+    type:     SCHEMA,
+    data:     res.data,
+    revision: res.revision
   });
 
   if ( watch !== false ) {
@@ -304,6 +305,7 @@ export default {
           ctx,
           type,
           data:      out.data,
+          revision:  out.revision,
           skipHaveAll,
           namespace: opt.namespaced,
         });
@@ -370,8 +372,9 @@ export default {
     commit('loadSelector', {
       ctx,
       type,
-      entries: res.data,
-      selector
+      entries:  res.data,
+      selector,
+      revision: res.revision,
     });
 
     if ( opt.watch !== false ) {

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -261,7 +261,8 @@ export function loadAll(state, {
   data,
   ctx,
   skipHaveAll,
-  namespace
+  namespace,
+  revision
 }) {
   const { getters } = ctx;
 
@@ -283,6 +284,7 @@ export function loadAll(state, {
 
   clear(cache.list);
   cache.map.clear();
+  cache.revision = revision || 0;
   cache.generation++;
 
   addObjects(cache.list, proxies);
@@ -320,7 +322,7 @@ export default {
   },
 
   loadSelector(state, {
-    type, entries, ctx, selector
+    type, entries, ctx, selector, revision
   }) {
     const cache = registerType(state, type);
 
@@ -329,6 +331,7 @@ export default {
     }
 
     cache.haveSelector[selector] = true;
+    cache.revision = revision || 0;
   },
 
   loadAll,

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -121,7 +121,8 @@ export default {
     data,
     ctx,
     skipHaveAll,
-    namespace
+    namespace,
+    revision
   }) {
     // Performance testing in dev and when env var is set
     if (process.env.dev && !!process.env.perfTest) {
@@ -129,7 +130,7 @@ export default {
     }
 
     const proxies = loadAll(state, {
-      type, data, ctx, skipHaveAll, namespace
+      type, data, ctx, skipHaveAll, namespace, revision
     });
 
     // If we loaded a set of pods, then update the podsByNamespace cache


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- Normally we fetch resources and then watch using the revision in that response
- If we get a resource.stop event we'll then try to find the current revision from the store
- This looks at the type cache's revision and revisions in each resource
- Bug
  - the type cache's revision is not updated, which leads to very old revisions from a resource being used
  - This can cause a `too old` error... which is handled by re-fetching the whole list
- Fix
  - Ensure we set the collection's revision when we're likely to need it again
- Tested
  - the different find/load store actions/mutations
  - this includes incremental loading
 - Connected to https://github.com/rancher/dashboard/pull/8224 
   - that change basically reverted the code back to a previous state
   - this bug is related to that previous state, and was a bug back then as well