### PR TITLE
Don't show registration details for Hosted Kubernetes Providers

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -517,10 +517,6 @@ export default {
         return this.extDetailTabs.registration;
       }
 
-      if ( this.value.isHostedKubernetesProvider && !this.isClusterReady ) {
-        return this.extDetailTabs.registration;
-      }
-
       return false;
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9402
<!-- Define findings related to the feature or bug issue. -->
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This removes the `HostedKubernetesCluster` check from `showRegistration` function where we don't need to registration details. Now the Hosted cluster like EKA/AKS/GKE will not show the registration details.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
After this fix, the registration tab doesn't appear on the cluster page while the cluster is getting provisioned, compared to what we see in #9402 
![Screenshot_20230921_184214](https://github.com/rancher/dashboard/assets/6758282/5b36ceaf-ab7c-42a2-8bc1-3911593da5fe)
