### PR TITLE
address misformatted banner on extensions por partners repo

### DIFF
--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -3,7 +3,6 @@ import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import ActionMenuPo from '@/cypress/e2e/po/components/action-menu.po';
-import BannersPo from '@/cypress/e2e/po/components/banners.po';
 import NameNsDescriptionPo from '@/cypress/e2e/po/components/name-ns-description.po';
 import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -103,14 +103,6 @@ export default class ExtensionsPo extends PagePo {
     return appRepoCreate.save();
   }
 
-  //  ------------------ new repos extension banner ------------------
-
-  newReposBanner() {
-    const newReposBanner = new BannersPo('[data-testid="extensions-new-repos-banner"]');
-
-    return newReposBanner;
-  }
-
   // ------------------ extension card ------------------
   extensionCard(extensionName: string) {
     return this.self().getId(`extension-card-${ extensionName }`);

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -70,7 +70,7 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   it('New repos banner should only appear once (after dismiss should NOT appear again)', () => {
     const extensionsPo = new ExtensionsPo();
 
-    extensionsPo.newReposBanner().closeButton();
+    extensionsPo.self().find('[data-testid="extensions-new-repos-banner-action-btn"]').click();
     extensionsPo.self().find('[data-testid="extensions-new-repos-banner"]').should('not.exist');
 
     // let's refresh the page to make sure it doesn't appear again...

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4147,7 +4147,7 @@ plugins:
     title: Extensions Safe Mode
     message: Extensions were not loaded
   addRepos:
-    banner: There are new extensions repositories available. To enable them, click the menu button at the top right of this page and select “Add Rancher Repositories”.
+    banner: There are new extensions repositories available. To enable these repositories, click the button on the right.
     bannerBtn: Add repositories
     title: Add Extensions repositories
     prompt: You can install multiple Rancher extension repositories to increase your extensions catalog

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -541,6 +541,7 @@ export default {
     },
 
     showAddExtensionReposDialog() {
+      this.updateAddReposSetting();
       this.refreshCharts(true);
       this.$refs.addExtensionReposDialog.showDialog();
     },
@@ -745,14 +746,13 @@ export default {
         <Banner
           v-if="showAddReposBanner"
           color="warning"
-          class="mb-20"
-          :closable="true"
+          class="add-repos-banner mb-20"
           data-testid="extensions-new-repos-banner"
-          @close="updateAddReposSetting"
         >
           <span>{{ t('plugins.addRepos.banner', {}, true) }}</span>
           <button
             class="ml-10 btn btn-sm role-primary"
+            data-testid="extensions-new-repos-banner-action-btn"
             @click="showAddExtensionReposDialog()"
           >
             {{ t('plugins.addRepos.bannerBtn') }}
@@ -1237,9 +1237,14 @@ export default {
       }
     }
   }
-
   ::v-deep .checkbox-label {
     font-weight: normal !important;
+  }
+
+  ::v-deep .add-repos-banner .banner__content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 
   @media screen and (max-width: 1200px) {


### PR DESCRIPTION
Fixes #9214 

- sneaky-fix to address misformatted banner on extensions for partners repo

**Before**
![Screenshot 2023-07-18 at 06 45 42](https://github.com/rancher/dashboard/assets/97888974/bc3a3f46-9152-4a25-aa0b-ebe07532f883)

**After**
![Screenshot 2023-07-18 at 10 23 57](https://github.com/rancher/dashboard/assets/97888974/3d42451d-9d15-4132-950e-77a8832ec08f)

