### PR TITLE
save method in model fixes payload, validator catches the rest

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5712,6 +5712,7 @@ validation:
       missingResource: You must specify a Resource for each resource grant
       missingApiGroup: You must specify an API Group for each resource grant
       missingOneResource: You must specify at least one Resource, Non-Resource URL or API Group for each resource grant
+      noResourceAndNonResource: Each rule may contain Resources or Non-Resource URLs but not both
   service:
     externalName:
       none: External Name is required on an ExternalName Service.

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -2,6 +2,8 @@
 import { MANAGEMENT, RBAC } from '@shell/config/types';
 import CruResource from '@shell/components/CruResource';
 import CreateEditView from '@shell/mixins/create-edit-view';
+import FormValidation from '@shell/mixins/form-validation';
+import Error from '@shell/components/form/Error';
 import { RadioGroup } from '@components/Form/Radio';
 import Select from '@shell/components/form/Select';
 import ArrayList from '@shell/components/form/ArrayList';
@@ -58,9 +60,10 @@ export default {
     Tabbed,
     SortableTable,
     Loading,
+    Error
   },
 
-  mixins: [CreateEditView],
+  mixins: [CreateEditView, FormValidation],
 
   async fetch() {
     // We don't want to get all schemas from the cluster because there are
@@ -109,6 +112,9 @@ export default {
       scopedResources:      SCOPED_RESOURCES,
       defaultValue:         false,
       selectFocused:        null,
+      fvFormRuleSets:       [
+        { path: 'displayName', rules: ['required'] }
+      ],
     };
   },
 
