### PR TITLE
Now uses the same data as the cluster homepage, delayed load not needed.

### DIFF
--- a/shell/components/formatter/PodsUsage.vue
+++ b/shell/components/formatter/PodsUsage.vue
@@ -8,25 +8,22 @@ export default {
     },
   },
   computed: {
-    ready() {
-      return this.row?.isReady;
-    },
     podsUsage() {
       const usedPods = this.row?.mgmt?.status?.requested?.pods;
       const totalPods = this.row?.mgmt?.status?.allocatable?.pods;
 
-      return totalPods ? `${ usedPods || 0 }/${ totalPods }` : '—';
+      if (!this.row?.isReady || !totalPods) {
+        return '—';
+      }
+
+      return `${ usedPods || 0 }/${ totalPods }`;
     }
   }
 };
 </script>
 
 <template>
-  <i
-    v-if="!ready"
-    class="icon icon-spinner icon-spin"
-  />
-  <p v-else>
+  <p>
     <span>{{ podsUsage }}</span>
   </p>
 </template>

--- a/shell/components/formatter/PodsUsage.vue
+++ b/shell/components/formatter/PodsUsage.vue
@@ -1,5 +1,4 @@
 <script>
-import { POD } from '@shell/config/types';
 export default {
   name:  'PodsUsage',
   props: {
@@ -8,47 +7,17 @@ export default {
       required: true
     },
   },
-  data() {
-    return {
-      loading:   true,
-      podsUsage: null
-    };
-  },
-  methods: {
-    async startDelayedLoading() {
-      const id = this.row?.mgmt?.id;
+  computed: {
+    podsUsage() {
+      const usedPods = this.row?.mgmt?.status?.requested?.pods;
+      const totalPods = this.row?.mgmt?.status?.allocatable?.pods;
 
-      if (this.row?.isReady && id) {
-        const req = await this.$store.dispatch('management/request', { url: `/k8s/clusters/${ id }/v1/counts` });
-
-        this.loading = false;
-        const usedPods = req.data?.[0]?.counts[POD]?.summary?.count || 0;
-        const totalPods = this.row?.mgmt?.status?.allocatable?.pods;
-
-        if (totalPods) {
-          this.podsUsage = `${ usedPods }/${ totalPods }`;
-        } else {
-          this.podsUsage = '—';
-        }
-      } else {
-        this.loading = false;
-        this.podsUsage = '—';
-      }
+      return totalPods ? `${ usedPods }/${ totalPods }` : '—';
     }
-  },
+  }
 };
 </script>
 
 <template>
-  <i
-    v-if="loading"
-    class="icon icon-spinner icon-spin"
-  />
-  <p v-else>
-    {{ podsUsage }}
-  </p>
+  <p>{{ podsUsage }}</p>
 </template>
-
-<style lang="scss" scoped>
-
-</style>

--- a/shell/components/formatter/PodsUsage.vue
+++ b/shell/components/formatter/PodsUsage.vue
@@ -8,16 +8,25 @@ export default {
     },
   },
   computed: {
+    ready() {
+      return this.row?.isReady;
+    },
     podsUsage() {
       const usedPods = this.row?.mgmt?.status?.requested?.pods;
       const totalPods = this.row?.mgmt?.status?.allocatable?.pods;
 
-      return totalPods ? `${ usedPods }/${ totalPods }` : '—';
+      return totalPods ? `${ usedPods || 0 }/${ totalPods }` : '—';
     }
   }
 };
 </script>
 
 <template>
-  <p>{{ podsUsage }}</p>
+  <i
+    v-if="!ready"
+    class="icon icon-spinner icon-spin"
+  />
+  <p v-else>
+    <span>{{ podsUsage }}</span>
+  </p>
 </template>

