### PR TITLE
Temporary fix for flaky tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
           cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
           cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
-          GREP_TAGS: '@adminUser'
+          GREP_TAGS: '@setup'
           TEST_USERNAME: admin
 
 
@@ -70,7 +70,7 @@ jobs:
           mkdir -p coverage-artifacts/coverage
           cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 
-          GREP_TAGS: '@standardUser'
+          GREP_TAGS: '@flaky'
           TEST_USERNAME: standard_user
         
       - name: Upload coverage

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ env:
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   CYPRESS_coverage: true
   # Build the dashboard to use in tests. When set to false it will grab `latest` from CDN (useful for running e2e tests quickly)
-  BUILD_DASHBOARD: false
+  BUILD_DASHBOARD: true
 
 jobs:
   e2e-test:
@@ -61,7 +61,7 @@ jobs:
           cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
           cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
-          GREP_TAGS: '@setup'
+          GREP_TAGS: '@adminUser'
           TEST_USERNAME: admin
 
       - name: Run standard user tests
@@ -73,7 +73,7 @@ jobs:
           mkdir -p coverage-artifacts/coverage
           cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 
-          GREP_TAGS: '@flaky'
+          GREP_TAGS: '@standardUser'
           TEST_USERNAME: standard_user
         
       - name: Upload coverage

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ env:
   CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   CYPRESS_coverage: true
+  # Build the dashboard to use in tests. When set to false it will grab `latest` from CDN (useful for running e2e tests quickly)
   BUILD_DASHBOARD: false
 
 jobs:
@@ -55,10 +56,10 @@ jobs:
       - name: Run admin user tests
         run: |
           yarn e2e:prod
-          echo "$BUILD_DASHBOARD"
-          [ "$BUILD_DASHBOARD" != "false" ] && mkdir -p coverage-artifacts/coverage
-          [ "$BUILD_DASHBOARD" != "false" ] && cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
-          [ "$BUILD_DASHBOARD" != "false" ] && cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
+          [ "$BUILD_DASHBOARD" != "false" ] || exit 0
+          mkdir -p coverage-artifacts/coverage
+          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
           GREP_TAGS: '@setup'
           TEST_USERNAME: admin
@@ -68,8 +69,9 @@ jobs:
         run: |
           yarn e2e:prod
           yarn docker:local:stop
-          [ "$BUILD_DASHBOARD" != "false" ] && mkdir -p coverage-artifacts/coverage
-          [ "$BUILD_DASHBOARD" != "false" ] && cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          [ "$BUILD_DASHBOARD" != "false" ] || exit 0
+          mkdir -p coverage-artifacts/coverage
+          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 
           GREP_TAGS: '@flaky'
           TEST_USERNAME: standard_user

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,8 +57,8 @@ jobs:
         run: |
           yarn e2e:prod
           mkdir -p coverage-artifacts/coverage
-          [ "$BUILD_DASHBOARD" != "false" ] cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
-          [ "$BUILD_DASHBOARD" != "false" ] cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
+          [ "$BUILD_DASHBOARD" != "false" ] && cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          [ "$BUILD_DASHBOARD" != "false" ] && cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
           GREP_TAGS: '@setup'
           TEST_USERNAME: admin
@@ -69,7 +69,7 @@ jobs:
           yarn e2e:prod
           yarn docker:local:stop
           mkdir -p coverage-artifacts/coverage
-          [ "$BUILD_DASHBOARD" != "false" ] cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          [ "$BUILD_DASHBOARD" != "false" ] && cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 
           GREP_TAGS: '@flaky'
           TEST_USERNAME: standard_user

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,8 +57,8 @@ jobs:
         run: |
           yarn e2e:prod
           mkdir -p coverage-artifacts/coverage
-          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
-          cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
+          [ "$BUILD_DASHBOARD" != "false" ] cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          [ "$BUILD_DASHBOARD" != "false" ] cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
           GREP_TAGS: '@setup'
           TEST_USERNAME: admin
@@ -69,13 +69,14 @@ jobs:
           yarn e2e:prod
           yarn docker:local:stop
           mkdir -p coverage-artifacts/coverage
