### PR TITLE
Remove overlay loading from pod details

### DIFF
--- a/shell/detail/pod.vue
+++ b/shell/detail/pod.vue
@@ -10,7 +10,6 @@ import DashboardMetrics from '@shell/components/DashboardMetrics';
 import V1WorkloadMetrics from '@shell/mixins/v1-workload-metrics';
 import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@shell/utils/grafana';
-import Loading from '@shell/components/Loading';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import day from 'dayjs';
 import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
@@ -24,7 +23,6 @@ export default {
 
   components: {
     DashboardMetrics,
-    Loading,
     ResourceTabs,
     Tab,
     SortableTable,
@@ -224,9 +222,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
   <ResourceTabs
-    v-else
     mode="view"
     class="mt-20"
     :value="value"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The overlay loading was only used to show/hide one of the tabs(pod-metrics) in the pod details page. After discussing this with the UX/UI team the final decision was to remove the loading.

Fixes #9236 
<!-- Define findings related to the feature or bug issue. -->