### PR TITLE
[2.7.2] Remove previous implementation of hiding PSP check for clusters with K8S 1.25 even if PSP is enabled in charts installation/update

### DIFF
--- a/shell/components/ChartPsp.vue
+++ b/shell/components/ChartPsp.vue
@@ -32,12 +32,6 @@ export default {
       default: null
     }
   },
-  data: () => {
-    return {
-      // This is required to keep the PSP visible also after unchecking the checkbox
-      hasPsp: false
-    };
-  },
   created() {
     if (!this.value.global.cattle) {
       this.$set(this.value.global, 'cattle', { psp: { enabled: false } });
@@ -45,8 +39,6 @@ export default {
     if (!this.value.global.cattle.psp) {
       this.$set(this.value.global.cattle, 'psp', { enabled: false });
     }
-
-    this.hasPsp = this.value.global.cattle.psp.enabled;
   },
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
@@ -59,7 +51,7 @@ export default {
       const version = clusterVersion.match(/\d+/g);
       const isRequiredVersion = version?.length ? +version[0] === 1 && +version[1] < 25 : false;
 
-      return this.hasPsp || isRequiredVersion;
+      return isRequiredVersion;
     }
   }
 };

--- a/shell/components/__tests__/ChartPsp.test.ts
+++ b/shell/components/__tests__/ChartPsp.test.ts
@@ -17,13 +17,11 @@ describe('component: ChartPsp', () => {
   });
 
   it.each([
-    ['v1.24.11+rke2r1', true],
-    ['v1.24.11+rke2r1', false],
-    ['v1.25.11+rke2r1', true],
-  ])('should display the checkbox for cluster with k8s version %p and psp.enabled as %p', (version, value) => {
+    ['v1.24.11+rke2r1'],
+  ])('should display the checkbox for cluster with k8s version %p', (version) => {
     const wrapper = shallowMount(ChartPsp, {
       propsData: {
-        value:   { global: { cattle: { psp: { enabled: value } } } },
+        value:   { global: { cattle: { psp: { enabled: false } } } },
         cluster: { kubernetesVersion: version }
       }
     });
@@ -34,11 +32,11 @@ describe('component: ChartPsp', () => {
   });
 
   it.each([
-    ['v1.25.11+rke2r1', false],
-  ])('should not display the checkbox for cluster with k8s version %p and psp.enabled as %p', (version, value) => {
+    ['v1.25.11+rke2r1'],
+  ])('should not display the checkbox for cluster with k8s version %p', (version) => {
     const wrapper = shallowMount(ChartPsp, {
       propsData: {
-        value:   { global: { cattle: { psp: { enabled: value } } } },
+        value:   { global: { cattle: { psp: { enabled: false } } } },
         cluster: { kubernetesVersion: version }
       }
     });
@@ -46,20 +44,6 @@ describe('component: ChartPsp', () => {
     const input = wrapper.find(`[data-testid="psp-checkbox"]`).element as HTMLInputElement;
 
     expect(input).toBeUndefined();
-  });
-
-  it('should display the checkbox after disabling PSP with K8S v1.25+', async() => {
-    const wrapper = mount(ChartPsp, {
-      propsData: {
-        value:   { global: { cattle: { psp: { enabled: true } } } },
-        cluster: { kubernetesVersion: 'v1.25.11+rke2r1' }
-      }
-    });
-    const input = wrapper.find(`[data-testid="psp-checkbox"]`).element as HTMLInputElement;
-
-    await wrapper.find('.checkbox-container').trigger('click');
-
-    expect(input).toBeDefined();
   });
 
   it('should update value.global.cattle.psp.enabled when checkbox is toggled', async() => {

--- a/shell/pages/c/_cluster/apps/charts/__tests__/install.helper.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/install.helper.test.ts
@@ -3,14 +3,12 @@ import { ignoreVariables } from '@shell/pages/c/_cluster/apps/charts/install.hel
 describe('fX: ignoreVariables', () => {
   describe.each([['epinio', 'global.rbac.pspEnabled']])('given chart %p with path %p', (name, path) => {
     it.each([
-      ['v1.24.11+rke2r1', true],
-      ['v1.24.11+rke2r1', false],
-      ['v1.25.11+rke2r1', true],
-    ])('should not return variable path list if cluster has k8s version %p and PSP setting %p', (version, hasPsp) => {
+      ['v1.24.11+rke2r1'],
+    ])('should not return variable path list if cluster has k8s version %p', (version) => {
       const cluster = { kubernetesVersion: version };
       const data = {
         chart:  { name },
-        values: { global: { rbac: { pspEnabled: hasPsp } } }
+        values: { global: { rbac: { pspEnabled: undefined } } }
       };
 
       const paths = ignoreVariables(cluster, data);
@@ -19,12 +17,12 @@ describe('fX: ignoreVariables', () => {
     });
 
     it.each([
-      ['v1.25.11+rke2r1', false],
-    ])('should return questions if cluster has k8s version %p and PSP setting %p', (version, hasPsp) => {
+      ['v1.25.11+rke2r1'],
+    ])('should return questions if cluster has k8s version %p', (version) => {
       const cluster = { kubernetesVersion: version };
       const data = {
         chart:  { name },
-        values: { global: { rbac: { pspEnabled: hasPsp } } }
+        values: { global: { rbac: { pspEnabled: undefined } } }
       };
 
       const paths = ignoreVariables(cluster, data);

--- a/shell/pages/c/_cluster/apps/charts/install.helpers.js
+++ b/shell/pages/c/_cluster/apps/charts/install.helpers.js
@@ -1,5 +1,3 @@
-import { get } from '@shell/utils/object';
-
 /**
  * Return list of variables to filter chart questions
  */
@@ -17,10 +15,9 @@ export const ignoreVariables = (cluster, data) => {
     const clusterVersion = cluster?.kubernetesVersion || '';
     const version = clusterVersion.match(/\d+/g);
     const isRequiredVersion = version?.length ? +version[0] === 1 && +version[1] < 25 : false;
-    const hasPsp = get(data.values, path);
 
     // Provide path as question variable to be ignored
-    if (!isRequiredVersion && !hasPsp) {
+    if (!isRequiredVersion) {
       return [path];
     }
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8528
Backport https://github.com/rancher/dashboard/pull/8553
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->