### PR TITLE
[2.7.2] Fix route collisions with /:product routes

### DIFF
--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -35,7 +35,7 @@ import { getVersionInfo, markSeenReleaseNotes } from '@shell/utils/version';
 import { sortBy } from '@shell/utils/sort';
 import PageHeaderActions from '@shell/mixins/page-actions';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
-import { getProductFromRoute } from '@shell/middleware/authenticated';
+import { getClusterFromRoute, getProductFromRoute } from '@shell/middleware/authenticated';
 import { BOTTOM } from '@shell/utils/position';
 import { BLANK_CLUSTER } from '@shell/store';
 
@@ -202,7 +202,7 @@ export default {
      */
     clusterAndRouteReady() {
       return this.clusterReady &&
-        this.clusterId === this.$route?.params?.cluster &&
+        this.clusterId === getClusterFromRoute(this.$route) &&
         this.currentProduct?.name === getProductFromRoute(this.$route);
     },
 

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -28,6 +28,30 @@ const getPackageFromRoute = (route) => {
 
 let beforeEachSetup = false;
 
+function findMeta(route, key) {
+  if (route?.meta) {
+    const meta = Array.isArray(route.meta) ? route.meta : [route.meta];
+
+    for (let i = 0; i < meta.length; i++) {
+      if (meta[i][key]) {
+        return meta[i][key];
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function getClusterFromRoute(to) {
+  let cluster = to.params?.cluster;
+
+  if (!cluster) {
+    cluster = findMeta(to, 'cluster');
+  }
+
+  return cluster;
+}
+
 export function getProductFromRoute(to) {
   let product = to.params?.product;
 
@@ -37,6 +61,11 @@ export function getProductFromRoute(to) {
     if ( match ) {
       product = match[1];
     }
+  }
+
+  // If still no product, see if the route indicates the product via route metadata
+  if (!product) {
+    product = findMeta(to, 'product');
   }
 
   return product;
@@ -278,6 +307,11 @@ export default async function({
 
   try {
     let clusterId = get(route, 'params.cluster');
+
+    // Route can provide cluster ID via metadata
+    if (!clusterId && route) {
+      clusterId = getClusterFromRoute(route);
+    }
 
     const pkg = getPackageFromRoute(route);
     const product = getProductFromRoute(route);


### PR DESCRIPTION
Fixes issue with route collisions in extensions.

Ensures any routes starting `/:product` have the product name instead. Uses route metadata to record product and cluster and uses this in the authenticated middleware since we rely on a product and cluster.