### PR TITLE
Add the ability to import layouts from extensions

### DIFF
--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -15,6 +15,7 @@ import {
   PluginRouteConfig, RegisterStore, UnregisterStore, CoreStoreSpecifics, CoreStoreConfig, OnNavToPackage, OnNavAwayFromPackage, OnLogOut
 } from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
+import { registerLayout } from '@shell/initialize/layouts';
 
 export type ProductFunction = (plugin: IPlugin, store: any) => void;
 
@@ -267,6 +268,14 @@ export class Plugin implements IPlugin {
       }
 
       this.l10n[name].push(fn);
+    } else if (type === 'layouts') {
+      fn().then((component: any) => {
+        if (component.default) {
+          registerLayout(name, component.default);
+        } else {
+          console.error(`Failed to load layout ${ name } because the file didn't export a default component.`); // eslint-disable-line no-console
+        }
+      });
     } else {
       if (!this.types[type]) {
         this.types[type] = {};

--- a/shell/initialize/App.js
+++ b/shell/initialize/App.js
@@ -1,23 +1,13 @@
 import Vue from 'vue';
 
-import {
-  getMatchedComponentsInstances, getChildrenComponentInstancesUsingFetch, promisify, globalHandleError, sanitizeComponent
-} from '../utils/nuxt';
+import { getMatchedComponentsInstances, getChildrenComponentInstancesUsingFetch, promisify, globalHandleError } from '../utils/nuxt';
 import NuxtError from '../layouts/error.vue';
 import NuxtLoading from '../components/nav/GlobalLoading.vue';
 
 import '../assets/styles/app.scss';
+import { getLayouts } from './layouts';
 
-import blank from '../layouts/blank.vue';
-import defaultLayout from '../layouts/default.vue';
-import home from '../layouts/home.vue';
-import plain from '../layouts/plain.vue';
-import unauthenticated from '../layouts/unauthenticated.vue';
-import standalone from '../layouts/standalone.vue';
-
-const layouts = {
-  _blank: sanitizeComponent(blank), _default: sanitizeComponent(defaultLayout), _home: sanitizeComponent(home), _plain: sanitizeComponent(plain), _unauthenticated: sanitizeComponent(unauthenticated), _standalone: sanitizeComponent(standalone)
-};
+const layouts = getLayouts();
 
 export default {
   render(h) {

--- a/shell/initialize/layouts.ts
+++ b/shell/initialize/layouts.ts
@@ -1,0 +1,26 @@
+import { sanitizeComponent } from '@shell/utils/nuxt';
+import blank from '@shell/layouts/blank.vue';
+import defaultLayout from '@shell/layouts/default.vue';
+import home from '@shell/layouts/home.vue';
+import plain from '@shell/layouts/plain.vue';
+import unauthenticated from '@shell/layouts/unauthenticated.vue';
+import standalone from '@shell/layouts/standalone.vue';
+
+export type Component = { [key: string]: any };
+export type Layouts = { [key: string]: Component };
+const layouts: Layouts = { };
+
+export function getLayouts(): Layouts {
+  return layouts;
+}
+
+export function registerLayout(name: string, component: Component): void {
+  layouts[`_${ name }`] = sanitizeComponent(component);
+}
+
+registerLayout('blank', blank) ;
+registerLayout('default', defaultLayout) ;
+registerLayout('home', home) ;
+registerLayout('plain', plain) ;
+registerLayout('unauthenticated', unauthenticated) ;
+registerLayout('standalone', standalone);

--- a/shell/pkg/auto-import.js
+++ b/shell/pkg/auto-import.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const contextFolders = ['chart', 'cloud-credential', 'content', 'detail', 'edit', 'list', 'machine-config', 'models', 'promptRemove', 'l10n', 'windowComponents', 'dialog', 'formatters', 'login'];
+const contextFolders = ['chart', 'cloud-credential', 'content', 'detail', 'edit', 'layouts', 'list', 'machine-config', 'models', 'promptRemove', 'l10n', 'windowComponents', 'dialog', 'formatters', 'login'];
 const contextMap = contextFolders.reduce((map, obj) => {
   map[obj] = true;
 

--- a/shell/utils/settings.ts
+++ b/shell/utils/settings.ts
@@ -1,7 +1,7 @@
 import { MANAGEMENT } from '@shell/config/types';
 import { Store } from 'vuex';
 import { DEFAULT_PERF_SETTING, SETTING } from '@shell/config/settings';
-import { GC_PREFERENCES } from 'utils/gc/gc-types';
+import { GC_PREFERENCES } from '@shell/utils/gc/gc-types';
 
 export const fetchOrCreateSetting = async(store: Store<any>, id: string, val: string, save = true): Promise<any> => {
   let setting;
@@ -56,7 +56,7 @@ export const getPerformanceSetting = (rootGetters: Record<string, (arg0: string,
   manualRefresh: {};
   disableWebsocketNotification: boolean;
   garbageCollection: GC_PREFERENCES;
-  forceNsFilterV2: {};
+  forceNsFilterV2: any;
   advancedWorker: {};
 } => {
   const perfSettingResource = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);


### PR DESCRIPTION
This allows extensions to create a layouts directly which will then be auto-imported and made available as nuxt style layouts.

Addresses one facet of https://github.com/rancher/dashboard/issues/9216
