### PR TITLE
fix e2e test in roles.spec

### DIFF
--- a/cypress/e2e/po/pages/page.po.ts
+++ b/cypress/e2e/po/pages/page.po.ts
@@ -19,7 +19,7 @@ export default class PagePo extends ComponentPo {
    */
   static goToAndWaitForGet(goTo: () => Cypress.Chainable, getUrls = [
     'v1/counts',
-  ]) {
+  ], timeout = 10000) {
     getUrls.forEach((cUrl, i) => {
       cy.intercept('GET', cUrl).as(`getUrl${ i }`);
     });
@@ -30,7 +30,7 @@ export default class PagePo extends ComponentPo {
       // If an intercept for the url already exists... use the same wait (it'll fire on that one)
       const existingIndexOrCurrent = getUrls.indexOf(getUrls[i]);
 
-      cy.wait([`@getUrl${ existingIndexOrCurrent }`], { timeout: 10000 });
+      cy.wait([`@getUrl${ existingIndexOrCurrent }`], { timeout });
     }
   }
 

--- a/cypress/e2e/po/pages/users-and-auth/users.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/users.po.ts
@@ -17,7 +17,7 @@ export default class UsersPo extends PagePo {
   }
 
   waitForRequests() {
-    UsersPo.goToAndWaitForGet(this.goTo.bind(this), ['/v3/users?limit=0']);
+    UsersPo.goToAndWaitForGet(this.goTo.bind(this), ['/v3/users?limit=0'], 15000);
   }
 
   list() {


### PR DESCRIPTION
### Summary
[One of the roles e2e test intermittently fails](http://139.59.134.103/instance/6cc9a893-c1ed-4177-b11e-af3e5a494b10/test/r8 ) with a timeout error when navigating to the Users page. This seems to be a scenario-specific issue; the admin user logs out, then the standard user logs in and navigates to the Users page. In this scenario, the Users page sometimes takes more than 10 seconds to load which is greater than the 10-second timeout set in the test.
Fix:
- Add `timeout` as an argument in the goToAndWaitForGet() function (default value of 10 sec)
- Increase timeout in users.po when navigating to the Users page (from 10 sec to 15 sec)

Failing test: http://139.59.134.103/instance/6cc9a893-c1ed-4177-b11e-af3e5a494b10/test/r8 (**see error on the first attempt - that's the relevant one**)


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2023-08-01 at 3 53 47 PM](https://github.com/rancher/dashboard/assets/127343932/a2ea8747-225b-4401-a955-ecade95fa1d2)
