### PR TITLE
ui automation: fix flaky branding and preferences tests

### DIFF
--- a/cypress/e2e/po/pages/global-settings/branding.po.ts
+++ b/cypress/e2e/po/pages/global-settings/branding.po.ts
@@ -45,4 +45,10 @@ export class BrandingPagePo extends RootClusterPage {
   applyButton() {
     return new AsyncButtonPo('[data-testid="branding-apply-async-button"]', this.self());
   }
+
+  applyAndWait(endpoint: string) {
+    cy.intercept('PUT', endpoint).as(endpoint);
+    this.applyButton().click();
+    cy.wait(`@${ endpoint }`).its('response.statusCode').should('eq', 200);
+  }
 }

--- a/cypress/e2e/po/pages/repositories.po.ts
+++ b/cypress/e2e/po/pages/repositories.po.ts
@@ -38,6 +38,6 @@ export default class ReposListPagePo extends PagePo {
 
     cy.intercept('GET', endpoint).as(interceptName);
     this.goTo();
-    cy.wait(`@${ interceptName }`, { timeout: 10000 }).its('response.statusCode').should('eq', 200);
+    cy.wait(`@${ interceptName }`, { timeout: 15000 }).its('response.statusCode').should('eq', 200);
   }
 }

--- a/cypress/e2e/tests/pages/global-settings/branding.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/branding.spec.ts
@@ -63,7 +63,7 @@ describe('Branding', () => {
     // brandingPage.privateLabel().value().should(`eq ${ settings.privateLabel.original }`);
     cy.title().should('not.eq', settings.privateLabel.new);
     brandingPage.privateLabel().set(settings.privateLabel.new);
-    brandingPage.applyButton().apply();
+    brandingPage.applyAndWait('**/ui-pl');
 
     // Visit the Home Page
     BurgerMenuPo.toggle();
@@ -86,7 +86,7 @@ describe('Branding', () => {
 
     // Reset
     brandingPage.privateLabel().set(settings.privateLabel.original);
-    brandingPage.applyButton().apply();
+    brandingPage.applyAndWait('**/ui-pl');
     cy.title().should('eq', settings.privateLabel.original);
   });
 
@@ -111,7 +111,7 @@ describe('Branding', () => {
     brandingPage.primaryColorCheckbox().set();
     brandingPage.primaryColorPicker().value().should('not.eq', settings.primaryColor.new);
     brandingPage.primaryColorPicker().set(settings.primaryColor.new);
-    brandingPage.applyButton().click();
+    brandingPage.applyAndWait('**/ui-primary-color');
 
     // Check in session
     brandingPage.primaryColorPicker().value().should('eq', settings.primaryColor.new);
@@ -131,7 +131,7 @@ describe('Branding', () => {
     // Reset
     brandingPage.primaryColorPicker().set(settings.primaryColor.original);
     brandingPage.primaryColorCheckbox().set();
-    brandingPage.applyButton().click();
+    brandingPage.applyAndWait('**/ui-primary-color');
   });
 
   it('Link Color', () => {
@@ -143,7 +143,7 @@ describe('Branding', () => {
     brandingPage.linkColorCheckbox().set();
     brandingPage.linkColorPicker().value().should('not.eq', settings.linkColor.new);
     brandingPage.linkColorPicker().set(settings.linkColor.new);
-    brandingPage.applyButton().click();
+    brandingPage.applyAndWait('**/ui-link-color');
 
     // Check in session
     brandingPage.linkColorPicker().value().should('eq', settings.linkColor.new);
@@ -157,6 +157,6 @@ describe('Branding', () => {
     // Reset
     brandingPage.linkColorPicker().set(settings.linkColor.original);
     brandingPage.linkColorCheckbox().set();
-    brandingPage.applyButton().click();
+    brandingPage.applyAndWait('**/ui-link-color');
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This pr addresses the flaky branding and preferences tests which both seem to be related to timing issues. 
- Branding test fix: Added intercept logic to wait for http response to occur after clicking the 'apply' button.
- Preferences test fix: Increase timeout by 5 seconds to wait for catalog.cattle.io.clusterrepos page to load.
