### PR TITLE
fix sort order of rke2/k3s kubernetes version list

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1313,8 +1313,9 @@ cluster:
   manageAction: Manage
   kubernetesVersion:
     label: Kubernetes Version
-    experimental: experimental
-    deprecated: deprecated
+    current: (current)
+    experimental: (experimental)
+    deprecated: (deprecated)
     deprecatedPatches: Show deprecated Kubernetes patch versions
     deprecatedPatchWarning: We recommend using the latest patch version for each minor Kubernetes version. Deprecated patch versions can be useful for migration purposes.
   toolsTip: Use the new Cluster Tools to manage and install Monitoring, Logging and other tools

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -427,8 +427,8 @@ export default {
       const existingRke2 = this.mode === _EDIT && cur.includes('rke2');
       const existingK3s = this.mode === _EDIT && cur.includes('k3s');
 
-      let allValidRke2Versions = this.getAllOptionsAfterMinVersion(this.rke2Versions, (existingRke2 ? cur : null), this.defaultRke2);
-      let allValidK3sVersions = this.getAllOptionsAfterMinVersion(this.k3sVersions, (existingK3s ? cur : null), this.defaultK3s);
+      let allValidRke2Versions = this.getAllOptionsAfterCurrentVersion(this.rke2Versions, (existingRke2 ? cur : null), this.defaultRke2);
+      let allValidK3sVersions = this.getAllOptionsAfterCurrentVersion(this.k3sVersions, (existingK3s ? cur : null), this.defaultK3s);
 
       if (!this.showDeprecatedPatchVersions) {
         // Normally, we only want to show the most recent patch version
@@ -463,8 +463,6 @@ export default {
 
         if ( existing ) {
           existing.disabled = false;
-        } else {
-          out.unshift({ label: `${ cur } (current)`, value: cur });
         }
       }
 
@@ -863,7 +861,7 @@ export default {
       const first = all[0]?.value;
       const preferred = all.find(x => x.value === this.defaultRke2)?.value;
 
-      const rke2 = this.getAllOptionsAfterMinVersion(this.rke2Versions, null);
+      const rke2 = this.getAllOptionsAfterCurrentVersion(this.rke2Versions, null);
       const showRke2 = rke2.length;
       let out;
 
@@ -1699,21 +1697,32 @@ export default {
       set(this.value.spec.rkeConfig.registries, 'configs', configs);
     },
 
-    getAllOptionsAfterMinVersion(versions, minVersion, defaultVersion) {
+    getAllOptionsAfterCurrentVersion(versions, currentVersion, defaultVersion) {
       const out = (versions || []).filter(obj => !!obj.serverArgs).map((obj) => {
         let disabled = false;
         let experimental = false;
+        let isCurrentVersion = false;
+        let label = obj.id;
 
-        if ( minVersion ) {
-          disabled = compare(obj.id, minVersion) < 0;
+        if ( currentVersion ) {
+          disabled = compare(obj.id, currentVersion) < 0;
+          isCurrentVersion = compare(obj.id, currentVersion) === 0;
         }
 
         if ( defaultVersion ) {
           experimental = compare(defaultVersion, obj.id) < 0;
         }
 
+        if (isCurrentVersion) {
+          label = `${ label } ${ this.t('cluster.kubernetesVersion.current') }`;
+        }
+
+        if (experimental) {
+          label = `${ label } ${ this.t('cluster.kubernetesVersion.experimental') }`;
+        }
+
         return {
-          label:      obj.id + (experimental ? ` (${ this.t('cluster.kubernetesVersion.experimental') })` : ''),
+          label,
           value:      obj.id,
           sort:       sortable(obj.id),
           serverArgs: obj.serverArgs,
@@ -1722,6 +1731,15 @@ export default {
           disabled,
         };
       });
+
+      if (currentVersion && !out.find(obj => obj.value === currentVersion)) {
+        out.push({
+          label: `${ currentVersion } ${ this.t('cluster.kubernetesVersion.current') }`,
+          value: currentVersion,
+          sort:  sortable(currentVersion),
+        });
+      }
+
       const sorted = sortBy(out, 'sort:desc');
 
       const mostRecentPatchVersions = this.getMostRecentPatchVersions(sorted);
@@ -1735,7 +1753,7 @@ export default {
 
         return {
           ...optionData,
-          label: `${ optionData.label } (${ this.t('cluster.kubernetesVersion.deprecated') })`
+          label: `${ optionData.label } ${ this.t('cluster.kubernetesVersion.deprecated') }`
         };
       });
 
@@ -1773,7 +1791,7 @@ export default {
         const majorMinor = `${ semver.major(version.value) }.${ semver.minor(version.value) }`;
 
         // Always show current version, else show if we haven't shown anything for this major.minor version yet
-        if (version === currentVersion || mostRecentPatchVersions[majorMinor] === version.value) {
+        if (version.value === currentVersion || mostRecentPatchVersions[majorMinor] === version.value) {
           return true;
         }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8440 
### Occurred changes and/or fixed issues
This issue occurred because we were pushing the current version into the sorted list of kubernetes versions if it wasn't present already. This PR updates the version sorting and filtering logic to include the current version in the correct place in the list, even if it is not an 'available' version, by modifying the `getAllOptionsAfterCurrentVersion` method in which sorting occurs.

At the same time I noticed some other inconsistent behavior in this list. We were only appending `(current)` if the current version wasn't in the list of available versions; I think we should indicate which version is currently selected either way. Same deal with the `(deprecated)` label.



### Areas or cases that should be tested
1. Upgrading an rke2 cluster whose version isn't in the list of available versions by default (I used the edit-as-yaml option to provision such a cluster on 2.7-head)
2. Upgrading an rke2 cluster whose version _is_ in the list of available versions



<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
![Screen Shot 2023-03-17 at 8 16 49 AM](https://user-images.githubusercontent.com/42977925/225946368-3e8a3deb-c5e4-4c33-b6c0-63520efefd85.png)

![Screen Shot 2023-03-17 at 8 16 55 AM](https://user-images.githubusercontent.com/42977925/225946365-d8fd78ae-948a-4c6f-8d29-bc6015f637f7.png)

![Screen Shot 2023-03-17 at 8 17 05 AM](https://user-images.githubusercontent.com/42977925/225946362-899ccab0-9f46-46e8-95a0-4f22e77e508b.png)
