### PR TITLE
Fixing the create app files

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -37,6 +37,7 @@
     "@innologica/vue-dropdown-menu": "0.1.3",
     "@novnc/novnc": "1.2.0",
     "@nuxt/types": "2.14.6",
+    "@nuxt/typescript-build": "2.1.0",
     "@nuxtjs/axios": "5.12.0",
     "@nuxtjs/eslint-config-typescript": "6.0.1",
     "@nuxtjs/eslint-module": "1.2.0",
@@ -47,6 +48,8 @@
     "@types/node": "16.4.3",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
+    "@vue/cli-plugin-babel": "4.5.15",
+    "@vue/cli-plugin-typescript": "4.5.15",
     "@vue/cli-service": "4.5.15",
     "@vue/test-utils": "1.2.1",
     "@vue/vue2-jest": "27.0.0",
@@ -150,8 +153,5 @@
       ".js",
       ".vue"
     ]
-  },
-  "devDependencies": {
-    "@vue/cli": "4.5.15"
   }
 }


### PR DESCRIPTION
It turns out the dependency changes that were made from Nuxt removal were causing problems with create app and this just reverts those changes.

I've verified each of these commands work:
- `yarn build`
- `yarn dev`
- `./shell/scripts/test-plugins-build.sh`
- `docker build --no-cache -t "test:Dockerfile" .`

fixes rancher/dashboard#8376

### Notes
- I will turn the workflow back on and notify our dev channel once this gets merged
- I attempted to switch back to Typescript but still no luck yet so I've opened this https://github.com/rancher/dashboard/issues/8428