### PR TITLE
Automation preventdefault on press enter

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -394,6 +394,7 @@ export default {
 
     onPressEnter(event) {
       if (this.preventEnterSubmit) {
+        console.log('preventDefault');
         event.preventDefault();
       }
     }

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -394,7 +394,6 @@ export default {
 
     onPressEnter(event) {
       if (this.preventEnterSubmit) {
-        console.log('preventDefault');
         event.preventDefault();
       }
     }

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -412,6 +412,7 @@ export default {
     </p>
     <form
       :is="(isView? 'div' : 'form')"
+      id="cru-form"
       class="create-resource-container cru__form"
       @submit.prevent
       @keydown.enter="onPressEnter($event)"

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -412,7 +412,7 @@ export default {
     </p>
     <form
       :is="(isView? 'div' : 'form')"
-      id="cru-form"
+      data-testid="cru-form"
       class="create-resource-container cru__form"
       @submit.prevent
       @keydown.enter="onPressEnter($event)"

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -1,10 +1,9 @@
-import { mount, shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
 import { _EDIT, _YAML } from '@shell/config/query-params';
 import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
 describe('component: CruResource', () => {
-
   it('should hide Cancel button', () => {
     const wrapper = mount(CruResource, {
       propsData: {
@@ -67,7 +66,7 @@ describe('component: CruResource', () => {
     expect(node.text()).toContain(errors[0]);
     expect(node.text()).toContain(errors[1]);
   });
-  
+
   it('should prevent default events on keypress Enter', async() => {
     const event = { preventDefault: jest.fn() };
     const wrapper = mount(CruResource, {
@@ -102,9 +101,9 @@ describe('component: CruResource', () => {
     const wrapper = mount(CruResource, {
       directives: { cleanHtmlDirective },
       propsData:  {
-        canYaml:  false,
-        mode:     _EDIT,
-        resource: {},
+        canYaml:            false,
+        mode:               _EDIT,
+        resource:           {},
         preventEnterSubmit: false
       },
       components: {
@@ -130,4 +129,4 @@ describe('component: CruResource', () => {
     await element.trigger('keydown.enter', event);
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
-});   
+});

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -1,9 +1,12 @@
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
 import { _EDIT, _YAML } from '@shell/config/query-params';
 import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
+import { DefaultProps } from 'vue/types/options';
+import { ExtendedVue, Vue } from 'vue/types/vue';
 
 describe('component: CruResource', () => {
+
   it('should hide Cancel button', () => {
     const wrapper = mount(CruResource, {
       propsData: {
@@ -66,4 +69,34 @@ describe('component: CruResource', () => {
     expect(node.text()).toContain(errors[0]);
     expect(node.text()).toContain(errors[1]);
   });
-});
+  
+  it('should prevent default events on keypress Enter', async() => {
+    const event = { preventDefault: jest.fn() };
+    const wrapper = mount(CruResource, {
+      propsData: {
+        canYaml:            false,
+        mode:               _EDIT,
+        resource:           {},
+        preventEnterSubmit: true
+      },
+      mocks: {
+        $store: {
+          getters: {
+            currentStore:              () => 'current_store',
+            'current_store/schemaFor': jest.fn(),
+            'current_store/all':       jest.fn(),
+            'i18n/t':                  jest.fn(),
+            'i18n/exists':             jest.fn(),
+          }
+        },
+        $route:  { query: { AS: _YAML } },
+        $router: { applyQuery: jest.fn() },
+      }
+    });
+    const element = wrapper.find('#cru-form');
+
+    await element.trigger('keydown.enter', event);
+
+    expect(event.preventDefault).toHaveBeenCalledWith();
+  });
+});   

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
+import KeyValue from '@shell/components/form/KeyValue.vue';
 import { _EDIT, _YAML } from '@shell/config/query-params';
 import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
@@ -90,7 +91,7 @@ describe('component: CruResource', () => {
         $router: { applyQuery: jest.fn() },
       }
     });
-    const element = wrapper.find('#cru-form');
+    const element = wrapper.find('[data-testid="cru-form"]');
 
     await element.trigger('keydown.enter', event);
     expect(event.preventDefault).toHaveBeenCalledWith();
@@ -124,9 +125,44 @@ describe('component: CruResource', () => {
         $router: { applyQuery: jest.fn() },
       }
     });
-    const element = wrapper.find('#cru-form');
+    const element = wrapper.find('[data-testid="cru-form"]');
 
     await element.trigger('keydown.enter', event);
     expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('should have line keypress Enter', async() => {
+    const event = { preventDefault: jest.fn() };
+    const wrapper = mount(CruResource, {
+      directives: { cleanHtmlDirective },
+      propsData:  {
+        canYaml:            false,
+        mode:               _EDIT,
+        resource:           {},
+        preventEnterSubmit: false
+      },
+      components: {
+        ResourceYaml:        { template: '<div></div> ' },
+        ResourceCancelModal: { template: '<div></div> ' },
+      },
+      mocks: {
+        $store: {
+          getters: {
+            currentStore:              () => 'current_store',
+            'current_store/schemaFor': jest.fn(),
+            'current_store/all':       jest.fn(),
+            'i18n/t':                  jest.fn(),
+            'i18n/exists':             jest.fn(),
+          }
+        },
+        $route:  { query: { AS: _YAML } },
+        $router: { applyQuery: jest.fn() },
+      }
+    });
+    const mainWrapper = wrapper.find('[data-testid="code-mirror-multiline-field"]');
+    
+    // const keyValue = mainWrapper.findComponent(KeyValue);
+   
+    expect(mainWrapper.exists()).toBe(true);
   });
 });

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -2,8 +2,6 @@ import { mount, shallowMount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
 import { _EDIT, _YAML } from '@shell/config/query-params';
 import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
-import { DefaultProps } from 'vue/types/options';
-import { ExtendedVue, Vue } from 'vue/types/vue';
 
 describe('component: CruResource', () => {
 
@@ -74,7 +72,7 @@ describe('component: CruResource', () => {
     const event = { preventDefault: jest.fn() };
     const wrapper = mount(CruResource, {
       propsData: {
-        canYaml:            false,
+        canYaml:            true,
         mode:               _EDIT,
         resource:           {},
         preventEnterSubmit: true
@@ -96,7 +94,40 @@ describe('component: CruResource', () => {
     const element = wrapper.find('#cru-form');
 
     await element.trigger('keydown.enter', event);
-
     expect(event.preventDefault).toHaveBeenCalledWith();
+  });
+
+  it('should not prevent default events on keypress Enter', async() => {
+    const event = { preventDefault: jest.fn() };
+    const wrapper = mount(CruResource, {
+      directives: { cleanHtmlDirective },
+      propsData:  {
+        canYaml:  false,
+        mode:     _EDIT,
+        resource: {},
+        preventEnterSubmit: false
+      },
+      components: {
+        ResourceYaml:        { template: '<div></div> ' },
+        ResourceCancelModal: { template: '<div></div> ' },
+      },
+      mocks: {
+        $store: {
+          getters: {
+            currentStore:              () => 'current_store',
+            'current_store/schemaFor': jest.fn(),
+            'current_store/all':       jest.fn(),
+            'i18n/t':                  jest.fn(),
+            'i18n/exists':             jest.fn(),
+          }
+        },
+        $route:  { query: { AS: _YAML } },
+        $router: { applyQuery: jest.fn() },
+      }
+    });
+    const element = wrapper.find('#cru-form');
+
+    await element.trigger('keydown.enter', event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
   });
 });   

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
-import KeyValue from '@shell/components/form/KeyValue.vue';
 import { _EDIT, _YAML } from '@shell/config/query-params';
 import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 
@@ -129,40 +128,5 @@ describe('component: CruResource', () => {
 
     await element.trigger('keydown.enter', event);
     expect(event.preventDefault).not.toHaveBeenCalled();
-  });
-
-  it('should have line keypress Enter', async() => {
-    const event = { preventDefault: jest.fn() };
-    const wrapper = mount(CruResource, {
-      directives: { cleanHtmlDirective },
-      propsData:  {
-        canYaml:            false,
-        mode:               _EDIT,
-        resource:           {},
-        preventEnterSubmit: false
-      },
-      components: {
-        ResourceYaml:        { template: '<div></div> ' },
-        ResourceCancelModal: { template: '<div></div> ' },
-      },
-      mocks: {
-        $store: {
-          getters: {
-            currentStore:              () => 'current_store',
-            'current_store/schemaFor': jest.fn(),
-            'current_store/all':       jest.fn(),
-            'i18n/t':                  jest.fn(),
-            'i18n/exists':             jest.fn(),
-          }
-        },
-        $route:  { query: { AS: _YAML } },
-        $router: { applyQuery: jest.fn() },
-      }
-    });
-    const mainWrapper = wrapper.find('[data-testid="code-mirror-multiline-field"]');
-    
-    // const keyValue = mainWrapper.findComponent(KeyValue);
-   
-    expect(mainWrapper.exists()).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8817
<!-- Define findings related to the feature or bug issue. -->
Automation:  should prevent default events on keypress Enter if the `preventEnterSubmit` property is false