### PR TITLE
check mgmt store and norman store before throwing resource not found

### DIFF
--- a/cypress/e2e/tests/navigation/not-found-page.spec.ts
+++ b/cypress/e2e/tests/navigation/not-found-page.spec.ts
@@ -58,6 +58,14 @@ describe('Not found page display', () => {
     clusterManager.errorTitle().should('not.exist');
   });
 
+  it('Will not show a 404 for a valid type from the Norman API', { tags: ['@adminUser', '@standardUser'] }, () => {
+    const cloudCredCreatePage = new NotFoundPagePo('/c/_/manager/cloudCredential/create');
+
+    cloudCredCreatePage.goTo();
+    cloudCredCreatePage.waitForPage();
+    cloudCredCreatePage.errorTitle().should('not.exist');
+  });
+
   it('Will not show a 404 for a valid type that does not have a real schema', { tags: '@adminUser' }, () => {
     const workloadPage = new NotFoundPagePo('/c/local/explorer/workload');
 

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -83,16 +83,18 @@ export default {
       default: 'resource-details'
     }
   },
+
   async fetch() {
     const store = this.$store;
     const route = this.$route;
     const params = route.params;
-    const inStore = this.storeOverride || store.getters['currentStore'](params.resource);
+    let resource = this.resourceOverride || params.resource;
+
+    const inStore = this.storeOverride || store.getters['currentStore'](resource);
     const realMode = this.realMode;
 
     // eslint-disable-next-line prefer-const
     let { namespace, id } = params;
-    let resource = this.resourceOverride || params.resource;
 
     // There are 6 "real" modes that can be put into the query string
     // These are mapped down to the 3 regular page "mode"s that create-edit-view components

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -38,6 +38,10 @@ export function init(store) {
         resource: CAPI.RANCHER_CLUSTER
       }
     },
+    typeStoreMap: {
+      [NORMAN.CLOUD_CREDENTIAL]: 'rancher',
+      cloudCredential:           'rancher',
+    }
   });
 
   virtualType({

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -128,6 +128,8 @@ function invalidResource(store, to, redirect) {
   const product = store.getters['currentProduct'];
   const inStore = product?.inStore;
   const schemaFor = store.getters[`${ inStore }/schemaFor`]; // There's a chance we're in an extension's product who's store could be anything
+  const mgmtSchemaFor = store.getters['management/schemaFor']; // inStore/schemaFor wont cover management resources in downstream clusters
+  const rancherSchemaFor = store.getters['rancher/schemaFor']; // pages may reference a norman type in url eg cloud credentials
   const resource = getResourceFromRoute(to);
 
   // In order to check a resource is valid we need all of these
@@ -136,7 +138,7 @@ function invalidResource(store, to, redirect) {
   }
 
   // Resource is valid if a schema exists for it (standard resource, spoofed resource) or it's a virtual resource
-  const validResource = schemaFor(resource) || store.getters['type-map/isVirtual'](resource);
+  const validResource = schemaFor(resource) || store.getters['type-map/isVirtual'](resource) || mgmtSchemaFor(resource) || rancherSchemaFor(resource);
 
   if (validResource) {
     return false;

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -126,19 +126,25 @@ function setProduct(store, to, redirect) {
  */
 function invalidResource(store, to, redirect) {
   const product = store.getters['currentProduct'];
-  const inStore = product?.inStore;
-  const schemaFor = store.getters[`${ inStore }/schemaFor`]; // There's a chance we're in an extension's product who's store could be anything
-  const mgmtSchemaFor = store.getters['management/schemaFor']; // inStore/schemaFor wont cover management resources in downstream clusters
-  const rancherSchemaFor = store.getters['rancher/schemaFor']; // pages may reference a norman type in url eg cloud credentials
   const resource = getResourceFromRoute(to);
 
-  // In order to check a resource is valid we need all of these
-  if (!product || !inStore || !schemaFor || !resource) {
+  // In order to check a resource is valid we need these
+  if (!product || !resource) {
+    return false;
+  }
+
+  // Note - don't use the current products store... because products can override stores for resources with `typeStoreMap`
+  const inStore = store.getters['currentStore'](resource);
+  // There's a chance we're in an extension's product who's store could be anything, so confirm schemaFor exists
+  const schemaFor = store.getters[`${ inStore }/schemaFor`];
+
+  // In order to check a resource is valid we need these
+  if (!inStore || !schemaFor) {
     return false;
   }
 
   // Resource is valid if a schema exists for it (standard resource, spoofed resource) or it's a virtual resource
-  const validResource = schemaFor(resource) || store.getters['type-map/isVirtual'](resource) || mgmtSchemaFor(resource) || rancherSchemaFor(resource);
+  const validResource = schemaFor(resource) || store.getters['type-map/isVirtual'](resource);
 
   if (validResource) {
     return false;

--- a/shell/pages/c/_cluster/manager/cloudCredential/_id.vue
+++ b/shell/pages/c/_cluster/manager/cloudCredential/_id.vue
@@ -9,7 +9,6 @@ export default {
 
 <template>
   <ResourceDetail
-    store-override="rancher"
     resource-override="cloudcredential"
     parent-route-override="c-cluster-manager-cloudCredential"
   />

--- a/shell/pages/c/_cluster/manager/cloudCredential/create.vue
+++ b/shell/pages/c/_cluster/manager/cloudCredential/create.vue
@@ -9,7 +9,6 @@ export default {
 
 <template>
   <ResourceDetail
-    store-override="rancher"
     resource-override="cloudcredential"
     parent-route-override="c-cluster-manager-cloudCredential"
   />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9377
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR also prevents the same 'resource not found' error from being shown on the cloud credential creation screen.

### Technical notes summary
Currently we're checking the current cluster's store for the existence of a given resource - in downstream clusters, this store wont include management resources that appear on eg cluster membership list view and project creation. I looked around and found one page that references a norman type in the url, cloud creds, so I added the rancher store to the schema check as well.

I didn't add a test for the cluster membership view as I think we need a downstream cluster present to catch the error reported in 9377. I'm leaving the tags in the test I did add to verify that CI passes - when https://github.com/rancher/dashboard/pull/9360 is merged this PR should be rebased + those individual test tags removed.


### Areas or cases that should be tested
* cluster membership list view in downstream clusters
* project create/edit in downstream clusters
* cloud cred create/edit
