### PR TITLE
Fix Link Icon margins

### DIFF
--- a/shell/components/formatter/Link.vue
+++ b/shell/components/formatter/Link.vue
@@ -139,7 +139,6 @@ export default {
     v-if="isInternal && href"
     :to="href"
     class="link-text-icon"
-
   >
     <i
       v-if="beforeIconClass"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#7976 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Updated link component styles

### Areas or cases that should be tested
- Navigate to Continuous delivery
- Create a gitRepo

### Areas which could experience regressions
- `before-icon-class` and `after-icon-class` doesn't seem to be in use. 
- In gitRepo its applied via formatter and through following getters which takes `before-icon-key` and  `after-icon-key`. Haven't really found usage outside of gitRepo. So I assume the impact would be minimal
```    beforeIconClass() {
      if ( this.beforeIconKey ) {
        return get(this.row, this.beforeIconKey);
      }

      return this.beforeIcon;
    },

    afterIconClass() {
      if ( this.afterIconKey ) {
        return get(this.row, this.afterIconKey);
      }

      return this.afterIcon;
    },
```