### PR TITLE
Harvester: Fix re-render old route component

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -300,7 +300,7 @@ export default {
                 <nuxt-link
                   v-if="c.ready"
                   class="cluster selector option"
-                  :to="{ name: 'c-cluster', params: { cluster: c.id } }"
+                  :to="{ name: 'c-cluster-explorer', params: { cluster: c.id } }"
                 >
                   <ClusterProviderIcon
                     :small="true"

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -201,9 +201,11 @@ export default {
      * Prevent rendering "outlet" until the route changes to avoid re-rendering old route content after its cluster is unloaded
      */
     clusterAndRouteReady() {
+      const targetRoute = this.$store.getters['targetRoute'];
+      const routeReady = targetRoute ? this.currentProduct?.name === getProductFromRoute(this.$route) && this.currentProduct?.name === getProductFromRoute(targetRoute) : this.currentProduct?.name === getProductFromRoute(this.$route);
+
       return this.clusterReady &&
-        this.clusterId === getClusterFromRoute(this.$route) &&
-        this.currentProduct?.name === getProductFromRoute(this.$route);
+        this.clusterId === getClusterFromRoute(this.$route) && routeReady;
     },
 
     pinClass() {

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -388,11 +388,12 @@ export default async function({
     await Promise.all([
       ...always,
       store.dispatch('loadCluster', {
-        id:     clusterId,
-        oldPkg: oldPkgPlugin,
-        newPkg: newPkgPlugin,
+        id:          clusterId,
+        oldPkg:      oldPkgPlugin,
+        newPkg:      newPkgPlugin,
         product,
         oldProduct,
+        targetRoute: route
       })
     ]);
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -237,6 +237,7 @@ export const state = () => {
     systemNamespaces:        [],
     isSingleProduct:         undefined,
     namespaceFilterMode:     null,
+    targetRoute:             null
   };
 };
 
@@ -582,6 +583,10 @@ export const getters = {
     return cluster?.status?.provider === VIRTUAL_HARVESTER_PROVIDER;
   },
 
+  targetRoute(state) {
+    return state.targetRoute;
+  },
+
   ...gcGetters
 };
 
@@ -680,6 +685,9 @@ export const mutations = {
     state.isSingleProduct = isSingleProduct;
   },
 
+  targetRoute(state, route) {
+    state.targetRoute = route;
+  }
 };
 
 export const actions = {
@@ -787,8 +795,9 @@ export const actions = {
   async loadCluster({
     state, commit, dispatch, getters
   }, {
-    id, product, oldProduct, oldPkg, newPkg
+    id, product, oldProduct, oldPkg, newPkg, targetRoute
   }) {
+    commit('targetRoute', targetRoute);
     const sameCluster = state.clusterId && state.clusterId === id;
     const samePackage = oldPkg?.name === newPkg?.name;
     const isMultiCluster = getters['isMultiCluster'];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix the issue of duplicate rendering of old route components when navigating from the Harvester page to the Explorer page within the same cluster.

Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://user-images.githubusercontent.com/24985926/233048695-bfcfc5f0-501a-4a6a-88a2-df9f6b7a3d8f.mov

