### PR TITLE
Automate docs team notification for release notes

### DIFF
--- a/.github/workflows/notify-docs-team.yml
+++ b/.github/workflows/notify-docs-team.yml
@@ -1,0 +1,17 @@
+name: Notify docs team
+
+on:
+  issues:
+      types: 
+        - labeled
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: jenschelkopf/issue-label-notification-action@1.3
+          with:
+             recipients: |
+                  release-note=@martyav
+             message:
+                  'Hello {recipients} - please add this issue to the Rancher release notes.'


### PR DESCRIPTION
This is a clean version of #9767 

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This solely pertains to the Github repo and internal processes.  It adds a Github action that automatically emails the docs team about release notes.

---

We use the `release-note` label to indicate issues that should be added to the release notes. However, unless an engineer or manager alerts the docs team, the docs team receives no notice that the issue needs to be added. Docs writers need to manually check the repo frequently to make sure they don't miss any issues during the release cycle. This can be especially hectic and failure-prone towards the end of a release.

This PR adds a brief (10-14 second) Github action that automatically adds a comment to issues labeled with `release-note`. The comment pings the docs team recipients listed in the .yml, which triggers an email notification that alerts them that an issue needs a release note.

See https://github.com/jenschelkopf/issue-label-notification-action for details on the Github action.