### PR TITLE
account for empty string values in Checked formatter

### DIFF
--- a/shell/components/formatter/Checked.vue
+++ b/shell/components/formatter/Checked.vue
@@ -2,8 +2,10 @@
 
 export default {
   props: {
+    // When sortabletable calculates these values it converts null and undefined to ''
+    // passing '' to a prop typed as Boolean coerces it to true
     value: {
-      type:    Boolean,
+      type:    [String, Boolean],
       default: true
     },
   }

--- a/shell/components/formatter/Checked.vue
+++ b/shell/components/formatter/Checked.vue
@@ -8,12 +8,18 @@ export default {
       type:    [String, Boolean],
       default: true
     },
-  }
+  },
+
+  computed: {
+    checked() {
+      return this.value === true || this.value === 'true';
+    }
+  },
 };
 </script>
 
 <template>
-  <span v-if="value">
+  <span v-if="checked">
     <i class="icon icon-checkmark" />
   </span>
   <span

--- a/shell/components/formatter/__tests__/Checked.test.ts
+++ b/shell/components/formatter/__tests__/Checked.test.ts
@@ -1,0 +1,19 @@
+import { mount } from '@vue/test-utils';
+import Checked from '@shell/components/formatter/Checked.vue';
+
+describe('component: Checked', () => {
+  it.each([true, 'abc'])('should display a checkmark when the value is truthy', (value: any) => {
+    const wrapper = mount(Checked, { propsData: { value } });
+    const checkmark = wrapper.find('.icon-checkmark');
+
+    expect(checkmark.exists()).toBe(true);
+  });
+
+  it.each([false, ''])('should not display a checkmark when the value is falsy', (value: any) => {
+    const wrapper = mount(Checked, { propsData: { value } });
+
+    const checkmark = wrapper.find('.icon-checkmark');
+
+    expect(checkmark.exists()).toBe(false);
+  });
+});

--- a/shell/components/formatter/__tests__/Checked.test.ts
+++ b/shell/components/formatter/__tests__/Checked.test.ts
@@ -2,14 +2,14 @@ import { mount } from '@vue/test-utils';
 import Checked from '@shell/components/formatter/Checked.vue';
 
 describe('component: Checked', () => {
-  it.each([true, 'abc'])('should display a checkmark when the value is truthy', (value: any) => {
+  it.each([true, 'true'])('should display a checkmark when the value is true or "true"', (value: any) => {
     const wrapper = mount(Checked, { propsData: { value } });
     const checkmark = wrapper.find('.icon-checkmark');
 
     expect(checkmark.exists()).toBe(true);
   });
 
-  it.each([false, ''])('should not display a checkmark when the value is falsy', (value: any) => {
+  it.each([false, '', 'abc'])('should not display a checkmark when the value is anything other than true or "true"', (value: any) => {
     const wrapper = mount(Checked, { propsData: { value } });
 
     const checkmark = wrapper.find('.icon-checkmark');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9800 


### Technical notes summary
The 'Built-In' column references a property on the globalrole object: when a custom role is created, that property is undefined. Sortable table converts undefined values to empty strings: https://github.com/rancher/dashboard/blob/master/shell/components/SortableTable/index.vue#L776-L778. Vue coerces empty strings to `true` when passed to a Boolean prop..even though an empty string is falsy. This PR updates the `Checked` component to accept string values so it correctly interprets `''` `undefined` and `null` column values as falsy.

### Areas or cases that should be tested
Global roles table + other tables that use the Checked formatter: 
* storage classes
* ingresses
* feature flags
* rke1 snapshots
* user detail view (permissions table)
