### PR TITLE
get support page tests

### DIFF
--- a/cypress/e2e/po/pages/get-support.po.ts
+++ b/cypress/e2e/po/pages/get-support.po.ts
@@ -1,0 +1,63 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import SimpleBoxPo from '~/cypress/e2e/po/components/simple-box.po';
+
+const burgerMenu = new BurgerMenuPo();
+
+/**
+ * Get Support page
+ */
+export default class SupportPagePo extends PagePo {
+  static url = '/support'
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(SupportPagePo.url);
+  }
+
+  constructor() {
+    super(SupportPagePo.url);
+  }
+
+  static navTo() {
+    BurgerMenuPo.toggle();
+    burgerMenu.support().click();
+  }
+
+  supportLinks(): Cypress.Chainable {
+    const simpleBox = new SimpleBoxPo();
+
+    return simpleBox.simpleBox().find('.support-link > a').should('be.visible');
+  }
+
+  externalSupportLinks(index: number): Cypress.Chainable {
+    return this.self().get('.external .support-link > a').eq(index);
+  }
+
+  /**
+   * Click support link
+   * Cypress does not support multiple tabs - must remove target attribute before clicking
+   * https://docs.cypress.io/guides/references/trade-offs#Multiple-tabs
+   * @param index
+   * @param isNewTab
+   * @returns
+   */
+  clickSupportLink(index: number, isNewTab?: boolean) {
+    if (isNewTab) {
+      this.supportLinks().eq(index).then((el) => {
+        expect(el).to.have.attr('target');
+      }).invoke('removeAttr', 'target')
+        .click();
+    } else {
+      return this.supportLinks().eq(index).then((el) => {
+        expect(el).to.not.have.attr('target');
+      }).click();
+    }
+  }
+
+  clickExternalSupportLinks(index: number) {
+    return this.externalSupportLinks(index).then((el) => {
+      expect(el).to.have.attr('target');
+    })
+      .invoke('removeAttr', 'target')
+      .click();
+  }
+}

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -4,6 +4,9 @@ import BannerGraphicPo from '@/cypress/e2e/po/components/banner-graphic.po';
 import BannersPo from '@/cypress/e2e/po/components/banners.po';
 import SimpleBoxPo from '@/cypress/e2e/po/components/simple-box.po';
 import HomeClusterListPo from '@/cypress/e2e/po/lists/home-cluster-list.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+
