### PR TITLE
Log validation warnings when creating/editing resources

### DIFF
--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -128,6 +128,10 @@ export default {
 
         finishDeferred(key, 'resolve', out);
 
+        if (opt.method === 'post' || opt.method === 'put') {
+          handleValidationWarnings(res);
+        }
+
         return out;
       });
     }
@@ -191,6 +195,24 @@ export default {
       finishDeferred(key, 'reject', out);
 
       return Promise.reject(out);
+    }
+
+    function handleValidationWarnings(res) {
+      const warnings = (res.headers?.warning || '').split(',');
+
+      if (!warnings.length || !warnings[0]) {
+        return;
+      }
+
+      const message = warnings.reduce((message, warning) => {
+        return `${ message }\n${ warning.trim() }`;
+      }, `Validation Warnings for ${ opt.url }\n`);
+
+      if (process.env.dev) {
+        console.warn(`${ message }\n\n`, res.data);
+      } else {
+        console.debug(message);
+      }
     }
   },
 

--- a/shell/plugins/steve/actions.js
+++ b/shell/plugins/steve/actions.js
@@ -209,9 +209,9 @@ export default {
       }, `Validation Warnings for ${ opt.url }\n`);
 
       if (process.env.dev) {
-        console.warn(`${ message }\n\n`, res.data);
+        console.warn(`${ message }\n\n`, res.data); // eslint-disable-line no-console
       } else {
-        console.debug(message);
+        console.debug(message); // eslint-disable-line no-console
       }
     }
   },


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- on by default in 1.25
- in dev world these are warnings, in prod they're debug
  - debatable that we output anything in prod, and downgrade dev warnings to debug
- see https://kubernetes.io/docs/reference/using-api/api-concepts/#validation-for-unrecognized-or-duplicate-fields-setting-the-field-validation-level
