### PR TITLE
Extension support for custom provisioning

### DIFF
--- a/docusaurus/docs/extensions/advanced/provisioning.md
+++ b/docusaurus/docs/extensions/advanced/provisioning.md
@@ -1,6 +1,6 @@
 # Cluster Provisioning (RKE2 / Custom)
 
-The Rancher UI provides a number of ways to customise the processes that creates RKE2/Custom clusters. This includes
+The UI provides a number of ways to customise the processes that creates RKE2/Custom clusters. This includes
 - Adding additional Cluster Provisioner types
 - Customising or replacing components used in the create process
 - Additional tabs
@@ -8,7 +8,7 @@ The Rancher UI provides a number of ways to customise the processes that creates
 - Overrides that replace the process to persist cluster resources
 
 ## Custom Components
-Existing components that manage cloud credentials and machine configuration can be replaced as per [Custom Node Driver UI](components/node-drivers.md). 
+Existing components that manage cloud credentials and machine configuration can be replaced as per [Custom Node Driver UI](../api/components/node-drivers.md). 
 
 ## Custom Cluster Provisioner
 New cluster provisioners can be added that can tailor the create/edit experience for their own needs.

--- a/docusaurus/docs/extensions/api/common.md
+++ b/docusaurus/docs/extensions/api/common.md
@@ -63,8 +63,9 @@ The admissible parameters for the `LocationConfig` object are:
 |`namespace`| Array | Array of the namespace identifier. Ex: `kube-system`, `cattle-global-data` or `cattle-system` |
 |`cluster`| Array | Array of the cluster identifier. Ex: `local` |
 |`id`| Array | Array of the identifier for a given resource. Ex: `deployment-unt6xmz` |
-|`mode`| Array | Array of modes which relates to the type of view on which the given enhancement should be applied. Admissable values are: `edit`, `config`, `detail` and `list` |
-|`customParams` | Object | ResourceTab only, when configured by that instance. Key value object which must match the object supplied to the instance of ResourceTab. Can be used to only show feature given context specific params (rather than generic params for the given resource). |
+|`mode`| Array | Array of modes which relates to the type of view on which the given enhancement should be applied. Admissible values are: `edit`, `config`, `detail` and `list` |
+|`context` | Object | Requirements set by the context itself. This is a key value object that must match the object provided where the feature is used. For instance if a ResourceTab should only include a tab given specific information where the ResourceTab is used. Ex `{ provider: "digitalocean" }` |
+| `queryParam` | Object | This is a key value object that must match the url's query param key values
 
 ### LocationConfig Examples
 

--- a/docusaurus/docs/extensions/api/common.md
+++ b/docusaurus/docs/extensions/api/common.md
@@ -54,7 +54,7 @@ which translates to:
 With this it's then possible to easily identify the parameters needed to populate the `LocationConfig` and add the UI enhancements to the areas that you like. YES, it's also possible to enhance other extensions!
 
 
-The admissable parameters for the `LocationConfig` object are:
+The admissible parameters for the `LocationConfig` object are:
 
 | Key | Type | Description |
 |---|---|---|
@@ -64,6 +64,7 @@ The admissable parameters for the `LocationConfig` object are:
 |`cluster`| Array | Array of the cluster identifier. Ex: `local` |
 |`id`| Array | Array of the identifier for a given resource. Ex: `deployment-unt6xmz` |
 |`mode`| Array | Array of modes which relates to the type of view on which the given enhancement should be applied. Admissable values are: `edit`, `config`, `detail` and `list` |
+|`customParams` | Object | ResourceTab only, when configured by that instance. Key value object which must match the object supplied to the instance of ResourceTab. Can be used to only show feature given context specific params (rather than generic params for the given resource). |
 
 ### LocationConfig Examples
 

--- a/docusaurus/docs/extensions/api/components/node-drivers.md
+++ b/docusaurus/docs/extensions/api/components/node-drivers.md
@@ -2,8 +2,11 @@
 
 Rancher allows UI to be created for custom Node Drivers by registering components for the following two component types:
 
-- `cloud-credential` - defines a custom component for collecting data for a cloud credential for a given node driver
-- `machine-config` - defined a custom component for the machine pool configuration for a cloud credential for a given node driver
+- `cloud-credential`
+  - defines a custom component for collecting data for a cloud credential for a given node driver
+  - If no cloud credentials are required, the extension can just set the component to `false`
+- `machine-config`
+  - defined a custom component for the machine pool configuration for a cloud credential for a given node driver
 
 In both cases, the `ID` when registering should match the Node Driver name.
 

