### PR TITLE
Improvements to flaky user avatar tests

### DIFF
--- a/cypress/e2e/po/components/banners.po.ts
+++ b/cypress/e2e/po/components/banners.po.ts
@@ -1,32 +1,12 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class BannersPo extends ComponentPo {
-  constructor(selector = '.dashboard-root') {
-    super(selector);
-  }
-
   /**
    * Get banner content
    * @returns
    */
   banner(): Cypress.Chainable {
-    return cy.getId('banner-content');
-  }
-
-  /**
-   * Get change log banner
-   * @returns
-   */
-  changelog(): Cypress.Chainable {
-    return cy.getId('changelog-banner');
-  }
-
-  /**
-   * Get set login page banner
-   * @returns
-   */
-  getLoginPageBanner(): Cypress.Chainable {
-    return cy.getId('set-login-page-banner');
+    return this.self().getId('banner-content');
   }
 
   /**
@@ -34,6 +14,6 @@ export default class BannersPo extends ComponentPo {
    * @returns
    */
   closeButton(): Cypress.Chainable {
-    return cy.getId('banner-close').click({ force: true });
+    return this.self().getId('banner-close').click({ force: true });
   }
 }

--- a/cypress/e2e/po/components/component.po.ts
+++ b/cypress/e2e/po/components/component.po.ts
@@ -46,4 +46,8 @@ export default class ComponentPo {
   checkExists(): Cypress.Chainable<boolean> {
     return this.self().should('exist');
   }
+
+  checkNotExists(): Cypress.Chainable<boolean> {
+    return this.self().should('not.exist');
+  }
 }

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -1,10 +1,9 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import PageActions from '@/cypress/e2e/po/side-bars/page-actions.po';
+import BannerGraphicPo from '~/cypress/e2e/po/components/banner-graphic.po';
 import BannersPo from '~/cypress/e2e/po/components/banners.po';
 import SimpleBoxPo from '~/cypress/e2e/po/components/simple-box.po';
 import HomeClusterListPo from '~/cypress/e2e/po/lists/home-cluster-list.po';
-
-const banners = new BannersPo();
 
 export default class HomePagePo extends PagePo {
   static url = '/home'
@@ -13,10 +12,21 @@ export default class HomePagePo extends PagePo {
   }
 
   static goToAndWaitForGet() {
+    // There's a lot of tests that start off on the home page
+    // There's issues reporting when this page is ready, specifically for the user avatar click
+    // To help with this be super sure the page is ready
+
     PagePo.goToAndWaitForGet(HomePagePo.goTo, [
       'v1/counts',
       'v1/namespaces',
     ]);
+
+    const homePage = new HomePagePo();
+
+    homePage.list().checkVisible();
+    homePage.bannerGraphic().checkVisible();
+
+    return homePage;
   }
 
   constructor() {
@@ -28,11 +38,11 @@ export default class HomePagePo extends PagePo {
   }
 
   prefPageLink(): Cypress.Chainable {
-    return banners.getLoginPageBanner().find('a');
+    return this.getLoginPageBanner().self().find('a');
   }
 
   whatsNewBannerLink(): Cypress.Chainable {
-    return banners.changelog().find('a');
+    return this.changelog().self().find('a');
   }
 
   restoreAndWait() {
@@ -63,6 +73,26 @@ export default class HomePagePo extends PagePo {
     const simpleBox = new SimpleBoxPo();
 
     return simpleBox.simpleBox().find('.support-link > a');
+  }
+
+  bannerGraphic() {
+    return new BannerGraphicPo();
+  }
+
+  /**
+   * Get change log banner
+   * @returns
+   */
+  changelog() {
+    return new BannersPo(cy.getId('changelog-banner'));
+  }
+
+  /**
+   * Get set login page banner
+   * @returns
+   */
+  getLoginPageBanner() {
+    return new BannersPo(cy.getId('set-login-page-banner'));
   }
 
   /**

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -4,17 +4,11 @@ import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
 import ClusterManagerListPagePo from '~/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerImportGenericPagePo from '~/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.generic.po';
 import WhatsNewPagePo from '~/cypress/e2e/po/pages/docs/whats-new.po';
-import BannerGraphicPo from '~/cypress/e2e/po/components/banner-graphic.po';
-import BannersPo from '~/cypress/e2e/po/components/banners.po';
-import SortableTablePo from '~/cypress/e2e/po/components/sortable-table.po';
 
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
 const whatsNewPage = new WhatsNewPagePo();
-const bannerGraphic = new BannerGraphicPo();
-const banners = new BannersPo();
-const sortableTable = new SortableTablePo('.dashboard-root');
 
 describe('Home Page', () => {
   beforeEach(() => {
@@ -38,7 +32,7 @@ describe('Home Page', () => {
       text.push(el);
     });
 
-    banners.changelog().invoke('text').then((el) => {
+    homePage.changelog().self().invoke('text').then((el) => {
       expect(el).contains(text[0]);
     });
 
@@ -50,7 +44,7 @@ describe('Home Page', () => {
 
     BurgerMenuPo.toggle();
     burgerMenuPo.home().click();
-    banners.changelog().should('not.exist');
+    homePage.changelog().self().should('not.exist');
   });
 
   it('Can navigate to Preferences page', { tags: ['@adminUser', '@standardUser'] }, () => {
@@ -74,18 +68,18 @@ describe('Home Page', () => {
 
     homePage.restoreAndWait();
 
-    bannerGraphic.graphicBanner().should('be.visible');
-    bannerGraphic.graphicBannerCloseButton();
-    bannerGraphic.graphicBanner().should('not.exist');
+    homePage.bannerGraphic().graphicBanner().should('be.visible');
+    homePage.bannerGraphic().graphicBannerCloseButton();
+    homePage.bannerGraphic().graphicBanner().should('not.exist');
 
-    banners.getLoginPageBanner().should('be.visible');
-    banners.closeButton();
-    banners.getLoginPageBanner().should('not.exist');
+    homePage.getLoginPageBanner().checkVisible();
+    homePage.getLoginPageBanner().closeButton();
+    homePage.getLoginPageBanner().checkNotExists();
 
     homePage.restoreAndWait();
 
-    bannerGraphic.graphicBanner().should('be.visible');
-    banners.getLoginPageBanner().should('be.visible');
+    homePage.bannerGraphic().graphicBanner().should('be.visible');
+    homePage.getLoginPageBanner().checkVisible();
   });
 
   it('Can see that cluster details match those in Cluster Manangement page', { tags: '@adminUser' }, () => {
@@ -157,12 +151,12 @@ describe('Home Page', () => {
      * Filter rows in the cluster list
      */
 
-    sortableTable.filter('random text');
+    homeClusterList.resourceTable().sortableTable().filter('random text');
     homeClusterList.resourceTable().sortableTable().rowElements().should((el) => {
       expect(el).to.contain.text('There are no rows which match your search query.');
     });
 
-    sortableTable.filter('local');
+    homeClusterList.resourceTable().sortableTable().filter('local');
     homeClusterList.name('local').should((el) => {
       expect(el).to.contain.text('local');
     });


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- many improvements to user menu po
  - take into account the v-popover container which can hide child menu content
  - fix selector of component that we click on to open menu
  - add naughty ensureOpen (as it contains an anti pattern...but included due to issues we've had with this component)
  - tidied up names
  - adding some logging
- move home page specific banner components in to home page po
  - also ensure these return an instance of the banner po

### Technical notes summary
- Testing locally with chrome never showed the issue that ci had (CI uses chrome as well)
- Switching to test locally with electron meant there was about a 30% chance of seeing the issue
