### PR TITLE
Backport 2.6: Disallow v-html usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
     'unicorn/no-new-buffer':    'off',
     'vue/html-self-closing':    'off',
     'vue/no-unused-components': 'warn',
-    'vue/no-v-html':            'on',
+    'vue/no-v-html':            'error',
     'wrap-iife':                'off',
 
     'array-bracket-spacing':             'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
     'unicorn/no-new-buffer':    'off',
     'vue/html-self-closing':    'off',
     'vue/no-unused-components': 'warn',
-    'vue/no-v-html':            'off',
+    'vue/no-v-html':            'on',
     'wrap-iife':                'off',
 
     'array-bracket-spacing':             'warn',

--- a/pkg/epinio/list/namespaces.vue
+++ b/pkg/epinio/list/namespaces.vue
@@ -135,7 +135,7 @@ export default {
         class="modal-content"
         :show-actions="true"
       >
-        <h4 slot="title" v-html="t('epinio.namespace.create')" />
+        <h4 slot="title" v-clean-html="t('epinio.namespace.create')" />
         <div slot="body" class="model-body">
           <LabeledInput
             ref="namespaceName"

--- a/pkg/epinio/windowComponents/ApplicationLogs.vue
+++ b/pkg/epinio/windowComponents/ApplicationLogs.vue
@@ -320,8 +320,8 @@ export default {
           <tbody class="logs-body">
             <template v-if="filtered.length">
               <tr v-for="line in filtered" :key="line.id">
-                <td :key="line.id + '-time'" class="time" v-html="format(line.time)" />
-                <td :key="line.id + '-msg'" class="msg" v-html="line.msg" />
+                <td :key="line.id + '-time'" v-clean-html="format(line.time)" class="time" />
+                <td :key="line.id + '-msg'" v-clean-html="line.msg" class="msg" />
               </tr>
             </template>
             <tr v-else-if="search">

--- a/pkg/harvester/components/UpgradeInfo.vue
+++ b/pkg/harvester/components/UpgradeInfo.vue
@@ -25,7 +25,7 @@ export default {
   <div>
     <Banner color="warning">
       <strong>{{ t('harvester.upgradePage.upgradeInfo.warning') }}:</strong>
-      <p class="mb-5" v-html="t('harvester.upgradePage.upgradeInfo.doc', {}, true)">
+      <p v-clean-html="t('harvester.upgradePage.upgradeInfo.doc', {}, true)" class="mb-5">
       </p>
 
       <p class="mb-5">

--- a/pkg/harvester/dialog/ConfirmRelatedToRemoveDialog.vue
+++ b/pkg/harvester/dialog/ConfirmRelatedToRemoveDialog.vue
@@ -135,12 +135,12 @@ export default {
     </h4>
     <div slot="body" class="pl-10 pr-10">
       <span
-        v-html="t(warningMessageKey, { type, names: resourceNames }, true)"
+        v-clean-html="t(warningMessageKey, { type, names: resourceNames }, true)"
       ></span>
 
       <div class="mt-10 mb-10">
         <span
-          v-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+          v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
         ></span>
       </div>
       <div class="mb-10">

--- a/pkg/harvester/dialog/HarvesterAddHotplugModal.vue
+++ b/pkg/harvester/dialog/HarvesterAddHotplugModal.vue
@@ -110,7 +110,7 @@ export default {
 
 <template>
   <Card ref="modal" name="modal" :show-highlight-border="false">
-    <h4 slot="title" class="text-default-text" v-html="t('harvester.modal.hotplug.title')" />
+    <h4 slot="title" v-clean-html="t('harvester.modal.hotplug.title')" class="text-default-text" />
 
     <template #body>
       <LabeledInput

--- a/pkg/harvester/dialog/HarvesterBackupModal.vue
+++ b/pkg/harvester/dialog/HarvesterBackupModal.vue
@@ -90,8 +90,8 @@ export default {
   <Card :show-highlight-border="false">
     <h4
       slot="title"
+      v-clean-html="t('harvester.modal.backup.addBackup')"
       class="text-default-text"
-      v-html="t('harvester.modal.backup.addBackup')"
     />
 
     <template #body>

--- a/pkg/harvester/dialog/HarvesterUnplugVolume.vue
+++ b/pkg/harvester/dialog/HarvesterUnplugVolume.vue
@@ -81,8 +81,8 @@ export default {
   <Card ref="modal" name="modal" :show-highlight-border="false">
     <h4
       slot="title"
+      v-clean-html="t('harvester.virtualMachine.unplug.title', { name: diskName })"
       class="text-default-text"
-      v-html="t('harvester.virtualMachine.unplug.title', { name: diskName })"
     />
 
     <div slot="actions" class="actions">

--- a/pkg/harvester/dialog/HarvesterVMSnapshotDialog.vue
+++ b/pkg/harvester/dialog/HarvesterVMSnapshotDialog.vue
@@ -112,8 +112,8 @@ export default {
   <Card :show-highlight-border="false">
     <h4
       slot="title"
+      v-clean-html="t('harvester.modal.vmSnapshot.title')"
       class="text-default-text"
-      v-html="t('harvester.modal.vmSnapshot.title')"
     />
 
     <template #body>

--- a/pkg/harvester/edit/harvesterhci.io.setting.vue
+++ b/pkg/harvester/edit/harvesterhci.io.setting.vue
@@ -145,9 +145,9 @@ export default {
     @finish="saveSettings"
     @cancel="done"
   >
-    <h4 v-html="description"></h4>
+    <h4 v-clean-html="description"></h4>
 
-    <h5 v-if="editHelp" class="edit-help" v-html="editHelp" />
+    <h5 v-if="editHelp" v-clean-html="editHelp" class="edit-help" />
 
     <div class="edit-change mt-20">
       <h5 v-t="'advancedSettings.edit.changeSetting'" />

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/DeviceList.vue
@@ -108,7 +108,7 @@ export default {
         <button v-else type="button" class="btn btn-sm role-secondary mr-5" @click="e=>{enableGroup(group.rows); e.target.blur()}">
           {{ t('harvester.pci.enableGroup') }}
         </button>
-        <span v-html="group.key" />
+        <span v-clean-html="group.key" />
       </div>
     </template>
     <template #cell:claimed="{row}">

--- a/pkg/harvester/list/harvesterhci.io.setting.vue
+++ b/pkg/harvester/list/harvesterhci.io.setting.vue
@@ -194,7 +194,7 @@ export default {
               Modified
             </span>
           </h1>
-          <h2 v-html="t(setting.description, {}, true)">
+          <h2 v-clean-html="t(setting.description, {}, true)">
           </h2>
         </div>
         <div v-if="setting.hasActions" :id="setting.id" class="action">

--- a/pkg/harvester/list/harvesterhci.io.virtualmachinetemplateversion.vue
+++ b/pkg/harvester/list/harvesterhci.io.virtualmachinetemplateversion.vue
@@ -111,7 +111,7 @@ export default {
     <template #group-by="group">
       <div class="group-bar">
         <div class="group-tab">
-          <div class="project-name" v-html="templateLabel(group.group)" />
+          <div v-clean-html="templateLabel(group.group)" class="project-name" />
         </div>
 
         <div class="right">

--- a/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
+++ b/pkg/harvester/promptRemove/kubevirt.io.virtualmachine.vue
@@ -134,7 +134,7 @@ export default {
 <template>
   <div class="mt-10">
     {{ t('promptRemove.attemptingToRemove', {type}) }}
-    <span v-html="resourceNames(names, plusMore, t)"></span>
+    <span v-clean-html="resourceNames(names, plusMore, t)"></span>
 
     <div class="mt-10">
       {{ t('harvester.virtualMachine.promptRemove.title') }}

--- a/pkg/rancher-components/src/components/Banner/Banner.test.ts
+++ b/pkg/rancher-components/src/components/Banner/Banner.test.ts
@@ -1,10 +1,18 @@
 import { mount } from '@vue/test-utils';
 import { Banner } from './index';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive'
 
 describe('component: Banner', () => {
   it('should display text based on label', () => {
     const label = 'test';
-    const wrapper = mount(Banner, { propsData: { label } });
+    const wrapper = mount(
+      Banner,
+      {
+        directives: {
+         cleanHtmlDirective 
+        },
+        propsData: { label }
+      });
 
     const element = wrapper.find('span').element;
 

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
     <slot>
       <t v-if="labelKey" :k="labelKey" :raw="true" />
       <span v-else-if="messageLabel">{{ messageLabel }}</span>
-      <span v-else v-html="nlToBr(label)" />
+      <span v-else v-clean-html="nlToBr(label)" />
     </slot>
     <div v-if="closable" class="closer" @click="$emit('close')">
       <i class="icon icon-2x icon-close closer-icon" />

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -152,7 +152,7 @@ export default Vue.extend({
         v-if="label"
         :class="[ muteLabel ? 'text-muted' : '', 'radio-label', 'm-0']"
         :for="name"
-        v-html="label"
+        v-clean-html="label"
       >
         <slot name="label">{{ label }}</slot>
       </label>

--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -170,7 +170,7 @@ export default {
       <div class="custom-overlay">
         <Banner color="info">
           <span
-            v-html="t('istio.customOverlayFile.tip', {}, true)"
+            v-clean-html="t('istio.customOverlayFile.tip', {}, true)"
           ></span>
         </Banner>
         <YamlEditor

--- a/shell/chart/logging/index.vue
+++ b/shell/chart/logging/index.vue
@@ -57,7 +57,7 @@ export default {
           :label="t('logging.install.systemdLogPath')"
           :tooltip="t('logging.install.tooltip', {}, true)"
         />
-        <p class="mt-6" v-html="t('logging.install.url', {}, true)">
+        <p v-clean-html="t('logging.install.url', {}, true)" class="mt-6">
         </p>
       </div>
     </div>

--- a/shell/chart/monitoring/steps/uninstall-v1.vue
+++ b/shell/chart/monitoring/steps/uninstall-v1.vue
@@ -87,7 +87,7 @@ export default {
           <p>
             {{ t('monitoring.installSteps.uninstallV1.warning1') }}
           </p>
-          <p class="mt-10" v-html="t('monitoring.installSteps.uninstallV1.warning2', {}, true)">
+          <p v-clean-html="t('monitoring.installSteps.uninstallV1.warning2', {}, true)" class="mt-10">
           </p>
         </template>
       </IconMessage>
@@ -108,7 +108,7 @@ export default {
         <p class="">
           {{ t('monitoring.installSteps.uninstallV1.success1') }}
         </p>
-        <p class="mt-10" v-html="t('monitoring.installSteps.uninstallV1.success2')">
+        <p v-clean-html="t('monitoring.installSteps.uninstallV1.success2')" class="mt-10">
         </p>
       </template>
     </IconMessage>

--- a/shell/cloud-credential/aws.vue
+++ b/shell/cloud-credential/aws.vue
@@ -93,6 +93,6 @@ export default {
       :options="knownRegions"
       @input="value.setData('defaultRegion', $event);"
     />
-    <p class="text-muted mt-5" v-html="t('cluster.credential.aws.defaultRegion.help', {}, true)" />
+    <p v-clean-html="t('cluster.credential.aws.defaultRegion.help', {}, true)" class="text-muted mt-5" />
   </div>
 </template>

--- a/shell/cloud-credential/digitalocean.vue
+++ b/shell/cloud-credential/digitalocean.vue
@@ -39,6 +39,6 @@ export default {
       :mode="mode"
       @input="value.setData('accessToken', $event);"
     />
-    <p class="text-muted mt-10" v-html="t('cluster.credential.digitalocean.accessToken.help', {}, true)" />
+    <p v-clean-html="t('cluster.credential.digitalocean.accessToken.help', {}, true)" class="text-muted mt-10" />
   </div>
 </template>

--- a/shell/cloud-credential/gcp.vue
+++ b/shell/cloud-credential/gcp.vue
@@ -59,6 +59,6 @@ export default {
       @input="value.setData('authEncodedJson', $event);"
     />
     <FileSelector class="role-primary btn-sm mt-20 mb-20" :label="t('generic.readFromFile')" @selected="onFileSelected" />
-    <p class="text-muted" v-html="t('cluster.credential.gcp.authEncodedJson.help', {}, true)" />
+    <p v-clean-html="t('cluster.credential.gcp.authEncodedJson.help', {}, true)" class="text-muted" />
   </div>
 </template>

--- a/shell/cloud-credential/linode.vue
+++ b/shell/cloud-credential/linode.vue
@@ -39,6 +39,6 @@ export default {
       :mode="mode"
       @input="value.setData('token', $event);"
     />
-    <p class="text-muted mt-10" v-html="t('cluster.credential.linode.accessToken.help', {}, true)" />
+    <p v-clean-html="t('cluster.credential.linode.accessToken.help', {}, true)" class="text-muted mt-10" />
   </div>
 </template>

--- a/shell/components/ActionMenu.vue
+++ b/shell/components/ActionMenu.vue
@@ -241,7 +241,7 @@ export default {
         @click="execute(opt, $event)"
       >
         <i v-if="opt.icon" :class="{icon: true, [opt.icon]: true}" />
-        <span v-html="opt.label" />
+        <span v-clean-html="opt.label" />
       </li>
       <li v-if="!hasOptions(menuOptions)" class="no-actions">
         <span v-t="'sortableTable.noActions'" />

--- a/shell/components/AssignTo.vue
+++ b/shell/components/AssignTo.vue
@@ -113,7 +113,7 @@ export default {
     :scrollable="true"
   >
     <Card v-if="loaded" :show-highlight-border="false">
-      <h4 slot="title" class="text-default-text" v-html="t('assignTo.title', {count: resourceCount}, true)" />
+      <h4 slot="title" v-clean-html="t('assignTo.title', {count: resourceCount}, true)" class="text-default-text" />
 
       <div slot="body" class="pl-10 pr-10">
         <form>

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -256,7 +256,7 @@ export default Vue.extend({
     <span
       v-if="labelAs === 'text' && displayLabel"
       v-tooltip="tooltip"
-      v-html="displayLabel"
+      v-clean-html="displayLabel"
     />
   </button>
 </template>

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -38,9 +38,9 @@ export default {
     </div>
     <h1
       v-else-if="title"
+      v-clean-html="title"
       data-testid="banner-title"
       class="title"
-      v-html="title"
     ></h1>
     <div v-if="pref" class="close-button" @click="hide()">
       <i class="icon icon-close" />

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -416,7 +416,7 @@ export default {
                     <h5>
                       <span
                         v-if="$store.getters['i18n/exists'](subtype.label)"
-                        v-html="t(subtype.label)"
+                        v-clean-html="t(subtype.label)"
                       ></span>
                       <span v-else>{{ subtype.label }}</span>
                     </h5>
@@ -426,7 +426,7 @@ export default {
                   <div v-if="subtype.description" class="description">
                     <span
                       v-if="$store.getters['i18n/exists'](subtype.description)"
-                      v-html="t(subtype.description, {}, true)"
+                      v-clean-html="t(subtype.description, {}, true)"
                     ></span>
                     <span v-else>{{ subtype.description }}</span>
                   </div>

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -157,7 +157,7 @@ export default {
       :class="{'conceal': concealed}"
     />
 
-    <span v-else :class="{'conceal': concealed, 'monospace': monospace && !isBinary}" v-html="bodyHtml" />
+    <span v-else v-clean-html="bodyHtml" :class="{'conceal': concealed, 'monospace': monospace && !isBinary}" />
 
     <template v-if="!isBinary && !jsonStr && isLong && !expanded">
       <a href="#" @click.prevent="expand">{{ plusMore }}</a>

--- a/shell/components/DisableAuthProviderModal.vue
+++ b/shell/components/DisableAuthProviderModal.vue
@@ -49,7 +49,7 @@ export default {
       </h4>
       <div slot="body">
         <div class="mb-10">
-          <p v-html="t('promptRemove.attemptingToRemoveAuthConfig', null, true)" />
+          <p v-clean-html="t('promptRemove.attemptingToRemoveAuthConfig', null, true)" />
         </div>
       </div>
       <template #actions>

--- a/shell/components/EmberPage.vue
+++ b/shell/components/EmberPage.vue
@@ -512,7 +512,7 @@ export default {
 <template>
   <div ref="emberPage" class="ember-page">
     <Loading v-if="!inline" :loading="!loaded" mode="content" :no-delay="true" />
-    <div v-if="inline && !loaded" class="inline-loading" v-html="t('generic.loading', {}, true)" />
+    <div v-if="inline && !loaded" v-clean-html="t('generic.loading', {}, true)" class="inline-loading" />
     <div v-if="error" class="ember-page-error">
       <div>{{ t('embedding.unavailable') }}</div>
       <button class="btn role-primary" @click="initFrame()">

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -328,7 +328,7 @@ export default {
       <template #group-by="group">
         <div class="project-bar" :class="{'has-description': projectDescription(group.group)}">
           <div v-trim-whitespace class="group-tab">
-            <div class="project-name" v-html="projectLabel(group.group)" />
+            <div v-clean-html="projectLabel(group.group)" class="project-name" />
             <div v-if="projectDescription(group.group)" class="description text-muted text-small">
               {{ projectDescription(group.group) }}
             </div>

--- a/shell/components/FileDiff.vue
+++ b/shell/components/FileDiff.vue
@@ -97,7 +97,7 @@ export default {
 <template>
   <div>
     <resize-observer @notify="fit" />
-    <div ref="root" class="root" v-html="html" />
+    <div ref="root" v-clean-html="html" class="root" />
   </div>
 </template>
 

--- a/shell/components/LogItem.vue
+++ b/shell/components/LogItem.vue
@@ -36,8 +36,8 @@ export default {
   <div class="line">
     <span class="time">{{ format(source.time) }}</span>
     <span
+      v-clean-html="source.msg"
       class="msg"
-      v-html="source.msg"
     />
   </div>
 </template>

--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -75,7 +75,7 @@ export default {
 </script>
 
 <template>
-  <div v-if="loaded" class="markdown" v-html="sanitized" />
+  <div v-if="loaded" v-clean-html="sanitized" class="markdown" />
   <Loading v-else />
 </template>
 

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -337,7 +337,7 @@ export default {
         <div class="mb-10">
           <template v-if="!hasCustomRemove">
             {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-              v-html="resourceNames(names, plusMore, t)"
+              v-clean-html="resourceNames(names, plusMore, t)"
             ></span>
           </template>
 
@@ -358,7 +358,7 @@ export default {
             />
             <div v-if="needsConfirm" class="mt-10">
               <span
-                v-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+                v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
               ></span>
             </div>
           </template>

--- a/shell/components/PromptRestore.vue
+++ b/shell/components/PromptRestore.vue
@@ -212,7 +212,7 @@ export default {
     :scrollable="true"
   >
     <Card v-if="loaded" class="prompt-restore" :show-highlight-border="false">
-      <h4 slot="title" class="text-default-text" v-html="t('promptRestore.title', null, true)" />
+      <h4 slot="title" v-clean-html="t('promptRestore.title', null, true)" class="text-default-text" />
 
       <div slot="body" class="pl-10 pr-10">
         <form>

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -402,7 +402,7 @@ export default {
     </template>
 
     <template #group-by="{group: thisGroup}">
-      <div class="group-tab" v-html="thisGroup.ref" />
+      <div v-clean-html="thisGroup.ref" class="group-tab" />
     </template>
 
     <!-- Pass down templates provided by the caller -->

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -126,7 +126,7 @@ export default {
         @click.prevent="changeSort($event, col)"
       >
         <span v-if="col.sort" v-tooltip="col.tooltip">
-          <span v-html="labelFor(col)" />
+          <span v-clean-html="labelFor(col)" />
           <span class="icon-stack">
             <i class="icon icon-sort icon-stack-1x faded" />
             <i v-if="isCurrent(col) && !descending" class="icon icon-sort-down icon-stack-1x" />

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -858,7 +858,7 @@ export default {
                 @mouseleave="setBulkActionOfInterest(null)"
               >
                 <i v-if="act.icon" :class="act.icon" />
-                <span v-html="act.label" />
+                <span v-clean-html="act.label" />
               </button>
               <ActionDropdown :class="bulkActionsDropdownClass" class="bulk-actions-dropdown" :disable-button="!selectedRows.length" size="sm">
                 <template #button-content>
@@ -884,7 +884,7 @@ export default {
                       @mouseleave="setBulkActionOfInterest(null)"
                     >
                       <i v-if="act.icon" :class="act.icon" />
-                      <span v-html="act.label" />
+                      <span v-clean-html="act.label" />
                     </li>
                   </ul>
                 </template>

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
 import { _EDIT, _YAML } from '@shell/config/query-params';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('component: CruResource', () => {
   it('should hide Cancel button', () => {
@@ -33,7 +34,8 @@ describe('component: CruResource', () => {
   it('should display errors', () => {
     const errors = ['mistake!', 'BiG MiStAke11'];
     const wrapper = mount(CruResource, {
-      propsData: {
+      directives: { cleanHtmlDirective },
+      propsData:  {
         canYaml:  false,
         mode:     _EDIT,
         resource: {},

--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -62,7 +62,7 @@ export default {
           <i class="icon icon-spinner icon-lg" />
         </div>
       </div>
-      <div class="name" :class="{'text-muted': useMuted}" v-html="t('principal.loading', null, true)" />
+      <div v-clean-html="t('principal.loading', null, true)" class="name" :class="{'text-muted': useMuted}" />
       <div class="description" />
     </template>
 

--- a/shell/components/form/ServiceNameSelect.vue
+++ b/shell/components/form/ServiceNameSelect.vue
@@ -149,8 +149,8 @@ export default {
     <template v-if="serviceNameNew">
       <div class="row span-6">
         <Banner
+          v-clean-html="t('workload.serviceAccountName.createMessage', { name: serviceName }) "
           color="info"
-          v-html="t('workload.serviceAccountName.createMessage', { name: serviceName }) "
         ></Banner>
       </div>
     </template>

--- a/shell/components/formatter/ServiceTargets.vue
+++ b/shell/components/formatter/ServiceTargets.vue
@@ -103,7 +103,7 @@ export default {
       <Endpoints v-model="parsed" :row="{}" :col="{}" />
     </div>
     <div v-for="(port, index) in parsed" v-else :key="index" class="text-small">
-      <span v-html="port.label"></span>
+      <span v-clean-html="port.label"></span>
     </div>
   </div>
 </template>

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -190,9 +190,9 @@ export default {
     <div v-if="showHeader" class="header" :class="{'active': isOverview, 'noHover': !canCollapse}" @click="groupSelected()">
       <slot name="header">
         <n-link v-if="hasOverview" :to="group.children[0].route" :exact="group.children[0].exact">
-          <h6 v-html="group.labelDisplay || group.label" />
+          <h6 v-clean-html="group.labelDisplay || group.label" />
         </n-link>
-        <h6 v-else v-html="group.labelDisplay || group.label" />
+        <h6 v-else v-clean-html="group.labelDisplay || group.label" />
       </slot>
       <i v-if="!onlyHasOverview && canCollapse" class="icon toggle" :class="{'icon-chevron-down': !isExpanded, 'icon-chevron-up': isExpanded}" @click="peek($event, true)" />
     </div>

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -341,9 +341,9 @@ export default {
           <div @click="hide()">
             <nuxt-link
               v-tooltip="{ content: fullVersion, classes: 'footer-tooltip' }"
+              v-clean-html="displayVersion"
               :to="{ name: 'about' }"
               class="version"
-              v-html="displayVersion"
             />
           </div>
         </div>

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -85,7 +85,7 @@ export default {
       @mouseleave="setNear(false)"
     >
       <span v-if="type.labelKey" class="label"><t :k="type.labelKey" /></span>
-      <span v-else class="label" :class="{'no-icon': !type.icon}" v-html="type.labelDisplay || type.label" />
+      <span v-else v-clean-html="type.labelDisplay || type.label" class="label" :class="{'no-icon': !type.icon}" />
       <span v-if="showFavorite || showCount" class="count">
         <Favorite v-if="showFavorite" :resource="type.name" />
         {{ type.count }}

--- a/shell/creators/app/.eslintrc.js
+++ b/shell/creators/app/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     'unicorn/no-new-buffer':    'off',
     'vue/html-self-closing':    'off',
     'vue/no-unused-components': 'warn',
-    'vue/no-v-html':            'off',
+    'vue/no-v-html':            'on',
     'wrap-iife':                'off',
 
     'array-bracket-spacing':             'warn',

--- a/shell/creators/app/.eslintrc.js
+++ b/shell/creators/app/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     'unicorn/no-new-buffer':    'off',
     'vue/html-self-closing':    'off',
     'vue/no-unused-components': 'warn',
-    'vue/no-v-html':            'on',
+    'vue/no-v-html':            'error',
     'wrap-iife':                'off',
 
     'array-bracket-spacing':             'warn',

--- a/shell/detail/harvesterhci.io.management.cluster.vue
+++ b/shell/detail/harvesterhci.io.management.cluster.vue
@@ -77,17 +77,17 @@ export default {
       class="p-10"
     >
       <h4
-        v-html="t('cluster.harvester.registration.step1', null, true)"
+        v-clean-html="t('cluster.harvester.registration.step1', null, true)"
       />
 
       <h4
+        v-clean-html="t('cluster.harvester.registration.step2', null, true)"
         class="mt-10"
-        v-html="t('cluster.harvester.registration.step2', null, true)"
       />
 
       <h4
+        v-clean-html="t('cluster.harvester.registration.step3', null, true)"
         class="mt-10"
-        v-html="t('cluster.harvester.registration.step3', null, true)"
       />
       <CopyCode class="m-10 p-10">
         {{ registrationURL }}

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -624,8 +624,8 @@ export default {
           <template #group-by="{group}">
             <div class="pool-row" :class="{'has-description':group.ref && group.ref.template}">
               <div v-trim-whitespace class="group-tab">
-                <div v-if="group && group.ref" v-html="group.ref.groupByPoolShortLabel" />
-                <div v-else v-html="t('resourceTable.groupLabel.notInANodePool')">
+                <div v-if="group && group.ref" v-clean-html="group.ref.groupByPoolShortLabel" />
+                <div v-else v-clean-html="t('resourceTable.groupLabel.notInANodePool')">
                 </div>
                 <div v-if="group.ref && group.ref.template" class="description text-muted text-small">
                   {{ group.ref.providerDisplay }} &ndash;  {{ group.ref.providerLocation }} / {{ group.ref.providerSize }} ({{ group.ref.providerName }})
@@ -666,9 +666,9 @@ export default {
           <template #group-by="{group}">
             <div class="pool-row" :class="{'has-description':group.ref && group.ref.nodeTemplate}">
               <div v-trim-whitespace class="group-tab">
-                <div v-if="group.ref" v-html="t('resourceTable.groupLabel.nodePool', { name: group.ref.spec.hostnamePrefix}, true)">
+                <div v-if="group.ref" v-clean-html="t('resourceTable.groupLabel.nodePool', { name: group.ref.spec.hostnamePrefix}, true)">
                 </div>
-                <div v-else v-html="t('resourceTable.groupLabel.notInANodePool')">
+                <div v-else v-clean-html="t('resourceTable.groupLabel.notInANodePool')">
                 </div>
                 <div v-if="group.ref && group.ref.nodeTemplate" class="description text-muted text-small">
                   {{ group.ref.providerDisplay }} &ndash;  {{ group.ref.providerLocation }} / {{ group.ref.providerSize }} ({{ group.ref.providerName }})
@@ -699,8 +699,8 @@ export default {
           <tbody class="logs-body">
             <template v-if="logs.length">
               <tr v-for="line in logs" :key="line.id">
-                <td :key="line.id + '-time'" class="time" v-html="format(line.time)" />
-                <td :key="line.id + '-msg'" class="msg" v-html="line.msg" />
+                <td :key="line.id + '-time'" v-clean-html="format(line.time)" class="time" />
+                <td :key="line.id + '-msg'" v-clean-html="line.msg" class="msg" />
               </tr>
             </template>
             <tr v-else-if="!logOpen" v-t="'cluster.log.connecting'" colspan="2" class="msg text-muted" />
@@ -713,17 +713,17 @@ export default {
         <Banner color="warning" :label="t('cluster.import.warningBanner')" />
         <CustomCommand v-if="value.isCustom" :cluster-token="clusterToken" :cluster="value" @copied-windows="hasWindowsMachine ? null : showWindowsWarning = true" />
         <template v-else>
-          <h4 v-html="t('cluster.import.commandInstructions', null, true)" />
+          <h4 v-clean-html="t('cluster.import.commandInstructions', null, true)" />
           <CopyCode class="m-10 p-10">
             {{ clusterToken.command }}
           </CopyCode>
 
-          <h4 class="mt-10" v-html="t('cluster.import.commandInstructionsInsecure', null, true)" />
+          <h4 v-clean-html="t('cluster.import.commandInstructionsInsecure', null, true)" class="mt-10" />
           <CopyCode class="m-10 p-10">
             {{ clusterToken.insecureCommand }}
           </CopyCode>
 
-          <h4 class="mt-10" v-html="t('cluster.import.clusterRoleBindingInstructions', null, true)" />
+          <h4 v-clean-html="t('cluster.import.clusterRoleBindingInstructions', null, true)" class="mt-10" />
           <CopyCode class="m-10 p-10">
             {{ t('cluster.import.clusterRoleBindingCommand', null, true) }}
           </CopyCode>

--- a/shell/dialog/AddClusterMemberDialog.vue
+++ b/shell/dialog/AddClusterMemberDialog.vue
@@ -40,7 +40,7 @@ export default {
 
 <template>
   <Card class="prompt-rotate" :show-highlight-border="false">
-    <h4 slot="title" class="text-default-text" v-html="t('addClusterMemberDialog.title')" />
+    <h4 slot="title" v-clean-html="t('addClusterMemberDialog.title')" class="text-default-text" />
 
     <div slot="body" class="pl-10 pr-10">
       <ClusterPermissionsEditor v-model="bindings" :use-two-columns-for-custom="true" />

--- a/shell/dialog/AddProjectMemberDialog.vue
+++ b/shell/dialog/AddProjectMemberDialog.vue
@@ -77,7 +77,7 @@ export default {
 
 <template>
   <Card class="prompt-rotate" :show-highlight-border="false" :sticky="true">
-    <h4 slot="title" class="text-default-text" v-html="t('addProjectMemberDialog.title')" />
+    <h4 slot="title" v-clean-html="t('addProjectMemberDialog.title')" class="text-default-text" />
 
     <div slot="body" class="pl-10 pr-10">
       <ProjectMemberEditor v-model="member" :use-two-columns-for-custom="true" />

--- a/shell/dialog/ForceMachineRemoveDialog.vue
+++ b/shell/dialog/ForceMachineRemoveDialog.vue
@@ -76,7 +76,7 @@ export default {
     </h4>
     <div slot="body" class="pl-10 pr-10">
       <span
-        v-html="t('promptForceRemove.removeWarning', { nameToMatch }, true)"
+        v-clean-html="t('promptForceRemove.removeWarning', { nameToMatch }, true)"
       ></span>
       <div class="mt-10 mb-10">
         {{ t('promptForceRemove.confirmName') }}

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -58,11 +58,11 @@ export default {
 
 <template>
   <Card class="prompt-restore" :show-highlight-border="false">
-    <h4 slot="title" class="text-default-text" v-html="title" />
+    <h4 slot="title" v-clean-html="title" class="text-default-text" />
 
     <template slot="body">
       <slot name="body">
-        <div class="pl-10 pr-10" style="min-height: 50px; display: flex;" v-html="body">
+        <div v-clean-html="body" class="pl-10 pr-10" style="min-height: 50px; display: flex;">
         </div>
       </slot>
     </template>

--- a/shell/dialog/RotateEncryptionKeyDialog.vue
+++ b/shell/dialog/RotateEncryptionKeyDialog.vue
@@ -123,7 +123,7 @@ export default {
 
 <template>
   <Card class="prompt-rotate" :show-highlight-border="false">
-    <h4 slot="title" class="text-default-text" v-html="t('promptRotateEncryptionKey.title')" />
+    <h4 slot="title" v-clean-html="t('promptRotateEncryptionKey.title')" class="text-default-text" />
 
     <div slot="body" class="pl-10 pr-10">
       <Banner color="warning" label-key="promptRotateEncryptionKey.warning" />

--- a/shell/dialog/SaveAsRKETemplateDialog.vue
+++ b/shell/dialog/SaveAsRKETemplateDialog.vue
@@ -77,7 +77,7 @@ export default {
 
 <template>
   <Card class="prompt-restore" :show-highlight-border="false">
-    <h4 slot="title" class="text-default-text" v-html="t('promptSaveAsRKETemplate.title', { cluster: cluster.displayName }, true)" />
+    <h4 slot="title" v-clean-html="t('promptSaveAsRKETemplate.title', { cluster: cluster.displayName }, true)" class="text-default-text" />
 
     <div slot="body" class="pl-10 pr-10">
       <form>

--- a/shell/dialog/ScaleMachineDownDialog.vue
+++ b/shell/dialog/ScaleMachineDownDialog.vue
@@ -107,7 +107,7 @@ export default {
         </div>
         <div v-if="ignored.length" class="retained-machine">
           <span class="mb-20">{{ t('promptScaleMachineDown.retainedMachine1') }}</span>
-          <span v-for="i in ignored" :key="i.name" v-html="t('promptScaleMachineDown.retainedMachine2', { name: i.name }, true)"></span>
+          <span v-for="i in ignored" :key="i.name" v-clean-html="t('promptScaleMachineDown.retainedMachine2', { name: i.name }, true)"></span>
         </div>
       </div>
     </template>

--- a/shell/edit/auth/github.vue
+++ b/shell/edit/auth/github.vue
@@ -172,9 +172,9 @@ export default {
 
         <InfoBox :step="1" class="step-box">
           <ul class="step-list">
-            <li v-html="t(`authConfig.${NAME}.form.prefix.1`, tArgs, true)" />
-            <li v-html="t(`authConfig.${NAME}.form.prefix.2`, tArgs, true)" />
-            <li v-html="t(`authConfig.${NAME}.form.prefix.3`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.prefix.1`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.prefix.2`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.prefix.3`, tArgs, true)" />
           </ul>
         </InfoBox>
         <InfoBox :step="2" class="step-box">
@@ -182,9 +182,9 @@ export default {
             <li>
               {{ t(`authConfig.${NAME}.form.instruction`, tArgs, true) }}
               <ul class="mt-10">
-                <li><b>{{ t(`authConfig.${NAME}.form.app.label`) }}</b>: <span v-html="t(`authConfig.${NAME}.form.app.value`, tArgs, true)" /></li>
+                <li><b>{{ t(`authConfig.${NAME}.form.app.label`) }}</b>: <span v-clean-html="t(`authConfig.${NAME}.form.app.value`, tArgs, true)" /></li>
                 <li><b>{{ t(`authConfig.${NAME}.form.homepage.label`) }}</b>: {{ serverUrl }} <CopyToClipboard label-as="tooltip" :text="serverUrl" class="icon-btn" action-color="bg-transparent" /></li>
-                <li><b>{{ t(`authConfig.${NAME}.form.description.label`) }}</b>: <span v-html="t(`authConfig.${NAME}.form.description.value`, tArgs, true)" /></li>
+                <li><b>{{ t(`authConfig.${NAME}.form.description.label`) }}</b>: <span v-clean-html="t(`authConfig.${NAME}.form.description.value`, tArgs, true)" /></li>
                 <li><b>{{ t(`authConfig.${NAME}.form.callback.label`) }}</b>: {{ serverUrl }} <CopyToClipboard :text="serverUrl" label-as="tooltip" class="icon-btn" action-color="bg-transparent" /></li>
               </ul>
             </li>
@@ -192,8 +192,8 @@ export default {
         </InfoBox>
         <InfoBox :step="3" class="mb-20">
           <ul class="step-list">
-            <li v-html="t(`authConfig.${NAME}.form.suffix.1`, tArgs, true)" />
-            <li v-html="t(`authConfig.${NAME}.form.suffix.2`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.suffix.1`, tArgs, true)" />
+            <li v-clean-html="t(`authConfig.${NAME}.form.suffix.2`, tArgs, true)" />
           </ul>
         </InfoBox>
 
@@ -216,7 +216,7 @@ export default {
         </div>
         <div v-if="!model.enabled" class="row">
           <div class="col span-12">
-            <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+            <Banner v-clean-html="t('authConfig.associatedWarning', tArgs, true)" color="info" />
           </div>
         </div>
       </template>

--- a/shell/edit/auth/googleoauth.vue
+++ b/shell/edit/auth/googleoauth.vue
@@ -119,7 +119,7 @@ export default {
           </div>
         </div>
         <InfoBox :step="1" class=" mt-20 mb-20">
-          <h3 v-html="t('authConfig.googleoauth.steps.1.title', tArgs, true)" />
+          <h3 v-clean-html="t('authConfig.googleoauth.steps.1.title', tArgs, true)" />
           <ul class="mt-0 step-list">
             <li>{{ t('authConfig.googleoauth.steps.1.body.1', {}, true) }} </li>
             <li><b>{{ t('authConfig.googleoauth.steps.1.body.2', {}, true) }}</b> {{ t('authConfig.googleoauth.steps.1.topPrivateDomain', {}, true) }} <CopyToClipboardText :plain="true" :text="tArgs.hostname" /> </li>
@@ -130,7 +130,7 @@ export default {
         </InfoBox>
         <InfoBox :step="2" class="mb-20">
           <div class="row">
-            <h3 v-html="t('authConfig.googleoauth.steps.2.title', tArgs, true)" />
+            <h3 v-clean-html="t('authConfig.googleoauth.steps.2.title', tArgs, true)" />
           </div>
           <div class="row">
             <div class="col span-6">
@@ -158,11 +158,11 @@ export default {
         </InfoBox>
         <InfoBox :step="3" class="mb-20">
           <div class="row">
-            <h3 v-html="t('authConfig.googleoauth.steps.3.title', tArgs, true)" />
+            <h3 v-clean-html="t('authConfig.googleoauth.steps.3.title', tArgs, true)" />
           </div>
           <div class="row">
             <div class="col span-6">
-              <div v-html="t('authConfig.googleoauth.steps.3.introduction', tArgs, true)" />
+              <div v-clean-html="t('authConfig.googleoauth.steps.3.introduction', tArgs, true)" />
               <ul class="mt-10 step-list">
                 <li>{{ t('authConfig.googleoauth.steps.3.body.1', {}, true) }} </li>
                 <li>{{ t('authConfig.googleoauth.steps.3.body.2', {}, true) }} </li>
@@ -186,7 +186,7 @@ export default {
 
         <div v-if="!model.enabled" class="row">
           <div class="col span-12">
-            <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+            <Banner v-clean-html="t('authConfig.associatedWarning', tArgs, true)" color="info" />
           </div>
         </div>
       </template>

--- a/shell/edit/auth/ldap/index.vue
+++ b/shell/edit/auth/ldap/index.vue
@@ -128,7 +128,7 @@ export default {
       </template>
       <div v-if="!model.enabled" class="row">
         <div class="col span-12">
-          <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+          <Banner v-clean-html="t('authConfig.associatedWarning', tArgs, true)" color="info" />
         </div>
       </div>
     </CruResource>

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -251,7 +251,7 @@ export default {
       </template>
       <div v-if="!model.enabled" class="row">
         <div class="col span-12">
-          <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+          <Banner v-clean-html="t('authConfig.associatedWarning', tArgs, true)" color="info" />
         </div>
       </div>
     </CruResource>

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -214,7 +214,7 @@ export default {
       </template>
       <div v-if="!model.enabled" class="row">
         <div class="col span-12">
-          <Banner color="info" v-html="t('authConfig.associatedWarning', tArgs, true)" />
+          <Banner v-clean-html="t('authConfig.associatedWarning', tArgs, true)" color="info" />
         </div>
       </div>
     </CruResource>

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -288,7 +288,7 @@ export default {
           <div class="row mb-20">
             <div class="col span-12">
               <Banner v-if="scanAlertRule.alertOnFailure || scanAlertRule.alertOnComplete" class="mt-0" :color="hasAlertManager ? 'info' : 'warning'">
-                <span v-html="t('cis.alertNeeded', {link: monitoringUrl}, true)" />
+                <span v-clean-html="t('cis.alertNeeded', {link: monitoringUrl}, true)" />
               </banner>
               <Checkbox v-model="scanAlertRule.alertOnComplete" :mode="mode" :label="t('cis.alertOnComplete')" />
               <Checkbox v-model="scanAlertRule.alertOnFailure" :mode="mode" :label="t('cis.alertOnFailure')" />

--- a/shell/edit/fleet.cattle.io.clustergroup.vue
+++ b/shell/edit/fleet.cattle.io.clustergroup.vue
@@ -141,11 +141,11 @@ export default {
       @input="matchChanged($event)"
     />
     <Banner v-if="matchingClusters" :color="(matchingClusters.isNone || matchingClusters.isAll ? 'warning' : 'success')">
-      <span v-if="matchingClusters.isAll" v-html="t('fleet.clusterGroup.selector.matchesAll', matchingClusters)" />
-      <span v-else-if="matchingClusters.isNone" v-html="t('fleet.clusterGroup.selector.matchesNone', matchingClusters)" />
+      <span v-if="matchingClusters.isAll" v-clean-html="t('fleet.clusterGroup.selector.matchesAll', matchingClusters)" />
+      <span v-else-if="matchingClusters.isNone" v-clean-html="t('fleet.clusterGroup.selector.matchesNone', matchingClusters)" />
       <span
         v-else
-        v-html="t('fleet.clusterGroup.selector.matchesSome', matchingClusters)"
+        v-clean-html="t('fleet.clusterGroup.selector.matchesSome', matchingClusters)"
       />
     </Banner>
 

--- a/shell/edit/management.cattle.io.setting.vue
+++ b/shell/edit/management.cattle.io.setting.vue
@@ -99,7 +99,7 @@ export default {
   >
     <h4>{{ description }}</h4>
 
-    <h5 v-if="editHelp" class="edit-help" v-html="editHelp" />
+    <h5 v-if="editHelp" v-clean-html="editHelp" class="edit-help" />
 
     <div class="edit-change mt-20">
       <h5 v-t="'advancedSettings.edit.changeSetting'" />

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/webhook.vue
@@ -141,7 +141,7 @@ export default {
 
 <template>
   <div>
-    <Banner v-if="mode !== view" color="info" v-html="t('monitoringReceiver.webhook.banner', {}, raw=true)" />
+    <Banner v-if="mode !== view" v-clean-html="t('monitoringReceiver.webhook.banner', {}, raw=true)" color="info" />
     <div class="row mb-20">
       <LabeledSelect
         v-model="selectedWebhookType"
@@ -160,7 +160,7 @@ export default {
         </h3>
       </div>
     </div>
-    <Banner v-if="showNamespaceBanner" color="info" v-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)" />
+    <Banner v-if="showNamespaceBanner" v-clean-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)" color="info" />
     <div class="row mb-20">
       <div class="col span-12">
         <LabeledInput

--- a/shell/edit/monitoring.coreos.com.receiver/tls.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/tls.vue
@@ -35,7 +35,7 @@ export default {
     <div class="row">
       <div class="col span-12">
         <h3>{{ t('monitoring.receiver.tls.label') }}</h3>
-        <Banner color="info" v-html="t('monitoring.receiver.tls.secretsBanner', {}, true)" />
+        <Banner v-clean-html="t('monitoring.receiver.tls.secretsBanner', {}, true)" color="info" />
       </div>
     </div>
     <div class="row mb-20">

--- a/shell/edit/monitoring.coreos.com.receiver/types/webhook.banner.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/webhook.banner.vue
@@ -20,5 +20,5 @@ export default {
 };
 </script>
 <template>
-  <Banner v-if="model.length === 0 && !isView" color="info" v-html="t('monitoringReceiver.webhook.banner', {}, raw=true)" />
+  <Banner v-if="model.length === 0 && !isView" v-clean-html="t('monitoringReceiver.webhook.banner', {}, raw=true)" color="info" />
 </template>

--- a/shell/edit/monitoring.coreos.com.receiver/types/webhook.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/webhook.vue
@@ -48,7 +48,7 @@ export default {
         </h3>
       </div>
     </div>
-    <Banner v-if="showNamespaceBanner" color="info" v-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)" />
+    <Banner v-if="showNamespaceBanner" v-clean-html="t('monitoringReceiver.webhook.modifyNamespace', {}, raw=true)" color="info" />
     <div class="row mb-20">
       <div class="col span-12">
         <LabeledInput v-model="value.url" :mode="mode" label="URL" :tooltip="t('monitoringReceiver.webhook.urlTooltip')" />

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -247,7 +247,7 @@ export default {
       <div class="row">
         <div class="col span-12">
           <Banner color="success">
-            <span v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
+            <span v-clean-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
           </Banner>
         </div>
       </div>
@@ -267,7 +267,7 @@ export default {
       <div class="row">
         <div class="col span-12">
           <Banner color="success">
-            <span v-html="t('networkpolicy.selectors.matchingNamespaces.matchesSome', matchingNamespaces)" />
+            <span v-clean-html="t('networkpolicy.selectors.matchingNamespaces.matchesSome', matchingNamespaces)" />
           </Banner>
         </div>
       </div>

--- a/shell/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/index.vue
@@ -230,7 +230,7 @@ export default {
             <div class="row">
               <div class="col span-12">
                 <Banner color="success">
-                  <span v-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
+                  <span v-clean-html="t('networkpolicy.selectors.matchingPods.matchesSome', matchingPods)" />
                 </Banner>
               </div>
             </div>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1672,7 +1672,7 @@ export default {
       v-if="isEdit"
       color="warning"
     >
-      <span v-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
+      <span v-clean-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
     </Banner>
     <SelectCredential
       v-if="needCredential"
@@ -1766,7 +1766,7 @@ export default {
             color="warning"
           >
             <span
-              v-html="t('cluster.harvester.warning.cloudProvider.incompatible', null, true)"
+              v-clean-html="t('cluster.harvester.warning.cloudProvider.incompatible', null, true)"
             />
           </Banner>
           <div class="row mb-10">

--- a/shell/edit/resources.cattle.io.backup.vue
+++ b/shell/edit/resources.cattle.io.backup.vue
@@ -262,7 +262,7 @@ export default {
           </template>
         </template>
         <Banner v-else color="error">
-          <span v-html="t('backupRestoreOperator.noResourceSet')" />
+          <span v-clean-html="t('backupRestoreOperator.noResourceSet')" />
         </Banner>
       </template>
     </CruResource>

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -388,7 +388,7 @@ export default {
         <div class="row">
           <div class="col span-12">
             <Banner :color="(matchingPods.none ? 'warning' : 'success')">
-              <span v-html="t('servicesPage.selectors.matchingPods.matchesSome', matchingPods)" />
+              <span v-clean-html="t('servicesPage.selectors.matchingPods.matchesSome', matchingPods)" />
             </Banner>
           </div>
         </div>

--- a/shell/edit/workload/__tests__/Job.test.ts
+++ b/shell/edit/workload/__tests__/Job.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils';
 import Job from '@shell/edit/workload/Job.vue';
 import { _EDIT } from '@shell/config/query-params';
 import { WORKLOAD_TYPES } from '@shell/config/types';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('component: Job', () => {
   describe('given CronJob types', () => {
@@ -10,7 +11,8 @@ describe('component: Job', () => {
       'failed',
     ])('should emit an update on %p input', (field) => {
       const wrapper = mount(Job, {
-        propsData: {
+        directives: { cleanHtmlDirective },
+        propsData:  {
           mode: _EDIT,
           type: WORKLOAD_TYPES.CRON_JOB
         }

--- a/shell/list/harvesterhci.io.management.cluster.vue
+++ b/shell/list/harvesterhci.io.management.cluster.vue
@@ -167,7 +167,7 @@ export default {
         <div>{{ t('harvesterManager.cluster.description') }}</div>
       </div>
       <div class="tagline sub-tagline">
-        <div v-html="t('harvesterManager.cluster.learnMore', {}, true)"></div>
+        <div v-clean-html="t('harvesterManager.cluster.learnMore', {}, true)"></div>
       </div>
     </div>
   </div>

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -573,6 +573,7 @@ export default function(dir, _appConfig) {
       path.join(NUXT_SHELL, 'plugins/vue-clipboard2'),
       path.join(NUXT_SHELL, 'plugins/v-select'),
       path.join(NUXT_SHELL, 'plugins/directives'),
+      path.join(NUXT_SHELL, 'plugins/clean-html-directive'),
       path.join(NUXT_SHELL, 'plugins/transitions'),
       { src: path.join(NUXT_SHELL, 'plugins/vue-js-modal') },
       { src: path.join(NUXT_SHELL, 'plugins/js-yaml'), ssr: false },

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -280,8 +280,8 @@ export default {
 
           <template v-if="mustChangePassword">
             <p
+              v-clean-html="t(isFirstLogin ? 'setup.setPassword' : 'setup.newUserSetPassword', { username }, true)"
               class="text-center mb-20 mt-20 setup-title"
-              v-html="t(isFirstLogin ? 'setup.setPassword' : 'setup.newUserSetPassword', { username }, true)"
             ></p>
 
             <Password

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -139,18 +139,18 @@ export default {
       </div>
       <div v-if="requires.length || warnings.length || targetedAppWarning || osWarning" class="mt-20">
         <Banner v-if="osWarning" color="error">
-          <span v-html="osWarning" />
+          <span v-clean-html="osWarning" />
         </Banner>
         <Banner v-for="msg in requires" :key="msg" color="error">
-          <span v-html="msg" />
+          <span v-clean-html="msg" />
         </Banner>
 
         <Banner v-for="msg in warnings" :key="msg" color="warning">
-          <span v-html="msg" />
+          <span v-clean-html="msg" />
         </Banner>
 
         <Banner v-if="targetedAppWarning" color="warning">
-          <span v-html="targetedAppWarning" />
+          <span v-clean-html="targetedAppWarning" />
         </Banner>
       </div>
       <div v-else-if="version && version.description" class="description mt-10">

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1250,11 +1250,11 @@ export default {
           </Banner>
           <div v-if="requires.length || warnings.length" class="mb-15">
             <Banner v-for="msg in requires" :key="msg" color="error">
-              <span v-html="msg" />
+              <span v-clean-html="msg" />
             </Banner>
 
             <Banner v-for="msg in warnings" :key="msg" color="warning">
-              <span v-html="msg" />
+              <span v-clean-html="msg" />
             </Banner>
           </div>
           <div v-if="showSelectVersionOrChart" class="row mb-20">
@@ -1321,7 +1321,7 @@ export default {
           <div class="step__values__controls--spacer" style="flex:1">
 &nbsp;
           </div>
-          <Banner v-if="isNamespaceNew" color="info" v-html="t('catalog.install.steps.basics.createNamespace', {namespace: value.metadata.namespace}, true) ">
+          <Banner v-if="isNamespaceNew" v-clean-html="t('catalog.install.steps.basics.createNamespace', {namespace: value.metadata.namespace}, true) " color="info">
           </Banner>
 
           <Checkbox v-model="showCommandStep" class="mb-20" :label="t('catalog.install.steps.helmCli.checkbox', { action, existing: !!existing })" />
@@ -1541,14 +1541,14 @@ export default {
           {{ t('catalog.install.error.legacy.label', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true) }}
         </span>
         <template v-if="!legacyEnabled">
-          <span v-html="t('catalog.install.error.legacy.enableLegacy.prompt', true)" />
+          <span v-clean-html="t('catalog.install.error.legacy.enableLegacy.prompt', true)" />
           <nuxt-link :to="legacyFeatureRoute">
             {{ t('catalog.install.error.legacy.enableLegacy.goto') }}
           </nuxt-link>
         </template>
         <template v-else>
           <nuxt-link :to="mcapp ? mcmRoute : legacyAppRoute">
-            <span v-html="t('catalog.install.error.legacy.navigate', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true)" />
+            <span v-clean-html="t('catalog.install.error.legacy.navigate', { legacyType: mcapp ? legacyDefs.mcm : legacyDefs.legacy }, true)" />
           </nuxt-link>
         </template>
       </Banner>

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -409,7 +409,7 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" />
   <div v-else-if="options.length">
-    <h1 v-html="t('catalog.tools.header')" />
+    <h1 v-clean-html="t('catalog.tools.header')" />
     <TypeDescription v-if="!legacyEnabled" resource="chart" />
 
     <div class="grid">
@@ -442,35 +442,35 @@ export default {
           </div>
         </div>
         <div class="description">
-          <div class="description-content" v-html="opt.chart.chartDescription" />
+          <div v-clean-html="opt.chart.chartDescription" class="description-content" />
         </div>
         <div v-if="opt.app && !opt.chart.legacy" class="state">
           <AppSummaryGraph :row="opt.app" label-key="generic.resourceCount" :link-to="opt.app.detailLocation" />
         </div>
         <div class="action">
           <template v-if="opt.blocked">
-            <button disabled="true" class="btn btn-sm role-primary" v-html="t('catalog.tools.action.install')" />
+            <button v-clean-html="t('catalog.tools.action.install')" disabled="true" class="btn btn-sm role-primary" />
           </template>
           <template v-else-if="opt.app && opt.chart.legacy">
-            <button class="btn btn-sm role-secondary" @click="openV1Tool(opt.chart.legacyPage)" v-html="t('catalog.tools.action.manage')" />
+            <button v-clean-html="t('catalog.tools.action.manage')" class="btn btn-sm role-secondary" @click="openV1Tool(opt.chart.legacyPage)" />
           </template>
           <template v-else-if="opt.app && opt.upgradeAvailable && !opt.chart.legacy">
             <button class="btn btn-sm role-secondary" @click="remove(opt.app, $event)">
               <i class="icon icon-delete icon-lg" />
             </button>
-            <button class="btn btn-sm role-secondary" @click="edit(opt.app, opt.app.upgradeAvailable)" v-html="t('catalog.tools.action.upgrade')" />
+            <button v-clean-html="t('catalog.tools.action.upgrade')" class="btn btn-sm role-secondary" @click="edit(opt.app, opt.app.upgradeAvailable)" />
           </template>
           <template v-else-if="opt.app">
             <button class="btn btn-sm role-secondary" @click="remove(opt.app, $event)">
               <i class="icon icon-delete icon-lg" />
             </button>
-            <button class="btn btn-sm role-secondary" @click="edit(opt.app)" v-html="t('catalog.tools.action.edit')" />
+            <button v-clean-html="t('catalog.tools.action.edit')" class="btn btn-sm role-secondary" @click="edit(opt.app)" />
           </template>
           <template v-else-if="opt.chart.legacy">
-            <button class="btn btn-sm role-primary" @click="openV1Tool(opt.chart.legacyPage)" v-html="t('catalog.tools.action.install')" />
+            <button v-clean-html="t('catalog.tools.action.install')" class="btn btn-sm role-primary" @click="openV1Tool(opt.chart.legacyPage)" />
           </template>
           <template v-else>
-            <button class="btn btn-sm role-primary" @click="install(opt.chart)" v-html="t('catalog.tools.action.install')" />
+            <button v-clean-html="t('catalog.tools.action.install')" class="btn btn-sm role-primary" @click="install(opt.chart)" />
           </template>
         </div>
       </div>

--- a/shell/pages/c/_cluster/istio/index.vue
+++ b/shell/pages/c/_cluster/istio/index.vue
@@ -72,7 +72,7 @@ export default {
 <template>
   <div>
     <h1>Overview</h1>
-    <h4 v-html="t('istio.poweredBy', {}, true)" />
+    <h4 v-clean-html="t('istio.poweredBy', {}, true)" />
     <div class="links">
       <div :class="{'disabled':!kialiUrl}" class="box link-container">
         <span
@@ -96,12 +96,12 @@ export default {
             </a>
             <hr />
             <div class="description">
-              <span v-html="t('istio.links.kiali.description', {link: monitoringUrl}, true)" />
+              <span v-clean-html="t('istio.links.kiali.description', {link: monitoringUrl}, true)" />
             </div>
           </div>
         </span>
         <div v-if="!kialiUrl" class="disabled-msg">
-          <span v-html="t('istio.links.disabled', {app: 'Kiali'})" />
+          <span v-clean-html="t('istio.links.disabled', {app: 'Kiali'})" />
         </div>
       </div>
       <div :class="{'disabled':!jaegerUrl}" class="box link-container">
@@ -126,12 +126,12 @@ export default {
             </a>
             <hr />
             <div class="description">
-              <span v-html="t('istio.links.jaeger.description', true)" />
+              <span v-clean-html="t('istio.links.jaeger.description', true)" />
             </div>
           </div>
         </span>
         <div v-if="!jaegerUrl" class="disabled-msg">
-          <span v-html="t('istio.links.disabled', {app: 'Jaeger'})" />
+          <span v-clean-html="t('istio.links.disabled', {app: 'Jaeger'})" />
         </div>
       </div>
     </div>

--- a/shell/pages/c/_cluster/manager/cloudCredential/index.vue
+++ b/shell/pages/c/_cluster/manager/cloudCredential/index.vue
@@ -81,7 +81,7 @@ export default {
         {{ row.id.replace('cattle-global-data:','') }}
       </template>
       <template #cell:apikey="{row}">
-        <span v-if="row.publicData" v-html="row.publicData" />
+        <span v-if="row.publicData" v-clean-html="row.publicData" />
         <span v-else class="text-muted">&mdash;</span>
       </template>
     </ResourceTable>

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -284,7 +284,7 @@ export default {
             color="info whats-new"
           >
             <div>{{ t('landing.seeWhatsNew') }}</div>
-            <a class="hand" @click.prevent.stop="showWhatsNew"><span v-html="t('landing.whatsNewLink')" /></a>
+            <a class="hand" @click.prevent.stop="showWhatsNew"><span v-clean-html="t('landing.whatsNewLink')" /></a>
           </Banner>
         </div>
       </div>
@@ -312,7 +312,7 @@ export default {
             <div class="col span-12">
               <Banner color="set-login-page" :closable="true" @close="closeSetLoginBanner()">
                 <div>{{ t('landing.landingPrefs.title') }}</div>
-                <a class="hand mr-20" @click.prevent.stop="showUserPrefs"><span v-html="t('landing.landingPrefs.userPrefs')" /></a>
+                <a class="hand mr-20" @click.prevent.stop="showUserPrefs"><span v-clean-html="t('landing.landingPrefs.userPrefs')" /></a>
               </Banner>
             </div>
           </div>

--- a/shell/plugins/clean-html-directive.js
+++ b/shell/plugins/clean-html-directive.js
@@ -1,0 +1,31 @@
+import Vue from 'vue';
+import DOMPurify from 'dompurify';
+
+const ALLOWED_TAGS = [
+  'code',
+  'li',
+  'a',
+  'p',
+  'b',
+  'br',
+  'ul',
+  'pre',
+  'span',
+  'div',
+  'i',
+  'em',
+  'strong',
+];
+
+const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
+
+export const cleanHtmlDirective = {
+  inserted(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  },
+  componentUpdated(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  }
+};
+
+Vue.directive('clean-html', cleanHtmlDirective);

--- a/shell/plugins/directives.js
+++ b/shell/plugins/directives.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import DOMPurify from 'dompurify';
 
 Vue.directive('focus', {
   inserted(_el, _binding, vnode) {
@@ -39,3 +40,30 @@ const getElement = (vnode) => {
     return componentInstance.$refs.input.$refs.value;
   }
 };
+
+const ALLOWED_TAGS = [
+  'code',
+  'li',
+  'a',
+  'p',
+  'b',
+  'br',
+  'ul',
+  'pre',
+  'span',
+  'div',
+  'i',
+  'em',
+  'strong',
+];
+
+const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
+
+Vue.directive('clean-html', {
+  inserted(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  },
+  componentUpdated(el, binding) {
+    el.innerHTML = purifyHTML(binding.value);
+  }
+});

--- a/shell/plugins/directives.js
+++ b/shell/plugins/directives.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import DOMPurify from 'dompurify';
 
 Vue.directive('focus', {
   inserted(_el, _binding, vnode) {
@@ -40,30 +39,3 @@ const getElement = (vnode) => {
     return componentInstance.$refs.input.$refs.value;
   }
 };
-
-const ALLOWED_TAGS = [
-  'code',
-  'li',
-  'a',
-  'p',
-  'b',
-  'br',
-  'ul',
-  'pre',
-  'span',
-  'div',
-  'i',
-  'em',
-  'strong',
-];
-
-const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
-
-Vue.directive('clean-html', {
-  inserted(el, binding) {
-    el.innerHTML = purifyHTML(binding.value);
-  },
-  componentUpdated(el, binding) {
-    el.innerHTML = purifyHTML(binding.value);
-  }
-});

--- a/shell/promptRemove/management.cattle.io.globalrole.vue
+++ b/shell/promptRemove/management.cattle.io.globalrole.vue
@@ -23,11 +23,11 @@ export default {
   <div>
     <template>
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-html="resourceNames(names, plusMore, t)"
+        v-clean-html="resourceNames(names, plusMore, t)"
       ></span>
     </template>
     <div v-if="info" class="text info mb-10 mt-20">
-      <span v-html="info" />
+      <span v-clean-html="info" />
     </div>
     <div v-if="warning" class="text-warning mb-10 mt-20">
       {{ warning }}

--- a/shell/promptRemove/management.cattle.io.project.vue
+++ b/shell/promptRemove/management.cattle.io.project.vue
@@ -99,13 +99,13 @@ export default {
         {{ t('promptRemove.attemptingToRemove', { type }) }} <span class="display-name">{{ `${displayName}.` }}</span>
         <template v-if="!canSeeProjectlessNamespaces">
           <span class="delete-warning"> {{ t('promptRemove.willDeleteAssociatedNamespaces') }}</span> <br />
-          <div class="mt-10" v-html="resourceNames(names, plusMore, t)"></div>
+          <div v-clean-html="resourceNames(names, plusMore, t)" class="mt-10"></div>
         </template>
       </div>
       <div v-if="filteredNamespaces.length > 0 && canSeeProjectlessNamespaces" class="mt-20 remove-project-dialog">
         <Checkbox v-model="deleteProjectNamespaces" :label="t('promptRemove.deleteAssociatedNamespaces')" />
         <div class="mt-10 ml-20">
-          <span v-html="resourceNames(names, plusMore, t)"></span>
+          <span v-clean-html="resourceNames(names, plusMore, t)"></span>
         </div>
       </div>
     </div>

--- a/shell/promptRemove/management.cattle.io.roletemplate.vue
+++ b/shell/promptRemove/management.cattle.io.roletemplate.vue
@@ -23,11 +23,11 @@ export default {
   <div>
     <template>
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-html="resourceNames(names, plusMore, t)"
+        v-clean-html="resourceNames(names, plusMore, t)"
       ></span>
     </template>
     <div v-if="info" class="text info mb-10 mt-20">
-      <span v-html="info" />
+      <span v-clean-html="info" />
     </div>
     <div v-if="warning" class="text-warning mb-10 mt-20">
       {{ warning }}

--- a/shell/promptRemove/pod.vue
+++ b/shell/promptRemove/pod.vue
@@ -107,7 +107,7 @@ export default {
 <template>
   <div class="mt-10">
     <div class="mb-30">
-      {{ t('promptRemove.attemptingToRemove', { type }) }} <span class="machine-name" v-html="podNames" />
+      {{ t('promptRemove.attemptingToRemove', { type }) }} <span v-clean-html="podNames" class="machine-name" />
     </div>
     <div class="mb-30">
       <Checkbox


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This replaces the use of the `v-html` directive with a custom `v-clean-html` directive that uses the `DOMPurify` library to sanitize HTML input before rendering it. `v-html` usage is discouraged[^1] in the Vue documentation, and should only be used on trusted content. Our widespread usage of `v-html` makes this difficult to guarantee safe usage across the board, so it's better to disallow `v-html` and sanitize existing usages in Rancher Dashboard.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Disallows use of `v-html` with `eslint`
- Adds new `v-clean-html` directive that only allows existing tags used in `en-us.yaml`
- Replaces all existing instances of `v-html` with `v-clean-html` 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The current implementations contains a list of allowed tags for use with `v-clean-html`:

```javascript
const ALLOWED_TAGS = [
  'code',
  'li',
  'a',
  'p',
  'b',
  'br',
  'ul',
  'pre',
  'span',
  'div',
  'i',
  'em',
  'strong',
];
```

These tags are derived from a list of unique tags obtained from `en-us.yaml`. An alternative approach might be to replace this list of allowed tags with the `DOMPurify` `html` profile[^2], which should allow all safe HTML (e.g. `DOMPurify.sanitize(dirty, {USE_PROFILES: {html: true}});`)

### Areas or cases that should be tested
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
We need to identify at least one instance for each of the allowed tags to ensure that content is rendered properly.

Backports #8466

[^1]: https://v2.vuejs.org/v2/guide/syntax.html#Raw-HTML
[^2]: https://github.com/cure53/DOMPurify#can-i-configure-dompurify