### PR TITLE
Add extension translation docs

### DIFF
--- a/docusaurus/docs/code-base-works/on-screen-text-and-translations.md
+++ b/docusaurus/docs/code-base-works/on-screen-text-and-translations.md
@@ -1,7 +1,7 @@
 
 # On-screen Text and Translations
 
-This page covers Internationalisation (i18n) and localisation (i10n).
+This page covers Internationalisation (i18n) and localisation (l10n).
 
 
 ## Internationalization (i18n)
@@ -58,7 +58,7 @@ For example, if we want to dynamically fill in the description of a resource bas
 
 In this case, the quotation marks are required because some Secret types, such as `kubernetes.io/basic-auth`, include a slash.
 
-## i10n 
+## l10n 
 
 Localisation files can be found in `./assets/translations/en-us.yaml`.
 

--- a/docusaurus/docs/extensions/advanced.md
+++ b/docusaurus/docs/extensions/advanced.md
@@ -1,5 +1,11 @@
 # Miscellaneous
 
+## Translations and Localizations
+
+Extensive documentation on translations and localizations can be found in the [On-screen Text and Translations](../code-base-works/on-screen-text-and-translations.md) section. Apart from directory location, the same rules for Rancher Dashboard apply for extensions.
+
+Generating localizations in extensions is done per package via a translation YAML file found in the `./pkg/<extension-name>/l10n` directory. If a translation is not included in the user's selected language, it will fall back to English.
+
 ## Using yarn link
 
 You may want to develop your extension with the very latest dashboard code rather than the code published in the `@rancher/shell` npm module.


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Reference #8310 

This adds information for extensions regarding translations. Since the existing documentation for localization is rather extensive and applies, I felt we could reuse this as much as possible.
Also updated the title for Localization to `l10n` from `i10n`.  