### PR TITLE
Fix the header icon alignment in Standalone mode

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -706,6 +706,10 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  $side-menu-logo-margin-left: 5px;
+  // It would be nice to grab this from `Group.vue`, but there's margin, padding and border, which is overkill to var
+  $side-menu-group-padding-left: 16px;
+
   HEADER {
     display: flex;
     z-index: z-index('mainHeader');
@@ -720,6 +724,9 @@ export default {
       &.isSingleProduct  {
         display: flex;
         justify-content: center;
+        // Align the icon with the side nav menu items ($side-menu-group-padding-left)
+        // There's margin already in the icon component, so take that in to account ($side-menu-logo-margin-left)
+        margin-left: $side-menu-group-padding-left - $side-menu-logo-margin-left;
       }
     }
 
@@ -808,7 +815,7 @@ export default {
       display: flex;
       margin-right: 8px;
       height: 55px;
-      margin-left: 5px;
+      margin-left: $side-menu-logo-margin-left;
       max-width: 200px;
       padding: 12px 0;
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix the alignment of the header icon when in standalone mode

### Technical notes summary
- Screenshot is of epinio. This will also fix harvester standalone world

### Screenshot/Video
Before
![image](https://github.com/rancher/dashboard/assets/18697775/a5e47a2e-3d44-47b7-9d41-1a231f1e441d)


After
![image](https://github.com/rancher/dashboard/assets/18697775/b01691e6-4df6-4062-a722-be4048c88f4e)
