### PR TITLE
Bump shell - Clean up temporary charts - fix chart url path

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",

--- a/shell/scripts/extension/publish
+++ b/shell/scripts/extension/publish
@@ -280,7 +280,7 @@ for d in pkg/*/ ; do
     fi
 
     # Base URL referencing assets directly from GitHub
-    BASE_URL="assets/${pkg}"
+    BASE_URL="assets/"
 
     # Relative URL references assets within the container deployment
     RELATIVE_URL="plugin/"
@@ -320,6 +320,8 @@ if [ "${GITHUB_BUILD}" == "false" ]; then
 
   # Build the docker image
   ${SCRIPT_DIR}/bundle ${BASE_EXT} ${EXT_VERSION} ${REGISTRY} ${REGISTRY_ORG} ${IMAGE_PREFIX} ${PUSH}
+else
+  rm -rf ${CHART_TEMPLATE}
 fi
 
 if [ "${GITHUB_BUILD}" == "true" ] && [ -f ${ROOT_INDEX} ]; then


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This fixes an issue where initial extension packages will have a duplicated folder name in the `url` path for the package chart. Also removed unnecessary directory lingering in artifact build.

Bumps shell to `0.3.13`