### PR TITLE
Fix usage of plugin metadata annotations

### DIFF
--- a/pkg/harvester-manager/package.json
+++ b/pkg/harvester-manager/package.json
@@ -4,7 +4,9 @@
   "version": "0.1.0",
   "private": false,
   "rancher": {
-    "catalog.cattle.io/display-name": "Virtualization Manager"
+    "annotations": {
+      "catalog.cattle.io/display-name": "Virtualization Manager"
+    }
   },
   "scripts": {
     "dev": "./node_modules/.bin/nuxt dev",

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -305,7 +305,7 @@ export default {
         if (!chart) {
           // A plugin is loaded, but there is no chart, so add an item so that it shows up
           const rancher = typeof p.metadata?.rancher === 'object' ? p.metadata.rancher : {};
-          const label = rancher[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || p.name;
+          const label = rancher.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || p.name;
           const item = {
             name:           p.name,
             label,


### PR DESCRIPTION
Annotations for an extension/plugin should be defined in package.json at rancher.annotations object so that the annotations are correctly copied when generating a Helm chart and correctly used in the dashboard.

Fixes https://github.com/rancher/dashboard/issues/9501