### PR TITLE
Removed hasClass method

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -858,8 +858,10 @@ export default {
       const elem = this.focusAdjacent(true);
       const row = getParent(elem, 'tr');
 
-      if (row.hasClass('row-selected')) {
-        return;
+      if (row !== null) {
+        if (row.classList.contains('row-selected')) {
+          return;
+        }
       }
 
       this.keySelectRow(row, more);
@@ -869,8 +871,10 @@ export default {
       const elem = this.focusAdjacent(false);
       const row = getParent(elem, 'tr');
 
-      if (row.hasClass('row-selected')) {
-        return;
+      if (row !== null) {
+        if (row.classList.contains('row-selected')) {
+          return;
+        }
       }
 
       this.keySelectRow(row, more);

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -858,10 +858,8 @@ export default {
       const elem = this.focusAdjacent(true);
       const row = getParent(elem, 'tr');
 
-      if (row !== null) {
-        if (row.classList.contains('row-selected')) {
-          return;
-        }
+      if (row?.classList.contains('row-selected')) {
+        return;
       }
 
       this.keySelectRow(row, more);
@@ -871,10 +869,8 @@ export default {
       const elem = this.focusAdjacent(false);
       const row = getParent(elem, 'tr');
 
-      if (row !== null) {
-        if (row.classList.contains('row-selected')) {
-          return;
-        }
+      if (row?.classList.contains('row-selected')) {
+        return;
       }
 
       this.keySelectRow(row, more);


### PR DESCRIPTION
Fixes #8273

After merging #8419 PR in the master, there was an issue with the 'hasClass`method. This PR is to fix it when you select rows in a table by pressing 'shift+j' or 'shift+k 