### PR TITLE
fix issue when all extensions versions not available

### DIFF
--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -131,15 +131,16 @@ export function isSupportedChartVersion(chartVersion, rancherVersion) {
 }
 
 export function isChartVersionAvailableForInstall(version, rancherVersion, returnObj = false) {
-  const regex = new RegExp('^[A-Za-z0-9]{9}$');
-  const isRancherVersionHashString = regex.test(rancherVersion);
+  const parsedRancherVersion = rancherVersion.split('-')?.[0];
+  const regexHashString = new RegExp('^[A-Za-z0-9]{9}$');
+  const isRancherVersionHashString = regexHashString.test(rancherVersion);
   const requiredUiVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.UI_VERSION];
   const versionObj = { ...version };
 
   versionObj.isCompatibleWithUi = true;
 
   // if it's a head version of Rancher, then we skip the validation and enable them all
-  if (!isRancherVersionHashString && requiredUiVersion && !semver.satisfies(rancherVersion, requiredUiVersion)) {
+  if (!isRancherVersionHashString && requiredUiVersion && !semver.satisfies(parsedRancherVersion, requiredUiVersion)) {
     if (!returnObj) {
       return false;
     }

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -214,10 +214,11 @@ export default {
           item.displayVersion = latestCompatible.version;
           item.icon = latestCompatible.icon;
         } else {
+          item.displayVersion = item.versions?.[0]?.version;
           item.icon = chart.icon || latestCompatible.annotations['catalog.cattle.io/ui-icon'];
         }
 
-        if (latestNotCompatible && isChartVersionHigher(latestNotCompatible.version, item.installableVersions?.[0].version)) {
+        if (latestNotCompatible && item.installableVersions.length && isChartVersionHigher(latestNotCompatible.version, item.installableVersions?.[0].version)) {
           item.incompatibleDisclaimer = this.t('plugins.incompatibleDisclaimer', { version: latestNotCompatible.version, rancherVersion: latestNotCompatible.requiredUiVersion }, true);
         }
 


### PR DESCRIPTION
This PR addresses an issue with `v2.7.2-rc5` where for Elemental all versions of the extension were not available due to the presence of `catalog.cattle.io/ui-version` annotation (for rc version, `semver` comparison was always returning `false`).

- fix issue when all versions of an extension are not available (ui was crashing - not double-checking the `installableVersions` array)
- support `semver` comparison for `rc` versions of Rancher by getting only the version part (string split)