### PR TITLE
RadioGroup: Expose `isDisabled` slot prop

### DIFF
--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -209,6 +209,7 @@ export default Vue.extend({
         <slot
           :listeners="$listeners"
           :option="option"
+          :isDisabled="isDisabled"
           :name="i"
         >
           <RadioButton


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR exposes the `isDisabled` slot prop in the indexed slots of the `RadioGroup` component. This is particularly useful when creating customized radio button groups. 

By providing the `isDisabled` slot prop, consumers can relay the disabled state information from the `RadioGroup` component to their custom radio button compositions.

Fixes #8977

Example usage rancher-sandbox/rancher-desktop#4758
