### PR TITLE
Add latest rancher version annotation to extension pkg package.json

### DIFF
--- a/shell/creators/pkg/init
+++ b/shell/creators/pkg/init
@@ -2,6 +2,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const https = require('https');
 
 const targets = {
   dev:  './node_modules/.bin/nuxt dev',
@@ -88,11 +89,68 @@ Object.keys(targets).forEach((target) => {
   }
 });
 
+// Add annotation for the latest Rancher version by default
+function fetchLatestVersion() {
+  console.log('  Fetching latest Rancher Version');
+  const options = { headers: { 'User-Agent': 'nodejs' } };
+
+  https.get('https://api.github.com/repos/rancher/rancher/releases/latest', options, (res) => {
+    const { statusCode } = res;
+    const contentType = res.headers['content-type'];
+
+    let error;
+
+    if ( statusCode !== 200 ) {
+      error = new Error('  Request Failed.\n' +
+                        `  Status Code: ${ statusCode }`);
+    } else if ( !/^application\/json/.test(contentType) ) {
+      error = new Error('  Invalid content-type.\n' +
+                        `  Expected application/json but received ${ contentType }`);
+    }
+
+    if ( error ) {
+      console.log(error.message);
+
+      res.resume();
+
+      return;
+    }
+
+    res.setEncoding('utf8');
+    let rawData = '';
+
+    res.on('data', (chunk) => {
+      rawData += chunk;
+    });
+    res.on('end', () => {
+      try {
+        const release = JSON.parse(rawData);
+
+        if ( release.tag_name ) {
+          console.log(`  Adding rancher-version annotation '>= ${ release.tag_name }' to package.json`);
+
+          pkg.rancher = { annotations: { 'catalog.cattle.io/rancher-version': `>= ${ release.tag_name }` } };
+          writePackageJson();
+        }
+      } catch (e) {
+        console.log('  Error parsing release data', e);
+      }
+    });
+  }).on('error', (e) => {
+    console.log('  Error fetching latest Rancher Version', e);
+  });
+}
+
+fetchLatestVersion();
+writePackageJson();
+
 // Add dependencies
 // pkg.dependencies['@rancher/shell'] = '^0.6.2';
 // pkg.dependencies['core-js'] = '3.18.3';
 
-fs.writeFileSync(path.join(pkgFolder, 'package.json'), JSON.stringify(pkg, null, 2));
+function writePackageJson() {
+  fs.writeFileSync(path.join(pkgFolder, 'package.json'), JSON.stringify(pkg, null, 2));
+}
 
 // Create type folders if needed
 if (addTypeFolders) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9418 
<!-- Define findings related to the feature or bug issue. -->
This adds the annotation `catalog.cattle.io/rancher-version` to newly created extension packages by default. When running `yarn create @rancher/pkg <pkg>`, the init script will fetch the latest Rancher version from: https://api.github.com/repos/rancher/rancher/releases/latest

