### PR TITLE
fix /meta/proxy requests when running locally

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -576,6 +576,7 @@ function proxyMetaOpts(target) {
     target,
     followRedirects: true,
     secure:          !dev,
+    changeOrigin:    true,
     onProxyReq,
     onProxyReqWs,
     onError,


### PR DESCRIPTION
Similar to the fix here: https://github.com/rancher/dashboard/pull/8386/commits/724d952e962243b1d663dd2f34b0c89ad88b5d71 I'm seeing requests to cloud providers eg  `.../meta/proxy/api.digitalocean.com/v2/regions?per_page=1000` fail when running the dash locally. Given that no one else has brought this up I have to think that like the other issue this isn't happening on all rancher instances; I can share my setup to repro if needed. 

![Screen Shot 2023-03-27 at 2 38 03 PM](https://user-images.githubusercontent.com/42977925/228072650-4caebb41-c055-44ee-8c1e-8f2584b44fbf.png)
