### PR TITLE
Fix scaling of deployment in bad state

### DIFF
--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -108,8 +108,8 @@ export default {
   computed: {
     ...mapGetters(['currentCluster']),
 
-    isActive() {
-      return this.value.metadata.state.name === 'active';
+    isScalable() {
+      return this.value?.canUpdate;
     },
 
     isJob() {
@@ -335,7 +335,7 @@ export default {
         class="text-right"
         :label="t('tableHeaders.scale')"
         :value="value.spec.replicas"
-        :disabled="!isActive"
+        :disabled="!isScalable"
         @minus="scaleDown"
         @plus="scaleUp"
       />

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -108,8 +108,8 @@ export default {
   computed: {
     ...mapGetters(['currentCluster']),
 
-    isScalable() {
-      return this.value?.canUpdate;
+    isActive() {
+      return this.value.metadata.state.name === 'active';
     },
 
     isJob() {
@@ -335,7 +335,7 @@ export default {
         class="text-right"
         :label="t('tableHeaders.scale')"
         :value="value.spec.replicas"
-        :disabled="!isScalable"
+        :disabled="!isActive"
         @minus="scaleDown"
         @plus="scaleUp"
       />

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -649,8 +649,4 @@ export default class Workload extends WorkloadService {
 
     return matching(allInNamespace, selector);
   }
-
-  get canUpdate() {
-    return this.hasLink('update');
-  }
 }

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -649,4 +649,8 @@ export default class Workload extends WorkloadService {
 
     return matching(allInNamespace, selector);
   }
+
+  get canUpdate() {
+    return this.hasLink('update');
+  }
 }


### PR DESCRIPTION
Fixes #8215 

- change condition to check if buttons for scale up/scale down on deployment details are enabled

Note: Also checked the formatter WorkloadHealthScale and the condition for it to work was:
1- It's a scalable type
2- Model returns a true `canUpdate` 

So I went for that approach as well.