### PR TITLE
Wire in extension table column feature to cluster `node` list and other hardcoded places

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -4,8 +4,9 @@ import { get } from '@shell/utils/object';
 import { mapPref, GROUP_RESOURCES } from '@shell/store/prefs';
 import ButtonGroup from '@shell/components/ButtonGroup';
 import SortableTable from '@shell/components/SortableTable';
-import { NAMESPACE } from '@shell/config/table-headers';
+import { NAMESPACE, AGE } from '@shell/config/table-headers';
 import { findBy } from '@shell/utils/array';
+import { ExtensionPoint, TableColumnLocation } from '@shell/core/types';
 
 // Default group-by in the case the group stored in the preference does not apply
 const DEFAULT_GROUP = 'namespace';
@@ -216,11 +217,52 @@ export default {
     _headers() {
       let headers;
       const showNamespace = this.showNamespaceColumn;
+      const type = this.schema?.id ? this.schema?.id : this.$route?.params?.resource ? this.$route?.params?.resource : undefined;
 
       if ( this.headers ) {
         headers = this.headers.slice();
       } else {
         headers = this.$store.getters['type-map/headersFor'](this.schema);
+      }
+
+      // add custom table columns provided by the extensions ExtensionPoint.TABLE_COL hook
+      // gate it so that we prevent errors on older versions of dashboard
+      if (this.$store.$plugin?.getUIConfig) {
+        const extensionCols = this.$store.$plugin.getUIConfig(ExtensionPoint.TABLE_COL, TableColumnLocation.RESOURCE);
+
+        // Try and insert the columns before the Age column
+        let insertPosition = headers.length;
+
+        if (headers.length > 0) {
+          const ageColIndex = headers.findIndex(h => h.name === AGE.name);
+
+          if (ageColIndex >= 0) {
+            insertPosition = ageColIndex;
+          } else {
+            // we've found some labels with ' ', which isn't necessarily empty (explore action/button)
+            // if we are to add cols, let's push them before these so that the UI doesn't look weird
+            const lastViableColIndex = headers.findIndex(h => (!h.label || !h.label?.trim()) && (!h.labelKey || !h.labelKey?.trim()));
+
+            if (lastViableColIndex >= 0) {
+              insertPosition = lastViableColIndex;
+            }
+          }
+        }
+
+        // adding extension defined cols to the correct header config
+        extensionCols.forEach((col) => {
+          if (col.locationConfig.resource) {
+            col.locationConfig.resource.forEach((resource) => {
+              if (resource && type === resource) {
+                // we need the 'value' prop to be populated in order for the rows to show the values
+                if (!col.value && col.getValue) {
+                  col.value = col.getValue;
+                }
+                headers.splice(insertPosition, 0, col);
+              }
+            });
+          }
+        });
       }
 
       // If only one namespace is selected, hide the namespace column

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -58,6 +58,12 @@ export default {
       required: false
     },
 
+    keyField: {
+      // Field that is unique for each row.
+      type:    String,
+      default: '_key',
+    },
+
     headers: {
       type:    Array,
       default: null,
@@ -217,7 +223,7 @@ export default {
     _headers() {
       let headers;
       const showNamespace = this.showNamespaceColumn;
-      const type = this.schema?.id ? this.schema?.id : this.$route?.params?.resource ? this.$route?.params?.resource : undefined;
+      const type = this.schema?.id || this.$route?.params?.resource || undefined;
 
       if ( this.headers ) {
         headers = this.headers.slice();
@@ -234,14 +240,14 @@ export default {
         let insertPosition = headers.length;
 
         if (headers.length > 0) {
-          const ageColIndex = headers.findIndex(h => h.name === AGE.name);
+          const ageColIndex = headers.findIndex((h) => h.name === AGE.name);
 
           if (ageColIndex >= 0) {
             insertPosition = ageColIndex;
           } else {
             // we've found some labels with ' ', which isn't necessarily empty (explore action/button)
             // if we are to add cols, let's push them before these so that the UI doesn't look weird
-            const lastViableColIndex = headers.findIndex(h => (!h.label || !h.label?.trim()) && (!h.labelKey || !h.labelKey?.trim()));
+            const lastViableColIndex = headers.findIndex((h) => (!h.label || !h.label?.trim()) && (!h.labelKey || !h.labelKey?.trim()));
 
             if (lastViableColIndex >= 0) {
               insertPosition = lastViableColIndex;
@@ -489,7 +495,7 @@ export default {
     :has-advanced-filtering="hasAdvancedFiltering"
     :adv-filter-hide-labels-as-cols="advFilterHideLabelsAsCols"
     :adv-filter-prevent-filtering-labels="advFilterPreventFilteringLabels"
-    key-field="_key"
+    :key-field="keyField"
     :sort-generation-fn="safeSortGenerationFn"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
     :force-update-live-and-delayed="forceUpdateLiveAndDelayed"

--- a/shell/detail/node.vue
+++ b/shell/detail/node.vue
@@ -1,7 +1,7 @@
 <script>
 import ConsumptionGauge from '@shell/components/ConsumptionGauge';
 import Alert from '@shell/components/Alert';
-import SortableTable from '@shell/components/SortableTable';
+import ResourceTable from '@shell/components/ResourceTable';
 import Tab from '@shell/components/Tabbed/Tab';
 import {
   EFFECT,
@@ -35,7 +35,7 @@ export default {
     Loading,
     ResourceTabs,
     Tab,
-    SortableTable,
+    ResourceTable,
     EmberPage,
   },
 
@@ -252,7 +252,7 @@ export default {
         :label="t('node.detail.tab.pods')"
         :weight="4"
       >
-        <SortableTable
+        <ResourceTable
           key-field="_key"
           :headers="podTableHeaders"
           :rows="value.pods"
@@ -283,7 +283,7 @@ export default {
         class="bordered-table"
         :weight="2"
       >
-        <SortableTable
+        <ResourceTable
           key-field="_key"
           :headers="infoTableHeaders"
           :rows="infoTableRows"
@@ -298,7 +298,7 @@ export default {
         :label="t('node.detail.tab.images')"
         :weight="1"
       >
-        <SortableTable
+        <ResourceTable
           key-field="_key"
           :headers="imageTableHeaders"
           :rows="imageTableRows"
@@ -311,7 +311,7 @@ export default {
         :label="t('node.detail.tab.taints')"
         :weight="0"
       >
-        <SortableTable
+        <ResourceTable
           key-field="_key"
           :headers="taintTableHeaders"
           :rows="taintTableRows"

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -4,7 +4,7 @@ import { NAMESPACE as NAMESPACE_COL } from '@shell/config/table-headers';
 import {
   POD, WORKLOAD_TYPES, SCALABLE_WORKLOAD_TYPES, SERVICE, INGRESS, NODE
 } from '@shell/config/types';
-import SortableTable from '@shell/components/SortableTable';
+import ResourceTable from '@shell/components/ResourceTable';
 import Tab from '@shell/components/Tabbed/Tab';
 import Loading from '@shell/components/Loading';
 import ResourceTabs from '@shell/components/form/ResourceTabs';
@@ -46,7 +46,7 @@ export default {
     Loading,
     ResourceTabs,
     CountGauge,
-    SortableTable,
+    ResourceTable,
     PlusMinus
   },
 
@@ -380,12 +380,12 @@ export default {
         :label="t('tableHeaders.jobs')"
         :weight="4"
       >
-        <SortableTable
+        <ResourceTable
           :rows="value.jobs"
           :headers="jobHeaders"
           key-field="id"
           :schema="jobSchema"
-          :show-groups="false"
+          :groupable="false"
           :search="false"
         />
       </Tab>
@@ -395,7 +395,7 @@ export default {
         :label="t('tableHeaders.pods')"
         :weight="4"
       >
-        <SortableTable
+        <ResourceTable
           v-if="value.pods"
           :rows="value.pods"
           :headers="podHeaders"
@@ -458,13 +458,13 @@ export default {
         >
           {{ t('workload.detail.serviceListCaption') }}
         </p>
-        <SortableTable
+        <ResourceTable
           v-if="serviceSchema && matchingServices.length > 0"
           :rows="matchingServices"
           :headers="serviceHeaders"
           key-field="id"
           :schema="serviceSchema"
-          :show-groups="false"
+          :groupable="false"
           :search="false"
           :table-actions="false"
         />
@@ -499,13 +499,13 @@ export default {
         >
           {{ t('workload.detail.ingressListCaption') }}
         </p>
-        <SortableTable
+        <ResourceTable
           v-if="ingressSchema && matchingIngresses.length > 0"
           :rows="matchingIngresses"
           :headers="ingressHeaders"
           key-field="id"
           :schema="ingressSchema"
-          :show-groups="false"
+          :groupable="false"
           :search="false"
           :table-actions="false"
         />

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -229,33 +229,6 @@ export function DSL(store, product, module = 'type-map') {
     },
 
     headers(type, headers) {
-      // gate it so that we prevent errors on older versions of dashboard
-      if (store.$plugin?.getUIConfig) {
-        const extensionCols = store.$plugin.getUIConfig(ExtensionPoint.TABLE_COL, TableColumnLocation.RESOURCE);
-
-        // Try and insert the columns before the Age column, if that is the last column
-        let insertPosition = headers.length;
-
-        if (headers.length > 0) {
-          const lastColumn = headers[headers.length - 1];
-
-          if (lastColumn?.name === AGE.name) {
-            insertPosition--;
-          }
-        }
-
-        // adding extension defined cols to the correct header config
-        extensionCols.forEach((col) => {
-          if (col.locationConfig.resource) {
-            col.locationConfig.resource.forEach((resource) => {
-              if (resource && type === resource) {
-                headers.splice(insertPosition, 0, col);
-              }
-            });
-          }
-        });
-      }
-
       headers.forEach((header) => {
         // If on the client, then use the value getter if there is one
         if (header.getValue) {

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -151,8 +151,6 @@ import { sortBy } from '@shell/utils/sort';
 import { haveV1Monitoring, haveV2Monitoring } from '@shell/utils/monitoring';
 import { NEU_VECTOR_NAMESPACE } from '@shell/config/product/neuvector';
 
-import { ExtensionPoint, TableColumnLocation } from '@shell/core/types';
-
 export const NAMESPACED = 'namespaced';
 export const CLUSTER_LEVEL = 'cluster';
 export const BOTH = 'both';


### PR DESCRIPTION
Fixes #8674 

- add logic to support new table cols via extensions hook on `resource table` instead of `type-map` so that we can capture tables/resources with locally defined headers like the `nodes` list

## How to test
- create a new extension/package on rancher dashboard by running the following command: `yarn create @rancher/pkg test`
- edit the `index.ts` file of the newly added test extension/package with the following code:
```
import { importTypes } from '@rancher/auto-import';
import { IPlugin, TableColumnLocation } from '@shell/core/types';

// Init the package
export default function(plugin: IPlugin) {
  // Auto-import model, detail, edit from the folders
  importTypes(plugin);

  // Provide plugin metadata from package.json
  plugin.metadata = require('./package.json');

  // Load a product
  // plugin.addProduct(require('./product'));
  plugin.addTableColumn(
    TableColumnLocation.RESOURCE,
    { resource: ['node', 'catalog.cattle.io.app'] },
    {
      name:     'some-prop-col',
      labelKey: 'generic.comingSoon',
      getValue: (row: any) => {
        return `${ row.id }-DEMO-COL-STRING-ADDED!`;
      },
      width:  100,
      sort:   ['stateSort', 'nameSort'],
      search: ['stateSort', 'nameSort'],
    }
  );
}
```
- run your local Rancher Dashboard and go to `local` -> `nodes` and see if a new column called `Coming Soon` appears
- go to `local` -> `apps` -> `installed apps` and see if a new column called `Coming Soon` appears
 
## Screenshots
![Screenshot 2023-06-23 at 09 37 28](https://github.com/rancher/dashboard/assets/97888974/cdab4821-6588-4d6c-b348-f6d7f298967f)
![Screenshot 2023-06-23 at 09 37 37](https://github.com/rancher/dashboard/assets/97888974/1ca88730-bd0c-4956-bed5-f09568f527a5)

