### PR TITLE
Ensure CRDs are always installed with the same global values as the main chart

### DIFF
--- a/shell/chart/gatekeeper.vue
+++ b/shell/chart/gatekeeper.vue
@@ -27,12 +27,13 @@ export default {
       get() {
         const crdInfo = this.autoInstallInfo.find(info => info.chart.name.includes('crd'));
 
-        return crdInfo ? crdInfo.values : null;
+        // values are defaults from the chart; allValues are defaults + anything set on previous install if this is an update/upgrade
+        return crdInfo ? crdInfo.allValues : null;
       },
       set(values) {
         const crdInfo = this.autoInstallInfo.find(info => info.chart.name.includes('crd'));
 
-        this.$set(crdInfo, 'values', values);
+        this.$set(crdInfo, 'allValues', values);
       }
     }
   }

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -14,6 +14,8 @@ import { CAPI, CATALOG } from '@shell/config/types';
 import { isPrerelease } from '@shell/utils/version';
 import difference from 'lodash/difference';
 import { LINUX } from '@shell/store/catalog';
+import { clone } from 'utils/object';
+import { merge } from 'lodash';
 
 export default {
   data() {
@@ -391,7 +393,6 @@ export default {
           */
 
         if ( provider ) {
-          // more.push(provider);
           try {
             const crdVersionInfo = await this.$store.dispatch('catalog/getVersionInfo', {
               repoType:    provider.repoType,
@@ -399,6 +400,33 @@ export default {
               chartName:   provider.name,
               versionName: provider.version
             });
+            let existingCRDApp;
+
+            // search for an existing crd app to track any non-default values used on the previous install/upgrade
+            if (this.mode === _EDIT) {
+              const targetNamespace = crdVersionInfo?.chart?.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE];
+              const targetName = crdVersionInfo?.chart?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME];
+
+              if (targetName && targetNamespace) {
+                existingCRDApp = await this.$store.dispatch('cluster/find', {
+                  type: CATALOG.APP,
+                  id:   `${ targetNamespace }/${ targetName }`,
+                });
+              }
+            }
+            if (existingCRDApp) {
+              // spec.values are any non-default values the user configured
+              // the installation form should show these, as well as any default values from the chart
+              const existingValues = clone(existingCRDApp.spec?.values || {});
+              const defaultValues = clone(existingCRDApp.spec?.chart?.values || {});
+
+              crdVersionInfo.existingValues = existingValues;
+              crdVersionInfo.allValues = merge(defaultValues, existingValues);
+            } else {
+              // allValues will potentially be updated in the UI - we want to track this separately from values to avoid mutating the chart object in the store
+              // this is similar to userValues for the main chart
+              crdVersionInfo.allValues = clone(crdVersionInfo.values);
+            }
 
             out.push(crdVersionInfo);
           } catch (e) {

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -31,9 +31,7 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, PROJECT } from '@shell/config/labels-annotations';
 
 import { exceptionToErrorsArray } from '@shell/utils/error';
-import {
-  clone, diff, get, pickBy, set
-} from '@shell/utils/object';
+import { clone, diff, get, set } from '@shell/utils/object';
 import { ignoreVariables } from './install.helpers';
 import { findBy, insertAt } from '@shell/utils/array';
 import Vue from 'vue';


### PR DESCRIPTION
This PR addresses the bug described here specifically: https://github.com/rancher/dashboard/issues/8612#issuecomment-1496222854

### Occurred changes and/or fixed issues
This PR updates the logic around CRD chart values in a few ways. There are two requests for 2.7.2 we need to accomodate in this area:
* CRDs should be installed with the same global values as the main chart https://github.com/rancher/dashboard/issues/8062
* Custom UIs should be able to configure CRD chart values: https://github.com/rancher/dashboard/issues/8238

### Technical notes summary
#### Background info
In the install/upgrade request the UI passes only values that differ from the chart's default values. This means that when looking at the API call made,  if 'enable PSPs' is not checked, we shouldn't see `values.global.cattle.psp.enabled` in the request body of either chart at all. When it is checked, it should be there. Similarly, in #8238 we should only `values. enableRuntimeDefaultSeccompProfile` in the request when it has set to false in the UI. 

When viewing an installed app's detail view 'Values YAML' the user is shown all values the chart has been installed with, which is the combination of the default values and any customized values sent during installation/upgrading.

#### Changes in this PR
Previously we were mutating the CRD `values` object returned from `getVersionInfo` and sending that whole modified object in the request. We need to: 
1. use a new object each install to avoid polluting cached charts
2. only send values that are different from default
3. if upgrading, retrieve previously configured values and populate the UI form with them 


### Areas or cases that should be tested
#### Monitoring
1. Install monitoring with PSP enabled and ensure both the main and CRD charts have `values.global.cattle.psp.enabled: true`
2. Wait for installation to finish.
3. Upgrade monitoring and uncheck the PSP option, then ensure both main chart and CRD *do not send* `values.global.cattle.psp.enabled` in the request - this should result in the 'values YAML' tab of detail view showing `psp.enabled: false` for both charts.

#### Gatekeeper
1. Install gatekeeper with enableRuntimeDefaultSeccompProfile set to false (not the default) and ensure the CRD chart int he request (but not main chart) has `values.enableRuntimeDefaultSeccompProfile: false`
2. Navigate back to the gatekeeper install/upgrade form and verify that the checkbox is still unchecked
4. Re-check the box; upgrade and verify the request does not contain `enableRuntimeDefaultSeccompProfile`
5. Navigate back to the gatekeeper install page and upgrade with PSP enabled; verify the request shows both main chart and CRD have this configured.
