### PR TITLE
Update extension test script and add doc for the extension tests

### DIFF
--- a/docusaurus/docs/testing/extensions-test.md
+++ b/docusaurus/docs/testing/extensions-test.md
@@ -15,18 +15,31 @@ The tests check the following:
 - Verifies that the extension can be build standalone
 - Verifies that an extension can be added to the existing dashboard and that the dashboard build passes with the new extension present
 
-## Possible causs of test failures
+## Running Tests locally
+
+You can run the script `./shell/scripts/test-plugins-build.sh` locally in a terminal to run the test suite on a developer machine.
+
+Run the script with `-h` to see the list of options available.
+
+## Possible causes of test failures
 
 ### Dependencies
 
 For the standalone case of a new app using the `@rancher/shell` package, the dependency versions can end up being different to that of the dashboard codebase. This is typically due to dependencies being top-level dependencies in the case of the dashboard codebase, but child dependencies in the case of the new app. In the later case, yarn can hoist dependency versions differently.
 
+To debug this situation, run the test script with `-i -k` - this will only run the standalone tests (`-i` ignores the in-tree tests) and will keep the generate application after the test run (`-k`).
+
+After the test run, cd to the test app folder (as logged by the test run) and then cd into the `test-app` folder.
+
+If you run `yarn build` you should see the same error that the tests reported.
+
+Dependency errors can occur in the in-tree tests (these create an extension in the dashboard repository folder and test with the dashboard shell code in-tree, rather than being referenced by the shell package).
+
+To run only the in-tree tests, run the test script with `-s` - this will ignore the standalone tests. Additionally, running with `-e` will keep the test extension in the folder `./pkg/test-pkg`.
+
+To debug, run: `yarn build-pkg test-pkg` and you should see the same error as the in-tree test report.
+
 ### Imports
 
-Importing Vue components using the `~` syntax should not be used - this will build in the case of the dashboard repository, but not in the case of a standalone app.
+Importing Vue components using the `~` syntax should not be used - this will build in the case of the dashboard repository (in-tree test), but not in the case of a standalone app (standalone test).
 
-## Running Tests locally
-
-You can run the script `./shell/scripts/test-plugins-build.sh` locally in a terminal to run the test suite on a developer machine.
-
-> Note: After running the tests the `package.json` files in `shell` and `pkg/rancher-components` will be modified - ensure you reset these and do not check in changes.

--- a/docusaurus/docs/testing/extensions-test.md
+++ b/docusaurus/docs/testing/extensions-test.md
@@ -1,0 +1,32 @@
+# Extensions Tests
+
+The Extensions framework is tested by the GitHub action `check-plugins.yaml`. This runs the script `./shell/scripts/test-plugins-build.sh`
+which runs the actual tests.
+
+The tests check the following:
+
+- Ensures that Verdaccio is installed and running locally (Verdaccio provides a local NPM registry that the tests can use to publish packages without having to publish to npm)
+- Verifies the build of the following, by building and then publishing them to the local registry
+  - Shell
+  - Yarn Creator packages
+  - Rancher components package
+- Verifies that a new app can be created with the `@rancher/app` creator and built (test case of a new extension in a new repository)
+- Verifies that an extension can be added with the `@rancher/pkg` creator to the new app and that the dashboard build passes with the new extension present
+- Verifies that the extension can be build standalone
+- Verifies that an extension can be added to the existing dashboard and that the dashboard build passes with the new extension present
+
+## Possible causs of test failures
+
+### Dependencies
+
+For the standalone case of a new app using the `@rancher/shell` package, the dependency versions can end up being different to that of the dashboard codebase. This is typically due to dependencies being top-level dependencies in the case of the dashboard codebase, but child dependencies in the case of the new app. In the later case, yarn can hoist dependency versions differently.
+
+### Imports
+
+Importing Vue components using the `~` syntax should not be used - this will build in the case of the dashboard repository, but not in the case of a standalone app.
+
+## Running Tests locally
+
+You can run the script `./shell/scripts/test-plugins-build.sh` locally in a terminal to run the test suite on a developer machine.
+
+> Note: After running the tests the `package.json` files in `shell` and `pkg/rancher-components` will be modified - ensure you reset these and do not check in changes.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -123,6 +123,7 @@ const sidebars = {
         'testing/unit-test',
         'testing/e2e-test',
         'testing/stress-test',
+        'testing/extensions-test',
       ],
     },
     'terminology',

--- a/shell/scripts/extension-test/test-plugins-parse-login
+++ b/shell/scripts/extension-test/test-plugins-parse-login
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const readline = require('readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false
+});
+
+let jsonData = '';
+
+rl.on('line', (line) => {
+    jsonData += `${line}\n`;
+});
+
+rl.once('close', () => {
+    const data = JSON.parse(jsonData);
+
+    if (data.error) {
+      console.error(`ERROR creating user in Verdaccio: ${data.error}`);
+      process.exitCode = 1;
+    } else {
+      console.log(data.token);
+    }
+});

