### PR TITLE
Update v-html to v-clean-html

### DIFF
--- a/shell/chart/istio.vue
+++ b/shell/chart/istio.vue
@@ -238,7 +238,7 @@ export default {
         <div class="col span-12">
           <Banner color="info">
             <span
-              v-html="t('istio.pilotRequired', {}, true)"
+              v-clean-html="t('istio.pilotRequired', {}, true)"
             />
           </Banner>
         </div>


### PR DESCRIPTION
Fixes lint issue on master.

v-html was used in PR that had been approved and then merged after the lint rules were updated.

This PR updates to use the new `v-clean-html` directive.