### PR TITLE
fix issue with environment not being passed as data when checking cre…

### DIFF
--- a/shell/cloud-credential/__tests__/azure.test.ts
+++ b/shell/cloud-credential/__tests__/azure.test.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils';
+import AzureCloudCreds from '@shell/cloud-credential/azure.vue';
+
+const mockStore = {
+  getters:  { 'i18n/t': jest.fn() },
+  dispatch: () => jest.fn()
+};
+
+describe('cloud credentials: Azure', () => {
+  const wrapper = mount(AzureCloudCreds, {
+    propsData: {
+      value: {
+        decodedData: {
+          environment:    '',
+          subscriptionId: '',
+          clientId:       '',
+          clientSecret:   '',
+        },
+        setData: jest.fn()
+      }
+    },
+    mocks: { $store: mockStore }
+  });
+
+  it('should pass all the correct fields when checking if credentials are valid', async() => {
+    const spyDispatch = jest.spyOn(mockStore, 'dispatch');
+
+    wrapper.setData({
+      value: {
+        decodedData: {
+          environment:    'my-env',
+          subscriptionId: 'my-sub-id',
+          clientId:       'my-c-id',
+          clientSecret:   'my-c-secret',
+        }
+      }
+    });
+
+    await wrapper.vm.test();
+
+    expect(spyDispatch).toHaveBeenCalledWith('management/request', {
+      data: {
+        environment:    'my-env',
+        subscriptionId: 'my-sub-id',
+        clientId:       'my-c-id',
+        clientSecret:   'my-c-secret',
+      },
+      method:               'POST',
+      redirectUnauthorized: false,
+      url:                  '/meta/aksCheckCredentials'
+    });
+  });
+});

--- a/shell/cloud-credential/azure.vue
+++ b/shell/cloud-credential/azure.vue
@@ -40,6 +40,7 @@ export default {
         clientId,
         clientSecret,
         subscriptionId,
+        environment,
       } = this.value.decodedData;
 
       try {
@@ -50,6 +51,7 @@ export default {
             clientId,
             clientSecret,
             subscriptionId,
+            environment,
           },
           redirectUnauthorized: false,
         });
@@ -96,6 +98,7 @@ export default {
           :searchable="false"
           :required="true"
           :label="t('cluster.credential.azure.environment.label')"
+          data-testid="azure-cloud-credentials-environment"
           @input="value.setData('environment', $event)"
         />
       </div>
@@ -106,6 +109,7 @@ export default {
           type="text"
           :mode="mode"
           :required="true"
+          data-testid="azure-cloud-credentials-subscription-id"
           @input="value.setData('subscriptionId', $event)"
         />
       </div>
@@ -118,6 +122,7 @@ export default {
           type="text"
           :mode="mode"
           :required="true"
+          data-testid="azure-cloud-credentials-client-id"
           @input="value.setData('clientId', $event)"
         />
       </div>
@@ -128,6 +133,7 @@ export default {
           type="password"
           :mode="mode"
           :required="true"
+          data-testid="azure-cloud-credentials-client-secret"
           @input="value.setData('clientSecret', $event)"
         />
       </div>


### PR DESCRIPTION
Fixes #9311 

- fix issue with `environment` not being passed as data when checking credentials 
- unit test this scenario

## To test
- create your azure creds, click to create, and check if on the payload of `aksCheckCredentials` network request all information is being sent, including the `environment` property (ping me if you need creds to test this issue)