### PR TITLE
Create the base for a new stripped down version of extensions

### DIFF
--- a/shell/core/extensions/extension/index.ts
+++ b/shell/core/extensions/extension/index.ts
@@ -1,0 +1,82 @@
+import Router, { IRouter } from './router';
+
+export interface ExtensionMetadata {
+  name: string;
+  version: string;
+  description: string;
+  icon: string;
+}
+
+export interface IExtension {
+  id: string;
+  name: string;
+  description: string;
+  metadata: ExtensionMetadata;
+
+  isInitialized: boolean;
+  router: IRouter;
+}
+
+export class Extension implements IExtension {
+  private _isInitialized: boolean = false;
+  private _router: Router;
+  private _metadata: ExtensionMetadata;
+
+  /**
+   * @param metadata - Metadata that can be used by the APIs to do things like namespaces routes if necessary
+   * @param app - Gives the API access to the internals of the Vue application
+   */
+  constructor(metadata: ExtensionMetadata, app: any) {
+    this._isInitialized = true;
+    this._router = new Router(metadata, app);
+    this._metadata = metadata;
+  }
+
+  /**
+   * @returns the extension id
+   */
+  get id(): string {
+    return this._metadata.name;
+  }
+
+  /**
+   * @returns the extension name
+   */
+  get name(): string {
+    return this._metadata.name;
+  }
+
+  /**
+   * @returns the extension description
+   */
+  get description(): string {
+    return this._metadata.description;
+  }
+
+  /**
+   * @returns the extension metadata {@link @ExtensionMetadata}
+   */
+  get metadata(): ExtensionMetadata {
+    return this._metadata;
+  }
+
+  /**
+   * @returns a boolean which indicates whether or not the API object has been initialized.
+   */
+  get isInitialized(): boolean {
+    return this._isInitialized;
+  }
+
+  /**
+   * @returns an object which implements the IRouter interface
+   */
+  get router(): IRouter {
+    return this._router;
+  }
+
+  /**
+   * Responsible for doing any post configuration cleanup
+   */
+  _afterConfiguration() {
+  }
+}

--- a/shell/core/extensions/extension/provider.ts
+++ b/shell/core/extensions/extension/provider.ts
@@ -1,0 +1,33 @@
+import { ExtensionMetadata, IExtension, Extension } from './index';
+
+export type RegisterFn = (metadata: ExtensionMetadata) => IExtension;
+export type ConfigureFn = (registerMetadata: RegisterFn) => Promise<void>
+
+export class ExtensionProvider {
+    app: any;
+
+    constructor(app: any) {
+      this.app = app;
+    }
+
+    async create(configureFn: ConfigureFn) {
+      // Typescript can't know that the extension was set within the configureFn so this type conversion is necessary because TS will think api is never assigned
+      let extension: Extension = null as unknown as Extension;
+      let called = false;
+
+      await configureFn((metadata: ExtensionMetadata) => {
+        if (called) {
+          throw new Error(`The RegisterFn has already been called once for the ${ metadata.name } extension`);
+        }
+
+        called = true;
+        extension = new Extension(metadata, this.app);
+
+        return extension;
+      });
+
+      extension._afterConfiguration();
+
+      return extension;
+    }
+}

--- a/shell/core/extensions/extension/router.ts
+++ b/shell/core/extensions/extension/router.ts
@@ -1,0 +1,33 @@
+import { ExtensionMetadata } from './index';
+import { RouteConfig } from 'vue-router';
+
+export interface IRouter {
+   /**
+    * Add a new {@link RouteConfig | route record} as the child of an existing route. If the route has a `name` and there
+    * is already an existing one with the same one, it overwrites it.
+    *
+    * @param parentName - Parent Route Record where `route` should be appended at
+    * @param route - Route Record to add
+    */
+    addRoute(parentName: string, route: RouteConfig): void;
+    /**
+     * Add a new {@link RouteConfig | route} to the router. If the route has a `name` and there is already an existing one
+     * with the same one, it overwrites it.
+     * @param route - Route Record to add
+     */
+    addRoute(route: RouteConfig): void; // eslint-disable-line no-dupe-class-members
+}
+
+export default class Router implements IRouter {
+  private _app: any;
+  private _metadata: ExtensionMetadata;
+
+  constructor(metadata: ExtensionMetadata, app: any) {
+    this._metadata = metadata;
+    this._app = app;
+  }
+
+  addRoute(first: string | RouteConfig, second?: RouteConfig) { // eslint-disable-line no-dupe-class-members
+    this._app.router.addRoute(first);
+  }
+}

