### PR TITLE
UI says "Matches no existing clusters" when there is a null value for cluster selector in cluster groups

### DIFF
--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -218,12 +218,10 @@ export default {
 
           if ( rule.operator === 'Exists' || rule.operator === 'DoesNotExist') {
             val = null;
-          } else if (!val) {
-            return;
           }
 
           if ( val !== null ) {
-            expression.values = val.split(/\s*,\s*/).filter((x) => !!x);
+            expression.values = val.split(/\s*,\s*/);
           }
 
           return expression;

--- a/shell/utils/selector.js
+++ b/shell/utils/selector.js
@@ -198,7 +198,8 @@ export function matches(obj, selector, labelKey = 'metadata.labels') {
       }
       break;
     case 'In':
-      if ( !value || !rule.values.length || !rule.values.includes(value) ) {
+      // we need to cater empty strings because when creating a label with value = null it's translated into a empty string value ''
+      if ( !rule.values.length || !rule.values.includes(value) ) {
         return false;
       }
       break;
@@ -224,5 +225,9 @@ export function matches(obj, selector, labelKey = 'metadata.labels') {
 }
 
 export function matching(ary, selector, labelKey) {
+  console.log('array', ary);
+  console.log('selector', selector);
+  console.log('labelKey', labelKey);
+
   return ary.filter((obj) => matches(obj, selector, labelKey));
 }

--- a/shell/utils/selector.js
+++ b/shell/utils/selector.js
@@ -225,9 +225,5 @@ export function matches(obj, selector, labelKey = 'metadata.labels') {
 }
 
 export function matching(ary, selector, labelKey) {
-  console.log('array', ary);
-  console.log('selector', selector);
-  console.log('labelKey', labelKey);
-
   return ary.filter((obj) => matches(obj, selector, labelKey));
 }


### PR DESCRIPTION
Fixes #9256 

Notes: when creating via YAML a label with value `null`, the server returns it as an empty string, which falls in place with the usecase of this issue

- Fix issue where matching rules (for `Banner` string saying X matching ....) weren't accounting for an empty string value
- Fix issue in `MatchExpressions` where we were ignoring an expression value if it was an empty string, therefore removing that whole expression from the payload without considering it could be an empty string.
- Add missing dispatch to `FLEET.CLUSTER` on `edit/fleet.cattle.io.clustergroup.vue` so that page can work properly on hard refresh