### PR TITLE
Provide the relevant types for the product.ts and update the appropriate docs

### DIFF
--- a/docusaurus/docs/extensions/api/nav/custom-page.md
+++ b/docusaurus/docs/extensions/api/nav/custom-page.md
@@ -4,12 +4,14 @@
 As we've seen from the previous chapter, a developer can register a top-level product with the `product` function. How about adding a custom page to your extension product? To do that, we can use the function `virtualType` coming from `$plugin.DSL`. As an example usage of that method, one could do the following:
 
 ```ts
+import { IPlugin } from '@shell/core/types';
+
 // this is the definition of a "blank cluster" for Rancher Dashboard
 // definition of a "blank cluster" in Rancher Dashboard
 const BLANK_CLUSTER = '_';
 
 
-export function init($plugin, store) {
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   const CUSTOM_PAGE_NAME = 'page1';
   

--- a/docusaurus/docs/extensions/api/nav/products.md
+++ b/docusaurus/docs/extensions/api/nav/products.md
@@ -41,7 +41,9 @@ The module registered via `addProduct` must export an `init` method. This is inv
 An example `init` function for creating a new product is shown below:
 
 ```ts
-export function init($plugin, store) {
+import { IPlugin } from '@shell/core/types';
+
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   
   const { product } = $plugin.DSL(store, YOUR_PRODUCT_NAME);

--- a/docusaurus/docs/extensions/api/nav/resource-page.md
+++ b/docusaurus/docs/extensions/api/nav/resource-page.md
@@ -4,12 +4,14 @@
 One of the most common view types in Rancher Dashboard is the list view for a kubernetes resource. What if you wanted to include a similiar view on your Extension product for a given resource? For that we can use the function `configureType` coming from `$plugin.DSL`. As an example usage of that method, one could do the following:
 
 ```ts
+import { IPlugin } from '@shell/core/types';
+
 // this is the definition of a "blank cluster" for Rancher Dashboard
 // definition of a "blank cluster" in Rancher Dashboard
 const BLANK_CLUSTER = '_';
 
 
-export function init($plugin, store) {
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   // example of using an existing k8s resource as a page
   const YOUR_K8S_RESOURCE_NAME = 'provisioning.cattle.io.cluster';

--- a/docusaurus/docs/extensions/api/nav/routing.md
+++ b/docusaurus/docs/extensions/api/nav/routing.md
@@ -34,12 +34,14 @@ export default function(plugin: IPlugin) {
 Let's then take into consideration the following example a of `product.ts` config:
 
 ```ts
+import { IPlugin } from '@shell/core/types';
+
 // this is the definition of a "blank cluster" for Rancher Dashboard
 // definition of a "blank cluster" in Rancher Dashboard
 const BLANK_CLUSTER = '_';
 
 
-export function init($plugin, store) {
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   const YOUR_K8S_RESOURCE_NAME = 'provisioning.cattle.io.cluster';
   const CUSTOM_PAGE_NAME = 'page1';

--- a/docusaurus/docs/extensions/api/nav/side-menu.md
+++ b/docusaurus/docs/extensions/api/nav/side-menu.md
@@ -5,12 +5,14 @@
 With the `virtualType` and `configureType` we have learned how to configure a page for your Extension product, but that won't make it appear on the side-menu. For that you need to use the function `basicType` coming from `$plugin.DSL`. As an example usage of that method, one could do the following:
 
 ```ts
+import { IPlugin } from '@shell/core/types';
+
 // this is the definition of a "blank cluster" for Rancher Dashboard
 // definition of a "blank cluster" in Rancher Dashboard
 const BLANK_CLUSTER = '_';
 
 
-export function init($plugin, store) {
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   const YOUR_K8S_RESOURCE_NAME = 'provisioning.cattle.io.cluster';
   const CUSTOM_PAGE_NAME = 'page1';
@@ -93,11 +95,13 @@ Menu entries can also be grouped under a common "folder/group" in the side menu.
 How about if you wanted to change the side-menu ordering for your Extension product? That can be achieved by using the functions `weightType` and `weightGroup` coming from `$plugin.DSL`. Let's then look at the following example:
 
 ```ts
+import { IPlugin } from '@shell/core/types';
+
 // this is the definition of a "blank cluster" for Rancher Dashboard
 // definition of a "blank cluster" in Rancher Dashboard
 const BLANK_CLUSTER = '_';
 
-export function init($plugin, store) {
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   const YOUR_K8S_RESOURCE_NAME = 'provisioning.cattle.io.cluster';
   const CUSTOM_PAGE_NAME_1 = 'page1';
@@ -201,11 +205,13 @@ In the above example the side-menu output would be something like:
 If we wanted to define some custom ordering for these menu entries, we would need to use the functions `weightType` and `weightGroup`, like: 
 
 ```ts
+import { IPlugin } from '@shell/core/types';
+
 // this is the definition of a "blank cluster" for Rancher Dashboard
 // definition of a "blank cluster" in Rancher Dashboard
 const BLANK_CLUSTER = '_';
 
-export function init($plugin, store) {
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   const YOUR_K8S_RESOURCE_NAME = 'provisioning.cattle.io.cluster';
   const CUSTOM_PAGE_NAME_1 = 'page1';

--- a/docusaurus/docs/extensions/extensions-getting-started.md
+++ b/docusaurus/docs/extensions/extensions-getting-started.md
@@ -92,7 +92,9 @@ export default function(plugin: IPlugin) {
 Next, create a new file `./pkg/test/product.ts` with this content:
 
 ```ts
-export function init($plugin, store) {
+import { IPlugin } from '@shell/core/types';
+
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
 
   const { product } = $plugin.DSL(store, YOUR_PRODUCT_NAME);

--- a/docusaurus/docs/extensions/usecases/top-level-product.md
+++ b/docusaurus/docs/extensions/usecases/top-level-product.md
@@ -26,12 +26,14 @@ export default function(plugin: IPlugin) {
 The `product.ts` config will then define the product and which "pages/views" we want to add, such as:
 
 ```ts
+import { IPlugin } from '@shell/core/types';
+
 // this is the definition of a "blank cluster" for Rancher Dashboard
 // definition of a "blank cluster" in Rancher Dashboard
 const BLANK_CLUSTER = '_';
 
 
-export function init($plugin, store) {
+export function init($plugin: IPlugin, store: any) {
   const YOUR_PRODUCT_NAME = 'myProductName';
   const YOUR_K8S_RESOURCE_NAME = 'provisioning.cattle.io.cluster';
   const CUSTOM_PAGE_NAME = 'page1';

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -16,13 +16,15 @@ import {
   PluginRouteConfig, RegisterStore, UnregisterStore, CoreStoreSpecifics, CoreStoreConfig, OnNavToPackage, OnNavAwayFromPackage, OnLogOut
 } from '@shell/core/types';
 
+export type ProductFunction = (plugin: IPlugin, store: any) => void;
+
 export class Plugin implements IPlugin {
   public id: string;
   public name: string;
   public types: any = {};
   public l10n: { [key: string]: Function[] } = {};
   public locales: { locale: string, label: string}[] = [];
-  public products: Function[] = [];
+  public products: ProductFunction[] = [];
   public productNames: string[] = [];
   public routes: { parent?: string, route: RouteConfig }[] = [];
   public stores: { storeName: string, register: RegisterStore, unregister: UnregisterStore }[] = [];
@@ -83,7 +85,7 @@ export class Plugin implements IPlugin {
     return storeDSL;
   }
 
-  addProduct(product: Function): void {
+  addProduct(product: ProductFunction): void {
     this.products.push(product);
   }
 

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -1,3 +1,4 @@
+import { ProductFunction } from './plugin';
 import { RouteConfig } from 'vue-router';
 
 // package.json metadata
@@ -136,6 +137,255 @@ export type LocationConfig = {
   mode?: string[]
 };
 
+export interface ProductOptions {
+  /**
+   * The category this product belongs under. i.e. 'config'
+   */
+  category?: string;
+
+  /**
+   * Hide the Copy KubeConfig button in the header
+   */
+  hideCopyConfig?: boolean;
+
+  /**
+   * Hide the Download KubeConfig button in the header
+   */
+  hideKubeConfig?: boolean;
+
+  /**
+   * Hide the Kubectl Shell button in the header
+   */
+  hideKubeShell?: boolean;
+
+  /**
+   * Hide the Namespace location
+   */
+  hideNamespaceLocation?: boolean;
+
+  /**
+   * Hide the system resources
+   */
+
+  hideSystemResources?: boolean;
+  /**
+   * The icon that should be displayed beside this item in the navigation.
+   */
+  icon?: string,
+
+  /**
+   * Only load the product if the feature is present
+   */
+  ifFeature?: string | RegExp;
+
+  /**
+   * Only load the product if the type is present
+   */
+  ifHave?: string;
+
+  /**
+   * Only load the product if the group is present
+   */
+  ifHaveGroup?: string | RegExp;
+
+  /**
+   * Only load the product if the type is present
+   */
+  ifHaveType?: string | RegExp;
+
+  /**
+   * The vuex store that this product should use by default i.e. 'management'
+   */
+  inStore?: string;
+
+  /**
+   * Show the cluster switcher in the navigation
+   */
+  showClusterSwitcher?: boolean;
+
+  /**
+   * Show the namespace filter in the header
+   */
+  showNamespaceFilter?: boolean;
+
+  /**
+   * A number used to determine where in navigation this item will be placed. The highest number will be at the top of the list.
+   */
+  weight?: number;
+
+  /**
+   * Leaving these here for completeness but I don't think these should be advertised as useable to plugin creators.
+   */
+  // ifHaveVerb: string | RegExp;
+  // removable: string;
+  // showWorkspaceSwitcher: boolean;
+  // supportRoute: string;
+  // to: string;
+  // typeStoreMap: string;
+}
+
+export interface HeaderOptions {
+  /**
+   * Name of the header. This should be unique.
+   */
+  name?: string;
+
+  /**
+   * A translation key where the resulting string will show in the table column
+   */
+  labelKey?: string;
+
+  /**
+   * A string which represents the path to access the value from the row object i.e. `row.meta.value`.
+   */
+  value?: string;
+
+  /**
+   * A string which represents the path to access the value from the row object which we'll use to sort i.e. `row.meta.value`
+   */
+  sort?: string;
+
+  /**
+   * A string which represents the path to access the value from the row object which we'll use to search i.e. `row.meta.value`
+   */
+  search?: string;
+
+  /**
+   * Number of pixels the column should be in the table
+   */
+  width?: number;
+
+  /**
+   * The name of a custom formatter. The available formatters can bee seen in `@rancher/shell/components/formatter`
+   */
+  formatter?: string;
+
+  /**
+   * These options are dependent on the formatter that's chosen. Examples can be seen in `@rancher/shell/components/formatter` and `@rancher/shell/config/table-headers`
+   */
+  formatterOpts?: any;
+
+  /**
+   * Provide a function which accets a row and returns the value that should be displayed in the column
+   * @param row This can be any value which represents the row
+   * @returns Can return {@link string | number | null | undefined} to display in the column
+   */
+  getValue?: (row: any) => string | number | null | undefined;
+}
+
+export interface ConfigureTypeOptions {
+  /**
+   * The resource can edit/show yaml
+   */
+  canYaml?: boolean;
+
+  /**
+   * Modify the way the name looks when displayed
+   */
+  displayName?: string;
+
+  /**
+   * New resources can be created of this type
+   */
+  isCreatable?: boolean;
+
+  /**
+   * Resources of this type can be deleted/removed
+   */
+  isRemovable?: boolean;
+
+  /**
+   * This type should be grouped by namespaces when displayed in a table
+   */
+  namespaced?: boolean;
+
+  /**
+   * Show the age column in when displaying this type in a table
+   */
+  showAge?: boolean;
+
+   /**
+   * Show the masthead at the top of the list view of this type
+   */
+  showListMasthead?: boolean;
+
+   /**
+   * Show the state column in when displaying this type in a table
+   */
+  showState?: boolean;
+
+  /**
+   * Leaving these here for completeness but I don't think these should be advertised as useable to plugin creators.
+   */
+  // alias
+  // customRoute
+  // customRoute
+  // depaginate
+  // graphConfig
+  // hasGraph
+  // isEditable
+  // limit
+  // listGroups
+  // localOnly
+  // location
+  // match
+  // realResource
+  // resource
+  // resourceDetail
+  // resourceEdit
+  // showConfigView
+}
+
+export interface DSLReturnType {
+  /**
+   * Register multiple types by name and place them all in a group if desired. Primarily used for grouping things in the cluster explorer navigation.
+   * @param types A list of types that are going to be registered
+   * @param group Conditionally a group you want to places all the types in
+   * @returns {@link void}
+   */
+  basicType: (types: string[], group?: string) => void;
+
+  /**
+   * Configure a myriad of options for the specified type
+   * @param type The type to be configured
+   * @param options {@link ConfigureTypeOptions}
+   * @returns {@link void}
+   */
+  configureType: (type: string, options: ConfigureTypeOptions) => void;
+
+  /**
+   * Register the headers/columns that should be used when rendering a table for the specified type.
+   * @param type The type you'd like to register headers/columns for.
+   * @param headers {@link HeaderOptions[]}
+   * @returns {@link void}
+   */
+  headers: (type: string, headers: HeaderOptions[]) => void;
+
+  /**
+   * Create and register a new product
+   * @param options {@link ProductOptions}
+   * @returns {@link void}
+   */
+  product: (options: ProductOptions) => void;
+
+  /**
+   * Leaving these here for completeness but I don't think these should be advertised as useable to plugin creators.
+   */
+  // componentForType: (type: string, replacementType: string)
+  // groupBy: (type: string, field: string)
+  // hideBulkActions: (type: string, field)
+  // ignoreGroup: (regexOrString)
+  // ignoreType: (regexOrString)
+  // mapGroup: (match, replace)
+  // mapType: (match, replace)
+  // moveType: (match, group)
+  // setGroupDefaultType: (input, defaultType)
+  // spoofedType: (obj)
+  // virtualType: (obj)
+  // weightGroup: (input, weight, forBasic)
+  // weightType: (input, weight, forBasic)
+}
+
 /**
  * Interface for a Dashboard plugin
  */
@@ -144,7 +394,7 @@ export interface IPlugin {
    * Add a product
    * @param importFn Function that will import the module containing a product definition
    */
-  addProduct(importFn: Function): void;
+  addProduct(importFn: ProductFunction): void;
 
   /**
    * Add a locale to the i18n store
@@ -249,4 +499,11 @@ export interface IPlugin {
    * @param {Function} fn function that dynamically loads the module for the thing being registered
    */
   register(type: string, name: string, fn: Function): void;
+
+  /**
+   * Will return all of the configuration functions used for creating a new product.
+   * @param store The store that was passed to the function that's passed to `plugin.addProduct(function)`
+   * @param productName The name of the new product. This name is displayed in the navigation.
+   */
+  DSL(store: any, productName: string): DSLReturnType;
 }

--- a/shell/types/rancher/index.d.ts
+++ b/shell/types/rancher/index.d.ts
@@ -5,3 +5,5 @@ declare module '@rancher/auto-import' {
 declare module '@shell/store/type-map' {
   export function DSL(store: any, name: string): any;
 }
+
+declare module '@shell/plugins/dashboard-store';


### PR DESCRIPTION
https://github.com/rancher/dashboard/issues/8744 - `Fix the TS error regarding implicit any on the $plugin and store arguments`

### Note
The `Leaving these here for completeness but I don't think these should be advertised as usable to plugin creators.` comment sections should probably be removed. I just wanted the both of you to get a chance to comment if you think they should be a part of the interfaces or not.