+const burgerMenu = new BurgerMenuPo();
 
 export default class HomePagePo extends PagePo {
   static url = '/home'
@@ -31,6 +34,11 @@ export default class HomePagePo extends PagePo {
 
   constructor() {
     super(HomePagePo.url);
+  }
+
+  static navTo() {
+    BurgerMenuPo.toggle();
+    burgerMenu.home().click();
   }
 
   title(): Cypress.Chainable<string> {

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -122,4 +122,12 @@ export default class BurgerMenuPo extends ComponentPo {
   about(): Cypress.Chainable {
     return this.self().contains('About');
   }
+
+  /**
+   * Get the Get Support link
+   * @returns {Cypress.Chainable}
+   */
+  support(): Cypress.Chainable {
+    return this.self().contains('Get Support');
+  }
 }

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -30,8 +30,8 @@ describe('Support Page', () => {
 
     it('can click on Suse Rancher Support link', () => {
       supportPage.clickExternalSupportLinks(0);
-      cy.origin('https://www.suse.com/', () => {
-        cy.url().should('include', 'suse-rancher/support-matrix');
+      cy.origin('https://www.rancher.com/', () => {
+        cy.url().should('include', 'support');
       });
     });
 

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -42,11 +42,8 @@ describe('Support Page', () => {
       });
     });
 
-    it.skip('can click on Docs link', () => {
+    it('can click on Docs link', () => {
       supportPage.supportLinks().should('have.length', 5);
-
-      // click Docs link -- this test will sometimes fail due to https://github.com/rancher/rancher-docs/issues/727
-      // skipping this test until issue is resolved
       supportPage.clickSupportLink(0, true);
       cy.origin('https://ranchermanager.docs.rancher.com', () => {
         cy.url().should('include', 'ranchermanager.docs.rancher.com');

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -31,7 +31,7 @@ describe('Support Page', () => {
     it('can click on Suse Rancher Support link', () => {
       supportPage.clickExternalSupportLinks(0);
       cy.origin('https://www.suse.com/', () => {
-        cy.url().should('contain', 'suse-rancher/support-matrix');
+        cy.url().should('include', 'suse-rancher/support-matrix');
       });
     });
 

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -79,8 +79,8 @@ describe('Support Page', () => {
 
     it('can click on Get Started link', () => {
     // click Get Started link
-      supportPage.clickSupportLink(4);
-      cy.url().should('include', 'docs/getting-started');
+      supportPage.clickSupportLink(4, true);
+      cy.url().should('include', 'ranchermanager.docs.rancher.com/getting-started/overview');
     });
   });
 });

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -5,7 +5,7 @@ import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 const burgerMenu = new BurgerMenuPo();
 const supportPage = new SupportPagePo();
 
-describe('Support Page', { testIsolation: 'off' }, () => {
+describe('Support Page', () => {
   before(() => {
     cy.login();
   });
@@ -22,7 +22,30 @@ describe('Support Page', { testIsolation: 'off' }, () => {
     burgerMenu.support().should('not.exist');
   });
 
-  describe('Support Links', { tags: '@adminUser' }, () => {
+  describe('Get Support Links section', { tags: '@adminUser' }, () => {
+    // Click the support links and verify user lands on the correct page
+    // Note: We need to keep these tests in a separate describe block
+    beforeEach(() => {
+      cy.login();
+      supportPage.goTo();
+    });
+
+    it('can click on Suse Rancher Support link', () => {
+      supportPage.clickExternalSupportLinks(0);
+      cy.origin('https://www.suse.com/suse-rancher/support-matrix', () => {
+        cy.url().should('include', 'suse-rancher/support-matrix');
+      });
+    });
+
+    it('can click on Contact us for pricing link', () => {
+      supportPage.clickExternalSupportLinks(1);
+      cy.origin('https://www.rancher.com/pricing', () => {
+        cy.url().should('include', 'pricing');
+      });
+    });
+  });
+
+  describe('Links section', { testIsolation: 'off', tags: '@adminUser' }, () => {
     // Click the support links and verify user lands on the correct page
     before(() => {
       cy.login();
@@ -71,21 +94,6 @@ describe('Support Page', { testIsolation: 'off' }, () => {
     // click Get Started link
       supportPage.clickSupportLink(4);
       cy.url().should('include', 'docs/getting-started');
-    });
-
-    it('can click on Contact us for pricing link', () => {
-      supportPage.clickExternalSupportLinks(1);
-      cy.origin('https://www.rancher.com/pricing', () => {
-        cy.url().should('include', 'pricing');
-      });
-    });
-
-    it('can click on Suse Rancher Support link', () => {
-      supportPage.clickExternalSupportLinks(0);
-      cy.origin('https://www.suse.com/suse-rancher/support-matrix', () => {
-        cy.on('uncaught:exception', () => false);
-        cy.url().should('include', 'suse-rancher/support-matrix');
-      });
     });
   });
 });

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -1,0 +1,90 @@
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import SupportPagePo from '@/cypress/e2e/po/pages/get-support.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+
+const burgerMenu = new BurgerMenuPo();
+const supportPage = new SupportPagePo();
+
+describe('About Page', { testIsolation: 'off' }, () => {
+  before(() => {
+    cy.login();
+  });
+
+  it('can navigate to Support page', { tags: '@adminUser' }, () => {
+    HomePagePo.goToAndWaitForGet();
+    SupportPagePo.navTo();
+    supportPage.waitForPage();
+  });
+
+  it('standard user does not have access to Support page', { tags: '@standardUser' }, () => {
+    HomePagePo.goToAndWaitForGet();
+    BurgerMenuPo.toggle();
+    burgerMenu.support().should('not.exist');
+  });
+
+  describe('Support Links', { tags: '@adminUser' }, () => {
+    // Click the support links and verify user lands on the correct page
+    before(() => {
+      cy.login();
+    });
+
+    beforeEach(() => {
+      supportPage.goTo();
+    });
+
+    it.skip('can click on Docs link', () => {
+      supportPage.supportLinks().should('have.length', 6);
+
+      // click Docs link -- this test will sometimes fail due to https://github.com/rancher/rancher-docs/issues/727
+      // skipping this test until issue is resolved
+      supportPage.clickSupportLink(0, true);
+      cy.origin('https://ranchermanager.docs.rancher.com', () => {
+        cy.url().should('include', 'ranchermanager.docs.rancher.com');
+      });
+    });
+
+    it('can click on Forums link', () => {
+    // click Forums link
+      supportPage.clickSupportLink(1, true);
+      cy.origin('https://forums.rancher.com', () => {
+        cy.url().should('include', 'forums.rancher.com/');
+      });
+    });
+
+    it('can click on Slack link', () => {
+    // click Slack link
+      supportPage.clickSupportLink(2, true);
+      cy.origin('https://slack.rancher.io', () => {
+        cy.url().should('include', 'slack.rancher.io/');
+      });
+    });
+
+    it('can click on File an Issue link', () => {
+    // click File an Issue link
+      supportPage.clickSupportLink(3, true);
+      cy.origin('https://github.com', () => {
+        cy.url().should('include', 'github.com/login');
+      });
+    });
+
+    it('can click on Get Started link', () => {
+    // click Get Started link
+      supportPage.clickSupportLink(4);
+      cy.url().should('include', 'docs/getting-started');
+    });
+
+    it('can click on Contact us for pricing link', () => {
+      supportPage.clickExternalSupportLinks(1);
+      cy.origin('https://www.rancher.com/pricing', () => {
+        cy.url().should('include', 'pricing');
+      });
+    });
+
+    it('can click on Suse Rancher Support link', () => {
+      supportPage.clickExternalSupportLinks(0);
+      cy.origin('https://www.suse.com/suse-rancher/support-matrix', () => {
+        cy.url().should('include', 'suse-rancher/support-matrix');
+      });
+    });
+  });
+});

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -6,7 +6,7 @@ const burgerMenu = new BurgerMenuPo();
 const supportPage = new SupportPagePo();
 
 describe('Support Page', () => {
-  before(() => {
+  beforeEach(() => {
     cy.login();
   });
 
@@ -25,7 +25,6 @@ describe('Support Page', () => {
   describe('Support Links', { tags: '@adminUser' }, () => {
     // Click the support links and verify user lands on the correct page
     beforeEach(() => {
-      cy.login();
       supportPage.goTo();
     });
 

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -5,7 +5,7 @@ import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 const burgerMenu = new BurgerMenuPo();
 const supportPage = new SupportPagePo();
 
-describe('About Page', { testIsolation: 'off' }, () => {
+describe('Support Page', { testIsolation: 'off' }, () => {
   before(() => {
     cy.login();
   });
@@ -83,6 +83,7 @@ describe('About Page', { testIsolation: 'off' }, () => {
     it('can click on Suse Rancher Support link', () => {
       supportPage.clickExternalSupportLinks(0);
       cy.origin('https://www.suse.com/suse-rancher/support-matrix', () => {
+        cy.on('uncaught:exception', () => false);
         cy.url().should('include', 'suse-rancher/support-matrix');
       });
     });

--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -22,9 +22,8 @@ describe('Support Page', () => {
     burgerMenu.support().should('not.exist');
   });
 
-  describe('Get Support Links section', { tags: '@adminUser' }, () => {
+  describe('Support Links', { tags: '@adminUser' }, () => {
     // Click the support links and verify user lands on the correct page
-    // Note: We need to keep these tests in a separate describe block
     beforeEach(() => {
       cy.login();
       supportPage.goTo();
@@ -32,8 +31,8 @@ describe('Support Page', () => {
 
     it('can click on Suse Rancher Support link', () => {
       supportPage.clickExternalSupportLinks(0);
-      cy.origin('https://www.suse.com/suse-rancher/support-matrix', () => {
-        cy.url().should('include', 'suse-rancher/support-matrix');
+      cy.origin('https://www.suse.com/', () => {
+        cy.url().should('contain', 'suse-rancher/support-matrix');
       });
     });
 
@@ -43,20 +42,9 @@ describe('Support Page', () => {
         cy.url().should('include', 'pricing');
       });
     });
-  });
-
-  describe('Links section', { testIsolation: 'off', tags: '@adminUser' }, () => {
-    // Click the support links and verify user lands on the correct page
-    before(() => {
-      cy.login();
-    });
-
-    beforeEach(() => {
-      supportPage.goTo();
-    });
 
     it.skip('can click on Docs link', () => {
-      supportPage.supportLinks().should('have.length', 6);
+      supportPage.supportLinks().should('have.length', 5);
 
       // click Docs link -- this test will sometimes fail due to https://github.com/rancher/rancher-docs/issues/727
       // skipping this test until issue is resolved

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -8,10 +8,9 @@ const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
 
 describe('Home Page', () => {
-  describe('Home Page', () => {
-    beforeEach(() => {
+  describe('Home Page', { testIsolation: 'off' }, () => {
+    before(() => {
       cy.login();
-
       HomePagePo.goToAndWaitForGet();
     });
 
@@ -60,7 +59,7 @@ describe('Home Page', () => {
      * Click the restore link
      * Verify banners display on home page
      */
-
+      HomePagePo.navTo();
       homePage.restoreAndWait();
 
       homePage.bannerGraphic().graphicBanner().should('be.visible');
@@ -129,6 +128,7 @@ describe('Home Page', () => {
       const clusterManagerPage = new ClusterManagerListPagePo('_');
       const genericCreateClusterPage = new ClusterManagerImportGenericPagePo('_');
 
+      HomePagePo.navTo();
       homePage.manageButton().click();
       clusterManagerPage.waitForPage();
 
@@ -145,7 +145,7 @@ describe('Home Page', () => {
     /**
      * Filter rows in the cluster list
      */
-
+      HomePagePo.navTo();
       homeClusterList.resourceTable().sortableTable().filter('random text');
       homeClusterList.resourceTable().sortableTable().rowElements().should((el) => {
         expect(el).to.contain.text('There are no rows which match your search query.');
@@ -158,19 +158,15 @@ describe('Home Page', () => {
     });
   });
 
-  describe('Support Links', { testIsolation: 'off', tags: ['@adminUser', '@standardUser'] }, () => {
+  describe('Support Links', { tags: ['@adminUser', '@standardUser'] }, () => {
     // Click the support links and verify user lands on the correct page
-    before(() => {
-      cy.login();
-    });
     beforeEach(() => {
+      cy.login();
       HomePagePo.goTo();
     });
-    it.skip('can click on Docs link', () => {
-      homePage.supportLinks().should('have.length', 6);
 
-      // click Docs link -- this test will sometimes fail due to https://github.com/rancher/rancher-docs/issues/727
-      // skipping this test until issue is resolved
+    it('can click on Docs link', () => {
+      homePage.supportLinks().should('have.length', 6);
       homePage.clickSupportLink(0, true);
       cy.origin('https://ranchermanager.docs.rancher.com', () => {
         cy.url().should('include', 'ranchermanager.docs.rancher.com');
@@ -201,8 +197,7 @@ describe('Home Page', () => {
       });
     });
 
-    // this hits the same error as the home page test
-    it.skip('can click on Get Started link', () => {
+    it('can click on Get Started link', () => {
     // click Get Started link
       homePage.clickSupportLink(4, true);
       cy.url().should('include', 'ranchermanager.docs.rancher.com/getting-started/overview');

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -7,7 +7,9 @@ registerCypressGrep();
 
 // TODO handle redirection errors better?
 // we see a lot of 'error navigation cancelled' uncaught exceptions that don't actually break anything; ignore them here
-Cypress.on('uncaught:exception', (e, runnable) => {
+Cypress.on('uncaught:exception', (err, runnable) => {
   // returning false here prevents Cypress from failing the test
-  return false;
+  if (err.message.includes('navigation guard')) {
+    return false;
+  }
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -7,9 +7,7 @@ registerCypressGrep();
 
 // TODO handle redirection errors better?
 // we see a lot of 'error navigation cancelled' uncaught exceptions that don't actually break anything; ignore them here
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on('uncaught:exception', (e, runnable) => {
   // returning false here prevents Cypress from failing the test
-  if (err.message.includes('navigation guard')) {
-    return false;
-  }
+  return false;
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR covers the functionality within the Get Support page
View Test Plan https://github.com/rancher/qa-tasks/issues/764

### Additional Notes:
- added `navTo` method for the Home page and updated those tests
- enabled skipped tests after [bug fix](https://github.com/rancher/rancher-docs/issues/727)