### PR TITLE
Fix import for clone from utils/object - Bump 0.3.9 

### DIFF
--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -14,7 +14,7 @@ import { CAPI, CATALOG } from '@shell/config/types';
 import { isPrerelease } from '@shell/utils/version';
 import difference from 'lodash/difference';
 import { LINUX } from '@shell/store/catalog';
-import { clone } from 'utils/object';
+import { clone } from '@shell/utils/object';
 import { merge } from 'lodash';
 
 export default {

--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This fixes the import for the `clone` method as this is causing build failures with extensions using the chart mixin. Example [here](https://github.com/kubewarden/ui/actions/runs/4938978264/jobs/8829388513#step:9:145)

Also bumps `0.3.9` of `@rancher/shell`