### PR TITLE
Fix Grafana URLs in local cluster for new monitoring version

### DIFF
--- a/shell/components/EtcdInfoBanner.vue
+++ b/shell/components/EtcdInfoBanner.vue
@@ -8,7 +8,8 @@ import { CATALOG } from '@shell/config/types';
 export default {
   components: { Banner, Loading },
   async fetch() {
-    const res = await this.$store.dispatch(`cluster/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+    const inStore = this.$store.getters['currentProduct'].inStore;
+    const res = await this.$store.dispatch(`${ inStore }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
     const monitoringVersion = res?.currentVersion;
     const leader = await hasLeader(monitoringVersion, this.$store.dispatch, this.currentCluster.id);
 

--- a/shell/components/EtcdInfoBanner.vue
+++ b/shell/components/EtcdInfoBanner.vue
@@ -3,15 +3,18 @@ import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
 import { mapGetters } from 'vuex';
 import { hasLeader, leaderChanges, failedProposals } from '@shell/utils/grafana';
+import { CATALOG } from '@shell/config/types';
 
 export default {
   components: { Banner, Loading },
   async fetch() {
-    const leader = await hasLeader(this.$store.dispatch, this.currentCluster.id);
+    const res = await this.$store.dispatch(`cluster/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+    const monitoringVersion = res?.currentVersion;
+    const leader = await hasLeader(monitoringVersion, this.$store.dispatch, this.currentCluster.id);
 
     this.hasLeader = leader ? this.t('generic.yes') : this.t('generic.no');
-    this.leaderChanges = await leaderChanges(this.$store.dispatch, this.currentCluster.id);
-    this.failedProposals = await failedProposals(this.$store.dispatch, this.currentCluster.id);
+    this.leaderChanges = await leaderChanges(monitoringVersion, this.$store.dispatch, this.currentCluster.id);
+    this.failedProposals = await failedProposals(monitoringVersion, this.$store.dispatch, this.currentCluster.id);
   },
   data() {
     return {

--- a/shell/components/GrafanaDashboard.vue
+++ b/shell/components/GrafanaDashboard.vue
@@ -2,6 +2,7 @@
 import Loading from '@shell/components/Loading';
 import { Banner } from '@components/Banner';
 import { computeDashboardUrl } from '@shell/utils/grafana';
+import { CATALOG } from '@shell/config/types';
 
 export default {
   components: { Banner, Loading },
@@ -31,9 +32,14 @@ export default {
       default: 'dark'
     }
   },
+  async fetch() {
+    const res = await this.$store.dispatch(`cluster/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+
+    this.monitoringVersion = res?.currentVersion;
+  },
   data() {
     return {
-      loading: false, error: false, interval: null, initialUrl: this.computeUrl(), errorTimer: null
+      loading: false, error: false, interval: null, initialUrl: this.computeUrl(), errorTimer: null, monitoringVersion: null
     };
   },
   computed: {
@@ -131,7 +137,7 @@ export default {
       const clusterId = this.$store.getters['currentCluster'].id;
       const params = this.computeParams();
 
-      return computeDashboardUrl(embedUrl, clusterId, params);
+      return computeDashboardUrl(this.monitoringVersion, embedUrl, clusterId, params);
     },
     computeParams() {
       const params = {};

--- a/shell/components/GrafanaDashboard.vue
+++ b/shell/components/GrafanaDashboard.vue
@@ -33,7 +33,8 @@ export default {
     }
   },
   async fetch() {
-    const res = await this.$store.dispatch(`cluster/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+    const inStore = this.$store.getters['currentProduct'].inStore;
+    const res = await this.$store.dispatch(`${ inStore }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
 
     this.monitoringVersion = res?.currentVersion;
   },

--- a/shell/utils/__tests__/grafana.test.ts
+++ b/shell/utils/__tests__/grafana.test.ts
@@ -1,0 +1,44 @@
+import { getClusterPrefix } from '@shell/utils/grafana';
+
+describe('fx: getClusterPrefix', () => {
+  it('old monitoring version, downstream cluster', () => {
+    const prefix = getClusterPrefix('101.0.0+up19.0.3', 'c-abcd');
+
+    expect(prefix).toStrictEqual('/k8s/clusters/c-abcd');
+  });
+  it('old monitoring version, local cluster', () => {
+    const prefix = getClusterPrefix('101.0.0+up19.0.3', 'local');
+
+    expect(prefix).toStrictEqual('');
+  });
+  it('new monitoring version, downstream cluster', () => {
+    const prefix = getClusterPrefix('102.0.0+up40.1.2', 'c-abcd');
+
+    expect(prefix).toStrictEqual('/k8s/clusters/c-abcd');
+  });
+  it('new monitoring version, local cluster', () => {
+    const prefix = getClusterPrefix('102.0.0+up40.1.2', 'local');
+
+    expect(prefix).toStrictEqual('/k8s/clusters/local');
+  });
+  it('future monitoring version, downstream cluster', () => {
+    const prefix = getClusterPrefix('103.0.0+up41.0.0', 'c-abcd');
+
+    expect(prefix).toStrictEqual('/k8s/clusters/c-abcd');
+  });
+  it('future monitoring version, local cluster', () => {
+    const prefix = getClusterPrefix('103.0.0+up41.0.0', 'local');
+
+    expect(prefix).toStrictEqual('/k8s/clusters/local');
+  });
+  it('empty monitoring version, downstream cluster', () => {
+    const prefix = getClusterPrefix('', 'c-abcd');
+
+    expect(prefix).toStrictEqual('/k8s/clusters/c-abcd');
+  });
+  it('empty monitoring version, local cluster', () => {
+    const prefix = getClusterPrefix('', 'local');
+
+    expect(prefix).toStrictEqual('/k8s/clusters/local');
+  });
+});

--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -1,10 +1,22 @@
 import { haveV2Monitoring } from '@shell/utils/monitoring';
 import { parse as parseUrl, addParam } from '@shell/utils/url';
+import { compare } from '@shell/utils/version';
+import { CATALOG } from '@shell/config/types';
 
-export function computeDashboardUrl(embedUrl, clusterId, params) {
+const MONITORING_VERSION_NEW_URL_PATTERN = '102.0.0+up40.1.2';
+
+export function getClusterPrefix(monitoringVersion, clusterId) {
+  if (compare(monitoringVersion, MONITORING_VERSION_NEW_URL_PATTERN) >= 0) {
+    return `/k8s/clusters/${ clusterId }`;
+  }
+
+  return clusterId === 'local' ? '' : `/k8s/clusters/${ clusterId }`;
+}
+
+export function computeDashboardUrl(monitoringVersion, embedUrl, clusterId, params) {
   const url = parseUrl(embedUrl);
 
-  let newUrl = `/k8s/clusters/${ clusterId }${ url.path }`;
+  let newUrl = `${ getClusterPrefix(monitoringVersion, clusterId) }${ url.path }`;
 
   if (url.query.viewPanel) {
     newUrl = addParam(newUrl, 'viewPanel', url.query.viewPanel);
@@ -19,13 +31,13 @@ export function computeDashboardUrl(embedUrl, clusterId, params) {
   return newUrl;
 }
 
-export async function dashboardExists(store, clusterId, embedUrl, storeName = 'cluster') {
+export async function dashboardExists(monitoringVersion, store, clusterId, embedUrl, storeName = 'cluster') {
   if ( !haveV2Monitoring(store.getters) ) {
     return false;
   }
 
   const url = parseUrl(embedUrl);
-  const prefix = `/k8s/clusters/${ clusterId }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/`;
+  const prefix = `${ getClusterPrefix(monitoringVersion, clusterId) }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/`;
   const delimiter = 'http:rancher-monitoring-grafana:80/proxy/';
   const path = url.path.split(delimiter)[1];
   const uid = path.split('/')[1];
@@ -41,40 +53,43 @@ export async function dashboardExists(store, clusterId, embedUrl, storeName = 'c
 }
 
 export async function allDashboardsExist(store, clusterId, embeddedUrls, storeName = 'cluster') {
-  const existPromises = embeddedUrls.map(url => dashboardExists(store, clusterId, url, storeName));
+  const res = await store.dispatch(`cluster/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+  const monitoringVersion = res?.currentVersion;
+
+  const existPromises = embeddedUrls.map(url => dashboardExists(monitoringVersion, store, clusterId, url, storeName));
 
   return (await Promise.all(existPromises)).every(exists => exists);
 }
 
-export function queryGrafana(dispatch, clusterId, query, range, step) {
-  const url = `/k8s/clusters/${ clusterId }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/api/datasources/proxy/1/api/v1/query_range?query=${ query }&start=${ range.start }&end=${ range.end }&step=${ step }`;
+export function queryGrafana(monitoringVersion, dispatch, clusterId, query, range, step) {
+  const url = `${ getClusterPrefix(monitoringVersion, clusterId) }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/api/datasources/proxy/1/api/v1/query_range?query=${ query }&start=${ range.start }&end=${ range.end }&step=${ step }`;
 
   return dispatch('cluster/request', { url, redirectUnauthorized: false });
 }
 
-export async function hasLeader(dispatch, clusterId) {
+export async function hasLeader(monitoringVersion, dispatch, clusterId) {
   const end = Date.now() / 1000;
   const start = end - (5 * 60);
 
-  const response = await queryGrafana(dispatch, clusterId, 'max(etcd_server_has_leader)', { start, end }, 30);
+  const response = await queryGrafana(monitoringVersion, dispatch, clusterId, 'max(etcd_server_has_leader)', { start, end }, 30);
 
   return response.data.result[0]?.values?.[0]?.[1] === '1';
 }
 
-export async function leaderChanges(dispatch, clusterId) {
+export async function leaderChanges(monitoringVersion, dispatch, clusterId) {
   const end = Date.now() / 1000;
   const start = end - (60 * 60);
 
-  const response = await queryGrafana(dispatch, clusterId, 'max(etcd_server_leader_changes_seen_total)', { start, end }, 30);
+  const response = await queryGrafana(monitoringVersion, dispatch, clusterId, 'max(etcd_server_leader_changes_seen_total)', { start, end }, 30);
 
   return response.data.result[0]?.values?.[0]?.[1] || 0;
 }
 
-export async function failedProposals(dispatch, clusterId) {
+export async function failedProposals(monitoringVersion, dispatch, clusterId) {
   const end = Date.now() / 1000;
   const start = end - (60 * 60);
 
-  const response = await queryGrafana(dispatch, clusterId, 'sum(etcd_server_proposals_failed_total)', { start, end }, 30);
+  const response = await queryGrafana(monitoringVersion, dispatch, clusterId, 'sum(etcd_server_proposals_failed_total)', { start, end }, 30);
 
   return response.data.result[0]?.values?.[0]?.[1] || 0;
 }

--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -3,9 +3,8 @@ import { parse as parseUrl, addParam } from '@shell/utils/url';
 
 export function computeDashboardUrl(embedUrl, clusterId, params) {
   const url = parseUrl(embedUrl);
-  const clusterPrefix = clusterId === 'local' ? '' : `/k8s/clusters/${ clusterId }`;
 
-  let newUrl = `${ clusterPrefix }${ url.path }`;
+  let newUrl = `/k8s/clusters/${ clusterId }${ url.path }`;
 
   if (url.query.viewPanel) {
     newUrl = addParam(newUrl, 'viewPanel', url.query.viewPanel);
@@ -26,8 +25,7 @@ export async function dashboardExists(store, clusterId, embedUrl, storeName = 'c
   }
 
   const url = parseUrl(embedUrl);
-  const clusterPrefix = clusterId === 'local' ? '' : `/k8s/clusters/${ clusterId }`;
-  const prefix = `${ clusterPrefix }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/`;
+  const prefix = `/k8s/clusters/${ clusterId }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/`;
   const delimiter = 'http:rancher-monitoring-grafana:80/proxy/';
   const path = url.path.split(delimiter)[1];
   const uid = path.split('/')[1];
@@ -49,8 +47,7 @@ export async function allDashboardsExist(store, clusterId, embeddedUrls, storeNa
 }
 
 export function queryGrafana(dispatch, clusterId, query, range, step) {
-  const clusterPrefix = clusterId === 'local' ? '' : `/k8s/clusters/${ clusterId }`;
-  const url = `${ clusterPrefix }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/api/datasources/proxy/1/api/v1/query_range?query=${ query }&start=${ range.start }&end=${ range.end }&step=${ step }`;
+  const url = `/k8s/clusters/${ clusterId }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/api/datasources/proxy/1/api/v1/query_range?query=${ query }&start=${ range.start }&end=${ range.end }&step=${ step }`;
 
   return dispatch('cluster/request', { url, redirectUnauthorized: false });
 }

--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -53,7 +53,7 @@ export async function dashboardExists(monitoringVersion, store, clusterId, embed
 }
 
 export async function allDashboardsExist(store, clusterId, embeddedUrls, storeName = 'cluster') {
-  const res = await store.dispatch(`cluster/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+  const res = await store.dispatch(`${ storeName }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
   const monitoringVersion = res?.currentVersion;
 
   const existPromises = embeddedUrls.map(url => dashboardExists(monitoringVersion, store, clusterId, url, storeName));


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/dashboard/issues/8346

### Occurred changes and/or fixed issues
With the new version of Rancher-Monitoring, the embedded Grafana dashboards and links in the local cluster do not work anymore, but return a 404 from Grafana.

In all other clusters the links are correct.

This changes an exception in the creation of these links for the local cluster, which is not needed anymore in the new monitoring version >=102.0.0+up40.1.2.

### Areas or cases that should be tested
Embedded Grafana dashboards and Grafana links in the local cluster.

### Areas which could experience regressions
* Cluster Overview page
* Workload detail page
* Pod detail page
* Node detail page
* Grafana link on Monitoring detail page
