### PR TITLE
Fix issues with Namespace filter and missing types in Istio view

### DIFF
--- a/shell/config/product/istio.js
+++ b/shell/config/product/istio.js
@@ -1,4 +1,4 @@
-import { AGE, NAME as NAME_HEADER, STATE } from '@shell/config/table-headers';
+import { AGE, NAME as NAME_HEADER, NAMESPACE as NAMESPACE_HEADER, STATE } from '@shell/config/table-headers';
 import { ISTIO } from '@shell/config/types';
 import { DSL, IF_HAVE } from '@shell/store/type-map';
 
@@ -14,9 +14,10 @@ export function init(store) {
   } = DSL(store, NAME);
 
   product({
-    ifHaveGroup: /^(.*\.)*istio\.io$/,
-    ifHave:      IF_HAVE.NOT_V1_ISTIO,
-    icon:        'istio',
+    ifHaveGroup:         /^(.*\.)*istio\.io$/,
+    ifHave:              IF_HAVE.NOT_V1_ISTIO,
+    icon:                'istio',
+    showNamespaceFilter: true,
   });
 
   virtualType({
@@ -42,7 +43,9 @@ export function init(store) {
     'networking.istio.io.envoyfilter',
     'networking.istio.io.serviceentry',
     'networking.istio.io.sidecar',
-    'networking.istio.io.workloadentrie',
+    'networking.istio.io.proxyconfig',
+    'networking.istio.io.workloadentry',
+    'networking.istio.io.workloadgroup',
   ], 'Networking');
 
   basicType([
@@ -58,9 +61,17 @@ export function init(store) {
     'security.istio.io.requestauthentication',
   ], 'Security');
 
+  basicType([
+    'install.istio.io.istiooperator',
+    'telemetry.istio.io.telemetry',
+    'extensions.istio.io.wasmplugin',
+  ], 'Advanced');
+
+
   headers(ISTIO.VIRTUAL_SERVICE, [
     STATE,
     NAME_HEADER,
+    NAMESPACE_HEADER,
     {
       name:      'gateways',
       label:     'Gateways',

--- a/shell/config/product/istio.js
+++ b/shell/config/product/istio.js
@@ -67,7 +67,6 @@ export function init(store) {
     'extensions.istio.io.wasmplugin',
   ], 'Advanced');
 
-
   headers(ISTIO.VIRTUAL_SERVICE, [
     STATE,
     NAME_HEADER,


### PR DESCRIPTION
Fixes #9739 

This PR:

- Ensures that the namespace selector drop down is shown for the Istio product
- Adds 6 missing types for Istio to the Istio product (1 was there but spelt incorrectly)
- Adds the namespace column to the Virtual Services type, since this uses a custom table definition and the namespace column was missing

To test:

- On the local or downstream cluster, install Istio using cluster tools
- Explore the cluster where you installed Istio
- Go to the Istio section in the side nav and verify that the namespace choose appears in the header bar at the top right
- Go to Virtual Services and verify that the table now contains the Namespace column:
<img width="1270" alt="image" src="https://github.com/rancher/dashboard/assets/1955897/b06a98f6-5ca1-4c4e-bdf1-d44fdd85915e">

- Check that the Istio side nav includes a new Advanced section and looks like this:
<img width="320" alt="image" src="https://github.com/rancher/dashboard/assets/1955897/491c8ecd-d7db-4176-b160-a093fc5f0255">
 