### PR TITLE
Add enableDefaultSeccompProfile option to the Gatekeeper chart install ui

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2232,6 +2232,11 @@ gatekeeperIndex:
   unavailable: OPA + Gatekeeper is not available in the system-charts catalog.
   violations: Violations
 
+gatekeeperInstall: 
+  auditInterval: Auto Interval
+  constraintViolationsLimit: Constraint Violations Limit
+  runtimeDefaultSeccompProfile: Enable Runtime Default Seccomp Profile
+
 glance:
   created: Created
   cpu: CPU Usage

--- a/shell/chart/gatekeeper.vue
+++ b/shell/chart/gatekeeper.vue
@@ -1,14 +1,36 @@
 <script>
 import UnitInput from '@shell/components/form/UnitInput';
 import ChartPsp from '@shell/components/ChartPsp';
+import { Checkbox } from '@components/Form/Checkbox';
 
 export default {
-  components: { UnitInput, ChartPsp },
-  props:      {
+  components: {
+    UnitInput, ChartPsp, Checkbox
+  },
+  props: {
     value: {
       type:    Object,
       default: () => {
         return {};
+      }
+    },
+    autoInstallInfo: {
+      type:    Array,
+      default: () => []
+    }
+  },
+
+  computed: {
+    crdValues: {
+      get() {
+        const crdInfo = this.autoInstallInfo.find(info => info.chart.name.includes('crd'));
+
+        return crdInfo ? crdInfo.values : null;
+      },
+      set(values) {
+        const crdInfo = this.autoInstallInfo.find(info => info.chart.name.includes('crd'));
+
+        this.$set(crdInfo, 'values', values);
       }
     }
   }
@@ -20,8 +42,8 @@ export default {
       <div class="col span-6">
         <UnitInput
           v-model="value.auditInterval"
-          label="Audit interval"
-          suffix="Seconds"
+          :label="t('gatekeeperInstall.auditInterval')"
+          :suffix="t('generic.seconds')"
         />
       </div>
     </div>
@@ -29,8 +51,8 @@ export default {
       <div class="col span-6">
         <UnitInput
           v-model="value.constraintViolationsLimit"
-          label="Constraint violations limit"
-          suffix="Violations"
+          :label="t('gatekeeperInstall.constraintViolationsLimit')"
+          :suffix="t('gatekeeperIndex.violations')"
         />
       </div>
     </div>
@@ -39,5 +61,13 @@ export default {
         <ChartPsp :value="value" />
       </div>
     </div>
+    <template v-if="crdValues">
+      <!-- gatekeeper versions <1.0.2 do not have this option -->
+      <Checkbox
+        v-if="crdValues.enableRuntimeDefaultSeccompProfile ||crdValues.enableRuntimeDefaultSeccompProfile === false"
+        v-model="crdValues.enableRuntimeDefaultSeccompProfile"
+        :label="t('gatekeeperInstall.runtimeDefaultSeccompProfile')"
+      />
+    </template>
   </div>
 </template>

--- a/shell/chart/gatekeeper.vue
+++ b/shell/chart/gatekeeper.vue
@@ -43,7 +43,7 @@ export default {
         <UnitInput
           v-model="value.auditInterval"
           :label="t('gatekeeperInstall.auditInterval')"
-          :suffix="t('generic.seconds')"
+          :suffix="t('suffix.seconds', {count: value.auditInterval})"
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/rancher/dashboard/issues/8238, specifically the requirement from [this comment](https://github.com/rancher/dashboard/issues/8238#issuecomment-1453456555)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR allows custom chart ui components to edit crd values, specifically `enableDefaultSeccompProfile` for Gatekeeper - see comment [here](https://github.com/rancher/dashboard/issues/8238#issuecomment-1453456555)

### Technical notes summary
Code in the chart install page has been shuffled around a bit to fetch crd version info upfront rather than during the 'save' process, and pass that info to custom ui components. The original issue is very general in its title but the problem being solved is specifically around OPA gatekeeper...I've written this PR in such a way that we should be able to expand editing CRD values to other charts if needed in the future.

### Areas or cases that should be tested
* Verify that the latest version of OPA Gatekeeper installs correctly with and without enableDefaultSeccompProfile checked (check the network request to verify the crd chart has this value set)
* OPA Gatekeeper versions <1.0.2 should not have any seccomp configuration option during install
* Verify other chart installation is not impacted - I tested logging, backups, cis benchmark
