### PR TITLE
Hide `EPINIO_APP_DATA` from user, fix edit of source from non-git sources

### DIFF
--- a/pkg/epinio/components/application/AppInfo.vue
+++ b/pkg/epinio/components/application/AppInfo.vue
@@ -73,7 +73,7 @@ export default Vue.extend<Data, any, any, any>({
       values:        undefined,
       capitalize,
       validSettings: {},
-      sanitisedEnvs: {}
+      sanitizedEnvs: {}
     };
   },
 
@@ -97,7 +97,7 @@ export default Vue.extend<Data, any, any, any>({
 
     const { [APPLICATION_ENV_VAR]:appEnvVar = '', ...otherEnvVars } = values.configuration.environment;
 
-    this.sanitisedEnvs = {
+    this.sanitizedEnvs = {
       appEnvVar,
       otherEnvVars
     };
@@ -260,10 +260,10 @@ export default Vue.extend<Data, any, any, any>({
       }
     },
 
-    envsChanged(env: environment, b: any) {
+    envsChanged(env: environment) {
       this.values.configuration.environment = {
         ...env,
-        [APPLICATION_ENV_VAR]: this.sanitisedEnvs.appEnvVar
+        [APPLICATION_ENV_VAR]: this.sanitizedEnvs?.appEnvVar
       };
     }
   },
@@ -371,7 +371,7 @@ export default Vue.extend<Data, any, any, any>({
     </div>
     <div class="col span-8">
       <KeyValue
-        :value="sanitisedEnvs.otherEnvVars"
+        :value="sanitizedEnvs.otherEnvVars"
         data-testid="epinio_app-info_envs"
         :mode="mode"
         :title="t('epinio.applications.create.envvar.title')"

--- a/pkg/epinio/components/application/AppInfo.vue
+++ b/pkg/epinio/components/application/AppInfo.vue
@@ -261,10 +261,10 @@ export default Vue.extend<Data, any, any, any>({
     },
 
     envsChanged(env: environment) {
-      this.values.configuration.environment = {
-        ...env,
-        [APPLICATION_ENV_VAR]: this.sanitizedEnvs?.appEnvVar
-      };
+      this.values.configuration.environment = { ...env };
+      if (this.sanitizedEnvs?.appEnvVar) {
+        this.values.configuration.environment[APPLICATION_ENV_VAR] = this.sanitizedEnvs.appEnvVar;
+      }
     }
   },
 

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -192,9 +192,10 @@ export default Vue.extend<Data, any, any, any>({
             namespace: this.namespaces?.[0]?.name || ''
           },
           configuration: {
-            configurations: parsed.configuration?.configurations || [],
+            configurations: parsed.configuration?.configurations as string[] || [],
             instances:      parsed.configuration.instances || 1,
             environment:    parsed.configuration.environment || {},
+            settings:       parsed.configuration?.settings || {},
             routes:         parsed.configuration.routes || []
           }
         };

--- a/pkg/epinio/detail/applications.vue
+++ b/pkg/epinio/detail/applications.vue
@@ -151,14 +151,14 @@ export default Vue.extend<Data, any, any, any>({
 
     envVarGitSource(): EPINIO_APP_ENV_VAR_GIT | null {
       if (this.envVarSourceType === APPLICATION_SOURCE_TYPE.GIT_HUB || this.envVarSourceType === APPLICATION_SOURCE_TYPE.GIT_LAB ) {
-        return this.envVar.source?.[this.envVarSourceType] as EPINIO_APP_ENV_VAR_GIT;
+        return this.envVar?.source?.[this.envVarSourceType] as EPINIO_APP_ENV_VAR_GIT;
       }
 
       return null;
     },
 
     envVarSourceType(): APPLICATION_SOURCE_TYPE {
-      return this.envVar.source?.type;
+      return this.envVar?.source?.type;
     },
 
     gitType() {

--- a/pkg/epinio/models/applications.js
+++ b/pkg/epinio/models/applications.js
@@ -262,6 +262,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
     const appSource = {
       type:      this.sourceType,
       appChart:  this.configuration?.appchart,
+      git:       {},
       github:    {},
       gitUrl:    {},
       container: {},
@@ -396,7 +397,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
           }, {
             label: 'Revision',
             icon:  'icon-commit',
-            value: source?.branch?.name || source.branch.id || this.origin.git.revision
+            value: source?.branch?.name || source?.branch?.id || this.origin.git.revision
           }, appChart, builderImage
         ]
       };
@@ -415,7 +416,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
           }, {
             label: 'Branch',
             icon:  'icon-commit',
-            value: source?.branch?.name || source.branch.id || this.origin.git.revision
+            value: source?.branch?.name || source?.branch?.id || this.origin.git.revision
           }, appChart, builderImage
         ]
       };
@@ -434,7 +435,7 @@ export default class EpinioApplicationModel extends EpinioNamespacedResource {
           }, {
             label: 'Branch',
             icon:  'icon-commit',
-            value: source?.branch?.name || source.branch.id || this.origin.git.revision
+            value: source?.branch?.name || source?.branch?.id || this.origin.git.revision
           }, appChart, builderImage
         ]
       };


### PR DESCRIPTION
- App create/edit pages should hide the EPINIO_APP_DATA env var
- fix edit of apps from non-git sources
- fixes https://github.com/epinio/ui/issues/220
