### PR TITLE
Show ad migration login error message

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3008,6 +3008,7 @@ login:
     noResponse: "No response received"
   error: An error occurred logging in. Please try again.
   clientError: Invalid username or password. Please try again.
+  specificError: 'An error occured logging in: {msg}'
   useLocal: Use a local user
   loginWithProvider: Log in with {provider}
   username: Username

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -149,7 +149,7 @@ export default {
         return this.t('login.error');
       }
 
-      return this.err;
+      return this.err?.length ? this.t('login.specificError', { msg: this.err }) : '';
     },
 
     errorToDisplay() {

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -303,6 +303,8 @@ export const actions = {
         return Promise.reject(LOGIN_ERRORS.CLIENT_UNAUTHORIZED);
       } else if ( err._status >= 400 && err._status <= 499 ) {
         return Promise.reject(LOGIN_ERRORS.CLIENT);
+      } else if (err.message) {
+        return Promise.reject(err.message);
       }
 
       return Promise.reject(LOGIN_ERRORS.SERVER);

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -301,10 +301,10 @@ export const actions = {
     } catch (err) {
       if (err._status === 401) {
         return Promise.reject(LOGIN_ERRORS.CLIENT_UNAUTHORIZED);
-      } else if ( err._status >= 400 && err._status <= 499 ) {
-        return Promise.reject(LOGIN_ERRORS.CLIENT);
       } else if (err.message) {
         return Promise.reject(err.message);
+      } else if ( err._status >= 400 && err._status <= 499 ) {
+        return Promise.reject(LOGIN_ERRORS.CLIENT);
       }
 
       return Promise.reject(LOGIN_ERRORS.SERVER);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9482

Currently when a login request fails we show one of two generic error messages. This PR updates the error-catching behavior to show a specific error message when one has been provided, except 401 errors, which still show `Invalid username or password. Please try again.`

![Screen Shot 2023-08-08 at 4 09 52 PM](https://github.com/rancher/dashboard/assets/42977925/a49a9b97-06a9-455f-b307-4351e7aef0d2)
