### PR TITLE
No matching clusters msg fix

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -337,7 +337,6 @@ export default {
                 {{ t('nav.home') }}
               </div>
             </nuxt-link>
-
             <div
               v-if="showClusterSearch"
               class="clusters-search"
@@ -451,7 +450,7 @@ export default {
                   </span>
                 </div>
                 <div
-                  v-if="clustersFiltered.length != 0 && pinFiltered.length > 0"
+                  v-if="clustersFiltered.length > 0"
                   class="category-title"
                 >
                   <hr>

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -37,7 +37,8 @@ export default {
       hasProvCluster,
       maxClustersToShow: MENU_MAX_CLUSTERS,
       emptyCluster:      BLANK_CLUSTER,
-      showPinClusters:   false
+      showPinClusters:   false,
+      searchActive:      false
     };
   },
 
@@ -114,10 +115,12 @@ export default {
 
       if (search) {
         this.showPinClusters = false;
+        this.searchActive = !sorted.length > 0;
 
         return sorted;
       }
       this.showPinClusters = true;
+      this.searchActive = false;
 
       if (sorted.length >= this.maxClustersToShow) {
         const sortedPinOut = sorted.filter((item) => !item.pinned).slice(0, this.maxClustersToShow);
@@ -448,6 +451,7 @@ export default {
                   </span>
                 </div>
                 <div
+                  v-if="clustersFiltered.length != 0 && pinFiltered.length > 0"
                   class="category-title"
                 >
                   <hr>
@@ -496,7 +500,7 @@ export default {
                 </div>
               </div>
               <div
-                v-if="clustersFiltered.length === 0 && shown"
+                v-if="(clustersFiltered.length === 0 || pinFiltered.length === 0) && searchActive"
                 class="none-matching"
               >
                 {{ t('nav.search.noResults') }}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9683
<!-- Define findings related to the feature or bug issue. -->
Fixed condition for `No matching clusters` text


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
==== No cluster pin  ======
<img width="162" alt="Screenshot 2023-09-14 at 10 08 38" src="https://github.com/rancher/dashboard/assets/18264463/0f2b36ee-dc4d-4c9f-90db-4cf3ab8d46a7">



==== All clusters are pinned ======

<img width="162" alt="Screenshot 2023-09-14 at 10 07 51" src="https://github.com/rancher/dashboard/assets/18264463/e1852a9c-1343-40d7-99ca-8b67d6bb5814">

