### PR TITLE
add growl message to display warning messages from response headers

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2,6 +2,8 @@
 # Special stuff
 ##############################
 generic:
+  update: Update
+  warning: Warning
   add: Add
   all: All
   and: ' and '
@@ -15,6 +17,7 @@ generic:
   comma: ', '
   copy: Copy
   create: Create
+  creation: Creation
   created: Created
   customize: Customize
   dashboard: Dashboard

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2,8 +2,6 @@
 # Special stuff
 ##############################
 generic:
-  update: Update
-  warning: Warning
   add: Add
   all: All
   and: ' and '
@@ -17,7 +15,6 @@ generic:
   comma: ', '
   copy: Copy
   create: Create
-  creation: Creation
   created: Created
   customize: Customize
   dashboard: Dashboard
@@ -2360,6 +2357,9 @@ growl:
   podSecurity:
     message: "The creation of this Pod would violate existing restricted policies for the adopted Namespace"
     title: PodSecurity violation
+  kubeApiHeaderWarning:
+    titleCreate: "{resourceType} Creation Warning"
+    titleUpdate: "{resourceType} Update Warning"
 
 hpa:
   detail:

--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -135,7 +135,7 @@ export default {
     width: 100%;
 
     @media only screen and (min-width: map-get($breakpoints, '--viewport-7')) {
-      width: 350px;
+      width: 420px;
     }
   }
 
