### PR TITLE
Fix broken rke1 e2e tests

### DIFF
--- a/cypress/e2e/po/components/ember/ember-input.po.ts
+++ b/cypress/e2e/po/components/ember/ember-input.po.ts
@@ -23,6 +23,6 @@ export default class EmberInputPo extends EmberComponentPo {
    * @returns HTML Element
    */
   private input(): Cypress.Chainable {
-    return this.self().find('input');
+    return this.self();
   }
 }


### PR DESCRIPTION
- caused by change in rancher/ui to data-testid for ember input component
- matches incoming fix from https://github.com/rancher/dashboard/pull/9247/files#diff-a28e7dd962b16d8e0570014b50460e8d8fbc8b47e72bd58c6d272e75bb821e49R27