### PR TITLE
Network Policy, combine `podSelector` and `namespaceSelector` in the same rule

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3490,6 +3490,7 @@ networkpolicy:
           other {Matches {matched, number} of {total, number} existing namespaces, including "{sample}"}
         }
     matchingNamespacesAndPods:
+      tooltip: A single entry rule that specifies both Namespace Selector and Pod Selector that selects particular Pods within particular namespaces
       matchesSome: |-
         {matchedPods, plural,
           =0 {Matches 0 of {totalPods, number} pods}

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3440,6 +3440,8 @@ networkpolicy:
   labelsAnnotations:
     label: Labels & Annotations
   rules:
+    pod: Pod
+    namespace: Namespace
     ruleLabel: Rule {index}
     addPort: Add allowed port
     type: Rule type
@@ -3466,6 +3468,8 @@ networkpolicy:
       label: Pod Selector
     namespaceSelector:
       label: Namespace Selector
+    namespaceAndPodSelector:
+      label: Namespace/Pod Selector
   config:
     label: Configuration
   selectors:
@@ -3484,6 +3488,17 @@ networkpolicy:
           =0 {Matches 0 of {total, number} namespaces}
           =1 {Matches 1 of {total, number} namespaces: "{sample}"}
           other {Matches {matched, number} of {total, number} existing namespaces, including "{sample}"}
+        }
+    matchingNamespacesAndPods:
+      matchesSome: |-
+        {matchedPods, plural,
+          =0 {Matches 0 of {totalPods, number} pods}
+          =1 {Matches 1 of {totalPods, number} pods: "{samplePods}"}
+          other {Matches {matchedPods, number} of {totalPods, number} existing pods, including "{samplePods}"}
+        } in {matchedNamespaces, plural,
+          =0 {0 of {totalNamespaces, number} namespaces}
+          =1 {1 of {totalNamespaces, number} namespaces: "{sampleNamespaces}"}
+          other {{matchedNamespaces, number} of {totalNamespaces, number} existing namespaces, including "{sampleNamespaces}"}
         }
 node:
   list:

--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -35,6 +35,18 @@ export default {
       default: false,
     },
 
