### PR TITLE
Add `Rancher UI Extensions` to setup info in github issue bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,7 @@ assignees: ''
 <!--------- For bugs and general issues --------->
 **Setup**
 - Rancher version:
+- Rancher UI Extensions:
 - Browser type & version:
 
 **Describe the bug**


### PR DESCRIPTION
Not all users may be able to provide this (page is only available to admins). We might want to add extensions list to the diagnostics page?