@@ -174,6 +174,7 @@ export default {
 
       > div {
         font-size: 16px;
+        margin-bottom: 20px;
       }
 
       > P {
@@ -183,7 +184,7 @@ export default {
 
     .icon-container {
       flex-basis: 10%;
-      padding: 10px;
+      padding: 10px 20px 10px 10px;
       i {
         font-size: 24px;
       }

--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -99,15 +99,17 @@ export default {
             <i :class="{icon: true, ['icon-'+growl.icon]: true}" />
           </div>
           <div class="growl-text">
-            <div>{{ growl.title }}</div>
+            <i
+              class="close hand icon icon-close"
+              @click="close(growl)"
+            />
+            <div class="growl-text-title">
+              {{ growl.title }}
+            </div>
             <p v-if="growl.message">
               {{ growl.message }}
             </p>
           </div>
-          <i
-            class="close hand icon icon-close"
-            @click="close(growl)"
-          />
         </div>
       </div>
     </div>
@@ -149,13 +151,15 @@ export default {
     margin: 10px;
     position: relative;
     word-break: break-all;
-
-    .close {
-      padding: 5px;
-    }
+    box-shadow: 0 3px 5px 0px var(--shadow);
 
     .icon-container {
       align-self: center;
+      flex-basis: 10%;
+      padding: 10px 20px 10px 10px;
+      i {
+        font-size: 24px;
+      }
     }
 
     .growl-message {
@@ -164,29 +168,27 @@ export default {
       &.growl-center {
         align-items: center;
       }
-    }
 
-    .growl-text {
-      flex-basis: 90%;
-      padding: 10px 10px 10px 0;
-      word-break: break-word;
-      white-space: normal;
+      .growl-text {
+        position: relative;
+        flex-basis: 90%;
+        padding: 10px 10px 10px 0;
+        word-break: break-word;
+        white-space: normal;
 
-      > div {
-        font-size: 16px;
-        margin-bottom: 20px;
-      }
+        .close {
+          position: absolute;
+          top: 12px;
+          right: 10px;
+        }
+        .growl-text-title {
+          font-size: 16px;
+          margin-bottom: 20px;
+        }
 
-      > P {
-        margin-top: 5px;
-      }
-    }
-
-    .icon-container {
-      flex-basis: 10%;
-      padding: 10px 20px 10px 10px;
-      i {
-        font-size: 24px;
+        > P {
+          margin-top: 5px;
+        }
       }
     }
   }

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -1,5 +1,5 @@
 // Settings
-import { GC_DEFAULTS } from '../utils/gc/gc-types';
+import { GC_DEFAULTS, GC_PREFERENCES } from '@shell/utils/gc/gc-types';
 
 interface GlobalSettingRuleset {
   name: string,
@@ -148,7 +148,47 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
   [SETTING.HIDE_LOCAL_CLUSTER]: { kind: 'boolean' },
 };
 
-export const DEFAULT_PERF_SETTING = {
+/**
+ * Settings on how to handle warnings returning in api responses, specifically which to show as growls
+ */
+export interface PerfSettingsWarningHeaders {
+  /**
+   * Warning is a string containing multiple entries. This determines how they are split up
+   *
+   * See https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1693-warnings#design-details
+   */
+  separator: string,
+  /**
+   * Show warnings in a notification if they're not in this block list
+   */
+  notificationBlockList: string[]
+}
+
+export interface PerfSettingsKubeApi {
+  /**
+   * Settings related to the response header `warnings` value
+   */
+  warningHeader: PerfSettingsWarningHeaders
+}
+
+export interface PerfSettings {
+  inactivity: {
+      enabled: boolean;
+      threshold: number;
+  };
+  incrementalLoading: {
+      enabled: boolean;
+      threshold: number;
+  };
+  manualRefresh: {};
+  disableWebsocketNotification: boolean;
+  garbageCollection: GC_PREFERENCES;
+  forceNsFilterV2: any;
+  advancedWorker: {};
+  kubeAPI: PerfSettingsKubeApi;
+}
+
+export const DEFAULT_PERF_SETTING: PerfSettings = {
   inactivity: {
     enabled:   false,
     threshold: 900,
@@ -165,4 +205,21 @@ export const DEFAULT_PERF_SETTING = {
   garbageCollection:            GC_DEFAULTS,
   forceNsFilterV2:              { enabled: false },
   advancedWorker:               { enabled: false },
+  kubeAPI:                      {
+    /**
+     * Settings related to the response header `warnings` value
+     */
+    warningHeader: {
+      /**
+       * Warning is a string containing multiple entries. This determines how they are split up
+       *
+       * See https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1693-warnings#design-details
+       */
+      separator:             '299 - ',
+      /**
+       * Show warnings in a notification if they're not in this block list
+       */
+      notificationBlockList: ['299 - unknown field']
+    }
+  }
 };

--- a/shell/plugins/steve/__tests__/header-warnings.spec.ts
+++ b/shell/plugins/steve/__tests__/header-warnings.spec.ts
@@ -1,0 +1,238 @@
+import { handleKubeApiHeaderWarnings } from '@shell/plugins/steve/header-warnings';
+import { DEFAULT_PERF_SETTING } from '@shell/config/settings';
+
+describe('steve: header-warnings', () => {
+  // eslint-disable-next-line jest/no-hooks
+
+  function setupMocks(settings = {
+    separator:             '299 - ',
+    notificationBlockList: ['299 - unknown field']
+  }) {
+    return {
+      dispatch:     jest.fn(),
+      consoleWarn:  jest.spyOn(console, 'warn').mockImplementation(),
+      consoleDebug: jest.spyOn(console, 'debug').mockImplementation(),
+      rootGetter:   {
+        'management/byId': (resource: string, id: string): { value: string} => {
+          return {
+            value: JSON.stringify({
+              ...DEFAULT_PERF_SETTING,
+              kubeAPI: { warningHeader: settings }
+            })
+          };
+        },
+        'i18n/t': (key: string, { resourceType }: any) => {
+          return `${ key }_${ resourceType }`;
+        }
+      }
+    };
+  }
+
+  function createMockRes( headers = {}, data = { type: inputResourceType }) {
+    return {
+      headers, config: { url: 'unit/test' }, data
+    };
+  }
+
+  function createGrowlResponse(message: string, action = updateKey) {
+    return [
+      'growl/warning',
+      {
+        message, timeout: 0, title: `${ action }_${ inputResourceType }`
+      },
+      { root: true }
+    ];
+  }
+
+  function createConsoleResponse(warnings: string) {
+    return `Validation Warnings for unit/test\n\n${ warnings }`;
+  }
+
+  const inputResourceType = 'abc';
+  const updateKey = 'growl.kubeApiHeaderWarning.titleUpdate';
+  const createKey = 'growl.kubeApiHeaderWarning.titleCreate';
+  const podSecurity = '299 - would violate PodSecurity "restricted:latest": unrestricted capabilities (container "container-0" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (container "container-0" must not set securityContext.runAsNonRoot=false), seccompProfile (pod or container "container-0" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")';
+  const deprecated = "299 - i'm deprecated";
+  const validation = '299 - unknown field "spec.containers[0].__active"';
+
+  describe('no warnings', () => {
+    it('put, no header warning', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(createMockRes(),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'put',
+        true,
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).not.toHaveBeenCalled();
+    });
+
+    it('post, no header warning', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(createMockRes(),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'post',
+        true,
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).not.toHaveBeenCalled();
+    });
+
+    it('patch, no header warning', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(createMockRes(),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'patch',
+        true,
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).not.toHaveBeenCalled();
+    });
+
+    it('get, no header warning', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(createMockRes(),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'get',
+        true,
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).not.toHaveBeenCalled();
+    });
+
+    it('get, warnings', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(createMockRes( { warnings: ['erg'] }),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'get',
+        true,
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).not.toHaveBeenCalled();
+    });
+
+    it('blocked (via default config)', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(
+        createMockRes({ warning: validation }),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'put',
+        true
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).toHaveBeenCalledWith(createConsoleResponse(validation));
+    });
+
+    it('blocked (via custom config)', () => {
+      const mocks = setupMocks({
+        separator:             '299 - ',
+        notificationBlockList: [deprecated]
+      });
+
+      handleKubeApiHeaderWarnings(
+        createMockRes({ warning: deprecated }),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'put',
+        true
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).toHaveBeenCalledWith(createConsoleResponse(deprecated));
+    });
+
+    it('multi blocked (via custom config)', () => {
+      const mocks = setupMocks({
+        separator:             '299 - ',
+        notificationBlockList: [deprecated, podSecurity]
+      });
+
+      handleKubeApiHeaderWarnings(
+        createMockRes({ warning: `${ deprecated },${ podSecurity }` }),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'put',
+        true
+      );
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).toHaveBeenCalledWith(createConsoleResponse(`${ deprecated }\n${ podSecurity }`));
+    });
+  });
+
+  describe('warnings', () => {
+    it('deprecated', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(
+        createMockRes({ warning: deprecated }),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'put',
+        true,
+      );
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(...createGrowlResponse(deprecated));
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).toHaveBeenCalledWith(createConsoleResponse(deprecated));
+    });
+
+    it('pod security', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(
+        createMockRes({ warning: podSecurity }),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'post',
+        true,
+      );
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(...createGrowlResponse(podSecurity, createKey));
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).toHaveBeenCalledWith(createConsoleResponse(podSecurity));
+    });
+
+    it('deprecated & pod security', () => {
+      const mocks = setupMocks();
+
+      handleKubeApiHeaderWarnings(
+        createMockRes({ warning: `${ deprecated },${ podSecurity }` }),
+        mocks.dispatch,
+        mocks.rootGetter,
+        'put',
+        true,
+      );
+
+      expect(mocks.dispatch).toHaveBeenCalledWith(...createGrowlResponse(`${ deprecated }, ${ podSecurity }` ));
+      expect(mocks.consoleWarn).not.toHaveBeenCalled();
+      expect(mocks.consoleDebug).toHaveBeenCalledWith(createConsoleResponse(`${ deprecated }\n${ podSecurity }`));
+    });
+  });
+});

