### PR TITLE
Update docs to indicate Windows is not support as a dev environment

### DIFF
--- a/docusaurus/docs/extensions/extensions-getting-started.md
+++ b/docusaurus/docs/extensions/extensions-getting-started.md
@@ -4,6 +4,8 @@ This guide will walk through creating a new extension from scratch.
 
 ## Prerequisites
 
+> Note: Extensions development is only currently supported on Mac and Linux. Windows is not currently supported.
+
 You will need a recent version of nodejs installed (Tested with node version: `v16.19.1`).
 
 You'll also need the yarn package manager installed, which can be done with `npm install -g yarn`.

--- a/docusaurus/docs/getting-started/development_environment.md
+++ b/docusaurus/docs/getting-started/development_environment.md
@@ -2,6 +2,8 @@
 
 This is part of the developer [getting started guide](https://github.com/rancher/dashboard/blob/master/README.md).
 
+> Note: Development is only currently supported on Mac and Linux. Windows is not currently supported.
+
 ## Stack
 
 A good base knowledge of Vue, Vuex and Nuxt should be reached before going through the code. Looking through `nuxt.config.js` is a good way to understand how the Dashboard is glued together, importantly how plugins are brought in and how the frontend proxies requests to Rancher's APIs.


### PR DESCRIPTION
Fixes #7759
Fixes #8178

Adds to the two docs for dashboard and extensions to be clear Windows is not supported as a development environment.

![image](https://user-images.githubusercontent.com/1955897/233081462-61ab6e02-07ac-49b3-bd4c-9688aaccd34e.png)

![image](https://user-images.githubusercontent.com/1955897/233081369-26c4ef6e-5ac5-4bb8-a852-4f10b40c0036.png)