### PR TITLE
Fix issue where project owner does not have permission to update PSP template bindings for a project

### DIFF
--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -177,6 +177,7 @@ export const MANAGEMENT = {
   GLOBAL_ROLE:                   'management.cattle.io.globalrole',
   GLOBAL_ROLE_BINDING:           'management.cattle.io.globalrolebinding',
   POD_SECURITY_POLICY_TEMPLATE:  'management.cattle.io.podsecuritypolicytemplate',
+  PSP_TEMPLATE_BINDING:          'management.cattle.io.podsecuritypolicytemplateprojectbinding',
   PSA:                           'management.cattle.io.podsecurityadmissionconfigurationtemplate',
   MANAGED_CHART:                 'management.cattle.io.managedchart',
   USER_NOTIFICATION:             'management.cattle.io.rancherusernotification',

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -29,6 +29,11 @@ export default {
     if ( this.$store.getters['management/canList'](MANAGEMENT.POD_SECURITY_POLICY_TEMPLATE) ) {
       this.allPSPs = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.POD_SECURITY_POLICY_TEMPLATE });
     }
+
+    // User can only change the PSP if the user has permissions to see the binding schema for PSP Templates
+    const pspBindingSchema = this.$store.getters['management/schemaFor'](MANAGEMENT.PSP_TEMPLATE_BINDING);
+
+    this.canEditPSPBindings = !!pspBindingSchema;
   },
   data() {
     this.$set(this.value, 'spec', this.value.spec || {});
@@ -52,6 +57,7 @@ export default {
       HARVESTER_TYPES,
       RANCHER_TYPES,
       fvFormRuleSets:     [{ path: 'spec.displayName', rules: ['required'] }],
+      canEditPSPBindings: true,
     };
   },
   computed: {
@@ -225,6 +231,7 @@ export default {
           class="psp"
           :mode="mode"
           :options="pspOptions"
+          :disabled="!canEditPSPBindings"
           :label="t('project.psp.label')"
         />
       </div>

--- a/shell/models/management.cattle.io.project.js
+++ b/shell/models/management.cattle.io.project.js
@@ -128,7 +128,12 @@ export default class Project extends HybridModel {
       }
     };
 
-    await finishProjectCreation();
+    // Only update PSP template if the value changed
+    const newPSPTemplateID = this.spec.podSecurityPolicyTemplateId || null;
+
+    if (norman.podSecurityPolicyTemplateId !== newPSPTemplateID) {
+      await finishProjectCreation();
+    }
 
     return newValue;
   }


### PR DESCRIPTION
Fixes #8508 

This PR addresses the issue above.

Detailed steps to test are in the issue.

This PR:

- Disables the editing of the PSP on a project if the user does not have permissions to access PSP template bindings
- Updates the model so we only attempt to save the PSP Template binding if the value changes

UI when the user does not have permissions:

![image](https://user-images.githubusercontent.com/1955897/232855936-7633c35c-4a81-4293-af2a-66b77e59d6ae.png)
