### PR TITLE
[2.7.2]use secret name not id for git repo clientSecretName and helmSecretName

### DIFF
--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -425,7 +425,7 @@ export default {
       await secret.save();
 
       await this.$nextTick(() => {
-        this.updateAuth(secret.id, name);
+        this.updateAuth(secret.metadata.name, name);
       });
 
       return secret;


### PR DESCRIPTION
Fixes #8592 

backport of https://github.com/rancher/dashboard/pull/8591