### PR TITLE
Fixed state icon margin/padding

### DIFF
--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -423,6 +423,7 @@ export default {
               :subtype="resourceSubtype"
               :name="displayName"
               :escapehtml="false"
+              class="mr-5"
             />
             <BadgeState
               v-if="!isCreate && parent.showState"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8389
<!-- Define findings related to the feature or bug issue. -->
Fixed state icon margin/padding

**Note:**  I did some investigation, this can be caused by nuxt removal and is not related to the code or styling.


### How to test
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Navigate to a cluster detail page > in the heading, there should be space between cluster name and state