### PR TITLE
Add e2e tests for Kubewarden extension installation

### DIFF
--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -63,21 +63,24 @@ export default class ExtensionsPo extends PagePo {
   }
 
   /**
-   * install rancher-plugin-examples
+   * Adds a cluster repo for extensions
+   * @param repo - The repository url (e.g. https://github.com/rancher/ui-plugin-examples)
+   * @param branch - The git branch to target
+   * @param name - A name for the repository
+   * @returns {Cypress.Chainable}
    */
-  installRancherPluginExamples() {
+  addExtensionsRepository(repo: string, branch: string, name: string): Cypress.Chainable {
     // we should be on the extensions page
     // this.title().should('contain', 'Extensions');
     this.waitForPage();
 
     // go to app repos
     this.extensionMenuToggle();
-
     this.manageReposClick();
 
+    // create a new clusterrepo
     const appRepoList = new ReposListPagePo('local', 'apps');
 
-    // create a new clusterrepo
     appRepoList.waitForPage();
     appRepoList.create();
 
@@ -89,9 +92,9 @@ export default class ExtensionsPo extends PagePo {
     appRepoCreate.selectRadioOptionGitRepo(1);
     appRepoCreate.nameNsDescription().name().self().scrollIntoView()
       .should('be.visible');
-    appRepoCreate.nameNsDescription().name().set('rancher-plugin-examples');
-    appRepoCreate.enterGitRepoName('https://github.com/rancher/ui-plugin-examples');
-    appRepoCreate.enterGitBranchName('main');
+    appRepoCreate.nameNsDescription().name().set(name);
+    appRepoCreate.enterGitRepoName(repo);
+    appRepoCreate.enterGitBranchName(branch);
 
     // save it
     return appRepoCreate.save();

--- a/cypress/e2e/po/pages/extensions/kubewarden.po.ts
+++ b/cypress/e2e/po/pages/extensions/kubewarden.po.ts
@@ -1,0 +1,29 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
+
+export default class KubewardenExtensionPo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/kubewarden`;
+  }
+
+  static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
+    throw new Error('invalid');
+  }
+
+  constructor(clusterId = 'local') {
+    super(KubewardenExtensionPo.createPath(clusterId));
+  }
+
+  /** add ui-plugin-charts repository */
+  addChartsRepoIfNeeded(): void {
+    const extensionsPo: ExtensionsPo = new ExtensionsPo();
+
+    extensionsPo.waitForPage();
+
+    cy.get('body').then(($body: any) => {
+      if ( $body.find('[data-testid="extension-card-kubewarden"]').length === 0 ) {
+        extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-charts', 'main', 'rancher-extensions');
+      }
+    });
+  }
+}

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -13,7 +13,7 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
     extensionsPo.installExtensionsOperatorIfNeeded();
 
     // install the rancher plugin examples
-    extensionsPo.installRancherPluginExamples();
+    extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-examples', 'main', 'rancher-plugin-examples');
   });
 
   beforeEach(() => {

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -1,0 +1,104 @@
+import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
+import { ChartsPage } from '@/cypress/e2e/po/pages/charts.po';
+import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import KubewardenExtensionPo from '@/cypress/e2e/po/pages/extensions/kubewarden.po';
+
+const extensionName = 'kubewarden';
+
+describe('Kubewarden Extension', { tags: '@adminUser' }, () => {
+  before(() => {
+    cy.login();
+
+    ExtensionsPo.goTo();
+    const extensionsPo = new ExtensionsPo();
+    const kubewardenPo = new KubewardenExtensionPo();
+
+    // install extensions operator if it's not installed
+    extensionsPo.installExtensionsOperatorIfNeeded();
+    kubewardenPo.addChartsRepoIfNeeded();
+  });
+
+  beforeEach(() => {
+    cy.login();
+    ExtensionsPo.goTo();
+  });
+
+  it('Should install Kubewarden extension', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.extensionTabAvailableClick();
+
+    // click on install button on card
+    extensionsPo.extensionCardInstallClick(extensionName);
+    extensionsPo.extensionInstallModal().should('be.visible');
+
+    // click install
+    extensionsPo.installModalInstallClick();
+
+    // check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    // make sure extension card is in the installed tab
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+    extensionsPo.extensionDetailsCloseClick();
+  });
+
+  it('Check Apps/Charts and Apps/Repo pages for route collisions', () => {
+    const chartsPage: ChartsPage = new ChartsPage('/c/local/apps/charts');
+
+    chartsPage.goTo();
+    chartsPage.waitForPage();
+    chartsPage.self().getId('charts-header-title').invoke('text').should('contain', 'Charts');
+
+    const appRepoList: ReposListPagePo = new ReposListPagePo('local', 'apps');
+
+    appRepoList.goTo();
+    appRepoList.waitForPage();
+    cy.get('h1').contains('Repositories').should('exist');
+  });
+
+  it('Side-nav should contain Kubewarden menu item', () => {
+    const kubewardenPo = new KubewardenExtensionPo();
+    const productMenu = new ProductNavPo();
+
+    kubewardenPo.goTo();
+
+    const kubewardenNavItem = productMenu.groups().contains('Kubewarden');
+
+    kubewardenNavItem.should('exist');
+    kubewardenNavItem.click();
+  });
+
+  it('Kubewarden dashboard view should exist', () => {
+    const kubewardenPo = new KubewardenExtensionPo();
+
+    kubewardenPo.goTo();
+
+    cy.get('h1').contains('Kubewarden').should('exist');
+    cy.get('button').contains('Install Kubewarden').should('exist');
+  });
+
+  it('Should uninstall Kubewarden', () => {
+    const extensionsPo = new ExtensionsPo();
+
+    extensionsPo.extensionTabInstalledClick();
+
+    // click on uninstall button on card
+    extensionsPo.extensionCardUninstallClick(extensionName);
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
+
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    // make sure extension card is in the available tab
+    extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionCardClick(extensionName);
+    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  });
+});

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -352,7 +352,10 @@ export default {
   <div v-else>
     <header>
       <div class="title">
-        <h1 class="m-0">
+        <h1
+          data-testid="charts-header-title"
+          class="m-0"
+        >
           {{ t('catalog.charts.header') }}
         </h1>
       </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9231 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This adds e2e tests for installing the Kubewarden extension. Includes:
- Enabling extensions
- Installing the Kubewarden extension
- Checking for route collisions with the Apps/Charts and Apps/Repositories pages
- Checks that 'Kubewarden' is shown in the side-navigation
- Checks that the Kubewarden dashboard page loads correctly.

