### PR TITLE
Backport - Fix stuck loading indicator (auth)

### DIFF
--- a/shell/pages/c/_cluster/auth/config/_id.vue
+++ b/shell/pages/c/_cluster/auth/config/_id.vue
@@ -19,6 +19,12 @@ export default {
       // Ensure we re-evaluate the redirect in case this auth provider has been disabled
       const authProvs = await authProvidersInfo(this.$store);
 
+      // Nuxt does not remove it's loading indicator - if we are not changing route, then hide it
+      // https://nuxtjs.org/docs/features/loading/
+      if (authProvs.enabledLocation) {
+        this.$nuxt.$loading.finish();
+      }
+
       next(!authProvs.enabledLocation);
     } else {
       next();


### PR DESCRIPTION
Fixes: https://github.com/rancher/dashboard/issues/8319
Original issue https://github.com/rancher/dashboard/issues/7818

The Nuxt loading indicator does not get removed when we prevent the navigation in this use case - this PR forces the loading indicator to be removed.