### PR TITLE
Automation: Allow user to change the volume name when creating a workload

### DIFF
--- a/shell/edit/workload/storage/__tests__/Storage.test.ts
+++ b/shell/edit/workload/storage/__tests__/Storage.test.ts
@@ -30,7 +30,7 @@ describe('component: Storage', () => {
           },
         },
         mocks: {
-          t:      (text: string) => text, // Fixes another issue with another i18n logic not from the getters
+          t:      (text: string) => text, // Mock i18n global function used as alternative to the getter
           $store: {
             getters: {
               'i18n/t':      jest.fn(),
@@ -60,7 +60,7 @@ describe('component: Storage', () => {
           },
         },
         mocks: {
-          t:      (text: string) => text, // Fixes another issue with another i18n logic not from the getters
+          t:      (text: string) => text, // Mock i18n global function used as alternative to the getter
           $store: {
             getters: {
               'i18n/t':      jest.fn(),
@@ -82,7 +82,7 @@ describe('component: Storage', () => {
     const wrapper = mount(Storage, {
       propsData: { savePvcHookName: '' },
       mocks:     {
-        t:      (text: string) => text, // Fixes another issue with another i18n logic not from the getters
+        t:      (text: string) => text, // Mock i18n global function used as alternative to the getter
         $store: { getters: { 'i18n/t': jest.fn() } }
       },
     });

--- a/shell/edit/workload/storage/__tests__/Storage.test.ts
+++ b/shell/edit/workload/storage/__tests__/Storage.test.ts
@@ -2,7 +2,81 @@ import { mount } from '@vue/test-utils';
 import Storage from '@shell/edit//workload/storage/index.vue';
 
 describe('component: Storage', () => {
-  // TODO: Complete test after integrating #5631
+  describe.each([
+    'awsElasticBlockStore',
+    'azureDisk',
+    'azureFile',
+    'configMap',
+    // 'createPVC',
+    'csi',
+    'emptyDir',
+    'gcePersistentDisk',
+    'gcePersistentDisk',
+    'hostPath',
+    'secret',
+    'vsphereVolume'
+  ])('given volume type %p', (volumeType) => {
+    it('should display the volume name as first input of the form array', () => {
+      const name = 'whatever';
+      const wrapper = mount(Storage, {
+        propsData: {
+          savePvcHookName: '',
+          value:           {
+            volumes: [{
+              _type:        volumeType,
+              [volumeType]: {},
+              name
+            }]
+          },
+        },
+        mocks: {
+          t:      (text: string) => text, // Fixes another issue with another i18n logic not from the getters
+          $store: {
+            getters: {
+              'i18n/t':      jest.fn(),
+              'i18n/exists': jest.fn()
+            }
+          }
+        },
+      });
+
+      const input = wrapper.find('input').element as HTMLInputElement;
+
+      expect(input.value).toStrictEqual(name);
+    });
+
+    it('should edit the volume name', () => {
+      const name = 'whatever';
+      const newName = 'new whatever';
+      const wrapper = mount(Storage, {
+        propsData: {
+          savePvcHookName: '',
+          value:           {
+            volumes: [{
+              _type:        volumeType,
+              [volumeType]: {},
+              name
+            }]
+          },
+        },
+        mocks: {
+          t:      (text: string) => text, // Fixes another issue with another i18n logic not from the getters
+          $store: {
+            getters: {
+              'i18n/t':      jest.fn(),
+              'i18n/exists': jest.fn()
+            }
+          }
+        },
+      });
+
+      wrapper.find('input').setValue(newName);
+
+      expect(wrapper.vm.value.volumes[0].name).toStrictEqual(newName);
+    });
+  });
+
+  // TODO: find how to interact with the tooltip selection outside of the component
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should allow to add a new volume', async() => {
     const wrapper = mount(Storage, {
@@ -13,9 +87,14 @@ describe('component: Storage', () => {
       },
     });
 
-    await wrapper.find('#add-volume').trigger('click');
-    const title = wrapper.find('h3');
+    await wrapper.find('#select-volume').trigger('click');
+    await wrapper.trigger('keydown.down');
+    await wrapper.trigger('keydown.enter');
 
-    expect(title.isVisible).toBe(true);
+    expect(wrapper.vm.value.volumes[0]).toStrictEqual({
+      _type:                'awsElasticBlockStore',
+      awsElasticBlockStore: {},
+      name:                 ''
+    });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8772
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Tested all the volumes cases from the Storage wrapper to:
- Display volume name field
- Recognize volume name change

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->