### PR TITLE
ui automation: home page automation

### DIFF
--- a/cypress/e2e/po/components/banner-graphic.po.ts
+++ b/cypress/e2e/po/components/banner-graphic.po.ts
@@ -1,0 +1,15 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class BannerGraphicPo extends ComponentPo {
+  constructor(selector: string = '.dashboard-root') {
+    super(selector);
+  }
+
+  graphicBanner(): Cypress.Chainable {
+    return cy.getId('home-banner-graphic');
+  }
+
+  graphicBannerCloseButton(): Cypress.Chainable {
+    return cy.getId('graphic-banner-close').click({ force: true });
+  }
+}

--- a/cypress/e2e/po/components/banner-graphic.po.ts
+++ b/cypress/e2e/po/components/banner-graphic.po.ts
@@ -1,7 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class BannerGraphicPo extends ComponentPo {
-  constructor(selector: string = '.dashboard-root') {
+  constructor(selector = '.dashboard-root') {
     super(selector);
   }
 

--- a/cypress/e2e/po/components/banners.po.ts
+++ b/cypress/e2e/po/components/banners.po.ts
@@ -1,5 +1,39 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class BannersPo extends ComponentPo {
+  constructor(selector: string = '.dashboard-root') {
+    super(selector);
+  }
 
+  /**
+   * Get banner content
+   * @returns
+   */
+  banner(): Cypress.Chainable {
+    return cy.getId('banner-content');
+  }
+
+  /**
+   * Get change log banner
+   * @returns
+   */
+  changelog(): Cypress.Chainable {
+    return cy.getId('changelog-banner');
+  }
+
+  /**
+   * Get set login page banner
+   * @returns
+   */
+  setLoginPageBanner(): Cypress.Chainable {
+    return cy.getId('set-login-page-banner');
+  }
+
+  /**
+   * Click close button
+   * @returns
+   */
+  closeButton(): Cypress.Chainable {
+    return cy.getId('banner-close').click({ force: true });
+  }
 }

--- a/cypress/e2e/po/components/banners.po.ts
+++ b/cypress/e2e/po/components/banners.po.ts
@@ -1,7 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class BannersPo extends ComponentPo {
-  constructor(selector: string = '.dashboard-root') {
+  constructor(selector = '.dashboard-root') {
     super(selector);
   }
 

--- a/cypress/e2e/po/components/banners.po.ts
+++ b/cypress/e2e/po/components/banners.po.ts
@@ -25,7 +25,7 @@ export default class BannersPo extends ComponentPo {
    * Get set login page banner
    * @returns
    */
-  setLoginPageBanner(): Cypress.Chainable {
+  getLoginPageBanner(): Cypress.Chainable {
     return cy.getId('set-login-page-banner');
   }
 

--- a/cypress/e2e/po/components/simple-box.po.ts
+++ b/cypress/e2e/po/components/simple-box.po.ts
@@ -1,7 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class SimpleBoxPo extends ComponentPo {
-  constructor(selector: string = '.dashboard-root') {
+  constructor(selector = '.dashboard-root') {
     super(selector);
   }
 

--- a/cypress/e2e/po/components/simple-box.po.ts
+++ b/cypress/e2e/po/components/simple-box.po.ts
@@ -1,0 +1,11 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class SimpleBoxPo extends ComponentPo {
+  constructor(selector: string = '.dashboard-root') {
+    super(selector);
+  }
+
+  simpleBox(): Cypress.Chainable {
+    return cy.getId('simple-box-container');
+  }
+}

--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -59,6 +59,18 @@ export default class SortableTablePo extends ComponentPo {
     return cy.get('.action-availability');
   }
 
+  /**
+   * Search box to query rows
+   * @param searchText
+   * @returns
+   */
+  filter(searchText: string) {
+    return cy.get('[data-testid="search-box-filter-row"] input')
+      .focus()
+      .clear()
+      .type(searchText);
+  }
+
   //
   // sortable-table
   //

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.po.ts
@@ -4,10 +4,16 @@ import ClusterManagerCreateImportPagePo from '@/cypress/e2e/po/edit/provisioning
  * Covers core functionality that's common to the dashboard's import cluster pages
  */
 export default class ClusterManagerImportPagePo extends ClusterManagerCreateImportPagePo {
-  static url = '/c/local/manager/provisioning.cattle.io.cluster/create'
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/manager/provisioning.cattle.io.cluster/create`;
+  }
 
-  constructor() {
-    super(ClusterManagerImportPagePo.url);
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(ClusterManagerImportPagePo.createPath(clusterId));
+  }
+
+  constructor(clusterId: string) {
+    super(ClusterManagerImportPagePo.createPath(clusterId));
   }
 
   selectKubeProvider(index: number) {

--- a/cypress/e2e/po/lists/home-cluster-list.po.ts
+++ b/cypress/e2e/po/lists/home-cluster-list.po.ts
@@ -1,0 +1,22 @@
+import BaseResourceList from '~/cypress/e2e/po/lists/base-resource-list.po';
+
+/**
+ * List component for home page cluster resources
+ */
+export default class HomeClusterListPo extends BaseResourceList {
+  state(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(0);
+  }
+
+  name(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(1);
+  }
+
+  version(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(3);
+  }
+
+  provider(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(2);
+  }
+}

--- a/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
@@ -4,6 +4,22 @@ import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
  * List component for provisioning.cattle.io.cluster resources
  */
 export default class ProvClusterListPo extends BaseResourceList {
+  state(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(1);
+  }
+
+  name(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(2);
+  }
+
+  version(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(3);
+  }
+
+  provider(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(4);
+  }
+
   explore(clusterName: string) {
     return this.resourceTable().sortableTable().rowWithName(clusterName).column(7)
       .find('.btn');

--- a/cypress/e2e/po/pages/docs/whats-new.po.ts
+++ b/cypress/e2e/po/pages/docs/whats-new.po.ts
@@ -1,7 +1,7 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 
 export default class WhatsNewPagePo extends PagePo {
-  static url: string = '/docs/whats-new'
+  static url = '/docs/whats-new'
   static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
     return super.goTo(WhatsNewPagePo.url);
   }

--- a/cypress/e2e/po/pages/docs/whats-new.po.ts
+++ b/cypress/e2e/po/pages/docs/whats-new.po.ts
@@ -1,0 +1,16 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+
+export default class WhatsNewPagePo extends PagePo {
+  static url: string = '/docs/whats-new'
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(WhatsNewPagePo.url);
+  }
+
+  constructor() {
+    super(WhatsNewPagePo.url);
+  }
+
+  title(): Cypress.Chainable {
+    return cy.get('.breadcrumbs');
+  }
+}

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -1,4 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
+import PageActions from '@/cypress/e2e/po/side-bars/page-actions.po';
+import HomeClusterListPo from '~/cypress/e2e/po/lists/home-cluster-list.po';
 
 export default class HomePagePo extends PagePo {
   static url = '/home'
@@ -18,10 +20,98 @@ export default class HomePagePo extends PagePo {
   }
 
   title(): Cypress.Chainable<string> {
-    return this.self().getId('banner-title').invoke('text');
+    return cy.getId('banner-title').invoke('text');
   }
 
-  changelog(): Cypress.Chainable<string> {
-    return this.self().getId('changelog-banner').invoke('text');
+  graphicBanner(): Cypress.Chainable {
+    return cy.getId('home-banner-graphic');
+  }
+
+  graphicBannerCloseButton(): Cypress.Chainable {
+    return cy.getId('graphic-banner-close').click({ force: true });
+  }
+
+  setLoginPageBanner(): Cypress.Chainable {
+    return cy.getId('set-login-page-banner');
+  }
+
+  closeButton(): Cypress.Chainable {
+    return cy.getId('banner-close').click({ force: true });
+  }
+
+  banner(): Cypress.Chainable {
+    return cy.getId('banner-content');
+  }
+
+  prefPageLink(): Cypress.Chainable {
+    return cy.getId('pref-banner-link');
+  }
+
+  changelog(): Cypress.Chainable {
+    return cy.getId('changelog-banner');
+  }
+
+  whatsNewBannerLink(): Cypress.Chainable {
+    return cy.get('[data-testid="changelog-banner"] a');
+  }
+
+  waitForRestore() {
+    const pageActionsPo = new PageActions();
+
+    cy.intercept('PUT', 'v1/userpreferences/*', (req) => {
+      if (req?.body?.data?.['home-page-cards'] === '{}') {
+        req.alias = 'restoreBanners';
+      }
+    });
+    pageActionsPo.restoreLink().click();
+    cy.wait('@restoreBanners');
+  }
+
+  list(): HomeClusterListPo {
+    return new HomeClusterListPo('[data-testid="cluster-list-container"]');
+  }
+
+  manangeButton() {
+    return cy.getId('cluster-management-manage-button');
+  }
+
+  importExistingButton() {
+    return cy.getId('cluster-create-import-button');
+  }
+
+  createButton() {
+    return cy.getId('cluster-create-button');
+  }
+
+  filter(searchText: string) {
+    return cy.get('[data-testid="search-box-filter-row"] input')
+      .focus()
+      .clear()
+      .type(searchText);
+  }
+
+  supportLinks() {
+    return cy.getId('simple-box-container').find('.support-link > a');
+  }
+
+  /**
+   * Click support link
+   * Cypress does not support multiple tabs - must remove target attribute before clicking
+   * https://docs.cypress.io/guides/references/trade-offs#Multiple-tabs
+   * @param index
+   * @param isNewTab
+   * @returns
+   */
+  clickSupportLink(index: number, isNewTab?: boolean) {
+    if (isNewTab) {
+      this.supportLinks().eq(index).then((el) => {
+        expect(el).to.have.attr('target');
+      }).invoke('removeAttr', 'target')
+        .click();
+    } else {
+      return this.supportLinks().eq(index).then((el) => {
+        expect(el).to.not.have.attr('target');
+      }).click();
+    }
   }
 }

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -1,6 +1,10 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import PageActions from '@/cypress/e2e/po/side-bars/page-actions.po';
+import BannersPo from '~/cypress/e2e/po/components/banners.po';
+import SimpleBoxPo from '~/cypress/e2e/po/components/simple-box.po';
 import HomeClusterListPo from '~/cypress/e2e/po/lists/home-cluster-list.po';
+
+const banners = new BannersPo();
 
 export default class HomePagePo extends PagePo {
   static url = '/home'
@@ -23,36 +27,12 @@ export default class HomePagePo extends PagePo {
     return cy.getId('banner-title').invoke('text');
   }
 
-  graphicBanner(): Cypress.Chainable {
-    return cy.getId('home-banner-graphic');
-  }
-
-  graphicBannerCloseButton(): Cypress.Chainable {
-    return cy.getId('graphic-banner-close').click({ force: true });
-  }
-
-  setLoginPageBanner(): Cypress.Chainable {
-    return cy.getId('set-login-page-banner');
-  }
-
-  closeButton(): Cypress.Chainable {
-    return cy.getId('banner-close').click({ force: true });
-  }
-
-  banner(): Cypress.Chainable {
-    return cy.getId('banner-content');
-  }
-
   prefPageLink(): Cypress.Chainable {
-    return cy.getId('pref-banner-link');
-  }
-
-  changelog(): Cypress.Chainable {
-    return cy.getId('changelog-banner');
+    return banners.setLoginPageBanner().find('a');
   }
 
   whatsNewBannerLink(): Cypress.Chainable {
-    return cy.get('[data-testid="changelog-banner"] a');
+    return banners.changelog().find('a');
   }
 
   restoreAndWait() {
@@ -79,15 +59,10 @@ export default class HomePagePo extends PagePo {
     return cy.getId('cluster-create-button');
   }
 
-  filter(searchText: string) {
-    return cy.get('[data-testid="search-box-filter-row"] input')
-      .focus()
-      .clear()
-      .type(searchText);
-  }
+  supportLinks(): Cypress.Chainable {
+    const simpleBox = new SimpleBoxPo();
 
-  supportLinks() {
-    return cy.getId('simple-box-container').find('.support-link > a');
+    return simpleBox.simpleBox().find('.support-link > a');
   }
 
   /**

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -55,16 +55,12 @@ export default class HomePagePo extends PagePo {
     return cy.get('[data-testid="changelog-banner"] a');
   }
 
-  waitForRestore() {
+  restoreAndWait() {
     const pageActionsPo = new PageActions();
 
-    cy.intercept('PUT', 'v1/userpreferences/*', (req) => {
-      if (req?.body?.data?.['home-page-cards'] === '{}') {
-        req.alias = 'restoreBanners';
-      }
-    });
+    cy.intercept('PUT', 'v1/userpreferences/*').as('restoreBanners');
     pageActionsPo.restoreLink().click();
-    cy.wait('@restoreBanners');
+    cy.wait(['@restoreBanners', '@restoreBanners']);
   }
 
   list(): HomeClusterListPo {

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -28,7 +28,7 @@ export default class HomePagePo extends PagePo {
   }
 
   prefPageLink(): Cypress.Chainable {
-    return banners.setLoginPageBanner().find('a');
+    return banners.getLoginPageBanner().find('a');
   }
 
   whatsNewBannerLink(): Cypress.Chainable {

--- a/cypress/e2e/po/side-bars/page-actions.po.ts
+++ b/cypress/e2e/po/side-bars/page-actions.po.ts
@@ -10,7 +10,7 @@ export default class PageActionsPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   static open(): Cypress.Chainable {
-    return cy.getId('page-actions-menu').click({ force: true });
+    return cy.getId('page-actions-menu').should('be.visible').click();
   }
 
   /**
@@ -40,7 +40,7 @@ export default class PageActionsPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   links(): Cypress.Chainable {
-    return this.self().find('.user-menu-item');
+    return this.self().find('.user-menu-item').should('be.visible');
   }
 
   /**

--- a/cypress/e2e/po/side-bars/page-actions.po.ts
+++ b/cypress/e2e/po/side-bars/page-actions.po.ts
@@ -36,11 +36,13 @@ export default class PageActionsPo extends ComponentPo {
   }
 
   /**
-   * Get all the links of the side navigation
+   * Open page action menu and get all the links
    * @returns {Cypress.Chainable}
    */
   links(): Cypress.Chainable {
-    return this.self().find('.user-menu-item').should('be.visible');
+    return PageActionsPo.open().then(() => {
+      PageActionsPo.pageActionsMenu().find('.user-menu-item');
+    });
   }
 
   /**

--- a/cypress/e2e/tests/pages/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/cluster-manager.spec.ts
@@ -115,7 +115,7 @@ describe('Cluster Manager', () => {
   });
 
   describe('Imported', () => {
-    const importClusterPage = new ClusterManagerImportGenericPagePo();
+    const importClusterPage = new ClusterManagerImportGenericPagePo('local');
 
     describe('Generic', () => {
       const editImportedClusterPage = new ClusterManagerEditGenericPagePo(importGenericName);

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -4,11 +4,17 @@ import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
 import ClusterManagerListPagePo from '~/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerImportGenericPagePo from '~/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.generic.po';
 import WhatsNewPagePo from '~/cypress/e2e/po/pages/docs/whats-new.po';
+import BannerGraphicPo from '~/cypress/e2e/po/components/banner-graphic.po';
+import BannersPo from '~/cypress/e2e/po/components/banners.po';
+import SortableTablePo from '~/cypress/e2e/po/components/sortable-table.po';
 
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
 const whatsNewPage = new WhatsNewPagePo();
+const bannerGraphic = new BannerGraphicPo();
+const banners = new BannersPo();
+const sortableTable = new SortableTablePo('.dashboard-root');
 
 describe('User can perform actions on the Home Page', () => {
   beforeEach(() => {
@@ -28,15 +34,15 @@ describe('User can perform actions on the Home Page', () => {
 
     homePage.restoreAndWait();
 
-    homePage.whatsNewBannerLink().invoke('text').then((el) => {
+    banners.changelog().find('a').invoke('text').then((el) => {
       text.push(el);
     });
 
-    homePage.changelog().invoke('text').then((el) => {
+    banners.changelog().invoke('text').then((el) => {
       expect(el).contains(text[0]);
     });
 
-    homePage.whatsNewBannerLink().click();
+    banners.changelog().find('a').click();
     whatsNewPage.waitForPage();
     whatsNewPage.title().invoke('text').then((el: string) => {
       expect(el.toLowerCase()).contains(text[0].toLowerCase());
@@ -44,7 +50,7 @@ describe('User can perform actions on the Home Page', () => {
 
     BurgerMenuPo.toggle();
     burgerMenuPo.home().click();
-    homePage.changelog().should('not.exist');
+    banners.changelog().should('not.exist');
   });
 
   it('Can navigate to Preferences page', () => {
@@ -68,18 +74,18 @@ describe('User can perform actions on the Home Page', () => {
 
     homePage.restoreAndWait();
 
-    homePage.graphicBanner().should('be.visible');
-    homePage.graphicBannerCloseButton();
-    homePage.graphicBanner().should('not.exist');
+    bannerGraphic.graphicBanner().should('be.visible');
+    bannerGraphic.graphicBannerCloseButton();
+    bannerGraphic.graphicBanner().should('not.exist');
 
-    homePage.setLoginPageBanner().should('be.visible');
-    homePage.closeButton();
-    homePage.setLoginPageBanner().should('not.exist');
+    banners.setLoginPageBanner().should('be.visible');
+    banners.closeButton();
+    banners.setLoginPageBanner().should('not.exist');
 
     homePage.restoreAndWait();
 
-    homePage.graphicBanner().should('be.visible');
-    homePage.setLoginPageBanner().should('be.visible');
+    bannerGraphic.graphicBanner().should('be.visible');
+    banners.setLoginPageBanner().should('be.visible');
   });
 
   it('Can see that cluster details match those in Cluster Manangement page', () => {
@@ -151,12 +157,12 @@ describe('User can perform actions on the Home Page', () => {
      * Filter rows in the cluster list
      */
 
-    homePage.filter('random text');
+    sortableTable.filter('random text');
     homeClusterList.resourceTable().sortableTable().rowElements().should((el) => {
       expect(el).to.contain.text('There are no rows which match your search query.');
     });
 
-    homePage.filter('local');
+    sortableTable.filter('local');
     homeClusterList.name('local').should((el) => {
       expect(el).to.contain.text('local');
     });

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -34,7 +34,7 @@ describe('User can perform actions on the Home Page', () => {
 
     homePage.restoreAndWait();
 
-    banners.changelog().find('a').invoke('text').then((el) => {
+    homePage.whatsNewBannerLink().invoke('text').then((el) => {
       text.push(el);
     });
 
@@ -42,7 +42,7 @@ describe('User can perform actions on the Home Page', () => {
       expect(el).contains(text[0]);
     });
 
-    banners.changelog().find('a').click();
+    homePage.whatsNewBannerLink().click();
     whatsNewPage.waitForPage();
     whatsNewPage.title().invoke('text').then((el: string) => {
       expect(el.toLowerCase()).contains(text[0].toLowerCase());

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -15,7 +15,7 @@ describe('User can perform actions on the Home Page', () => {
   beforeEach(() => {
     cy.login();
 
-    HomePagePo.goTo();
+    HomePagePo.goToAndWaitForGet();
   });
 
   it('Can navigate to What\'s new page', () => {

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -78,14 +78,14 @@ describe('User can perform actions on the Home Page', () => {
     bannerGraphic.graphicBannerCloseButton();
     bannerGraphic.graphicBanner().should('not.exist');
 
-    banners.setLoginPageBanner().should('be.visible');
+    banners.getLoginPageBanner().should('be.visible');
     banners.closeButton();
-    banners.setLoginPageBanner().should('not.exist');
+    banners.getLoginPageBanner().should('not.exist');
 
     homePage.restoreAndWait();
 
     bannerGraphic.graphicBanner().should('be.visible');
-    banners.setLoginPageBanner().should('be.visible');
+    banners.getLoginPageBanner().should('be.visible');
   });
 
   it('Can see that cluster details match those in Cluster Manangement page', () => {

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -137,11 +137,11 @@ describe('User can perform actions on the Home Page', () => {
     homePage.manangeButton().click();
     clusterManagerPage.waitForPage();
 
-    HomePagePo.goTo();
+    HomePagePo.goToAndWaitForGet();
     homePage.importExistingButton().click();
     genericCreateClusterPage.waitForPage('mode=import');
 
-    HomePagePo.goTo();
+    HomePagePo.goToAndWaitForGet();
     homePage.createButton().click();
     genericCreateClusterPage.waitForPage();
   });
@@ -179,33 +179,33 @@ describe('User can perform actions on the Home Page', () => {
     // click Forums link
     // NOTE: Cypress does not recognize when the Forum page's contents are loaded
     // which is resulting in a time out error and this test to fail
-    // HomePagePo.goTo();
+    // HomePagePo.goToAndWaitForGet();
     // homePage.clickSupportLink(1, true);
     // cy.origin('https://rancher.com', () => {
     //   cy.url().should('include', 'forums.rancher.com/');
     // });
 
     // click Slack link
-    HomePagePo.goTo();
+    HomePagePo.goToAndWaitForGet();
     homePage.clickSupportLink(2, true);
     cy.origin('https://rancher.io', () => {
       cy.url().should('include', 'slack.rancher.io/');
     });
 
     // click File an Issue link
-    HomePagePo.goTo();
+    HomePagePo.goToAndWaitForGet();
     homePage.clickSupportLink(3, true);
     cy.origin('https://github.com', () => {
       cy.url().should('include', 'github.com/login');
     });
 
     // click Get Started link
-    HomePagePo.goTo();
+    HomePagePo.goToAndWaitForGet();
     homePage.clickSupportLink(4);
     cy.url().should('include', 'docs/getting-started');
 
     // click Commercial Support link
-    HomePagePo.goTo();
+    HomePagePo.goToAndWaitForGet();
     homePage.clickSupportLink(5);
     cy.url().should('include', '/support');
   });

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -28,7 +28,7 @@ describe('User can perform actions on the Home Page', () => {
     const text: string[] = [];
 
     PageActions.open();
-    homePage.waitForRestore();
+    homePage.restoreAndWait();
 
     homePage.whatsNewBannerLink().invoke('text').then((el) => {
       text.push(el);
@@ -69,7 +69,7 @@ describe('User can perform actions on the Home Page', () => {
      */
 
     PageActions.open();
-    homePage.waitForRestore();
+    homePage.restoreAndWait();
 
     homePage.graphicBanner().should('be.visible');
     homePage.graphicBannerCloseButton();
@@ -80,7 +80,7 @@ describe('User can perform actions on the Home Page', () => {
     homePage.setLoginPageBanner().should('not.exist');
 
     PageActions.open();
-    homePage.waitForRestore();
+    homePage.restoreAndWait();
 
     homePage.graphicBanner().should('be.visible');
     homePage.setLoginPageBanner().should('be.visible');

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -1,6 +1,5 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
-import PageActions from '@/cypress/e2e/po/side-bars/page-actions.po';
 import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
 import ClusterManagerListPagePo from '~/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerImportGenericPagePo from '~/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.generic.po';
@@ -27,7 +26,6 @@ describe('User can perform actions on the Home Page', () => {
     const burgerMenuPo = new BurgerMenuPo();
     const text: string[] = [];
 
-    PageActions.open();
     homePage.restoreAndWait();
 
     homePage.whatsNewBannerLink().invoke('text').then((el) => {
@@ -68,7 +66,6 @@ describe('User can perform actions on the Home Page', () => {
      * Verify banners display on home page
      */
 
-    PageActions.open();
     homePage.restoreAndWait();
 
     homePage.graphicBanner().should('be.visible');
@@ -79,7 +76,6 @@ describe('User can perform actions on the Home Page', () => {
     homePage.closeButton();
     homePage.setLoginPageBanner().should('not.exist');
 
-    PageActions.open();
     homePage.restoreAndWait();
 
     homePage.graphicBanner().should('be.visible');

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -1,34 +1,216 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import PageActions from '@/cypress/e2e/po/side-bars/page-actions.po';
+import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
+import ClusterManagerListPagePo from '~/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import ClusterManagerImportGenericPagePo from '~/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.generic.po';
+import WhatsNewPagePo from '~/cypress/e2e/po/pages/docs/whats-new.po';
 
-describe('Home Page', () => {
+const homePage = new HomePagePo();
+const homeClusterList = homePage.list();
+const provClusterList = new ClusterManagerListPagePo('local');
+const whatsNewPage = new WhatsNewPagePo();
+
+describe('User can perform actions on the Home Page', () => {
   beforeEach(() => {
     cy.login();
 
     HomePagePo.goTo();
   });
 
-  it('Has a top-level nav menu', () => {
-    BurgerMenuPo.toggle();
-
+  it('Can navigate to What\'s new page', () => {
+    /**
+     * Click link on home page and verify user lands on What's new page
+     * Verify contents of What's new page
+     * Verify changlog banner is hidden after navigating to the page
+     */
     const burgerMenuPo = new BurgerMenuPo();
-
-    burgerMenuPo.checkVisible();
-  });
-
-  it.skip('Displays changelog section', () => {
-    const homePage = new HomePagePo();
-    const pageActionsPo = new PageActions();
+    const text: string[] = [];
 
     PageActions.open();
-    pageActionsPo.restoreLink().click();
-    homePage
-      .checkIsCurrentPage();
+    homePage.waitForRestore();
 
-    // This element is hidden after navigating to the page
-    homePage
-      .changelog()
-      .should('contain', `What's new in`);
+    homePage.whatsNewBannerLink().invoke('text').then((el) => {
+      text.push(el);
+    });
+
+    homePage.changelog().invoke('text').then((el) => {
+      expect(el).contains(text[0]);
+    });
+
+    homePage.whatsNewBannerLink().click();
+    whatsNewPage.waitForPage();
+    whatsNewPage.title().invoke('text').then((el: string) => {
+      expect(el.toLowerCase()).contains(text[0].toLowerCase());
+    });
+
+    BurgerMenuPo.toggle();
+    burgerMenuPo.home().click();
+    homePage.changelog().should('not.exist');
+  });
+
+  it('Can navigate to Preferences page', () => {
+    /**
+     * Click link and verify user lands on preferences page
+     */
+    const prefPage = new PreferencesPagePo();
+
+    homePage.prefPageLink().click();
+    prefPage.waitForPage();
+    prefPage.checkIsCurrentPage();
+    prefPage.title();
+  });
+
+  it('Can restore hidden cards', () => {
+    /**
+     * Hide home page banners
+     * Click the restore link
+     * Verify banners display on home page
+     */
+
+    PageActions.open();
+    homePage.waitForRestore();
+
+    homePage.graphicBanner().should('be.visible');
+    homePage.graphicBannerCloseButton();
+    homePage.graphicBanner().should('not.exist');
+
+    homePage.setLoginPageBanner().should('be.visible');
+    homePage.closeButton();
+    homePage.setLoginPageBanner().should('not.exist');
+
+    PageActions.open();
+    homePage.waitForRestore();
+
+    homePage.graphicBanner().should('be.visible');
+    homePage.setLoginPageBanner().should('be.visible');
+  });
+
+  it('Can see that cluster details match those in Cluster Manangement page', () => {
+    /**
+     * Get cluster details from the Home page
+     * Verify that the cluster details match those on the Cluster Management page
+     */
+
+    const clusterDetails: string[] = [];
+
+    homeClusterList.state('local').invoke('text').then((el) => {
+      clusterDetails.push(el.trim());
+    });
+
+    homeClusterList.name('local').invoke('text').then((el) => {
+      clusterDetails.push(el.trim());
+    });
+
+    homeClusterList.version('local').invoke('text').then((el) => {
+      clusterDetails.push(el.trim());
+    });
+
+    homeClusterList.provider('local').invoke('text').then((el) => {
+      clusterDetails.push(el.trim());
+    });
+
+    provClusterList.goTo();
+
+    provClusterList.list().state('local').should((el) => {
+      expect(el).to.include.text(clusterDetails[0]);
+    });
+
+    provClusterList.list().name('local').should((el) => {
+      expect(el).to.include.text(clusterDetails[1]);
+    });
+
+    provClusterList.list().version('local').should((el) => {
+      expect(el).to.include.text(clusterDetails[2]);
+    });
+
+    provClusterList.list().provider('local').should((el) => {
+      expect(el).to.include.text(clusterDetails[3]);
+    });
+  });
+
+  it('Can use the Manage, Import Existing, and Create buttons', () => {
+    /**
+     * Click 'Manage' button and verify user lands on the Cluster Management page
+     * Click on the Import Existing button and verify user lands on the cluster creation page in import mode
+     * Click on the Create button and verify user lands on the cluster creation page
+     */
+    const clusterManagerPage = new ClusterManagerListPagePo('_');
+    const genericCreateClusterPage = new ClusterManagerImportGenericPagePo('_');
+
+    homePage.manangeButton().click();
+    clusterManagerPage.waitForPage();
+
+    HomePagePo.goTo();
+    homePage.importExistingButton().click();
+    genericCreateClusterPage.waitForPage('mode=import');
+
+    HomePagePo.goTo();
+    homePage.createButton().click();
+    genericCreateClusterPage.waitForPage();
+  });
+
+  it('Can filter rows in the cluster list', () => {
+    /**
+     * Filter rows in the cluster list
+     */
+
+    homePage.filter('random text');
+    homeClusterList.resourceTable().sortableTable().rowElements().should((el) => {
+      expect(el).to.contain.text('There are no rows which match your search query.');
+    });
+
+    homePage.filter('local');
+    homeClusterList.name('local').should((el) => {
+      expect(el).to.contain.text('local');
+    });
+  });
+
+  it('Can click on support links', () => {
+    /**
+     * Click the support links and verify user lands on the correct page
+     */
+
+    homePage.supportLinks().should('have.length', 6);
+
+    // click Docs
+    homePage.clickSupportLink(0, true);
+    cy.origin('https://rancher.com', () => {
+      cy.on('uncaught:exception', () => false);
+      cy.url().should('include', 'ranchermanager.docs.rancher.com');
+    });
+
+    // click Forums link
+    // NOTE: Cypress does not recognize when the Forum page's contents are loaded
+    // which is resulting in a time out error and this test to fail
+    // HomePagePo.goTo();
+    // homePage.clickSupportLink(1, true);
+    // cy.origin('https://rancher.com', () => {
+    //   cy.url().should('include', 'forums.rancher.com/');
+    // });
+
+    // click Slack link
+    HomePagePo.goTo();
+    homePage.clickSupportLink(2, true);
+    cy.origin('https://rancher.io', () => {
+      cy.url().should('include', 'slack.rancher.io/');
+    });
+
+    // click File an Issue link
+    HomePagePo.goTo();
+    homePage.clickSupportLink(3, true);
+    cy.origin('https://github.com', () => {
+      cy.url().should('include', 'github.com/login');
+    });
+
+    // click Get Started link
+    HomePagePo.goTo();
+    homePage.clickSupportLink(4);
+    cy.url().should('include', 'docs/getting-started');
+
+    // click Commercial Support link
+    HomePagePo.goTo();
+    homePage.clickSupportLink(5);
+    cy.url().should('include', '/support');
   });
 });

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -53,6 +53,7 @@ export default {
     <div
       v-if="pref"
       class="close-button"
+      data-testid="graphic-banner-close"
       @click="hide()"
     >
       <i class="icon icon-close" />

--- a/shell/components/SimpleBox.vue
+++ b/shell/components/SimpleBox.vue
@@ -31,6 +31,7 @@ export default {
   <div
     v-if="shown"
     class="simple-box"
+    data-testid="simple-box-container"
     v-on="$listeners"
   >
     <div

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -903,7 +903,10 @@ export default {
 </script>
 
 <template>
-  <div ref="container">
+  <div
+    ref="container"
+    data-testid="cluster-list-container"
+  >
     <div
       :class="{'titled': $slots.title && $slots.title.length}"
       class="sortable-table-header"
@@ -1001,6 +1004,7 @@ export default {
         <div
           v-if="search || hasAdvancedFiltering || isTooManyItemsToAutoUpdate || ($slots['header-right'] && $slots['header-right'].length)"
           class="search row"
+          data-testid="search-box-filter-row"
         >
           <ul
             v-if="hasAdvancedFiltering"

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -347,7 +347,6 @@ export default {
                 </div>
                 <a
                   class="hand mr-20"
-                  data-testid="pref-banner-link"
                   @click.prevent.stop="showUserPrefs"
                 ><span v-clean-html="t('landing.landingPrefs.userPrefs')" /></a>
               </Banner>

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -306,6 +306,7 @@ export default {
       :title="t('landing.welcomeToRancher', {vendor})"
       :pref="HIDE_HOME_PAGE_CARDS"
       pref-key="welcomeBanner"
+      data-testid="home-banner-graphic"
     />
     <IndentedPanel class="mt-20 mb-20">
       <div
@@ -337,6 +338,7 @@ export default {
             <div class="col span-12">
               <Banner
                 color="set-login-page mt-0"
+                data-testid="set-login-page-banner"
                 :closable="true"
                 @close="closeSetLoginBanner()"
               >
@@ -345,6 +347,7 @@ export default {
                 </div>
                 <a
                   class="hand mr-20"
+                  data-testid="pref-banner-link"
                   @click.prevent.stop="showUserPrefs"
                 ><span v-clean-html="t('landing.landingPrefs.userPrefs')" /></a>
               </Banner>
@@ -384,6 +387,7 @@ export default {
                       v-if="canManageClusters"
                       :to="manageLocation"
                       class="btn btn-sm role-secondary"
+                      data-testid="cluster-management-manage-button"
                     >
                       {{ t('cluster.manageAction') }}
                     </n-link>
@@ -391,6 +395,7 @@ export default {
                       v-if="canCreateCluster"
                       :to="importLocation"
                       class="btn btn-sm role-primary"
+                      data-testid="cluster-create-import-button"
                     >
                       {{ t('cluster.importAction') }}
                     </n-link>
@@ -398,6 +403,7 @@ export default {
                       v-if="canCreateCluster"
                       :to="createLocation"
                       class="btn btn-sm role-primary"
+                      data-testid="cluster-create-button"
                     >
                       {{ t('generic.create') }}
                     </n-link>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Added test for the Home page which are:

- User can navigate to What\'s new page
- User can navigate to Preferences page
- User can restore hidden cards
- User can see that cluster details match those in Cluster Management page
- User can use the Manage, Import Existing, and Create buttons 
- User can filter rows in the cluster list
- User can click on support links

### Technical notes summary
1. Under the "Can click on support links" it block, I have commented out the "click Forums link" test because it is failing with a timeout error. Although the Forums page contents load, Cypress does not recognize it (probably because it's an iframe). Cypress' event listener is waiting for the page load event to occur before moving to the next step and because that event is not returned the test fails with time out error. Need more time to investigate how to handle for this.2. 
2. A bug was found while implementing the "Can navigate to What\'s new page" test. This test will fail until this issue is resolved https://github.com/rancher/dashboard/issues/8979
3. This bug is causing flakiness to the support links test https://github.com/rancher/dashboard/issues/9211. Test will fail from time to time until the issue is resolved.

### Screenshot/Video
![Screen Shot 2023-05-23 at 2 37 19 PM](https://github.com/rancher/dashboard/assets/127343932/9f016281-1fa0-4b97-b8be-ccd84eb58084)
