### PR TITLE
fix config/types import path in fleetintro

### DIFF
--- a/shell/components/fleet/FleetIntro.vue
+++ b/shell/components/fleet/FleetIntro.vue
@@ -1,6 +1,6 @@
 <script>
 import { AS, _YAML } from '@shell/config/query-params';
-import { FLEET } from 'config/types';
+import { FLEET } from '@shell/config/types';
 
 export default {
 


### PR DESCRIPTION
This PR (should) fix failing storybook builds:
```
ERR! resolve 'config/types' in '/home/runner/work/dashboard/dashboard/shell/components/fleet'
ERR!   Parsed request is a module
ERR!   using description file: /home/runner/work/dashboard/dashboard/shell/package.json (relative path: ./components/fleet)
ERR!     Field 'browser' doesn't contain a valid alias configuration
ERR!     resolve as module
```