### PR TITLE
Correctly filter helm charts with display-name annotation

### DIFF
--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -245,7 +245,7 @@ export default {
         // Label can be overridden by chart annotation
         const label = uiPluginAnnotation(UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME) || chart.chartNameDisplay;
         const item = {
-          name:         chart.chartNameDisplay,
+          name:         chart.chartName,
           label,
           description:  chart.chartDescription,
           id:           chart.id,


### PR DESCRIPTION
When calculating available extension helm charts and combining them with uiplugins the chart item name must be set to chartName instead of chartDisplayName.

Fixes https://github.com/rancher/dashboard/issues/9496