### PR TITLE
New cluster template isn't displayed after repository refresh

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -83,7 +83,9 @@ export default {
       mgmtClusters: this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
       provClusters: this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
 
-      catalog: this.$store.dispatch('catalog/load'),
+      // have force: true and reset: true because of cluster templates, which can be changed and updated via repo refresh
+      // https://github.com/rancher/dashboard/issues/9510
+      catalog: this.$store.dispatch('catalog/load', { force: true, reset: true }),
     };
 
     if (this.$store.getters[`management/canList`](MANAGEMENT.NODE_DRIVER)) {

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -83,9 +83,7 @@ export default {
       mgmtClusters: this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
       provClusters: this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
 
-      // have force: true and reset: true because of cluster templates, which can be changed and updated via repo refresh
-      // https://github.com/rancher/dashboard/issues/9510
-      catalog: this.$store.dispatch('catalog/load', { force: true, reset: true }),
+      catalog: this.$store.dispatch('catalog/load'),
     };
 
     if (this.$store.getters[`management/canList`](MANAGEMENT.NODE_DRIVER)) {

--- a/shell/models/catalog.cattle.io.clusterrepo.js
+++ b/shell/models/catalog.cattle.io.clusterrepo.js
@@ -29,11 +29,15 @@ export default class ClusterRepo extends SteveModel {
     return out;
   }
 
-  refresh() {
+  async refresh() {
     const now = (new Date()).toISOString().replace(/\.\d+Z$/, 'Z');
 
     this.spec.forceUpdate = now;
-    this.save();
+    await this.save();
+
+    await this.waitForState('active', 10000, 1000);
+
+    this.$dispatch('catalog/load', { force: true, reset: true }, { root: true });
   }
 
   get isGit() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9510 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- force fetch and reset of catalog/load in order to get updated cluster templates every time we hit refresh on the cluster repo

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Fork https://github.com/susesgartner/cluster-template-examples so that you can edit it
- **NOTE:** The below sequence should be without any browser refresh of the tab that shows your Dashboard
- Go to `Cluster Management` -> `Advanced` -> `Repositories` and add your fork as a repo (branch main)
- Go `Cluster Management` -> `Clusters` and hit `Create`
- Check that on the options for cluster creation you have 2 cluster templates (if you haven't modified your forked repo)
- Go to `Cluster Management` -> `Advanced` -> `Repositories` and stay on that screen
- In a new tab, go to your fork of https://github.com/susesgartner/cluster-template-examples and edit the `index.yaml` file to only show `cluster-template1 `
- Go back to the tab where you are on the `Repositories` view of Dashboard and go to the 3 dots menu for your repo/fork and select the option `refresh`
- Go `Cluster Management` -> `Clusters` and hit `Create`
- Check that on the options for cluster creation you have 1 cluster template (you should only see `cluster-template1`, as per the edit of `index.yaml`)


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/97888974/81a9c32a-2aaa-42b7-bf98-57455f46eb4a


