### PR TITLE
Disable failed S3 snapshots

### DIFF
--- a/shell/components/PromptRestore.vue
+++ b/shell/components/PromptRestore.vue
@@ -122,7 +122,7 @@ export default {
         promise = this.$store.dispatch('management/findAll', { type: SNAPSHOT }).then((snapshots) => {
           const toRestoreClusterName = cluster?.clusterName || cluster?.metadata?.name;
 
-          return snapshots.filter((s) => s?.snapshotFile?.status !== STATES_ENUM.FAILED && s.clusterName === toRestoreClusterName
+          return snapshots.filter((s) => s?.snapshotFile?.status === STATES_ENUM.SUCCESSFUL && s.clusterName === toRestoreClusterName
           );
         });
       }

--- a/shell/models/rke.cattle.io.etcdsnapshot.js
+++ b/shell/models/rke.cattle.io.etcdsnapshot.js
@@ -12,7 +12,7 @@ export default class EtcdBackup extends NormanModel {
    * Restrict actions for snapshots to restore only
    */
   get _availableActions() {
-    const enabled = get(this, 'snapshotFile.status') !== STATES_ENUM.FAILED;
+    const enabled = this.snapshotFile?.status === STATES_ENUM.SUCCESSFUL;
 
     return [{
       action: 'promptRestore',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Checking successful status instead of not failed to cover falsy values like `undefined`;

Fixes #8839 
<!-- Define findings related to the feature or bug issue. -->