### PR TITLE
fix generic cloud credential key option logic

### DIFF
--- a/shell/cloud-credential/generic.vue
+++ b/shell/cloud-credential/generic.vue
@@ -21,8 +21,8 @@ export default {
     const normanType = this.$store.getters['plugins/credentialFieldForDriver'](this.driverName);
     const normanSchema = this.$store.getters['rancher/schemaFor'](`${ normanType }credentialconfig`);
 
-    if ( normanSchema ) {
-      keyOptions = Object.keys(normanSchema.resourceFields || {});
+    if ( normanSchema?.resourceFields ) {
+      keyOptions = Object.keys(normanSchema.resourceFields);
     } else {
       keyOptions = this.$store.getters['plugins/fieldNamesForDriver'](this.driverName);
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8523 


### Occurred changes and/or fixed issues
See comment [here](https://github.com/rancher/dashboard/issues/8523#issuecomment-1485581660) - there is an open backend issue related to this area, and this PR only fixes the messed up key/value component.

### Areas or cases that should be tested
Cloud credential creation for custom cloud drivers that do not provide `<cloudconfig schema>.resourceFields`, eg cloud.ca, should show a keyvalue component with `apiKey` selected in a key dropdown.


### Areas which could experience regressions
Cloud credential creation for custom cloud drivers that _do_ provide resourceFields, eg Open Telekom Cloud, should show a keyvalue component with prepopulated, uneditable keys.
