### PR TITLE
Added create name space button on flat list view

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3334,7 +3334,7 @@ namespace:
   resourceQuotas: Resource Quotas
   project:
     label: Project
-    placeholder: Select a project
+    none: (None)
   resources: Resources
   enableAutoInjection: Enable Istio Auto Injection
   disableAutoInjection: Disable Istio Auto Injection

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3334,6 +3334,7 @@ namespace:
   resourceQuotas: Resource Quotas
   project:
     label: Project
+    placeholder: Select a project
   resources: Resources
   enableAutoInjection: Enable Istio Auto Injection
   disableAutoInjection: Disable Istio Auto Injection

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -292,7 +292,7 @@ export default {
       const location = this.createNamespaceLocationOverride ? { ...this.createNamespaceLocationOverride } : {
         name:   'c-cluster-product-resource-create',
         params: {
-          product:  this.$store.getters['currentProduct'].name,
+          product:  this.$store.getters['currentProduct']?.name,
           resource: NAMESPACE
         },
       };
@@ -369,7 +369,6 @@ export default {
         <n-link
           :to="createNamespaceLocationFlatList()"
           class="btn role-primary mr-10"
-          data-testid="cluster-manager-list-import"
         >
           {{ t('projectNamespaces.createNamespace') }}
         </n-link>

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -4,7 +4,7 @@ import ResourceTable from '@shell/components/ResourceTable';
 import { STATE, AGE, NAME } from '@shell/config/table-headers';
 import { uniq } from '@shell/utils/array';
 import { MANAGEMENT, NAMESPACE, VIRTUAL_TYPES } from '@shell/config/types';
-import { PROJECT_ID } from '@shell/config/query-params';
+import { PROJECT_ID, FLAT_VIEW } from '@shell/config/query-params';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { mapPref, GROUP_RESOURCES, ALL_NAMESPACES } from '@shell/store/prefs';
 import MoveModal from '@shell/components/MoveModal';
@@ -236,12 +236,16 @@ export default {
 
     notInProjectKey() {
       return this.$store.getters['i18n/t']('resourceTable.groupLabel.notInAProject');
+    },
+    showCreateNsButton() {
+      return this.groupPreference !== 'namespace';
     }
   },
   methods: {
     /**
      * Get PSA HTML to be displayed in the tooltips
      */
+
     getPsaTooltip(row) {
       const dictionary = row.psaTooltipsDescription;
       const list = Object.values(dictionary)
@@ -281,9 +285,22 @@ export default {
       };
 
       location.query = { [PROJECT_ID]: project?.metadata.name };
-
       return location;
     },
+
+    createNamespaceLocationFlatList() {
+      const location = this.createNamespaceLocationOverride ? { ...this.createNamespaceLocationOverride } : {
+        name:   'c-cluster-product-resource-create',
+        params: {
+          product:  this.$store.getters['currentProduct'].name,
+          resource: NAMESPACE
+        },
+      };
+
+      location.query = {[FLAT_VIEW]: true };  
+      return location;
+    },
+
     showProjectAction(event, group) {
       const project = group.rows[0].project;
 
@@ -343,7 +360,20 @@ export default {
       :show-incremental-loading-indicator="showIncrementalLoadingIndicator"
       :load-resources="loadResources"
       :load-indeterminate="loadIndeterminate"
-    />
+    >
+      <template
+        v-if="showCreateNsButton"
+        slot="extraActions"
+      >
+        <n-link
+          :to="createNamespaceLocationFlatList()"
+          class="btn role-primary mr-10"
+          data-testid="cluster-manager-list-import"
+        >
+          {{ t('projectNamespaces.createNamespace') }}
+        </n-link>
+      </template>
+    </Masthead>
     <ResourceTable
       ref="table"
       class="table"
@@ -434,7 +464,7 @@ export default {
             class="empty text-center"
             colspan="5"
           >
-            {{ t('projectNamespaces.noNamespaces') }}
+            {{ t('projectNamespaces.noNamespaces') }}rrr
           </td>
         </tr>
       </template>
@@ -444,7 +474,7 @@ export default {
             class="empty text-center"
             colspan="5"
           >
-            {{ t('projectNamespaces.noProjectNoNamespaces') }}
+            {{ t('projectNamespaces.noProjectNoNamespaces') }}ss
           </td>
         </tr>
       </template>

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -245,7 +245,6 @@ export default {
     /**
      * Get PSA HTML to be displayed in the tooltips
      */
-
     getPsaTooltip(row) {
       const dictionary = row.psaTooltipsDescription;
       const list = Object.values(dictionary)
@@ -464,7 +463,7 @@ export default {
             class="empty text-center"
             colspan="5"
           >
-            {{ t('projectNamespaces.noNamespaces') }}rrr
+            {{ t('projectNamespaces.noNamespaces') }}
           </td>
         </tr>
       </template>
@@ -474,7 +473,7 @@ export default {
             class="empty text-center"
             colspan="5"
           >
-            {{ t('projectNamespaces.noProjectNoNamespaces') }}ss
+            {{ t('projectNamespaces.noProjectNoNamespaces') }}
           </td>
         </tr>
       </template>

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -284,6 +284,7 @@ export default {
       };
 
       location.query = { [PROJECT_ID]: project?.metadata.name };
+
       return location;
     },
 
@@ -296,7 +297,8 @@ export default {
         },
       };
 
-      location.query = {[FLAT_VIEW]: true };  
+      location.query = { [FLAT_VIEW]: true };
+
       return location;
     },
 

--- a/shell/config/query-params.js
+++ b/shell/config/query-params.js
@@ -73,3 +73,4 @@ export const CLOUD_CREDENTIAL = 'cloud';
 
 // NAMESPACE/PROJECT
 export const PROJECT_ID = 'projectId';
+export const FLAT_VIEW = 'flatView';

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -87,7 +87,7 @@ export default {
 
       out.unshift({
         label: '(None)',
-        value: 'null',
+        value: null,
       });
 
       return out;
@@ -104,7 +104,7 @@ export default {
     showContainerResourceLimit() {
       return !this.isSingleHarvester;
     },
-  
+
     flatView() {
       return this.$route.query[FLAT_VIEW];
     }
@@ -189,7 +189,6 @@ export default {
     >
       <div class="col span-3">
         <LabeledSelect
-          :mode="mode"
           v-model="projectName"
           :label="t('namespace.project.label')"
           :options="projectOpts"

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -10,7 +10,7 @@ import PodSecurityAdmission from '@shell/components/PodSecurityAdmission';
 import Tabbed from '@shell/components/Tabbed';
 import Tab from '@shell/components/Tabbed/Tab';
 import CruResource from '@shell/components/CruResource';
-import { PROJECT_ID, _VIEW } from '@shell/config/query-params';
+import { PROJECT_ID, _VIEW, FLAT_VIEW } from '@shell/config/query-params';
 import MoveModal from '@shell/components/MoveModal';
 import ResourceQuota from '@shell/components/form/ResourceQuota/Namespace';
 import Loading from '@shell/components/Loading';
@@ -50,7 +50,7 @@ export default {
       originalQuotaId = `${ this.liveValue.metadata.name }/default-quota`;
     }
 
-    const projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID];
+    const projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID] || '(None)';
 
     return {
       originalQuotaId,
@@ -87,7 +87,7 @@ export default {
 
       out.unshift({
         label: '(None)',
-        value: null,
+        value: 'null',
       });
 
       return out;
@@ -104,7 +104,10 @@ export default {
     showContainerResourceLimit() {
       return !this.isSingleHarvester;
     },
-
+  
+    flatView() {
+      return this.$route.query[FLAT_VIEW];
+    }
   },
 
   watch: {
@@ -144,8 +147,7 @@ export default {
 
       return project?.spec?.containerDefaultResourceLimit || {};
     }
-  }
-
+  },
 };
 </script>
 
@@ -181,7 +183,19 @@ export default {
         />
       </template>
     </NameNsDescription>
-
+    <div
+      v-if="flatView"
+      class="row mb-20"
+    >
+      <div class="col span-3">
+        <LabeledSelect
+          :mode="mode"
+          v-model="projectName"
+          :label="t('namespace.project.label')"
+          :options="projectOpts"
+        />
+      </div>
+    </div>
     <Tabbed :side-tabs="true">
       <Tab
         v-if="showResourceQuota"

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -118,6 +118,9 @@ export default {
     },
 
     projectName(newProjectName) {
+      if (newProjectName === null) {
+        this.projectName = '(None)';
+      }
       this.$set(this, 'project', this.projects.find(p => p.id.includes(newProjectName)));
     }
   },
@@ -171,9 +174,9 @@ export default {
       :value="value"
       :namespaced="false"
       :mode="mode"
+      :extra-columns="['project-col']"
     >
       <template
-        v-if="project"
         #project-col
       >
         <LabeledSelect

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -50,7 +50,7 @@ export default {
       originalQuotaId = `${ this.liveValue.metadata.name }/default-quota`;
     }
 
-    const projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID] || '(None)';
+    const projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID] || this.t('namespace.project.none');
 
     return {
       originalQuotaId,
@@ -86,7 +86,7 @@ export default {
       });
 
       out.unshift({
-        label: '(None)',
+        label: this.t('namespace.project.none'),
         value: null,
       });
 
@@ -118,9 +118,6 @@ export default {
     },
 
     projectName(newProjectName) {
-      if (newProjectName === null) {
-        this.projectName = '(None)';
-      }
       this.$set(this, 'project', this.projects.find(p => p.id.includes(newProjectName)));
     }
   },
@@ -177,6 +174,7 @@ export default {
       :extra-columns="['project-col']"
     >
       <template
+        v-if="flatView || project"
         #project-col
       >
         <LabeledSelect
@@ -186,18 +184,6 @@ export default {
         />
       </template>
     </NameNsDescription>
-    <div
-      v-if="flatView"
-      class="row mb-20"
-    >
-      <div class="col span-3">
-        <LabeledSelect
-          v-model="projectName"
-          :label="t('namespace.project.label')"
-          :options="projectOpts"
-        />
-      </div>
-    </div>
     <Tabbed :side-tabs="true">
       <Tab
         v-if="showResourceQuota"

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -10,7 +10,7 @@ import PodSecurityAdmission from '@shell/components/PodSecurityAdmission';
 import Tabbed from '@shell/components/Tabbed';
 import Tab from '@shell/components/Tabbed/Tab';
 import CruResource from '@shell/components/CruResource';
-import { PROJECT_ID, _VIEW, FLAT_VIEW } from '@shell/config/query-params';
+import { PROJECT_ID, _VIEW, FLAT_VIEW, _CREATE } from '@shell/config/query-params';
 import MoveModal from '@shell/components/MoveModal';
 import ResourceQuota from '@shell/components/form/ResourceQuota/Namespace';
 import Loading from '@shell/components/Loading';
@@ -50,7 +50,7 @@ export default {
       originalQuotaId = `${ this.liveValue.metadata.name }/default-quota`;
     }
 
-    const projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID] || this.t('namespace.project.none');
+    const projectName = this.value?.metadata?.labels?.[PROJECT] || this.$route.query[PROJECT_ID];
 
     return {
       originalQuotaId,
@@ -67,6 +67,10 @@ export default {
   computed: {
     ...mapGetters(['isSingleProduct']),
 
+    isCreate() {
+      return this.mode === _CREATE;
+    },
+
     isSingleHarvester() {
       return this.$store.getters['currentProduct'].inStore === HARVESTER && this.isSingleProduct;
     },
@@ -77,7 +81,6 @@ export default {
 
       // Filter out projects not for the current cluster
       projects = projects.filter(c => c.spec?.clusterName === clusterId);
-
       const out = projects.map((project) => {
         return {
           label: project.nameDisplay,
@@ -106,7 +109,7 @@ export default {
     },
 
     flatView() {
-      return this.$route.query[FLAT_VIEW];
+      return (this.$route.query[FLAT_VIEW] || false);
     }
   },
 
@@ -142,7 +145,6 @@ export default {
       }
 
       const projects = this.$store.getters['management/all'](MANAGEMENT.PROJECT);
-
       const project = projects.find(p => p.id.includes(projectName));
 
       return project?.spec?.containerDefaultResourceLimit || {};
@@ -174,7 +176,7 @@ export default {
       :extra-columns="['project-col']"
     >
       <template
-        v-if="flatView || project"
+        v-if="flatView && isCreate"
         #project-col
       >
         <LabeledSelect


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8216
<!-- Define findings related to the feature or bug issue. -->
Create Namespaces Button is not visible when using the "Flat List" view

### How to test
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

> Go to local cluster > Projects/Namespaces > click on `Flat list` view
> Create Namespaces Button should be there > click on `Create Namespaces Button`
> Create screen should have a dropdown of projects.