### PR TITLE
Fix extension displayName annotation conditions - add configuration docs

### DIFF
--- a/cypress/e2e/tests/pages/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions.spec.ts
@@ -183,6 +183,20 @@ describe('Extensions page', { tags: '@adminUser' }, () => {
     extensionsPo.extensionDetailsCloseClick();
   });
 
+  it('Should not display installed extensions within the available tab', () => {
+    const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.goTo();
+
+    // check for installed extension in "installed" tab
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCard(EXTENSION_NAME).should('be.visible');
+
+    // check for installed extension in "available" tab
+    extensionsPo.extensionTabAvailableClick();
+    extensionsPo.extensionCard(EXTENSION_NAME).should('not.exist');
+  });
+
   it('Should update an extension version', () => {
     const extensionsPo = new ExtensionsPagePo();
 

--- a/docusaurus/docs/extensions/extensions-configuration.md
+++ b/docusaurus/docs/extensions/extensions-configuration.md
@@ -3,3 +3,43 @@
 Follow instructions [here](./extensions-getting-started.md) to scaffold your extension. This will assist you in the creation of an extension as a top-level product inside Rancher Dashboard.
 
 Once you've done so, there are some initialization steps specific to extensions. Beyond that, extensions largely work the same as the rest of the dashboard. There are a set of top-level folders that can be defined and used as they are in the dashboard: `chart`, `cloud-credential`, `content`, `detail`, `edit`, `list`, `machine-config`, `models`, `promptRemove`, `l10n`, `windowComponents`, `dialog`, and `formatters`. You can read about what each of these folders does [here](../code-base-works/directory-structure.md).
+
+## Extension Package Metadata
+
+Each extension package has the ability to customize certain aspects when it comes to compatibility with Rancher Manager/Kubernetes or displaying extension names. These are determined by the `rancher.annotations` object applied to the `package.json` of an extension package.
+
+These annotations allow you to specify compatibility with Kubernetes, Rancher Manager, the Extensions API, and the Rancher UI version by relying on [semver ranges](https://www.npmjs.com/package/semver/v/6.3.0#ranges). As well as version compatibility, you can also specify a Display Name for the Extension package as it appears on the "Extensions" page within the UI.
+
+### Configurable Annotations
+
+| Annotation | Value | Description |
+| ------ | :------: | --------------|
+| `catalog.cattle.io/kube-version` | `Range` | Determines if the Kubernetes version that Rancher Manager is utilizing is compatible with the Extension package. |
+| `catalog.cattle.io/rancher-version` | `Range` | Determines the compatibility of the installed Rancher Manager version with the Extension package. |
+| `catalog.cattle.io/ui-extensions-version` | `Range` | Determines the Extensions API version that is compatible with the Extension package. |
+| `catalog.cattle.io/ui-version` | `Range` | Determines the Rancher UI version that is compatible with the Extension package. |
+| `catalog.cattle.io/display-name` | `String` | Specifies the Display Name for an Extension package's card on the "Extensions" page. |
+
+### Example Configuration
+
+Here's an example configuration of an extensions `package.json`:
+
+___`./pkg/my-package/package.json`___
+```json
+{
+  "name": "my-package",
+  "description": "my-package plugin description",
+  "version": "0.1.0",
+  "rancher": {
+    "annotations": {
+      "catalog.cattle.io/kube-version": ">= v1.26.0-0 < v1.28.0-0",
+      "catalog.cattle.io/rancher-version": ">= 2.7.7-0 < 2.8.0-0",
+      "catalog.cattle.io/ui-extensions-version": ">= 1.1.0",
+      "catalog.cattle.io/ui-version": ">= 2.7.7-0 < 2.8.0-0",
+      "catalog.cattle.io/display-name": "My Super Great Extension"
+    }
+  },
+  ...
+}
+```
+

--- a/pkg/harvester-manager/package.json
+++ b/pkg/harvester-manager/package.json
@@ -4,7 +4,9 @@
   "version": "0.1.0",
   "private": false,
   "rancher": {
-    "catalog.cattle.io/display-name": "Virtualization Manager"
+    "annotations": {
+      "catalog.cattle.io/display-name": "Virtualization Manager"
+    }
   },
   "scripts": {
     "dev": "./node_modules/.bin/nuxt dev",

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -243,9 +243,9 @@ export default {
 
       all = all.map((chart) => {
         // Label can be overridden by chart annotation
-        const label = uiPluginAnnotation(UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME) || chart.chartNameDisplay;
+        const label = uiPluginAnnotation(chart, UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME) || chart.chartNameDisplay;
         const item = {
-          name:         chart.chartNameDisplay,
+          name:         chart.chartName,
           label,
           description:  chart.chartDescription,
           id:           chart.id,
@@ -305,7 +305,7 @@ export default {
         if (!chart) {
           // A plugin is loaded, but there is no chart, so add an item so that it shows up
           const rancher = typeof p.metadata?.rancher === 'object' ? p.metadata.rancher : {};
-          const label = rancher[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || p.name;
+          const label = rancher.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || p.name;
           const item = {
             name:           p.name,
             label,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9501 Fixes #9318
<!-- Define findings related to the feature or bug issue. -->
The issues mentioned by @jtomasek about how we displayed the `catalog.cattle.io/display-name` for an extension was different depending on the existence of an extension chart. Also we were not searching for the correct property (`rancher.annotations`) for this annotation. Enforcing the "annotations" property within the `package.json` should be the correct approach.

There was also an issue in how we were determining if an extension was installed by comparing the `plugin.name` with the `chart.name` - However, the `chart.name` was determined by the `chartDisplayName` rather than the actual chart name. So when the `catalog.cattle.io/display-name` was declared, the `chartNameDisplay`, which did not match the name of the installed extension, was being used to filter all `installed` extensions from the "Available" tab. 

If needed, I can provide an extension repository with annotations for testing.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Modified the `package.json` for Harvester Manager to include the `annotations` property
- Fixed how we were calling the `uiPluginAnnotation` method by supplying the necessary `chart`
- Changed the `available` extensions to use the `chart.chartName` instead of `chart.chartNameDisplay`
- Properly filtering for `rancher.annotations` on installed extensions without a chart
- Added e2e for testing that an installed extension does not appear in the "Available" tab
  - The [Clock extension](https://github.com/rancher/ui-plugin-examples) should be able to utilize the `catalog.cattle.io/display-name` correctly now
- Added documentation on how to configure the extension package annotations.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
***Before***
![11](https://github.com/rancher/dashboard/assets/40806497/04ace448-e24d-428b-a55c-b2e5fc20620b)
![12](https://github.com/rancher/dashboard/assets/40806497/2049c405-186f-4a80-b375-66609c4e031f)

***After***
![21](https://github.com/rancher/dashboard/assets/40806497/3f8fd662-fd30-4fc0-8c17-158cf5c9e237)
![22](https://github.com/rancher/dashboard/assets/40806497/af790e12-11ee-40ca-9ad9-5cd1f65ed116)
