### PR TITLE
Sanitize custom roles in `ProjectMemberEditor`

### DIFF
--- a/shell/components/form/ProjectMemberEditor.vue
+++ b/shell/components/form/ProjectMemberEditor.vue
@@ -7,6 +7,7 @@ import { Card } from '@components/Card';
 import { RadioGroup } from '@components/Form/Radio';
 import { Checkbox } from '@components/Form/Checkbox';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
+import DOMPurify from 'dompurify';
 
 export default {
   components: {
@@ -160,9 +161,9 @@ export default {
 
     options() {
       const customRoles = this.customRoles.map(role => ({
-        label:       role.nameDisplay,
-        description: role.description || role.metadata?.annotations?.[DESCRIPTION] || this.t('projectMembers.projectPermissions.noDescription'),
-        value:       role.id
+        label:       this.purifyOption(role.nameDisplay),
+        description: this.purifyOption(role.description || role.metadata?.annotations?.[DESCRIPTION] || this.t('projectMembers.projectPermissions.noDescription')),
+        value:       this.purifyOption(role.id),
       }));
 
       return [
@@ -245,6 +246,9 @@ export default {
       }
 
       return [permissionGroup];
+    },
+    purifyOption(option) {
+      return DOMPurify.sanitize(option, { ALLOWED_TAGS: ['span'] });
     }
   }
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This utilizes `DOMPurify` to sanitize custom roles displayed in the Add Project Member dialog. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- The add project member dialog

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

![image](https://github.com/rancher/dashboard/assets/835961/6999e2ba-50e6-4efd-8f0c-cde839dec1c0)

#### After

![image](https://github.com/rancher/dashboard/assets/835961/d4e098d3-c346-4762-9e40-36a6ec3dc8e8)
