### PR TITLE
Aws In-tree support

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1846,6 +1846,7 @@ cluster:
       header: Cloud Provider Config
       defaultValue:
         label: Default - RKE2 Embedded
+      unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
     security:
       header: Security
     cis:

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1226,18 +1226,6 @@ export default {
         this.rke2Versions = res.rke2Versions.data || [];
         this.k3sVersions = res.k3sVersions.data || [];
 
-        // For testing ---------------------------------------------------------------------------------------------
-        // Fake a 1.27 version by copying the latest version (1.26) and remove the aws cloud provider from it
-        // const add = JSON.parse(JSON.stringify(this.rke2Versions[this.rke2Versions.length -1]));
-
-        // add.id = 'v1.27.0+rke2r1';
-        // add.version = add.id;
-        // add.agentArgs['cloud-provider-name'].options = add.agentArgs['cloud-provider-name'].options.filter((a) => a !== 'aws'); // Remove the aws cloud provider
-
-        // this.rke2Versions.push(add);
-
-        /// ^^^ End of code that should be removed ---------------------------------------------------------------------------------------
-
         if (!defaultRke2) {
           const rke2Channels = res.rke2Channels.data || [];
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -252,6 +252,7 @@ export default {
       busy:                  false,
       machinePoolValidation: {}, // map of validation states for each machine pool
       allNamespaces:         [],
+      initialCloudProvider:  this.value?.agentConfig?.['cloud-provider-name'],
       extensionTabs:         getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
     };
   },
@@ -555,11 +556,48 @@ export default {
 
       const cur = this.agentConfig['cloud-provider-name'];
 
-      if ( cur && !out.find((x) => x.value === cur) ) {
-        out.unshift({ label: `${ cur } (Current)`, value: cur });
+      if (cur && !out.find((x) => x.value === cur)) {
+        // Localization missing
+        // Look up cur in the localization file
+        const label = this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ cur }".label`, null, cur);
+
+        out.unshift({
+          label:       `${ label } (Current)`,
+          value:       cur,
+          unsupported: true,
+          disabled:    true
+        });
+      }
+
+      const initial = this.initialCloudProvider;
+
+      if (cur !== initial && initial && !out.find((x) => x.value === initial)) {
+        const label = this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ initial }".label`, null, initial);
+
+        out.unshift({
+          label:       `${ label } (Current)`,
+          value:       initial,
+          unsupported: true,
+          disabled:    true
+        });
       }
 
       return out;
+    },
+
+    unsupportedCloudProvider() {
+      // The current cloud provider
+      const cur = this.initialCloudProvider;
+
+      const provider = cur && this.cloudProviderOptions.find((x) => x.value === cur);
+
+      return !!provider?.unsupported;
+    },
+
+    canNotEditCloudProvider() {
+      const canNotEdit = this.clusterIsAlreadyCreated && !this.unsupportedCloudProvider;
+
+      return canNotEdit;
     },
 
     /**
@@ -1187,6 +1225,18 @@ export default {
         this.allPSAs = res.allPSAs || [];
         this.rke2Versions = res.rke2Versions.data || [];
         this.k3sVersions = res.k3sVersions.data || [];
+
+        // For testing ---------------------------------------------------------------------------------------------
+        // Fake a 1.27 version by copying the latest version (1.26) and remove the aws cloud provider from it
+        // const add = JSON.parse(JSON.stringify(this.rke2Versions[this.rke2Versions.length -1]));
+
+        // add.id = 'v1.27.0+rke2r1';
+        // add.version = add.id;
+        // add.agentArgs['cloud-provider-name'].options = add.agentArgs['cloud-provider-name'].options.filter((a) => a !== 'aws'); // Remove the aws cloud provider
+
+        // this.rke2Versions.push(add);
+
+        /// ^^^ End of code that should be removed ---------------------------------------------------------------------------------------
 
         if (!defaultRke2) {
           const rke2Channels = res.rke2Channels.data || [];
@@ -2245,6 +2295,18 @@ export default {
         if (this.isHarvesterDriver && this.mode === _CREATE && this.isHarvesterIncompatible) {
           this.setHarvesterDefaultCloudProvider();
         }
+
+        // Cloud Provider check
+        // If the cloud provider is unsupported, switch provider to 'external'
+        if (this.unsupportedCloudProvider) {
+          set(this.agentConfig, 'cloud-provider-name', 'external');
+        } else {
+          // Switch the cloud provider back to the initial value
+          // Use changed the Kubernetes version back to a version where the initial cloud provider is valid - so switch back to this one
+          // to undo the change to external that we may have made
+          // Note: Cloud Provider can only be changed on edit when the initial provider is no longer supported
+          set(this.agentConfig, 'cloud-provider-name', this.initialCloudProvider);
+        }
       }
     },
 
@@ -2463,7 +2525,7 @@ export default {
               <LabeledSelect
                 v-model="agentConfig['cloud-provider-name']"
                 :mode="mode"
-                :disabled="clusterIsAlreadyCreated"
+                :disabled="canNotEditCloudProvider"
                 :options="cloudProviderOptions"
                 :label="t('cluster.rke2.cloudProvider.label')"
               />
@@ -2504,6 +2566,12 @@ export default {
             <div class="spacer" />
 
             <div class="col span-12">
+              <Banner
+                v-if="unsupportedCloudProvider"
+                class="error mt-5"
+              >
+                {{ t('cluster.rke2.cloudProvider.unsupported') }}
+              </Banner>
               <h3>
                 {{ t('cluster.rke2.cloudProvider.header') }}
               </h3>


### PR DESCRIPTION
Fixes #9110 
Fixes #9204 

Create an AWS cluster and select the AWS Cloud Provider.

Edit the cluster and change the k8s version to 1.27 - we now change the provider to 'External' and show a banner. If you change back to 1.26, we revert to the AWS Cloud provider.

Note: Added some test code (commented out) that can be un-commented to add a fake 1.27 version for dev/testing.