### PR TITLE
Fix volumeMounts from being overwritten

### DIFF
--- a/shell/edit/workload/storage/ContainerMountPaths.vue
+++ b/shell/edit/workload/storage/ContainerMountPaths.vue
@@ -1,9 +1,11 @@
 <script>
-import ButtonDropdown from '@shell/components/ButtonDropdown';
-import Mount from '@shell/edit/workload/storage/Mount';
+import { clone } from '@shell/utils/object';
 import { _VIEW } from '@shell/config/query-params';
-import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 import { randomStr } from '@shell/utils/string';
+
+import Mount from '@shell/edit/workload/storage/Mount';
+import ButtonDropdown from '@shell/components/ButtonDropdown';
+import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 
 export default {
   name:       'ContainerMountPaths',
@@ -109,7 +111,7 @@ export default {
       const names = volumeMounts.map(({ name }) => name);
 
       // Extract storage volumes to allow mutation, if matches mount map
-      return this.value.volumes.filter((volume) => names.includes(volume.name));
+      return clone(this.value.volumes.filter((volume) => names.includes(volume.name)));
     },
 
     getSelectedContainerVolumes() {
@@ -118,7 +120,7 @@ export default {
       const names = volumeMounts.map(({ name }) => name);
 
       // Extract storage volumes to allow mutation, if matches mount map
-      return this.value.volumes.filter((volume) => names.includes(volume.name));
+      return clone(this.value.volumes.filter((volume) => names.includes(volume.name)));
     },
 
     /**


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9607 
<!-- Define findings related to the feature or bug issue. -->

The `volumeMounts` for a pod template spec were being overwritten if there was not a defined `volume` for the mount. In this case the `volumeMount` was referencing a `volumeClaimTemplate`, as the claim was not determined in the `volumes` property, this mount was being overwritten when filtering for volumes matching a `volumeMount` name.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Where the volumes are fetched, those methods are now returning a clone of the value rather than the filtered value itself.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/40806497/a13415d9-3ae4-44e7-acf6-259302c5b2a7

