### PR TITLE
update rke2 node drain default value

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef */
 import { config } from '@vue/test-utils';
 import { directiveSsr as t } from '@shell/plugins/i18n';
-import { VCleanTooltip } from '@shell/plugins/clean-tooltip-directive';
 import VTooltip from 'v-tooltip';
 import VModal from 'vue-js-modal';
 import vSelect from 'vue-select';

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import { config } from '@vue/test-utils';
 import { directiveSsr as t } from '@shell/plugins/i18n';
+import { VCleanTooltip } from '@shell/plugins/clean-tooltip-directive';
 import VTooltip from 'v-tooltip';
 import VModal from 'vue-js-modal';
 import vSelect from 'vue-select';
@@ -12,6 +13,7 @@ import Vue from 'vue';
 
 Vue.config.productionTip = false;
 Vue.use(VTooltip).use(VModal);
+Vue.use(VCleanTooltip);
 Vue.component('v-select', vSelect);
 Vue.component(ClientOnly.name, ClientOnly);
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1888,8 +1888,20 @@ cluster:
       toolTip: "This can be either a fixed number of nodes (e.g. 1) at a time or a percentage (e.g. 10%)"
     drain:
       label: Drain Nodes
-      toolTip: Draining preemptively removes the pods on each node so there are no running workloads on the nodes being upgraded.  Upgrading without draining is faster and causes less shuffling around, but pods may still be restarted depending on the upgrade being performed.
-    deleteEmptyDir: "By default, pods using emptyDir volumes will be deleted on upgrade. Operations reliant on emptyDir volumes persisting through the pod's lifecycle may be impacted."
+      toolTip: Draining preemptively removes the pods on each node so there are no running workloads on the nodes being upgraded.  Upgrading without draining is faster and causes less shuffling around, but pods may still be restarted depending on the upgrade being performed. 
+      deleteEmptyDir: 
+        warning: "By default, pods using emptyDir volumes will be deleted on upgrade. Operations reliant on emptyDir volumes persisting through the pod's lifecycle may be impacted."
+        label: Delete pods using emptyDir volumes
+        tooltip: emptyDir volumes are often used for ephemeral data, but the data will be permanently deleted.  Draining will fail if this is not set and there are pods using emptyDir.
+      force:
+        label: Delete standalone pods
+        tooltip: Delete standalone pods which are not managed by a Workload controller (Deployment, Job, etc).  Draining will fail if this is not set and there are standalone pods.
+      gracePeriod:
+        checkboxLabel: Override pod termination grace periods
+        inputLabel: Grace Period
+      timeout:
+        checkboxLabel: Timeout after
+        inputLabel: Drain Timeout
     truncateHostnames: Truncate hostnames to 15 characters for NetBIOS compatibility.
     address:
       tooltip: Cluster networking values cannot be changed after the cluster is created.

