### PR TITLE
Fix null profile in custom cluster creation

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1424,6 +1424,11 @@ export default {
         return;
       }
 
+      // Remove null profile on machineGlobalConfig - https://github.com/rancher/dashboard/issues/8480
+      if (this.value.spec?.rkeConfig?.machineGlobalConfig?.profile === null) {
+        delete this.value.spec.rkeConfig.machineGlobalConfig.profile;
+      }
+
       await this.save(btnCb);
     },
     // create a secret to reference the harvester cluster kubeconfig in rkeConfig


### PR DESCRIPTION
Fixes #8480 

Removed the `profile` key if it is null.

Request now looks like this:

![image](https://user-images.githubusercontent.com/1955897/226616002-6441ce95-9725-484c-8955-b9756c5f5630.png)
