### PR TITLE
Remove *.tgz from extension .gitignore

### DIFF
--- a/shell/creators/app/files/.gitignore
+++ b/shell/creators/app/files/.gitignore
@@ -59,9 +59,6 @@ jspm_packages/
 # Optional REPL history
 .node_repl_history
 
-# Output of 'npm pack'
-*.tgz
-
 # Yarn Integrity file
 .yarn-integrity
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes an issue with the extension which caused any `tgz` files to not be committed - During the release process `./assets` must be pushed with with the packages asset file which was being ignored.