### PR TITLE
Adding standalone layout for use with standalone extensions

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -344,7 +344,7 @@ export default {
     const $main = document.querySelector('main');
 
     this._onScroll = this.onScroll.bind(this);
-    $main.addEventListener('scroll', this._onScroll);
+    $main?.addEventListener('scroll', this._onScroll);
   },
 
   beforeDestroy() {

--- a/shell/initialize/App.js
+++ b/shell/initialize/App.js
@@ -8,14 +8,15 @@ import NuxtLoading from '../components/nav/GlobalLoading.vue';
 
 import '../assets/styles/app.scss';
 
-import _77180f1e from '../layouts/blank.vue';
-import _6f6c098b from '../layouts/default.vue';
-import _2d2495d5 from '../layouts/home.vue';
-import _77dd5794 from '../layouts/plain.vue';
-import _44002f80 from '../layouts/unauthenticated.vue';
+import blank from '../layouts/blank.vue';
+import defaultLayout from '../layouts/default.vue';
+import home from '../layouts/home.vue';
+import plain from '../layouts/plain.vue';
+import unauthenticated from '../layouts/unauthenticated.vue';
+import standalone from '../layouts/standalone.vue';
 
 const layouts = {
-  _blank: sanitizeComponent(_77180f1e), _default: sanitizeComponent(_6f6c098b), _home: sanitizeComponent(_2d2495d5), _plain: sanitizeComponent(_77dd5794), _unauthenticated: sanitizeComponent(_44002f80)
+  _blank: sanitizeComponent(blank), _default: sanitizeComponent(defaultLayout), _home: sanitizeComponent(home), _plain: sanitizeComponent(plain), _unauthenticated: sanitizeComponent(unauthenticated), _standalone: sanitizeComponent(standalone)
 };
 
 export default {

--- a/shell/layouts/standalone.vue
+++ b/shell/layouts/standalone.vue
@@ -1,0 +1,13 @@
+<script>
+export default { middleware: ['unauthenticated'] };
+</script>
+
+<template>
+  <nuxt />
+</template>
+
+<style lang="scss">
+body, #__nuxt, #__layout {
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
Adding the necessary support for standalone extensions. Specifically the changes needed to allow the opni extension to function without rancher.

1. Added the standalone layout which uses the unauthenticated middleware.
2. Fixed an issue where SortableTable expected a `main` component to exist on the page for scrollbars. This check was already done on line 360 so I think it should be fine and seems to work in opni.