### PR TITLE
Bump `shell` to v0.3.16

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",
@@ -106,7 +106,7 @@
     "nyc": "15.1.0",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "rancher-icons": "rancher/icons#v2.0.14",
+    "rancher-icons": "rancher/icons#v2.0.16",
     "require-extension-hooks": "0.3.3",
     "require-extension-hooks-babel": "1.0.0",
     "require-extension-hooks-vue": "3.0.0",


### PR DESCRIPTION
- Bump shell/rancher-icons from `v2.0.15` to `v2.0.16`
- Bump shell from `v0.3.15` to `v0.3.16`

We need the last version of rancher-icons in Epinio Ui, where `shell` pkg is used
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to https://github.com/epinio/ui/issues/267
<!-- Define findings related to the feature or bug issue. -->
