### PR TITLE
fix issue with Resources Select in globalRoles edit/create interface

### DIFF
--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -668,6 +668,7 @@ export default {
                     :value="getRule('resources', props.row.value)"
                     :disabled="isBuiltin"
                     :options="resourceOptions"
+                    option-key="optionKey"
                     :searchable="true"
                     :taggable="true"
                     :mode="mode"

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -135,7 +135,7 @@ export default {
       return true;
     },
     getOptionKey(opt) {
-      if (this.optionKey) {
+      if (opt && this.optionKey) {
         return get(opt, this.optionKey);
       }
 

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -145,6 +145,10 @@ export default {
       if (typeof label === 'string' || typeof label === 'number') {
         return label;
       } else {
+        if (opt?.optionKey) {
+          return get(opt, opt.optionKey);
+        }
+
         return Math.random(100000);
       }
     },

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -134,10 +134,26 @@ export default {
 
       return true;
     },
+    /**
+     * Get a unique value to represent the option
+     */
     getOptionKey(opt) {
+      // Use the property from a component level key
       if (opt && this.optionKey) {
         return get(opt, this.optionKey);
       }
+
+      // Use the property from an option level key
+      // This doesn't seem right, think it was meant to represent the actual option key... rather than the key to find the option key
+      // This approach also doesn't appear in LabeledSelect
+      if (opt?.optionKey) {
+        // opt.optionKey should in theory be optionKeyKey
+        return get(opt, opt.optionKey);
+      }
+
+      // There's no configuration to help us get a sensible key. Fall back on ..
+      // - the label
+      // - something random
 
       const label = this.getOptionLabel(opt);
 
@@ -145,10 +161,6 @@ export default {
       if (typeof label === 'string' || typeof label === 'number') {
         return label;
       } else {
-        if (opt?.optionKey) {
-          return get(opt, opt.optionKey);
-        }
-
         return Math.random(100000);
       }
     },

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -135,8 +135,8 @@ export default {
       return true;
     },
     getOptionKey(opt) {
-      if (opt?.optionKey) {
-        return get(opt, opt.optionKey);
+      if (this.optionKey) {
+        return get(opt, this.optionKey);
       }
 
       const label = this.getOptionLabel(opt);

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -140,8 +140,6 @@ export default {
     >
       <Select
         v-model="serviceName"
-        option-label="label"
-        option-key="label"
         :options="serviceTargets"
         :status="serviceTargetStatus"
         :taggable="true"


### PR DESCRIPTION
Fixes #9209 

- Fix issue with Select `resources` in GlobalRoles edit/create view where selecting an item with duplicate labels caused the Select to become unusable
- update `getOptionKey` in `Select` component to match the same code as in `LabeledSelect` (since it's the same usage of `v-select`, don't understand the particularity of the code before, also given the fact that `LabeledSelect` works fine)
- Remove `option-key` and `option-label` from the only place where the usage of the component `Select` had it defined in Dashboard, since it's the default for components that use `v-select`

Notes:
- Both Kubewarden and Elemental don't make use of `Select` component - checked it
- Cannot fix the `Select` pointing to `apps` in `project.cattle.io`, since both have the exact same label. In this case, it's not relevant because what the `value` uses for `resource` is just the string `app`. The `API Groups` value (which also come from this select) works as expected.

**Screenshots**
![Screenshot 2023-06-26 at 15 44 47](https://github.com/rancher/dashboard/assets/97888974/1e36734e-6bba-4a6d-b254-8e2c17b370e8)
