### PR TITLE
Align theme of loading indicator page with dashboard theme

### DIFF
--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -13,7 +13,12 @@
     <div id="app">
         <script>
             (() => {
-                const isDark = document.cookie.includes('R_PCS=dark');
+                const isDark = document.cookie.includes('R_THEME=auto') ?
+                    // User selected automatic theme, so use pcs (set when ui previously loaded and is either os theme or time of day based
+                    document.cookie.includes('R_PCS=dark') :
+                    // Otherwise user selected light/dark theme directly
+                    document.cookie.includes('R_THEME=dark');
+
                 const color = isDark ? '#1b1c21' : '#FFF';
                 const style = document.createElement('style');
                 style.innerHTML = ':root { --loading-bg-color: ' + color + ';}';


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- theme comes from preference `theme` cookie
- when theme is auto `pcs` cookie is used instead
- `pcs` is set to the OS theme, or failing that based on time of day
