### PR TITLE
Fix authenticated middleware schema check for users who cant access the local cluster

### DIFF
--- a/cypress/e2e/po/pages/explorer/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads.po.ts
@@ -1,17 +1,17 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
 
-export default class WorkloadPo extends PagePo {
+export default class WorkloadPagePo extends PagePo {
   private static createPath(clusterId: string) {
     return `/c/${ clusterId }/explorer/workload`;
   }
 
   static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
-    return super.goTo(WorkloadPo.createPath(clusterId));
+    return super.goTo(WorkloadPagePo.createPath(clusterId));
   }
 
   constructor(clusterId = 'local') {
-    super(WorkloadPo.createPath(clusterId));
+    super(WorkloadPagePo.createPath(clusterId));
   }
 
   goToDetailsPage(elemName: string) {

--- a/cypress/e2e/po/pages/page.po.ts
+++ b/cypress/e2e/po/pages/page.po.ts
@@ -72,6 +72,12 @@ export default class PagePo extends ComponentPo {
     BurgerMenuPo.burgerMenuNavToClusterbyLabel(label);
   }
 
+  navToSideMenuGroupByLabel(label: string) {
+    const nav = new ProductNavPo();
+
+    nav.navToSideMenuGroupByLabel(label);
+  }
+
   navToSideMenuEntryByLabel(label: string) {
     const nav = new ProductNavPo();
 

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -29,6 +29,14 @@ export default class ProductNavPo extends ComponentPo {
   }
 
   /**
+   * Navigate to a side menu group by label
+   */
+  navToSideMenuGroupByLabel(label: string): Cypress.Chainable {
+    return this.self().should('exist').find('.header > a > h6').contains(label)
+      .click();
+  }
+
+  /**
    * Navigate to a side menu entry by label
    */
   navToSideMenuEntryByLabel(label: string): Cypress.Chainable {

--- a/cypress/e2e/tests/navigation/not-found-page.spec.ts
+++ b/cypress/e2e/tests/navigation/not-found-page.spec.ts
@@ -1,6 +1,6 @@
 import NotFoundPagePo from '@/cypress/e2e/po/pages/not-found-page.po';
 
-describe('Not found page display', () => {
+describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });
@@ -43,5 +43,13 @@ describe('Not found page display', () => {
 
     notFound.errorTitle().contains('Error');
     notFound.errorMessage().contains('Product bogus-product-id not found');
+  });
+
+  it('Will not show a 404 if we have a valid product + resource', () => {
+    const notFound = new NotFoundPagePo('/c/local/explorer/pod');
+
+    notFound.goTo();
+    notFound.waitForPage();
+    notFound.errorTitle().should('not.exist');
   });
 });

--- a/cypress/e2e/tests/navigation/not-found-page.spec.ts
+++ b/cypress/e2e/tests/navigation/not-found-page.spec.ts
@@ -46,10 +46,22 @@ describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, ()
   });
 
   it('Will not show a 404 if we have a valid product + resource', () => {
-    const notFound = new NotFoundPagePo('/c/local/explorer/pod');
+    const podPage = new NotFoundPagePo('/c/local/explorer/pod');
 
-    notFound.goTo();
-    notFound.waitForPage();
-    notFound.errorTitle().should('not.exist');
+    podPage.goTo();
+    podPage.waitForPage();
+    podPage.errorTitle().should('not.exist');
+
+    const workloadPage = new NotFoundPagePo('/c/local/explorer/workload');
+
+    workloadPage.goTo();
+    workloadPage.waitForPage();
+    workloadPage.errorTitle().should('not.exist');
+
+    const clusterManager = new NotFoundPagePo('/c/_/manager/provisioning.cattle.io.cluster');
+
+    clusterManager.goTo();
+    clusterManager.waitForPage();
+    clusterManager.errorTitle().should('not.exist');
   });
 });

--- a/cypress/e2e/tests/navigation/not-found-page.spec.ts
+++ b/cypress/e2e/tests/navigation/not-found-page.spec.ts
@@ -5,13 +5,13 @@ import WorkloadListPagePo from '~/cypress/e2e/po/pages/explorer/workloads.po';
 import HomePagePo from '~/cypress/e2e/po/pages/home.po';
 import PagePo from '~/cypress/e2e/po/pages/page.po';
 
-describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, () => {
+describe('Not found page display', () => {
   beforeEach(() => {
     cy.login();
   });
 
-  it('Will show a 404 if we do not have a valid Product id on the route path', () => {
-    const notFound = new NotFoundPagePo('/c/local/bogus-product-id');
+  it('Will show a 404 if we do not have a valid Product id on the route path', { tags: ['@adminUser', '@standardUser'] }, () => {
+    const notFound = new NotFoundPagePo('/c/_/bogus-product-id');
 
     notFound.goTo();
     notFound.waitForPage();
@@ -20,8 +20,8 @@ describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, ()
     notFound.errorMessage().contains('Product bogus-product-id not found');
   });
 
-  it('Will show a 404 if we do not have a valid Resource type on the route path', () => {
-    const notFound = new NotFoundPagePo('/c/local/explorer/bogus-resource-type');
+  it('Will show a 404 if we do not have a valid Resource type on the route path', { tags: ['@adminUser', '@standardUser'] }, () => {
+    const notFound = new NotFoundPagePo('/c/_/manager/bogus-resource-type');
 
     notFound.goTo();
     notFound.waitForPage();
@@ -30,18 +30,18 @@ describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, ()
     notFound.errorMessage().contains('Resource type bogus-resource-type not found');
   });
 
-  it('Will show a 404 if we do not have a valid Resource id on the route path', () => {
-    const notFound = new NotFoundPagePo('/c/local/explorer/node/bogus-resource-id');
+  it('Will show a 404 if we do not have a valid Resource id on the route path', { tags: ['@adminUser', '@standardUser'] }, () => {
+    const notFound = new NotFoundPagePo('/c/_/manager/provisioning.cattle.io.cluster/fleet-default/bogus-resource-id');
 
     notFound.goTo();
     notFound.waitForPage();
 
     notFound.errorTitle().contains('Error');
-    notFound.errorMessage().contains('Resource node with id bogus-resource-id not found, unable to display resource details');
+    notFound.errorMessage().contains('Resource provisioning.cattle.io.cluster with id fleet-default/bogus-resource-id not found, unable to display resource details');
   });
 
-  it('Will show a 404 if we do not have a valid product + resource + resource id', () => {
-    const notFound = new NotFoundPagePo('/c/local/bogus-product-id/bogus-resource/bogus-resource-id');
+  it('Will show a 404 if we do not have a valid product + resource + resource id', { tags: ['@adminUser', '@standardUser'] }, () => {
+    const notFound = new NotFoundPagePo('/c/_/bogus-product-id/bogus-resource/bogus-resource-id');
 
     notFound.goTo();
     notFound.waitForPage();
@@ -50,19 +50,7 @@ describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, ()
     notFound.errorMessage().contains('Product bogus-product-id not found');
   });
 
-  it('Will not show a 404 if we have a valid product + resource', () => {
-    const podPage = new NotFoundPagePo('/c/local/explorer/pod');
-
-    podPage.goTo();
-    podPage.waitForPage();
-    podPage.errorTitle().should('not.exist');
-
-    const workloadPage = new NotFoundPagePo('/c/local/explorer/workload');
-
-    workloadPage.goTo();
-    workloadPage.waitForPage();
-    workloadPage.errorTitle().should('not.exist');
-
+  it('Will not show a 404 if we have a valid product + resource', { tags: ['@adminUser', '@standardUser'] }, () => {
     const clusterManager = new NotFoundPagePo('/c/_/manager/provisioning.cattle.io.cluster');
 
     clusterManager.goTo();
@@ -70,7 +58,15 @@ describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, ()
     clusterManager.errorTitle().should('not.exist');
   });
 
-  it('Will not show a 404 if we have a valid product + resource and we nav to page', () => {
+  it('Will not show a 404 for a valid type that does not have a real schema', { tags: '@adminUser' }, () => {
+    const workloadPage = new NotFoundPagePo('/c/local/explorer/workload');
+
+    workloadPage.goTo();
+    workloadPage.waitForPage();
+    workloadPage.errorTitle().should('not.exist');
+  });
+
+  it('Will not show a 404 if we have a valid product + resource and we nav to page', { tags: '@adminUser' }, () => {
     const page = new PagePo('');
     const homePage = new HomePagePo();
     const notFoundPage = new NotFoundPagePo('');

--- a/cypress/e2e/tests/navigation/not-found-page.spec.ts
+++ b/cypress/e2e/tests/navigation/not-found-page.spec.ts
@@ -1,4 +1,9 @@
 import NotFoundPagePo from '@/cypress/e2e/po/pages/not-found-page.po';
+import ClusterManagerListPagePo from '~/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import { WorkloadsPodsListPagePo } from '~/cypress/e2e/po/pages/explorer/workloads-pods.po';
+import WorkloadListPagePo from '~/cypress/e2e/po/pages/explorer/workloads.po';
+import HomePagePo from '~/cypress/e2e/po/pages/home.po';
+import PagePo from '~/cypress/e2e/po/pages/page.po';
 
 describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
@@ -63,5 +68,30 @@ describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, ()
     clusterManager.goTo();
     clusterManager.waitForPage();
     clusterManager.errorTitle().should('not.exist');
+  });
+
+  it('Will not show a 404 if we have a valid product + resource and we nav to page', () => {
+    const page = new PagePo('');
+    const homePage = new HomePagePo();
+    const notFoundPage = new NotFoundPagePo('');
+    const workloadsPage = new WorkloadListPagePo();
+    const workloadPodsPage = new WorkloadsPodsListPagePo();
+    const clustersPage = new ClusterManagerListPagePo('_');
+
+    homePage.goTo();
+
+    page.navToClusterMenuEntry('local');
+
+    page.navToSideMenuGroupByLabel('Workloads');
+    workloadsPage.waitForPage();
+    notFoundPage.errorTitle().should('not.exist');
+
+    page.navToSideMenuEntryByLabel('Pods');
+    workloadPodsPage.waitForPage();
+    notFoundPage.errorTitle().should('not.exist');
+
+    page.navToMenuEntry('Cluster Management');
+    clustersPage.waitForPage();
+    notFoundPage.errorTitle().should('not.exist');
   });
 });

--- a/cypress/e2e/tests/pages/explorer/api/api-services.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/api/api-services.spec.ts
@@ -1,6 +1,6 @@
 import { APIServicesPagePo } from '@/cypress/e2e/po/pages/explorer/api-services.po';
 
-describe('Cluster Explorer', () => {
+describe('Cluster Explorer', { tags: ['@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
@@ -7,7 +7,7 @@ const runPrefix = `e2e-test-${ runTimestamp }`;
 const username = `${ runPrefix }-cluster-proj-member`;
 const standardPassword = 'standard-password';
 
-describe('Cluster Project and Members', () => {
+describe('Cluster Project and Members', { tags: ['@adminUser'] }, () => {
   it('Members added to both Cluster Membership should not show "Loading..." next to their names', () => {
     const usersAdmin = new UsersAndAuthPo('_', 'management.cattle.io.user');
 

--- a/cypress/e2e/tests/pages/explorer/workloads/workloads.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/workloads/workloads.spec.ts
@@ -1,7 +1,7 @@
 import { WorkloadsPodsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-pods.po';
 import { createPodBlueprint } from '@/cypress/e2e/blueprints/explorer/workload-pods';
 import PodPo from '@/cypress/e2e/po/components/workloads/pod.po';
-import WorkloadPo from '@/cypress/e2e/po/pages/explorer/workloads.po';
+import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 
 const podName = 'some-pod-name';
 
@@ -22,7 +22,7 @@ describe('Workloads', { tags: '@adminUser' }, () => {
     createPodPo.createPodViaKubectl(createPodBlueprint);
 
     // check if Pod is in the Workloads list
-    const workload = new WorkloadPo('local');
+    const workload = new WorkloadPagePo('local');
 
     workload.goTo();
     workload.goToDetailsPage(podName);

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -193,7 +193,7 @@ export default {
           opt:  { watch: true }
         });
       } catch (e) {
-        if (e.status === 404) {
+        if (e.status === 404 || e.status === 403) {
           store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceIdNotFound', { resource, fqid }, true)));
         }
         liveModel = {};

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -4,7 +4,7 @@ import {
   SETUP, TIMED_OUT, UPGRADED, _FLAGGED, _UNFLAG
 } from '@shell/config/query-params';
 import { SETTING } from '@shell/config/settings';
-import { MANAGEMENT, NORMAN, DEFAULT_WORKSPACE, WORKLOAD } from '@shell/config/types';
+import { MANAGEMENT, NORMAN, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { applyProducts } from '@shell/store/type-map';
 import { findBy } from '@shell/utils/array';

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -115,6 +115,40 @@ function setProduct(store, to, redirect) {
   return false;
 }
 
+/**
+ * Check that the resource is valid, if not redirect to fail whale
+ *
+ * This requires that
+ * - product is set
+ * - product's store is set and setup (so we can check schema's within it)
+ * - product's store has the schemaFor getter (extension stores might not have it)
+ * - there's a resource associated with route (meta or param)
+ */
+function invalidResource(store, to, redirect) {
+  const product = store.getters['currentProduct'];
+  const inStore = product?.inStore;
+  const schemaFor = store.getters[`${ inStore }/schemaFor`]; // There's a chance we're in an extension's product who's store could be anything
+  const resource = getResourceFromRoute(to);
+
+  // In order to check a resource is valid we need all of these
+  if (!product || !inStore || !schemaFor || !resource) {
+    return false;
+  }
+
+  // Resource is valid if a schema exists for it (standard resource, spoofed resource) or it's a virtual resource
+  const validResource = schemaFor(resource) || store.getters['type-map/isVirtual'](resource);
+
+  if (validResource) {
+    return false;
+  }
+
+  // Unknown resource, redirect to fail whale
+
+  store.dispatch('loadingError', new Error(store.getters['i18n/t']('nav.failWhale.resourceNotFound', { resource }, true)));
+
+  return () => redirect(302, '/fail-whale');
+}
+
 export default async function({
   route, app, store, redirect, $cookies, req, isDev, from, $plugin, next
 }) {
@@ -302,14 +336,25 @@ export default async function({
   store.dispatch('gcRouteChanged', route);
 
   // Load stuff
+  let localCheckResource = false;
+
   await applyProducts(store, $plugin);
+
   // Setup a beforeEach hook once to keep track of the current product
   if ( !beforeEachSetup ) {
     beforeEachSetup = true;
+    // This only needs to happen when beforeEach hook hasn't run (the initial load)
+    localCheckResource = true;
 
     store.app.router.beforeEach((to, from, next) => {
       // NOTE - This beforeEach runs AFTER this middleware. So anything in this middleware that requires it must set it manually
-      const redirected = setProduct(store, to, redirect);
+      let redirected = setProduct(store, to, redirect);
+
+      if (redirected) {
+        return redirected();
+      }
+
+      redirected = invalidResource(store, to, redirect);
 
       if (redirected) {
         return redirected();
@@ -432,15 +477,12 @@ export default async function({
       })
     ]);
 
-    const resource = getResourceFromRoute(route);
-    const inStore = store.getters['currentProduct'].inStore;
+    if (localCheckResource) {
+      const redirected = invalidResource(store, route, redirect);
 
-    // if we have resource param, but can't get the schema, it means the resource doesn't exist!
-    // NOTE: workload doesn't have a schema, so let's just bypass this with the identifier
-    if (resource && resource !== WORKLOAD && !store.getters['management/schemaFor'](resource) && !store.getters['rancher/schemaFor'](resource) && !store.getters[`${ inStore }/schemaFor`](resource)) {
-      store.dispatch('loadingError', new Error(store.getters['i18n/t']('nav.failWhale.resourceNotFound', { resource }, true)));
-
-      return redirect(302, '/fail-whale');
+      if (redirected) {
+        return redirected();
+      }
     }
 
     if (!clusterId) {

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -433,10 +433,11 @@ export default async function({
     ]);
 
     const resource = getResourceFromRoute(route);
+    const inStore = store.getters['currentProduct'].inStore;
 
     // if we have resource param, but can't get the schema, it means the resource doesn't exist!
     // NOTE: workload doesn't have a schema, so let's just bypass this with the identifier
-    if (resource && resource !== WORKLOAD && !store.getters['management/schemaFor'](resource) && !store.getters['rancher/schemaFor'](resource)) {
+    if (resource && resource !== WORKLOAD && !store.getters['management/schemaFor'](resource) && !store.getters['rancher/schemaFor'](resource) && !store.getters[`${ inStore }/schemaFor`](resource)) {
       store.dispatch('loadingError', new Error(store.getters['i18n/t']('nav.failWhale.resourceNotFound', { resource }, true)));
 
       return redirect(302, '/fail-whale');

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -753,6 +753,15 @@ export const getters = {
     };
   },
 
+  isVirtual(state, getters, rootState, rootGetters) {
+    return (name, product) => {
+      product = product || rootGetters['productId'];
+      const productVirtualTypes = state.virtualTypes[product] || [];
+
+      return productVirtualTypes.some((st) => st.name === name);
+    };
+  },
+
   getSpoofedInstances(state, getters, rootState, rootGetters) {
     return async(type, product) => {
       product = product || rootGetters['productId'];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9336
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the schema check in auth middleware to also look in the current store. The problem described in #9336 seems to be happening because the standard user can't see pods in the management store, as they only have access to pods in the downstream cluster.


### Areas or cases that should be tested
Pages generated by dynamic routes in downstream clusters as a user with limited access to the local cluster; bogus routes should still fail
