### PR TITLE
fix missing job/pod resources on CronJobs/Jobs detail page

### DIFF
--- a/shell/models/batch.cronjob.js
+++ b/shell/models/batch.cronjob.js
@@ -2,6 +2,7 @@ import { insertAt } from '@shell/utils/array';
 import { clone } from '@shell/utils/object';
 import { WORKLOAD_TYPES } from '@shell/config/types';
 import Workload from './workload';
+import { WORKLOAD_TYPE_TO_KIND_MAPPING } from '@shell/detail/workload/index';
 
 export default class CronJob extends Workload {
   get state() {
@@ -47,12 +48,26 @@ export default class CronJob extends Workload {
   }
 
   async runNow() {
-    const job = await this.$dispatch('create', clone(this.spec.jobTemplate));
+    const ownerRef = {
+      apiVersion: this.apiVersion,
+      controller: true,
+      kind:       this.kind,
+      name:       this.metadata.name,
+      uid:        this.metadata.uid
+    };
 
-    job.type = WORKLOAD_TYPES.JOB;
+    // Set type and kind to ensure the correct model is returned (via classify). This object will be persisted to the store
+    const job = await this.$dispatch('create', {
+      type: WORKLOAD_TYPES.JOB,
+      kind: WORKLOAD_TYPE_TO_KIND_MAPPING[WORKLOAD_TYPES.JOB],
+      ...clone(this.spec.jobTemplate)
+    });
+
     job.metadata = job.metadata || {};
     job.metadata.namespace = this.metadata.namespace;
-    job.metadata.generateName = `${ this.metadata.name }-`;
+    // Can't use `generatedName` and no `name`... as this fails schema validation
+    job.metadata.name = `${ this.metadata.name }-${ Date.now() }`;
+    job.metadata.ownerReferences = [ownerRef];
 
     await job.save();
 

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -296,7 +296,7 @@ export default class Workload extends WorkloadService {
   }
 
   get endpoint() {
-    return this?.metadata?.annotations[CATTLE_PUBLIC_ENDPOINTS];
+    return this?.metadata?.annotations?.[CATTLE_PUBLIC_ENDPOINTS];
   }
 
   get desired() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8683
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
1. Add ownerReferences property to the cron job `runNow` request body，so that the cron job details page can look up the associated job
2. Update the endpoint get method of the workload model, because deleting a job from the cronjob details page will report an error
<img width="585" alt="image" src="https://user-images.githubusercontent.com/3406205/234441686-8e061b50-b2fb-46ef-8371-d5baa35366c5.png">


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. CronJob detail page
5. DaemonSet detail page
6. Deployment detail page
7. Job detail page
8. StatefulSet detail page
9. Pod detail page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->