### PR TITLE
fix circular reference bug

### DIFF
--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -235,6 +235,7 @@ export default {
         'aws',
         'digitalocean',
         'linode',
+        'targetRoute', // contains circular references, isn't useful (added later to store)
       ];
 
       const clearListsKeys = [


### PR DESCRIPTION
Fixes #9463 

- Fix issue with circular reference on download diagnostics where a recently added state property `targetRoute` caused the issue of download not working anymore (https://github.com/rancher/dashboard/commit/717a2b2c144a362daa8b21b69287527bfc230c26#diff-de86d0a4fac14b29141d7979ab7f5410499a628cab2f66aa58931eb266ffbde1R246)