### PR TITLE
cypress UI automation: account and api keys tests

### DIFF
--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -66,6 +66,25 @@ export default class SortableTablePo extends ComponentPo {
   }
 
   /**
+   * Check row element count on sortable table
+   * @param isEmpty true if empty state expected (empty state message should display on row 1)
+   * @param expected number of rows shown
+   * @returns
+   */
+  checkRowCount(isEmpty: boolean, expected: number) {
+    return this.rowElements().should((el) => {
+      if (isEmpty) {
+        expect(el).to.have.length(expected);
+        expect(el).to.have.text('There are no rows to show.');
+        expect(el).to.have.attr('class', 'no-rows');
+      } else {
+        expect(el).to.have.length(expected);
+        expect(el).to.have.attr('data-testid');
+      }
+    });
+  }
+
+  /**
    * For a row with the given name open it's action menu and return the drop down
    */
   rowActionMenuOpen(name: string, actionMenuColumn: number) {
@@ -81,5 +100,12 @@ export default class SortableTablePo extends ComponentPo {
    */
   rowSelectCtlWithName(clusterName: string) {
     return new CheckboxInputPo(this.rowWithName(clusterName).column(0));
+  }
+
+  /**
+   * Select all list items
+   */
+  selectAllCheckbox(): CheckboxInputPo {
+    return new CheckboxInputPo('[data-testid="check_select_all"]');
   }
 }

--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -79,7 +79,7 @@ export default class SortableTablePo extends ComponentPo {
         expect(el).to.have.attr('class', 'no-rows');
       } else {
         expect(el).to.have.length(expected);
-        expect(el).to.have.attr('data-testid');
+        expect(el).to.have.attr('data-node-id');
       }
     });
   }

--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -41,6 +41,13 @@ export default class SortableTablePo extends ComponentPo {
     return popOver.find('li').contains(name);
   }
 
+  /**
+   * Delete button (displays on page after row element selected)
+   */
+  deleteButton() {
+    return cy.getId('sortable-table-promptRemove');
+  }
+
   //
   // sortable-table
   //
@@ -106,6 +113,6 @@ export default class SortableTablePo extends ComponentPo {
    * Select all list items
    */
   selectAllCheckbox(): CheckboxInputPo {
-    return new CheckboxInputPo('[data-testid="check_select_all"]');
+    return new CheckboxInputPo('[data-testid="sortable-table_check_select_all"]');
   }
 }

--- a/cypress/e2e/po/lists/account-api-keys-list.po.ts
+++ b/cypress/e2e/po/lists/account-api-keys-list.po.ts
@@ -1,0 +1,14 @@
+import BaseResourceList from '~/cypress/e2e/po/lists/base-resource-list.po';
+
+/**
+ * List component for api key resources
+ */
+export default class ApiKeysListPo extends BaseResourceList {
+  actionMenu(accessKey: string) {
+    return this.resourceTable().sortableTable().rowActionMenuOpen(accessKey, 7);
+  }
+
+  details(accessKey: string, index: number) {
+    return this.resourceTable().sortableTable().rowWithName(accessKey).column(index);
+  }
+}

--- a/cypress/e2e/po/lists/account-api-keys-list.po.ts
+++ b/cypress/e2e/po/lists/account-api-keys-list.po.ts
@@ -11,11 +11,4 @@ export default class ApiKeysListPo extends BaseResourceList {
   details(accessKey: string, index: number) {
     return this.resourceTable().sortableTable().rowWithName(accessKey).column(index);
   }
-
-  /**
-   * Delete button (displays on page after row element selected)
-   */
-  deleteButton() {
-    return cy.getId('sortable-table-promptRemove');
-  }
 }

--- a/cypress/e2e/po/lists/account-api-keys-list.po.ts
+++ b/cypress/e2e/po/lists/account-api-keys-list.po.ts
@@ -11,4 +11,11 @@ export default class ApiKeysListPo extends BaseResourceList {
   details(accessKey: string, index: number) {
     return this.resourceTable().sortableTable().rowWithName(accessKey).column(index);
   }
+
+  /**
+   * Delete button (displays on page after row element selected)
+   */
+  deleteButton() {
+    return cy.getId('sortable-table-promptRemove');
+  }
 }

