### PR TITLE
Fix remove of project role via role tag

### DIFF
--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -6,6 +6,13 @@ export default class HomePagePo extends PagePo {
     return super.goTo(HomePagePo.url);
   }
 
+  static goToAndWaitForGet() {
+    PagePo.goToAndWaitForGet(HomePagePo.goTo, [
+      'v1/counts',
+      'v1/namespaces',
+    ]);
+  }
+
   constructor() {
     super(HomePagePo.url);
   }

--- a/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
@@ -22,7 +22,7 @@ describe('User can make changes to their account', () => {
      * Verify user can change their password and change it back
      */
 
-    HomePagePo.goToAndWaitForCounts(HomePagePo.goTo);
+    HomePagePo.goToAndWaitForGet();
     userMenu.toggle();
     userMenu.isOpen();
     userMenu.clickMenuItem('Account & API Keys');

--- a/cypress/e2e/tests/pages/user_menu/logout.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/logout.spec.ts
@@ -17,7 +17,7 @@ describe('User can logout of Rancher', () => {
     Attempt to navigate to the Home page without logging back in
     Verify user remains on login page
     */
-    HomePagePo.goToAndWaitForCounts(HomePagePo.goTo);
+    HomePagePo.goToAndWaitForGet();
     userMenu.toggle();
     userMenu.isOpen();
     userMenu.clickMenuItem('Log Out');

--- a/cypress/e2e/tests/pages/user_menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/preferences.spec.ts
@@ -22,7 +22,7 @@ describe('Standard user can update their preferences', () => {
     Verify url includes endpoint '/prefs'
     Verify preference page title
     */
-    HomePagePo.goToAndWaitForCounts(HomePagePo.goTo);
+    HomePagePo.goToAndWaitForGet();
     userMenu.toggle();
     userMenu.isOpen();
     userMenu.clickMenuItem('Preferences');

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -250,12 +250,12 @@ export default {
     },
 
     getProjectRoleBinding(row, role) {
-      // Each row is a combination of user/group and project
-      // So find the specfic roleBindingTemplate corresponding to the specific role + project
+      // Each row is a combination of project, role and user/group
+      // So find the specfic roleBindingTemplate corresponding to the specific project, role + user/group
       const userOrGroupKey = row.userId ? 'userId' : 'groupPrincipalId';
 
       return this.projectRoleTemplateBindings.find((r) => {
-        return r.roleTemplateId === role.id && r[userOrGroupKey] === row[userOrGroupKey];
+        return r.projectId === row.projectId && r.roleTemplateId === role.id && r[userOrGroupKey] === row[userOrGroupKey];
       });
     },
 


### PR DESCRIPTION
### Summary
- Clicking on `x` to remove a role tries to find the associated binding by only looks for matching role and user
- If the user has the same role in another project it selected whichever it found first
- This results in the intended role remaining and another mysteriously being removed