@@ -524,7 +530,8 @@ export default {
     :can-yaml="!isCreate"
     :mode="mode"
     :resource="value"
-    :errors="errors"
+    :errors="fvUnreportedValidationErrors"
+    :validation-passed="fvFormIsValid"
     :cancel-event="true"
     @error="e=>errors = e"
     @finish="save"
@@ -568,6 +575,7 @@ export default {
         name-key="displayName"
         description-key="description"
         label="Name"
+        :rules="{ name: fvGetAndReportPathRules('displayName') }"
       />
       <div
         v-if="isRancherType"
@@ -606,6 +614,11 @@ export default {
           :label="t('rbac.roletemplate.tabs.grantResources.label')"
           :weight="1"
         >
+          <Error
+            :value="value.rules"
+            :rules="fvGetAndReportPathRules('rules')"
+            as-banner
+          />
           <ArrayList
             v-model="value.rules"
             label="Resources"

--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -4,7 +4,6 @@ import { CATTLE_API_GROUP, SUBTYPE_MAPPING, CREATE_VERBS } from '@shell/models/m
 import { uniq } from '@shell/utils/array';
 import { get } from '@shell/utils/object';
 import SteveDescriptionModel from '@shell/plugins/steve/steve-description-class';
-import Role from './rbac.authorization.k8s.io.role';
 import { AS, MODE, _CLONE, _UNFLAG } from '@shell/config/query-params';
 
 const BASE = 'user-base';
@@ -16,7 +15,14 @@ const GLOBAL = SUBTYPE_MAPPING.GLOBAL.key;
 
 export default class GlobalRole extends SteveDescriptionModel {
   get customValidationRules() {
-    return Role.customValidationRules();
+    return [
+      {
+        path:       'rules',
+        validators: [`roleTemplateRules:${ this.type }`],
+        nullable:   false,
+        type:       'array',
+      },
+    ];
   }
 
   get details() {
@@ -136,6 +142,15 @@ export default class GlobalRole extends SteveDescriptionModel {
 
   async save() {
     const norman = await this.norman;
+
+    for (const rule of norman.rules) {
+      if (rule.nonResourceURLs.length) {
+        delete rule.resources;
+        delete rule.apiGroups;
+      } else {
+        delete rule.nonResourceURLs;
+      }
+    }
 
     return norman.save();
   }

--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -3,7 +3,6 @@ import { get } from '@shell/utils/object';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { NORMAN } from '@shell/config/types';
 import SteveDescriptionModel from '@shell/plugins/steve/steve-description-class';
-import Role from './rbac.authorization.k8s.io.role';
 import { AS, MODE, _CLONE, _UNFLAG } from '@shell/config/query-params';
 
 export const CATTLE_API_GROUP = '.cattle.io';
@@ -60,7 +59,14 @@ export const CREATE_VERBS = new Set(['PUT', 'blocked-PUT']);
 
 export default class RoleTemplate extends SteveDescriptionModel {
   get customValidationRules() {
-    return Role.customValidationRules();
+    return [
+      {
+        path:       'rules',
+        validators: [`roleTemplateRules:${ this.type }`],
+        nullable:   false,
+        type:       'array',
+      },
+    ];
   }
 
   get details() {
@@ -184,6 +190,15 @@ export default class RoleTemplate extends SteveDescriptionModel {
 
   async save() {
     const norman = await this.norman;
+
+    for (const rule of norman.rules) {
+      if (rule.nonResourceURLs.length) {
+        delete rule.resources;
+        delete rule.apiGroups;
+      } else {
+        delete rule.nonResourceURLs;
+      }
+    }
 
     return norman.save();
   }

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -393,6 +393,18 @@ describe('formRules', () => {
     expect(formRuleResult).toStrictEqual(expectedResult);
   });
 
+  it('"roleTemplateRules" : returns correct message when type is RBAC role rule defines both resources and nonResourceURLs', () => {
+    const testValue: [{}] = [
+      {
+        verbs: ['verb1'], resources: ['resource1'], apiGroups: ['apiGroup1'], nonResourceURLs: ['nonResourceUrl1']
+      }
+    ];
+    const formRuleResult = formRules.roleTemplateRules('rbac.authorization.k8s.io.role')(testValue);
+    const expectedResult = JSON.stringify({ message: 'validation.roleTemplate.roleTemplateRules.noResourceAndNonResource' });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
   it('"roleTemplateRules" : returns correct message when type is RBAC role and value is missing apiGroups', () => {
     const testValue: [{}] = [
       {
@@ -408,7 +420,7 @@ describe('formRules', () => {
   it('"roleTemplateRules" : returns undefined when type is not RBAC role and value contains valid rules', () => {
     const testValue: [{}] = [
       {
-        verbs: ['verb1'], nonResourceURLs: ['nonResourceURL1'], resources: ['resource1'], apiGroups: ['apiGroup1']
+        verbs: ['verb1'], resources: ['resource1'], apiGroups: ['apiGroup1']
       }
     ];
     const formRuleResult = formRules.roleTemplateRules('nonrbactype')(testValue);

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -370,6 +370,10 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions): {
       return t('validation.roleTemplate.roleTemplateRules.missingVerb');
     }
 
+    if (val.some((rule: any) => rule.resources?.length && rule.nonResourceURLs?.length)) {
+      return t('validation.roleTemplate.roleTemplateRules.noResourceAndNonResource');
+    }
+
     if (type === RBAC.ROLE) {
       if (val.some((rule: any) => isEmpty(rule.resources))) {
         return t('validation.roleTemplate.roleTemplateRules.missingResource');

--- a/shell/utils/validators/role-template.js
+++ b/shell/utils/validators/role-template.js
@@ -6,6 +6,10 @@ export function roleTemplateRules(rules = [], getters, errors, validatorArgs = [
     errors.push(getters['i18n/t']('validation.roleTemplate.roleTemplateRules.missingVerb'));
   }
 
+  if (rules.some((rule) => rule.resources?.length && rule.nonResourceURLs?.length)) {
+    errors.push(getters['i18n/t']('validation.roleTemplate.roleTemplateRules.noResourceAndNonResource'));
+  }
+
   if (validatorArgs[0] === RBAC.ROLE) {
     if (rules.some((rule) => isEmpty(rule.resources))) {
       errors.push(getters['i18n/t']('validation.roleTemplate.roleTemplateRules.missingResource'));
@@ -13,7 +17,11 @@ export function roleTemplateRules(rules = [], getters, errors, validatorArgs = [
     if (rules.some((rule) => isEmpty(rule.apiGroups))) {
       errors.push(getters['i18n/t']('validation.roleTemplate.roleTemplateRules.missingApiGroup'));
     }
-  } else if (rules.some((rule) => isEmpty(rule.resources) && isEmpty(rule.nonResourceURLs) && isEmpty(rule.apiGroups))) {
+  } else if (rules.some((rule) => rule.resources?.length && rule.nonResourceUrls?.length)) {
+    errors.push(getters['i18n/t']('validation.roleTemplate.roleTemplateRules.noResourceAndNonResource'));
+  }
+
+  if (rules.some((rule) => isEmpty(rule.resources) && isEmpty(rule.nonResourceURLs) && isEmpty(rule.apiGroups))) {
     errors.push(getters['i18n/t']('validation.roleTemplate.roleTemplateRules.missingOneResource'));
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9078 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Implemented form validation to provide user feedback when they have an invalid rule in their roletemplate. customValidationRules in `management.cattle.io.roletemplate` and `management.cattle.io.globalrole` looked to be broken as they were referencing a non-static method on another model which doesn't work. Changed them to what they had been prior to that breaking change and it seems to work now.

### Areas or cases that should be tested
Add a global role and a cluster role
On both, fill out both Resource and Non-Resource URLs
Notice validation message
Notice "Create" button is disabled

### Areas which could experience regressions
None that I can think of, the only orthogonal code change made here was to code that was in a broken state.

### Screenshot/Video
<img width="982" alt="image" src="https://github.com/rancher/dashboard/assets/37550899/0b9af34b-50e2-41f9-913c-ea13acdde496">
<img width="990" alt="image" src="https://github.com/rancher/dashboard/assets/37550899/da850be4-3524-4ecd-97e9-745bbfcc5d45">
