### PR TITLE
fix issue with height on containerShell

### DIFF
--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -316,7 +316,7 @@ export default {
 
       this.fitAddon.fit();
 
-      const { rows, cols } = this.fitAddon.proposeDimensions();
+      const { rows, cols } = this.fitAddon.proposeDimensions() || {};
 
       if (!this.isOpen) {
         return;

--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -40,8 +40,8 @@ export default {
 
     // The height of the window
     height: {
-      type:     Number,
-      required: true,
+      type:    Number,
+      default: undefined,
     },
 
     // The width of the window


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9422 
 
 - Update `height` prop definition to not be required, like `width` in `ContainerShell`
 - Update `proposeDimensions` return to be empty object in the case it can return `undefined`
 
 **NOTE:** with UI 2.7.5 (remote instance) I couldn't reproduce the bug
 
 ## To test
 - run latest UI code
 - go to `local` cluster explorer
 - Open a shell (header button)
 - Go to `profile` -> `Account & api keys`
 - Navigate back to local cluster explorer (back button on `Account & api keys` page)
 - Check that there are no logs on the console