### PR TITLE
Ensure Project Members tab shows groups

### DIFF
--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -186,17 +186,25 @@ export default {
 
       // We need to group each of the TemplateRoleBindings by the user + project
       const userRoles = [...fakeRows, ...this.filteredProjectRoleTemplateBindings].reduce((rows, curr) => {
-        const { userId, roleTemplate, projectId } = curr;
+        const {
+          userId, groupPrincipalId, roleTemplate, projectId
+        } = curr;
 
-        const userKey = userId + projectId;
+        const userOrGroup = userId || groupPrincipalId;
 
-        if (!rows[userKey] && userId ) {
-          rows[userKey] = curr;
-          rows[userKey].allRoles = [];
+        if (!userOrGroup) {
+          return rows;
         }
 
-        if (roleTemplate && userId) {
-          rows[userKey].allRoles.push(curr.roleTemplate);
+        const userOrGroupKey = userOrGroup + projectId;
+
+        if (!rows[userOrGroupKey] ) {
+          rows[userOrGroupKey] = curr;
+          rows[userOrGroupKey].allRoles = [];
+        }
+
+        if (roleTemplate) {
+          rows[userOrGroupKey].allRoles.push(curr.roleTemplate);
         }
 
         return rows;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#8924
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Groups were shown on Cluster & Project Members page cluster tab, but not on the project tabs
- Now groups are shown on that tab

### Areas or cases that should be tested
- Project roles of users
- Project roles of groups

Note - It looks like configuring an Auth Provider, like Github, does not work when serving the dashboard locally (due to the server middleware which redirects `/verify-auth` to `/auth/verify` not being wired in). I had to add the following to `routes` in `shell/config/router.js`

```
{
    path:     '/verify-auth',
    redirect: (to) => {
      return 'auth/verify';
    },
  }
```

See https://github.com/rancher/dashboard/issues/8961