### PR TITLE
Add conditions for updating root index of extension

### DIFF
--- a/shell/scripts/extension/publish
+++ b/shell/scripts/extension/publish
@@ -299,12 +299,12 @@ for d in pkg/*/ ; do
   fi
 done
 
-if [ -f ${ROOT_INDEX} ]; then
+if [ -f ${ROOT_INDEX} ] && [ "${GITHUB_BUILD}" == "false" ]; then
   UPDATE="--merge ${ROOT_INDEX}"
   helm repo index ${ASSETS} ${UPDATE}
 fi
 
-if [ -f ${ASSETS}/index.yaml ]; then
+if [ -f ${ASSETS}/index.yaml ] && ! [ -e "${ROOT_INDEX}" ]; then
   cp ${ASSETS}/index.yaml ${BASE_DIR}
 fi
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9277 
<!-- Define findings related to the feature or bug issue. -->

The `urls` property was being correctly populated with the `BASE_URL` (`assets/`) directory initially but was being overwritten when the script reached lines 302 or 307.  This would only occur if the Root index existed, so in the case of the issue, the `index.yaml` was found and placed at the root level - As it existed the index was being updated with the assets within the `./assets` directory while not specifying the `--url` property, thus overwriting what had been previously applied on line 293.

These conditions exist for container image build, as this could be an initial build (i.e. no root index.yaml exists yet) or it could be an updated build where the index.yaml would most likely exist.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added two conditions:
1. If the root index.yaml exists && the build is not classified as a Github build, then create an index.yaml within the assets directory by merging the root index.
2. If the assets/index.yaml file exists && the root index.yaml does not exist, then copy the assets/index.yaml into the root directory for the image build.  

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Extension builds that both contain and do not contain an index.yaml (migrating extensions from a `main` branch to a `gh-pages` branch could be a good example)
- Extension builds that are not built within a Git repository
- Extension container builds 
