### PR TITLE
Handle extensions that are already installed and shouldn't run in a particular kube version

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3989,7 +3989,9 @@ inactivity:
 
 # Rancher Extensions
 plugins:
-  incompatibleDisclaimer: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ rancherVersion })."
+  incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ rancherVersion })."
+  incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ kubeVersion })."
+  currentInstalledVersionBlockedByKubeVersion: "This version is not compatible with the current Kubernetes version ({ kubeVersion }  Vs  { kubeVersionToCheck })."
   labels:
     builtin: Built-in
     experimental: Experimental
@@ -4026,7 +4028,8 @@ plugins:
     detail: Detail
     versions: Versions
     versionError: Could not load version information
-    requiresVersion: "Requires Rancher {version}"
+    requiresRancherVersion: "Requires Rancher {version}"
+    requiresKubeVersion: "Requires Kube version {version}"
   empty:
     all: Extensions are neither installed nor available
     available: No Extensions available

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -3996,7 +3996,7 @@ inactivity:
 
 # Rancher Extensions
 plugins:
-  incompatibleDisclaimer: "此扩展的最新版本 ({ version }) 与当前的 Rancher 版本 ({ rancherVersion }) 不兼容。"
+  incompatibleRancherVersion: "此扩展的最新版本 ({ version }) 与当前的 Rancher 版本 ({ rancherVersion }) 不兼容。"
   labels:
     builtin: 内置角色
     experimental: 实验功能
@@ -4032,7 +4032,7 @@ plugins:
     detail: 详情
     versions: 版本
     versionError: 无法加载版本信息
-    requiresVersion: "需要 Rancher {version}"
+    requiresRancherVersion: "需要 Rancher {version}"
   empty:
     all: 扩展未安装或不可用
     available: 没有可用的扩展

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -31,6 +31,7 @@ export const UI_PLUGINS_REPO_BRANCH = 'main';
 
 // Chart annotations
 export const UI_PLUGIN_CHART_ANNOTATIONS = {
+  KUBE_VERSION:       'catalog.cattle.io/kube-version',
   RANCHER_VERSION:    'catalog.cattle.io/rancher-version',
   EXTENSIONS_VERSION: 'catalog.cattle.io/ui-extensions-version',
   UI_VERSION:         'catalog.cattle.io/ui-version',
@@ -121,16 +122,18 @@ export function shouldNotLoadPlugin(plugin, rancherVersion, loadedPlugins) {
 }
 
 // Can a chart version be used for this Rancher (based on the annotations on the chart)?
-export function isSupportedChartVersion(chartVersion, rancherVersion) {
+export function isSupportedChartVersion(versionsData) {
+  const { version, rancherVersion, kubeVersion } = versionsData;
+
   // Plugin specified a required extension API version
-  const requiredAPI = chartVersion.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION];
+  const requiredAPI = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION];
 
   if (requiredAPI && !semver.satisfies(UI_PLUGIN_API_VERSION, requiredAPI)) {
     return false;
   }
 
   // Host application
-  const requiredHost = chartVersion.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_HOST];
+  const requiredHost = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_HOST];
 
   if (requiredHost && requiredHost !== UI_PLUGIN_HOST_APP) {
     return false;
@@ -138,9 +141,18 @@ export function isSupportedChartVersion(chartVersion, rancherVersion) {
 
   // Rancher version
   if (rancherVersion) {
-    const requiredRancherVersion = chartVersion.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.RANCHER_VERSION];
+    const requiredRancherVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.RANCHER_VERSION];
 
     if (requiredRancherVersion && !semver.satisfies(rancherVersion, requiredRancherVersion)) {
+      return false;
+    }
+  }
+
+  // Kube version
+  if (kubeVersion) {
+    const requiredKubeVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION];
+
+    if (requiredKubeVersion && !semver.satisfies(kubeVersion, requiredKubeVersion)) {
       return false;
     }
   }
@@ -148,14 +160,18 @@ export function isSupportedChartVersion(chartVersion, rancherVersion) {
   return true;
 }
 
-export function isChartVersionAvailableForInstall(version, rancherVersion, returnObj = false) {
+export function isChartVersionAvailableForInstall(versionsData, returnObj = false) {
+  const { version, rancherVersion, kubeVersion } = versionsData;
+
   const parsedRancherVersion = rancherVersion.split('-')?.[0];
   const regexHashString = new RegExp('^[A-Za-z0-9]{9}$');
   const isRancherVersionHashString = regexHashString.test(rancherVersion);
   const requiredUiVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.UI_VERSION];
+  const requiredKubeVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION];
   const versionObj = { ...version };
 
   versionObj.isCompatibleWithUi = true;
