### PR TITLE
Fix repeated style definitions from _mixins.scss

### DIFF
--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -1,3 +1,5 @@
+@import "./mixins";
+
 // -----------------------------------------------------------------------------
 // This file contains very basic styles.
 // -----------------------------------------------------------------------------
@@ -109,3 +111,19 @@ HR.vertical {
   margin-left: -1px;
   top: 0;
 }
+
+// --------------------------------------------------------------------------------------------------------
+// These were declared in _mixins, but that results in these styles being declared for every Vue component
+// Moved here, as these are styles and mixing should only include mixing definitions, not style definitions
+// --------------------------------------------------------------------------------------------------------
+
+.clearfix         { @include clearfix; }
+.list-unstyled    { @include list-unstyled }
+.no-select        { @include no-select }
+.no-resize        { @include no-resize }
+.hand             { @include hand }
+.fixed            { @include fixed }
+.clip             { @include clip }
+.force-wrap       { @include force-wrap }
+.bordered-section { @include bordered-section }
+.section-divider  { @include section-divider }

--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -114,7 +114,7 @@ HR.vertical {
 
 // --------------------------------------------------------------------------------------------------------
 // These were declared in _mixins, but that results in these styles being declared for every Vue component
-// Moved here, as these are styles and mixing should only include mixing definitions, not style definitions
+// Moved here, as these are styles and mixins should only include mixing definitions, not style definitions
 // --------------------------------------------------------------------------------------------------------
 
 .clearfix         { @include clearfix; }

--- a/shell/assets/styles/base/_mixins.scss
+++ b/shell/assets/styles/base/_mixins.scss
@@ -63,17 +63,6 @@
   margin-top: 20px;
 }
 
-.clearfix         { @include clearfix; }
-.list-unstyled    { @include list-unstyled }
-.no-select        { @include no-select }
-.no-resize        { @include no-resize }
-.hand             { @include hand }
-.fixed            { @include fixed }
-.clip             { @include clip }
-.force-wrap       { @include force-wrap }
-.bordered-section { @include bordered-section }
-.section-divider  { @include section-divider }
-
 /// Sets the specified background color and calculates a dark or light contrasted text color.
 @mixin contrasted($background-color, $dark: $contrasted-dark, $light: $contrasted-light) {
   color: contrast-color($background-color, $dark, $light);

--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -52,9 +52,7 @@ $breakpoints: (
 
 $font-size-h2: 21px;
 
-/*
- * Global spacing variables
- */
+//Global spacing variables
 $space-s: 10px;
 $space-m: 20px;
 $space-l: 40px;

--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -52,7 +52,7 @@ $breakpoints: (
 
 $font-size-h2: 21px;
 
-//Global spacing variables
+// Global spacing variables
 $space-s: 10px;
 $space-m: 20px;
 $space-l: 40px;


### PR DESCRIPTION
Fixes #8663 

This PR fixes an issue with our CSS.

`_mixins.scss` defines not only mixins but also a few styles. This file in included in every Vue component's styles, so that they can access the mixins. This results in the styles be defined within every component.

This PR moves the style declrations out of `_mixins.css`, so that they are only delcared once. Mixins now only declares actual scss mixins.

Also changed the comment in `_variables.scss` to use `//`, so that it is removed - the `/*` style of comments is preserved - meaning we get the comment included at the top of every style generated for every Vue component.
