### PR TITLE
Extensions: Reduce error logging when operator not installed

### DIFF
--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -40,7 +40,12 @@ export default async function(context) {
         });
       }
     } catch (e) {
-      console.error('Could not load UI Plugin list', e); // eslint-disable-line no-console
+      if (e?.code === 404) {
+        // Not found, so extensions operator probably not installed
+        console.log('Could not load UI Extensions list (Extensions Operator may not be installed)'); // eslint-disable-line no-console
+      } else {
+        console.error('Could not load UI Extensions list', e); // eslint-disable-line no-console
+      }
     }
 
     // Load all of the plugins


### PR DESCRIPTION
Fixes #8253 

This PR updates the extensions load logic, so if the error is 404, we only show an info message and we don't show the error detail - this gives a better experience in the browser console for the case when the extensions operator is not installed.