### PR TITLE
Handle correctdrift for previously created repos.

### DIFF
--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -1,4 +1,5 @@
 <script>
+import Vue from 'vue';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import { mapGetters } from 'vuex';
 import {
@@ -82,7 +83,7 @@ export default {
     this.tlsMode = tls;
 
     if (this.value.spec.correctDrift === undefined) {
-      this.value.spec.correctDrift = { enabled: false };
+      Vue.set(this.value.spec, 'correctDrift', { enabled: false });
     }
 
     this.updateTargets();

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import { convert, matching, convertSelectorObj } from '@shell/utils/selector';
 import jsyaml from 'js-yaml';
 import { escapeHtml, randomStr } from '@shell/utils/string';
@@ -32,7 +33,8 @@ export default class GitRepo extends SteveModel {
 
     spec.paths = spec.paths || [];
     spec.clientSecretName = spec.clientSecretName || null;
-    spec.correctDrift = { enabled: false };
+
+    Vue.set(spec, 'correctDrift', { enabled: false });
 
     set(this, 'spec', spec);
     set(this, 'metadata', meta);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes: rancher/dashboard#9575

Backport of rancher/dashboard#9573 

### Technical notes summary
If `correctDrift === undefined` set `correctDrift.enabled` to `false`

### Areas or cases that should be tested
1. Create a GitRepo with Dashboard < v2.8
2. Navigate to GitRepo > Edit

### Areas which could experience regressions
- GitRepo Create / Edit

