### PR TITLE
allow saving global roles with no displayName

### DIFF
--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -152,6 +152,10 @@ export default {
       });
     }
 
+    if (this.value?.metadata?.name && !this.value.displayName) {
+      this.$set(this.value, 'displayName', this.value.metadata.name);
+    }
+
     this.$nextTick(() => {
       this.$emit('set-subtype', this.label);
     });

--- a/shell/components/auth/__tests__/RoleDetailEdit.test.ts
+++ b/shell/components/auth/__tests__/RoleDetailEdit.test.ts
@@ -1,7 +1,6 @@
 import { mount } from '@vue/test-utils';
 import RoleDetailEdit from '@shell/components/auth/RoleDetailEdit.vue';
 import { SUBTYPE_MAPPING } from '@shell/models/management.cattle.io.roletemplate';
-import jestConfig from '~/jest.config';
 
 const role = {
   apiVersion:            'management.cattle.io/v3',

--- a/shell/components/auth/__tests__/RoleDetailEdit.test.ts
+++ b/shell/components/auth/__tests__/RoleDetailEdit.test.ts
@@ -1,0 +1,42 @@
+import { mount } from '@vue/test-utils';
+import RoleDetailEdit from '@shell/components/auth/RoleDetailEdit.vue';
+import { SUBTYPE_MAPPING } from '@shell/models/management.cattle.io.roletemplate';
+import jestConfig from '~/jest.config';
+
+const role = {
+  apiVersion:            'management.cattle.io/v3',
+  kind:                  'GlobalRole',
+  metadata:              { name: 'global-role-with-inherited' },
+  inheritedClusterRoles: ['cluster-admin'],
+  rules:
+[{
+  verbs:     ['get', 'list'],
+  resources: ['pods'],
+  apiGroups: ['']
+}],
+  subtype: SUBTYPE_MAPPING.GLOBAL.id
+};
+
+describe('component: RoleDetailEdit', () => {
+  it('does not have validation errors when the role has no displayName', () => {
+    const wrapper = mount(RoleDetailEdit, {
+      propsData: { value: role },
+      mocks:     {
+        $fetchState: { pending: false },
+        $route:      { name: 'anything' },
+        $store:      {
+          getters: {
+            currentStore: () => 'store', 'i18n/t': jest.fn(), 'store/schemaFor': jest.fn()
+          }
+        }
+      },
+      stubs: {
+        CruResource: { template: '<div><slot></slot></div>' },
+        // NameNsDescription: true,
+        Tab:         { template: '<div><slot></slot></div>' },
+      }
+    });
+
+    expect((wrapper.vm as any).fvFormIsValid).toBe(true);
+  });
+});

--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -144,7 +144,7 @@ export default class GlobalRole extends SteveDescriptionModel {
     const norman = await this.norman;
 
     for (const rule of norman.rules) {
-      if (rule.nonResourceURLs.length) {
+      if (rule.nonResourceURLs && rule.nonResourceURLs.length) {
         delete rule.resources;
         delete rule.apiGroups;
       } else {

--- a/shell/models/management.cattle.io.roletemplate.js
+++ b/shell/models/management.cattle.io.roletemplate.js
@@ -192,7 +192,7 @@ export default class RoleTemplate extends SteveDescriptionModel {
     const norman = await this.norman;
 
     for (const rule of norman.rules) {
-      if (rule.nonResourceURLs.length) {
+      if (rule.nonResourceURLs && rule.nonResourceURLs.length) {
         delete rule.resources;
         delete rule.apiGroups;
       } else {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9802 

### Technical notes summary
In this form NameNsDescription uses `displayName` instead of `metadata.name` - this PR updates the form to set `displayName` if its not defined and `metadata.name` is. I hit another issue editing the example role provided in the issue where the save function fails because `nonResourceURLs` is undefined.


### Areas or cases that should be tested
* editing a custom role without displayName as outlined in the issue
* editing a custom role _with_ displayName
* creating a custom role through the ui
