### PR TITLE
Fix switching between github/gitlab manifests

### DIFF
--- a/pkg/epinio/components/application/AppSource.vue
+++ b/pkg/epinio/components/application/AppSource.vue
@@ -79,19 +79,6 @@ export default Vue.extend<Data, any, any, any>({
     const defaultBuilderImage = this.info?.default_builder_image || DEFAULT_BUILD_PACK;
     const builderImage = this.source?.builderImage?.value || defaultBuilderImage;
 
-    const git = {
-      usernameOrOrg: this.source?.git?.usernameOrOrg || '',
-      repo:          this.source?.git?.repo || '',
-      commit:        this.source?.git?.commit || '',
-      branch:        this.source?.git?.branch || '',
-      url:           this.source?.git?.url || '',
-      sourceData:    this.source?.git?.sourceData || {
-        repos:    [],
-        branches: [],
-        commits:  []
-      }
-    };
-
     return {
       open:  false,
       valid: this.validate(),
@@ -110,18 +97,20 @@ export default Vue.extend<Data, any, any, any>({
         validGitUrl: false,
       },
 
-      git,
-
-      initValue: {
-        type:             this.source?.type,
-        selectedAccOrOrg: git.usernameOrOrg,
-        selectedRepo:     git.repo,
-        selectedBranch:   git.branch,
-        selectedCommit:   { sha: git.commit },
-        repos:            git.sourceData.repos,
-        branches:         git.sourceData.branches,
-        commits:          git.sourceData.commits,
+      git: {
+        usernameOrOrg: this.source?.git?.usernameOrOrg || '',
+        repo:          this.source?.git?.repo || '',
+        commit:        this.source?.git?.commit || '',
+        branch:        this.source?.git?.branch || '',
+        url:           this.source?.git?.url || '',
+        sourceData:    this.source?.git?.sourceData || {
+          repos:    [],
+          branches: [],
+          commits:  []
+        }
       },
+
+      gitSkipTypeReset: false,
 
       builderImage: {
         value:   builderImage,
@@ -140,6 +129,7 @@ export default Vue.extend<Data, any, any, any>({
       EDIT: _EDIT
     };
   },
+
   mounted() {
     if (!this.appChart) {
       if (this.appCharts[0]?.value) {
@@ -188,6 +178,7 @@ export default Vue.extend<Data, any, any, any>({
 
         const type = AppUtils.getSourceType(parsed.origin);
 
+        this.gitSkipTypeReset = true;
         Vue.set(this, 'type', type);
 
         switch (type) {
@@ -305,6 +296,7 @@ export default Vue.extend<Data, any, any, any>({
 
       this.update();
     },
+
     gitUpdate({
       repo, selectedAccOrOrg, branch, commit, sourceData
     }: {
@@ -346,13 +338,21 @@ export default Vue.extend<Data, any, any, any>({
       case APPLICATION_SOURCE_TYPE.GIT_LAB:
         return !!this.git.usernameOrOrg && !!this.git.url && !!this.git.repo && !!this.git.branch && !!this.git.commit;
       }
-    },
+    }
   },
 
   watch: {
     type() {
+      // If we don't skip reseting the git type... we lose changes from loaded manifests
+      if (this.gitSkipTypeReset) {
+        this.gitSkipTypeReset = false;
+      } else {
+        this.git = {};
+      }
+
       this.update();
     },
+
     valid(neu) {
       this.$emit('valid', neu);
     }
@@ -380,12 +380,14 @@ export default Vue.extend<Data, any, any, any>({
       }));
     },
 
-    sourceValue() {
+    gitSource() {
       return {
-        ...this.source.git,
-        type: this.type
+        selectedAccOrOrg: this.git.usernameOrOrg,
+        selectedRepo:     this.git.repo,
+        selectedBranch:   this.git.branch,
+        selectedCommit:   { sha: this.git.commit }
       };
-    },
+    }
   }
 });
 </script>
@@ -503,13 +505,11 @@ export default Vue.extend<Data, any, any, any>({
       </div>
     </template>
     <template v-else>
-      <KeepAlive>
-        <GitPicker
-          :init-value="initValue"
-          :value="sourceValue"
-          @change="gitUpdate"
-        />
-      </KeepAlive>
+      <GitPicker
+        :value="gitSource"
+        :type="type"
+        @change="gitUpdate"
+      />
     </template>
     <Collapse
       :open.sync="open"

--- a/shell/components/form/GitPicker.vue
+++ b/shell/components/form/GitPicker.vue
@@ -39,14 +39,15 @@ export default Vue.extend<Data, any, any, any>({
   },
 
   props: {
-    initValue: {
-      type:    Object,
-      default: null
-    },
     value: {
       type:    Object,
       default: null
     },
+
+    type: {
+      type:    String,
+      default: null
+    }
   },
 
   data() {
@@ -74,16 +75,16 @@ export default Vue.extend<Data, any, any, any>({
   },
 
   watch: {
-    'value.type': {
+    value: {
       async handler(neu, old) {
-        if (neu !== old) {
-          this.reset();
-          if (neu === this.initValue.type) {
-            await this.loadSourceCache();
-          }
+        if (JSON.stringify(neu) === JSON.stringify(old)) {
+          return;
         }
+        this.reset();
+        await this.loadSourceCache(neu.selectedAccOrOrg, neu.selectedRepo, neu.selectedBranch, neu.selectedCommit);
       },
       immediate: true,
+      deep:      true,
     }
   },
 
@@ -92,11 +93,11 @@ export default Vue.extend<Data, any, any, any>({
       return [
         {
           name:  'index',
-          label: this.t(`gitPicker.${ this.value.type }.tableHeaders.choose.label`),
+          label: this.t(`gitPicker.${ this.type }.tableHeaders.choose.label`),
           width: 60,
         }, {
           name:          'sha',
-          label:         this.t(`gitPicker.${ this.value.type }.tableHeaders.sha.label`),
+          label:         this.t(`gitPicker.${ this.type }.tableHeaders.sha.label`),
           width:         90,
           formatter:     'Link',
           formatterOpts: { urlKey: 'htmlUrl' },
@@ -104,21 +105,21 @@ export default Vue.extend<Data, any, any, any>({
         },
         {
           name:  'author',
-          label: this.t(`gitPicker.${ this.value.type }.tableHeaders.author.label`),
+          label: this.t(`gitPicker.${ this.type }.tableHeaders.author.label`),
           width: 190,
           value: 'author.login',
           sort:  'author.login',
         },
         {
           name:  'message',
-          label: this.t(`gitPicker.${ this.value.type }.tableHeaders.message.label`),
+          label: this.t(`gitPicker.${ this.type }.tableHeaders.message.label`),
           value: 'message',
           sort:  'message',
         },
         {
           name:        'date',
           width:       220,
-          label:       this.t(`gitPicker.${ this.value.type }.tableHeaders.date.label`),
+          label:       this.t(`gitPicker.${ this.type }.tableHeaders.date.label`),
           value:       'date',
           sort:        ['date:desc'],
           formatter:   'Date',
@@ -130,11 +131,13 @@ export default Vue.extend<Data, any, any, any>({
     preparedRepos() {
       return this.normalizeArray(this.repos, (item: any) => ({ id: item.id, name: item.name }));
     },
+
     preparedBranches() {
       return this.normalizeArray(this.branches, (item: any) => ({ id: item.id, name: item.name }));
     },
+
     preparedCommits() {
-      return this.normalizeArray(this.commits, (c: any) => GitUtils[this.value.type].normalize.commit(c));
+      return this.normalizeArray(this.commits, (c: any) => GitUtils[this.type].normalize.commit(c));
     },
   },
 
@@ -148,6 +151,7 @@ export default Vue.extend<Data, any, any, any>({
         return await callback(query);
       }, 1000);
     },
+
     reset() {
       this.repos = [];
       this.selectedAccOrOrg = null;
@@ -157,6 +161,7 @@ export default Vue.extend<Data, any, any, any>({
 
       this.communicateReset();
     },
+
     communicateReset() {
       this.$emit('change', {
         selectedAccOrOrg: this.selectedAccOrOrg,
@@ -165,35 +170,35 @@ export default Vue.extend<Data, any, any, any>({
       });
     },
 
-    async loadSourceCache() {
-      this.selectedAccOrOrg = this.initValue.selectedAccOrOrg;
+    async loadSourceCache(accOrOrg: string, repo: { name: string}, branch: { name: string}, commit: { sha: string}) {
+      this.selectedAccOrOrg = accOrOrg;
       if (this.selectedAccOrOrg) {
         await this.fetchRepos()
           .then(() => {
             if (this.repos.length && !this.hasError.repo) {
-              this.selectedRepo = this.initValue.selectedRepo;
+              this.selectedRepo = repo;
 
               return this.fetchBranches();
             }
           })
           .then(() => {
             if (this.branches.length && !this.hasError.branch) {
-              this.selectedBranch = this.initValue.selectedBranch;
+              this.selectedBranch = branch;
 
               return this.fetchCommits();
             }
           });
 
-        const commit = this.commits.find((c: commit) => {
+        const selectedCommit = this.commits.find((c: commit) => {
           // Github has sha's
           // Gitlab has id's as sha's
           const sha = c.sha || c.id;
 
-          return sha === this.initValue.selectedCommit.sha;
+          return sha === commit.sha;
         });
 
-        if (commit) {
-          this.final(commit.sha || commit.id);
+        if (selectedCommit) {
+          this.final(selectedCommit.sha || selectedCommit.id);
         }
       }
     },
@@ -206,7 +211,7 @@ export default Vue.extend<Data, any, any, any>({
         this.communicateReset();
 
         try {
-          const res = await this.$store.dispatch(`${ this.value.type }/fetchRecentRepos`, { username: this.selectedAccOrOrg });
+          const res = await this.$store.dispatch(`${ this.type }/fetchRecentRepos`, { username: this.selectedAccOrOrg });
 
           this.repos = res;
 
@@ -225,7 +230,7 @@ export default Vue.extend<Data, any, any, any>({
       this.communicateReset();
 
       try {
-        const res = await this.$store.dispatch(`${ this.value.type }/fetchBranches`, { repo: this.selectedRepo, username: this.selectedAccOrOrg });
+        const res = await this.$store.dispatch(`${ this.type }/fetchBranches`, { repo: this.selectedRepo, username: this.selectedAccOrOrg });
 
         this.branches = res;
         this.hasError.branch = false;
@@ -233,13 +238,14 @@ export default Vue.extend<Data, any, any, any>({
         this.hasError.branch = true;
       }
     },
+
     async fetchCommits() {
       this.selectedCommit = {};
 
       this.communicateReset();
 
       try {
-        const res = await this.$store.dispatch(`${ this.value.type }/fetchCommits`, {
+        const res = await this.$store.dispatch(`${ this.type }/fetchCommits`, {
           repo:     this.selectedRepo,
           username: this.selectedAccOrOrg,
           branch:   this.selectedBranch,
@@ -262,7 +268,7 @@ export default Vue.extend<Data, any, any, any>({
     final(commitId: string) {
       this.selectedCommit = this.preparedCommits.find((c: { commitId?: string }) => c.commitId === commitId);
 
-      if (this.selectedAccOrOrg && this.selectedRepo && this.selectedCommit.commitId) {
+      if (this.selectedAccOrOrg && this.selectedRepo && this.selectedCommit?.commitId) {
         this.$emit('change', {
           selectedAccOrOrg: this.selectedAccOrOrg,
           repo:             this.selectedRepo,
@@ -277,6 +283,7 @@ export default Vue.extend<Data, any, any, any>({
         });
       }
     },
+
     async searchRepo(query: string) {
       if (query.length) {
         // Check if the result is already in the fetched list.
@@ -284,7 +291,7 @@ export default Vue.extend<Data, any, any, any>({
 
         if (!resultInCurrentState.length) {
           // Search for specific repo under the username
-          const res = await this.$store.dispatch(`${ this.value.type }/search`, {
+          const res = await this.$store.dispatch(`${ this.type }/search`, {
             repo:     { id: query, name: query },
             username: this.selectedAccOrOrg
           });
@@ -301,8 +308,9 @@ export default Vue.extend<Data, any, any, any>({
         }
       }
     },
+
     async searchBranch(query: string) {
-      const res = await this.$store.dispatch(`${ this.value.type }/search`, {
+      const res = await this.$store.dispatch(`${ this.type }/search`, {
         repo:     this.selectedRepo,
         branch:   { name: query },
         username: this.selectedAccOrOrg,
@@ -314,14 +322,17 @@ export default Vue.extend<Data, any, any, any>({
         this.branches = res;
       }
     },
+
     status(value: boolean) {
       return value ? 'error' : null;
     },
+
     reposRules() {
-      return this.hasError.repo ? this.t(`gitPicker.${ this.value.type }.errors.noAccount`) : null;
+      return this.hasError.repo ? this.t(`gitPicker.${ this.type }.errors.noAccount`) : null;
     },
+
     branchesRules() {
-      return this.hasError.branch ? this.t(`gitPicker.${ this.value.type }.errors.noBranch`) : null;
+      return this.hasError.branch ? this.t(`gitPicker.${ this.type }.errors.noBranch`) : null;
     },
   },
 });
@@ -334,8 +345,8 @@ export default Vue.extend<Data, any, any, any>({
         <LabeledInput
           v-model="selectedAccOrOrg"
           data-testid="epinio_app-source_git-username"
-          :tooltip="t(`gitPicker.${ value.type }.username.tooltip`)"
-          :label="t(`gitPicker.${ value.type }.username.inputLabel`)"
+          :tooltip="t(`gitPicker.${ type }.username.tooltip`)"
+          :label="t(`gitPicker.${ type }.username.inputLabel`)"
           :required="true"
           :rules="[reposRules]"
           :delay="500"
@@ -351,7 +362,7 @@ export default Vue.extend<Data, any, any, any>({
         <LabeledSelect
           v-model="selectedRepo"
           :required="true"
-          :label="t(`gitPicker.${ value.type }.repo.inputLabel`)"
+          :label="t(`gitPicker.${ type }.repo.inputLabel`)"
           :options="preparedRepos"
           :clearable="true"
           :searchable="true"
@@ -371,7 +382,7 @@ export default Vue.extend<Data, any, any, any>({
         <LabeledSelect
           v-model="selectedBranch"
           :required="true"
-          :label="t(`gitPicker.${ value.type }.branch.inputLabel`)"
+          :label="t(`gitPicker.${ type }.branch.inputLabel`)"
           :options="preparedBranches"
           :clearable="false"
           :reduce="(e) => e"
@@ -423,7 +434,7 @@ export default Vue.extend<Data, any, any, any>({
                 </a>
               </template>
               <template v-else>
-                {{ t(`gitPicker.${ value.type }.tableHeaders.author.unknown`) }}
+                {{ t(`gitPicker.${ type }.tableHeaders.author.unknown`) }}
               </template>
             </div>
           </template>


### PR DESCRIPTION
- Make switching between github/gitlab in all scenarios simpler
- in git picker whenever the value changes ... we reset and reload
- in app source ensure the value only changes when there's been a required reload
  - this includes forcing one when type changes from any type to any type
- this does mean there will be more http requests to gitX when switching between types

Fixes https://github.com/epinio/ui/issues/238