### PR TITLE
Removed cluster tools banner from dashboard page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1332,7 +1332,6 @@ cluster:
     deprecated: (deprecated)
     deprecatedPatches: Show deprecated Kubernetes patch versions
     deprecatedPatchWarning: We recommend using the latest patch version for each minor Kubernetes version. Deprecated patch versions can be useful for migration purposes.
-  toolsTip: Use the new Cluster Tools to manage and install Monitoring, Logging and other tools
   legacyWarning: The legacy feature flag is enabled and not all legacy features are supported in Kubernetes 1.21+.
   log:
     connecting: Connecting…

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -1339,7 +1339,6 @@ cluster:
     deprecated: （已弃用）
     deprecatedPatches: 显示已弃用的 Kubernetes 补丁版本
     deprecatedPatchWarning: 建议为每个 Kubernetes 次要版本使用最新的补丁版本，已弃用的补丁版本可能对迁移有用。
-  toolsTip: 使用新集群工具来管理和安装 Monitoring、Logging 等工具。
   legacyWarning: 旧版功能开关已开启，但是不是所有旧版功能都在 Kubernetes 1.21+ 中支持。
   log:
     connecting: 正在连接

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -27,7 +27,7 @@ import {
   STATE,
 } from '@shell/config/table-headers';
 
-import { mapPref, CLUSTER_TOOLS_TIP, PSP_DEPRECATION_BANNER } from '@shell/store/prefs';
+import { mapPref, PSP_DEPRECATION_BANNER } from '@shell/store/prefs';
 import { haveV1Monitoring, monitoringStatus } from '@shell/utils/monitoring';
 import Tabbed from '@shell/components/Tabbed';
 import Tab from '@shell/components/Tabbed/Tab';
@@ -173,7 +173,6 @@ export default {
       return this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
     },
 
-    hideClusterToolsTip:      mapPref(CLUSTER_TOOLS_TIP),
     hidePspDeprecationBanner: mapPref(PSP_DEPRECATION_BANNER),
 
     hasV1Monitoring() {
@@ -441,14 +440,6 @@ export default {
         :raw="true"
       />
     </Banner>
-    <Banner
-      v-if="!hideClusterToolsTip"
-      :closable="true"
-      class="cluster-tools-tip"
-      color="info"
-      label-key="cluster.toolsTip"
-      @close="hideClusterToolsTip = true"
-    />
     <div
       class="cluster-dashboard-glance"
     >

--- a/shell/store/prefs.js
+++ b/shell/store/prefs.js
@@ -111,9 +111,6 @@ export const _RKE1 = 'rke1';
 export const _RKE2 = 'rke2';
 export const PROVISIONER = create('provisioner', _RKE2, { options: [_RKE1, _RKE2] });
 
-// Promo for Cluster Tools feature on Cluster Dashboard page
-export const CLUSTER_TOOLS_TIP = create('hide-cluster-tools-tip', false, { parseJSON });
-
 // Promo for Pod Security Policies (PSPs) being deprecated on kube version 1.25 on Cluster Dashboard page
 export const PSP_DEPRECATION_BANNER = create('hide-psp-deprecation-banner', false, { parseJSON });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9229
<!-- Define findings related to the feature or bug issue. -->
Removed new cluster tools banner from the dashboard page


### How to test
Go to cluster dashboard > cluster tools banner should not be there


<img width="1908" alt="Screenshot 2023-06-29 at 12 24 48" src="https://github.com/rancher/dashboard/assets/18264463/f1059102-c3c3-49ea-9083-b69dff21f065">
