### PR TITLE
Only publish docusaurus if something has changed for docs

### DIFF
--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docusaurus/**'
   pull_request:
     branches:
       - master
+    paths:
+      - 'docusaurus/**'
 jobs:
   deploy:
     name: Publish Docusaurus

--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -1,16 +1,13 @@
 name: Publish Docusaurus
 
 on:
+  on:
   push:
-    branches:
-      - master
-    paths:
-      - 'docusaurus/**'
+    branches: ['master']
+    paths: ['docusaurus/**']
   pull_request:
-    branches:
-      - master
-    paths:
-      - 'docusaurus/**'
+    branches: ['master']
+    paths: ['docusaurus/**']
 jobs:
   deploy:
     name: Publish Docusaurus

--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -1,7 +1,6 @@
 name: Publish Docusaurus
 
 on:
-  on:
   push:
     branches: ['master']
     paths: ['docusaurus/**']


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the docusaurus github action so that it will only attempt to publish docs if there has been a change made to the `docusaurus` directory.