### PR TITLE
Modify PSP deprecation warning message when upgrading a K3s custom cluster to v1.25

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1779,7 +1779,7 @@ cluster:
     modal:
       pspChange:
         title: Pod Security Policy deprecation
-        body: Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If your cluster has PodSecurityPolicy admission controller enabled via "kube-apiserver-arg.enable-admission-plugins" in Cluster YAML, it has to be MANUALLY removed before proceeding with the upgrade. Additionally, any PSPs that may be present in the cluster will no longer be available/enforced. Proceed?
+        body: Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If your cluster has PodSecurityPolicy admission controller enabled via "kube-apiserver-arg.enable-admission-plugins" in Cluster YAML, it has to be <i>manually</i> removed before proceeding with the upgrade. Additionally, any PSPs that may be present in the cluster will no longer be available/enforced. Do you want to proceed?
     snapshots:
       suffix: Snapshots per node
     systemService:

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -3,6 +3,7 @@ import AsyncButton from '@shell/components/AsyncButton';
 import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
 import { exceptionToErrorsArray } from '@shell/utils/error';
+import { decodeHtml } from '@shell/utils/string';
 
 export default {
   components: {
@@ -41,6 +42,7 @@ export default {
   },
 
   methods: {
+    decodeHtml,
     close() {
       this.confirm(false);
       this.$emit('close', false);
@@ -57,7 +59,7 @@ export default {
         buttonDone(false);
       }
     }
-  }
+  },
 };
 </script>
 
@@ -76,8 +78,7 @@ export default {
       <slot name="body">
         <div
           class="pl-10 pr-10"
-          style="min-height: 50px; display: flex;"
-          v-html="body"
+          v-html="decodeHtml(body)"
         />
       </slot>
     </template>

--- a/shell/utils/__tests__/string.test.ts
+++ b/shell/utils/__tests__/string.test.ts
@@ -1,0 +1,12 @@
+import { decodeHtml } from '@shell/utils/string';
+
+describe('fx: decodeHtml', () => {
+  it('should decode HTML values from escaped string into valid markup', () => {
+    const text = '&lt;i&gt;whatever&lt;/i&gt;';
+    const expectation = `<i>whatever</i>`;
+
+    const result = decodeHtml(text);
+
+    expect(result).toStrictEqual(expectation);
+  });
+});

--- a/shell/utils/string.js
+++ b/shell/utils/string.js
@@ -60,6 +60,19 @@ export function escapeHtml(html) {
   });
 }
 
+/**
+ * Return HTML markup from escaped HTML string, allowing specific tags
+ * @param text string
+ * @returns string
+ */
+export function decodeHtml(text) {
+  const div = document.createElement('div');
+
+  div.innerHTML = text;
+
+  return div.textContent || div.innerText || '';
+}
+
 export function escapeRegex(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8384
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Updated text as indicated in the issue

### Technical notes summary
- Enabled HTML injection within modal content
- Created test and utility to decode encoded HTML using DOM APIs

Note: [VueJS automatically escapes](https://vuejs.org/guide/best-practices/security.html#best-practices) all the strings passed as props to the components for XSS.
Since we systematically already pass HTML for i18n values, we can as well for this component.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/225973186-ad5322e8-9f1d-4965-b185-f3a55f7303a1.mov

