### PR TITLE
checks to see if membership editor is project and adds a project filter

### DIFF
--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -56,8 +56,13 @@ export default {
   },
 
   async fetch() {
+    const roleBindingRequestParams = { type: this.type, opt: { force: true } };
+
+    if (this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING && this.parentId) {
+      Object.assign(roleBindingRequestParams, { opt: { filter: { projectId: this.parentId.split('/').join(':') } } });
+    }
     const userHydration = [
-      this.schema ? this.$store.dispatch(`rancher/findAll`, { type: this.type, opt: { force: true } }) : [],
+      this.schema ? this.$store.dispatch(`rancher/findAll`, roleBindingRequestParams) : [],
       this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL }),
       this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }),
       this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.USER })

--- a/shell/plugins/steve/__tests__/getters.spec.ts
+++ b/shell/plugins/steve/__tests__/getters.spec.ts
@@ -68,8 +68,14 @@ describe('steve: getters', () => {
     it('returns a string with a single filter statement applied if a single filter statement is applied', () => {
       expect(urlOptionsGetter('foo', { filter: { bar: 'baz' } })).toBe('foo?bar=baz');
     });
+    it('returns a string with a single filter statement applied and formatted for steve if a single filter statement is applied and the url starts with "/v1"', () => {
+      expect(urlOptionsGetter('/v1/foo', { filter: { bar: 'baz' } })).toBe('/v1/foo?filter=bar=baz&exclude=metadata.managedFields');
+    });
     it('returns a string with a multiple filter statements applied if a single filter statement is applied', () => {
       expect(urlOptionsGetter('foo', { filter: { bar: 'baz', far: 'faz' } })).toBe('foo?bar=baz&far=faz');
+    });
+    it('returns a string with a multiple filter statements applied and formatted for steve if a single filter statement is applied and the url starts with "/v1"', () => {
+      expect(urlOptionsGetter('/v1/foo', { filter: { bar: 'baz', far: 'faz' } })).toBe('/v1/foo?filter=bar=baz&far=faz&exclude=metadata.managedFields');
     });
     it('returns a string with an exclude statement for "bar" and "metadata.managedFields" if excludeFields is a single element array with the string "bar" and the url starts with "/v1/"', () => {
       expect(urlOptionsGetter('/v1/foo', { excludeFields: ['bar'] })).toBe('/v1/foo?exclude=bar&exclude=metadata.managedFields');
@@ -86,8 +92,17 @@ describe('steve: getters', () => {
     it('returns a string with a sorting criteria if the sort option is provided', () => {
       expect(urlOptionsGetter('foo', { sortBy: 'bar' })).toBe('foo?sort=bar');
     });
+    it('returns a string with a sorting criteria formatted for steve if the sort option is provided and the url starts with "/v1"', () => {
+      expect(urlOptionsGetter('/v1/foo', { sortBy: 'bar' })).toBe('/v1/foo?exclude=metadata.managedFields&sort=bar');
+    });
     it('returns a string with a sorting criteria if the sort option is provided and an order if sortOrder is provided', () => {
       expect(urlOptionsGetter('foo', { sortBy: 'bar', sortOrder: 'baz' })).toBe('foo?sort=bar&order=baz');
+    });
+    it('returns a string with a sorting criteria formatted for steve if the sort option is provided and an order if sortOrder is provided and the url starts with "/v1"', () => {
+      expect(urlOptionsGetter('/v1/foo', { sortBy: 'bar', sortOrder: 'baz' })).toBe('/v1/foo?exclude=metadata.managedFields&sort=bar');
+    });
+    it('returns a string with a sorting criteria formatted for steve if the sort option is provided and an order if sortOrder is "desc" and the url starts with "/v1"', () => {
+      expect(urlOptionsGetter('/v1/foo', { sortBy: 'bar', sortOrder: 'desc' })).toBe('/v1/foo?exclude=metadata.managedFields&sort=-bar');
     });
   });
 });

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -31,8 +31,8 @@ export default {
     const isSteve = parsedUrl.path.startsWith('/v1');
 
     // Filter
-    // Steve's filter options work differently nowadays (https://github.com/rancher/steve#filter) #9341
     if ( opt.filter ) {
+      url += `${ (url.includes('?') ? '&' : '?') }`;
       const keys = Object.keys(opt.filter);
 
       keys.forEach((key) => {
@@ -42,9 +42,18 @@ export default {
           vals = [vals];
         }
 
-        vals.forEach((val) => {
-          url += `${ (url.includes('?') ? '&' : '?') + encodeURIComponent(key) }=${ encodeURIComponent(val) }`;
+        // Steve's filter options now support more complex filtering not yet implemented here #9341
+        if (isSteve) {
+          url += `${ (url.includes('filter=') ? '&' : 'filter=') }`;
+        }
+
+        const filterStrings = vals.map((val) => {
+          return `${ encodeURI(key) }=${ encodeURI(val) }`;
         });
+        const urlEnding = url.charAt(url.length - 1);
+        const nextStringConnector = ['&', '?', '='].includes(urlEnding) ? '' : '&';
+
+        url += `${ nextStringConnector }${ filterStrings.join('&') }`;
       });
     }
 
@@ -82,18 +91,21 @@ export default {
     // End: Limit
 
     // Sort
-    // Steve's sort options work differently nowadays (https://github.com/rancher/steve#sort) #9341
+    // Steve's sort options supports multi-column sorting and column specific sort orders, not implemented yet #9341
     const sortBy = opt.sortBy;
-
-    if ( sortBy ) {
-      url += `${ url.includes('?') ? '&' : '?' }sort=${ encodeURIComponent(sortBy) }`;
-    }
-
     const orderBy = opt.sortOrder;
 
-    if ( orderBy ) {
-      url += `${ url.includes('?') ? '&' : '?' }order=${ encodeURIComponent(orderBy) }`;
+    if ( sortBy ) {
+      if (isSteve) {
+        url += `${ url.includes('?') ? '&' : '?' }sort=${ (orderBy === 'desc' ? '-' : '') + encodeURI(sortBy) }`;
+      } else {
+        url += `${ url.includes('?') ? '&' : '?' }sort=${ encodeURI(sortBy) }`;
+        if ( orderBy ) {
+          url += `${ url.includes('?') ? '&' : '?' }order=${ encodeURI(orderBy) }`;
+        }
+      }
     }
+
     // End: Sort
 
     return url;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8574 
Progresses #9341

This looks to be primarily a performance issue wherein loading a project edit page with a 'members' list (actually the `projectRoleTemplateBindings` resource) can either simply fail or get stuck in a repeating pattern at scale due to the way that `projectRoleTemplateBindings` scales across projects and clusters. Adding a project filter to the `projectRoleTemplateBindings` should cut down on the cost of this API call significantly.

### Occurred changes and/or fixed issues
The membership editor will now check if it's type is set to Norman's `projectRoleTemplateBindings` and will append a `projectId` field (Norman specific, Steve's `management.cattle.io.projectRoleTemplateBindings` uses `projectName` but is not used on this page.

While not strictly required by this PR, changes have been added to better support filtering and Sorting for Steve.

Changed out `uriEncodeComponent` for `uriEncode` since `uriEncodeComponent` was encoding characters that it shouldn't such as ":". Tested thoroughly and all existing tests still pass. New tests added to cover Steve specific url options.

### Technical notes summary
Please refer to the ReadMe on https://github.com/rancher/steve to verify URL options correctness for Steve. Specific Correctness of the "projectId" field for Norman's `projectRoleTemplateBindings` can be found on the collection itself under the `filters` key and the API call can also always be called directly or inspected in the network tab of the browser's developer tools to validate correctness. The actual spec used for Norman's query options can be found [here](https://github.com/rancher/api-spec/blob/master/specification.md#filtering).

### Areas or cases that should be tested
This is primarily a performance enhancement, if you'd like to actually see the specific performance impact, you'll want to create a rancher instance with a downstream cluster using ~400 projects and ~150 users on a single-node rancher instance but for the most part what is needed is just simple functional validation. The members list does load, it shows the correct members, no broken API calls, etc...

### Areas which could experience regressions
No Steve API calls were using filters and/or sorting in them so nothing should break there, all existing unit tests on urlOptions still pass so I'm not assuming any regressions there either.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->