### PR TITLE
Fix broken YAML File Diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "d3-selection": "1.4.1",
     "dagre-d3": "0.6.4",
     "dayjs": "1.8.29",
-    "diff2html": "2.11.2",
+    "diff2html": "3.4.24",
     "dompurify": "2.4.5",
     "event-target-shim": "5.0.1",
     "express": "4.17.1",

--- a/shell/components/FileDiff.vue
+++ b/shell/components/FileDiff.vue
@@ -1,5 +1,7 @@
 <script>
-import { Diff2Html } from 'diff2html';
+import { Diff2HtmlUI } from 'diff2html/lib/ui/js/diff2html-ui-slim.js';
+import 'diff2html/bundles/css/diff2html.min.css';
+
 import { createPatch } from 'diff';
 
 export default {
@@ -38,36 +40,40 @@ export default {
     }
   },
 
-  computed: {
-    html() {
-      const outputFormat = this.sideBySide ? 'side-by-side' : 'line-by-line';
-      const showFiles = false;
-      const matching = 'words';
+  mounted() {
+    this.draw();
+  },
 
+  watch: {
+    sideBySide() {
+      this.draw();
+    }
+  },
+
+  methods: {
+    draw() {
+      const targetElement = document.getElementById('diffElement');
       const patch = createPatch(
         this.filename,
         this.orig,
         this.neu
       );
+      const configuration = {
+        // UI
+        synchronisedScroll: true,
 
-      const json = Diff2Html.getJsonFromDiff(patch, {
-        inputFormat: 'diff',
-        outputFormat,
-        showFiles,
-        matching
-      });
+        // Base
+        outputFormat: this.sideBySide ? 'side-by-side' : 'line-by-line',
+        drawFileList: false,
+        matching:     'words',
+      };
 
-      return Diff2Html.getPrettyHtml(json, {
-        inputFormat:        'json',
-        outputFormat,
-        showFiles,
-        matching,
-        synchronizedScroll: true,
-      });
-    }
-  },
+      const diff2htmlUi = new Diff2HtmlUI(targetElement, patch, configuration);
 
-  methods: {
+      diff2htmlUi.draw();
+      this.fit();
+    },
+
     fit() {
       if ( !this.autoResize ) {
         return;
@@ -97,8 +103,8 @@ export default {
   <div>
     <resize-observer @notify="fit" />
     <div
+      id="diffElement"
       ref="root"
-      v-clean-html="html"
       class="root"
     />
   </div>
@@ -112,66 +118,67 @@ export default {
 }
 </style>
 
-<style lang="scss">
-@import 'node_modules/diff2html/dist/diff2html.min.css';
+<style scoped lang="scss">
+// These styles predomindently but not exclusively ensure dark mode looks ok
+::v-deep .d2h-wrapper {
+  .d2h-file-header {
+    display: none;
+  }
 
-.d2h-file-header {
-  display: none;
-}
+  .d2h-file-wrapper {
+    border-color: var(--diff-border);
+  }
 
-.d2h-file-wrapper {
-  border-color: var(--diff-border);
-}
+  .d2h-diff-table {
+    font-family: Menlo,Consolas,monospace;
+    font-size: 13px;
+  }
 
-.d2h-diff-table {
-  font-family: Menlo,Consolas,monospace;
-  font-size: 13px;
-}
+  .d2h-emptyplaceholder, .d2h-code-side-emptyplaceholder {
+    border-color: var(--diff-linenum-border);
+    background-color: var(--diff-empty-placeholder);
+  }
 
-.d2h-emptyplaceholder, .d2h-code-side-emptyplaceholder {
-  border-color: var(--diff-linenum-border);
-  background-color: var(--diff-empty-placeholder);
-}
+  .d2h-code-linenumber,
+  .d2h-code-side-linenumber {
+    background-color: var(--diff-linenum-bg);
+    color: var(--diff-linenum);
+    border-color: var(--diff-linenum-border);
+    border-left: 0;
+  }
 
-.d2h-code-linenumber,
-.d2h-code-side-linenumber {
-  background-color: var(--diff-linenum-bg);
-  color: var(--diff-linenum);
-  border-color: var(--diff-linenum-border);
-  border-left: 0;
-}
+  .d2h-code-line del,.d2h-code-side-line del {
+    background-color: var(--diff-line-del-bg);
+  }
 
-.d2h-code-line del,.d2h-code-side-line del {
-  background-color: var(--diff-line-del-bg);
-}
+  .d2h-code-line ins,.d2h-code-side-line ins {
+    background-color: var(--diff-line-ins-bg);
+  }
 
-.d2h-code-line ins,.d2h-code-side-line ins {
-  background-color: var(--diff-line-ins-bg);
-}
+  .d2h-del {
+    background-color: var(--diff-del-bg);
+    border-color: var(--diff-del-border);
+    color: var(--body-text);
+  }
 
-.d2h-del {
-  background-color: var(--diff-del-bg);
-  border-color: var(--diff-del-border);
-  color: var(--body-text);
-}
+  .d2h-ins {
+    background-color: var(--diff-ins-bg);
+    border-color: var(--diff-ins-border);
+    color: var(--body-text);
+  }
 
-.d2h-ins {
-  background-color: var(--diff-ins-bg);
-  border-color: var(--diff-ins-border);
-  color: var(--body-text);
-}
+  .d2h-info {
+    background-color: var(--diff-header-bg);
+    color: var(--diff-header);
+    border-color: var(--diff-header-border);
+  }
 
-.d2h-info {
-  background-color: var(--diff-header-bg);
-  color: var(--diff-header);
-  border-color: var(--diff-header-border);
-}
+  .d2h-file-diff .d2h-del.d2h-change {
+    background-color: var(--diff-chg-del);
+  }
 
-.d2h-file-diff .d2h-del.d2h-change {
-  background-color: var(--diff-chg-del);
-}
-
-.d2h-file-diff .d2h-ins.d2h-change {
-  background-color: var(--diff-chg-ins);
+  .d2h-file-diff .d2h-ins.d2h-change {
+    background-color: var(--diff-chg-ins);
+  }
 }
 </style>

--- a/shell/components/FileDiff.vue
+++ b/shell/components/FileDiff.vue
@@ -1,6 +1,5 @@
 <script>
 import { Diff2HtmlUI } from 'diff2html/lib/ui/js/diff2html-ui-slim.js';
-import 'diff2html/bundles/css/diff2html.min.css';
 
 import { createPatch } from 'diff';
 
@@ -119,7 +118,8 @@ export default {
 </style>
 
 <style scoped lang="scss">
-// These styles predomindently but not exclusively ensure dark mode looks ok
+@import 'node_modules/diff2html/bundles/css/diff2html.min.css';
+
 ::v-deep .d2h-wrapper {
   .d2h-file-header {
     display: none;

--- a/shell/components/YamlEditor.vue
+++ b/shell/components/YamlEditor.vue
@@ -241,6 +241,7 @@ export default {
       :side-by-side="diffMode === 'split'"
       :orig="original"
       :neu="curValue"
+      :footer-space="80"
     />
   </div>
 </template>

--- a/shell/package.json
+++ b/shell/package.json
@@ -69,7 +69,7 @@
     "d3-selection": "1.4.1",
     "dagre-d3": "0.6.4",
     "dayjs": "1.8.29",
-    "diff2html": "2.11.2",
+    "diff2html": "3.4.24",
     "dompurify": "2.4.5",
     "eslint": "7.32.0",
     "eslint-config-standard": "16.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6827,15 +6827,20 @@ diff-sequences@^27.5.1:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
-diff2html@2.11.2:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-2.11.2.tgz#f3f27c6b81a75b5a8a3cfb7ae2fda2127290c809"
-  integrity sha512-FKDFFXW0cHyt+joiYeyWxbcLWZsQYeYRRrHKWZEvu+XMFMM1ChxTkGhET53zAU0tvVjyRRxRjUcrn5ImSqD0ZQ==
+diff2html@3.4.24:
+  version "3.4.24"
+  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.24.tgz#42811f1830fa12b9ad73baebcf63431b20c2445d"
+  integrity sha512-eVzxAj8r52nm5QLVCVlVD/J0VR4X9vVLkgkdI7w7b5cw81pyYxgqed9WetjBwjYXzprdkOcmILKK3qzWg/ld3A==
   dependencies:
-    diff "^4.0.1"
-    hogan.js "^3.0.2"
-    merge "^1.2.1"
-    whatwg-fetch "^3.0.0"
+    diff "5.1.0"
+    hogan.js "3.0.2"
+  optionalDependencies:
+    highlight.js "11.6.0"
+
+diff@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
@@ -8888,6 +8893,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highlight.js@11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.6.0.tgz#a50e9da05763f1bb0c1322c8f4f755242cff3f5a"
+  integrity sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==
+
 highlight.js@^10.7.1:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
@@ -8902,7 +8912,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hogan.js@^3.0.2:
+hogan.js@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
   integrity sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==
@@ -11202,7 +11212,7 @@ merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-merge@>=2.1.1, merge@^1.2.1:
+merge@>=2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/merge/-/merge-2.1.1.tgz#59ef4bf7e0b3e879186436e8481c06a6c162ca98"
   integrity sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==
@@ -15875,11 +15885,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@^3.0.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
-  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9313
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- FileDiff component used in the YAML editor
  - Seen when Editing by YAML, or Editing by Config and switching to YAML. Then press show diff button at bottom
- Rendering was completely off in the old version of diff2html, so use latest
- Latest version of diff2html requires use of new component to render component same as before
  - This has a slightly different implementation
- Bonus point - Fixed a rendering issue when editing yaml --> switch to diff --> resize. the bottom bar action buttons disappeared off screen. Now fixed

### Areas or cases that should be tested
Component is used in two contexts
1. Resource --> Edit YAML --> (make change) --> Show Diff
2. Resource --> Edit Config --> Edit as YAML --> Show Diff

Component should render ok in light and dark modes

Both unified and split modes should render ok

### Screenshot/Video
![image](https://github.com/rancher/dashboard/assets/18697775/c4e509c4-7126-483c-8fa7-444c8b22af36)

![image](https://github.com/rancher/dashboard/assets/18697775/51f2f454-03fa-4c5c-af8d-0be190d7d438)

![image](https://github.com/rancher/dashboard/assets/18697775/fffb4e1b-9b83-45c9-b692-1b9499868c13)

![image](https://github.com/rancher/dashboard/assets/18697775/10a13f47-8371-45c8-9e0f-d22a007cc5dd)


