### PR TITLE
Fixed 'imported' label not showing up for imported AKS/EKS clusters

### DIFF
--- a/shell/components/formatter/ClusterProvider.vue
+++ b/shell/components/formatter/ClusterProvider.vue
@@ -7,14 +7,20 @@ export default {
     },
   },
   data(props) {
+    const mgmt = props.row?.mgmt;
+
     return {
       // The isImported getter on the provisioning cluster
       // model doesn't work for imported K3s clusters, in
       // which case it returns 'k3s' instead of 'imported.'
       // This is the workaround.
-      isImported: props.row?.mgmt?.providerForEmberParam === 'import' ||
-        // when imported cluster is Google GKE
-        props.row?.mgmt?.spec?.gkeConfig?.imported
+      isImported: mgmt?.providerForEmberParam === 'import' ||
+        // when imported cluster is GKE
+        !!mgmt?.spec?.gkeConfig?.imported ||
+        // or AKS
+        !!mgmt?.spec?.aksConfig?.imported ||
+        // or EKS
+        !!mgmt?.spec?.eksConfig?.imported
     };
   },
 };

--- a/shell/components/formatter/__tests__/ClusterProvider.test.ts
+++ b/shell/components/formatter/__tests__/ClusterProvider.test.ts
@@ -3,15 +3,19 @@ import ClusterProvider from '@shell/components/formatter/ClusterProvider.vue';
 
 describe('component: ClusterProvider', () => {
   const importedGkeClusterInfo = { mgmt: { spec: { gkeConfig: { imported: true } } } };
+  const importedAksClusterInfo = { mgmt: { spec: { aksConfig: { imported: true } } } };
+  const importedEksClusterInfo = { mgmt: { spec: { eksConfig: { imported: true } } } };
   const notImportedGkeClusterInfo = { mgmt: { spec: { gkeConfig: { imported: false } } } };
   const importedClusterInfoWithProviderForEmberParam = { mgmt: { providerForEmberParam: 'import' } };
 
   describe('isImported', () => {
     const testCases = [
       [importedGkeClusterInfo, true],
+      [importedAksClusterInfo, true],
+      [importedEksClusterInfo, true],
       [notImportedGkeClusterInfo, false],
       [importedClusterInfoWithProviderForEmberParam, true],
-      [{}, undefined],
+      [{}, false],
     ];
 
     it.each(testCases)('should return the isImported value properly based on the props data', (row, expected) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Additional checks for covering imported AKS/EKS clusters.

Fixes #9519 
<!-- Define findings related to the feature or bug issue. -->