### PR TITLE
Changed navlink page and improved error handling for FileImageUpload

### DIFF
--- a/docusaurus/docs/code-base-works/forms-and-validation.md
+++ b/docusaurus/docs/code-base-works/forms-and-validation.md
@@ -70,6 +70,8 @@ While individual fields are typically responsible for displaying their own valid
 To use the `form-validation` mixin, import the mixin and include it in `mixins` in the component like any other mixin. Once included, ensure the following:
 1. Set the "validation-passed" property on the `CruResource` component to "fvFormIsValid" (computed property provided by the mixin). This conditionally disables the "save" button on the form.
 2. Set the "errors" property on the `CruResource` component to "fvUnreportedValidationErrors" (computed property provided by the mixin) or some other value that aggregates errors not otherwise shown in the form as a fallback means of displaying error state to the user.
+3. Add ":rules" to the input component to bind validation rule to the field.
+
 
 The `form-validation` mixin itself includes most of the information a developer will need to use it in comments in the file itself but a high-level summary would cover the following points:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,8 @@ module.exports = {
   transform: {
     '^.+\\.js$':   '<rootDir>/node_modules/babel-jest', // process js with `babel-jest`
     '.*\\.(vue)$': '<rootDir>/node_modules/@vue/vue2-jest', // process `*.vue` files with `vue-jest`
-    '^.+\\.tsx?$': 'ts-jest' // process `*.ts` files with `ts-jest`
+    '^.+\\.tsx?$': 'ts-jest', // process `*.ts` files with `ts-jest`
+    '^.+\\.svg$':  '<rootDir>/svgTransform.js' // to mock `*.svg` files
   },
   snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],
   collectCoverage:     false,

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3512,10 +3512,13 @@ navLink:
         label: Group name
         tooltip: Assign link to a group
       sideLabel:
-        label: Link Label
+        label: Link label
       description:
         label: Link description
+    groupImage:
+      label: Group Image
       iconSrc:
+        tip: 'Image height should be 21 pixels with a max width of 200 pixels. Max file size is 20KB. Accepted formats: JPEG, PNG, SVG.'
         label: Add image
 networkpolicy:
   egress:

