### PR TITLE
Fix initialisation of `ui-brand` setting

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3020,6 +3020,9 @@ login:
   remember:
     label: Remember Username
 
+logout:
+  message: Logging Out...
+
 managementNode:
   customName: Custom Name
 

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -82,7 +82,8 @@ export default {
     },
 
     canCalcCspAdapter() {
-      // We need to take consider the loggedIn state, as the brand mixin is used in the logout page
+      // We need to take consider the loggedIn state, as the brand mixin is used in the logout page where we can be in a mixed state
+      // (things in store but user has no auth to make changes)
       return this.loggedIn && this.haveAppsAndSettings;
     }
   },
@@ -139,7 +140,7 @@ export default {
       } else if (!neu) {
         const brandSetting = findBy(this.globalSettings, 'id', SETTING.BRAND);
 
-        if (brandSetting) {
+        if (brandSetting.value !== '') {
           brandSetting.value = '';
           brandSetting.save();
         }

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -117,11 +117,9 @@ export default {
         return;
       }
 
-      // The brand setting will only get updated if
-      // 1) There should be a brand... but there's no brand setting
-      // 2) There should not be a brand... but there is a brand setting
-
+      // The brand setting will only get updated if...
       if (neu && !this.brand) {
+        // 1) There should be a brand... but there's no brand setting
         const brandSetting = findBy(this.globalSettings, 'id', SETTING.BRAND);
 
         if (brandSetting) {
@@ -140,7 +138,8 @@ export default {
       } else if (!neu) {
         const brandSetting = findBy(this.globalSettings, 'id', SETTING.BRAND);
 
-        if (brandSetting.value !== '') {
+        if (brandSetting && brandSetting.value !== '') {
+          // 2) There should not be a brand... but there is a brand setting
           brandSetting.value = '';
           brandSetting.save();
         }

--- a/shell/pages/auth/logout.vue
+++ b/shell/pages/auth/logout.vue
@@ -11,8 +11,16 @@ export default {
 
 <template>
   <main class="main-layout">
-    <h1 class="text-center mt-50">
-      Logging Out&hellip;
-    </h1>
+    <div>
+      <h1 v-t="'logout.message'" />
+    </div>
   </main>
 </template>
+<style lang="scss" scoped>
+  main > div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+  }
+</style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9270
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Green branding should be applied when the `rancher-csp-adapter` app is installed (https://github.com/rancher/csp-adapter)
- This was not happening, fix is to ensure the reactive parts fire correctly again
- I'm not sure when this came in, possibly 2.7.5

### Technical notes summary
- ui-brand setting comes from the existence of a helm app
- this was broken for the initial case
  -  cause by a computed property not re-running given change after `fetch`
- fixing this reactivity exposed some other scenarios where we need to be safe
  - for instance when logged out, or in the process thereof

> Also fixed the position of the `Logging Out...` text. Previously this was at the top of the page, it's now in the centre

To Test in Dev
- Update `return this.apps.find((a) => a.metadata.name === 'rancher-csp-adapter');`  to look for any chart, for example  `traefik`

To Test in Deployed
```
helm repo add rancher-charts https://charts.rancher.io
helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --set aws.enabled=true --set aws.accountNumber=1234 --set aws.roleName=abc
```

### Areas or cases that should be tested
- Systems where the `rancher-csp-adapter` app is installed (and ui-branding goes green)
- Systems where the `rancher-csp-adapter` app has been uninstalled (and ui-branding returns to blue)
