### PR TITLE
Ensure the correct input is given the the Cluster list BadgeState component

### DIFF
--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -193,8 +193,7 @@ export default {
       <!-- updates were getting lost. This isn't performant as normal columns, but the list shouldn't grow -->
       <!-- big enough for the performance to matter -->
       <template #cell:state="{row}">
-        <!-- mimic prov cluster stateObj (if harvester use hardcoded stateObj from prov cluster) -->
-        <BadgeState :value="row.isHarvester ? row : row.mgmt || row" />
+        <BadgeState :color="row.stateBackground" :label="row.stateDisplay" />
       </template>
       <template #sub-row="{fullColspan, row, keyField, componentTestid, i, onRowMouseEnter, onRowMouseLeave}">
         <tr

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -193,7 +193,10 @@ export default {
       <!-- updates were getting lost. This isn't performant as normal columns, but the list shouldn't grow -->
       <!-- big enough for the performance to matter -->
       <template #cell:state="{row}">
-        <BadgeState :color="row.stateBackground" :label="row.stateDisplay" />
+        <BadgeState
+          :color="row.stateBackground"
+          :label="row.stateDisplay"
+        />
       </template>
       <template #sub-row="{fullColspan, row, keyField, componentTestid, i, onRowMouseEnter, onRowMouseLeave}">
         <tr


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8292
<!-- Define findings related to the feature or bug issue. -->
### Occurred changes and/or fixed issues
- RKE2 clusters were using the mgmt cluster instead of provisioning cluster for status
- Only RKE1 clusters should use the mgmt cluster
- Bug was introduced in https://github.com/rancher/dashboard/pull/8249
- Fix is to use the generic state getters that handles the mgmt/prov state split in models

### Areas or cases that should be tested
- RKE1 / RKE2 provisioning