### PR TITLE
Add HorizontalPodAutoscaler scaling behavior support

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2389,11 +2389,32 @@ hpa:
     name:
       label: Referent Name
       placeholder: e.g. php-apache
+  scaleDownRules:
+    label: Scale down behavior
+    enable: Configure scale down behavior
+  scaleUpRules:
+    label: Scale up behavior
+    enable: Configure scale up behavior
+  scalingRule:
+    policyHeader: Policies
+    addPolicy: Add policy
+    selectPolicy: Select policy
+    selectPolicyTooltip: Select the policy with the maximum value, minimum value or disable scaling.
+    stabilizationWindowSeconds: Stabilization window seconds
+    stabilizationWindowSecondsTooltip: Number of seconds for which past recommendations should be considered while scaling up or scaling down.
+    policy:
+      type: Type
+      typeTooltip: Set policy based on the amount of Pods to scale or the percentage of current replicas to scale.
+      value: Value
+      valueTooltip: The amount of change which is permitted by the policy.
+      periodSeconds: Period seconds
+      periodSecondsTooltip: The window of time for which the policy should hold true.
   tabs:
     labels: Labels
     metrics: Metrics
     target: Target
     workload: Workload
+    behavior: Behavior
   types:
     cpu: CPU
     memory: Memory

--- a/shell/detail/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/detail/autoscaling.horizontalpodautoscaler/index.vue
@@ -94,7 +94,7 @@ export default {
       name="metrics"
       :label="t('hpa.tabs.metrics')"
       class="bordered-table hpa-metrics-table"
-      :weight="3"
+      :weight="4"
     >
       <div
         v-for="(metric, index) in mappedMetrics"
@@ -179,6 +179,55 @@ export default {
               </div>
               <div v-else>
                 <t k="hpa.detail.currentMetrics.noMetrics" />
+              </div>
+            </div>
+          </div>
+        </InfoBox>
+      </div>
+    </Tab>
+    <Tab
+      v-if="!!value.spec.behavior"
+      name="behavior"
+      :label="t('hpa.tabs.behavior')"
+      class="bordered-table hpa-behavior-table"
+      :weight="3"
+    >
+      <div
+        v-for="(type, i) in ['scaleDown', 'scaleUp']"
+        :key="`${i}`"
+      >
+        <InfoBox v-if="!!value.spec.behavior[type]">
+          <div class="row info-row">
+            <div class="col span-6 info-column">
+              <h4>
+                <t
+                  :k="`hpa.${type}Rules.label`"
+                />
+              </h4>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col span-6">
+              <label><t k="hpa.scalingRule.policyHeader" /></label>
+              <ul
+                v-for="(current, currentIndex) in value.spec.behavior[type].policies"
+                :key="`${currentIndex}`"
+              >
+                <li>
+                  <span>{{ current.value }}</span>
+                  <span>{{ current.type }}</span>
+                  <span>(for {{ current.periodSeconds }}s)</span>
+                </li>
+              </ul>
+            </div>
+            <div class="col span-6">
+              <div>
+                <label><t k="hpa.scalingRule.selectPolicy" />: </label>
+                <span>{{ value.spec.behavior[type].selectPolicy }}</span>
+              </div>
+              <div>
+                <label><t k="hpa.scalingRule.stabilizationWindowSeconds" />: </label>
+                <span>{{ value.spec.behavior[type].stabilizationWindowSeconds }}s</span>
               </div>
             </div>
           </div>

--- a/shell/detail/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/detail/autoscaling.horizontalpodautoscaler/index.vue
@@ -207,8 +207,8 @@ export default {
             </div>
           </div>
           <div class="row">
-            <div class="col span-6">
-              <label><t k="hpa.scalingRule.policyHeader" /></label>
+            <div class="col span-6 info-column">
+              <label class="text-label"><t k="hpa.scalingRule.policyHeader" /></label>
               <ul
                 v-for="(current, currentIndex) in value.spec.behavior[type].policies"
                 :key="`${currentIndex}`"
@@ -221,12 +221,12 @@ export default {
               </ul>
             </div>
             <div class="col span-6">
-              <div>
-                <label><t k="hpa.scalingRule.selectPolicy" />: </label>
+              <div class="mb-5">
+                <label class="text-label"><t k="hpa.scalingRule.selectPolicy" />: </label>
                 <span>{{ value.spec.behavior[type].selectPolicy }}</span>
               </div>
-              <div>
-                <label><t k="hpa.scalingRule.stabilizationWindowSeconds" />: </label>
+              <div class="mb-5">
+                <label class="text-label"><t k="hpa.scalingRule.stabilizationWindowSeconds" />: </label>
                 <span>{{ value.spec.behavior[type].stabilizationWindowSeconds }}s</span>
               </div>
             </div>

--- a/shell/edit/autoscaling.horizontalpodautoscaler/hpa-scaling-rule.vue
+++ b/shell/edit/autoscaling.horizontalpodautoscaler/hpa-scaling-rule.vue
@@ -1,0 +1,130 @@
+<script>
+
+import { _EDIT } from '@shell/config/query-params';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import ArrayListGrouped from '@shell/components/form/ArrayListGrouped.vue';
+
+export default {
+  components: {
+    ArrayListGrouped,
+    LabeledInput,
+    LabeledSelect
+  },
+  props: {
+    value: {
+      type:    Object,
+      default: () => {
+      }
+    },
+    mode: {
+      type:    String,
+      default: _EDIT
+    },
+    type: {
+      type:    String,
+      default: 'scaleUp'
+    },
+  },
+  data() {
+    if (!this.value.spec.behavior[this.type].policies) {
+      this.$set(this.value.spec.behavior[this.type], 'policies', []);
+    }
+    if (!this.value.spec.behavior[this.type].selectPolicy) {
+      this.$set(this.value.spec.behavior[this.type], 'selectPolicy', 'Max');
+    }
+    if (this.value.spec.behavior[this.type].stabilizationWindowSeconds === null || typeof this.value.spec.behavior[this.type].stabilizationWindowSeconds === 'undefined') {
+      if (this.type === 'scaleUp') {
+        this.$set(this.value.spec.behavior[this.type], 'stabilizationWindowSeconds', 0);
+      }
+      if (this.type === 'scaleDown') {
+        this.$set(this.value.spec.behavior[this.type], 'stabilizationWindowSeconds', 300);
+      }
+    }
+
+    return { selectPolicyOptions: ['Max', 'Min', 'Disabled'], policyTypeOptions: ['Pods', 'Percent'] };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <div class="row mb-20">
+      <div class="col span-12">
+        <ArrayListGrouped
+          v-model="value.spec.behavior[type].policies"
+          :add-label="t('hpa.scalingRule.addPolicy')"
+          :default-add-value="{}"
+          :mode="mode"
+        >
+          <template #default="props">
+            <div class="row">
+              <div class="col span-4">
+                <LabeledSelect
+                  v-model="props.row.value.type"
+                  :mode="mode"
+                  :options="policyTypeOptions"
+                  :multiple="false"
+                  :taggable="true"
+                  :searchable="true"
+                  :required="true"
+                  :tooltip="t('hpa.scalingRule.policy.typeTooltip')"
+                  :label="t('hpa.scalingRule.policy.type')"
+                />
+              </div>
+              <div class="col span-4">
+                <LabeledInput
+                  v-model.number="props.row.value.value"
+                  :mode="mode"
+                  type="number"
+                  min="1"
+                  :required="true"
+                  :tooltip="t('hpa.scalingRule.policy.valueTooltip')"
+                  :label="t('hpa.scalingRule.policy.value')"
+                />
+              </div>
+              <div class="col span-4">
+                <LabeledInput
+                  v-model.number="props.row.value.periodSeconds"
+                  :mode="mode"
+                  type="number"
+                  min="1"
+                  max="1800"
+                  :required="true"
+                  :tooltip="t('hpa.scalingRule.policy.periodSecondsTooltip')"
+                  :label="t('hpa.scalingRule.policy.periodSeconds')"
+                />
+              </div>
+            </div>
+          </template>
+        </ArrayListGrouped>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.spec.behavior[type].selectPolicy"
+          :mode="mode"
+          :options="selectPolicyOptions"
+          :multiple="false"
+          :taggable="true"
+          :searchable="true"
+          :label="t('hpa.scalingRule.selectPolicy')"
+          :tooltip="t('hpa.scalingRule.selectPolicyTooltip')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model.number="value.spec.behavior[type].stabilizationWindowSeconds"
+          :mode="mode"
+          type="number"
+          min="0"
+          max="3600"
+          :label="t('hpa.scalingRule.stabilizationWindowSeconds')"
+          :tooltip="t('hpa.scalingRule.stabilizationWindowSecondsTooltip')"
+        />
+      </div>
+    </div>
+    <div class="row mb-40" />
+  </div>
+</template>

--- a/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -12,12 +12,14 @@ import Tabbed from '@shell/components/Tabbed';
 import MetricsRow from '@shell/edit/autoscaling.horizontalpodautoscaler/metrics-row';
 import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 import { DEFAULT_RESOURCE_METRIC } from '@shell/edit/autoscaling.horizontalpodautoscaler/resource-metric';
+import { Checkbox } from '@components/Form/Checkbox';
 
 import { API_SERVICE, SCALABLE_WORKLOAD_TYPES } from '@shell/config/types';
 import isEmpty from 'lodash/isEmpty';
 import find from 'lodash/find';
 import endsWith from 'lodash/endsWith';
 import { findBy } from '@shell/utils/array';
+import HpaScalingRule from '@shell/edit/autoscaling.horizontalpodautoscaler/hpa-scaling-rule.vue';
 
 const RESOURCE_METRICS_API_GROUP = 'metrics.k8s.io';
 
@@ -25,7 +27,9 @@ export default {
   name: 'CruHPA',
 
   components: {
+    HpaScalingRule,
     ArrayListGrouped,
+    Checkbox,
     CruResource,
     LabeledInput,
     LabeledSelect,
@@ -106,6 +110,40 @@ export default {
       const match = findBy(allWorkloadsFiltered, 'metadata.name', name);
 
       return match ?? null;
+    },
+    hasScaleDownRules: {
+      get() {
+        return !!this.value.spec.behavior?.scaleDown;
+      },
+      set(hasScaleDownRules) {
+        if (hasScaleDownRules) {
+          if (!this.value.spec.behavior) {
+            this.$set(this.value.spec, 'behavior', {});
+          }
+          if (!this.value.spec.behavior?.scaleDown) {
+            this.$set(this.value.spec.behavior, 'scaleDown', {});
+          }
+        } else {
+          this.$delete(this.value.spec.behavior, 'scaleDown');
+        }
+      }
+    },
+    hasScaleUpRules: {
+      get() {
+        return !!this.value.spec.behavior?.scaleUp;
+      },
+      set(hasScaleUpRules) {
+        if (hasScaleUpRules) {
+          if (!this.value.spec.behavior) {
+            this.$set(this.value.spec, 'behavior', {});
+          }
+          if (!this.value.spec.behavior?.scaleUp) {
+            this.$set(this.value.spec.behavior, 'scaleUp', {});
+          }
+        } else {
+          this.$delete(this.value.spec.behavior, 'scaleUp');
+        }
+      }
     },
   },
 
@@ -241,6 +279,43 @@ export default {
               />
             </template>
           </ArrayListGrouped>
+        </Tab>
+        <Tab
+          name="behavior"
+          :label="t('hpa.tabs.behavior')"
+        >
+          <div class="col span-12 mb-10">
+            <h3>
+              {{ t('hpa.scaleDownRules.label') }}
+            </h3>
+            <Checkbox
+              v-model="hasScaleDownRules"
+              :mode="mode"
+              :label="t('hpa.scaleDownRules.enable')"
+            />
+            <HpaScalingRule
+              v-if="hasScaleDownRules"
+              v-model="value"
+              type="scaleDown"
+              :mode="mode"
+            />
+          </div>
+          <div class="col span-12">
+            <h3>
+              {{ t('hpa.scaleUpRules.label') }}
+            </h3>
+            <Checkbox
+              v-model="hasScaleUpRules"
+              :mode="mode"
+              :label="t('hpa.scaleUpRules.enable')"
+            />
+            <HpaScalingRule
+              v-if="hasScaleUpRules"
+              v-model="value"
+              type="scaleUp"
+              :mode="mode"
+            />
+          </div>
         </Tab>
         <Tab
           name="labels-and-annotations"

--- a/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -288,11 +288,13 @@ export default {
             <h3>
               {{ t('hpa.scaleDownRules.label') }}
             </h3>
-            <Checkbox
-              v-model="hasScaleDownRules"
-              :mode="mode"
-              :label="t('hpa.scaleDownRules.enable')"
-            />
+            <div class="row mb-10">
+              <Checkbox
+                v-model="hasScaleDownRules"
+                :mode="mode"
+                :label="t('hpa.scaleDownRules.enable')"
+              />
+            </div>
             <HpaScalingRule
               v-if="hasScaleDownRules"
               v-model="value"
@@ -304,11 +306,13 @@ export default {
             <h3>
               {{ t('hpa.scaleUpRules.label') }}
             </h3>
-            <Checkbox
-              v-model="hasScaleUpRules"
-              :mode="mode"
-              :label="t('hpa.scaleUpRules.enable')"
-            />
+            <div class="row mb-10">
+              <Checkbox
+                v-model="hasScaleUpRules"
+                :mode="mode"
+                :label="t('hpa.scaleUpRules.enable')"
+              />
+            </div>
             <HpaScalingRule
               v-if="hasScaleUpRules"
               v-model="value"


### PR DESCRIPTION
### Summary
Kubernetes added additional functionality to HorizontalPodAutoscalers to configure the autoscaling behavior. This has been stable since Kubernetes 1.23.

Documentation https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
API Reference https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/horizontal-pod-autoscaler-v2/#HorizontalPodAutoscalerSpec

Fixes #9032

### Occurred changes and/or fixed issues
* Adds form fields to edit the autoscaling behavior in the HPA edit form
* Adds autoscaling behavior information on the HPA detail page

### Areas or cases that should be tested
HPA creation/edit form, HPA detail page.

### Areas which could experience regressions
HPA creation/edit form, HPA detail page.

### Screenshot/Video
<img width="1255" alt="Bildschirmfoto 2023-06-02 um 13 40 46" src="https://github.com/rancher/dashboard/assets/243056/0f6c872e-77f9-44fa-9ae1-ab20ce001786">
<img width="1266" alt="Bildschirmfoto 2023-06-02 um 13 37 51" src="https://github.com/rancher/dashboard/assets/243056/5da1f4ad-e168-4a76-ba9b-1b1bb745cb36">

