### PR TITLE
Add async/await tag to the RKE2 PSP check function

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1856,7 +1856,7 @@ export default {
      * Check if current cluster has PSP enabled
      * Consider exclusively RKE2 provisioned clusters in edit mode
      */
-    checkPsps() {
+    async checkPsps() {
       // As server returns 500 we exclude all the possible cases
       if (
         this.mode !== _CREATE &&
@@ -1868,7 +1868,7 @@ export default {
         const url = `/k8s/clusters/${ clusterId }/v1/${ PSPS }`;
 
         try {
-          return this.$store.dispatch('cluster/request', { url });
+          return await this.$store.dispatch('cluster/request', { url });
         } catch (error) {
           // PSP may not exists for this cluster and an error is returned without need to handle
         }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#8300
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Prevent blocking the editing in case of clusters RKE2 with version < 1.25.x without PSPs and status `provisioning` or `updating`.

### Technical notes summary
Added missing `async/await` tag to the function.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
