### PR TITLE
improve location config cross-check with path param

### DIFF
--- a/docusaurus/docs/extensions/api/common.md
+++ b/docusaurus/docs/extensions/api/common.md
@@ -61,6 +61,7 @@ The admissible parameters for the `LocationConfig` object are:
 |`product`| Array | Array of the product identifier. Ex: `fleet`, `manager` (Cluster Management), `harvesterManager` (Virtualization Management), `explorer` (Cluster Explorer) or `home` (Homepage) |
 |`resource`| Array | Array of the identifier of the kubernetes resource to be bound to. Ex: `apps.deployment`, `storage.k8s.io.storageclass` or `secret`  |
 |`namespace`| Array | Array of the namespace identifier. Ex: `kube-system`, `cattle-global-data` or `cattle-system` |
+|`path`| Array | Array of objects that does matching for the `path` part of the url. Admissable properties for the object are: `urlPath` (string), `exact` (boolean, default or omission: `true`, which defines the type of match it does) and `endsWith` (boolean, defaults to false) .Ex: { `urlPath`: '/c/local/explorer/projectsnamespaces',  `exact`: true } or { `urlPath`: 'explorer/projectsnamespaces',  `endsWith`: true } |
 |`cluster`| Array | Array of the cluster identifier. Ex: `local` |
 |`id`| Array | Array of the identifier for a given resource. Ex: `deployment-unt6xmz` |
 |`mode`| Array | Array of modes which relates to the type of view on which the given enhancement should be applied. Admissible values are: `edit`, `config`, `detail` and `list` |

--- a/docusaurus/docs/extensions/api/common.md
+++ b/docusaurus/docs/extensions/api/common.md
@@ -56,17 +56,17 @@ With this it's then possible to easily identify the parameters needed to populat
 
 The admissible parameters for the `LocationConfig` object are:
 
-| Key | Type | Description |
-|---|---|---|
-|`product`| Array | Array of the product identifier. Ex: `fleet`, `manager` (Cluster Management), `harvesterManager` (Virtualization Management), `explorer` (Cluster Explorer) or `home` (Homepage) |
-|`resource`| Array | Array of the identifier of the kubernetes resource to be bound to. Ex: `apps.deployment`, `storage.k8s.io.storageclass` or `secret`  |
-|`namespace`| Array | Array of the namespace identifier. Ex: `kube-system`, `cattle-global-data` or `cattle-system` |
-|`path`| Array | Array of objects that does matching for the `path` part of the url. Admissable properties for the object are: `urlPath` (string), `exact` (boolean, default or omission: `true`, which defines the type of match it does) and `endsWith` (boolean, defaults to false) .Ex: { `urlPath`: '/c/local/explorer/projectsnamespaces',  `exact`: true } or { `urlPath`: 'explorer/projectsnamespaces',  `endsWith`: true } |
-|`cluster`| Array | Array of the cluster identifier. Ex: `local` |
-|`id`| Array | Array of the identifier for a given resource. Ex: `deployment-unt6xmz` |
-|`mode`| Array | Array of modes which relates to the type of view on which the given enhancement should be applied. Admissible values are: `edit`, `config`, `detail` and `list` |
-|`context` | Object | Requirements set by the context itself. This is a key value object that must match the object provided where the feature is used. For instance if a ResourceTab should only include a tab given specific information where the ResourceTab is used. Ex `{ provider: "digitalocean" }` |
-| `queryParam` | Object | This is a key value object that must match the url's query param key values
+| Key | Compatible Version | Type | Description |
+|---|---|---|---|
+|`product`| `v2.7.2` | Array | Array of the product identifier. Ex: `fleet`, `manager` (Cluster Management), `harvesterManager` (Virtualization Management), `explorer` (Cluster Explorer) or `home` (Homepage) |
+|`resource`| `v2.7.2` | Array | Array of the identifier of the kubernetes resource to be bound to. Ex: `apps.deployment`, `storage.k8s.io.storageclass` or `secret`  |
+|`namespace`| `v2.7.2` | Array | Array of the namespace identifier. Ex: `kube-system`, `cattle-global-data` or `cattle-system` |
+|`path`| `v2.7.7` | Array | Array of objects that does matching for the `path` part of the url. Admissable properties for the object are: `urlPath` (string), `exact` (boolean, default or omission: `true`, which defines the type of match it does) and `endsWith` (boolean, defaults to false) .Ex: { `urlPath`: '/c/local/explorer/projectsnamespaces',  `exact`: true } or { `urlPath`: 'explorer/projectsnamespaces',  `endsWith`: true } |
+|`cluster`| `v2.7.2` | Array | Array of the cluster identifier. Ex: `local` |
+|`id`| `v2.7.2` | Array | Array of the identifier for a given resource. Ex: `deployment-unt6xmz` |
+|`mode`| `v2.7.2` | Array | Array of modes which relates to the type of view on which the given enhancement should be applied. Admissible values are: `edit`, `config`, `detail` and `list` |
+|`context`| `v2.7.2`| Object | Requirements set by the context itself. This is a key value object that must match the object provided where the feature is used. For instance if a ResourceTab should only include a tab given specific information where the ResourceTab is used. Ex `{ provider: "digitalocean" }` |
+| `queryParam`| `v2.7.2` | Object | This is a key value object that must match the url's query param key values
 
 ### LocationConfig Examples
 

--- a/shell/core/plugin-helpers.js
+++ b/shell/core/plugin-helpers.js
@@ -52,6 +52,7 @@ function checkExtensionRouteBinding($route, locationConfig, context) {
     'cluster',
     'id',
     'mode',
+    'path',
     // url query params
     'queryParam',
     // Custom context specific params provided by the extension, not to be confused with location params
@@ -79,8 +80,18 @@ function checkExtensionRouteBinding($route, locationConfig, context) {
           } else if (param === 'context') {
             // Need all keys and values to match
             res = isEqual(locationConfigParam, context);
+            // evaluate queryParam in route
           } else if (param === 'queryParam') {
             res = isEqual(locationConfigParam, $route.query);
+            // evaluate path in route
+          } else if (param === 'path' && locationConfigParam.urlPath) {
+            if (locationConfigParam.endsWith) {
+              res = $route.path.endsWith(locationConfigParam.urlPath);
+            } else if (!Object.keys(locationConfigParam).includes('exact') || locationConfigParam.exact) {
+              res = locationConfigParam.urlPath === $route.path;
+            } else {
+              res = $route.path.includes(locationConfigParam.urlPath);
+            }
           } else if (locationConfigParam === params[param]) {
             res = true;
           } else {

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -140,6 +140,10 @@ export type LocationConfig = {
   id?: string[],
   mode?: string[],
   /**
+   * path match from URL (excludes host address)
+   */
+  path?: { [key: string]: string | boolean}[],
+  /**
    * Query Params from URL
    */
   queryParam?: { [key: string]: string},


### PR DESCRIPTION
Fixes #9384 

- Update `locationConfig` cross-check to use a new `path` param when using extensions API

## How to test
- create a new package `yarn create @rancher/pkg test`
- try and add a new table col with `path` to `projectnamespaces` page