### PR TITLE
Update `vue` peer dependency for `@rancher/components`

### DIFF
--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -2,7 +2,7 @@
   "name": "@rancher/components",
   "repository": "git://github.com:rancher/dashboard.git",
   "license": "Apache-2.0",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "module": "./main.js",
   "main": "./dist/@rancher/components.umd.min.js",
   "files": [
@@ -49,6 +49,6 @@
   },
   "peerDependencies": {
     "core-js": "3.25.3",
-    "vue": "2.7.14"
+    "vue": "^2.6.14"
   }
 }


### PR DESCRIPTION
This PR updates the peer dependency for `vue` in `@rancher/components`. This change ensures compatibility with a wider range of `vue` versions, specifically for Rancher Desktop, which is still on vue `2.6.14`. 