--- a/shell/scripts/extension-test/test-plugins-parse-login
+++ b/shell/scripts/extension-test/test-plugins-parse-login
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+// This small helper reads JSON from stdin and parses the JSON object
+// looking for either the .error or .token properties.
+
+// This is used by the extensions test script, passing in the output of the
+// curl command to POST to the registry auth endpoint to log the user in
+// NOTE: We can not just use `npm login` as there is no way to non-interactively supply the password
+
 const readline = require('readline');
 
 const rl = readline.createInterface({

--- a/shell/scripts/extension-test/test-plugins-reset
+++ b/shell/scripts/extension-test/test-plugins-reset
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Reset the top-level package file and remove the extra script that may have been added
-const fs = require('fs-extra');
+const fs = require('fs');
 const path = require('path');
 const dir = path.resolve('.');
 const topFile = path.join(dir, 'package.json');

--- a/shell/scripts/extension-test/test-plugins-reset
+++ b/shell/scripts/extension-test/test-plugins-reset
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+// Reset the top-level package file and remove the extra script that may have been added
+const fs = require('fs-extra');
+const path = require('path');
+const dir = path.resolve('.');
+const topFile = path.join(dir, 'package.json');
+const mainPkg = JSON.parse(fs.readFileSync(topFile));
+
+if (mainPkg.scripts['publish-pkgs']) {
+  delete mainPkg.scripts['publish-pkgs'];
+  fs.writeFileSync(topFile, JSON.stringify(mainPkg, undefined, 2) + '\n');
+}

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -2,22 +2,132 @@
 
 set -e
 
-echo "Checking plugin build"
+CYAN="\033[96m"
+YELLOW="\033[93m"
+RESET="\033[0m"
+BOLD="\033[1m"
+NORMAL="\033[22m"
+
+echo -e "${BOLD}${CYAN}Extensions framework build tests${RESET}"
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BASE_DIR="$( cd $SCRIPT_DIR && cd ../.. & pwd)"
 SHELL_DIR=$BASE_DIR/shell/
 
-echo ${SCRIPT_DIR}
+# ---- Options ----------------------------------------------------------------------------------------------------
 
-SKIP_SETUP="false"
-SKIP_STANDALONE="false"
+KEEP_FOLDER=false
+KEEP_PKG=false
+SKIP_IN_TREE=false
+SKIP_SETUP=false
+SKIP_STANDALONE=false
 
-if [ "$1" == "-s" ]; then
-  SKIP_SETUP="true"
-fi
+REG_USER=admin
+REG_PWD=admin
 
-if [ $SKIP_SETUP == "false" ]; then
+usage() {
+  echo "Usage: $0 [<options>] [plugins]"
+  echo " options:"
+  echo "  -k           Keep the folder for the test application after run"
+  echo "  -e           Keep the test extension after run (in-tree tests)"
+  echo "  -i           Skip in-tree tests"
+  echo "  -s           Skip standalone tests"
+  echo "  -x           Skip test setup"
+  echo "  -u <name>    Verdaccio user name for publishing (default: admin)"
+  echo "  -p <name>    Verdaccio password for publishing"
+  exit 1
+}
+
+while getopts "hkeisr:p:" opt; do
+  case $opt in
+    h)
+      usage
+      ;;
+    k)
+      KEEP_FOLDER=true
+      echo "Folder for test appliaction will not be deleted after test run"
+      ;;
+    e)
+      KEEP_PKG=true
+      echo "Folder for test extension will not be deleted after test run"
+      ;;
+    i)
+      SKIP_IN_TREE=true
+      echo "In-tree tests will not be run"
+      ;;
+    s)
+      SKIP_STANDALONE=true
+      echo "Standalone tests will not be run"
+      ;;
+    x)
+      SKIP_SETUP=true
+      echo "Setup will be skipped"
+      ;;
+    r)
+      REG_USER=${OPTARG}
+      echo "Registry user: ${REG_USER}"
+      ;;
+    p)
+      REG_PWD=${OPTARG}
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+# ---- Cleanup ----------------------------------------------------------------------------------------------------
+# Cleanup called on exit and if process if stopped via CTRL+C
+cleanup() {
+  echo ""
+
+  set +e
+
+  rm -f ~/.npmrc.bak
+
+  if [ -n "${TEMP_APP_FOLDER}" ]; then
+    if [ ${KEEP_FOLDER} == false ]; then
+      echo "Removing test application folder"
+      rm -rf ${TEMP_APP_FOLDER}
+    else
+      echo -e "${BOLD}${CYAN}Test application was not deleted - folder:"
+      echo -e "${TEMP_APP_FOLDER}${RESET}"
+    fi
+  fi
+
+  if [ ${KEEP_PKG} == false ]; then
+    rm -rf ./pkg/test-pkg
+  fi
+
+  # Restore shell version
+  if [ -n "${SHELL_VERSION}" ]; then
+    sed -i.bak -e "s/\"version\": \"7.7.7\",/\"version\": \"${SHELL_VERSION}\",/g" ${SHELL_DIR}/package.json
+    rm -f ${SHELL_DIR}/package.json.bak
+  fi
+
+  # Restore rancher components version
+  if [ -n "${RANCHER_COMPONENTS_VERSION}" ]; then
+    sed -i.bak -e "s/\"version\": \"7.7.7\",/\"version\": \"${RANCHER_COMPONENTS_VERSION}\",/g" ${BASE_DIR}/pkg/rancher-components/package.json
+    rm -f ${BASE_DIR}/pkg/rancher-components/package.json.bak
+  fi
+
+  # Remove extra script target that may have been added to the top level package file
+  ${SCRIPT_DIR}/extension-test/test-plugins-reset
+
+  # Stop Verdaccio if we started it
+  if [ -n "${PID}" ]; then
+    echo "Stopping Verdaccio ..."
+    kill ${PID}
+  fi
+}
+
+# Run cleanup function on exit
+trap cleanup EXIT
+
+# ---- Test Setup ----------------------------------------------------------------------------------------------------
+if [ $SKIP_SETUP == false ]; then
   set +e
   which verdaccio > /dev/null
   RET=$?
