### PR TITLE
Add additional error handling to install chart page

### DIFF
--- a/cypress/e2e/po/components/ember/ember-input.po.ts
+++ b/cypress/e2e/po/components/ember/ember-input.po.ts
@@ -23,6 +23,6 @@ export default class EmberInputPo extends EmberComponentPo {
    * @returns HTML Element
    */
   private input(): Cypress.Chainable {
-    return this.self().find('input');
+    return this.self();
   }
 }

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -19,6 +19,13 @@ import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 // If the logo is not named with the provider name, add an override here
 const PROVIDER_LOGO_OVERRIDE = {};
 
+function findRelationship(verb, type, relationships = []) {
+  const from = `${ verb }Type`;
+  const id = `${ verb }Id`;
+
+  return relationships.find((r) => r[from] === type)?.[id];
+}
+
 export default class MgmtCluster extends HybridModel {
   get details() {
     const out = [
@@ -440,9 +447,12 @@ export default class MgmtCluster extends HybridModel {
     // cluster has the less human readable management cluster ID in it: fleet-default/c-khk48
 
     const verb = this.isLocal || isRKE1 || this.isHostedKubernetesProvider ? 'to' : 'from';
-    const from = `${ verb }Type`;
-    const id = `${ verb }Id`;
+    const res = findRelationship(verb, CAPI.RANCHER_CLUSTER, this.metadata?.relationships);
 
-    return this.metadata.relationships.find((r) => r[from] === CAPI.RANCHER_CLUSTER)?.[id];
+    if (res) {
+      return res;
+    }
+
+    return findRelationship(verb === 'to' ? 'from' : 'to', CAPI.RANCHER_CLUSTER, this.metadata?.relationships);
   }
 }

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -81,6 +81,9 @@ export default {
   ],
 
   async fetch() {
+    this.errors = [];
+    // IMPORTANT! Any exception thrown before this.value is set will result in an empty page
+
     /*
       fetchChart is defined in shell/mixins. It first checks the URL
       query for an app name and namespace. It uses those values to check
@@ -91,23 +94,43 @@ export default {
       it checks for target name and namespace values defined in the
       Helm chart itself.
     */
-    await this.fetchChart();
+    try {
+      await this.fetchChart();
+    } catch (e) {
+      console.warn('Unable to fetch chart: ', e); // eslint-disable-line no-console
+    }
 
-    await this.fetchAutoInstallInfo();
-    this.errors = [];
+    try {
+      await this.fetchAutoInstallInfo();
+    } catch (e) {
+      console.warn('Unable to determine if other charts require install: ', e); // eslint-disable-line no-console
+    }
 
     // If the chart doesn't contain system `systemDefaultRegistry` properties there's no point applying them
     if (this.showCustomRegistry) {
       // Note: Cluster scoped registry is only supported for node driver clusters
-      this.clusterRegistry = await this.getClusterRegistry();
-      this.globalRegistry = await this.getGlobalRegistry();
+      try {
+        this.clusterRegistry = await this.getClusterRegistry();
+      } catch (e) {
+        console.warn('Unable to get cluster registry: ', e); // eslint-disable-line no-console
+      }
+
+      try {
+        this.globalRegistry = await this.getGlobalRegistry();
+      } catch (e) {
+        console.warn('Unable to get global registry: ', e); // eslint-disable-line no-console
+      }
       this.defaultRegistrySetting = this.clusterRegistry || this.globalRegistry;
     }
 
-    this.serverUrlSetting = await this.$store.dispatch('management/find', {
-      type: MANAGEMENT.SETTING,
-      id:   'server-url'
-    });
+    try {
+      this.serverUrlSetting = await this.$store.dispatch('management/find', {
+        type: MANAGEMENT.SETTING,
+        id:   'server-url'
+      });
+    } catch (e) {
+      console.error('Unable to fetch `server-url` setting: ', e); // eslint-disable-line no-console
+    }
 
     /*
       Figure out the namespace where the chart is
@@ -137,11 +160,22 @@ export default {
     }
 
     /* Check if the app is deprecated. */
-    this.legacyApp = this.existing ? await this.existing.deployedAsLegacy() : false;
+    try {
+      this.legacyApp = this.existing ? await this.existing.deployedAsLegacy() : false;
+    } catch (e) {
+      this.legacyApp = false;
+      console.warn('Unable to determine if existing install is a legacy app: ', e); // eslint-disable-line no-console
+    }
 
     /* Check if the app is a multicluster deprecated app.
     (Multicluster apps were replaced by Fleet.) */
-    this.mcapp = this.existing ? await this.existing.deployedAsMultiCluster() : false;
+
+    try {
+      this.mcapp = this.existing ? await this.existing.deployedAsMultiCluster() : false;
+    } catch (e) {
+      this.mcapp = false;
+      console.warn('Unable to determine if existing install is a mc app: ', e); // eslint-disable-line no-console
+    }
 
     /* The form state is intialized as a chartInstallAction resource. */
     this.value = await this.$store.dispatch('cluster/create', {
@@ -803,12 +837,18 @@ export default {
 
       if (hasPermissionToSeeProvCluster) {
         const mgmCluster = this.$store.getters['currentCluster'];
-        const provCluster = mgmCluster?.provClusterId ? await this.$store.dispatch('management/find', {
-          type: CAPI.RANCHER_CLUSTER,
-          id:   mgmCluster.provClusterId
-        }) : {};
+        let provCluster;
 
-        if (provCluster.isRke2) { // isRke2 returns true for both RKE2 and K3s clusters.
+        try {
+          provCluster = mgmCluster?.provClusterId ? await this.$store.dispatch('management/find', {
+            type: CAPI.RANCHER_CLUSTER,
+            id:   mgmCluster?.provClusterId
+          }) : {};
+        } catch (e) {
+          console.error(`Unable to fetch prov cluster '${ mgmCluster?.provClusterId }': `, e); // eslint-disable-line no-console
+        }
+
+        if (provCluster?.isRke2) { // isRke2 returns true for both RKE2 and K3s clusters.
           const agentConfig = provCluster.spec?.rkeConfig?.machineSelectorConfig?.find((x) => !x.machineLabelSelector).config;
 
           // If a cluster scoped registry exists,
@@ -819,10 +859,11 @@ export default {
             return clusterRegistry;
           }
         }
-        if (provCluster.isRke1) {
+
+        if (provCluster?.isRke1) {
           // For RKE1 clusters, the cluster scoped private registry is on the management
           // cluster, not the provisioning cluster.
-          const rke1Registries = mgmCluster.spec?.rancherKubernetesEngineConfig?.privateRegistries;
+          const rke1Registries = mgmCluster?.spec?.rancherKubernetesEngineConfig?.privateRegistries;
 
           if (rke1Registries?.length > 0) {
             const defaultRegistry = rke1Registries.find((registry) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to https://github.com/rancher/dashboard/issues/8841
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Any exception thrown prior to `this.value` being set will result in an empty page
- These changes might solve some issues with blank pages, 
- For cases where the exception thrown is something that we latter depend on causing other issues.... we at least know where to start looking

### Technical notes summary
- I also moved `this.error = []` up to the start, as one of the functions adds an entry to it

### Areas or cases that should be tested
- Installing a chart
- Installing a chart where there is a global or cluster registry

### Areas which could experience regressions
- Installing a chart
- Installing a chart where there is a global or cluster registry
