### PR TITLE
Fix issue where popperjs spammed console warnings

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -242,7 +242,7 @@ export default {
         return {
           content:       this.shown ? null : item,
           placement:     'right',
-          popperOptions: { modifiers: { preventOverflow: { enabled: false } } }
+          popperOptions: { modifiers: { preventOverflow: { enabled: false }, hide: { enabled: false } } }
         };
       } else {
         return { content: undefined };


### PR DESCRIPTION
### Occurred changes and/or fixed issues

The following is spammed to console when cluster name tooltips are shown

![image](https://github.com/rancher/dashboard/assets/18697775/21a391d1-0845-4e5f-8b75-76fea5951c8b)

Needed `hide` - https://popper.js.org/docs/v2/modifiers/hide/
