### PR TITLE
Fixed sticky footer in Helm Chart Install Yaml

### DIFF
--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -468,6 +468,9 @@ $spacer: 10px;
   flex-direction: column;
   flex: 1;
   padding: 0;
+  height: 100%;
+  position: relative;
+  justify-content: flex-start;
 }
 
 .header {
@@ -643,9 +646,8 @@ $spacer: 10px;
   flex-direction: column;
 
   &__step {
-    display: flex;
-    flex-direction: column;
     flex: 1;
+    overflow: auto;
   }
 }
 

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1480,42 +1480,44 @@ export default {
         </div>
       </template>
       <template #helmValues>
-        <Banner
-          v-if="step2Description"
-          color="info"
-          class="description"
-        >
-          {{ step2Description }}
-        </Banner>
-        <div class="step__values__controls">
-          <ButtonGroup
-            v-model="preFormYamlOption"
-            :options="formYamlOptions"
-            inactive-class="bg-disabled btn-sm"
-            active-class="bg-primary btn-sm"
-            :disabled="preFormYamlOption != formYamlOption"
-          />
-          <div class="step__values__controls--spacer">
-&nbsp;
-          </div>
-          <ButtonGroup
-            v-if="showDiff"
-            v-model="diffMode"
-            :options="yamlDiffModeOptions"
-            inactive-class="bg-disabled btn-sm"
-            active-class="bg-primary btn-sm"
-          />
-          <div
-            v-if="hasReadme && !showingReadmeWindow"
-            class="btn-group"
+        <div class="sticky-header">
+          <Banner
+            v-if="step2Description"
+            color="info"
+            class="description"
           >
-            <button
-              type="button"
-              class="btn bg-primary btn-sm"
-              @click="showSlideIn = !showSlideIn"
+            {{ step2Description }}
+          </Banner>
+          <div class="step__values__controls">
+            <ButtonGroup
+              v-model="preFormYamlOption"
+              :options="formYamlOptions"
+              inactive-class="bg-disabled btn-sm"
+              active-class="bg-primary btn-sm"
+              :disabled="preFormYamlOption != formYamlOption"
+            />
+            <div class="step__values__controls--spacer">
+  &nbsp;
+            </div>
+            <ButtonGroup
+              v-if="showDiff"
+              v-model="diffMode"
+              :options="yamlDiffModeOptions"
+              inactive-class="bg-disabled btn-sm"
+              active-class="bg-primary btn-sm"
+            />
+            <div
+              v-if="hasReadme && !showingReadmeWindow"
+              class="btn-group"
             >
-              {{ t('catalog.install.steps.helmValues.chartInfo.button') }}
-            </button>
+              <button
+                type="button"
+                class="btn bg-primary btn-sm"
+                @click="showSlideIn = !showSlideIn"
+              >
+                {{ t('catalog.install.steps.helmValues.chartInfo.button') }}
+              </button>
+            </div>
           </div>
         </div>
         <div class="scroll__container">
@@ -1936,8 +1938,6 @@ export default {
   .scroll {
     &__container {
       $yaml-height: 200px;
-      display: flex;
-      flex: 1;
       min-height: $yaml-height;
       height: 0;
     }
@@ -2034,6 +2034,15 @@ export default {
   background-color: var(--warning-banner-bg);
   color:var(--warning);
   margin-top: 5px;
+}
+
+.sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  background: var(--primary-text);
 }
 
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7975
<!-- Define findings related to the feature or bug issue. -->
Fixed sticky footer in Helm Chart Install Yaml Values editor

### How to test
<!-- Include information of the changes, including collateral areas affected by this PR as requirement or for convenience. -->
Go to cluster tools, OPA Gatekeeper and install, click next to get the Values step.
The footer container the wizard buttons should be sticky as in the previous step: