### PR TITLE
Fix incorrect i18n string for CSI suffix

### DIFF
--- a/shell/edit/storage.k8s.io.storageclass/index.vue
+++ b/shell/edit/storage.k8s.io.storageclass/index.vue
@@ -125,7 +125,7 @@ export default {
         if (driver.metadata.name === LONGHORN_DRIVER || provisionerOptionsDrivers.includes(driver.metadata.name)) {
           return;
         }
-        const fallback = `${ driver.metadata.name }  ${ this.t('persistentVolume.csi.drivers.suffix') }`;
+        const fallback = `${ driver.metadata.name }  ${ this.t('persistentVolume.csi.suffix') }`;
 
         dropdownOptions.push({
           value: driver.metadata.name,

--- a/shell/models/persistentvolume.js
+++ b/shell/models/persistentvolume.js
@@ -115,7 +115,7 @@ export default class PV extends SteveModel {
   // plugin display value table
   get source() {
     const csiDriver = this.spec?.csi?.driver;
-    const fallback = `${ csiDriver } ${ this.t('persistentVolume.csi.drivers.suffix') }`;
+    const fallback = `${ csiDriver } ${ this.t('persistentVolume.csi.suffix') }`;
 
     if (csiDriver) {
       return this.$rootGetters['i18n/withFallback'](`persistentVolume.csi.drivers.${ csiDriver.replaceAll('.', '-') }`, null, fallback);


### PR DESCRIPTION
Fixes #8820 

The issue is caused by an incorrect 18n key.

`persistentVolume.csi.drivers.suffix` should be `persistentVolume.csi.suffix`

After this fix:

![image](https://github.com/rancher/dashboard/assets/1955897/efa554ff-b8af-40a8-bdd6-376b8067387c)
 
Note: You can test this without EKS by finding the CSI Driver resource and creating a new one - just supply a name for the resource - you'll then see this when you try to create a Storage class

Manual QA by dev team should be fine for this