### PR TITLE
use secret name not id for git repo clientSecretName and helmSecretName

### DIFF
--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -425,7 +425,7 @@ export default {
       await secret.save();
 
       await this.$nextTick(() => {
-        this.updateAuth(secret.id, name);
+        this.updateAuth(secret.metadata.name, name);
       });
 
       return secret;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8589 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
When creating gitrepos that reference an auth secret, the secret's name should be used, not id: https://github.com/rancher/dashboard/issues/8589#issuecomment-1492369082

### Technical notes summary
`clientSecretName` and `helmSecretName` are passed into the `SelectOrCreateAuthSecret`, which is written with the expectation that a name rather and id may be passed in: https://github.com/rancher/dashboard/blob/master/shell/components/form/SelectOrCreateAuthSecret.vue#L158

### Areas or cases that should be tested
The gitrepo payload should be verified to contain a clientSecretName that references a secret name, not id (no '/' in the value) when created with: 
1. a new https auth secret
2. a new ssh auth secret
3. an existing https auth secret
4. an existing ssh auth secret
The same should be true of creating a git repo with a helm secret, and the `helmSecretName` field. 