--- a/cypress/e2e/po/pages/account-api-keys-create_key.po.ts
+++ b/cypress/e2e/po/pages/account-api-keys-create_key.po.ts
@@ -29,7 +29,7 @@ export default class CreateKeyPagePo extends PagePo {
   }
 
   apiAccessKey() {
-    return cy.getId('api_key_info').first();
+    return cy.getId('detail-top_html').first();
   }
 
   done(): Cypress.Chainable {

--- a/cypress/e2e/po/pages/account-api-keys-create_key.po.ts
+++ b/cypress/e2e/po/pages/account-api-keys-create_key.po.ts
@@ -1,0 +1,42 @@
+import PagePo from '~/cypress/e2e/po/pages/page.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+
+export default class CreateKeyPagePo extends PagePo {
+  static url: string = '/account/create-key'
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(CreateKeyPagePo.url);
+  }
+
+  constructor() {
+    super(CreateKeyPagePo.url);
+  }
+
+  title(): Cypress.Chainable {
+    return this.self().get('h1').should('include.text', 'API Key:');
+  }
+
+  description(): LabeledInputPo {
+    return LabeledInputPo.byLabel(this.self(), 'Description');
+  }
+
+  createButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="action-button-async-button"]', this.self());
+  }
+
+  doneButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="done_create_button"]', this.self());
+  }
+
+  apiAccessKey() {
+    return cy.getId('api_key_info').first();
+  }
+
+  done(): Cypress.Chainable {
+    return this.doneButton().click();
+  }
+
+  create(): Cypress.Chainable {
+    return this.createButton().click();
+  }
+}

--- a/cypress/e2e/po/pages/account-api-keys-create_key.po.ts
+++ b/cypress/e2e/po/pages/account-api-keys-create_key.po.ts
@@ -25,7 +25,7 @@ export default class CreateKeyPagePo extends PagePo {
   }
 
   doneButton(): AsyncButtonPo {
-    return new AsyncButtonPo('[data-testid="done_create_button"]', this.self());
+    return new AsyncButtonPo('[data-testid="token_done_create_button"]', this.self());
   }
 
   apiAccessKey() {

--- a/cypress/e2e/po/pages/account-api-keys.po.ts
+++ b/cypress/e2e/po/pages/account-api-keys.po.ts
@@ -1,0 +1,59 @@
+import PagePo from '~/cypress/e2e/po/pages/page.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+import ApiKeysListPo from '@/cypress/e2e/po/lists/account-api-keys-list.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+
+export default class AccountPagePo extends PagePo {
+  static url: string = '/account'
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(AccountPagePo.url);
+  }
+
+  constructor() {
+    super(AccountPagePo.url);
+  }
+
+  title(): Cypress.Chainable {
+    return this.self().get('h1').should('have.text', 'Account and API Keys');
+  }
+
+  private createApiKeyButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="account_create_api_keys"]', this.self());
+  }
+
+  private changePasswordButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="account_change_password"]', this.self());
+  }
+
+  create(): Cypress.Chainable {
+    return this.createApiKeyButton().click();
+  }
+
+  changePassword(): Cypress.Chainable {
+    return this.changePasswordButton().click();
+  }
+
+  list(): ApiKeysListPo {
+    return new ApiKeysListPo('[data-testid="api_keys_list"]');
+  }
+
+  applyButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="action-button-async-button"]', this.self());
+  }
+
+  apply(): Cypress.Chainable {
+    return this.applyButton().click();
+  }
+
+  currentPassword(): LabeledInputPo {
+    return LabeledInputPo.byLabel(this.self(), 'Current Password');
+  }
+
+  newPassword(): LabeledInputPo {
+    return LabeledInputPo.byLabel(this.self(), 'New Password');
+  }
+
+  confirmPassword(): LabeledInputPo {
+    return LabeledInputPo.byLabel(this.self(), 'Confirm Password');
+  }
+}

--- a/cypress/e2e/po/pages/account-api-keys.po.ts
+++ b/cypress/e2e/po/pages/account-api-keys.po.ts
@@ -1,7 +1,7 @@
 import PagePo from '~/cypress/e2e/po/pages/page.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import ApiKeysListPo from '@/cypress/e2e/po/lists/account-api-keys-list.po';
