### PR TITLE
Support server-side pagination - alpha

### DIFF
--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -165,7 +165,6 @@ export default {
       const { filter: neuFilter, sort: neuSort, ...newPrimitiveTypes } = neu;
       const { filter: oldFilter, sort: oldSort, ...oldPrimitiveTypes } = old;
 
-      debugger;
       if (
         isEqual(newPrimitiveTypes, oldPrimitiveTypes) &&
         isEqual(neuFilter, oldFilter) &&
@@ -177,7 +176,7 @@ export default {
       if (neu && !this.hasFetch) {
         this.$fetchType(this.resource);
       }
-    }
+    },
   },
 
   created() {
@@ -248,6 +247,7 @@ export default {
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
       :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
       :external-pagination="!!pagination"
+      :external-pagination-result="paginationResult"
       @pagination-changed="paginationChanged"
     />
   </div>

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -9,6 +9,7 @@ import { ResourceListComponentName } from './resource-list.config';
 import { PanelLocation, ExtensionPoint } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
 import { sameContents } from '@shell/utils/array';
+import { isEqual } from '@shell/utils/object';
 
 export default {
   name: ResourceListComponentName,
@@ -155,6 +156,25 @@ export default {
       if (neu && !this.hasFetch) {
         this.$fetchType(this.resource);
       }
+    },
+
+    // TODO: RC comment
+    pagination(neu, old) {
+      const { filter: neuFilter, sort: neuSort, ...newPrimitiveTypes } = neu;
+      const { filter: oldFilter, sort: oldSort, ...oldPrimitiveTypes } = old;
+
+      debugger;
+      if (
+        isEqual(newPrimitiveTypes, oldPrimitiveTypes) &&
+        isEqual(neuFilter, oldFilter) &&
+        sameContents(neuSort, oldSort)
+      ) {
+        return;
+      }
+
+      if (neu && !this.hasFetch) {
+        this.$fetchType(this.resource);
+      }
     }
   },
 
@@ -225,11 +245,13 @@ export default {
       :adv-filter-prevent-filtering-labels="advFilterPreventFilteringLabels"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
       :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
+      :external-pagination="!!pagination"
+      @pagination-changed="paginationChanged"
     />
   </div>
 </template>
 
-  <style lang="scss" scoped>
+<style lang="scss" scoped>
     .header {
       position: relative;
     }
@@ -245,4 +267,4 @@ export default {
       top: 10px;
       right: 10px;
     }
-  </style>
+</style>

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -8,7 +8,7 @@ import IconMessage from '@shell/components/IconMessage.vue';
 import { ResourceListComponentName } from './resource-list.config';
 import { PanelLocation, ExtensionPoint } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
-import { sameContents } from '@shell/utils/array';
+import { sameArrayObjects, sameContents } from '@shell/utils/array';
 import { isEqual } from '@shell/utils/object';
 
 export default {
@@ -170,7 +170,7 @@ export default {
       if (
         isEqual(newPrimitiveTypes, oldPrimitiveTypes) &&
         isEqual(neuFilter, oldFilter) &&
-        sameContents(neuSort, oldSort)
+        sameArrayObjects(neuSort, oldSort)
       ) {
         // TODO: RC TEST more
         return;

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -78,7 +78,7 @@ export default {
 
       // See comment for `namespaceFilterRequired` watcher, skip fetch if we don't have a valid NS
       // TODO: RC TODO tie in to comment above
-      if (!this.namespaceFilterRequired && !this.canPaginate) { // TODO: RC comment. also we should show loading indicator
+      if (!this.namespaceFilterRequired && !this.canPaginate) {
         await this.$fetchType(resource);
       }
     }
@@ -163,7 +163,6 @@ export default {
       }
     },
 
-    // TODO: RC comment
     pagination(neu, old) {
       const { filter: neuFilter, sort: neuSort, ...newPrimitiveTypes } = neu;
       const { filter: oldFilter, sort: oldSort, ...oldPrimitiveTypes } = old;
@@ -173,6 +172,7 @@ export default {
         isEqual(neuFilter, oldFilter) &&
         sameContents(neuSort, oldSort)
       ) {
+        // TODO: RC TEST more
         return;
       }
 

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -77,7 +77,8 @@ export default {
       }
 
       // See comment for `namespaceFilterRequired` watcher, skip fetch if we don't have a valid NS
-      if (!this.namespaceFilterRequired && !this.__paginationRequired) { // TODO: RC comment. also we should show loading indicator
+      // TODO: RC TODO tie in to comment above
+      if (!this.namespaceFilterRequired && !this.canPaginate) { // TODO: RC comment. also we should show loading indicator
         await this.$fetchType(resource);
       }
     }
@@ -125,9 +126,11 @@ export default {
         return [];
       }
 
-      // TODO: RC
-      return this.$store.getters['type-map/paginationHeadersFor'](this.schema) ||
-      this.$store.getters['type-map/headersFor'](this.schema);
+      if (this.pagination) {
+        return this.paginationHeaders;
+      }
+
+      return this.$store.getters['type-map/headersFor'](this.schema);
     },
 
     groupBy() {

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -77,7 +77,7 @@ export default {
       }
 
       // See comment for `namespaceFilterRequired` watcher, skip fetch if we don't have a valid NS
-      if (!this.namespaceFilterRequired) {
+      if (!this.namespaceFilterRequired && !this.__paginationRequired) { // TODO: RC comment. also we should show loading indicator
         await this.$fetchType(resource);
       }
     }
@@ -125,7 +125,9 @@ export default {
         return [];
       }
 
-      return this.$store.getters['type-map/headersFor'](this.schema);
+      // TODO: RC
+      return this.$store.getters['type-map/paginationHeadersFor'](this.schema) ||
+      this.$store.getters['type-map/headersFor'](this.schema);
     },
 
     groupBy() {

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -157,6 +157,11 @@ export default {
     forceUpdateLiveAndDelayed: {
       type:    Number,
       default: 0
+    },
+
+    externalPagination: {
+      type:    Boolean,
+      default: false
     }
   },
 
@@ -301,11 +306,14 @@ export default {
       if (
         !this.isNamespaced || // Resource type isn't namespaced
         this.ignoreFilter || // Component owner strictly states no filtering
+        this.externalPagination || // TODO: RC
         (isAll && !this.currentProduct?.hideSystemResources) || // Need all
         (this.inStore ? this.$store.getters[`${ this.inStore }/haveNamespace`](this.schema.id)?.length : false)// Store reports type has namespace filter, so rows already contain the correctly filtered resources
       ) {
         return this.rows || [];
       }
+
+      console.warn('NOOOOO');
 
       const includedNamespaces = this.$store.getters['namespaces']();
 

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -239,7 +239,7 @@ export default {
       if ( this.headers ) {
         headers = this.headers.slice();
       } else {
-        headers = this.$store.getters['type-map/headersFor'](this.schema); // TODO: RC
+        headers = this.$store.getters['type-map/headersFor'](this.schema); // TODO: RC not required atm, but needs to be integrated with pagination headers
       }
 
       // add custom table columns provided by the extensions ExtensionPoint.TABLE_COL hook

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -507,6 +507,7 @@ export default {
     :sort-generation-fn="safeSortGenerationFn"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
     :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
+    :external-pagination="externalPagination"
     @clickedActionButton="handleActionButtonClick"
     @group-value-change="group = $event"
     v-on="$listeners"

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -305,6 +305,9 @@ export default {
       return headers;
     },
 
+    /**
+     * Take rows and filter out entries given the namespace filter
+     */
     filteredRows() {
       const isAll = this.$store.getters['isAllNamespaces'];
 
@@ -312,7 +315,7 @@ export default {
       if (
         !this.isNamespaced || // Resource type isn't namespaced
         this.ignoreFilter || // Component owner strictly states no filtering
-        this.externalPagination || // TODO: RC
+        this.externalPagination ||
         (isAll && !this.currentProduct?.hideSystemResources) || // Need all
         (this.inStore ? this.$store.getters[`${ this.inStore }/haveNamespace`](this.schema.id)?.length : false)// Store reports type has namespace filter, so rows already contain the correctly filtered resources
       ) {
@@ -344,7 +347,7 @@ export default {
       });
     },
 
-    _group: mapPref(GROUP_RESOURCES), // TODO: RC ensure group preference sticks
+    _group: mapPref(GROUP_RESOURCES),
 
     // The group stored in the preference (above) might not be valid for this resource table - so ensure we
     // choose a group that is applicable (the default)

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -162,6 +162,11 @@ export default {
     externalPagination: {
       type:    Boolean,
       default: false
+    },
+
+    externalPaginationResult: {
+      type:    Object,
+      default: null
     }
   },
 
@@ -508,6 +513,7 @@ export default {
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
     :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
     :external-pagination="externalPagination"
+    :external-pagination-result="externalPaginationResult"
     @clickedActionButton="handleActionButtonClick"
     @group-value-change="group = $event"
     v-on="$listeners"

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -322,8 +322,6 @@ export default {
         return this.rows || [];
       }
 
-      console.warn('NOOOOO');
-
       const includedNamespaces = this.$store.getters['namespaces']();
 
       // Shouldn't happen, but does for resources like management.cattle.io.preference

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -187,6 +187,7 @@ export default {
   data() {
     const options = this.$store.getters[`type-map/optionsFor`](this.schema);
     const listGroups = options?.listGroups || [];
+    const listGroupsWillOverride = options?.listGroupsWillOverride;
     const listGroupMapped = listGroups.reduce((acc, grp) => {
       acc[grp.value] = grp;
 
@@ -197,7 +198,7 @@ export default {
     const inStore = this.schema?.id ? this.$store.getters['currentStore'](this.schema.id) : undefined;
 
     return {
-      listGroups, listGroupMapped, inStore
+      listGroups, listGroupsWillOverride, listGroupMapped, inStore
     };
   },
 
@@ -238,7 +239,7 @@ export default {
       if ( this.headers ) {
         headers = this.headers.slice();
       } else {
-        headers = this.$store.getters['type-map/headersFor'](this.schema);
+        headers = this.$store.getters['type-map/headersFor'](this.schema); // TODO: RC
       }
 
       // add custom table columns provided by the extensions ExtensionPoint.TABLE_COL hook
@@ -343,7 +344,7 @@ export default {
       });
     },
 
-    _group: mapPref(GROUP_RESOURCES),
+    _group: mapPref(GROUP_RESOURCES), // TODO: RC ensure group preference sticks
 
     // The group stored in the preference (above) might not be valid for this resource table - so ensure we
     // choose a group that is applicable (the default)
@@ -395,6 +396,10 @@ export default {
     },
 
     groupOptions() {
+      if (this.listGroupsWillOverride && this.listGroups?.length) {
+        return this.listGroups;
+      }
+
       const standard = [
         {
           tooltipKey: 'resourceTable.groupBy.none',

--- a/shell/components/SortableTable/filtering.js
+++ b/shell/components/SortableTable/filtering.js
@@ -162,7 +162,11 @@ export default {
     arrangedRows(q) {
       // The rows changed so the old filter result is no longer useful
       this.previousResult = null;
-    }
+    },
+
+    searchQuery() {
+      this.paginationChanged();
+    },
   },
 };
 

--- a/shell/components/SortableTable/filtering.js
+++ b/shell/components/SortableTable/filtering.js
@@ -169,7 +169,7 @@ export default {
     },
 
     searchQuery() {
-      this.paginationChanged();
+      this.debouncedPaginationChanged();
     },
   },
 };

--- a/shell/components/SortableTable/filtering.js
+++ b/shell/components/SortableTable/filtering.js
@@ -33,6 +33,10 @@ export default {
     }),
     */
     filteredRows() {
+      if (this.externalPagination) {
+        return;
+      }
+
       // PROP hasAdvancedFiltering comes from Advanced Filtering mixin (careful changing data var there...)
       if (!this.hasAdvancedFiltering) {
         return this.handleFiltering();

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -917,6 +917,7 @@ export default {
     },
 
     paginationChanged() {
+      // TODO: RC debounce
       console.warn('ss', 'methods', 'paginationChanged', {
         page:    this.page,
         perPage: this.perPage,

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -918,6 +918,7 @@ export default {
     },
 
     paginationChanged() {
+      // eslint-disable-next-line no-console
       console.warn('ss', 'methods', 'paginationChanged', {
         page:    this.page,
         perPage: this.perPage,

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -326,8 +326,6 @@ export default {
     }
   },
 
-  // TODO: RC ??? on group change.... do something
-
   data() {
     let searchQuery = '';
     let eventualSearchQuery = '';

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -48,10 +48,12 @@ export const COLUMN_BREAKPOINTS = {
 
 // Data Flow:
 // rows prop
-// -> arrangedRows (sorting.js)
-// -> filteredRows (filtering.js)
-// -> pagedRows    (paging.js)
-// -> groupedRows  (grouping.js)
+// --> sorting.js arrangedRows
+// --> filtering.js handleFiltering()
+// --> filtering.js filteredRows
+// --> paging.js pageRows
+// --> grouping.js groupedRows
+// --> index.vue displayedRows
 
 export default {
   name:       'SortableTable',
@@ -312,6 +314,11 @@ export default {
     forceUpdateLiveAndDelayed: {
       type:    Number,
       default: 0
+    },
+
+    externalPagination: {
+      required: true,
+      default:  true
     }
   },
 

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -317,10 +317,12 @@ export default {
     },
 
     externalPagination: {
-      required: true,
-      default:  true
+      type:    Boolean,
+      default: false
     }
   },
+
+  // TODO: RC on group change.... do something
 
   data() {
     let searchQuery = '';
@@ -904,6 +906,22 @@ export default {
         event,
         targetElement: this.$refs[`actionButton${ i }`][0],
       });
+    },
+
+    paginationChanged() {
+      console.warn('ss', 'methods', 'paginationChanged', {
+        page:    this.page,
+        perPage: this.perPage,
+        filter:  this.searchFields,
+        sort:    this.sortFields,
+      });
+      this.$emit('pagination-changed', {
+        page:       this.page,
+        perPage:    this.perPage,
+        filter:     this.searchFields,
+        sort:       this.sortFields,
+        descending: this.descending
+      });
     }
   }
 };
@@ -1450,7 +1468,7 @@ export default {
   </div>
 </template>
 
-  <style lang="scss" scoped>
+<style lang="scss" scoped>
 
   .manual-refresh {
     height: 40px;
@@ -1614,9 +1632,9 @@ export default {
     margin-left: 10px;
     min-width: 180px;
   }
-  </style>
+</style>
 
-  <style lang="scss">
+<style lang="scss">
   //
   // Important: Almost all selectors in here need to be ">"-ed together so they
   // apply only to the current table, not one nested inside another table.
@@ -1948,4 +1966,4 @@ export default {
       min-width: 200px;
     }
   }
-  </style>
+</style>

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -326,7 +326,7 @@ export default {
     }
   },
 
-  // TODO: RC on group change.... do something
+  // TODO: RC ??? on group change.... do something
 
   data() {
     let searchQuery = '';
@@ -339,12 +339,13 @@ export default {
     }
 
     return {
-      currentPhase:     ASYNC_BUTTON_STATES.WAITING,
-      expanded:         {},
+      currentPhase:               ASYNC_BUTTON_STATES.WAITING,
+      expanded:                   {},
       searchQuery,
       eventualSearchQuery,
-      actionOfInterest: null,
-      loadingDelay:     false,
+      actionOfInterest:           null,
+      loadingDelay:               false,
+      debouncedPaginationChanged: null,
     };
   },
 
@@ -360,7 +361,7 @@ export default {
     $main?.addEventListener('scroll', this._onScroll);
 
     if (this.externalPagination) {
-      this.paginationChanged();
+      this.debouncedPaginationChanged();
     }
   },
 
@@ -445,6 +446,7 @@ export default {
 
   created() {
     this.debouncedRefreshTableData = debounce(this.refreshTableData, 500);
+    this.debouncedPaginationChanged = debounce(this.paginationChanged, 500);
   },
 
   computed: {
@@ -917,7 +919,6 @@ export default {
     },
 
     paginationChanged() {
-      // TODO: RC debounce
       console.warn('ss', 'methods', 'paginationChanged', {
         page:    this.page,
         perPage: this.perPage,

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -341,6 +341,7 @@ export default {
       expanded:                   {},
       searchQuery,
       eventualSearchQuery,
+      subMatches:                 null,
       actionOfInterest:           null,
       loadingDelay:               false,
       debouncedPaginationChanged: null,
@@ -444,7 +445,7 @@ export default {
 
   created() {
     this.debouncedRefreshTableData = debounce(this.refreshTableData, 500);
-    this.debouncedPaginationChanged = debounce(this.paginationChanged, 500);
+    this.debouncedPaginationChanged = debounce(this.paginationChanged, 50);
   },
 
   computed: {

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -354,6 +354,10 @@ export default {
 
     this._onScroll = this.onScroll.bind(this);
     $main?.addEventListener('scroll', this._onScroll);
+
+    if (this.externalPagination) {
+      this.paginationChanged();
+    }
   },
 
   beforeDestroy() {
@@ -916,9 +920,12 @@ export default {
         sort:    this.sortFields,
       });
       this.$emit('pagination-changed', {
-        page:       this.page,
-        perPage:    this.perPage,
-        filter:     this.searchFields,
+        page:    this.page,
+        perPage: this.perPage,
+        filter:  {
+          searchFields: this.searchFields,
+          searchQuery:  this.searchQuery
+        },
         sort:       this.sortFields,
         descending: this.descending
       });

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -319,6 +319,10 @@ export default {
     externalPagination: {
       type:    Boolean,
       default: false
+    },
+    externalPaginationResult: {
+      type:    Object,
+      default: null
     }
   },
 

--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -71,11 +71,11 @@ export default {
     },
 
     page() {
-      this.paginationChanged();
+      this.debouncedPaginationChanged();
     },
 
     perPage() {
-      this.paginationChanged();
+      this.debouncedPaginationChanged();
     },
 
   },

--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -3,9 +3,12 @@ import { ROWS_PER_PAGE } from '@shell/store/prefs';
 export default {
   computed: {
     totalRows() {
-      debugger;
+      console.warn('ss', 'mixins', 'paging', 'computed', 'totalrows', this.externalPaginationResult);
+      if (this.externalPagination) {
+        return this.externalPaginationResult?.count || 0;
+      }
 
-      return this.externalPagination ? 15 : this.filteredRows.length; // TODO: RC
+      return this.filteredRows.length;
     },
 
     indexFrom() {

--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -3,6 +3,8 @@ import { ROWS_PER_PAGE } from '@shell/store/prefs';
 export default {
   computed: {
     totalRows() {
+      debugger;
+
       return this.externalPagination ? 15 : this.filteredRows.length; // TODO: RC
     },
 
@@ -32,12 +34,11 @@ export default {
         to:    this.indexTo,
       };
 
-      console.warn('pagingDisplay', opt);
-
       return this.$store.getters['i18n/t'](this.pagingLabel, opt);
     },
 
     pagedRows() {
+      console.warn('sortable', 'mixin', 'paging', 'pagedRows', this.externalPagination);
       if (this.externalPagination) {
         return this.rows;
       } else if ( this.paging ) {

--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -3,7 +3,7 @@ import { ROWS_PER_PAGE } from '@shell/store/prefs';
 export default {
   computed: {
     totalRows() {
-      console.warn('ss', 'mixins', 'paging', 'computed', 'totalrows', this.externalPaginationResult);
+      console.warn('ss', 'mixins', 'paging', 'computed', 'totalrows', this.externalPaginationResult); // eslint-disable-line no-console
       if (this.externalPagination) {
         return this.externalPaginationResult?.count || 0;
       }
@@ -41,7 +41,7 @@ export default {
     },
 
     pagedRows() {
-      console.warn('sortable', 'mixin', 'paging', 'pagedRows', this.externalPagination);
+      console.warn('sortable', 'mixin', 'paging', 'pagedRows', this.externalPagination); // eslint-disable-line no-console
       if (this.externalPagination) {
         return this.rows;
       } else if ( this.paging ) {

--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -2,16 +2,20 @@ import { ROWS_PER_PAGE } from '@shell/store/prefs';
 
 export default {
   computed: {
+    totalRows() {
+      return this.externalPagination ? 15 : this.filteredRows.length; // TODO: RC
+    },
+
     indexFrom() {
       return Math.max(0, 1 + this.perPage * (this.page - 1));
     },
 
     indexTo() {
-      return Math.min(this.filteredRows.length, this.indexFrom + this.perPage - 1);
+      return Math.min(this.totalRows, this.indexFrom + this.perPage - 1);
     },
 
     totalPages() {
-      return Math.ceil(this.filteredRows.length / this.perPage );
+      return Math.ceil(this.totalRows / this.perPage );
     },
 
     showPaging() {
@@ -22,17 +26,21 @@ export default {
       const opt = {
         ...(this.pagingParams || {}),
 
-        count: this.filteredRows.length,
+        count: this.totalRows,
         pages: this.totalPages,
         from:  this.indexFrom,
         to:    this.indexTo,
       };
 
+      console.warn('pagingDisplay', opt);
+
       return this.$store.getters['i18n/t'](this.pagingLabel, opt);
     },
 
     pagedRows() {
-      if ( this.paging ) {
+      if (this.externalPagination) {
+        return this.rows;
+      } else if ( this.paging ) {
         return this.filteredRows.slice(this.indexFrom - 1, this.indexTo);
       } else {
         return this.filteredRows;
@@ -51,12 +59,21 @@ export default {
       // Go to the last page if we end up "past" the last page because the table changed
 
       const from = this.indexFrom;
-      const last = this.filteredRows.length;
+      const last = this.totalRows;
 
       if ( this.totalPages > 0 && this.page > 1 && from > last ) {
         this.setPage(this.totalPages);
       }
-    }
+    },
+
+    page() {
+      this.paginationChanged();
+    },
+
+    perPage() {
+      this.paginationChanged();
+    },
+
   },
 
   methods: {

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -24,7 +24,7 @@ export default {
       const out = [...fromGroup, ...fromColumn];
 
       if (this.externalPagination) {
-        addObject(out, 'metadata.name'); // TODO: RC FIX
+        addObject(out, 'metadata.name'); // TODO: RC FIX its a steve things
       } else {
         addObject(out, 'nameSort');
       }

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -113,12 +113,12 @@ export default {
 
   watch: {
     sortFields(neu) {
-      console.warn('paging', 'watch', 'sortFields', neu);
+      console.warn('paging', 'watch', 'sortFields', neu); // eslint-disable-line no-console
       this.debouncedPaginationChanged();
     },
 
     descending(neu) {
-      console.warn('paging', 'watch', 'descending', neu);
+      console.warn('paging', 'watch', 'descending', neu); // eslint-disable-line no-console
       this.debouncedPaginationChanged();
     }
   }

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -4,6 +4,7 @@ import { addObject } from '@shell/utils/array';
 export default {
   computed: {
     sortFields() {
+      // TODO: RC WARNING - group sort?! DISABLE
       let fromGroup = ( this.groupBy ? this.groupSort || this.groupBy : null) || [];
       let fromColumn = [];
 
@@ -101,4 +102,16 @@ export default {
       this.setPage(1);
     },
   },
+
+  watch: {
+    sortFields(neu) {
+      console.warn('paging', 'watch', 'sortFields', neu);
+      this.paginationChanged();
+    },
+
+    descending(neu) {
+      console.warn('paging', 'watch', 'descending', neu);
+      this.paginationChanged();
+    }
+  }
 };

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -4,7 +4,6 @@ import { addObject } from '@shell/utils/array';
 export default {
   computed: {
     sortFields() {
-      // TODO: RC WARNING - group sort?! DISABLE ish...
       let fromGroup = ( this.groupBy ? this.groupSort || this.groupBy : null) || [];
       let fromColumn = [];
 
@@ -24,7 +23,12 @@ export default {
 
       const out = [...fromGroup, ...fromColumn];
 
-      addObject(out, 'nameSort'); // TODO: RC don't add this automatically
+      if (this.externalPagination) {
+        addObject(out, 'metadata.name'); // TODO: RC FIX
+      } else {
+        addObject(out, 'nameSort');
+      }
+
       addObject(out, 'id');
 
       return out;
@@ -110,12 +114,12 @@ export default {
   watch: {
     sortFields(neu) {
       console.warn('paging', 'watch', 'sortFields', neu);
-      this.paginationChanged();
+      this.debouncedPaginationChanged();
     },
 
     descending(neu) {
       console.warn('paging', 'watch', 'descending', neu);
-      this.paginationChanged();
+      this.debouncedPaginationChanged();
     }
   }
 };

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -4,7 +4,7 @@ import { addObject } from '@shell/utils/array';
 export default {
   computed: {
     sortFields() {
-      // TODO: RC WARNING - group sort?! DISABLE
+      // TODO: RC WARNING - group sort?! DISABLE ish...
       let fromGroup = ( this.groupBy ? this.groupSort || this.groupBy : null) || [];
       let fromColumn = [];
 
@@ -24,13 +24,17 @@ export default {
 
       const out = [...fromGroup, ...fromColumn];
 
-      addObject(out, 'nameSort');
+      addObject(out, 'nameSort'); // TODO: RC don't add this automatically
       addObject(out, 'id');
 
       return out;
     },
 
     arrangedRows() {
+      if (this.externalPagination) {
+        return;
+      }
+
       let key;
 
       if ( this.sortGenerationFn ) {

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -17,7 +17,7 @@ import {
   NAMESPACE_FILTER_P_FULL_PREFIX,
 } from '@shell/utils/namespace-filter';
 import { KEY } from '@shell/utils/platform';
-import pAndNFiltering from '@shell/utils/projectAndNamespaceFiltering.utils';
+import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
 import { SETTING } from '@shell/config/settings';
 
 const forcedNamespaceValidTypes = [NAMESPACE_FILTER_KINDS.DIVIDER, NAMESPACE_FILTER_KINDS.PROJECT, NAMESPACE_FILTER_KINDS.NAMESPACE];

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -17,7 +17,7 @@ import {
   NAMESPACE_FILTER_P_FULL_PREFIX,
 } from '@shell/utils/namespace-filter';
 import { KEY } from '@shell/utils/platform';
-import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
+import pAndNFiltering from '@shell/plugins/steve/projectAndNamespaceFiltering.utils';
 import { SETTING } from '@shell/config/settings';
 
 const forcedNamespaceValidTypes = [NAMESPACE_FILTER_KINDS.DIVIDER, NAMESPACE_FILTER_KINDS.PROJECT, NAMESPACE_FILTER_KINDS.NAMESPACE];

--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -12,7 +12,7 @@ export const STEVE_STATE_COL = {
   value:     'metadata.state.name',
   sort:      ['metadata.state.name'],
   search:    'metadata.state.name',
-  formatter: null // TODO: RC document. as we use raw value... we can't show anything but as sorting/filtering will be wrong. same goes for others
+  formatter: null
 };
 
 export const STEVE_AGE_COL = {
@@ -41,6 +41,46 @@ export const STEVE_LIST_GROUPS = [{
   tooltipKey: 'resourceTable.groupBy.namespace'
 }];
 
+// TODO: RC TODO (can be later than alpha)
+// - loading indicator when pages are being requests (take care not to blip)
+// - performance setting (global enable / disable)
+// - improve - the list group by feature adds a namespace option if resource is namespaced. we replace this with config for paths via `listGroupsWillOverride`. this isn't so neat
+// - improve - there's a lot of computed properties in sortable table that fire when things happen in store. need to avoid these
+
+// TODO: RC TODO (should be part of alpha)
+// - we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again. alt is
+// - update comments... everywhere
+// - remove debug consoles
+// - there are two subscribe messages sent for the list's type
+
+// TODO: RC Comment
+// - only applies to
+//   - cluster store. management store should in theory be simple to support (TODO: RC add to gh issue)
+//   - resources that don't have their own custom list. this should be easy to resolve though
+//   - specifically configmaps and secrets. other resources can be incrementally added
+// - sorting / filtering
+//   - we cannot sort or filter by anything that is computed locally (model getters).
+//     - state - we convert some `metadata.state.name` values to something more readable
+//     - secret - subTypeDisplay - translates things like `kubernetes.io/service-account-token` to `Svc Acct Token`
+//     - configmaps - data - we convert data from two properties into something more readable
+// - Design / Patterns
+//   - We can only sort and filter by values known to the backend. Therefore a lot of the existing table headers, which reference model properties
+//     are invalid. To get around this we define new headers which refer directly to properties on the raw resource. see pagination-table-headers
+//     this means we avoid things like `name` & `namespace` property helpers, searchFields that are functions to values, etc
+//   - the revision of the list is ignored. when user goes to page two it will be page 2 at that new time (rather than from the time page 1 was requested)
+//   - Question. the only way for a user to update their page is to change pagination in some way. we should consider a refresh button
+
+// TODO: RC Backend / API Issues
+// - configmaps
+//   - different `count` provided when adding/removing `sort=-metadata.namespace`
+//     - configmaps?page=1&pagesize=10&sort=-metadata.namespace,-metadata.name,-id&filter=metadata.name=kube. count:14
+//     - configmaps?page=2&pagesize=10&sort=-metadata.namespace,-metadata.name,-id&filter=metadata.name=kube. count:14
+//     - configmaps?page=1&pagesize=10&sort=-metadata.name,-id&filter=metadata.name=kube,metadata.namespace=kube. count:18
+//     - configmaps?page=2&pagesize=10&sort=-metadata.name,-id&filter=metadata.name=kube,metadata.namespace=kube. count:18
+// - secrets
+//   - the resource has a `_type` field, yet `sort=_type` does not work
+//   - the resource has a `_type` field, yet `filter_type` does not work
+
 // TODO: RC Test cases
 // - group by namespace / no namespace
 // - group by namespace sticks on refresh
@@ -48,37 +88,4 @@ export const STEVE_LIST_GROUPS = [{
 // - the pref ALL_NAMESPACES (determines namespaces used in filters)
 // - TODO: RC flesh out
 // - no regressions in separate namespace/project filtering
-
-// TODO: RC TODO
-// - loading indicator
-// - performance setting (global enable / disable)
-// - the list group by feature adds a namespace option if resource is namespaced. we replace this with config for paths via `listGroupsWillOverride`. this isn't so neat
-
-// TODO: RC Comment
-// - only applies to
-//   - cluster store. should in theory be simple to support
-//   - resources that don't have their own custom list. this should be easy to resolve though
-//   - specifically configmaps and secrets
-// - the revision of the list is ignored. when user goes to page two it will be page 2 at that new time (rather than cached time)
-// - sorting / filtering
-//   - we cannot sort or filter by anything that is computed locally (model getters).
-//     - state - we convert some `metadata.state.name` values to something more readable
-//     - secret - subTypeDisplay - translates things like `kubernetes.io/service-account-token` to `Svc Acct Token`
-//     - configmaps - data - we convert data from two properties into something more readable
-// - the only way for a user to update their page is to change pagination in some way. we should consider a refresh button
-// - Design / Patterns
-//   - We can only sort and filter by values known to the backend. Therefore a lot of the existing table headers, which reference model properties
-//     are invalid. To get around this we define new headers which refer directly to properties on the raw resource. see pagination-table-headers
-//     this means we avoid things like `name` & `namespace` property helpers, searchFields that are functions to values, etc
-
-// TODO: RC Backend / API Issues
-// - configmaps
-// - secrets
-//   - the resource has a `_type` field, yet `sort=_type` does not work
-//   - the resource has a `_type` field, yet `filter_type` does not work
-
-// TODO: RC FIXME
-// - we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again. alt is
-// - update comments... everywhere
-// - remove debug consoles
-// - there are two subscribe messages send for the list's type
+// - with advanced filtering on

--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -46,12 +46,12 @@ export const STEVE_LIST_GROUPS = [{
 }];
 
 // TODO: RC TODO (can be later than alpha)
-// - loading indicator when pages are being requests (take care not to blip)
+// - loading indicator when pages are being requested (take care not to blip)
 // - performance setting (global enable / disable)
 // - improve - the list group by feature adds a namespace option if resource is namespaced. we replace this with config for paths via `listGroupsWillOverride`. this isn't so neat
 // - improve - there's a lot of computed properties in sortable table that fire when things happen in store. need to avoid these
-// - we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again
-// - resolve `TODO: RC FIX`
+// - we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again. could leave as is, candidate for refresh button
+// - resolve two `TODO: RC FIX`
 
 // TODO: RC TODO (should be part of alpha)
 // - add/update comments... everywhere

--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -1,0 +1,84 @@
+import { STATE, NAME as NAME_COL, NAMESPACE as NAMESPACE_COL, AGE } from '@shell/config/table-headers';
+
+export const STEVE_NAME_COL = {
+  ...NAME_COL,
+  value:  'metadata.name',
+  sort:   ['metadata.name'],
+  search: 'metadata.name',
+};
+
+export const STEVE_STATE_COL = {
+  ...STATE,
+  value:     'metadata.state.name',
+  sort:      ['metadata.state.name'],
+  search:    'metadata.state.name',
+  formatter: null // TODO: RC document. as we use raw value... we can't show anything but as sorting/filtering will be wrong. same goes for others
+};
+
+export const STEVE_AGE_COL = {
+  ...AGE,
+  value:  'metadata.creationTimestamp',
+  sort:   'metadata.creationTimestamp:desc',
+  search: false,
+};
+
+export const STEVE_NAMESPACE_COL = {
+  ...NAMESPACE_COL,
+  value:  'metadata.namespace',
+  sort:   'metadata.namespace',
+  search: 'metadata.namespace',
+};
+
+export const STEVE_LIST_GROUPS = [{
+  tooltipKey: 'resourceTable.groupBy.none',
+  icon:       'icon-list-flat',
+  value:      'none',
+}, {
+  icon:       'icon-folder',
+  value:      'metadata.namespace',
+  field:      'metadata.namespace',
+  hideColumn: NAMESPACE_COL.name,
+  tooltipKey: 'resourceTable.groupBy.namespace'
+}];
+
+// TODO: RC Test cases
+// - group by namespace / no namespace
+// - group by namespace sticks on refresh
+// - the hideSystemResources product config (determines namespaces used in filters)
+// - the pref ALL_NAMESPACES (determines namespaces used in filters)
+// - TODO: RC flesh out
+// - no regressions in separate namespace/project filtering
+
+// TODO: RC TODO
+// - loading indicator
+// - performance setting (global enable / disable)
+// - the list group by feature adds a namespace option if resource is namespaced. we replace this with config for paths via `listGroupsWillOverride`. this isn't so neat
+
+// TODO: RC Comment
+// - only applies to
+//   - cluster store. should in theory be simple to support
+//   - resources that don't have their own custom list. this should be easy to resolve though
+//   - specifically configmaps and secrets
+// - the revision of the list is ignored. when user goes to page two it will be page 2 at that new time (rather than cached time)
+// - sorting / filtering
+//   - we cannot sort or filter by anything that is computed locally (model getters).
+//     - state - we convert some `metadata.state.name` values to something more readable
+//     - secret - subTypeDisplay - translates things like `kubernetes.io/service-account-token` to `Svc Acct Token`
+//     - configmaps - data - we convert data from two properties into something more readable
+// - the only way for a user to update their page is to change pagination in some way. we should consider a refresh button
+// - Design / Patterns
+//   - We can only sort and filter by values known to the backend. Therefore a lot of the existing table headers, which reference model properties
+//     are invalid. To get around this we define new headers which refer directly to properties on the raw resource. see pagination-table-headers
+//     this means we avoid things like `name` & `namespace` property helpers, searchFields that are functions to values, etc
+
+// TODO: RC Backend / API Issues
+// - configmaps
+// - secrets
+//   - the resource has a `_type` field, yet `sort=_type` does not work
+//   - the resource has a `_type` field, yet `filter_type` does not work
+
+// TODO: RC FIXME
+// - we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again. alt is
+// - update comments... everywhere
+// - remove debug consoles
+// - there are two subscribe messages send for the list's type

--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -52,6 +52,7 @@ export const STEVE_LIST_GROUPS = [{
 // - update comments... everywhere
 // - remove debug consoles
 // - there are two subscribe messages sent for the list's type
+// - state but not state column
 
 // TODO: RC Comment
 // - only applies to
@@ -80,8 +81,11 @@ export const STEVE_LIST_GROUPS = [{
 // - secrets
 //   - the resource has a `_type` field, yet `sort=_type` does not work
 //   - the resource has a `_type` field, yet `filter_type` does not work
+// - pod
+//   - question. spec.containers is an array containers. we'd like to sort/search using container.image
 
 // TODO: RC Test cases
+// - non-paginated lists work fine
 // - group by namespace / no namespace
 // - group by namespace sticks on refresh
 // - the hideSystemResources product config (determines namespaces used in filters)

--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -1,5 +1,9 @@
 import { STATE, NAME as NAME_COL, NAMESPACE as NAMESPACE_COL, AGE } from '@shell/config/table-headers';
 
+// These contain paths set to specific values within a resource returned by the server
+// In the future specific resource types will extend these with their own definitions
+// For tidyness that should be done alongside their models
+
 export const STEVE_NAME_COL = {
   ...NAME_COL,
   value:  'metadata.name',
@@ -9,10 +13,10 @@ export const STEVE_NAME_COL = {
 
 export const STEVE_STATE_COL = {
   ...STATE,
-  value:     'metadata.state.name',
-  sort:      ['metadata.state.name'],
-  search:    'metadata.state.name',
-  formatter: null
+  // value:     'metadata.state.name', // This means what the user sees does not align with what column is sorted or filtered on
+  // formatter: null
+  sort:   ['metadata.state.name'],
+  search: 'metadata.state.name',
 };
 
 export const STEVE_AGE_COL = {
@@ -36,7 +40,7 @@ export const STEVE_LIST_GROUPS = [{
 }, {
   icon:       'icon-folder',
   value:      'metadata.namespace',
-  field:      'metadata.namespace',
+  field:      'metadata.namespace', // Default groupByLabel field in models is NS based
   hideColumn: NAMESPACE_COL.name,
   tooltipKey: 'resourceTable.groupBy.namespace'
 }];
@@ -46,24 +50,31 @@ export const STEVE_LIST_GROUPS = [{
 // - performance setting (global enable / disable)
 // - improve - the list group by feature adds a namespace option if resource is namespaced. we replace this with config for paths via `listGroupsWillOverride`. this isn't so neat
 // - improve - there's a lot of computed properties in sortable table that fire when things happen in store. need to avoid these
+// - we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again
+// - resolve `TODO: RC FIX`
 
 // TODO: RC TODO (should be part of alpha)
-// - we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again. alt is
-// - update comments... everywhere
+// - add/update comments... everywhere
 // - remove debug consoles
 // - there are two subscribe messages sent for the list's type
-// - state but not state column
+// - ns filter not applied on load / first visit
+// - there's no label on the namespace groups. this is due to the `field` used to search instead of the `value`
 
 // TODO: RC Comment
 // - only applies to
-//   - cluster store. management store should in theory be simple to support (TODO: RC add to gh issue)
+//   - cluster store. management store should in theory be simple to support
 //   - resources that don't have their own custom list. this should be easy to resolve though
-//   - specifically configmaps and secrets. other resources can be incrementally added
-// - sorting / filtering
-//   - we cannot sort or filter by anything that is computed locally (model getters).
+//   - specifically configmaps, secrets and pods. other resources can be incrementally added
+// - sorting / filtering are disabled for...
+//   - any column who's value was computed locally (model getters).
 //     - state - we convert some `metadata.state.name` values to something more readable
 //     - secret - subTypeDisplay - translates things like `kubernetes.io/service-account-token` to `Svc Acct Token`
 //     - configmaps - data - we convert data from two properties into something more readable
+//   - values that are within an object in an array
+//     - pod - Container image - spec.container[0].image
+//   - columns that were originally from schemas cannot
+//     - pod - `Ready`, `Restarts` and `IP` all come from schema --> metadata.fields[index] (attributes.columns[0].field: "$.metadata.fields[1])
+
 // - Design / Patterns
 //   - We can only sort and filter by values known to the backend. Therefore a lot of the existing table headers, which reference model properties
 //     are invalid. To get around this we define new headers which refer directly to properties on the raw resource. see pagination-table-headers
@@ -82,14 +93,19 @@ export const STEVE_LIST_GROUPS = [{
 //   - the resource has a `_type` field, yet `sort=_type` does not work
 //   - the resource has a `_type` field, yet `filter_type` does not work
 // - pod
-//   - question. spec.containers is an array containers. we'd like to sort/search using container.image
+//   - question. spec.containers is an array of container objects. we'd like to sort/search using container.image
+//   - question. some columns come from schemas (pod 'ready' field is from schema..`attributes.columns[0].field: "$.metadata.fields[1]"` ). the field is a specific value in an array. can we sort / filter by it?
 
 // TODO: RC Test cases
-// - non-paginated lists work fine
+// - no regressions for
+//   - non-paginated lists
+//   - namespace/project filtering
+//   - manual refresh (list)
+//   - incremental loading (list)
+//   - garbage collection (?)
+//   - advanced filtering
+//   - fleet workspace selection
 // - group by namespace / no namespace
 // - group by namespace sticks on refresh
 // - the hideSystemResources product config (determines namespaces used in filters)
 // - the pref ALL_NAMESPACES (determines namespaces used in filters)
-// - TODO: RC flesh out
-// - no regressions in separate namespace/project filtering
-// - with advanced filtering on

--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -57,7 +57,6 @@ export const STEVE_LIST_GROUPS = [{
 // - add/update comments... everywhere
 // - remove debug consoles
 // - there are two subscribe messages sent for the list's type
-// - ns filter not applied on load / first visit
 // - there's no label on the namespace groups. this is due to the `field` used to search instead of the `value`
 
 // TODO: RC Comment

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -289,6 +289,22 @@ export function init(store) {
     value: 'metadata.creationTimestamp',
     sort:  'metadata.creationTimestamp:desc',
   }]);
+  configureType(SECRET, {
+    listGroups: [{
+      tooltipKey: 'resourceTable.groupBy.none',
+      icon:       'icon-list-flat',
+      value:      'none',
+    }, {
+      icon:       'icon-folder',
+      value:      'metadata.namespace',
+      field:      'metadata.namespace',
+      hideColumn: NAMESPACE_COL.name,
+      tooltipKey: 'resourceTable.groupBy.namespace'
+    }
+    ],
+    listGroupsWillOverride: true,
+  });
+
   headers(INGRESS, [STATE, NAME_COL, NAMESPACE_COL, INGRESS_TARGET, INGRESS_DEFAULT_BACKEND, INGRESS_CLASS, AGE]);
   headers(SERVICE, [STATE, NAME_COL, NAMESPACE_COL, TARGET_PORT, SELECTOR, SPEC_TYPE, AGE]);
   headers(EVENT, [STATE, { ...LAST_SEEN_TIME, defaultSort: true }, EVENT_TYPE, REASON, OBJECT, 'Subobject', 'Source', MESSAGE, 'First Seen', 'Count', NAME_COL, NAMESPACE_COL]);

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -252,7 +252,7 @@ export function init(store) {
     [STEVE_STATE_COL, STEVE_NAME_COL, STEVE_NAMESPACE_COL, {
       ...POD_IMAGES,
       sort:   false,
-      search: 'spec.containers'
+      search: false
     }, 'Ready', 'Restarts', 'IP', {
       ...NODE_COL,
       search: 'spec.nodeName'
@@ -266,7 +266,7 @@ export function init(store) {
       {
         icon:       'icon-cluster',
         value:      'role',
-        field:      'spec.nodeName', // TODO: RC PROCESS this was spec?.nodeName in groupByNode
+        field:      'spec.nodeName',
         hideColumn: 'groupByNode',
         tooltipKey: 'resourceTable.groupBy.node'
       }

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -249,16 +249,19 @@ export function init(store) {
 
   headers(POD,
     [STATE, NAME_COL, NAMESPACE_COL, POD_IMAGES, 'Ready', 'Restarts', 'IP', NODE_COL, AGE],
-    [STEVE_STATE_COL, STEVE_NAME_COL, STEVE_NAMESPACE_COL, {
-      ...POD_IMAGES,
-      sort:   false,
-      search: false
-    }, 'Ready', 'Restarts', 'IP', {
-      ...NODE_COL,
-      search: 'spec.nodeName'
-    },
-    STEVE_AGE_COL]
-  );
+    [
+      STEVE_STATE_COL,
+      STEVE_NAME_COL,
+      STEVE_NAMESPACE_COL, {
+        ...POD_IMAGES,
+        sort:   false,
+        search: false
+      }, 'Ready', 'Restarts', 'IP', {
+        ...NODE_COL,
+        search: 'spec.nodeName'
+      },
+      STEVE_AGE_COL
+    ]);
   configureType(POD, {
     listGroups: [
       ...STEVE_LIST_GROUPS,

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -22,6 +22,9 @@ import {
 } from '@shell/config/table-headers';
 
 import { DSL } from '@shell/store/type-map';
+import {
+  STEVE_AGE_COL, STEVE_LIST_GROUPS, STEVE_NAMESPACE_COL, STEVE_NAME_COL, STEVE_STATE_COL
+} from 'config/pagination-table-headers';
 
 export const NAME = 'explorer';
 
@@ -195,57 +198,23 @@ export function init(store) {
   configureType(MANAGEMENT.PSA, { localOnly: true });
 
   headers(PV, [STATE, NAME_COL, RECLAIM_POLICY, PERSISTENT_VOLUME_CLAIM, PERSISTENT_VOLUME_SOURCE, PV_REASON, AGE]);
-  headers(CONFIG_MAP, [NAME_COL, NAMESPACE_COL, KEYS, AGE]);
 
-  // export const STATE = {
-  //   name:      'state',
-  //   labelKey:  'tableHeaders.state',
-  //   sort:      ['stateSort', 'nameSort'],
-  //   value:     'stateDisplay',
-  //   getValue:  (row) => row.stateDisplay,
-  //   width:     100,
-  //   default:   'unknown',
-  //   formatter: 'BadgeStateFormatter',
-  // };
-
-  // export const NAME = {
-  //   name:          'name',
-  //   labelKey:      'tableHeaders.name',
-  //   value:         'nameDisplay',
-  //   getValue:      (row) => row.nameDisplay,
-  //   sort:          ['nameSort'],
-  //   formatter:     'LinkDetail',
-  //   canBeVariable: true,
-  // };
-
-  // export const NAMESPACE = {
-  //   name:        'namespace',
-  //   labelKey:    'tableHeaders.namespace',
-  //   value:       'namespace',
-  //   getValue:    (row) => row.namespace,
-  //   sort:        'namespace',
-  //   dashIfEmpty: true,
-  // };
-
-  // export const SUB_TYPE = {
-  //   name:     'subType',
-  //   labelKey: 'tableHeaders.subType',
-  //   value:    'subTypeDisplay',
-  //   sort:     ['subTypeDisplay'],
-  //   width:    120,
-  // };
-
-  // export const AGE = {
-  //   name:      'age',
-  //   labelKey:  'tableHeaders.age',
-  //   value:     'creationTimestamp',
-  //   getValue:  (row) => row.creationTimestamp,
-  //   sort:      'creationTimestamp:desc',
-  //   search:    false,
-  //   formatter: 'LiveDate',
-  //   width:     100,
-  //   align:     'left'
-  // };
+  headers(CONFIG_MAP,
+    [NAME_COL, NAMESPACE_COL, KEYS, AGE],
+    [
+      STEVE_NAME_COL,
+      STEVE_NAMESPACE_COL, {
+        ...KEYS,
+        sort:   false,
+        search: false,
+      },
+      STEVE_AGE_COL
+    ]
+  );
+  configureType(CONFIG_MAP, {
+    listGroups:             STEVE_LIST_GROUPS,
+    listGroupsWillOverride: true,
+  });
 
   const secretData = {
     name:      'data',
@@ -261,47 +230,20 @@ export function init(store) {
     SUB_TYPE,
     secretData,
     AGE
-  ], [{
-    ...STATE,
-    value:     'metadata.state.name',
-    sort:      ['metadata.state.name'],
-    search:    'metadata.state.name',
-    formatter: null // TODO: RC document. as we use raw value... we can't show anything but as sorting/filtering will be wrong. same goes for others
-  }, {
-    ...NAME_COL,
-    value:  'metadata.name',
-    sort:   ['metadata.name'],
-    search: 'metadata.name',
-  }, {
-    ...NAMESPACE_COL,
-    value:  'metadata.namespace',
-    sort:   ['metadata.namespace'],
-    search: 'metadata.namespace',
-  }, {
-    ...SUB_TYPE,
-    value:  '_type', // TODO: RC document. model - fallback. also translations
-    sort:   [], // TODO: RC does not work (backend doesn't sort on it)
-    search: false, // TODO: RC does not work (backend doesn't sort on it)
-  },
-  secretData,
-  {
-    ...AGE,
-    value: 'metadata.creationTimestamp',
-    sort:  'metadata.creationTimestamp:desc',
-  }]);
+  ], [
+    STEVE_STATE_COL,
+    STEVE_NAME_COL,
+    STEVE_NAMESPACE_COL, {
+      ...SUB_TYPE,
+      value:  '_type',
+      sort:   false,
+      search: false,
+    },
+    secretData,
+    STEVE_AGE_COL
+  ]);
   configureType(SECRET, {
-    listGroups: [{
-      tooltipKey: 'resourceTable.groupBy.none',
-      icon:       'icon-list-flat',
-      value:      'none',
-    }, {
-      icon:       'icon-folder',
-      value:      'metadata.namespace',
-      field:      'metadata.namespace',
-      hideColumn: NAMESPACE_COL.name,
-      tooltipKey: 'resourceTable.groupBy.namespace'
-    }
-    ],
+    listGroups:             STEVE_LIST_GROUPS,
     listGroupsWillOverride: true,
   });
 

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -24,7 +24,7 @@ import {
 import { DSL } from '@shell/store/type-map';
 import {
   STEVE_AGE_COL, STEVE_LIST_GROUPS, STEVE_NAMESPACE_COL, STEVE_NAME_COL, STEVE_STATE_COL
-} from 'config/pagination-table-headers';
+} from '@shell/config/pagination-table-headers';
 
 export const NAME = 'explorer';
 

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -196,19 +196,99 @@ export function init(store) {
 
   headers(PV, [STATE, NAME_COL, RECLAIM_POLICY, PERSISTENT_VOLUME_CLAIM, PERSISTENT_VOLUME_SOURCE, PV_REASON, AGE]);
   headers(CONFIG_MAP, [NAME_COL, NAMESPACE_COL, KEYS, AGE]);
+
+  // export const STATE = {
+  //   name:      'state',
+  //   labelKey:  'tableHeaders.state',
+  //   sort:      ['stateSort', 'nameSort'],
+  //   value:     'stateDisplay',
+  //   getValue:  (row) => row.stateDisplay,
+  //   width:     100,
+  //   default:   'unknown',
+  //   formatter: 'BadgeStateFormatter',
+  // };
+
+  // export const NAME = {
+  //   name:          'name',
+  //   labelKey:      'tableHeaders.name',
+  //   value:         'nameDisplay',
+  //   getValue:      (row) => row.nameDisplay,
+  //   sort:          ['nameSort'],
+  //   formatter:     'LinkDetail',
+  //   canBeVariable: true,
+  // };
+
+  // export const NAMESPACE = {
+  //   name:        'namespace',
+  //   labelKey:    'tableHeaders.namespace',
+  //   value:       'namespace',
+  //   getValue:    (row) => row.namespace,
+  //   sort:        'namespace',
+  //   dashIfEmpty: true,
+  // };
+
+  // export const SUB_TYPE = {
+  //   name:     'subType',
+  //   labelKey: 'tableHeaders.subType',
+  //   value:    'subTypeDisplay',
+  //   sort:     ['subTypeDisplay'],
+  //   width:    120,
+  // };
+
+  // export const AGE = {
+  //   name:      'age',
+  //   labelKey:  'tableHeaders.age',
+  //   value:     'creationTimestamp',
+  //   getValue:  (row) => row.creationTimestamp,
+  //   sort:      'creationTimestamp:desc',
+  //   search:    false,
+  //   formatter: 'LiveDate',
+  //   width:     100,
+  //   align:     'left'
+  // };
+
+  const secretData = {
+    name:      'data',
+    labelKey:  'tableHeaders.data',
+    value:     'dataPreview',
+    formatter: 'SecretData'
+  };
+
   headers(SECRET, [
     STATE,
     NAME_COL,
     NAMESPACE_COL,
     SUB_TYPE,
-    {
-      name:      'data',
-      labelKey:  'tableHeaders.data',
-      value:     'dataPreview',
-      formatter: 'SecretData'
-    },
+    secretData,
     AGE
-  ]);
+  ], [{
+    ...STATE,
+    value:     'metadata.state.name',
+    sort:      ['metadata.state.name'],
+    search:    'metadata.state.name',
+    formatter: null // TODO: RC document. as we use raw value... we can't show anything but as sorting/filtering will be wrong. same goes for others
+  }, {
+    ...NAME_COL,
+    value:  'metadata.name',
+    sort:   ['metadata.name'],
+    search: 'metadata.name',
+  }, {
+    ...NAMESPACE_COL,
+    value:  'metadata.namespace',
+    sort:   ['metadata.namespace'],
+    search: 'metadata.namespace',
+  }, {
+    ...SUB_TYPE,
+    value:  '_type', // TODO: RC document. model - fallback. also translations
+    sort:   [], // TODO: RC does not work (backend doesn't sort on it)
+    search: false, // TODO: RC does not work (backend doesn't sort on it)
+  },
+  secretData,
+  {
+    ...AGE,
+    value: 'metadata.creationTimestamp',
+    sort:  'metadata.creationTimestamp:desc',
+  }]);
   headers(INGRESS, [STATE, NAME_COL, NAMESPACE_COL, INGRESS_TARGET, INGRESS_DEFAULT_BACKEND, INGRESS_CLASS, AGE]);
   headers(SERVICE, [STATE, NAME_COL, NAMESPACE_COL, TARGET_PORT, SELECTOR, SPEC_TYPE, AGE]);
   headers(EVENT, [STATE, { ...LAST_SEEN_TIME, defaultSort: true }, EVENT_TYPE, REASON, OBJECT, 'Subobject', 'Source', MESSAGE, 'First Seen', 'Count', NAME_COL, NAMESPACE_COL]);

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -55,7 +55,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduct', 'currentCluster', 'namespaceFilters', 'namespaces']),
+    ...mapGetters(['currentProduct', 'currentCluster', 'namespaceFilters', 'namespaces', 'currentStore']), // TODO: RC currentStore
     /**
      * Returns the namespace that requests should be filtered by
      */
@@ -63,14 +63,6 @@ export default {
       // TODO: RC get from  store (including revision)
       // TODO: RC sortable table --> store
       console.warn('mixin', 'pagination', 'pagination', this.__paginationRequired, this.pPagination);
-
-      // {
-      //   namespaces: undefined,
-      //   page:       1,
-      //   pageSize:   10,
-      //   sort:       [],
-      //   filter:     {}
-      // }
 
       return this.__paginationRequired ? this.pPagination : '';
     },
@@ -88,6 +80,14 @@ export default {
       // return this.__areResourcesNamespaced;
 
       return true;
+    },
+
+    paginationResult() {
+      return this.havePaginated?.result;
+    },
+
+    havePaginated() {
+      return this.$store.getters[`cluster/havePaginated`](this.resource); // TODO: RC
     },
 
   },

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -52,14 +52,14 @@ export default {
     ...mapGetters(['currentProduct', 'namespaceFilters']),
 
     canPaginate() {
-      return this.__paginationRequired && this.paginationHeaders;
+      return this.__paginationRequired && !!this.paginationHeaders;
     },
 
     /**
      * Returns the namespace that requests should be filtered by
      */
     pagination() {
-      console.warn('mixin', 'pagination', 'pagination', this.canPaginate, this.pPagination);
+      console.warn('mixin', 'computed', 'pagination', this.canPaginate, this.pPagination);
 
       return this.canPaginate ? this.pPagination : '';
     },

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -44,7 +44,7 @@ export default {
           value: event.filter.searchQuery,
         })) : []
       };
-      console.warn('mixin', 'method', 'paginationChanged', this.pPagination);
+      console.warn('mixin', 'method', 'paginationChanged', this.pPagination); // eslint-disable-line no-console
     }
   },
 
@@ -59,7 +59,7 @@ export default {
      * Returns the namespace that requests should be filtered by
      */
     pagination() {
-      console.warn('mixin', 'computed', 'pagination', this.canPaginate, this.pPagination);
+      console.warn('mixin', 'computed', 'pagination', this.canPaginate, this.pPagination); // eslint-disable-line no-console
 
       return this.canPaginate ? this.pPagination : '';
     },
@@ -144,7 +144,7 @@ export default {
     },
 
     async pagination(neu) {
-      console.warn('mixin', 'watch', 'pagination', this.pagination);
+      console.warn('mixin', 'watch', 'pagination', this.pagination); // eslint-disable-line no-console
 
       // TODO: RC TEST - this shouldn't fire on lists that don't support pagination
 

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -1,5 +1,4 @@
 import { NAMESPACE_FILTER_ALL_SYSTEM, NAMESPACE_FILTER_ALL_USER } from '@shell/utils/namespace-filter';
-import Vue from 'vue';
 import { mapGetters } from 'vuex';
 import { ResourceListComponentName } from '../components/ResourceList/resource-list.config';
 
@@ -30,34 +29,26 @@ export default {
     paginationChanged(event) {
       console.warn('mixin', 'method', 'paginationChanged', event);
 
-      // this.currentProduct?.hideSystemResources // TODO: RC oh lordy - need to wire in this as a filter
-
+      // TODO: RC wire in currentProduct?.hideSystemResources to namespaces?
       this.pPagination = {
         // namespaces: this.namespaceFilters,
         ...this.pPagination,
         page:     event.page,
         pageSize: event.perPage,
-        sort:     event.sort?.map((field) => {
-          let safeField = field; // TODO: RC oh lordy
-
-          switch (field) {
-          case 'nameSort':
-            safeField = this.rows[0].namePath; // TODO: RC oh lordy
-            break;
-          case 'namespace':
-            safeField = 'metadata.namespace';
-            break;
-          case 'subTypeDisplay':
-            safeField = '_type'; // TODO: RC secret. this isn't by label of the type. this doesn't work anyway
-            break;
-          }
-
-          return {
-            field: safeField,
-            asc:   !event.descending
-          };
-        }),
-        filter: {} // TODO: RC oh lordy. this contains not only model values... but `getValue` fns as well
+        // TODO: RC document. headers. sort
+        // `nameSort` --> path of name
+        // `namespace` --> metadata.namespaces
+        // `subTypeDisplay` --> `_type` (minus localisation and fallback)
+        sort:     event.sort?.map((field) => ({
+          field,
+          asc: !event.descending
+        })),
+        // TODO: RC document. headers. filter
+        // searchFields contains fns (getValue) to find the value to apply the searchQuery to
+        filter: event.filter.searchQuery ? event.filter.searchFields.map((field) => ({
+          field,
+          value: event.filter.searchQuery,
+        })) : []
       };
       console.warn('mixin', 'method', 'paginationChanged', this.pPagination);
     }
@@ -71,7 +62,7 @@ export default {
     pagination() {
       // TODO: RC get from  store (including revision)
       // TODO: RC sortable table --> store
-      console.warn('mixin', 'pagination', this.__paginationRequired, this.pPagination);
+      console.warn('mixin', 'pagination', 'pagination', this.__paginationRequired, this.pPagination);
 
       // {
       //   namespaces: undefined,

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -31,7 +31,7 @@ export default {
 
     paginationChanged(event) {
       this.pPagination = {
-        // namespaces: this.namespaceFilters, // TODO: RC
+        // namespaces: this.namespaceFilters,
         ...this.pPagination,
         page:     event.page,
         pageSize: event.perPage,

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -52,7 +52,7 @@ export default {
     ...mapGetters(['currentProduct', 'namespaceFilters']),
 
     canPaginate() {
-      return this.__paginationRequired && !!this.paginationHeaders;
+      return this.__paginationRequired && !!this.paginationHeaders?.length;
     },
 
     /**

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -1,9 +1,9 @@
 import { NAMESPACE_FILTER_ALL_SYSTEM, NAMESPACE_FILTER_ALL_USER } from '@shell/utils/namespace-filter';
-import { NAMESPACE } from 'config/types';
-import { ALL_NAMESPACES } from 'store/prefs';
+import { NAMESPACE } from '@shell/config/types';
+import { ALL_NAMESPACES } from '@shell/store/prefs';
 import { mapGetters } from 'vuex';
 import { ResourceListComponentName } from '../components/ResourceList/resource-list.config';
-import stevePaginationUtils from 'plugins/steve/pagination-utils';
+import stevePaginationUtils from '@shell/plugins/steve/pagination-utils';
 
 /**
  * Companion mixin used with `resource-fetch` for `ResourceList` to determine if the user needs to filter the list by a single namespace

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -93,51 +93,54 @@ export default {
   },
 
   watch: {
-    async namespaceFilters(neu) {
-      const isAll = this.$store.getters['isAllNamespaces'];
+    namespaceFilters: {
+      immediate: true,
+      async handler(neu) {
+        const isAll = this.$store.getters['isAllNamespaces'];
 
-      const namespaced = this.schema.attributes.namespaced;
-      const paginationRequires = this.canPaginate;
+        const namespaced = this.schema.attributes.namespaced;
+        const paginationRequires = this.canPaginate;
 
-      if (!namespaced || !paginationRequires) {
-        return;
-      }
-
-      const pref = this.$store.getters['prefs/get'](ALL_NAMESPACES);
-      const hideSystemResources = this.currentProduct.hideSystemResources;
-
-      const allButHidingSystemResources = isAll && (hideSystemResources || pref);
-
-      let namespaces = neu;
-
-      const allNamespaces = this.$store.getters[`${ this.inStore }/all`](NAMESPACE);
-
-      if (allButHidingSystemResources) {
-        // Determine the disallowed namespaces (rather than possibly thousands of allowed)
-        namespaces = allNamespaces
-          .filter((ns) => {
-            const isObscure = pref ? false : ns.isObscure; // Filter out Rancher system namespaces
-            const isSystem = hideSystemResources ? ns.isSystem : false; // Filter out Fleet system namespaces
-
-            return isObscure || isSystem;
-          })
-          .map((ns) => `-${ ns.name }`);
-      } else if (neu.length === 1) {
-        const allSystem = allNamespaces.filter((ns) => ns.isSystem);
-
-        if (neu[0] === NAMESPACE_FILTER_ALL_SYSTEM) {
-          // get a list of all system namespaces
-          namespaces = allSystem.map((ns) => `${ ns.name }`);
-        } else if (neu[0] === NAMESPACE_FILTER_ALL_USER) {
-          // Determine the disallowed namespaces (rather than possibly thousands of allowed)
-          namespaces = allSystem.map((ns) => `-${ ns.name }`);
+        if (!namespaced || !paginationRequires) {
+          return;
         }
-      }
 
-      this.pPagination = {
-        ...this.pPagination,
-        namespaces,
-      };
+        const pref = this.$store.getters['prefs/get'](ALL_NAMESPACES);
+        const hideSystemResources = this.currentProduct.hideSystemResources;
+
+        const allButHidingSystemResources = isAll && (hideSystemResources || pref);
+
+        let namespaces = neu;
+
+        const allNamespaces = this.$store.getters[`${ this.inStore }/all`](NAMESPACE);
+
+        if (allButHidingSystemResources) {
+          // Determine the disallowed namespaces (rather than possibly thousands of allowed)
+          namespaces = allNamespaces
+            .filter((ns) => {
+              const isObscure = pref ? false : ns.isObscure; // Filter out Rancher system namespaces
+              const isSystem = hideSystemResources ? ns.isSystem : false; // Filter out Fleet system namespaces
+
+              return isObscure || isSystem;
+            })
+            .map((ns) => `-${ ns.name }`);
+        } else if (neu.length === 1) {
+          const allSystem = allNamespaces.filter((ns) => ns.isSystem);
+
+          if (neu[0] === NAMESPACE_FILTER_ALL_SYSTEM) {
+            // get a list of all system namespaces
+            namespaces = allSystem.map((ns) => `${ ns.name }`);
+          } else if (neu[0] === NAMESPACE_FILTER_ALL_USER) {
+            // Determine the disallowed namespaces (rather than possibly thousands of allowed)
+            namespaces = allSystem.map((ns) => `-${ ns.name }`);
+          }
+        }
+
+        this.pPagination = {
+          ...this.pPagination,
+          namespaces,
+        };
+      }
     },
 
     async pagination(neu) {

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -1,0 +1,87 @@
+import { mapGetters } from 'vuex';
+import { ResourceListComponentName } from '../components/ResourceList/resource-list.config';
+
+/**
+ * Companion mixin used with `resource-fetch` for `ResourceList` to determine if the user needs to filter the list by a single namespace TODO: RC
+ */
+export default {
+
+  data() {
+    return { forceUpdateLiveAndDelayed: 0 }; // TODO: RC
+  },
+
+  methods: {
+    haveAllPaginated(type) {
+      return this.$store.getters['haveAllPaginated'](type);
+    },
+  },
+
+  computed: {
+    ...mapGetters(['currentProduct', 'currentCluster']),
+
+    // /**
+    //  * Does the user need to update the filter to supply a single namespace?
+    //  */
+    // namespaceFilterRequired() {
+    //   return this.__namespaceRequired && !this.__validFilter;
+    // },
+    // __validFilter
+
+    /**
+     * Returns the namespace that requests should be filtered by
+     */
+    pagination() {
+      // TODO: RC get from  store
+      // TODO: RC sortable table --> store
+      const pagination = {
+        page:      1,
+        total:     10,
+        filter:    '',
+        namespace: undefined,
+        sort:      {
+          field:     undefined,
+          direction: undefined,
+        }
+      };
+
+      return this.__paginationRequired ? pagination : '';
+    },
+
+    /**
+     * Do we need to filter the list by a namespace? This will control whether the user is shown an error
+     *
+     * We shouldn't show an error on pages with resources that aren't namespaced
+     */
+    __paginationRequired() {
+      // if (!pAndNFiltering.isEnabled(this.$store.getters)) {
+      //   return false;
+      // }
+
+      // return this.__areResourcesNamespaced;
+
+      return true;
+    },
+
+  },
+
+  watch: {
+    async pagination(neu) {
+      // TODO: RC if not namespaced,  don't bother with ns      this.__areResourcesNamespaced
+
+      if (neu) {
+        // When a NS filter is required and the user selects a different one, kick off a new set of API requests
+        //
+        // ResourceList has two modes
+        // 1) ResourceList component handles API request to fetch resources
+        // 2) Custom list component handles API request to fetch resources
+        //
+        // This covers case 2
+        if (this.$options.name !== ResourceListComponentName && !!this.$fetch) {
+          await this.$fetch();
+        }
+        // Ensure any live/delayed columns get updated
+        this.forceUpdateLiveAndDelayed = new Date().getTime();
+      }
+    }
+  }
+};

--- a/shell/mixins/resource-fetch-namespaced.js
+++ b/shell/mixins/resource-fetch-namespaced.js
@@ -1,7 +1,7 @@
 import { NAMESPACE_FILTER_NS_PREFIX, NAMESPACE_FILTER_P_PREFIX } from '@shell/utils/namespace-filter';
 import { mapGetters } from 'vuex';
 import { ResourceListComponentName } from '../components/ResourceList/resource-list.config';
-import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
+import pAndNFiltering from '@shell/plugins/steve/projectAndNamespaceFiltering.utils';
 
 /**
  * Companion mixin used with `resource-fetch` for `ResourceList` to determine if the user needs to filter the list by a single namespace

--- a/shell/mixins/resource-fetch-namespaced.js
+++ b/shell/mixins/resource-fetch-namespaced.js
@@ -1,7 +1,7 @@
 import { NAMESPACE_FILTER_NS_PREFIX, NAMESPACE_FILTER_P_PREFIX } from '@shell/utils/namespace-filter';
 import { mapGetters } from 'vuex';
 import { ResourceListComponentName } from '../components/ResourceList/resource-list.config';
-import pAndNFiltering from '@shell/utils/projectAndNamespaceFiltering.utils';
+import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
 
 /**
  * Companion mixin used with `resource-fetch` for `ResourceList` to determine if the user needs to filter the list by a single namespace

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -126,7 +126,9 @@ export default {
 
       const schema = this.$store.getters[`${ currStore }/schemaFor`](type);
 
-      if (schema?.attributes?.namespaced) { // Is this specific resource namespaced (could be primary or secondary resource)?
+      if (this.pagination) {
+        opt.pagination = this.pagination;
+      } else if (schema?.attributes?.namespaced) { // Is this specific resource namespaced (could be primary or secondary resource)?
         opt.namespaced = this.namespaceFilter; // namespaceFilter will only be populated if applicable for primary resource
       }
 

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -2,13 +2,17 @@ import { mapGetters } from 'vuex';
 import { COUNT, MANAGEMENT } from '@shell/config/types';
 import { SETTING, DEFAULT_PERF_SETTING } from '@shell/config/settings';
 import ResourceFetchNamespaced from '@shell/mixins/resource-fetch-namespaced';
+import ResourceFetchApiPagination from '@shell/mixins/resource-fetch-api-pagination';
 
 // Number of pages to fetch when loading incrementally
 const PAGES = 4;
 
 export default {
 
-  mixins: [ResourceFetchNamespaced],
+  mixins: [
+    ResourceFetchNamespaced,
+    ResourceFetchApiPagination
+  ],
 
   data() {
     // fetching the settings related to manual refresh from global settings

--- a/shell/plugins/dashboard-store/__tests__/mutations.spec.ts
+++ b/shell/plugins/dashboard-store/__tests__/mutations.spec.ts
@@ -26,14 +26,15 @@ describe('dashboard-store: mutations', () => {
   const createPodResource = (props = {}) => createResource(POD, props);
 
   const createCache = (props) => ({
-    generation:    0,
-    haveAll:       false,
-    haveNamespace: undefined,
-    haveSelector:  {},
-    list:          [],
-    loadCounter:   0,
-    revision:      0,
-    map:           new Map(),
+    generation:     0,
+    haveAll:        false,
+    haveNamespace:  undefined,
+    havePagination: undefined,
+    haveSelector:   {},
+    list:           [],
+    loadCounter:    0,
+    revision:       0,
+    map:            new Map(),
     ...props
   });
 

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -315,8 +315,13 @@ export default {
           revision:   out.revision,
           skipHaveAll,
           namespace:  opt.namespaced,
-          pagination: opt.pagination,
-          count:      out.count // TODO: RC steve specific
+          pagination: opt.pagination ? {
+            request: opt.pagination,
+            result:  {
+              count: out.count,
+              pages: out.pages
+            }
+          } : undefined,
         });
       }
     }

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -152,7 +152,8 @@ export default {
     // No need to request the resources if we have them already
     if (
       opt.force !== true &&
-      (getters['haveAllPaginated'](type, opt.pagination) || getters['haveAll'](type) || getters['haveAllNamespace'](type, opt.namespaced))
+      (opt.pagination ? getters['haveAllPaginated'](type, opt.pagination) : true) &&
+      (getters['haveAll'](type) || getters['haveAllNamespace'](type, opt.namespaced))
     ) {
       // TODO: RC TEST that when returning to a list we don't re-fetch
       const args = {

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -154,13 +154,13 @@ export default {
       opt.force !== true &&
       (getters['haveAllPaginated'](type, opt.pagination) || getters['haveAll'](type) || getters['haveAllNamespace'](type, opt.namespaced))
     ) {
+      // TODO: RC TEST that when returning to a list we don't re-fetch
       const args = {
         type,
         revision:  '',
         // watchNamespace - used sometimes when we haven't fetched the results of a single namespace
         // namespaced - used when we have fetched the result of a single namespace (see https://github.com/rancher/dashboard/pull/7329/files)
         namespace: opt.watchNamespace || opt.namespaced
-        //  TODO: RC ALL watch and namespaced? this does the filtering
       };
 
       if (opt.watch !== false ) {

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -315,7 +315,8 @@ export default {
           revision:   out.revision,
           skipHaveAll,
           namespace:  opt.namespaced,
-          pagination: opt.pagination
+          pagination: opt.pagination,
+          count:      out.count // TODO: RC steve specific
         });
       }
     }

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -150,13 +150,17 @@ export default {
     }
 
     // No need to request the resources if we have them already
-    if ( opt.force !== true && (getters['haveAll'](type) || getters['haveAllNamespace'](type, opt.namespaced))) {
+    if (
+      opt.force !== true &&
+      (getters['haveAllPaginated'](type, opt.pagination) || getters['haveAll'](type) || getters['haveAllNamespace'](type, opt.namespaced))
+    ) {
       const args = {
         type,
         revision:  '',
         // watchNamespace - used sometimes when we haven't fetched the results of a single namespace
         // namespaced - used when we have fetched the result of a single namespace (see https://github.com/rancher/dashboard/pull/7329/files)
         namespace: opt.watchNamespace || opt.namespaced
+        //  TODO: RC ALL watch and namespaced? this does the filtering
       };
 
       if (opt.watch !== false ) {
@@ -307,10 +311,11 @@ export default {
         commit('loadAll', {
           ctx,
           type,
-          data:      out.data,
-          revision:  out.revision,
+          data:       out.data,
+          revision:   out.revision,
           skipHaveAll,
-          namespace: opt.namespaced
+          namespace:  opt.namespaced,
+          pagination: opt.pagination
         });
       }
     }
@@ -321,6 +326,7 @@ export default {
         type,
         revision:  out.revision,
         namespace: opt.watchNamespace || opt.namespaced, // it could be either apparently
+        // TODO:  RC watch
         // ToDo: SM namespaced is sometimes a boolean and sometimes a string, I don't see it as especially broken but we should refactor that in the future
         force:     opt.forceWatch === true,
       };

--- a/shell/plugins/dashboard-store/dashboard-store.types.ts
+++ b/shell/plugins/dashboard-store/dashboard-store.types.ts
@@ -1,0 +1,27 @@
+/**
+ * Pagination settings sent to actions and persisted to store
+ */
+export interface OptPagination {
+  namespaces?: string[];
+  page: number,
+  pageSize: number,
+  sort: { field: string, asc: boolean }[],
+  filter: { field: string, value: string }[]
+}
+
+/**
+ * Object persisted to store
+ */
+export interface StorePagination {
+  request: OptPagination,
+  result: {
+    count: number,
+    pages: number
+  }
+}
+
+export type FindAllOpt = {
+  [key: string]: any,
+  namespaced?: string[],
+  pagination?: OptPagination,
+}

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -274,12 +274,18 @@ export default {
     return false;
   },
 
-  haveAllPaginated: (state, getters) => (type) => {
+  haveAllPaginated: (state, getters) => (type, pagination) => {
+    if (!pagination) {
+      return false;
+    }
+
     type = getters.normalizeType(type);
     const entry = state.types[type];
 
     if ( entry ) {
-      return !!entry.havePaginated;
+      // TODO: RC FIXME confirm that pagination === entry.havePagination
+
+      return !!entry.havePagination;
     }
 
     return false;

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -274,10 +274,32 @@ export default {
     return false;
   },
 
+  haveAllPaginated: (state, getters) => (type, pagination) => {
+    if (!pagination) {
+      return false;
+    }
+
+    type = getters.normalizeType(type);
+    const entry = state.types[type];
+
+    if ( entry ) {
+      // TODO: RC
+      // return entry.havePaginated === namespace;
+    }
+
+    return false;
+  },
+
   haveNamespace: (state, getters) => (type) => {
     type = getters.normalizeType(type);
 
     return state.types[type]?.haveNamespace || null;
+  },
+
+  havePaginated: (state, getters) => (type) => {
+    type = getters.normalizeType(type);
+
+    return state.types[type]?.havePaginated || null;
   },
 
   haveSelector: (state, getters) => (type, selector) => {

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -274,17 +274,12 @@ export default {
     return false;
   },
 
-  haveAllPaginated: (state, getters) => (type, pagination) => {
-    if (!pagination) {
-      return false;
-    }
-
+  haveAllPaginated: (state, getters) => (type) => {
     type = getters.normalizeType(type);
     const entry = state.types[type];
 
     if ( entry ) {
-      // TODO: RC
-      // return entry.havePaginated === namespace;
+      return !!entry.havePaginated;
     }
 
     return false;
@@ -299,7 +294,7 @@ export default {
   havePaginated: (state, getters) => (type) => {
     type = getters.normalizeType(type);
 
-    return state.types[type]?.havePaginated || null;
+    return state.types[type]?.havePagination || null;
   },
 
   haveSelector: (state, getters) => (type, selector) => {

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -265,8 +265,7 @@ export function loadAll(state, {
   skipHaveAll,
   namespace,
   pagination,
-  revision,
-  count
+  revision
 }) {
   const { getters } = ctx;
 
@@ -302,11 +301,7 @@ export function loadAll(state, {
     // TODO: RC haveNamespace and havePagination to move to steve mutation
     if (pagination) {
       // : StorePagination
-      cache.havePagination = {
-        ...pagination,
-        count,
-        revision
-      };
+      cache.havePagination = pagination;
       cache.haveNamespace = undefined;
       cache.haveAll = undefined;
     } else if (namespace) {

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -262,6 +262,7 @@ export function loadAll(state, {
   ctx,
   skipHaveAll,
   namespace,
+  pagination,
   revision
 }) {
   const { getters } = ctx;
@@ -295,8 +296,19 @@ export function loadAll(state, {
 
   // Allow requester to skip setting that everything has loaded
   if (!skipHaveAll) {
-    cache.haveNamespace = namespace;
-    cache.haveAll = !namespace;
+    if (pagination) {
+      cache.havePagination = pagination;
+      cache.haveNamespace = undefined;
+      cache.haveAll = undefined;
+    } else if (namespace) {
+      cache.havePagination = false;
+      cache.haveNamespace = namespace;
+      cache.haveAll = false;
+    } else {
+      cache.havePagination = false;
+      cache.haveNamespace = false;
+      cache.haveAll = true;
+    }
   }
 
   return proxies;

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -11,13 +11,14 @@ function registerType(state, type) {
 
   if ( !cache ) {
     cache = {
-      list:          [],
-      haveAll:       false,
-      haveSelector:  {},
-      haveNamespace: undefined, // If the cached list only contains resources for a namespace, this will contain the ns name
-      revision:      0, // The highest known resourceVersion from the server for this type
-      generation:    0, // Updated every time something is loaded for this type
-      loadCounter:   0, // Used to cancel incremental loads if the page changes during load
+      list:           [],
+      haveAll:        false,
+      haveSelector:   {},
+      haveNamespace:  undefined, // If the cached list only contains resources for a namespace, this will contain the ns name
+      havePagination: undefined, // TODO: RC
+      revision:       0, // The highest known resourceVersion from the server for this type
+      generation:     0, // Updated every time something is loaded for this type
+      loadCounter:    0, // Used to cancel incremental loads if the page changes during load
     };
 
     // Not enumerable so they don't get sent back to the client for SSR
@@ -121,6 +122,7 @@ export function forgetType(state, type) {
     cache.haveAll = false;
     cache.haveSelector = {};
     cache.haveNamespace = undefined;
+    cache.havePagination = undefined;
     cache.revision = 0;
     cache.generation = 0;
     clear(cache.list);
@@ -263,7 +265,8 @@ export function loadAll(state, {
   skipHaveAll,
   namespace,
   pagination,
-  revision
+  revision,
+  count
 }) {
   const { getters } = ctx;
 
@@ -296,8 +299,14 @@ export function loadAll(state, {
 
   // Allow requester to skip setting that everything has loaded
   if (!skipHaveAll) {
+    // TODO: RC haveNamespace and havePagination to move to steve mutation
     if (pagination) {
-      cache.havePagination = pagination;
+      // : StorePagination
+      cache.havePagination = {
+        ...pagination,
+        count,
+        revision
+      };
       cache.haveNamespace = undefined;
       cache.haveAll = undefined;
     } else if (namespace) {

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -15,7 +15,7 @@ function registerType(state, type) {
       haveAll:        false,
       haveSelector:   {},
       haveNamespace:  undefined, // If the cached list only contains resources for a namespace, this will contain the ns name
-      havePagination: undefined, // TODO: RC
+      havePagination: undefined,
       revision:       0, // The highest known resourceVersion from the server for this type
       generation:     0, // Updated every time something is loaded for this type
       loadCounter:    0, // Used to cancel incremental loads if the page changes during load
@@ -298,9 +298,8 @@ export function loadAll(state, {
 
   // Allow requester to skip setting that everything has loaded
   if (!skipHaveAll) {
-    // TODO: RC haveNamespace and havePagination to move to steve mutation
     if (pagination) {
-      // : StorePagination
+      // havePagination is of type `StorePagination`
       cache.havePagination = pagination;
       cache.haveNamespace = undefined;
       cache.haveAll = undefined;

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -645,7 +645,28 @@ export default class Resource {
   }
 
   get nameDisplay() {
-    return this.displayName || this.spec?.displayName || this.metadata?.annotations?.[NORMAN_NAME] || this.name || this.metadata?.name || this.id;
+    return this[this.namePath];
+    // return this.displayName || this.spec?.displayName || this.metadata?.annotations?.[NORMAN_NAME] || this.name || this.metadata?.name || this.id;
+  }
+
+  get namePath() {
+    if (this.displayName) {
+      return 'displayName';
+    }
+    if (this.spec?.displayName) {
+      return 'spec.displayName';
+    }
+    if (this.metadata?.annotations?.[NORMAN_NAME]) {
+      return `metadata.annotations.${ NORMAN_NAME }`;
+    }
+    if (this.name) {
+      return 'name';
+    }
+    if (this.metadata?.name) {
+      return 'metadata.name';
+    }
+
+    return 'id';
   }
 
   get nameSort() {

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -645,28 +645,7 @@ export default class Resource {
   }
 
   get nameDisplay() {
-    return this[this.namePath];
-    // return this.displayName || this.spec?.displayName || this.metadata?.annotations?.[NORMAN_NAME] || this.name || this.metadata?.name || this.id;
-  }
-
-  get namePath() {
-    if (this.displayName) {
-      return 'displayName';
-    }
-    if (this.spec?.displayName) {
-      return 'spec.displayName';
-    }
-    if (this.metadata?.annotations?.[NORMAN_NAME]) {
-      return `metadata.annotations.${ NORMAN_NAME }`;
-    }
-    if (this.name) {
-      return 'name';
-    }
-    if (this.metadata?.name) {
-      return 'metadata.name';
-    }
-
-    return 'id';
+    return this.displayName || this.spec?.displayName || this.metadata?.annotations?.[NORMAN_NAME] || this.name || this.metadata?.name || this.id;
   }
 
   get nameSort() {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -30,6 +30,8 @@ export default {
     const parsedUrl = parse(url);
     const isSteve = parsedUrl.path.startsWith('/v1');
 
+    //  TODO: RC ADD PAGINATION
+
     // Filter
     // Steve's filter options work differently nowadays (https://github.com/rancher/steve#filter) #9341
     if ( opt.filter ) {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -8,8 +8,8 @@ import HybridModel, { cleanHybridResources } from './hybrid-class';
 import NormanModel from './norman-class';
 import { urlFor } from '@shell/plugins/dashboard-store/getters';
 import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
-import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
-import stevePaginationUtils from 'plugins/steve/pagination-utils';
+import pAndNFiltering from '@shell/plugins/steve/projectAndNamespaceFiltering.utils';
+import stevePaginationUtils from '@shell/plugins/steve/pagination-utils';
 import { parse } from '@shell/utils/url';
 
 export const STEVE_MODEL_TYPES = {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -31,7 +31,8 @@ export default {
     const parsedUrl = parse(url);
     const isSteve = parsedUrl.path.startsWith('/v1');
 
-    //  TODO: RC ADD PAGINATION
+    // TODO: RC steve (mgmt steve) vs steve (proxy to kube)
+
     // Pagination
     const stevePagination = stevePaginationUtils.checkAndCreateParam(opt);
 

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -8,7 +8,8 @@ import HybridModel, { cleanHybridResources } from './hybrid-class';
 import NormanModel from './norman-class';
 import { urlFor } from '@shell/plugins/dashboard-store/getters';
 import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
-import pAndNFiltering from '@shell/utils/projectAndNamespaceFiltering.utils';
+import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
+import stevePaginationUtils from 'plugins/steve/pagination-utils';
 import { parse } from '@shell/utils/url';
 
 export const STEVE_MODEL_TYPES = {
@@ -31,6 +32,12 @@ export default {
     const isSteve = parsedUrl.path.startsWith('/v1');
 
     //  TODO: RC ADD PAGINATION
+    // Pagination
+    const stevePagination = stevePaginationUtils.checkAndCreateParam(opt);
+
+    if (stevePagination) {
+      url += `${ (url.includes('?') ? '&' : '?') + stevePagination }`;
+    }
 
     // Filter
     // Steve's filter options work differently nowadays (https://github.com/rancher/steve#filter) #9341

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -123,8 +123,7 @@ export default {
     skipHaveAll,
     namespace,
     revision,
-    pagination,
-    count
+    pagination
   }) {
     // Performance testing in dev and when env var is set
     if (process.env.dev && !!process.env.perfTest) {
@@ -132,7 +131,7 @@ export default {
     }
 
     const proxies = loadAll(state, {
-      type, data, ctx, skipHaveAll, namespace, revision, pagination, count
+      type, data, ctx, skipHaveAll, namespace, revision, pagination
     });
 
     // If we loaded a set of pods, then update the podsByNamespace cache

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -122,7 +122,9 @@ export default {
     ctx,
     skipHaveAll,
     namespace,
-    revision
+    revision,
+    pagination,
+    count
   }) {
     // Performance testing in dev and when env var is set
     if (process.env.dev && !!process.env.perfTest) {
@@ -130,7 +132,7 @@ export default {
     }
 
     const proxies = loadAll(state, {
-      type, data, ctx, skipHaveAll, namespace, revision
+      type, data, ctx, skipHaveAll, namespace, revision, pagination, count
     });
 
     // If we loaded a set of pods, then update the podsByNamespace cache

--- a/shell/plugins/steve/pagination-utils.ts
+++ b/shell/plugins/steve/pagination-utils.ts
@@ -24,7 +24,6 @@ class StevePaginationUtils {
       params.push(`pagesize=${ opt.pagination.pageSize }`);
     }
 
-    debugger;
     if (opt.pagination.sort?.length) {
       const joined = opt.pagination.sort
         .map((s) => `${ s.asc ? '' : '-' }${ s.field }`)
@@ -33,7 +32,15 @@ class StevePaginationUtils {
       params.push(`sort=${ joined }`);
     }
 
-    // TODO: RC if not force... add revision
+    if (opt.pagination.filter?.length) {
+      const joined = opt.pagination.filter
+        .map(({ field, value }) => `${ field }=${ value }`)
+        .join(',');
+
+      params.push(`filter=${ joined }`);
+    }
+
+    // TODO: RC if not force... add revision?
 
     console.warn('steve page utils', 'checkAndCreateParam', 'res', params);
 

--- a/shell/plugins/steve/pagination-utils.ts
+++ b/shell/plugins/steve/pagination-utils.ts
@@ -66,6 +66,9 @@ class StevePaginationUtils {
       params.push(`filter=${ joined }`);
     }
 
+    // Note - There is a `limit` property that is by default 100,000. This can be disabled by using `limit=-1`,
+    // but we shouldn't be fetching any pages big enough to exceed the default
+
     console.warn('steve page utils', 'checkAndCreateParam', 'res', params);
 
     return params.join('&');

--- a/shell/plugins/steve/pagination-utils.ts
+++ b/shell/plugins/steve/pagination-utils.ts
@@ -1,6 +1,28 @@
-import projectAndNamespaceFilteringUtils, { FindAllOpt } from 'plugins/steve/projectAndNamespaceFiltering.utils';
+import projectAndNamespaceFilteringUtils from '@shell/plugins/steve/projectAndNamespaceFiltering.utils';
+import { FindAllOpt } from '@shell/plugins/dashboard-store/dashboard-store.types';
+// import { getPerformanceSetting } from 'utils/settings';
 
+/**
+ * Help functions for steve pagination
+ */
 class StevePaginationUtils {
+  /**
+   * Is pagination enabled at a global level
+   */
+  isEnabled({ rootGetters }: any) {
+    const currentProduct = rootGetters['currentProduct'];
+
+    // Only enable for the cluster store at the moment. In theory this should work in management as well, as they're both 'steve' stores
+    if (currentProduct?.inStore !== 'cluster') {
+      return false;
+    }
+
+    // ... no perf setting yet
+    // const perfConfig = getPerformanceSetting(rootGetters);
+
+    return true;
+  }
+
   checkAndCreateParam(opt: FindAllOpt): string | undefined {
     if (!opt.pagination) {
       return;
@@ -16,12 +38,16 @@ class StevePaginationUtils {
       params.push(namespaceParam);
     }
 
-    if (opt.pagination.page) { // TODO: RC what if not here?
+    if (opt.pagination.page) {
       params.push(`page=${ opt.pagination.page }`);
+    } else {
+      throw new Error(`A pagination request is required but no 'page' property provided: ${ JSON.stringify(opt) }`);
     }
 
     if (opt.pagination.pageSize) {
       params.push(`pagesize=${ opt.pagination.pageSize }`);
+    } else {
+      throw new Error(`A pagination request is required but no 'page' property provided: ${ JSON.stringify(opt) }`);
     }
 
     if (opt.pagination.sort?.length) {
@@ -40,8 +66,6 @@ class StevePaginationUtils {
       params.push(`filter=${ joined }`);
     }
 
-    // TODO: RC if not force... add revision?
-
     console.warn('steve page utils', 'checkAndCreateParam', 'res', params);
 
     return params.join('&');
@@ -52,7 +76,6 @@ class StevePaginationUtils {
       return '';
     }
 
-    // TODO: RC do this at the moment, but in future need to handle NOT cases (aka all not system = user)
     return projectAndNamespaceFilteringUtils.createParam(opt.pagination?.namespaces);
   }
 }

--- a/shell/plugins/steve/pagination-utils.ts
+++ b/shell/plugins/steve/pagination-utils.ts
@@ -1,0 +1,53 @@
+import projectAndNamespaceFilteringUtils, { FindAllOpt } from 'plugins/steve/projectAndNamespaceFiltering.utils';
+
+class StevePaginationUtils {
+  checkAndCreateParam(opt: FindAllOpt): string | undefined {
+    if (!opt.pagination) {
+      return;
+    }
+
+    console.warn('steve page utils', 'checkAndCreateParam', opt.pagination);
+
+    const params: string[] = [];
+
+    const namespaceParam = this.createNamespacesParam(opt);
+
+    if (namespaceParam) {
+      params.push(namespaceParam);
+    }
+
+    if (opt.pagination.page) { // TODO: RC what if not here?
+      params.push(`page=${ opt.pagination.page }`);
+    }
+
+    if (opt.pagination.pageSize) {
+      params.push(`pagesize=${ opt.pagination.pageSize }`);
+    }
+
+    debugger;
+    if (opt.pagination.sort?.length) {
+      const joined = opt.pagination.sort
+        .map((s) => `${ s.asc ? '' : '-' }${ s.field }`)
+        .join(',');
+
+      params.push(`sort=${ joined }`);
+    }
+
+    // TODO: RC if not force... add revision
+
+    console.warn('steve page utils', 'checkAndCreateParam', 'res', params);
+
+    return params.join('&');
+  }
+
+  private createNamespacesParam(opt: FindAllOpt): string | undefined {
+    if (!opt.pagination?.namespaces) {
+      return '';
+    }
+
+    // TODO: RC do this at the moment, but in future need to handle NOT cases (aka all not system = user)
+    return projectAndNamespaceFilteringUtils.createParam(opt.pagination?.namespaces);
+  }
+}
+
+export default new StevePaginationUtils();

--- a/shell/plugins/steve/pagination-utils.ts
+++ b/shell/plugins/steve/pagination-utils.ts
@@ -28,7 +28,7 @@ class StevePaginationUtils {
       return;
     }
 
-    console.warn('steve page utils', 'checkAndCreateParam', opt.pagination);
+    console.warn('steve page utils', 'checkAndCreateParam', opt.pagination); // eslint-disable-line no-console
 
     const params: string[] = [];
 
@@ -69,7 +69,7 @@ class StevePaginationUtils {
     // Note - There is a `limit` property that is by default 100,000. This can be disabled by using `limit=-1`,
     // but we shouldn't be fetching any pages big enough to exceed the default
 
-    console.warn('steve page utils', 'checkAndCreateParam', 'res', params);
+    console.warn('steve page utils', 'checkAndCreateParam', 'res', params); // eslint-disable-line no-console
 
     return params.join('&');
   }

--- a/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
+++ b/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
@@ -72,14 +72,36 @@ class ProjectAndNamespaceFiltering {
       return '';
     }
 
-    const projectsOrNamespaces = namespaceFilter
-      .map((f) => f
-        .replace(NAMESPACE_FILTER_NS_FULL_PREFIX, '')
-        .replace(NAMESPACE_FILTER_P_FULL_PREFIX, '')
-      )
-      .join(',');
+    // TODO: RC test n and p filtering outside of pagination
 
-    return `${ ProjectAndNamespaceFiltering.param }=${ projectsOrNamespaces }`;
+    debugger;
+    const namespaces = namespaceFilter.reduce((res, n) => {
+      const name = n
+        .replace(NAMESPACE_FILTER_NS_FULL_PREFIX, '')
+        .replace(NAMESPACE_FILTER_P_FULL_PREFIX, '');
+
+      if (name.startsWith('-')) {
+        res.exclude.push(n.substring(1, n.length));
+      } else {
+        res.include.push(name);
+      }
+
+      return res;
+    }, { include: [] as string[], exclude: [] as string[] });
+
+    let res = '';
+
+    console.warn('pAndNUtil', 'createParam', namespaces.include, namespaces.exclude);
+
+    if (namespaces.include.length) {
+      res = `${ ProjectAndNamespaceFiltering.param }=${ namespaces.include.join(',') }`;
+    }
+
+    if (namespaces.exclude.length) {
+      res = `${ ProjectAndNamespaceFiltering.param }!=${ namespaces.exclude.join(',') }`;
+    }
+
+    return res;
   }
 }
 

--- a/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
+++ b/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
@@ -1,29 +1,6 @@
 import { NAMESPACE_FILTER_NS_FULL_PREFIX, NAMESPACE_FILTER_P_FULL_PREFIX } from '@shell/utils/namespace-filter';
 import { getPerformanceSetting } from '@shell/utils/settings';
-
-export interface OptPagination {
-  namespaces?: string[];
-  page: number,
-  pageSize: number,
-  sort: { field: string, asc: boolean }[],
-  filter: { field: string, value: string }[]
-}
-
-// TODO: RC persist from response
-export interface StorePagination {
-  request: OptPagination,
-  result: {
-    count: number,
-    pages: number
-  }
-}
-
-// TODO: RC
-export type FindAllOpt = {
-  [key: string]: any,
-  namespaced?: string[],
-  pagination?: OptPagination,
-}
+import { FindAllOpt } from '@shell/plugins/dashboard-store/dashboard-store.types';
 
 class ProjectAndNamespaceFiltering {
   static param = 'projectsornamespaces'
@@ -72,9 +49,6 @@ class ProjectAndNamespaceFiltering {
       return '';
     }
 
-    // TODO: RC test n and p filtering outside of pagination
-
-    debugger;
     const namespaces = namespaceFilter.reduce((res, n) => {
       const name = n
         .replace(NAMESPACE_FILTER_NS_FULL_PREFIX, '')

--- a/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
+++ b/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
@@ -10,9 +10,12 @@ export interface OptPagination {
 }
 
 // TODO: RC persist from response
-export interface StorePagination extends OptPagination {
-  count: number,
-  revision: number,
+export interface StorePagination {
+  request: OptPagination,
+  result: {
+    count: number,
+    pages: number
+  }
 }
 
 // TODO: RC

--- a/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
+++ b/shell/plugins/steve/projectAndNamespaceFiltering.utils.ts
@@ -65,7 +65,7 @@ class ProjectAndNamespaceFiltering {
 
     let res = '';
 
-    console.warn('pAndNUtil', 'createParam', namespaces.include, namespaces.exclude);
+    console.warn('pAndNUtil', 'createParam', namespaces.include, namespaces.exclude); // eslint-disable-line no-console
 
     if (namespaces.include.length) {
       res = `${ ProjectAndNamespaceFiltering.param }=${ namespaces.include.join(',') }`;

--- a/shell/plugins/steve/steve-class.js
+++ b/shell/plugins/steve/steve-class.js
@@ -3,7 +3,7 @@ import HybridModel from './hybrid-class';
 
 export default class SteveModel extends HybridModel {
   get name() {
-    return this.metadata?.name || this._name; // TODO: RC
+    return this.metadata?.name || this._name;
   }
 
   get namespace() {

--- a/shell/plugins/steve/steve-class.js
+++ b/shell/plugins/steve/steve-class.js
@@ -3,7 +3,7 @@ import HybridModel from './hybrid-class';
 
 export default class SteveModel extends HybridModel {
   get name() {
-    return this.metadata?.name || this._name;
+    return this.metadata?.name || this._name; // TODO: RC
   }
 
   get namespace() {

--- a/shell/plugins/steve/subscribe-namespace-handler.ts
+++ b/shell/plugins/steve/subscribe-namespace-handler.ts
@@ -1,0 +1,71 @@
+import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
+
+/**
+ * Sockets will not be able to subscribe to more than one namespace. If this is requested we pretend to handle it
+ * - Changes to all resources are monitored (no namespace provided in sub)
+ * - We ignore any events not from a required namespace (we have the conversion of project --> namespaces already)
+ */
+class SubscribeNamespaceHandler {
+  typeIsNamespaced({ getters }: any, type: string) {
+    const haveNamespace = getters.haveNamespace(type);
+    const havePaginated = getters.havePaginated(type);
+
+    return haveNamespace?.length || havePaginated?.request.namespaces?.length;
+  }
+
+  filteredNamespaces({ rootGetters }: any) {
+    // Note - activeNamespaceCache should be accurate for both namespace/project filtering and pagination namespace/project filtering
+    return rootGetters.activeNamespaceCache;
+  }
+
+  /**
+   * Note - namespace can be a list of projects or namespaces
+   */
+  subscribeNamespace(namespace: string[]) {
+    if (pAndNFiltering.isApplicable({ namespaced: namespace }) && namespace.length) {
+      return undefined; // AKA sub to everything
+    }
+
+    return namespace;
+  }
+
+  validChange({ getters, rootGetters }: any, type: string, data: any) {
+    if (this.typeIsNamespaced({ getters }, type)) {
+      const namespaces = this.filteredNamespaces({ rootGetters });
+
+      if (!namespaces[data.metadata.namespace]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  validateBatchChange({ getters, rootGetters }: any, batch: { [key: string]: any}) {
+    const namespaces = this.filteredNamespaces({ rootGetters });
+
+    Object.entries(batch).forEach(([type, entries]) => {
+      if (!this.typeIsNamespaced({ getters }, type)) {
+        return;
+      }
+
+      const schema = getters.schemaFor(type);
+
+      if (!schema?.attributes?.namespaced) {
+        return;
+      }
+
+      Object.keys(entries).forEach((id) => {
+        const namespace = id.split('/')[0];
+
+        if (!namespace || !namespaces[namespace]) {
+          delete entries[id];
+        }
+      });
+    });
+
+    return batch;
+  }
+}
+
+export default new SubscribeNamespaceHandler();

--- a/shell/plugins/steve/subscribe-namespace-handler.ts
+++ b/shell/plugins/steve/subscribe-namespace-handler.ts
@@ -1,4 +1,4 @@
-import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
+import pAndNFiltering from '@shell/plugins/steve/projectAndNamespaceFiltering.utils';
 
 /**
  * Sockets will not be able to subscribe to more than one namespace. If this is requested we pretend to handle it

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -31,7 +31,7 @@ import { escapeHtml } from '@shell/utils/string';
 import { keyForSubscribe } from '@shell/plugins/steve/resourceWatcher';
 import { waitFor } from '@shell/utils/async';
 import { WORKER_MODES } from './worker';
-import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
+import namespaceHandler from './subscribe-namespace-handler';
 import { BLANK_CLUSTER, STORE } from '@shell/store/store-types.js';
 
 // minimum length of time a disconnect notification is shown
@@ -203,67 +203,6 @@ export function equivalentWatch(a, b) {
 
   return true;
 }
-
-/**
- * Sockets will not be able to subscribe to more than one namespace. If this is requested we pretend to handle it
- * - Changes to all resources are monitored (no namespace provided in sub)
- * - We ignore any events not from a required namespace (we have the conversion of project --> namespaces already)
- */
-const namespaceHandler = {
-  /**
-   * Note - namespace can be a list of projects or namespaces
-   */
-  subscribeNamespace: (namespace) => {
-    if (pAndNFiltering.isApplicable({ namespaced: namespace }) && namespace.length) {
-      return undefined; // AKA sub to everything
-    }
-
-    return namespace;
-  },
-
-  validChange: ({ getters, rootGetters }, type, data) => {
-    // TODO: RC
-    const haveNamespace = getters.haveNamespace(type);
-
-    if (haveNamespace?.length) {
-      const namespaces = rootGetters.activeNamespaceCache;
-
-      if (!namespaces[data.metadata.namespace]) {
-        return false;
-      }
-    }
-
-    return true;
-  },
-
-  validateBatchChange: ({ getters, rootGetters }, batch) => {
-    const namespaces = rootGetters.activeNamespaceCache;
-
-    Object.entries(batch).forEach(([type, entries]) => {
-      const haveNamespace = getters.haveNamespace(type);
-
-      if (!haveNamespace?.length) {
-        return;
-      }
-
-      const schema = getters.schemaFor(type);
-
-      if (!schema?.attributes?.namespaced) {
-        return;
-      }
-
-      Object.keys(entries).forEach((id) => {
-        const namespace = id.split('/')[0];
-
-        if (!namespace || !namespaces[namespace]) {
-          delete entries[id];
-        }
-      });
-    });
-
-    return batch;
-  }
-};
 
 function queueChange({ getters, state, rootGetters }, { data, revision }, load, label) {
   const type = getters.normalizeType(data.type);

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -222,6 +222,7 @@ const namespaceHandler = {
   },
 
   validChange: ({ getters, rootGetters }, type, data) => {
+    // TODO: RC
     const haveNamespace = getters.haveNamespace(type);
 
     if (haveNamespace?.length) {

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -31,7 +31,7 @@ import { escapeHtml } from '@shell/utils/string';
 import { keyForSubscribe } from '@shell/plugins/steve/resourceWatcher';
 import { waitFor } from '@shell/utils/async';
 import { WORKER_MODES } from './worker';
-import pAndNFiltering from '@shell/utils/projectAndNamespaceFiltering.utils';
+import pAndNFiltering from 'plugins/steve/projectAndNamespaceFiltering.utils';
 import { BLANK_CLUSTER, STORE } from '@shell/store/store-types.js';
 
 // minimum length of time a disconnect notification is shown

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -475,7 +475,7 @@ export const getters = {
       canYaml:                true,
       namespaced:             null,
       listGroups:             [],
-      listGroupsWillOverride: false, // TODO: RC
+      listGroupsWillOverride: false,
       depaginate:             false,
       customRoute:            undefined,
       resourceEditMasthead:   true,
@@ -967,10 +967,9 @@ export const getters = {
     };
   },
 
-  paginationHeadersFor(state, getters, rootState, rootGetters) {
+  paginationHeadersFor(state) {
     return (schema) => {
-      // TODO: RC what do if none? wire in to mixin?
-      return state.paginationHeaders[schema.id] || getters.headersFor(schema);
+      return state.paginationHeaders[schema.id];
     };
   },
 

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -226,7 +226,7 @@ export function DSL(store, product, module = 'type-map') {
       store.commit(`${ module }/groupBy`, { type, field });
     },
 
-    headers(type, headers) {
+    headers(type, headers, paginationHeaders = []) {
       headers.forEach((header) => {
         // If on the client, then use the value getter if there is one
         if (header.getValue) {
@@ -239,6 +239,7 @@ export function DSL(store, product, module = 'type-map') {
       });
 
       store.commit(`${ module }/headers`, { type, headers });
+      store.commit(`${ module }/paginationHeaders`, { type, paginationHeaders });
     },
 
     hideBulkActions(type, field) {
@@ -368,6 +369,7 @@ export const state = function() {
     typeOptions:             [],
     groupBy:                 {},
     headers:                 {},
+    paginationHeaders:       {},
     hideBulkActions:         {},
     schemaGeneration:        1,
     cache:                   {
@@ -964,6 +966,13 @@ export const getters = {
     };
   },
 
+  paginationHeadersFor(state, getters, rootState, rootGetters) {
+    return (schema) => {
+      // TODO: RC what do if none? wire in to mixin?
+      return state.paginationHeaders[schema.id] || getters.headersFor(schema);
+    };
+  },
+
   headersFor(state, getters, rootState, rootGetters) {
     return (schema) => {
       const attributes = schema.attributes || {};
@@ -1536,6 +1545,10 @@ export const mutations = {
 
   headers(state, { type, headers }) {
     state.headers[type] = headers;
+  },
+
+  paginationHeaders(state, { type, paginationHeaders }) {
+    state.paginationHeaders[type] = paginationHeaders;
   },
 
   hideBulkActions(state, { type, field }) {

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -467,17 +467,18 @@ export const getters = {
 
   optionsFor(state) {
     const def = {
-      isCreatable:          true,
-      isEditable:           true,
-      isRemovable:          true,
-      showState:            true,
-      showAge:              true,
-      canYaml:              true,
-      namespaced:           null,
-      listGroups:           [],
-      depaginate:           false,
-      customRoute:          undefined,
-      resourceEditMasthead: true,
+      isCreatable:            true,
+      isEditable:             true,
+      isRemovable:            true,
+      showState:              true,
+      showAge:                true,
+      canYaml:                true,
+      namespaced:             null,
+      listGroups:             [],
+      listGroupsWillOverride: false, // TODO: RC
+      depaginate:             false,
+      customRoute:            undefined,
+      resourceEditMasthead:   true,
     };
 
     return (schemaOrType) => {

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -979,8 +979,9 @@ export const getters = {
           if ( col ) {
             return {
               ...fromSchema(col, rootGetters),
-              sort:   false, // TODO: RC Process. LOST Pod Ready, Restarts, IP
-              search: false // TODO: RC Process. LOST Pod Ready, Restarts, IP
+              // Automatically disable sort and search, not currently supported API side
+              sort:   false,
+              search: false
             };
           } else {
             return null;

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -972,7 +972,7 @@ export const getters = {
       const attributes = schema.attributes || {};
       const columns = attributes.columns || [];
 
-      const c = state.paginationHeaders[schema.id]?.map((entry) => {
+      return state.paginationHeaders[schema.id]?.map((entry) => {
         if ( typeof entry === 'string' ) {
           const col = findBy(columns, 'name', entry);
 
@@ -991,8 +991,6 @@ export const getters = {
         }
       })
         .filter((col) => !!col);
-
-      return c;
     };
   },
 

--- a/shell/utils/array.ts
+++ b/shell/utils/array.ts
@@ -1,5 +1,5 @@
 import xor from 'lodash/xor';
-import { get } from '@shell/utils/object';
+import { get, isEqual } from '@shell/utils/object';
 
 export function removeObject<T>(ary: T[], obj: T): T[] {
   const idx = ary.indexOf(obj);
@@ -178,6 +178,25 @@ export function hasDuplicatedStrings(items: string[], caseSensitive = true): boo
 
 export function sameContents<T>(aryA: T[], aryB: T[]): boolean {
   return xor(aryA, aryB).length === 0;
+}
+
+export function sameArrayObjects<T>(aryA: T[], aryB: T[]): boolean {
+  if (!aryA && !aryB) {
+    // catch calls from js (where props aren't type checked)
+    return false;
+  }
+  if (aryA?.length !== aryB?.length) {
+    // catch one null and not t'other, and different lengths
+    return false;
+  }
+
+  for (let i = 0; i < aryA.length; i++) {
+    if (!isEqual(aryA[i], aryB[i])) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export function uniq<T>(ary: T[]): T[] {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9478
<!-- Define findings related to the feature or bug issue. -->

### ----------------
###  This is an alpha and not meant for production or review (see list of updates required)
### ----------------

### Occurred changes and/or fixed issues
- only applies to
  - specifically configmaps, secrets and pods. other resources can be incrementally added
  - cluster store. management store should in theory be simple to support
  - resources that don't have their own custom list. this should be easy to resolve though
 - sorting / filtering are disabled for...
   - any column who's value was computed locally (e.g. model getters).
     - secret - subTypeDisplay - translates things like `kubernetes.io/service-account-token` to `Svc Acct Token`
     - configmaps - data - we convert data from two properties into something more readable
- sorting is enabled but not working for (backend issue)
   - columns that were originally from schemas
     - pod - `Ready`, `Restarts` and `IP` all come from schema --> metadata.fields[index] (attributes.columns[0].field: "$.metadata.fields[1])
- special note - state sort & search is done via actual value, rather than the label we apply locally


#### Updates post alpha
- loading indicator when pages are being requested (take care not to blip)
  - should be subtle, as per incremental loading indicator
- performance setting (global enable / disable)
- improve - the list group by feature adds a namespace option if resource is namespaced. we replace this with config for paths via `listGroupsWillOverride`. this isn't so neat
- improve - there's a lot of computed properties in sortable table that fire when things happen in store. need to avoid these
- ~we re-fetch the list when we return to the page. this means the list is updated, but user has to wait for http request again. could leave as is, candidate for refresh button~
  - Refetch list on every visit
  - Add refresh button
- resolve two `TODO: RC FIX`
- list changed notification - when we receive a socket message for resource that is outside of current page
- when leave a resource list where pagination is enabled make sure to unsub

#### Updates that really should be in alpha
- add/update comments... everywhere
- remove debug consoles
- there are two subscribe messages sent for the list's type
- there's no label on the namespace groups. this is due to the `field` used to search instead of the `value`
- workload lists fail to load


### Technical notes summary

General flow
- new resource list mixin determines if a list supports pagination, bubbles down to sortable table
- sortable table bubbles up pagination changes
- resource list pagination mixin makes request for new page given pagination settings
- find action takes pagination settings
- pagination settings applied in urlFor
- find action persists page, pagination settings and pagination results (total results)
- resource list bubbles down pagination results (total results) to sortable table


Design / Patterns
  - updates to resources that are not in the current page are ignored
  - We can only sort and filter by values known to the backend. Therefore a lot of the existing table headers, which reference model properties
    are invalid. To get around this we define new headers which refer directly to properties on the raw resource. see pagination-table-headers
    this means we avoid things like `name` & `namespace` property helpers, searchFields that are functions to values, etc
  - the revision of the list is ignored. when user goes to page two it will be page 2 at that new time (rather than from the time page 1 was requested)
  - Question. the only way for a user to update their page is to change pagination in some way. we should consider a refresh button
     
#### Backend / API Issues
- configmaps
  - ~different `count` provided when adding/removing `sort=-metadata.namespace`~
    - Update: This might be FE... looks like the ns filter is also being removed alongside sort 
    - Update2: It is a FE issue, toggling group by is for some reason removing the filter on ns
- secrets
  - the resource has a `_type` field, yet `sort=_type` does not work
  - the resource has a `_type` field, yet `filter_type` does not work
  - ![image](https://github.com/rancher/dashboard/assets/18697775/b2c51d2c-7cff-46ef-9b15-78ec3da5e3dc)
- pod
  - ~question. `spec.containers` is an array of container objects. we'd like to sort/search using container.image.~
    - these can be filtered `filter=spec.containers.image=alpine` as per docs. sorting doesn't make sense
  - some columns come from schemas. the field is a specific value in an array. can we sort by it?
    - pod 'restarts' field is determined from a reference in it's schema. `attributes.columns[3]` `field` points to roughly the path in the pod object where the value is `$.metadata.fields[3]"`.
    - we can filter by this (`filter=metadata.fields.3=xyz`)
    - sorting though doesn't seem to work (`sort: metadata.fields.3`)
     
     
### Areas or cases that should be tested
- no regressions for
  - non-paginated lists
  - namespace/project filtering
  - manual refresh (list)
  - incremental loading (list)
  - garbage collection (?)
  - advanced filtering
  - fleet workspace selection
- group by namespace / no namespace
- group by namespace sticks on refresh
- the hideSystemResources product config (determines namespaces used in filters)
- the pref ALL_NAMESPACES (determines namespaces used in filters)
- user navigates to last page in a list with a single result on the last page --> in another browser delete the resource
- user navigates to page before last in a list with a single result on the last page --> in another browser delete the resource --> nav to last page

