### PR TITLE
Update vue options to preserve whitespace

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -583,7 +583,7 @@ module.exports = function(dir, _appConfig) {
       // Need to find the vue loader in the webpack config and update the setting
       config.module.rules.forEach((loader) => {
         if (loader.use) {
-          loaders.use.forEach((use) => {
+          loader.use.forEach((use) => {
             if (use.loader.includes('vue-loader')) {
               use.options.compilerOptions.whitespace = 'preserve';
             }

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -577,6 +577,19 @@ module.exports = function(dir, _appConfig) {
       ];
 
       config.module.rules.push(...loaders);
+
+      // Update vue-loader to set whitespace to 'preserve'
+      // This was the setting with nuxt, but is not the default with vue cli
+      // Need to find the vue loader in the webpack config and update the setting
+      config.module.rules.forEach((loader) => {
+        if (loader.use) {
+          loaders.use.forEach((use) => {
+            if (use.loader.includes('vue-loader')) {
+              use.options.compilerOptions.whitespace = 'preserve';
+            }
+          });
+        }
+      });
     },
   };
 


### PR DESCRIPTION
Addresses #8389

This PR fixes an issue with Nuxt removal where whitespace is not preserved.

This PR updates the webpack configuration to set whitespace to 'preserve' - in Vue it defaults to 'compact'.