### PR TITLE
ui automation: update api env variable

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -87,7 +87,7 @@ export default defineConfig({
         'pkg/rancher-components/src/components/**/*.{vue,ts,js}',
       ]
     },
-    api:               process.env.API || process.env.TEST_BASE_URL.split('/').slice(0, -2).join('/'),
+    api:               process.env.API || baseUrl.split('/').slice(0, -1).join('/'),
     username:          process.env.TEST_USERNAME || DEFAULT_USERNAME,
     password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -64,6 +64,8 @@ if (skipSetup) {
 
 console.log(`    Dashboard URL: ${ baseUrl }`); // eslint-disable-line no-console
 
+const apiUrl = baseUrl.includes('/dashboard') ? baseUrl.split('/').slice(0, -1).join('/') : baseUrl;
+
 export default defineConfig({
   projectId:             process.env.TEST_PROJECT_ID,
   defaultCommandTimeout: process.env.TEST_TIMEOUT ? +process.env.TEST_TIMEOUT : 60000,
@@ -87,7 +89,7 @@ export default defineConfig({
         'pkg/rancher-components/src/components/**/*.{vue,ts,js}',
       ]
     },
-    api:               process.env.API || baseUrl.split('/').slice(0, -1).join('/'),
+    api:               process.env.API || apiUrl,
     username:          process.env.TEST_USERNAME || DEFAULT_USERNAME,
     password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -64,7 +64,9 @@ if (skipSetup) {
 
 console.log(`    Dashboard URL: ${ baseUrl }`); // eslint-disable-line no-console
 
-const apiUrl = baseUrl.includes('/dashboard') ? baseUrl.split('/').slice(0, -1).join('/') : baseUrl;
+const apiUrl = process.env.API || (baseUrl.endsWith('/dashboard') ? baseUrl.split('/').slice(0, -1).join('/') : baseUrl);
+
+console.log(`    Rancher API URL: ${ apiUrl }`); // eslint-disable-line no-console
 
 export default defineConfig({
   projectId:             process.env.TEST_PROJECT_ID,
@@ -89,7 +91,7 @@ export default defineConfig({
         'pkg/rancher-components/src/components/**/*.{vue,ts,js}',
       ]
     },
-    api:               process.env.API || apiUrl,
+    api:               apiUrl,
     username:          process.env.TEST_USERNAME || DEFAULT_USERNAME,
     password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

updated api env variable:
- handles cases where TEST_BASE_URL may or may not contain `/dashboard` suffix.
- this is done by checking if '/dashboard' exists in baseUrl, if so remove it, else do nothing. that way if `localhost:8005` is used as TEST_BASE_URL we will still be able to send api requests.