### PR TITLE
Bump the rancher version used in e2e tests to 2.8

### DIFF
--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -14,7 +14,7 @@ docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -e CATTLE_PASSWORD_MIN_LENGTH=3 \
   --name cypress \
   --privileged \
-  rancher/rancher:v2.7-head
+  rancher/rancher:v2.8-head
 
 docker ps
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
bump from 2.7-head to 2.8-head
