### PR TITLE
Ensure we always fetch rke2 cluster addon charts

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -219,6 +219,13 @@ export default {
       defaultRke2:                     '',
       defaultK3s:                      '',
       s3Backup:                        false,
+      /**
+       * All info related to a specific version of the chart
+       *
+       * This includes chart itself, README and values
+       *
+       * { [chartName:string]: { chart: json, readme: string, values: json } }
+       */
       versionInfo:                     {},
       membershipUpdate:                {},
       showDeprecatedPatchVersions:     false,
@@ -555,6 +562,9 @@ export default {
       return out;
     },
 
+    /**
+     * Kube Version
+     */
     selectedVersion() {
       const str = this.value.spec.kubernetesVersion;
 
@@ -579,6 +589,11 @@ export default {
       return this.selectedVersion?.agentArgs || {};
     },
 
+    /**
+     * The addons (kube charts) applicable for the selected kube version
+     *
+     * { [chartName:string]: { repo: string, version: string } }
+     */
     chartVersions() {
       return this.selectedVersion?.charts || {};
     },
@@ -788,6 +803,9 @@ export default {
       return this.agentArgs['cloud-provider-name'];
     },
 
+    /**
+     * The chart names of the addons applicable to the current kube version and selected cloud provider
+     */
     addonNames() {
       const names = [];
       const cni = this.serverConfig.cni;
@@ -811,8 +829,13 @@ export default {
       return names;
     },
 
+    /**
+     * The charts of the addons applicable to the current kube version and selected cloud provider
+     *
+     * These are the charts themselves and do not include chart readme or values
+     */
     addonVersions() {
-      const versions = this.addonNames.map((name) => this.chartVersionFor(name));
+      const versions = this.addonNames.map((name) => this.versionInfo[name]?.chart);
 
       return versions.filter((x) => !!x);
     },
@@ -1723,41 +1746,37 @@ export default {
       });
     },
 
-    chartVersionFor(chartName) {
-      const entry = this.chartVersions[chartName];
-
-      if ( !entry ) {
-        return null;
-      }
-
-      const out = this.$store.getters['catalog/version']({
-        repoType:    'cluster',
-        repoName:    entry.repo,
-        chartName,
-        versionName: entry.version,
-      });
-
-      return out;
-    },
-
+    /**
+     * Ensure all chart information required to show addons is available
+     *
+     * This basically means
+     * 1) That the full chart relating to the addon is fetched (which includes core chart, readme and values)
+     * 2) We're ready to cache any values the user provides for each addon
+     */
     async initAddons() {
-      for ( const v of this.addonVersions ) {
-        if ( this.versionInfo[v.name] ) {
+      for ( const chartName of this.addonNames ) {
+        const entry = this.chartVersions[chartName];
+
+        if ( this.versionInfo[chartName] ) {
           continue;
         }
 
-        const res = await this.$store.dispatch('catalog/getVersionInfo', {
-          repoType:    'cluster',
-          repoName:    v.repoName,
-          chartName:   v.name,
-          versionName: v.version
-        });
+        try {
+          const res = await this.$store.dispatch('catalog/getVersionInfo', {
+            repoType:    'cluster',
+            repoName:    entry.repo,
+            chartName,
+            versionName: entry.version,
+          });
 
-        set(this.versionInfo, v.name, res);
-        const key = this.chartVersionKey(v.name);
+          set(this.versionInfo, chartName, res);
+          const key = this.chartVersionKey(chartName);
 
-        if (!this.userChartValues[key]) {
-          this.userChartValues[key] = {};
+          if (!this.userChartValues[key]) {
+            this.userChartValues[key] = {};
+          }
+        } catch (e) {
+          console.error(`Failed to fetch or process chart info for ${ chartName }`); // eslint-disable-line no-console
         }
       }
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9520 (ish, see below and https://github.com/rancher/dashboard/issues/9520#issuecomment-1702869821)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Overview
- Addons are helm charts installed into the provisioned cluster
- Addons to install are determined by kube version and cloud provider
- Addons have values/config that can be provided when provisioning

Bug
- Previously we were looking for the helm chart associated with the addon in the chart cache
- The cached charts are specific to the kube version of the host. If the chart is invalid due to kube version of host, it's not supplied to us thus not in cache
- If a user wants to install a valid chart in the provisioned cluster which was invalid for the local cluster, we would fail to find the chart

Fix
- In all worlds, regardless of global cache state, we need to fetch the full chart (to fetch chart `values` to present to user)
- Fix is to ensure this happens ... and are used instead of looking in the global cache first
- This means the global cache remains unchanged and skipFilter / k8sVersion query params are not needed to fix the root bug (to confirm)
 
### Areas which could experience regressions
- provisioning custom clusters with different cloud providers, specifically setting their addon config