### PR TITLE
Replace dex/sso terminology with Auth Provider

### DIFF
--- a/pkg/epinio/l10n/en-us.yaml
+++ b/pkg/epinio/l10n/en-us.yaml
@@ -340,6 +340,6 @@ epinio:
 model:
   authConfig:
     provider:
-      epinio: Dex
+      epinio: Auth Provider
 login:
-  genericProvider: Log in with SSO
+  genericProvider: Log in with Auth Provider


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/epinio/ui/issues/240

- Replace both old `Dex` (specific auth provider) and new `SSO` (technical acronym) references with a more non-technical `Auth Provider` string

### Technical notes summary
This does introduce some odd verbage, but the local provider should rarely be used in production and the fix avoids adding additional plumbing around the core dashboard screens

### Screenshot/Video
![image](https://github.com/rancher/dashboard/assets/18697775/9a590e46-c1c6-4794-9a80-f8c68f7a9502)

![image](https://github.com/rancher/dashboard/assets/18697775/8ed73547-90f4-4398-a10f-f45c40ac9174)