--- a/shell/plugins/steve/header-warnings.ts
+++ b/shell/plugins/steve/header-warnings.ts
@@ -1,0 +1,91 @@
+import { PerfSettingsWarningHeaders } from '@shell/config/settings';
+import { getPerformanceSetting } from '@shell/utils/settings';
+
+interface HttpResponse {
+  headers?: { [key: string]: string},
+  data?: any,
+  config: {
+    url: string,
+  }
+}
+
+/**
+ * Cache the kube api warning header settings that will determine if they are growled or not
+ */
+let warningHeaderSettings: PerfSettingsWarningHeaders;
+
+/**
+ * Extract sanitised warnings from the warnings header string
+ */
+function kubeApiHeaderWarnings(allWarnings: string): string[] {
+  // Find each warning.
+  // Each warning is separated by `,`... however... this can appear within the warning itself so can't `split` on it
+  // Instead provide a configurable way to split (default 299 - )
+  const warnings = allWarnings.split(warningHeaderSettings.separator) || [];
+
+  // Trim and remove effects of split
+  return warnings.reduce((res, warning) => {
+    const trimmedWarning = warning.trim();
+
+    if (!trimmedWarning) {
+      return res;
+    }
+
+    const fixedWarning = trimmedWarning.endsWith(',') ? trimmedWarning.slice(0, -1) : trimmedWarning;
+
+    // Why add the separator again? It's almost certainly `299 - ` which is important info to include
+    res.push(warningHeaderSettings.separator + fixedWarning);
+
+    return res;
+  }, [] as string[]);
+}
+
+/**
+ * Take action given the `warnings` in the response header of a kube api request
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function handleKubeApiHeaderWarnings(res: HttpResponse, dispatch: any, rootGetters: any, method: string, refreshCache = false): void {
+  const safeMethod = method?.toLowerCase(); // Some requests have this as uppercase
+
+  // Exit early if there's no warnings
+  if ((safeMethod !== 'post' && safeMethod !== 'put') || !res.headers?.warning) {
+    return;
+  }
+
+  // Grab the required settings
+  if (!warningHeaderSettings || refreshCache) {
+    const settings = getPerformanceSetting(rootGetters);
+
+    // Cache this, we don't need to react to changes within the same session
+    warningHeaderSettings = settings?.kubeAPI.warningHeader;
+  }
+
+  // Determine each warning
+  const sanitisedWarnings = kubeApiHeaderWarnings(res.headers?.warning);
+
+  if (!sanitisedWarnings.length) {
+    return;
+  }
+
+  // Shows warnings as growls
+  const growlWarnings = sanitisedWarnings.filter((w) => !warningHeaderSettings.notificationBlockList.find((blocked) => w.startsWith(blocked)));
+
+  if (growlWarnings.length) {
+    const resourceType = res.data?.type || res.data?.kind || rootGetters['i18n/t']('generic.resource', { count: 1 });
+
+    dispatch('growl/warning', {
+      title:   method === 'put' ? rootGetters['i18n/t']('growl.kubeApiHeaderWarning.titleUpdate', { resourceType }) : rootGetters['i18n/t']('growl.kubeApiHeaderWarning.titleCreate', { resourceType }),
+      message: growlWarnings.join(', '),
+      timeout: 0,
+    }, { root: true });
+  }
+
+  // Print warnings to console
+  const message = `Validation Warnings for ${ res.config.url }\n\n${ sanitisedWarnings.join('\n') }`;
+
+  if (process.env.dev) {
+    console.warn(`${ message }\n\n`, res.data); // eslint-disable-line no-console
+  } else {
+    console.debug(message); // eslint-disable-line no-console
+  }
+}

--- a/shell/utils/settings.ts
+++ b/shell/utils/settings.ts
@@ -1,7 +1,6 @@
 import { MANAGEMENT } from '@shell/config/types';
 import { Store } from 'vuex';
-import { DEFAULT_PERF_SETTING, SETTING } from '@shell/config/settings';
-import { GC_PREFERENCES } from '@shell/utils/gc/gc-types';
+import { DEFAULT_PERF_SETTING, PerfSettings, SETTING } from '@shell/config/settings';
 
 export const fetchOrCreateSetting = async(store: Store<any>, id: string, val: string, save = true): Promise<any> => {
   let setting;
@@ -44,21 +43,7 @@ export const setSetting = async(store: Store<any>, id: string, val: string): Pro
   return setting;
 };
 
-export const getPerformanceSetting = (rootGetters: Record<string, (arg0: string, arg1: string) => any>): {
-  inactivity: {
-      enabled: boolean;
-      threshold: number;
-  };
-  incrementalLoading: {
-      enabled: boolean;
-      threshold: number;
-  };
-  manualRefresh: {};
-  disableWebsocketNotification: boolean;
-  garbageCollection: GC_PREFERENCES;
-  forceNsFilterV2: any;
-  advancedWorker: {};
-} => {
+export const getPerformanceSetting = (rootGetters: Record<string, (arg0: string, arg1: string) => any>): PerfSettings => {
   const perfSettingResource = rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_PERFORMANCE);
   let perfSetting = {};
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8502 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add growl message to display warning messages from response headers
- update growl styling based on feedback from @edenhernandez-suse 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- This was the only mechanism that we have of "easy access" to display warnings from response headers. Also, these types of warnings are non-persistent (they don't exist on the object resource), so we can't show them on the details screen (ex: in this particular case `DaemonSets`, but you have the related events).

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Test scenario of the above mentioned issue #8502 to check that the mechanism works as expected


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Took the time creating a few different resource instances (clusters, global role, pod, persistent volume, some things in fleet, etc) just to check if there were any additional growls that we didn't know about (we don't want to flood the UI with these messages) and no other warning/growl was generated in consequence. (only the pod, because it's supposed to fail in the same scenario as per issue description)

### Screenshot/Video
**Growl**
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2023-08-24 at 12 51 16](https://github.com/rancher/dashboard/assets/97888974/e969ace6-6d13-4fa6-9c27-c2accf625323)

**DaemonSets details page - events table**
![Screenshot 2023-08-23 at 11 11 28](https://github.com/rancher/dashboard/assets/97888974/ae253a9a-ff01-4563-bef0-0bf63dac7cf7)
