### PR TITLE
Fixed extra space bug in the generic cluster-page

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/import.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/import.vue
@@ -136,16 +136,17 @@ export default {
     @error="e=>errors = e"
   >
     <Banner
-      v-if="harvesterLocation"
       color="info"
       :closable="true"
       class="mb-20"
       @close="hideHarvesterNotice"
     >
-      {{ t('cluster.harvester.importNotice') }}
-      <nuxt-link class="ml-5" :to="harvesterLocation">
-        {{ t('product.harvesterManager') }}
-      </nuxt-link>
+      <div>
+        {{ t('cluster.harvester.importNotice') }}
+        <nuxt-link to="harvesterLocation">
+          {{ t('product.harvesterManager') }}
+        </nuxt-link>
+      </div>
     </Banner>
 
     <NameNsDescription

--- a/shell/edit/provisioning.cattle.io.cluster/import.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/import.vue
@@ -142,12 +142,10 @@ export default {
       class="mb-20"
       @close="hideHarvesterNotice"
     >
-      <div>
-        {{ t('cluster.harvester.importNotice') }}
-        <nuxt-link :to="harvesterLocation">
-          {{ t('product.harvesterManager') }}
-        </nuxt-link>
-      </div>
+      {{ t('cluster.harvester.importNotice') }}
+      <nuxt-link :to="harvesterLocation">
+        {{ t('product.harvesterManager') }}
+      </nuxt-link>
     </Banner>
 
     <NameNsDescription

--- a/shell/edit/provisioning.cattle.io.cluster/import.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/import.vue
@@ -135,31 +135,29 @@ export default {
     @finish="saveOverride"
     @error="e=>errors = e"
   >
-    <div class="mt-20">
-      <Banner
-        v-if="harvesterLocation"
-        color="info"
-        :closable="true"
-        class="mb-20"
-        @close="hideHarvesterNotice"
-      >
-        {{ t('cluster.harvester.importNotice') }}
-        <nuxt-link :to="harvesterLocation">
-          {{ t('product.harvesterManager') }}
-        </nuxt-link>
-      </Banner>
+    <Banner
+      v-if="harvesterLocation"
+      color="info"
+      :closable="true"
+      class="mb-20"
+      @close="hideHarvesterNotice"
+    >
+      {{ t('cluster.harvester.importNotice') }}
+      <nuxt-link class="ml-5" :to="harvesterLocation">
+        {{ t('product.harvesterManager') }}
+      </nuxt-link>
+    </Banner>
 
-      <NameNsDescription
-        v-if="!isView"
-        v-model="value"
-        :mode="mode"
-        :namespaced="false"
-        name-label="cluster.name.label"
-        name-placeholder="cluster.name.placeholder"
-        description-label="cluster.description.label"
-        description-placeholder="cluster.description.placeholder"
-      />
-    </div>
+    <NameNsDescription
+      v-if="!isView"
+      v-model="value"
+      :mode="mode"
+      :namespaced="false"
+      name-label="cluster.name.label"
+      name-placeholder="cluster.name.placeholder"
+      description-label="cluster.description.label"
+      description-placeholder="cluster.description.placeholder"
+    />
 
     <Tabbed :side-tabs="true">
       <Tab

--- a/shell/edit/provisioning.cattle.io.cluster/import.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/import.vue
@@ -136,6 +136,7 @@ export default {
     @error="e=>errors = e"
   >
     <Banner
+      v-if="harvesterLocation"
       color="info"
       :closable="true"
       class="mb-20"
@@ -143,7 +144,7 @@ export default {
     >
       <div>
         {{ t('cluster.harvester.importNotice') }}
-        <nuxt-link to="harvesterLocation">
+        <nuxt-link :to="harvesterLocation">
           {{ t('product.harvesterManager') }}
         </nuxt-link>
       </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8106
<!-- Define findings related to the feature or bug issue. -->
- Fixed space between via and Virtualization Management
- Excess space above banner

I checked the change history and the generic component from the start had the `mt-20` class, having some extra space on top, which is not required.

For the space between via and Virtualization Management in the banner - I have created a new issue to fix banner components to take care of different use cases.

### How to test
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Go to
Cluster Management --> Import Cluster --> Generic, this fix should solve the bugs