### PR TITLE
ClusterRepo detail page: Add git commit hash for git repos

### DIFF
--- a/shell/detail/catalog.cattle.io.clusterrepo.vue
+++ b/shell/detail/catalog.cattle.io.clusterrepo.vue
@@ -19,10 +19,17 @@ export default {
     </div>
     <div
       v-if="value.isGit"
-      class="span-6"
+      class="span-3"
     >
       <h3>{{ t('tableHeaders.branch') }}</h3>
       <span>{{ value.branchDisplay }}</span>
+    </div>
+    <div
+      v-if="value.isGit"
+      class="span-3"
+    >
+      <h3>{{ t('tableHeaders.commit') }}</h3>
+      <span>{{ value.status.commit }}</span>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Summary
ClusterRepo detail page: Add git commit hash for git repos

Fixes #8983

### Areas or cases that should be tested
App repository detail page for git repos and http repos should still work.

### Areas which could experience regressions
App repository detail page

### Screenshot/Video
![Bildschirmfoto 2023-05-25 um 13 55 30](https://github.com/rancher/dashboard/assets/243056/1515f709-5e55-4a69-b4d1-aa1a4457d0e3)
