### PR TITLE
Two RC related build fixes

### DIFF
--- a/scripts/build-embedded
+++ b/scripts/build-embedded
@@ -21,7 +21,7 @@ DIR=${GIT_TAG:-$COMMIT_BRANCH}
 OUTPUT_DIR=dist/${DIR}-embedded
 
 echo "Building..."
-COMMIT=${COMMIT} VERSION=${VERSION} OUTPUT_DIR=$OUTPUT_DIR ROUTER_BASE='/dashboard' yarn run build
+COMMIT=${COMMIT} VERSION=${VERSION} OUTPUT_DIR=$OUTPUT_DIR ROUTER_BASE='/dashboard/' RESOURCE_BASE='/dashboard/' yarn run build
 
 if [ -v EMBED_PKG ]; then
     echo "Build and embed plugin from: $EMBED_PKG"


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- Apply build-hosted resource base ending `/` (https://github.com/rancher/dashboard/pull/8401)
- Ensure resource links in index.html match that of previous releases
  - These all started with `/dashboard` and had `<base href='/dashboard/'`
  - Note - base is still missing (everything still seems to work)
  - Note - base is ignored for href's starting `/` anyway
  - It's assumed nuxt added this resource prefix via nuxt.config.js build publicPath