### PR TITLE
Services, fix apps count in warning message

### DIFF
--- a/pkg/epinio/promptRemove/services.vue
+++ b/pkg/epinio/promptRemove/services.vue
@@ -36,7 +36,11 @@ export default {
     },
 
     bounded() {
-      return this.value.filter(row => row.boundapps?.length);
+      return this.value?.reduce((acc, svc) => {
+        const apps = svc?.boundapps ?? [];
+
+        return [...acc, ...apps];
+      }, []) || [];
     },
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Test cases:

- [x] select a Service without applications bound and delete.
- [x] select a Service with 1 or more applications bound and delete.
- [x] select multiple Services, some with applications bound and some without, and delete.

Fixes https://github.com/epinio/ui/issues/208
<!-- Define findings related to the feature or bug issue. -->
