### PR TITLE
Revert "Remove jquery from dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "is-base64": "^1.1.0",
     "is-url": "1.2.4",
     "jexl": "2.2.2",
+    "jquery": "3.5.1",
     "js-cookie": "2.2.1",
     "js-yaml": "4.1.0",
     "js-yaml-loader": "1.2.2",

--- a/shell/core/plugins-loader.js
+++ b/shell/core/plugins-loader.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import $ from 'jquery';
 import JSZip from 'jszip';
 import jsyaml from 'js-yaml';
 
@@ -25,6 +26,7 @@ export default function({
     window.Vue = Vue;
 
     // Global libraries - allows us to externalise these to reduce package bundle size
+    window.$ = $;
     window.__jszip = JSZip;
     window.__jsyaml = jsyaml;
   }

--- a/shell/package.json
+++ b/shell/package.json
@@ -89,6 +89,7 @@
     "jest": "27.5.1",
     "jest-serializer-vue": "2.0.2",
     "jexl": "2.2.2",
+    "jquery": "3.5.1",
     "js-cookie": "2.2.1",
     "js-yaml": "4.1.0",
     "js-yaml-loader": "1.2.2",

--- a/shell/pkg/vue.config.js
+++ b/shell/pkg/vue.config.js
@@ -82,6 +82,7 @@ module.exports = function(dir) {
       // These modules will be externalised and not included with the build of a package library
       // This helps reduce the package size, but these dependencies must be provided by the hosting application
       config.externals = {
+        jquery:    '$',
         jszip:     '__jszip',
         'js-yaml': '__jsyaml'
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10419,6 +10419,11 @@ joi@^17.4.0:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
+jquery@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.9:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"


### PR DESCRIPTION
Reverts rancher/dashboard#8272
Seen as part of: https://github.com/rancher/dashboard/issues/8686
Removing jQuery has broken some extensions: I tried harvester 1.0.3, harvester 1.1.0, elemental 1.0.0 and elemental 1.1.0...it's likely others are broken too. 
![Screen Shot 2023-05-12 at 11 50 54 AM](https://github.com/rancher/dashboard/assets/42977925/91be79a1-f2f6-4826-872c-fdb471c8f3c4)
