### PR TITLE
fix growl text overflow

### DIFF
--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -155,7 +155,7 @@ export default {
 
   .growl-list {
     max-height: calc(100vh - 50px);
-    overflow: hidden;
+    overflow: scroll;
   }
 
   .growl {

--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -155,7 +155,7 @@ export default {
 
   .growl-list {
     max-height: calc(100vh - 50px);
-    overflow: scroll;
+    overflow: hidden;
   }
 
   .growl {
@@ -203,6 +203,10 @@ export default {
 
         > P {
           padding-top: 2px;
+
+          // Limit size of message and scroll just the message, not the entire growl, so that the title and icon are always visible
+          max-height: 200px;
+          overflow-y: scroll;
 
           &.has-title {
             margin-top: 5px;


### PR DESCRIPTION
Fixes #14793

### Occurred changes and/or fixed issues

I've updated this PR to add the height limit and scroll to the growl message rather than the outer container - so each growl now has a restricted height and the growl scrolls, rather than the a scroll bar being added to the entire app for the growl list.

See below:

### Technical notes summary

Added a `max-height` and `overflow-y` to the growl message text to ensure it does not grow to a very largge height.

### Screenshot/Video

<img width="478" height="317" alt="image" src="https://github.com/user-attachments/assets/17da22a4-196a-470e-a0bd-225f40c389a1" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`