-          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          [ "$BUILD_DASHBOARD" != "false" ] cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 
           GREP_TAGS: '@flaky'
           TEST_USERNAME: standard_user
         
       - name: Upload coverage
         uses: actions/upload-artifact@v3
+        if: env.BUILD_DASHBOARD != 'false'
         with:
           name: ${{github.run_number}}-${{github.run_attempt}}-coverage
           path: coverage-artifacts/**/*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,7 @@ env:
   CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   CYPRESS_coverage: true
+  BUILD_DASHBOARD: false
 
 jobs:
   e2e-test:
@@ -50,13 +51,12 @@ jobs:
       
       - name: Prepare build
         run: yarn e2e:pre-prod
-        env:
-          BUILD_DASHBOARD: false
       
       - name: Run admin user tests
         run: |
           yarn e2e:prod
-          mkdir -p coverage-artifacts/coverage
+          echo "$BUILD_DASHBOARD"
+          [ "$BUILD_DASHBOARD" != "false" ] && mkdir -p coverage-artifacts/coverage
           [ "$BUILD_DASHBOARD" != "false" ] && cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
           [ "$BUILD_DASHBOARD" != "false" ] && cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
@@ -68,7 +68,7 @@ jobs:
         run: |
           yarn e2e:prod
           yarn docker:local:stop
-          mkdir -p coverage-artifacts/coverage
+          [ "$BUILD_DASHBOARD" != "false" ] && mkdir -p coverage-artifacts/coverage
           [ "$BUILD_DASHBOARD" != "false" ] && cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 
           GREP_TAGS: '@flaky'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
       
       - name: Prepare build
         run: yarn e2e:pre-prod
+        env:
+          BUILD_DASHBOARD: false
       
       - name: Run admin user tests
         run: |
@@ -60,7 +62,6 @@ jobs:
         env: 
           GREP_TAGS: '@setup'
           TEST_USERNAME: admin
-
 
       - name: Run standard user tests
         if: ${{ success() || failure() }}

