### PR TITLE
fix: some scenarios with the smallIdentifier()

### DIFF
--- a/shell/components/ClusterIconMenu.vue
+++ b/shell/components/ClusterIconMenu.vue
@@ -1,4 +1,6 @@
 <script>
+import { abbreviateClusterName } from '@shell/utils/cluster';
+
 export default {
   props: {
     cluster: {
@@ -12,13 +14,6 @@ export default {
     },
   },
   methods: {
-    /**
-     * Shortens an input string based on the number of segments it contains.
-     * @param {string} input - The input string to be shortened.
-     * @returns {string} - The shortened string.
-     * @example smallIdentifier('local') => 'lcl'
-     * @example smallIdentifier('word-wide-web') => 'www'
-     */
     smallIdentifier(input) {
       if (this.cluster.badge?.iconText) {
         return this.cluster.badge?.iconText;
@@ -28,38 +23,8 @@ export default {
         return undefined;
       }
 
-      if (!input) {
-        return '';
-      }
-
-      if (input.length <= 3) {
-        return input;
-      }
-
-      const segments = input.match(/([A-Za-z]+|\d+)/g);
-
-      if (!segments) return ''; // In case no valid segments are found
-
-      let result = '';
-
-      switch (segments.length) {
-      case 1:
-        // eslint-disable-next-line no-case-declarations
-        const word = segments[0];
-
-        result = `${ word[0] }${ word[Math.floor(word.length / 2)] }${ word[word.length - 1] }`;
-        break;
-      case 2:
-
-        result = `${ segments[0][0] }${ segments[0].length >= 2 ? segments[0][segments[0].length - 1] : segments[1][0] }${ segments[1][segments[1].length - 1] }`;
-        break;
-      default:
-        result = segments.slice(0, 3).map((segment) => segment[0]).join('');
-      }
-
-      return result;
-    },
-
+      return abbreviateClusterName(input);
+    }
   }
 };
 </script>

--- a/shell/utils/__tests__/cluster.test.ts
+++ b/shell/utils/__tests__/cluster.test.ts
@@ -1,0 +1,55 @@
+import { abbreviateClusterName } from '@shell/utils/cluster';
+
+describe('fx: abbreviateClusterName', () => {
+  it.each([
+    ['local', 'lcl'],
+    ['world-wide-web', 'www'],
+    ['a', 'a'],
+    ['ab', 'ab'],
+    ['abc', 'abc'],
+    ['', ''],
+    ['1', '1'],
+    ['12', '12'],
+    ['123', '123'],
+    ['a1', 'a1'],
+    ['aa1', 'aa1'],
+    ['aaa1', 'aa1'],
+    ['a-b', 'a-b'],
+    ['1-2', '1-2'],
+    ['a-b-c', 'abc'],
+    ['abc-def-ghi', 'adg'],
+    ['abcd-efgh', 'adh'],
+    ['a-bc', 'abc'],
+    ['ab-c', 'abc'],
+    ['ab-cd', 'abd'],
+    ['a-bcd', 'abd'],
+    ['abc-d', 'acd'],
+    ['0123-4567-89ab-cdef', '048'],
+    ['0123-4567-89ab-cdef-ghij', '048'],
+    ['0123-4567-8901-2345', '048'],
+    ['0123-4567-8901-2345-6789', '048'],
+    ['a1b', 'a1b'],
+    ['a1b2', 'a1b'],
+    ['ab12cd34', 'a1c'],
+    ['test-cluster-one', 'tco'],
+    ['test-cluster-1', 'tc1'],
+    ['customer-support-team-1', 'cst'],
+    ['customer-support-team-one', 'cst'],
+    ['customer-support-team-prod', 'cst'],
+    ['customer-support-team-dev', 'cst'],
+    ['customer-support-team-prod-1', 'cst'],
+    ['customer-support-team-dev-1', 'cst'],
+    ['customer-support-team-prod-2', 'cst'],
+    ['customer-support-team-dev-2', 'cst'],
+
+    ['s322', 's32'],
+    ['sowmya2', 'sa2'],
+    ['sowmya4', 'sa4'],
+    ['sowmya', 'sma'],
+    ['sowmyatest4', 'st4'],
+  ])('should evaluate %p as %p', (value, expected) => {
+    const result = abbreviateClusterName(value);
+
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/shell/utils/cluster.js
+++ b/shell/utils/cluster.js
@@ -44,3 +44,49 @@ export function filterHiddenLocalCluster(mgmtClusters, store) {
     return !target.isLocal;
   });
 }
+
+const clusterNameSegments = /([A-Za-z]+|\d+)/g;
+
+/**
+ * Shortens an input string based on the number of segments it contains.
+ * @param {string} input - The input string to be shortened.
+ * @returns {string} - The shortened string.
+ * @example smallIdentifier('local') => 'lcl'
+ * @example smallIdentifier('word-wide-web') => 'www'
+ */
+export function abbreviateClusterName(input) {
+  if (!input) {
+    return '';
+  }
+
+  if (input.length <= 3) {
+    return input;
+  }
+
+  const segments = input.match(clusterNameSegments);
+
+  if (!segments) return ''; // In case no valid segments are found
+
+  let result = '';
+
+  switch (segments.length) {
+  case 1: {
+    const word = segments[0];
+
+    result = `${ word[0] }${ word[Math.floor(word.length / 2)] }${ word[word.length - 1] }`;
+    break;
+  }
+  case 2: {
+    const w1 = `${ segments[0][0] }`;
+    const w2 = `${ segments[0].length >= 2 ? segments[0][segments[0].length - 1] : segments[1][0] }`;
+    const w3 = `${ segments[1][segments[1].length - 1] }`;
+
+    result = w1 + w2 + w3;
+    break;
+  }
+  default:
+    result = segments.slice(0, 3).map((segment) => segment[0]).join('');
+  }
+
+  return result;
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/9702
Fixes https://github.com/rancher/dashboard/issues/9658
<!-- Define findings related to the feature or bug issue. -->

There was an unexpected behavior where name conventions such as `sowmya2` or `sowmya4` would result in `s22` and `s44` where the expected output would be `sa2`& `sa4`.

## Test
Now for names with the format `stringNumber` it should match the first and last letter of the string + number.
Creating a new cluster name with `sowmya2` it should output `sa2`



## Screenshoots
![image](https://github.com/rancher/dashboard/assets/88777903/e8a994c8-2db3-4eb9-98a6-f945f3ae464d)


## Additional 

Edge case not covered on this first iteration, we can follow up on further iterations since I have a feeling that we would have to check all cluster names & abbreviate (we could push all abbreviators to an array and compare if the new generated one already exists and if so, do some extra work)

![image](https://github.com/rancher/dashboard/assets/88777903/36245218-ab31-4f2c-92ef-b37934a0a3f3)