--- a/shell/components/formatter/__tests__/PodsUsage.test.ts
+++ b/shell/components/formatter/__tests__/PodsUsage.test.ts
@@ -2,37 +2,44 @@ import { mount } from '@vue/test-utils';
 import PodsUsage from '@shell/components/formatter/PodsUsage.vue';
 
 describe('component: PodsUsage', () => {
-  it('should not display values if data is not ready', () => {
-    const wrapper = mount(PodsUsage, {
-      propsData: { row: {} },
-      mocks:     { $store: { dispatch: { 'management/request': jest.fn() } } }
-    });
-
-    const element = wrapper.find('p').element;
-
-    expect(element).toBeUndefined();
-  });
-
-  it('should display spinning icon', () => {
-    const wrapper = mount(PodsUsage, {
-      propsData: { row: {} },
-      mocks:     { $store: { dispatch: { 'management/request': jest.fn() } } }
-    });
-
-    const element = wrapper.find('i').element;
-
-    expect(element).toBeDefined();
-  });
-
   it('should display podsUsage value', () => {
     const wrapper = mount(PodsUsage, {
-      propsData: { row: { isReady: true } },
-      data:      () => ({ loading: false }),
-      mocks:     { $store: { dispatch: { 'management/request': jest.fn() } } }
+      propsData: {
+        row: {
+          mgmt: {
+            status: {
+              requested:   { pods: 10 },
+              allocatable: { pods: 20 }
+            }
+          }
+        }
+      },
+      mocks: { $store: { dispatch: { 'management/request': jest.fn() } } }
     });
 
     const element = wrapper.find('p').element;
 
     expect(element.textContent).toBeDefined();
+    expect(element.textContent).toBe('10/20');
+  });
+  it('should display dash when there are no totalPods', () => {
+    const wrapper = mount(PodsUsage, {
+      propsData: {
+        row: {
+          mgmt: {
+            status: {
+              requested:   { pods: 10 },
+              allocatable: { pods: 0 }
+            }
+          }
+        }
+      },
+      mocks: { $store: { dispatch: { 'management/request': jest.fn() } } }
+    });
+
+    const element = wrapper.find('p').element;
+
+    expect(element.textContent).toBeDefined();
+    expect(element.textContent).toBe('—');
   });
 });

--- a/shell/components/formatter/__tests__/PodsUsage.test.ts
+++ b/shell/components/formatter/__tests__/PodsUsage.test.ts
@@ -6,7 +6,8 @@ describe('component: PodsUsage', () => {
     const wrapper = mount(PodsUsage, {
       propsData: {
         row: {
-          mgmt: {
+          isReady: true,
+          mgmt:    {
             status: {
               requested:   { pods: 10 },
               allocatable: { pods: 20 }
@@ -17,7 +18,7 @@ describe('component: PodsUsage', () => {
       mocks: { $store: { dispatch: { 'management/request': jest.fn() } } }
     });
 
-    const element = wrapper.find('p').element;
+    const { element } = wrapper.find('p');
 
     expect(element.textContent).toBeDefined();
     expect(element.textContent).toBe('10/20');
@@ -26,7 +27,8 @@ describe('component: PodsUsage', () => {
     const wrapper = mount(PodsUsage, {
       propsData: {
         row: {
-          mgmt: {
+          isReady: true,
+          mgmt:    {
             status: {
               requested:   { pods: 10 },
               allocatable: { pods: 0 }
@@ -37,7 +39,15 @@ describe('component: PodsUsage', () => {
       mocks: { $store: { dispatch: { 'management/request': jest.fn() } } }
     });
 
-    const element = wrapper.find('p').element;
+    const { element } = wrapper.find('p');
+
+    expect(element.textContent).toBeDefined();
+    expect(element.textContent).toBe('—');
+  });
+  it('should display a dash when there is no management cluster ti query for status', () => {
+    const wrapper = mount(PodsUsage, { propsData: { row: { isReady: true } } });
+
+    const { element } = wrapper.find('p');
 
     expect(element.textContent).toBeDefined();
     expect(element.textContent).toBe('—');

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -192,7 +192,7 @@ export default {
           label:        this.t('tableHeaders.pods'),
           name:         'pods',
           value:        '',
-          sort:         ['status.allocatable.pods', 'status.available.pods'],
+          sort:         ['status.allocatable.pods', 'status.requested.pods'],
           formatter:    'PodsUsage',
           delayLoading: true
         },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9363
There was a similar fix for #8543 [PR](https://github.com/rancher/dashboard/pull/8756/files) and it looks like we didn't fix the formatter for the cluster list so there was a mismatch. This basically just makes the same change in the column Formatter so everything lines up again.

### Occurred changes and/or fixed issues
The cluster list shouldn't need to delay on loading pods capacity anymore and we've reduced subsequent api calls as well.

### Technical notes summary
used pods in the `cluster.status.requested.pods` is accurate for pods capacity, removed subsequent API calls and just using that to create the capacity string.

### Areas or cases that should be tested
Cluster home page pod capacity and cluster list pod capacities should always match per cluster