### PR TITLE
8657 - dynamic versions for support link

### DIFF
--- a/shell/pages/support/index.vue
+++ b/shell/pages/support/index.vue
@@ -8,6 +8,7 @@ import { SETTING } from '@shell/config/settings';
 import { findBy } from '@shell/utils/array';
 import { addParam } from '@shell/utils/url';
 import { isRancherPrime } from '@shell/config/version';
+import { isDevBuild } from 'utils/version';
 
 export default {
   layout: 'home',
@@ -47,6 +48,7 @@ export default {
     this.brandSetting = await fetchOrCreateSetting(SETTING.BRAND, '');
     this.serverUrlSetting = await fetchOrCreateSetting(SETTING.SERVER_URL, '');
     this.uiIssuesSetting = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.ISSUES });
+    this.settings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.SETTING });
   },
 
   data() {
@@ -57,6 +59,7 @@ export default {
       brandSetting:    null,
       uiIssuesSetting: null,
       serverSetting:   null,
+      settings:        null,
       promos:          [
         'support.promos.one',
         'support.promos.two',
@@ -103,6 +106,20 @@ export default {
 
     sccLink() {
       return this.hasAWSSupport ? addParam('https://scc.suse.com', 'from_marketplace', '1') : 'https://scc.suse.com';
+    },
+
+    supportLink() {
+      const defaultSupportURL = 'https://rancher.com/support-maintenance-terms';
+      const version = this.settings?.find(s => s.id === SETTING.VERSION_RANCHER)?.value;
+
+      if (!version || isDevBuild(version)) {
+        return defaultSupportURL;
+      }
+
+      const baseUrl = 'https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-';
+      const formattedVersion = version.split('.').join('-');
+
+      return baseUrl + formattedVersion;
     }
   },
 
@@ -124,7 +141,7 @@ export default {
               <div class="support-link">
                 <a
                   class="support-link"
-                  href="https://rancher.com/support-maintenance-terms"
+                  :href="supportLink"
                   target="_blank"
                   rel="noopener noreferrer nofollow"
                 >{{ t('support.community.learnMore') }}</a>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR adds the functionality to have dynamic support links. In result, based on the Rancher version you have installed it'll redirect you to the related version of the support link.

Place you see the link:
Rancher Home -> Commercial Support -> Find out more about SUSE Rancher Support

Fixes rancher/dashboard#8657 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
If the build is in dev mode, the support link will go to the latest version support. `https://rancher.com/support-maintenance-terms`
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
https://github.com/rancher/dashboard/assets/135728925/b3f46215-1b28-4ebe-ab0b-ba1b33e55f56