### PR TITLE
Custom chart UIs show PSP switch on Kubernetes v1.25

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "kubectl",
     "Kubernetes",
     "kubevirt",
+    "neuvector",
     "nuxt",
     "overcommit",
     "prepending",

--- a/shell/chart/gatekeeper.vue
+++ b/shell/chart/gatekeeper.vue
@@ -2,6 +2,7 @@
 import UnitInput from '@shell/components/form/UnitInput';
 import ChartPsp from '@shell/components/ChartPsp';
 import { Checkbox } from '@components/Form/Checkbox';
+import { mapGetters } from 'vuex';
 
 export default {
   components: {
@@ -21,6 +22,7 @@ export default {
   },
 
   computed: {
+    ...mapGetters(['currentCluster']),
     crdValues: {
       get() {
         const crdInfo = this.autoInstallInfo.find(info => info.chart.name.includes('crd'));
@@ -58,7 +60,10 @@ export default {
     </div>
 
     <!-- Conditionally display PSP checkbox -->
-    <ChartPsp :value="value" />
+    <ChartPsp
+      :value="value"
+      :cluster="currentCluster"
+    />
 
     <template v-if="crdValues">
       <!-- gatekeeper versions <1.0.2 do not have this option -->

--- a/shell/chart/gatekeeper.vue
+++ b/shell/chart/gatekeeper.vue
@@ -56,11 +56,10 @@ export default {
         />
       </div>
     </div>
-    <div class="row mt-10">
-      <div class="col span-6">
-        <ChartPsp :value="value" />
-      </div>
-    </div>
+
+    <!-- Conditionally display PSP checkbox -->
+    <ChartPsp :value="value" />
+
     <template v-if="crdValues">
       <!-- gatekeeper versions <1.0.2 do not have this option -->
       <Checkbox

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -132,11 +132,10 @@ export default {
     <h3>
       {{ t('catalog.chart.global') }}
     </h3>
-    <div class="row mb-20">
-      <div class="col">
-        <ChartPsp :value="value" />
-      </div>
-    </div>
+
+    <!-- Conditionally display PSP checkbox -->
+    <ChartPsp :value="value" />
+
     <h3>
       {{ t('istio.titles.components') }}
     </h3>

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -78,6 +78,7 @@ export default {
   },
 
   computed: {
+    ...mapGetters(['currentCluster'], { t: 'i18n/t' }),
     valuesYaml: {
       get() {
         try {
@@ -98,8 +99,6 @@ export default {
         }
       }, 500)
     },
-
-    ...mapGetters({ t: 'i18n/t' })
   },
 
   methods: {
@@ -129,12 +128,12 @@ export default {
 
 <template>
   <div>
-    <h3>
-      {{ t('catalog.chart.global') }}
-    </h3>
-
     <!-- Conditionally display PSP checkbox -->
-    <ChartPsp :value="value" />
+    <ChartPsp
+      :value="value"
+      :title="t('catalog.chart.global')"
+      :cluster="currentCluster"
+    />
 
     <h3>
       {{ t('istio.titles.components') }}

--- a/shell/chart/logging/index.vue
+++ b/shell/chart/logging/index.vue
@@ -83,10 +83,8 @@ export default {
         />
       </div>
     </div>
-    <div class="row mb-20">
-      <div class="col span-6">
-        <ChartPsp :value="value" />
-      </div>
-    </div>
+
+    <!-- Conditionally display PSP checkbox -->
+    <ChartPsp :value="value" />
   </div>
 </template>

--- a/shell/chart/logging/index.vue
+++ b/shell/chart/logging/index.vue
@@ -85,6 +85,9 @@ export default {
     </div>
 
     <!-- Conditionally display PSP checkbox -->
-    <ChartPsp :value="value" />
+    <ChartPsp
+      :value="value"
+      :cluster="currentCluster"
+    />
   </div>
 </template>

--- a/shell/chart/monitoring/index.vue
+++ b/shell/chart/monitoring/index.vue
@@ -261,11 +261,9 @@ export default {
             />
           </div>
         </div>
-        <div class="row mt-20">
-          <div class="col span-6">
-            <ChartPsp :value="value" />
-          </div>
-        </div>
+
+        <!-- Conditionally display PSP checkbox -->
+        <ChartPsp :value="value" />
       </div>
     </Tab>
     <Tab

--- a/shell/chart/monitoring/index.vue
+++ b/shell/chart/monitoring/index.vue
@@ -263,7 +263,10 @@ export default {
         </div>
 
         <!-- Conditionally display PSP checkbox -->
-        <ChartPsp :value="value" />
+        <ChartPsp
+          :value="value"
+          :cluster="currentCluster"
+        />
       </div>
     </Tab>
     <Tab

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -86,8 +86,7 @@ export default {
       return { options, labels };
     },
 
-    ...mapGetters({ t: 'i18n/t' })
-
+    ...mapGetters(['currentCluster'], { t: 'i18n/t' }),
   },
 
   watch: {
@@ -168,7 +167,10 @@ export default {
       name="chartOptions"
     >
       <!-- Conditionally display PSP checkbox -->
-      <ChartPsp :value="value" />
+      <ChartPsp
+        :value="value"
+        :cluster="currentCluster"
+      />
 
       <Banner
         color="info"

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -167,11 +167,9 @@ export default {
       label="Chart Options"
       name="chartOptions"
     >
-      <div class="row">
-        <div class="col">
-          <ChartPsp :value="value" />
-        </div>
-      </div>
+      <!-- Conditionally display PSP checkbox -->
+      <ChartPsp :value="value" />
+
       <Banner
         color="info"
         :label="t('backupRestoreOperator.deployment.storage.tip')"

--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -14,6 +14,22 @@ export default {
     mode: {
       type:    String,
       default: 'edit'
+    },
+
+    /**
+     * Optional title section prior checkbox
+     */
+    title: {
+      type:    String,
+      default: null
+    },
+
+    /**
+     * Cluster information
+     */
+    cluster: {
+      type:    Object,
+      default: null
     }
   },
   created() {
@@ -24,15 +40,38 @@ export default {
       this.$set(this.value.global.cattle, 'psp', { enabled: false });
     }
   },
-  computed: { ...mapGetters({ t: 'i18n/t' }) }
+  computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+
+    /**
+     * Display checkbox only if contains PSP or K8S version is less than 1.25
+     */
+    hasCheckbox() {
+      const hasPsp = this.value.global.cattle?.psp?.enabled;
+      const clusterVersion = this.cluster?.metadata?.annotations?.['management.cattle.io/current-cluster-controllers-version'] || '';
+      const version = clusterVersion.match(/\d+/g);
+      const isRequiredVersion = version?.length ? +version[0] === 1 && +version[1] < 25 : false;
+
+      return hasPsp || isRequiredVersion;
+    }
+  }
 };
 </script>
 
 <template>
-  <Checkbox
-    v-model="value.global.cattle.psp.enabled"
-    class="mt-20 mb-20"
-    :mode="mode"
-    :label="t('catalog.chart.enablePSP')"
-  />
+  <div
+    v-if="hasCheckbox"
+    class="mt-10 mb-10"
+  >
+    <h3 v-if="title">
+      {{ title }}
+    </h3>
+
+    <Checkbox
+      v-model="value.global.cattle.psp.enabled"
+      data-testid="psp-checkbox"
+      :mode="mode"
+      :label="t('catalog.chart.enablePSP')"
+    />
+  </div>
 </template>

--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -55,7 +55,7 @@ export default {
      * Display checkbox only if contains PSP or K8S version is less than 1.25
      */
     hasCheckbox() {
-      const clusterVersion = this.cluster?.metadata?.annotations?.['management.cattle.io/current-cluster-controllers-version'] || '';
+      const clusterVersion = this.cluster?.kubernetesVersion || '';
       const version = clusterVersion.match(/\d+/g);
       const isRequiredVersion = version?.length ? +version[0] === 1 && +version[1] < 25 : false;
 

--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -32,6 +32,12 @@ export default {
       default: null
     }
   },
+  data: () => {
+    return {
+      // This is required to keep the PSP visible also after unchecking the checkbox
+      hasPsp: false
+    };
+  },
   created() {
     if (!this.value.global.cattle) {
       this.$set(this.value.global, 'cattle', { psp: { enabled: false } });
@@ -39,6 +45,8 @@ export default {
     if (!this.value.global.cattle.psp) {
       this.$set(this.value.global.cattle, 'psp', { enabled: false });
     }
+
+    this.hasPsp = this.value.global.cattle.psp.enabled;
   },
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
@@ -47,12 +55,11 @@ export default {
      * Display checkbox only if contains PSP or K8S version is less than 1.25
      */
     hasCheckbox() {
-      const hasPsp = this.value.global.cattle?.psp?.enabled;
       const clusterVersion = this.cluster?.metadata?.annotations?.['management.cattle.io/current-cluster-controllers-version'] || '';
       const version = clusterVersion.match(/\d+/g);
       const isRequiredVersion = version?.length ? +version[0] === 1 && +version[1] < 25 : false;
 
-      return hasPsp || isRequiredVersion;
+      return this.hasPsp || isRequiredVersion;
     }
   }
 };

--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -31,6 +31,7 @@ export default {
 <template>
   <Checkbox
     v-model="value.global.cattle.psp.enabled"
+    class="mt-20 mb-20"
     :mode="mode"
     :label="t('catalog.chart.enablePSP')"
   />

--- a/shell/components/__tests__/ChartPsp.test.ts
+++ b/shell/components/__tests__/ChartPsp.test.ts
@@ -9,7 +9,7 @@ describe('component: ChartPsp', () => {
     const wrapper = shallowMount(ChartPsp, {
       propsData: {
         value:   { global: { cattle: { psp: { enabled: value } } } },
-        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+        cluster: { kubernetesVersion: version }
       }
     });
 
@@ -24,7 +24,7 @@ describe('component: ChartPsp', () => {
     const wrapper = shallowMount(ChartPsp, {
       propsData: {
         value:   { global: { cattle: { psp: { enabled: value } } } },
-        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+        cluster: { kubernetesVersion: version }
       }
     });
 
@@ -39,7 +39,7 @@ describe('component: ChartPsp', () => {
     const wrapper = shallowMount(ChartPsp, {
       propsData: {
         value:   { global: { cattle: { psp: { enabled: value } } } },
-        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+        cluster: { kubernetesVersion: version }
       }
     });
 
@@ -52,7 +52,7 @@ describe('component: ChartPsp', () => {
     const wrapper = mount(ChartPsp, {
       propsData: {
         value:   { global: { cattle: { psp: { enabled: true } } } },
-        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': 'v1.25.11+rke2r1' } } },
+        cluster: { kubernetesVersion: 'v1.25.11+rke2r1' }
       }
     });
     const input = wrapper.find(`[data-testid="psp-checkbox"]`).element as HTMLInputElement;
@@ -68,7 +68,7 @@ describe('component: ChartPsp', () => {
     const wrapper = mount(ChartPsp, {
       propsData: {
         value:   chartValues,
-        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+        cluster: { kubernetesVersion: version }
       }
     });
 

--- a/shell/components/__tests__/ChartPsp.test.ts
+++ b/shell/components/__tests__/ChartPsp.test.ts
@@ -48,6 +48,20 @@ describe('component: ChartPsp', () => {
     expect(input).toBeUndefined();
   });
 
+  it('should display the checkbox after disabling PSP with K8S v1.25+', async() => {
+    const wrapper = mount(ChartPsp, {
+      propsData: {
+        value:   { global: { cattle: { psp: { enabled: true } } } },
+        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': 'v1.25.11+rke2r1' } } },
+      }
+    });
+    const input = wrapper.find(`[data-testid="psp-checkbox"]`).element as HTMLInputElement;
+
+    await wrapper.find('.checkbox-container').trigger('click');
+
+    expect(input).toBeDefined();
+  });
+
   it('should update value.global.cattle.psp.enabled when checkbox is toggled', async() => {
     const chartValues = { global: {} } as any;
     const version = 'v1.24.11+rke2r1';

--- a/shell/components/__tests__/ChartPsp.test.ts
+++ b/shell/components/__tests__/ChartPsp.test.ts
@@ -2,9 +2,10 @@ import { shallowMount, mount } from '@vue/test-utils';
 import ChartPsp from '@shell/components/ChartPsp.vue';
 
 describe('component: ChartPsp', () => {
-  it.each([[
-    { global: { cattle: { psp: { enabled: true } } } }, true
-  ], [{ global: { cattle: { psp: { enabled: false } } } }, false]])('should render checkbox referencing value.global.cattle.psp.enabled', (chartValue, checkboxValue) => {
+  it.each([
+    [{ global: { cattle: { psp: { enabled: true } } } }, true],
+    [{ global: { cattle: { psp: { enabled: false } } } }, false]
+  ])('should render checkbox referencing value.global.cattle.psp.enabled', (chartValue, checkboxValue) => {
     const wrapper = shallowMount(ChartPsp, { propsData: { value: chartValue } });
 
     expect(wrapper.findComponent({ name: 'Checkbox' }).props().value).toBe(checkboxValue);

--- a/shell/components/__tests__/ChartPsp.test.ts
+++ b/shell/components/__tests__/ChartPsp.test.ts
@@ -3,17 +3,60 @@ import ChartPsp from '@shell/components/ChartPsp.vue';
 
 describe('component: ChartPsp', () => {
   it.each([
-    [{ global: { cattle: { psp: { enabled: true } } } }, true],
-    [{ global: { cattle: { psp: { enabled: false } } } }, false]
-  ])('should render checkbox referencing value.global.cattle.psp.enabled', (chartValue, checkboxValue) => {
-    const wrapper = shallowMount(ChartPsp, { propsData: { value: chartValue } });
+    true, false
+  ])('should render checkbox referencing value.global.cattle.psp.enabled as %p', (value) => {
+    const version = 'v1.24.11+rke2r1';
+    const wrapper = shallowMount(ChartPsp, {
+      propsData: {
+        value:   { global: { cattle: { psp: { enabled: value } } } },
+        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+      }
+    });
 
-    expect(wrapper.findComponent({ name: 'Checkbox' }).props().value).toBe(checkboxValue);
+    expect(wrapper.findComponent({ name: 'Checkbox' }).props().value).toBe(value);
+  });
+
+  it.each([
+    ['v1.24.11+rke2r1', true],
+    ['v1.24.11+rke2r1', false],
+    ['v1.25.11+rke2r1', true],
+  ])('should display the checkbox for cluster with k8s version %p and psp.enabled as %p', (version, value) => {
+    const wrapper = shallowMount(ChartPsp, {
+      propsData: {
+        value:   { global: { cattle: { psp: { enabled: value } } } },
+        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+      }
+    });
+
+    const input = wrapper.find(`[data-testid="psp-checkbox"]`).element as HTMLInputElement;
+
+    expect(input).toBeDefined();
+  });
+
+  it.each([
+    ['v1.25.11+rke2r1', false],
+  ])('should not display the checkbox for cluster with k8s version %p and psp.enabled as %p', (version, value) => {
+    const wrapper = shallowMount(ChartPsp, {
+      propsData: {
+        value:   { global: { cattle: { psp: { enabled: value } } } },
+        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+      }
+    });
+
+    const input = wrapper.find(`[data-testid="psp-checkbox"]`).element as HTMLInputElement;
+
+    expect(input).toBeUndefined();
   });
 
   it('should update value.global.cattle.psp.enabled when checkbox is toggled', async() => {
     const chartValues = { global: {} } as any;
-    const wrapper = mount(ChartPsp, { propsData: { value: chartValues } });
+    const version = 'v1.24.11+rke2r1';
+    const wrapper = mount(ChartPsp, {
+      propsData: {
+        value:   chartValues,
+        cluster: { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } },
+      }
+    });
 
     await wrapper.find('.checkbox-container').trigger('click');
 
@@ -24,11 +67,11 @@ describe('component: ChartPsp', () => {
   });
 
   it.each([
-    [{ global: {} } as any, false],
-    [{ global: { cattle: {} } } as any, false],
-  ])('should define cattle.psp.enabled and set to false if not present in value.global', (chartValues, expected) => {
+    { global: {} } as any,
+    { global: { cattle: {} } } as any,
+  ])('should define cattle.psp.enabled and set to false', (chartValues) => {
     shallowMount(ChartPsp, { propsData: { value: chartValues } });
 
-    expect(chartValues.global.cattle.psp.enabled).toBe(expected);
+    expect(chartValues.global.cattle.psp.enabled).toBe(false);
   });
 });

--- a/shell/pages/c/_cluster/apps/charts/__tests__/install.helper.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/install.helper.test.ts
@@ -7,7 +7,7 @@ describe('fX: ignoreVariables', () => {
       ['v1.24.11+rke2r1', false],
       ['v1.25.11+rke2r1', true],
     ])('should not return variable path list if cluster has k8s version %p and PSP setting %p', (version, hasPsp) => {
-      const cluster = { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } };
+      const cluster = { kubernetesVersion: version };
       const data = {
         chart:  { name },
         values: { global: { rbac: { pspEnabled: hasPsp } } }
@@ -21,7 +21,7 @@ describe('fX: ignoreVariables', () => {
     it.each([
       ['v1.25.11+rke2r1', false],
     ])('should return questions if cluster has k8s version %p and PSP setting %p', (version, hasPsp) => {
-      const cluster = { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } };
+      const cluster = { kubernetesVersion: version };
       const data = {
         chart:  { name },
         values: { global: { rbac: { pspEnabled: hasPsp } } }

--- a/shell/pages/c/_cluster/apps/charts/__tests__/install.helper.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/install.helper.test.ts
@@ -1,0 +1,35 @@
+import { ignoreVariables } from '@shell/pages/c/_cluster/apps/charts/install.helpers';
+
+describe('fX: ignoreVariables', () => {
+  describe.each([['epinio', 'global.rbac.pspEnabled']])('given chart %p with path %p', (name, path) => {
+    it.each([
+      ['v1.24.11+rke2r1', true],
+      ['v1.24.11+rke2r1', false],
+      ['v1.25.11+rke2r1', true],
+    ])('should not return variable path list if cluster has k8s version %p and PSP setting %p', (version, hasPsp) => {
+      const cluster = { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } };
+      const data = {
+        chart:  { name },
+        values: { global: { rbac: { pspEnabled: hasPsp } } }
+      };
+
+      const paths = ignoreVariables(cluster, data);
+
+      expect(paths).toStrictEqual([]);
+    });
+
+    it.each([
+      ['v1.25.11+rke2r1', false],
+    ])('should return questions if cluster has k8s version %p and PSP setting %p', (version, hasPsp) => {
+      const cluster = { metadata: { annotations: { 'management.cattle.io/current-cluster-controllers-version': version } } };
+      const data = {
+        chart:  { name },
+        values: { global: { rbac: { pspEnabled: hasPsp } } }
+      };
+
+      const paths = ignoreVariables(cluster, data);
+
+      expect(paths).toStrictEqual([path]);
+    });
+  });
+});

--- a/shell/pages/c/_cluster/apps/charts/install.helpers.js
+++ b/shell/pages/c/_cluster/apps/charts/install.helpers.js
@@ -1,0 +1,29 @@
+import { get } from '@shell/utils/object';
+
+/**
+ * Return list of variables to filter chart questions
+ */
+export const ignoreVariables = (cluster, data) => {
+  const pspChartMap = {
+    epinio:                     'global.rbac.pspEnabled',
+    longhorn:                   'enablePSP',
+    'rancher-alerting-drivers': 'global.cattle.psp.enabled',
+    neuvector:                  'global.cattle.psp.enabled',
+    'prometheus-federator':     'global.rbac.pspEnabled',
+  };
+  const path = pspChartMap[data.chart.name];
+
+  if (path) {
+    const clusterVersion = cluster?.metadata?.annotations?.['management.cattle.io/current-cluster-controllers-version'] || '';
+    const version = clusterVersion.match(/\d+/g);
+    const isRequiredVersion = version?.length ? +version[0] === 1 && +version[1] < 25 : false;
+    const hasPsp = get(data.values, path);
+
+    // Provide path as question variable to be ignored
+    if (!isRequiredVersion && !hasPsp) {
+      return [path];
+    }
+  }
+
+  return [];
+};

--- a/shell/pages/c/_cluster/apps/charts/install.helpers.js
+++ b/shell/pages/c/_cluster/apps/charts/install.helpers.js
@@ -14,7 +14,7 @@ export const ignoreVariables = (cluster, data) => {
   const path = pspChartMap[data.chart.name];
 
   if (path) {
-    const clusterVersion = cluster?.metadata?.annotations?.['management.cattle.io/current-cluster-controllers-version'] || '';
+    const clusterVersion = cluster?.kubernetesVersion || '';
     const version = clusterVersion.match(/\d+/g);
     const isRequiredVersion = version?.length ? +version[0] === 1 && +version[1] < 25 : false;
     const hasPsp = get(data.values, path);

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -32,6 +32,7 @@ import { CATALOG as CATALOG_ANNOTATIONS, PROJECT } from '@shell/config/labels-an
 
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import { clone, diff, get, set } from '@shell/utils/object';
+import { ignoreVariables } from './install.helpers';
 import { findBy, insertAt } from '@shell/utils/array';
 import Vue from 'vue';
 import { saferDump } from '@shell/utils/create-yaml';
@@ -93,7 +94,6 @@ export default {
     await this.fetchChart();
 
     await this.fetchAutoInstallInfo();
-
     this.errors = [];
 
     // If the chart doesn't contain system `systemDefaultRegistry` properties there's no point applying them
@@ -427,6 +427,13 @@ export default {
   computed: {
     ...mapGetters({ inStore: 'catalog/inStore', features: 'features/get' }),
     mcm: mapFeature(MULTI_CLUSTER),
+
+    /**
+     * Return list of variables to filter chart questions
+     */
+    ignoreVariables() {
+      return ignoreVariables(this.currentCluster, this.versionInfo);
+    },
 
     namespaceIsNew() {
       const all = this.$store.getters['cluster/all'](NAMESPACE);
@@ -1520,7 +1527,7 @@ export default {
         </div>
         <div class="scroll__container">
           <div class="scroll__content">
-            <!-- Values (as Custom Component) -->
+            <!-- Values (as Custom Component in ./shell/charts/) -->
             <template v-if="valuesComponent && showValuesComponent">
               <Tabbed
                 v-if="componentHasTabs"
@@ -1563,7 +1570,8 @@ export default {
                 />
               </template>
             </template>
-            <!-- Values (as Questions)  -->
+
+            <!-- Values (as Questions, abstracted component based on question.yaml configuration from repositories)  -->
             <Tabbed
               v-else-if="hasQuestions && showQuestions"
               ref="tabs"
@@ -1577,6 +1585,7 @@ export default {
                 :in-store="inStore"
                 :mode="mode"
                 :source="versionInfo"
+                :ignore-variables="ignoreVariables"
                 tabbed="multiple"
                 :target-namespace="targetNamespace"
               />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8434
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
PSP checkbox to be displayed if K8S < 1.25 or PSP is already enabled.
This is applied for the charts:
- OPA Gatekeeper
- Istio
- Logging
- Monitoring
- Rancher Backup
- Alerting
- Epinio
- Longhorn
- NeuVector
- Prometheus Federator

### Technical notes summary
- Moved markup within the component to avoid empty spaces
- Allowed to pass title for areas which require one
- Passed cluster object to parse version
- Extended tests
- Created helper to get ignored questions with variables matching the path of the current cluster (ignore logic already existed) for same condition
- Added tests to the helper, created separately due high complexity of the component (2500+ lines)

### Areas or cases that should be tested
All the charts above for clusters with K3/RKE2 and K8S < v1.25 or >= 1.25 and PSP disabled/enabled

### Areas which could experience regressions
Same as above.

### Screenshot/Video

#### Custom charts

PSP checkbox present in all the charts for 1.24 and not 1.25

https://user-images.githubusercontent.com/5009481/227222888-c7e4e624-3a73-4af3-95c3-87e716d5f8e5.mp4

Proof of Cluster update (with error in the navigation 🤔 )

https://user-images.githubusercontent.com/5009481/227243291-86042c2e-0b8e-4917-b365-da42a900a45b.mp4

Disabling PSP but with an error in the server response

https://user-images.githubusercontent.com/5009481/227243277-c9369f63-9a5e-460b-91c1-4a22d30b84ed.mp4

#### Standard charts (question.yaml)

PSP checkbox present in the charts for 1.24 and not 1.25

https://user-images.githubusercontent.com/5009481/227595029-4f15e81e-92f0-4f09-a96c-81de8057c1eb.mp4

Disabling PSP but with an error in the server response


https://user-images.githubusercontent.com/5009481/227595125-055229b4-22a1-4be8-b604-98d5e6467e6a.mp4

