### PR TITLE
Hostname truncation: Update to sync with backend

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -306,7 +306,7 @@ export default {
     const lastDefaultPodSecurityPolicyTemplateName = this.value.spec.defaultPodSecurityPolicyTemplateName;
     const previousKubernetesVersion = this.value.spec.kubernetesVersion;
 
-    const truncateLimit = this.value.machinePoolDefaults?.hostnameLengthLimit;
+    const truncateLimit = this.value.defaultHostnameLengthLimit;
 
     return {
       loadedOnce:                      false,

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -308,11 +308,6 @@ export default {
 
     const truncateLimit = this.value.machinePoolDefaults?.hostnameLengthLimit;
 
-    // Is hostname truncation supported by the backend?
-    const provSchema = this.$store.getters['management/schemaFor'](CAPI.RANCHER_CLUSTER);
-    const specSchemaName = provSchema?.resourceFields?.spec?.type;
-    const specSchema = specSchemaName ? this.$store.getters['management/schemaFor'](specSchemaName) : {};
-
     return {
       loadedOnce:                      false,
       lastIdx:                         0,
@@ -350,7 +345,6 @@ export default {
       psps:                  null, // List of policies if any
       truncateHostnames:     truncateLimit === NETBIOS_TRUNCATION_LENGTH,
       truncateLimit,
-      supportsTruncation:    !!specSchema?.resourceFields?.machinePoolDefaults,
     };
   },
 
@@ -1100,14 +1094,9 @@ export default {
      */
     truncateName() {
       if (this.truncateHostnames) {
-        this.value.machinePoolDefaults = this.value.machinePoolDefaults || {};
-        this.value.machinePoolDefaults.hostnameLengthLimit = 15;
+        this.value.defaultHostnameLengthLimit = NETBIOS_TRUNCATION_LENGTH;
       } else {
-        delete this.value.machinePoolDefaults.hostnameLengthLimit;
-
-        if (Object.keys(this.value.machinePoolDefaults).length === 0) {
-          delete this.value.machinePoolDefaults;
-        }
+        this.value.removeDefaultHostnameLengthLimit();
       }
     },
     /**
@@ -2598,7 +2587,6 @@ export default {
               />
             </div>
             <div
-              v-if="supportsTruncation"
               class="col span-6"
             >
               <Checkbox

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -403,6 +403,10 @@ export default class ProvCluster extends SteveModel {
     this.spec.rkeConfig.machinePoolDefaults.hostnameLengthLimit = value;
   }
 
+ get defaultHostnameLengthLimit() {
+  return this.spec.rkeConfig?.machinePoolDefaults?.hostnameLengthLimit;
+  }
+
   removeDefaultHostnameLengthLimit() {
     if (this.machinePoolDefaults?.hostnameLengthLimit) {
       delete this.spec.rkeConfig.machinePoolDefaults.hostnameLengthLimit;

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -393,6 +393,26 @@ export default class ProvCluster extends SteveModel {
     }
   }
 
+  get machinePoolDefaults() {
+    return this.spec.rkeConfig?.machinePoolDefaults;
+  }
+
+  set defaultHostnameLengthLimit(value) {
+    this.spec.rkeConfig = this.spec.rkeConfig || {};
+    this.spec.rkeConfig.machinePoolDefaults = this.spec.rkeConfig.machinePoolDefaults || {};
+    this.spec.rkeConfig.machinePoolDefaults.hostnameLengthLimit = value;
+  }
+
+  removeDefaultHostnameLengthLimit() {
+    if (this.machinePoolDefaults?.hostnameLengthLimit) {
+      delete this.spec.rkeConfig.machinePoolDefaults.hostnameLengthLimit;
+
+      if (Object.keys(this.spec?.rkeConfig?.machinePoolDefaults).length === 0) {
+        delete this.spec.rkeConfig.machinePoolDefaults;
+      }
+    }
+  }
+
   get nodes() {
     return this.$rootGetters['management/all'](MANAGEMENT.NODE).filter(node => node.id.startsWith(this.mgmtClusterId));
   }

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -403,8 +403,8 @@ export default class ProvCluster extends SteveModel {
     this.spec.rkeConfig.machinePoolDefaults.hostnameLengthLimit = value;
   }
 
- get defaultHostnameLengthLimit() {
-  return this.spec.rkeConfig?.machinePoolDefaults?.hostnameLengthLimit;
+  get defaultHostnameLengthLimit() {
+    return this.spec.rkeConfig?.machinePoolDefaults?.hostnameLengthLimit;
   }
 
   removeDefaultHostnameLengthLimit() {


### PR DESCRIPTION
Updates so property matches backend - machinePools was under spec.rk3eConfig, not at the top level

Removed check for schema, as property will always be in backend now.