### PR TITLE
allow users who can view roles to see the users & auth product

### DIFF
--- a/shell/config/product/auth.js
+++ b/shell/config/product/auth.js
@@ -27,7 +27,7 @@ export function init(store) {
 
   product({
     ifHaveType:          new RegExp(`${ MANAGEMENT.USER }|${ MANAGEMENT.AUTH_CONFIG }`, 'i'),
-    ifHaveVerb:          'PUT',
+    ifHaveVerb:          'GET',
     ifFeature:           MULTI_CLUSTER,
     inStore:             'management',
     icon:                'user',
@@ -43,7 +43,8 @@ export function init(store) {
     name:       'config',
     weight:     -1,
     route:      { name: 'c-cluster-auth-config' },
-    ifHaveType: MANAGEMENT.AUTH_CONFIG
+    ifHaveType: MANAGEMENT.AUTH_CONFIG,
+    ifHaveVerb: 'PUT'
   });
 
   virtualType({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8344
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the Users & Auth product to better accomodate custom roles. Previously the product was only visible to users who can edit users and/or auth configs.

### Technical notes summary
The auth config pages are created with the assumption that anyone viewing them can edit authconfigs. I did look into making this work with view-only permissions but it would require fairly substantial changes to look and behave correctly for users who can only view authconfigs. That would require re-verifying enabling, disabling, and editing every supported auth provider which is quite a lot to dump on QA for such an unlikely use-case; consequently, this PR keeps those pages hidden from users who only have get/list permissions for authconfigs. 

### Areas or cases that should be tested
1. Standard users with a custom role to get/list global roles should be able to see that section of the users & auth product
   a. These users shouldn't see any options for creating nor editing roles eg no 'create' button, nothing about it in the action menu
3. Standard users with a custom role to get/list authconfigs should *not* be able to see the auth provider section of the users & auth product
4. The above 2 scenarios should apply to user base users as well
5. The built in roles for configuring auth providers and managing users should still work as expected.

Additional note: Every user can list cluster roles, project roles, and their own user object, so those lists are always visible within users & auth.
