### PR TITLE
Fix: Missing of spacing to min-width in pagination area

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1933,12 +1933,13 @@ export default {
   }
 
   .paging {
-    margin-top: 10px;
+    margin-top: 20px;
     text-align: center;
 
     SPAN {
       display: inline-block;
       min-width: 200px;
+      padding: 0 20px 0 20px;
     }
   }
   </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/9653

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
In some cases the minimum width of the pagination text (200px) may not be sufficient. In case of wider text, the text will directly hit the navigation elements. Minor CSS adjustments in this PR fixes the behaviour.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Seen at Harvester Dashboard under Advanced -> PCI Devices (when enough devices are added to trigger the pagination)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Not expected (fix only applies to pagination area. The view has not changed when the pagination text is inside the min-width of 200px)

### Screenshot/Video
Before:
<img width="591" alt="Screenshot 2023-09-04 at 18 12 02" src="https://github.com/rancher/dashboard/assets/33026403/0015c71b-e609-4b0a-a3a7-246d72f2d83d">

After:
<img width="598" alt="Screenshot 2023-09-04 at 18 11 45" src="https://github.com/rancher/dashboard/assets/33026403/45d42e40-3ef1-48b8-8fd2-362dc2a828ad">


