### PR TITLE
[2.7.2] Fix setting Helm values for ProjectHelmCharts

### DIFF
--- a/shell/edit/helm.cattle.io.projecthelmchart.vue
+++ b/shell/edit/helm.cattle.io.projecthelmchart.vue
@@ -48,6 +48,10 @@ export default {
   },
 
   data() {
+    if (!this.value.spec.values) {
+      this.$set(this.value.spec, 'values', {});
+    }
+
     return {
       systemNamespaces: null,
       namespaces:       [],
@@ -128,7 +132,7 @@ export default {
           :side-tabs="true"
         >
           <Questions
-            v-model="value"
+            v-model="value.spec.values"
             tabbed="multiple"
             :target-namespace="value.metadata.namespace"
             :source="selectedNamespaceQuestions"


### PR DESCRIPTION
### Summary
Fix setting Helm values for ProjectHelmCharts.

Fixes https://github.com/rancher/dashboard/issues/8366

### Occurred changes and/or fixed issues
The values must be stored into `spec.values` and not top-level in the resource.

### Areas or cases that should be tested
Creating/Editing ProjectHelmCharts such as Project Monitors.

### Screenshot/Video
Before:
![Bildschirm­foto 2023-03-06 um 10 21 21](https://user-images.githubusercontent.com/243056/223072359-d1088289-e401-4857-991f-f676058e0720.png)

After:
![Bildschirm­foto 2023-03-06 um 10 29 11](https://user-images.githubusercontent.com/243056/223072384-c98c99db-c8eb-487c-a3c8-a3f194970474.png)

