### PR TITLE
Auth: Preserve error code

### DIFF
--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -209,6 +209,13 @@ export default async function({
     if ( route.name === 'index' ) {
       return redirect(302, '/auth/login');
     } else {
+      // Don't lose the error code
+      const errorCode = route.query?.errorCode;
+
+      if (errorCode) {
+        return redirect(302, `/auth/login?errorCode=${ errorCode }`);
+      }
+
       return redirect(302, `/auth/login?${ TIMED_OUT }`);
     }
   }

--- a/shell/pages/auth/verify.vue
+++ b/shell/pages/auth/verify.vue
@@ -34,6 +34,20 @@ export default {
         out = store.getters['i18n/withFallback'](`login.serverError.${ errorMsg }`, null, errorMsg);
       }
 
+      const openerLoc = window.opener?.location;
+      const thisLoc = window.location;
+
+      // Check to see if we are verifying auth from a config page - if we are, we should reply to it, rather than redirecting
+      // This way we will show the error in the original window, rather than leaving a new window open with the error in it
+      // (user probably can not do anything useful in the new window to rectify the error)
+      if (window.opener && window.opener !== window && openerLoc && thisLoc &&
+        openerLoc.origin === thisLoc.origin && openerLoc.pathname.startsWith('/c/local/auth/config/')) {
+
+        reply(out, errorCode);
+
+        return;
+      }
+      
       redirect(`/auth/login?err=${ escape(out) }`);
 
       return;

--- a/shell/pages/auth/verify.vue
+++ b/shell/pages/auth/verify.vue
@@ -42,12 +42,11 @@ export default {
       // (user probably can not do anything useful in the new window to rectify the error)
       if (window.opener && window.opener !== window && openerLoc && thisLoc &&
         openerLoc.origin === thisLoc.origin && openerLoc.pathname.startsWith('/c/local/auth/config/')) {
-
         reply(out, errorCode);
 
         return;
       }
-      
+
       redirect(`/auth/login?err=${ escape(out) }`);
 
       return;


### PR DESCRIPTION
WIP: Preserve the error code from the auth flow

Not sure both changes are needed for: #9482 

Probably only the change in `authenticated.js` is needed to preserve error code - will probably need something to preserve and pass along the error message.