### PR TITLE
Revert display of Cluster and Projects page for users with project roles and no cluster roles

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3026,7 +3026,6 @@ managementNode:
 members:
   clusterMembers: Cluster Members
   clusterAndProject: Cluster and Project Members
-  project: Project Members
   createActionLabel: Add
   clusterMemebership: Cluster Membership
   projectMembership: Project Membership

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3026,7 +3026,6 @@ managementNode:
 members:
   clusterMembers: Cluster Members
   clusterAndProject: Cluster and Project Members
-  cluster: Cluster Members
   project: Project Members
   createActionLabel: Add
   clusterMemebership: Cluster Membership

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -129,6 +129,7 @@ export default {
       ],
       loadingProjectBindings: true,
       loadingClusterBindings: true,
+      userCanManageCluster:   undefined,
       userCanManageProject:   {}
     };
   },
@@ -198,6 +199,14 @@ export default {
         };
       });
 
+      // We're assigning userCanManageCluster and userCanManageCluster in a getter for performance reasons
+      // There can be a LOT of cluster and project bindings and a LOT of churn for them over sockets
+      // To miminise the impact of this try and populate them both in the most efficient way
+      if (typeof this.userCanManageCluster === 'undefined' && this.filteredClusterRoleTemplateBindings.length) {
+        // Doing this once means we won't update buttons if the user gains/loses cluster rights, but avoids looping through a large list often
+        this.userCanManageCluster = this.filteredClusterRoleTemplateBindings.some(crtb => (crtb.user?.isCurrentUser || crtb.isCurrentUser) && crtb.roleTemplateName === 'cluster-owner');
+      }
+
       // We need to group each of the TemplateRoleBindings by the user + project
       const userRoles = [...fakeRows, ...this.filteredProjectRoleTemplateBindings].reduce((rows, curr) => {
         const {
@@ -227,7 +236,6 @@ export default {
         // We can skip this if..
         // - user can manage cluster, that trumps everything else
         // - not current user, we only use this for showing permissions of that user
-        // We're assigning userCanManageProject in a getter for performance reasons
         if (!this.userCanManageCluster && isCurrentUser) {
           this.userCanManageProject[projectId] = allRoles.some((rtb) => {
             const { id, rules } = rtb;
@@ -246,20 +254,6 @@ export default {
       }, {});
 
       return Object.values(userRoles);
-    },
-    userCanManageCluster() {
-      // There can be a LOT of cluster and project bindings and a LOT of churn for them over sockets
-      // So once we have the required information to determine this... do it and only once.
-      // This means we won't update buttons if the user gains/loses cluster rights, but avoids looping through a large list often
-      if (
-        typeof this._userCanManageCluster === 'undefined' &&
-        this.$store.getters['management/all'](MANAGEMENT.USER)?.length &&
-        this.filteredClusterRoleTemplateBindings.length
-      ) {
-        this._userCanManageCluster = this.filteredClusterRoleTemplateBindings.some(crtb => (crtb.user?.isCurrentUser || crtb.isCurrentUser) && crtb.roleTemplateName === 'cluster-owner');
-      }
-
-      return this._userCanManageCluster;
     },
     canViewClusterMemberPermissions() {
       return canViewClusterPermissions(this.$store);

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -9,18 +9,10 @@ import Loading from '@shell/components/Loading';
 import { Checkbox } from '@components/Form/Checkbox';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 
-export function canEditClusterPermissions(store) {
-  // blocked-post means you can post through norman, but not through steve.
-  // collectionMethods and resourceMethods on norman schema itself are not accurate for permission checking here.
-  return !!(store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).find(method => ['blocked-post', 'post'].includes(method.toLowerCase())) &&
+export function canViewClusterPermissionsEditor(store) {
+  return !!store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING) &&
     !!store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE) &&
     !!store.getters['management/schemaFor'](MANAGEMENT.USER);
-}
-
-export function canViewClusterPermissions(store) {
-  return (store.getters['management/schemaFor'](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).includes('GET') &&
-    (store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE)?.collectionMethods || []).includes('GET') &&
-    (store.getters['management/schemaFor'](MANAGEMENT.USER)?.collectionMethods || []).includes('GET');
 }
 
 export default {

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -52,11 +52,6 @@ export default {
     modalSticky: {
       type:    Boolean,
       default: false,
-    },
-
-    canManage: {
-      type:    Boolean,
-      default: true,
     }
   },
 
@@ -190,17 +185,15 @@ export default {
     </template>
     <template #add>
       <button
-        v-if="canManage"
         type="button"
         class="btn role-primary mt-10"
         @click="addMember"
       >
         {{ t('generic.add') }}
       </button>
-      <span v-else />
     </template>
     <template #remove-button="{remove, i}">
-      <span v-if="(isCreate && i === 0) || isView || !canManage" />
+      <span v-if="(isCreate && i === 0) || isView" />
       <button
         v-else
         type="button"

--- a/shell/components/form/Members/ProjectMembershipEditor.vue
+++ b/shell/components/form/Members/ProjectMembershipEditor.vue
@@ -1,25 +1,11 @@
 <script>
-import { MANAGEMENT, NORMAN } from '@shell/config/types';
+import { NORMAN } from '@shell/config/types';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import MembershipEditor from '@shell/components/form/Members/MembershipEditor';
 import { canViewMembershipEditor } from '@shell/components/form/Members/MembershipEditor.vue';
 
 export function canViewProjectMembershipEditor(store) {
   return canViewMembershipEditor(store, true);
-}
-
-export function canEditProjectPermissions(store) {
-  // blocked-post means you can post through norman, but not through steve.
-  // collectionMethods and resourceMethods on norman schema itself are not accurate for permission checking here.
-  return !!(store.getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).find(method => ['blocked-post', 'post'].includes(method.toLowerCase())) &&
-    !!store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE) &&
-    !!store.getters['management/schemaFor'](MANAGEMENT.USER);
-}
-
-export function canViewProjectPermissions(store) {
-  return (store.getters['management/schemaFor'](MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING)?.collectionMethods || []).includes('GET') &&
-    (store.getters['management/schemaFor'](MANAGEMENT.ROLE_TEMPLATE)?.collectionMethods || []).includes('GET') &&
-    (store.getters['management/schemaFor'](MANAGEMENT.USER)?.collectionMethods || []).includes('GET');
 }
 
 export default {
@@ -50,9 +36,6 @@ export default {
 
     isView() {
       return this.mode === _VIEW;
-    },
-    canManageProjectMembers() {
-      return canEditProjectPermissions(this.$store);
     }
   },
 
@@ -75,7 +58,6 @@ export default {
     :default-binding-handler="defaultBindingHandler"
     :type="NORMAN.PROJECT_ROLE_TEMPLATE_BINDING"
     :mode="mode"
-    :can-manage="canManageProjectMembers"
     parent-key="projectId"
     :parent-id="parentId"
     v-on="$listeners"

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -283,16 +283,16 @@ export function init(store) {
   });
 
   virtualType({
-    labelKey:       'members.clusterAndProject',
-    group:          'cluster',
-    namespaced:     false,
-    name:           VIRTUAL_TYPES.CLUSTER_MEMBERS,
-    icon:           'globe',
-    weight:         -1,
-    route:          { name: 'c-cluster-product-members' },
-    exact:          true,
-    ifHaveSubTypes: {
-      types: [MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING],
+    labelKey:   'members.clusterAndProject',
+    group:      'cluster',
+    namespaced: false,
+    name:       VIRTUAL_TYPES.CLUSTER_MEMBERS,
+    icon:       'globe',
+    weight:     -1,
+    route:      { name: 'c-cluster-product-members' },
+    exact:      true,
+    ifHaveType: {
+      type:  MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
       store: 'management'
     }
   });

--- a/shell/models/clusterroletemplatebinding.js
+++ b/shell/models/clusterroletemplatebinding.js
@@ -22,13 +22,6 @@ export default class CRTB extends NormanModel {
     return this.$rootGetters[`management/byId`](MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, this.id?.replace(':', '/'));
   }
 
-  get isCurrentUser() {
-    // This only checks the user is bound to the role... and not if the user is part of group that is bound to it
-    const out = this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userId);
-
-    return !!out?.isCurrentUser;
-  }
-
   get steve() {
     return this.$dispatch(`management/find`, {
       type: MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,

--- a/shell/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/shell/models/management.cattle.io.clusterroletemplatebinding.js
@@ -28,7 +28,7 @@ export default class CRTB extends HybridModel {
   }
 
   get principal() {
-    const principalId = this.principalId?.replace(/\//g, '%2F');
+    const principalId = this.principalId.replace(/\//g, '%2F');
 
     return this.$dispatch('rancher/find', {
       type: NORMAN.PRINCIPAL,

--- a/shell/models/projectroletemplatebinding.js
+++ b/shell/models/projectroletemplatebinding.js
@@ -18,13 +18,6 @@ export default class PRTB extends NormanModel {
     return this.$rootGetters['management/byId'](MANAGEMENT.ROLE_TEMPLATE, this.roleTemplateId);
   }
 
-  get isCurrentUser() {
-    // This only checks the user is bound to the role... and not if the user is part of group that is bound to it
-    const out = this.$rootGetters['management/byId'](MANAGEMENT.USER, this.userId);
-
-    return !!out?.isCurrentUser;
-  }
-
   get steve() {
     return this.$dispatch(`management/find`, {
       type: MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING,

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -933,10 +933,8 @@ export const getters = {
           }
 
           if ( item.ifHaveSubTypes ) {
-            const targetedSchemas = Array.isArray(item.ifHaveSubTypes) ? schemas : rootGetters[`${ item.ifHaveSubTypes.store }/all`](SCHEMA);
-            const subTypes = Array.isArray(item.ifHaveSubTypes) ? item.ifHaveSubTypes : item.ifHaveSubTypes.types;
-            const hasSome = (subTypes || []).some((type) => {
-              return !!findBy(targetedSchemas, 'id', normalizeType(type));
+            const hasSome = (item.ifHaveSubTypes || []).some((type) => {
+              return !!findBy(schemas, 'id', normalizeType(type));
             });
 
             if (!hasSome) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/9198

The requirement to work out permissions per project UI side have caused a number of issues. 
Given
- How close we are to release
- The nature of the obscure bugs that have arisen
- The remaining work to address scaling issues with grb and general scaling testing
- The lack of support for admins who gain role via a group

The changes related to https://github.com/rancher/dashboard/issues/9049 will be reverted

Obsoletes
- https://github.com/rancher/dashboard/issues/9159
- https://github.com/rancher/dashboard/issues/9195
- https://github.com/rancher/dashboard/pull/9184

### Occurred changes and/or fixed issues
Reverts
- https://github.com/rancher/dashboard/pull/9100
- https://github.com/rancher/dashboard/pull/9166
- https://github.com/rancher/dashboard/pull/9160

This means we go back to the 2.7.4 state
- Those with cluster roles will be able to see the Cluster and Projects page
- Those without cluster roles but with project roles will not be able to see the Cluster and Projects page

### Areas or cases that should be tested
- admins, restricted admins, those with cluster roles (users or groups) should be able to see the page
- those with only project based roles should not be able to see the page

