### PR TITLE
Removed duplicted error banner when adding user to the cluster

### DIFF
--- a/shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts
@@ -1,0 +1,58 @@
+/* eslint-disable jest/no-hooks */
+import { mount } from '@vue/test-utils';
+import ClusterRoleTemplateBinding from '@shell/edit/management.cattle.io.clusterroletemplatebinding.vue';
+import Banner from '@components/Banner/Banner.vue';
+import CruResource from '@shell/components/CruResource';
+
+describe('view: management.cattle.io.clusterroletemplatebinding should', () => {
+  let wrapper: any;
+
+  const stubs = {
+    ClusterPermissionsEditor: true,
+    Loading:                  true
+  };
+
+  const requiredSetup = () => ({
+    // Remove all these mocks after migration to Vue 2.7/3 due mixin logic
+    mocks: {
+      $store: {
+        getters: {
+          currentStore:              () => 'current_store',
+          'current_store/schemaFor': jest.fn(),
+          'current_store/all':       jest.fn(),
+          currentCluster:            { id: 'my-cluster' },
+          currentProduct:            { inStore: 'whatever' },
+          'i18n/t':                  (val) => val,
+          'i18n/exists':             jest.fn(),
+        },
+        dispatch: { 'management/findAll': () => ([]) }
+      },
+      $fetchState: { pending: false },
+      $route:      { query: { AS: '' } },
+      $router:     {
+        applyQuery: jest.fn(),
+        replace:    jest.fn()
+      },
+    },
+    propsData: { value: {} },
+    stubs,
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  it('should only show one error banner', async() => {
+    const errors = ['mistake!'];
+
+    wrapper = mount(ClusterRoleTemplateBinding, { ...requiredSetup() });
+
+    const cruResourceElem = wrapper.findComponent(CruResource);
+
+    await cruResourceElem.vm.$emit('error', errors);
+
+    const bannerElems = wrapper.findAllComponents(Banner);
+
+    expect(bannerElems).toHaveLength(1);
+  });
+});

--- a/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
+++ b/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
@@ -1,7 +1,6 @@
 <script>
 import CreateEditView from '@shell/mixins/create-edit-view';
 import CruResource from '@shell/components/CruResource';
-import Banner from '@components/Banner/Banner.vue';
 import { MANAGEMENT } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import ClusterPermissionsEditor from '@shell/components/form/Members/ClusterPermissionsEditor';
@@ -9,7 +8,6 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 
 export default {
   components: {
-    Banner,
     ClusterPermissionsEditor,
     CruResource,
     Loading,
@@ -67,12 +65,6 @@ export default {
     <ClusterPermissionsEditor
       v-model="bindings"
       :cluster-name="$store.getters['currentCluster'].id"
-    />
-    <Banner
-      v-for="(err, i) in errors"
-      :key="i"
-      color="error"
-      :label="err"
     />
   </CruResource>
 </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8593
management.cattle.io.clusterroletemplatebinding had an error banner,however it is using CruResource that already handles errors. Duplicated banner was redundant since they display the same array of errors.

### Occurred changes and/or fixed issues
Removed banner from management.cattle.io.clusterroletemplatebinding component

### Technical notes summary
N/A

### Areas or cases that should be tested
Test that the error is still displayed when adding user fails.

### Areas which could experience regressions
N/A

### Screenshot/Video
![D0CD508D-EE2C-447D-8C97-B3E66FC85F66_1_201_a](https://github.com/rancher/dashboard/assets/133266076/e69cb94a-84ff-4283-ab14-4e7c3912ca9a)

