### PR TITLE
update icon logic on extensions

### DIFF
--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -212,6 +212,8 @@ export default {
 
         if (latestCompatible) {
           item.displayVersion = latestCompatible.version;
+          item.icon = latestCompatible.icon;
+        } else {
           item.icon = chart.icon || latestCompatible.annotations['catalog.cattle.io/ui-icon'];
         }
 


### PR DESCRIPTION
- update icon logic on extensions to show the icon of the latest compatible version and not the chart icon

Note: Elemental will use a new icon on `v1.1.0` and it uses rancher `v2.7.2`. If we were on a `v2.7.1` system (or even earlier) it would get the chart icon from Elemental `v1.1.0` (old logic - get's the icon from the latest existing version), which might not even be available for use, therefore breaking the card icon.