### PR TITLE
Added check box for truncate Hostnames

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1689,6 +1689,9 @@ cluster:
     noAccessBanner: "You do not have access to see this machine pool's configuration."
     configNotFound: "We could not find this machine pool's configuration. We recommend that you create a new cluster with the desired configuration."
     noPoolsDisclaimer: You do not have any machine pools defined, click the plus to add one.
+    truncationPool: "Hostname truncation has been manually configured for this pool to"
+    truncationCluster: "Hostname truncation has been manually configured for this cluster to"
+
     autoReplace:
       label: Auto Replace
       toolTip: If greater than 0, nodes that are unreachable for this duration will be automatically deleted and replaced.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1831,6 +1831,7 @@ cluster:
       label: Drain Nodes
       toolTip: Draining preemptively removes the pods on each node so there are no running workloads on the nodes being upgraded.  Upgrading without draining is faster and causes less shuffling around, but pods may still be restarted depending on the upgrade being performed.
     deleteEmptyDir: "By default, pods using emptyDir volumes will be deleted on upgrade. Operations reliant on emptyDir volumes persisting through the pod's lifecycle may be impacted."
+    truncateHostnames: Truncate hostnames to 15 characters for NetBIOS compatibility.
     address:
       tooltip: Cluster networking values cannot be changed after the cluster is created.
       header: Addressing

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1689,8 +1689,8 @@ cluster:
     noAccessBanner: "You do not have access to see this machine pool's configuration."
     configNotFound: "We could not find this machine pool's configuration. We recommend that you create a new cluster with the desired configuration."
     noPoolsDisclaimer: You do not have any machine pools defined, click the plus to add one.
