### PR TITLE
Fix issue where new param was not included in old test

### DIFF
--- a/cypress/e2e/po/pages/explorer/api-services.po.ts
+++ b/cypress/e2e/po/pages/explorer/api-services.po.ts
@@ -15,7 +15,7 @@ export class APIServicesPagePo extends PagePo {
   }
 
   waitForRequests() {
-    APIServicesPagePo.goToAndWaitForGet(this.goTo.bind(this), ['/v1/apiregistration.k8s.io.apiservices']);
+    APIServicesPagePo.goToAndWaitForGet(this.goTo.bind(this), ['/v1/apiregistration.k8s.io.apiservices?exclude=metadata.managedFields']);
   }
 
   resourcesList() {


### PR DESCRIPTION
### Summary
- Caused by new excludeParam missing from url check
- the old test wasn't run given it lacked grep tag
- the pr that brought in excludeParam was in this state
- at some point the old test was enabled (sans excludeParam change)


