### PR TITLE
use projecthelmchart dashboardValues for grafana url

### DIFF
--- a/shell/components/DashboardMetrics.vue
+++ b/shell/components/DashboardMetrics.vue
@@ -26,6 +26,12 @@ export default {
       type:    Boolean,
       default: true,
     },
+    // change the grafana url prefix for local clusters in certain monitoring versions
+    // project monitoring (projectHelmCharts) supply a grafana url that never needs to be modified in this way
+    modifyPrefix: {
+      type:    Boolean,
+      default: true
+    }
   },
   data() {
     return {
@@ -74,6 +80,7 @@ export default {
         :range="graphOptions.range"
         :url="detailUrl"
         :vars="vars"
+        :modify-prefix="modifyPrefix"
       />
       <GrafanaDashboard
         v-else
@@ -85,6 +92,7 @@ export default {
         :range="graphOptions.range"
         :url="summaryUrl"
         :vars="vars"
+        :modify-prefix="modifyPrefix"
       />
     </div>
   </div>

--- a/shell/components/GrafanaDashboard.vue
+++ b/shell/components/GrafanaDashboard.vue
@@ -23,6 +23,12 @@ export default {
       type:    String,
       default: null
     },
+    // change the grafana url prefix for local clusters in certain monitoring versions
+    // project monitoring (projectHelmCharts) supply a grafana url that never needs to be modified in this way
+    modifyPrefix: {
+      type:    Boolean,
+      default: true
+    },
     backgroundColor: {
       type:    String,
       default: '#1b1c21'
@@ -138,7 +144,7 @@ export default {
       const clusterId = this.$store.getters['currentCluster'].id;
       const params = this.computeParams();
 
-      return computeDashboardUrl(this.monitoringVersion, embedUrl, clusterId, params);
+      return computeDashboardUrl(this.monitoringVersion, embedUrl, clusterId, params, this.modifyPrefix);
     },
     computeParams() {
       const params = {};

--- a/shell/detail/helm.cattle.io.projecthelmchart.vue
+++ b/shell/detail/helm.cattle.io.projecthelmchart.vue
@@ -5,7 +5,6 @@ import Tab from '@shell/components/Tabbed/Tab';
 import DashboardMetrics from '@shell/components/DashboardMetrics';
 import AlertTable from '@shell/components/AlertTable';
 import { Banner } from '@components/Banner';
-import { parse as parseUrl } from '@shell/utils/url';
 import { ENDPOINTS } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
 
@@ -33,33 +32,34 @@ export default {
     };
   },
   computed: {
-    relativeDashboardValues() {
-      const { alertmanagerURL, grafanaURL, prometheusURL } = this?.value?.status?.dashboardValues;
+    // there is a since-fixed bug in some versions of prom federator where this url is missing the trailing slash, which causes a redirect to an invalid grafana url
+    grafanaURL() {
+      const { grafanaURL } = this.value.status.dashboardValues;
 
-      return {
-        alertmanagerURL: this.makeRelativeURL(alertmanagerURL),
-        grafanaURL:      this.makeRelativeURL(grafanaURL),
-        prometheusURL:   this.makeRelativeURL(prometheusURL)
-      };
+      if (!grafanaURL.endsWith('/')) {
+        return `${ grafanaURL }/`;
+      }
+
+      return grafanaURL;
     },
     monitoringNamespace() {
       // picking the prometheusURL here, they're all going to be the same, but alertmanager and grafana can be deactivated
-      return this.pullKeyFromUrl(this.relativeDashboardValues.prometheusURL, 'namespaces');
+      return this.pullKeyFromUrl(this.value.status.dashboardValues.prometheusURL, 'namespaces');
     },
     alertServiceEndpoint() {
-      return this.pullServiceEndpointFromUrl(this.relativeDashboardValues.alertmanagerURL);
+      return this.pullServiceEndpointFromUrl(this.value.status.dashboardValues.alertmanagerURL);
     },
     alertServiceEndpointEnabled() {
       return this.checkEndpointEnabled(this.alertServiceEndpoint);
     },
     grafanaServiceEndpoint() {
-      return this.pullServiceEndpointFromUrl(this.relativeDashboardValues.grafanaURL);
+      return this.pullServiceEndpointFromUrl(this.value.status.dashboardValues.grafanaURL);
     },
     grafanaServiceEndpointEnabled() {
       return this.checkEndpointEnabled(this.grafanaServiceEndpoint);
     },
     prometheusServiceEndpoint() {
-      return this.pullServiceEndpointFromUrl(this.relativeDashboardValues.prometheusURL);
+      return this.pullServiceEndpointFromUrl(this.value.status.dashboardValues.prometheusURL);
     },
     prometheusServiceEndpointEnabled() {
       return this.checkEndpointEnabled(this.prometheusServiceEndpoint);
@@ -83,21 +83,7 @@ export default {
 
       return !isEmpty(endpoint) && !isEmpty(endpoint?.subsets);
     },
-    makeRelativeURL(url) {
-      if (!url) {
-        return '';
-      }
 
-      // most of the downstream components that use these URL expect the everything before and including the clusterid stripped out of the URL
-      const parsedUrl = parseUrl(url);
-      // we really just need the remaining bit of the url but the destructure makes it clear what we're leaving behind
-      // eslint-disable-next-line no-unused-vars
-      const [_empty, _k8s, _clusters, _clusterId, ...restUrl] = parsedUrl.relative.split('/');
-      // the above processing strips out the leading '/' which we need
-      const relativeUrl = `/${ restUrl.join('/') }`;
-
-      return relativeUrl;
-    },
     pullKeyFromUrl(url = '', key) {
       const splitUrl = url.split('/');
       const keyIndex = splitUrl.indexOf(key);
@@ -138,10 +124,11 @@ export default {
         <template #default="props">
           <DashboardMetrics
             v-if="props.active && grafanaServiceEndpointEnabled"
-            :detail-url="`${relativeDashboardValues.grafanaURL}/d/rancher-pod-1/rancher-pod?orgId=1&kiosk`"
-            :summary-url="`${relativeDashboardValues.grafanaURL}/d/rancher-workload-1/rancher-workload?orgId=1&kiosk`"
+            :detail-url="`${value.status.dashboardValues.grafanaURL}/d/rancher-pod-1/rancher-pod?orgId=1&kiosk`"
+            :summary-url="`${value.status.dashboardValues.grafanaURL}/d/rancher-workload-1/rancher-workload?orgId=1&kiosk`"
             graph-height="825px"
             project
+            :modify-prefix="false"
           />
         </template>
       </Tab>
@@ -211,7 +198,7 @@ export default {
           </div>
           <a
             :class="{disabled: !grafanaServiceEndpointEnabled}"
-            :href="value.status.dashboardValues.grafanaURL"
+            :href="grafanaURL"
             target="_blank"
           > {{ t('monitoring.overview.linkedList.grafana.label') }} <i class="icon icon-external-link" /></a>
           <a

--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -14,10 +14,10 @@ export function getClusterPrefix(monitoringVersion, clusterId) {
   return clusterId === 'local' ? '' : `/k8s/clusters/${ clusterId }`;
 }
 
-export function computeDashboardUrl(monitoringVersion, embedUrl, clusterId, params) {
+export function computeDashboardUrl(monitoringVersion, embedUrl, clusterId, params, modifyPrefix = true) {
   const url = parseUrl(embedUrl);
 
-  let newUrl = `${ getClusterPrefix(monitoringVersion, clusterId) }${ url.path }`;
+  let newUrl = modifyPrefix ? `${ getClusterPrefix(monitoringVersion, clusterId) }${ url.path }` : url.path;
 
   if (url.query.viewPanel) {
     newUrl = addParam(newUrl, 'viewPanel', url.query.viewPanel);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9099 

On most page that the component for embedded grafana dashboards is used, a hardcoded url is passed in, which is then modified to apply a cluster id for downstream clusters, and sometimes the local cluster depending on the version of monitoring installed. The project monitoring detail page, however, does not use hardcoded urls: the urls are pulled from `<projecthelmchart>.status.dashboardValues`. Previously we accounted for the url prefixing the `GrafanaDashboard` component performs by stripping those prefixes from the url that the project monitoring page passes in. This was ..._okay_, until the logic for project monitoring diverged from other monitoring grafana dashboards. 

The solution implemented here is to just trust that the url the backend has provided in the projecthelmchart is going to work whether the cluster is local or downstream (from my testing, it does). This PR removes the url-modifying logic from the project monitor detail page, and updates the embedded grafana dashboard component to optionally bypass all prefix modification so we can avoid messing with the urls provided by the projecthelmchart resource.

The modification of `prometheusURL` and `alertmanagerURL` didn't appear to do anything so that's removed too. While investigating we noticed that if the grafana url provided by `status.dashboardValues` was missing the trailing slash, the request would be re-routed to an invalid url. That can be avoided by ensuring there's always a trailing slash in the grafana link on the project monitor detail page (BE is aware of this issue and will implement a fix, but we should catch it here so links made by existing versions of prom federator work).

### Areas or cases that should be tested
Monitoring 102.0.1+up40.1.2 (local cluster has a different grafana url prefix) and 102.0.0+up40.1.2 (local cluster does not have a different grafana url prefix) should each be installed on the local cluster and the following areas checked:
- Project monitor detail view embedded graphs and grafana link (involves ins talling prometheus federator too)
- Main monitoring embedded graphs, eg those on the cluster dashboard
