### PR TITLE
Fix spacing in setup page, remove border

### DIFF
--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -326,60 +326,59 @@ export default {
         </div>
         <div
           v-if="firstLogin"
-          class="first-login-message"
+          class="first-login-message pl-10 pr-10"
+          :class="{'mt-30': !hasLoginMessage}"
           data-testid="first-login-message"
         >
-          <InfoBox color="info">
+          <t
+            k="setup.defaultPassword.intro"
+            :raw="true"
+          />
+
+          <div>
             <t
-              k="setup.defaultPassword.intro"
+              k="setup.defaultPassword.dockerPrefix"
               :raw="true"
             />
+          </div>
+          <ul>
+            <li>
+              <t
+                k="setup.defaultPassword.dockerPs"
+                :raw="true"
+              />
+            </li>
+            <li>
+              <CopyCode>
+                docker logs <u>container-id</u> 2&gt;&amp;1 | grep "Bootstrap Password:"
+              </CopyCode>
+            </li>
+          </ul>
+          <div>
+            <t
+              k="setup.defaultPassword.dockerSuffix"
+              :raw="true"
+            />
+          </div>
 
-            <div>
-              <t
-                k="setup.defaultPassword.dockerPrefix"
-                :raw="true"
-              />
-            </div>
-            <ul>
-              <li>
-                <t
-                  k="setup.defaultPassword.dockerPs"
-                  :raw="true"
-                />
-              </li>
-              <li>
-                <CopyCode>
-                  docker logs <u>container-id</u> 2&gt;&amp;1 | grep "Bootstrap Password:"
-                </CopyCode>
-              </li>
-            </ul>
-            <div>
-              <t
-                k="setup.defaultPassword.dockerSuffix"
-                :raw="true"
-              />
-            </div>
-
-            <br>
-            <div>
-              <t
-                k="setup.defaultPassword.helmPrefix"
-                :raw="true"
-              />
-            </div>
-            <br>
-            <CopyCode>
-              {{ kubectlCmd }}
-            </CopyCode>
-            <br>
-            <div>
-              <t
-                k="setup.defaultPassword.helmSuffix"
-                :raw="true"
-              />
-            </div>
-          </InfoBox>
+          <br>
+          <div>
+            <t
+              k="setup.defaultPassword.helmPrefix"
+              :raw="true"
+            />
+          </div>
+          <br>
+          <CopyCode>
+            {{ kubectlCmd }}
+          </CopyCode>
+          <br>
+          <div>
+            <t
+              k="setup.defaultPassword.helmSuffix"
+              :raw="true"
+            />
+          </div>
         </div>
 
         <div
@@ -508,6 +507,8 @@ export default {
     }
 
     .login-messages {
+      display: flex;
+      justify-content: center;
       align-items: center;
 
       .banner {
@@ -519,11 +520,7 @@ export default {
       &--hasContent {
         min-height: 70px;
       }
-    }
 
-    .login-messages, .first-login-message {
-      display: flex;
-      justify-content: center;
       .text-error, .banner {
         max-width: 80%;
       }


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- Setup page consists of
  - Welcome message
  - First login message
  - Local log in form
- Align first log in message mt with log in local login form mt
- Remove first log in message bottom (spacing handled by log in mt)
- Remove InfoBox (border around first login message

### Areas which could experience regressions
- Display of incorrect password in setup pages
- Display of normal log in page & errors

### Screenshot/Video

#### Before
![image(12)](https://github.com/rancher/dashboard/assets/18697775/940d0776-8e26-4f08-acd2-1f3360f89086)


#### After
![image(11)](https://github.com/rancher/dashboard/assets/18697775/fece9a4f-3a34-4111-bf95-ba6d10fd1f40)
