### PR TITLE
Auth Provider: Support Okta with LDAP search

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -455,7 +455,13 @@ authConfig:
     objectClass: Object Class
     password: Password
     port: Port
+    protocol: Protocol
+    protocols:
+      starttls: Start TLS
+      ldap: LDAP
+      tls: LDAPS (TLS)
     customizeSchema: Customize Schema
+    oktaSchema: 'The defaults below are for a generic OpenLDAP server. For more information on the values to use when using the Okta LDAP interface, see: <a target="_blank" rel="noopener noreferrer nofollow" href="https://help.okta.com/en-us/Content/Topics/Directory/LDAP-interface-connection-settings.htm">Okta LDAP Interface connection settings</a>'
     users: Users
     groups: Groups
     searchAttribute: Search Attribute
@@ -500,6 +506,13 @@ authConfig:
     shibboleth: Configure a Shibboleth account
     showLdap: Configure an OpenLDAP Server
     userName: User Name Field
+    search:
+      title: User and Group Search
+      message: The SAML Protocol does not support search or lookup for users or groups. In order to enabled search, an OpenLDAP server must be configured.
+      on: LDAP User and Group search has been configured
+      off: LDAP User and Group search is not configured
+      show: Show details
+      hide: Hide details
   azuread:
     tenantId: Tenant ID
     applicationId: Application ID

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -73,6 +73,12 @@ export default {
     >
       <slot name="rows" />
     </table>
+
+    <slot
+      v-if="$slots.footer"
+      name="footer"
+    />
+
     <DisableAuthProviderModal
       ref="disableAuthProviderModal"
       @disable="disable"

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -51,8 +51,8 @@ export default {
   },
 
   computed: {
-    // Does the auth provider support LDAP for search in addition to SAML
-    samlProvider() {
+    // Does the auth provider support LDAP for search in addition to SAML?
+    isSamlProvider() {
       return this.type === SHIBBOLETH || this.type === OKTA;
     }
   },
@@ -369,7 +369,7 @@ export default {
           />
         </div>
         <div
-          v-if="!samlProvider"
+          v-if="!isSamlProvider"
           class=" col span-6"
         >
           <RadioGroup

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -5,6 +5,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import UnitInput from '@shell/components/form/UnitInput';
 import { Banner } from '@components/Banner';
 import FileSelector from '@shell/components/form/FileSelector';
+import { OKTA, SHIBBOLETH } from '../saml';
 
 const DEFAULT_NON_TLS_PORT = 389;
 const DEFAULT_TLS_PORT = 636;
@@ -47,6 +48,13 @@ export default {
       hostname:      this.value.servers.join(','),
       serverSetting: null,
     };
+  },
+
+  computed: {
+    // Does the auth provider support LDAP for search in addition to SAML
+    samlProvider() {
+      return this.type === SHIBBOLETH || this.type === OKTA;
+    }
   },
 
   watch: {
@@ -361,7 +369,7 @@ export default {
           />
         </div>
         <div
-          v-if="type!=='shibboleth'"
+          v-if="!samlProvider"
           class=" col span-6"
         >
           <RadioGroup

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -34,6 +34,11 @@ export default {
     type: {
       type:     String,
       required: true
+    },
+
+    isCreate: {
+      type:    Boolean,
+      default: false
     }
 
   },
@@ -47,6 +52,7 @@ export default {
       model:         this.value,
       hostname:      this.value.servers.join(','),
       serverSetting: null,
+      OKTA
     };
   },
 
@@ -240,6 +246,12 @@ export default {
       <div class="row">
         <h3>  {{ t('authConfig.ldap.customizeSchema') }}</h3>
       </div>
+      <Banner
+        v-if="type === OKTA && isCreate"
+        class="row"
+        color="info"
+        label-key="authConfig.ldap.oktaSchema"
+      />
       <div class="row">
         <div class="col span-6">
           <h4>{{ t('authConfig.ldap.users') }}</h4>

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -90,7 +90,8 @@ export default {
       if (neu && !this.model.openLdapConfig) {
         const config = this.NAME === OKTA ? LDAP_OKTA_DEFAULTS : LDAP_DEFAULTS;
 
-        this.$set(this.model, 'openLdapConfig', config);
+        // Use a spread of config, so that if don't make changes to the defaults if the user edits them
+        this.$set(this.model, 'openLdapConfig', { ...config });
       }
     }
   }

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -82,9 +82,9 @@ export default {
     },
 
     ldapProtocol() {
-      if (this.model.openLdapConfig.starttls) {
+      if (this.model?.openLdapConfig?.starttls) {
         return this.t('authConfig.ldap.starttls');
-      } else if (this.model.openLdapConfig.tls) {
+      } else if (this.model?.openLdapConfig?.tls) {
         return this.t('authConfig.ldap.protocols.tls');
       }
 
@@ -333,7 +333,7 @@ export default {
           </div>
           <div class="row mt-20 mb-20">
             <config
-              v-if="showLdap"
+              v-if="showLdap && model.openLdapConfig"
               v-model="model.openLdapConfig"
               :type="NAME"
               :mode="mode"

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -83,7 +83,7 @@ export default {
 
     ldapProtocol() {
       if (this.model?.openLdapConfig?.starttls) {
-        return this.t('authConfig.ldap.starttls');
+        return this.t('authConfig.ldap.protocols.starttls');
       } else if (this.model?.openLdapConfig?.tls) {
         return this.t('authConfig.ldap.protocols.tls');
       }

--- a/shell/utils/gc/gc.ts
+++ b/shell/utils/gc/gc.ts
@@ -29,7 +29,7 @@ class GarbageCollect {
    * To avoid JSON.parse on the `ui-performance` setting keep a local cache
    */
   private getUiPerfGarbageCollection = (rootState: any) => {
-    const uiPerfSetting = rootState.management.types[MANAGEMENT.SETTING].list.find((s: any) => s.id === SETTING.UI_PERFORMANCE);
+    const uiPerfSetting = rootState.management.types[MANAGEMENT.SETTING]?.list.find((s: any) => s.id === SETTING.UI_PERFORMANCE);
 
     if (!uiPerfSetting || !uiPerfSetting.value) {
       // Could be in the process of logging out


### PR DESCRIPTION
Fixes #8675 

Adds the option to the OKTA Auth Provider to specify LDAP configuration for advanced group search. This follow the same pattern as the Shibboleth auth provider.