@@ -34,6 +144,7 @@ if [ $SKIP_SETUP == "false" ]; then
   set -e
 
   if [ $RUNNING -eq 0 ]; then
+    echo -e "${CYAN}Starting Verdaccio ...${RESET}"
     verdaccio > verdaccio.log &
     PID=$!
 
@@ -48,18 +159,35 @@ if [ $SKIP_SETUP == "false" ]; then
       sed -i.bak -e '/^admin:/d' ~/.config/verdaccio/htpasswd
     fi
 
-    curl -XPUT -H "Content-type: application/json" -d '{ "name": "admin", "password": "admin" }' 'http://localhost:4873/-/user/admin' > login.json
-    TOKEN=$(jq -r .token login.json)
-    rm login.json
-    cat > ~/.npmrc << EOF
+    # Login to the registry - can't do this non-interactively via CLI, so use curl to get a token
+    # and then manually add this token to ~/.npmrc
+    JSON=$(curl -s -XPUT -H "Content-type: application/json" -d '{ "name": "'${REG_USER}'", "password": "'${REG_PWD}'" }' 'http://localhost:4873/-/user/admin')
+
+    set +e
+    TOKEN=$(echo $JSON | node --no-deprecation ${SCRIPT_DIR}/extension-test/test-plugins-parse-login)
+    RETVAL=$?
+    set -e
+
+    if [ $RETVAL -ne 0 ]; then
+      exit $RETVAL
+    fi
+
+    # Remove old creds from .npmrc
+    sed -i.bak -e '/127\.0\.0\.1:4873/d' ~/.npmrc
+    sed -i.bak -e '/localhost:4873/d' ~/.npmrc
+
+    # Store new token for the registry, so that we are authenticated
+    cat >> ~/.npmrc << EOF
 //127.0.0.1:4873/:_authToken="$TOKEN"
 //localhost:4873/:_authToken="$TOKEN"
 EOF
   else
     echo "Verdaccio is already running"
+    echo "You should ensure a user is set up and logged in for publishing" 
   fi
 fi
 
