### PR TITLE
remember the chosen chart version when installation is cancelled

### DIFF
--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -292,7 +292,13 @@ export default {
       // use the first version provided by the Helm chart
       // as the default.
       if ( !this.query.versionName && this.chart.versions?.length ) {
-        this.query.versionName = this.chart.versions[0].version;
+        if (this.showPreRelease) {
+          this.query.versionName = this.chart.versions[0].version;
+        } else {
+          const firstRelease = this.chart.versions.find(v => !isPrerelease(v.version));
+
+          this.query.versionName = firstRelease?.version || this.chart.versions[0].version;
+        }
       }
 
       if ( !this.query.versionName ) {
@@ -426,7 +432,7 @@ export default {
         repoType: this.chart.repoType,
         repoName: this.chart.repoName,
         name:     this.chart.chartName,
-        version:  this.chart.versionName,
+        version:  this.query.versionName,
       };
 
       return {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8491 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Two problems:
1. The `cancel` method during chart installation wasn't retaining the version selected because `versionName` is not a property on `chart`; that resource has an array of possible versions
2. If there's no version present in the route query,  we select the latest version present without filtering prereleases out when the relevant user pref is configured to hide them


### Areas or cases that should be tested
* The selected chart version should be remembered when cancelling a chart install
* If the user loads the chart page w/ no version in the query, the one automatically selected shouldn't be a pre-release if there's a user pref set to hide them

