### PR TITLE
Update `dompurify` to 2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dagre-d3": "0.6.4",
     "dayjs": "1.8.29",
     "diff2html": "2.11.2",
-    "dompurify": "2.0.12",
+    "dompurify": "2.4.5",
     "event-target-shim": "5.0.1",
     "express": "4.17.1",
     "file-saver": "2.0.2",

--- a/shell/package.json
+++ b/shell/package.json
@@ -69,7 +69,7 @@
     "dagre-d3": "0.6.4",
     "dayjs": "1.8.29",
     "diff2html": "2.11.2",
-    "dompurify": "2.0.12",
+    "dompurify": "2.4.5",
     "eslint": "7.32.0",
     "eslint-config-standard": "16.0.3",
     "eslint-import-resolver-node": "0.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6882,10 +6882,10 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@2.0.12:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.12.tgz#284a2b041e1c60b8e72d7b4d2fadad36141254ae"
-  integrity sha512-Fl8KseK1imyhErHypFPA8qpq9gPzlsJ/EukA6yk9o0gX23p1TzC+rh9LqNg1qvErRTc0UNMYlKxEGSfSh43NDg==
+dompurify@2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.5.tgz#0e89a27601f0bad978f9a924e7a05d5d2cccdd87"
+  integrity sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==
 
 domutils@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates `dompurify` to version 2.4.5. 

[Changelog for 2.0.12...2.4.5
](https://github.com/cure53/DOMPurify/compare/2.0.12...2.4.5)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Basic smoke testing should suffice with this change. We need to ensure anything that relies on `dompurify` still renders content properly and without error.  