### PR TITLE
Fix error listing clusters for a base user (fix for master branch)

### DIFF
--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -103,7 +103,7 @@ export default class ProvCluster extends SteveModel {
     const clusterTemplatesSchema = this.$getters['schemaFor']('management.cattle.io.clustertemplate');
     let canUpdateClusterTemplate = false;
 
-    if (clusterTemplatesSchema && (clusterTemplatesSchema.resourceMethods.includes('blocked-PUT') || clusterTemplatesSchema.resourceMethods.includes('PUT'))) {
+    if (clusterTemplatesSchema && (clusterTemplatesSchema.resourceMethods?.includes('blocked-PUT') || clusterTemplatesSchema.resourceMethods?.includes('PUT'))) {
       canUpdateClusterTemplate = true;
     }
 


### PR DESCRIPTION
**Updating master with the fix**

Fixes #8393 

- add check to `resourceMethods` property so that UI doesn't fail when `clusterTemplatesSchema` is empty due to restricted access by the user

### To test:
- Provision a `rancher - 2.7-head commit id: 70455b1 ` system
- As an admin, create a `base user` and add `Create new Cluster` role and `Create new RKE Cluster Templates` role.
- Login as the user just created
- Create an RKE1 cluster (use Digital Ocean, for example)
- Check that the `Cluster Management` page or the `homepage` doesn't break when displaying the list of clusters