### PR TITLE
Fixes Advanced Socket Worker after Nuxt removal

### DIFF
--- a/shell/plugins/dashboard-store/index.js
+++ b/shell/plugins/dashboard-store/index.js
@@ -38,7 +38,7 @@ export default (vuexModule, config, init) => {
     store.registerModule(namespace, vuexModule);
     store.commit(`${ namespace }/applyConfig`, config);
 
-    if ( !process.client || !window.__NUXT__ ) {
+    if ( !process.client ) {
       return;
     }
 


### PR DESCRIPTION
### Summary
Fixes #
It doesn't look like window.__NUXT__ actually exists anymore which makes sense since we removed NUXT but there's still a lot of references for it in code.

### Occurred changes and/or fixed issues
Removed a check for the window.__NUXT__ object which caused store initialization to return early.

### Technical notes summary
I didn't remove all references to the window.__NUXT__ object in code since that'd require pretty exhaustive testing but that's something we should look at in the near future.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
Tested on chrome latest
Tester should see that with the advanced webworker enabled, the cluster socket never appears in the "ws" tab of chrome's dev tools indicating that either the socket was never created or the worker was never created (the latter being the actual cause).

### Areas which could experience regressions
Unknown