### PR TITLE
HARVESTER: Validate ccm & csi maximum version

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -318,7 +318,6 @@ export default {
       harvesterVersionRange: {},
       lastDefaultPodSecurityPolicyTemplateName, // Used for reset on k8s version changes
       previousKubernetesVersion,
-      harvesterVersion:      '',
       cisOverride:           false,
       cisPsaChangeBanner:    false,
       psps:                  null, // List of policies if any
@@ -950,7 +949,6 @@ export default {
     },
 
     isHarvesterIncompatible() {
-      const CompareVersion = '<v1.2';
       let ccmRke2Version = (this.chartVersions['harvester-cloud-provider'] || {})['version'];
       let csiRke2Version = (this.chartVersions['harvester-csi-driver'] || {})['version'];
 
@@ -966,11 +964,7 @@ export default {
       }
 
       if (ccmVersion && csiVersion) {
-        if (semver.satisfies(this.harvesterVersion, CompareVersion, { includePrerelease: true }) || !(this.harvesterVersion || '').startsWith('v')) {
-          // When harveste version is less than `CompareVersion`, compatibility is not determined,
-          // At the same time, version numbers like this will not be checked: master-14bbee2c-head
-          return false;
-        } else if (semver.satisfies(ccmRke2Version, ccmVersion) &&
+        if (semver.satisfies(ccmRke2Version, ccmVersion) &&
           semver.satisfies(csiRke2Version, csiVersion)) {
           return false;
         } else {
@@ -1831,10 +1825,7 @@ export default {
         const res = await this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.SETTING }s` });
 
         const version = (res?.data || []).find(s => s.id === 'harvester-csi-ccm-versions');
-        // get harvester server-version
-        const serverVersion = (res?.data || []).find(s => s.id === 'server-version');
 
-        this.harvesterVersion = serverVersion.value;
         if (version) {
           this.harvesterVersionRange = JSON.parse(version.value || version.default || '{}');
         } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

<!-- Define findings related to the feature or bug issue. -->
According to https://github.com/harvester/harvester/issues/3404#issue-1567534567 describe:  remove `do not check when the Harvester version is <v1.2` constrain on the upstream Rancher UI (starting from v2.7.2), we still need to validate ccm & csi maximum version, so revert PR https://github.com/rancher/dashboard/pull/8080

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- https://github.com/harvester/harvester/issues/3404

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

**Case 1**
1. Import an existing Harvester cluster(e.g., v1.1.2-rc3) into a Rancher server
2. Spin up a guest RKE2 k8s cluster(>= v1.24.10); its built-in Harvester CCM chart version is v0.1.14
3. The Harvester cloud provider can not be selected.

**Case 2**
1. Import an existing Harvester cluster(e.g., v1.1.2-rc3) into a Rancher server
2. Change the Harvester `harvester-csi-ccm-versions` setting to `{"harvester-cloud-provider":">=0.0.1 <0.2.0","harvester-csi-provider":">=0.0.1 <0.2.0"}`
3. Spin up a guest RKE2 k8s cluster(>= v1.24.10); its built-in Harvester CCM chart version is v0.1.14
4. The Harvester cloud provider can be selected.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->