### PR TITLE
Ensure cancel when creating a NS sets valid selected option

### DIFF
--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -354,7 +354,8 @@ export default {
     cancelCreateNamespace(e) {
       this.createNamespace = false;
       this.$parent.$emit('createNamespace', false);
-      this.namespace = this.$store.getters['defaultNamespace'];
+      // In practise we should always have a defaultNamespace... unless we're in non-kube extension world,  so fall back on options
+      this.namespace = this.$store.getters['defaultNamespace'] || this.options.find(o => !!o.value)?.value ;
     },
 
     selectNamespace(e) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/epinio/ui/issues/205
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- In epinio world defaultNamespace isn't valid
- This would be undefined, which was probably handled as a falsy which matched the 'create a ns' option
- So fall back on something sensible

Supersedes https://github.com/rancher/dashboard/pull/9065 