### PR TITLE
Improve OPA Gatekeeper constraint detail page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2197,6 +2197,7 @@ footer:
   slack: Slack
 
 gatekeeperConstraint:
+  downloadViolations: Download Violations
   match:
     title: Match
   tab:
@@ -2228,7 +2229,7 @@ gatekeeperConstraint:
     action: Enforcement Action
   violations:
     title: "Violations: {total}"
-    notAll: Not all are shown - the constraint only includes details for {shown}
+    notAll: Not all are shown due to the configured OPA Gatekeeper constraint violation limit - the constraint only includes details for {shown}
 
 gatekeeperIndex:
   poweredBy: OPA Gatekeeper
@@ -5196,6 +5197,7 @@ tableHeaders:
   clusterGroups: Cluster Groups
   commit: Commit
   condition: Condition
+  constraint: Constraint
   completions: Completions
   count: Count
   createdAt: Created At
@@ -5361,6 +5363,7 @@ tableHeaders:
   target: Target
   targetKind: Target Type
   targetPort: Target
+  template: Template
   type: Type
   updated: Updated
   up-to-date: Up To Date

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -718,7 +718,7 @@ export const APP_SUMMARY = {
 
 export const CONSTRAINT_VIOLATION_CONSTRAINT_LINK = {
   name:          'Constraint',
-  label:         'Constraint',
+  labelKey:      'tableHeaders.constraint',
   value:         'constraintLink',
   sort:          `constraintLink.text`,
   formatter:     'Link',
@@ -727,30 +727,39 @@ export const CONSTRAINT_VIOLATION_CONSTRAINT_LINK = {
 
 export const CONSTRAINT_VIOLATION_RESOURCE_LINK = {
   name:          'Name',
-  label:         'Name',
+  labelKey:      'tableHeaders.name',
   value:         'resourceLink',
   sort:          `resourceLink.text`,
+  search:        `resourceLink.text`,
   formatter:     'Link',
   formatterOpts: { options: { internal: true } },
 };
 
 export const CONSTRAINT_VIOLATION_TYPE = {
-  name:  'Type',
-  label: 'Type',
-  value: `kind`,
-  sort:  `kind`
+  name:     'Type',
+  labelKey: 'tableHeaders.type',
+  value:    `kind`,
+  sort:     `kind`
+};
+
+export const CONSTRAINT_VIOLATION_NAMESPACE = {
+  name:     'Namespace',
+  labelKey: 'tableHeaders.namespace',
+  value:    `namespace`,
+  sort:     `namespace`,
+  search:   `namespace`,
 };
 
 export const CONSTRAINT_VIOLATION_MESSAGE = {
-  name:  'Message',
-  label: 'Message',
-  value: `message`,
-  sort:  `message`
+  name:     'Message',
+  labelKey: 'tableHeaders.message',
+  value:    `message`,
+  sort:     `message`
 };
 
 export const CONSTRAINT_VIOLATION_TEMPLATE_LINK = {
   name:          'TemplateLink',
-  label:         'Template',
+  labelKey:      'tableHeaders.template',
   value:         `templateLink`,
   sort:          `templateLink.text`,
   formatter:     'Link',
@@ -759,7 +768,7 @@ export const CONSTRAINT_VIOLATION_TEMPLATE_LINK = {
 
 export const CONSTRAINT_VIOLATION_COUNT = {
   name:          'Count',
-  label:         'Count',
+  labelKey:      'tableHeaders.count',
   value:         `count`,
   sort:          `count`,
   formatter:     'QualityText',

--- a/shell/detail/constraints.gatekeeper.sh.constraint.vue
+++ b/shell/detail/constraints.gatekeeper.sh.constraint.vue
@@ -2,18 +2,26 @@
 import CreateEditView from '@shell/mixins/create-edit-view';
 import SortableTable from '@shell/components/SortableTable';
 import Banner from '@components/Banner/Banner.vue';
-import { CONSTRAINT_VIOLATION_RESOURCE_LINK, CONSTRAINT_VIOLATION_MESSAGE, CONSTRAINT_VIOLATION_TYPE } from '@shell/config/table-headers';
+import {
+  CONSTRAINT_VIOLATION_RESOURCE_LINK,
+  CONSTRAINT_VIOLATION_MESSAGE,
+  CONSTRAINT_VIOLATION_TYPE,
+  CONSTRAINT_VIOLATION_NAMESPACE,
+} from '@shell/config/table-headers';
 
 export default {
   components: { Banner, SortableTable },
   mixins:     [CreateEditView],
   data() {
+    const headers = [
+      CONSTRAINT_VIOLATION_TYPE,
+      CONSTRAINT_VIOLATION_NAMESPACE,
+      CONSTRAINT_VIOLATION_RESOURCE_LINK,
+      CONSTRAINT_VIOLATION_MESSAGE
+    ];
+
     return {
-      headers: [
-        CONSTRAINT_VIOLATION_TYPE,
-        CONSTRAINT_VIOLATION_RESOURCE_LINK,
-        CONSTRAINT_VIOLATION_MESSAGE
-      ],
+      headers,
       violations: this.value.violations.map((violation, i) => ({ ...violation, id: i }))
     };
   }
@@ -46,7 +54,6 @@ export default {
         <SortableTable
           :headers="headers"
           :rows="violations"
-          :search="false"
           :table-actions="false"
           :row-actions="false"
           :paging="true"


### PR DESCRIPTION
### Summary
This adds the following functionality to the violations list on the OPA Gatekeeper constraint detail page:

* Add a namespace column to the violations
* Make the violations list searchable
* Allow to download the violations as a CSV, similar to CIS scanner violations

Fixes #8585

### Technical notes summary
A constraint to use for testing could be:

```
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sRequiredLabels
metadata:
  name: all-must-have-owner
spec:
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["Pod"]
  parameters:
    message: "All pods must have an `owner` label that points to your company username"
    labels:
      - key: owner
        allowedRegex: "^[a-zA-Z]+.agilebank.demo$"
```

### Areas or cases that should be tested
Constraint detail page with violations

### Areas which could experience regressions
Constraint detail page

### Screenshot/Video
<img width="963" alt="Bildschirmfoto 2023-03-31 um 14 54 32" src="https://user-images.githubusercontent.com/243056/229127828-aa2904d1-09da-4eac-9097-881d2b1e9580.png">
<img width="274" alt="Bildschirmfoto 2023-03-31 um 14 54 10" src="https://user-images.githubusercontent.com/243056/229127849-498c9270-5a37-49d9-b11c-0eb577d64e6f.png">
<img width="1505" alt="Bildschirmfoto 2023-03-31 um 14 53 41" src="https://user-images.githubusercontent.com/243056/229127857-08ed79cd-343a-4a76-b893-c1e41b496489.png">
<img width="1509" alt="Bildschirmfoto 2023-03-31 um 14 53 27" src="https://user-images.githubusercontent.com/243056/229127862-2d863ae8-d09b-49a7-8a17-2b4d7bec9687.png">

Example for generated CSV
[violations-all-must-have-owner.csv](https://github.com/rancher/dashboard/files/11122059/violations-all-must-have-owner.csv)

