### PR TITLE
Reduce performance impact of LabeledSelect getOptionLabel

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -155,11 +155,9 @@ export default {
         const newOption = this.getUpdatedOption(option);
 
         if (newOption) {
-          if (newOption) {
-            const label = get(newOption, this.optionLabel);
+          const label = get(newOption, this.optionLabel);
 
-            return this.localizedLabel ? this.$store.getters['i18n/t'](label) || label : label;
-          }
+          return this.localizedLabel ? this.$store.getters['i18n/t'](label) || label : label;
         }
       }
 

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -180,14 +180,9 @@ export default {
     // If the option's label changed in parent but value did not, the label wont be automatically updated here
     // Ensure that the label being shown is still present in the options prop and find the new one if not
     getUpdatedOption(option) {
-      let out;
-      const isOutdated = !this.options.find((opt) => option[this.optionLabel] === opt[this.optionLabel]);
+      const isOutdated = this.options && !this.options.find((opt) => option[this.optionLabel] === opt[this.optionLabel]);
 
-      if (isOutdated && this.options) {
-        out = this.options.find((opt) => isEqual(this.reduce(option), this.reduce(opt)));
-      }
-
-      return out;
+      return isOutdated ? this.options.find((opt) => isEqual(this.reduce(option), this.reduce(opt))) : undefined;
     },
 
     positionDropdown(dropdownList, component, { width }) {

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -149,16 +149,20 @@ export default {
         return;
       }
 
-      // Force to update the option label if prop has been changed
-      const isOutdated = !this.options.find((opt) => option[this.optionLabel] === opt[this.optionLabel]);
+      // This check is only needed if its possible for an option's label to change without the option's value changing - we can skip this if options are just strings or numbers
+      // HOWEVER even if strings are passed to v-select the 'option' in the slot is normalized to {label: <option>} so we have to check the options prop here instead of the 'option' itself
+      if (typeof this.options[0] === 'object') {
+        // Force to update the option label if prop has been changed
+        const isOutdated = !this.options.find((opt) => option[this.optionLabel] === opt[this.optionLabel]);
 
-      if (isOutdated && this.options) {
-        const newOption = this.options.find((opt) => isEqual(this.reduce(option), this.reduce(opt)));
+        if (isOutdated && this.options) {
+          const newOption = this.options.find((opt) => isEqual(this.reduce(option), this.reduce(opt)));
 
-        if (newOption) {
-          const label = get(newOption, this.optionLabel);
+          if (newOption) {
+            const label = get(newOption, this.optionLabel);
 
-          return this.localizedLabel ? this.$store.getters['i18n/t'](label) || label : label;
+            return this.localizedLabel ? this.$store.getters['i18n/t'](label) || label : label;
+          }
         }
       }
 

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -152,12 +152,9 @@ export default {
       // This check is only needed if its possible for an option's label to change without the option's value changing - we can skip this if options are just strings or numbers
       // HOWEVER even if strings are passed to v-select the 'option' in the slot is normalized to {label: <option>} so we have to check the options prop here instead of the 'option' itself
       if (typeof this.options[0] === 'object') {
-        // Force to update the option label if prop has been changed
-        const isOutdated = !this.options.find((opt) => option[this.optionLabel] === opt[this.optionLabel]);
+        const newOption = this.getUpdatedOption(option);
 
-        if (isOutdated && this.options) {
-          const newOption = this.options.find((opt) => isEqual(this.reduce(option), this.reduce(opt)));
-
+        if (newOption) {
           if (newOption) {
             const label = get(newOption, this.optionLabel);
 
@@ -180,6 +177,19 @@ export default {
       } else {
         return option;
       }
+    },
+
+    // If the option's label changed in parent but value did not, the label wont be automatically updated here
+    // Ensure that the label being shown is still present in the options prop and find the new one if not
+    getUpdatedOption(option) {
+      let out;
+      const isOutdated = !this.options.find((opt) => option[this.optionLabel] === opt[this.optionLabel]);
+
+      if (isOutdated && this.options) {
+        out = this.options.find((opt) => isEqual(this.reduce(option), this.reduce(opt)));
+      }
+
+      return out;
     },
 
     positionDropdown(dropdownList, component, { width }) {

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -133,6 +133,24 @@ describe('component: LabeledSelect', () => {
         // Component is from a library and class is not going to be changed
         expect(wrapper.find('.vs__selected').text()).toBe(translation);
       });
+
+      it.each([
+        [['a'], 'b', 0],
+        [[{ value: 'a', label: 'A' }], { value: 'a', label: 'B' }, 4]
+      ])('should only check for a new label if options are objects', async(options: any[], newOption, checkUpdateCalled: number) => {
+        const spyUpdatedOption = jest.spyOn(LabeledSelect.methods, 'getUpdatedOption');
+
+        const wrapper = mount(LabeledSelect, {
+          propsData: {
+            value: 'a',
+            options
+          }
+        });
+
+        await wrapper.setProps({ options: [newOption] });
+
+        expect(spyUpdatedOption).toHaveBeenCalledTimes(checkUpdateCalled);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9668 

Two things contributing to this:
1. `getOptionLabel` iterates over every option for each option, to address https://github.com/rancher/dashboard/issues/8149
2. `getOptionLabel` is called _a lot_ 

By adding a console.log to `getOptionLabel` I can see that the function re-runs for each option when the user mouses over options. Even providing the minimum necessary configuration to v-select I see this happening, which makes me think it is baked into the component library we are using.

### Occurred changes and/or fixed issues
This PR updates `getOptionLabel` to skip the label-checking logic when options don't have separate labels and values. This means that the LabeledSelect performance with very long lists of options is _only_ fixed if the options prop is an array of strings or numbers. I couldn't work out how else to address #9668 without re-introducing https://github.com/rancher/dashboard/issues/8149 because the matter of `getOptionLabel` being called over 9000 times for even the shortest of options arrays seems to be out of our hands.

The bug seen in https://github.com/rancher/dashboard/pull/8133 was the original motivation for the `isOutdated` check and has not been re-introduced by this change, as verified by rke2 unit tests and manual testing.

### Areas or cases that should be tested
This bug was seen in code not yet merged so to test, alter any instance of LabeledSelect to have a lot of options: `:options="Array.from(Array(800).keys())"` and verify opening and scrolling the list of options isn't laggy. 

PSA version-dependent default labeling should be verified as still working too.


### Screenshot/Video
old:


https://github.com/rancher/dashboard/assets/42977925/0ee27c4d-81a9-4866-a39d-96c549f2fe90



new:


https://github.com/rancher/dashboard/assets/42977925/b06419a4-d219-49a9-bce8-597cbd4f2591