### PR TITLE
Warning for RKE2 custom clusters when setting node roles

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1137,6 +1137,7 @@ cluster:
     nodeRole:
       label: Node Role
       detail: Choose what roles the node will have in the cluster.  The cluster needs to have at least one node with each role.
+      warning: The cluster needs to have at least one node with each role to be usable.
     advanced:
       label: Advanced
       detail: Additional control over how the node will be registered.  These values will often need to be different for each node registered.

--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -170,6 +170,11 @@ export default {
         v-model="worker"
         label-key="model.machine.role.worker"
       />
+      <Banner
+        v-if="!etcd || !controlPlane || !worker"
+        color="warning"
+        :label="t('cluster.custom.nodeRole.warning')"
+      />
     </InfoBox>
 
     <InfoBox

--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -172,6 +172,7 @@ export default {
       />
       <Banner
         v-if="!etcd || !controlPlane || !worker"
+        data-testid="node-role-warning"
         color="warning"
         :label="t('cluster.custom.nodeRole.warning')"
       />

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.tests.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.tests.ts
@@ -2,35 +2,83 @@ import { mount } from '@vue/test-utils';
 import CustomCommand from '@shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue';
 
 describe('component: CustomCommand', () => {
-  it('should return linux commands with the right flags based on cluster information', () => {
-    const token = 'MY_TOKEN';
-    const ip = 'MY_IP';
-    const checkSum = 'MY_CHECKSUM';
-    const wrapper = mount(CustomCommand, {
-      propsData: {
-        cluster:      {},
-        clusterToken: {
-          insecureNodeCommand: ` curl --insecure -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum }`,
-          nodeCommand:         ` curl -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum }`
+  const token = 'MY_TOKEN';
+  const ip = 'MY_IP';
+  const checkSum = 'MY_CHECKSUM';
+  const wrapper = mount(CustomCommand, {
+    mocks: {
+      $store: {
+        getters: {
+          currentStore:           () => 'current_store',
+          'management/schemaFor': jest.fn(),
+          'current_store/all':    jest.fn(),
+          'i18n/t':               jest.fn(),
+          'i18n/withFallback':    jest.fn(),
         }
       },
-      // stubs: { CopyCode: { template: '<div></div> ' } },
-      data: () => ({
-        address:         '',
-        controlPlane:    true,
-        etcd:            true,
-        insecure:        false,
-        internalAddress: '',
-        labels:          {},
-        nodeName:        '',
-        taints:          [],
-        worker:          true,
-      }),
-    });
+    },
+    propsData: {
+      cluster:      {},
+      clusterToken: {
+        insecureNodeCommand: ` curl --insecure -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum }`,
+        nodeCommand:         ` curl -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum }`
+      }
+    },
+    data: () => ({
+      address:         '',
+      controlPlane:    true,
+      etcd:            true,
+      insecure:        false,
+      internalAddress: '',
+      labels:          {},
+      nodeName:        '',
+      taints:          [],
+      worker:          true,
+    }),
+  });
 
+  it('should return linux commands with the right flags based on cluster information', () => {
     const value = `curl -fL ${ ip }/system-agent-install.sh | sudo  sh -s - --server ${ ip } --label 'cattle.io/os=linux' --token ${ token } --ca-checksum ${ checkSum } --etcd --controlplane --worker`;
     const element = wrapper.find('#copiedLinux').element;
 
     expect(element.textContent).toContain(value);
+  });
+
+  it('should not display warning message if all node roles are selected', async() => {
+    await wrapper.setData({
+      controlPlane: true,
+      etcd:         true,
+      worker:       true,
+    });
+
+    const element = wrapper.find('[data-testid="node-role-warning"]').element;
+
+    expect(element).toBeUndefined();
+  });
+
+  describe('should display warning message if at least one of the node roles is unselected', () => {
+    it.each([
+      [true, true, false],
+      [true, false, true],
+      [true, false, false],
+      [false, true, true],
+      [false, true, false],
+      [false, false, true],
+      [false, false, false],
+    ])('controlPlane: %p, etcd: %p, worker: %p', async(
+      controlPlane,
+      etcd,
+      worker
+    ) => {
+      await wrapper.setData({
+        controlPlane,
+        etcd,
+        worker
+      });
+
+      const element = wrapper.find('[data-testid="node-role-warning"]').element;
+
+      expect(element).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9609
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The warning message should be displayed only for `custom` RKE2 clusters.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Create a new Cluster
- Check Registration tab -> Step 1 card -> warning message on bottom of the card 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/rancher/dashboard/assets/26394656/b3a487b1-f22f-4c12-a902-3c5ee08be837)

