### PR TITLE
Fix 'What's New' page

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -536,20 +536,6 @@ module.exports = function(dir, _appConfig) {
           test: /\.md$/,
           use:  [
             {
-              loader:  'url-loader',
-              options: {
-                name:     '[path][name].[ext]',
-                limit:    1,
-                esModule: false
-              },
-            }
-          ]
-        },
-        // Prevent warning in log with the md files in the content folder
-        {
-          test: /\.md$/,
-          use:  [
-            {
               loader:  'frontmatter-markdown-loader',
               options: { mode: ['body'] }
             }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8979
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Remove clash of `test: /\.md$/,` entries
  - the wrong loader `url-loader` was used instead of `frontmatter-markdown-loader`
  - this resulted in the `require` for the md just returning a string
- The removed entry might be a copy and paste error. Going back to pre-nuxt removal the `url-loader` was associated with loading images
  - https://github.com/rancher/dashboard/blob/v2.7.2/shell/nuxt.config.js#L492
  - i'm not sure if we don't need the custom loader now, images do seem to work

> Clicking on whats new will remove the banner with the link, it can be shown again by nav'ing to `<rancher url>v3/preferences/read-whatsnew` and deleting the resource
