### PR TITLE
enableRowActions looking at the wrong schema

### DIFF
--- a/shell/list/management.cattle.io.feature.vue
+++ b/shell/list/management.cattle.io.feature.vue
@@ -82,7 +82,7 @@ export default {
     },
 
     enableRowActions() {
-      const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.SETTING);
+      const schema = this.$store.getters[`management/schemaFor`](MANAGEMENT.FEATURE);
 
       return schema?.resourceMethods?.includes('PUT');
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes [rancherlabs/ranchersecurity/1205](https://github.com/rancherlabs/rancher-security/issues/1205)
It looks like the code that should've enabled the row actions on the features list was looking at the `setting` schema instead of the `feature` schema in the management store like it should've been.

### Occurred changes and/or fixed issues
Just changed the type we're looking for on the features list to enable row actions on the features list.

### Technical notes summary
When a user has minimal permissions to change features (presumably uncommon, the user will usually be an admin of some type), it's critical that we validate permissions against the correct schema until a more robust permission checking method can be implemented.

### Areas or cases that should be tested
Should be able to just test the rowActions on the table at `/c/_/settings/management.cattle.io.feature` to make sure they appear correctly when the user has the permissions listed under `https://github.com/rancherlabs/rancher-security/issues/1205`
### Areas which could experience regressions
This is a pretty targeted change, no regressions expected.