### PR TITLE
Changing how we serve the favicon

### DIFF
--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="shortcut icon" type="image/x-icon" href="/public/favicon.png">
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png">
     <title>Rancher</title>
 </head>
 

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -408,8 +408,8 @@ module.exports = function(dir, _appConfig) {
         }),
       }));
 
-      // The static assets need to be in the built public folder in order to get served (primarily the favicon for now)
-      config.plugins.push(new CopyWebpackPlugin([{ from: path.join(SHELL_ABS, 'static'), to: 'public' }]));
+      // The static assets need to be in the built assets directory in order to get served (primarily the favicon)
+      config.plugins.push(new CopyWebpackPlugin([{ from: path.join(SHELL_ABS, 'static'), to: '.' }]));
 
       config.resolve.extensions.push(...['.tsx', '.ts', '.js', '.vue', '.scss']);
       config.watchOptions = config.watchOptions || {};


### PR DESCRIPTION
The release version of rancher appears to expect the favicon at the root directory. Dev expected it to be under the public directory. I changed dev to use the root directory as well

https://github.com/rancher/dashboard/issues/8794

Locally I verified the default and branded icon both load.
<img width="78" alt="image" src="https://user-images.githubusercontent.com/55104481/236472766-435ea577-4219-4813-ae09-8f72f986505d.png">
<img width="69" alt="image" src="https://user-images.githubusercontent.com/55104481/236472807-6be9cc45-7706-45e7-a76f-eed8dd02f80c.png">

