### PR TITLE
Fix prometheus links on project monitor detail page

### DIFF
--- a/shell/detail/helm.cattle.io.projecthelmchart.vue
+++ b/shell/detail/helm.cattle.io.projecthelmchart.vue
@@ -43,8 +43,8 @@ export default {
       };
     },
     monitoringNamespace() {
-      // arbitrarily picking the alertmanagerURL here, they're all going to be the same.
-      return this.pullKeyFromUrl(this.relativeDashboardValues.alertmanagerURL, 'namespaces');
+      // picking the prometheusURL here, they're all going to be the same, but alertmanager and grafana can be deactivated
+      return this.pullKeyFromUrl(this.relativeDashboardValues.prometheusURL, 'namespaces');
     },
     alertServiceEndpoint() {
       return this.pullServiceEndpointFromUrl(this.relativeDashboardValues.alertmanagerURL);


### PR DESCRIPTION
### Summary
If alertmanager is deactivated, the prometheus links should not be disabled. Previously all links were disabled as soon as the alertmanager was disabled, because it picked the namespace from the alertmanager url, which is empty if disabled.

Fixes https://github.com/rancher/dashboard/issues/8350

### Areas or cases that should be tested
Project monitor detail page

### Areas which could experience regressions
Project monitor detail page

### Screenshot/Video
Before:
![Bildschirm­foto 2023-03-06 um 14 44 00](https://user-images.githubusercontent.com/243056/223129023-568fcaef-de47-4bf3-b8d7-77565cf409a7.png)


After:
![Bildschirm­foto 2023-03-06 um 14 45 57](https://user-images.githubusercontent.com/243056/223129030-83f25f9f-d41e-46a9-b21e-ae96cdc5c015.png)

