### PR TITLE
Fix theme of initial loading page when user hasn't previously selected a theme

### DIFF
--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -13,8 +13,10 @@
     <div id="app">
         <script>
             (() => {
-                const isDark = document.cookie.includes('R_THEME=auto') ?
-                    // User selected automatic theme, so use pcs (set when ui previously loaded and is either os theme or time of day based
+                // Has the user chosen to auto detect the theme.... or if they haven't chosen anything.. --> check the auto-detected theme via R_PCS
+                // Otherwise check if they've specifically selected a theme --> R_THEME
+                const isDark = document.cookie.includes('R_THEME=auto') || !document.cookie.includes('R_THEME') ?
+                    // User selected automatic theme, so use PCS (set when ui previously loaded and is either os theme or time of day based)
                     document.cookie.includes('R_PCS=dark') :
                     // Otherwise user selected light/dark theme directly
                     document.cookie.includes('R_THEME=dark');


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->

### Occurred changes and/or fixed issues
- previously we would wait till the user sets a theme to either auto or dark for the initial loading indicator to be dark
- this change means we treat no theme set as auto (aka pick up from OS)
  - this will be the case for most users
- as soon as the user sets a theme the code should continue as before
- follows on from https://github.com/rancher/dashboard/pull/9022
