### PR TITLE
Backport 2.7.4: Fix the v-clean-html directive (#8617)

### DIFF
--- a/shell/plugins/clean-html-directive.js
+++ b/shell/plugins/clean-html-directive.js
@@ -25,6 +25,9 @@ export const cleanHtmlDirective = {
   },
   componentUpdated(el, binding) {
     el.innerHTML = purifyHTML(binding.value);
+  },
+  unbind(el) {
+    el.innerHTML = '';
   }
 };
 


### PR DESCRIPTION
Fixes #8615 

The `v-clean-html` directive does not work when used inside a `<template>` section.

Looking at https://github.com/LeSuisse/vue-dompurify-html/blob/main/packages/vue-dompurify-html/src/dompurify-html.ts the trick seems to be to add an `unbind` to the directive.

This PR updates our directive to do this - this resolves the original issue.

backports #8617