### PR TITLE
When creating a resource, limit the namespace options based on filters in top nav

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
     "kubevirt",
     "nuxt",
     "overcommit",
+    "prefs",
     "prepending",
     "protip",
     "PSPS",

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -169,7 +169,7 @@ export default {
     if (this.nameKey) {
       name = get(v, this.nameKey);
     } else {
-      name = metadata.name;
+      name = metadata?.name;
     }
 
     if (this.namespaced) {
@@ -222,6 +222,7 @@ export default {
 
     namespaces() {
       const currentStore = this.$store.getters['currentStore'](this.namespaceType);
+
       const namespaces = this.namespacesOverride || this.$store.getters[`${ currentStore }/all`](this.namespaceType);
       const filterNamespace = this.$store.getters['allNamespaces'];
 
@@ -232,14 +233,12 @@ export default {
         if (this.currentProduct?.customNamespaceFilter && this.currentProduct?.inStore) {
           out = filterNamespace.find(NS => NS.metadata.name === namespace.metadata.name);
         } else if (this.currentProduct?.hideSystemResources) {
-          // Filter out the namespace
-          // if it is a system namespace or if it is managed by
-          // Fleet.
+          // Hide system and fleet namespaces
           out = !namespace.isSystem && !namespace.isFleetManaged;
         }
 
         if (this.mode === _CREATE) {
-          out = out && !!namespace.links.update;
+          out = out && !!namespace.links?.update;
         }
 
         return out;

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -1,14 +1,13 @@
 <script>
 import Vue from 'vue';
-import { mapGetters, mapState } from 'vuex';
+import { mapGetters } from 'vuex';
 import { get, set } from '@shell/utils/object';
 import { sortBy } from '@shell/utils/sort';
 import { NAMESPACE } from '@shell/config/types';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
-import { _VIEW, _EDIT, _CREATE } from '@shell/config/query-params';
+import { _VIEW, _EDIT } from '@shell/config/query-params';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
-import { NAMESPACE_FILTERS } from '@shell/store/prefs';
 
 export function normalizeName(str) {
   return (str || '')
@@ -225,31 +224,8 @@ export default {
      * Map namespaces from the store to options, adding divider and create button
      */
     options() {
-      // Use last picked filter from user preferences
-      // const currentStore = this.$store.getters['currentStore'](this.namespaceType);
-      // const namespaces = this.namespacesOverride || this.$store.getters[`${ currentStore }/all`](this.namespaceType);
-      // const filterNamespace = this.$store.getters['allNamespaces'];
-
-      // const filtered = namespaces.filter( this.namespaceFilter || ((namespace) => {
-      //   // By default, include the namespace in the dropdown.
-      //   let out = true;
-
-      //   if (this.currentProduct?.customNamespaceFilter && this.currentProduct?.inStore) {
-      //     out = filterNamespace.find(NS => NS.metadata.name === namespace.metadata.name);
-      //   } else if (this.currentProduct?.hideSystemResources) {
-      //     // Hide system and fleet namespaces
-      //     out = !namespace.isSystem && !namespace.isFleetManaged;
-      //   }
-
-      //   if (this.mode === _CREATE) {
-      //     out = out && !!namespace.links?.update;
-      //   }
-
-      //   return out;
-      // }));
-
       const options = Object.keys(this.namespaces())
-        .map(ns => ({ nameDisplay: ns, id: ns }))
+        .map(namespace => ({ nameDisplay: namespace, id: namespace }))
         .map(this.namespaceMapper || (obj => ({
           label: obj.nameDisplay,
           value: obj.id,

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -224,7 +224,7 @@ export default {
      * Map namespaces from the store to options, adding divider and create button
      */
     options() {
-      const options = Object.keys(this.isView ? this.namespaces() : this.allowedNamespaces())
+      const options = Object.keys(this.isCreate ? this.allowedNamespaces() : this.namespaces())
         .map(namespace => ({ nameDisplay: namespace, id: namespace }))
         .map(this.namespaceMapper || (obj => ({
           label: obj.nameDisplay,
@@ -260,11 +260,11 @@ export default {
     },
 
     isView() {
-      return this.mode === _CREATE;
+      return this.mode === _VIEW;
     },
 
     isCreate() {
-      return this.mode === _VIEW;
+      return this.mode === _CREATE;
     },
 
     colSpan() {

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -5,7 +5,7 @@ import { get, set } from '@shell/utils/object';
 import { sortBy } from '@shell/utils/sort';
 import { NAMESPACE } from '@shell/config/types';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
-import { _VIEW, _EDIT } from '@shell/config/query-params';
+import { _VIEW, _EDIT, _CREATE } from '@shell/config/query-params';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 
@@ -209,7 +209,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduct', 'currentCluster', 'namespaces']),
+    ...mapGetters(['currentProduct', 'currentCluster', 'namespaces', 'allowedNamespaces']),
     namespaceReallyDisabled() {
       return (
         !!this.forceNamespace || this.namespaceDisabled || this.mode === _EDIT
@@ -224,7 +224,7 @@ export default {
      * Map namespaces from the store to options, adding divider and create button
      */
     options() {
-      const options = Object.keys(this.namespaces())
+      const options = Object.keys(this.isView ? this.namespaces() : this.allowedNamespaces())
         .map(namespace => ({ nameDisplay: namespace, id: namespace }))
         .map(this.namespaceMapper || (obj => ({
           label: obj.nameDisplay,
@@ -260,6 +260,10 @@ export default {
     },
 
     isView() {
+      return this.mode === _CREATE;
+    },
+
+    isCreate() {
       return this.mode === _VIEW;
     },
 

--- a/shell/components/form/__tests__/NameNsDescription.ts
+++ b/shell/components/form/__tests__/NameNsDescription.ts
@@ -3,12 +3,12 @@ import NameNsDescription from '@shell/components/form/NameNsDescription.vue';
 
 describe('component: NameNsDescription', () => {
   // Accessing to computed value due code complexity
-  it.each([
-    [['all://user'], ['filtered', 'unfiltered'], 'filtered'],
-    [['ns://my-filter'], ['filtered', 'unfiltered'], 'filtered'],
-    [['ns://my-filter'], ['filtered', 'unfiltered'], 'filtered'],
-    [[], ['filtered', 'unfiltered'], 'unfiltered'],
-  ])('should display filtered list of namespaces', (filters, namespaces, filteredNamespaces) => {
+  it('should map namespaces to options', () => {
+    const namespaceName = 'test';
+    const result = [{
+      label: namespaceName,
+      value: namespaceName
+    }];
     const wrapper = mount(NameNsDescription, {
       propsData: {
         value: {},
@@ -17,20 +17,15 @@ describe('component: NameNsDescription', () => {
       mocks: {
         $store: {
           getters: {
-            inStore:             jest.fn(),
-            currentCluster:      jest.fn(),
+            namespaces:          () => ({ [namespaceName]: true }),
             currentStore:        () => 'cluster',
-            'prefs/get':         () => filters,
             'cluster/schemaFor': jest.fn(),
-            currentProduct:      jest.fn(),
-            'cluster/all':       () => namespaces,
             'i18n/t':            jest.fn()
           },
         },
       }
     });
 
-    expect((wrapper.vm as any).namespaces).toBe(filteredNamespaces);
-    // expect((wrapper.vm as any).namespaces[0].label).toBe(filteredNamespaces);
+    expect((wrapper.vm as any).options).toStrictEqual(result);
   });
 });

--- a/shell/components/form/__tests__/NameNsDescription.ts
+++ b/shell/components/form/__tests__/NameNsDescription.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils';
+import NameNsDescription from '@shell/components/form/NameNsDescription.vue';
+
+describe('component: NameNsDescription', () => {
+  // Accessing to computed value due code complexity
+  it.each([
+    [['all://user'], ['filtered', 'unfiltered'], 'filtered'],
+    [['ns://my-filter'], ['filtered', 'unfiltered'], 'filtered'],
+    [['ns://my-filter'], ['filtered', 'unfiltered'], 'filtered'],
+    [[], ['filtered', 'unfiltered'], 'unfiltered'],
+  ])('should display filtered list of namespaces', (filters, namespaces, filteredNamespaces) => {
+    const wrapper = mount(NameNsDescription, {
+      propsData: {
+        value: {},
+        mode:  'create',
+      },
+      mocks: {
+        $store: {
+          getters: {
+            inStore:             jest.fn(),
+            currentCluster:      jest.fn(),
+            currentStore:        () => 'cluster',
+            'prefs/get':         () => filters,
+            'cluster/schemaFor': jest.fn(),
+            currentProduct:      jest.fn(),
+            'cluster/all':       () => namespaces,
+            'i18n/t':            jest.fn()
+          },
+        },
+      }
+    });
+
+    expect((wrapper.vm as any).namespaces).toBe(filteredNamespaces);
+    // expect((wrapper.vm as any).namespaces[0].label).toBe(filteredNamespaces);
+  });
+});

--- a/shell/components/form/__tests__/NameNsDescription.ts
+++ b/shell/components/form/__tests__/NameNsDescription.ts
@@ -17,7 +17,8 @@ describe('component: NameNsDescription', () => {
       mocks: {
         $store: {
           getters: {
-            namespaces:          () => ({ [namespaceName]: true }),
+            namespaces:          jest.fn(),
+            allowedNamespaces:   () => ({ [namespaceName]: true }),
             currentStore:        () => 'cluster',
             'cluster/schemaFor': jest.fn(),
             'i18n/t':            jest.fn()

--- a/shell/store/__tests__/index.test.ts
+++ b/shell/store/__tests__/index.test.ts
@@ -1,0 +1,110 @@
+import { getters } from '../index';
+
+describe('getters', () => {
+  describe('namespaces', () => {
+    it('should return empty dictionary', () => {
+      const expectation = {};
+      const state = {};
+      const stateGetters = { currentProduct: () => ({}) };
+
+      const result = getters.namespaces(state, stateGetters)();
+
+      expect(result).toStrictEqual(expectation);
+    });
+
+    it('should return all the namespaces for related category', () => {
+      const clusterId = 'my-cluster';
+      const namespaceId = 'my-namespace';
+      const expectation = { [namespaceId]: true };
+      const state = {
+        allNamespaces:    [{ id: namespaceId }],
+        prefs:            { data: { 'all-namespaces': false } },
+        namespaceFilters: []
+      };
+      const stateGetters = {
+        isAllNamespaces: true,
+        currentProduct:  { inStore: 'whatever' },
+        'whatever/all':  {},
+        currentCluster:  { id: clusterId },
+      };
+
+      const result = getters.namespaces(state, stateGetters)();
+
+      expect(result).toStrictEqual(expectation);
+    });
+
+    it('should return Rancher system namespaces', () => {
+      const clusterId = 'my-cluster';
+      const namespaceId = 'my-rancher-system-namespace';
+      const expectation = { [namespaceId]: true };
+      const state = {
+        allNamespaces: [{
+          id:        namespaceId,
+          isObscure: true
+        }],
+        prefs:            { data: { 'all-namespaces': true } },
+        namespaceFilters: []
+      };
+      const stateGetters = {
+        isAllNamespaces: true,
+        currentProduct:  { inStore: 'whatever' },
+        'whatever/all':  {},
+        currentCluster:  { id: clusterId },
+      };
+
+      const result = getters.namespaces(state, stateGetters)();
+
+      expect(result).toStrictEqual(expectation);
+    });
+
+    it('should filter Rancher system namespaces', () => {
+      const clusterId = 'my-cluster';
+      const namespaceId = 'my-rancher-system-namespace';
+      const expectation = { };
+      const state = {
+        allNamespaces: [{
+          id:        namespaceId,
+          isObscure: true
+        }],
+        prefs:            { data: { 'all-namespaces': false } },
+        namespaceFilters: []
+      };
+      const stateGetters = {
+        isAllNamespaces: true,
+        currentProduct:  { inStore: 'whatever' },
+        'whatever/all':  {},
+        currentCluster:  { id: clusterId },
+      };
+
+      const result = getters.namespaces(state, stateGetters)();
+
+      expect(result).toStrictEqual(expectation);
+    });
+
+    it('should filter namespaces by project', () => {
+      const clusterId = 'my-cluster';
+      const namespaceId = 'my-product-namespace';
+      const projectId = 'my-project';
+      const expectation = { [namespaceId]: true };
+      const state = {
+        allNamespaces:    [{ id: namespaceId }],
+        prefs:            { data: { 'all-namespaces': false } },
+        namespaceFilters: [`project://${ projectId }`]
+      };
+      const stateGetters = {
+        isAllNamespaces:   false,
+        currentProduct:    { inStore: 'whatever' },
+        'whatever/all':    {},
+        'management/byId': () => ({
+          id:         projectId,
+          namespaces: [{ id: namespaceId }]
+        }),
+        currentCluster: { id: clusterId },
+      };
+
+      const result = getters.namespaces(state, stateGetters)();
+
+      expect(result).toStrictEqual(expectation);
+    });
+  });
+});

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -86,9 +86,13 @@ const getActiveNamespaces = (state, getters) => {
     return out;
   }
 
-  const hasNamespaces = Array.isArray(state.allNamespaces) && state.allNamespaces.length > 0;
   // Use default "All Namespaces" category if no namespaces is found
-  const namespaces = hasNamespaces ? state.allNamespaces : getters[`${ inStore }/all`](NAMESPACE);
+  const hasNamespaces = Array.isArray(state.allNamespaces) && state.allNamespaces.length > 0;
+  const allNamespaces = hasNamespaces ? state.allNamespaces : getters[`${ inStore }/all`](NAMESPACE);
+
+  // Filter out Rancher system namespaces
+  const showRancherNamespaces = state.prefs.data['all-namespaces'];
+  const namespaces = allNamespaces.filter(ns => showRancherNamespaces ? true : !ns.isObscure);
 
   // Retrieve all the filters selected by the user
   const filters = state.namespaceFilters.filter(

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -171,9 +171,9 @@ const getActiveNamespaces = (state, getters, readonly = false) => {
   const hasNamespaces = Array.isArray(state.allNamespaces) && state.allNamespaces.length > 0;
   const allNamespaces = hasNamespaces ? state.allNamespaces : getters[`${ inStore }/all`](NAMESPACE);
 
-  // Filter out Rancher system namespaces
-  const showRancherNamespaces = state.prefs.data['all-namespaces'];
-  const allowedNamespaces = allNamespaces.filter(ns => showRancherNamespaces ? true : !ns.isObscure);
+  const allowedNamespaces = allNamespaces
+    .filter(ns => state.prefs.data['all-namespaces'] ? true : !ns.isObscure) // Filter out Rancher system namespaces
+    .filter(ns => product.hideSystemResources ? !ns.isSystem : true); // Filter out Fleet system namespaces
 
   // Retrieve all the filters selected by the user
   const filters = state.namespaceFilters.filter(

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -120,7 +120,7 @@ const getActiveSingleNamespaces = (getters, filters) => {
 };
 
 /**
- * Get only namespaces where the user can create resources
+ * Get only namespaces for user with roles "Cluster Member" and "View All Projects"
  * @returns Record<string, true>
  */
 const getReadOnlyActiveNamespaces = (namespaces, activeNamespaces) => {

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -105,10 +105,10 @@ const getActiveNamespaces = (state, getters) => {
   const includeUser = filters.includes(ALL_USER);
   const includeOrphans = filters.includes(ALL_ORPHANS);
 
-  // Special cases to pull in all the user, system, or orphaned namespaces
-  const hasSpecialCases = includeAll || includeOrphans || includeSystem || includeUser;
+  // Categories to pull in all the user, system, or orphaned namespaces
+  const hasCategory = includeAll || includeOrphans || includeSystem || includeUser;
 
-  if ( hasSpecialCases ) {
+  if ( hasCategory ) {
     for ( const ns of namespaces ) {
       if (
         includeAll ||


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6094
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Filtered NS options inside resource form, based on selection from top navigation filter.

### Technical notes summary
- Replaced component filtering logic with state getter
- Added comments to existing logic
- Added unit tests for the component and state
- Moved logic for other filters
- Split function used by getters in more understandable bits
 
### Areas or cases that should be tested
In resource NS filter inspect the list of the available values based on the conditions:
- Filter by user NS
- Display all NS
- Filter by NS inside projects
- Filter by single NS
- Hide/show Rancher system NS
- Local and provisioned clusters
- Filter NS which are readonly as the user has no rights to create resources ([follow these steps to reproduce](https://github.com/harvester/harvester/issues/1986#issuecomment-1261745712))
- Filter NS for products (e.g. Harvester) which have flag `hideSystemResources`
- Filter NS for Harvester NS with flag `isFleetManaged `

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

Namespaces dropdown filtering Rancher system items

https://user-images.githubusercontent.com/5009481/225085965-f0cef244-41f2-4aa0-8ecf-27764a93147e.mov

Dropdown for user with role `Cluster Member` and `View All Projects` ([as indicated here](https://github.com/harvester/harvester/issues/1986#issuecomment-1261745712)) while creating a resource 


https://user-images.githubusercontent.com/5009481/226931851-34e42a08-eaeb-404d-a38a-c0e4a95348f0.mov

