### PR TITLE
Fix log in --> redirect to log out

### DIFF
--- a/shell/plugins/steve/worker/index.js
+++ b/shell/plugins/steve/worker/index.js
@@ -4,9 +4,10 @@ import basicWorkerConstructor from '@shell/plugins/steve/worker/web-worker.basic
 import advancedWorkerConstructor from '@shell/plugins/steve/worker/web-worker.advanced.js';
 
 export const WORKER_MODES = {
-  WAITING:  'waiting',
-  BASIC:    'basic',
-  ADVANCED: 'advanced'
+  WAITING:      'waiting',
+  DESTROY_MOCK: 'destroy',
+  BASIC:        'basic',
+  ADVANCED:     'advanced'
 };
 
 export default function storeWorker(mode, options = {}, closures = {}) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#8921
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- This occurred because..
  - The user tries to access resource with 401 response --> onLogout dispatched
  - onLogout unbsubscribes to all stores
  - destroyWorker is called
  - stores are waiting for mgmt stores to be ready (from when they were created) and delaying any execution of messages
  - user still redirected to log in page (not sure how...)
  - user logs in
  - mgmt stores now ready
  - stores now unblocked from waiting for mgmt --> continue in original onLogOut action
- Fix is to ensure we exit the wait early if we get the call to unsubscribe


### Areas or cases that should be tested
- log in, out, shake it all about works fine
- above works with both advanced worker enabled and disabled
