### PR TITLE
Automation: Cronjob Run Now does generate resources in Jobs Detail page

### DIFF
--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -6,8 +6,6 @@ import { _VIEW } from '@shell/config/query-params';
 import { ExtensionPoint, PanelLocation } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
 
-export const SEPARATOR = { separator: true };
-
 export default {
   components: {
     DetailText, Tag, ExtensionPanel

--- a/shell/config/workload.ts
+++ b/shell/config/workload.ts
@@ -1,0 +1,1 @@
+export const SEPARATOR = { separator: true };

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -15,7 +15,7 @@ import V1WorkloadMetrics from '@shell/mixins/v1-workload-metrics';
 import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@shell/utils/grafana';
 import PlusMinus from '@shell/components/form/PlusMinus';
-import { matches } from '~shell/utils/selector';
+import { matches } from '@shell/utils/selector';
 
 const SCALABLE_TYPES = Object.values(SCALABLE_WORKLOAD_TYPES);
 const WORKLOAD_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-workload-pods-1/rancher-workload-pods?orgId=1';

--- a/shell/models/__tests__/batch.cronjob.test.ts
+++ b/shell/models/__tests__/batch.cronjob.test.ts
@@ -64,5 +64,25 @@ describe('class Cronjob', () => {
 
       expect(cronjob.metadata).toStrictEqual(expected);
     });
+
+    it('should redirect to another page', async() => {
+      const jobData = {
+        metadata: { name: 'any-name' },
+        spec:     { jobTemplate: {} }
+      };
+      const callback = jest.fn();
+      const dispatcher = () => ({
+        ...jobData,
+        save:       jest.fn(),
+        goToDetail: callback
+      });
+      const cronjob = new Cronjob(jobData, { dispatch: dispatcher });
+
+      jest.spyOn(cronjob, '$dispatch').mockImplementation(dispatcher);
+
+      await cronjob.runNow();
+
+      expect(callback).toHaveBeenCalledWith();
+    });
   });
 });

--- a/shell/models/__tests__/batch.cronjob.test.ts
+++ b/shell/models/__tests__/batch.cronjob.test.ts
@@ -1,0 +1,68 @@
+import Cronjob from '@shell/models/batch.cronjob';
+describe('class Cronjob', () => {
+  it('should have no ownerReferences by default', () => {
+    const cronJobData = {
+      id:         'any-id',
+      type:       'batch.job',
+      apiVersion: 'batch/v1',
+      kind:       'Job',
+      metadata:   {
+        name:      'any-name',
+        namespace: 'any-namespace',
+        uid:       'any-uid'
+      },
+      spec: { jobTemplate: {} }
+    };
+    const expectation = {
+      name: 'any-name', namespace: 'any-namespace', uid: 'any-uid'
+    };
+    const cronjob = new Cronjob(cronJobData);
+
+    expect(cronjob.metadata).toStrictEqual(expectation);
+  });
+
+  describe('method runNow', () => {
+    it('should populate job metadata', async() => {
+      const jobData = {
+        id:         'any-id',
+        type:       'batch.job',
+        apiVersion: 'batch/v1',
+        kind:       'Job',
+        metadata:   {
+          name:      'any-name',
+          namespace: 'any-namespace',
+          uid:       'any-uid'
+        },
+        spec: { jobTemplate: {} }
+      };
+      const date = Date.now();
+      const expected = {
+        name:            `${ jobData.metadata.name }-${ date }`,
+        namespace:       jobData.metadata.namespace,
+        ownerReferences: [{
+          apiVersion: 'batch/v1',
+          controller: true,
+          kind:       'Job',
+          name:       jobData.metadata.name,
+          uid:        jobData.metadata.uid
+        }],
+        uid: jobData.metadata.uid
+      };
+      const dispatcher = () => ({
+        ...jobData,
+        save:       jest.fn(),
+        goToDetail: jest.fn()
+      });
+      const cronjob = new Cronjob(jobData, { dispatch: dispatcher });
+
+      jest
+        .useFakeTimers()
+        .setSystemTime(date);
+      jest.spyOn(cronjob, '$dispatch').mockImplementation(dispatcher);
+
+      await cronjob.runNow();
+
+      expect(cronjob.metadata).toStrictEqual(expected);
+    });
+  });
+});

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -4,7 +4,7 @@ import { WORKLOAD_TYPES, SERVICE, POD } from '@shell/config/types';
 import { get, set } from '@shell/utils/object';
 import day from 'dayjs';
 import { convertSelectorObj, matching, matches } from '@shell/utils/selector';
-import { SEPARATOR } from '@shell/components/DetailTop';
+import { SEPARATOR } from '@shell/config/workload';
 import WorkloadService from '@shell/models/workload.service';
 
 export const defaultContainer = {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8829
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
- Added tests to ensure
  - ownership data inheritance from CronJob
  - redirection to default value
- Moved `SEPARATOR` into a new config file
- Corrected import complained by linter

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->