### PR TITLE
Add unit tests for sortBy

### DIFF
--- a/shell/utils/__tests__/sort.test.ts
+++ b/shell/utils/__tests__/sort.test.ts
@@ -1,0 +1,61 @@
+import { sortBy } from '@shell/utils/sort';
+
+describe('fx: sort', () => {
+  describe('sortBy', () => {
+    const testSortBy = <T = object[]>(ary: T[], key: string[], expected: T[], desc?: boolean) => {
+      const result = sortBy(ary, key, desc);
+
+      expect(result).toStrictEqual(expected);
+    };
+
+    it.each([
+      [[{ a: 1 }, { a: 9 }], ['a'], [{ a: 1 }, { a: 9 }]],
+      [[{ a: 2 }, { a: 1 }], ['a'], [{ a: 1 }, { a: 2 }]],
+    ])('should sort by single property', (ary, key, expected) => {
+      testSortBy(ary, key, expected);
+    });
+
+    it.each([
+      [[{ a: 1, b: 1 }, { a: 9, b: 9 }], ['a', 'b'], [{ a: 1, b: 1 }, { a: 9, b: 9 }]],
+      [[{ a: 2, b: 2 }, { a: 1, b: 1 }], ['a', 'b'], [{ a: 1, b: 1 }, { a: 2, b: 2 }]],
+      [[{ a: 2, b: 1 }, { a: 1, b: 9 }], ['a', 'b'], [{ a: 1, b: 9 }, { a: 2, b: 1 }]],
+      [[{ a: 1, b: 2 }, { a: 9, b: 1 }], ['a', 'b'], [{ a: 1, b: 2 }, { a: 9, b: 1 }]],
+      [[{ a: 1, b: 1 }, { a: 9, b: 9 }], ['a', 'b'], [{ a: 1, b: 1 }, { a: 9, b: 9 }]],
+    ])('should sort by two properties (primary property always first)', (ary, key, expected) => {
+      testSortBy(ary, key, expected);
+    });
+
+    it.each([
+      [[{ a: 1, b: 1 }, { a: 1, b: 9 }], ['a', 'b'], [{ a: 1, b: 1 }, { a: 1, b: 9 }]],
+      [[{ a: 1, b: 2 }, { a: 1, b: 1 }], ['a', 'b'], [{ a: 1, b: 1 }, { a: 1, b: 2 }]],
+    ])('should sort by two properties (primary property the same)', (ary, key, expected) => {
+      testSortBy(ary, key, expected);
+    });
+
+    describe('descending', () => {
+      it.each([
+        [[{ a: 1 }, { a: 9 }], ['a'], [{ a: 9 }, { a: 1 }]],
+        [[{ a: 2 }, { a: 1 }], ['a'], [{ a: 2 }, { a: 1 }]],
+      ])('should sort by single property', (ary, key, expected) => {
+        testSortBy(ary, key, expected, true);
+      });
+
+      it.each([
+        [[{ a: 1, b: 1 }, { a: 9, b: 9 }], ['a', 'b'], [{ a: 9, b: 9 }, { a: 1, b: 1 }]],
+        [[{ a: 2, b: 2 }, { a: 1, b: 1 }], ['a', 'b'], [{ a: 2, b: 2 }, { a: 1, b: 1 }]],
+        [[{ a: 2, b: 1 }, { a: 1, b: 9 }], ['a', 'b'], [{ a: 2, b: 1 }, { a: 1, b: 9 }]],
+        [[{ a: 1, b: 2 }, { a: 9, b: 1 }], ['a', 'b'], [{ a: 9, b: 1 }, { a: 1, b: 2 }]],
+        [[{ a: 1, b: 1 }, { a: 9, b: 9 }], ['a', 'b'], [{ a: 9, b: 9 }, { a: 1, b: 1 }]],
+      ])('should sort by two properties', (ary, key, expected) => {
+        testSortBy(ary, key, expected, true);
+      });
+
+      it.each([
+        [[{ a: 1, b: 1 }, { a: 1, b: 9 }], ['a', 'b'], [{ a: 1, b: 9 }, { a: 1, b: 1 }]],
+        [[{ a: 1, b: 2 }, { a: 1, b: 1 }], ['a', 'b'], [{ a: 1, b: 2 }, { a: 1, b: 1 }]],
+      ])('should sort by two properties (primary property the same)', (ary, key, expected) => {
+        testSortBy(ary, key, expected, true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- Following on from a discussion regarding the app bar i was investigating the `sortBy` function
- Realised this might as well take the form of unit tests
- There's more angles we could take on this, but it covers the basic set of a single sort property, two sort properties and descending features
