### PR TITLE
Add missing '/' to the ROUTER_BASE in build-hosted

### DIFF
--- a/scripts/build-hosted
+++ b/scripts/build-hosted
@@ -25,4 +25,4 @@ BASE=${BASE:-https://releases.rancher.com/dashboard/${DIR}}
 
 echo "Building for ${BASE}..."
 
-COMMIT=${COMMIT} VERSION=${VERSION} OUTPUT_DIR=dist/${DIR} ROUTER_BASE="/dashboard" RESOURCE_BASE="${BASE}" yarn run build
+COMMIT=${COMMIT} VERSION=${VERSION} OUTPUT_DIR=dist/${DIR} ROUTER_BASE="/dashboard/" RESOURCE_BASE="${BASE}" yarn run build


### PR DESCRIPTION
The missing ending '/' was causing the router to parse routes incorrectly

Verified using this build `https://releases.rancher.com/dashboard/prod-dashboard-dev/index.html`