### PR TITLE
Fixed broken paragraph message for psp warning

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1830,7 +1830,7 @@ cluster:
     modal:
       pspChange:
         title: Pod Security Policy deprecation
-        body: Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If your cluster has PodSecurityPolicy admission controller enabled via "kube-apiserver-arg.enable-admission-plugins" in Cluster YAML, it has to be <i>manually</i> removed before proceeding with the upgrade. Additionally, any PSPs that may be present in the cluster will no longer be available/enforced. Do you want to proceed?
+        body: <p>Kubernetes has removed support for Pod Security Policies (PSPs) starting with version 1.25. If your cluster has PodSecurityPolicy admission controller enabled via "kube-apiserver-arg.enable-admission-plugins" in Cluster YAML, it has to be <i>manually</i> removed before proceeding with the upgrade. Additionally, any PSPs that may be present in the cluster will no longer be available/enforced. Do you want to proceed?</p>
     snapshots:
       suffix: Snapshots per node
     systemService:

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -1838,7 +1838,7 @@ cluster:
     modal:
       pspChange:
         title: 弃用 Pod 安全策略
-        body: 从 v1.25 版开始，Kubernetes 已经取消了对 Pod 安全策略 (PSP) 的支持。如果你的集群通过集群 YAML 中的 “kube-apiserver-arg.enable-admission-plugins” 启用了 PodSecurityPolicy 准入控制器，你必须在继续升级之前<i>手动</i>删除它。此外，集群中存在的任何 PSP 将不再可用或强制执行。是否继续操作？
+        body: <p>从 v1.25 版开始，Kubernetes 已经取消了对 Pod 安全策略 (PSP) 的支持。如果你的集群通过集群 YAML 中的 “kube-apiserver-arg.enable-admission-plugins” 启用了 PodSecurityPolicy 准入控制器，你必须在继续升级之前<i>手动</i>删除它。此外，集群中存在的任何 PSP 将不再可用或强制执行。是否继续操作？</p>
     snapshots:
       suffix: 每个节点的快照
     systemService:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Added a paragraph tag as a wrapper for the message so the parent's flexbox styling doesn't break the message because of having italics tags `<i>` in it.

Fixes #9593 
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
Before:
<img width="633" alt="Screenshot 2023-09-01 at 12 12 41 PM" src="https://github.com/rancher/dashboard/assets/135728925/221587a0-f975-4060-afca-2b3b00693690">
<img width="642" alt="Screenshot 2023-09-01 at 12 12 10 PM" src="https://github.com/rancher/dashboard/assets/135728925/d22a9308-f2cd-4986-803f-e572aa0bf5b7">

After:
<img width="694" alt="Screenshot 2023-09-01 at 12 10 48 PM" src="https://github.com/rancher/dashboard/assets/135728925/0b74bfdc-2a5d-4f9d-8f5c-05301bc61a93">
<img width="646" alt="Screenshot 2023-09-01 at 12 11 21 PM" src="https://github.com/rancher/dashboard/assets/135728925/4150e307-777a-4295-ad4c-3474e2a65710">

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->