### PR TITLE
default size value for grafana v2

### DIFF
--- a/shell/chart/monitoring/grafana/index.vue
+++ b/shell/chart/monitoring/grafana/index.vue
@@ -136,7 +136,7 @@ export default {
         newValsOut = {
           accessModes:      null,
           storageClassName: null,
-          size:             null,
+          size:             '10Gi',
           subPath:          null,
           type:             'pvc',
           annotations:      null,
@@ -148,7 +148,7 @@ export default {
         newValsOut = {
           accessModes:      null,
           storageClassName: null,
-          size:             null,
+          size:             '10Gi',
           subPath:          null,
           type:             'statefulset',
           enabled:          true,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Default size value for Grafana v2 `10Gi` (same as v1)

Fixes rancher/dashboard#2615 
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video

https://github.com/rancher/dashboard/assets/135728925/dd845141-9e0f-49c1-8b37-4550674c0376


<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->