### PR TITLE
[2.7.2] remember the chosen chart version when installation is cancelled

### DIFF
--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -292,7 +292,13 @@ export default {
       // use the first version provided by the Helm chart
       // as the default.
       if ( !this.query.versionName && this.chart.versions?.length ) {
-        this.query.versionName = this.chart.versions[0].version;
+        if (this.showPreRelease) {
+          this.query.versionName = this.chart.versions[0].version;
+        } else {
+          const firstRelease = this.chart.versions.find(v => !isPrerelease(v.version));
+
+          this.query.versionName = firstRelease?.version || this.chart.versions[0].version;
+        }
       }
 
       if ( !this.query.versionName ) {
@@ -426,7 +432,7 @@ export default {
         repoType: this.chart.repoType,
         repoName: this.chart.repoName,
         name:     this.chart.chartName,
-        version:  this.chart.versionName,
+        version:  this.query.versionName,
       };
 
       return {


### PR DESCRIPTION
Fixes #8529 

backport of https://github.com/rancher/dashboard/pull/8514