### PR TITLE
Temporarily disable recording e2e tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -102,4 +102,5 @@ export default defineConfig({
     specPattern:                  getSpecPattern(),
     baseUrl
   },
+  video: false,
 });

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -2,4 +2,4 @@
 ID="$(echo ${TEST_RUN_ID:-`date +%s`} | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
 echo "$ID"
 
-CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' cy2 run --browser chrome --key rancher-dashboard
+CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' cy2 run --browser chrome --record --key rancher-dashboard --parallel --ci-build-id "$ID"

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -2,4 +2,4 @@
 ID="$(echo ${TEST_RUN_ID:-`date +%s`} | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
 echo "$ID"
 
-CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' cy2 run --browser chrome --record --key rancher-dashboard --parallel --ci-build-id "$ID"
+CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' cy2 run --browser chrome --key rancher-dashboard


### PR DESCRIPTION
- This will make it harder to debug flaky tests in CI
- BUT it might stop flaky tests if the recording consumes too much resources in container
