### PR TITLE
Hide PSA CRD in downstream clusters

### DIFF
--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -175,6 +175,11 @@ export function init(store) {
     },
   });
 
+  /** This CRD is installed on provisioned clusters because rancher webhook, used for both local and provisioned clusters, expects it to be there
+   * Creating instances of this resource on downstream clusters wont do anything - Only show them for the local cluster
+   */
+  configureType(MANAGEMENT.PSA, { localOnly: true });
+
   headers(PV, [STATE, NAME_COL, RECLAIM_POLICY, PERSISTENT_VOLUME_CLAIM, PERSISTENT_VOLUME_SOURCE, PV_REASON, AGE]);
   headers(CONFIG_MAP, [NAME_COL, NAMESPACE_COL, KEYS, AGE]);
   headers(SECRET, [
@@ -311,8 +316,6 @@ export function init(store) {
 
   // Ignore these types as they are managed through the auth product
   ignoreType(MANAGEMENT.USER);
-
-  // Ignore these types as they are managed through the auth product
   ignoreType(MANAGEMENT.GLOBAL_ROLE);
   ignoreType(MANAGEMENT.ROLE_TEMPLATE);
 }

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -105,6 +105,7 @@
 //                               hasGraph: undefined   -- If true, render ForceDirectedTreeChart graph (ATTENTION: option graphConfig is needed also!!!)
 //                               graphConfig: undefined   -- Use this to pass along the graph configuration
 //                               notFilterNamespace:  undefined -- Define namespaces that do not need to be filtered
+//                               localOnly: False -- Hide this type from the nav/search bar on downstream clusters
 //                           }
 // )
 // ignoreGroup(group):        Never show group or any types in it
@@ -869,6 +870,8 @@ export const getters = {
           // Skip the schemas that aren't top-level types
           continue;
         } else if ( typeof typeOptions.ifRancherCluster !== 'undefined' && typeOptions.ifRancherCluster !== rootGetters.isRancher ) {
+          continue;
+        } else if (typeOptions.localOnly && !rootGetters.currentCluster?.isLocal) {
           continue;
         }
 


### PR DESCRIPTION
Fixes #8274 

This PR hides the PSA resource in downstream clusters, because while the CRD needs to be installed, PSAs in downstream clusters can't be used for anything: they need to be configured in the local cluster.

As explained in the original issue:
https://github.com/rancher/dashboard/issues/8274#issuecomment-1449045952
>Some technical background information about the PodSecurityAdmissionConfigurationTemplate(PSACT) CRD in the downstream cluster:
The CRD exists in the downstream cluster but never be used. We have it due to a limitation in rancher-webhook: because the same rancher-webhook app is installed in both the local and downstream cluster(with different values, of course), and the app requires the PodSecurityAdmissionConfigurationTemplate CRD to exist in the cluster, therefore we have to install the CRD into the downstream clusters.
One more note: creating the CRs in the downstream cluster does not hurt anything, users cannot use it to configure the cluster or anything. It is simply useless.

### Testing
Create a 1.25 rke2 cluster and navigate to its cluster explorer
Use the search function (cmd k) to verify that there is no 'Pod Security Admissions' resource listed
Explore the local cluster, make the same search and verify that there is a 'Pod Security Admissions' resource
