### PR TITLE
Sanitize project label `v-html`

### DIFF
--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -11,6 +11,7 @@ import MoveModal from '@shell/components/MoveModal';
 import { defaultTableSortGenerationFn } from '@shell/components/ResourceTable.vue';
 import { NAMESPACE_FILTER_ALL_ORPHANS } from '@shell/utils/namespace-filter';
 import ResourceFetch from '@shell/mixins/resource-fetch';
+import DOMPurify from 'dompurify';
 
 export default {
   name:       'ListProjectNamespace',
@@ -319,7 +320,10 @@ export default {
       const row = group.rows[0];
 
       if (row.isFake) {
-        return this.t('resourceTable.groupLabel.project', { name: row.project?.nameDisplay }, true);
+        return DOMPurify.sanitize(
+          this.t('resourceTable.groupLabel.project', { name: row.project?.nameDisplay }, true),
+          { ALLOWED_TAGS: ['span'] }
+        );
       }
 
       return row.groupByLabel;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This removes the need to use `v-html` when displaying project labels by shifting the `span` tag outside of the translations inside of `en-us.yaml` and into the vue template.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Listing projects and namespaces.

#### Before

![image](https://github.com/rancher/dashboard/assets/835961/420989f6-31e0-4d75-90d0-e0ac90f3cdf8)

#### After

![image](https://github.com/rancher/dashboard/assets/835961/cef056a0-d165-45f9-9b23-9d5f2a8aca04)

