### PR TITLE
Fix import for utils/array

### DIFF
--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -8,7 +8,7 @@ import IconMessage from '@shell/components/IconMessage.vue';
 import { ResourceListComponentName } from './resource-list.config';
 import { PanelLocation, ExtensionPoint } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
-import { sameContents } from 'utils/array';
+import { sameContents } from '@shell/utils/array';
 
 export default {
   name: ResourceListComponentName,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes an issue with the import of `utils/array` within the ResourceList component. If this component is used within an extension, the module will not be found during a build.
An example can be [seen here](https://github.com/kubewarden/ui/actions/runs/5058140039/jobs/9077838810?pr=364#step:9:138)

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Updated the import to include `@shell`.

