### PR TITLE
Recover proxy config mechanism

### DIFF
--- a/shell/vue-config-helper.js
+++ b/shell/vue-config-helper.js
@@ -1,0 +1,135 @@
+const dev = (process.env.NODE_ENV !== 'production');
+const devPorts = dev || process.env.DEV_PORTS === 'true';
+const prime = process.env.PRIME;
+
+let api = process.env.API || 'http://localhost:8989';
+
+if ( !api.startsWith('http') ) {
+  api = `https://${ api }`;
+}
+
+// ===============================================================================================
+// Functions for the request proxying used in dev
+// ===============================================================================================
+
+function proxyMetaOpts(target) {
+  return {
+    target,
+    followRedirects: true,
+    secure:          !dev,
+    changeOrigin:    true,
+    onProxyReq,
+    onProxyReqWs,
+    onError,
+    onProxyRes,
+  };
+}
+
+function proxyOpts(target) {
+  return {
+    target,
+    secure:       !devPorts,
+    changeOrigin: true,
+    onProxyReq,
+    onProxyReqWs,
+    onError,
+    onProxyRes
+  };
+}
+
+// Intercept the /rancherversion API call wnad modify the 'RancherPrime' value
+// if configured to do so by the environment variable PRIME
+function proxyPrimeOpts(target) {
+  const opts = proxyOpts(target);
+
+  // Don't intercept if the PRIME environment variable is not set
+  if (!prime?.length) {
+    return opts;
+  }
+
+  opts.onProxyRes = (proxyRes, req, res) => {
+    const _end = res.end;
+    let body = '';
+
+    proxyRes.on( 'data', (data) => {
+      data = data.toString('utf-8');
+      body += data;
+    });
+
+    res.write = () => {};
+
+    res.end = () => {
+      let output = body;
+
+      try {
+        const out = JSON.parse(body);
+
+        out.RancherPrime = prime;
+        output = JSON.stringify(out);
+      } catch (err) {}
+
+      res.setHeader('content-length', output.length );
+      res.setHeader('content-type', 'application/json' );
+      res.setHeader('transfer-encoding', '');
+      res.setHeader('cache-control', 'no-cache');
+      res.writeHead(proxyRes.statusCode);
+      _end.apply(res, [output]);
+    };
+  };
+
+  return opts;
+}
+
+function onProxyRes(proxyRes, req, res) {
+  if (devPorts) {
+    proxyRes.headers['X-Frame-Options'] = 'ALLOWALL';
+  }
+}
+
+function proxyWsOpts(target) {
+  return {
+    ...proxyOpts(target),
+    ws:           true,
+    changeOrigin: true,
+  };
+}
+
+function onProxyReq(proxyReq, req) {
+  if (!(proxyReq._currentRequest && proxyReq._currentRequest._headerSent)) {
+    proxyReq.setHeader('x-api-host', req.headers['host']);
+    proxyReq.setHeader('x-forwarded-proto', 'https');
+  }
+}
+
+function onProxyReqWs(proxyReq, req, socket, options, head) {
+  req.headers.origin = options.target.href;
+  proxyReq.setHeader('origin', options.target.href);
+  proxyReq.setHeader('x-api-host', req.headers['host']);
+  proxyReq.setHeader('x-forwarded-proto', 'https');
+  // console.log(proxyReq.getHeaders());
+
+  socket.on('error', (err) => {
+    console.error('Proxy WS Error:', err); // eslint-disable-line no-console
+  });
+}
+
+function onError(err, req, res) {
+  res.statusCode = 598;
+  console.error('Proxy Error:', err); // eslint-disable-line no-console
+  res.write(JSON.stringify(err));
+}
+
+module.exports = {
+  dev,
+  devPorts,
+  prime,
+  api,
+  proxyMetaOpts,
+  proxyOpts,
+  proxyPrimeOpts,
+  onProxyRes,
+  proxyWsOpts,
+  onProxyReq,
+  onProxyReqWs,
+  onError
+};

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -271,27 +271,26 @@ module.exports = function(dir, _appConfig) {
   console.log(`API: '${ api }'. Env: '${ rancherEnv }'`); // eslint-disable-line no-console
   const proxy = {
     ...appConfig.proxies,
-    '/k8s':             configHelper.proxyWsOpts(api), // Straight to a remote cluster (/k8s/clusters/<id>/)
-    '/pp':              configHelper.proxyWsOpts(api), // For (epinio) standalone API
-    '/api':             configHelper.proxyWsOpts(api), // Management k8s API
-    '/apis':            configHelper.proxyWsOpts(api), // Management k8s API
-    '/v1':              configHelper.proxyWsOpts(api), // Management Steve API
-    '/v3':              configHelper.proxyWsOpts(api), // Rancher API
-    '/v3-public':       configHelper.proxyOpts(api), // Rancher Unauthed API
-    '/api-ui':          configHelper.proxyOpts(api), // Browser API UI
-    '/meta':            configHelper.proxyMetaOpts(api), // Browser API UI
-    '/v1-*':            configHelper.proxyOpts(api), // SAML, KDM, etc
-    '/rancherversion':  configHelper.proxyPrimeOpts(api), // Rancher version endpoint
-    '/rhn/manager/api': configHelper.proxyOpts(api),
+    '/k8s':            configHelper.proxyWsOpts(api), // Straight to a remote cluster (/k8s/clusters/<id>/)
+    '/pp':             configHelper.proxyWsOpts(api), // For (epinio) standalone API
+    '/api':            configHelper.proxyWsOpts(api), // Management k8s API
+    '/apis':           configHelper.proxyWsOpts(api), // Management k8s API
+    '/v1':             configHelper.proxyWsOpts(api), // Management Steve API
+    '/v3':             configHelper.proxyWsOpts(api), // Rancher API
+    '/v3-public':      configHelper.proxyOpts(api), // Rancher Unauthed API
+    '/api-ui':         configHelper.proxyOpts(api), // Browser API UI
+    '/meta':           configHelper.proxyMetaOpts(api), // Browser API UI
+    '/v1-*':           configHelper.proxyOpts(api), // SAML, KDM, etc
+    '/rancherversion': configHelper.proxyPrimeOpts(api), // Rancher version endpoint
     // These are for Ember embedding
-    '/c/*/edit':        configHelper.proxyOpts('https://127.0.0.1:8000'), // Can't proxy all of /c because that's used by Vue too
-    '/k/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
-    '/g/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
-    '/n/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
-    '/p/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
-    '/assets':          configHelper.proxyOpts('https://127.0.0.1:8000'),
-    '/translations':    configHelper.proxyOpts('https://127.0.0.1:8000'),
-    '/engines-dist':    configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/c/*/edit':       configHelper.proxyOpts('https://127.0.0.1:8000'), // Can't proxy all of /c because that's used by Vue too
+    '/k/':             configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/g/':             configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/n/':             configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/p/':             configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/assets':         configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/translations':   configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/engines-dist':   configHelper.proxyOpts('https://127.0.0.1:8000'),
   };
 
   const config = {

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -5,6 +5,7 @@ const webpack = require('webpack');
 const { generateDynamicTypeImport } = require('./pkg/auto-import');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const serverMiddlewares = require('./server/server-middleware.js');
+const configHelper = require('./vue-config-helper.js');
 
 // Suppress info level logging messages from http-proxy-middleware
 // This hides all of the "[HPM Proxy created] ..." messages
@@ -20,24 +21,18 @@ console.info = oldInfoLogger; // eslint-disable-line no-console
 // const { STANDARD } = require('./config/private-label');
 const STANDARD = 1;
 
-const dev = (process.env.NODE_ENV !== 'production');
-const devPorts = dev || process.env.DEV_PORTS === 'true';
+const dev = configHelper.dev;
+const devPorts = configHelper.devPorts;
 
 // human readable version used on rancher dashboard about page
 const dashboardVersion = process.env.DASHBOARD_VERSION;
-
-const prime = process.env.PRIME;
 
 const pl = process.env.PL || STANDARD;
 const commit = process.env.COMMIT || 'head';
 const perfTest = (process.env.PERF_TEST === 'true'); // Enable performance testing when in dev
 const instrumentCode = (process.env.TEST_INSTRUMENT === 'true'); // Instrument code for code coverage in e2e tests
 
-let api = process.env.API || 'http://localhost:8989';
-
-if ( !api.startsWith('http') ) {
-  api = `https://${ api }`;
-}
+const api = configHelper.api;
 // ===============================================================================================
 // Nuxt configuration
 // ===============================================================================================
@@ -276,26 +271,27 @@ module.exports = function(dir, _appConfig) {
   console.log(`API: '${ api }'. Env: '${ rancherEnv }'`); // eslint-disable-line no-console
   const proxy = {
     ...appConfig.proxies,
-    '/k8s':            proxyWsOpts(api), // Straight to a remote cluster (/k8s/clusters/<id>/)
-    '/pp':             proxyWsOpts(api), // For (epinio) standalone API
-    '/api':            proxyWsOpts(api), // Management k8s API
-    '/apis':           proxyWsOpts(api), // Management k8s API
-    '/v1':             proxyWsOpts(api), // Management Steve API
-    '/v3':             proxyWsOpts(api), // Rancher API
-    '/v3-public':      proxyOpts(api), // Rancher Unauthed API
-    '/api-ui':         proxyOpts(api), // Browser API UI
-    '/meta':           proxyMetaOpts(api), // Browser API UI
-    '/v1-*':           proxyOpts(api), // SAML, KDM, etc
-    '/rancherversion': proxyPrimeOpts(api), // Rancher version endpoint
+    '/k8s':             configHelper.proxyWsOpts(api), // Straight to a remote cluster (/k8s/clusters/<id>/)
+    '/pp':              configHelper.proxyWsOpts(api), // For (epinio) standalone API
+    '/api':             configHelper.proxyWsOpts(api), // Management k8s API
+    '/apis':            configHelper.proxyWsOpts(api), // Management k8s API
+    '/v1':              configHelper.proxyWsOpts(api), // Management Steve API
+    '/v3':              configHelper.proxyWsOpts(api), // Rancher API
+    '/v3-public':       configHelper.proxyOpts(api), // Rancher Unauthed API
+    '/api-ui':          configHelper.proxyOpts(api), // Browser API UI
+    '/meta':            configHelper.proxyMetaOpts(api), // Browser API UI
+    '/v1-*':            configHelper.proxyOpts(api), // SAML, KDM, etc
+    '/rancherversion':  configHelper.proxyPrimeOpts(api), // Rancher version endpoint
+    '/rhn/manager/api': configHelper.proxyOpts(api),
     // These are for Ember embedding
-    '/c/*/edit':       proxyOpts('https://127.0.0.1:8000'), // Can't proxy all of /c because that's used by Vue too
-    '/k/':             proxyOpts('https://127.0.0.1:8000'),
-    '/g/':             proxyOpts('https://127.0.0.1:8000'),
-    '/n/':             proxyOpts('https://127.0.0.1:8000'),
-    '/p/':             proxyOpts('https://127.0.0.1:8000'),
-    '/assets':         proxyOpts('https://127.0.0.1:8000'),
-    '/translations':   proxyOpts('https://127.0.0.1:8000'),
-    '/engines-dist':   proxyOpts('https://127.0.0.1:8000'),
+    '/c/*/edit':        configHelper.proxyOpts('https://127.0.0.1:8000'), // Can't proxy all of /c because that's used by Vue too
+    '/k/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/g/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/n/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/p/':              configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/assets':          configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/translations':    configHelper.proxyOpts('https://127.0.0.1:8000'),
+    '/engines-dist':    configHelper.proxyOpts('https://127.0.0.1:8000'),
   };
 
   const config = {
@@ -570,114 +566,3 @@ module.exports = function(dir, _appConfig) {
 
   return config;
 };
-
-// ===============================================================================================
-// Functions for the request proxying used in dev
-// ===============================================================================================
-
-function proxyMetaOpts(target) {
-  return {
-    target,
-    followRedirects: true,
-    secure:          !dev,
-    changeOrigin:    true,
-    onProxyReq,
-    onProxyReqWs,
-    onError,
-    onProxyRes,
-  };
-}
-
-function proxyOpts(target) {
-  return {
-    target,
-    secure:       !devPorts,
-    changeOrigin: true,
-    onProxyReq,
-    onProxyReqWs,
-    onError,
-    onProxyRes
-  };
-}
-
-// Intercept the /rancherversion API call wnad modify the 'RancherPrime' value
-// if configured to do so by the environment variable PRIME
-function proxyPrimeOpts(target) {
-  const opts = proxyOpts(target);
-
-  // Don't intercept if the PRIME environment variable is not set
-  if (!prime?.length) {
-    return opts;
-  }
-
-  opts.onProxyRes = (proxyRes, req, res) => {
-    const _end = res.end;
-    let body = '';
-
-    proxyRes.on( 'data', (data) => {
-      data = data.toString('utf-8');
-      body += data;
-    });
-
-    res.write = () => {};
-
-    res.end = () => {
-      let output = body;
-
-      try {
-        const out = JSON.parse(body);
-
-        out.RancherPrime = prime;
-        output = JSON.stringify(out);
-      } catch (err) {}
-
-      res.setHeader('content-length', output.length );
-      res.setHeader('content-type', 'application/json' );
-      res.setHeader('transfer-encoding', '');
-      res.setHeader('cache-control', 'no-cache');
-      res.writeHead(proxyRes.statusCode);
-      _end.apply(res, [output]);
-    };
-  };
-
-  return opts;
-}
-
-function onProxyRes(proxyRes, req, res) {
-  if (devPorts) {
-    proxyRes.headers['X-Frame-Options'] = 'ALLOWALL';
-  }
-}
-
-function proxyWsOpts(target) {
-  return {
-    ...proxyOpts(target),
-    ws:           true,
-    changeOrigin: true,
-  };
-}
-
-function onProxyReq(proxyReq, req) {
-  if (!(proxyReq._currentRequest && proxyReq._currentRequest._headerSent)) {
-    proxyReq.setHeader('x-api-host', req.headers['host']);
-    proxyReq.setHeader('x-forwarded-proto', 'https');
-  }
-}
-
-function onProxyReqWs(proxyReq, req, socket, options, head) {
-  req.headers.origin = options.target.href;
-  proxyReq.setHeader('origin', options.target.href);
-  proxyReq.setHeader('x-api-host', req.headers['host']);
-  proxyReq.setHeader('x-forwarded-proto', 'https');
-  // console.log(proxyReq.getHeaders());
-
-  socket.on('error', (err) => {
-    console.error('Proxy WS Error:', err); // eslint-disable-line no-console
-  });
-}
-
-function onError(err, req, res) {
-  res.statusCode = 598;
-  console.error('Proxy Error:', err); // eslint-disable-line no-console
-  res.write(JSON.stringify(err));
-}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9615 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Update shell vue.config to allow the passing of a proxy configuration

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Clone the SUMA POC extension https://github.com/aalves08/suma-extension
- update the `vue.config` in SUMA extension to:
```
const config = require('@rancher/shell/vue.config');
const configHelper = require('@rancher/shell/vue-config-helper.js');

module.exports = config(__dirname, {
  excludes: [],
  proxies:  { '/rhn/manager': configHelper.proxyOpts('https://ec2-52-206-103-214.compute-1.amazonaws.com') }
});
```
- run the project with `API=https://ec2-54-205-80-46.compute-1.amazonaws.com:8443 yarn dev`
- ping me for user credentials
- Go to Clusters -> Cluster management -> and click on the cluster `one` to view it's details
- make sure the col `SUMA patches` appears populated on the `machine pools` tab
- click on that machine, and check that a new tab appears called `SUMA patches` and that list is populated

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Test running dashboard locally to check that no problems arise

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2023-08-29 at 17 49 33](https://github.com/rancher/dashboard/assets/97888974/1a277a08-31ba-40c1-9ccd-6b3deeb42ac6)
![Screenshot 2023-08-29 at 17 49 39](https://github.com/rancher/dashboard/assets/97888974/ce8c1141-ea83-4fe2-837d-408c1ec54cf5)