--- a/cypress/e2e/po/side-bars/user-menu.po.ts
+++ b/cypress/e2e/po/side-bars/user-menu.po.ts
@@ -44,6 +44,7 @@ export default class UserMenuPo extends ComponentPo {
    * Check if menu is open
    */
   isOpen() {
+    // These should fail if `visibility: hidden` - https://docs.cypress.io/guides/core-concepts/interacting-with-elements#Visibility
     this.userMenuContainer().should('be.visible');
     this.userMenu().should('be.visible');
   }
@@ -52,12 +53,16 @@ export default class UserMenuPo extends ComponentPo {
     // Check the user avatar icon is there
     this.checkVisible();
 
+    // cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    this.open();
+
     // Check the v-popper drop down is open, if not open it
     // This isn't a pattern we want to use often, but this area has caused us lots of issues
     // (userMenu can be visible pass checks... but not the parent... making userMenu not visible)
     return this.userMenuContainer().should('have.length.gte', 0)
       .then(($el) => {
         if ($el.length) {
+          // It's meant to be open.... but is it visible? (clicks away from popover will hide it before removing from dom)
           if ($el.attr('style')?.includes('visibility: hidden')) {
             cy.log('User Avatar open but hidden, giving it a nudge');
 

--- a/cypress/e2e/po/side-bars/user-menu.po.ts
+++ b/cypress/e2e/po/side-bars/user-menu.po.ts
@@ -53,6 +53,8 @@ export default class UserMenuPo extends ComponentPo {
     // Check the user avatar icon is there
     this.checkVisible();
 
+    // Yep, these are _horrible_, but flakey user avatar tests have plagued us for months and no-one has yet fixed them
+    // This is a temporary step until that brave, tenacious champion of e2e resolves the underlying issue.
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
     this.open();
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting

--- a/cypress/e2e/po/side-bars/user-menu.po.ts
+++ b/cypress/e2e/po/side-bars/user-menu.po.ts
@@ -53,8 +53,9 @@ export default class UserMenuPo extends ComponentPo {
     // Check the user avatar icon is there
     this.checkVisible();
 
-    // cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
     this.open();
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     // Check the v-popper drop down is open, if not open it
     // This isn't a pattern we want to use often, but this area has caused us lots of issues

--- a/cypress/e2e/tests/pages/explorer/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/workloads/deployments.spec.ts
@@ -6,7 +6,7 @@ describe('Cluster Explorer', () => {
     cy.login();
   });
 
-  describe('Workloads', { tags: ['@standardUser', '@adminUser'] }, () => {
+  describe('Workloads', { tags: ['@standardUser', '@adminUser', '@flaky'] }, () => {
     let deploymentsListPage: WorkloadsDeploymentsListPagePo;
     let deploymentsCreatePage: WorkloadsDeploymentsCreatePagePo;
 
@@ -46,15 +46,15 @@ describe('Cluster Explorer', () => {
       const { name: workloadName, namespace } = createDeploymentBlueprint.metadata;
       const workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(workloadName);
 
-      // Collect the name of the workload for cleanup
-      e2eWorkloads.push({ name: workloadName, namespace });
-
       beforeEach(() => {
         cy.intercept('GET', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('testWorkload');
         cy.intercept('GET', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('clonedPod');
 
         deploymentsListPage.goTo();
         deploymentsListPage.createWithKubectl(createDeploymentBlueprint);
+
+        // Collect the name of the workload for cleanup
+        e2eWorkloads.push({ name: workloadName, namespace });
       });
 
       it('Should be able to scale the number of pods', () => {

--- a/cypress/e2e/tests/pages/explorer/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/workloads/deployments.spec.ts
@@ -89,8 +89,8 @@ describe('Cluster Explorer', () => {
     // This is here because need to delete the workload after the test
     // But need to reuse the same workload for multiple tests
     after(() => {
-      deploymentsListPage.goTo();
-      e2eWorkloads.forEach(({ name, namespace }) => {
+      deploymentsListPage?.goTo();
+      e2eWorkloads?.forEach(({ name, namespace }) => {
         deploymentsListPage.deleteWithKubectl(name, namespace);
       });
     });

--- a/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/account-api-keys.spec.ts
@@ -9,7 +9,7 @@ const accountPage = new AccountPagePo();
 const createKeyPage = new CreateKeyPagePo();
 const apiKeysList = accountPage.list();
 
-describe('User can make changes to their account', { tags: ['@adminUser', '@standardUser'] }, () => {
+describe('User can make changes to their account', { tags: ['@adminUser', '@standardUser', '@flaky'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/user_menu/logout.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/logout.spec.ts
@@ -5,7 +5,7 @@ import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
 const userMenu = new UserMenuPo();
 const loginPage = new LoginPagePo();
 
-describe('User can logout of Rancher', { tags: ['@adminUser', '@standardUser'] }, () => {
+describe('User can logout of Rancher', { tags: ['@adminUser', '@standardUser', '@flaky'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/user_menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user_menu/preferences.spec.ts
@@ -16,7 +16,7 @@ describe('User can update their preferences', () => {
     cy.login();
   });
 
-  it('Can navigate to Preferences Page', { tags: ['@adminUser', '@standardUser'] }, () => {
+  it('Can navigate to Preferences Page', { tags: ['@adminUser', '@standardUser', '@flaky'] }, () => {
     /*
     Open user menu and navigate to Preferences page
     Verify url includes endpoint '/prefs'

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -1,7 +1,7 @@
 import { RancherSetupPagePo } from '@/cypress/e2e/po/pages/rancher-setup.po';
 import { RancherSetupAuthVerifyPage } from '@/cypress/e2e/po/pages/rancher-setup-auth-verify.po';
 
-describe('Rancher setup', { tags: '@adminUser' }, () => {
+describe('Rancher setup', { tags: ['@adminUser', '@setup'] }, () => {
   it('Requires initial setup', () => {
     cy.visit('');
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "e2e:pre-dev": "yarn docker:local:stop && yarn docker:local:start && NODE_ENV=dev TEST_INSTRUMENT=true yarn build",
     "e2e:dev": "START_SERVER_AND_TEST_INSECURE=1 server-test start:dev https-get://localhost:8005 cy:run:sorry",
     "e2e:pre-prod": "yarn docker:local:stop && mkdir dist && TEST_INSTRUMENT=true ./scripts/build-e2e && ./scripts/e2e-docker-start ",
-    "e2e:prod": "GREP_TAGS=$GREP_TAGS TEST_USERNAME=$TEST_USERNAME TEST_BASE_URL=https://127.0.0.1/dashboard yarn cy:run:sorry",
+    "e2e:prod": "BUILD_DASHBOARD=$BUILD_DASHBOARD GREP_TAGS=$GREP_TAGS TEST_USERNAME=$TEST_USERNAME TEST_BASE_URL=https://127.0.0.1/dashboard yarn cy:run:sorry",
     "coverage": "npx nyc merge coverage coverage/coverage.json",
     "storybook": "cd storybook && yarn install && yarn storybook",
     "build-storybook": "cd storybook && yarn install --no-lockfile && NODE_OPTIONS=--max_old_space_size=4096 yarn build-storybook --quiet",

--- a/scripts/build-e2e
+++ b/scripts/build-e2e
@@ -15,24 +15,32 @@ if [[ -n "${BUILD_DEBUG}" ]]; then
     env
 fi
 
+# This can be used to skip building the dashboard if we're solely interested in testing tests / framework
+BUILD_DASHBOARD="${BUILD_DASHBOARD:-true}"
+
 cd $(dirname $0)/..
-
-echo "Building production build for e2e ..."
-yarn --pure-lockfile install
-
-source scripts/version
-echo "BRANCH: ${COMMIT_BRANCH:-<none>}"
-echo "TAG: ${GIT_TAG:-<none>}"
 
 OUTPUT_DIR=dist
 
-echo "Building..."
-COMMIT=${COMMIT} VERSION=${VERSION} OUTPUT_DIR=$OUTPUT_DIR ROUTER_BASE='/dashboard/' RESOURCE_BASE='/dashboard/' yarn run build
+# Note - When fetching dashboard / ui from CDN
+# we can't pull the `latest` or `latest2` directory and we don't build a tar.gz for latest builds...
+# ...so just fetch the latest index.html which references latest CDN bits
+
+if [ "$BUILD_DASHBOARD" == "true" ]; then
+    echo "Building production build for e2e ..."
+    yarn --pure-lockfile install
+
+    source scripts/version
+    echo "BRANCH: ${COMMIT_BRANCH:-<none>}"
+    echo "TAG: ${GIT_TAG:-<none>}"
+
+    echo "Building..."
+    COMMIT=${COMMIT} VERSION=${VERSION} OUTPUT_DIR=$OUTPUT_DIR ROUTER_BASE='/dashboard/' RESOURCE_BASE='/dashboard/' yarn run build
+else
+    curl https://releases.rancher.com/dashboard/latest/index.html -k -o $OUTPUT_DIR/index.html
+fi
 
 # Ensure we have the latest ember (rancher/ui) build as well
-# Note - We can't pull the `latest2` directory from CDN and we don't build a tar.gz for latest builds...
-# ..so just fetch the latest index.html which references latest CDN bits
-
 OUTPUT_EMBER_DIR=dist_ember
 
 echo "Pulling latest rancher/ui"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Temporary fix for flaky user avatar based tests
- Added a way to skip the build
- Added tags for setup and flaky tests

### Occurred changes and/or fixed issues
- Temporary fix for flaky user avatar based tests
  - It's not an ideal solution, but added 2 x 1 second `wait`s to fix flaky tests
    - is quicker than everyone re-trying e2e gate multiple times
    - brings down e2e gate total time to ~55 minutes 
  - The tests have run a total of 8 times (3 as full suite) and all have passed first time.

Also....
- Added an optional, off by default, way to skip the build step and grab the dashboard from CDN
  - `BUILD_DASHBOARD: false`
  - As the code isn't instrumented the code cov parts are skipped
  - This is only good for debugging e2e tests in GH
- Added setup and flaky to some tests.
  - Can be used in conjunction with `BUILD_DASHBOARD` for super quick test runs (15mins)
    - admin tests env `GREP_TAGS: '@setup'`
    - standard user tests env `GREP_TAGS: '@flaky'` 
- Fix failures in deployment spec when no tests run

