### PR TITLE
Disallow `v-html` usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -166,7 +166,7 @@ module.exports = {
     // Vue/HTML Formatting kept for HARVESTER ONLY!
     // TODO: Move back here the HTML formatting
     'vue/html-self-closing': 'off',
-    'vue/no-v-html':         'off',
+    'vue/no-v-html':         'error',
   },
   overrides: [
     {
@@ -194,7 +194,7 @@ module.exports = {
       excludedFiles: ['pkg/harvester/**/*.vue'],
       rules:         {
         // Vue/HTML Formatting
-        'vue/no-v-html':                    'off',
+        'vue/no-v-html':                    'error',
         'vue/html-indent':                  ['error', 2],
         'vue/html-closing-bracket-newline': ['error', {
           singleline: 'never',

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "@nuxtjs/eslint-module": "1.2.0",
     "@nuxtjs/style-resources": "1.2.1",
     "@types/copy-webpack-plugin": "^5.0.3",
+    "@types/dompurify": "^3.0.0",
     "@types/jest": "27.4.1",
     "@types/lodash": "4.14.184",
     "@types/node": "16.4.3",

--- a/pkg/epinio/list/namespaces.vue
+++ b/pkg/epinio/list/namespaces.vue
@@ -140,7 +140,7 @@ export default {
       >
         <h4
           slot="title"
-          v-html="t('epinio.namespace.create')"
+          v-clean-html="t('epinio.namespace.create')"
         />
         <div
           slot="body"

--- a/pkg/epinio/windowComponents/ApplicationLogs.vue
+++ b/pkg/epinio/windowComponents/ApplicationLogs.vue
@@ -361,13 +361,13 @@ export default {
               >
                 <td
                   :key="line.id + '-time'"
+                  v-clean-html="format(line.time)"
                   class="time"
-                  v-html="format(line.time)"
                 />
                 <td
                   :key="line.id + '-msg'"
+                  v-clean-html="line.msg"
                   class="msg"
-                  v-html="line.msg"
                 />
               </tr>
             </template>

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -186,7 +186,7 @@ export default {
         <div>{{ t('harvesterManager.cluster.description') }}</div>
       </div>
       <div class="tagline sub-tagline">
-        <div v-html="t('harvesterManager.cluster.learnMore', {}, true)" />
+        <div v-clean-html="t('harvesterManager.cluster.learnMore', {}, true)" />
       </div>
     </div>
   </div>

--- a/pkg/harvester/components/UpgradeInfo.vue
+++ b/pkg/harvester/components/UpgradeInfo.vue
@@ -25,7 +25,7 @@ export default {
   <div>
     <Banner color="warning">
       <strong>{{ t('harvester.upgradePage.upgradeInfo.warning') }}:</strong>
-      <p class="mb-5" v-html="t('harvester.upgradePage.upgradeInfo.doc', {}, true)">
+      <p v-clean-html="t('harvester.upgradePage.upgradeInfo.doc', {}, true)" class="mb-5">
       </p>
 
       <p class="mb-5">

--- a/pkg/harvester/dialog/ConfirmRelatedToRemoveDialog.vue
+++ b/pkg/harvester/dialog/ConfirmRelatedToRemoveDialog.vue
@@ -133,12 +133,12 @@ export default {
     </h4>
     <div slot="body" class="pl-10 pr-10">
       <span
-        v-html="t(warningMessageKey, { type, names: resourceNames }, true)"
+        v-clean-html="t(warningMessageKey, { type, names: resourceNames }, true)"
       ></span>
 
       <div class="mt-10 mb-10">
         <span
-          v-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+          v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
         ></span>
       </div>
       <div class="mb-10">

--- a/pkg/harvester/dialog/HarvesterAddHotplugModal.vue
+++ b/pkg/harvester/dialog/HarvesterAddHotplugModal.vue
@@ -110,7 +110,7 @@ export default {
 
 <template>
   <Card ref="modal" name="modal" :show-highlight-border="false">
-    <h4 slot="title" class="text-default-text" v-html="t('harvester.modal.hotplug.title')" />
+    <h4 slot="title" v-clean-html="t('harvester.modal.hotplug.title')" class="text-default-text" />
 
     <template #body>
       <LabeledInput

--- a/pkg/harvester/dialog/HarvesterBackupModal.vue
+++ b/pkg/harvester/dialog/HarvesterBackupModal.vue
@@ -90,8 +90,8 @@ export default {
   <Card :show-highlight-border="false">
     <h4
       slot="title"
+      v-clean-html="t('harvester.modal.backup.addBackup')"
       class="text-default-text"
-      v-html="t('harvester.modal.backup.addBackup')"
     />
 
     <template #body>

--- a/pkg/harvester/dialog/HarvesterUnplugVolume.vue
+++ b/pkg/harvester/dialog/HarvesterUnplugVolume.vue
@@ -81,8 +81,8 @@ export default {
   <Card ref="modal" name="modal" :show-highlight-border="false">
     <h4
       slot="title"
+      v-clean-html="t('harvester.virtualMachine.unplug.title', { name: diskName })"
       class="text-default-text"
-      v-html="t('harvester.virtualMachine.unplug.title', { name: diskName })"
     />
 
     <div slot="actions" class="actions">

--- a/pkg/harvester/edit/harvesterhci.io.setting.vue
+++ b/pkg/harvester/edit/harvesterhci.io.setting.vue
@@ -164,9 +164,9 @@ export default {
     @finish="saveSettings"
     @cancel="done"
   >
-    <h4 v-html="description"></h4>
+    <h4 v-clean-html="description"></h4>
 
-    <h5 v-if="editHelp" class="edit-help" v-html="editHelp" />
+    <h5 v-if="editHelp" v-clean-html="editHelp" class="edit-help" />
 
     <div class="edit-change mt-20">
       <h5 v-t="'advancedSettings.edit.changeSetting'" />

--- a/pkg/harvester/list/harvesterhci.io.setting.vue
+++ b/pkg/harvester/list/harvesterhci.io.setting.vue
@@ -173,7 +173,7 @@ export default {
               Modified
             </span>
           </h1>
-          <h2 v-html="t(setting.description, {}, true)">
+          <h2 v-clean-html="t(setting.description, {}, true)">
           </h2>
         </div>
         <div v-if="setting.hasActions" :id="setting.id" class="action">

--- a/pkg/harvester/list/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -111,7 +111,7 @@ export default {
     <template #group-by="group">
       <div class="group-bar">
         <div class="group-tab">
-          <div class="project-name" v-html="templateLabel(group.group)" />
+          <div v-clean-html="templateLabel(group.group)" class="project-name" />
         </div>
 
         <div class="right">

--- a/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
@@ -134,7 +134,7 @@ export default {
 <template>
   <div class="mt-10">
     {{ t('promptRemove.attemptingToRemove', {type}) }}
-    <span v-html="resourceNames(names, plusMore, t)"></span>
+    <span v-clean-html="resourceNames(names, plusMore, t)"></span>
 
     <div class="mt-10">
       {{ t('harvester.virtualMachine.promptRemove.title') }}

--- a/pkg/rancher-components/src/components/Banner/Banner.test.ts
+++ b/pkg/rancher-components/src/components/Banner/Banner.test.ts
@@ -1,10 +1,18 @@
 import { mount } from '@vue/test-utils';
 import { Banner } from './index';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive'
 
 describe('component: Banner', () => {
   it('should display text based on label', () => {
     const label = 'test';
-    const wrapper = mount(Banner, { propsData: { label } });
+    const wrapper = mount(
+      Banner,
+      {
+        directives: {
+         cleanHtmlDirective 
+        },
+        propsData: { label }
+      });
 
     const element = wrapper.find('span').element;
 

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -95,7 +95,7 @@ export default Vue.extend({
         <span v-else-if="messageLabel">{{ messageLabel }}</span>
         <span
           v-else
-          v-html="nlToBr(label)"
+          v-clean-html="nlToBr(label)"
         />
       </slot>
       <div

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -152,7 +152,7 @@ export default Vue.extend({
         v-if="label"
         :class="[ muteLabel ? 'text-muted' : '', 'radio-label', 'm-0']"
         :for="name"
-        v-html="label"
+        v-clean-html="label"
       >
         <slot name="label">{{ label }}</slot>
       </label>

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -225,7 +225,7 @@ export default {
     <div class="custom-overlay">
       <Banner color="info">
         <span
-          v-html="t('istio.customOverlayFile.tip', {}, true)"
+          v-clean-html="t('istio.customOverlayFile.tip', {}, true)"
         />
       </Banner>
       <YamlEditor

--- a/shell/chart/logging/index.vue
+++ b/shell/chart/logging/index.vue
@@ -70,8 +70,8 @@ export default {
           :tooltip="t('logging.install.tooltip', {}, true)"
         />
         <p
+          v-clean-html="t('logging.install.url', {}, true)"
           class="mt-6"
-          v-html="t('logging.install.url', {}, true)"
         />
       </div>
     </div>

--- a/shell/chart/monitoring/steps/uninstall-v1.vue
+++ b/shell/chart/monitoring/steps/uninstall-v1.vue
@@ -88,8 +88,8 @@ export default {
             {{ t('monitoring.installSteps.uninstallV1.warning1') }}
           </p>
           <p
+            v-clean-html="t('monitoring.installSteps.uninstallV1.warning2', {}, true)"
             class="mt-10"
-            v-html="t('monitoring.installSteps.uninstallV1.warning2', {}, true)"
           />
         </template>
       </IconMessage>
@@ -111,8 +111,8 @@ export default {
           {{ t('monitoring.installSteps.uninstallV1.success1') }}
         </p>
         <p
+          v-clean-html="t('monitoring.installSteps.uninstallV1.success2')"
           class="mt-10"
-          v-html="t('monitoring.installSteps.uninstallV1.success2')"
         />
       </template>
     </IconMessage>

--- a/shell/cloud-credential/aws.vue
+++ b/shell/cloud-credential/aws.vue
@@ -97,8 +97,8 @@ export default {
       @input="value.setData('defaultRegion', $event);"
     />
     <p
+      v-clean-html="t('cluster.credential.aws.defaultRegion.help', {}, true)"
       class="text-muted mt-5"
-      v-html="t('cluster.credential.aws.defaultRegion.help', {}, true)"
     />
   </div>
 </template>

--- a/shell/cloud-credential/digitalocean.vue
+++ b/shell/cloud-credential/digitalocean.vue
@@ -40,8 +40,8 @@ export default {
       @input="value.setData('accessToken', $event);"
     />
     <p
+      v-clean-html="t('cluster.credential.digitalocean.accessToken.help', {}, true)"
       class="text-muted mt-10"
-      v-html="t('cluster.credential.digitalocean.accessToken.help', {}, true)"
     />
   </div>
 </template>

--- a/shell/cloud-credential/gcp.vue
+++ b/shell/cloud-credential/gcp.vue
@@ -64,8 +64,8 @@ export default {
       @selected="onFileSelected"
     />
     <p
+      v-clean-html="t('cluster.credential.gcp.authEncodedJson.help', {}, true)"
       class="text-muted"
-      v-html="t('cluster.credential.gcp.authEncodedJson.help', {}, true)"
     />
   </div>
 </template>

--- a/shell/cloud-credential/linode.vue
+++ b/shell/cloud-credential/linode.vue
@@ -40,8 +40,8 @@ export default {
       @input="value.setData('token', $event);"
     />
     <p
+      v-clean-html="t('cluster.credential.linode.accessToken.help', {}, true)"
       class="text-muted mt-10"
-      v-html="t('cluster.credential.linode.accessToken.help', {}, true)"
     />
   </div>
 </template>

--- a/shell/cloud-credential/pnap.vue
+++ b/shell/cloud-credential/pnap.vue
@@ -72,8 +72,8 @@ export default {
     </div>
     <div class="row mt-5">
       <p
+        v-clean-html="t('cluster.credential.pnap.clientSecret.help', {}, true)"
         class="text-muted mt-10"
-        v-html="t('cluster.credential.pnap.clientSecret.help', {}, true)"
       />
     </div>
   </div>

--- a/shell/components/ActionMenu.vue
+++ b/shell/components/ActionMenu.vue
@@ -270,7 +270,7 @@ export default {
           class="icon"
           color="header"
         />
-        <span v-html="opt.label" />
+        <span v-clean-html="opt.label" />
       </li>
 
       <li

--- a/shell/components/AssignTo.vue
+++ b/shell/components/AssignTo.vue
@@ -118,8 +118,8 @@ export default {
     >
       <h4
         slot="title"
+        v-clean-html="t('assignTo.title', {count: resourceCount}, true)"
         class="text-default-text"
-        v-html="t('assignTo.title', {count: resourceCount}, true)"
       />
 
       <div

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -281,7 +281,7 @@ export default Vue.extend({
     <span
       v-if="labelAs === 'text' && displayLabel"
       v-tooltip="tooltip"
-      v-html="displayLabel"
+      v-clean-html="displayLabel"
     />
   </button>
 </template>

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -46,9 +46,9 @@ export default {
     </div>
     <h1
       v-else-if="title"
+      v-clean-html="title"
       data-testid="banner-title"
       class="title"
-      v-html="title"
     />
     <div
       v-if="pref"

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -465,7 +465,7 @@ export default {
                     <h5>
                       <span
                         v-if="$store.getters['i18n/exists'](subtype.label)"
-                        v-html="t(subtype.label)"
+                        v-clean-html="t(subtype.label)"
                       />
                       <span v-else>{{ subtype.label }}</span>
                     </h5>
@@ -484,7 +484,7 @@ export default {
                   >
                     <span
                       v-if="$store.getters['i18n/exists'](subtype.description)"
-                      v-html="t(subtype.description, {}, true)"
+                      v-clean-html="t(subtype.description, {}, true)"
                     />
                     <span v-else>{{ subtype.description }}</span>
                   </div>

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -169,8 +169,8 @@ export default {
 
     <span
       v-else
+      v-clean-html="bodyHtml"
       :class="{'conceal': concealed, 'monospace': monospace && !isBinary}"
-      v-html="bodyHtml"
     />
 
     <template v-if="!isBinary && !jsonStr && isLong && !expanded">

--- a/shell/components/DisableAuthProviderModal.vue
+++ b/shell/components/DisableAuthProviderModal.vue
@@ -49,7 +49,7 @@ export default {
       </h4>
       <div slot="body">
         <div class="mb-10">
-          <p v-html="t('promptRemove.attemptingToRemoveAuthConfig', null, true)" />
+          <p v-clean-html="t('promptRemove.attemptingToRemoveAuthConfig', null, true)" />
         </div>
       </div>
       <template #actions>

--- a/shell/components/EmberPage.vue
+++ b/shell/components/EmberPage.vue
@@ -522,8 +522,8 @@ export default {
     />
     <div
       v-if="inline && !loaded"
+      v-clean-html="t('generic.loading', {}, true)"
       class="inline-loading"
-      v-html="t('generic.loading', {}, true)"
     />
     <div
       v-if="error"

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -291,8 +291,8 @@ export default {
                 class="group-tab"
               >
                 <div
+                  v-clean-html="getProjectLabel(group)"
                   class="project-name"
-                  v-html="getProjectLabel(group)"
                 />
               </div>
               <div class="right">

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -368,8 +368,8 @@ export default {
             class="group-tab"
           >
             <div
+              v-clean-html="projectLabel(group.group)"
               class="project-name"
-              v-html="projectLabel(group.group)"
             />
             <div
               v-if="projectDescription(group.group)"

--- a/shell/components/FileDiff.vue
+++ b/shell/components/FileDiff.vue
@@ -98,8 +98,8 @@ export default {
     <resize-observer @notify="fit" />
     <div
       ref="root"
+      v-clean-html="html"
       class="root"
-      v-html="html"
     />
   </div>
 </template>

--- a/shell/components/LogItem.vue
+++ b/shell/components/LogItem.vue
@@ -36,8 +36,8 @@ export default {
   <div class="line">
     <span class="time">{{ format(source.time) }}</span>
     <span
+      v-clean-html="source.msg"
       class="msg"
-      v-html="source.msg"
     />
   </div>
 </template>

--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -77,8 +77,8 @@ export default {
 <template>
   <div
     v-if="loaded"
+    v-clean-html="sanitized"
     class="markdown"
-    v-html="sanitized"
   />
   <Loading v-else />
 </template>

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -343,7 +343,7 @@ export default {
         <div class="mb-10">
           <template v-if="!hasCustomRemove">
             {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-              v-html="resourceNames(names, plusMore, t)"
+              v-clean-html="resourceNames(names, plusMore, t)"
             />
           </template>
 
@@ -367,7 +367,7 @@ export default {
               class="mt-10"
             >
               <span
-                v-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+                v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
               />
             </div>
           </template>

--- a/shell/components/PromptRestore.vue
+++ b/shell/components/PromptRestore.vue
@@ -218,8 +218,8 @@ export default {
     >
       <h4
         slot="title"
+        v-clean-html="t('promptRestore.title', null, true)"
         class="text-default-text"
-        v-html="t('promptRestore.title', null, true)"
       />
 
       <div

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -177,8 +177,8 @@ export default {
   >
     <template #message>
       <span
+        v-clean-html="t('resourceList.nsFiltering', { resource: $store.getters['type-map/labelFor'](schema, 2) || customTypeDisplay }, true)"
         class="filter"
-        v-html="t('resourceList.nsFiltering', { resource: $store.getters['type-map/labelFor'](schema, 2) || customTypeDisplay }, true)"
       />
     </template>
   </IconMessage>

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -465,8 +465,8 @@ export default {
 
     <template #group-by="{group: thisGroup}">
       <div
+        v-clean-html="thisGroup.ref"
         class="group-tab"
-        v-html="thisGroup.ref"
       />
     </template>
 

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -242,7 +242,7 @@ export default {
             v-if="col.sort"
             v-tooltip="tooltip(col)"
           >
-            <span v-html="labelFor(col)" />
+            <span v-clean-html="labelFor(col)" />
             <i
               v-show="hasAdvancedFiltering && !col.isFilter"
               v-tooltip="t('sortableTable.tableHeader.noFilter')"

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -926,7 +926,7 @@ export default {
                   v-if="act.icon"
                   :class="act.icon"
                 />
-                <span v-html="act.label" />
+                <span v-clean-html="act.label" />
               </button>
               <ActionDropdown
                 :class="bulkActionsDropdownClass"
@@ -964,7 +964,7 @@ export default {
                         v-if="act.icon"
                         :class="act.icon"
                       />
-                      <span v-html="act.label" />
+                      <span v-clean-html="act.label" />
                     </li>
                   </ul>
                 </template>

--- a/shell/components/__tests__/AsyncButton.test.ts
+++ b/shell/components/__tests__/AsyncButton.test.ts
@@ -1,5 +1,6 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import AsyncButton, { ASYNC_BUTTON_STATES } from '@shell/components/AsyncButton.vue';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('component: AsyncButton', () => {
   it('should render appropriately with default config', () => {
@@ -7,7 +8,8 @@ describe('component: AsyncButton', () => {
     const mockT = jest.fn().mockReturnValue('some-string');
 
     const wrapper: Wrapper<InstanceType<typeof AsyncButton> & { [key: string]: any }> = mount(AsyncButton, {
-      mocks: {
+      directives: { cleanHtmlDirective },
+      mocks:      {
         $store: {
           getters: {
             'i18n/exists': mockExists,

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
 import { _EDIT, _YAML } from '@shell/config/query-params';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('component: CruResource', () => {
   it('should hide Cancel button', () => {
@@ -33,7 +34,8 @@ describe('component: CruResource', () => {
   it('should display multiple errors', () => {
     const errors = ['mistake!', 'BiG MiStAke11'];
     const wrapper = mount(CruResource, {
-      propsData: {
+      directives: { cleanHtmlDirective },
+      propsData:  {
         canYaml:  false,
         mode:     _EDIT,
         resource: {},

--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -66,9 +66,9 @@ export default {
         </div>
       </div>
       <div
+        v-clean-html="t('principal.loading', null, true)"
         class="name"
         :class="{'text-muted': useMuted}"
-        v-html="t('principal.loading', null, true)"
       />
       <div class="description" />
     </template>

--- a/shell/components/fleet/FleetNoWorkspaces.vue
+++ b/shell/components/fleet/FleetNoWorkspaces.vue
@@ -25,7 +25,7 @@ export default {
   <div class="intro-box">
     <i class="icon icon-repository" />
     <div class="title">
-      <span v-html="t('fleet.gitRepo.repo.noWorkspaces', null, true)" />
+      <span v-clean-html="t('fleet.gitRepo.repo.noWorkspaces', null, true)" />
     </div>
     <div
       v-if="canView"

--- a/shell/components/form/ResourceSelector.vue
+++ b/shell/components/form/ResourceSelector.vue
@@ -124,7 +124,7 @@ export default {
     <div class="row">
       <div class="col span-12">
         <Banner :color="(matchingResources.none ? 'warning' : 'success')">
-          <span v-html="t('generic.selectors.matchingResources.matchesSome', matchingResources)" />
+          <span v-clean-html="t('generic.selectors.matchingResources.matchesSome', matchingResources)" />
         </Banner>
       </div>
     </div>

--- a/shell/components/form/ServiceNameSelect.vue
+++ b/shell/components/form/ServiceNameSelect.vue
@@ -154,8 +154,8 @@ export default {
     <template v-if="serviceNameNew">
       <div class="row span-6">
         <Banner
+          v-clean-html="t('workload.serviceAccountName.createMessage', { name: serviceName }) "
           color="info"
-          v-html="t('workload.serviceAccountName.createMessage', { name: serviceName }) "
         />
       </div>
     </template>

--- a/shell/components/formatter/ServiceTargets.vue
+++ b/shell/components/formatter/ServiceTargets.vue
@@ -115,7 +115,7 @@ export default {
       :key="index"
       class="text-small"
     >
-      <span v-html="port.label" />
+      <span v-clean-html="port.label" />
     </div>
   </div>
 </template>

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -202,11 +202,11 @@ export default {
           :to="group.children[0].route"
           :exact="group.children[0].exact"
         >
-          <h6 v-html="group.labelDisplay || group.label" />
+          <h6 v-clean-html="group.labelDisplay || group.label" />
         </n-link>
         <h6
           v-else
-          v-html="group.labelDisplay || group.label"
+          v-clean-html="group.labelDisplay || group.label"
         />
       </slot>
       <i

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -90,9 +90,9 @@ export default {
       ><t :k="type.labelKey" /></span>
       <span
         v-else
+        v-clean-html="type.labelDisplay || type.label"
         class="label"
         :class="{'no-icon': !type.icon}"
-        v-html="type.labelDisplay || type.label"
       />
       <span
         v-if="showFavorite || showCount"

--- a/shell/creators/app/files/.eslintrc.js
+++ b/shell/creators/app/files/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     'unicorn/no-new-buffer':    'off',
     'vue/html-self-closing':    'off',
     'vue/no-unused-components': 'warn',
-    'vue/no-v-html':            'off',
+    'vue/no-v-html':            'on',
     'wrap-iife':                'off',
 
     'array-bracket-spacing':             'warn',

--- a/shell/creators/app/files/.eslintrc.js
+++ b/shell/creators/app/files/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     'unicorn/no-new-buffer':    'off',
     'vue/html-self-closing':    'off',
     'vue/no-unused-components': 'warn',
-    'vue/no-v-html':            'on',
+    'vue/no-v-html':            'error',
     'wrap-iife':                'off',
 
     'array-bracket-spacing':             'warn',

--- a/shell/detail/harvesterhci.io.management.cluster.vue
+++ b/shell/detail/harvesterhci.io.management.cluster.vue
@@ -81,17 +81,17 @@ export default {
       class="p-10"
     >
       <h4
-        v-html="t('cluster.harvester.registration.step1', null, true)"
+        v-clean-html="t('cluster.harvester.registration.step1', null, true)"
       />
 
       <h4
+        v-clean-html="t('cluster.harvester.registration.step2', null, true)"
         class="mt-10"
-        v-html="t('cluster.harvester.registration.step2', null, true)"
       />
 
       <h4
+        v-clean-html="t('cluster.harvester.registration.step3', null, true)"
         class="mt-10"
-        v-html="t('cluster.harvester.registration.step3', null, true)"
       />
       <CopyCode class="m-10 p-10">
         {{ registrationURL }}

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -727,11 +727,11 @@ export default {
               >
                 <div
                   v-if="group && group.ref"
-                  v-html="group.ref.groupByPoolShortLabel"
+                  v-clean-html="group.ref.groupByPoolShortLabel"
                 />
                 <div
                   v-else
-                  v-html="t('resourceTable.groupLabel.notInANodePool')"
+                  v-clean-html="t('resourceTable.groupLabel.notInANodePool')"
                 />
                 <div
                   v-if="group.ref && group.ref.template"
@@ -812,11 +812,11 @@ export default {
               >
                 <div
                   v-if="group.ref"
-                  v-html="t('resourceTable.groupLabel.nodePool', { name: group.ref.spec.hostnamePrefix}, true)"
+                  v-clean-html="t('resourceTable.groupLabel.nodePool', { name: group.ref.spec.hostnamePrefix}, true)"
                 />
                 <div
                   v-else
-                  v-html="t('resourceTable.groupLabel.notInANodePool')"
+                  v-clean-html="t('resourceTable.groupLabel.notInANodePool')"
                 />
                 <div
                   v-if="group.ref && group.ref.nodeTemplate"
@@ -888,13 +888,13 @@ export default {
               >
                 <td
                   :key="line.id + '-time'"
+                  v-clean-html="format(line.time)"
                   class="time"
-                  v-html="format(line.time)"
                 />
                 <td
                   :key="line.id + '-msg'"
+                  v-clean-html="line.msg"
                   class="msg"
-                  v-html="line.msg"
                 />
               </tr>
             </template>
@@ -932,22 +932,22 @@ export default {
           @copied-windows="hasWindowsMachine ? null : showWindowsWarning = true"
         />
         <template v-else>
-          <h4 v-html="t('cluster.import.commandInstructions', null, true)" />
+          <h4 v-clean-html="t('cluster.import.commandInstructions', null, true)" />
           <CopyCode class="m-10 p-10">
             {{ clusterToken.command }}
           </CopyCode>
 
           <h4
+            v-clean-html="t('cluster.import.commandInstructionsInsecure', null, true)"
             class="mt-10"
-            v-html="t('cluster.import.commandInstructionsInsecure', null, true)"
           />
           <CopyCode class="m-10 p-10">
             {{ clusterToken.insecureCommand }}
           </CopyCode>
 
           <h4
+            v-clean-html="t('cluster.import.clusterRoleBindingInstructions', null, true)"
             class="mt-10"
-            v-html="t('cluster.import.clusterRoleBindingInstructions', null, true)"
           />
           <CopyCode class="m-10 p-10">
             {{ t('cluster.import.clusterRoleBindingCommand', null, true) }}

--- a/shell/dialog/AddClusterMemberDialog.vue
+++ b/shell/dialog/AddClusterMemberDialog.vue
@@ -39,8 +39,8 @@ export default {
   >
     <h4
       slot="title"
+      v-clean-html="t('addClusterMemberDialog.title')"
       class="text-default-text"
-      v-html="t('addClusterMemberDialog.title')"
     />
 
     <div

--- a/shell/dialog/AddProjectMemberDialog.vue
+++ b/shell/dialog/AddProjectMemberDialog.vue
@@ -114,8 +114,8 @@ export default {
   >
     <h4
       slot="title"
+      v-clean-html="t('addProjectMemberDialog.title')"
       class="text-default-text"
-      v-html="t('addProjectMemberDialog.title')"
     />
 
     <div

--- a/shell/dialog/DiagnosticTimingsDialog.vue
+++ b/shell/dialog/DiagnosticTimingsDialog.vue
@@ -68,8 +68,8 @@ export default {
   >
     <h4
       slot="title"
+      v-clean-html="title"
       class="text-default-text"
-      v-html="title"
     />
 
     <template slot="body">

--- a/shell/dialog/ForceMachineRemoveDialog.vue
+++ b/shell/dialog/ForceMachineRemoveDialog.vue
@@ -83,7 +83,7 @@ export default {
       class="pl-10 pr-10"
     >
       <span
-        v-html="t('promptForceRemove.removeWarning', { nameToMatch }, true)"
+        v-clean-html="t('promptForceRemove.removeWarning', { nameToMatch }, true)"
       />
       <div class="mt-10 mb-10">
         {{ t('promptForceRemove.confirmName') }}

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -70,15 +70,16 @@ export default {
   >
     <h4
       slot="title"
+      v-clean-html="title"
       class="text-default-text"
-      v-html="title"
     />
 
     <template slot="body">
       <slot name="body">
         <div
+          v-clean-html="decodeHtml(body)"
           class="pl-10 pr-10"
-          v-html="decodeHtml(body)"
+          style="min-height: 50px; display: flex;"
         />
       </slot>
     </template>

--- a/shell/dialog/RotateEncryptionKeyDialog.vue
+++ b/shell/dialog/RotateEncryptionKeyDialog.vue
@@ -124,8 +124,8 @@ export default {
   >
     <h4
       slot="title"
+      v-clean-html="t('promptRotateEncryptionKey.title')"
       class="text-default-text"
-      v-html="t('promptRotateEncryptionKey.title')"
     />
 
     <div

--- a/shell/dialog/SaveAsRKETemplateDialog.vue
+++ b/shell/dialog/SaveAsRKETemplateDialog.vue
@@ -74,8 +74,8 @@ export default {
   >
     <h4
       slot="title"
+      v-clean-html="t('promptSaveAsRKETemplate.title', { cluster: cluster.displayName }, true)"
       class="text-default-text"
-      v-html="t('promptSaveAsRKETemplate.title', { cluster: cluster.displayName }, true)"
     />
 
     <div

--- a/shell/dialog/ScaleMachineDownDialog.vue
+++ b/shell/dialog/ScaleMachineDownDialog.vue
@@ -116,7 +116,7 @@ export default {
           <span
             v-for="i in ignored"
             :key="i.name"
-            v-html="t('promptScaleMachineDown.retainedMachine2', { name: i.name }, true)"
+            v-clean-html="t('promptScaleMachineDown.retainedMachine2', { name: i.name }, true)"
           />
         </div>
       </div>

--- a/shell/edit/auth/github.vue
+++ b/shell/edit/auth/github.vue
@@ -187,9 +187,9 @@ export default {
           class="step-box"
         >
           <ul class="step-list">
-            <li v-html="t(`authConfig.${NAME}.form.prefix.1`, tArgs, true)" />
-            <li v-html="t(`authConfig.${NAME}.form.prefix.2`, tArgs, true)" />
-            <li v-html="t(`authConfig.${NAME}.form.prefix.3`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.prefix.1`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.prefix.2`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.prefix.3`, tArgs, true)" />
           </ul>
         </InfoBox>
         <InfoBox
@@ -200,7 +200,7 @@ export default {
             <li>
               {{ t(`authConfig.${NAME}.form.instruction`, tArgs, true) }}
               <ul class="mt-10">
-                <li><b>{{ t(`authConfig.${NAME}.form.app.label`) }}</b>: <span v-html="t(`authConfig.${NAME}.form.app.value`, tArgs, true)" /></li>
+                <li><b>{{ t(`authConfig.${NAME}.form.app.label`) }}</b>: <span v-clean-html="t(`authConfig.${NAME}.form.app.value`, tArgs, true)" /></li>
                 <li>
                   <b>{{ t(`authConfig.${NAME}.form.homepage.label`) }}</b>: {{ serverUrl }} <CopyToClipboard
                     label-as="tooltip"
@@ -209,7 +209,7 @@ export default {
                     action-color="bg-transparent"
                   />
                 </li>
-                <li><b>{{ t(`authConfig.${NAME}.form.description.label`) }}</b>: <span v-html="t(`authConfig.${NAME}.form.description.value`, tArgs, true)" /></li>
+                <li><b>{{ t(`authConfig.${NAME}.form.description.label`) }}</b>: <span v-clean-html="t(`authConfig.${NAME}.form.description.value`, tArgs, true)" /></li>
                 <li>
                   <b>{{ t(`authConfig.${NAME}.form.callback.label`) }}</b>: {{ serverUrl }} <CopyToClipboard
                     :text="serverUrl"
@@ -227,8 +227,8 @@ export default {
           class="mb-20"
         >
           <ul class="step-list">
-            <li v-html="t(`authConfig.${NAME}.form.suffix.1`, tArgs, true)" />
-            <li v-html="t(`authConfig.${NAME}.form.suffix.2`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.suffix.1`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.suffix.2`, tArgs, true)" />
           </ul>
         </InfoBox>
 
@@ -255,8 +255,8 @@ export default {
         >
           <div class="col span-12">
             <Banner
+              v-clean-html="t('authConfig.associatedWarning', tArgs, true)"
               color="info"
-              v-html="t('authConfig.associatedWarning', tArgs, true)"
             />
           </div>
         </div>

--- a/shell/edit/auth/googleoauth.vue
+++ b/shell/edit/auth/googleoauth.vue
@@ -141,7 +141,7 @@ export default {
           :step="1"
           class=" mt-20 mb-20"
         >
-          <h3 v-html="t('authConfig.googleoauth.steps.1.title', tArgs, true)" />
+          <h3 v-clean-html="t('authConfig.googleoauth.steps.1.title', tArgs, true)" />
           <ul class="mt-0 step-list">
             <li>{{ t('authConfig.googleoauth.steps.1.body.1', {}, true) }} </li>
             <li>
@@ -165,7 +165,7 @@ export default {
           class="mb-20"
         >
           <div class="row">
-            <h3 v-html="t('authConfig.googleoauth.steps.2.title', tArgs, true)" />
+            <h3 v-clean-html="t('authConfig.googleoauth.steps.2.title', tArgs, true)" />
           </div>
           <div class="row">
             <div class="col span-6">
@@ -211,11 +211,11 @@ export default {
           class="mb-20"
         >
           <div class="row">
-            <h3 v-html="t('authConfig.googleoauth.steps.3.title', tArgs, true)" />
+            <h3 v-clean-html="t('authConfig.googleoauth.steps.3.title', tArgs, true)" />
           </div>
           <div class="row">
             <div class="col span-6">
-              <div v-html="t('authConfig.googleoauth.steps.3.introduction', tArgs, true)" />
+              <div v-clean-html="t('authConfig.googleoauth.steps.3.introduction', tArgs, true)" />
               <ul class="mt-10 step-list">
                 <li>{{ t('authConfig.googleoauth.steps.3.body.1', {}, true) }} </li>
                 <li>{{ t('authConfig.googleoauth.steps.3.body.2', {}, true) }} </li>
@@ -248,8 +248,8 @@ export default {
         >
           <div class="col span-12 google">
             <Banner
+              v-clean-html="t('authConfig.associatedWarning', tArgs, true)"
               color="info"
-              v-html="t('authConfig.associatedWarning', tArgs, true)"
             />
           </div>
         </div>

--- a/shell/edit/auth/ldap/index.vue
+++ b/shell/edit/auth/ldap/index.vue
@@ -148,8 +148,8 @@ export default {
       >
         <div class="col span-12">
           <Banner
+            v-clean-html="t('authConfig.associatedWarning', tArgs, true)"
             color="info"
-            v-html="t('authConfig.associatedWarning', tArgs, true)"
           />
         </div>
       </div>

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -277,8 +277,8 @@ export default {
       >
         <div class="col span-12">
           <Banner
+            v-clean-html="t('authConfig.associatedWarning', tArgs, true)"
             color="info"
-            v-html="t('authConfig.associatedWarning', tArgs, true)"
           />
         </div>
       </div>

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -257,8 +257,8 @@ export default {
       >
         <div class="col span-12">
           <Banner
+            v-clean-html="t('authConfig.associatedWarning', tArgs, true)"
             color="info"
-            v-html="t('authConfig.associatedWarning', tArgs, true)"
           />
         </div>
       </div>

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -322,7 +322,7 @@ export default {
                 class="mt-0"
                 :color="hasAlertManager ? 'info' : 'warning'"
               >
-                <span v-html="t('cis.alertNeeded', {link: monitoringUrl}, true)" />
+                <span v-clean-html="t('cis.alertNeeded', {link: monitoringUrl}, true)" />
               </banner>
               <Checkbox
                 v-model="scanAlertRule.alertOnComplete"

--- a/shell/edit/fleet.cattle.io.clustergroup.vue
+++ b/shell/edit/fleet.cattle.io.clustergroup.vue
@@ -148,15 +148,15 @@ export default {
     >
       <span
         v-if="matchingClusters.isAll"
-        v-html="t('fleet.clusterGroup.selector.matchesAll', matchingClusters)"
+        v-clean-html="t('fleet.clusterGroup.selector.matchesAll', matchingClusters)"
       />
       <span
         v-else-if="matchingClusters.isNone"
-        v-html="t('fleet.clusterGroup.selector.matchesNone', matchingClusters)"
+        v-clean-html="t('fleet.clusterGroup.selector.matchesNone', matchingClusters)"
       />
       <span
         v-else
-        v-html="t('fleet.clusterGroup.selector.matchesSome', matchingClusters)"
+        v-clean-html="t('fleet.clusterGroup.selector.matchesSome', matchingClusters)"
       />
     </Banner>
 

--- a/shell/edit/management.cattle.io.setting.vue
+++ b/shell/edit/management.cattle.io.setting.vue
@@ -122,8 +122,8 @@ export default {
 
     <h5
       v-if="editHelp"
+      v-clean-html="editHelp"
       class="edit-help"
-      v-html="editHelp"
     />
 
     <div class="edit-change mt-20">

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.vue
@@ -143,8 +143,8 @@ export default {
   <div>
     <Banner
       v-if="mode !== view"
+      v-clean-html="t('monitoringReceiver.webhook.banner', {}, raw=true)"
       color="info"
-      v-html="t('monitoringReceiver.webhook.banner', {}, raw=true)"
     />
     <div class="row mb-20">
       <LabeledSelect
@@ -166,8 +166,8 @@ export default {
     </div>
     <Banner
       v-if="showNamespaceBanner"
+      v-clean-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)"
       color="info"
-      v-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)"
     />
     <div class="row mb-20">
       <div class="col span-12">

--- a/shell/edit/monitoring.coreos.com.receiver/tls.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/tls.vue
@@ -36,8 +36,8 @@ export default {
       <div class="col span-12">
         <h3>{{ t('monitoring.receiver.tls.label') }}</h3>
         <Banner
+          v-clean-html="t('monitoring.receiver.tls.secretsBanner', {}, true)"
           color="info"
-          v-html="t('monitoring.receiver.tls.secretsBanner', {}, true)"
         />
       </div>
     </div>

--- a/shell/edit/monitoring.coreos.com.receiver/types/webhook.banner.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/webhook.banner.vue
@@ -22,7 +22,7 @@ export default {
 <template>
   <Banner
     v-if="model.length === 0 && !isView"
+    v-clean-html="t('monitoringReceiver.webhook.banner', {}, raw=true)"
     color="info"
-    v-html="t('monitoringReceiver.webhook.banner', {}, raw=true)"
   />
 </template>

--- a/shell/edit/monitoring.coreos.com.receiver/types/webhook.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/webhook.vue
@@ -50,8 +50,8 @@ export default {
     </div>
     <Banner
       v-if="showNamespaceBanner"
+      v-clean-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)"
       color="info"
-      v-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)"
     />
     <div class="row mb-20">
       <div class="col span-12">

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -269,7 +269,7 @@ export default {
       <div class="row">
         <div class="col span-12">
           <Banner color="success">
-            <span v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
+            <span v-clean-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
           </Banner>
         </div>
       </div>
@@ -289,7 +289,7 @@ export default {
       <div class="row">
         <div class="col span-12">
           <Banner color="success">
-            <span v-html="t('networkpolicy.selectors.matchingNamespaces.matchesSome', matchingNamespaces)" />
+            <span v-clean-html="t('networkpolicy.selectors.matchingNamespaces.matchesSome', matchingNamespaces)" />
           </Banner>
         </div>
       </div>
@@ -311,11 +311,11 @@ export default {
           <Banner color="success">
             <span
               v-if="!namespaceSelectorExpressions.length"
-              v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)"
+              v-clean-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)"
             />
             <span
               v-else
-              v-html="t('networkpolicy.selectors.matchingNamespacesAndPods.matchesSome', matchingNamespacesAndPods)"
+              v-clean-html="t('networkpolicy.selectors.matchingNamespacesAndPods.matchesSome', matchingNamespacesAndPods)"
             />
           </Banner>
         </div>

--- a/shell/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/index.vue
@@ -258,7 +258,7 @@ export default {
             <div class="row">
               <div class="col span-12">
                 <Banner color="success">
-                  <span v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
+                  <span v-clean-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
                 </Banner>
               </div>
             </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1977,7 +1977,7 @@ export default {
         v-if="isEdit"
         color="warning"
       >
-        <span v-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
+        <span v-clean-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
       </Banner>
     </div>
     <SelectCredential
@@ -2110,7 +2110,7 @@ export default {
             color="warning"
           >
             <span
-              v-html="t('cluster.harvester.warning.cloudProvider.incompatible', null, true)"
+              v-clean-html="t('cluster.harvester.warning.cloudProvider.incompatible', null, true)"
             />
           </Banner>
           <div class="row mb-10">
@@ -2215,7 +2215,7 @@ export default {
             v-if="showCisProfile && !isCisSupported && isEdit"
             color="info"
           >
-            <p v-html="t('cluster.rke2.banner.cisUnsupported', {cisProfile: serverConfig.profile || agentConfig.profile}, true)" />
+            <p v-clean-html="t('cluster.rke2.banner.cisUnsupported', {cisProfile: serverConfig.profile || agentConfig.profile}, true)" />
           </Banner>
 
           <div class="row mb-10">

--- a/shell/edit/resources.cattle.io.backup.vue
+++ b/shell/edit/resources.cattle.io.backup.vue
@@ -296,7 +296,7 @@ export default {
           v-else
           color="error"
         >
-          <span v-html="t('backupRestoreOperator.noResourceSet')" />
+          <span v-clean-html="t('backupRestoreOperator.noResourceSet')" />
         </Banner>
       </template>
     </CruResource>

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -390,7 +390,7 @@ export default {
         <div class="row">
           <div class="col span-12">
             <Banner :color="(matchingPods.none ? 'warning' : 'success')">
-              <span v-html="t('servicesPage.selectors.matchingPods.matchesSome', matchingPods)" />
+              <span v-clean-html="t('servicesPage.selectors.matchingPods.matchesSome', matchingPods)" />
             </Banner>
           </div>
         </div>

--- a/shell/edit/workload/__tests__/Job.test.ts
+++ b/shell/edit/workload/__tests__/Job.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils';
 import Job from '@shell/edit/workload/Job.vue';
 import { _EDIT } from '@shell/config/query-params';
 import { WORKLOAD_TYPES } from '@shell/config/types';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('component: Job', () => {
   describe('given CronJob types', () => {
@@ -10,7 +11,8 @@ describe('component: Job', () => {
       'failed',
     ])('should emit an update on %p input', (field) => {
       const wrapper = mount(Job, {
-        propsData: {
+        directives: { cleanHtmlDirective },
+        propsData:  {
           mode: _EDIT,
           type: WORKLOAD_TYPES.CRON_JOB
         }

--- a/shell/nuxt/index.js
+++ b/shell/nuxt/index.js
@@ -23,6 +23,7 @@ import '../plugins/tooltip';
 import '../plugins/vue-clipboard2';
 import '../plugins/v-select';
 import '../plugins/directives';
+import '../plugins/clean-html-directive';
 import '../plugins/transitions';
 import '../plugins/vue-js-modal';
 import '../plugins/js-yaml';

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -281,8 +281,8 @@ export default {
 
           <template v-if="mustChangePassword">
             <p
+              v-clean-html="t(isFirstLogin ? 'setup.setPassword' : 'setup.newUserSetPassword', { username }, true)"
               class="text-center mb-20 mt-20 setup-title"
-              v-html="t(isFirstLogin ? 'setup.setPassword' : 'setup.newUserSetPassword', { username }, true)"
             />
 
             <Password

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -159,14 +159,14 @@ export default {
           v-if="osWarning"
           color="error"
         >
-          <span v-html="osWarning" />
+          <span v-clean-html="osWarning" />
         </Banner>
         <Banner
           v-for="msg in requires"
           :key="msg"
           color="error"
         >
-          <span v-html="msg" />
+          <span v-clean-html="msg" />
         </Banner>
 
         <Banner
@@ -174,14 +174,14 @@ export default {
           :key="msg"
           color="warning"
         >
-          <span v-html="msg" />
+          <span v-clean-html="msg" />
         </Banner>
 
         <Banner
           v-if="targetedAppWarning"
           color="warning"
         >
-          <span v-html="targetedAppWarning" />
+          <span v-clean-html="targetedAppWarning" />
         </Banner>
       </div>
       <div

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1331,7 +1331,7 @@ export default {
               :key="msg"
               color="error"
             >
-              <span v-html="msg" />
+              <span v-clean-html="msg" />
             </Banner>
 
             <Banner
@@ -1339,7 +1339,7 @@ export default {
               :key="msg"
               color="warning"
             >
-              <span v-html="msg" />
+              <span v-clean-html="msg" />
             </Banner>
           </div>
           <div
@@ -1442,7 +1442,7 @@ export default {
             v-if="isNamespaceNew && value.metadata.namespace.length"
             color="info"
           >
-            <div v-html="t('catalog.install.steps.basics.createNamespace', {namespace: value.metadata.namespace}, true) " />
+            <div v-clean-html="t('catalog.install.steps.basics.createNamespace', {namespace: value.metadata.namespace}, true) " />
           </Banner>
         </div>
       </template>
@@ -1767,17 +1767,17 @@ export default {
           {{ t('catalog.install.error.legacy.label', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true) }}
         </span>
         <template v-if="!legacyEnabled">
-          <span v-html="t('catalog.install.error.legacy.enableLegacy.prompt', true)" />
+          <span v-clean-html="t('catalog.install.error.legacy.enableLegacy.prompt', true)" />
           <nuxt-link :to="legacyFeatureRoute">
             {{ t('catalog.install.error.legacy.enableLegacy.goto') }}
           </nuxt-link>
         </template>
         <template v-else-if="mcapp">
-          <span v-html="t('catalog.install.error.legacy.mcmNotSupported')" />
+          <span v-clean-html="t('catalog.install.error.legacy.mcmNotSupported')" />
         </template>
         <template v-else>
           <nuxt-link :to="legacyAppRoute">
-            <span v-html="t('catalog.install.error.legacy.navigate')" />
+            <span v-clean-html="t('catalog.install.error.legacy.navigate')" />
           </nuxt-link>
         </template>
       </Banner>

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -416,7 +416,7 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else-if="options.length">
-    <h1 v-html="t('catalog.tools.header')" />
+    <h1 v-clean-html="t('catalog.tools.header')" />
     <TypeDescription
       v-if="!legacyEnabled"
       resource="chart"
@@ -466,8 +466,8 @@ export default {
         </div>
         <div class="description">
           <div
+            v-clean-html="opt.chart.chartDescription"
             class="description-content"
-            v-html="opt.chart.chartDescription"
           />
         </div>
         <div
@@ -483,16 +483,16 @@ export default {
         <div class="action">
           <template v-if="opt.blocked">
             <button
+              v-clean-html="t('catalog.tools.action.install')"
               disabled="true"
               class="btn btn-sm role-primary"
-              v-html="t('catalog.tools.action.install')"
             />
           </template>
           <template v-else-if="opt.app && opt.chart.legacy">
             <button
+              v-clean-html="t('catalog.tools.action.manage')"
               class="btn btn-sm role-secondary"
               @click="openV1Tool(opt.chart.legacyPage)"
-              v-html="t('catalog.tools.action.manage')"
             />
           </template>
           <template v-else-if="opt.app && opt.upgradeAvailable && !opt.chart.legacy">
@@ -503,9 +503,9 @@ export default {
               <i class="icon icon-delete icon-lg" />
             </button>
             <button
+              v-clean-html="t('catalog.tools.action.upgrade')"
               class="btn btn-sm role-secondary"
               @click="edit(opt.app, opt.app.upgradeAvailable)"
-              v-html="t('catalog.tools.action.upgrade')"
             />
           </template>
           <template v-else-if="opt.app">
@@ -516,23 +516,23 @@ export default {
               <i class="icon icon-delete icon-lg" />
             </button>
             <button
+              v-clean-html="t('catalog.tools.action.edit')"
               class="btn btn-sm role-secondary"
               @click="edit(opt.app)"
-              v-html="t('catalog.tools.action.edit')"
             />
           </template>
           <template v-else-if="opt.chart.legacy">
             <button
+              v-clean-html="t('catalog.tools.action.install')"
               class="btn btn-sm role-primary"
               @click="openV1Tool(opt.chart.legacyPage)"
-              v-html="t('catalog.tools.action.install')"
             />
           </template>
           <template v-else>
             <button
+              v-clean-html="t('catalog.tools.action.install')"
               class="btn btn-sm role-primary"
               @click="install(opt.chart)"
-              v-html="t('catalog.tools.action.install')"
             />
           </template>
         </div>

--- a/shell/pages/c/_cluster/istio/index.vue
+++ b/shell/pages/c/_cluster/istio/index.vue
@@ -72,7 +72,7 @@ export default {
 <template>
   <div>
     <h1>Overview</h1>
-    <h4 v-html="t('istio.poweredBy', {}, true)" />
+    <h4 v-clean-html="t('istio.poweredBy', {}, true)" />
     <div class="links">
       <div
         :class="{'disabled':!kialiUrl}"
@@ -99,7 +99,7 @@ export default {
             </a>
             <hr>
             <div class="description">
-              <span v-html="t('istio.links.kiali.description', {link: monitoringUrl}, true)" />
+              <span v-clean-html="t('istio.links.kiali.description', {link: monitoringUrl}, true)" />
             </div>
           </div>
         </span>
@@ -107,7 +107,7 @@ export default {
           v-if="!kialiUrl"
           class="disabled-msg"
         >
-          <span v-html="t('istio.links.disabled', {app: 'Kiali'})" />
+          <span v-clean-html="t('istio.links.disabled', {app: 'Kiali'})" />
         </div>
       </div>
       <div
@@ -135,7 +135,7 @@ export default {
             </a>
             <hr>
             <div class="description">
-              <span v-html="t('istio.links.jaeger.description', true)" />
+              <span v-clean-html="t('istio.links.jaeger.description', true)" />
             </div>
           </div>
         </span>
@@ -143,7 +143,7 @@ export default {
           v-if="!jaegerUrl"
           class="disabled-msg"
         >
-          <span v-html="t('istio.links.disabled', {app: 'Jaeger'})" />
+          <span v-clean-html="t('istio.links.disabled', {app: 'Jaeger'})" />
         </div>
       </div>
     </div>

--- a/shell/pages/c/_cluster/manager/cloudCredential/index.vue
+++ b/shell/pages/c/_cluster/manager/cloudCredential/index.vue
@@ -89,7 +89,7 @@ export default {
       <template #cell:apikey="{row}">
         <span
           v-if="row.publicData"
-          v-html="row.publicData"
+          v-clean-html="row.publicData"
         />
         <span
           v-else

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -312,7 +312,7 @@ export default {
             <a
               class="hand"
               @click.prevent.stop="showWhatsNew"
-            ><span v-html="t('landing.whatsNewLink')" /></a>
+            ><span v-clean-html="t('landing.whatsNewLink')" /></a>
           </Banner>
         </div>
       </div>
@@ -335,7 +335,7 @@ export default {
                 <a
                   class="hand mr-20"
                   @click.prevent.stop="showUserPrefs"
-                ><span v-html="t('landing.landingPrefs.userPrefs')" /></a>
+                ><span v-clean-html="t('landing.landingPrefs.userPrefs')" /></a>
               </Banner>
             </div>
           </div>

--- a/shell/plugins/clean-html-directive.js
+++ b/shell/plugins/clean-html-directive.js
@@ -1,0 +1,31 @@
+import Vue from 'vue';
+import DOMPurify from 'dompurify';
+
+const ALLOWED_TAGS = [
+  'code',
+  'li',
+  'a',
+  'p',
+  'b',
+  'br',
+  'ul',
+  'pre',
+  'span',
+  'div',
+  'i',
+  'em',
+  'strong',
+];
+
+const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
+
+export const cleanHtmlDirective = {
+  inserted(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  },
+  componentUpdated(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  }
+};
+
+Vue.directive('clean-html', cleanHtmlDirective);

--- a/shell/plugins/directives.js
+++ b/shell/plugins/directives.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import DOMPurify from 'dompurify';
 
 Vue.directive('focus', {
   inserted(_el, _binding, vnode) {
@@ -39,3 +40,30 @@ const getElement = (vnode) => {
     return componentInstance.$refs.input.$refs.value;
   }
 };
+
+const ALLOWED_TAGS = [
+  'code',
+  'li',
+  'a',
+  'p',
+  'b',
+  'br',
+  'ul',
+  'pre',
+  'span',
+  'div',
+  'i',
+  'em',
+  'strong',
+];
+
+const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
+
+Vue.directive('clean-html', {
+  inserted(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  },
+  componentUpdated(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  }
+});

--- a/shell/plugins/directives.js
+++ b/shell/plugins/directives.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import DOMPurify from 'dompurify';
 
 Vue.directive('focus', {
   inserted(_el, _binding, vnode) {
@@ -40,30 +39,3 @@ const getElement = (vnode) => {
     return componentInstance.$refs.input.$refs.value;
   }
 };
-
-const ALLOWED_TAGS = [
-  'code',
-  'li',
-  'a',
-  'p',
-  'b',
-  'br',
-  'ul',
-  'pre',
-  'span',
-  'div',
-  'i',
-  'em',
-  'strong',
-];
-
-const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
-
-Vue.directive('clean-html', {
-  inserted(el, binding) {
-    el.innerHTML = purifyHTML(binding.value);
-  },
-  componentUpdated(el, binding) {
-    el.innerHTML = purifyHTML(binding.value);
-  }
-});

--- a/shell/promptRemove/management.cattle.io.globalrole.vue
+++ b/shell/promptRemove/management.cattle.io.globalrole.vue
@@ -23,14 +23,14 @@ export default {
   <div>
     <template>
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-html="resourceNames(names, plusMore, t)"
+        v-clean-html="resourceNames(names, plusMore, t)"
       />
     </template>
     <div
       v-if="info"
       class="text info mb-10 mt-20"
     >
-      <span v-html="info" />
+      <span v-clean-html="info" />
     </div>
     <div
       v-if="warning"

--- a/shell/promptRemove/management.cattle.io.project.vue
+++ b/shell/promptRemove/management.cattle.io.project.vue
@@ -100,8 +100,8 @@ export default {
         <template v-if="!canSeeProjectlessNamespaces">
           <span class="delete-warning"> {{ t('promptRemove.willDeleteAssociatedNamespaces') }}</span> <br>
           <div
+            v-clean-html="resourceNames(names, plusMore, t)"
             class="mt-10"
-            v-html="resourceNames(names, plusMore, t)"
           />
         </template>
       </div>
@@ -114,7 +114,7 @@ export default {
           :label="t('promptRemove.deleteAssociatedNamespaces')"
         />
         <div class="mt-10 ml-20">
-          <span v-html="resourceNames(names, plusMore, t)" />
+          <span v-clean-html="resourceNames(names, plusMore, t)" />
         </div>
       </div>
     </div>

--- a/shell/promptRemove/management.cattle.io.roletemplate.vue
+++ b/shell/promptRemove/management.cattle.io.roletemplate.vue
@@ -23,14 +23,14 @@ export default {
   <div>
     <template>
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-html="resourceNames(names, plusMore, t)"
+        v-clean-html="resourceNames(names, plusMore, t)"
       />
     </template>
     <div
       v-if="info"
       class="text info mb-10 mt-20"
     >
-      <span v-html="info" />
+      <span v-clean-html="info" />
     </div>
     <div
       v-if="warning"

--- a/shell/promptRemove/pod.vue
+++ b/shell/promptRemove/pod.vue
@@ -108,8 +108,8 @@ export default {
   <div class="mt-10">
     <div class="mb-30">
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
+        v-clean-html="podNames"
         class="machine-name"
-        v-html="podNames"
       />
     </div>
     <div class="mb-30">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,6 +3263,13 @@
     "@types/node" "*"
     "@types/webpack" "^4"
 
+"@types/dompurify@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.0.tgz#28388a1aff0ced6e635b5b912c5f5935711d45b9"
+  integrity sha512-EcSqmgm/xJwH8CcJPy9AHNypp/j58CYga3nWdl93/wLxX6OH+rSD3aAj75NQazcZd1YKHJ/pjNZ9qmgVajggwQ==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -3565,6 +3572,11 @@
   dependencies:
     "@types/webpack" "^4"
     terser "^4.3.9"
+
+"@types/trusted-types@*":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
+  integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
 "@types/uglify-js@*":
   version "3.17.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This replaces the use of the `v-html` directive with a custom `v-clean-html` directive that uses the `DOMPurify` library to sanitize HTML input before rendering it. `v-html` usage is discouraged[^1] in the Vue documentation, and should only be used on trusted content. Our widespread usage of `v-html` makes this difficult to guarantee safe usage across the board, so it's better to disallow `v-html` and sanitize existing usages in Rancher Dashboard.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Disallows use of `v-html` with `eslint`
- Adds new `v-clean-html` directive that only allows existing tags used in `en-us.yaml`
- Replaces all existing instances of `v-html` with `v-clean-html` 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The current implementations contains a list of allowed tags for use with `v-clean-html`:

```javascript
const ALLOWED_TAGS = [
  'code',
  'li',
  'a',
  'p',
  'b',
  'br',
  'ul',
  'pre',
  'span',
  'div',
  'i',
  'em',
  'strong',
];
```

These tags are derived from a list of unique tags obtained from `en-us.yaml`. An alternative approach might be to replace this list of allowed tags with the `DOMPurify` `html` profile[^2], which should allow all safe HTML (e.g. `DOMPurify.sanitize(dirty, {USE_PROFILES: {html: true}});`)

### Areas or cases that should be tested
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
We need to identify at least one instance for each of the allowed tags to ensure that content is rendered properly.

[^1]: https://v2.vuejs.org/v2/guide/syntax.html#Raw-HTML
[^2]: https://github.com/cure53/DOMPurify#can-i-configure-dompurify