### PR TITLE
Re-enable standard user page not found tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,10 @@ jobs:
       - name: Run standard user tests
         if: ${{ success() || failure() }}
         run: |
-          yarn e2e:prod && yarn docker:local:stop
+          yarn e2e:prod
+          echo "Result of e2e $?"
+          yarn docker:local:stop
+          echo "Result of docker $?"
           mkdir -p coverage-artifacts/coverage
           cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,9 +57,7 @@ jobs:
         if: ${{ success() || failure() }}
         run: |
           yarn e2e:prod
-          echo "Result of e2e $?"
           yarn docker:local:stop
-          echo "Result of docker $?"
           mkdir -p coverage-artifacts/coverage
           cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 

--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -91,16 +91,27 @@ export default class SortableTablePo extends ComponentPo {
     return new ListRowPo(this.rowElementWithName(name));
   }
 
-  rowNames() {
-    return this.rowElements().find('.cluster-link').then(($els: any) => {
+  /**
+   * Get rows names. To avoid the 'no rows' on first load use `noRowsShouldNotExist`
+   */
+  rowNames(rowNameSelector = 'td:nth-of-type(3)') {
+    return this.rowElements().find(rowNameSelector).then(($els: any) => {
       return (
-        Cypress.$.makeArray($els).map((el: any) => el.innerText)
+        Cypress.$.makeArray<string>($els).map((el: any) => el.innerText as string)
       );
     });
   }
 
   rowActionMenu() {
     return new ActionMenuPo();
+  }
+
+  noRowsShouldNotExist() {
+    return this.noRowsText().should('not.exist');
+  }
+
+  noRowsText() {
+    return this.self().find('tbody').find('.no-rows');
   }
 
   /**

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -6,6 +6,8 @@ import ActionMenuPo from '@/cypress/e2e/po/components/action-menu.po';
 import NameNsDescriptionPo from '@/cypress/e2e/po/components/name-ns-description.po';
 import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
+import BannersPo from '~/cypress/e2e/po/components/banners.po';
+import ComponentPo from '~/cypress/e2e/po/components/component.po';
 
 export default class ExtensionsPagePo extends PagePo {
   static url = '/c/local/uiplugins'
@@ -26,6 +28,14 @@ export default class ExtensionsPagePo extends PagePo {
    */
   title(): Cypress.Chainable<string> {
     return this.self().getId('extensions-page-title').invoke('text');
+  }
+
+  waitForTitle() {
+    return this.title().should('contain', 'Extensions');
+  }
+
+  loading() {
+    return this.self().get('.data-loading');
   }
 
   /**
@@ -202,6 +212,11 @@ export default class ExtensionsPagePo extends PagePo {
 
   extensionReloadClick(): Cypress.Chainable {
     return this.extensionReloadBanner().getId('extension-reload-banner-reload-btn').click();
+  }
+
+  // ------------------ new repos banner ------------------
+  repoBanner() {
+    return new BannersPo('[data-testid="extensions-new-repos-banner"]', this.self());
   }
 
   // ------------------ extension menu ------------------

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -7,7 +7,6 @@ import NameNsDescriptionPo from '@/cypress/e2e/po/components/name-ns-description
 import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
 import BannersPo from '~/cypress/e2e/po/components/banners.po';
-import ComponentPo from '~/cypress/e2e/po/components/component.po';
 
 export default class ExtensionsPagePo extends PagePo {
   static url = '/c/local/uiplugins'

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -7,16 +7,16 @@ import NameNsDescriptionPo from '@/cypress/e2e/po/components/name-ns-description
 import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
 
-export default class ExtensionsPo extends PagePo {
+export default class ExtensionsPagePo extends PagePo {
   static url = '/c/local/uiplugins'
   static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
-    return super.goTo(ExtensionsPo.url);
+    return super.goTo(ExtensionsPagePo.url);
   }
 
   extensionTabs: TabbedPo;
 
   constructor() {
-    super(ExtensionsPo.url);
+    super(ExtensionsPagePo.url);
 
     this.extensionTabs = new TabbedPo('[data-testid="extension-tabs"]');
   }

--- a/cypress/e2e/po/pages/extensions/kubewarden.po.ts
+++ b/cypress/e2e/po/pages/extensions/kubewarden.po.ts
@@ -1,5 +1,5 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
-import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
+import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
 
 export default class KubewardenExtensionPo extends PagePo {
   private static createPath(clusterId: string) {
@@ -16,7 +16,7 @@ export default class KubewardenExtensionPo extends PagePo {
 
   /** add ui-plugin-charts repository */
   addChartsRepoIfNeeded(): void {
-    const extensionsPo: ExtensionsPo = new ExtensionsPo();
+    const extensionsPo: ExtensionsPagePo = new ExtensionsPagePo();
 
     extensionsPo.waitForPage();
 

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -57,7 +57,7 @@ export default class HomePagePo extends PagePo {
     return new HomeClusterListPo('[data-testid="cluster-list-container"]');
   }
 
-  manangeButton() {
+  manageButton() {
     return cy.getId('cluster-management-manage-button');
   }
 

--- a/cypress/e2e/po/side-bars/user-menu.po.ts
+++ b/cypress/e2e/po/side-bars/user-menu.po.ts
@@ -28,11 +28,15 @@ export default class UserMenuPo extends ComponentPo {
   }
 
   /**
-   * Toggle user menu
-   * @returns
+   * Open the user menu
+   *
+   * Multiple clicks because sometimes just one ... isn't enough
+   *
    */
-  toggle(): Cypress.Chainable {
-    return this.self().click();
+  open(): Cypress.Chainable {
+    this.self().click();
+    this.self().click();
+    this.self().click();
   }
 
   /**
@@ -56,12 +60,12 @@ export default class UserMenuPo extends ComponentPo {
           if ($el.attr('style')?.includes('visibility: hidden')) {
             cy.log('User Avatar open but hidden, giving it a nudge');
 
-            return this.toggle();
+            return this.open();
           }
         } else {
           cy.log('User Avatar not open, opening');
 
-          return this.toggle();
+          return this.open();
         }
       })
       .then(() => this.isOpen());
@@ -87,13 +91,9 @@ export default class UserMenuPo extends ComponentPo {
    * @param label
    * @returns
    */
-  clickMenuItem(label: string) {
-    this.ensureOpen()
-      .then(() => this.ensureOpen())
-      .then(() => this.ensureOpen())
-      .then(() => this.ensureOpen())
-      .then(() => {
-        return this.getMenuItems().contains(label).click();
-      });
+  clickMenuItem(label: 'Preferences' | 'Account & API Keys' | 'Log Out') {
+    this.ensureOpen().then(() => {
+      return this.getMenuItems().contains(label).click();
+    });
   }
 }

--- a/cypress/e2e/po/side-bars/user-menu.po.ts
+++ b/cypress/e2e/po/side-bars/user-menu.po.ts
@@ -37,6 +37,7 @@ export default class UserMenuPo extends ComponentPo {
     this.self().click();
     this.self().click();
     this.self().click();
+    this.self().click();
   }
 
   /**

--- a/cypress/e2e/po/side-bars/user-menu.po.ts
+++ b/cypress/e2e/po/side-bars/user-menu.po.ts
@@ -88,8 +88,12 @@ export default class UserMenuPo extends ComponentPo {
    * @returns
    */
   clickMenuItem(label: string) {
-    this.ensureOpen().then(() => {
-      return this.getMenuItems().contains(label).click();
-    });
+    this.ensureOpen()
+      .then(() => this.ensureOpen())
+      .then(() => this.ensureOpen())
+      .then(() => this.ensureOpen())
+      .then(() => {
+        return this.getMenuItems().contains(label).click();
+      });
   }
 }

--- a/cypress/e2e/tests/navigation/not-found-page.spec.ts
+++ b/cypress/e2e/tests/navigation/not-found-page.spec.ts
@@ -1,16 +1,16 @@
 import NotFoundPagePo from '@/cypress/e2e/po/pages/not-found-page.po';
-import ClusterManagerListPagePo from '~/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
-import { WorkloadsPodsListPagePo } from '~/cypress/e2e/po/pages/explorer/workloads-pods.po';
-import WorkloadListPagePo from '~/cypress/e2e/po/pages/explorer/workloads.po';
-import HomePagePo from '~/cypress/e2e/po/pages/home.po';
-import PagePo from '~/cypress/e2e/po/pages/page.po';
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import { WorkloadsPodsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-pods.po';
+import WorkloadListPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import PagePo from '@/cypress/e2e/po/pages/page.po';
 
-describe('Not found page display', () => {
+describe('Not found page display', { tags: ['@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });
 
-  it('Will show a 404 if we do not have a valid Product id on the route path', { tags: ['@adminUser', '@standardUser'] }, () => {
+  it('Will show a 404 if we do not have a valid Product id on the route path', () => {
     const notFound = new NotFoundPagePo('/c/_/bogus-product-id');
 
     notFound.goTo();
@@ -20,7 +20,7 @@ describe('Not found page display', () => {
     notFound.errorMessage().contains('Product bogus-product-id not found');
   });
 
-  it('Will show a 404 if we do not have a valid Resource type on the route path', { tags: ['@adminUser', '@standardUser'] }, () => {
+  it('Will show a 404 if we do not have a valid Resource type on the route path', () => {
     const notFound = new NotFoundPagePo('/c/_/manager/bogus-resource-type');
 
     notFound.goTo();
@@ -30,7 +30,7 @@ describe('Not found page display', () => {
     notFound.errorMessage().contains('Resource type bogus-resource-type not found');
   });
 
-  it('Will show a 404 if we do not have a valid Resource id on the route path', { tags: ['@adminUser', '@standardUser'] }, () => {
+  it('Will show a 404 if we do not have a valid Resource id on the route path', () => {
     const notFound = new NotFoundPagePo('/c/_/manager/provisioning.cattle.io.cluster/fleet-default/bogus-resource-id');
 
     notFound.goTo();
@@ -40,7 +40,7 @@ describe('Not found page display', () => {
     notFound.errorMessage().contains('Resource provisioning.cattle.io.cluster with id fleet-default/bogus-resource-id not found, unable to display resource details');
   });
 
-  it('Will show a 404 if we do not have a valid product + resource + resource id', { tags: ['@adminUser', '@standardUser'] }, () => {
+  it('Will show a 404 if we do not have a valid product + resource + resource id', () => {
     const notFound = new NotFoundPagePo('/c/_/bogus-product-id/bogus-resource/bogus-resource-id');
 
     notFound.goTo();
@@ -50,7 +50,7 @@ describe('Not found page display', () => {
     notFound.errorMessage().contains('Product bogus-product-id not found');
   });
 
-  it('Will not show a 404 if we have a valid product + resource', { tags: ['@adminUser', '@standardUser'] }, () => {
+  it('Will not show a 404 if we have a valid product + resource', () => {
     const clusterManager = new NotFoundPagePo('/c/_/manager/provisioning.cattle.io.cluster');
 
     clusterManager.goTo();
@@ -58,7 +58,7 @@ describe('Not found page display', () => {
     clusterManager.errorTitle().should('not.exist');
   });
 
-  it('Will not show a 404 for a valid type from the Norman API', { tags: ['@adminUser', '@standardUser'] }, () => {
+  it('Will not show a 404 for a valid type from the Norman API', () => {
     const cloudCredCreatePage = new NotFoundPagePo('/c/_/manager/cloudCredential/create');
 
     cloudCredCreatePage.goTo();
@@ -66,7 +66,7 @@ describe('Not found page display', () => {
     cloudCredCreatePage.errorTitle().should('not.exist');
   });
 
-  it('Will not show a 404 for a valid type that does not have a real schema', { tags: '@adminUser' }, () => {
+  it('Will not show a 404 for a valid type that does not have a real schema', () => {
     const workloadPage = new NotFoundPagePo('/c/local/explorer/workload');
 
     workloadPage.goTo();
@@ -74,7 +74,7 @@ describe('Not found page display', () => {
     workloadPage.errorTitle().should('not.exist');
   });
 
-  it('Will not show a 404 if we have a valid product + resource and we nav to page', { tags: '@adminUser' }, () => {
+  it('Will not show a 404 if we have a valid product + resource and we nav to page', () => {
     const page = new PagePo('');
     const homePage = new HomePagePo();
     const notFoundPage = new NotFoundPagePo('');

--- a/cypress/e2e/tests/pages/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/cluster-manager.spec.ts
@@ -120,7 +120,7 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
         clusterList.sortableTable().rowElementWithName(rke2CustomName).should('exist', { timeout: 15000 });
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
 
-        clusterList.sortableTable().rowNames().then((rows: any) => {
+        clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
           const promptRemove = new PromptRemove();
 
           promptRemove.confirm(rke2CustomName);
@@ -128,7 +128,7 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
 
           clusterList.waitForPage();
           clusterList.sortableTable().checkRowCount(false, rows.length - 1);
-          clusterList.sortableTable().rowNames().should('not.contain', rke2CustomName);
+          clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', rke2CustomName);
         });
       });
     });
@@ -257,7 +257,7 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
         clusterList.sortableTable().bulkActionDropDownOpen();
         clusterList.sortableTable().bulkActionDropDownButton('Delete').click();
 
-        clusterList.sortableTable().rowNames().then((rows: any) => {
+        clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
           const promptRemove = new PromptRemove();
 
           promptRemove.confirm(importGenericName);
@@ -265,7 +265,7 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
 
           clusterList.waitForPage();
           clusterList.sortableTable().checkRowCount(false, rows.length - 1);
-          clusterList.sortableTable().rowNames().should('not.contain', importGenericName);
+          clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', importGenericName);
         });
       });
     });

--- a/cypress/e2e/tests/pages/explorer/api/api-services.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/api/api-services.spec.ts
@@ -14,7 +14,7 @@ describe('Cluster Explorer', { tags: ['@adminUser'] }, () => {
       apiServicesPage.waitForRequests();
     });
 
-    it('Should be able to use shift+j to select corre', () => {
+    it('Should be able to use shift+j to select rows and the count of selected is correct', () => {
       apiServicesPage.title().should('contain', 'APIServices');
 
       const sortableTable = apiServicesPage.sortableTable();

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -1,4 +1,4 @@
-import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
+import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
 import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
 
 const EXTENSION_NAME = 'clock';
@@ -8,8 +8,10 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   before(() => {
     cy.login();
 
-    ExtensionsPo.goTo();
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.goTo();
+    extensionsPo.waitForPage();
 
     // install extensions operator if it's not installed
     extensionsPo.installExtensionsOperatorIfNeeded();
@@ -20,11 +22,11 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
 
   beforeEach(() => {
     cy.login();
-    ExtensionsPo.goTo();
+    ExtensionsPagePo.goTo();
   });
 
   it('using "Add Rancher Repositories" should add a new repository (Partners repo)', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     // go to "add rancher repositories"
     extensionsPo.extensionMenuToggle();
@@ -43,7 +45,7 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('Should disable and enable extension support', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     // open menu and click on disable extension support
     extensionsPo.extensionMenuToggle();
@@ -60,7 +62,8 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
 
     // wait for operation to finish and refresh...
     extensionsPo.extensionTabs.checkVisible();
-    ExtensionsPo.goTo();
+    extensionsPo.goTo();
+    extensionsPo.waitForPage();
 
     // let's make sure all went good
     extensionsPo.extensionTabAvailableClick();
@@ -68,19 +71,20 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('New repos banner should only appear once (after dismiss should NOT appear again)', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.self().find('[data-testid="extensions-new-repos-banner-action-btn"]').click();
     extensionsPo.self().find('[data-testid="extensions-new-repos-banner"]').should('not.exist');
 
     // let's refresh the page to make sure it doesn't appear again...
-    ExtensionsPo.goTo();
+    extensionsPo.goTo();
+    extensionsPo.waitForPage();
     extensionsPo.title().should('contain', 'Extensions');
     extensionsPo.self().find('[data-testid="extensions-new-repos-banner"]').should('not.exist');
   });
 
   it('Should toggle the extension details', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.extensionTabAvailableClick();
 
@@ -108,7 +112,7 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('Should install an extension', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.extensionTabAvailableClick();
 
@@ -132,7 +136,7 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('Should update an extension version', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.extensionTabInstalledClick();
 
@@ -151,7 +155,7 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('Should rollback an extension version', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.extensionTabInstalledClick();
 
@@ -170,7 +174,7 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('Should uninstall an extension', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.extensionTabInstalledClick();
 

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -1,8 +1,10 @@
 import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
 import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
+import PromptRemove from '~/cypress/e2e/po/prompts/promptRemove.po';
 
 const EXTENSION_NAME = 'clock';
-const PARTNERS_REPO_URL = 'https://github.com/rancher/partner-extensions';
+const UI_PLUGINS_PARTNERS_REPO_URL = 'https://github.com/rancher/partner-extensions';
+const UI_PLUGINS_PARTNERS_REPO_NAME = 'partner-extensions';
 
 describe('Extensions page', { tags: '@adminUser' }, () => {
   before(() => {
@@ -22,11 +24,12 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
 
   beforeEach(() => {
     cy.login();
-    ExtensionsPagePo.goTo();
   });
 
   it('using "Add Rancher Repositories" should add a new repository (Partners repo)', () => {
     const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.goTo();
 
     // go to "add rancher repositories"
     extensionsPo.extensionMenuToggle();
@@ -41,11 +44,13 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
 
     appRepoList.goTo();
     appRepoList.waitForPage();
-    appRepoList.sortableTable().rowElementWithName(PARTNERS_REPO_URL).should('exist');
+    appRepoList.sortableTable().rowElementWithName(UI_PLUGINS_PARTNERS_REPO_URL).should('exist');
   });
 
   it('Should disable and enable extension support', () => {
     const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.goTo();
 
     // open menu and click on disable extension support
     extensionsPo.extensionMenuToggle();
@@ -71,25 +76,50 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('New repos banner should only appear once (after dismiss should NOT appear again)', () => {
+    const appRepoList = new ReposListPagePo('local', 'apps');
+
+    // Ensure that the banner should be shown (by confirming that a required repo isn't there)
+    appRepoList.goTo();
+    appRepoList.waitForPage();
+    appRepoList.sortableTable().noRowsShouldNotExist();
+    appRepoList.sortableTable().rowNames().then((names) => {
+      if (names.includes(UI_PLUGINS_PARTNERS_REPO_NAME)) {
+        appRepoList.list().actionMenu(UI_PLUGINS_PARTNERS_REPO_NAME).getMenuItem('Delete').click();
+        const promptRemove = new PromptRemove();
+
+        return promptRemove.remove();
+      }
+    });
+
+    // Now go to extensions (by nav, not page load....)
+    appRepoList.navToMenuEntry('Extensions');
+
     const extensionsPo = new ExtensionsPagePo();
 
-    extensionsPo.self().find('[data-testid="extensions-new-repos-banner-action-btn"]').click();
-    extensionsPo.self().find('[data-testid="extensions-new-repos-banner"]').should('not.exist');
+    extensionsPo.waitForPage();
+    extensionsPo.loading().should('not.exist');
+
+    extensionsPo.repoBanner().checkVisible();
+    extensionsPo.repoBanner().self().find('[data-testid="extensions-new-repos-banner-action-btn"]').click();
+    extensionsPo.repoBanner().checkNotExists();
 
     // let's refresh the page to make sure it doesn't appear again...
     extensionsPo.goTo();
     extensionsPo.waitForPage();
-    extensionsPo.title().should('contain', 'Extensions');
-    extensionsPo.self().find('[data-testid="extensions-new-repos-banner"]').should('not.exist');
+    extensionsPo.waitForTitle();
+    extensionsPo.loading().should('not.exist');
+    extensionsPo.repoBanner().checkNotExists();
   });
 
   it('Should toggle the extension details', () => {
     const extensionsPo = new ExtensionsPagePo();
 
+    extensionsPo.goTo();
+
     extensionsPo.extensionTabAvailableClick();
 
     // we should be on the extensions page
-    extensionsPo.title().should('contain', 'Extensions');
+    extensionsPo.waitForTitle();
 
     // show extension details
     extensionsPo.extensionCardClick(EXTENSION_NAME);
@@ -113,6 +143,8 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
 
   it('Should install an extension', () => {
     const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.goTo();
 
     extensionsPo.extensionTabAvailableClick();
 
@@ -138,6 +170,8 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   it('Should update an extension version', () => {
     const extensionsPo = new ExtensionsPagePo();
 
+    extensionsPo.goTo();
+
     extensionsPo.extensionTabInstalledClick();
 
     // click on update button on card
@@ -157,6 +191,8 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   it('Should rollback an extension version', () => {
     const extensionsPo = new ExtensionsPagePo();
 
+    extensionsPo.goTo();
+
     extensionsPo.extensionTabInstalledClick();
 
     // click on the rollback button on card
@@ -175,6 +211,8 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
 
   it('Should uninstall an extension', () => {
     const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.goTo();
 
     extensionsPo.extensionTabInstalledClick();
 

--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -76,6 +76,22 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
   });
 
   it('New repos banner should only appear once (after dismiss should NOT appear again)', () => {
+    cy.getRancherResource('v3', 'setting', 'display-add-extension-repos-banner', null).then((resp: Cypress.Response<any>) => {
+      const notFound = resp.status === 404;
+      const requiredValue = resp.body?.value === 'true';
+
+      if (notFound || requiredValue) {
+        cy.log('Good test state', '/v3/setting/display-add-extension-repos-banner', resp.status, JSON.stringify(resp?.body || {}));
+      } else {
+        cy.log('Bad test state', '/v3/setting/display-add-extension-repos-banner', resp.status, JSON.stringify(resp?.body || {}));
+
+        return cy.setRancherResource('v3', 'setting', 'display-add-extension-repos-banner', {
+          ...resp.body,
+          value: 'true'
+        });
+      }
+    });
+
     const appRepoList = new ReposListPagePo('local', 'apps');
 
     // Ensure that the banner should be shown (by confirming that a required repo isn't there)

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -1,4 +1,4 @@
-import ExtensionsPo from '@/cypress/e2e/po/pages/extensions.po';
+import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
 import { ChartsPage } from '@/cypress/e2e/po/pages/charts.po';
 import ReposListPagePo from '@/cypress/e2e/po/pages/repositories.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
@@ -10,8 +10,8 @@ describe('Kubewarden Extension', { tags: '@adminUser' }, () => {
   before(() => {
     cy.login();
 
-    ExtensionsPo.goTo();
-    const extensionsPo = new ExtensionsPo();
+    ExtensionsPagePo.goTo();
+    const extensionsPo = new ExtensionsPagePo();
     const kubewardenPo = new KubewardenExtensionPo();
 
     // install extensions operator if it's not installed
@@ -21,11 +21,11 @@ describe('Kubewarden Extension', { tags: '@adminUser' }, () => {
 
   beforeEach(() => {
     cy.login();
-    ExtensionsPo.goTo();
+    ExtensionsPagePo.goTo();
   });
 
   it('Should install Kubewarden extension', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.extensionTabAvailableClick();
 
@@ -83,7 +83,7 @@ describe('Kubewarden Extension', { tags: '@adminUser' }, () => {
   });
 
   it('Should uninstall Kubewarden', () => {
-    const extensionsPo = new ExtensionsPo();
+    const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.extensionTabInstalledClick();
 

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -16,7 +16,7 @@ describe('Home Page', () => {
 
   it('Can navigate to What\'s new page', { tags: ['@adminUser', '@standardUser'] }, () => {
     /**
-     * Verify changlog banner is hidden after clicking link
+     * Verify changelog banner is hidden after clicking link
      * Verify release notes link is valid github page
      */
     const text: string[] = [];
@@ -128,7 +128,7 @@ describe('Home Page', () => {
     const clusterManagerPage = new ClusterManagerListPagePo('_');
     const genericCreateClusterPage = new ClusterManagerImportGenericPagePo('_');
 
-    homePage.manangeButton().click();
+    homePage.manageButton().click();
     clusterManagerPage.waitForPage();
 
     HomePagePo.goToAndWaitForGet();

--- a/cypress/e2e/tests/pages/login.spec.ts
+++ b/cypress/e2e/tests/pages/login.spec.ts
@@ -1,5 +1,7 @@
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
 
+const successStatusCode = 200;
+
 describe('Local authentication', { tags: ['@adminUser', '@standardUser'] }, () => {
   it('Log in with valid credentials', () => {
     LoginPagePo.goTo();
@@ -8,7 +10,11 @@ describe('Local authentication', { tags: ['@adminUser', '@standardUser'] }, () =
     cy.login(Cypress.env('username'), Cypress.env('password'), false);
 
     cy.wait('@loginReq').then((login) => {
-      expect(login.response?.statusCode).to.equal(200);
+      if (login.response?.statusCode !== successStatusCode) {
+        cy.log('Login incorrectly failed', login.response?.statusCode, login.response?.statusMessage, JSON.stringify(login.response?.body || {}));
+      }
+      expect(login.response?.statusCode).to.equal(successStatusCode);
+
       cy.url().should('not.equal', `${ Cypress.config().baseUrl }/auth/login`);
     });
   });
@@ -21,7 +27,11 @@ describe('Local authentication', { tags: ['@adminUser', '@standardUser'] }, () =
     cy.login(Cypress.env('username'), `${ Cypress.env('password') }abc`, false);
 
     cy.wait('@loginReq').then((login) => {
-      expect(login.response?.statusCode).to.not.equal(200);
+      if (login.response?.statusCode === successStatusCode) {
+        cy.log('Login incorrectly succeeded', login.response?.statusCode, login.response?.statusMessage, JSON.stringify(login.response?.body || {}));
+      }
+      expect(login.response?.statusCode).to.not.equal(successStatusCode);
+
       // URL is partial as it may change based on the authentication configuration present
       cy.url().should('include', `${ Cypress.config().baseUrl }/auth/login`);
     });

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -50,6 +50,14 @@ describe('Rancher setup', { tags: '@adminUser' }, () => {
     cy.login();
 
     // Note: the username argument here should match the TEST_USERNAME env var used when running non-admin tests
-    cy.createUser('standard_user', 'user');
+    cy.createUser({
+      username:    'standard_user0',
+      globalRole:  { role: 'user' },
+      projectRole: {
+        clusterId:   'local',
+        projectName: 'Default',
+        role:        'project-member',
+      }
+    });
   });
 });

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -51,7 +51,7 @@ describe('Rancher setup', { tags: '@adminUser' }, () => {
 
     // Note: the username argument here should match the TEST_USERNAME env var used when running non-admin tests
     cy.createUser({
-      username:    'standard_user0',
+      username:    'standard_user',
       globalRole:  { role: 'user' },
       projectRole: {
         clusterId:   'local',

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -1,4 +1,5 @@
 import { Verbs } from '@shell/types/api';
+import { UserPreferences } from '@shell/types/userPreferences';
 
 type Matcher = '$' | '^' | '~' | '*' | '';
 
@@ -9,9 +10,13 @@ declare namespace Cypress {
     state(state: any): any;
 
     login(username?: string, password?: string, cacheSession?: boolean): Chainable<Element>;
-    byLabel(label: string,): Chainable<Element>;
+    byLabel(label: string): Chainable<Element>;
+
     createUser(username: string, role?: string): Chainable;
     setGlobalRoleBinding(userId: string, role: string): Chainable;
+    setClusterRoleBinding(clusterId: string, userPrincipalId: string, role: string): Chainable;
+    setProjectRoleBinding(clusterId: string, userPrincipalId: string, projectName: string, role: string): Chainable;
+    getProject(clusterId: string, projectName: string): Chainable;
 
     /**
      *  Wrapper for cy.get() to simply define the data-testid value that allows you to pass a matcher to find the element.

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -3,6 +3,22 @@ import { UserPreferences } from '@shell/types/userPreferences';
 
 type Matcher = '$' | '^' | '~' | '*' | '';
 
+export type CreateUserParams = {
+  username: string,
+  globalRole?: {
+    role: string,
+  },
+  clusterRole?: {
+    clusterId: string,
+    role: string,
+  },
+  projectRole?: {
+    clusterId: string,
+    projectName: string,
+    role: string,
+  }
+}
+
 // eslint-disable-next-line no-unused-vars
 declare namespace Cypress {
   interface Chainable {
@@ -12,7 +28,7 @@ declare namespace Cypress {
     login(username?: string, password?: string, cacheSession?: boolean): Chainable<Element>;
     byLabel(label: string): Chainable<Element>;
 
-    createUser(username: string, role?: string): Chainable;
+    createUser(params: CreateUserParams): Chainable;
     setGlobalRoleBinding(userId: string, role: string): Chainable;
     setClusterRoleBinding(clusterId: string, userPrincipalId: string, role: string): Chainable;
     setProjectRoleBinding(clusterId: string, userPrincipalId: string, projectName: string, role: string): Chainable;

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -32,7 +32,10 @@ declare namespace Cypress {
     setGlobalRoleBinding(userId: string, role: string): Chainable;
     setClusterRoleBinding(clusterId: string, userPrincipalId: string, role: string): Chainable;
     setProjectRoleBinding(clusterId: string, userPrincipalId: string, projectName: string, role: string): Chainable;
-    getProject(clusterId: string, projectName: string): Chainable;
+    getProjectByName(clusterId: string, projectName: string): Chainable;
+
+    getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, expectedStatusCode: string): Chainable;
+    setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
 
     /**
      *  Wrapper for cy.get() to simply define the data-testid value that allows you to pass a matcher to find the element.

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -88,7 +88,7 @@ Cypress.Commands.add('createUser', (username, role?) => {
         const userPrincipalId = resp.body.principalIds[0];
 
         if (role) {
-          return cy.setGlobalRoleBinding(userPrincipalId, role)
+          return cy.setGlobalRoleBinding(resp.body.id, role)
             .then(() => cy.setClusterRoleBinding('local', userPrincipalId, 'cluster-member'))
             .then(() => cy.setProjectRoleBinding('local', userPrincipalId, 'Default', 'project-member'));
         }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -89,7 +89,6 @@ Cypress.Commands.add('createUser', (username, role?) => {
 
         if (role) {
           return cy.setGlobalRoleBinding(resp.body.id, role)
-            .then(() => cy.setClusterRoleBinding('local', userPrincipalId, 'cluster-member'))
             .then(() => cy.setProjectRoleBinding('local', userPrincipalId, 'Default', 'project-member'));
         }
       }

--- a/cypress/support/commands/commands.ts
+++ b/cypress/support/commands/commands.ts
@@ -1,0 +1,52 @@
+import { Matcher } from '@/cypress/support/types';
+
+/**
+ * Get input field for given label
+ */
+Cypress.Commands.add('byLabel', (label) => {
+  return cy.get('.labeled-input').contains(label).siblings('input');
+});
+
+/**
+ * Wrap the cy.find() command to simplify the selector declaration of the data-testid
+ */
+Cypress.Commands.add('findId', (id: string, matcher?: Matcher = '') => {
+  return cy.find(`[data-testid${ matcher }="${ id }"]`);
+});
+
+/**
+ * Wrap the cy.get() command to simplify the selector declaration of the data-testid
+ */
+Cypress.Commands.add('getId', (id: string, matcher?: Matcher = '') => {
+  return cy.get(`[data-testid${ matcher }="${ id }"]`);
+});
+
+Cypress.Commands.add('keyboardControls', (triggerKeys: any = {}, count = 1) => {
+  for (let i = 0; i < count; i++) {
+    cy.get('body').trigger('keydown', triggerKeys);
+  }
+});
+
+/**
+ * Intercept all requests and return
+ * @param {array} intercepts - Array of intercepts to return
+ * return {array} - Array of intercepted request strings
+ * return {string} - Intercepted request string
+ */
+Cypress.Commands.add('interceptAllRequests', (method = '/GET/POST/PUT/PATCH/', urls = ['/v1/*']) => {
+  const interceptedUrls: string[] = urls.map((cUrl, i) => {
+    cy.intercept(method, cUrl).as(`interceptAllRequests${ i }`);
+
+    return `@interceptAllRequests${ i }`;
+  });
+
+  return cy.wrap(interceptedUrls);
+});
+
+Cypress.Commands.add('iFrame', () => {
+  return cy
+    .get('[data-testid="ember-iframe"]', { log: false })
+    .its('0.contentDocument.body', { log: false })
+    .should('not.be.empty')
+    .then((body) => cy.wrap(body));
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,5 +1,6 @@
 import '@cypress/code-coverage/support';
-import './commands';
+import './commands/commands';
+import './commands/rancher-api-commands.ts';
 import registerCypressGrep from '@cypress/grep/src/support';
 
 registerCypressGrep();

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -103,7 +103,7 @@ export default {
         `Determine etcd metrics`
       );
 
-      if (this.currentCluster.isLocal) {
+      if (this.currentCluster.isLocal && this.$store.getters['management/schemaFor'](MANAGEMENT.NODE)) {
         this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
       }
     }

--- a/shell/types/userPreferences.d.ts
+++ b/shell/types/userPreferences.d.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-interface UserPreferences {
+export interface UserPreferences {
   'after-login-route': string,
   cluster: string,
   'group-by': string,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Following on from https://github.com/rancher/dashboard/pull/9338
- Add standard user to project in local cluster, which gives pods visibility,
  - new commands to add cluster and project roles. also to find a project
    - We should make a helper functions / framework for making http requests to rancher in cypress
- Run not found tests as both admin and non-admin

Also
- Fixed issue where user's who can get to the 'local' cluster dashboard page but do not have access to mgmt nodes won't see a warning of failure to fetch mgmt nodes
- Possibly fixed an issue where failures when running the standard users tests did not result in the gh workflow to fail
- "Improve" user avatar open yet again
- Improve flaky `New repos banner should only appear once (after dismiss should NOT appear again)` test (ensure banner is shown... to test it's shown)
- Add better logging to login test to debug 422 response when logging in
