### PR TITLE
Backport 2.7.4: Purify tooltip content with `v-clean-tooltip` directive

### DIFF
--- a/pkg/epinio/components/application/AppProgress.vue
+++ b/pkg/epinio/components/application/AppProgress.vue
@@ -232,7 +232,7 @@ export default Vue.extend<Data, any, any, any>({
           <div class="status">
             <i
               v-if="row.state === APPLICATION_ACTION_STATE.RUNNING"
-              v-tooltip="row.stateDisplay"
+              v-clean-tooltip="row.stateDisplay"
               class="icon icon-lg icon-spinner icon-spin"
             />
             <BadgeState

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -321,7 +321,7 @@ export default Vue.extend<Data, any, any, any>({
         :reduce="(e) => e.value"
       />
       <FileSelector
-        v-tooltip="t('epinio.applications.steps.source.manifest.tooltip')"
+        v-clean-tooltip="t('epinio.applications.steps.source.manifest.tooltip')"
         data-testid="epinio_app-source_manifest"
         class="role-tertiary add mt-5"
         :label="t('epinio.applications.steps.source.manifest.button')"

--- a/pkg/harvester/components/HarvesterUpgradeHeader.vue
+++ b/pkg/harvester/components/HarvesterUpgradeHeader.vue
@@ -106,7 +106,7 @@ export default {
 <template>
   <div v-if="enabled && isShow" class="upgrade">
     <v-popover
-      v-tooltip="{
+      v-clean-tooltip="{
         placement: 'bottom-left',
       }"
       class="hand"

--- a/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostDisk.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostDisk.vue
@@ -103,14 +103,14 @@ export default {
           <div class="pull-right">
             Conditions:
             <BadgeState
-              v-tooltip="readyCondition.message"
+              v-clean-tooltip="readyCondition.message"
               :color="readyCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="readyCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Ready"
               class="mr-10 ml-10 state"
             />
             <BadgeState
-              v-tooltip="schedulableCondition.message"
+              v-clean-tooltip="schedulableCondition.message"
               :color="schedulableCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="schedulableCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Schedulable"

--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -150,14 +150,14 @@ export default {
           <div class="pull-right">
             Conditions:
             <BadgeState
-              v-tooltip="readyCondition.message"
+              v-clean-tooltip="readyCondition.message"
               :color="readyCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="readyCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Ready"
               class="mr-10 ml-10 state"
             />
             <BadgeState
-              v-tooltip="schedulableCondition.message"
+              v-clean-tooltip="schedulableCondition.message"
               :color="schedulableCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="schedulableCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Schedulable"

--- a/pkg/harvester/formatters/HarvesterDiskState.vue
+++ b/pkg/harvester/formatters/HarvesterDiskState.vue
@@ -58,7 +58,7 @@ export default {
 <template>
   <div>
     <BadgeState
-      v-tooltip="errorMessage"
+      v-clean-tooltip="errorMessage"
       :color="stateBackground"
       :label="stateDisplay"
     />

--- a/pkg/harvester/formatters/HarvesterIpAddress.vue
+++ b/pkg/harvester/formatters/HarvesterIpAddress.vue
@@ -87,7 +87,7 @@ export default {
 <template>
   <div v-if="showIP">
     <span v-for="{ip, name} in ips" :key="ip">
-      <span v-tooltip="name">{{ ip }}</span>
+      <span v-clean-tooltip="name">{{ ip }}</span>
       <CopyToClipboard :text="ip" label-as="tooltip" class="icon-btn" action-color="bg-transparent" />
     </span>
   </div>

--- a/pkg/harvester/list/harvesterhci.io.dashboard.vue
+++ b/pkg/harvester/list/harvesterhci.io.dashboard.vue
@@ -534,7 +534,7 @@ export default {
           {{ t('harvester.dashboard.version') }}:
         </label>
         <span>
-          <span v-tooltip="{content: currentVersion}">
+          <span v-clean-tooltip="{content: currentVersion}">
             {{ currentVersion }}
           </span>
         </span>

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -251,12 +251,12 @@ export default Vue.extend({
           <template v-else-if="label">{{ label }}</template>
           <i
             v-if="tooltipKey"
-            v-tooltip="t(tooltipKey)"
+            v-clean-tooltip="t(tooltipKey)"
             class="checkbox-info icon icon-info icon-lg"
           />
           <i
             v-else-if="tooltip"
-            v-tooltip="tooltip"
+            v-clean-tooltip="tooltip"
             class="checkbox-info icon icon-info icon-lg"
           />
         </slot>

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -184,12 +184,12 @@ export default Vue.extend({
           </template>
           <i
             v-if="tooltipKey"
-            v-tooltip="t(tooltipKey)"
+            v-clean-tooltip="t(tooltipKey)"
             class="icon icon-info icon-lg"
           />
           <i
             v-else-if="tooltip"
-            v-tooltip="tooltip"
+            v-clean-tooltip="tooltip"
             class="icon icon-info icon-lg"
           />
         </h3>

--- a/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
+++ b/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
   >
     <template v-if="hover">
       <i
-        v-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value"
+        v-clean-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value"
         :class="{'hover':!value, [iconClass]: true}"
         class="icon status-icon"
       />

--- a/shell/chart/rancher-backup/S3.vue
+++ b/shell/chart/rancher-backup/S3.vue
@@ -139,7 +139,7 @@ export default {
           />
           <div class="ca-tooltip">
             <i
-              v-tooltip="t('backupRestoreOperator.s3.endpointCA.prompt')"
+              v-clean-tooltip="t('backupRestoreOperator.s3.endpointCA.prompt')"
               class="icon icon-info"
             />
           </div>

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -275,12 +275,12 @@ export default Vue.extend({
   >
     <i
       v-if="displayIcon"
-      v-tooltip="tooltip"
+      v-clean-tooltip="tooltip"
       :class="{icon: true, 'icon-lg': true, [displayIcon]: true}"
     />
     <span
       v-if="labelAs === 'text' && displayLabel"
-      v-tooltip="tooltip"
+      v-clean-tooltip="tooltip"
       v-clean-html="displayLabel"
     />
   </button>

--- a/shell/components/ButtonGroup.vue
+++ b/shell/components/ButtonGroup.vue
@@ -75,7 +75,7 @@ export default {
     <button
       v-for="(opt,idx) in optionObjects"
       :key="idx"
-      v-tooltip="opt.tooltipKey ? t(opt.tooltipKey) : opt.tooltip"
+      v-clean-tooltip="opt.tooltipKey ? t(opt.tooltipKey) : opt.tooltip"
       :data-testid="`button-group-child-${idx}`"
       type="button"
       :class="opt.class"

--- a/shell/components/CompoundStatusBadge.vue
+++ b/shell/components/CompoundStatusBadge.vue
@@ -24,7 +24,7 @@ export default {
 
 <template>
   <div
-    v-tooltip.bottom="tooltipText"
+    v-clean-tooltip.bottom="tooltipText"
     class="compound-cluster-badge"
     :class="`bg-${badgeClass}`"
   >

--- a/shell/components/CopyCode.vue
+++ b/shell/components/CopyCode.vue
@@ -53,7 +53,7 @@ export default {
 
 <template>
   <code
-    v-tooltip="tooltip"
+    v-clean-tooltip="tooltip"
     class="copy"
     @click.stop.prevent="clicked"
   ><slot /></code>

--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -252,7 +252,7 @@ export default {
           />
           <span
             v-if="internalTooltips[key]"
-            v-tooltip="prop ? `${key} : ${prop}` : key"
+            v-clean-tooltip="prop ? `${key} : ${prop}` : key"
           >
             <span>{{ internalTooltips[key] ? internalTooltips[key] : key }}</span>
             <span v-if="showAllLabels">: {{ key }}</span>

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -421,7 +421,7 @@ export default {
           </span>
           <i
             v-if="row.hasSystemLabels"
-            v-tooltip="getPsaTooltip(row)"
+            v-clean-tooltip="getPsaTooltip(row)"
             class="icon icon-lock ml-5"
           />
         </div>
@@ -498,7 +498,7 @@ export default {
 <style lang="scss">
   .psa-tooltip {
     // These could pop up a lot as the mouse moves around, keep them as small and unintrusive as possible
-    // (easier to test with v-tooltip="{ content: getPSA(row), autoHide: false, show: true }")
+    // (easier to test with v-clean-tooltip="{ content: getPSA(row), autoHide: false, show: true }")
     margin: 3px 0;
     padding: 0 8px 0 22px;
   }

--- a/shell/components/GlobalRoleBindings.vue
+++ b/shell/components/GlobalRoleBindings.vue
@@ -341,7 +341,7 @@ export default {
                       <span class="checkbox-label">{{ role.nameDisplay }}</span>
                       <i
                         v-if="!!assignOnlyRoles[role.id]"
-                        v-tooltip="t('rbac.globalRoles.assignOnlyRole')"
+                        v-clean-tooltip="t('rbac.globalRoles.assignOnlyRole')"
                         class="checkbox-info icon icon-info icon-lg"
                       />
                     </div>

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -240,12 +240,12 @@ export default {
         >
           <span
             v-if="col.sort"
-            v-tooltip="tooltip(col)"
+            v-clean-tooltip="tooltip(col)"
           >
             <span v-clean-html="labelFor(col)" />
             <i
               v-show="hasAdvancedFiltering && !col.isFilter"
-              v-tooltip="t('sortableTable.tableHeader.noFilter')"
+              v-clean-tooltip="t('sortableTable.tableHeader.noFilter')"
               class="icon icon-info not-filter-icon"
             />
             <span class="icon-stack">
@@ -262,7 +262,7 @@ export default {
           </span>
           <span
             v-else
-            v-tooltip="tooltip(col)"
+            v-clean-tooltip="tooltip(col)"
           >{{ labelFor(col) }}</span>
         </div>
       </th>

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -912,7 +912,7 @@ export default {
                 v-for="act in availableActions"
                 :id="act.action"
                 :key="act.action"
-                v-tooltip="actionTooltip"
+                v-clean-tooltip="actionTooltip"
                 type="button"
                 class="btn role-primary"
                 :class="{[bulkActionClass]:true}"
@@ -951,7 +951,7 @@ export default {
                       v-for="act in hiddenActions"
                       :key="act.action"
                       v-close-popover
-                      v-tooltip="{
+                      v-clean-tooltip="{
                         content: actionTooltip,
                         placement: 'right'
                       }"
@@ -1009,7 +1009,7 @@ export default {
           <slot name="header-right" />
           <AsyncButton
             v-if="isTooManyItemsToAutoUpdate"
-            v-tooltip="t('performance.manualRefresh.buttonTooltip')"
+            v-clean-tooltip="t('performance.manualRefresh.buttonTooltip')"
             class="manual-refresh"
             mode="refresh"
             :current-phase="currentPhase"

--- a/shell/components/Tabbed/Tab.vue
+++ b/shell/components/Tabbed/Tab.vue
@@ -102,7 +102,7 @@ export default {
         {{ labelDisplay }}
         <i
           v-if="tooltip"
-          v-tooltip="tooltip"
+          v-clean-tooltip="tooltip"
           class="icon icon-info icon-lg"
         />
       </h2>

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -255,7 +255,7 @@ export default {
           >{{ tab.badge }}</span>
           <i
             v-if="hasIcon(tab)"
-            v-tooltip="t('validation.tab')"
+            v-clean-tooltip="t('validation.tab')"
             class="conditions-alert-icon icon-error"
           />
         </a>

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -627,7 +627,7 @@ export default {
                   <span class="text-label">
                     {{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.resources') }}
                     <i
-                      v-tooltip="t('rbac.roletemplate.tabs.grantResources.resourceOptionInfo')"
+                      v-clean-tooltip="t('rbac.roletemplate.tabs.grantResources.resourceOptionInfo')"
                       class="icon icon-info"
                     />
                     <span

--- a/shell/components/auth/SelectPrincipal.vue
+++ b/shell/components/auth/SelectPrincipal.vue
@@ -175,7 +175,7 @@ export default {
   <LabeledSelect
     ref="labeled-select"
     v-model="newValue"
-    v-tooltip="{
+    v-clean-tooltip="{
       content: tooltipContent,
       placement: 'bottom',
       classes: ['select-principal-tooltip']

--- a/shell/components/fleet/FleetRepos.vue
+++ b/shell/components/fleet/FleetRepos.vue
@@ -146,7 +146,7 @@ export default {
           {{ row.clusterInfo.ready }}/{{ row.clusterInfo.total }}
           <i
             v-if="!row.clusterInfo.total"
-            v-tooltip.bottom="parseTargetMode(row)"
+            v-clean-tooltip.bottom="parseTargetMode(row)"
             class="icon icon-warning"
           />
         </span>

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -206,7 +206,7 @@ export default {
           {{ title }}
           <i
             v-if="showProtip"
-            v-tooltip="protip"
+            v-clean-tooltip="protip"
             class="icon icon-info"
           />
         </h3>

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -533,7 +533,7 @@ export default {
           {{ title }}
           <i
             v-if="titleProtip"
-            v-tooltip="titleProtip"
+            v-clean-tooltip="titleProtip"
             class="icon icon-info"
           />
         </h3>
@@ -548,7 +548,7 @@ export default {
           {{ keyLabel }}
           <i
             v-if="protip && !isView && addAllowed"
-            v-tooltip="protip"
+            v-clean-tooltip="protip"
             class="icon icon-info"
           />
         </label>

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -407,7 +407,7 @@ export default {
         @click="cancelCreateNamespace"
       >
         <i
-          v-tooltip="t('generic.cancel')"
+          v-clean-tooltip="t('generic.cancel')"
           class="icon icon-close align-value"
         />
       </button>

--- a/shell/components/form/PlusMinus.vue
+++ b/shell/components/form/PlusMinus.vue
@@ -50,7 +50,7 @@ export default {
       class="label"
     >{{ label }} </span>
     <button
-      v-tooltip="minusTooltip"
+      v-clean-tooltip="minusTooltip"
       :disabled="disabled || !canMinus"
       type="button"
       class="btn btn-sm role-secondary"
@@ -62,7 +62,7 @@ export default {
       {{ value }}
     </div>
     <button
-      v-tooltip="plusTooltip"
+      v-clean-tooltip="plusTooltip"
       :disabled="disabled || !canPlus"
       type="button"
       class="btn btn-sm role-secondary"

--- a/shell/components/form/Probe.vue
+++ b/shell/components/form/Probe.vue
@@ -149,7 +149,7 @@ export default {
         {{ label }}
         <i
           v-if="description"
-          v-tooltip="description"
+          v-clean-tooltip="description"
           class="icon icon-info"
         />
       </h3>

--- a/shell/components/form/ResourceQuota/NamespaceRow.vue
+++ b/shell/components/form/ResourceQuota/NamespaceRow.vue
@@ -182,7 +182,7 @@ export default {
     />
     <div class="resource-availability mr-10">
       <PercentageBar
-        v-tooltip="tooltip"
+        v-clean-tooltip="tooltip"
         class="percentage-bar"
         :value="percentageUsed"
         :slices="slices"

--- a/shell/components/form/ServicePorts.vue
+++ b/shell/components/form/ServicePorts.vue
@@ -137,7 +137,7 @@ export default {
         <span class="port">
           <t k="servicePorts.rules.listening.label" />
           <i
-            v-tooltip="t('servicesPage.listeningPorts')"
+            v-clean-tooltip="t('servicesPage.listeningPorts')"
             class="icon icon-info flex"
           />
           <span class="text-error">*</span>
@@ -151,7 +151,7 @@ export default {
         <span class="target-port">
           <t k="servicePorts.rules.target.label" />
           <i
-            v-tooltip="t('servicesPage.targetPorts')"
+            v-clean-tooltip="t('servicesPage.targetPorts')"
             class="icon icon-info flex"
           />
           <span class="text-error">*</span>

--- a/shell/components/formatter/ClusterLink.vue
+++ b/shell/components/formatter/ClusterLink.vue
@@ -64,17 +64,17 @@ export default {
     <span v-else>{{ value }}</span>
     <i
       v-if="row.unavailableMachines"
-      v-tooltip="row.unavailableMachines"
+      v-clean-tooltip="row.unavailableMachines"
       class="conditions-alert-icon icon-alert icon"
     />
     <i
       v-if="row.rkeTemplateUpgrade"
-      v-tooltip="t('cluster.rkeTemplateUpgrade', { name: row.rkeTemplateUpgrade })"
+      v-clean-tooltip="t('cluster.rkeTemplateUpgrade', { name: row.rkeTemplateUpgrade })"
       class="template-upgrade-icon icon-alert icon"
     />
     <i
       v-if="row.hasError"
-      v-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
+      v-clean-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
       class="conditions-alert-icon icon-error icon-lg"
     />
   </span>

--- a/shell/components/formatter/LiveDate.vue
+++ b/shell/components/formatter/LiveDate.vue
@@ -135,7 +135,7 @@ export default {
   </span>
   <span
     v-else-if="showTooltip"
-    v-tooltip="{content: title, placement: tooltipPlacement}"
+    v-clean-tooltip="{content: title, placement: tooltipPlacement}"
     class="live-date"
   >
     {{ suffixedLabel }}

--- a/shell/components/formatter/PodImages.vue
+++ b/shell/components/formatter/PodImages.vue
@@ -59,7 +59,7 @@ export default {
     <span>{{ mainImage }}</span><br>
     <span
       v-if="images.length-1>0"
-      v-tooltip.bottom="imageLabels"
+      v-clean-tooltip.bottom="imageLabels"
       class="plus-more"
     >{{ t('generic.plusMore', {n:images.length-1}) }}</span>
   </span>

--- a/shell/components/formatter/RKETemplateName.vue
+++ b/shell/components/formatter/RKETemplateName.vue
@@ -14,7 +14,7 @@ export default {
     <span>{{ value.displayName }}</span>
     <i
       v-if="value.upgrade"
-      v-tooltip="t('cluster.rkeTemplateUpgrade', { name: value.upgrade })"
+      v-clean-tooltip="t('cluster.rkeTemplateUpgrade', { name: value.upgrade })"
       class="template-upgrade-icon icon-alert icon"
     />
   </div>

--- a/shell/components/formatter/Shortened.vue
+++ b/shell/components/formatter/Shortened.vue
@@ -45,7 +45,7 @@ export default {
   </span>
   <span
     v-else-if="showTooltip"
-    v-tooltip="{content: longValue, placement: tooltipPlacement}"
+    v-clean-tooltip="{content: longValue, placement: tooltipPlacement}"
   >
     {{ value }}
   </span>

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -360,7 +360,7 @@ export default {
     >
       <div
         v-if="currentProduct && currentProduct.showClusterSwitcher"
-        v-tooltip="nameTooltip"
+        v-clean-tooltip="nameTooltip"
         class="cluster cluster-clipped"
       >
         <div
@@ -455,7 +455,7 @@ export default {
         <template v-if="currentProduct && currentProduct.showClusterSwitcher">
           <button
             v-if="showImportYaml"
-            v-tooltip="t('nav.import')"
+            v-clean-tooltip="t('nav.import')"
             :disabled="!importEnabled"
             type="button"
             class="btn header-btn role-tertiary"
@@ -478,7 +478,7 @@ export default {
 
           <button
             v-if="showKubeShell"
-            v-tooltip="t('nav.shellShortcut', {key: shellShortcut})"
+            v-clean-tooltip="t('nav.shellShortcut', {key: shellShortcut})"
             v-shortkey="{windows: ['ctrl', '`'], mac: ['meta', '`']}"
             :disabled="!shellEnabled"
             type="button"
@@ -491,7 +491,7 @@ export default {
 
           <button
             v-if="showKubeConfig"
-            v-tooltip="t('nav.kubeconfig.download')"
+            v-clean-tooltip="t('nav.kubeconfig.download')"
             :disabled="!kubeConfigEnabled"
             type="button"
             class="btn header-btn role-tertiary"
@@ -502,7 +502,7 @@ export default {
 
           <button
             v-if="showCopyConfig"
-            v-tooltip="t('nav.kubeconfig.copy')"
+            v-clean-tooltip="t('nav.kubeconfig.copy')"
             :disabled="!kubeConfigEnabled"
             type="button"
             class="btn header-btn role-tertiary"
@@ -521,7 +521,7 @@ export default {
 
         <button
           v-if="showSearch"
-          v-tooltip="t('nav.resourceSearch.toolTip', {key: searchShortcut})"
+          v-clean-tooltip="t('nav.resourceSearch.toolTip', {key: searchShortcut})"
           v-shortkey="{windows: ['ctrl', 'k'], mac: ['meta', 'k']}"
           type="button"
           class="btn header-btn role-tertiary"
@@ -549,7 +549,7 @@ export default {
         <button
           v-for="action, i in extensionHeaderActions"
           :key="`${action.label}${i}`"
-          v-tooltip="handleExtensionTooltip(action)"
+          v-clean-tooltip="handleExtensionTooltip(action)"
           v-shortkey="action.shortcutKey"
           :disabled="action.enabled ? !action.enabled(ctx) : false"
           type="button"

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -674,7 +674,7 @@ export default {
       <div
         v-else
         ref="values"
-        v-tooltip="tooltip"
+        v-clean-tooltip="tooltip"
         data-testid="namespaces-values"
         class="ns-values"
       >
@@ -708,7 +708,7 @@ export default {
       <div
         v-if="hidden > 0"
         ref="more"
-        v-tooltip="tooltip"
+        v-clean-tooltip="tooltip"
         class="ns-more"
       >
         {{ t('namespaceFilter.more', { more: hidden }) }}
@@ -754,7 +754,7 @@ export default {
           class="ns-singleton-info"
         >
           <i
-            v-tooltip="t('resourceList.nsFilterToolTip', { mode: namespaceFilterMode})"
+            v-clean-tooltip="t('resourceList.nsFilterToolTip', { mode: namespaceFilterMode})"
             class="icon icon-info"
           />
         </div>

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -751,7 +751,7 @@ export default {
                 />
                 <template v-if="value.hasLink('update') && group.ref.showScalePool">
                   <button
-                    v-tooltip="t('node.list.scaleDown')"
+                    v-clean-tooltip="t('node.list.scaleDown')"
                     :disabled="!group.ref.canScaleDownPool()"
                     type="button"
                     class="btn btn-sm role-secondary"
@@ -760,7 +760,7 @@ export default {
                     <i class="icon icon-sm icon-minus" />
                   </button>
                   <button
-                    v-tooltip="t('node.list.scaleUp')"
+                    v-clean-tooltip="t('node.list.scaleUp')"
                     :disabled="!group.ref.canScaleUpPool()"
                     type="button"
                     class="btn btn-sm role-secondary ml-10"
@@ -836,7 +836,7 @@ export default {
                 />
                 <template v-if="group.ref.hasLink('update')">
                   <button
-                    v-tooltip="t('node.list.scaleDown')"
+                    v-clean-tooltip="t('node.list.scaleDown')"
                     :disabled="group.ref.spec.quantity < 2"
                     type="button"
                     class="btn btn-sm role-secondary"
@@ -845,7 +845,7 @@ export default {
                     <i class="icon icon-sm icon-minus" />
                   </button>
                   <button
-                    v-tooltip="t('node.list.scaleUp')"
+                    v-clean-tooltip="t('node.list.scaleUp')"
                     type="button"
                     class="btn btn-sm role-secondary ml-10"
                     @click="group.ref.scalePool(1)"

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -266,7 +266,7 @@ export default {
           class="col span-6"
         >
           <span>{{ t('cis.scoreWarning.label') }}</span> <i
-            v-tooltip="t('cis.scoreWarning.protip')"
+            v-clean-tooltip="t('cis.scoreWarning.protip')"
             class="icon icon-info"
           />
           <RadioGroup

--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -433,7 +433,7 @@ export default {
           <template #selected-option="option">
             <i
               v-if="isTag(clusterOutputChoices, option)"
-              v-tooltip="t('logging.flow.clusterOutputs.doesntExistTooltip')"
+              v-clean-tooltip="t('logging.flow.clusterOutputs.doesntExistTooltip')"
               class="icon icon-info status-icon text-warning"
             />
             {{ option.label }}
@@ -454,7 +454,7 @@ export default {
           <template #selected-option="option">
             <i
               v-if="isTag(outputChoices, option)"
-              v-tooltip="t('logging.flow.outputs.doesntExistTooltip')"
+              v-clean-tooltip="t('logging.flow.outputs.doesntExistTooltip')"
               class="icon icon-info status-icon text-warning"
             />
             {{ option.label }}

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -236,7 +236,7 @@ export default {
                 {{ t('monitoring.receiver.addReceiver') }}
                 <i
                   v-if="mode === create"
-                  v-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
+                  v-clean-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
                   class="icon icon-info"
                 />
               </button>

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
@@ -49,7 +49,7 @@ export default {
     <h3>
       Receiver
       <i
-        v-tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')"
+        v-clean-tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')"
         class="icon icon-info"
       />
     </h3>
@@ -72,7 +72,7 @@ export default {
         <span class="label">
           {{ t("monitoringRoute.groups.addGroupByLabel'") }}
           <i
-            v-tooltip="t('monitoringRoute.groups.groupByTooltip')"
+            v-clean-tooltip="t('monitoringRoute.groups.groupByTooltip')"
             class="icon icon-info"
           />
         </span>

--- a/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -122,7 +122,7 @@ export default {
         <t k="prometheusRule.recordingRules.label" />
         <i
           v-if="disableAddRecord"
-          v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
+          v-clean-tooltip="t('validation.prometheusRule.groups.singleAlert')"
           class="icon icon-info"
         />
       </h3>
@@ -165,7 +165,7 @@ export default {
           <t k="prometheusRule.alertingRules.label" />
           <i
             v-if="disableAddAlert"
-            v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
+            v-clean-tooltip="t('validation.prometheusRule.groups.singleAlert')"
             class="icon icon-info"
           />
         </h3>

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRule.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRule.vue
@@ -54,7 +54,7 @@ export default {
         <h2>
           {{ t(`networkpolicy.${type}.ruleLabel`) }}
           <i
-            v-tooltip="t(`networkpolicy.${type}.ruleHint`)"
+            v-clean-tooltip="t(`networkpolicy.${type}.ruleHint`)"
             class="icon icon-info"
           />
         </h2>
@@ -83,7 +83,7 @@ export default {
         <h2>
           {{ t('networkpolicy.rules.ports.label') }}
           <i
-            v-tooltip="t(`networkpolicy.${type}.portHint`)"
+            v-clean-tooltip="t(`networkpolicy.${type}.portHint`)"
             class="icon icon-info"
           />
         </h2>

--- a/shell/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/index.vue
@@ -241,7 +241,7 @@ export default {
             <h2>
               {{ t('networkpolicy.selectors.label') }}
               <i
-                v-tooltip="t('networkpolicy.selectors.hint')"
+                v-clean-tooltip="t('networkpolicy.selectors.hint')"
                 class="icon icon-info"
               />
             </h2>

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -260,7 +260,7 @@ export default {
           <h3>
             {{ t('cluster.machinePool.autoReplace.label') }}
             <i
-              v-tooltip="t('cluster.machinePool.autoReplace.toolTip')"
+              v-clean-tooltip="t('cluster.machinePool.autoReplace.toolTip')"
               class="icon icon-info icon-lg"
             />
           </h3>

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -119,7 +119,7 @@ export default {
     <h3>
       {{ t('registryConfig.header') }}
       <i
-        v-tooltip="t('registryConfig.toolTip')"
+        v-clean-tooltip="t('registryConfig.toolTip')"
         class="icon icon-info"
       />
     </h3>

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -77,7 +77,7 @@ export default {
     <h3>
       {{ t('registryMirror.header') }}
       <i
-        v-tooltip="t('registryMirror.toolTip')"
+        v-clean-tooltip="t('registryMirror.toolTip')"
         class="icon icon-info"
       />
     </h3>
@@ -116,7 +116,7 @@ export default {
             <h3>
               {{ t('registryMirrorRewrite.header') }}
               <i
-                v-tooltip="t('registryMirrorRewrite.toolTip')"
+                v-clean-tooltip="t('registryMirrorRewrite.toolTip')"
                 class="icon icon-info"
               />
             </h3>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2038,21 +2038,21 @@ export default {
             class="pull-right"
           >
             <BadgeState
-              v-tooltip="nodeTotals.tooltip.etcd"
+              v-clean-tooltip="nodeTotals.tooltip.etcd"
               :color="nodeTotals.color.etcd"
               :icon="nodeTotals.icon.etcd"
               :label="nodeTotals.label.etcd"
               class="mr-10"
             />
             <BadgeState
-              v-tooltip="nodeTotals.tooltip.controlPlane"
+              v-clean-tooltip="nodeTotals.tooltip.controlPlane"
               :color="nodeTotals.color.controlPlane"
               :icon="nodeTotals.icon.controlPlane"
               :label="nodeTotals.label.controlPlane"
               class="mr-10"
             />
             <BadgeState
-              v-tooltip="nodeTotals.tooltip.worker"
+              v-clean-tooltip="nodeTotals.tooltip.worker"
               :color="nodeTotals.color.worker"
               :icon="nodeTotals.icon.worker"
               :label="nodeTotals.label.worker"
@@ -2469,7 +2469,7 @@ export default {
           <h3>
             {{ t('cluster.rke2.address.header') }}
             <i
-              v-tooltip="t('cluster.rke2.address.tooltip')"
+              v-clean-tooltip="t('cluster.rke2.address.tooltip')"
               class="icon icon-info"
             />
           </h3>
@@ -2741,7 +2741,7 @@ export default {
             <h3>
               {{ t('cluster.addOns.additionalManifest.title') }}
               <i
-                v-tooltip="t('cluster.addOns.additionalManifest.tooltip')"
+                v-clean-tooltip="t('cluster.addOns.additionalManifest.tooltip')"
                 class="icon icon-info"
               />
             </h3>

--- a/shell/edit/resources.cattle.io.restore.vue
+++ b/shell/edit/resources.cattle.io.restore.vue
@@ -274,7 +274,7 @@ export default {
               >
                 <template #label>
                   <span
-                    v-tooltip="t('backupRestoreOperator.prune.tip')"
+                    v-clean-tooltip="t('backupRestoreOperator.prune.tip')"
                     class="text-label"
                   >
                     {{ t('backupRestoreOperator.prune.label') }} <i class="icon icon-info" />
@@ -290,7 +290,7 @@ export default {
               >
                 <template #label>
                   <label
-                    v-tooltip="t('backupRestoreOperator.deleteTimeout.tip')"
+                    v-clean-tooltip="t('backupRestoreOperator.deleteTimeout.tip')"
                     class="has-tooltip"
                   >
                     {{ t('backupRestoreOperator.deleteTimeout.label') }} <i class="icon icon-info" />

--- a/shell/edit/workload/Job.vue
+++ b/shell/edit/workload/Job.vue
@@ -265,7 +265,7 @@ export default {
               >
                 {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
                 <i
-                  v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')"
+                  v-clean-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')"
                   class="icon icon-info"
                 />
               </label>
@@ -326,7 +326,7 @@ export default {
             >
               {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
               <i
-                v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')"
+                v-clean-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')"
                 class="icon icon-info"
               />
             </label>

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -252,7 +252,7 @@ export default {
                 <h3>
                   {{ t('workload.container.ports.expose') }}
                   <i
-                    v-tooltip="t('workload.container.ports.toolTip')"
+                    v-clean-tooltip="t('workload.container.ports.toolTip')"
                     class="icon icon-info"
                   />
                 </h3>

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -665,7 +665,7 @@ export default {
           </nuxt-link>
 
           <span
-            v-tooltip="{content: displayVersion, placement: 'top'}"
+            v-clean-tooltip="{content: displayVersion, placement: 'top'}"
             class="clip version text-muted"
           >
             {{ displayVersion }}

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -607,6 +607,7 @@ export default function(dir, _appConfig) {
       // Third-party
       path.join(NUXT_SHELL, 'plugins/axios'),
       path.join(NUXT_SHELL, 'plugins/tooltip'),
+      path.join(NUXT_SHELL, 'plugins/clean-tooltip-directive'),
       path.join(NUXT_SHELL, 'plugins/vue-clipboard2'),
       path.join(NUXT_SHELL, 'plugins/v-select'),
       path.join(NUXT_SHELL, 'plugins/directives'),

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -224,7 +224,7 @@ export default {
             <b v-if="vers.originalVersion === version.version">{{ vers.originalVersion === currentVersion ? t('catalog.install.versions.current', { ver: currentVersion }): vers.shortLabel }}</b>
             <a
               v-else
-              v-tooltip="vers.label.length > 16 ? vers.label : null"
+              v-clean-tooltip="vers.label.length > 16 ? vers.label : null"
               @click.prevent="selectVersion(vers)"
             >
               {{ vers.originalVersion === currentVersion ? t('catalog.install.versions.current', { ver: currentVersion }): vers.shortLabel }}

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1725,7 +1725,7 @@ export default {
         {{ t('catalog.install.steps.helmValues.chartInfo.label') }}
         <div class="slideIn__header__buttons">
           <div
-            v-tooltip="t('catalog.install.slideIn.dock')"
+            v-clean-tooltip="t('catalog.install.slideIn.dock')"
             class="slideIn__header__button"
             @click="showSlideIn = false; showReadmeWindow()"
           >

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -462,7 +462,7 @@ export default {
       </div>
       <p
         v-if="displayPspDeprecationBanner && hidePspDeprecationBanner"
-        v-tooltip="t('landing.deprecatedPsp')"
+        v-clean-tooltip="t('landing.deprecatedPsp')"
         class="alt-psp-deprecation-info"
       >
         <span>{{ t('landing.psps') }}</span>

--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -170,7 +170,7 @@ export default {
           <a
             v-for="fel in externalLinks"
             :key="fel.label"
-            v-tooltip="
+            v-clean-tooltip="
               !fel.enabled ? t('monitoring.overview.linkedList.na') : undefined
             "
             :href="fel.enabled ? fel.link : void 0"

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -206,7 +206,7 @@ export default {
             :key="v.version"
           >
             <a
-              v-tooltip="v.requiredUiVersion ? t('plugins.info.requiresVersion', { version: v.requiredUiVersion }) : ''"
+              v-clean-tooltip="v.requiredUiVersion ? t('plugins.info.requiresVersion', { version: v.requiredUiVersion }) : ''"
               class="version-link"
               :class="{'version-active': v.version === infoVersion, 'disabled': !v.isCompatibleWithUi}"
               @click="loadPluginVersionInfo(v.version)"

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -671,7 +671,7 @@ export default {
                   <span>{{ plugin.displayVersion }}</span>
                   <span
                     v-if="plugin.upgrade"
-                    v-tooltip="t('plugins.upgradeAvailable')"
+                    v-clean-tooltip="t('plugins.upgradeAvailable')"
                   > -> {{ plugin.upgrade }}</span>
                   <p
                     v-if="plugin.incompatibleDisclaimer"
@@ -694,13 +694,13 @@ export default {
               >
                 <div
                   v-if="!plugin.certified"
-                  v-tooltip="t('plugins.descriptions.third-party')"
+                  v-clean-tooltip="t('plugins.descriptions.third-party')"
                 >
                   {{ t('plugins.labels.third-party') }}
                 </div>
                 <div
                   v-if="plugin.experimental"
-                  v-tooltip="t('plugins.descriptions.experimental')"
+                  v-clean-tooltip="t('plugins.descriptions.experimental')"
                 >
                   {{ t('plugins.labels.experimental') }}
                 </div>
@@ -710,7 +710,7 @@ export default {
               <div class="plugin-actions">
                 <template v-if="plugin.error">
                   <div
-                    v-tooltip="plugin.error"
+                    v-clean-tooltip="plugin.error"
                     class="plugin-error"
                   >
                     <i class="icon icon-warning" />
@@ -719,7 +719,7 @@ export default {
                 <!-- plugin status -->
                 <div
                   v-if="plugin.helmError"
-                  v-tooltip="t('plugins.helmError')"
+                  v-clean-tooltip="t('plugins.helmError')"
                   class="plugin-error"
                 >
                   <i class="icon icon-warning" />

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -406,7 +406,7 @@ export default {
                       </span>
                       <i
                         v-if="row.unavailableMachines"
-                        v-tooltip="row.unavailableMachines"
+                        v-clean-tooltip="row.unavailableMachines"
                         class="conditions-alert-icon icon-alert icon"
                       />
                     </div>

--- a/shell/plugins/clean-html-directive.js
+++ b/shell/plugins/clean-html-directive.js
@@ -17,7 +17,7 @@ const ALLOWED_TAGS = [
   'strong',
 ];
 
-const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
+export const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
 
 export const cleanHtmlDirective = {
   inserted(el, binding) {

--- a/shell/plugins/clean-tooltip-directive.js
+++ b/shell/plugins/clean-tooltip-directive.js
@@ -1,0 +1,33 @@
+import Vue from 'vue';
+import { VTooltip } from 'v-tooltip';
+import { purifyHTML } from './clean-html-directive';
+
+function purifyContent(value) {
+  const type = typeof value;
+
+  if (type === 'string') {
+    return purifyHTML(value);
+  } else if (value && type === 'object' && typeof value.content === 'string') {
+    return { ...value, content: purifyHTML(value.content) };
+  } else {
+    return value;
+  }
+}
+
+function bind(el, { value, oldValue, modifiers }) {
+  const purifiedValue = purifyContent(value);
+
+  VTooltip.bind(
+    el,
+    {
+      value: purifiedValue, oldValue, modifiers
+    });
+}
+
+const VCleanTooltip = {
+  ...VTooltip,
+  bind,
+  update: bind,
+};
+
+Vue.directive('clean-tooltip', VCleanTooltip);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This replaces the use of the `v-tooltip` directive with a custom `v-clean-tooltip` directive that uses the `DOMPurify` library to sanitize HTML input before rendering. `html` usage is discouraged by `v-tooltip`[^1], and should only be used on trusted content. Similar to #8466, we sanitize existing usages across the board throughout Rancher Dashboard.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Adds new `v-clean-tooltip` directive that sanitizes tooltip content based on rules defined in `shell/plugins/clean-html-directive.js`
- Replaces all existing instances of `v-tooltip` with `v-clean-tooltip` 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In essence, we are monkey patching the `bind` method that `v-tooltip` utilizes to configure the directive. By taking this approach, we can ensure that we are able to sanitize tooltip content without altering the original behavior of the `v-tooltip` directive.

### Areas or cases that should be tested
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
We need to investigate tooltips throughout Rancher Dashboard and ensure that there are no notable regressions after this change has been applied. 

backports #8919 into `release-2.7.4`

[^1]: https://floating-vue.starpad.dev/legacy/v2/#directive