### PR TITLE
improve developer experience on extensions

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4009,6 +4009,7 @@ plugins:
     host: This Extension is not compatible with this application
     version: This Extension is not compatible with this version of Rancher
     load: An error occurred loading the code for this Extension
+    developerPkg: This Extension has been loaded internally, so we won't load the external version
   success:
     title: Loaded extension {name}
     message: Extension was loaded successfully

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -78,7 +78,7 @@ export function uiPluginAnnotation(chart, name) {
 
 // Should we load a plugin, based on the metadata returned by the backend?
 // Returns error key string or false
-export function shouldNotLoadPlugin(plugin, rancherVersion) {
+export function shouldNotLoadPlugin(plugin, rancherVersion, loadedPlugins) {
   if (!plugin.name || !plugin.version || !plugin.endpoint) {
     return 'plugins.error.generic';
   }
@@ -104,6 +104,13 @@ export function shouldNotLoadPlugin(plugin, rancherVersion) {
     if (requiredRancherVersion && !semver.satisfies(rancherVersion, requiredRancherVersion)) {
       return 'plugins.error.version';
     }
+  }
+
+  // check if a builtin extension has been loaded before - improve developer experience
+  const checkLoaded = loadedPlugins.find(p => p?.name === plugin?.name);
+
+  if (checkLoaded && checkLoaded.builtin) {
+    return 'plugins.error.developerPkg';
   }
 
   if (plugin.metadata?.[UI_PLUGIN_LABELS.CATALOG]) {

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -30,7 +30,7 @@ export default async function(context) {
         const entries = res.entries || res.Entries || {};
 
         Object.values(entries).forEach((plugin) => {
-          const shouldNotLoad = shouldNotLoadPlugin(plugin, rancherVersion); // Error key string or boolean
+          const shouldNotLoad = shouldNotLoadPlugin(plugin, rancherVersion, context.store.getters['uiplugins/plugins'] || []); // Error key string or boolean
 
           if (!shouldNotLoad) {
             hash[plugin.name] = context.$plugin.loadPluginAsync(plugin);


### PR DESCRIPTION
Fixes #9013 

Tackles item  `Better experience when developing against a rancher instance that already has your extension installed.`

- improve developer experience on extensions where builtin extensions will prevent external extension with the same name to load

**To test**
- Have an "external" version extension installed (ex: Elemental)
- Create a new `pkg`/extension on Dashboard named Elemental
- Check that while on local environment, the `pkg`/extension loads instead of the external version

**Screenshots/video**

https://github.com/rancher/dashboard/assets/97888974/a7ef7499-1b75-45eb-9f24-b671f1dece50

