### PR TITLE
Filtered out non-opaque secrets in backup/restore

### DIFF
--- a/shell/edit/resources.cattle.io.backup.vue
+++ b/shell/edit/resources.cattle.io.backup.vue
@@ -16,8 +16,7 @@ import { allHash } from '@shell/utils/promise';
 import { NAMESPACE, _VIEW } from '@shell/config/query-params';
 import { sortBy } from '@shell/utils/sort';
 import { get } from '@shell/utils/object';
-
-const OPAQUE_SECRET_TYPE = 'Opaque';
+import { formatEncryptionSecretNames } from '@shell/utils/formatter';
 
 export default {
 
@@ -111,14 +110,7 @@ export default {
     },
 
     encryptionSecretNames() {
-      const filtered = this.allSecrets.filter(
-        (secret) => (secret.data || {})['encryption-provider-config.yaml'] &&
-        secret.metadata.namespace === this.chartNamespace &&
-        !secret.metadata?.state?.error &&
-        secret._type === OPAQUE_SECRET_TYPE
-      );
-
-      return filtered.map((secret) => secret.metadata.name).sort();
+      return formatEncryptionSecretNames(this.allSecrets, this.chartNamespace);
     },
 
     storageOptions() {

--- a/shell/edit/resources.cattle.io.backup.vue
+++ b/shell/edit/resources.cattle.io.backup.vue
@@ -16,6 +16,9 @@ import { allHash } from '@shell/utils/promise';
 import { NAMESPACE, _VIEW } from '@shell/config/query-params';
 import { sortBy } from '@shell/utils/sort';
 import { get } from '@shell/utils/object';
+
+const OPAQUE_SECRET_TYPE = 'Opaque';
+
 export default {
 
   components: {
@@ -108,7 +111,14 @@ export default {
     },
 
     encryptionSecretNames() {
-      return this.allSecrets.filter((secret) => (secret.data || {})['encryption-provider-config.yaml'] && secret.metadata.namespace === this.chartNamespace && !secret.metadata?.state?.error).map((secret) => secret.metadata.name);
+      const filtered = this.allSecrets.filter(
+        (secret) => (secret.data || {})['encryption-provider-config.yaml'] &&
+        secret.metadata.namespace === this.chartNamespace &&
+        !secret.metadata?.state?.error &&
+        secret._type === OPAQUE_SECRET_TYPE
+      );
+
+      return filtered.map((secret) => secret.metadata.name).sort();
     },
 
     storageOptions() {

--- a/shell/edit/resources.cattle.io.restore.vue
+++ b/shell/edit/resources.cattle.io.restore.vue
@@ -13,6 +13,9 @@ import { SECRET, BACKUP_RESTORE, CATALOG } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
 import { get } from '@shell/utils/object';
 import { _CREATE } from '@shell/config/query-params';
+
+const OPAQUE_SECRET_TYPE = 'Opaque';
+
 export default {
 
   components: {
@@ -93,7 +96,14 @@ export default {
     },
 
     encryptionSecretNames() {
-      return this.allSecrets.filter((secret) => !!(secret.data || {})['encryption-provider-config.yaml'] && secret.metadata.namespace === this.chartNamespace && !secret.metadata?.state?.error).map((secret) => secret.metadata.name);
+      const filtered = this.allSecrets.filter(
+        (secret) => !!(secret.data || {})['encryption-provider-config.yaml'] &&
+        secret.metadata.namespace === this.chartNamespace &&
+        !secret.metadata?.state?.error &&
+        secret._type === OPAQUE_SECRET_TYPE
+      );
+
+      return filtered.map((secret) => secret.metadata.name).sort();
     },
 
     isEncrypted() {

--- a/shell/edit/resources.cattle.io.restore.vue
+++ b/shell/edit/resources.cattle.io.restore.vue
@@ -13,8 +13,7 @@ import { SECRET, BACKUP_RESTORE, CATALOG } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
 import { get } from '@shell/utils/object';
 import { _CREATE } from '@shell/config/query-params';
-
-const OPAQUE_SECRET_TYPE = 'Opaque';
+import { formatEncryptionSecretNames } from '@shell/utils/formatter';
 
 export default {
 
@@ -96,14 +95,7 @@ export default {
     },
 
     encryptionSecretNames() {
-      const filtered = this.allSecrets.filter(
-        (secret) => !!(secret.data || {})['encryption-provider-config.yaml'] &&
-        secret.metadata.namespace === this.chartNamespace &&
-        !secret.metadata?.state?.error &&
-        secret._type === OPAQUE_SECRET_TYPE
-      );
-
-      return filtered.map((secret) => secret.metadata.name).sort();
+      return formatEncryptionSecretNames(this.allSecrets, this.chartNamespace);
     },
 
     isEncrypted() {

--- a/shell/utils/__tests__/formatter.test.ts
+++ b/shell/utils/__tests__/formatter.test.ts
@@ -3,133 +3,67 @@ import { formatEncryptionSecretNames } from '@shell/utils/formatter';
 describe('formatter', () => {
   const secrets = [
     {
-      id:    'test5',
-      type:  'secret',
-      links: {
-        remove: 'https://test5:8000', self: 'https://test5:8000', update: 'https://test5:8000', view: 'https://test5:8000'
-      },
-      _type:      'Opaque',
-      apiVersion: 'v1',
-      data:       { hash: 'test5', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
-      immutable:  true,
-      kind:       'Secret',
-      metadata:   {
-        annotations:       { 'field.cattle.io/projectId': 'test' },
-        creationTimestamp: '2023-06-26T22:51:42Z',
-        fields:            ['Opaque', 1, '56d'],
-        name:              'test5',
-        namespace:         'test',
-        relationships:     null,
-        resourceVersion:   '4306',
-        state:             {
+      id:       'test5',
+      _type:    'Opaque',
+      data:     { hash: 'test5', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      metadata: {
+        name:      'test5',
+        namespace: 'test',
+        state:     {
           error: false, message: 'Resource is always ready', name: 'active', transitioning: false
-        },
-        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a8'
+        }
       }
     },
     {
-      id:    'test2',
-      type:  'secret',
-      links: {
-        remove: 'https://test2:8000', self: 'https://test2:8000', update: 'https://test2:8000', view: 'https://test2:8000'
-      },
-      _type:      'Opaque',
-      apiVersion: 'v1',
-      data:       { hash: 'test', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
-      immutable:  true,
-      kind:       'Secret',
-      metadata:   {
-        annotations:       { 'field.cattle.io/projectId': 'test' },
-        creationTimestamp: '2023-06-26T22:51:42Z',
-        fields:            ['Opaque', 1, '56d'],
-        name:              'test2',
-        namespace:         'test',
-        relationships:     null,
-        resourceVersion:   '4306',
-        state:             {
+      id:       'test2',
+      _type:    'Opaque',
+      data:     { hash: 'test', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      metadata: {
+        name:      'test2',
+        namespace: 'test',
+        state:     {
           error: false, message: 'Resource is always ready', name: 'active', transitioning: false
-        },
-        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a7'
+        }
       }
     },
     {
-      id:    'test4',
-      type:  'secret',
-      links: {
-        remove: 'https://test4:8000', self: 'https://test4:8000', update: 'https://test4:8000', view: 'https://test4:8000'
-      },
-      _type:      'Opaque',
-      apiVersion: 'v1',
-      data:       { hash: 'test4' },
-      immutable:  true,
-      kind:       'Secret',
-      metadata:   {
-        annotations:       { 'field.cattle.io/projectId': 'test4' },
-        creationTimestamp: '2023-06-26T22:51:42Z',
-        fields:            ['Opaque', 1, '56d'],
-        name:              'test4',
-        namespace:         'test',
-        relationships:     null,
-        resourceVersion:   '4306',
-        state:             {
+      id:       'test4',
+      _type:    'Opaque',
+      data:     { hash: 'test4' },
+      metadata: {
+        name:      'test4',
+        namespace: 'test',
+        state:     {
           error: false, message: 'Resource is always ready', name: 'active', transitioning: false
-        },
-        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a6'
+        }
       }
     },
     {
-      id:    'test1',
-      type:  'secret',
-      links: {
-        remove: 'https://test1:8000', self: 'https://test1:8000', update: 'https://test1:8000', view: 'https://test1:8000'
-      },
-      _type:      'Custom',
-      apiVersion: 'v1',
-      data:       { hash: 'test1', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
-      immutable:  true,
-      kind:       'Secret',
-      metadata:   {
-        annotations:       { 'field.cattle.io/projectId': 'test' },
-        creationTimestamp: '2023-06-26T22:51:42Z',
-        fields:            [1, '56d'],
-        name:              'test1',
-        namespace:         'test',
-        relationships:     null,
-        resourceVersion:   '4306',
-        state:             {
+      id:       'test1',
+      _type:    'Custom',
+      data:     { hash: 'test1', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      metadata: {
+        name:      'test1',
+        namespace: 'test',
+        state:     {
           error: false, message: 'Resource is always ready', name: 'active', transitioning: false
         },
-        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a9'
       }
     },
     {
-      id:    'test3',
-      type:  'secret',
-      links: {
-        remove: 'https://test3:8000', self: 'https://test3:8000', update: 'https://test3:8000', view: 'https://test3:8000'
-      },
-      _type:      'Opaque',
-      apiVersion: 'v1',
-      data:       { hash: 'test', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
-      immutable:  true,
-      kind:       'Secret',
-      metadata:   {
-        annotations:       { 'field.cattle.io/projectId': 'test' },
-        creationTimestamp: '2023-06-26T22:51:42Z',
-        fields:            ['Opaque', 1, '56d'],
-        namespace:         'test',
-        relationships:     null,
-        resourceVersion:   '4306',
-        state:             {
+      id:       'test3',
+      _type:    'Opaque',
+      data:     { hash: 'test', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      metadata: {
+        namespace: 'test',
+        state:     {
           error: false, message: 'Resource is always ready', name: 'active', transitioning: false
-        },
-        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a6'
+        }
       }
     }];
   const chart = 'test';
-  const testCases = [[chart, 2], ['test1', 0]];
 
-  it.each(testCases)( 'should show correct number of secrets', ( chartVal: string, result: number) => {
+  it.each([[chart, 2], ['test1', 0]])( 'should show correct number of secrets', ( chartVal: string, result: number) => {
     const res = formatEncryptionSecretNames(secrets, chartVal);
 
     expect(res).toHaveLength(result);
@@ -137,7 +71,6 @@ describe('formatter', () => {
   it('should return correct results in a correct order', () => {
     const res = formatEncryptionSecretNames(secrets, chart);
 
-    expect(res[0]).toBe('test2');
-    expect(res[1]).toBe('test5');
+    expect(res).toStrictEqual(['test2', 'test5']);
   });
 });

--- a/shell/utils/__tests__/formatter.test.ts
+++ b/shell/utils/__tests__/formatter.test.ts
@@ -1,22 +1,143 @@
 import { formatEncryptionSecretNames } from '@shell/utils/formatter';
 
 describe('formatter', () => {
-    const secrets = [
-    {"id":"test5","type":"secret","links":{"remove":"https://test5:8000","self":"https://test5:8000","update":"https://test5:8000","view":"https://test5:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test5", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"name":"test5","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a8"}},
-    {"id":"test2","type":"secret","links":{"remove":"https://test2:8000","self":"https://test2:8000","update":"https://test2:8000","view":"https://test2:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"name":"test2","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a7"}},
-    {"id":"test4","type":"secret","links":{"remove":"https://test4:8000","self":"https://test4:8000","update":"https://test4:8000","view":"https://test4:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test4"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test4"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"name":"test4","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a6"}},
-    {"id":"test1","type":"secret","links":{"remove":"https://test1:8000","self":"https://test1:8000","update":"https://test1:8000","view":"https://test1:8000"},"_type":"Custom","apiVersion":"v1","data":{"hash":"test1", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":[1,"56d"],"name":"test1","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a9"}},
-    {"id":"test3","type":"secret","links":{"remove":"https://test3:8000","self":"https://test3:8000","update":"https://test3:8000","view":"https://test3:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a6"}}]
-    const chart = "test"
-    const testCases = [[chart, 2], ['test1', 0]];
-    it.each(testCases)( 'should show correct number of secrets',( chartVal: string, result: number) => {
-       const res =  formatEncryptionSecretNames(secrets, chartVal);
-       expect(res.length).toBe(result);
+  const secrets = [
+    {
+      id:    'test5',
+      type:  'secret',
+      links: {
+        remove: 'https://test5:8000', self: 'https://test5:8000', update: 'https://test5:8000', view: 'https://test5:8000'
+      },
+      _type:      'Opaque',
+      apiVersion: 'v1',
+      data:       { hash: 'test5', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      immutable:  true,
+      kind:       'Secret',
+      metadata:   {
+        annotations:       { 'field.cattle.io/projectId': 'test' },
+        creationTimestamp: '2023-06-26T22:51:42Z',
+        fields:            ['Opaque', 1, '56d'],
+        name:              'test5',
+        namespace:         'test',
+        relationships:     null,
+        resourceVersion:   '4306',
+        state:             {
+          error: false, message: 'Resource is always ready', name: 'active', transitioning: false
+        },
+        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a8'
+      }
+    },
+    {
+      id:    'test2',
+      type:  'secret',
+      links: {
+        remove: 'https://test2:8000', self: 'https://test2:8000', update: 'https://test2:8000', view: 'https://test2:8000'
+      },
+      _type:      'Opaque',
+      apiVersion: 'v1',
+      data:       { hash: 'test', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      immutable:  true,
+      kind:       'Secret',
+      metadata:   {
+        annotations:       { 'field.cattle.io/projectId': 'test' },
+        creationTimestamp: '2023-06-26T22:51:42Z',
+        fields:            ['Opaque', 1, '56d'],
+        name:              'test2',
+        namespace:         'test',
+        relationships:     null,
+        resourceVersion:   '4306',
+        state:             {
+          error: false, message: 'Resource is always ready', name: 'active', transitioning: false
+        },
+        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a7'
+      }
+    },
+    {
+      id:    'test4',
+      type:  'secret',
+      links: {
+        remove: 'https://test4:8000', self: 'https://test4:8000', update: 'https://test4:8000', view: 'https://test4:8000'
+      },
+      _type:      'Opaque',
+      apiVersion: 'v1',
+      data:       { hash: 'test4' },
+      immutable:  true,
+      kind:       'Secret',
+      metadata:   {
+        annotations:       { 'field.cattle.io/projectId': 'test4' },
+        creationTimestamp: '2023-06-26T22:51:42Z',
+        fields:            ['Opaque', 1, '56d'],
+        name:              'test4',
+        namespace:         'test',
+        relationships:     null,
+        resourceVersion:   '4306',
+        state:             {
+          error: false, message: 'Resource is always ready', name: 'active', transitioning: false
+        },
+        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a6'
+      }
+    },
+    {
+      id:    'test1',
+      type:  'secret',
+      links: {
+        remove: 'https://test1:8000', self: 'https://test1:8000', update: 'https://test1:8000', view: 'https://test1:8000'
+      },
+      _type:      'Custom',
+      apiVersion: 'v1',
+      data:       { hash: 'test1', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      immutable:  true,
+      kind:       'Secret',
+      metadata:   {
+        annotations:       { 'field.cattle.io/projectId': 'test' },
+        creationTimestamp: '2023-06-26T22:51:42Z',
+        fields:            [1, '56d'],
+        name:              'test1',
+        namespace:         'test',
+        relationships:     null,
+        resourceVersion:   '4306',
+        state:             {
+          error: false, message: 'Resource is always ready', name: 'active', transitioning: false
+        },
+        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a9'
+      }
+    },
+    {
+      id:    'test3',
+      type:  'secret',
+      links: {
+        remove: 'https://test3:8000', self: 'https://test3:8000', update: 'https://test3:8000', view: 'https://test3:8000'
+      },
+      _type:      'Opaque',
+      apiVersion: 'v1',
+      data:       { hash: 'test', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      immutable:  true,
+      kind:       'Secret',
+      metadata:   {
+        annotations:       { 'field.cattle.io/projectId': 'test' },
+        creationTimestamp: '2023-06-26T22:51:42Z',
+        fields:            ['Opaque', 1, '56d'],
+        namespace:         'test',
+        relationships:     null,
+        resourceVersion:   '4306',
+        state:             {
+          error: false, message: 'Resource is always ready', name: 'active', transitioning: false
+        },
+        uid: 'fcc4aa44-ce0c-4a7d-bd67-e77040b889a6'
+      }
+    }];
+  const chart = 'test';
+  const testCases = [[chart, 2], ['test1', 0]];
 
-    });
-    it('should return correct results in a correct order', () => {
-        const res =  formatEncryptionSecretNames(secrets, chart);
-        expect(res[0]).toBe("test2");
-        expect(res[1]).toBe("test5");
-    });
-})
+  it.each(testCases)( 'should show correct number of secrets', ( chartVal: string, result: number) => {
+    const res = formatEncryptionSecretNames(secrets, chartVal);
+
+    expect(res).toHaveLength(result);
+  });
+  it('should return correct results in a correct order', () => {
+    const res = formatEncryptionSecretNames(secrets, chart);
+
+    expect(res[0]).toBe('test2');
+    expect(res[1]).toBe('test5');
+  });
+});

--- a/shell/utils/__tests__/formatter.test.ts
+++ b/shell/utils/__tests__/formatter.test.ts
@@ -60,7 +60,19 @@ describe('formatter', () => {
           error: false, message: 'Resource is always ready', name: 'active', transitioning: false
         }
       }
-    }];
+    },
+    {
+      id:       'test6',
+      _type:    'Opaque',
+      data:     { hash: 'test5', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
+      metadata: {
+        name:      'test5',
+        namespace: 'test',
+        state:     {
+          error: true, message: 'Failed', name: 'active', transitioning: true
+        }
+      }
+    },];
   const chart = 'test';
 
   it.each([[chart, 2], ['test1', 0]])( 'should show correct number of secrets', ( chartVal: string, result: number) => {

--- a/shell/utils/__tests__/formatter.test.ts
+++ b/shell/utils/__tests__/formatter.test.ts
@@ -72,7 +72,7 @@ describe('formatter', () => {
           error: true, message: 'Failed', name: 'active', transitioning: true
         }
       }
-    },];
+    }];
   const chart = 'test';
 
   it.each([[chart, 2], ['test1', 0]])( 'should show correct number of secrets', ( chartVal: string, result: number) => {

--- a/shell/utils/__tests__/formatter.test.ts
+++ b/shell/utils/__tests__/formatter.test.ts
@@ -1,0 +1,22 @@
+import { formatEncryptionSecretNames } from '@shell/utils/formatter';
+
+describe('formatter', () => {
+    const secrets = [
+    {"id":"test5","type":"secret","links":{"remove":"https://test5:8000","self":"https://test5:8000","update":"https://test5:8000","view":"https://test5:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test5", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"name":"test5","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a8"}},
+    {"id":"test2","type":"secret","links":{"remove":"https://test2:8000","self":"https://test2:8000","update":"https://test2:8000","view":"https://test2:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"name":"test2","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a7"}},
+    {"id":"test4","type":"secret","links":{"remove":"https://test4:8000","self":"https://test4:8000","update":"https://test4:8000","view":"https://test4:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test4"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test4"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"name":"test4","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a6"}},
+    {"id":"test1","type":"secret","links":{"remove":"https://test1:8000","self":"https://test1:8000","update":"https://test1:8000","view":"https://test1:8000"},"_type":"Custom","apiVersion":"v1","data":{"hash":"test1", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":[1,"56d"],"name":"test1","namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a9"}},
+    {"id":"test3","type":"secret","links":{"remove":"https://test3:8000","self":"https://test3:8000","update":"https://test3:8000","view":"https://test3:8000"},"_type":"Opaque","apiVersion":"v1","data":{"hash":"test", "encryption-provider-config.yaml":"MTIzNFFhYWEh"},"immutable":true,"kind":"Secret","metadata":{"annotations":{"field.cattle.io/projectId":"test"},"creationTimestamp":"2023-06-26T22:51:42Z","fields":["Opaque",1,"56d"],"namespace":"test","relationships":null,"resourceVersion":"4306","state":{"error":false,"message":"Resource is always ready","name":"active","transitioning":false},"uid":"fcc4aa44-ce0c-4a7d-bd67-e77040b889a6"}}]
+    const chart = "test"
+    const testCases = [[chart, 2], ['test1', 0]];
+    it.each(testCases)( 'should show correct number of secrets',( chartVal: string, result: number) => {
+       const res =  formatEncryptionSecretNames(secrets, chartVal);
+       expect(res.length).toBe(result);
+
+    });
+    it('should return correct results in a correct order', () => {
+        const res =  formatEncryptionSecretNames(secrets, chart);
+        expect(res[0]).toBe("test2");
+        expect(res[1]).toBe("test5");
+    });
+})

--- a/shell/utils/__tests__/formatter.test.ts
+++ b/shell/utils/__tests__/formatter.test.ts
@@ -51,17 +51,6 @@ describe('formatter', () => {
       }
     },
     {
-      id:       'test3',
-      _type:    'Opaque',
-      data:     { hash: 'test', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
-      metadata: {
-        namespace: 'test',
-        state:     {
-          error: false, message: 'Resource is always ready', name: 'active', transitioning: false
-        }
-      }
-    },
-    {
       id:       'test6',
       _type:    'Opaque',
       data:     { hash: 'test5', 'encryption-provider-config.yaml': 'MTIzNFFhYWEh' },
@@ -75,7 +64,7 @@ describe('formatter', () => {
     }];
   const chart = 'test';
 
-  it.each([[chart, 2], ['test1', 0]])( 'should show correct number of secrets', ( chartVal: string, result: number) => {
+  it.each([[chart, 2], ['test1', 0]])('should show correct number of secrets', (chartVal: string, result: number) => {
     const res = formatEncryptionSecretNames(secrets, chartVal);
 
     expect(res).toHaveLength(result);

--- a/shell/utils/formatter.js
+++ b/shell/utils/formatter.js
@@ -1,0 +1,12 @@
+
+const OPAQUE_SECRET_TYPE = 'Opaque';
+
+export function formatEncryptionSecretNames(secrets, chartNamespace) {
+  return secrets.filter(
+    (secret) => (secret.data || {})['encryption-provider-config.yaml'] &&
+        secret.metadata.namespace === chartNamespace &&
+        !secret.metadata?.state?.error &&
+        !!secret.metadata?.name &&
+        secret._type === OPAQUE_SECRET_TYPE
+  ).map((secret) => secret.metadata.name).sort();
+}

--- a/shell/utils/formatter.js
+++ b/shell/utils/formatter.js
@@ -4,9 +4,8 @@ import { SECRET_TYPES } from '@shell/config/secret';
 export function formatEncryptionSecretNames(secrets, chartNamespace) {
   return secrets.filter(
     (secret) => (secret.data || {})['encryption-provider-config.yaml'] &&
-        secret.metadata.namespace === chartNamespace &&
-        !secret.metadata?.state?.error &&
-        !!secret.metadata?.name &&
-        secret._type === SECRET_TYPES.OPAQUE
+      secret.metadata.namespace === chartNamespace &&
+      !secret.metadata?.state?.error &&
+      secret._type === SECRET_TYPES.OPAQUE
   ).map((secret) => secret.metadata.name).sort();
 }

--- a/shell/utils/formatter.js
+++ b/shell/utils/formatter.js
@@ -1,5 +1,5 @@
 
-const OPAQUE_SECRET_TYPE = 'Opaque';
+import { SECRET_TYPES } from '@shell/config/secret';
 
 export function formatEncryptionSecretNames(secrets, chartNamespace) {
   return secrets.filter(
@@ -7,6 +7,6 @@ export function formatEncryptionSecretNames(secrets, chartNamespace) {
         secret.metadata.namespace === chartNamespace &&
         !secret.metadata?.state?.error &&
         !!secret.metadata?.name &&
-        secret._type === OPAQUE_SECRET_TYPE
+        secret._type === SECRET_TYPES.OPAQUE
   ).map((secret) => secret.metadata.name).sort();
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #2405 
Dropdown is already only showing secrets that belongs to the current namespace.

### Occurred changes and/or fixed issues
Sorted and filtered out non-opaque secrets in "Encryption config secret" drop down in "Backup" and "Restore" wizards

### Areas or cases that should be tested
Go to the cluster -> "Rancher backups" -> "Backups"/"Restores" -> Create backup/restore
Select "Encrypt backups using an Encryption Config secret (Recommended)"
"Encryption config secret" dropdown should only contain Opaque secrets and they should be sorted alphabetically
