### PR TITLE
Update fleet ui for users with fewer permissions

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2188,8 +2188,6 @@ fleet:
           =0 { Adding namespaces here will create a GitRepoRestriction. }
           other { Only the Git Repo Restriction's <code>allowedTargetNamespaces</code> is managed here. You can make additional changes to the Git Repo Restriction} 
         }"
-    notAllowed: You must have permission to create Git Repo Restrictions to define allowed target namespaces.
-    readOnly: You must have permission to edit Git Repo Restrictions to manage the workspace's allowed target namespaces.
 footer:
   docs: Docs
   download: Download CLI

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -22,6 +22,7 @@ generic:
   disabled: Disabled
   done: Done
   enabled: Enabled
+  here: here
   id: ID
   ignored: Ignored
   invalidCron: Invalid cron schedule
@@ -2184,9 +2185,11 @@ fleet:
     addTitle: 'allowedTargetNamespaces'
     addLabel: Add
     banner: "{count, plural,
-          =0 { Setting allowedTargetNamespaces here will create a GitRepoRestriction. }
-          other { Only GitRepoRestriction.allowedTargetNamespaces is managed here. You can make additional changes} 
+          =0 { Adding namespaces here will create a GitRepoRestriction. }
+          other { Only the Git Repo Restriction's <code>allowedTargetNamespaces</code> is managed here. You can make additional changes to the Git Repo Restriction} 
         }"
+    notAllowed: You must have permission to create Git Repo Restrictions to define allowed target namespaces.
+    readOnly: You must have permission to edit Git Repo Restrictions to manage the workspace's allowed target namespaces.
 footer:
   docs: Docs
   download: Download CLI

--- a/shell/components/fleet/FleetIntro.vue
+++ b/shell/components/fleet/FleetIntro.vue
@@ -1,5 +1,6 @@
 <script>
 import { AS, _YAML } from '@shell/config/query-params';
+import { FLEET } from 'config/types';
 
 export default {
 
@@ -18,10 +19,14 @@ export default {
       query: { [AS]: _YAML },
     };
 
+    const gitRepoSchema = this.$store.getters['management/schemaFor'](FLEET.GIT_REPO);
+    const canCreateRepos = gitRepoSchema && gitRepoSchema.resourceMethods.includes('PUT');
+
     return {
       formRoute,
       yamlRoute,
       hasEditComponent,
+      canCreateRepos
     };
   },
 };
@@ -32,7 +37,10 @@ export default {
     <div class="title">
       {{ t('fleet.gitRepo.repo.noRepos') }}
     </div>
-    <div class="actions">
+    <div
+      v-if="canCreateRepos"
+      class="actions"
+    >
       <n-link
         :to="formRoute"
         class="btn role-secondary"

--- a/shell/components/fleet/FleetIntro.vue
+++ b/shell/components/fleet/FleetIntro.vue
@@ -1,6 +1,5 @@
 <script>
 import { AS, _YAML } from '@shell/config/query-params';
-import { FLEET } from 'config/types';
 
 export default {
 
@@ -19,14 +18,10 @@ export default {
       query: { [AS]: _YAML },
     };
 
-    const gitRepoSchema = this.$store.getters['management/schemaFor'](FLEET.GIT_REPO);
-    const canCreateRepos = gitRepoSchema && gitRepoSchema.resourceMethods.includes('PUT');
-
     return {
       formRoute,
       yamlRoute,
       hasEditComponent,
-      canCreateRepos
     };
   },
 };
@@ -37,10 +32,7 @@ export default {
     <div class="title">
       {{ t('fleet.gitRepo.repo.noRepos') }}
     </div>
-    <div
-      v-if="canCreateRepos"
-      class="actions"
-    >
+    <div class="actions">
       <n-link
         :to="formRoute"
         class="btn role-secondary"

--- a/shell/edit/management.cattle.io.fleetworkspace.vue
+++ b/shell/edit/management.cattle.io.fleetworkspace.vue
@@ -211,7 +211,11 @@ export default {
           color="info"
         >
           <div>
-            {{ t('fleet.restrictions.banner', { count: allowedTargetNamespaces.length }, true) }}
+            <t
+              k="fleet.restrictions.banner"
+              :count="allowedTargetNamespaces.length"
+              :raw="true"
+            />
             <a
               v-if="!!allowedTargetNamespaces.length"
               @click="workSpaceRestriction.goToDetail()"

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -475,6 +475,11 @@ export default {
         commit('registerType', type);
       }
     }
+    // Inject special fields for indexing schemas
+    if ( type === SCHEMA ) {
+      addSchemaIndexFields(data);
+    }
+
     const keyField = getters.keyFieldForType(type);
     const id = data?.[keyField] || existing?.[keyField];
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  https://github.com/rancher/dashboard/issues/8468
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
~This PR updates the workspace create/edit form to make sense for users who do not have permission to create reporestrictions and gitrepo repo-less list view for users who don't have permission to create repos.~ 

### Technical notes summary
The Continuous Delivery ui is only visible to users who can view git repos. I opted not to change this because from what I understand there isn't much a user could do in the fleet ui if they can't even view repos.

### Areas or cases that should be tested
~1. The workspace create/edit/detail pages should be tested by users who can:~
~a. Get/list git repos and get/list/create/edit workspaces but nothing else in fleet~
  ~b. Get/list git repos and repo restrictions, and get/list/create/edit workspaces~

~2. The git repo list view when no repos are present should only show the button to create repos for users who have permission to do so.~
~3. The 'here' link in the banner above the allowed target namespace section should direct to the yaml view of the relevant repo restriction in edit mode~

### Updates following review
This PR has been changed substantially following review of actual fleet RBAC behavior. When a user creates a workspace, they are granted permission to create git repo restrictions. The dashboard threw an error trying to save git repo restrictions initially because it hadn't loaded a schema for them; the schema only becomes available once the user has created the workspace. This PR fixes that by querying for the git repo restriction schema after the workspace has been created but before attempting to create the git repo restriction.

### Updated testing:
Users with permission to create workspaces should also be able to set targetNamespaces during creation.
