### PR TITLE
Added value to select key

### DIFF
--- a/shell/pages/__tests__/prefs.test.ts
+++ b/shell/pages/__tests__/prefs.test.ts
@@ -1,0 +1,96 @@
+import { shallowMount } from '@vue/test-utils';
+import Preferences from '@shell/pages/prefs.vue';
+
+describe('page: prefs should', () => {
+  it.each([
+    ['Fri, May 5 2023', 0],
+    ['Fri, 5 May 2023', 1],
+    ['5/5/2023 (D/M/YYYY)', 2],
+    ['5/5/2023 (M/D/YYYY)', 3],
+    ['2023-05-05 (YYYY-MM-DD)', 4],
+  ])('format the date optionally with a cue as %p for date 05/05/2023', (expected, index) => {
+    const date = '05/05/2023';
+    const format = ['ddd, MMM D YYYY', 'ddd, D MMM YYYY', 'D/M/YYYY', 'M/D/YYYY', 'YYYY-MM-DD'];
+
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date(date));
+
+    const wrapper = shallowMount(Preferences, {
+      propsData: { value: 'asd' },
+      computed:  {
+        pm: jest.fn(),
+        am: jest.fn(),
+      },
+      mocks: {
+        $store: {
+          getters: {
+            'prefs/options':        () => format,
+            'prefs/get':            jest.fn(),
+            'management/schemaFor': jest.fn(),
+            isSingleProduct:        jest.fn(),
+            'i18n/t':               jest.fn(),
+          }
+        }
+      },
+      stubs: {
+        BackLink:              { template: '<div />' },
+        ButtonGroup:           { template: '<div />' },
+        LabeledSelect:         { template: '<div />' },
+        Checkbox:              { template: '<div />' },
+        LandingPagePreference: { template: '<div />' },
+        LocaleSelector:        { template: '<div />' },
+      }
+    });
+
+    const options = (wrapper.vm as unknown as any).dateOptions;
+
+    expect(options[index].label).toBe(expected);
+  });
+
+  it.each([
+    ['Mon, May 1 2023', 0],
+    ['Mon, 1 May 2023', 1],
+    ['1/5/2023', 2],
+    ['5/1/2023', 3],
+    ['2023-05-01', 4],
+  ])('format the date %p without cue for date 01/05/2023', (expected, index) => {
+    const date = '05/01/2023';
+    const format = ['ddd, MMM D YYYY', 'ddd, D MMM YYYY', 'D/M/YYYY', 'M/D/YYYY', 'YYYY-MM-DD'];
+
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date(date));
+
+    const wrapper = shallowMount(Preferences, {
+      propsData: { value: 'asd' },
+      computed:  {
+        pm: jest.fn(),
+        am: jest.fn(),
+      },
+      mocks: {
+        $store: {
+          getters: {
+            'prefs/options':        () => format,
+            'prefs/get':            jest.fn(),
+            'management/schemaFor': jest.fn(),
+            isSingleProduct:        jest.fn(),
+            'i18n/t':               jest.fn(),
+          }
+        }
+      },
+      stubs: {
+        BackLink:              { template: '<div />' },
+        ButtonGroup:           { template: '<div />' },
+        LabeledSelect:         { template: '<div />' },
+        Checkbox:              { template: '<div />' },
+        LandingPagePreference: { template: '<div />' },
+        LocaleSelector:        { template: '<div />' },
+      }
+    });
+
+    const options = (wrapper.vm as unknown as any).dateOptions;
+
+    expect(options[index].label).toBe(expected);
+  });
+});

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -73,6 +73,8 @@ export default {
       const currentDate = this.$store.getters['prefs/options'](DATE_FORMAT).map((value) => {
         return now.format(value);
       });
+
+      // Check for duplication of date (date with same digit in month and day) in options list eg. (3/3/2023)
       const isDuplicate = currentDate.some((item, idx) => {
         return currentDate.indexOf(item) !== idx;
       });

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -210,6 +210,7 @@ export default {
             v-model="dateFormat"
             data-testid="prefs__displaySetting__dateFormat"
             :label="t('prefs.dateFormat.label')"
+            option-key="value"
             :options="dateOptions"
           />
         </div>

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -70,7 +70,16 @@ export default {
     dateOptions() {
       const now = day();
 
-      return this.$store.getters['prefs/options'](DATE_FORMAT).map((value) => {
+      return this.$store.getters['prefs/options'](DATE_FORMAT).map((value, index) => {
+        const updateValue = `${ now.format(value) } - (${ value })`;
+
+        if (index > 1) {
+          return {
+            label: updateValue,
+            value
+          };
+        }
+
         return {
           label: now.format(value),
           value

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -70,16 +70,22 @@ export default {
     dateOptions() {
       const now = day();
 
-      return this.$store.getters['prefs/options'](DATE_FORMAT).map((value, index) => {
-        const updateValue = `${ now.format(value) } - (${ value })`;
+      const currentDate = this.$store.getters['prefs/options'](DATE_FORMAT).map((value) => {
+        return now.format(value)
+      })
+      const isDuplicate = currentDate.some(function(item, idx){ 
+          return currentDate.indexOf(item) != idx 
+      });
 
-        if (index > 1) {
+      return this.$store.getters['prefs/options'](DATE_FORMAT).map((value, index) => {
+        const updateValue = `${ now.format(value) } (${ value })`;
+
+        if (index > 1 && isDuplicate) {
           return {
             label: updateValue,
             value
           };
         }
-
         return {
           label: now.format(value),
           value

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -71,10 +71,10 @@ export default {
       const now = day();
 
       const currentDate = this.$store.getters['prefs/options'](DATE_FORMAT).map((value) => {
-        return now.format(value)
-      })
-      const isDuplicate = currentDate.some(function(item, idx){ 
-          return currentDate.indexOf(item) != idx 
+        return now.format(value);
+      });
+      const isDuplicate = currentDate.some((item, idx) => {
+        return currentDate.indexOf(item) !== idx;
       });
 
       return this.$store.getters['prefs/options'](DATE_FORMAT).map((value, index) => {
@@ -86,6 +86,7 @@ export default {
             value
           };
         }
+
         return {
           label: now.format(value),
           value


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8801
<!-- Define findings related to the feature or bug issue. -->

Fixed bug for date format preference when the user selects date format (M/D/YYYY or D/M/YYYY) on a day where the month and day are the same values (e.g. 5/5/2023).


https://github.com/rancher/dashboard/assets/18264463/f82585db-0e6f-4b1c-a01e-00c3a08e6d44

Added visual cue for date formats 

<img width="592" alt="Screenshot 2023-05-24 at 11 19 52" src="https://github.com/rancher/dashboard/assets/18264463/d595c40b-5971-465d-a969-c4d330c2a7ea">


