### PR TITLE
fix grafana url prefix for local clusters

### DIFF
--- a/shell/components/GrafanaDashboard.vue
+++ b/shell/components/GrafanaDashboard.vue
@@ -40,7 +40,7 @@ export default {
   },
   data() {
     return {
-      loading: false, error: false, interval: null, initialUrl: this.computeUrl(), errorTimer: null, monitoringVersion: null
+      loading: false, error: false, interval: null, errorTimer: null, monitoringVersion: null
     };
   },
   computed: {
@@ -242,7 +242,7 @@ export default {
       v-show="!error"
       ref="frame"
       :class="{loading, frame: true}"
-      :src="initialUrl"
+      :src="currentUrl"
       frameborder="0"
       scrolling="no"
     />

--- a/shell/utils/__tests__/grafana.test.ts
+++ b/shell/utils/__tests__/grafana.test.ts
@@ -29,7 +29,7 @@ describe('fx: getClusterPrefix', () => {
   it('future monitoring version, local cluster', () => {
     const prefix = getClusterPrefix('103.0.0+up41.0.0', 'local');
 
-    expect(prefix).toStrictEqual('/k8s/clusters/local');
+    expect(prefix).toStrictEqual('');
   });
   it('empty monitoring version, downstream cluster', () => {
     const prefix = getClusterPrefix('', 'c-abcd');
@@ -39,6 +39,6 @@ describe('fx: getClusterPrefix', () => {
   it('empty monitoring version, local cluster', () => {
     const prefix = getClusterPrefix('', 'local');
 
-    expect(prefix).toStrictEqual('/k8s/clusters/local');
+    expect(prefix).toStrictEqual('');
   });
 });

--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -1,12 +1,13 @@
 import { haveV2Monitoring } from '@shell/utils/monitoring';
 import { parse as parseUrl, addParam } from '@shell/utils/url';
-import { compare } from '@shell/utils/version';
 import { CATALOG } from '@shell/config/types';
 
-const MONITORING_VERSION_NEW_URL_PATTERN = '102.0.0+up40.1.2';
+// these two versions of monitoring included a bug fix attempt that required the local cluster to use a different url
+// the solution going forward doesn't require this, see https://github.com/rancher/dashboard/issues/8885
+const MONITORING_VERSION_ALT_URL = ['100.2.0+up40.1.2', '102.0.0+up40.1.2'];
 
 export function getClusterPrefix(monitoringVersion, clusterId) {
-  if (compare(monitoringVersion, MONITORING_VERSION_NEW_URL_PATTERN) >= 0) {
+  if (MONITORING_VERSION_ALT_URL.includes(monitoringVersion)) {
     return `/k8s/clusters/${ clusterId }`;
   }
 


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/dashboard/issues/8885
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
* updated grafana url-construction utility to only apply the `/k8s/clusters/${ clusterId }` prefix for monitoring versions `100.2.0+up40.1.2` and `102.0.0+up40.1.2`
* updated the grafana link on the monitoring index page to use the above utility
* updated the embedded grafana dashboard component to use the correct url for iframe src

### Technical notes summary
The GrafanaDashboard component was using a url generated before fetching the installed monitoring version, so it was wrong some of the time. I've updated it to use the `currentUrl` computed property which properly accounts for the monitoring version.

### Areas or cases that should be tested
Test both `100.2.0+up40.1.2` and `102.0.0+up40.1.2` monitoring each on a local and downstream cluster. Verify that the embedded grafana views and grafana link on the cluster dashboard work, and verify that the grafana link on the monitoring index works.

I hit issues intermittently when runing this code locally - sometimes requests to the grafana service proxy returned 401. To get around this I built and uploaded the dashboard, so rather than running this code locally you can also test this PR by changing your ui-dashboard-index setting to https://releases.rancher.com/dashboard/nancy-dev/index.html