### PR TITLE
Fix white page errors in prod

### DIFF
--- a/shell/initialize/App.js
+++ b/shell/initialize/App.js
@@ -1,3 +1,5 @@
+// Taken from @nuxt/vue-app/template/App.js
+
 import Vue from 'vue';
 
 import { getMatchedComponentsInstances, getChildrenComponentInstancesUsingFetch, promisify, globalHandleError } from '../utils/nuxt';

--- a/shell/initialize/client.js
+++ b/shell/initialize/client.js
@@ -79,30 +79,23 @@ if (debug) {
         handled = defaultErrorHandler(err, vm, info, ...rest);
       }
       if (handled === true) {
-        console.warn('nuxt client.js', 1);
-
         return handled;
       }
 
       if (vm && vm.$root) {
-        console.warn('nuxt client.js', 2);
         const nuxtApp = Object.keys(Vue.config.$nuxt)
           .find((nuxtInstance) => vm.$root[nuxtInstance]);
 
         // Show Nuxt Error Page
         if (nuxtApp && vm.$root[nuxtApp].error && info !== 'render function') {
-          console.warn('nuxt client.js', 3);
           const currentApp = vm.$root[nuxtApp];
 
           // Load error layout
           let layout = (NuxtError.options || NuxtError).layout;
 
-          console.warn('nuxt client.js', 4, NuxtError.options, NuxtError );
-
           if (typeof layout === 'function') {
             layout = layout(currentApp.context);
           }
-          console.warn('nuxt client.js', 5, layout);
           if (layout) {
             await currentApp.loadLayout(layout).catch(() => {});
           }

--- a/shell/initialize/client.js
+++ b/shell/initialize/client.js
@@ -1,3 +1,5 @@
+// Taken from @nuxt/vue-app/template/client.js
+
 import Vue from 'vue';
 import fetch from 'unfetch';
 import middleware from '../config/middleware.js';
@@ -21,7 +23,7 @@ import { createApp, NuxtError } from './index.js';
 import fetchMixin from '../mixins/fetch.client';
 import NuxtLink from '../components/nuxt/nuxt-link.client.js'; // should be included after ./index.js
 
-// Mimic old @nuxt/node_modules/vue-app/template/client.js
+// Mimic old @nuxt/vue-app/template/client.js
 const isDev = process.env.dev;
 const debug = isDev;
 

--- a/shell/initialize/index.js
+++ b/shell/initialize/index.js
@@ -1,3 +1,5 @@
+// Taken from @nuxt/vue-app/template/index.js
+
 import Vue from 'vue';
 import Meta from 'vue-meta';
 import ClientOnly from 'vue-client-only';

--- a/shell/mixins/fetch.client.js
+++ b/shell/mixins/fetch.client.js
@@ -75,9 +75,9 @@ async function $_fetch() { // eslint-disable-line camelcase
   try {
     await this.$options.fetch.call(this);
   } catch (err) {
-    if (process.dev) {
-      console.error('Error in fetch():', err); // eslint-disable-line no-console
-    }
+    // In most cases we don't handle errors at all in `fetch`es. Lets always log to help in production
+    console.error('Error in fetch():', err); // eslint-disable-line no-console
+
     error = normalizeError(err);
   }
 

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -253,10 +253,6 @@ module.exports = function(dir, _appConfig) {
     console.log(`Version: ${ dashboardVersion }`); // eslint-disable-line no-console
   }
 
-  if ( !dev ) {
-    console.log(`Version: ${ dashboardVersion }`); // eslint-disable-line no-console
-  }
-
   if ( resourceBase ) {
     console.log(`Resource Base URL: ${ resourceBase }`); // eslint-disable-line no-console
   }
@@ -413,6 +409,12 @@ module.exports = function(dir, _appConfig) {
           rancherEnv,
           dashboardVersion
         }),
+
+        // Set some process properties from @nuxt/webpack/dist/webpack.js that are still in use
+        'process.mode':   JSON.stringify(dev ? 'development' : 'production'),
+        'process.dev':    dev,
+        'process.static': false,
+        'process.target': JSON.stringify('server'),
       }));
 
       // The static assets need to be in the built assets directory in order to get served (primarily the favicon)

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -410,11 +410,6 @@ module.exports = function(dir, _appConfig) {
           dashboardVersion
         }),
 
-        // Set some process properties from @nuxt/webpack/dist/webpack.js that are still in use
-        'process.mode':   JSON.stringify(dev ? 'development' : 'production'),
-        'process.dev':    dev,
-        'process.static': false,
-        'process.target': JSON.stringify('server'),
       }));
 
       // The static assets need to be in the built assets directory in order to get served (primarily the favicon)


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9542
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- white page errors should not be visible in prod
- these were enabled in all envs via the port of shell/initialize/client.js after nuxt
- that file came from the output of a rendered template
- the rendered template has features enabled only when debug/isDev process envs are on
- the rendered file had these on, so features were on in prod
- fix is to at run time disable these features
- Additionally..
  - set some process values that were being skipped but still used
  - always log uncaught errors in `fetch`s. in theory we should be monitoring $fetchState.error but we never do. this has led to some painful debugging with customers


### Areas or cases that should be tested
- anywhere an error might occur
- see issue description, the easiest way is to edit code

