### PR TITLE
Use the latest rancher/ui build in e2e tests

### DIFF
--- a/scripts/build-e2e
+++ b/scripts/build-e2e
@@ -28,3 +28,13 @@ OUTPUT_DIR=dist
 
 echo "Building..."
 COMMIT=${COMMIT} VERSION=${VERSION} OUTPUT_DIR=$OUTPUT_DIR ROUTER_BASE='/dashboard/' RESOURCE_BASE='/dashboard/' yarn run build
+
+# Ensure we have the latest ember (rancher/ui) build as well
+# Note - We can't pull the `latest2` directory from CDN and we don't build a tar.gz for latest builds...
+# ..so just fetch the latest index.html which references latest CDN bits
+
+OUTPUT_EMBER_DIR=dist_ember
+
+echo "Pulling latest rancher/ui"
+mkdir $OUTPUT_EMBER_DIR
+curl https://releases.rancher.com/ui/latest2/index.html -k -o $OUTPUT_EMBER_DIR/index.html

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -2,10 +2,13 @@
 
 DIR=$(cd $(dirname $0)/..; pwd)
 
-DIST=${DIR}/dist
+# See `script/build-e2e`
+DASHBOARD_DIST=${DIR}/dist
+EMBER_DIST=${DIR}/dist_ember
 
 docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
-  -v ${DIST}:/usr/share/rancher/ui-dashboard/dashboard \
+  -v ${DASHBOARD_DIST}:/usr/share/rancher/ui-dashboard/dashboard \
+  -v ${EMBER_DIST}:/usr/share/rancher/ui \
   -e CATTLE_UI_OFFLINE_PREFERRED=true \
   -e CATTLE_BOOTSTRAP_PASSWORD=password \
   -e CATTLE_PASSWORD_MIN_LENGTH=3 \


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/9217


### Occurred changes and/or fixed issues
- given we now serve the (built) dashboard files we set CATTLE_UI_OFFLINE_PREFERRED=true
- this means the embedded rancher/ui is used
- so now we do something similar to ensure the latest rancher/ui is used