### PR TITLE
SimpleSecretSelector: Consume emitted values from `LabeledSelect`

### DIFF
--- a/shell/components/form/SimpleSecretSelector.vue
+++ b/shell/components/form/SimpleSecretSelector.vue
@@ -107,18 +107,18 @@ export default {
   },
 
   methods: {
-    updateSecretName(value) {
-      if (value === this.none) {
+    updateSecretName(e) {
+      if (e.value === this.none) {
         // The key should appear blank if the secret name is cleared
         this.key = '';
       }
-      if (value) {
-        this.$emit('updateSecretName', value);
+      if (e.value) {
+        this.$emit('updateSecretName', e.value);
       }
     },
-    updateSecretKey(value) {
-      if (value) {
-        this.$emit('updateSecretKey', value);
+    updateSecretKey(e) {
+      if (e.value) {
+        this.$emit('updateSecretKey', e.value);
       }
     }
   }
@@ -135,7 +135,7 @@ export default {
         :options="secretNames"
         :label="secretNameLabel"
         :mode="mode"
-        @selecting="updateSecretName(name)"
+        @selecting="updateSecretName"
       />
       <LabeledSelect
         v-model="key"
@@ -144,7 +144,7 @@ export default {
         :options="keys"
         :label="keyNameLabel"
         :mode="mode"
-        @selecting="updateSecretKey(key)"
+        @selecting="updateSecretKey"
       />
     </div>
   </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This improves the design of `SimpleSecretSelector.vue` by consuming values emitted by `LabeledSelect.vue` instead of data props that can be mutated at different times depending on the underlying usage of `selected`/`selecting` events in `LabeledSelect.vue`.

We should be able to follow-up in a another PR to revert #6302 and properly emit the `selecting` event.  

Fixes #8342
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
This PR better adheres the principle of uni-directional data flow by implementing the props-down, events-up pattern. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Alertmanager Configuration: See testing notes in #8324

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Alertmanager Configuration: See testing notes in #8324