### PR TITLE
Added UI to enable Fleet self-healing

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2150,8 +2150,10 @@ fleet:
       protocolBanner: Enter a valid HTTPS or SSH URL to a git repository.
     resources:
       label: 'Resource Handling'
-      keepResources: Keep resources after deletion
-      resourceBanner: When enabled above, resources will be kept when deleting a GitRepo or Bundle - only Helm release secrets will be deleted.
+      keepResources: Always Keep Resources
+      keepResourcesBanner: When enabled above, resources will be kept when deleting a GitRepo or Bundle - only Helm release secrets will be deleted.
+      correctDrift: Enable Self-Healing
+      correctDriftBanner: When enabled, Fleet will ensure that the cluster resources are kept in sync with the git repository. All resource changes made on th ecluster will be lost.
     add:
       steps:
         repoInfo:

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -1,0 +1,62 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import GitRepo from '@shell/edit/fleet.cattle.io.gitrepo.vue';
+import Vuex from 'vuex';
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+
+describe('view: fleet.cattle.io.gitrepo should', () => {
+  const mockStore = {
+    getters: {
+      'i18n/t':                  (text: string) => text,
+      t:                         (text: string) => text,
+      currentStore:              () => 'current_store',
+      'current_store/schemaFor': jest.fn(),
+      'current_store/all':       jest.fn(),
+      workspace:                 jest.fn(),
+    }
+  };
+  const mocks = {
+    $store:      mockStore,
+    $fetchState: { pending: false },
+    $route:      {
+      query: { AS: '' },
+      name:  {
+        endsWith: () => {
+          return false;
+        }
+      }
+    }
+  };
+  const values = {
+    metadata: { namespace: 'test' }, spec: { template: {}, correctDrift: { enabled: false } }, targetInfo: { mode: 'all' },
+  };
+  const wrapper = mount(GitRepo, {
+    localVue,
+    propsData: { value: values },
+    mocks
+  });
+
+  it('should have self-healing checkbox and banner', () => {
+    const correctDriftCheckbox = wrapper.find('[data-testid="GitRepo-correctDrift-checkbox"]');
+    const correctDriftBanner = wrapper.find('[data-testid="GitRepo-correctDrift-banner"]');
+
+    expect(correctDriftCheckbox.exists()).toBeTruthy();
+    expect(correctDriftBanner.exists()).toBeTruthy();
+    expect(correctDriftCheckbox.props().value).toBeFalsy();
+  });
+
+  it('should enable drift if self-healing is checked', async() => {
+    const correctDriftCheckbox = wrapper.find('[data-testid="GitRepo-correctDrift-checkbox"]');
+    const correctDriftContainer = wrapper.find('[data-testid="GitRepo-correctDrift-checkbox"] .checkbox-container');
+
+    expect(correctDriftContainer.exists()).toBeTruthy();
+
+    await correctDriftContainer.trigger('click');
+
+    expect(correctDriftCheckbox.emitted('input')).toHaveLength(1);
+    expect(correctDriftCheckbox.emitted('input')![0][0]).toBe(true);
+    expect(correctDriftCheckbox.props().value).toBeTruthy();
+  });
+});

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -604,6 +604,23 @@ export default {
       </template>
       <div class="spacer" />
       <h2 v-t="'fleet.gitRepo.resources.label'" />
+      <div data-testid="GitRepo-correctDrift-container">
+        <Checkbox
+          v-model="value.spec.correctDrift.enabled"
+          data-testid="GitRepo-correctDrift-checkbox"
+          class="check"
+          type="checkbox"
+          label-key="fleet.gitRepo.resources.correctDrift"
+          :mode="mode"
+        />
+        <Banner
+          data-testid="GitRepo-correctDrift-banner"
+          color="info"
+        >
+          {{ t('fleet.gitRepo.resources.correctDriftBanner') }}
+        </Banner>
+      </div>
+
       <Checkbox
         v-model="value.spec.keepResources"
         class="check"
@@ -614,7 +631,7 @@ export default {
       <Banner
         color="info"
       >
-        {{ t('fleet.gitRepo.resources.resourceBanner') }}
+        {{ t('fleet.gitRepo.resources.keepResourcesBanner') }}
       </Banner>
       <div class="spacer" />
       <h2 v-t="'fleet.gitRepo.paths.label'" />

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -604,7 +604,7 @@ export default {
       </template>
       <div class="spacer" />
       <h2 v-t="'fleet.gitRepo.resources.label'" />
-      <div data-testid="GitRepo-correctDrift-container">
+      <div>
         <Checkbox
           v-model="value.spec.correctDrift.enabled"
           data-testid="GitRepo-correctDrift-checkbox"

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -30,6 +30,7 @@ export default class GitRepo extends SteveModel {
 
     spec.paths = spec.paths || [];
     spec.clientSecretName = spec.clientSecretName || null;
+    spec.correctDrift = { enabled: false };
 
     set(this, 'spec', spec);
     set(this, 'metadata', meta);


### PR DESCRIPTION
### Summary
Fixes #9223 
Added a checkbox to enable self-healing feature for the Drift.

### Occurred changes and/or fixed issues
Added a checkbox.

### Technical notes summary
Added a checkbox corresponding to spec.correctDrift.enabled.
It is disabled by default.

### Areas or cases that should be tested
Go to "Continuous delivery" -> "Git repos" -> "Add repository"
Step 1 should have "Enable Self-healing checkbox"
After creation, created resource should have "spec.correctDrift.enabled" set to the value of the checkbox.

### Areas which could experience regressions
"Add repository" wizard and edit views

### Screenshot/Video
<img width="1728" alt="Screenshot 2023-07-12 at 12 01 04 PM" src="https://github.com/rancher/dashboard/assets/133266076/764a6689-f1be-466f-b423-31096481c5c8">