### PR TITLE
Fix `selecting` event in LabeledSelect.vue

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1062,7 +1062,7 @@ export default {
                   :multiple="false"
                   :taggable="false"
                   :placeholder="t('sortableTable.selectCol')"
-                  @selecting="(col) => advFilterSelectedLabel = col.label"
+                  @selected="(col) => advFilterSelectedLabel = col.label"
                 />
               </div>
               <div class="bottom-block">

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -285,7 +285,7 @@ export default {
       @search="onSearch"
       @open="onOpen"
       @close="onClose"
-      @option:selected="$emit('selecting', $event)"
+      @option:selected="$emit('selected', $event)"
     >
       <template #option="option">
         <template v-if="option.kind === 'group'">

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -285,6 +285,7 @@ export default {
       @search="onSearch"
       @open="onOpen"
       @close="onClose"
+      @option:selecting="$emit('selecting', $event)"
       @option:selected="$emit('selected', $event)"
     >
       <template #option="option">

--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -290,7 +290,7 @@ export default {
           :mode="mode"
           :options="matchingSelectOptions"
           :data-testid="`input-match-type-field-control-${index}`"
-          @selecting="update"
+          @selected="update"
         />
       </div>
       <div

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -419,7 +419,7 @@ export default {
         :placeholder="t('namespace.selectOrCreate')"
         :rules="rules.namespace"
         required
-        @selecting="selectNamespace"
+        @selected="selectNamespace"
       />
     </div>
 

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -419,7 +419,7 @@ export default {
         :placeholder="t('namespace.selectOrCreate')"
         :rules="rules.namespace"
         required
-        @selected="selectNamespace"
+        @selecting="selectNamespace"
       />
     </div>
 

--- a/shell/components/form/SimpleSecretSelector.vue
+++ b/shell/components/form/SimpleSecretSelector.vue
@@ -135,7 +135,7 @@ export default {
         :options="secretNames"
         :label="secretNameLabel"
         :mode="mode"
-        @selecting="updateSecretName"
+        @selected="updateSecretName"
       />
       <LabeledSelect
         v-model="key"
@@ -144,7 +144,7 @@ export default {
         :options="keys"
         :label="keyNameLabel"
         :mode="mode"
-        @selecting="updateSecretKey"
+        @selected="updateSecretKey"
       />
     </div>
   </div>

--- a/shell/edit/networking.k8s.io.ingress/IngressClass.vue
+++ b/shell/edit/networking.k8s.io.ingress/IngressClass.vue
@@ -59,7 +59,7 @@ export default {
       :label="t('ingress.ingressClass.label')"
       :options="ingressClassOptions"
       option-label="label"
-      @selecting="update"
+      @selected="update"
     />
   </div>
 </template>

--- a/shell/edit/persistentvolume/plugins/csi.vue
+++ b/shell/edit/persistentvolume/plugins/csi.vue
@@ -89,7 +89,7 @@ export default {
           :placeholder="t('persistentVolume.csi.driver.placeholder')"
           searchable
           taggable
-          @selecting="selectDriver"
+          @selected="selectDriver"
         />
       </div>
       <div class="col span-6">

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -610,7 +610,7 @@ export default {
           :label="t('cluster.machineConfig.azure.size.label')"
           :tooltip="value.acceleratedNetworking ? t('cluster.machineConfig.azure.size.tooltip') : ''"
           :disabled="disabled"
-          @selecting="handleVmSizeInput"
+          @selected="handleVmSizeInput"
         />
         <Banner
           v-if="vmSizeAcceleratedNetworkingWarning"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/epinio/ui/issues/205
<!-- Define findings related to the feature or bug issue. -->

We need this to fix a wrong behavior on Epinio namespace selectors, where we have the option to create a new namespace.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The 'Create a new namespace' option is on top of the namespaces list, in Epinio UI.
When the user edit the new namespace's name and then clicks on 'X' icon, the creation option is no more selectable.
The Namespace dropdown element is made on top of `LabeledSelect.vue` that send a selecting event when a new option is selected by the user:

```
@option:selected="$emit('selecting', $event)"
```
When the creation option is clicked for the second time, the `@option:selected` is not fired since v-select already have this value internally.
This is fixed by replace @option:selected with @option:selecting, which is fired every time an option is selected, regardless of what is the value stored by `v-select`.
Difference between selected and selecting for `v-select`: https://vue-select.org/api/events.html#open