### PR TITLE
Add keepResources property to GitRepo creation and edit.

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2113,7 +2113,7 @@ fleet:
     resources:
       label: 'Resource Handling'
       keepResources: Keep resources after deletion
-      resourceBanner: Resources will be kept when deleting a GitRepo or Bundle - only Helm release secrets will be deleted.
+      resourceBanner: When enabled above, resources will be kept when deleting a GitRepo or Bundle - only Helm release secrets will be deleted.
     add:
       steps:
         repoInfo:

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -604,12 +604,6 @@ export default {
       </template>
       <div class="spacer" />
       <h2 v-t="'fleet.gitRepo.resources.label'" />
-
-      <Banner
-        color="info"
-      >
-        {{ t('fleet.gitRepo.resources.resourceBanner') }}
-      </Banner>
       <Checkbox
         v-model="value.spec.keepResources"
         class="check"
@@ -617,6 +611,11 @@ export default {
         label-key="fleet.gitRepo.resources.keepResources"
         :mode="mode"
       />
+      <Banner
+        color="info"
+      >
+        {{ t('fleet.gitRepo.resources.resourceBanner') }}
+      </Banner>
       <div class="spacer" />
       <h2 v-t="'fleet.gitRepo.paths.label'" />
       <ArrayList


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#8455 

### Occurred changes and/or fixed issues
- Add a checkbox to toggle boolean value of  `value.spec.keepResources`
- Field is updatable via YAML as well.

### Technical notes summary
Related Fleet work:
- Issue: https://github.com/rancher/fleet/issues/680
- PR: https://github.com/rancher/fleet/pull/1382

### Areas or cases that should be tested
- Ensure that Backend is using latest rancher head with the commit with PR: https://github.com/rancher/fleet/pull/1382
- Navigate to Continuous Delivery > Git Repos
- Click on `Add Repository` or Edit Existing repository
- There is a new section `Resource Handling` which allows to set the field.
- It can also be set via YAML.

### Areas which could experience regressions
- GitRepo creation and edit

### Screenshot/Video
<img width="815" alt="image" src="https://user-images.githubusercontent.com/1387263/232749229-06dd7999-934e-4820-98fa-a2474d3dd950.png">
