### PR TITLE
Remove large, disco loading indicators when creating/editing RKE2 clusters

### DIFF
--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -107,7 +107,7 @@ export function shouldNotLoadPlugin(plugin, rancherVersion, loadedPlugins) {
   }
 
   // check if a builtin extension has been loaded before - improve developer experience
-  const checkLoaded = loadedPlugins.find(p => p?.name === plugin?.name);
+  const checkLoaded = loadedPlugins.find((p) => p?.name === plugin?.name);
 
   if (checkLoaded && checkLoaded.builtin) {
     return 'plugins.error.developerPkg';

--- a/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/MachinePool.vue
@@ -262,6 +262,7 @@ export default {
       :pool-index="idx"
       :machine-pools="machinePools"
       :busy="busy"
+      class="configComponent"
       @error="e=>errors = e"
       @updateMachineCount="updateMachineCount"
       @expandAdvanced="expandAdvanced"
@@ -351,5 +352,9 @@ export default {
   .advanced ::v-deep >.vue-portal-target:empty,
   .advanced ::v-deep >.vue-portal-target:empty + .spacer {
     display: none;
+  }
+  .configComponent {
+    position: relative;
+    min-height:40px
   }
 </style>

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -62,6 +62,8 @@ export default {
     } else if ( !this.filteredCredentials.length ) {
       this.credentialId = _NEW;
     }
+
+    this.loadedOnce = true;
   },
 
   data() {
@@ -71,7 +73,8 @@ export default {
       credentialId:           this.value || _NONE,
       newCredential:          null,
       createValidationPassed: false,
-      originalId:             this.value
+      originalId:             this.value,
+      loadedOnce:             false,
     };
   },
 
@@ -212,7 +215,10 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
+  <Loading
+    v-if="!loadedOnce"
+    mode="relative"
+  />
   <CruResource
     v-else
     :mode="mode"

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -64,6 +64,8 @@ const defaultMocks = {
   },
 };
 
+const defaultData = () => ({ loadedOnce: true });
+
 const defaultSpec = {
   rkeConfig:   { etcd: { disableSnapshots: false } },
   chartValues: {},
@@ -113,7 +115,8 @@ describe('component: rke2', () => {
           }
         },
       },
-      stubs: defaultStubs
+      stubs: defaultStubs,
+      data:  defaultData
     });
 
     const select = wrapper.find('[data-testid="rke2-custom-edit-psa"]');
@@ -154,7 +157,8 @@ describe('component: rke2', () => {
           }
         },
       },
-      stubs: defaultStubs
+      stubs: defaultStubs,
+      data:  defaultData
     });
 
     const select = wrapper.find('[data-testid="rke2-custom-edit-psa"]');
@@ -205,7 +209,8 @@ describe('component: rke2', () => {
           }
         },
       },
-      stubs: defaultStubs
+      stubs: defaultStubs,
+      data:  defaultData
     });
 
     wrapper.setData({ cisOverride: override });
@@ -237,7 +242,8 @@ describe('component: rke2', () => {
         ...defaultMocks,
         $store: { getters: defaultGetters },
       },
-      stubs: defaultStubs
+      stubs: defaultStubs,
+      data:  defaultData
     });
 
     expect((wrapper.vm as any).validationPassed).toBe(result);
@@ -256,7 +262,7 @@ describe('component: rke2', () => {
         },
         provider: 'custom'
       },
-      data:     () => ({ credentialId: 'I am authenticated' }),
+      data:     () => ({ credentialId: 'I am authenticated', ...defaultData() }),
       computed: defaultComputed,
       mocks:    {
         ...defaultMocks,

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -290,6 +290,8 @@ export default {
     if ( !this.value.spec[FLEET_AGENT_CUSTOMIZATION] ) {
       set(this.value.spec, FLEET_AGENT_CUSTOMIZATION, {});
     }
+
+    this.loadedOnce = true;
   },
 
   data() {
@@ -2092,7 +2094,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending && !loadedOnce" />
+  <Loading v-if="!loadedOnce" />
   <Banner
     v-else-if="$fetchState.error"
     color="error"
@@ -2124,15 +2126,20 @@ export default {
         <span v-clean-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
       </Banner>
     </div>
-    <SelectCredential
+
+    <div
       v-if="needCredential"
-      v-model="credentialId"
-      :mode="mode"
-      :provider="provider"
-      :cancel="cancelCredential"
-      :showing-form="showForm"
-      class="mt-20"
-    />
+      class="credentials-container"
+    >
+      <SelectCredential
+        v-model="credentialId"
+        :mode="mode"
+        :provider="provider"
+        :cancel="cancelCredential"
+        :showing-form="showForm"
+        class="mt-20"
+      />
+    </div>
 
     <div
       v-if="showForm"
@@ -3053,5 +3060,10 @@ export default {
   }
   .header-warnings .banner {
     margin-bottom: 0;
+  }
+
+  .credentials-container {
+    position: relative;
+    min-height:40px
   }
 </style>

--- a/shell/machine-config/digitalocean.vue
+++ b/shell/machine-config/digitalocean.vue
@@ -86,6 +86,8 @@ export default {
     } catch (e) {
       this.errors = exceptionToErrorsArray(e);
     }
+
+    this.loadedOnce = true;
   },
 
   data() {
@@ -100,7 +102,8 @@ export default {
       regionOptions:   null,
       imageOptions:    null,
       instanceOptions: null,
-      tags
+      tags,
+      loadedOnce:      false,
     };
   },
 
@@ -138,8 +141,8 @@ export default {
 
 <template>
   <Loading
-    v-if="$fetchState.pending"
-    :delayed="true"
+    v-if="!loadedOnce"
+    mode="relative"
   />
   <div v-else-if="errors.length">
     <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/9201
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Two issues caused by multiple `Loading` components (root RKE2, one for credentials and one for machine configs)
- Large loading indicators shown
  - Use 'relative' loading indicators (component only shown where content is loading)
  - Ensure there's a relative element to position to
- Flashing, disco like loading indicators
  - All indicators worked on same $fetchState.pending
  - Use specific, context relative flag tp show indicators instead
  - Note - there's still one blip on refresh, guessing this has to do with rendering given components in flux

### Technical notes summary
- This is draft at the moment, if after review it's fine i'll extend to all other machine config providers

### Areas or cases that should be tested
- RKE2 create screens for each provider (amazon, azure, linode, pngp and vmware)


![image](https://github.com/rancher/dashboard/assets/18697775/aa0c8c09-2de9-4356-8e2d-f859061c4f43)

