### PR TITLE
fix pages/c/_cluster/auth/roles/_resource/_id webpackchunkname

### DIFF
--- a/shell/config/router.js
+++ b/shell/config/router.js
@@ -338,7 +338,7 @@ export const routerOptions = {
     name:      'c-cluster-monitoring-alertmanagerconfig-alertmanagerconfigid-receiver'
   }, {
     path:      '/c/:cluster/auth/roles/:resource/:id?',
-    component: () => interopDefault(import('../pages/c/_cluster/auth/roles/_resource/_id.vue' /* webpackChunkName: "/pages/c/_cluster/auth/roles/_resource/_id" */)),
+    component: () => interopDefault(import('../pages/c/_cluster/auth/roles/_resource/_id.vue' /* webpackChunkName: "pages/c/_cluster/auth/roles/_resource/_id" */)),
     name:      'c-cluster-auth-roles-resource-id'
   }, {
     path:      '/c/:cluster/monitoring/monitor/:namespace/:id?',


### PR DESCRIPTION
Loading the dash from `https://releases.rancher.com/dashboard/latest/index.html` is broken due to malformed webpackChunkName:
![screenshot_2023-03-21_at_07 27 29](https://user-images.githubusercontent.com/42977925/226656109-21216ad7-efd2-455f-82ba-b85a51e4e996.png)

I verified this fix by pushing to a `-dev` branch and updating my ui-dashboard-index setting to use that build