### PR TITLE
Extension improvements (kube version check + annotations persistence)

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4174,7 +4174,7 @@ plugins:
     title: Add Extensions repositories
     prompt: You can install multiple Rancher extension repositories to increase your extensions catalog
   kubeIncompatibility:
-    banner: There are some installed extensions that may not work properly because they are incompatible with the current Kubernetes version of your local cluster.
+    banner: Some installed extensions may not function property as they are incompatible with the Kubernetes version of your 'local' cluster
   setup:
     installed: Already installed
     uninstalled: Already uninstalled

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4048,7 +4048,7 @@ inactivity:
 plugins:
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ rancherVersion })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ kubeVersion })."
-  currentInstalledVersionBlockedByKubeVersion: "This version is not compatible with the current Kubernetes version ({ kubeVersion }  Vs  { kubeVersionToCheck })."
+  currentInstalledVersionBlockedByKubeVersion: "This version is not compatible with the current Kubernetes version ({ kubeVersion }) which should be { kubeVersionToCheck }"
   labels:
     builtin: Built-in
     experimental: Experimental
@@ -4172,6 +4172,8 @@ plugins:
     bannerBtn: Add repositories
     title: Add Extensions repositories
     prompt: You can install multiple Rancher extension repositories to increase your extensions catalog
+  kubeIncompatibility:
+    banner: There are some installed extensions that may not work properly because they are incompatible with the current Kubernetes version of your local cluster.
   setup:
     installed: Already installed
     uninstalled: Already uninstalled

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4174,7 +4174,7 @@ plugins:
     title: Add Extensions repositories
     prompt: You can install multiple Rancher extension repositories to increase your extensions catalog
   kubeIncompatibility:
-    banner: Some installed extensions may not function property as they are incompatible with the Kubernetes version of your 'local' cluster
+    banner: Some installed extensions may not function properly as they are incompatible with the Kubernetes version of your 'local' cluster
   setup:
     installed: Already installed
     uninstalled: Already uninstalled

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4068,6 +4068,7 @@ plugins:
     api: This Extension is not compatible with the Extensions API
     host: This Extension is not compatible with this application
     version: This Extension is not compatible with this version of Rancher
