### PR TITLE
Modify zube auto-labelling action

### DIFF
--- a/.github/workflows/add-to-triage-label.yaml
+++ b/.github/workflows/add-to-triage-label.yaml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Label issues
-        if: "!(contains(github.event.issue.labels.*.name, '[zube]: Working') || contains(github.event.issue.labels.*.name, '[zube]: Backlog') || contains(github.event.issue.labels.*.name, '[zube]: Backend Blocked') || contains(github.event.issue.labels.*.name, '[zube]: Next Up') || contains(github.event.issue.labels.*.name, '[zube]: Review'))"
+        if: "!startsWith(github.event.issue.labels.*.name, '[zube]:')"
         uses: github/issue-labeler@v2.5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/add-to-triage-label.yaml
+++ b/.github/workflows/add-to-triage-label.yaml
@@ -10,8 +10,24 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Check Labels
+        id: check-labels
+        env:
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+        run: |
+          # Check if issue has zube labels
+          set +e
+          echo ${ISSUE_LABELS} > labels
+          cat labels
+          grep -c -E "\s*\[zube\]:" labels
+          if [ $? -eq 1 ]; then
+            echo "update=true" >> $GITHUB_OUTPUT
+            echo "Can not find any existing zube labels"
+          else
+            echo "Found existing zube labels"
+          fi
       - name: Label issues
-        if: "!startsWith(github.event.issue.labels.*.name, '[zube]:')"
+        if: steps.check-labels.outputs.update == 'true'
         uses: github/issue-labeler@v2.5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Updates the auto-labelling GH Action workflow to ignore all labels starting `[zube]:` when deciding whether to auto-label an issue with the `Triage` label.

Have to do a bit of work to check the labels - ended up using a small bash script to do this.