### PR TITLE
Filter failed RKE1 s3 snapshots

### DIFF
--- a/shell/components/PromptRestore.vue
+++ b/shell/components/PromptRestore.vue
@@ -116,7 +116,7 @@ export default {
 
       if (!cluster?.isRke2) {
         promise = this.$store.dispatch('rancher/findAll', { type: NORMAN.ETCD_BACKUP }).then((snapshots) => {
-          return snapshots.filter((s) => s.clusterId === cluster.metadata.name);
+          return snapshots.filter((s) => s.state === STATES_ENUM.ACTIVE && s.clusterId === cluster.metadata.name);
         });
       } else {
         promise = this.$store.dispatch('management/findAll', { type: SNAPSHOT }).then((snapshots) => {

--- a/shell/components/__tests__/PromptRestore.test.ts
+++ b/shell/components/__tests__/PromptRestore.test.ts
@@ -3,60 +3,130 @@ import PromptRestore from '@shell/components/PromptRestore.vue';
 import Vuex from 'vuex';
 import { ExtendedVue, Vue } from 'vue/types/vue';
 import { DefaultProps } from 'vue/types/options';
-import { CAPI } from '@shell/config/types';
+import { CAPI, NORMAN } from '@shell/config/types';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 
-const SUCCESSFUL_SNAPSHOT_1 = {
-  isRke2:       true,
+const RKE2_CLUSTER_NAME = 'rke2_cluster_name';
+const RKE2_SUCCESSFUL_SNAPSHOT_1 = {
+  clusterName:  RKE2_CLUSTER_NAME,
   type:         CAPI.RANCHER_CLUSTER,
   created:      'Thu Jul 20 2023 11:11:39',
   snapshotFile: { status: STATES_ENUM.SUCCESSFUL },
-  id:           'id',
-  name:         'name'
+  id:           'rke2_id_1',
+  name:         'rke2_name_1'
 };
-const SUCCESSFUL_SNAPSHOT_2 = {
-  isRke2:       true,
+const RKE2_SUCCESSFUL_SNAPSHOT_2 = {
+  clusterName:  RKE2_CLUSTER_NAME,
   type:         CAPI.RANCHER_CLUSTER,
   created:      'Thu Jul 20 2022 11:11:39',
   snapshotFile: { status: STATES_ENUM.SUCCESSFUL },
-  id:           'id2',
-  name:         'name2'
+  id:           'rke2_id_2',
+  name:         'rke2_name_2'
 };
-const FAILED_SNAPSHOT = {
-  isRke2:       true,
+const RKE2_FAILED_SNAPSHOT = {
+  clusterName:  RKE2_CLUSTER_NAME,
   type:         CAPI.RANCHER_CLUSTER,
   created:      'Thu Jul 20 2021 11:11:39',
   snapshotFile: { status: STATES_ENUM.FAILED },
-  id:           'id_3',
-  name:         'name_3'
+  id:           'rke2_id_3',
+  name:         'rke2_name_3'
 };
 
-describe('component: GrowlManager', () => {
+const RKE1_CLUSTER_NAME = 'rke1_cluster_name';
+const RKE1_SUCCESSFUL_SNAPSHOT_1 = {
+  clusterId: RKE1_CLUSTER_NAME,
+  type:      NORMAN.ETCD_BACKUP,
+  state:     STATES_ENUM.ACTIVE,
+  created:   'Thu Jul 30 2023 11:11:39',
+  id:        'rke1_id_1',
+  name:      'rke1_name_1'
+};
+const RKE1_SUCCESSFUL_SNAPSHOT_2 = {
+  clusterId: RKE1_CLUSTER_NAME,
+  type:      NORMAN.ETCD_BACKUP,
+  state:     STATES_ENUM.ACTIVE,
+  created:   'Thu Jul 30 2022 11:11:39',
+  id:        'rke1_id_2',
+  name:      'rke1_name_2'
+};
+const RKE1_WITH_ERROR_SNAPSHOT = {
+  clusterId: RKE1_CLUSTER_NAME,
+  type:      NORMAN.ETCD_BACKUP,
+  state:     STATES_ENUM.ERROR,
+  created:   'Thu Jul 30 2021 11:11:39',
+  id:        'rke1_id_3',
+  name:      'rke1_name_3'
+};
+
+describe('component: PromptRestore', () => {
   const localVue = createLocalVue();
 
   localVue.use(Vuex);
 
-  const testCases = [
+  const rke2TestCases = [
     [[], 0],
-    [[FAILED_SNAPSHOT], 0],
-    [[SUCCESSFUL_SNAPSHOT_1], 1],
-    [[SUCCESSFUL_SNAPSHOT_1, SUCCESSFUL_SNAPSHOT_2], 2],
-    [[FAILED_SNAPSHOT, SUCCESSFUL_SNAPSHOT_1, SUCCESSFUL_SNAPSHOT_2], 2]
+    [[RKE2_FAILED_SNAPSHOT], 0],
+    [[RKE2_SUCCESSFUL_SNAPSHOT_1], 1],
+    [[RKE2_SUCCESSFUL_SNAPSHOT_1, RKE2_SUCCESSFUL_SNAPSHOT_2], 2],
+    [[RKE2_FAILED_SNAPSHOT, RKE2_SUCCESSFUL_SNAPSHOT_1, RKE2_SUCCESSFUL_SNAPSHOT_2], 2]
   ];
 
-  it.each(testCases)('should list RKE2 snapshots properly', async(snapShots, expected) => {
+  it.each(rke2TestCases)('should list RKE2 snapshots properly', async(snapShots, expected) => {
     const store = new Vuex.Store({
       modules: {
         'action-menu': {
           namespaced: true,
           state:      {
             showPromptRestore: true,
-            toRestore:         snapShots
+            toRestore:         [{
+              isRke2:   true,
+              type:     CAPI.RANCHER_CLUSTER,
+              metadata: { name: RKE2_CLUSTER_NAME },
+              snapShots
+            }]
           },
         },
       },
       getters: { 'i18n/t': () => jest.fn(), 'prefs/get': () => jest.fn() },
       actions: { 'management/findAll': jest.fn().mockResolvedValue(snapShots), 'rancher/findAll': jest.fn().mockResolvedValue([]) }
+    });
+
+    const wrapper = shallowMount(PromptRestore as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      store,
+      localVue
+    });
+
+    await wrapper.vm.fetchSnapshots();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.clusterSnapshots).toHaveLength(expected);
+  });
+
+  const rke1TestCases = [
+    [[], 0],
+    [[RKE1_WITH_ERROR_SNAPSHOT], 0],
+    [[RKE1_SUCCESSFUL_SNAPSHOT_1], 1],
+    [[RKE1_SUCCESSFUL_SNAPSHOT_1, RKE1_SUCCESSFUL_SNAPSHOT_2], 2],
+    [[RKE1_WITH_ERROR_SNAPSHOT, RKE1_SUCCESSFUL_SNAPSHOT_1, RKE1_SUCCESSFUL_SNAPSHOT_2], 2]
+  ];
+
+  it.each(rke1TestCases)('should list RKE1 snapshots properly', async(snapShots, expected) => {
+    const store = new Vuex.Store({
+      modules: {
+        'action-menu': {
+          namespaced: true,
+          state:      {
+            showPromptRestore: true,
+            toRestore:         [{
+              type:     CAPI.RANCHER_CLUSTER,
+              metadata: { name: RKE1_CLUSTER_NAME },
+              snapShots
+            }]
+          },
+        },
+      },
+      getters: { 'i18n/t': () => jest.fn(), 'prefs/get': () => jest.fn() },
+      actions: { 'rancher/findAll': jest.fn().mockResolvedValue(snapShots) }
     });
 
     const wrapper = shallowMount(PromptRestore as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {

--- a/shell/models/etcdbackup.js
+++ b/shell/models/etcdbackup.js
@@ -1,10 +1,11 @@
 import NormanModel from '@shell/plugins/steve/norman-class';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 
 export default class Rke1EtcdBackup extends NormanModel {
   get _availableActions() {
     const restore = {
       action:  'promptRestore',
-      enabled: true,
+      enabled: this.state === STATES_ENUM.ACTIVE,
       icon:    'icon icon-fw icon-backup-restore',
       label:   'Restore'
     };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Unlike RKE2, provisioning an RKE1 cluster will fail if invalid S3 bucket values are provided. However, when creating S3 snapshots, there may still be instances of an error state. This pull request ensures that only snapshots with an 'active' state can be used for restore purposes.

Fixes #9409 
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
https://github.com/rancher/dashboard/assets/135728925/d11011b6-b803-4dd2-8195-5142936d0e1d
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->