### PR TITLE
add cluster-name label to prometheus recording and alerting rules

### DIFF
--- a/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -33,9 +33,10 @@ export default {
       expr:   '',
       for:    '0s',
       labels: {
-        severity:   'none',
-        namespace:  'default',
-        cluster_id: this.$store.getters['clusterId']
+        severity:     'none',
+        namespace:    'default',
+        cluster_id:   this.$store.getters['clusterId'],
+        cluster_name: this.$store.getters['currentCluster'].spec.displayName
       },
     };
 
@@ -95,9 +96,11 @@ export default {
           record: '',
           expr:   '',
           labels: {
-            severity:   'none',
-            namespace:  'default',
-            cluster_id: this.$store.getters['clusterId']
+            severity:     'none',
+            namespace:    'default',
+            cluster_id:   this.$store.getters['clusterId'],
+            cluster_name: this.$store.getters['currentCluster'].spec.displayName
+
           },
         });
         break;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8902 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds another default label to prometheus alerting rules, as we do with the cluster id (#7935):
![Screen Shot 2023-05-22 at 3 00 42 PM](https://github.com/rancher/dashboard/assets/42977925/e9dc09ba-234d-4f66-8e84-d723419b750d)

