### PR TITLE
Fix how custom cluster drivers identify themselves

### DIFF
--- a/shell/models/management.cattle.io.kontainerdriver.js
+++ b/shell/models/management.cattle.io.kontainerdriver.js
@@ -15,8 +15,10 @@ export const KONTAINER_TO_DRIVER = {
   huaweicontainercloudengine:       'huaweicce', // Does this actually exist?
   huaweiengine:                     'huaweicce',
   linodekubernetesengine:           'linodelke', // Does this actually exist?
+  lke:                              'linodelke',
   lkeengine:                        'linodelke',
   okeengine:                        'oracleoke',
+  oke:                              'oracleoke',
   oraclecontainerengine:            'oracleoke', // Does this actually exist?
   rke2:                             'rke2',
   tencentengine:                    'tencenttke',
@@ -63,6 +65,18 @@ export default class KontainerDriver extends HybridModel {
   }
 
   get driverName() {
+    if (!this.spec.builtIn) {
+      // if the driver is not built in, there's a good change its a custom one
+      // custom drivers have a random id, so shouldn't be used as the type
+      // instead use the status.displayName. this will map to the name extracted from the binary
+      const driverName = this.status?.displayName?.toLowerCase();
+
+      if (driverName) {
+        // some drivers are built in but don't have the builtIn flag. ensure we pass these through K_TO_D
+        return KONTAINER_TO_DRIVER[driverName] || driverName;
+      }
+    }
+
     return KONTAINER_TO_DRIVER[this.id] || this.id;
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/6810
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- the dashboard uses the kontainerdriver id for things like images, text and also to provide embedded ember with a key to identify the cluster ... and which custom ui to use
- this works fine when the id is the type of kontainerdriver
- this doesn't if the kontainerdriver is custom and has a random id
  - for these cases use the status.displayName 
- everything is done via the driverName (id, and also ember key) so fix it there

> The localised name and logo for the custom driver card come from the dashboard. creators of custom cluster drivers will need to create an extension with those in. 

### Technical notes summary
See repo steps in https://github.com/rancher/dashboard/issues/6810

### Areas or cases that should be tested
- provisioning different types of cluster drivers

### Areas which could experience regressions
- i've tested EKS, other built in ones should be tested as well
- a good one to test would be linode. i have no creds for that though

### Screenshot/Video
![image](https://github.com/rancher/dashboard/assets/18697775/cc2424c7-3726-47c5-812e-b1ea06667f42)

![image](https://github.com/rancher/dashboard/assets/18697775/24b387de-dc25-4a6d-810c-439dc7750920)

![image](https://github.com/rancher/dashboard/assets/18697775/56d26833-6749-4b17-b833-4af42eb4bd9a)

> Note the `This is custom UX for mydriver` which proves out the custom ui is used for the custom driver

