### PR TITLE
Handle enabled flag per row for table actions properly (as a function) on extension API

### DIFF
--- a/docusaurus/docs/extensions/api/actions.md
+++ b/docusaurus/docs/extensions/api/actions.md
@@ -118,6 +118,7 @@ _BULKABLE/GLOBAL TABLE ACTION_
 |`svg`| Function | icon based on a SVG file which can be included using `@require` |
 |`divider`| Boolean | Shows a line separator (divider) in actions menu |
 |`multiple`| Boolean | Whether the action/button is bulkable (can be performed on multiple list items) |
+|`enabled`| Function | Whether the action/button is enabled or not |
 |`invoke`| Function | function executed when action/button is clicked |
 
 
@@ -143,6 +144,9 @@ plugin.addAction(
     label:    'some-extension-action',
     labelKey: 'plugin-examples.table-action-one',
     icon:     'icon-pipeline',
+    enabled(ctx: any) {
+      return true;
+    },
     invoke(opts: ActionOpts, values: any[]) {
       console.log('table action executed 1', this, opts, values); // eslint-disable-line no-console
     }
@@ -162,6 +166,9 @@ plugin.addAction(
     labelKey: 'plugin-examples.table-action-two',
     svg:      require('@pkg/test-features/icons/rancher-desktop.svg'),
     multiple: true,
+    enabled(ctx: any) {
+      return true;
+    },
     invoke(opts: ActionOpts, values: any[]) {
       console.log('table action executed 2', this); // eslint-disable-line no-console
       console.log(opts); // eslint-disable-line no-console

--- a/shell/core/plugin-helpers.js
+++ b/shell/core/plugin-helpers.js
@@ -119,6 +119,10 @@ export function getApplicableExtensionEnhancements(pluginCtx, actionType, uiArea
             // sets the enabled flag to true if omitted on the config
             if (!Object.keys(action).includes('enabled')) {
               actions[i].enabled = true;
+            } else if (Object.keys(action).includes('enabled') && typeof action.enabled === 'function') {
+              actions[i].enabled = action.enabled(translationCtx);
+            } else if (Object.keys(action).includes('enabled')) {
+              actions[i].enabled = action.enabled;
             }
 
             // bulkable flag

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -97,7 +97,7 @@ export type Action = {
   svg?: Function;
   icon?: string;
   multiple?: boolean;
-  enabled?: (ctx: any) => boolean;
+  enabled?: Function | boolean;
   invoke: (opts: ActionOpts, resources: any[]) => void | boolean | Promise<boolean>;
 };
 


### PR DESCRIPTION
Fixes #8117 

- add support for enabled as a function in table action extension point + update extension docs

## How to test
- create a new extension/package on rancher dashboard by running the following command: `yarn create @rancher/pkg test`
- edit the `index.ts file` of the newly added test extension/package with the following code:
```
import { importTypes } from '@rancher/auto-import';
import { IPlugin, ActionLocation, ActionOpts } from '@shell/core/types';

// Init the package
export default function(plugin: IPlugin) {
  // Auto-import model, detail, edit from the folders
  importTypes(plugin);

  // Provide plugin metadata from package.json
  plugin.metadata = require('./package.json');

  // Load a product
  // plugin.addProduct(require('./product'));

  plugin.addAction(
    ActionLocation.TABLE,
    { resource: ['provisioning.cattle.io.cluster'] },
    {
      label: 'some-extension-action',
      // labelKey: 'plugin-examples.table-action-one',
      icon:  'icon-pipeline',
      enabled(ctx: any) {
        return true;
      },
      invoke(opts: ActionOpts, values: any[]) {
        console.log('table action executed 1', this, opts, values); // eslint-disable-line no-console
      }
    }
  );
}
```
- run your local Rancher Dashboard and go to `Cluster Management`
- Make sure there's a new table action called `some-extension-action` and that you can control it's display by playing with the return of the function `enabled` (return should be a boolean)
- It should also work as an object property (ex: enabled: true)

## Screenshots
![Screenshot 2023-06-21 at 13 04 34](https://github.com/rancher/dashboard/assets/97888974/e4105236-39ab-4701-ad78-1d3250b78bf3)