-import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import PasswordPo from '~/cypress/e2e/po/components/password.po';
 
 export default class AccountPagePo extends PagePo {
   static url: string = '/account'
@@ -17,12 +17,12 @@ export default class AccountPagePo extends PagePo {
     return this.self().get('h1').should('have.text', 'Account and API Keys');
   }
 
-  private createApiKeyButton(): AsyncButtonPo {
-    return new AsyncButtonPo('[data-testid="account_create_api_keys"]', this.self());
+  createApiKeyButton() {
+    return this.self().getId('account_create_api_keys');
   }
 
-  private changePasswordButton(): AsyncButtonPo {
-    return new AsyncButtonPo('[data-testid="account_change_password"]', this.self());
+  changePasswordButton() {
+    return this.self().getId('account_change_password');
   }
 
   create(): Cypress.Chainable {
@@ -45,15 +45,15 @@ export default class AccountPagePo extends PagePo {
     return this.applyButton().click();
   }
 
-  currentPassword(): LabeledInputPo {
-    return LabeledInputPo.byLabel(this.self(), 'Current Password');
+  currentPassword(): PasswordPo {
+    return new PasswordPo('[data-testid="account__current_password"]');
   }
 
-  newPassword(): LabeledInputPo {
-    return LabeledInputPo.byLabel(this.self(), 'New Password');
+  newPassword(): PasswordPo {
+    return new PasswordPo('[data-testid="account__new_password"]');
   }
 
-  confirmPassword(): LabeledInputPo {
-    return LabeledInputPo.byLabel(this.self(), 'Confirm Password');
+  confirmPassword(): PasswordPo {
+    return new PasswordPo('[data-testid="account__confirm_password"]');
   }
 }

--- a/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
@@ -59,7 +59,7 @@ describe('User can make changes to their account', () => {
 
     accountPage.goTo();
     apiKeysList.resourceTable().sortableTable().selectAllCheckbox().set();
-    apiKeysList.deleteButton().click();
+    apiKeysList.resourceTable().sortableTable().deleteButton().click();
 
     const promptRemove = new PromptRemove();
 

--- a/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
@@ -1,0 +1,92 @@
+import HomePagePo from '~/cypress/e2e/po/pages/home.po';
+import UserMenuPo from '@/cypress/e2e/po/side-bars/user-menu.po';
+import AccountPagePo from '~/cypress/e2e/po/pages/account-api-keys.po';
+import CreateKeyPagePo from '~/cypress/e2e/po/pages/account-api-keys-create_key.po';
+import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
+
+const userMenu = new UserMenuPo();
+const accountPage = new AccountPagePo();
+const createKeyPage = new CreateKeyPagePo();
+const apiKeysList = accountPage.list();
+
+describe('User can make changes to their account', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('Can navigate to Account and API Keys page', () => {
+    /*
+    Open user menu and navigate to Account and API Keys page
+    Verify url includes endpoint '/account'
+    Verify page title
+    */
+    HomePagePo.goTo();
+    userMenu.checkVisible();
+    userMenu.toggle();
+    userMenu.isOpen();
+    userMenu.clickMenuItem('Account & API Keys');
+    userMenu.isClosed();
+    accountPage.waitForPage();
+    accountPage.checkIsCurrentPage();
+    accountPage.title();
+  });
+
+  it('Can change their password', () => {
+    /**
+     * Verify user can change their password and change it back
+     */
+
+    accountPage.goTo();
+
+    accountPage.changePassword();
+    accountPage.currentPassword().set(Cypress.env('password'));
+    accountPage.newPassword().set('NewPassword11!!');
+    accountPage.confirmPassword().set('NewPassword11!!');
+    cy.intercept('POST', '/v3/users?action=changepassword').as('changePw');
+    accountPage.apply();
+    cy.wait('@changePw').its('response.statusCode').should('eq', 200);
+
+    accountPage.changePassword();
+    accountPage.currentPassword().set('NewPassword11!!');
+    accountPage.newPassword().set(Cypress.env('password'));
+    accountPage.confirmPassword().set(Cypress.env('password'));
+    accountPage.apply();
+    cy.wait('@changePw').its('response.statusCode').should('eq', 200);
+  });
+
+  it('Can create and delete API keys', () => {
+    /**
+     * Verify user can create API key
+     * Grab access key after creation and validate API key details
+     * Verify user can delete API key
+     */
+    const keyDesc = `keyDescription${ Date.now() }`;
+
+    accountPage.goTo();
+    accountPage.create();
+    createKeyPage.waitForPage();
+    createKeyPage.isCurrentPage();
+    createKeyPage.title();
+    createKeyPage.description().set(keyDesc);
+    createKeyPage.create();
+
+    const accessKey: string[] = [];
+
+    createKeyPage.apiAccessKey().invoke('text').then((el) => {
+      accessKey.push(el);
+
+      createKeyPage.done();
+      apiKeysList.checkVisible();
+      apiKeysList.details(accessKey[0], 2).should('include.text', accessKey[0]);
+      apiKeysList.details(accessKey[0], 3).should('include.text', keyDesc);
+      apiKeysList.actionMenu(accessKey[0]).getMenuItem('Delete').click();
+    });
+    const promptRemove = new PromptRemove();
+
+    promptRemove.self().then(() => {
+      cy.intercept('DELETE', `/v3/tokens/${ accessKey[0] }`).as('deleteApiKey');
+      promptRemove.remove();
+      cy.wait('@deleteApiKey').its('response.statusCode').should('eq', 204);
+    });
+  });
+});

--- a/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
@@ -14,29 +14,20 @@ describe('User can make changes to their account', () => {
     cy.login();
   });
 
-  it('Can navigate to Account and API Keys page', () => {
-    /*
-    Open user menu and navigate to Account and API Keys page
-    Verify url includes endpoint '/account'
-    Verify page title
-    */
-    HomePagePo.goTo();
-    userMenu.checkVisible();
-    userMenu.toggle();
-    userMenu.isOpen();
-    userMenu.clickMenuItem('Account & API Keys');
-    userMenu.isClosed();
-    accountPage.waitForPage();
-    accountPage.checkIsCurrentPage();
-    accountPage.title();
-  });
-
-  it('Can change their password', () => {
+  it('Can navigate to Account and API Keys page and change their password', () => {
     /**
+     * Open user menu and navigate to Account and API Keys page
+     * Verify url includes endpoint '/account'
+     * Verify page title
      * Verify user can change their password and change it back
      */
 
-    accountPage.goTo();
+    HomePagePo.goTo();
+    userMenu.toggle();
+    userMenu.clickMenuItem('Account & API Keys');
+    accountPage.waitForPage();
+    accountPage.checkIsCurrentPage();
+    accountPage.title();
 
     accountPage.changePassword();
     accountPage.currentPassword().set(Cypress.env('password'));
@@ -83,10 +74,8 @@ describe('User can make changes to their account', () => {
     });
     const promptRemove = new PromptRemove();
 
-    promptRemove.self().then(() => {
-      cy.intercept('DELETE', `/v3/tokens/${ accessKey[0] }`).as('deleteApiKey');
-      promptRemove.remove();
-      cy.wait('@deleteApiKey').its('response.statusCode').should('eq', 204);
-    });
+    cy.intercept('DELETE', '/v3/tokens/*').as('deleteApiKey');
+    promptRemove.remove();
+    cy.wait('@deleteApiKey').its('response.statusCode').should('eq', 204);
   });
 });

--- a/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
@@ -3,7 +3,6 @@ import UserMenuPo from '@/cypress/e2e/po/side-bars/user-menu.po';
 import AccountPagePo from '~/cypress/e2e/po/pages/account-api-keys.po';
 import CreateKeyPagePo from '~/cypress/e2e/po/pages/account-api-keys-create_key.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
-import CheckboxInputPo from '~/cypress/e2e/po/components/checkbox-input.po';
 
 const userMenu = new UserMenuPo();
 const accountPage = new AccountPagePo();

--- a/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
@@ -23,7 +23,9 @@ describe('User can make changes to their account', () => {
      */
 
     HomePagePo.goTo();
+    userMenu.checkVisible();
     userMenu.toggle();
+    userMenu.isOpen();
     userMenu.clickMenuItem('Account & API Keys');
     accountPage.waitForPage();
     accountPage.checkIsCurrentPage();

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -170,6 +170,7 @@ export default {
     <span
       v-else
       v-clean-html="bodyHtml"
+      data-testid="api_key_info"
       :class="{'conceal': concealed, 'monospace': monospace && !isBinary}"
     />
 

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -170,7 +170,7 @@ export default {
     <span
       v-else
       v-clean-html="bodyHtml"
-      data-testid="api_key_info"
+      data-testid="detail-top_html"
       :class="{'conceal': concealed, 'monospace': monospace && !isBinary}"
     />
 

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -217,6 +217,7 @@ export default {
         <Checkbox
           v-model="isAll"
           class="check"
+          data-testid="check_select_all"
           :indeterminate="isIndeterminate"
           :disabled="noRows || noResults"
         />

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -217,7 +217,7 @@ export default {
         <Checkbox
           v-model="isAll"
           class="check"
-          data-testid="check_select_all"
+          data-testid="sortable-table_check_select_all"
           :indeterminate="isIndeterminate"
           :disabled="noRows || noResults"
         />

--- a/shell/components/form/ChangePassword.vue
+++ b/shell/components/form/ChangePassword.vue
@@ -342,6 +342,7 @@ export default {
         <Password
           v-if="isChange"
           v-model="passwordCurrent"
+          data-testid="account__current_password"
           class="mt-10"
           :required="true"
           :label="t('changePassword.currentPassword.label')"
@@ -368,6 +369,7 @@ export default {
           <div :class="{'col': isCreateEdit, 'span-4': isCreateEdit}">
             <Password
               v-model="passwordNew"
+              data-testid="account__new_password"
               class="mt-10"
               :label="t('changePassword.userGen.newPassword.label')"
               :required="userGeneratedPasswordsRequired"
@@ -377,6 +379,7 @@ export default {
           <div :class="{'col': isCreateEdit, 'span-4': isCreateEdit}">
             <Password
               v-model="passwordConfirm"
+              data-testid="account__confirm_password"
               class="mt-10"
               :label="t('changePassword.userGen.confirmPassword.label')"
               :required="userGeneratedPasswordsRequired"

--- a/shell/edit/token.vue
+++ b/shell/edit/token.vue
@@ -273,6 +273,7 @@ export default {
       <div class="right">
         <button
           type="button"
+          data-testid="done_create_button"
           class="btn role-primary"
           @click="doneCreate"
         >

--- a/shell/edit/token.vue
+++ b/shell/edit/token.vue
@@ -273,7 +273,7 @@ export default {
       <div class="right">
         <button
           type="button"
-          data-testid="done_create_button"
+          data-testid="token_done_create_button"
           class="btn role-primary"
           @click="doneCreate"
         >

--- a/shell/pages/account/index.vue
+++ b/shell/pages/account/index.vue
@@ -159,6 +159,7 @@ export default {
           v-if="canChangePassword"
           type="button"
           class="btn role-primary"
+          data-testid="account_change_password"
           @click="$refs.promptChangePassword.show(true)"
         >
           {{ t("accountAndKeys.account.change") }}
@@ -179,6 +180,7 @@ export default {
       <button
         v-if="apiKeySchema"
         class="btn role-primary add mb-20"
+        data-testid="account_create_api_keys"
         @click="addKey"
       >
         {{ t('accountAndKeys.apiKeys.add.label') }}
@@ -193,6 +195,7 @@ export default {
         :rows="apiKeys"
         :headers="apiKeyheaders"
         key-field="id"
+        data-testid="api_keys_list"
         :search="true"
         :row-actions="true"
         :table-actions="true"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Added test for the Account & API Keys page which are:

- User can navigate to Account and API Keys page
- User can change their password
- User can create and delete API keys

### Screenshot/Video
<img width="793" alt="Screen Shot 2023-05-11 at 5 21 47 PM" src="https://github.com/rancher/dashboard/assets/127343932/df46a93e-637c-4cbb-adb0-b06f95490298">
