### PR TITLE
hide continuous delivery get started btn if user cant create gitrepos

### DIFF
--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -46,7 +46,7 @@ export default {
     this.fleetWorkspacesData = hash.fleetWorkspaces || [];
 
     try {
-      const permissions = await checkPermissions({ workspaces: { type: FLEET.WORKSPACE }, gitRepos: { type: FLEET.GIT_REPO } }, this.$store.getters);
+      const permissions = await checkPermissions({ workspaces: { type: FLEET.WORKSPACE }, gitRepos: { type: FLEET.GIT_REPO, schemaValidator: schema => schema.resourceMethods.includes('PUT') } }, this.$store.getters);
 
       this.permissions = permissions;
     } catch (e) {
@@ -322,15 +322,17 @@ export default {
           {{ t('fleet.dashboard.learnMore') }} <i class="icon icon-external-link" />
         </a>
       </p>
-      <h3 class="mb-30">
-        {{ t('fleet.dashboard.noRepo', null, true) }}
-      </h3>
-      <n-link
-        :to="getStartedLink"
-        class="btn role-secondary"
-      >
-        {{ t('fleet.dashboard.getStarted') }}
-      </n-link>
+      <template v-if="permissions.gitRepos">
+        <h3 class="mb-30">
+          {{ t('fleet.dashboard.noRepo', null, true) }}
+        </h3>
+        <n-link
+          :to="getStartedLink"
+          class="btn role-secondary"
+        >
+          {{ t('fleet.dashboard.getStarted') }}
+        </n-link>
+      </template>
     </div>
     <!-- fleet dashboard with repos -->
     <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8467 see comment on backport [here](https://github.com/rancher/dashboard/issues/8531#issuecomment-1492112791)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Updated the fleet landing page shown when a user has no git repos to hide the 'get started' button when the user can't create git repos.

### Technical notes summary
I've updated the `permissions` property to check available methods on the git repo schema rather than just checking for its existence - though git repos were added to this permission check previously, I don't see them used in the component elsewhere, so this change looks fine to me. 

### Areas or cases that should be tested
1. Users with permission to list but not create/edit gitrepos should not see 'get started' button on the fleet landing page