+    kubeVersion: This Extension is not compatible with the current Kubernetes version
     load: An error occurred loading the code for this Extension
     developerPkg: This Extension has been loaded internally, so we won't load the external version
   success:

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -91,7 +91,7 @@ export function uiPluginAnnotation(chart, name) {
 
 // Should we load a plugin, based on the metadata returned by the backend?
 // Returns error key string or false
-export function shouldNotLoadPlugin(plugin, rancherVersion, loadedPlugins) {
+export function shouldNotLoadPlugin(plugin, rancherVersion, kubeVersion, loadedPlugins) {
   if (!plugin.name || !plugin.version || !plugin.endpoint) {
     return 'plugins.error.generic';
   }
@@ -108,6 +108,15 @@ export function shouldNotLoadPlugin(plugin, rancherVersion, loadedPlugins) {
 
   if (requiredHost && requiredHost !== UI_PLUGIN_HOST_APP) {
     return 'plugins.error.host';
+  }
+
+  // Kube version
+  if (kubeVersion) {
+    const requiredKubeVersion = plugin.metadata?.[UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION];
+
+    if (requiredKubeVersion && !semver.satisfies(kubeVersion, requiredKubeVersion)) {
+      return 'plugins.error.kubeVersion';
+    }
   }
 
   // Rancher version

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -43,7 +43,7 @@ export default function({
       return internal;
     },
 
-    // Load a plugin from a UI package
+    // Load a plugin from a UI package (external packages, not built-in)
     loadPluginAsync(plugin) {
       const { name, version } = plugin;
       const id = `${ name }-${ version }`;

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -454,11 +454,20 @@ export default {
       const installed = this.$store.getters['uiplugins/plugins'];
       const shouldHaveLoaded = (installed || []).filter((p) => !this.uiErrors[p.name] && !p.builtin);
       let changes = 0;
+      let plugin;
+
+      // grab the UIPlugin resource if we did an install of an extension
+      if (this.latestInstalledPlugin?.name) {
+        plugin = neu.find((x) => x.spec?.plugin?.name === this.latestInstalledPlugin?.name) || undefined;
+      }
 
       // An install occured and a plugin was added, let add all annotations to the UIPlugin resource (useful for other checks)
-      if (neu?.length === 1 && !installed.find((x) => neu[0].id === x.id) &&
-      this.latestInstalledPlugin && neu[0].name === this.latestInstalledPlugin.name) {
-        const plugin = neu[0];
+      if (
+        neu.length &&
+        plugin &&
+        !installed.find((x) => plugin.id === x.id) &&
+        this.latestInstalledPlugin &&
+        plugin.name === this.latestInstalledPlugin.name) {
         const installedVersion = this.latestInstalledPlugin?.versions?.find((v) => v.version === plugin.version);
 
         this.latestInstalledPlugin = undefined;

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -395,10 +395,11 @@ export default {
 
         // check if kube version compatibility is met for installed extension
         if (plugin.uiplugin) {
-          const pluginSupportedKubeVersion = plugin?.uiplugin?.metadata?.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION];
+          const pluginSupportedKubeVersion = plugin?.uiplugin?.spec?.plugin?.metadata?.[UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION];
 
           if (pluginSupportedKubeVersion) {
-            const version = { annotations: { ...plugin?.uiplugin?.metadata?.annotations } };
+            // format needed for checks
+            const version = { annotations: { ...plugin?.uiplugin?.spec?.plugin?.metadata } };
 
             if (this.kubeVersion && !isSupportedChartVersion({ version, kubeVersion: this.kubeVersion })) {
               this.showKubeVersionIncompatibilityBanner = true;
@@ -463,8 +464,11 @@ export default {
         this.latestInstalledPlugin = undefined;
 
         if (installedVersion.annotations) {
-          plugin.metadata.annotations = {
-            ...plugin.metadata.annotations,
+          if (!plugin.spec.plugin.metadata) {
+            plugin.spec.plugin.metadata = {};
+          }
+          plugin.spec.plugin.metadata = {
+            ...plugin.spec.plugin.metadata,
             ...installedVersion.annotations
           };
 

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -63,7 +63,7 @@ export default async function(context) {
     // Load all of the plugins
     const pluginLoads = await allHashSettled(hash);
 
-    // Some pluigns may have failed to load - store this
+    // Some plugins may have failed to load - store this
     Object.keys(pluginLoads).forEach((name) => {
       const res = pluginLoads[name];
 

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -29,31 +29,47 @@ export default async function(context) {
     // TODO: Get rancher version using the new API (can't use setting as we have not loading the store)
     const rancherVersion = undefined;
 
-    // Fetch list of installed plugins from endpoint
-    try {
-      const res = await context.store.dispatch('management/request', {
+    const reqs = await allHashSettled({
+      // fetch clusters to get local cluster kube version
+      clusters: context.store.dispatch('management/request', {
+        url:                  `v3/clusters`,
+        method:               'GET',
+        headers:              { accept: 'application/json' },
+        redirectUnauthorized: false,
+      }),
+      // Fetch list of installed plugins from endpoint
+      installedPlugins: context.store.dispatch('management/request', {
         url:                  `${ UI_PLUGIN_BASE_URL }/index.json`,
         method:               'GET',
         headers:              { accept: 'application/json' },
         redirectUnauthorized: false,
-      });
+      })
+    });
 
-      if (res) {
-        const entries = res.entries || res.Entries || {};
+    if (reqs.installedPlugins.status === 'fulfilled' && reqs.installedPlugins.value._status === 200) {
+      const entries = reqs.installedPlugins.value.entries || reqs.installedPlugins.value.Entries || {};
 
-        Object.values(entries).forEach((plugin) => {
-          const shouldNotLoad = shouldNotLoadPlugin(plugin, rancherVersion, context.store.getters['uiplugins/plugins'] || []); // Error key string or boolean
+      let currKubeVersion = '';
 
-          if (!shouldNotLoad) {
-            hash[plugin.name] = context.$plugin.loadPluginAsync(plugin);
-          } else {
-            context.store.dispatch('uiplugins/setError', { name: plugin.name, error: shouldNotLoad });
-          }
-        });
+      if (reqs.clusters.status === 'fulfilled' && reqs.clusters.value._status === 200) {
+        const localCluster = reqs.clusters.value.data.find((c) => c.id === 'local');
+
+        if (localCluster) {
+          currKubeVersion = localCluster.k3sConfig?.kubernetesVersion || '';
+        }
       }
-    } catch (e) {
-      if (e?.code === 404) {
-        // Not found, so extensions operator probably not installed
+      Object.values(entries).forEach((plugin) => {
+        const shouldNotLoad = shouldNotLoadPlugin(plugin, rancherVersion, currKubeVersion, context.store.getters['uiplugins/plugins'] || []); // Error key string or boolean
+
+        if (!shouldNotLoad) {
+          hash[plugin.name] = context.$plugin.loadPluginAsync(plugin);
+        } else {
+          context.store.dispatch('uiplugins/setError', { name: plugin.name, error: shouldNotLoad });
+        }
+      });
+    } else {
+      if (reqs.installedPlugins.value._status.code === 404) {
+      // Not found, so extensions operator probably not installed
         console.log('Could not load UI Extensions list (Extensions Operator may not be installed)'); // eslint-disable-line no-console
       } else {
         console.error('Could not load UI Extensions list', e); // eslint-disable-line no-console

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -46,8 +46,6 @@ export default async function(context) {
       })
     });
 
-    console.error('reqs', reqs);
-
     if (reqs.installedPlugins.status === 'fulfilled' && reqs.installedPlugins.value._status === 200) {
       const entries = reqs.installedPlugins.value.entries || reqs.installedPlugins.value.Entries || {};
 

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -46,6 +46,8 @@ export default async function(context) {
       })
     });
 
+    console.error('reqs', reqs);
+
     if (reqs.installedPlugins.status === 'fulfilled' && reqs.installedPlugins.value._status === 200) {
       const entries = reqs.installedPlugins.value.entries || reqs.installedPlugins.value.Entries || {};
 
@@ -72,7 +74,7 @@ export default async function(context) {
       // Not found, so extensions operator probably not installed
         console.log('Could not load UI Extensions list (Extensions Operator may not be installed)'); // eslint-disable-line no-console
       } else {
-        console.error('Could not load UI Extensions list', e); // eslint-disable-line no-console
+        console.error('Could not load UI Extensions list', reqs.installedPlugins.reason); // eslint-disable-line no-console
       }
     }
 

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -32,7 +32,7 @@ export default async function(context) {
     const reqs = await allHashSettled({
       // fetch clusters to get local cluster kube version
       clusters: context.store.dispatch('management/request', {
-        url:                  `v3/clusters`,
+        url:                  `v3/clusters/local`,
         method:               'GET',
         headers:              { accept: 'application/json' },
         redirectUnauthorized: false,
@@ -52,12 +52,13 @@ export default async function(context) {
       let currKubeVersion = '';
 
       if (reqs.clusters.status === 'fulfilled' && reqs.clusters.value._status === 200) {
-        const localCluster = reqs.clusters.value.data.find((c) => c.id === 'local');
+        const localCluster = reqs.clusters.value;
 
         if (localCluster) {
           currKubeVersion = localCluster.k3sConfig?.kubernetesVersion || '';
         }
       }
+
       Object.values(entries).forEach((plugin) => {
         const shouldNotLoad = shouldNotLoadPlugin(plugin, rancherVersion, currKubeVersion, context.store.getters['uiplugins/plugins'] || []); // Error key string or boolean
 

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -68,7 +68,7 @@ export default async function(context) {
         }
       });
     } else {
-      if (reqs.installedPlugins.value._status.code === 404) {
+      if (reqs.installedPlugins?.value?._status.code === 404) {
       // Not found, so extensions operator probably not installed
         console.log('Could not load UI Extensions list (Extensions Operator may not be installed)'); // eslint-disable-line no-console
       } else {


### PR DESCRIPTION
Fixes #9132 

- prevent extension load if `local` cluster kube version is not compatible with `uiPlugin` kube version
- improve kube version incompatibility check mechanism for extensions (it was flawed before because it assumed we had the versions available to cross-check it, but if the kube version is incompatible then the extension operator doesn't even load it from the backend, making it non-existent for the cross-check)
- add banner to extensions screen when there's a kube version incompatibility with any of the installed extensions
- add extension chart version annotations to the `uiPlugin` resource on extension installation

**To test**
 - install `elemental` extension (latest version)
 - check that the `uiPlugin` resource created for `elemental` has the annotations from the chart version under `spec.plugin.metadata`
 - quick test for new kube version incompatibility banner: edit https://github.com/rancher/dashboard/blob/master/shell/pages/c/_cluster/uiplugins/index.vue#L127 after install to `v1.29.2` so that the current installed version of `elemental` becomes "incompatible" with the current kube version
 - quick test for not loading extension: edit  `currKubeVersion` variable in `plugin.js` file to `v1.29.12+k3s1`so that the `local` cluster kube version is greater than `v1.28` (`elemental` default)

**Screenshots**
![Screenshot 2023-09-26 at 18 24 31](https://github.com/rancher/dashboard/assets/97888974/c96b3837-62f8-4278-82a8-c840691ce91c)

![Screenshot 2023-09-01 at 13 58 01](https://github.com/rancher/dashboard/assets/97888974/dbf895fa-9608-4f80-9a6e-3ea713c73d3c)
