### PR TITLE
App breaks when creating a new namespace from a workload

### DIFF
--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -330,7 +330,7 @@ export default {
       }
 
       if (this.namespaced) {
-        this.$emit('isNamespaceNew', !val || (this.namespaces && !this.namespaces.find(n => n.value === val)));
+        this.$emit('isNamespaceNew', !val || (this.options && !this.options.find(n => n.value === val)));
       }
 
       if (this.namespaceKey) {

--- a/shell/components/form/__tests__/NameNsDescription.ts
+++ b/shell/components/form/__tests__/NameNsDescription.ts
@@ -29,4 +29,31 @@ describe('component: NameNsDescription', () => {
 
     expect((wrapper.vm as any).options).toStrictEqual(result);
   });
+
+  it('should emit in case of new namespace', () => {
+    const namespaceName = 'test';
+    const newNamespaceName = 'bananas';
+    const wrapper = mount(NameNsDescription, {
+      propsData: {
+        value: { metadata: {} },
+        mode:  'create',
+      },
+      mocks: {
+        $store: {
+          getters: {
+            namespaces:          jest.fn(),
+            allowedNamespaces:   () => ({ [namespaceName]: true }),
+            currentStore:        () => 'cluster',
+            'cluster/schemaFor': jest.fn(),
+            'i18n/t':            jest.fn()
+          },
+        },
+        $refs: { name: { focus: jest.fn() } }
+      }
+    });
+
+    (wrapper.vm as any).updateNamespace(newNamespaceName);
+
+    expect(wrapper.emitted().isNamespaceNew?.[0][0]).toBe(true);
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8632
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Prevented reported break.

### Technical notes summary
Reference to the variable was not updated, previously `this.namespace`, while we are checking the presence of `this.options`

### Areas or cases that should be tested
As in issue.

### Areas which could experience regressions
None.

### Screenshot/Video

https://user-images.githubusercontent.com/5009481/230189419-e9ad302b-2851-4477-bbeb-c182c9ab1f0c.mp4

