### PR TITLE
Added validation to 'Rancher backups' chart installer

### DIFF
--- a/shell/chart/__tests__/S3.test.ts
+++ b/shell/chart/__tests__/S3.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable jest/no-hooks */
+import { mount, createLocalVue } from '@vue/test-utils';
+
+import S3 from '@shell/chart/rancher-backup/S3';
+import Vuex from 'vuex';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('rancher-backup: S3', () => {
+  const mockStore = { getters: { 'i18n/t': (text: string) => text, t: (text: string) => text } };
+  const wrapper = mount(S3, { mocks: { $store: mockStore } });
+
+  it('should emit invalid when form is not filled', () => {
+    expect(wrapper.emitted('valid')).toHaveLength(1);
+    expect(wrapper.emitted('valid')![0][0]).toBeFalsy();
+  });
+
+  it('should emit valid when required fields are filled', async() => {
+    const bucketName = wrapper.find('[data-testid="S3-bucketName"]').find('input');
+    const endpoint = wrapper.find('[data-testid="S3-endpoint"]').find('input');
+    const testCases = [
+      {
+        bucketNameInput: 'val',
+        endpointInput:   '',
+        result:          false
+      },
+      {
+        bucketNameInput: '',
+        endpointInput:   'val',
+        result:          false
+      }
+    ];
+
+    for (const testCase of testCases) {
+      bucketName.setValue(testCase.bucketNameInput);
+      endpoint.setValue(testCase.endpointInput);
+      await wrapper.vm.$nextTick();
+      expect(wrapper.emitted('valid')).toHaveLength(1);
+      expect(wrapper.emitted('valid')![0][0]).toBe(false);
+    }
+
+    bucketName.setValue('val1');
+    endpoint.setValue('val2');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('valid')).toHaveLength(2);
+    expect(wrapper.emitted('valid')![1][0]).toBe(true);
+  });
+});

--- a/shell/chart/rancher-backup/S3.vue
+++ b/shell/chart/rancher-backup/S3.vue
@@ -4,6 +4,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import FileSelector from '@shell/components/form/FileSelector';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { mapGetters } from 'vuex';
+
 export default {
   components: {
     LabeledInput,
@@ -30,6 +31,15 @@ export default {
     }
   },
 
+  mounted() {
+    this.$emit('valid', this.valid);
+  },
+
+  watch: {
+    valid() {
+      this.$emit('valid', this.valid);
+    }
+  },
   computed: {
     credentialSecret: {
       get() {
@@ -44,6 +54,9 @@ export default {
         this.$set(this.value, 'credentialSecretName', name);
         this.$set(this.value, 'credentialSecretNamespace', namespace);
       }
+    },
+    valid() {
+      return !!this.value.endpoint && !!this.value.bucketName;
     },
     ...mapGetters({ t: 'i18n/t' })
   },
@@ -87,8 +100,10 @@ export default {
       <div class="col span-6">
         <LabeledInput
           v-model="value.bucketName"
+          data-testid="S3-bucketName"
           :mode="mode"
           :label="t('backupRestoreOperator.s3.bucketName')"
+          required
         />
       </div>
     </div>
@@ -114,6 +129,8 @@ export default {
           v-model="value.endpoint"
           :mode="mode"
           :label="t('backupRestoreOperator.s3.endpoint')"
+          data-testid="S3-endpoint"
+          required
         />
         <Checkbox
           v-model="value.insecureTLSSkipVerify"

--- a/shell/chart/rancher-backup/S3.vue
+++ b/shell/chart/rancher-backup/S3.vue
@@ -35,6 +35,10 @@ export default {
     this.$emit('valid', this.valid);
   },
 
+  beforeDestroy() {
+    this.$emit('valid', true);
+  },
+
   watch: {
     valid() {
       this.$emit('valid', this.valid);

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -154,6 +154,9 @@ export default {
       }
 
       return 'none';
+    },
+    updatePageValid(update) {
+      this.$emit('valid', update);
     }
   },
   get
@@ -189,6 +192,7 @@ export default {
         :value="value.s3"
         :secrets="secrets"
         :mode="mode"
+        @valid="updatePageValid($event)"
       />
       <template v-else>
         <div class="row">

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1251,6 +1251,10 @@ export default {
       this.steps[0].ready = okRequires && okChart;
     },
 
+    updateStepTwoReady(update) {
+      this.updateStep('helmValues', { ready: update });
+    },
+
     getOptionLabel(opt) {
       return opt?.chartNameDisplay;
     },
@@ -1567,6 +1571,7 @@ export default {
                   @warn="e=>errors.push(e)"
                   @register-before-hook="registerBeforeHook"
                   @register-after-hook="registerAfterHook"
+                  @valid="updateStepTwoReady($event)"
                 />
               </Tabbed>
               <template v-else>


### PR DESCRIPTION
### Summary
Fixes #6181
Marked bucket name and endpoint fields as required and disabled "install" and "update" buttons if these fields are empty.

### Occurred changes and/or fixed issues
- Marked fields as "required"
- Disabled default behaviour for "values" step for backup chart

### Technical notes summary
No default behaviour has changed. Added a "valid" event listener to chart installer that should be used by other charts if fields require validation.

### Areas or cases that should be tested
Tested in Chrome
1. Go to "Apps"-> "Charts"
2. Select "Rancher backups"
3. There are 2 scenarios here. New chart creation and updating already existing chart. This fix applies to both.
4. Click "Install" (for new) or "Update" (for existing)
5. Click "Next"
6. Select "Use an S3-compatible object store"
7. Validate that "Bucket Name" and "Endpoint" fields are marked as required
8. Validate that "Install" or "Update" button is only enabled when both fields have non-empty values. Try removing each and both and validate the behaviour.

### Areas which could experience regressions
- Chart installer

### Screenshot/Video
<img width="1728" alt="Screenshot 2023-07-06 at 1 09 08 PM" src="https://github.com/rancher/dashboard/assets/133266076/d85ac60d-1b8b-4aaf-a1d3-63f9c98384d9">
