### PR TITLE
Unit test to check Receivers and Output email should have port and ho…

### DIFF
--- a/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
+++ b/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import Email from '@shell/edit/monitoring.coreos.com.receiver/types/email.vue';
 
 describe('page: Routes and Receivers', () => {
-  it('email should have host and port fields', () => {
+  it('should have host field with a valid integer value under Email form', () => {
     const wrapper = mount(Email, {
       propsData: {
         mode:  'create',
@@ -20,12 +20,12 @@ describe('page: Routes and Receivers', () => {
     });
 
     const host = wrapper.find('[data-testid="input-email-host"]');
-    const port = wrapper.find('[data-testid="input-email-port"]');
+    host.setValue('10.2.300.3');
 
     expect(host.exists()).toBe(true);
-    expect(port.exists()).toBe(true);
+    expect(host.element.value).toStrictEqual('10.2.300.3');
   });
-  it('email host and posrt field should have value to a valid integer', () => {
+  it('should have port field with a valid integer value under Email form', () => {
     const wrapper = mount(Email, {
       propsData: {
         mode:  'create',
@@ -41,14 +41,11 @@ describe('page: Routes and Receivers', () => {
         }
       },
     });
-
-    const host = wrapper.find('[data-testid="input-email-host"]');
+  
     const port = wrapper.find('[data-testid="input-email-port"]');
-
-    host.setValue('10.2.300.3');
     port.setValue('8080');
 
-    expect(host.element.value).toStrictEqual('10.2.300.3');
+    expect(port.exists()).toBe(true);
     expect(port.element.value).toStrictEqual('8080');
   });
 });

--- a/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
+++ b/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
@@ -20,6 +20,7 @@ describe('page: Routes and Receivers', () => {
     });
 
     const host = wrapper.find('[data-testid="input-email-host"]');
+
     host.setValue('10.2.300.3');
 
     expect(host.exists()).toBe(true);
@@ -41,8 +42,9 @@ describe('page: Routes and Receivers', () => {
         }
       },
     });
-  
+
     const port = wrapper.find('[data-testid="input-email-port"]');
+
     port.setValue('8080');
 
     expect(port.exists()).toBe(true);

--- a/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
+++ b/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
@@ -1,0 +1,19 @@
+import { mount } from '@vue/test-utils';
+import Email from '@shell/edit/monitoring.coreos.com.receiver/types/email.vue';
+
+describe('page: Routes and Receivers', () => {
+  it('email should have host and port fields', () => {
+    const wrapper = mount(Email, {
+      propsData: {
+        mode:  'create',
+        value: {}
+      },
+    });
+
+    const host = wrapper.find('[data-testid="input-email-host"]');
+    const port = wrapper.find('[data-testid="input-email-port"]');
+
+    expect(host.exists()).toBe(true);
+    expect(port.exists()).toBe(true);
+  });
+});

--- a/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
+++ b/shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts
@@ -8,6 +8,15 @@ describe('page: Routes and Receivers', () => {
         mode:  'create',
         value: {}
       },
+      mocks: {
+        t:      (text: string) => text, // Mock i18n global function used as alternative to the getter
+        $store: {
+          getters: {
+            'i18n/t':      jest.fn(),
+            'i18n/exists': jest.fn()
+          }
+        }
+      },
     });
 
     const host = wrapper.find('[data-testid="input-email-host"]');
@@ -15,5 +24,31 @@ describe('page: Routes and Receivers', () => {
 
     expect(host.exists()).toBe(true);
     expect(port.exists()).toBe(true);
+  });
+  it('email host and posrt field should have value to a valid integer', () => {
+    const wrapper = mount(Email, {
+      propsData: {
+        mode:  'create',
+        value: {}
+      },
+      mocks: {
+        t:      (text: string) => text, // Mock i18n global function used as alternative to the getter
+        $store: {
+          getters: {
+            'i18n/t':      jest.fn(),
+            'i18n/exists': jest.fn()
+          }
+        }
+      },
+    });
+
+    const host = wrapper.find('[data-testid="input-email-host"]');
+    const port = wrapper.find('[data-testid="input-email-port"]');
+
+    host.setValue('10.2.300.3');
+    port.setValue('8080');
+
+    expect(host.element.value).toStrictEqual('10.2.300.3');
+    expect(port.element.value).toStrictEqual('8080');
   });
 });

--- a/shell/edit/monitoring.coreos.com.receiver/types/email.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/email.vue
@@ -78,6 +78,7 @@ export default {
           v-model="value.host"
           :mode="mode"
           label="Host"
+          data-testid="input-email-host"
           placeholder="e.g. 192.168.1.121"
         />
       </div>
@@ -86,6 +87,7 @@ export default {
           v-model="value.port"
           :mode="mode"
           label="Port"
+          data-testid="input-email-port"
           placeholder="e.g. 80"
         />
       </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8830
<!-- Define findings related to the feature or bug issue. -->
Unit test to check Receivers and Output email should have port and host fields
 
### Test cases 

To reproduce:

Ensure Logging is installed.
Under Alerting Receiver, create a new receiver and under Email, verify that there are separate Host and Port elements

