### PR TITLE
Resource Quota up-and-down input doesn't update the value on the request quota object to be sent

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -207,6 +207,13 @@ export default (
     },
 
     /**
+     * Emit on input change
+     */
+    onChange(event: Event): void {
+      this.$emit('change', event);
+    },
+
+    /**
      * Emit on input with delay. Note: Arrow function is avoided due context
      * binding.
      */
@@ -299,6 +306,7 @@ export default (
         @input="onInput($event.target.value)"
         @focus="onFocus"
         @blur="onBlur"
+        @change="onChange"
       >
     </slot>
 

--- a/shell/components/form/UnitInput.vue
+++ b/shell/components/form/UnitInput.vue
@@ -224,6 +224,7 @@ export default {
     :required="required"
     :placeholder="placeholder"
     :hide-arrows="hideArrows"
+    @change="update($event.target.value)"
     @blur="update($event.target.value)"
   >
     <template #suffix>

--- a/shell/components/form/__tests__/UnitInput.test.ts
+++ b/shell/components/form/__tests__/UnitInput.test.ts
@@ -10,25 +10,13 @@ describe('component: UnitInput', () => {
     expect(wrapper.isVisible()).toBe(true);
   });
 
-  it('should emit input event on "blur" ev', async() => {
+  it.each(['blur', 'change'])('should emit input event when "%p" is fired', async(event) => {
     const wrapper = mount(UnitInput, { propsData: { value: 1, delay: 0 } });
-    const inputBlur = wrapper.find('input');
+    const input = wrapper.find('input');
 
-    await inputBlur.setValue(2);
-    await inputBlur.setValue(4);
-    inputBlur.trigger('blur');
-
-    expect(wrapper.emitted('input')).toHaveLength(1);
-  });
-
-  // the @change event coming from LabeledInput goes out as "input" type event
-  it('should emit input event on "change" ev', async() => {
-    const wrapper = mount(UnitInput, { propsData: { value: 1, delay: 0 } });
-    const inputChange = wrapper.find('input');
-
-    inputChange.setValue(4);
-    inputChange.setValue(5);
-    inputChange.trigger('change');
+    await input.setValue(2);
+    await input.setValue(4);
+    input.trigger(event);
 
     expect(wrapper.emitted('input')).toHaveLength(1);
   });

--- a/shell/components/form/__tests__/UnitInput.test.ts
+++ b/shell/components/form/__tests__/UnitInput.test.ts
@@ -10,13 +10,25 @@ describe('component: UnitInput', () => {
     expect(wrapper.isVisible()).toBe(true);
   });
 
-  it('should emit input event on value change', async() => {
+  it('should emit input event on "blur" ev', async() => {
     const wrapper = mount(UnitInput, { propsData: { value: 1, delay: 0 } });
-    const input = wrapper.find('input');
+    const inputBlur = wrapper.find('input');
 
-    await input.setValue(2);
-    await input.setValue(4);
-    input.trigger('blur');
+    await inputBlur.setValue(2);
+    await inputBlur.setValue(4);
+    inputBlur.trigger('blur');
+
+    expect(wrapper.emitted('input')).toHaveLength(1);
+  });
+
+  // the @change event coming from LabeledInput goes out as "input" type event
+  it('should emit input event on "change" ev', async() => {
+    const wrapper = mount(UnitInput, { propsData: { value: 1, delay: 0 } });
+    const inputChange = wrapper.find('input');
+
+    inputChange.setValue(4);
+    inputChange.setValue(5);
+    inputChange.trigger('change');
 
     expect(wrapper.emitted('input')).toHaveLength(1);
   });


### PR DESCRIPTION
Fixes #9467 

- add @change event to capture arrow presses for `UnitInput` on firefox (is sent still as an `input` event, so that it won't break the current usage of `UnitInput` throughout the UI)

## To test
Follow repro steps on https://github.com/rancher/dashboard/issues/9467 (issue was found on Firefox 116)

