### PR TITLE
Adding a descriptive error message to the serve-pkgs script

### DIFF
--- a/shell/scripts/serve-pkgs
+++ b/shell/scripts/serve-pkgs
@@ -2,12 +2,16 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-
-console.log(__dirname);
+const { exit } = require('process');
 
 const dir = path.resolve('.');
 const pkgs = path.join(dir, 'dist-pkg');
 let port = 4500;
+
+if (!fs.existsSync(pkgs)) {
+  console.log(`\n\x1B[31m%s\x1B[0m\n`, `Error: The 'dist-pkg directory doesn't exist. You likely need to run the 'yarn build-pkg <pkg name>' command first.`);
+  exit(1);
+}
 
 const express = require('express');
 const serveStatic = require('serve-static');


### PR DESCRIPTION
<img width="844" alt="Screenshot 2023-05-01 at 7 50 54 PM" src="https://user-images.githubusercontent.com/55104481/235513535-fbf26953-3693-4872-961b-e89109fbe4e2.png">

https://github.com/rancher/dashboard/issues/8744

https://rancher.github.io/dashboard/extensions/extensions-getting-started#loading-into-another-rancher-instance
- Give a friendly error message when running yarn serve-pkgs if yarn build-pkg test wasn't run? Or maybe run it for them?
