### PR TITLE
Outputs form sticky footer

### DIFF
--- a/shell/edit/logging.banzaicloud.io.output/index.vue
+++ b/shell/edit/logging.banzaicloud.io.output/index.vue
@@ -258,6 +258,14 @@ export default {
   $logo: 60px;
 
 .output {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+
+  .side-tabs {
+    background: yellow;
+    flex: 1;
+  }
   .provider {
     h1 {
       display: inline-block;

--- a/shell/edit/logging.banzaicloud.io.output/index.vue
+++ b/shell/edit/logging.banzaicloud.io.output/index.vue
@@ -263,7 +263,6 @@ export default {
   flex-grow: 1;
 
   .side-tabs {
-    background: yellow;
     flex: 1;
   }
   .provider {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7978
<!-- Define findings related to the feature or bug issue. -->

fixed sticky footer in Logging `Cluster Outputs` and `Outputs` create forms

### How to test

- install logging cluster tool
- navigate to either of the two resources
- click create
- the footer isn't stuck to the bottom

<img width="1920" alt="Screenshot 2023-06-19 at 10 04 03" src="https://github.com/rancher/dashboard/assets/18264463/8c7941e2-cb23-463f-8860-5f8df0d42bad">
