### PR TITLE
[2.7.2] Correct base path with absolute value for RKE2 CIS hardening documentation and avoid banner on creation

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1774,7 +1774,7 @@ cluster:
     banner:
       psaChange: PSACT is now set to Rancher default automatically
       cisOverride: Changing this setting may affect cluster security as it overrides default CIS settings
-      cisUnsupported: The selected Kubernetes Version no longer supports CIS Profile "{cisProfile}". Please select a supported profile. We recommend reviewing the <a href="{docsBase}/security/hardening_guide" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to evaluate the impact of changing the CIS Profile.
+      cisUnsupported: The selected Kubernetes Version no longer supports CIS Profile "{cisProfile}". Please select a supported profile. We recommend reviewing the <a href="https://docs.rke2.io/security/hardening_guide" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to evaluate the impact of changing the CIS Profile.
     modal:
       pspChange:
         title: Pod Security Policy deprecation

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2212,7 +2212,7 @@ export default {
           />
 
           <Banner
-            v-if="showCisProfile && !isCisSupported"
+            v-if="showCisProfile && !isCisSupported && isEdit"
             color="info"
           >
             <p v-html="t('cluster.rke2.banner.cisUnsupported', {cisProfile: serverConfig.profile || agentConfig.profile}, true)" />


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/8123
Backport https://github.com/rancher/dashboard/pull/8396