### PR TITLE
Align wizard title row

### DIFF
--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -595,6 +595,7 @@ $spacer: 10px;
         display: flex;
         align-items: center;
         justify-content: space-evenly;
+        position: relative;
 
         & > .subtitle {
           margin-right: 20px;

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -525,7 +525,7 @@ $spacer: 10px;
           align-items: center;
           width: 40px;
           overflow: visible;
-          padding-top: 15px;
+          padding-top: 7px;
 
           .cru__content & {
             padding-top: 0;
@@ -565,7 +565,7 @@ $spacer: 10px;
         flex-basis: 100%;
         border-top: 1px solid var(--border);
         position: relative;
-        top: 28px;
+        top: 17px;
 
         .cru__content & {
           top: 13px;

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1283,7 +1283,7 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <div
     v-else-if="!legacyApp && !mcapp"
-    class="install-steps"
+    class="install-steps mt-20"
     :class="{ 'isPlainLayout': isPlainLayout}"
   >
     <TypeDescription resource="chart" />

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1283,7 +1283,7 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <div
     v-else-if="!legacyApp && !mcapp"
-    class="install-steps mt-20"
+    class="install-steps pt-20"
     :class="{ 'isPlainLayout': isPlainLayout}"
   >
     <TypeDescription resource="chart" />

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1296,6 +1296,7 @@ export default {
       :banner-title-subtext="stepperSubtext"
       :finish-mode="action"
       class="wizard"
+      :class="{'windowsIncompatible': windowsIncompatible}"
       @cancel="cancel"
       @finish="finish"
     >
@@ -1840,7 +1841,6 @@ export default {
       border: $padding solid white;
       border-radius: calc( 3 * var(--border-radius));
       position: relative;
-      margin-bottom: 15px
     }
 
     .logo {
@@ -1855,6 +1855,22 @@ export default {
       left: 0;
       margin: auto;
     }
+
+    // Hack - We're adding an absolute tag under the logo that we want to consume space without breaking vertical alignment of row.
+    // W  ith the slots available this isn't possible without adding tag specific styles to the root wizard classes
+    &.windowsIncompatible {
+      ::v-deep .header {
+        padding-bottom: 15px;
+      }
+    }
+
+    .os-label {
+      position: absolute;
+      background-color: var(--warning-banner-bg);
+      color:var(--warning);
+      margin-top: 5px;
+    }
+
   }
 
   .step {
@@ -2051,14 +2067,6 @@ export default {
       }
     }
   }
-}
-
-.os-label {
-  position: relative;
-  background-color: var(--warning-banner-bg);
-  color:var(--warning);
-  margin-top: 5px;
-  top: 21px;
 }
 
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix issue where app chart wizard header alignment was off

![image](https://github.com/rancher/dashboard/assets/18697775/726650dd-a43c-4e4c-aee2-2cd367dee9b8)

### Occurred changes and/or fixed issues
- Ensure step vertical bar is aligned correctly
- For App Chart Install ensure the os warning tag is placed correctly WITHOUT borking the alignment of the header or changing wizard classes
- Tested
  - Wizard in app chart install - linux only warning and no warning
  - Wizard in cru resource (fleet git repo)
  - Will also validate in epinio wizard later on

Supersede https://github.com/rancher/dashboard/pull/9079

### Screenshot/Video
![image](https://github.com/rancher/dashboard/assets/18697775/65bf9bd3-51b0-49bb-a814-28e8e15bf154)

![image](https://github.com/rancher/dashboard/assets/18697775/47356d67-14be-4f71-acd4-d5e5f666d3f6)

![image](https://github.com/rancher/dashboard/assets/18697775/d70f2b50-d9f1-4733-881f-f57ade78c227)
