### PR TITLE
Increase build memory for e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cy:run:sorry": "./scripts/e2e",
     "e2e:pre-dev": "yarn docker:local:stop && yarn docker:local:start && NODE_ENV=dev TEST_INSTRUMENT=true yarn build",
     "e2e:dev": "START_SERVER_AND_TEST_INSECURE=1 server-test start:dev https-get://localhost:8005 cy:run:sorry",
-    "e2e:pre-prod": "yarn docker:local:stop && yarn docker:local:start && DEV_PORTS=true TEST_INSTRUMENT=true yarn build --max-old-space-size=4096",
+    "e2e:pre-prod": "yarn docker:local:stop && yarn docker:local:start && DEV_PORTS=true TEST_INSTRUMENT=true yarn build --max-old-space-size=8192",
     "e2e:prod": "START_SERVER_AND_TEST_INSECURE=1 server-test start:prod https-get://localhost:8005 cy:run:sorry",
     "coverage": "npx nyc merge coverage coverage/coverage.json",
     "storybook": "cd storybook && yarn install && yarn storybook",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cy:run:sorry": "./scripts/e2e",
     "e2e:pre-dev": "yarn docker:local:stop && yarn docker:local:start && NODE_ENV=dev TEST_INSTRUMENT=true yarn build",
     "e2e:dev": "START_SERVER_AND_TEST_INSECURE=1 server-test start:dev https-get://localhost:8005 cy:run:sorry",
-    "e2e:pre-prod": "yarn docker:local:stop && yarn docker:local:start && DEV_PORTS=true TEST_INSTRUMENT=true yarn build",
+    "e2e:pre-prod": "yarn docker:local:stop && yarn docker:local:start && DEV_PORTS=true TEST_INSTRUMENT=true yarn build --max-old-space-size=4096",
     "e2e:prod": "START_SERVER_AND_TEST_INSECURE=1 server-test start:prod https-get://localhost:8005 cy:run:sorry",
     "coverage": "npx nyc merge coverage coverage/coverage.json",
     "storybook": "cd storybook && yarn install && yarn storybook",


### PR DESCRIPTION
- Note - this is only required for pre 2.7 next2 due to nuxt removal
- Memory available to node can be tested with targets like
  ```
  "e2e:debug1": "yarn run e2e:debug2 --max-old-space-size=2000",
  "e2e:debug2": "node -e 'console.log(v8.getHeapStatistics().heap_size_limit/(1024*1024))'",
  ```