### PR TITLE
Treat no cloudcredential schema resourceFields as having no schema

### DIFF
--- a/shell/cloud-credential/generic.vue
+++ b/shell/cloud-credential/generic.vue
@@ -33,7 +33,7 @@ export default {
     for ( const k of keyOptions ) {
       const sk = simplify(k);
 
-      if ( normanSchema || likelyFields.includes(sk) || iffyFields.includes(sk) ) {
+      if ( normanSchema?.resourceFields || likelyFields.includes(sk) || iffyFields.includes(sk) ) {
         keys.push(k);
       }
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Relates to https://github.com/rancher/dashboard/issues/8523
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- For CloudCA NodeDriver a cloudcredential schema is created (cloudcacredentialconfig)
- This does not contain resourceFields
- In https://github.com/rancher/dashboard/pull/8564/files we changed the logic in one place to look at the resourceFields collection instead of itself
- Need to make a similar change in code below
- This fix aligns what we show in dashboard with ember

### Screenshot/Video

![image](https://github.com/rancher/dashboard/assets/18697775/4ee989b6-b7fa-4bc8-a223-bfa1a1240c29)

![image](https://github.com/rancher/dashboard/assets/18697775/5fa9bde7-7089-4fc2-bef1-0d338c123a15)