--- a/shell/components/LazyImage.vue
+++ b/shell/components/LazyImage.vue
@@ -3,12 +3,12 @@ export default {
   props: {
     initialSrc: {
       type:    String,
-      default: require('~shell/assets/images/generic-catalog.svg'),
+      default: require('@shell/assets/images/generic-catalog.svg'),
     },
 
     errorSrc: {
       type:    String,
-      default: require('~shell/assets/images/generic-catalog.svg'),
+      default: require('@shell/assets/images/generic-catalog.svg'),
     },
 
     src: {

--- a/shell/components/form/FileImageSelector.vue
+++ b/shell/components/form/FileImageSelector.vue
@@ -3,6 +3,8 @@ import LazyImage from '@shell/components/LazyImage';
 import FileSelector from '@shell/components/form/FileSelector';
 import { _VIEW } from '@shell/config/query-params';
 
+import { IMAGE_TYPE } from '@shell/utils/fileTypes';
+
 export default {
   components: { FileSelector, LazyImage },
   props:      {
@@ -35,6 +37,9 @@ export default {
   computed: {
     isView() {
       return this.mode === _VIEW;
+    },
+    getImageType() {
+      return IMAGE_TYPE;
     }
   },
   methods: {
@@ -44,6 +49,9 @@ export default {
      */
     setIcon(event) {
       this.$emit('input', event);
+    },
+    setError(error) {
+      this.$emit('error', error);
     }
   }
 };
@@ -58,7 +66,9 @@ export default {
     :read-as-data-url="true"
     :byte-limit="byteLimit"
     :label="label"
+    :fileType="getImageType"
     @selected="setIcon"
+    @error="setError"
   />
 
   <div

--- a/shell/components/form/FileImageSelector.vue
+++ b/shell/components/form/FileImageSelector.vue
@@ -3,8 +3,6 @@ import LazyImage from '@shell/components/LazyImage';
 import FileSelector from '@shell/components/form/FileSelector';
 import { _VIEW } from '@shell/config/query-params';
 
-import { IMAGE_TYPE } from '@shell/utils/fileTypes';
-
 export default {
   components: { FileSelector, LazyImage },
   props:      {
@@ -33,13 +31,14 @@ export default {
       type:    Number,
       default: 200000
     },
+    accept: {
+      type:    String,
+      default: 'image/*'
+    }
   },
   computed: {
     isView() {
       return this.mode === _VIEW;
-    },
-    getImageType() {
-      return IMAGE_TYPE;
     }
   },
   methods: {
@@ -66,7 +65,7 @@ export default {
     :read-as-data-url="true"
     :byte-limit="byteLimit"
     :label="label"
-    :fileType="getImageType"
+    :accept="accept"
     @selected="setIcon"
     @error="setError"
   />

--- a/shell/components/form/FileSelector.vue
+++ b/shell/components/form/FileSelector.vue
@@ -1,6 +1,20 @@
 <script>
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import { set } from '@shell/utils/object';
+import { IMAGE_TYPE } from '@shell/utils/fileTypes';
+const SVG_TYPE = 'image/svg+xml';
+const IMAGE_MIMES = [
+  {
+    mime:    'image/jpeg',
+    pattern: [0xFF, 0xD8, 0xFF],
+    mask:    [0xFF, 0xFF, 0xFF],
+  },
+  {
+    mime:    'image/png',
+    pattern: [0x89, 0x50, 0x4E, 0x47],
+    mask:    [0xFF, 0xFF, 0xFF, 0xFF],
+  }
+];
 
 export function createOnSelected(field) {
   return function(contents) {
@@ -63,7 +77,13 @@ export default {
     accept: {
       type:    String,
       default: '*'
-    }
+    },
+
+    fileType: {
+      type:    String,
+      default: ''
+    },
+
   },
 
   computed: {
@@ -93,6 +113,18 @@ export default {
         }
       }
 
+      if (this.fileType === IMAGE_TYPE) {
+        for (const file of files) {
+          const isImage = await this.checkIsImage(file);
+
+          if (!isImage) {
+            this.$emit('error', `${ file.name } is not an image.`);
+
+            return;
+          }
+        }
+      }
+
       if (this.rawData) {
         const unboxedContents = !this.multiple && files.length === 1 ? files[0] : files;
 
@@ -113,6 +145,45 @@ export default {
           this.$store.dispatch('growl/fromError', { title: 'Error reading file', error }, { root: true });
         }
       }
+    },
+
+    checkMime(bytes, mime) {
+      for (let i = 0, l = mime.mask.length; i < l; ++i) {
+        if ((bytes[i] & mime.mask[i]) - mime.pattern[i] !== 0) {
+          return false;
+        }
+      }
+
+      return true;
+    },
+
+    async checkIsImage(file) {
+      return new Promise((resolve, reject) => {
+        if (file.type === SVG_TYPE) {
+          resolve(true);
+        }
+        const blob = file.slice(0, 4);
+
+        const reader = new FileReader();
+
+        reader.onloadend = (e) => {
+          if (e.target.readyState === FileReader.DONE) {
+            const bytes = new Uint8Array(e.target.result);
+
+            for (let i = 0, l = IMAGE_MIMES.length; i < l; ++i) {
+              if (this.checkMime(bytes, IMAGE_MIMES[i])) {
+                resolve(true);
+              }
+            }
+
+            resolve(false);
+          }
+        };
+        reader.onerror = (err) => {
+          reject(err);
+        };
+        reader.readAsArrayBuffer(blob);
+      });
     },
 
     getFileContents(file) {

--- a/shell/components/form/FileSelector.vue
+++ b/shell/components/form/FileSelector.vue
@@ -1,20 +1,6 @@
 <script>
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import { set } from '@shell/utils/object';
-import { IMAGE_TYPE } from '@shell/utils/fileTypes';
-const SVG_TYPE = 'image/svg+xml';
-const IMAGE_MIMES = [
-  {
-    mime:    'image/jpeg',
-    pattern: [0xFF, 0xD8, 0xFF],
-    mask:    [0xFF, 0xFF, 0xFF],
-  },
-  {
-    mime:    'image/png',
-    pattern: [0x89, 0x50, 0x4E, 0x47],
-    mask:    [0xFF, 0xFF, 0xFF, 0xFF],
-  }
-];
 
 export function createOnSelected(field) {
   return function(contents) {
@@ -79,11 +65,6 @@ export default {
       default: '*'
     },
 
-    fileType: {
-      type:    String,
-      default: ''
-    },
-
   },
 
   computed: {
@@ -113,18 +94,6 @@ export default {
         }
       }
 
-      if (this.fileType === IMAGE_TYPE) {
-        for (const file of files) {
-          const isImage = await this.checkIsImage(file);
-
-          if (!isImage) {
-            this.$emit('error', `${ file.name } is not an image.`);
-
-            return;
-          }
-        }
-      }
-
       if (this.rawData) {
         const unboxedContents = !this.multiple && files.length === 1 ? files[0] : files;
 
@@ -145,45 +114,6 @@ export default {
           this.$store.dispatch('growl/fromError', { title: 'Error reading file', error }, { root: true });
         }
       }
-    },
-
-    checkMime(bytes, mime) {
-      for (let i = 0, l = mime.mask.length; i < l; ++i) {
-        if ((bytes[i] & mime.mask[i]) - mime.pattern[i] !== 0) {
-          return false;
-        }
-      }
-
-      return true;
-    },
-
-    async checkIsImage(file) {
-      return new Promise((resolve, reject) => {
-        if (file.type === SVG_TYPE) {
-          resolve(true);
-        }
-        const blob = file.slice(0, 4);
-
-        const reader = new FileReader();
-
-        reader.onloadend = (e) => {
-          if (e.target.readyState === FileReader.DONE) {
-            const bytes = new Uint8Array(e.target.result);
-
-            for (let i = 0, l = IMAGE_MIMES.length; i < l; ++i) {
-              if (this.checkMime(bytes, IMAGE_MIMES[i])) {
-                resolve(true);
-              }
-            }
-
-            resolve(false);
-          }
-        };
-        reader.onerror = (err) => {
-          reject(err);
-        };
-        reader.readAsArrayBuffer(blob);
-      });
     },
 
     getFileContents(file) {

--- a/shell/components/form/__tests__/FileImageSelector.test.ts
+++ b/shell/components/form/__tests__/FileImageSelector.test.ts
@@ -1,0 +1,41 @@
+import FileImageSelector from '@shell/components/form/FileImageSelector';
+import { mount } from '@vue/test-utils';
+import FileSelector from '@shell/components/form/FileSelector';
+
+describe('component: FileImageSelector', () => {
+  let wrapper: any;
+
+  beforeEach(() => {
+    wrapper = mount(FileImageSelector, {
+      propsData: { label: 'upload' },
+      mocks:     {},
+      methods:   {},
+    });
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  it('should render', () => {
+    const uploadButton = wrapper.find('.btn');
+
+    expect(wrapper.isVisible()).toBe(true);
+    expect(uploadButton.exists()).toBeTruthy();
+  });
+  it('should throw error if file could not be uploaded', async() => {
+    const fs = wrapper.findComponent(FileSelector);
+
+    expect(fs.exists()).toBeTruthy();
+    await fs.vm.$emit('error');
+
+    expect(wrapper.emitted('error')).toHaveLength(1);
+  });
+
+  it('should emit input on image upload', async() => {
+    const fs = wrapper.findComponent(FileSelector);
+
+    await fs.vm.$emit('selected');
+    expect(wrapper.emitted('input')).toHaveLength(1);
+  });
+});

--- a/shell/components/form/__tests__/FileImageSelector.test.ts
+++ b/shell/components/form/__tests__/FileImageSelector.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-hooks */
 import FileImageSelector from '@shell/components/form/FileImageSelector';
 import { mount } from '@vue/test-utils';
 import FileSelector from '@shell/components/form/FileSelector';

--- a/shell/components/form/__tests__/FileSelector.test.ts
+++ b/shell/components/form/__tests__/FileSelector.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-hooks */
 import FileSelector from '@shell/components/form/FileSelector';
 import { mount } from '@vue/test-utils';
 

--- a/shell/components/form/__tests__/FileSelector.test.ts
+++ b/shell/components/form/__tests__/FileSelector.test.ts
@@ -64,6 +64,7 @@ describe('component: FileSelector', () => {
       methods:   {},
     });
     const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
+    const readAsTextSpy = jest.spyOn(FileReader.prototype, 'readAsText');
 
     const event = {
       target: {
@@ -75,7 +76,8 @@ describe('component: FileSelector', () => {
 
     await wrapper.vm.fileChange(event);
     expect(wrapper.emitted('selected')).toHaveLength(1);
-    expect(readAsArrayBufferSpy).toHaveBeenCalled();
+    expect(readAsArrayBufferSpy).toHaveBeenCalledWith(jpegBlobFile.slice(0, 4));
+    expect(readAsTextSpy).toHaveBeenCalledWith(jpegBlobFile);
   });
   it('should fail when expects an image but got json', async() => {
     wrapper = mount(FileSelector, {
@@ -84,6 +86,7 @@ describe('component: FileSelector', () => {
       methods:   {},
     });
     const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
+    const readAsTextSpy = jest.spyOn(FileReader.prototype, 'readAsText');
 
     const event = {
       target: {
@@ -95,6 +98,7 @@ describe('component: FileSelector', () => {
 
     await wrapper.vm.fileChange(event);
     expect(wrapper.emitted('error')).toHaveLength(1);
-    expect(readAsArrayBufferSpy).toHaveBeenCalled();
+    expect(readAsArrayBufferSpy).toHaveBeenCalledWith(jsonBlobFile.slice(0, 4));
+    expect(readAsTextSpy).not.toHaveBeenCalledWith(jsonBlobFile);
   });
 });

--- a/shell/components/form/__tests__/FileSelector.test.ts
+++ b/shell/components/form/__tests__/FileSelector.test.ts
@@ -1,0 +1,99 @@
+import FileSelector from '@shell/components/form/FileSelector';
+import { mount } from '@vue/test-utils';
+
+describe('component: FileSelector', () => {
+  let wrapper: any;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  const binaryString = Buffer.from('/9j/4AAQSkZJRgABAQAASABIAAD/4QCARXhpZgAATU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAKgAgAEAAAAAQAAADmgAwAEAAAAAQAAAFEAAAAA/+0AOFBob3Rvc2hvcCAzLjAAOEJJTQQEAAAAAAAAOEJJTQQlAAAAAAAQ1B2M2Y8AsgTpgAmY7PhCfv/iAihJQ0NfUFJPRklMRQABAQAAAhgAAAAABDAAAG1udHJSR0IgWFlaIAAAAAAAAAAAAAAAAGFjc3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD21gABAAAAANMtAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACWRlc2MAAADwAAAAdHJYWVoAAAFkAAAAFGdYWVoAAAF4AAAAFGJYWVoAAAGMAAAAFHJUUkMAAAGgAAAAKGdUUkMAAAGgAAAAKGJUUkMAAAGgAAAAKHd0cHQAAAHIAAAAFGNwcnQAAAHcAAAAPG1sdWMAAAAAAAAAAQAAAAxlblVTAAAAWAAAABwAcwBSAEcAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWFlaIAAAAAAAAG+iAAA49QAAA5BYWVogAAAAAAAAYpkAALeFAAAY2lhZWiAAAAAAAAAkoAAAD4QAALbPcGFyYQAAAAAABAAAAAJmZgAA8qcAAA1ZAAAT0AAAClsAAAAAAAAAAFhZWiAAAAAAAAD21gABAAAAANMtbWx1YwAAAAAAAAABAAAADGVuVVMAAAAgAAAAHABHAG8AbwBnAGwAZQAgAEkAbgBjAC4AIAAyADAAMQA2/8AAEQgAUQA5AwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/bAEMAEAsMDgwKEA4NDhIREBMYKBoYFhYYMSMlHSg6Mz08OTM4N0BIXE5ARFdFNzhQbVFXX2JnaGc+TXF5cGR4XGVnY//bAEMBERISGBUYLxoaL2NCOEJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY//dAAQABP/aAAwDAQACEQMRAD8AdRRRX0B4gUUUUAFFFFABRRRQB//QdRRRX0B4gUUUUAFFFFABRRRQB//RdRRRX0B4gUUUUAFFFFABRRRQB//SdRRRX0B4gUUUUAFFFFABRRRQB//TdRRRX0B4gUUUUAFFFFAwooooA//UdRRRX0B4gUUUUAFFFFAwooooA//Z', 'base64'); // Binary data string
+  const jpegBlobFile = new Blob([binaryString], { type: 'image/jpeg' });
+  const obj = { hello: 'world' };
+  const jsonBlobFile = new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' });
+
+  it('should render', () => {
+    wrapper = mount(FileSelector, {
+      propsData: { label: 'upload' },
+      mocks:     {},
+      methods:   {},
+    });
+
+    const uploadButton = wrapper.find('.btn');
+
+    expect(wrapper.isVisible()).toBe(true);
+    expect(uploadButton.exists()).toBeTruthy();
+  });
+  it('should identify image correctly', async() => {
+    wrapper = mount(FileSelector, {
+      propsData: { label: 'upload', fileType: 'img' },
+      mocks:     {},
+      methods:   {},
+    });
+    const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
+
+    const testCases =
+    [
+      {
+        file:   jpegBlobFile,
+        result: true
+      },
+      {
+        file:   jsonBlobFile,
+        result: false
+      }
+    ];
+
+    for (const testCase of testCases) {
+      const res = await wrapper.vm.checkIsImage(testCase.file);
+
+      expect(res).toBe(testCase.result);
+
+      expect(readAsArrayBufferSpy).toHaveBeenCalledWith(testCase.file.slice(0, 4));
+    }
+  });
+  it('should succeed when loading an image', async() => {
+    wrapper = mount(FileSelector, {
+      propsData: { label: 'upload', fileType: 'img' },
+      mocks:     {},
+      methods:   {},
+    });
+    const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
+
+    const event = {
+      target: {
+        files: [
+          jpegBlobFile
+        ]
+      }
+    };
+
+    await wrapper.vm.fileChange(event);
+    expect(wrapper.emitted('selected')).toHaveLength(1);
+    expect(readAsArrayBufferSpy).toHaveBeenCalled();
+  });
+  it('should fail when expects an image but got json', async() => {
+    wrapper = mount(FileSelector, {
+      propsData: { label: 'upload', fileType: 'img' },
+      mocks:     {},
+      methods:   {},
+    });
+    const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
+
+    const event = {
+      target: {
+        files: [
+          jsonBlobFile
+        ]
+      }
+    };
+
+    await wrapper.vm.fileChange(event);
+    expect(wrapper.emitted('error')).toHaveLength(1);
+    expect(readAsArrayBufferSpy).toHaveBeenCalled();
+  });
+});

--- a/shell/components/form/__tests__/FileSelector.test.ts
+++ b/shell/components/form/__tests__/FileSelector.test.ts
@@ -29,41 +29,13 @@ describe('component: FileSelector', () => {
     expect(wrapper.isVisible()).toBe(true);
     expect(uploadButton.exists()).toBeTruthy();
   });
-  it('should identify image correctly', async() => {
-    wrapper = mount(FileSelector, {
-      propsData: { label: 'upload', fileType: 'img' },
-      mocks:     {},
-      methods:   {},
-    });
-    const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
 
-    const testCases =
-    [
-      {
-        file:   jpegBlobFile,
-        result: true
-      },
-      {
-        file:   jsonBlobFile,
-        result: false
-      }
-    ];
-
-    for (const testCase of testCases) {
-      const res = await wrapper.vm.checkIsImage(testCase.file);
-
-      expect(res).toBe(testCase.result);
-
-      expect(readAsArrayBufferSpy).toHaveBeenCalledWith(testCase.file.slice(0, 4));
-    }
-  });
   it('should succeed when loading an image', async() => {
     wrapper = mount(FileSelector, {
-      propsData: { label: 'upload', fileType: 'img' },
+      propsData: { label: 'upload', accept: 'image/jpeg,image/png,image/svg+xml' },
       mocks:     {},
       methods:   {},
     });
-    const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
     const readAsTextSpy = jest.spyOn(FileReader.prototype, 'readAsText');
 
     const event = {
@@ -76,29 +48,29 @@ describe('component: FileSelector', () => {
 
     await wrapper.vm.fileChange(event);
     expect(wrapper.emitted('selected')).toHaveLength(1);
-    expect(readAsArrayBufferSpy).toHaveBeenCalledWith(jpegBlobFile.slice(0, 4));
     expect(readAsTextSpy).toHaveBeenCalledWith(jpegBlobFile);
   });
-  it('should fail when expects an image but got json', async() => {
+
+  it('should fail when file is too big', async() => {
     wrapper = mount(FileSelector, {
-      propsData: { label: 'upload', fileType: 'img' },
-      mocks:     {},
-      methods:   {},
+      propsData: {
+        label: 'upload', accept: 'image/jpeg,image/png,image/svg+xml', byteLimit: 10
+      },
+      mocks:   {},
+      methods: {},
     });
-    const readAsArrayBufferSpy = jest.spyOn(FileReader.prototype, 'readAsArrayBuffer');
     const readAsTextSpy = jest.spyOn(FileReader.prototype, 'readAsText');
 
     const event = {
       target: {
         files: [
-          jsonBlobFile
+          jpegBlobFile
         ]
       }
     };
 
     await wrapper.vm.fileChange(event);
     expect(wrapper.emitted('error')).toHaveLength(1);
-    expect(readAsArrayBufferSpy).toHaveBeenCalledWith(jsonBlobFile.slice(0, 4));
     expect(readAsTextSpy).not.toHaveBeenCalledWith(jsonBlobFile);
   });
 });

--- a/shell/edit/__tests__/ui.cattle.io.navlink.test.ts
+++ b/shell/edit/__tests__/ui.cattle.io.navlink.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-hooks */
 import { mount } from '@vue/test-utils';
 import Navlink from '@shell/edit/ui.cattle.io.navlink.vue';
 import { _CREATE } from '@shell/config/query-params';

--- a/shell/edit/__tests__/ui.cattle.io.navlink.test.ts
+++ b/shell/edit/__tests__/ui.cattle.io.navlink.test.ts
@@ -1,0 +1,109 @@
+import { mount } from '@vue/test-utils';
+import Navlink from '@shell/edit/ui.cattle.io.navlink.vue';
+import { _CREATE } from '@shell/config/query-params';
+import CruResource from '@shell/components/CruResource';
+
+describe('view: ui.cattle.io.navlink should', () => {
+  const name = 'test';
+  const url = 'http://test.com';
+  let wrapper: any;
+
+  const requiredSetup = () => ({
+    // Remove all these mocks after migration to Vue 2.7/3 due mixin logic
+    mocks: {
+      $store: {
+        getters: {
+          currentStore:              () => 'current_store',
+          'current_store/schemaFor': jest.fn(),
+          'current_store/all':       jest.fn(),
+          'i18n/t':                  (val) => val,
+          'i18n/exists':             jest.fn(),
+        }
+      },
+      $route:  { query: { AS: '' } },
+      $router: { applyQuery: jest.fn() },
+    },
+    propsData: {
+      metadata:   { namespace: 'test' },
+      spec:       { template: {} },
+      targetInfo: { mode: 'all' },
+      value:      {},
+      mode:       _CREATE,
+    },
+
+  });
+
+  beforeEach(() => {
+    wrapper = mount(Navlink, { ...requiredSetup() });
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  it('have "Create" button disabled before fields are filled in', () => {
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+    expect(saveButton.disabled).toBe(true);
+  });
+  it('have "Create" button disabled when Link type is URL and only name is filled in', async() => {
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+    const nameField = wrapper.find('[data-testid="Navlink-name-field"]').find('input');
+
+    nameField.setValue(name);
+
+    await wrapper.vm.$nextTick();
+
+    expect(saveButton.disabled).toBe(true);
+  });
+  it('have "Create" button enabled when Link type is URL and all required fields are filled in', async() => {
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+    const nameField = wrapper.find('[data-testid="Navlink-name-field"]').find('input');
+    const urlField = wrapper.find('[data-testid="Navlink-url-field"]');
+
+    nameField.setValue(name);
+    urlField.setValue(url);
+
+    await wrapper.vm.$nextTick();
+
+    expect(saveButton.disabled).toBe(false);
+  });
+
+  it('have "Create" button disabled when Link type is Service and and only name is filled in', async() => {
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+    const nameField = wrapper.find('[data-testid="Navlink-name-field"]').find('input');
+    const rg = wrapper.find('[data-testid="Navlink-link-radiogroup"]');
+
+    const serviceBttn = rg.findAll('.radio-label').at(1);
+
+    nameField.setValue(name);
+    serviceBttn.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(saveButton.disabled).toBe(true);
+  });
+
+  it('have "Create" button enabled when Link type is Service and and all required fields are filled in', async() => {
+    const nameField = wrapper.find('[data-testid="Navlink-name-field"]').find('input');
+    const rg = wrapper.find('[data-testid="Navlink-link-radiogroup"]');
+
+    const serviceBttn = rg.findAll('.radio-label').at(1);
+
+    nameField.setValue(name);
+    serviceBttn.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    const schemeField = wrapper.find('[data-testid="Navlink-scheme-field"]');
+    const serviceField = wrapper.find('[data-testid="Navlink-currentService-field"]');
+
+    schemeField.find('button').trigger('click');
+    await wrapper.trigger('keydown.down');
+    await wrapper.trigger('keydown.enter');
+
+    serviceField.find('button').trigger('click');
+    await wrapper.trigger('keydown.down');
+    await wrapper.trigger('keydown.enter');
+
+    expect(CruResource.computed.canSave()).toBe(true);
+  });
+});

--- a/shell/edit/ui.cattle.io.navlink.vue
+++ b/shell/edit/ui.cattle.io.navlink.vue
@@ -7,11 +7,10 @@ import CruResource from '@shell/components/CruResource';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
 import FileImageSelector from '@shell/components/form/FileImageSelector';
-import NameNsDescription from '@shell/components/form/NameNsDescription';
-import Tab from '@shell/components/Tabbed/Tab';
-import Tabbed from '@shell/components/Tabbed';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
-import { normalizeName } from '@shell/utils/kube';
+import NameNsDescription, { normalizeName } from '@shell/components/form/NameNsDescription';
+import { Banner } from '@components/Banner';
+import FormValidation from '@shell/mixins/form-validation';
 
 const LINK_TYPE_URL = 'url';
 const LINK_TYPE_SERVICE = 'service';
@@ -20,16 +19,15 @@ const LINK_TARGET_BLANK = '_blank';
 const LINK_TARGET_SELF = '_self';
 
 export default {
-  mixins:     [CreateEditView],
+  mixins:     [CreateEditView, FormValidation],
   components: {
     CruResource,
     LabeledInput,
     RadioGroup,
     NameNsDescription,
-    Tabbed,
-    Tab,
     FileImageSelector,
-    LabeledSelect
+    LabeledSelect,
+    Banner
   },
   data() {
     return {
@@ -57,12 +55,19 @@ export default {
           label: this.t('navLink.tabs.link.type.service')
         }
       ],
-      currentLinkType:  null,
-      targetName:       null,
-      currentTarget:    LINK_TARGET_BLANK,
-      protocolsOptions: PROTOCOLS,
-      services:         [],
-      currentService:   null,
+      currentLinkType:   null,
+      targetName:        null,
+      currentTarget:     LINK_TARGET_BLANK,
+      protocolsOptions:  PROTOCOLS,
+      services:          [],
+      currentService:    null,
+      imageErrorMessage: '',
+      fvFormRuleSets:    [
+        { path: 'metadata.name', rules: ['nameRequired'] },
+        { path: 'spec.toURL', rules: ['urlRequired'] },
+        { path: 'spec.toService.namespace', rules: ['serviceNamespaceRequired'] },
+        { path: 'spec.toService.scheme', rules: ['serviceSchemeRequired'] }],
+
     };
   },
   props: {
@@ -113,6 +118,44 @@ export default {
         label: id, id, name, namespace
       }) );
     },
+    imageError() {
+      return !!this.imageErrorMessage && !this.value.spec.iconSrc;
+    },
+    fvExtraRules() {
+      const isLinkTypeUrl = this.currentLinkType === LINK_TYPE_URL;
+      const isServiceTypeUrl = this.currentLinkType === LINK_TYPE_SERVICE;
+
+      return {
+        nameRequired: () => {
+          if (!this.value.metadata.name) {
+            return this.getError('navLink.name.label');
+          }
+        },
+
+        urlRequired: () => {
+          const condition = this.value.spec.toURL;
+
+          if (isLinkTypeUrl && !condition) {
+            return this.getError('navLink.tabs.link.toURL.label');
+          }
+        },
+        serviceNamespaceRequired: () => {
+          const condition = this.value.spec.toService.name && this.value.spec.toService.namespace;
+
+          if (isServiceTypeUrl && !condition) {
+            return this.getError('navLink.tabs.link.toService.service.label');
+          }
+        },
+        serviceSchemeRequired: () => {
+          const condition = this.value.spec.toService.scheme;
+
+          if (isServiceTypeUrl && !condition) {
+            return this.getError('navLink.tabs.link.toService.scheme.label');
+          }
+        }
+
+      };
+    }
   },
   async fetch() {
     this.services = await this.$store
@@ -215,50 +258,20 @@ export default {
     getError(label) {
       return this.$store.getters['i18n/t']('validation.required', { key: this.t(label) });
     },
-    /**
-     * Verify all fields are fulfilled or display footer notification
-     */
-    validate() {
-      const errors = [];
 
-      switch (this.currentLinkType) {
-      case LINK_TYPE_URL:
-        if (!this.value.spec.toURL) {
-          errors.push(this.getError('navLink.tabs.link.toURL.label'));
-        }
-        break;
-
-      case LINK_TYPE_SERVICE:
-        if (!this.value.spec.toService.name || !this.value.spec.toService.namespace) {
-          errors.push(this.getError(`navLink.tabs.link.toService.service.label`));
-        }
-
-        if (!this.value.spec.toService.scheme) {
-          errors.push(this.getError(`navLink.tabs.link.toService.scheme.label`));
-        }
-        break;
-
-        // no default
-      }
-
-      if (!this.value.metadata.name) {
-        errors.push(this.getError('navLink.name.label'));
-      }
-
-      if (errors.length) {
-        throw (errors.join('\n'));
-      }
+    setImageError(e) {
+      this.imageErrorMessage = e;
     },
+    setIcon(value) {
+      this.imageErrorMessage = '';
+      this.$emit('update:value.spec.iconSrc ', value);
+    }
   },
   created() {
     this.setDefaultValues();
     this.setUrlType();
     this.setTargetOption();
     this.setCurrentService();
-    // Validate error presence by allowing or resetting submission process
-    if (this.registerBeforeHook) {
-      this.registerBeforeHook(this.validate);
-    }
   }
 };
 </script>
@@ -268,8 +281,10 @@ export default {
     :can-yaml="!isCreate"
     :mode="mode"
     :resource="value"
-    :errors="errors"
+    :errors="fvUnreportedValidationErrors"
     :cancel-event="true"
+    :validation-passed="fvFormIsValid"
+    data-testid="Navlink-CRU"
     @error="e=>errors = e"
     @finish="save"
     @cancel="done()"
@@ -285,147 +300,157 @@ export default {
       name-placeholder="navLink.name.placeholder"
       description-label="navLink.label.label"
       description-placeholder="navLink.label.placeholder"
+      data-testid="Navlink-name-field"
+      :rules="{ name: fvGetAndReportPathRules('metadata.name'), namespace: [], description: [] }"
     />
 
-    <Tabbed
-      :side-tabs="true"
+    <div class="spacer" />
+    <h2 v-t="'navLink.tabs.link.label'" />
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="linkType"
+          name="type"
+          :mode="mode"
+          :options="urlTypeOptions"
+          data-testid="Navlink-link-radiogroup"
+        />
+      </div>
+    </div>
+
+    <template v-if="isURL">
+      <div class="row mb-20">
+        <LabeledInput
+          v-model="value.spec.toURL"
+          :mode="mode"
+          :label="t('navLink.tabs.link.toURL.label')"
+          :required="isURL"
+          :placeholder="t('navLink.tabs.link.toURL.placeholder')"
+          :rules="fvGetAndReportPathRules('spec.toURL')"
+          data-testid="Navlink-url-field"
+        />
+      </div>
+    </template>
+    <template v-if="isService">
+      <div class="row mb-20">
+        <div class="col span-2">
+          <LabeledSelect
+            v-model="value.spec.toService.scheme"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.scheme.label')"
+            :required="isService"
+            :options="protocolsOptions"
+            :placeholder="t('navLink.tabs.link.toService.scheme.placeholder')"
+            :rules="fvGetAndReportPathRules('spec.toService.scheme')"
+            data-testid="Navlink-scheme-field"
+          />
+        </div>
+        <div class="col span-5">
+          <LabeledSelect
+            v-model="currentService"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.service.label')"
+            :options="mappedServices"
+            :required="isService"
+            :placeholder="t('navLink.tabs.link.toService.service.placeholder')"
+            :rules="fvGetAndReportPathRules('spec.toService.namespace')"
+            data-testid="Navlink-currentService-field"
+            @input="setService"
+          />
+        </div>
+        <div class="col span-2">
+          <LabeledInput
+            v-model="value.spec.toService.port"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.port.label')"
+            type="number"
+            :placeholder="t('navLink.tabs.link.toService.port.placeholder')"
+          />
+        </div>
+        <div class="col span-3">
+          <LabeledInput
+            v-model="value.spec.toService.path"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.path.label')"
+            :placeholder="t('navLink.tabs.link.toService.path.placeholder')"
+          />
+        </div>
+      </div>
+    </template>
+    <div class="spacer" />
+    <h2 v-t="'navLink.tabs.target.label'" />
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model="currentTarget"
+          name="type"
+          :mode="mode"
+          :options="targetOptions"
+          @input="setTargetValue($event)"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-if="isNamedWindow"
+          v-model="targetName"
+          :mode="mode"
+          :label="t('navLink.tabs.target.namedValue.label')"
+          @input="setTargetValue($event);"
+        />
+      </div>
+    </div>
+    <div class="spacer" />
+    <h2 v-t="'navLink.tabs.group.label'" />
+
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.spec.group"
+          :mode="mode"
+          :tooltip="t('navLink.tabs.group.group.tooltip')"
+          :label="t('navLink.tabs.group.group.label')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.spec.sideLabel"
+          :mode="mode"
+          :label="t('navLink.tabs.group.sideLabel.label')"
+        />
+      </div>
+    </div>
+
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model="value.spec.description"
+          :mode="mode"
+          :label="t('navLink.tabs.group.description.label')"
+        />
+      </div>
+    </div>
+
+    <h4 v-t="'navLink.tabs.groupImage.label'" />
+    <div class="row">
+      <label class="text-label">
+        {{ t('navLink.tabs.groupImage.iconSrc.tip', {}, true) }}
+      </label>
+    </div>
+    <div class="row">
+      <FileImageSelector
+        v-model="value.spec.iconSrc"
+        :read-as-data-url="true"
+        :mode="mode"
+        :label="t('navLink.tabs.groupImage.iconSrc.label')"
+        @error="setImageError"
+        @input="setIcon"
+      />
+    </div>
+    <Banner
+      v-if="imageError"
+      color="error"
     >
-      <Tab
-        name="link"
-        :label="t('navLink.tabs.link.label')"
-      >
-        <div class="row mb-20">
-          <div class="col span-6">
-            <RadioGroup
-              v-model="linkType"
-              name="type"
-              :mode="mode"
-              :options="urlTypeOptions"
-            />
-          </div>
-        </div>
-
-        <template v-if="isURL">
-          <div class="row mb-20">
-            <LabeledInput
-              v-model="value.spec.toURL"
-              :mode="mode"
-              :label="t('navLink.tabs.link.toURL.label')"
-              :required="isURL"
-              :placeholder="t('navLink.tabs.link.toURL.placeholder')"
-            />
-          </div>
-        </template>
-        <template v-if="isService">
-          <div class="row mb-20">
-            <div class="col span-2">
-              <LabeledSelect
-                v-model="value.spec.toService.scheme"
-                :mode="mode"
-                :label="t('navLink.tabs.link.toService.scheme.label')"
-                :required="isService"
-                :options="protocolsOptions"
-                :placeholder="t('navLink.tabs.link.toService.scheme.placeholder')"
-              />
-            </div>
-            <div class="col span-5">
-              <LabeledSelect
-                v-model="currentService"
-                :mode="mode"
-                :label="t('navLink.tabs.link.toService.service.label')"
-                :options="mappedServices"
-                :required="isService"
-                :placeholder="t('navLink.tabs.link.toService.service.placeholder')"
-                @input="setService"
-              />
-            </div>
-            <div class="col span-2">
-              <LabeledInput
-                v-model="value.spec.toService.port"
-                :mode="mode"
-                :label="t('navLink.tabs.link.toService.port.label')"
-                type="number"
-                :placeholder="t('navLink.tabs.link.toService.port.placeholder')"
-              />
-            </div>
-            <div class="col span-3">
-              <LabeledInput
-                v-model="value.spec.toService.path"
-                :mode="mode"
-                :label="t('navLink.tabs.link.toService.path.label')"
-                :placeholder="t('navLink.tabs.link.toService.path.placeholder')"
-              />
-            </div>
-          </div>
-        </template>
-      </Tab>
-
-      <Tab
-        name="target"
-        :label="t('navLink.tabs.target.label')"
-      >
-        <div class="row mb-20">
-          <div class="col span-6">
-            <RadioGroup
-              v-model="currentTarget"
-              name="type"
-              :mode="mode"
-              :options="targetOptions"
-              :required="true"
-              @input="setTargetValue($event)"
-            />
-          </div>
-          <div class="col span-6">
-            <LabeledInput
-              v-if="isNamedWindow"
-              v-model="targetName"
-              :mode="mode"
-              :label="t('navLink.tabs.target.namedValue.label')"
-              @input="setTargetValue($event);"
-            />
-          </div>
-        </div>
-      </Tab>
-
-      <Tab
-        name="group"
-        :label="t('navLink.tabs.group.label')"
-      >
-        <div class="row mb-20">
-          <div class="col span-6">
-            <LabeledInput
-              v-model="value.spec.group"
-              :mode="mode"
-              :tooltip="t('navLink.tabs.group.group.tooltip')"
-              :label="t('navLink.tabs.group.group.label')"
-            />
-          </div>
-          <div class="col span-6">
-            <LabeledInput
-              v-model="value.spec.sideLabel"
-              :mode="mode"
-              :label="t('navLink.tabs.group.sideLabel.label')"
-            />
-          </div>
-        </div>
-
-        <div class="row mb-20">
-          <div class="col span-6">
-            <LabeledInput
-              v-model="value.spec.description"
-              :mode="mode"
-              :label="t('navLink.tabs.group.description.label')"
-            />
-          </div>
-          <div class="col span-2">
-            <FileImageSelector
-              v-model="value.spec.iconSrc"
-              :mode="mode"
-              :label="t('navLink.tabs.group.iconSrc.label')"
-            />
-          </div>
-        </div>
-      </Tab>
-    </Tabbed>
+      {{ imageErrorMessage }}
+    </Banner>
   </CruResource>
 </template>

--- a/shell/edit/ui.cattle.io.navlink.vue
+++ b/shell/edit/ui.cattle.io.navlink.vue
@@ -442,6 +442,7 @@ export default {
         :read-as-data-url="true"
         :mode="mode"
         :label="t('navLink.tabs.groupImage.iconSrc.label')"
+        accept="image/jpeg,image/png,image/svg+xml"
         @error="setImageError"
         @input="setIcon"
       />

--- a/shell/pages/c/_cluster/settings/brand.vue
+++ b/shell/pages/c/_cluster/settings/brand.vue
@@ -4,7 +4,7 @@ import ColorInput from '@shell/components/form/ColorInput';
 import TypeDescription from '@shell/components/TypeDescription';
 
 import { Checkbox } from '@components/Form/Checkbox';
-import FileSelector from '@shell/components/form/FileSelector';
+import FileImageSelector from '@shell/components/form/FileImageSelector';
 import SimpleBox from '@shell/components/SimpleBox';
 import Loading from '@shell/components/Loading';
 import AsyncButton from '@shell/components/AsyncButton';
@@ -23,7 +23,7 @@ export default {
   layout: 'authenticated',
 
   components: {
-    LabeledInput, Checkbox, FileSelector, Loading, SimpleBox, AsyncButton, Banner, ColorInput, TypeDescription
+    LabeledInput, Checkbox, FileImageSelector, Loading, SimpleBox, AsyncButton, Banner, ColorInput, TypeDescription
   },
 
   async fetch() {
@@ -222,14 +222,14 @@ export default {
       >
         <div class="col logo-container span-6">
           <div class="mb-10">
-            <FileSelector
+            <FileImageSelector
               :byte-limit="20000"
               :read-as-data-url="true"
               class="role-secondary"
               :label="t('branding.logos.uploadLight')"
               :mode="mode"
               @error="setError"
-              @selected="updateLogo($event, 'uiLogoLight')"
+              @input="updateLogo($event, 'uiLogoLight')"
             />
           </div>
           <SimpleBox
@@ -245,14 +245,14 @@ export default {
         </div>
         <div class="col logo-container span-6">
           <div class="mb-10">
-            <FileSelector
+            <FileImageSelector
               :byte-limit="20000"
               :read-as-data-url="true"
               class="role-secondary"
               :label="t('branding.logos.uploadDark')"
               :mode="mode"
               @error="setError"
-              @selected="updateLogo($event, 'uiLogoDark')"
+              @input="updateLogo($event, 'uiLogoDark')"
             />
           </div>
           <SimpleBox
@@ -289,14 +289,14 @@ export default {
       >
         <div class="col logo-container span-12">
           <div class="mb-10">
-            <FileSelector
+            <FileImageSelector
               :byte-limit="20000"
               :read-as-data-url="true"
               class="role-secondary"
               :label="t('branding.favicon.upload')"
               :mode="mode"
               @error="setError"
-              @selected="updateLogo($event, 'uiFavicon')"
+              @input="updateLogo($event, 'uiFavicon')"
             />
           </div>
           <SimpleBox v-if="uiFavicon">

--- a/shell/pages/c/_cluster/settings/brand.vue
+++ b/shell/pages/c/_cluster/settings/brand.vue
@@ -228,6 +228,7 @@ export default {
               class="role-secondary"
               :label="t('branding.logos.uploadLight')"
               :mode="mode"
+              accept="image/jpeg,image/png,image/svg+xml"
               @error="setError"
               @input="updateLogo($event, 'uiLogoLight')"
             />
@@ -251,6 +252,7 @@ export default {
               class="role-secondary"
               :label="t('branding.logos.uploadDark')"
               :mode="mode"
+              accept="image/jpeg,image/png,image/svg+xml"
               @error="setError"
               @input="updateLogo($event, 'uiLogoDark')"
             />
@@ -295,6 +297,7 @@ export default {
               class="role-secondary"
               :label="t('branding.favicon.upload')"
               :mode="mode"
+              accept="image/jpeg,image/png,image/svg+xml"
               @error="setError"
               @input="updateLogo($event, 'uiFavicon')"
             />

--- a/shell/utils/fileTypes.js
+++ b/shell/utils/fileTypes.js
@@ -1,0 +1,1 @@
+export const IMAGE_TYPE = 'img';

--- a/shell/utils/fileTypes.js
+++ b/shell/utils/fileTypes.js
@@ -1,1 +1,0 @@
-export const IMAGE_TYPE = 'img';

--- a/svgTransform.js
+++ b/svgTransform.js
@@ -1,0 +1,8 @@
+module.exports = {
+  process() {
+    return { code: 'module.exports = {};' };
+  },
+  getCacheKey() {
+    return 'svgTransform';
+  },
+};


### PR DESCRIPTION
### Summary
Fixes #9348
Fixes #5184 

Changed "Navlinks" page from tabular to regular page, added validation to it and error message on file upload. Changed FileSelector to FileImageSelector on "Branding" page.

### Occurred changes and/or fixed issues
For Branding page:
- Changed all occurrences of FileSelector to FileImageSelector
For Navlinks page:
- Disabled  "Create" button if required fields are not filled in
- Removed tabs
- Added error on file upload
For FileSelector:
- Added type validation if expected type is image

### Technical notes summary
Added MIME byte checking to validate that uploaded file is an image (https://mimesniff.spec.whatwg.org/#matching-an-image-type-pattern) 

### Areas or cases that should be tested
Used Chrome for local testing.
Open "Local" -> "NavLinks" -> "Create"
- Tabs should be removed
- "Create" button should be disabled
- Validate that filling in required fields enables "Create" button
- Switch to the different link type and validate that filling in new required fields also enables the button
- "Group Image" subsection is added.
- Appropriate error should be displayed if image is too big or has wrong type.

Open "Global settings" -> "Branding"
- Try uploading custom "logo" and "favicon" and make sure appropriate error is displayed if file is too big or has incorrect format


### Areas which could experience regressions
FIleSelector required additional testing to make sure it is still working for non-image case