--- a/shell/core/extensions/loader.js
+++ b/shell/core/extensions/loader.js
@@ -1,0 +1,36 @@
+import { ExtensionProvider } from './extension/provider';
+
+export default function({
+  app,
+  store,
+}, inject) {
+  const extensionProvider = new ExtensionProvider(app);
+
+  // Things we want to expose to components via the '$extension' property
+  inject('extension', {});
+
+  // Load the extensions
+  // The '@rancher/extensionsConfiguration' module is generated in webpack to load each package
+  const extensionsConfiguration = require('@rancher/extensionsConfiguration');
+
+  if (!extensionsConfiguration) {
+    return;
+  }
+
+  extensionsConfiguration?.default({
+    // This 'configure' method is used in the webpack configuration which generates '@rancher/extensionsConfiguration'
+    async configure(module) {
+      let extension;
+
+      try {
+        extension = await extensionProvider.create(module.default);
+
+        // Add to the plugin store so the extensions page is aware it's been loaded/configured
+        store.dispatch('uiplugins/addPlugin', extension);
+      } catch (e) {
+        console.error(`Error loading extension ${ extension.name }`); // eslint-disable-line no-console
+        console.error(e); // eslint-disable-line no-console
+      }
+    }
+  });
+}

--- a/shell/core/extensions/types.ts
+++ b/shell/core/extensions/types.ts
@@ -1,0 +1,7 @@
+/**
+ * We're using interfaces to hide implementation details that the consumers of
+ * our apis shouldn't have to concern themselves with.
+ */
+export { IExtension } from './extension/index';
+export { RegisterFn } from './extension/provider';
+export { IRouter } from './extension/router';

--- a/shell/nuxt/index.js
+++ b/shell/nuxt/index.js
@@ -18,6 +18,7 @@ import cookieUniversalNuxt from './cookie-universal-nuxt.js';
 import axios from './axios.js';
 import plugins from '../core/plugins.js';
 import pluginsLoader from '../core/plugins-loader.js';
+import extensionsLoader from '../core/extensions/loader.js';
 import axiosShell from '../plugins/axios';
 import '../plugins/tooltip';
 import '../plugins/vue-clipboard2';
@@ -309,6 +310,12 @@ async function createApp(ssrContext, config = {}) {
 
   if (process.client && typeof steveCreateWorker === 'function') {
     await steveCreateWorker(app.context, inject);
+  }
+
+  // This needs to be loaded after the 'pluginsLoader' and 'plugin' calls because they trample all over the vue router and will erase
+  // anything this extension loader changes
+  if (typeof extensionsLoader === 'function') {
+    await extensionsLoader(app.context, inject);
   }
 
   // if (process.client && typeof formatters === 'function') {


### PR DESCRIPTION
- fixes rancher/dashboard#8580
- fixes rancher/dashboard#8582

### What
Adds support for a new way to register extensions without interfering with the existing method. The new method still closely resembles the old method.

Example extension configuration
```ts
// pkg/chat/configure.ts 

import { IExtension, RegisterFn } from '@shell/core/extensions/types';
import Chat from './components/Chat/index.vue';

// Configure the extension
export default function(register: RegisterFn) {
  const extension: IExtension = register(require('./package.json'));

  extension.router.addRoute({
    name:      'chat',
    path:      '/chat',
    component: Chat
  });
}
```

### Extension bootstrapping steps
1. In `shell/vue.config.js` we create a new virtual module / import named `@rancher/extensionsConfiguration` which imports the `config.ts` of each pkg if it exists.
1. In `shell/nuxt/index.js` we will execute the `shell/core/extensions/loader` as though it were a nuxt plugin in order to bootstrap the new version of extensions.
1. In `shell/core/extensions/loader.js` we import and execute `@rancher/extensionsConfiguration` by passing it an object with a `configure` method that the import is aware of.
1. The `configure` method in the previous step will create the object which implements the `IExtension` interface and pass the object to the default method defined in the `config.ts` of each pkg.
