### PR TITLE
Automation namespaces button flatlist

### DIFF
--- a/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
+++ b/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
@@ -1,0 +1,42 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import ProvClusterListPo from '@/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po';
+
+export default class ProjectNamespacePagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/explorer/projectsnamespaces`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(ProjectNamespacePagePo.createPath(clusterId));
+  }
+
+  constructor(clusterId: string) {
+    super(ProjectNamespacePagePo.createPath(clusterId));
+  }
+
+  list(): ProvClusterListPo {
+    return new ProvClusterListPo(this.self().find('[data-testid="cluster-list"]'));
+  }
+
+
+  flatListButton() {
+    return this.self().getId('button-group-child-0');
+  }
+
+  flatListClick(): Cypress.Chainable {
+    return this.flatListButton().click();
+  }
+
+  createProjectNamespaceButton() {
+    return this.self().getId('create_project_namespaces');
+  }
+
+  createProjectNamespaceClick(): Cypress.Chainable {
+    return this.createProjectNamespaceButton().click();
+  }
+
+  nsProject() {
+    return this.self().getId('name-ns-description-project');
+  }
+  
+}

--- a/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
+++ b/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
@@ -18,7 +18,6 @@ export default class ProjectNamespacePagePo extends PagePo {
     return new ProvClusterListPo(this.self().find('[data-testid="cluster-list"]'));
   }
 
-
   flatListButton() {
     return this.self().getId('button-group-child-0');
   }
@@ -38,5 +37,4 @@ export default class ProjectNamespacePagePo extends PagePo {
   nsProject() {
     return this.self().getId('name-ns-description-project');
   }
-  
 }

--- a/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
+++ b/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
@@ -1,5 +1,4 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
-import ProvClusterListPo from '@/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po';
 
 export default class ProjectNamespacePagePo extends PagePo {
   private static createPath(clusterId: string) {
@@ -12,10 +11,6 @@ export default class ProjectNamespacePagePo extends PagePo {
 
   constructor(clusterId: string) {
     super(ProjectNamespacePagePo.createPath(clusterId));
-  }
-
-  list(): ProvClusterListPo {
-    return new ProvClusterListPo(this.self().find('[data-testid="cluster-list"]'));
   }
 
   flatListButton() {

--- a/cypress/e2e/tests/pages/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/project-namespace.spec.ts
@@ -1,0 +1,22 @@
+import projectsNamespacesePo from '@/cypress/e2e/po/pages/explorer/projects-namespaces.po';
+
+
+describe('Projects/Namespaces', () => {
+  const projectsNamespacesesPage = new projectsNamespacesePo('local');
+
+  beforeEach(() => {
+    cy.login();
+
+    projectsNamespacesesPage.goTo();
+  });
+
+  it('flat list view should have create tNamespace button', () => {
+    projectsNamespacesesPage.flatListClick();
+    projectsNamespacesesPage.createProjectNamespaceButton().should('exist');
+  })
+
+  it('create screen should have a dropdown of projects.', () => {
+    projectsNamespacesesPage.createProjectNamespaceClick();
+    projectsNamespacesesPage.nsProject().should('exist');
+  })
+});

--- a/cypress/e2e/tests/pages/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/project-namespace.spec.ts
@@ -1,6 +1,5 @@
 import projectsNamespacesePo from '@/cypress/e2e/po/pages/explorer/projects-namespaces.po';
 
-
 describe('Projects/Namespaces', () => {
   const projectsNamespacesesPage = new projectsNamespacesePo('local');
 
@@ -10,13 +9,13 @@ describe('Projects/Namespaces', () => {
     projectsNamespacesesPage.goTo();
   });
 
-  it('flat list view should have create tNamespace button', () => {
+  it('flat list view should have create Namespace button', () => {
     projectsNamespacesesPage.flatListClick();
     projectsNamespacesesPage.createProjectNamespaceButton().should('exist');
-  })
+  });
 
-  it('create screen should have a dropdown of projects.', () => {
+  it('create namespace screen should have a projects dropdown', () => {
     projectsNamespacesesPage.createProjectNamespaceClick();
     projectsNamespacesesPage.nsProject().should('exist');
-  })
+  });
 });

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -373,6 +373,7 @@ export default {
         <n-link
           :to="createNamespaceLocationFlatList()"
           class="btn role-primary mr-10"
+          data-testid="create_project_namespaces"
         >
           {{ t('projectNamespaces.createNamespace') }}
         </n-link>

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -181,6 +181,7 @@ export default {
       >
         <LabeledSelect
           v-model="projectName"
+          data-testid="name-ns-description-project"
           :label="t('namespace.project.label')"
           :options="projectOpts"
         />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8784
<!-- Define findings related to the feature or bug issue. -->
Automation: Create Namespaces Button is not visible when using the "Flat List" view


### Test cases 

When a user is on Projects/Namespaces Flat list view > `create Namespaces` Button should be there
When a user clicks on Create Namespaces Button > Create screen should have a projects dropdown.