--- a/docusaurus/docs/extensions/api/provisioning.md
+++ b/docusaurus/docs/extensions/api/provisioning.md
@@ -45,24 +45,43 @@ The class provides a way to...
 > To make API calls from the UI to a different domain see [here](../../code-base-works/machine-drivers.md#api-calls). For instance to fetch region or machine size information used to create a machine config
 
 ### Components
-In addition to the provisioner class, the user can provide components as per the `Custom Components` section.
+When creating or editing a cluster the user can see the cloud credential and machine pool components.
+
+These can be provided as per the `Custom Components` section.
 
 ```
   plugin.register('cloud-credential', 'my-provisioner', false);
   plugin.register('machine-config', 'my-provisioner', () => import('./src/test.vue'));
 ```
 
-This example registers that no cloud credential is needed and registers a custom component to be used for Machine Configuration within a node/machine pool - this is the same as with Node Drivers - e.g. with the OpenStack node driver example. 
+This example registers that no cloud credential is needed and registers a custom component to be used for Machine Configuration within a node/machine pool - this is the same as with Node Drivers - e.g. with the OpenStack node driver example.
+
+### Custom tabs in the Cluster's Cluster Configuration 
+
+When creating a cluster or editing the cluster the user can see a set of `Cluster Configuration` tabs that contain configuration applicable to the entire cluster.
+
+Extensions can add additional tabs here.
+
+```
+  plugin.addTab(TabLocation.CLUSTER_CREATE_RKE2, {
+    resource:     ['provisioning.cattle.io.cluster'],
+    queryParam:    { type: ExampleProvisioner.ID }
+  }, {
+    name:      'custom-cluster-config',
+    labelKey:     'exampleClusterConfigTab.tabLabel',
+    component: () => import('./src/example-cluster-config-tab.vue')
+  });
+```
+Note we use the new `queryParam` property to allow us to target the tab only when the cluster is of our provider type.
 
 ### Custom tabs in the Cluster's detail page
 
-When clicking on a created cluster in the UI the user is shown details for the cluster. This page has some tabs which may not be applicable
-to the custom provider. The provider class has a way to hide these. To add a new custom tab the following can be used
+When clicking on a created cluster in the UI the user is shown details for the cluster. This page has some tabs which may not be applicable to the custom provider. The provider class has a way to hide these. To add a new custom tab the following can be used
 
 ```
   plugin.addTab(TabLocation.RESOURCE_DETAIL, {
     resource:     ['provisioning.cattle.io.cluster'],
-    customParams:   { provider: ExampleProvisioner.ID }
+    context:   { provider: ExampleProvisioner.ID }
   }, {
     name:      'custom',
     label:     'Custom Tab',
@@ -70,7 +89,7 @@ to the custom provider. The provider class has a way to hide these. To add a new
   });
 ```
 
-Note we use the new `customParams` to allow us to target the tab only when the cluster is of our provider type.
+Note we use the new `context` property to allow us to target the tab only when the cluster is of our provider type.
 
 ### Localisation
 

--- a/docusaurus/docs/extensions/api/provisioning.md
+++ b/docusaurus/docs/extensions/api/provisioning.md
@@ -1,0 +1,77 @@
+# Cluster Provisioning (RKE2 / Custom)
+
+The Rancher UI provides a number of hooks to support custom components and processes when managing RKE2/Custom clusters.
+
+## Custom Components
+To implement components for an existing node driver see [Custom Node Driver UI](components/node-drivers.md). For example new / replacement components to manage cloud credentials and/or machine configs can be supplied.
+
+## Custom Create/Edit
+
+### Resources
+Creating an cluster revolves around two resources
+- The machine configuration
+  - The machine configuration defines how the individual nodes within a node pool will be provisioned. For instance which region and size they may be
+  - These normally have an type of `rke-machine-config.cattle.io.<provider name>config`, which matches the id of it's schema object
+- The provisioning cluster
+  - The `provisioning.cattle.io.cluster` which, aside from machine configuration, contains all details of the cluster
+  - In the UI this is an instance of the `rancher/dashboard` `shell/models/provisioning.cattle.io.cluster.js` class
+     - This has lots of great helper functions, most importantly `save`
+  - This process will create a cluster of type `custom`
+
+### Provisioner Class
+To customise the process of creating or editing these resources the extension should register a provisioner class which implements the `IClusterProvisioner` interface.
+
+```
+  plugin.register('provisioner', 'my-provisioner', ExampleProvisioner);
+```
+
+> Note that `register` allows us to register an arbitrary extension and we introduce the type `provisioner`.
+
+Below is outline for the functionality the class provides, for detail about the `IClusterProvisioner` interface see the inline documentation.
+
+The class provides a way to...
+1. show a card for the new cluster type to the user when selecting the type of cluster to provision
+1. handle custom machine configs that haven't necessarily been provided by the usual node driver way
+1. hooks to extend/override the cluster save process. Either..
+    - Override all of the cluster save process
+    - Extend/Override parts of the cluster save process. This allows a lot of the boilerplate code to manage addons, member bindings, etc to run
+    - run code before the cluster resource is saved
+    - replace the code that saves the core cluster
+    - run code after the cluster resource is saved
+1. show a custom label for the provider of the custom cluster
+    - This is done by setting the `ui.rancher/provider` annotation in the cluster
+1. show custom tabs on the Detail page of the custom cluster
+
+> To make API calls from the UI to a different domain see [here](../../code-base-works/machine-drivers.md#api-calls). For instance to fetch region or machine size information used to create a machine config
+
+### Components
+In addition to the provisioner class, the user can provide components as per the `Custom Components` section.
+
+```
+  plugin.register('cloud-credential', 'my-provisioner', false);
+  plugin.register('machine-config', 'my-provisioner', () => import('./src/test.vue'));
+```
+
+This example registers that no cloud credential is needed and registers a custom component to be used for Machine Configuration within a node/machine pool - this is the same as with Node Drivers - e.g. with the OpenStack node driver example. 
+
+### Custom tabs in the Cluster's detail page
+
+When clicking on a created cluster in the UI the user is shown details for the cluster. This page has some tabs which may not be applicable
+to the custom provider. The provider class has a way to hide these. To add a new custom tab the following can be used
+
+```
+  plugin.addTab(TabLocation.RESOURCE_DETAIL, {
+    resource:     ['provisioning.cattle.io.cluster'],
+    customParams:   { provider: ExampleProvisioner.ID }
+  }, {
+    name:      'custom',
+    label:     'Custom Tab',
+    component: () => import('./src/example-tab.vue')
+  });
+```
+
+Note we use the new `customParams` to allow us to target the tab only when the cluster is of our provider type.
+
+### Localisation
+
+The custom cluster type's label is defined as per any other extension text in `l10n/en-us.yaml` as `cluster.provider.<provider name>`.

--- a/docusaurus/docs/extensions/home.md
+++ b/docusaurus/docs/extensions/home.md
@@ -7,7 +7,3 @@ Extensions can be created independently of Rancher and their code can live in se
 You can find some example extensions here: https://github.com/rancher/ui-plugin-examples
 
 > Note: Rancher Extensions is in early development - support for Extensions was recently added to Rancher 2.7.0 and the internal Rancher team is building out extensions using the extensions framework. Over time, the extensions API will improve and the supporting documentation will be built out, to enable the wider developer community to build their own extensions.
-
-
-// TODO: RC Add new section to cover IClusterProvisioner. Section should include cloud-crednetial and machine-config bits. Reference section from `code-base-works/machine-drivers` page
-// TODO: RC Add new info to addTab part about customParams

--- a/docusaurus/docs/extensions/home.md
+++ b/docusaurus/docs/extensions/home.md
@@ -7,3 +7,7 @@ Extensions can be created independently of Rancher and their code can live in se
 You can find some example extensions here: https://github.com/rancher/ui-plugin-examples
 
 > Note: Rancher Extensions is in early development - support for Extensions was recently added to Rancher 2.7.0 and the internal Rancher team is building out extensions using the extensions framework. Over time, the extensions API will improve and the supporting documentation will be built out, to enable the wider developer community to build their own extensions.
+
+
+// TODO: RC Add new section to cover IClusterProvisioner. Section should include cloud-crednetial and machine-config bits. Reference section from `code-base-works/machine-drivers` page
+// TODO: RC Add new info to addTab part about customParams

--- a/docusaurus/docs/guide/custom-dev-build.md
+++ b/docusaurus/docs/guide/custom-dev-build.md
@@ -8,6 +8,11 @@ To use a custom dashboard build that is publicly available
 1. Scroll down to `ui-dashboard-index`. Use the three dot menu on the right to change this value to the location of the custom build
 1. Scroll down to `ui-offline-preferred`. Use the three dot menu on the right to change this value to `Remote`
 
-> It's important to get this right. If there's a typo or any other issue the Rancher UI will become unavailable. If this happens, whilst your UI session is still alive, go to `<rancher url>/v3/settings/ui-offline-preferred` and change to `true`. Refresh the Rancher UI and it should be back.
+It's important to get this right. If there's a typo or any other issue the Rancher UI will become unavailable. If this happens either..
+
+- whilst your UI session is still alive, go to `<rancher url>/v3/settings/ui-offline-preferred` and change to `true`.
+- with your kube context point to the local / upstream cluster, run `kubectl edit settings.management.cattle.io ui-offline-preferred` and set `value` to `true`
+
+Refresh the Rancher UI and it should be back, allowing the settings to be correctly updated.
 
 This change will apply to all users of the dashboard after they refresh their page.

--- a/docusaurus/docs/guide/custom-dev-build.md
+++ b/docusaurus/docs/guide/custom-dev-build.md
@@ -1,0 +1,13 @@
+# Custom Dashboard Dev Build
+
+> This does not apply to the usual development cycle and is only used in specific custom cases
+
+To use a custom dashboard build that is publicly available
+
+1. Go to the burger menu (top left) --> `Global Settings` --> `Settings`
+1. Scroll down to `ui-dashboard-index`. Use the three dot menu on the right to change this value to the location of the custom build
+1. Scroll down to `ui-offline-preferred`. Use the three dot menu on the right to change this value to `Remote`
+
+> It's important to get this right. If there's a typo or any other issue the Rancher UI will become unavailable. If this happens, whilst your UI session is still alive, go to `<rancher url>/v3/settings/ui-offline-preferred` and change to `true`. Refresh the Rancher UI and it should be back.
+
+This change will apply to all users of the dashboard after they refresh their page.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -124,6 +124,7 @@ const sidebars = {
           label: 'Advanced',
           items: [
             'extensions/advanced/air-gapped-environments',
+            'extensions/advanced/provisioning',
             'extensions/advanced/localization',
             'extensions/advanced/hooks',
             'extensions/advanced/stores',

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -130,6 +130,10 @@ export default {
       type:    String,
       default: null,
     },
+    namespaceOptions: {
+      type:    Array,
+      default: null,
+    },    
     descriptionKey: {
       type:    String,
       default: null,
@@ -228,9 +232,18 @@ export default {
      * Map namespaces from the store to options, adding divider and create button
      */
     options() {
-      const namespaces = this.namespacesOverride ||
-        (Object.keys(this.isCreate ? this.allowedNamespaces() : this.namespaces()));
-      const options = namespaces
+      // Use the provided namespaces options if supplied via the component property
+      let namespaces = this.namespaceOptions;
+
+      if (namespaces) {
+        namespaces = (namespaces.map(ns => ns.name) || []).sort();
+      } else {
+        const namespaceObjs = this.isCreate ? this.allowedNamespaces() : this.namespaces();
+
+        namespaces = Object.keys(namespaceObjs);
+      }
+
+      const options = namespaces      
         .map((namespace) => ({ nameDisplay: namespace, id: namespace }))
         .map(this.namespaceMapper || ((obj) => ({
           label: obj.nameDisplay,

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -8,16 +8,7 @@ import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { _VIEW, _EDIT, _CREATE } from '@shell/config/query-params';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
-
-export function normalizeName(str) {
-  return (str || '')
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '');
-}
+import { normalizeName } from '@shell/utils/kube';
 
 export default {
   name:       'NameNsDescription',

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -133,7 +133,7 @@ export default {
     namespaceOptions: {
       type:    Array,
       default: null,
-    },    
+    },
     descriptionKey: {
       type:    String,
       default: null,
@@ -236,14 +236,14 @@ export default {
       let namespaces = this.namespaceOptions;
 
       if (namespaces) {
-        namespaces = (namespaces.map(ns => ns.name) || []).sort();
+        namespaces = (namespaces.map((ns) => ns.name) || []).sort();
       } else {
         const namespaceObjs = this.isCreate ? this.allowedNamespaces() : this.namespaces();
 
         namespaces = Object.keys(namespaceObjs);
       }
 
-      const options = namespaces      
+      const options = namespaces
         .map((namespace) => ({ nameDisplay: namespace, id: namespace }))
         .map(this.namespaceMapper || ((obj) => ({
           label: obj.nameDisplay,

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -101,7 +101,17 @@ export default {
       type:    Boolean,
       default: false
     },
+    /**
+     * Use these objects instead of namespaces
+     */
     namespacesOverride: {
+      type:    Array,
+      default: null,
+    },
+    /**
+     * User these namespaces instead of determining list within component
+     */
+    namespaceOptions: {
       type:    Array,
       default: null,
     },
@@ -128,10 +138,6 @@ export default {
     },
     namespaceKey: {
       type:    String,
-      default: null,
-    },
-    namespaceOptions: {
-      type:    Array,
       default: null,
     },
     descriptionKey: {
@@ -232,15 +238,21 @@ export default {
      * Map namespaces from the store to options, adding divider and create button
      */
     options() {
-      // Use the provided namespaces options if supplied via the component property
-      let namespaces = this.namespaceOptions;
+      let namespaces;
 
-      if (namespaces) {
-        namespaces = (namespaces.map((ns) => ns.name) || []).sort();
+      if (this.namespacesOverride) {
+        // Use the resources provided
+        namespaces = this.namespacesOverride;
       } else {
-        const namespaceObjs = this.isCreate ? this.allowedNamespaces() : this.namespaces();
+        if (this.namespaceOptions) {
+          // Use the namespaces provided
+          namespaces = (this.namespaceOptions.map((ns) => ns.name) || []).sort();
+        } else {
+          // Determine the namespaces
+          const namespaceObjs = this.isCreate ? this.allowedNamespaces() : this.namespaces();
 
-        namespaces = Object.keys(namespaceObjs);
+          namespaces = Object.keys(namespaceObjs);
+        }
       }
 
       const options = namespaces

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -60,6 +60,11 @@ export default {
     needRelated: {
       type:    Boolean,
       default: true
+    },
+
+    extensionParams: {
+      type:     Object,
+      required: false,
     }
   },
 
@@ -71,7 +76,7 @@ export default {
       allEvents:     [],
       selectedTab:   this.defaultTab,
       didLoadEvents: false,
-      extensionTabs: getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.RESOURCE_DETAIL, this.$route),
+      extensionTabs: getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.RESOURCE_DETAIL, this.$route, this, this.extensionParams),
     };
   },
 

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -63,8 +63,8 @@ export default {
     },
 
     extensionParams: {
-      type:     Object,
-      required: false,
+      type:    Object,
+      default: null
     }
   },
 

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -151,6 +151,9 @@ export const CLUSTER_BADGE = {
   ICON_TEXT: 'ui.rancher/badge-icon-text',
 };
 
+// Annotation for overriding the cluster provider
+export const PROVIDER = 'ui.rancher/provider';
+
 export const SYSTEM_LABELS = [
   'io.cattle.lifecycle.',
   'beta.kubernetes.io',

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -58,7 +58,7 @@ export const CAPI = {
   /**
    * Annotation for overriding the cluster provider,
    */
-  PROVIDER_UI:          'ui.rancher/provider'
+  UI_CUSTOM_PROVIDER:   'ui.rancher/provider'
 };
 
 export const CATALOG = {

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -54,7 +54,11 @@ export const CAPI = {
   DELETE_MACHINE:       'cluster.x-k8s.io/delete-machine',
   PROVIDER:             'provider.cattle.io',
   SECRET_AUTH:          'v2prov-secret-authorized-for-cluster',
-  SECRET_WILL_DELETE:   'v2prov-authorized-secret-deletes-on-cluster-removal'
+  SECRET_WILL_DELETE:   'v2prov-authorized-secret-deletes-on-cluster-removal',
+  /**
+   * Annotation for overriding the cluster provider,
+   */
+  PROVIDER_UI:          'ui.rancher/provider'
 };
 
 export const CATALOG = {
@@ -150,9 +154,6 @@ export const CLUSTER_BADGE = {
   // Custom icon text - max 2 characters
   ICON_TEXT: 'ui.rancher/badge-icon-text',
 };
-
-// Annotation for overriding the cluster provider
-export const PROVIDER = 'ui.rancher/provider';
 
 export const SYSTEM_LABELS = [
   'io.cattle.lifecycle.',

--- a/shell/core/plugin-helpers.js
+++ b/shell/core/plugin-helpers.js
@@ -74,6 +74,7 @@ function checkExtensionRouteBinding($route, locationConfig, customParams) {
           } else if (param === 'params') {
             // Need all keys and values to match
             let okay = true;
+
             Object.keys(locationConfigParam).forEach((p) => {
               const desired = locationConfigParam[p];
               const actual = customParams[p];

--- a/shell/core/plugin-helpers.js
+++ b/shell/core/plugin-helpers.js
@@ -3,7 +3,7 @@ import { isMac } from '@shell/utils/platform';
 import { ucFirst, randomStr } from '@shell/utils/string';
 import { _EDIT, _CONFIG, _DETAIL, _LIST } from '@shell/config/query-params';
 import { getProductFromRoute } from '@shell/middleware/authenticated';
-import { diff, isEqual } from 'utils/object';
+import { isEqual } from '@shell/utils/object';
 
 function checkRouteProduct({ name, params, query }, locationConfigParam) {
   const product = getProductFromRoute({

--- a/shell/core/plugin-helpers.js
+++ b/shell/core/plugin-helpers.js
@@ -50,7 +50,8 @@ function checkExtensionRouteBinding($route, locationConfig, customParams) {
     'cluster',
     'id',
     'mode',
-    'params',
+    // Custom params provided by the extension, not to be confused with location params
+    'customParams',
   ];
 
   let res = true;
@@ -71,7 +72,7 @@ function checkExtensionRouteBinding($route, locationConfig, customParams) {
           // also handle "mode" in a separate way because it mainly depends on query params
           } else if (param === 'mode') {
             res = checkRouteMode($route, locationConfigParam);
-          } else if (param === 'params') {
+          } else if (param === 'customParams') {
             // Need all keys and values to match
             let okay = true;
 
@@ -105,7 +106,7 @@ function checkExtensionRouteBinding($route, locationConfig, customParams) {
   return res;
 }
 
-export function getApplicableExtensionEnhancements(pluginCtx, actionType, uiArea, currRoute, translationCtx = pluginCtx, params) {
+export function getApplicableExtensionEnhancements(pluginCtx, actionType, uiArea, currRoute, translationCtx = pluginCtx, customParams) {
   const extensionEnhancements = [];
 
   // gate it so that we prevent errors on older versions of dashboard
@@ -113,7 +114,7 @@ export function getApplicableExtensionEnhancements(pluginCtx, actionType, uiArea
     const actions = pluginCtx.$plugin.getUIConfig(actionType, uiArea);
 
     actions.forEach((action, i) => {
-      if (checkExtensionRouteBinding(currRoute, action.locationConfig, params || {})) {
+      if (checkExtensionRouteBinding(currRoute, action.locationConfig, customParams || {})) {
         // ADD CARD PLUGIN UI ENHANCEMENT
         if (actionType === ExtensionPoint.CARD) {
           // intercept to apply translation

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -1,12 +1,17 @@
 /**
+ * A function to run as part of the save cluster process
+ */
+export type ClusterSaveHook = (cluster: any) => Promise<any>
+
+/**
  * Register a function to run as part of the save cluster process
  *
  * @param hook function to run
  * @param name unique identifier
  * @param priority higher numbers are lower priority
- * @param fnContext the `this` context from inside the function. If left blank will be a Vue component
+ * @param fnContext the `this` context from inside the function. If left blank will be a Vue component (where this.value will be the cluster)
  */
-export type ClusterSaveHook = (hook: (cluster: any) => void, name: string, priority?: number, fnContext?: any) => void;
+export type RegisterClusterSaveHook = (hook: ClusterSaveHook, name: string, priority?: number, fnContext?: any) => void;
 
 /**
  * Interface that a custom Cluster Provisioner should implement
@@ -123,13 +128,13 @@ export interface IClusterProvisioner {
    *
    * @param registerBeforeHook
    *  Call `registerBeforeHook` with a function. The function will be executed before the cluster is saved.
-   *  This allows the model used in the API request to be updated before being sent.
+   *  This allows the model used in the API request to be updated before being sent
    * @param registerAfterHook
    *  Call `registerAfterHook` with a function. The function will be executed after the cluster has been saved.
    *  This allows the model received in response to the API request to be updated
    * @param cluster The cluster (`provisioning.cattle.io.cluster`)
    */
-  registerSaveHooks?(registerBeforeHook: ClusterSaveHook, registerAfterHook: ClusterSaveHook, cluster: any): void;
+  registerSaveHooks?(registerBeforeHook: RegisterClusterSaveHook, registerAfterHook: RegisterClusterSaveHook, cluster: any): void;
 
   /**
    * Optionally override the save of the cluster resource itself.

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -17,12 +17,38 @@ export type RegisterClusterSaveHook = (hook: ClusterSaveHook, name: string, prio
  * Params used when constructing an instance of the cluster provisioner
  */
 export interface ClusterProvisionerContext {
+  /**
+   * Dispatch vuex actions
+   */
   dispatch: any,
+  /**
+   * Get from vuex store
+   */
   getters: any,
+  /**
+   * Used to make http requests
+   */
   axios: any,
+  /**
+   * Definition of the extension
+   */
   $plugin: any,
+  /**
+   * Function to retrieve a localised string
+   */
   t: (key: string) => string,
+  /**
+   * Are we in the context of creating a cluster
+   */
   isCreate: boolean
+  /**
+   * Are we in the context of editing an existing cluster
+   */
+  isEdit: boolean
+  /**
+   * Are we viewing an existing cluster
+   */
+  isView: boolean
 }
 
 /**

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -1,0 +1,17 @@
+export type SaveHook = (hook: Function, name: string) => void;
+
+/**
+ * Interface that a custom Cluster Provisioner should implement
+ */
+export interface IClusterProvisioner {
+
+  /**
+   * Unique ID of the Cluster Provisioner
+   */
+  id: String;
+
+  /**
+   * Should the UI show a namespace selector when using this provisioner
+   */
+  namespaced: Boolean;
+}

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -14,6 +14,18 @@ export type ClusterSaveHook = (cluster: any) => Promise<any>
 export type RegisterClusterSaveHook = (hook: ClusterSaveHook, name: string, priority?: number, fnContext?: any) => void;
 
 /**
+ * Params used when constructing an instance of the cluster provisioner
+ */
+export interface ClusterProvisionerContext {
+  dispatch: any,
+  getters: any,
+  axios: any,
+  $plugin: any,
+  t: (key: string) => string,
+  isCreate: boolean
+}
+
+/**
  * Interface that a custom Cluster Provisioner should implement
  *
  * The majority of these hooks are used in shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -23,17 +35,63 @@ export interface IClusterProvisioner {
   /**
    * Unique ID of the Cluster Provisioner
    */
-  id: String;
+  id: string;
 
   /**
    * Should the UI show a namespace selector when using this provisioner
    */
-  namespaced: boolean;
+  namespaced?: boolean;
+
+  /* --------------------------------------------------------------------------------------
+   * Define how the cluster provider is presented in a card to the user
+   * --------------------------------------------------------------------------------------- */
+
+  /**
+   * If missing the `cluster.provider.<provider id>` translation will be used
+   *
+   * It is recommended to not hardcode anything that might be localised
+   */
+  label?: string;
+
+  /**
+   * The description will be shown when the user is selecting the type of cluster provider
+   *
+   * This isn't normally used.
+   */
+  description?: string;
 
   /**
    * Icon shown when the user is selecting the type of cluster provider
    */
-  icon: any;
+  icon?: any;
+
+  /**
+   * Cluster providers are in groups
+   *
+   * `rke2` - default
+   * `kontainer`
+   * `custom2`
+   */
+  group?: string;
+
+  /**
+   * Disable the cluster provider card
+   */
+  disabled?: boolean;
+
+  /**
+   * Custom Dashboard route to navigate to when the cluster provider card is clicked
+   */
+  link?: string;
+
+  /**
+   * Text to show top right on the cluster provider card. For example `Experimental`
+   */
+  tag?: string;
+
+  /* --------------------------------------------------------------------------------------
+   * Custer Details View
+   * --------------------------------------------------------------------------------------- */
 
   /**
    * Existing tabs to show or hide in the cluster's detail view
@@ -71,9 +129,9 @@ export interface IClusterProvisioner {
     conditions: boolean
   };
 
-  /**
+  /* --------------------------------------------------------------------------------------
    * Getters / Functions for Managing Machine Configs
-   */
+  * --------------------------------------------------------------------------------------- */
 
   /**
    * Schema for machine config object. For example rke-machine-config.cattle.io.digitaloceanconfig
@@ -117,11 +175,11 @@ export interface IClusterProvisioner {
    */
   saveMachinePoolConfigs?(pools: any[], cluster: any): Promise<any>
 
-  /**
+  /* --------------------------------------------------------------------------------------
    * Optionally override parts of the cluster save process with
    * - hooks that run before or after the cluster resource is saved
    * - the actual save of the cluster resource
-   */
+  * --------------------------------------------------------------------------------------- */
 
   /**
    * Update the cluster before and or after the cluster is saved
@@ -147,6 +205,10 @@ export interface IClusterProvisioner {
    * @returns Rejected promise / exception from `await` if failed to save
    */
   saveCluster?(cluster: any): Promise<any>
+
+  /* --------------------------------------------------------------------------------------
+   * Optionally override all of cluster save process
+   * --------------------------------------------------------------------------------------- */
 
   /**
    * Optionally override all of the ui's save cluster process (including hooks and saving the resource)

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -1,4 +1,4 @@
-export type SaveHook = (hook: Function, name: string) => void;
+export type ClusterSaveHook = (hook: (cluster: any) => void, name: string, priority?: number, ) => void;
 
 /**
  * Interface that a custom Cluster Provisioner should implement
@@ -30,10 +30,10 @@ export interface IClusterProvisioner {
    * The `attributes: { kind: <value> }` should match the last part of the id
    * The `attributes: { group: <value> }` should match the remaining parts of the id
    */
-  machineConfigSchema: { [key: string]: any };
+  machineConfigSchema?: { [key: string]: any };
 
   /**
-   * Override the default method to create a machine config that will be inserted into a new machine pool
+   * Override the default method to create a machine config object that will be inserted into a new machine pool
    *
    * The machine config will be an instance related to the machine config schema
    *
@@ -41,9 +41,9 @@ export interface IClusterProvisioner {
    *
    * @param idx Index of new pool
    * @param pools Existing machine pools
-   * @returns TODO: RC
+   * @returns Instance of a machine config
    */
-  createMachinePoolMachineConfig(idx: number, pools: any[]): Promise<{[key: string]: any}>;
+  createMachinePoolMachineConfig?(idx: number, pools: any[]): Promise<{[key: string]: any}>;
 
   /**
    * Update the cluster before and or after the cluster is saved
@@ -56,7 +56,7 @@ export interface IClusterProvisioner {
    *  This allows the model received in response to the API request to be updated
    * @param cluster The cluster (`provisioning.cattle.io.cluster`)
    */
-  registerSaveHooks(registerBeforeHook: SaveHook, registerAfterHook: SaveHook, cluster: any): void;
+  registerSaveHooks?(registerBeforeHook: ClusterSaveHook, registerAfterHook: ClusterSaveHook, cluster: any): void;
 
   /**
    * Override the default process to save the machine config's associated with the machine pools
@@ -65,11 +65,14 @@ export interface IClusterProvisioner {
    *
    * The pool will have `create: true` if the pool is new or `update: true` if the pool already exists
    *
+   * For information on proxying HTTP requests from the browser via Rancher https://rancher.github.io/dashboard/code-base-works/machine-drivers#api-calls
+   * These docs also cover how to reference a Cloud Credential and use it's properties in the proxy's request `Authorization` header
+   *
    * @param pools Machine pools
    * @param cluster The cluster (`provisioning.cattle.io.cluster`)
-   * @returns TODO: RC
+   * @returns Content of async result / promise N/A, only the success / fail state
    */
-  saveMachinePoolConfigs(pools: any[], cluster: any): Promise<any>
+  saveMachinePoolConfigs?(pools: any[], cluster: any): Promise<any>
 
   /**
    * Existing tabs to show or hide in the cluster's detail view
@@ -110,9 +113,12 @@ export interface IClusterProvisioner {
   /**
    * Override the default process to save the cluster (`provisioning.cattle.io.cluster`)
    *
+   * For information on proxying HTTP requests from the browser via Rancher https://rancher.github.io/dashboard/code-base-works/machine-drivers#api-calls
+   * These docs also cover how to reference a Cloud Credential and use it's properties in the proxy's request `Authorization` header
+   *
    * @param pools Machine pools
    * @param cluster The cluster (`provisioning.cattle.io.cluster`)
    * @returns Array of errors. If there are no errors the array will be empty
    */
-  provision(cluster: any, pools: any[]): Promise<any[]>;
+  provision?(cluster: any, pools: any[]): Promise<any[]>;
 }

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -2,6 +2,8 @@ export type SaveHook = (hook: Function, name: string) => void;
 
 /**
  * Interface that a custom Cluster Provisioner should implement
+ *
+ * The majority of these hooks are used in shell/edit/provisioning.cattle.io.cluster/rke2.vue
  */
 export interface IClusterProvisioner {
 
@@ -14,4 +16,103 @@ export interface IClusterProvisioner {
    * Should the UI show a namespace selector when using this provisioner
    */
   namespaced: Boolean;
+
+  /**
+   * Icon shown when the user is selecting the type of cluster provider
+   */
+  icon: any;
+
+  /**
+   * Schema for machine config object. For example rke-machine-config.cattle.io.digitaloceanconfig
+   *
+   * The `id` should be in the format of `rke-machine-config.cattle.io.${ provider id }config`
+   *
+   * The `attributes: { kind: <value> }` should match the last part of the id
+   * The `attributes: { group: <value> }` should match the remaining parts of the id
+   */
+  machineConfigSchema: { [key: string]: any };
+
+  /**
+   * Override the default method to create a machine config that will be inserted into a new machine pool
+   *
+   * The machine config will be an instance related to the machine config schema
+   *
+   * This is usually used when the user has selected to add a machine pool when creating/editing the cluster
+   *
+   * @param idx Index of new pool
+   * @param pools Existing machine pools
+   * @returns TODO: RC
+   */
+  createMachinePoolMachineConfig(idx: number, pools: any[]): Promise<{[key: string]: any}>;
+
+  /**
+   * Update the cluster before and or after the cluster is saved
+   *
+   * @param registerBeforeHook
+   *  Call `registerBeforeHook` with a function. The function will be executed before the cluster is saved.
+   *  This allows the model used in the API request to be updated before being sent.
+   * @param registerAfterHook
+   *  Call `registerAfterHook` with a function. The function will be executed after the cluster has been saved.
+   *  This allows the model received in response to the API request to be updated
+   * @param cluster The cluster (`provisioning.cattle.io.cluster`)
+   */
+  registerSaveHooks(registerBeforeHook: SaveHook, registerAfterHook: SaveHook, cluster: any): void;
+
+  /**
+   * Override the default process to save the machine config's associated with the machine pools
+   *
+   * If machine config's will be the pool's `config` property.
+   *
+   * The pool will have `create: true` if the pool is new or `update: true` if the pool already exists
+   *
+   * @param pools Machine pools
+   * @param cluster The cluster (`provisioning.cattle.io.cluster`)
+   * @returns TODO: RC
+   */
+  saveMachinePoolConfigs(pools: any[], cluster: any): Promise<any>
+
+  /**
+   * Existing tabs to show or hide in the cluster's detail view
+   *
+   * `plugin.addTab(TabLocation.RESOURCE_DETAIL... ` can be used to add additional tabs to the same view
+   */
+  detailTabs: {
+    /**
+     * RKE2 machine pool tabs
+     */
+    machines: boolean,
+    /**
+     * RKE2 provisioning logs
+     */
+    logs: boolean,
+    /**
+     * RKE2 registration commands
+     */
+    registration: boolean,
+    /**
+     * RKE2 snapshots
+     */
+    snapshots: boolean,
+    /**
+     * Kube resources related to the instance of provisioning.cattle.io.cluster
+     */
+    related: boolean,
+    /**
+     * Kube events associated with the instance of provisioning.cattle.io.cluster
+     */
+    events: boolean,
+    /**
+     * Kube conditions of the provisioning.cattle.io.cluster instance
+     */
+    conditions: boolean
+  };
+
+  /**
+   * Override the default process to save the cluster (`provisioning.cattle.io.cluster`)
+   *
+   * @param pools Machine pools
+   * @param cluster The cluster (`provisioning.cattle.io.cluster`)
+   * @returns Array of errors. If there are no errors the array will be empty
+   */
+  provision(cluster: any, pools: any[]): Promise<any[]>;
 }

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -138,7 +138,10 @@ export type LocationConfig = {
   cluster?: string[],
   id?: string[],
   mode?: string[],
-  params: { [key: string]: string},
+  /**
+   * Custom params provided by the extension, not to be confused with location params
+   */
+  customParams?: { [key: string]: string},
 };
 
 export interface ProductOptions {

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -65,6 +65,7 @@ export enum PanelLocation {
 /** Enum regarding tab locations that are extensionable in the UI */
 export enum TabLocation {
   RESOURCE_DETAIL = 'tab', // eslint-disable-line no-unused-vars
+  CLUSTER_CREATE_RKE2 = 'cluster-create-rke2', // eslint-disable-line no-unused-vars
 }
 
 /** Enum regarding card locations that are extensionable in the UI */
@@ -139,9 +140,15 @@ export type LocationConfig = {
   id?: string[],
   mode?: string[],
   /**
-   * Custom params provided by the extension, not to be confused with location params
+   * Query Params from URL
    */
-  customParams?: { [key: string]: string},
+  queryParam?: { [key: string]: string},
+  /**
+   * Context specific params.
+   *
+   * Components can provide additional context specific params that this value must match
+   */
+  context?: { [key: string]: string},
 };
 
 export interface ProductOptions {

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -1,6 +1,9 @@
 import { ProductFunction } from './plugin';
 import { RouteConfig, Location } from 'vue-router';
 
+// Cluster Provisioning types
+export * from './types-provisioning';
+
 // package.json metadata
 export interface PackageMetadata {
   name: string;
@@ -134,7 +137,8 @@ export type LocationConfig = {
   namespace?: string[],
   cluster?: string[],
   id?: string[],
-  mode?: string[]
+  mode?: string[],
+  params: { [key: string]: string},
 };
 
 export interface ProductOptions {
@@ -516,7 +520,7 @@ export interface IPlugin {
    * @param {String} name unique name of 'something'
    * @param {Function} fn function that dynamically loads the module for the thing being registered
    */
-  register(type: string, name: string, fn: Function): void;
+  register(type: string, name: string, fn: Function | Boolean): void;
 
   /**
    * Will return all of the configuration functions used for creating a new product.

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -686,6 +686,7 @@ export default {
       v-model="value"
       :default-tab="defaultTab"
       :need-related="hasLocalAccess"
+      :extension-params="{ provider: value.machineProvider }"
     >
       <Tab
         v-if="showMachines"

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -81,6 +81,24 @@ export default {
 
   async fetch() {
     await this.value.waitForProvisioner();
+
+    const extClass = this.$plugin.getDynamic('provisioner', this.value.machineProvider);
+
+    if (extClass) {
+      this.extProvider = new extClass({
+        dispatch: this.$store.dispatch,
+        getters:  this.$store.getters,
+        axios:    this.$store.$axios,
+        $plugin:  this.$store.app.$plugin,
+        $t:       this.t
+      });
+      this.extDetailTabs = {
+        ...this.extDetailTabs,
+        ...this.extProvider.detailTabs
+      };
+      this.extCustomParams = { provider: this.value.machineProvider };
+    }
+
     const fetchOne = {};
 
     if ( this.$store.getters['management/canList'](CAPI.MACHINE_DEPLOYMENT) ) {
@@ -205,6 +223,18 @@ export default {
       logOpen:   false,
       logSocket: null,
       logs:      [],
+
+      extProvider:     null,
+      extCustomParams: null,
+      extDetailTabs:   {
+        machines:     true, // in this component
+        logs:         true, // in this component
+        registration: true, // in this component
+        snapshots:    true, // in this component
+        related:      true, // in ResourceTabs
+        events:       true, // in ResourceTabs
+        conditions:   true, // in ResourceTabs
+      },
 
       showWindowsWarning: false
     };
@@ -336,7 +366,9 @@ export default {
     },
 
     showMachines() {
-      return this.haveMachines && (this.value.isRke2 || !!this.machines.length);
+      const showMachines = this.haveMachines && (this.value.isRke2 || !!this.machines.length);
+
+      return showMachines && this.extDetailTabs.machines;
     },
 
     showNodes() {
@@ -345,9 +377,9 @@ export default {
 
     showSnapshots() {
       if (this.value.isRke1) {
-        return this.$store.getters['rancher/canList'](NORMAN.ETCD_BACKUP);
+        return this.$store.getters['rancher/canList'](NORMAN.ETCD_BACKUP) && this.extDetailTabs.snapshots;
       } else if (this.value.isRke2) {
-        return this.$store.getters['management/canList'](SNAPSHOT);
+        return this.$store.getters['management/canList'](SNAPSHOT) && this.extDetailTabs.snapshots;
       }
 
       return false;
@@ -476,15 +508,15 @@ export default {
       }
 
       if ( this.value.isImported ) {
-        return !this.value.mgmt?.isReady;
+        return !this.value.mgmt?.isReady && this.extDetailTabs.registration;
       }
 
       if ( this.value.isCustom ) {
-        return true;
+        return this.extDetailTabs.registration;
       }
 
       if ( this.value.isHostedKubernetesProvider && !this.isClusterReady ) {
-        return true;
+        return this.extDetailTabs.registration;
       }
 
       return false;
@@ -495,7 +527,9 @@ export default {
     },
 
     showLog() {
-      return this.value.mgmt?.hasLink('log');
+      const showLog = this.value.mgmt?.hasLink('log');
+
+      return showLog && this.extDetailTabs.logs;
     },
 
     dateTimeFormatStr() {
@@ -686,7 +720,10 @@ export default {
       v-model="value"
       :default-tab="defaultTab"
       :need-related="hasLocalAccess"
-      :extension-params="{ provider: value.machineProvider }"
+      :extension-params="extCustomParams"
+      :needRelated="extDetailTabs.related"
+      :needEvents="extDetailTabs.events"
+      :needConditions="extDetailTabs.conditions"
     >
       <Tab
         v-if="showMachines"
@@ -774,6 +811,7 @@ export default {
           </template>
         </ResourceTable>
       </Tab>
+
       <Tab
         v-else-if="showNodes"
         name="node-pools"

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -151,7 +151,8 @@ export default {
         getters:  this.$store.getters,
         axios:    this.$store.$axios,
         $plugin:  this.$store.app.$plugin,
-        $t:       this.t
+        t:        (...args) => this.t.apply(this, args),
+        isCreate: this.isCreate,
       }));
     } catch (e) {
       console.error('Error loading provisioner(s) from extensions', e); // eslint-disable-line no-console

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -153,6 +153,8 @@ export default {
         $plugin:  this.$store.app.$plugin,
         t:        (...args) => this.t.apply(this, args),
         isCreate: this.isCreate,
+        isEdit:   this.isEdit,
+        isView:   this.isView,
       }));
     } catch (e) {
       console.error('Error loading provisioner(s) from extensions', e); // eslint-disable-line no-console

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -146,16 +146,15 @@ export default {
 
       // We can't pass in this.$store as this leads to a circular-reference that causes Vue to freeze,
       // so pass in specific services that the provisioner extension may need
-      this.extensions = extensionClasses.map(c => new c({
+      this.extensions = extensionClasses.map((c) => new c({
         dispatch: this.$store.dispatch,
         getters:  this.$store.getters,
         axios:    this.$store.$axios,
         $plugin:  this.$store.app.$plugin,
         $t:       this.t
       }));
-
-    } catch(e) {
-      console.error('Error loading provisioner(s) from extensions', e); //eslint=
+    } catch (e) {
+      console.error('Error loading provisioner(s) from extensions', e); // eslint-disable-line no-console
     }
   },
 
@@ -321,7 +320,6 @@ export default {
       return out;
 
       function addExtensionType(ext, getters) {
-
         let iconClass = ext.iconClass;
         let icon = ext.icon;
 
@@ -332,15 +330,15 @@ export default {
         }
 
         const subtype = {
-          id: ext.id,
-          label: ext.label || getters['i18n/t'](`cluster.provider.${ ext.id }`),
+          id:          ext.id,
+          label:       ext.label || getters['i18n/t'](`cluster.provider.${ ext.id }`),
           description: ext.description,
           icon,
           iconClass,
-          group: ext.group || 'rke2',
-          disabled: ext.disabled || false,
-          link: ext.link,
-          tag: ext.tag
+          group:       ext.group || 'rke2',
+          disabled:    ext.disabled || false,
+          link:        ext.link,
+          tag:         ext.tag
         };
 
         out.push(subtype);

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1084,8 +1084,6 @@ export default {
     validationPassed() {
       const validRequiredPools = this.hasMachinePools ? this.hasRequiredNodes() : true;
 
-      // TODO: RC detemine what this TODO means. should be fine?
-      // TODO
       let base = (this.provider === 'custom' || this.isElementalCluster || !!this.credentialId || !this.needCredential);
 
       // and in all of the validation statuses for each machine pool
@@ -1271,7 +1269,6 @@ export default {
     },
 
     async addMachinePool(idx) {
-      console.warn('rk2', 'addMachinePool', idx); // TODO: RC DEBUG remove
       // this.machineConfigSchema is the schema for the Machine Pool's machine configuration for the given provider
       if ( !this.machineConfigSchema ) {
         return;

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -259,7 +259,7 @@ export default {
     // Namespaces if required - this is mainly for custom provisioners via extensions that want
     // to allow creating their resources in a different namespace
     if (this.needsNamespace) {
-      // TODO: RC permissions
+      // TODO: RC permissions (local cluster namespaces)?
       this.allNamespaces = await this.$store.dispatch('management/findAll', { type: NAMESPACE });
     }
 
@@ -1082,7 +1082,7 @@ export default {
     validationPassed() {
       const validRequiredPools = this.hasMachinePools ? this.hasRequiredNodes() : true;
 
-      // TODO: RC just needs a mock in extension and then check for/used here? needs validating throughout
+      // TODO: RC detemine what this TODO means. should be fine?
       // TODO
       let base = (this.provider === 'custom' || this.isElementalCluster || !!this.credentialId || !this.needCredential);
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -72,6 +72,8 @@ import SelectCredential from './SelectCredential';
 import AdvancedSection from '@shell/components/AdvancedSection.vue';
 import { ELEMENTAL_SCHEMA_IDS, KIND, ELEMENTAL_CLUSTER_PROVIDER } from '../../config/elemental-types';
 import AgentConfiguration, { cleanAgentConfiguration } from './AgentConfiguration';
+import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
+import { ExtensionPoint, TabLocation } from '@shell/core/types';
 
 const PUBLIC = 'public';
 const PRIVATE = 'private';
@@ -373,6 +375,7 @@ export default {
       busy:                  false,
       machinePoolValidation: {}, // map of validation states for each machine pool
       allNamespaces:         [],
+      extensionTabs:         getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
     };
   },
 
@@ -3133,6 +3136,26 @@ export default {
           v-model="value"
           :mode="mode"
         />
+
+        <!-- Extension tabs -->
+        <Tab
+          v-for="tab, i in extensionTabs"
+          :key="`${tab.name}${i}`"
+          :name="tab.name"
+          :label="tab.label"
+          :label-key="tab.labelKey"
+          :weight="tab.weight"
+          :tooltip="tab.tooltip"
+          :show-header="tab.showHeader"
+          :display-alert-icon="tab.displayAlertIcon"
+          :error="tab.error"
+          :badge="tab.badge"
+        >
+          <component
+            :is="tab.component"
+            :resource="value"
+          />
+        </Tab>
       </Tabbed>
     </div>
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -262,7 +262,7 @@ export default {
       const all = await this.$store.dispatch('management/findAll', { type: NAMESPACE });
 
       this.allNamespaces = all;
-    }    
+    }
 
     if ( !this.machinePools ) {
       await this.initMachinePools(this.value.spec.rkeConfig.machinePools);
@@ -748,7 +748,7 @@ export default {
     // Extension provider where being provisioned by an extension
     extensionProvider() {
       const extClass = this.$plugin.getDynamic('provisioner', this.provider);
-      let ext = undefined;
+      let ext;
 
       if (extClass) {
         ext = new extClass({
@@ -781,6 +781,7 @@ export default {
 
       // If this is an extension provider then the extension can provide the schema
       const extensionSchema = this.extensionProvider?.machineConfigSchema;
+
       if (extensionSchema) {
         // machineConfigSchema can either be the schema name (string) or the schema itself (object)
         if (typeof extensionSchema === 'object') {
@@ -789,7 +790,7 @@ export default {
 
         // Name of schema to use
         schema = extensionSchema;
-      }      
+      }
 
       return this.$store.getters['management/schemaFor'](schema);
     },
@@ -1287,7 +1288,6 @@ export default {
         config.applyDefaults(idx, this.machinePools);
       }
 
-
       const name = `pool${ ++this.lastIdx }`;
       const pool = {
         id:     name,
@@ -1367,7 +1367,7 @@ export default {
       // If the extension provider wants to do this, let them
       if (this.extensionProvider?.saveMachinePools) {
         return this.extensionProvider.saveMachinePools(this.machinePools, this.value);
-      }      
+      }
 
       for ( const entry of this.machinePools ) {
         if ( entry.remove ) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -257,11 +257,10 @@ export default {
     }
 
     // Namespaces if required - this is mainly for custom provisioners via extensions that want
-    // to allow creation their resources in a different namespace
+    // to allow creating their resources in a different namespace
     if (this.needsNamespace) {
-      const all = await this.$store.dispatch('management/findAll', { type: NAMESPACE });
-
-      this.allNamespaces = all;
+      // TODO: RC permissions
+      this.allNamespaces = await this.$store.dispatch('management/findAll', { type: NAMESPACE });
     }
 
     if ( !this.machinePools ) {
@@ -745,13 +744,14 @@ export default {
       return (this.machinePools || []).filter((x) => !x.remove);
     },
 
-    // Extension provider where being provisioned by an extension
+    /**
+     * Extension provider where being provisioned by an extension
+     */
     extensionProvider() {
       const extClass = this.$plugin.getDynamic('provisioner', this.provider);
-      let ext;
 
       if (extClass) {
-        ext = new extClass({
+        return new extClass({
           dispatch: this.$store.dispatch,
           getters:  this.$store.getters,
           axios:    this.$store.$axios,
@@ -760,10 +760,12 @@ export default {
         });
       }
 
-      return ext;
+      return undefined;
     },
 
-    // Is a namespace needed? Only supported for providers from extensions, otherwise default is no
+    /**
+     * Is a namespace needed? Only supported for providers from extensions, otherwise default is no
+     */
     needsNamespace() {
       return this.extensionProvider ? !!this.extensionProvider.namespaced : false;
     },
@@ -1080,6 +1082,7 @@ export default {
     validationPassed() {
       const validRequiredPools = this.hasMachinePools ? this.hasRequiredNodes() : true;
 
+      // TODO: RC just needs a mock in extension and then check for/used here? needs validating throughout
       // TODO
       let base = (this.provider === 'custom' || this.isElementalCluster || !!this.credentialId || !this.needCredential);
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1278,8 +1278,8 @@ export default {
 
       let config;
 
-      if (this.extensionProvider?.createMachinePool) {
-        config = this.extensionProvider.createMachinePool(idx, this.machinePools);
+      if (this.extensionProvider?.createMachinePoolMachineConfig) {
+        config = this.extensionProvider.createMachinePoolMachineConfig(idx, this.machinePools);
       } else {
         // Default - use the schema
         config = await this.$store.dispatch('management/createPopulated', {
@@ -1369,7 +1369,7 @@ export default {
 
       // If the extension provider wants to do this, let them
       if (this.extensionProvider?.saveMachinePools) {
-        return this.extensionProvider.saveMachinePools(this.machinePools, this.value);
+        return await this.extensionProvider.saveMachinePools(this.machinePools, this.value);
       }
 
       for ( const entry of this.machinePools ) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -6,6 +6,7 @@ import merge from 'lodash/merge';
 import { mapGetters } from 'vuex';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
+import { normalizeName } from '@shell/utils/kube';
 
 import {
   CAPI,
@@ -43,7 +44,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import Loading from '@shell/components/Loading';
 import MatchExpressions from '@shell/components/form/MatchExpressions';
-import NameNsDescription, { normalizeName } from '@shell/components/form/NameNsDescription';
+import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { RadioGroup } from '@components/Form/Radio';
 import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
@@ -1269,6 +1270,7 @@ export default {
     },
 
     async addMachinePool(idx) {
+      console.warn('rk2', 'addMachinePool', idx); // TODO: RC DEBUG remove
       // this.machineConfigSchema is the schema for the Machine Pool configuration for the given provider
       if ( !this.machineConfigSchema ) {
         return;
@@ -1279,7 +1281,7 @@ export default {
       let config;
 
       if (this.extensionProvider?.createMachinePoolMachineConfig) {
-        config = this.extensionProvider.createMachinePoolMachineConfig(idx, this.machinePools);
+        config = await this.extensionProvider.createMachinePoolMachineConfig(idx, this.machinePools);
       } else {
         // Default - use the schema
         config = await this.$store.dispatch('management/createPopulated', {
@@ -1368,8 +1370,8 @@ export default {
       const finalPools = [];
 
       // If the extension provider wants to do this, let them
-      if (this.extensionProvider?.saveMachinePools) {
-        return await this.extensionProvider.saveMachinePools(this.machinePools, this.value);
+      if (this.extensionProvider?.saveMachinePoolConfigs) {
+        return await this.extensionProvider.saveMachinePoolConfigs(this.machinePools, this.value);
       }
 
       for ( const entry of this.machinePools ) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -262,7 +262,6 @@ export default {
     // Namespaces if required - this is mainly for custom provisioners via extensions that want
     // to allow creating their resources in a different namespace
     if (this.needsNamespace) {
-      // TODO: RC permissions (local cluster namespaces)?
       this.allNamespaces = await this.$store.dispatch('management/findAll', { type: NAMESPACE });
     }
 

--- a/shell/edit/ui.cattle.io.navlink.vue
+++ b/shell/edit/ui.cattle.io.navlink.vue
@@ -7,10 +7,11 @@ import CruResource from '@shell/components/CruResource';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
 import FileImageSelector from '@shell/components/form/FileImageSelector';
-import NameNsDescription, { normalizeName } from '@shell/components/form/NameNsDescription';
+import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import { normalizeName } from '@shell/utils/kube';
 
 const LINK_TYPE_URL = 'url';
 const LINK_TYPE_SERVICE = 'service';

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -135,6 +135,13 @@ export default {
     },
 
     harvesterEnabled: mapFeature(HARVESTER_FEATURE),
+
+    nonStandardNamespaces() {
+      // Show the namespace grouping option if there's clusters with namespaces other than 'fleet-default' or 'fleet-local'
+      // This will be used when there's clusters from extension based provisioners
+      // We should re-visit this for scaling reasons
+      return this.filteredRows.some((c) => c.metadata.namespace !== 'fleet-local' && c.metadata.namespace !== 'fleet-default');
+    }
   },
 
   $loadingResources() {
@@ -182,7 +189,7 @@ export default {
     <ResourceTable
       :schema="schema"
       :rows="filteredRows"
-      :namespaced="false"
+      :namespaced="nonStandardNamespaces"
       :loading="loading"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
       :data-testid="'cluster-list'"

--- a/shell/mixins/child-hook.js
+++ b/shell/mixins/child-hook.js
@@ -20,8 +20,8 @@ export default {
       });
     },
 
-    registerAfterHook(boundFn, name, priority) {
-      this._registerHook(AFTER_SAVE_HOOKS, boundFn, name, priority);
+    registerAfterHook(boundFn, name, priority = 99, boundFnContext) {
+      this._registerHook(AFTER_SAVE_HOOKS, boundFn, name, priority, boundFnContext);
     },
 
     async applyHooks(key, ...args) {

--- a/shell/mixins/create-edit-view/impl.js
+++ b/shell/mixins/create-edit-view/impl.js
@@ -124,7 +124,7 @@ export default {
       }
 
       try {
-        await this.applyHooks(BEFORE_SAVE_HOOKS);
+        await this.applyHooks(BEFORE_SAVE_HOOKS, this.value);
 
         // Remove the labels map if it's empty
         if ( this.value?.metadata?.labels && Object.keys(this.value.metadata.labels || {}).length === 0 ) {
@@ -152,7 +152,7 @@ export default {
           await this.$store.dispatch('cluster/findAll', { type: this.value.type, opt: { force: true } }, { root: true });
         }
 
-        await this.applyHooks(AFTER_SAVE_HOOKS);
+        await this.applyHooks(AFTER_SAVE_HOOKS, this.value);
         buttonDone && buttonDone(true);
 
         this.done();

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -9,6 +9,7 @@ import { ucFirst } from '@shell/utils/string';
 import { compare } from '@shell/utils/version';
 import { AS, MODE, _VIEW, _YAML } from '@shell/config/query-params';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
+import { PROVIDER as PROVIDER_ANNOTATION} from '@shell/config/labels-annotations';
 
 /**
  * Class representing Cluster resource.
@@ -381,6 +382,13 @@ export default class ProvCluster extends SteveModel {
   }
 
   get machineProvider() {
+    // First check annotation - useful for clusters created by extension providers
+    const fromAnnotation = this.annotations?.[PROVIDER_ANNOTATION];
+
+    if (fromAnnotation) {
+      return fromAnnotation;
+    }
+    
     if (this.isHarvester) {
       return HARVESTER;
     } else if ( this.isImported ) {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -9,11 +9,11 @@ import { ucFirst } from '@shell/utils/string';
 import { compare } from '@shell/utils/version';
 import { AS, MODE, _VIEW, _YAML } from '@shell/config/query-params';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
-import { PROVIDER as PROVIDER_ANNOTATION } from '@shell/config/labels-annotations';
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 /**
  * Class representing Cluster resource.
- * @extends SteveModal
+ * @extends SteveModel
  */
 export default class ProvCluster extends SteveModel {
   get details() {
@@ -383,7 +383,7 @@ export default class ProvCluster extends SteveModel {
 
   get machineProvider() {
     // First check annotation - useful for clusters created by extension providers
-    const fromAnnotation = this.annotations?.[PROVIDER_ANNOTATION];
+    const fromAnnotation = this.annotations?.[CAPI_ANNOTATIONS.PROVIDER_UI];
 
     if (fromAnnotation) {
       return fromAnnotation;

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -9,7 +9,7 @@ import { ucFirst } from '@shell/utils/string';
 import { compare } from '@shell/utils/version';
 import { AS, MODE, _VIEW, _YAML } from '@shell/config/query-params';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
-import { PROVIDER as PROVIDER_ANNOTATION} from '@shell/config/labels-annotations';
+import { PROVIDER as PROVIDER_ANNOTATION } from '@shell/config/labels-annotations';
 
 /**
  * Class representing Cluster resource.
@@ -388,7 +388,7 @@ export default class ProvCluster extends SteveModel {
     if (fromAnnotation) {
       return fromAnnotation;
     }
-    
+
     if (this.isHarvester) {
       return HARVESTER;
     } else if ( this.isImported ) {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -383,7 +383,7 @@ export default class ProvCluster extends SteveModel {
 
   get machineProvider() {
     // First check annotation - useful for clusters created by extension providers
-    const fromAnnotation = this.annotations?.[CAPI_ANNOTATIONS.PROVIDER_UI];
+    const fromAnnotation = this.annotations?.[CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER];
 
     if (fromAnnotation) {
       return fromAnnotation;

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -18,6 +18,7 @@ ${BASE_DIR}/node_modules/.bin/tsc shell/utils/*.js --declaration --allowJs --emi
 ${BASE_DIR}/node_modules/.bin/tsc shell/config/query-params.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/config > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc shell/config/table-headers.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/config > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc shell/config/types.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/config > /dev/null
+${BASE_DIR}/node_modules/.bin/tsc shell/config/labels-annotations.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/config > /dev/null
 
 # store
 ${BASE_DIR}/node_modules/.bin/tsc shell/store/features.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null

--- a/shell/store/plugins.js
+++ b/shell/store/plugins.js
@@ -59,10 +59,9 @@ const driverMap = {
 
 // Map a driver component back to the cloud credential field name their data has to be stored in
 const driverToFieldMap = {
-  aws:                 'amazonec2',
-  gcp:                 'google',
-  oracle:              'oci',
-  digitaloceanexample: 'digitalocean' // TODO: RC DEBUG remove
+  aws:    'amazonec2',
+  gcp:    'google',
+  oracle: 'oci',
 };
 
 // Machine driver fields that are probably a credential field

--- a/shell/store/plugins.js
+++ b/shell/store/plugins.js
@@ -59,9 +59,10 @@ const driverMap = {
 
 // Map a driver component back to the cloud credential field name their data has to be stored in
 const driverToFieldMap = {
-  aws:    'amazonec2',
-  gcp:    'google',
-  oracle: 'oci',
+  aws:                 'amazonec2',
+  gcp:                 'google',
+  oracle:              'oci',
+  digitaloceanexample: 'digitalocean' // TODO: RC DEBUG remove
 };
 
 // Machine driver fields that are probably a credential field

--- a/shell/utils/kube.js
+++ b/shell/utils/kube.js
@@ -1,0 +1,9 @@
+export function normalizeName(str) {
+  return (str || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+}

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -218,6 +218,33 @@ export function diff(from, to) {
   return out;
 }
 
+/**
+ * Super simple lodash isEqual equivalent.
+ *
+ * Only checks root properties for strict equality
+ */
+function isEqualBasic(from, to) {
+  const fromKeys = Object.keys(from || {});
+  const toKeys = Object.keys(to || {});
+
+  if (fromKeys.length !== toKeys.length) {
+    return false;
+  }
+
+  for (let i = 0; i < fromKeys.length; i++) {
+    const fromValue = from[fromKeys[i]];
+    const toValue = to[fromKeys[i]];
+
+    if (fromValue !== toValue) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export { isEqualBasic as isEqual };
+
 export function changeset(from, to, parentPath = []) {
   let out = {};
 


### PR DESCRIPTION
This is work-in-progress changes to allow Extensions to add custom provisioning UI into Dashboard without needing to use the NodeDriver approach.

See https://github.com/nwmac/provisioning for more information

Changes in this PR:

- Update `NameNsDescription` component so that it can be supplied with a list of namespaces that the user can select from - custom provisioning might want to allow the user to choose a namespace - the current provisioning always creates resources in `fleet-default`
- Updates `ResourceTabs` to add `extensionParams` to allow custom tabs to be targeted to a specific context based on some arbitrary parameters - in the case of provisioning, we want to only show a custom tab for a specific provisioner
- Adds an annotation `ui.rancher/provider` that can be used to explicitly set the provisioner for a cluster (as far as the UI is concerned)
- Updates `plugin-helpers` to support custom params - this is what we use to show a custom tab only for a given provider - without this change we can't do this. Also makes an improvement where the location configs have to be arrays - this allows an array or a single item - this presents a better API for the core use case of just one
- Adds `types-provisioning` - this is incomplete, but this is the interface that a custom provisioner should implement
- Updates `register` in `types` so that we can register a boolean - this is used to allow custom providers to register `false` for the cloud credential to indicate that that a cloud credential is not needed
- Updates the UI for cluster provisioning to show cards to providers registered via extensions - this should be generic enough to allow a provider to be added to any group and to support a simple link to a specific route as well as the more advanced extension to the RKE2 provisioning
- Updates the rke2 UI to allow a namespace selector to be shown if the custom provider supports that
- Updates the rke2 UI to use a custom provider when provided by an extension - the API for this is used at various points within the rke2 UI
- Updates the cluster provisioning model to support using the annotation for determining provider - this is needed for a custom provider that doesn't have a node driver and allows us to change the provider type - this ensures that in lists (etc) we show the cluster with the correct cluster type