### PR TITLE
Fix boundRoles for undefined principals

### DIFF
--- a/shell/components/formatter/PrincipalGroupBindings.vue
+++ b/shell/components/formatter/PrincipalGroupBindings.vue
@@ -16,7 +16,7 @@ export default {
 
       return globalRoleBindings
         // Bindings for this group
-        .filter((globalRoleBinding) => globalRoleBinding.groupPrincipalName === principal.id)
+        .filter((globalRoleBinding) => globalRoleBinding.groupPrincipalName === principal?.id)
         // Display name of role associated with binding
         .map((binding) => {
           const role = this.$store.getters['management/byId'](MANAGEMENT.GLOBAL_ROLE, binding.globalRoleName);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9633 
<!-- Define findings related to the feature or bug issue. -->
When displaying the global role bindings, we were checking for any bound roles that were tied to a `principal.id`. If the `principal` was undefined the `boundRoles` computed property would cause an error.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a null coalescing operator to catch undefined principals.

***Groups error before***

https://github.com/rancher/dashboard/assets/40806497/5f0d45a0-6a90-4ca4-adb9-8ec99cb9e2e1

***Groups error after***

https://github.com/rancher/dashboard/assets/40806497/9447a76c-8345-4906-90bf-5a1a8fd79319


