### PR TITLE
Use Chrome 116 for e2e tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: '14.x'
 
-     - name: Install Chrome 116
+      - name: Install Chrome 116
         run: |
           sudo apt-get install -y wget
           cd /tmp

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,15 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-      
+
+     - name: Install Chrome 116
+        run: |
+          sudo apt-get install -y wget
+          cd /tmp
+          wget -q http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.187-1_amd64.deb
+          sudo apt-get install -y --allow-downgrades ./google-chrome-stable_116.0.5845.187-1_amd64.deb
+          google-chrome --version
+
       - name: Install packages
         run: yarn install:ci
       


### PR DESCRIPTION
Fixes #9755

Chrome 117 introduced a bug with headless mode that is not fixed until version 119.

This PR installs version 116 so that the e2e tests run.