--- a/shell/edit/provisioning.cattle.io.cluster/DrainOptions.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/DrainOptions.vue
@@ -2,11 +2,12 @@
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import UnitInput from '@shell/components/form/UnitInput.vue';
+import { mapGetters } from 'vuex';
 
 const DEFAULTS = {
   deleteEmptyDirData:              true, // Show; Kill pods using emptyDir volumes and lose the data
   disableEviction:                 false, // Hide; false = evict pods, true = delete pods
-  enabled:                         false, // Show; true = Nodes must be drained before upgrade; false = YOLO
+  enabled:                         true, // Show; true = Nodes must be drained before upgrade; false = YOLO
   force:                           false, // Show; true = Delete standalone pods, false = fail if there are any
   gracePeriod:                     -1, // Show; Pod shut down time, negative value uses pod default
   ignoreDaemonSets:                true, // Hide; true = work, false = never work because there's always daemonSets
@@ -51,6 +52,8 @@ export default {
     this.update();
   },
 
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
+
   methods: {
     update() {
       const out = {};
@@ -90,8 +93,8 @@ export default {
       <div class="mt-20">
         <Checkbox
           v-model="deleteEmptyDirData"
-          label="Delete pods using emptyDir volumes"
-          tooltip="emptyDir volumes are often used for ephemeral data, but the data will be permanently deleted.  Draining will fail if this is not set and there are pods using emptyDir."
+          label-key="cluster.rke2.drain.deleteEmptyDir.label"
+          tooltip-key="cluster.rke2.drain.deleteEmptyDir.tooltip"
           @input="update"
         />
       </div>
@@ -99,21 +102,23 @@ export default {
         <Checkbox
           v-model="force"
           label="Delete standalone pods"
+          label-key="cluster.rke2.drain.force.label"
           tooltip="Delete standalone pods which are not managed by a Workload controller (Deployment, Job, etc).  Draining will fail if this is not set and there are standalone pods."
+          tooltop-key="cluster.rke2.drain.force.tooltip"
           @input="update"
         />
       </div>
       <div>
         <Checkbox
           v-model="customGracePeriod"
-          label="Override pod termination grace periods"
+          label-key="cluster.rke2.drain.gracePeriod.checkboxLabel"
           @input="update"
         />
         <UnitInput
           v-if="customGracePeriod"
           v-model="gracePeriod"
-          label="Grace Period"
-          suffix="Seconds"
+          label-key="cluster.rke2.drain.gracePeriod.inputLabel"
+          :suffix="t('suffix.seconds', {count: timeout})"
           class="mb-10"
           @input="update"
         />
@@ -121,14 +126,14 @@ export default {
       <div>
         <Checkbox
           v-model="customTimeout"
-          label="Timeout after"
+          label-key="cluster.rke2.drain.timeout.checkboxLabel"
           @input="update"
         />
         <UnitInput
           v-if="customTimeout"
           v-model="timeout"
-          label="Drain Timeout"
-          suffix="Seconds"
+          label-key="cluster.rke2.drain.timeout.inputLabel"
+          :suffix="t('suffix.seconds', {count: timeout})"
           class="drain-timeout"
           @input="update"
         />

--- a/shell/edit/provisioning.cattle.io.cluster/DrainOptions.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/DrainOptions.vue
@@ -7,7 +7,7 @@ import { mapGetters } from 'vuex';
 const DEFAULTS = {
   deleteEmptyDirData:              true, // Show; Kill pods using emptyDir volumes and lose the data
   disableEviction:                 false, // Hide; false = evict pods, true = delete pods
-  enabled:                         true, // Show; true = Nodes must be drained before upgrade; false = YOLO
+  enabled:                         false, // Show; true = Nodes must be drained before upgrade; false = YOLO
   force:                           false, // Show; true = Delete standalone pods, false = fail if there are any
   gracePeriod:                     -1, // Show; Pod shut down time, negative value uses pod default
   ignoreDaemonSets:                true, // Hide; true = work, false = never work because there's always daemonSets

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DrainOptions.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DrainOptions.test.ts
@@ -14,7 +14,7 @@ describe('drain options', () => {
     expect(wrapper.emitted('input')?.[0]?.[0]).toStrictEqual({
       deleteEmptyDirData:              true,
       disableEviction:                 false,
-      enabled:                         true,
+      enabled:                         false,
       force:                           false,
       gracePeriod:                     -1,
       ignoreDaemonSets:                true,
@@ -27,7 +27,7 @@ describe('drain options', () => {
     const upgradeStrategy = {
       deleteEmptyDirData: false,
       disableEviction:    false,
-      enabled:            true,
+      enabled:            false,
       force:              true,
       ignoreDaemonSets:   false,
       timeout:            90,
@@ -41,7 +41,7 @@ describe('drain options', () => {
     expect(wrapper.emitted('input')?.[0]?.[0]).toStrictEqual({
       deleteEmptyDirData:              false,
       disableEviction:                 false,
-      enabled:                         true,
+      enabled:                         false,
       force:                           true,
       gracePeriod:                     -1,
       ignoreDaemonSets:                false,

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DrainOptions.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DrainOptions.test.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils';
+import DrainOptions from '@shell/edit/provisioning.cattle.io.cluster/DrainOptions.vue';
+import { DefaultProps } from 'vue/types/options';
+import { ExtendedVue, Vue } from 'vue/types/vue';
+
+describe('drain options', () => {
+  it('should update an empty value with default drain options', () => {
+    const wrapper = mount(DrainOptions as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: { }, mode: 'create' },
+      mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } },
+
+    });
+
+    expect(wrapper.emitted('input')?.[0]?.[0]).toStrictEqual({
+      deleteEmptyDirData:              true,
+      disableEviction:                 false,
+      enabled:                         true,
+      force:                           false,
+      gracePeriod:                     -1,
+      ignoreDaemonSets:                true,
+      skipWaitForDeleteTimeoutSeconds: 0,
+      timeout:                         120,
+    });
+  });
+
+  it('should not overwrite existing drain option values', () => {
+    const upgradeStrategy = {
+      deleteEmptyDirData: false,
+      disableEviction:    false,
+      enabled:            true,
+      force:              true,
+      ignoreDaemonSets:   false,
+      timeout:            90,
+    };
+    const wrapper = mount(DrainOptions as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: upgradeStrategy, mode: 'create' },
+      mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } },
+
+    });
+
+    expect(wrapper.emitted('input')?.[0]?.[0]).toStrictEqual({
+      deleteEmptyDirData:              false,
+      disableEviction:                 false,
+      enabled:                         true,
+      force:                           true,
+      gracePeriod:                     -1,
+      ignoreDaemonSets:                false,
+      skipWaitForDeleteTimeoutSeconds: 0,
+      timeout:                         90,
+    });
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -158,6 +158,34 @@ describe('component: rke2', () => {
     expect((wrapper.vm as any).validationPassed).toBe(true);
   });
 
+  it('should initialize machine pools with drain before delete true', async() => {
+    const k8s = 'v1.25.0+k3s1';
+    const wrapper = mount(rke2, {
+      propsData: {
+        mode:  'create',
+        value: {
+          spec: {
+            ...defaultSpec,
+            kubernetesVersion: k8s
+          },
+          agentConfig: { 'cloud-provider-name': 'any' }
+        },
+        provider: 'custom'
+      },
+      data:     () => ({ credentialId: 'I am authenticated' }),
+      computed: defaultComputed,
+      mocks:    {
+        ...defaultMocks,
+        $store: { getters: defaultGetters },
+      },
+      stubs: defaultStubs
+    });
+
+    await wrapper.vm.initSpecs();
+
+    wrapper.vm.machinePools.forEach((p: any) => expect(p.drainBeforeDelete).toBe(true));
+  });
+
   // TODO: Complete test after implementing fetch https://github.com/rancher/dashboard/issues/9322
   // eslint-disable-next-line jest/no-disabled-tests
   describe.skip('should initialize agent configuration values', () => {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2555,7 +2555,7 @@ export default {
             v-if="get(rkeConfig, 'upgradeStrategy.controlPlaneDrainOptions.deleteEmptyDirData')"
             color="warning"
           >
-            {{ t('cluster.rke2.deleteEmptyDir', {}, true) }}
+            {{ t('cluster.rke2.drain.deleteEmptyDir.warning', {}, true) }}
           </Banner>
           <div class="row">
             <div class="col span-6">

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1159,6 +1159,7 @@ export default {
       }
 
       const name = `pool${ ++this.lastIdx }`;
+
       const pool = {
         id:     name,
         config,
@@ -1179,6 +1180,7 @@ export default {
             kind: this.machineConfigSchema.attributes?.kind,
             name: null,
           },
+          drainBeforeDelete: true
         },
       };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9108 

Per internal ref, this requested change is for provisioned clusters - see comment on original issue re: imported cluster UI

### Occurred changes and/or fixed issues
* updated the rke2/k3s upgrade strategy configuration to default to drain nodes 'yes'
* updated DrainOptions component to use i18n
* added unit tests for DrainOptions
* added v-clean-tooltip support to jest config (I was getting `Failed to resolve directive: v-clean-tooltip`)
