### PR TITLE
checks for globalRole of 'admin' now, also now handles group permissions

### DIFF
--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -57,6 +57,10 @@ export const getters = {
     return state.v3User;
   },
 
+  currentUser(state) {
+    return state.v3User.id;
+  },
+
   initialPass(state) {
     return state.initialPass;
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#9159 (https://github.com/rancher/dashboard/issues/9159#issuecomment-1603104745) ~#9158~

### Occurred changes and/or fixed issues
Added new getter to auth store, requests /v3/principals as part of initial fetch on <cluster>/explorer/members page, parses principles for current user membership

### Technical notes summary
We now pull globalRoleBindings as part of the initial fetch on this page so we can determine if the current user has the "admin" role template which beats out all of the other permission checks we do and thus short circuits the "userCanManageCluster" check which short-circuits all of the other permission checks we do on this page.

My early debugging of the "admin" issue centered on group permissions and I ended up writing some code that solved the earlier problem of determining a user's group membership and thus group inherited permissions to projects. Since that solves an otherwise known issue we had with the initial fix, I decided to leave that in but I can also split it out into it's own PR if that's easier.

Edit: RC: 
```
issue with the admin was specific to the admin user within a cluster that the restricted-admin had created
```