### PR TITLE
Fixed ui-brand value automatically reverted issue

### DIFF
--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -141,13 +141,6 @@ export default {
             }).then((setting) => setting.save());
           }
         }
-      } else if (!neu) {
-        const brandSetting = findBy(this.globalSettings, 'id', SETTING.BRAND);
-
-        if (brandSetting && brandSetting.value !== '') {
-          // 2) There should not be a brand... but there is a brand setting
-          brandSetting.save();
-        }
       }
     }
   },

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -146,7 +146,6 @@ export default {
 
         if (brandSetting && brandSetting.value !== '') {
           // 2) There should not be a brand... but there is a brand setting
-          brandSetting.value = '';
           brandSetting.save();
         }
       }


### PR DESCRIPTION
Fixes #9551

This PR fixes the above issue - as is the brand setting is reset if the CSP adapter is removed but the code for this also is called first time around if there is no CSP adapter, causing the reset.

This PR removes the reset - the only downside is if the CSP adapter is removed, the brand is not reset - but I think that is a fair compromise.
