### PR TITLE
Add additional permission check for cluster and project member admin

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3026,6 +3026,7 @@ managementNode:
 members:
   clusterMembers: Cluster Members
   clusterAndProject: Cluster and Project Members
+  project: Project Members
   createActionLabel: Add
   clusterMemebership: Cluster Membership
   projectMembership: Project Membership

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -9,10 +9,18 @@ import Loading from '@shell/components/Loading';
 import { Checkbox } from '@components/Form/Checkbox';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 
-export function canViewClusterPermissionsEditor(store) {
-  return !!store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING) &&
+export function canEditClusterPermissions(store) {
+  // blocked-post means you can post through norman, but not through steve.
+  // collectionMethods and resourceMethods on norman schema itself are not accurate for permission checking here.
+  return !!(store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).find(method => ['blocked-post', 'post'].includes(method.toLowerCase())) &&
     !!store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE) &&
     !!store.getters['management/schemaFor'](MANAGEMENT.USER);
+}
+
+export function canViewClusterPermissions(store) {
+  return (store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).includes('GET') &&
+    (store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE)?.collectionMethods || []).includes('GET') &&
+    (store.getters['management/schemaFor'](MANAGEMENT.USER)?.collectionMethods || []).includes('GET');
 }
 
 export default {

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -52,6 +52,11 @@ export default {
     modalSticky: {
       type:    Boolean,
       default: false,
+    },
+
+    canManage: {
+      type:    Boolean,
+      default: true,
     }
   },
 
@@ -185,15 +190,17 @@ export default {
     </template>
     <template #add>
       <button
+        v-if="canManage"
         type="button"
         class="btn role-primary mt-10"
         @click="addMember"
       >
         {{ t('generic.add') }}
       </button>
+      <span v-else />
     </template>
     <template #remove-button="{remove, i}">
-      <span v-if="(isCreate && i === 0) || isView" />
+      <span v-if="(isCreate && i === 0) || isView || !canManage" />
       <button
         v-else
         type="button"

--- a/shell/components/form/Members/ProjectMembershipEditor.vue
+++ b/shell/components/form/Members/ProjectMembershipEditor.vue
@@ -1,11 +1,25 @@
 <script>
-import { NORMAN } from '@shell/config/types';
+import { MANAGEMENT, NORMAN } from '@shell/config/types';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import MembershipEditor from '@shell/components/form/Members/MembershipEditor';
 import { canViewMembershipEditor } from '@shell/components/form/Members/MembershipEditor.vue';
 
 export function canViewProjectMembershipEditor(store) {
   return canViewMembershipEditor(store, true);
+}
+
+export function canEditProjectPermissions(store) {
+  // blocked-post means you can post through norman, but not through steve.
+  // collectionMethods and resourceMethods on norman schema itself are not accurate for permission checking here.
+  return !!(store.getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).find(method => ['blocked-post', 'post'].includes(method.toLowerCase())) &&
+    !!store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE) &&
+    !!store.getters['management/schemaFor'](MANAGEMENT.USER);
+}
+
+export function canViewProjectPermissions(store) {
+  return (store.getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).includes('GET') &&
+    (store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE)?.collectionMethods || []).includes('GET') &&
+    (store.getters['management/schemaFor'](MANAGEMENT.USER)?.collectionMethods || []).includes('GET');
 }
 
 export default {

--- a/shell/components/form/Members/ProjectMembershipEditor.vue
+++ b/shell/components/form/Members/ProjectMembershipEditor.vue
@@ -50,6 +50,9 @@ export default {
 
     isView() {
       return this.mode === _VIEW;
+    },
+    canManageProjectMembers() {
+      return canEditProjectPermissions(this.$store);
     }
   },
 
@@ -72,6 +75,7 @@ export default {
     :default-binding-handler="defaultBindingHandler"
     :type="NORMAN.PROJECT_ROLE_TEMPLATE_BINDING"
     :mode="mode"
+    :can-manage="canManageProjectMembers"
     parent-key="projectId"
     :parent-id="parentId"
     v-on="$listeners"

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -283,16 +283,16 @@ export function init(store) {
   });
 
   virtualType({
-    labelKey:   'members.clusterAndProject',
-    group:      'cluster',
-    namespaced: false,
-    name:       VIRTUAL_TYPES.CLUSTER_MEMBERS,
-    icon:       'globe',
-    weight:     -1,
-    route:      { name: 'c-cluster-product-members' },
-    exact:      true,
-    ifHaveType: {
-      type:  MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
+    labelKey:       'members.clusterAndProject',
+    group:          'cluster',
+    namespaced:     false,
+    name:           VIRTUAL_TYPES.CLUSTER_MEMBERS,
+    icon:           'globe',
+    weight:         -1,
+    route:          { name: 'c-cluster-product-members' },
+    exact:          true,
+    ifHaveSubTypes: {
+      types: [MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING],
       store: 'management'
     }
   });

--- a/shell/models/clusterroletemplatebinding.js
+++ b/shell/models/clusterroletemplatebinding.js
@@ -22,6 +22,12 @@ export default class CRTB extends NormanModel {
     return this.$rootGetters[`management/byId`](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, this.id?.replace(':', '/'));
   }
 
+  get isCurrentUser() {
+    const out = this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userId);
+
+    return !!out?.isCurrentUser;
+  }
+
   get steve() {
     return this.$dispatch(`management/find`, {
       type: MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,

--- a/shell/models/clusterroletemplatebinding.js
+++ b/shell/models/clusterroletemplatebinding.js
@@ -23,6 +23,7 @@ export default class CRTB extends NormanModel {
   }
 
   get isCurrentUser() {
+    // This only checks the user is bound to the role... and not if the user is part of group that is bound to it
     const out = this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userId);
 
     return !!out?.isCurrentUser;

--- a/shell/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/shell/models/management.cattle.io.clusterroletemplatebinding.js
@@ -28,7 +28,7 @@ export default class CRTB extends HybridModel {
   }
 
   get principal() {
-    const principalId = this.principalId.replace(/\//g, '%2F');
+    const principalId = this.principalId?.replace(/\//g, '%2F');
 
     return this.$dispatch('rancher/find', {
       type: NORMAN.PRINCIPAL,

--- a/shell/models/projectroletemplatebinding.js
+++ b/shell/models/projectroletemplatebinding.js
@@ -18,6 +18,12 @@ export default class PRTB extends NormanModel {
     return this.$rootGetters['management/byId'](MANAGEMENT.ROLE_TEMPLATE, this.roleTemplateId);
   }
 
+  get isCurrentUser() {
+    const out = this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userId);
+
+    return !!out?.isCurrentUser;
+  }
+
   get steve() {
     return this.$dispatch(`management/find`, {
       type: MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING,

--- a/shell/models/projectroletemplatebinding.js
+++ b/shell/models/projectroletemplatebinding.js
@@ -19,6 +19,7 @@ export default class PRTB extends NormanModel {
   }
 
   get isCurrentUser() {
+    // This only checks the user is bound to the role... and not if the user is part of group that is bound to it
     const out = this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userId);
 
     return !!out?.isCurrentUser;

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -933,8 +933,10 @@ export const getters = {
           }
 
           if ( item.ifHaveSubTypes ) {
-            const hasSome = (item.ifHaveSubTypes || []).some((type) => {
-              return !!findBy(schemas, 'id', normalizeType(type));
+            const targetedSchemas = Array.isArray(item.ifHaveSubTypes) ? schemas : rootGetters[`${ item.ifHaveSubTypes.store }/all`](SCHEMA);
+            const subTypes = Array.isArray(item.ifHaveSubTypes) ? item.ifHaveSubTypes : item.ifHaveSubTypes.types;
+            const hasSome = (subTypes || []).some((type) => {
+              return !!findBy(targetedSchemas, 'id', normalizeType(type));
             });
 
             if (!hasSome) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9049
<!-- Define findings related to the feature or bug issue. -->
The issue originates from the "Project and Cluster Members" option in the nav menu only checking for cluster member schemas which means that project member admins will never see the link

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added functionality for "ifHaveSubTypes" on virtualTypes to accept an object like the "ifHaveType" parameter option

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Ensure that the correct tabs "Cluster", "Project", or both are shown for the appropriate permissions of the logged in user.
Ensure that the "Cluster and Project Members" option in the nav menu does not appear if users should not be able to use either.
A simple Project admin who manages project members will need the appropriate project permissions as well as a global role with the following rules:
<img width="279" alt="image" src="https://github.com/rancher/dashboard/assets/37550899/095b39c5-ba79-47d1-9b79-3eb16d24757a">
Note: This can only be accomplished for a custom role by either creating the role directly with Yaml or copying an existing role in which `principals` and `roletemplates` fall under the same apiGroups yaml heading, this is not currently achievable via the UI. A standard global role template such as "Standard User" will also work just fine so long as it has the above permissions.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Ensure that the correct tabs "Cluster", "Project", or both are shown for the appropriate permissions of the logged in user.
Ensure that the "Cluster and Project Members" option in the nav menu does not appear if users should not be able to use either.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->