+# Clear out old Rancher packages fro Verdaccio
 if [ -d ~/.local/share/verdaccio/storage/@rancher ]; then 
   rm -rf ~/.local/share/verdaccio/storage/@rancher/*
 else
@@ -69,18 +197,32 @@ fi
 export YARN_REGISTRY=http://localhost:4873
 export NUXT_TELEMETRY_DISABLED=1
 
+# ---- Check that we are logged in to Verdaccio -------------------------------------------------------------------------------------------
+WHOAMI=$(npm whoami --registry=${YARN_REGISTRY})
+
+if [ "$WHOAMI" != "${REG_USER}" ]; then
+  echo -e "${YELLOW}${BOLD}Not logged in to Verdaccio - can not proceed"
+  echo -e "User: ${WHOAMI}${RESET}"
+  exit 1
+fi
+
+# ---- Test preparation -------------------------------------------------------------------------------------------------------------------
+
 # Remove test package from previous run, if present
 rm -rf ${BASE_DIR}/pkg/test-pkg
 
 # We need to patch the version number of the shell, otherwise if we are running
 # with the currently published version, things will fail as those versions
 # are already published and Verdaccio will check, since it is a read-through cache
+SHELL_VERSION=$(node -p -e "require('${SHELL_DIR}/package.json').version")
 sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\",/\"version\": \"7.7.7\",/g" ${SHELL_DIR}/package.json
 rm ${SHELL_DIR}/package.json.bak
 
 # Same as above for Rancher Components
 # We might have bumped the version number but its not published yet, so this will fail
+RANCHER_COMPONENTS_VERSION=$(node -p -e "require('${BASE_DIR}/pkg/rancher-components/package.json').version")
 sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\",/\"version\": \"7.7.7\",/g" ${BASE_DIR}/pkg/rancher-components/package.json
+rm ${BASE_DIR}/pkg/rancher-components/package.json.bak
 
 # Publish shell
 echo "Publishing shell packages to local registry"
@@ -95,9 +237,12 @@ yarn publish:lib
 # to ensure the build fails in these cases
 set -o pipefail
 
-if [ "${SKIP_STANDALONE}" == "false" ]; then
+if [ ${SKIP_STANDALONE} == false ]; then
   DIR=$(mktemp -d)
+  TEMP_APP_FOLDER=${DIR}
   pushd $DIR > /dev/null
+
+  echo -e "${BOLD}${CYAN}Validating standalone extension test case${RESET}"
 
   echo "Using temporary directory ${DIR}"
 
@@ -124,25 +269,27 @@ if [ "${SKIP_STANDALONE}" == "false" ]; then
 
   FORCE_COLOR=true yarn build-pkg test-pkg | cat
 
-  echo "Cleaning temporary dir"
   popd > /dev/null
-
-  rm -rf ${DIR}
 fi
 
 pushd $BASE_DIR
 pwd
 ls
 
-# Now try a plugin within the dashboard codebase
-echo "Validating in-tree package"
+if [ ${SKIP_IN_TREE} == false ]; then
+  # Now try a plugin within the dashboard codebase
+  echo -e "${BOLD}${CYAN}Validating in-tree extension test case${RESET}"
 
-yarn install
+  yarn install
 
-rm -rf ./pkg/test-pkg
-yarn create @rancher/pkg test-pkg -t
-cp ${SHELL_DIR}/list/catalog.cattle.io.clusterrepo.vue ./pkg/test-pkg/list
-FORCE_COLOR=true yarn build-pkg test-pkg | cat
-rm -rf ./pkg/test-pkg
+  rm -rf ./pkg/test-pkg
+
+  echo -e "${CYAN}Creating test-pkg extension using the package creator${RESET}"
+  yarn create @rancher/pkg test-pkg -t
+  cp ${SHELL_DIR}/list/catalog.cattle.io.clusterrepo.vue ./pkg/test-pkg/list
+
+  echo -e "${CYAN}Building test-pkg extension${RESET}"
+  FORCE_COLOR=true yarn build-pkg test-pkg | cat
+fi
 
 echo "All done"

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -173,6 +173,7 @@ if [ $SKIP_SETUP == false ]; then
     fi
 
     # Remove old creds from .npmrc
+    touch ~/.npmrc
     sed -i.bak -e '/127\.0\.0\.1:4873/d' ~/.npmrc
     sed -i.bak -e '/localhost:4873/d' ~/.npmrc
 

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -188,13 +188,6 @@ EOF
   fi
 fi
 
-# Clear out old Rancher packages fro Verdaccio
-if [ -d ~/.local/share/verdaccio/storage/@rancher ]; then 
-  rm -rf ~/.local/share/verdaccio/storage/@rancher/*
-else
-  rm -rf ~/.config/verdaccio/storage/@rancher/*
-fi
-
 export YARN_REGISTRY=http://localhost:4873
 export NUXT_TELEMETRY_DISABLED=1
 
@@ -206,6 +199,16 @@ if [ "$WHOAMI" != "${REG_USER}" ]; then
   echo -e "User: ${WHOAMI}${RESET}"
   exit 1
 fi
+
+# ---- Remove old published packages ------------------------------------------------------------------------------------------------------
+
+# Clear out old Rancher packages from Verdaccio
+
+npm unpublish @rancher/shell@7.7.7 --registry=http://127.0.0.1:4873
+npm unpublish @rancher/components@7.7.7 --registry=http://127.0.0.1:4873
+npm unpublish @rancher/create-app@7.7.7 --registry=http://127.0.0.1:4873
+npm unpublish @rancher/create-pkg@7.7.7 --registry=http://127.0.0.1:4873
+npm unpublish @rancher/create-update@7.7.7 --registry=http://127.0.0.1:4873
 
 # ---- Test preparation -------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Simple documentation for the extensions tests.

Updates to the test script to better handle error cases and be more resilient, particularly when running locally in dev.