### PR TITLE
RKE1 / RKE2 custom clusters tab redirect

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -250,7 +250,7 @@ export default {
 
   computed: {
     defaultTab() {
-      if (this.showRegistration && !this.machines?.length) {
+      if (this.showRegistration && ((this.value.isRke2 && !this.machines?.length) || (!this.value.isRke2 && !this.nodes?.length))) {
         return 'registration';
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8513 
<!-- Define findings related to the feature or bug issue. -->
When reviewing this PR, [As per agreed with UX](https://github.com/rancher/dashboard/issues/8513#issuecomment-1691252844), the behaviour for both `rke1` and `rke2` should be:
- If there are no registered nodes, will default to the `registration` tab
- If there's at least one registered node, will default to the `machines` tab 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add missing conditions for `rke1` custom cluster to redirect to `registration` tab when there are no machines registered

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->