+  versionObj.isCompatibleWithKubeVersion = true;
 
   // if it's a head version of Rancher, then we skip the validation and enable them all
   if (!isRancherVersionHashString && requiredUiVersion && !semver.satisfies(parsedRancherVersion, requiredUiVersion)) {
@@ -164,6 +180,23 @@ export function isChartVersionAvailableForInstall(version, rancherVersion, retur
     }
     versionObj.isCompatibleWithUi = false;
     versionObj.requiredUiVersion = requiredUiVersion;
+
+    if (returnObj) {
+      return versionObj;
+    }
+  }
+
+  // check kube version
+  if (kubeVersion && requiredKubeVersion && !semver.satisfies(kubeVersion, requiredKubeVersion)) {
+    if (!returnObj) {
+      return false;
+    }
+    versionObj.isCompatibleWithKubeVersion = false;
+    versionObj.requiredKubeVersion = requiredKubeVersion;
+
+    if (returnObj) {
+      return versionObj;
+    }
   }
 
   if (returnObj) {

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -115,6 +115,10 @@ export default {
       }
 
       return '';
+    },
+
+    handleVersionBtnClass(version) {
+      return { 'version-active': version.version === this.infoVersion, disabled: !version.isCompatibleWithUi || !version.isCompatibleWithKubeVersion };
     }
   }
 };
@@ -220,7 +224,7 @@ export default {
             <a
               v-clean-tooltip="handleVersionBtnTooltip(v)"
               class="version-link"
-              :class="{'version-active': v.version === infoVersion, 'disabled': !v.isCompatibleWithUi || !v.isCompatibleWithKubeVersion}"
+              :class="handleVersionBtnClass(v)"
               @click="loadPluginVersionInfo(v.version)"
             >
               {{ v.version }}

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -66,8 +66,9 @@ export default {
       const versionName = version || this.info.displayVersion;
 
       const isVersionNotCompatibleWithUi = this.info.versions?.find((v) => v.version === versionName && !v.isCompatibleWithUi);
+      const isVersionNotCompatibleWithKubeVersion = this.info.versions?.find((v) => v.version === versionName && !v.isCompatibleWithKubeVersion);
 
-      if (!this.info.chart || isVersionNotCompatibleWithUi) {
+      if (!this.info.chart || isVersionNotCompatibleWithUi || isVersionNotCompatibleWithKubeVersion) {
         return;
       }
 
@@ -103,6 +104,17 @@ export default {
         this.versionError = true;
         console.error('Unable to fetch VersionInfo: ', e); // eslint-disable-line no-console
       }
+    },
+
+    handleVersionBtnTooltip(version) {
+      if (version.requiredUiVersion) {
+        return this.t('plugins.info.requiresRancherVersion', { version: version.requiredUiVersion });
+      }
+      if (version.requiredKubeVersion) {
+        return this.t('plugins.info.requiresKubeVersion', { version: version.requiredKubeVersion });
+      }
+
+      return '';
     }
   }
 };
@@ -206,9 +218,9 @@ export default {
             :key="v.version"
           >
             <a
-              v-clean-tooltip="v.requiredUiVersion ? t('plugins.info.requiresVersion', { version: v.requiredUiVersion }) : ''"
+              v-clean-tooltip="handleVersionBtnTooltip(v)"
               class="version-link"
-              :class="{'version-active': v.version === infoVersion, 'disabled': !v.isCompatibleWithUi}"
+              :class="{'version-active': v.version === infoVersion, 'disabled': !v.isCompatibleWithUi || !v.isCompatibleWithKubeVersion}"
               @click="loadPluginVersionInfo(v.version)"
             >
               {{ v.version }}

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -369,6 +369,7 @@ export default {
           plugin.description = `${ plugin.description.substr(0, MAX_DESCRIPTION_LENGTH) } ...`;
         }
 
+        // check if kube version compatibility is met for installed extension
         if (plugin.uiplugin) {
           const versionInstalled = plugin.uiplugin.spec?.plugin?.version;
           const versionInstalledData = plugin.versions.find((v) => v.version === versionInstalled);

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -363,7 +363,7 @@ export default {
         }
       });
 
-      all.forEach((plugin, i) => {
+      all.forEach((plugin) => {
         // Clamp the lengths of the descriptions
         if (plugin.description && plugin.description.length > MAX_DESCRIPTION_LENGTH) {
           plugin.description = `${ plugin.description.substr(0, MAX_DESCRIPTION_LENGTH) } ...`;


### PR DESCRIPTION
Fixes #9113 

- add logic to display message on installed extension card to warn user when kubernetes version for installed extension is not met 
- add logic to disable version buttons on info side panel
- Improve display of incompatibility messages
- code cleanup

**Screenshots**
![Screenshot 2023-06-15 at 16 10 19](https://github.com/rancher/dashboard/assets/97888974/b0204f9b-0781-4784-a585-0f9d52111dee)
![Screenshot 2023-06-15 at 16 10 01](https://github.com/rancher/dashboard/assets/97888974/27664d96-cb73-4488-99f0-f9a81dc49242)
