### PR TITLE
Add initial value to empty object for rkeconfig.configMap[hostname] d…

### DIFF
--- a/cypress/e2e/po/pages/explorer/api-services.po.ts
+++ b/cypress/e2e/po/pages/explorer/api-services.po.ts
@@ -15,7 +15,7 @@ export class APIServicesPagePo extends PagePo {
   }
 
   waitForRequests() {
-    APIServicesPagePo.goToAndWaitForGet(this.goTo.bind(this), ['/v1/apiregistration.k8s.io.apiservices']);
+    APIServicesPagePo.goToAndWaitForGet(this.goTo.bind(this), ['/v1/apiregistration.k8s.io.apiservices?exclude=metadata.managedFields']);
   }
 
   resourcesList() {

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -43,14 +43,28 @@ export default {
     const configMap = this.value.spec.rkeConfig?.registries?.configs || {};
     const entries = [];
 
+    const defaultAddValue = {
+      hostname:             '',
+      authConfigSecretName: null,
+      caBundle:             '',
+      insecureSkipVerify:   false,
+      tlsSecretName:        null,
+    };
+
     for ( const hostname in configMap ) {
+      if (configMap[hostname]) {
+        configMap[hostname].insecureSkipVerify = configMap[hostname].insecureSkipVerify ?? defaultAddValue.insecureSkipVerify;
+        configMap[hostname].authConfigSecretName = configMap[hostname].authConfigSecretName ?? defaultAddValue.authConfigSecretName;
+        configMap[hostname].caBundle = configMap[hostname].caBundle ?? defaultAddValue.caBundle;
+        configMap[hostname].tlsSecretName = configMap[hostname].tlsSecretName ?? defaultAddValue.tlsSecretName;
+      }
       entries.push({
         hostname,
         ...configMap[hostname],
       });
     }
 
-    return { entries };
+    return { entries, defaultAddValue };
   },
 
   computed: {
@@ -58,16 +72,6 @@ export default {
       get() {
         return TYPES.TLS;
       },
-    },
-
-    defaultAddValue() {
-      return {
-        hostname:             '',
-        authConfigSecretName: null,
-        caBundle:             '',
-        insecureSkipVerify:   false,
-        tlsSecretName:        null,
-      };
     },
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
### issue
Fixes https://github.com/rancher/dashboard/issues/8849

### Areas or cases that should be tested
1. Create custom rke2 cluster without select the `Skip TLS certificate` option.
2. Edit the rke2 cluster and select the `Skip TLS certificate` option.
3. When saving the RKE2 cluster, it is found that the "Skip TLS certificate" value is not passed to the backend.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Vue.js's watcher mechanism is based on the getter and setter of JavaScript objects. When an object is set to be reactive, Vue rewrites the getter and setter of the object through Object.defineProperty() or ES6's Proxy so that it can receive notifications and trigger the corresponding watcher when the property value changes. The issue occurs when we bind an empty object to the data object of a Vue instance because Vue does not automatically set the getter and setter for the properties of the object. Therefore, when we add a property to the object and assign it a value during component creation, Vue is not aware of this change because the property of the object has not been set to be reactive. As a result, it is necessary to initialize the corresponding property value.