### PR TITLE
Reset network property when region is updated

### DIFF
--- a/shell/machine-config/amazonec2.vue
+++ b/shell/machine-config/amazonec2.vue
@@ -303,6 +303,7 @@ export default {
     },
 
     'value.region'() {
+      this.updateNetwork();
       this.$fetch();
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9636 
<!-- Define findings related to the feature or bug issue. -->
The `value.subnetId`, `value.vpcId`, and `selectedNetwork` properties were not being updated/reset when the region was updated. 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a call to the `updateNetwork` method within the `watch` for `value.regions`, this will reset the `value.subnetId`, `value.vpcId`, and `selectedNetwork` properties to the original `null` value.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I decided adding in the form validation as suggested in the original issue would over-complicate the machine-config when simply resetting the value would suffice.
