### PR TITLE
Separate label slot in `RadioButton.vue`

### DIFF
--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -2,7 +2,7 @@
   "name": "@rancher/components",
   "repository": "git://github.com:rancher/dashboard.git",
   "license": "Apache-2.0",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "module": "./main.js",
   "main": "./dist/@rancher/components.umd.min.js",
   "files": [

--- a/pkg/rancher-components/src/components/Banner/Banner.test.ts
+++ b/pkg/rancher-components/src/components/Banner/Banner.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { Banner } from './index';
-import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive'
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('component: Banner', () => {
   it('should display text based on label', () => {
@@ -8,10 +8,8 @@ describe('component: Banner', () => {
     const wrapper = mount(
       Banner,
       {
-        directives: {
-         cleanHtmlDirective 
-        },
-        propsData: { label }
+        directives: { cleanHtmlDirective },
+        propsData:  { label }
       });
 
     const element = wrapper.find('span').element;

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
@@ -1,37 +1,25 @@
-import { shallowMount } from '@vue/test-utils'
-import { RadioButton } from './index'
+import { shallowMount } from '@vue/test-utils';
+import { RadioButton } from './index';
 
 describe('RadioButton.vue', () => {
   it('renders label slot contents', () => {
-    const wrapper = shallowMount(RadioButton, {
-      slots: {
-        label: 'Test Label'
-      },
-    });
+    const wrapper = shallowMount(RadioButton, { slots: { label: 'Test Label' } });
 
     expect(wrapper.find('.labeling').text()).toBe('Test Label');
   });
 
   it('renders label prop contents', () => {
-    const wrapper = shallowMount(RadioButton, {
-      propsData: {
-        label: 'Test Label',
-      }
-    });
+    const wrapper = shallowMount(RadioButton, { propsData: { label: 'Test Label' } });
 
     expect(wrapper.find('.radio-label').text()).toBe('Test Label');
   });
 
   it('renders slot contents when both slot and label prop are provided', () => {
     const wrapper = shallowMount(RadioButton, {
-      slots: {
-        label: 'Test Label - Slot'
-      },
-      propsData: {
-        label: 'Test Label - Props',
-      },
+      slots:     { label: 'Test Label - Slot' },
+      propsData: { label: 'Test Label - Props' },
     });
 
     expect(wrapper.find('.labeling').text()).toBe('Test Label - Slot');
-  })
+  });
 });

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
@@ -17,7 +17,6 @@ describe('RadioButton.vue', () => {
         propsData: { label: 'Test Label' }
       });
 
-    console.log(wrapper.html())
     expect(wrapper.find('.radio-label').text()).toBe('Test Label');
   });
 

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
@@ -1,16 +1,23 @@
 import { shallowMount } from '@vue/test-utils';
 import { RadioButton } from './index';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('RadioButton.vue', () => {
   it('renders label slot contents', () => {
     const wrapper = shallowMount(RadioButton, { slots: { label: 'Test Label' } });
 
-    expect(wrapper.find('.labeling').text()).toBe('Test Label');
+    expect(wrapper.find('.radio-label').text()).toBe('Test Label');
   });
 
   it('renders label prop contents', () => {
-    const wrapper = shallowMount(RadioButton, { propsData: { label: 'Test Label' } });
+    const wrapper = shallowMount(
+      RadioButton,
+      {
+        directives: { cleanHtmlDirective },
+        propsData: { label: 'Test Label' }
+      });
 
+    console.log(wrapper.html())
     expect(wrapper.find('.radio-label').text()).toBe('Test Label');
   });
 
@@ -20,6 +27,6 @@ describe('RadioButton.vue', () => {
       propsData: { label: 'Test Label - Props' },
     });
 
-    expect(wrapper.find('.labeling').text()).toBe('Test Label - Slot');
+    expect(wrapper.find('.radio-label').text()).toBe('Test Label - Slot');
   });
 });

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
@@ -1,0 +1,37 @@
+import { shallowMount } from '@vue/test-utils'
+import { RadioButton } from './index'
+
+describe('RadioButton.vue', () => {
+  it('renders label slot contents', () => {
+    const wrapper = shallowMount(RadioButton, {
+      slots: {
+        label: 'Test Label'
+      },
+    });
+
+    expect(wrapper.find('.labeling').text()).toBe('Test Label');
+  });
+
+  it('renders label prop contents', () => {
+    const wrapper = shallowMount(RadioButton, {
+      propsData: {
+        label: 'Test Label',
+      }
+    });
+
+    expect(wrapper.find('.radio-label').text()).toBe('Test Label');
+  });
+
+  it('renders slot contents when both slot and label prop are provided', () => {
+    const wrapper = shallowMount(RadioButton, {
+      slots: {
+        label: 'Test Label - Slot'
+      },
+      propsData: {
+        label: 'Test Label - Props',
+      },
+    });
+
+    expect(wrapper.find('.labeling').text()).toBe('Test Label - Slot');
+  })
+});

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -152,7 +152,7 @@ export default Vue.extend({
       role="radio"
     />
     <div class="labeling">
-      <slot 
+      <slot
         v-if="hasLabelSlot"
         name="label"
       >
@@ -160,9 +160,9 @@ export default Vue.extend({
       </slot>
       <label
         v-else-if="label"
+        v-clean-html="label"
         :class="[ muteLabel ? 'text-muted' : '', 'radio-label', 'm-0']"
         :for="name"
-        v-clean-html="label"
       />
       <div
         v-if="descriptionKey || description"

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -96,6 +96,10 @@ export default Vue.extend({
     hasDescriptionSlot(): boolean {
       return !!this.$slots.description;
     },
+
+    hasLabelSlot(): boolean {
+      return !!this.$slots.label || !!this.$scopedSlots.label;
+    }
   },
 
   watch: {
@@ -148,14 +152,18 @@ export default Vue.extend({
       role="radio"
     />
     <div class="labeling">
+      <slot 
+        v-if="hasLabelSlot"
+        name="label"
+      >
+        <!-- slot content -->
+      </slot>
       <label
-        v-if="label"
+        v-else-if="label"
         :class="[ muteLabel ? 'text-muted' : '', 'radio-label', 'm-0']"
         :for="name"
         v-clean-html="label"
-      >
-        <slot name="label">{{ label }}</slot>
-      </label>
+      />
       <div
         v-if="descriptionKey || description"
         class="radio-button-outer-container-description"

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -152,18 +152,21 @@ export default Vue.extend({
       role="radio"
     />
     <div class="labeling">
-      <slot
-        v-if="hasLabelSlot"
-        name="label"
-      >
-        <!-- slot content -->
-      </slot>
       <label
-        v-else-if="label"
-        v-clean-html="label"
         :class="[ muteLabel ? 'text-muted' : '', 'radio-label', 'm-0']"
         :for="name"
-      />
+      >
+        <slot
+          v-if="hasLabelSlot"
+          name="label"
+        >
+          <!-- slot content -->
+        </slot>
+        <span
+          v-else-if="label"
+          v-clean-html="label"
+        />
+      </label>
       <div
         v-if="descriptionKey || description"
         class="radio-button-outer-container-description"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This separates `label` slot from the `label` prop content in `RadioButton.vue`. Doing this will allow developers to provide custom content to the `label` slot that would otherwise get overwritten by the `v-html` directive. 

Fixes #8619
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I did a search for existing `RadioButton` instances that make used of the `label` slot an none came up. Please double-check that this is the case. 

I suspect that we won't find any instances in our code because this use case was never supported with the existing implementation.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Anything that uses a radio button.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Anything that uses a radio button.