### PR TITLE
fix issue with Tolerations component

### DIFF
--- a/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
+++ b/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
@@ -264,13 +264,11 @@ export const payloadComparisonData = {
       {
         key:      'key1',
         operator: 'Exists',
-        effect:   null
       },
       {
         key:      'key2',
         operator: 'Equal',
         value:    'val2',
-        effect:   null
       },
       {
         key:      'key3',
@@ -568,13 +566,11 @@ export const payloadComparisonData = {
       {
         key:      'key1',
         operator: 'Exists',
-        effect:   null
       },
       {
         key:      'key2',
         operator: 'Equal',
         value:    'val2',
-        effect:   null
       },
       {
         key:      'key3',

--- a/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
+++ b/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
@@ -264,13 +264,13 @@ export const payloadComparisonData = {
       {
         key:      'key1',
         operator: 'Exists',
-        effect:   'All'
+        effect:   null
       },
       {
         key:      'key2',
         operator: 'Equal',
         value:    'val2',
-        effect:   'All'
+        effect:   null
       },
       {
         key:      'key3',
@@ -568,13 +568,13 @@ export const payloadComparisonData = {
       {
         key:      'key1',
         operator: 'Exists',
-        effect:   'All'
+        effect:   null
       },
       {
         key:      'key2',
         operator: 'Equal',
         value:    'val2',
-        effect:   'All'
+        effect:   null
       },
       {
         key:      'key3',

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6027,7 +6027,7 @@ workload:
         noExecute: NoExecute
         noSchedule: "NoSchedule"
         preferNoSchedule: PreferNoSchedule
-      labelKey: Label Key
+      labelKey: Key
       operator: Operator
       operatorOptions:
         equal: =

--- a/shell/components/form/Tolerations.vue
+++ b/shell/components/form/Tolerations.vue
@@ -39,7 +39,7 @@ export default {
         if (!Object.keys(v).includes('effect')) {
           rules.push({
             ...v,
-            effect: null
+            effect: ''
           });
         } else {
           rules.push(v);
@@ -103,7 +103,7 @@ export default {
       return [
         {
           label: this.t('workload.scheduling.tolerations.effectOptions.all'),
-          value: null
+          value: ''
         },
         {
           label: this.t('workload.scheduling.tolerations.effectOptions.noSchedule'),
@@ -149,6 +149,13 @@ export default {
           newRule.value = null;
         }
 
+        // remove effect from payload sent upstream, as it's empty
+        // it should be null, but the Select input doesn't seem to like it
+        // so we keep it as '' and sanitize it here
+        if (newRule.effect === '') {
+          delete newRule.effect;
+        }
+
         return newRule;
       });
 
@@ -156,7 +163,7 @@ export default {
     },
 
     addToleration() {
-      this.rules.push({ vKey: random32(), effect: null });
+      this.rules.push({ vKey: random32(), effect: '' });
     },
 
     updateEffect(neu, rule) {

--- a/shell/components/form/Tolerations.vue
+++ b/shell/components/form/Tolerations.vue
@@ -27,7 +27,27 @@ export default {
   },
 
   data() {
-    return { rules: [...this.value] };
+    const rules = [];
+
+    // on creation in agent configuration, the backend "eats"
+    // the empty "effect" string, which doesn't happen on edit
+    // just to make sure we populate it correcty, let's consider
+    // no prop "effect" as an empty string which means all
+    // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core
+    if (this.value.length) {
+      this.value.forEach((v) => {
+        if (!Object.keys(v).includes('effect')) {
+          rules.push({
+            ...v,
+            effect: null
+          });
+        } else {
+          rules.push(v);
+        }
+      });
+    }
+
+    return { rules };
   },
 
   computed: {
@@ -83,7 +103,7 @@ export default {
       return [
         {
           label: this.t('workload.scheduling.tolerations.effectOptions.all'),
-          value: 'All'
+          value: null
         },
         {
           label: this.t('workload.scheduling.tolerations.effectOptions.noSchedule'),
@@ -136,7 +156,7 @@ export default {
     },
 
     addToleration() {
-      this.rules.push({ vKey: random32() });
+      this.rules.push({ vKey: random32(), effect: null });
     },
 
     updateEffect(neu, rule) {

--- a/shell/edit/provisioning.cattle.io.cluster/AgentConfiguration.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/AgentConfiguration.vue
@@ -25,9 +25,11 @@ export function cleanAgentConfiguration(model, key) {
         delete v[k];
       }
 
-      // prevent cleanup of namespaceSelector when an empty object because it represents all namespaces in pod/node affinity
+      // prevent cleanup of "namespaceSelector" when an empty object because it represents all namespaces in pod/node affinity
       // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinityterm-v1-core
-      if (k !== 'namespaceSelector') {
+      // same for "effect" on Tolerations as an empty string means "All"
+      // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core
+      if (k !== 'namespaceSelector' || k !== 'effect') {
         cleanAgentConfiguration(v, k);
       }
     });

--- a/shell/edit/provisioning.cattle.io.cluster/AgentConfiguration.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/AgentConfiguration.vue
@@ -27,9 +27,7 @@ export function cleanAgentConfiguration(model, key) {
 
       // prevent cleanup of "namespaceSelector" when an empty object because it represents all namespaces in pod/node affinity
       // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podaffinityterm-v1-core
-      // same for "effect" on Tolerations as an empty string means "All"
-      // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core
-      if (k !== 'namespaceSelector' || k !== 'effect') {
+      if (k !== 'namespaceSelector') {
         cleanAgentConfiguration(v, k);
       }
     });


### PR DESCRIPTION
Fixes #8886 

- fixes issue with `Tolerations` component not covering the spec correct correctly when talking about effect `All`. It should not send string `effect: All`, but `effect: null` as per the kubernetes spec https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core

Fixes #8910 
- Change label in Tolerations from `Label Key` to `Key`

Follow reproduction steps on issue