### PR TITLE
Backport 2.6: Purify tooltip content with `v-clean-tooltip` directive

### DIFF
--- a/pkg/epinio/components/application/AppProgress.vue
+++ b/pkg/epinio/components/application/AppProgress.vue
@@ -226,7 +226,7 @@ export default Vue.extend<Data, any, any, any>({
           <div class="status">
             <i
               v-if="row.state === APPLICATION_ACTION_STATE.RUNNING"
-              v-tooltip="row.stateDisplay"
+              v-clean-tooltip="row.stateDisplay"
               class="icon icon-lg icon-spinner icon-spin"
             />
             <BadgeState v-else :color="row.stateBackground" :label="row.stateDisplay" class="badge" />

--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -321,7 +321,7 @@ export default Vue.extend<Data, any, any, any>({
         :reduce="(e) => e.value"
       />
       <FileSelector
-        v-tooltip="t('epinio.applications.steps.source.manifest.tooltip')"
+        v-clean-tooltip="t('epinio.applications.steps.source.manifest.tooltip')"
         data-testid="epinio_app-source_manifest"
         class="role-tertiary add mt-5"
         :label="t('epinio.applications.steps.source.manifest.button')"

--- a/pkg/harvester/components/HarvesterUpgradeHeader.vue
+++ b/pkg/harvester/components/HarvesterUpgradeHeader.vue
@@ -106,7 +106,7 @@ export default {
 <template>
   <div v-if="enabled && isShow" class="upgrade">
     <v-popover
-      v-tooltip="{
+      v-clean-tooltip="{
         placement: 'bottom-left',
       }"
       class="hand"

--- a/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostDisk.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/HarvesterHostDisk.vue
@@ -116,14 +116,14 @@ export default {
           <div class="pull-right">
             Conditions:
             <BadgeState
-              v-tooltip="readyCondition.message"
+              v-clean-tooltip="readyCondition.message"
               :color="readyCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="readyCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Ready"
               class="mr-10 ml-10 state"
             />
             <BadgeState
-              v-tooltip="schedulableCondition.message"
+              v-clean-tooltip="schedulableCondition.message"
               :color="schedulableCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="schedulableCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Schedulable"

--- a/pkg/harvester/detail/harvesterhci.io.host/VlanStatus/index.vue
+++ b/pkg/harvester/detail/harvesterhci.io.host/VlanStatus/index.vue
@@ -49,7 +49,7 @@ export default {
         <div class="pull-right">
           {{ t('resourceTabs.conditions.tab') }}:
           <BadgeState
-            v-tooltip="readyCondition.message"
+            v-clean-tooltip="readyCondition.message"
             :color="readyCondition.status === 'True' ? 'bg-success' : 'bg-error' "
             :icon="readyCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
             :label="t('tableHeaders.ready')"

--- a/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
+++ b/pkg/harvester/edit/harvesterhci.io.host/HarvesterDisk.vue
@@ -163,14 +163,14 @@ export default {
           <div class="pull-right">
             Conditions:
             <BadgeState
-              v-tooltip="readyCondition.message"
+              v-clean-tooltip="readyCondition.message"
               :color="readyCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="readyCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Ready"
               class="mr-10 ml-10 state"
             />
             <BadgeState
-              v-tooltip="schedulableCondition.message"
+              v-clean-tooltip="schedulableCondition.message"
               :color="schedulableCondition.status === 'True' ? 'bg-success' : 'bg-error' "
               :icon="schedulableCondition.status === 'True' ? 'icon-checkmark' : 'icon-warning' "
               label="Schedulable"

--- a/pkg/harvester/edit/harvesterhci.io.managedchart/rancher-monitoring.vue
+++ b/pkg/harvester/edit/harvesterhci.io.managedchart/rancher-monitoring.vue
@@ -160,7 +160,7 @@ export default {
   <Tabbed :side-tabs="true">
     <Tab name="prometheus" :label="t('harvester.setting.harvesterMonitoring.section.prometheus')" :weight="-1">
       <a
-        v-tooltip="!externalLinks.prometheus.enabled ? t('monitoring.overview.linkedList.na') : undefined"
+        v-clean-tooltip="!externalLinks.prometheus.enabled ? t('monitoring.overview.linkedList.na') : undefined"
         :disabled="!externalLinks.prometheus.enabled"
         :href="externalLinks.prometheus.link"
         target="_blank"
@@ -307,7 +307,7 @@ export default {
     </Tab>
     <Tab v-if="value.spec.values.grafana.resources" name="grafana" :label="t('harvester.setting.harvesterMonitoring.section.grafana')" :weight="-3">
       <a
-        v-tooltip="!externalLinks.grafana.enabled ? t('monitoring.overview.linkedList.na') : undefined"
+        v-clean-tooltip="!externalLinks.grafana.enabled ? t('monitoring.overview.linkedList.na') : undefined"
         :disabled="!externalLinks.grafana.enabled"
         :href="externalLinks.grafana.link"
         target="_blank"
@@ -378,7 +378,7 @@ export default {
 
       <a
         v-if="value.spec.values.alertmanager.enabled"
-        v-tooltip="!externalLinks.alertmanager.enabled ? t('monitoring.overview.linkedList.na') : undefined"
+        v-clean-tooltip="!externalLinks.alertmanager.enabled ? t('monitoring.overview.linkedList.na') : undefined"
         :disabled="!externalLinks.alertmanager.enabled"
         :href="externalLinks.alertmanager.link"
         target="_blank"

--- a/pkg/harvester/edit/harvesterhci.io.monitoring.alertmanagerconfig/index.vue
+++ b/pkg/harvester/edit/harvesterhci.io.monitoring.alertmanagerconfig/index.vue
@@ -217,7 +217,7 @@ export default {
                 {{ t('monitoring.receiver.addReceiver') }}
                 <i
                   v-if="mode === create"
-                  v-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
+                  v-clean-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
                   class="icon icon-info"
                 />
               </button>

--- a/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/CompatibilityMatrix.vue
+++ b/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachinePciDevices/CompatibilityMatrix.vue
@@ -61,7 +61,7 @@ export default {
       </div>
     </div>
     <div v-for="deviceId in allDeviceIds" :key="deviceId" class="device-col">
-      <div v-tooltip="deviceDescription(deviceId)" class="compat-cell device-label">
+      <div v-clean-tooltip="deviceDescription(deviceId)" class="compat-cell device-label">
         {{ deviceId }}
       </div>
       <div

--- a/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
+++ b/pkg/harvester/edit/network.harvesterhci.io.vlanconfig/index.vue
@@ -228,7 +228,7 @@ export default {
               }"
             >
               <i
-                v-tooltip="t('generic.cancel')"
+                v-clean-tooltip="t('generic.cancel')"
                 class="icon icon-lg icon-close align-value"
               />
             </button>

--- a/pkg/harvester/formatters/HarvesterDiskState.vue
+++ b/pkg/harvester/formatters/HarvesterDiskState.vue
@@ -58,7 +58,7 @@ export default {
 <template>
   <div>
     <BadgeState
-      v-tooltip="errorMessage"
+      v-clean-tooltip="errorMessage"
       :color="stateBackground"
       :label="stateDisplay"
     />

--- a/pkg/harvester/formatters/HarvesterIpAddress.vue
+++ b/pkg/harvester/formatters/HarvesterIpAddress.vue
@@ -87,7 +87,7 @@ export default {
 <template>
   <div v-if="showIP">
     <span v-for="{ip, name} in ips" :key="ip">
-      <span v-tooltip="name">{{ ip }}</span>
+      <span v-clean-tooltip="name">{{ ip }}</span>
       <CopyToClipboard :text="ip" label-as="tooltip" class="icon-btn" action-color="bg-transparent" />
     </span>
   </div>

--- a/pkg/harvester/list/harvesterhci.io.dashboard.vue
+++ b/pkg/harvester/list/harvesterhci.io.dashboard.vue
@@ -534,7 +534,7 @@ export default {
           {{ t('harvester.dashboard.version') }}:
         </label>
         <span>
-          <span v-tooltip="{content: currentVersion}">
+          <span v-clean-tooltip="{content: currentVersion}">
             {{ currentVersion }}
           </span>
         </span>

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -238,8 +238,8 @@ export default Vue.extend({
         <slot name="label">
           <t v-if="labelKey" :k="labelKey" :raw="true" />
           <template v-else-if="label">{{ label }}</template>
-          <i v-if="tooltipKey" v-tooltip="t(tooltipKey)" class="checkbox-info icon icon-info icon-lg" />
-          <i v-else-if="tooltip" v-tooltip="tooltip" class="checkbox-info icon icon-info icon-lg" />
+          <i v-if="tooltipKey" v-clean-tooltip="t(tooltipKey)" class="checkbox-info icon icon-info icon-lg" />
+          <i v-else-if="tooltip" v-clean-tooltip="tooltip" class="checkbox-info icon icon-info icon-lg" />
         </slot>
       </span>
     </label>

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -176,8 +176,8 @@ export default Vue.extend({
           <template v-else-if="label">
             {{ label }}
           </template>
-          <i v-if="tooltipKey" v-tooltip="t(tooltipKey)" class="icon icon-info icon-lg" />
-          <i v-else-if="tooltip" v-tooltip="tooltip" class="icon icon-info icon-lg" />
+          <i v-if="tooltipKey" v-clean-tooltip="t(tooltipKey)" class="icon icon-info icon-lg" />
+          <i v-else-if="tooltip" v-clean-tooltip="tooltip" class="icon icon-info icon-lg" />
         </h3>
       </slot>
     </div>

--- a/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
+++ b/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
@@ -39,7 +39,7 @@ export default Vue.extend({
 <template>
   <div ref="container" class="labeled-tooltip" :class="{[status]: true, hoverable: hover}">
     <template v-if="hover">
-      <i v-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value" :class="{'hover':!value, [iconClass]: true}" class="icon status-icon" />
+      <i v-clean-tooltip="value.content ? { ...{content: value.content, classes: [`tooltip-${status}`]}, ...value } : value" :class="{'hover':!value, [iconClass]: true}" class="icon status-icon" />
     </template>
     <template v-else>
       <i :class="{'hover':!value}" class="icon status-icon" />

--- a/shell/chart/rancher-backup/S3.vue
+++ b/shell/chart/rancher-backup/S3.vue
@@ -106,7 +106,7 @@ export default {
         <div class="ca-controls">
           <FileSelector v-if="mode!=='view'" class="btn btn-sm role-primary mt-5" :mode="mode" :label="t('generic.readFromFile')" @selected="e=> setCA(e)" />
           <div class="ca-tooltip">
-            <i v-tooltip="t('backupRestoreOperator.s3.endpointCA.prompt')" class="icon icon-info" />
+            <i v-clean-tooltip="t('backupRestoreOperator.s3.endpointCA.prompt')" class="icon icon-info" />
           </div>
         </div>
       </div>

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -250,12 +250,12 @@ export default Vue.extend({
   >
     <i
       v-if="displayIcon"
-      v-tooltip="tooltip"
+      v-clean-tooltip="tooltip"
       :class="{icon: true, 'icon-lg': true, [displayIcon]: true}"
     />
     <span
       v-if="labelAs === 'text' && displayLabel"
-      v-tooltip="tooltip"
+      v-clean-tooltip="tooltip"
       v-clean-html="displayLabel"
     />
   </button>

--- a/shell/components/ButtonGroup.vue
+++ b/shell/components/ButtonGroup.vue
@@ -72,7 +72,7 @@ export default {
     <button
       v-for="(opt,idx) in optionObjects"
       :key="idx"
-      v-tooltip="opt.tooltipKey ? t(opt.tooltipKey) : opt.tooltip"
+      v-clean-tooltip="opt.tooltipKey ? t(opt.tooltipKey) : opt.tooltip"
       type="button"
       :class="opt.class"
       :disabled="disabled || opt.disabled"

--- a/shell/components/CompoundStatusBadge.vue
+++ b/shell/components/CompoundStatusBadge.vue
@@ -24,7 +24,7 @@ export default {
 
 <template>
   <div
-    v-tooltip.bottom="tooltipText"
+    v-clean-tooltip.bottom="tooltipText"
     class="compound-cluster-badge"
     :class="`bg-${badgeClass}`"
   >

--- a/shell/components/CopyCode.vue
+++ b/shell/components/CopyCode.vue
@@ -53,7 +53,7 @@ export default {
 
 <template>
   <code
-    v-tooltip="tooltip"
+    v-clean-tooltip="tooltip"
     class="copy"
     @click.stop.prevent="clicked"
   ><slot /></code>

--- a/shell/components/GlobalRoleBindings.vue
+++ b/shell/components/GlobalRoleBindings.vue
@@ -324,7 +324,7 @@ export default {
                   <template #label>
                     <div class="checkbox-label-slot">
                       <span class="checkbox-label">{{ role.nameDisplay }}</span>
-                      <i v-if="!!assignOnlyRoles[role.id]" v-tooltip="t('rbac.globalRoles.assignOnlyRole')" class="checkbox-info icon icon-info icon-lg" />
+                      <i v-if="!!assignOnlyRoles[role.id]" v-clean-tooltip="t('rbac.globalRoles.assignOnlyRole')" class="checkbox-info icon icon-info icon-lg" />
                     </div>
                   </template>
                 </Checkbox>

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -125,7 +125,7 @@ export default {
         :class="{ sortable: col.sort, [col.breakpoint]: !!col.breakpoint}"
         @click.prevent="changeSort($event, col)"
       >
-        <span v-if="col.sort" v-tooltip="col.tooltip">
+        <span v-if="col.sort" v-clean-tooltip="col.tooltip">
           <span v-clean-html="labelFor(col)" />
           <span class="icon-stack">
             <i class="icon icon-sort icon-stack-1x faded" />
@@ -133,7 +133,7 @@ export default {
             <i v-if="isCurrent(col) && descending" class="icon icon-sort-up icon-stack-1x" />
           </span>
         </span>
-        <span v-else v-tooltip="col.tooltip">{{ labelFor(col) }}</span>
+        <span v-else v-clean-tooltip="col.tooltip">{{ labelFor(col) }}</span>
       </th>
       <th v-if="rowActions" :width="rowActionsWidth">
       </th>

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -847,7 +847,7 @@ export default {
                 v-for="act in availableActions"
                 :id="act.action"
                 :key="act.action"
-                v-tooltip="actionTooltip"
+                v-clean-tooltip="actionTooltip"
                 type="button"
                 class="btn role-primary"
                 :class="{[bulkActionClass]:true}"
@@ -874,7 +874,7 @@ export default {
                       v-for="act in hiddenActions"
                       :key="act.action"
                       v-close-popover
-                      v-tooltip="{
+                      v-clean-tooltip="{
                         content: actionTooltip,
                         placement: 'right'
                       }"
@@ -899,7 +899,7 @@ export default {
           <slot name="header-middle" />
           <AsyncButton
             v-if="isTooManyItemsToAutoUpdate"
-            v-tooltip="t('performance.manualRefresh.buttonTooltip')"
+            v-clean-tooltip="t('performance.manualRefresh.buttonTooltip')"
             mode="refresh"
             :current-phase="currentPhase"
             @click="debouncedRefreshTableData"

--- a/shell/components/Tabbed/Tab.vue
+++ b/shell/components/Tabbed/Tab.vue
@@ -92,7 +92,7 @@ export default {
     <div v-if="shouldShowHeader" class="tab-header">
       <h2>
         {{ label }}
-        <i v-if="tooltip" v-tooltip="tooltip" class="icon icon-info icon-lg" />
+        <i v-if="tooltip" v-clean-tooltip="tooltip" class="icon icon-info icon-lg" />
       </h2>
       <slot name="tab-header-right" />
     </div>

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -239,7 +239,7 @@ export default {
           @click.prevent="select(tab.name, $event)"
         >
           <span>{{ tab.labelDisplay }}</span>
-          <i v-if="hasIcon(tab)" v-tooltip="t('validation.tab')" class="conditions-alert-icon icon-error icon-lg" />
+          <i v-if="hasIcon(tab)" v-clean-tooltip="t('validation.tab')" class="conditions-alert-icon icon-error icon-lg" />
         </a>
       </li>
       <li v-if="sideTabs && !sortedTabs.length" class="tab disabled">

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -602,7 +602,7 @@ export default {
                 <div :class="ruleClass">
                   <label class="text-label">
                     {{ t('rbac.roletemplate.tabs.grantResources.tableHeaders.resources') }}
-                    <i v-tooltip="t('rbac.roletemplate.tabs.grantResources.resourceOptionInfo')" class="icon icon-info" />
+                    <i v-clean-tooltip="t('rbac.roletemplate.tabs.grantResources.resourceOptionInfo')" class="icon icon-info" />
                     <span v-if="isNamespaced" class="required">*</span>
                   </label>
                 </div>

--- a/shell/components/fleet/FleetRepos.vue
+++ b/shell/components/fleet/FleetRepos.vue
@@ -121,7 +121,7 @@ export default {
           {{ row.clusterInfo.ready }}/{{ row.clusterInfo.total }}
           <i
             v-if="!row.clusterInfo.total"
-            v-tooltip.bottom="parseTargetMode(row)"
+            v-clean-tooltip.bottom="parseTargetMode(row)"
             class="icon icon-warning"
           />
         </span>

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -235,7 +235,7 @@ export default {
         <h3>
           {{ title }}
           <span v-if="required" class="required">*</span>
-          <i v-if="showProtip" v-tooltip="protip" class="icon icon-info" />
+          <i v-if="showProtip" v-clean-tooltip="protip" class="icon icon-info" />
         </h3>
       </slot>
     </div>

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -479,7 +479,7 @@ export default {
       <slot name="title">
         <h3>
           {{ title }}
-          <i v-if="titleProtip" v-tooltip="titleProtip" class="icon icon-info" />
+          <i v-if="titleProtip" v-clean-tooltip="titleProtip" class="icon icon-info" />
         </h3>
       </slot>
     </div>
@@ -487,7 +487,7 @@ export default {
       <template v-if="rows.length || isView">
         <label class="text-label">
           {{ keyLabel }}
-          <i v-if="protip && !isView && addAllowed" v-tooltip="protip" class="icon icon-info" />
+          <i v-if="protip && !isView && addAllowed" v-clean-tooltip="protip" class="icon icon-info" />
         </label>
         <label class="text-label">
           {{ valueLabel }}

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -397,7 +397,7 @@ export default {
         }"
       >
         <i
-          v-tooltip="t('generic.cancel')"
+          v-clean-tooltip="t('generic.cancel')"
           class="icon icon-lg icon-close align-value"
         />
       </button>

--- a/shell/components/form/PlusMinus.vue
+++ b/shell/components/form/PlusMinus.vue
@@ -46,13 +46,13 @@ export default {
 <template>
   <div class="plus-minus">
     <span v-if="label" class="label">{{ label }} </span>
-    <button v-tooltip="minusTooltip" :disabled="disabled || !canMinus" type="button" class="btn btn-sm role-secondary" @click="$emit('minus')">
+    <button v-clean-tooltip="minusTooltip" :disabled="disabled || !canMinus" type="button" class="btn btn-sm role-secondary" @click="$emit('minus')">
       <i class="icon icon-sm icon-minus" />
     </button>
     <div class="value">
       {{ value }}
     </div>
-    <button v-tooltip="plusTooltip" :disabled="disabled || !canPlus" type="button" class="btn btn-sm role-secondary" @click="$emit('plus')">
+    <button v-clean-tooltip="plusTooltip" :disabled="disabled || !canPlus" type="button" class="btn btn-sm role-secondary" @click="$emit('plus')">
       <i class="icon icon-sm icon-plus" />
     </button>
   </div>

--- a/shell/components/form/Probe.vue
+++ b/shell/components/form/Probe.vue
@@ -147,7 +147,7 @@ export default {
     <div class="title clearfix">
       <h3>
         {{ label }}
-        <i v-if="description" v-tooltip="description" class="icon icon-info" />
+        <i v-if="description" v-clean-tooltip="description" class="icon icon-info" />
       </h3>
     </div>
     <div class="row">

--- a/shell/components/form/ResourceQuota/NamespaceRow.vue
+++ b/shell/components/form/ResourceQuota/NamespaceRow.vue
@@ -179,7 +179,7 @@ export default {
     />
     <div class="resource-availability mr-10">
       <PercentageBar
-        v-tooltip="tooltip"
+        v-clean-tooltip="tooltip"
         class="percentage-bar"
         :value="percentageUsed"
         :slices="slices"

--- a/shell/components/formatter/ClusterLink.vue
+++ b/shell/components/formatter/ClusterLink.vue
@@ -65,12 +65,12 @@ export default {
     <span v-else>{{ value }}</span>
     <i
       v-if="row.rkeTemplateUpgrade"
-      v-tooltip="t('cluster.rkeTemplateUpgrade', { name: row.rkeTemplateUpgrade })"
+      v-clean-tooltip="t('cluster.rkeTemplateUpgrade', { name: row.rkeTemplateUpgrade })"
       class="template-upgrade-icon icon-alert icon"
     />
     <i
       v-if="clusterHasIssues"
-      v-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
+      v-clean-tooltip="{ content: `<div>${formattedConditions}</div>`, html: true }"
       class="conditions-alert-icon icon-error icon-lg"
     />
   </span>

--- a/shell/components/formatter/LiveDate.vue
+++ b/shell/components/formatter/LiveDate.vue
@@ -130,7 +130,7 @@ export default {
   <span v-if="!suffixedLabel" class="text-muted">
     &mdash;
   </span>
-  <span v-else-if="showTooltip" v-tooltip="{content: title, placement: tooltipPlacement}" class="live-date">
+  <span v-else-if="showTooltip" v-clean-tooltip="{content: title, placement: tooltipPlacement}" class="live-date">
     {{ suffixedLabel }}
   </span>
   <span v-else class="live-date">

--- a/shell/components/formatter/PodImages.vue
+++ b/shell/components/formatter/PodImages.vue
@@ -59,7 +59,7 @@ export default {
     <span>{{ mainImage }}</span><br>
     <span
       v-if="images.length-1>0"
-      v-tooltip.bottom="imageLabels"
+      v-clean-tooltip.bottom="imageLabels"
       class="plus-more"
     >{{ t('generic.plusMore', {n:images.length-1}) }}</span>
   </span>

--- a/shell/components/formatter/RKETemplateName.vue
+++ b/shell/components/formatter/RKETemplateName.vue
@@ -14,7 +14,7 @@ export default {
     <span>{{ value.displayName }}</span>
     <i
       v-if="value.upgrade"
-      v-tooltip="t('cluster.rkeTemplateUpgrade', { name: value.upgrade })"
+      v-clean-tooltip="t('cluster.rkeTemplateUpgrade', { name: value.upgrade })"
       class="template-upgrade-icon icon-alert icon"
     />
   </div>

--- a/shell/components/formatter/Shortened.vue
+++ b/shell/components/formatter/Shortened.vue
@@ -40,7 +40,7 @@ export default {
   <span v-if="!value" class="text-muted">
     &mdash;
   </span>
-  <span v-else-if="showTooltip" v-tooltip="{content: longValue, placement: tooltipPlacement}">
+  <span v-else-if="showTooltip" v-clean-tooltip="{content: longValue, placement: tooltipPlacement}">
     {{ value }}
   </span>
   <span v-else>

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -294,7 +294,7 @@ export default {
       </n-link>
     </div>
     <div v-if="!simple" ref="product" class="product">
-      <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-tooltip="nameTooltip" class="cluster cluster-clipped">
+      <div v-if="currentProduct && currentProduct.showClusterSwitcher" v-clean-tooltip="nameTooltip" class="cluster cluster-clipped">
         <div v-if="isSingleProduct" class="product-name">
           {{ t(isSingleProduct.productNameKey) }}
         </div>
@@ -342,7 +342,7 @@ export default {
         <template v-if="currentProduct && currentProduct.showClusterSwitcher">
           <button
             v-if="showImportYaml"
-            v-tooltip="t('nav.import')"
+            v-clean-tooltip="t('nav.import')"
             :disabled="!importEnabled"
             type="button"
             class="btn header-btn role-tertiary"
@@ -362,7 +362,7 @@ export default {
 
           <button
             v-if="showKubeShell"
-            v-tooltip="t('nav.shellShortcut', {key: shellShortcut})"
+            v-clean-tooltip="t('nav.shellShortcut', {key: shellShortcut})"
             v-shortkey="{windows: ['ctrl', '`'], mac: ['meta', '`']}"
             :disabled="!shellEnabled"
             type="button"
@@ -375,7 +375,7 @@ export default {
 
           <button
             v-if="showKubeConfig"
-            v-tooltip="t('nav.kubeconfig.download')"
+            v-clean-tooltip="t('nav.kubeconfig.download')"
             :disabled="!kubeConfigEnabled"
             type="button"
             class="btn header-btn role-tertiary"
@@ -386,7 +386,7 @@ export default {
 
           <button
             v-if="showCopyConfig"
-            v-tooltip="t('nav.kubeconfig.copy')"
+            v-clean-tooltip="t('nav.kubeconfig.copy')"
             :disabled="!kubeConfigEnabled"
             type="button"
             class="btn header-btn role-tertiary"
@@ -399,7 +399,7 @@ export default {
 
         <button
           v-if="showSearch"
-          v-tooltip="t('nav.resourceSearch.toolTip', {key: searchShortcut})"
+          v-clean-tooltip="t('nav.resourceSearch.toolTip', {key: searchShortcut})"
           v-shortkey="{windows: ['ctrl', 'k'], mac: ['meta', 'k']}"
           type="button"
           class="btn header-btn role-tertiary"

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -561,7 +561,7 @@ export default {
       <div v-else-if="isSingleSpecial" ref="values" class="ns-values">
         {{ value[0].label }}
       </div>
-      <div v-else ref="values" v-tooltip="tooltip" class="ns-values">
+      <div v-else ref="values" v-clean-tooltip="tooltip" class="ns-values">
         <div v-if="total" ref="total" class="ns-value ns-abs">
           {{ t('namespaceFilter.selected.label', { total }) }}
         </div>
@@ -570,7 +570,7 @@ export default {
           <i class="icon icon-close" @click="removeOption(ns, $event)" />
         </div>
       </div>
-      <div v-if="hidden > 0" ref="more" v-tooltip="tooltip" class="ns-more">
+      <div v-if="hidden > 0" ref="more" v-clean-tooltip="tooltip" class="ns-more">
         {{ t('namespaceFilter.more', { more: hidden }) }}
       </div>
       <i v-if="!isOpen" class="icon icon-chevron-down" />

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -340,7 +340,7 @@ export default {
           </div>
           <div @click="hide()">
             <nuxt-link
-              v-tooltip="{ content: fullVersion, classes: 'footer-tooltip' }"
+              v-clean-tooltip="{ content: fullVersion, classes: 'footer-tooltip' }"
               v-clean-html="displayVersion"
               :to="{ name: 'about' }"
               class="version"

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -633,10 +633,10 @@ export default {
               </div>
               <div v-if="group.ref" class="right mr-45">
                 <template v-if="value.hasLink('update')">
-                  <button v-tooltip="t('node.list.scaleDown')" :disabled="!group.ref.canScaleDownPool()" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
+                  <button v-clean-tooltip="t('node.list.scaleDown')" :disabled="!group.ref.canScaleDownPool()" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
                     <i class="icon icon-sm icon-minus" />
                   </button>
-                  <button v-tooltip="t('node.list.scaleUp')" type="button" class="btn btn-sm role-secondary ml-10" @click="group.ref.scalePool(1)">
+                  <button v-clean-tooltip="t('node.list.scaleUp')" type="button" class="btn btn-sm role-secondary ml-10" @click="group.ref.scalePool(1)">
                     <i class="icon icon-sm icon-plus" />
                   </button>
                 </template>
@@ -677,10 +677,10 @@ export default {
               <div v-if="group.ref" class="right group-header-buttons">
                 <MachineSummaryGraph :row="poolSummaryInfo[group.ref]" :horizontal="true" class="mr-20" />
                 <template v-if="group.ref.hasLink('update')">
-                  <button v-tooltip="t('node.list.scaleDown')" :disabled="group.ref.spec.quantity < 2" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
+                  <button v-clean-tooltip="t('node.list.scaleDown')" :disabled="group.ref.spec.quantity < 2" type="button" class="btn btn-sm role-secondary" @click="group.ref.scalePool(-1)">
                     <i class="icon icon-sm icon-minus" />
                   </button>
-                  <button v-tooltip="t('node.list.scaleUp')" type="button" class="btn btn-sm role-secondary ml-10" @click="group.ref.scalePool(1)">
+                  <button v-clean-tooltip="t('node.list.scaleUp')" type="button" class="btn btn-sm role-secondary ml-10" @click="group.ref.scalePool(1)">
                     <i class="icon icon-sm icon-plus" />
                   </button>
                 </template>

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -255,7 +255,7 @@ export default {
           />
         </div>
         <div v-if="canBeScheduled" class="col span-6">
-          <span>{{ t('cis.scoreWarning.label') }}</span> <i v-tooltip="t('cis.scoreWarning.protip')" class="icon icon-info" />
+          <span>{{ t('cis.scoreWarning.label') }}</span> <i v-clean-tooltip="t('cis.scoreWarning.protip')" class="icon icon-info" />
           <RadioGroup v-model="value.spec.scoreWarning" :mode="mode" name="scoreWarning" :options="['pass', 'fail']" :labels="[t('cis.scan.pass'), t('cis.scan.fail')]" />
         </div>
       </div>

--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -414,7 +414,7 @@ export default {
           :reduce="opt=>opt.value"
         >
           <template #selected-option="option">
-            <i v-if="isTag(clusterOutputChoices, option)" v-tooltip="t('logging.flow.clusterOutputs.doesntExistTooltip')" class="icon icon-info status-icon text-warning" />
+            <i v-if="isTag(clusterOutputChoices, option)" v-clean-tooltip="t('logging.flow.clusterOutputs.doesntExistTooltip')" class="icon icon-info status-icon text-warning" />
             {{ option.label }}
           </template>
         </LabeledSelect>
@@ -431,7 +431,7 @@ export default {
           :reduce="opt=>opt.value"
         >
           <template #selected-option="option">
-            <i v-if="isTag(outputChoices, option)" v-tooltip="t('logging.flow.outputs.doesntExistTooltip')" class="icon icon-info status-icon text-warning" />
+            <i v-if="isTag(outputChoices, option)" v-clean-tooltip="t('logging.flow.outputs.doesntExistTooltip')" class="icon icon-info status-icon text-warning" />
             {{ option.label }}
           </template>
         </LabeledSelect>

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -217,7 +217,7 @@ export default {
                 {{ t('monitoring.receiver.addReceiver') }}
                 <i
                   v-if="mode === create"
-                  v-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
+                  v-clean-tooltip="t('monitoring.alertmanagerConfig.disabledReceiverButton')"
                   class="icon icon-info"
                 />
               </button>

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/routeConfig.vue
@@ -49,7 +49,7 @@ export default {
     <h3>
       Receiver
       <i
-        v-tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')"
+        v-clean-tooltip="t('monitoring.alertmanagerConfig.receiverTooltip')"
         class="icon icon-info"
       />
     </h3>
@@ -72,7 +72,7 @@ export default {
         <span class="label">
           {{ t("monitoringRoute.groups.addGroupByLabel'") }}
           <i
-            v-tooltip="t('monitoringRoute.groups.groupByTooltip')"
+            v-clean-tooltip="t('monitoringRoute.groups.groupByTooltip')"
             class="icon icon-info"
           />
         </span>

--- a/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -114,7 +114,7 @@ export default {
         <t k="prometheusRule.recordingRules.label" />
         <i
           v-if="disableAddRecord"
-          v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
+          v-clean-tooltip="t('validation.prometheusRule.groups.singleAlert')"
           class="icon icon-info"
         />
       </h3>
@@ -152,7 +152,7 @@ export default {
           <t k="prometheusRule.alertingRules.label" />
           <i
             v-if="disableAddAlert"
-            v-tooltip="t('validation.prometheusRule.groups.singleAlert')"
+            v-clean-tooltip="t('validation.prometheusRule.groups.singleAlert')"
             class="icon icon-info"
           />
         </h3>

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRule.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRule.vue
@@ -53,7 +53,7 @@ export default {
       <div class="col span-12">
         <h2>
           {{ t(`networkpolicy.${type}.ruleLabel`) }}
-          <i v-tooltip="t(`networkpolicy.${type}.ruleHint`)" class="icon icon-info" />
+          <i v-clean-tooltip="t(`networkpolicy.${type}.ruleHint`)" class="icon icon-info" />
         </h2>
         <ArrayListGrouped v-model="value[targetKey]" :add-label="t(`networkpolicy.rules.${type}.add`)" :default-add-value="{}" :mode="mode">
           <template #default="props">
@@ -74,7 +74,7 @@ export default {
       <div class="col span-12">
         <h2>
           {{ t('networkpolicy.rules.ports.label') }}
-          <i v-tooltip="t(`networkpolicy.${type}.portHint`)" class="icon icon-info" />
+          <i v-clean-tooltip="t(`networkpolicy.${type}.portHint`)" class="icon icon-info" />
         </h2>
         <ArrayListGrouped v-model="value.ports" :add-label="t('networkpolicy.rules.addPort')" :default-add-value="{}" :mode="mode">
           <template #default="props">

--- a/shell/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/index.vue
@@ -215,7 +215,7 @@ export default {
           <Tab name="selectors" label-key="networkpolicy.selectors.label" :show-header="false" :weight="1">
             <h2>
               {{ t('networkpolicy.selectors.label') }}
-              <i v-tooltip="t('networkpolicy.selectors.hint')" class="icon icon-info" />
+              <i v-clean-tooltip="t('networkpolicy.selectors.hint')" class="icon icon-info" />
             </h2>
             <div class="row">
               <div class="col span-12">

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -229,7 +229,7 @@ export default {
         <div class="col span-4">
           <h3>
             {{ t('cluster.machinePool.autoReplace.label') }}
-            <i v-tooltip="t('cluster.machinePool.autoReplace.toolTip')" class="icon icon-info icon-lg" />
+            <i v-clean-tooltip="t('cluster.machinePool.autoReplace.toolTip')" class="icon icon-info icon-lg" />
           </h3>
           <UnitInput
             v-model.number="unhealthyNodeTimeoutInteger"

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -113,7 +113,7 @@ export default {
   <div>
     <h3>
       {{ t('registryConfig.header') }}
-      <i v-tooltip="t('registryConfig.toolTip')" class="icon icon-info" />
+      <i v-clean-tooltip="t('registryConfig.toolTip')" class="icon icon-info" />
     </h3>
     <ArrayListGrouped
       v-model="entries"

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryMirrors.vue
@@ -68,7 +68,7 @@ export default {
     <template #title>
       <h3>
         {{ t('registryMirror.header') }}
-        <i v-tooltip="t('registryMirror.toolTip')" class="icon icon-info" />
+        <i v-clean-tooltip="t('registryMirror.toolTip')" class="icon icon-info" />
       </h3>
     </template>
   </KeyValue>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1732,21 +1732,21 @@ export default {
           <h2 v-t="'cluster.tabs.machinePools'" class="pull-left" />
           <div v-if="!isView" class="pull-right">
             <BadgeState
-              v-tooltip="nodeTotals.tooltip.etcd"
+              v-clean-tooltip="nodeTotals.tooltip.etcd"
               :color="nodeTotals.color.etcd"
               :icon="nodeTotals.icon.etcd"
               :label="nodeTotals.label.etcd"
               class="mr-10"
             />
             <BadgeState
-              v-tooltip="nodeTotals.tooltip.controlPlane"
+              v-clean-tooltip="nodeTotals.tooltip.controlPlane"
               :color="nodeTotals.color.controlPlane"
               :icon="nodeTotals.icon.controlPlane"
               :label="nodeTotals.label.controlPlane"
               class="mr-10"
             />
             <BadgeState
-              v-tooltip="nodeTotals.tooltip.worker"
+              v-clean-tooltip="nodeTotals.tooltip.worker"
               :color="nodeTotals.color.worker"
               :icon="nodeTotals.icon.worker"
               :label="nodeTotals.label.worker"
@@ -2000,7 +2000,7 @@ export default {
         <Tab v-if="haveArgInfo" name="networking" label-key="cluster.tabs.networking">
           <h3>
             {{ t('cluster.rke2.address.header') }}
-            <i v-tooltip="t('cluster.rke2.address.tooltip')" class="icon icon-info" />
+            <i v-clean-tooltip="t('cluster.rke2.address.tooltip')" class="icon icon-info" />
           </h3>
           <Banner v-if="showIpv6Warning" color="warning">
             {{ t('cluster.rke2.address.ipv6.warning') }}
@@ -2184,7 +2184,7 @@ export default {
             <h3>
               {{ t('cluster.addOns.additionalManifest.title') }}
               <i
-                v-tooltip="t('cluster.addOns.additionalManifest.tooltip')"
+                v-clean-tooltip="t('cluster.addOns.additionalManifest.tooltip')"
                 class="icon icon-info"
               />
             </h3>

--- a/shell/edit/resources.cattle.io.restore.vue
+++ b/shell/edit/resources.cattle.io.restore.vue
@@ -243,14 +243,14 @@ export default {
             <div class="col span-6">
               <Checkbox v-model="value.spec.prune" class="mb-5" :label="t('backupRestoreOperator.prune.label')" :mode="mode">
                 <template #label>
-                  <span v-tooltip="t('backupRestoreOperator.prune.tip')" class="text-label">
+                  <span v-clean-tooltip="t('backupRestoreOperator.prune.tip')" class="text-label">
                     {{ t('backupRestoreOperator.prune.label') }} <i class="icon icon-info" />
                   </span>
                 </template>
               </Checkbox>
               <UnitInput v-if="value.spec.prune" v-model="value.spec.deleteTimeoutSeconds" :suffix="t('suffix.seconds', {count: value.spec.deleteTimeoutSeconds})" :mode="mode" :label="t('backupRestoreOperator.deleteTimeout.label')">
                 <template #label>
-                  <label v-tooltip="t('backupRestoreOperator.deleteTimeout.tip')" class="has-tooltip">
+                  <label v-clean-tooltip="t('backupRestoreOperator.deleteTimeout.tip')" class="has-tooltip">
                     {{ t('backupRestoreOperator.deleteTimeout.label') }} <i class="icon icon-info" />
                   </label>
                 </template>

--- a/shell/edit/workload/Job.vue
+++ b/shell/edit/workload/Job.vue
@@ -261,7 +261,7 @@ export default {
             <template #label>
               <label class="has-tooltip" :style="{'color':'var(--input-label)'}">
                 {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
-                <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" />
+                <i v-clean-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" />
               </label>
             </template>
           </UnitInput>
@@ -313,7 +313,7 @@ export default {
           <template #label>
             <label class="has-tooltip" :style="{'color':'var(--input-label)'}">
               {{ t('workload.upgrading.terminationGracePeriodSeconds.label') }}
-              <i v-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" />
+              <i v-clean-tooltip="t('workload.upgrading.terminationGracePeriodSeconds.tip')" class="icon icon-info" />
             </label>
           </template>
         </UnitInput>

--- a/shell/layouts/default.vue
+++ b/shell/layouts/default.vue
@@ -602,7 +602,7 @@ export default {
           </nuxt-link>
 
           <span
-            v-tooltip="{content: displayVersion, placement: 'top'}"
+            v-clean-tooltip="{content: displayVersion, placement: 'top'}"
             class="clip version text-muted"
           >
             {{ displayVersion }}

--- a/shell/nuxt.config.js
+++ b/shell/nuxt.config.js
@@ -570,6 +570,7 @@ export default function(dir, _appConfig) {
       // Third-party
       path.join(NUXT_SHELL, 'plugins/axios'),
       path.join(NUXT_SHELL, 'plugins/tooltip'),
+      path.join(NUXT_SHELL, 'plugins/clean-tooltip-directive'),
       path.join(NUXT_SHELL, 'plugins/vue-clipboard2'),
       path.join(NUXT_SHELL, 'plugins/v-select'),
       path.join(NUXT_SHELL, 'plugins/directives'),

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -174,7 +174,7 @@ export default {
           </h3>
           <div v-for="vers of versions" :key="vers.id" class="chart-content__right-bar__section--cVersion">
             <b v-if="vers.originalVersion === version.version">{{ vers.originalVersion === currentVersion ? t('catalog.install.versions.current', { ver: currentVersion }): vers.shortLabel }}</b>
-            <a v-else v-tooltip="vers.label.length > 16 ? vers.label : null" @click.prevent="selectVersion(vers)">
+            <a v-else v-clean-tooltip="vers.label.length > 16 ? vers.label : null" @click.prevent="selectVersion(vers)">
               {{ vers.originalVersion === currentVersion ? t('catalog.install.versions.current', { ver: currentVersion }): vers.shortLabel }}
             </a>
             <DateFormatter :value="vers.created" :show-time="false" />

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1499,7 +1499,7 @@ export default {
       <h2 class="slideIn__header">
         {{ t('catalog.install.steps.helmValues.chartInfo.label') }}
         <div class="slideIn__header__buttons">
-          <div v-tooltip="t('catalog.install.slideIn.dock')" class="slideIn__header__button" @click="showSlideIn = false; showReadmeWindow()">
+          <div v-clean-tooltip="t('catalog.install.slideIn.dock')" class="slideIn__header__button" @click="showSlideIn = false; showReadmeWindow()">
             <i class="icon icon-dock" />
           </div>
           <div class="slideIn__header__button" @click="showSlideIn = false">

--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -161,7 +161,7 @@ export default {
           <a
             v-for="fel in externalLinks"
             :key="fel.label"
-            v-tooltip="
+            v-clean-tooltip="
               !fel.enabled ? t('monitoring.overview.linkedList.na') : undefined
             "
             :href="fel.enabled ? fel.link : void 0"

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -267,7 +267,7 @@ export default {
       <div>
         <Checkbox
           v-model="includeResponseTimes"
-          v-tooltip.left="t('about.diagnostic.checkboxTooltip')"
+          v-clean-tooltip.left="t('about.diagnostic.checkboxTooltip')"
           :label="t('about.diagnostic.checkboxLabel')"
         />
         <AsyncButton

--- a/shell/plugins/clean-html-directive.js
+++ b/shell/plugins/clean-html-directive.js
@@ -17,7 +17,7 @@ const ALLOWED_TAGS = [
   'strong',
 ];
 
-const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
+export const purifyHTML = value => DOMPurify.sanitize(value, { ALLOWED_TAGS });
 
 export const cleanHtmlDirective = {
   inserted(el, binding) {

--- a/shell/plugins/clean-tooltip-directive.js
+++ b/shell/plugins/clean-tooltip-directive.js
@@ -1,0 +1,33 @@
+import Vue from 'vue';
+import { VTooltip } from 'v-tooltip';
+import { purifyHTML } from './clean-html-directive';
+
+function purifyContent(value) {
+  const type = typeof value;
+
+  if (type === 'string') {
+    return purifyHTML(value);
+  } else if (value && type === 'object' && typeof value.content === 'string') {
+    return { ...value, content: purifyHTML(value.content) };
+  } else {
+    return value;
+  }
+}
+
+function bind(el, { value, oldValue, modifiers }) {
+  const purifiedValue = purifyContent(value);
+
+  VTooltip.bind(
+    el,
+    {
+      value: purifiedValue, oldValue, modifiers
+    });
+}
+
+const VCleanTooltip = {
+  ...VTooltip,
+  bind,
+  update: bind,
+};
+
+Vue.directive('clean-tooltip', VCleanTooltip);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This replaces the use of the `v-tooltip` directive with a custom `v-clean-tooltip` directive that uses the `DOMPurify` library to sanitize HTML input before rendering. `html` usage is discouraged by `v-tooltip`[^1], and should only be used on trusted content. Similar to #8466, we sanitize existing usages across the board throughout Rancher Dashboard.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Adds new `v-clean-tooltip` directive that sanitizes tooltip content based on rules defined in `shell/plugins/clean-html-directive.js`
- Replaces all existing instances of `v-tooltip` with `v-clean-tooltip` 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In essence, we are monkey patching the `bind` method that `v-tooltip` utilizes to configure the directive. By taking this approach, we can ensure that we are able to sanitize tooltip content without altering the original behavior of the `v-tooltip` directive.

### Areas or cases that should be tested
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
We need to investigate tooltips throughout Rancher Dashboard and ensure that there are no notable regressions after this change has been applied. 

backports #8919 into `release-2.6`

[^1]: https://floating-vue.starpad.dev/legacy/v2/#directive