### PR TITLE
Add the ability to execute a container shell command immediately after the shell connects.

### DIFF
--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -61,6 +61,12 @@ export default {
       type:    String,
       default: null,
     },
+
+    // Runs this command immediately after connecting
+    commandOnFirstConnect: {
+      type:    String,
+      default: null
+    }
   },
 
   data() {
@@ -267,6 +273,10 @@ export default {
         this.isOpening = false;
         this.fit();
         this.flush();
+
+        if (this.commandOnFirstConnect) {
+          this.terminal.paste(`${ this.commandOnFirstConnect }`);
+        }
       });
 
       this.socket.addEventListener(EVENT_DISCONNECTED, (e) => {


### PR DESCRIPTION
Example usage:
<img width="413" alt="image" src="https://github.com/rancher/dashboard/assets/55104481/a5cccab0-4474-498e-b8fc-24b80483a78d">

Note:
I'm using `paste` instead of `write` because `write` either wasn't getting a response or wasn't processing the response. It would just render a message in the terminal.