### PR TITLE
Update bulk action condition to check for empty resource actions

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import day from 'dayjs';
+import isEmpty from 'lodash/isEmpty';
 import { dasherize, ucFirst } from '@shell/utils/string';
 import { get, clone } from '@shell/utils/object';
 import { removeObject } from '@shell/utils/array';
@@ -801,7 +802,7 @@ export default {
 
     // Can the action of interest be applied to the specified resource?
     canRunBulkActionOfInterest(resource) {
-      if (!this.actionOfInterest) {
+      if ( !this.actionOfInterest || isEmpty(resource?.availableActions) ) {
         return false;
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9779 
<!-- Define findings related to the feature or bug issue. -->
When removing a namespace from the "Not in a Project" group, this group would still be ran within a method looking for `availableActions`. With the project not being a real resource (or "Project"), it would not have any available actions and would cause the computed method `canRunBulkActionOfInterest` to fail.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added to the first condition to also check for the existence of a resource's `availableActions`.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/40806497/c3799716-c52a-418c-b8d1-02b55a297e4e