-    truncationPool: "Hostname truncation has been manually configured for this pool to"
-    truncationCluster: "Hostname truncation has been manually configured for this cluster to"
+    truncationPool: "Hostname truncation has been manually configured for this pool to {limit}"
+    truncationCluster: "Hostname truncation has been manually configured for this cluster to {limit}"
 
     autoReplace:
       label: Auto Replace

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -178,7 +178,7 @@ export default {
       color="info"
     >
       <div class="text">
-        {{ t('cluster.machinePool.truncationPool') }} {{ value.pool.hostnameLengthLimit }}
+        {{ t('cluster.machinePool.truncationPool', { limit: value.pool.hostnameLengthLimit }) }}
       </div>
     </Banner>
     <div class="row">

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -174,11 +174,11 @@ export default {
 <template>
   <div>
     <Banner
-      v-if="value.pool.instanceNameLimit"
+      v-if="value.pool.hostnameLengthLimit"
       color="info"
     >
       <div class="text">
-        {{ t('cluster.machinePool.truncationPool') }} {{ value.pool.instanceNameLimit }}
+        {{ t('cluster.machinePool.truncationPool') }} {{ value.pool.hostnameLengthLimit }}
       </div>
     </Banner>
     <div class="row">

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -173,6 +173,14 @@ export default {
 
 <template>
   <div>
+    <Banner
+      v-if="value.pool.instanceNameLimit"
+      color="info"
+    >
+      <div class="text">
+        {{ t('cluster.machinePool.truncationPool') }} {{ value.pool.instanceNameLimit }}
+      </div>
+    </Banner>
     <div class="row">
       <div class="col span-4">
         <LabeledInput
@@ -294,7 +302,6 @@ export default {
         :read-allowed="false"
         :value-can-be-empty="true"
       />
-
       <div class="spacer" />
 
       <Taints

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1093,8 +1093,8 @@ export default {
           pool.pool.instanceNameLimit = 15;
         });
       } else {
-          this.machinePools.filter((pool) => {
-            pool.pool.instanceNameLimit = null;
+        this.machinePools.filter((pool) => {
+          pool.pool.instanceNameLimit = null;
         });
       }
     },
@@ -1157,6 +1157,7 @@ export default {
 
           const truncateCheck = out.find((pool) => {
             this.truncateLimit = pool.pool.instanceNameLimit;
+
             return pool.pool.instanceNameLimit === 15;
           });
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -251,12 +251,6 @@ export default {
       set(this.rkeConfig.etcd, 'disableSnapshots', disableSnapshots);
     }
 
-    if ( !this.value.machinePoolDefaults ) {
-      set(this.value, 'machinePoolDefaults', {});
-    } else {
-      this.truncateLimit = this.value.machinePoolDefaults.hostnameLengthLimit;
-    }
-
     if ( !this.machinePools ) {
       await this.initMachinePools(this.value.spec.rkeConfig.machinePools);
       if ( this.mode === _CREATE && !this.machinePools.length ) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2570,9 +2570,9 @@ export default {
             </div>
             <div class="col span-6">
               <Checkbox
+                v-model="truncateHostnames"
                 class="mt-20"
                 :mode="mode"
-                v-model="truncateHostnames"
                 :label="t('cluster.rke2.truncateHostnames')"
               />
             </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1155,13 +1155,16 @@ export default {
             configMissing
           });
 
-          const truncateCheck = out.find((pool) => {
-            this.truncateLimit = pool.pool.instanceNameLimit;
+          // Added instanceNameLimit manually to each pool for testing purpose
+          // out.map((pool) => {
+          //   pool.pool.instanceNameLimit = 17;
+          // });
 
-            return pool.pool.instanceNameLimit === 15;
+          const truncateCheck = out.filter((pool) => {
+            this.truncateLimit = pool.pool.instanceNameLimit;
           });
 
-          if (truncateCheck) {
+          if (truncateCheck && this.truncateLimit === 15 ) {
             this.truncateHostnames = true;
           }
         }
@@ -2606,11 +2609,11 @@ export default {
                 @input="truncateName"
               />
               <Banner
-                v-if="truncateLimit !== 15"
+                v-if="isView && truncateLimit !== 15 && truncateLimit"
                 color="info"
               >
                 <div class="text">
-                  {{ t('cluster.machinePool.truncationCluster') }} {{ truncateLimit }}
+                  {{ t('cluster.machinePool.truncationCluster') }}{{ truncateLimit }}
                 </div>
               </Banner>
             </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -339,6 +339,7 @@ export default {
       cisOverride:           false,
       cisPsaChangeBanner:    false,
       psps:                  null, // List of policies if any
+      truncateHostnames:     false,
     };
   },
 
@@ -2565,6 +2566,14 @@ export default {
                 v-model="serverConfig['service-node-port-range']"
                 :mode="mode"
                 :label="t('cluster.rke2.address.nodePortRange.label')"
+              />
+            </div>
+            <div class="col span-6">
+              <Checkbox
+                class="mt-20"
+                :mode="mode"
+                v-model="truncateHostnames"
+                :label="t('cluster.rke2.truncateHostnames')"
               />
             </div>
           </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -340,15 +340,6 @@ export default {
       cisPsaChangeBanner:    false,
       psps:                  null, // List of policies if any
       truncateHostnames:     false,
-      pp:                    [{
-        id: 0, instanceNameLimit: ''
-      },
-      {
-        id: 1, instanceNameLimit: ''
-      },
-      {
-        id: 2, instanceNameLimit: ''
-      }],
     };
   },
 
@@ -1089,15 +1080,18 @@ export default {
     nlToBr,
     set,
 
+    /**
+     * set instanceNameLimit to 15 to all pool machine if truncateHostnames checkbox is clicked
+     */
     truncateName() {
-      if(this.truncateHostnames) {
+      if (this.truncateHostnames) {
         this.machinePools.find((pool) => {
           pool.pool.instanceNameLimit = 15;
-        })
+        });
       } else {
         this.machinePools.find((pool) => {
           pool.pool.instanceNameLimit = null;
-        })
+        });
       }
     },
     /**
@@ -1113,6 +1107,7 @@ export default {
 
     async initMachinePools(existing) {
       const out = [];
+
       if ( existing?.length ) {
         for ( const pool of existing ) {
           let type;
@@ -1158,14 +1153,14 @@ export default {
 
           const truncateCheck = out.find((pool) => {
             return pool.pool.instanceNameLimit;
-          })
+          });
 
           if (truncateCheck) {
             this.truncateHostnames = true;
           }
         }
       }
-  
+
       this.machinePools = out;
     },
 
@@ -1203,7 +1198,7 @@ export default {
             kind: this.machineConfigSchema.attributes.kind,
             name: null,
           },
-          instanceNameLimit:    null,
+          instanceNameLimit: null,
         },
       };
 
@@ -1215,7 +1210,6 @@ export default {
         pool.pool.machineConfigRef.apiVersion = `${ this.machineConfigSchema.attributes.group }/${ this.machineConfigSchema.attributes.version }`;
       }
 
-      
       this.machinePools.push(pool);
 
       this.$nextTick(() => {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1160,11 +1160,11 @@ export default {
           //   pool.pool.instanceNameLimit = 17;
           // });
 
-          const truncateCheck = out.filter((pool) => {
+          out.filter((pool) => {
             this.truncateLimit = pool.pool.instanceNameLimit;
           });
 
-          if (truncateCheck && this.truncateLimit === 15 ) {
+          if (this.truncateLimit === 15 ) {
             this.truncateHostnames = true;
           }
         }
@@ -2613,7 +2613,7 @@ export default {
                 color="info"
               >
                 <div class="text">
-                  {{ t('cluster.machinePool.truncationCluster') }}{{ truncateLimit }}
+                  {{ t('cluster.machinePool.truncationCluster') }} {{ truncateLimit }}
                 </div>
               </Banner>
             </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8223
<!-- Define findings related to the feature or bug issue. -->
Checkbox added to the right of 'NodePort Service Port Range' in the 'Networking' tab for hostnames Truncate


### How to test

 As of now the new param per machine pool named `instanceNameLimit`  is not available from the backend, so for the testing plead add this code:
 
out.find((pool) => {
       pool.pool.instanceNameLimit = 15;
});
> Go to Cluster management > create > select DO 

> In Cluster Configuration section > click 'Networking' tab 

> It should have a check box with a label for hostnames Truncate

**Some other use cases to test**
> Checkbox can ONLY be set on create - it should be disabled on edit
> On edit, ONLY if the value is 15, should we show the checkbox as checked
> On edit, if the value is present but NOT 15, we should show an info banner beneath the checkbox
> Show banner per-machine pool if the value is set.