### PR TITLE
fix: Adds margins to the app-bar when the global banner is enabled

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -3,6 +3,7 @@ $body-font: 'Lato', arial, helvetica, sans-serif;
 $mono-font: 'Roboto Mono', monospace;
 
 $app-bar-collapsed-width: 70px;
+$app-bar-height-with-global-banner: 2em;
 $max-width: 1440px !default;
 $min-width: 75% !default;
 $input-height: 61px;

--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -3,7 +3,6 @@ $body-font: 'Lato', arial, helvetica, sans-serif;
 $mono-font: 'Roboto Mono', monospace;
 
 $app-bar-collapsed-width: 70px;
-$app-bar-height-with-global-banner: 2em;
 $max-width: 1440px !default;
 $min-width: 75% !default;
 $input-height: 61px;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -45,7 +45,7 @@ export default {
   },
 
   fetch() {
-    this.bannerStoreSettings = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BANNERS);
+    this.bannerStoreSettings = this.fetchBannerSettings;
 
     if (this.hasProvCluster) {
       this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -59,26 +59,24 @@ export default {
       },
     },
 
-    fetchBannerSettings() {
-      return this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BANNERS);
-    },
-    bannerConfiguration() {
+    globalBannerSettings() {
       const settings = this.$store.getters['management/all'](MANAGEMENT.SETTING);
       const bannerSettings = settings.find((s) => s.id === SETTING.BANNERS);
 
       if (bannerSettings) {
         const parsed = JSON.parse(bannerSettings.value);
-        const { showHeader, showFooter } = parsed;
+        const {
+          showFooter, showHeader, bannerFooter, bannerHeader
+        } = parsed;
 
         return {
-          showHeader: showHeader === 'true',
-          showFooter: showFooter === 'true',
+          headerFont: showHeader === 'true' ? this.pxToEm(bannerHeader.fontSize) : '0px',
+          footerFont: showFooter === 'true' ? this.pxToEm(bannerFooter.fontSize) : '0px'
         };
       }
 
       return undefined;
     },
-
     legacyEnabled() {
       return this.features(LEGACY);
     },
@@ -246,11 +244,7 @@ export default {
   watch: {
     $route() {
       this.shown = false;
-    },
-
-    bannerStoreSettings() {
-      this.bannersStatus();
-    },
+    }
   },
 
   mounted() {
@@ -262,6 +256,19 @@ export default {
   },
 
   methods: {
+    /**
+     * Converts a pixel value to an em value based on the default font size.
+     * @param {number} elementFontSize - The font size of the element in pixels.
+     * @param {number} [defaultFontSize=14] - The default font size in pixels.
+     * @returns {string} The converted value in em units.
+     */
+    pxToEm(elementFontSize, defaultFontSize = 14) {
+      const lineHeightInPx = 2 * parseInt(elementFontSize);
+      const lineHeightInEm = lineHeightInPx / defaultFontSize;
+
+      return `${ lineHeightInEm }em`;
+    },
+
     handler(e) {
       if (e.keyCode === KEY.ESCAPE ) {
         this.hide();
@@ -316,7 +323,11 @@ export default {
       <div
         data-testid="side-menu"
         class="side-menu"
-        :class="{'menu-open': shown, 'menu-close':!shown, 'bannerHeader' : bannerConfiguration.showHeader, 'bannerFooter' : bannerConfiguration.showFooter}"
+        :class="{'menu-open': shown, 'menu-close':!shown}"
+        :style="{'marginBottom':
+                   globalBannerSettings?.footerFont,
+                 'marginTop':
+                   globalBannerSettings?.headerFont}"
         tabindex="-1"
       >
         <div class="title">
@@ -705,13 +716,13 @@ export default {
       }
     }
 
-    &.bannerHeader {
-      margin-top: 28px;
-    }
+    // &.bannerHeader {
+    //   margin-top: $app-bar-height-with-global-banner;
+    // }
 
-    &.bannerFooter {
-      margin-bottom: 28px;
-    }
+    // &.bannerFooter {
+    //   margin-bottom: $app-bar-height-with-global-banner;
+    // }
 
     position: fixed;
     top: 0;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -17,7 +17,6 @@ import { isRancherPrime } from '@shell/config/version';
 import Pinned from '@shell/components/nav/Pinned';
 
 export default {
-
   components: {
     BrandImage,
     ClusterIconMenu,
@@ -30,23 +29,19 @@ export default {
     const hasProvCluster = this.$store.getters[`management/schemaFor`](CAPI.RANCHER_CLUSTER);
 
     return {
-      shown:               false,
+      shown:             false,
       displayVersion,
       fullVersion,
-      clusterFilter:       '',
+      clusterFilter:     '',
       hasProvCluster,
-      maxClustersToShow:   MENU_MAX_CLUSTERS,
-      emptyCluster:        BLANK_CLUSTER,
-      showPinClusters:     false,
-      searchActive:        false,
-      bannerStoreSettings: null,
-      bannerConfiguration: null,
+      maxClustersToShow: MENU_MAX_CLUSTERS,
+      emptyCluster:      BLANK_CLUSTER,
+      showPinClusters:   false,
+      searchActive:      false,
     };
   },
 
   fetch() {
-    this.bannerStoreSettings = this.fetchBannerSettings;
-
     if (this.hasProvCluster) {
       this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
     }
@@ -67,13 +62,21 @@ export default {
     fetchBannerSettings() {
       return this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BANNERS);
     },
+    bannerConfiguration() {
+      const settings = this.$store.getters['management/all'](MANAGEMENT.SETTING);
+      const bannerSettings = settings.find((s) => s.id === SETTING.BANNERS);
 
-    dynamicAppBarMargins() {
-      const calcMargins = (val) => {
-        return val === 'true' ? '28px' : '0px';
-      };
+      if (bannerSettings) {
+        const parsed = JSON.parse(bannerSettings.value);
+        const { showHeader, showFooter } = parsed;
 
-      return { marginTop: calcMargins(this.bannerConfiguration?.showHeader), marginBottom: calcMargins(this.bannerConfiguration?.showFooter) };
+        return {
+          showHeader: showHeader === 'true',
+          showFooter: showFooter === 'true',
+        };
+      }
+
+      return undefined;
     },
 
     legacyEnabled() {
@@ -259,20 +262,6 @@ export default {
   },
 
   methods: {
-    bannersStatus() {
-      this.bannerConfiguration = this.fetchBannerSettings;
-
-      if (this.bannerConfiguration) {
-        const parsed = JSON.parse(this.bannerConfiguration.value);
-        const { showHeader, showFooter } = parsed;
-
-        this.bannerConfiguration = {
-          showHeader,
-          showFooter,
-        };
-      }
-    },
-
     handler(e) {
       if (e.keyCode === KEY.ESCAPE ) {
         this.hide();
@@ -327,8 +316,7 @@ export default {
       <div
         data-testid="side-menu"
         class="side-menu"
-        :class="{'menu-open': shown, 'menu-close':!shown}"
-        :style="{...dynamicAppBarMargins}"
+        :class="{'menu-open': shown, 'menu-close':!shown, 'bannerHeader' : bannerConfiguration.showHeader, 'bannerFooter' : bannerConfiguration.showFooter}"
         tabindex="-1"
       >
         <div class="title">
@@ -715,6 +703,14 @@ export default {
         height: 25px;
         fill: var(--header-btn-text);
       }
+    }
+
+    &.bannerHeader {
+      margin-top: 28px;
+    }
+
+    &.bannerFooter {
+      margin-bottom: 28px;
     }
 
     position: fixed;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -68,7 +68,7 @@ export default {
       return this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BANNERS);
     },
 
-    handleGlobalBannerMargins() {
+    dynamicAppBarMargins() {
       const calcMargins = (val) => {
         return val === 'true' ? '28px' : '0px';
       };
@@ -328,7 +328,7 @@ export default {
         data-testid="side-menu"
         class="side-menu"
         :class="{'menu-open': shown, 'menu-close':!shown}"
-        :style="{...handleGlobalBannerMargins}"
+        :style="{...dynamicAppBarMargins}"
         tabindex="-1"
       >
         <div class="title">

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -716,14 +716,6 @@ export default {
       }
     }
 
-    // &.bannerHeader {
-    //   margin-top: $app-bar-height-with-global-banner;
-    // }
-
-    // &.bannerFooter {
-    //   margin-bottom: $app-bar-height-with-global-banner;
-    // }
-
     position: fixed;
     top: 0;
     left: 0px;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -30,19 +30,23 @@ export default {
     const hasProvCluster = this.$store.getters[`management/schemaFor`](CAPI.RANCHER_CLUSTER);
 
     return {
-      shown:             false,
+      shown:               false,
       displayVersion,
       fullVersion,
-      clusterFilter:     '',
+      clusterFilter:       '',
       hasProvCluster,
-      maxClustersToShow: MENU_MAX_CLUSTERS,
-      emptyCluster:      BLANK_CLUSTER,
-      showPinClusters:   false,
-      searchActive:      false
+      maxClustersToShow:   MENU_MAX_CLUSTERS,
+      emptyCluster:        BLANK_CLUSTER,
+      showPinClusters:     false,
+      searchActive:        false,
+      bannerStoreSettings: null,
+      bannerConfiguration: null,
     };
   },
 
   fetch() {
+    this.bannerStoreSettings = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BANNERS);
+
     if (this.hasProvCluster) {
       this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
     }
@@ -58,6 +62,18 @@ export default {
       get() {
         return this.$store.getters['productId'];
       },
+    },
+
+    fetchBannerSettings() {
+      return this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BANNERS);
+    },
+
+    handleGlobalBannerMargins() {
+      const calcMargins = (val) => {
+        return val === 'true' ? '28px' : '0px';
+      };
+
+      return { marginTop: calcMargins(this.bannerConfiguration?.showHeader), marginBottom: calcMargins(this.bannerConfiguration?.showFooter) };
     },
 
     legacyEnabled() {
@@ -227,7 +243,11 @@ export default {
   watch: {
     $route() {
       this.shown = false;
-    }
+    },
+
+    bannerStoreSettings() {
+      this.bannersStatus();
+    },
   },
 
   mounted() {
@@ -239,6 +259,20 @@ export default {
   },
 
   methods: {
+    bannersStatus() {
+      this.bannerConfiguration = this.fetchBannerSettings;
+
+      if (this.bannerConfiguration) {
+        const parsed = JSON.parse(this.bannerConfiguration.value);
+        const { showHeader, showFooter } = parsed;
+
+        this.bannerConfiguration = {
+          showHeader,
+          showFooter,
+        };
+      }
+    },
+
     handler(e) {
       if (e.keyCode === KEY.ESCAPE ) {
         this.hide();
@@ -294,6 +328,7 @@ export default {
         data-testid="side-menu"
         class="side-menu"
         :class="{'menu-open': shown, 'menu-close':!shown}"
+        :style="{...handleGlobalBannerMargins}"
         tabindex="-1"
       >
         <div class="title">
@@ -663,25 +698,25 @@ export default {
   $option-padding-left: 14px;
   $option-height: $icon-size + $option-padding + $option-padding;
 
-  .menu {
-    position: absolute;
-    width: $app-bar-collapsed-width;
-    height: 54px;
-    top: 0;
-    grid-area: menu;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    .menu-icon {
-      width: 25px;
-      height: 25px;
-      fill: var(--header-btn-text);
-    }
-  }
-
   .side-menu {
+    .menu {
+      position: absolute;
+      width: $app-bar-collapsed-width;
+      height: 54px;
+      top: 0;
+      grid-area: menu;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      .menu-icon {
+        width: 25px;
+        height: 25px;
+        fill: var(--header-btn-text);
+      }
+    }
+
     position: fixed;
     top: 0;
     left: 0px;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9752 

### Test
Go to https://localhost:8005/c/local/settings/banners and enable the Header Banner, it should now take the whole width on the top of the page. Do the same for the Footer or both, same behavior is expected. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/rancher/dashboard/assets/88777903/fd87a283-af1d-40f5-88a3-9f070ba83431)
