### PR TITLE
Display errors in daemonSets

### DIFF
--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -2,7 +2,7 @@
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { NAMESPACE as NAMESPACE_COL } from '@shell/config/table-headers';
 import {
-  POD, WORKLOAD_TYPES, SCALABLE_WORKLOAD_TYPES, SERVICE, INGRESS, NODE, NAMESPACE,
+  POD, WORKLOAD_TYPES, SCALABLE_WORKLOAD_TYPES, SERVICE, INGRESS, NODE, NAMESPACE, EVENT
 } from '@shell/config/types';
 import ResourceTable from '@shell/components/ResourceTable';
 import Tab from '@shell/components/Tabbed/Tab';
@@ -69,6 +69,7 @@ export default {
       allPods:      this.$store.dispatch('cluster/findAll', { type: POD }),
       allServices:  this.$store.dispatch('cluster/findAll', { type: SERVICE }),
       allIngresses: this.$store.dispatch('cluster/findAll', { type: INGRESS }),
+      allEvents:    this.$store.dispatch('cluster/findAll', { type: EVENT }),
       // Nodes should be fetched because they may be referenced in the target
       // column of a service list item.
       allNodes:     hasNodes ? this.$store.dispatch('cluster/findAll', { type: NODE }) : []
@@ -100,6 +101,10 @@ export default {
     }
     this.findMatchingServices();
     this.findMatchingIngresses();
+  },
+
+  beforeDestroy() {
+    this.$store.dispatch('cluster/forgetType', EVENT);
   },
 
   data() {

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -1,7 +1,7 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
 import {
-  WORKLOAD_TYPES, SCHEMA, NODE, POD, LIST_WORKLOAD_TYPES
+  WORKLOAD_TYPES, SCHEMA, NODE, POD, LIST_WORKLOAD_TYPES, EVENT
 } from '@shell/config/types';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 
@@ -129,6 +129,11 @@ export default {
 
   methods: {
     loadHeathResources() {
+      // get events to populate possible error messages in daemonsets
+      // don't really agree with this, as it can be expensive in high scale systems for list views
+      // https://github.com/rancher/dashboard/issues/8502
+      this.$store.dispatch('cluster/findAll', { type: EVENT });
+
       // Fetch these in the background to populate workload health
       if ( this.allTypes ) {
         this.$fetchType(POD);
@@ -148,6 +153,10 @@ export default {
         }
       }
     }
+  },
+
+  beforeDestroy() {
+    this.$store.dispatch('cluster/forgetType', EVENT);
   },
 
   typeDisplay() {


### PR DESCRIPTION
Fixes #8502 

- override `stateObj` in `daemonSets` with events info to display possible errors on the UI side, both in list and details view

**NOTE:** Haven't created any tests, since we need to provision an RKE2 cluster with specific versions in order to test this properly. I believe this needs to be manually tested by QA despite the label on the issue.

### To test
Follow repro steps in #8502 

### Screenshots
![Screenshot 2023-08-21 at 16 46 31](https://github.com/rancher/dashboard/assets/97888974/6b24c5de-2416-49b6-a8cc-7c1cd3974102)
![Screenshot 2023-08-21 at 16 47 08](https://github.com/rancher/dashboard/assets/97888974/73258e42-22b3-47e2-8413-be402d950880)
![Screenshot 2023-08-21 at 17 57 40](https://github.com/rancher/dashboard/assets/97888974/8f00472a-833a-4749-ab00-e4494c061ec7)

