### PR TITLE
Disable Fleet workspace change for RKE2 clusters.

### DIFF
--- a/shell/list/fleet.cattle.io.cluster.vue
+++ b/shell/list/fleet.cattle.io.cluster.vue
@@ -30,8 +30,6 @@ export default {
     this.$fetchType(FLEET.WORKSPACE);
     await this.$fetchType(this.resource);
     this.allMgmt = await this.$fetchType(MANAGEMENT.CLUSTER);
-
-    console.log(this.allMgmt)
   },
 
   data() {

--- a/shell/models/fleet.cattle.io.cluster.js
+++ b/shell/models/fleet.cattle.io.cluster.js
@@ -1,10 +1,9 @@
 import { MANAGEMENT, NORMAN } from '@shell/config/types';
-import { CAPI } from '@shell/config/labels-annotations';
+import { CAPI, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
+import { _RKE2 } from '@shell/store/prefs';
+import SteveModel from '@shell/plugins/steve/steve-class';
 import { escapeHtml } from '@shell/utils/string';
 import { insertAt } from '@shell/utils/array';
-import { _RKE2 }from '@shell/store/prefs'
-import { FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
-import SteveModel from '@shell/plugins/steve/steve-class';
 
 export default class FleetCluster extends SteveModel {
   get _availableActions() {
@@ -34,16 +33,16 @@ export default class FleetCluster extends SteveModel {
       enabled:  !!this.links.update
     });
 
-    if(!this.isRke2) {
-    insertAt(out, 3, {
-      action:     'assignTo',
-      label:      'Change workspace',
-      icon:       'icon icon-copy',
-      bulkable:   true,
-      bulkAction: 'assignToBulk',
-      enabled:    !!this.links.update && !!this.mgmt,
-    });
-  }
+    if (!this.isRke2) {
+      insertAt(out, 3, {
+        action:     'assignTo',
+        label:      'Change workspace',
+        icon:       'icon icon-copy',
+        bulkable:   true,
+        bulkAction: 'assignToBulk',
+        enabled:    !!this.links.update && !!this.mgmt,
+      });
+    }
 
     insertAt(out, 4, { divider: true });
 
@@ -80,8 +79,9 @@ export default class FleetCluster extends SteveModel {
   }
 
   get isRke2() {
-      const provider = this?.metadata?.labels?.[CAPI.PROVIDER] || this?.status?.provider;
-      return provider === _RKE2;
+    const provider = this?.metadata?.labels?.[CAPI.PROVIDER] || this?.status?.provider;
+
+    return provider === _RKE2;
   }
 
   get nameDisplay() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#7734 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
- Add `get isRke2` to `shell/models/fleet.cattle.io.cluster.js`
- Conditionally include `Change workspace` action 

### Areas or cases that should be tested

1. Navigate to cluster management and create a RKE2 and a RKE cluster
2. Navigate to Continuous delivery 
3. Ensure correct workspace with the clusters selected.
4. Click on each cluster action
5. RKE2 dropdown should not have `Change workspace` action

### Areas which could experience regressions
- Change workspace 

### Screenshot/Video
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/1387263/226574282-287158c3-ed25-4e24-a348-835827e658f6.png">