### PR TITLE
recreate pr - Embed project monitoring metric dashboards

### DIFF
--- a/shell/detail/pod.vue
+++ b/shell/detail/pod.vue
@@ -14,6 +14,8 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import day from 'dayjs';
 import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
 import { escapeHtml } from '@shell/utils/string';
+import { NAMESPACE } from '@shell/config/types';
+import { PROJECT } from '@shell/config/labels-annotations';
 
 const POD_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-pod-containers-1/rancher-pod-containers?orgId=1';
 const POD_METRICS_SUMMARY_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-pod-1/rancher-pod?orgId=1';
@@ -33,6 +35,18 @@ export default {
 
   async fetch() {
     this.showMetrics = await allDashboardsExist(this.$store, this.currentCluster.id, [POD_METRICS_DETAIL_URL, POD_METRICS_SUMMARY_URL]);
+    if (!this.showMetrics) {
+      const namespace = await this.$store.dispatch('cluster/find', { type: NAMESPACE, id: this.value.metadata.namespace });
+
+      const projectId = namespace?.metadata?.labels[PROJECT];
+
+      if (projectId) {
+        this.POD_PROJECT_METRICS_DETAIL_URL = `/api/v1/namespaces/cattle-project-${ projectId }-monitoring/services/http:cattle-project-${ projectId }-monitoring-grafana:80/proxy/d/rancher-pod-containers-1/rancher-pod-containers?orgId=1'`;
+        this.POD_PROJECT_METRICS_SUMMARY_URL = `/api/v1/namespaces/cattle-project-${ projectId }-monitoring/services/http:cattle-project-${ projectId }-monitoring-grafana:80/proxy/d/rancher-pod-1/rancher-pod?orgId=1`;
+
+        this.showProjectMetrics = await allDashboardsExist(this.$store, this.currentCluster.id, [this.POD_PROJECT_METRICS_DETAIL_URL, this.POD_PROJECT_METRICS_SUMMARY_URL], 'cluster', projectId);
+      }
+    }
   },
 
   data() {
@@ -45,10 +59,13 @@ export default {
     return {
       POD_METRICS_DETAIL_URL,
       POD_METRICS_SUMMARY_URL,
+      POD_PROJECT_METRICS_DETAIL_URL:  '',
+      POD_PROJECT_METRICS_SUMMARY_URL: '',
       POD_OPTION,
-      showMetrics: false,
-      selection:   POD_OPTION,
-      metricsID:   null,
+      showMetrics:                     false,
+      showProjectMetrics:              false,
+      selection:                       POD_OPTION,
+      metricsID:                       null,
     };
   },
 
@@ -273,6 +290,22 @@ export default {
           v-if="props.active"
           :detail-url="POD_METRICS_DETAIL_URL"
           :summary-url="POD_METRICS_SUMMARY_URL"
+          :vars="graphVars"
+          graph-height="550px"
+        />
+      </template>
+    </Tab>
+    <Tab
+      v-if="showProjectMetrics"
+      :label="t('workload.container.titles.metrics')"
+      name="pod-metrics"
+      :weight="2.5"
+    >
+      <template #default="props">
+        <DashboardMetrics
+          v-if="props.active"
+          :detail-url="POD_PROJECT_METRICS_DETAIL_URL"
+          :summary-url="POD_PROJECT_METRICS_SUMMARY_URL"
           :vars="graphVars"
           graph-height="550px"
         />

--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -32,14 +32,19 @@ export function computeDashboardUrl(monitoringVersion, embedUrl, clusterId, para
   return newUrl;
 }
 
-export async function dashboardExists(monitoringVersion, store, clusterId, embedUrl, storeName = 'cluster') {
-  if ( !haveV2Monitoring(store.getters) ) {
+export async function dashboardExists(monitoringVersion, store, clusterId, embedUrl, storeName = 'cluster', projectId = null) {
+  if (!haveV2Monitoring(store.getters)) {
     return false;
   }
 
   const url = parseUrl(embedUrl);
-  const prefix = `${ getClusterPrefix(monitoringVersion, clusterId) }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/`;
-  const delimiter = 'http:rancher-monitoring-grafana:80/proxy/';
+  let prefix = `${ getClusterPrefix(monitoringVersion, clusterId) }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/`;
+  let delimiter = 'http:rancher-monitoring-grafana:80/proxy/';
+
+  if (projectId) {
+    prefix = `${ getClusterPrefix(monitoringVersion, clusterId) }/api/v1/namespaces/cattle-project-${ projectId }-monitoring/services/http:cattle-project-${ projectId }-monitoring-grafana:80/proxy/`;
+    delimiter = `http:cattle-project-${ projectId }-monitoring-grafana:80/proxy/`;
+  }
   const path = url.path.split(delimiter)[1];
   const uid = path.split('/')[1];
   const newUrl = `${ prefix }api/dashboards/uid/${ uid }`;
@@ -53,18 +58,25 @@ export async function dashboardExists(monitoringVersion, store, clusterId, embed
   }
 }
 
-export async function allDashboardsExist(store, clusterId, embeddedUrls, storeName = 'cluster') {
+export async function allDashboardsExist(store, clusterId, embeddedUrls, storeName = 'cluster', projectId = null) {
   let res;
 
-  try {
-    res = await store.dispatch(`${ storeName }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
-  } catch (err) {
-    return false;
+  let monitoringVersion = '';
+
+  if (!projectId) {
+    try {
+      res = await store.dispatch(`${ storeName }/find`, {
+        type: CATALOG.APP,
+        id:   'cattle-monitoring-system/rancher-monitoring'
+      });
+    } catch (err) {
+      return false;
+    }
+
+    monitoringVersion = res?.currentVersion;
   }
 
-  const monitoringVersion = res?.currentVersion;
-
-  const existPromises = embeddedUrls.map((url) => dashboardExists(monitoringVersion, store, clusterId, url, storeName));
+  const existPromises = embeddedUrls.map((url) => dashboardExists(monitoringVersion, store, clusterId, url, storeName, projectId));
 
   return (await Promise.all(existPromises)).every((exists) => exists);
 }


### PR DESCRIPTION
**- Recreation of https://github.com/rancher/dashboard/pull/9091**

### Summary
This embeds the project monitoring Grafana metric dashboards if they are present and user has no access to cluster monitoring.

Fixes #7286

### Technical notes summary
To test:
* Create a cluster
* Install cluster monitoring
* Install project federator
* Install project monitoring into the default project
* Create a user in Rancher that only has access to the default project in the cluster as a project member
* Deploy a workload into the default project
* Check that the limited user can see grafana dashboards under the pod detail page and workload detail page metrics tabs

### Areas or cases that should be tested
Pod detail page and workload detail page.

### Areas which could experience regressions
Embedding of Grafana metrics dashboards on pod and workload detail pages

### Screenshot/Video
<img width="1972" alt="Bildschirmfoto 2023-06-09 um 16 25 20" src="https://github.com/rancher/dashboard/assets/243056/468bf665-3781-46b1-94cf-23be766891c1">
