### PR TITLE
Remove .gitignore from exlude assets for publish action

### DIFF
--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -32,6 +32,8 @@ jobs:
           deploy_key: ${{ secrets.GH_PAGES_DEPLOY_KEY }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docusaurus/build
+          # Remove .gitignore from excludes
+          exclude_assets: ''
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Removes the file `.github` from `exclude_assets` environment variable in the publish Publish Docusaurus workflow.