### PR TITLE
HARVESTER: correct the metrics url

### DIFF
--- a/shell/components/GrafanaDashboard.vue
+++ b/shell/components/GrafanaDashboard.vue
@@ -32,20 +32,18 @@ export default {
       default: 'dark'
     }
   },
-  async fetch() {
-    const inStore = this.$store.getters['currentProduct'].inStore;
-    const res = await this.$store.dispatch(`${ inStore }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
-
-    this.monitoringVersion = res?.currentVersion;
-  },
   data() {
+    const inStore = this.$store.getters['currentProduct'].inStore;
+    const monitoring = this.$store.getters[`${ inStore }/byId`](CATALOG.APP, 'cattle-monitoring-system/rancher-monitoring');
+    const monitoringVersion = monitoring?.currentVersion;
+
     return {
-      loading: false, error: false, interval: null, initialUrl: this.computeUrl(), errorTimer: null, monitoringVersion: null
+      loading: false, error: false, interval: null, monitoringVersion, initialUrl: this.computeUrl(monitoringVersion), errorTimer: null
     };
   },
   computed: {
     currentUrl() {
-      return this.computeUrl();
+      return this.computeUrl(this.monitoringVersion);
     },
     grafanaUrl() {
       return this.currentUrl.replace('&kiosk', '');
@@ -133,12 +131,12 @@ export default {
         to:   `now`
       };
     },
-    computeUrl() {
+    computeUrl(monitoringVersion) {
       const embedUrl = this.url;
       const clusterId = this.$store.getters['currentCluster'].id;
       const params = this.computeParams();
 
-      return computeDashboardUrl(this.monitoringVersion, embedUrl, clusterId, params);
+      return computeDashboardUrl(monitoringVersion, embedUrl, clusterId, params);
     },
     computeParams() {
       const params = {};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
#### Testing Monitoring Version: `100.1.0+up19.0.3`

I find out the metrics url would be added the prefix `/k8s/clusters/${ clusterId }` even if the version of monitoring is older than `102.0.0+up40.1.2`.

It seems like `monitoringVersion` is `undefiend` when it is used by function `computeDashboardUrl`, maybe this is the root cause?
![image](https://github.com/rancher/dashboard/assets/15041915/212a2150-74cd-48ad-9ba5-f05f763c257e)

And I think the function `computeUrl` may emit always before the async fetch function. So I put the logic of getting monitoring version into `data` function.




### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->