+    // whether or not to show add rule button at bottom
+    showAddButton: {
+      type:    Boolean,
+      default: true
+    },
+
+    // whether or not to show remove rule button right side of the rule
+    showRemoveButton: {
+      type:    Boolean,
+      default: true
+    },
+
     // whether or not to show remove button in upper right
     showRemove: {
       type:    Boolean,
@@ -257,7 +269,10 @@ export default {
           @input="update"
         >
       </div>
-      <div class="remove-container">
+      <div
+        v-if="showRemoveButton"
+        class="remove-container"
+      >
         <button
           v-if="!isView"
           type="button"
@@ -272,7 +287,7 @@ export default {
       </div>
     </div>
     <div
-      v-if="!isView"
+      v-if="!isView && showAddButton"
       class="mt-20"
     >
       <button

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -308,7 +308,14 @@ export default {
       <div class="row">
         <div class="col span-12">
           <Banner color="success">
-            <span v-html="t('networkpolicy.selectors.matchingNamespacesAndPods.matchesSome', matchingNamespacesAndPods)" />
+            <span
+              v-if="!namespaceSelectorExpressions.length"
+              v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)"
+            />
+            <span
+              v-else
+              v-html="t('networkpolicy.selectors.matchingNamespacesAndPods.matchesSome', matchingNamespacesAndPods)"
+            />
           </Banner>
         </div>
       </div>

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -214,6 +214,7 @@ export default {
         <LabeledSelect
           v-model="targetType"
           :mode="mode"
+          :tooltip="targetType === TARGET_OPTIONS.NAMESPACE_AND_POD_SELECTOR ? t('networkpolicy.selectors.matchingNamespacesAndPods.tooltip') : null"
           :options="selectTargetOptions"
           :multiple="false"
           :label="t('networkpolicy.rules.type')"

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -369,7 +369,6 @@ export default {
     .label {
       display: block;
       margin-top: 32px;
-      color: var(--primary);
     }
   }
 </style>

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -11,9 +11,11 @@ import { Banner } from '@components/Banner';
 import throttle from 'lodash/throttle';
 import { isValidCIDR } from '@shell/utils/validators/cidr';
 
-const TARGET_OPTION_IP_BLOCK = 'ipBlock';
-const TARGET_OPTION_NAMESPACE_SELECTOR = 'namespaceSelector';
-const TARGET_OPTION_POD_SELECTOR = 'podSelector';
+const TARGET_OPTIONS = {
+  IP_BLOCK:           'ipBlock',
+  NAMESPACE_SELECTOR: 'namespaceSelector',
+  POD_SELECTOR:       'podSelector',
+};
 
 export default {
   components: {
@@ -52,9 +54,12 @@ export default {
     },
   },
   data() {
-    if (!this.value[TARGET_OPTION_IP_BLOCK] && !this.value[TARGET_OPTION_POD_SELECTOR] && !this.value[TARGET_OPTION_NAMESPACE_SELECTOR]) {
+    if (!this.value[TARGET_OPTIONS.IP_BLOCK] &&
+      !this.value[TARGET_OPTIONS.POD_SELECTOR] &&
+      !this.value[TARGET_OPTIONS.NAMESPACE_SELECTOR]
+    ) {
       this.$nextTick(() => {
-        this.$set(this.value, TARGET_OPTION_IP_BLOCK, {});
+        this.$set(this.value, TARGET_OPTIONS.IP_BLOCK, {});
       });
     }
 
@@ -64,38 +69,32 @@ export default {
       matchingNamespaces: {},
       invalidCidr:        null,
       invalidCidrs:       [],
-      TARGET_OPTION_IP_BLOCK,
-      TARGET_OPTION_NAMESPACE_SELECTOR,
-      TARGET_OPTION_POD_SELECTOR,
       POD,
-      targetOptions:      [
-        TARGET_OPTION_IP_BLOCK,
-        TARGET_OPTION_NAMESPACE_SELECTOR,
-        TARGET_OPTION_POD_SELECTOR
-      ],
+      TARGET_OPTIONS,
+      targetOptions:      Object.values(TARGET_OPTIONS),
     };
   },
   computed: {
     podSelectorExpressions: {
       get() {
         return convert(
-          this.value[TARGET_OPTION_POD_SELECTOR]?.matchLabels || {},
-          this.value[TARGET_OPTION_POD_SELECTOR]?.matchExpressions || []
+          this.value[TARGET_OPTIONS.POD_SELECTOR]?.matchLabels || {},
+          this.value[TARGET_OPTIONS.POD_SELECTOR]?.matchExpressions || []
         );
       },
       set(podSelectorExpressions) {
-        this.$set(this.value, TARGET_OPTION_POD_SELECTOR, simplify(podSelectorExpressions));
+        this.$set(this.value, TARGET_OPTIONS.POD_SELECTOR, simplify(podSelectorExpressions));
       }
     },
     namespaceSelectorExpressions: {
       get() {
         return convert(
-          this.value[TARGET_OPTION_NAMESPACE_SELECTOR]?.matchLabels || {},
-          this.value[TARGET_OPTION_NAMESPACE_SELECTOR]?.matchExpressions || []
+          this.value[TARGET_OPTIONS.NAMESPACE_SELECTOR]?.matchLabels || {},
+          this.value[TARGET_OPTIONS.NAMESPACE_SELECTOR]?.matchExpressions || []
         );
       },
       set(namespaceSelectorExpressions) {
-        this.$set(this.value, TARGET_OPTION_NAMESPACE_SELECTOR, simplify(namespaceSelectorExpressions));
+        this.$set(this.value, TARGET_OPTIONS.NAMESPACE_SELECTOR, simplify(namespaceSelectorExpressions));
       }
     },
     selectTargetOptions() {
@@ -121,9 +120,9 @@ export default {
         return null;
       },
       set(targetType) {
-        this.$delete(this.value, TARGET_OPTION_IP_BLOCK);
-        this.$delete(this.value, TARGET_OPTION_NAMESPACE_SELECTOR);
-        this.$delete(this.value, TARGET_OPTION_POD_SELECTOR);
+        this.$delete(this.value, TARGET_OPTIONS.IP_BLOCK);
+        this.$delete(this.value, TARGET_OPTIONS.NAMESPACE_SELECTOR);
+        this.$delete(this.value, TARGET_OPTIONS.POD_SELECTOR);
         this.$nextTick(() => {
           this.$set(this.value, targetType, {});
         });
@@ -150,14 +149,14 @@ export default {
   },
   methods: {
     validateCIDR() {
-      const exceptCidrs = this.value[TARGET_OPTION_IP_BLOCK]?.except || [];
+      const exceptCidrs = this.value[TARGET_OPTIONS.IP_BLOCK]?.except || [];
 
       this.invalidCidrs = exceptCidrs
         .filter(cidr => !isValidCIDR(cidr))
         .map(invalidCidr => invalidCidr || '<blank>');
 
-      if (this.value[TARGET_OPTION_IP_BLOCK]?.cidr && !isValidCIDR(this.value[TARGET_OPTION_IP_BLOCK].cidr)) {
-        this.invalidCidr = this.value[TARGET_OPTION_IP_BLOCK].cidr;
+      if (this.value[TARGET_OPTIONS.IP_BLOCK]?.cidr && !isValidCIDR(this.value[TARGET_OPTIONS.IP_BLOCK].cidr)) {
+        this.invalidCidr = this.value[TARGET_OPTIONS.IP_BLOCK].cidr;
       } else {
         this.invalidCidr = null;
       }
@@ -207,11 +206,11 @@ export default {
         />
       </div>
     </div>
-    <div v-if="targetType === TARGET_OPTION_IP_BLOCK">
+    <div v-if="targetType === TARGET_OPTIONS.IP_BLOCK">
       <div class="row">
         <div class="col span-6">
           <LabeledInput
-            v-model="value[TARGET_OPTION_IP_BLOCK].cidr"
+            v-model="value[TARGET_OPTIONS.IP_BLOCK].cidr"
             :mode="mode"
             :placeholder="t('networkpolicy.rules.ipBlock.cidr.placeholder')"
             :label="t('networkpolicy.rules.ipBlock.cidr.label')"
@@ -231,7 +230,7 @@ export default {
       <div class="row mt-20">
         <div class="col span-12">
           <ArrayList
-            v-model="value[TARGET_OPTION_IP_BLOCK].except"
+            v-model="value[TARGET_OPTIONS.IP_BLOCK].except"
             :add-label="t('networkpolicy.rules.ipBlock.addExcept')"
             :mode="mode"
             :show-header="true"
@@ -251,7 +250,7 @@ export default {
         </div>
       </div>
     </div>
-    <div v-if="targetType === TARGET_OPTION_POD_SELECTOR">
+    <div v-if="targetType === TARGET_OPTIONS.POD_SELECTOR">
       <div class="row">
         <div class="col span-12">
           <Banner color="success">
@@ -271,7 +270,7 @@ export default {
         </div>
       </div>
     </div>
-    <div v-if="targetType === TARGET_OPTION_NAMESPACE_SELECTOR">
+    <div v-if="targetType === TARGET_OPTIONS.NAMESPACE_SELECTOR">
       <div class="row">
         <div class="col span-12">
           <Banner color="success">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7660
<!-- Define findings related to the feature or bug issue. -->

This PR will introduce the possibility to define a single `to/from` entry that specifies both `namespaceSelector` _and_ `podSelector` that selects particular Pods within particular namespaces.

see k8s doc: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors