### PR TITLE
Fix malformed pod affinity and node affinity terms

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
     },
     experimentalSessionAndOrigin: true,
     specPattern:                  getSpecPattern(),
-    baseUrl
+    baseUrl,
+    numTestsKeptInMemory:         0
   },
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -97,7 +97,6 @@ export default defineConfig({
     },
     experimentalSessionAndOrigin: true,
     specPattern:                  getSpecPattern(),
-    baseUrl,
-    numTestsKeptInMemory:         0
+    baseUrl
   },
 });

--- a/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
+++ b/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
@@ -350,7 +350,6 @@ export const payloadComparisonData = {
                   ]
                 }
               ],
-              weight: 10
             }
           }
         ],
@@ -526,7 +525,6 @@ export const payloadComparisonData = {
           {
             podAffinityTerm: {
               namespaces:    null,
-              weight:        10,
               labelSelector: {
                 matchExpressions: [
                   {

--- a/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
+++ b/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
@@ -10,7 +10,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key1',
                   operator: 'In',
-                  matching: 'matchExpressions',
                   values:   [
                     'val1'
                   ]
@@ -18,7 +17,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key2',
                   operator: 'NotIn',
-                  matching: 'matchExpressions',
                   values:   [
                     'val2'
                   ]
@@ -26,17 +24,14 @@ export const payloadComparisonData = {
                 {
                   key:      'key3',
                   operator: 'Exists',
-                  matching: 'matchExpressions'
                 },
                 {
                   key:      'key4',
                   operator: 'DoesNotExist',
-                  matching: 'matchExpressions'
                 },
                 {
                   key:      'key5',
                   operator: 'Lt',
-                  matching: 'matchExpressions',
                   values:   [
                     'val5'
                   ]
@@ -44,7 +39,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key6',
                   operator: 'Gt',
-                  matching: 'matchExpressions',
                   values:   [
                     'val6'
                   ]
@@ -60,7 +54,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key1',
                   operator: 'In',
-                  matching: 'matchFields',
                   values:   [
                     'val1'
                   ]
@@ -68,7 +61,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key2',
                   operator: 'NotIn',
-                  matching: 'matchFields',
                   values:   [
                     'val2'
                   ]
@@ -76,17 +68,14 @@ export const payloadComparisonData = {
                 {
                   key:      'key3',
                   operator: 'Exists',
-                  matching: 'matchFields'
                 },
                 {
                   key:      'key4',
                   operator: 'DoesNotExist',
-                  matching: 'matchFields'
                 },
                 {
                   key:      'key5',
                   operator: 'Lt',
-                  matching: 'matchFields',
                   values:   [
                     'val5'
                   ]
@@ -94,7 +83,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key6',
                   operator: 'Gt',
-                  matching: 'matchFields',
                   values:   [
                     'val6'
                   ]
@@ -310,7 +298,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key1',
                   operator: 'In',
-                  matching: 'matchExpressions',
                   values:   [
                     'val1'
                   ]
@@ -318,7 +305,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key2',
                   operator: 'NotIn',
-                  matching: 'matchExpressions',
                   values:   [
                     'val2'
                   ]
@@ -326,17 +312,14 @@ export const payloadComparisonData = {
                 {
                   key:      'key3',
                   operator: 'Exists',
-                  matching: 'matchExpressions'
                 },
                 {
                   key:      'key4',
                   operator: 'DoesNotExist',
-                  matching: 'matchExpressions'
                 },
                 {
                   key:      'key5',
                   operator: 'Lt',
-                  matching: 'matchExpressions',
                   values:   [
                     'val5'
                   ]
@@ -344,7 +327,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key6',
                   operator: 'Gt',
-                  matching: 'matchExpressions',
                   values:   [
                     'val6'
                   ]
@@ -360,7 +342,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key1',
                   operator: 'In',
-                  matching: 'matchFields',
                   values:   [
                     'val1'
                   ]
@@ -368,7 +349,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key2',
                   operator: 'NotIn',
-                  matching: 'matchFields',
                   values:   [
                     'val2'
                   ]
@@ -376,17 +356,14 @@ export const payloadComparisonData = {
                 {
                   key:      'key3',
                   operator: 'Exists',
-                  matching: 'matchFields'
                 },
                 {
                   key:      'key4',
                   operator: 'DoesNotExist',
-                  matching: 'matchFields'
                 },
                 {
                   key:      'key5',
                   operator: 'Lt',
-                  matching: 'matchFields',
                   values:   [
                     'val5'
                   ]
@@ -394,7 +371,6 @@ export const payloadComparisonData = {
                 {
                   key:      'key6',
                   operator: 'Gt',
-                  matching: 'matchFields',
                   values:   [
                     'val6'
                   ]

--- a/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
+++ b/cypress/e2e/tests/pages/data/agent-configuration-rke2-payload.ts
@@ -50,7 +50,6 @@ export const payloadComparisonData = {
                   ]
                 }
               ],
-              weight: 10
             }
           }
         ],
@@ -149,7 +148,6 @@ export const payloadComparisonData = {
           {
             podAffinityTerm: {
               namespaces:    null,
-              weight:        10,
               labelSelector: {
                 matchExpressions: [
                   {

--- a/shell/components/form/NodeAffinity.vue
+++ b/shell/components/form/NodeAffinity.vue
@@ -95,11 +95,36 @@ export default {
       const requiredDuringSchedulingIgnoredDuringExecution = { nodeSelectorTerms: [] };
       const preferredDuringSchedulingIgnoredDuringExecution = [] ;
 
-      this.allSelectorTerms.forEach((term) => {
+      this.allSelectorTerms.forEach((t) => {
+        const term = { ...t };
+
+        // the 'matching' field isn't part of the affinity spec: including this in the save request will cause a flood of errors that might cause the request to fail
+        // same deal with term.preference.weight
+        if (term.matchExpressions) {
+          term.matchExpressions = (term.matchExpressions || []).map((expression) => {
+            const out = { ...expression };
+
+            delete out.matching;
+
+            return out;
+          });
+        }
+
+        if (term.matchFields) {
+          term.matchFields = (term.matchFields || []).map((field) => {
+            const out = { ...field };
+
+            delete out.matching;
+
+            return out;
+          });
+        }
+
         if (term.weight) {
-          const neu = { weight: term.weight, preference: { ...term } };
+          const neu = { weight: term.weight, preference: term };
 
           delete neu.preference.weight;
+
           preferredDuringSchedulingIgnoredDuringExecution.push(neu);
         } else {
           requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms.push(term);
@@ -145,12 +170,8 @@ export default {
           expressionsMatching[expression.matching || 'matchExpressions'].push(expression);
         });
 
-        if (expressionsMatching.matchFields.length) {
-          this.$set(row, 'matchFields', expressionsMatching.matchFields);
-        }
-        if (expressionsMatching.matchExpressions.length) {
-          this.$set(row, 'matchExpressions', expressionsMatching.matchExpressions);
-        }
+        this.$set(row, 'matchFields', expressionsMatching.matchFields);
+        this.$set(row, 'matchExpressions', expressionsMatching.matchExpressions);
 
         this.update();
       }

--- a/shell/components/form/NodeAffinity.vue
+++ b/shell/components/form/NodeAffinity.vue
@@ -97,8 +97,9 @@ export default {
 
       this.allSelectorTerms.forEach((term) => {
         if (term.weight) {
-          const neu = { weight: term.weight, preference: term };
+          const neu = { weight: term.weight, preference: { ...term } };
 
+          delete neu.preference.weight;
           preferredDuringSchedulingIgnoredDuringExecution.push(neu);
         } else {
           requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms.push(term);

--- a/shell/components/form/PodAffinity.vue
+++ b/shell/components/form/PodAffinity.vue
@@ -230,8 +230,9 @@ export default {
       this.allSelectorTerms.forEach((term) => {
         if (term._anti) {
           if (term.weight) {
-            const neu = { podAffinityTerm: term, weight: term.weight || this.defaultWeight };
+            const neu = { podAffinityTerm: { ...term }, weight: term.weight || this.defaultWeight };
 
+            delete neu.podAffinityTerm.weight;
             podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.push(neu);
           } else {
             podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.push(term);


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/9012 - this PR is for specifically the first issue described in this comment https://github.com/rancher/dashboard/issues/9012#issuecomment-1569155864 . As noted in slack discussion, the other two potential causes of the 502 error may be more complex to address so we're starting here.



The dashboard is sending an extra weight field within node/pod preferred terms,  `nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].preference.weight` we should only be sending `nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[].weight` Similarly the UI is sending `podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].podAffinityTerm.weight` and should only send `podAffinity.preferredDuringSchedulingIgnoredDuringExecution[].weight`
