### PR TITLE
App upgrade notification shown for incorrect app

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
     "storageclass",
     "testid",
     "tolerations",
+    "upgrader",
     "userpreferences",
     "virtualmachine",
     "vuex",

--- a/shell/config/os.ts
+++ b/shell/config/os.ts
@@ -1,0 +1,2 @@
+export const WINDOWS = 'windows';
+export const LINUX = 'linux';

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -12,7 +12,7 @@ import { mapGetters } from 'vuex';
 import { sortBy } from '@shell/utils/sort';
 import { set } from '@shell/utils/object';
 import { mapPref, PROVISIONER, _RKE1, _RKE2 } from '@shell/store/prefs';
-import { filterAndArrangeCharts } from '@shell/store/catalog';
+import { filterAndArrangeCharts } from '@shell/utils/chart';
 import { CATALOG } from '@shell/config/labels-annotations';
 import { CAPI, MANAGEMENT, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE } from '@shell/store/features';

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -14,7 +14,7 @@ import { formatSi, parseSi } from '@shell/utils/units';
 import { CAPI, CATALOG } from '@shell/config/types';
 import { isPrerelease } from '@shell/utils/version';
 import difference from 'lodash/difference';
-import { LINUX } from '@shell/store/catalog';
+import { LINUX } from '@shell/config/os';
 import { clone } from '@shell/utils/object';
 import { merge } from 'lodash';
 

--- a/shell/models/__tests__/catalog.cattle.io.app.test.ts
+++ b/shell/models/__tests__/catalog.cattle.io.app.test.ts
@@ -1,0 +1,80 @@
+import CatalogApp from '@shell/models/catalog.cattle.io.app';
+
+describe('class CatalogApp', () => {
+  describe('should return upgradeAvailable for this chart', () => {
+    describe('as false to be excluded from some logic if', () => {
+      const expectation = false;
+
+      it('is fleet', () => {
+        const catalogApp = new CatalogApp({ spec: { chart: { metadata: { annotations: { 'fleet.cattle.io/bundle-id': 'anything' } } } } });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+
+      it('is managed,', () => {
+        const catalogApp = new CatalogApp({ spec: { chart: { metadata: { annotations: { 'catalog.cattle.io/managed': 'anything' } } } } });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+    });
+
+    describe('as latest version', () => {
+      it('excluding pre-releases', () => {
+        const version = '1';
+        const catalogApp = new CatalogApp({});
+
+        catalogApp.spec = { chart: { metadata: { version: '0' } } };
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => ({ versions: [{ version }] }),
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(version);
+      });
+    });
+
+    describe('as null', () => {
+      const expectation = null;
+
+      it('if no chart', () => {
+        const catalogApp = new CatalogApp({});
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => [],
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+
+      it('if no version is available', () => {
+        const catalogApp = new CatalogApp({});
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => [],
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+
+      it('if current version is the latest', () => {
+        const catalogApp = new CatalogApp({});
+
+        catalogApp.spec = { chart: { metadata: { version: '1' } } };
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => ({ versions: [{ version: '0' }] }),
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+    });
+  });
+});

--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -76,7 +76,7 @@ export default class CatalogApp extends SteveModel {
     const showPreRelease = this.$rootGetters['prefs/get'](SHOW_PRE_RELEASE);
     const currentChartVersion = this.spec?.chart?.metadata?.version;
     const versions = !showPreRelease
-      ? matchingChart.versions.filter((v) => !isPrerelease(v.version))
+      ? matchingChart.versions?.filter((v) => !isPrerelease(v.version))
       : compatibleVersionsFor(matchingChart, workerOSs, showPreRelease);
     const newChartVersion = versions?.[0]?.version;
     const isOlder = compare(currentChartVersion, newChartVersion) < 0;

--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -41,23 +41,10 @@ export default class CatalogApp extends SteveModel {
   }
 
   matchingChart(includeHidden) {
-    const chart = this.spec?.chart;
-
-    if ( !chart ) {
-      return;
-    }
-
-    const chartName = chart.metadata?.name;
-    const preferRepoType = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE];
-    const preferRepoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME];
-    const match = this.$rootGetters['catalog/chart']({
-      chartName,
-      preferRepoType,
-      preferRepoName,
+    return this.$rootGetters['catalog/chart']({
+      chart: this.spec?.chart,
       includeHidden
     });
-
-    return match;
   }
 
   get currentVersion() {
@@ -68,7 +55,7 @@ export default class CatalogApp extends SteveModel {
    * Return possible upgrades
    * false = does not apply (managed by fleet)
    * null = no upgrade found
-   * object = version available to upgrade to
+   * string = version available to upgrade to
    */
   get upgradeAvailable() {
     // Things managed by fleet shouldn't show upgrade available even if there might be.
@@ -79,9 +66,9 @@ export default class CatalogApp extends SteveModel {
       return false;
     }
 
-    const chart = this.matchingChart(false);
+    const matchingChart = this.matchingChart(false);
 
-    if ( !chart ) {
+    if ( !matchingChart ) {
       return null;
     }
 
@@ -89,15 +76,9 @@ export default class CatalogApp extends SteveModel {
     const showPreRelease = this.$rootGetters['prefs/get'](SHOW_PRE_RELEASE);
     const currentChartVersion = this.spec?.chart?.metadata?.version;
     const versions = !showPreRelease
-      ? chart.versions.filter((v) => !isPrerelease(v.version))
-      : compatibleVersionsFor(chart, workerOSs, showPreRelease);
-
+      ? matchingChart.versions.filter((v) => !isPrerelease(v.version))
+      : compatibleVersionsFor(matchingChart, workerOSs, showPreRelease);
     const newChartVersion = versions?.[0]?.version;
-
-    if ( !currentChartVersion || !newChartVersion ) {
-      return null;
-    }
-
     const isOlder = compare(currentChartVersion, newChartVersion) < 0;
 
     if ( isOlder ) {

--- a/shell/models/chart.js
+++ b/shell/models/chart.js
@@ -1,4 +1,4 @@
-import { compatibleVersionsFor } from '@shell/store/catalog';
+import { compatibleVersionsFor } from '@shell/utils/chart';
 import {
   REPO_TYPE, REPO, CHART, VERSION, _FLAGGED, HIDE_SIDE_NAV
 } from '@shell/config/query-params';

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -12,7 +12,7 @@ import { isEmpty } from '@shell/utils/object';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import HybridModel from '@shell/plugins/steve/hybrid-class';
-import { LINUX, WINDOWS } from '@shell/store/catalog';
+import { LINUX, WINDOWS } from '@shell/config/os';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 import { PINNED_CLUSTERS } from '@shell/store/prefs';
 

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -8,7 +8,7 @@ import DateFormatter from '@shell/components/formatter/Date';
 import isEqual from 'lodash/isEqual';
 import { CHART, REPO, REPO_TYPE, VERSION } from '@shell/config/query-params';
 import { mapGetters } from 'vuex';
-import { compatibleVersionsFor } from '@shell/store/catalog';
+import { compatibleVersionsFor } from '@shell/utils/chart';
 import TypeDescription from '@shell/components/TypeDescription';
 export default {
   components: {

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -16,7 +16,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import Select from '@shell/components/form/Select';
 import { mapPref, HIDE_REPOS, SHOW_PRE_RELEASE, SHOW_CHART_MODE } from '@shell/store/prefs';
 import { removeObject, addObject, findBy } from '@shell/utils/array';
-import { compatibleVersionsFor, filterAndArrangeCharts } from '@shell/store/catalog';
+import { compatibleVersionsFor, filterAndArrangeCharts } from '@shell/utils/chart';
 import { CATALOG } from '@shell/config/labels-annotations';
 import { isUIPlugin } from '@shell/config/uiplugins';
 

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -36,7 +36,7 @@ import { ignoreVariables } from './install.helpers';
 import { findBy, insertAt } from '@shell/utils/array';
 import Vue from 'vue';
 import { saferDump } from '@shell/utils/create-yaml';
-import { LINUX, WINDOWS } from '@shell/store/catalog';
+import { LINUX, WINDOWS } from '@shell/config/os';
 
 const VALUES_STATE = {
   FORM: 'FORM',

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -2,7 +2,7 @@
 import { mapGetters } from 'vuex';
 import Loading from '@shell/components/Loading';
 import { _FLAGGED, DEPRECATED, HIDDEN, FROM_TOOLS } from '@shell/config/query-params';
-import { filterAndArrangeCharts } from '@shell/store/catalog';
+import { filterAndArrangeCharts } from '@shell/utils/chart';
 import { CATALOG, MANAGEMENT, NORMAN } from '@shell/config/types';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import LazyImage from '@shell/components/LazyImage';

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -1,0 +1,83 @@
+import { getters } from '../catalog';
+
+describe('getters', () => {
+  describe('chart', () => {
+    describe('should return latest version of matching chart for', () => {
+      it('given parameters', () => {
+        const options = {
+          chartName: 'chartName',
+          repoType:  'repoType',
+          repoName:  'repoName',
+        };
+        const common = { deprecated: false };
+        const chart1 = {
+          ...options,
+          ...common
+        };
+        const chart2 = {
+          ...options,
+          ...common,
+          repoName: 'somethingElse'
+        };
+        const state = {};
+        const stateGetters = { charts: [chart2, chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)(options);
+
+        expect(result).toStrictEqual(chart1);
+      });
+
+      it('given key', () => {
+        const key = 'repoType/repoName/chartName';
+        const chart1 = {
+          chartName:  'chartName',
+          repoType:   'repoType',
+          repoName:   'repoName',
+          deprecated: false
+        };
+        const chart2 = {
+          ...chart1,
+          repoName: 'somethingElse'
+        };
+        const state = {};
+        const stateGetters = { charts: [chart2, chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)({ key });
+
+        expect(result).toStrictEqual(chart1);
+      });
+
+      it.each([
+        {
+          metadata: {
+            name:        'chartName',
+            annotations: {
+              'catalog.cattle.io/ui-source-repo-type': 'repoType',
+              'catalog.cattle.io/ui-source-repo':      'repoName'
+            }
+          }
+        }
+      ])('given chart with same name %p', (chart) => {
+        const chart1 = {
+          chartName:  'chartName',
+          repoType:   'repoType',
+          repoName:   'repoName',
+          deprecated: false
+        };
+        const chart2 = {
+          ...chart1,
+          repoName: 'somethingElse'
+        };
+        const state = {};
+        const stateGetters = { charts: [chart2, chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)({ chart });
+
+        expect(result).toStrictEqual(chart1);
+      });
+    });
+  });
+});

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -64,6 +64,11 @@ describe('getters', () => {
               'catalog.cattle.io/ui-source-repo':      'repoName'
             }
           }
+        },
+        {
+          metadata: { name: 'chartName' },
+          repoType: 'repoType',
+          repoName: 'repoName',
         }
       ])('given chart with same name %p', (chart) => {
         const chart1 = {

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -2,6 +2,12 @@ import { getters } from '../catalog';
 
 describe('getters', () => {
   describe('chart', () => {
+    it('should return nothing if no parameter is passed', () => {
+      const result = (getters.chart as any)({}, {})({});
+
+      expect(result).toBeUndefined();
+    });
+
     describe('should return latest version of matching chart for', () => {
       it('given parameters', () => {
         const options = {

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -2,10 +2,37 @@ import { getters } from '../catalog';
 
 describe('getters', () => {
   describe('chart', () => {
-    it('should return nothing if no parameter is passed', () => {
-      const result = (getters.chart as any)({}, {})({});
+    describe('should return nothing and avoid mismatches', () => {
+      it('if no parameter is passed', () => {
+        const result = (getters.chart as any)({}, {})({});
 
-      expect(result).toBeUndefined();
+        expect(result).toBeUndefined();
+      });
+
+      it.each([
+        {
+          repoType:  'repoType',
+          repoName:  'repoName',
+          chartName: undefined,
+        },
+        {
+          repoType:  undefined,
+          repoName:  'repoName',
+          chartName: 'chartName',
+        },
+        {
+          repoType:  'repoType',
+          repoName:  undefined,
+          chartName: 'chartName',
+        },
+      ])('if missing arguments for filtering', (options) => {
+        const result = (getters.chart as any)({}, {})({
+          key: undefined,
+          ...options
+        });
+
+        expect(result).toBeUndefined();
+      });
     });
 
     describe('should return latest version of matching chart for', () => {
@@ -56,15 +83,6 @@ describe('getters', () => {
       });
 
       it.each([
-        {
-          metadata: {
-            name:        'chartName',
-            annotations: {
-              'catalog.cattle.io/ui-source-repo-type': 'repoType',
-              'catalog.cattle.io/ui-source-repo':      'repoName'
-            }
-          }
-        },
         {
           metadata: { name: 'chartName' },
           repoType: 'repoType',

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -100,7 +100,11 @@ export const getters = {
    */
   chart(state, getters) {
     return ({
-      chart, key, repoType, repoName, chartName, preferRepoType, preferRepoName, includeHidden
+      chart, // to extract parameters
+      key, // filtering mode 1
+      repoType, repoName, chartName, // filtering mode 2
+      preferRepoType, preferRepoName, // sorting
+      includeHidden
     }) => {
       // Get data from the Chart
       if ( chart && !key && !repoType && !repoName && !chartName) {
@@ -109,6 +113,11 @@ export const getters = {
         preferRepoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME];
         repoType = chart.repoType;
         repoName = chart.repoName;
+      }
+
+      // Return nothing if cannot filter the charts, to avoid mismatches
+      if (!(key || (repoType && repoName && chartName))) {
+        return;
       }
 
       // Get data as key of the retrieved Charts (currently same as ID)
@@ -135,6 +144,7 @@ export const getters = {
         return;
       }
 
+      // Sorting by preference
       if ( preferRepoType && preferRepoName ) {
         preferSameRepo(matchingCharts, preferRepoType, preferRepoName);
       }

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -107,6 +107,8 @@ export const getters = {
         chartName = chart.metadata?.name;
         preferRepoType = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE];
         preferRepoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME];
+        repoType = chart.repoType;
+        repoName = chart.repoName;
       }
 
       // Get data as key of the retrieved Charts (currently same as ID)

--- a/shell/types/catalog.ts
+++ b/shell/types/catalog.ts
@@ -1,0 +1,30 @@
+export interface IChartVersions {
+  annotations?: Record<string, any>,
+  version: string,
+}
+
+export interface IChart {
+  versions: IChartVersions[];
+  deprecated: boolean;
+  hidden: boolean;
+  repoKey: string;
+  chartType: string;
+  chartName: string;
+  categories: string[];
+  chartDescription: string;
+  chartNameDisplay: string;
+}
+
+export interface IChartOptions {
+  clusterProvider?: string;
+  operatingSystems?: string | string[];
+  category?: string;
+  searchQuery?: string;
+  showDeprecated?: boolean;
+  showHidden?: boolean;
+  showPrerelease?: boolean;
+  hideRepos?: string[];
+  showRepos?: string[];
+  showTypes?: string[];
+  hideTypes?: string[];
+}

--- a/shell/utils/__tests__/array.test.ts
+++ b/shell/utils/__tests__/array.test.ts
@@ -323,6 +323,11 @@ describe('fx: filterBy', () => {
         expected: { key: 'qux', booleanKey: true }
       },
       {
+        case:     'including part of declared keys and values',
+        keyOrObj: { key: 'qux' },
+        expected: { key: 'qux', booleanKey: true }
+      },
+      {
         case:     'including a matching key',
         keyOrObj: { booleanKey: undefined },
         expected: { key: 'qux', booleanKey: true }

--- a/shell/utils/__tests__/version.test.ts
+++ b/shell/utils/__tests__/version.test.ts
@@ -1,4 +1,40 @@
-import { isDevBuild } from '@shell/utils/version';
+import { isDevBuild, compare } from '@shell/utils/version';
+
+describe('fx: compare', () => {
+  it('should return null if no value is provided', () => {
+    const expectation = null;
+
+    const result = compare();
+
+    expect(result).toStrictEqual(expectation);
+  });
+
+  describe('should return -1', () => {
+    const expectation = -1;
+
+    it('given bigger first value', () => {
+      const result = compare(1, 0);
+
+      expect(result).toStrictEqual(expectation);
+    });
+  });
+
+  describe('should return 1', () => {
+    const expectation = 1;
+
+    it('given 0 to both values', () => {
+      const result = compare(0, 0);
+
+      expect(result).toStrictEqual(expectation);
+    });
+
+    it('given bigger second value', () => {
+      const result = compare(0, 1);
+
+      expect(result).toStrictEqual(expectation);
+    });
+  });
+});
 
 describe('fx: isDevBuild', () => {
   it.each([

--- a/shell/utils/chart.ts
+++ b/shell/utils/chart.ts
@@ -2,7 +2,7 @@ import difference from 'lodash/difference';
 import { isArray } from '@shell/utils/array';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { LINUX } from '@shell/config/os';
-import { isPrerelease } from 'utils/version';
+import { isPrerelease } from '@shell/utils/version';
 import { ensureRegex } from '@shell/utils/string';
 import { sortBy } from '@shell/utils/sort';
 import { IChart, IChartVersions, IChartOptions } from 'types/catalog';

--- a/shell/utils/chart.ts
+++ b/shell/utils/chart.ts
@@ -1,0 +1,91 @@
+import difference from 'lodash/difference';
+import { isArray } from '@shell/utils/array';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { LINUX } from '@shell/config/os';
+import { isPrerelease } from 'utils/version';
+import { ensureRegex } from '@shell/utils/string';
+import { sortBy } from '@shell/utils/sort';
+import { IChart, IChartVersions, IChartOptions } from 'types/catalog';
+
+/*
+catalog.cattle.io/deploys-on-os: OS -> requires global.cattle.OS.enabled: true
+  default: nothing
+catalog.cattle.io/permits-os: OS -> will break on clusters containing nodes that are not OS
+  default if not found: catalog.cattle.io/permits-os: linux
+*/
+export function compatibleVersionsFor(chart: IChart, os?: string | string[], includePrerelease = true): IChartVersions[] {
+  const versions = chart.versions;
+
+  if (os && !isArray(os)) {
+    os = [os as string];
+  }
+
+  return versions.filter((ver) => {
+    const osPermitted = (ver?.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || LINUX).split(',');
+
+    if ( !includePrerelease && isPrerelease(ver.version) ) {
+      return false;
+    }
+
+    if ( !os || difference(os, osPermitted).length === 0) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
+export function filterAndArrangeCharts(charts: IChart[], {
+  clusterProvider = '',
+  operatingSystems,
+  category,
+  searchQuery,
+  showDeprecated = false,
+  showHidden = false,
+  showPrerelease = true,
+  hideRepos = [],
+  showRepos = [],
+  showTypes = [],
+  hideTypes = [],
+}: IChartOptions = {}): IChart[] {
+  const out = charts.filter((c) => {
+    if (
+      ( c.deprecated && !showDeprecated ) ||
+      ( c.hidden && !showHidden ) ||
+      ( hideRepos?.length && hideRepos.includes(c.repoKey) ) ||
+      ( showRepos?.length && !showRepos.includes(c.repoKey) ) ||
+      ( hideTypes?.length && hideTypes.includes(c.chartType) ) ||
+      ( showTypes?.length && !showTypes.includes(c.chartType) ) ||
+      (c.chartName === 'rancher-wins-upgrader' && clusterProvider === 'rke2')
+    ) {
+      return false;
+    }
+
+    if (compatibleVersionsFor(c, operatingSystems, showPrerelease).length <= 0) {
+      // There's no versions compatible with the specified os
+      return false;
+    }
+
+    if ( category && !c.categories.includes(category) ) {
+      // The category filter doesn't match
+      return false;
+    }
+
+    if ( searchQuery ) {
+      // The search filter doesn't match
+      const searchTokens = searchQuery.split(/\s*[, ]\s*/).map((x) => ensureRegex(x, false));
+
+      for ( const token of searchTokens ) {
+        const chartDescription = c.chartDescription || '';
+
+        if ( !c.chartNameDisplay.match(token) && !chartDescription.match(token) ) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  });
+
+  return sortBy(out, ['certifiedSort', 'repoName', 'chartNameDisplay']);
+}

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -21,6 +21,10 @@ export function sortable(str) {
 }
 
 export function compare(in1, in2) {
+  if (in1 === undefined && in2 === undefined) {
+    return null;
+  }
+
   if ( !in1 ) {
     return 1;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9613
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Prevented to display mismatching updates if chart data is malformed and unable to filter other cases.
Specifically, it's not possible to filter charts with the same name using `repoName` and `repoType`.

### Technical notes summary
- Refactored catalog store
  - Moved functions into chart utils with TS and interface based on existing logic
  - Moved constant into config
  - Updated affected cases
- Added tests
  - Catalog model
  - Catalog store
  - Version util `compare()` function
- Updated Version util `compare()` to handle cases without values and return `null`
- Updated test for Array util `filterBy()` for partial object filtering

### Areas or cases that should be tested
Issue is very specific and requires dedicated instance with malformed data.

If necessary to mock, this is the dump:

Path: `/c/local/apps/catalog.cattle.io.app?q=epinio`


<details><summary>Chart model</summary>
<pre><code>
{
    "metadata": {
        "annotations": {
            "catalog.cattle.io/certified": "rancher",
            "catalog.cattle.io/kube-version": ">= 1.16.0-0 < 1.28.0-0",
            "catalog.cattle.io/namespace": "cattle-ui-plugin-system",
            "catalog.cattle.io/os": "linux",
            "catalog.cattle.io/permits-os": "linux, windows",
            "catalog.cattle.io/rancher-version": ">= 2.7.0-0 < 2.8.0-0",
            "catalog.cattle.io/scope": "management",
            "catalog.cattle.io/ui-component": "plugins"
        },
        "apiVersion": "v2",
        "appVersion": "1.9.0-0",
        "description": "Application Development Engine for Kubernetes",
        "icon": "https://raw.githubusercontent.com/rancher/dashboard/0b6cbe93e9ed3292294da178f119a500cc494db9/pkg/epinio/assets/logo-epinio.svg",
        "name": "epinio",
        "type": "application",
        "version": "1.9.0-0"
    },
    "values": {
        "fullnameOverride": "",
        "nameOverride": "",
        "plugin": {
            "enabled": true,
            "noCache": false,
            "versionOverride": ""
        }
    }
}
</code></pre>
</details>


<details><summary>Charts with the name "epinio"</summary>
<pre><code>
[
    {
        "key": "cluster/rancher-charts/epinio",
        "type": "chart",
        "id": "cluster/rancher-charts/epinio",
        "certified": "rancher",
        "sideLabel": "Experimental",
        "repoType": "cluster",
        "repoName": "rancher-charts",
        "repoNameDisplay": "Rancher",
        "certifiedSort": 1,
        "icon": "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/rancher-charts?chartName=epinio&link=icon&version=102.0.4%2Bup1.9.0",
        "color": "rancher",
        "chartType": "app",
        "chartName": "epinio",
        "chartNameDisplay": "Epinio",
        "chartDescription": "Epinio deploys Kubernetes applications directly from source code in one step.",
        "repoKey": "2d3268f0-1bca-4a7c-8049-56345324cd86",
        "versions": [
            {
                "name": "epinio",
                "home": "https://github.com/epinio/epinio",
                "sources": [
                    "https://github.com/epinio/epinio"
                ],
                "version": "102.0.4+up1.9.0",
                "description": "Epinio deploys Kubernetes applications directly from source code in one step.",
                "keywords": [
                    "epinio",
                    "paas"
                ],
                "maintainers": [
                    {
                        "name": "SUSE",
                        "email": "team@epinio.io"
                    }
                ],
                "icon": "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/rancher-charts?chartName=epinio&link=icon&version=102.0.4%2Bup1.9.0",
                "apiVersion": "v2",
                "appVersion": "v1.9.0",
                "annotations": {
                    "artifacthub.io/license": "Apache-2.0",
                    "artifacthub.io/prerelease": "false",
                    "catalog.cattle.io/auto-install": "epinio-crd=match",
                    "catalog.cattle.io/certified": "rancher",
                    "catalog.cattle.io/display-name": "Epinio",
                    "catalog.cattle.io/experimental": "true",
                    "catalog.cattle.io/kube-version": ">= 1.23.0-0 < 1.28.0-0",
                    "catalog.cattle.io/namespace": "cattle-epinio-system",
                    "catalog.cattle.io/permits-os": "linux",
                    "catalog.cattle.io/rancher-version": ">= 2.7.0-0 < 2.8.0-0",
                    "catalog.cattle.io/release-name": "epinio",
                    "catalog.cattle.io/type": "app",
                    "catalog.cattle.io/upstream-version": "1.9.0"
                },
                "dependencies": [
                    {
                        "name": "dex",
                        "repository": "file://./charts/dex",
                        "condition": "global.dex.enabled",
                        "tags": [
                            "dex"
                        ]
                    },
                    {
                        "name": "kubed",
                        "repository": "file://./charts/kubed",
                        "condition": "kubed.enabled, global.kubed.enabled",
                        "tags": [
                            "kubed"
                        ]
                    },
                    {
                        "name": "minio",
                        "repository": "file://./charts/minio",
                        "condition": "minio.enabled, global.minio.enabled",
                        "tags": [
                            "minio"
                        ]
                    },
                    {
                        "name": "s3gw",
                        "repository": "file://./charts/s3gw",
                        "condition": "s3gw.enabled, global.s3gw.enabled",
                        "tags": [
                            "s3gw"
                        ]
                    }
                ],
                "urls": [
                    "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/rancher-charts?chartName=epinio&link=chart&version=102.0.4%2Bup1.9.0"
                ],
                "created": "2023-07-25T13:57:01.838813997+02:00",
                "digest": "553ab5adf47549107e205a2dddf5d362189f525757ef8a69a0bb4d365fe5afa5",
                "key": "cluster/rancher-charts/epinio/102.0.4+up1.9.0",
                "repoType": "cluster",
                "repoName": "rancher-charts"
            },
            {
                "name": "epinio",
                "home": "https://github.com/epinio/epinio",
                "sources": [
                    "https://github.com/epinio/epinio"
                ],
                "version": "102.0.3+up1.8.1",
                "description": "Epinio deploys Kubernetes applications directly from source code in one step.",
                "keywords": [
                    "epinio",
                    "paas"
                ],
                "maintainers": [
                    {
                        "name": "SUSE",
                        "email": "team@epinio.io"
                    }
                ],
                "icon": "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/rancher-charts?chartName=epinio&link=icon&version=102.0.3%2Bup1.8.1",
                "apiVersion": "v2",
                "appVersion": "v1.8.1",
                "annotations": {
                    "artifacthub.io/license": "Apache-2.0",
                    "catalog.cattle.io/auto-install": "epinio-crd=match",
                    "catalog.cattle.io/certified": "rancher",
                    "catalog.cattle.io/display-name": "Epinio",
                    "catalog.cattle.io/experimental": "true",
                    "catalog.cattle.io/kube-version": ">= 1.23.0-0 < 1.28.0-0",
                    "catalog.cattle.io/namespace": "cattle-epinio-system",
                    "catalog.cattle.io/permits-os": "linux",
                    "catalog.cattle.io/rancher-version": ">= 2.7.0-0 < 2.8.0-0",
                    "catalog.cattle.io/release-name": "epinio",
                    "catalog.cattle.io/type": "app",
                    "catalog.cattle.io/upstream-version": "1.6.2"
                },
                "dependencies": [
                    {
                        "name": "dex",
                        "repository": "file://./charts/dex",
                        "condition": "global.dex.enabled",
                        "tags": [
                            "dex"
                        ]
                    },
                    {
                        "name": "kubed",
                        "repository": "file://./charts/kubed",
                        "condition": "kubed.enabled, global.kubed.enabled",
                        "tags": [
                            "kubed"
                        ]
                    },
                    {
                        "name": "minio",
                        "repository": "file://./charts/minio",
                        "condition": "minio.enabled, global.minio.enabled",
                        "tags": [
                            "minio"
                        ]
                    },
                    {
                        "name": "s3gw",
                        "repository": "file://./charts/s3gw",
                        "condition": "s3gw.enabled, global.s3gw.enabled",
                        "tags": [
                            "s3gw"
                        ]
                    }
                ],
                "urls": [
                    "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/rancher-charts?chartName=epinio&link=chart&version=102.0.3%2Bup1.8.1"
                ],
                "created": "2023-06-21T11:13:03.876515375+02:00",
                "digest": "0d71ba6a8d2287ab1816824e136c97b9d94b0e6a9c5b9c1a383a399516c9bbf1",
                "key": "cluster/rancher-charts/epinio/102.0.3+up1.8.1",
                "repoType": "cluster",
                "repoName": "rancher-charts"
            }
        ],
        "categories": [
            "PaaS"
        ],
        "deprecated": false,
        "hidden": false,
        "targetNamespace": "cattle-epinio-system",
        "targetName": "epinio",
        "provides": [],
        "windowsIncompatible": true,
        "deploysOnWindows": false
    },
    {
        "key": "cluster/epinio-extension/epinio",
        "type": "chart",
        "id": "cluster/epinio-extension/epinio",
        "certified": "other",
        "sideLabel": null,
        "repoType": "cluster",
        "repoName": "epinio-extension",
        "repoNameDisplay": "epinio-extension",
        "certifiedSort": 3,
        "icon": "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/epinio-extension?chartName=epinio&link=icon&version=1.9.0-0",
        "color": null,
        "chartType": "app",
        "chartName": "epinio",
        "chartNameDisplay": "epinio",
        "chartDescription": "Application Development Engine for Kubernetes",
        "repoKey": "f0ff1702-a30e-4a23-abbd-6558bd5b9b98",
        "versions": [
            {
                "name": "epinio",
                "version": "1.9.0-0",
                "description": "Application Development Engine for Kubernetes",
                "icon": "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/epinio-extension?chartName=epinio&link=icon&version=1.9.0-0",
                "apiVersion": "v2",
                "appVersion": "1.9.0-0",
                "annotations": {
                    "catalog.cattle.io/certified": "rancher",
                    "catalog.cattle.io/kube-version": ">= 1.16.0-0 < 1.28.0-0",
                    "catalog.cattle.io/namespace": "cattle-ui-plugin-system",
                    "catalog.cattle.io/os": "linux",
                    "catalog.cattle.io/permits-os": "linux, windows",
                    "catalog.cattle.io/rancher-version": ">= 2.7.0-0 < 2.8.0-0",
                    "catalog.cattle.io/scope": "management",
                    "catalog.cattle.io/ui-component": "plugins"
                },
                "type": "application",
                "urls": [
                    "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/epinio-extension?chartName=epinio&link=chart&version=1.9.0-0"
                ],
                "created": "2023-07-24T15:17:33.287309601Z",
                "digest": "929a55b50f7b2c65a8745da32041b4b0d17fa88d52e42c8975e807e611bee681",
                "key": "cluster/epinio-extension/epinio/1.9.0-0",
                "repoType": "cluster",
                "repoName": "epinio-extension"
            }
        ],
        "categories": [],
        "deprecated": false,
        "hidden": false,
        "targetNamespace": "cattle-ui-plugin-system",
        "scope": "management",
        "provides": [],
        "windowsIncompatible": false,
        "deploysOnWindows": false
    },
    {
        "key": "cluster/epinio-repo/epinio",
        "type": "chart",
        "id": "cluster/epinio-repo/epinio",
        "certified": "other",
        "sideLabel": null,
        "repoType": "cluster",
        "repoName": "epinio-repo",
        "repoNameDisplay": "epinio-repo",
        "certifiedSort": 3,
        "icon": "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/epinio-repo?chartName=epinio&link=icon&version=1.10.0",
        "color": null,
        "chartType": "app",
        "chartName": "epinio",
        "chartNameDisplay": "epinio",
        "chartDescription": "Epinio deploys Kubernetes applications directly from source code in one step.",
        "repoKey": "b898243b-8f33-4eba-98c7-def9c2268f25",
        "versions": [
            {
                "name": "epinio",
                "home": "https://github.com/epinio/epinio",
                "sources": [
                    "https://github.com/epinio/epinio"
                ],
                "version": "1.10.0",
                "description": "Epinio deploys Kubernetes applications directly from source code in one step.",
                "keywords": [
                    "epinio",
                    "paas"
                ],
                "maintainers": [
                    {
                        "name": "SUSE",
                        "email": "team@epinio.io"
                    }
                ],
                "icon": "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/epinio-repo?chartName=epinio&link=icon&version=1.10.0",
                "apiVersion": "v2",
                "appVersion": "v1.10.0",
                "annotations": {
                    "artifacthub.io/license": "Apache-2.0",
                    "artifacthub.io/prerelease": "false"
                },
                "dependencies": [
                    {
                        "name": "dex",
                        "version": "0.15.2",
                        "repository": "https://charts.dexidp.io",
                        "condition": "global.dex.enabled",
                        "tags": [
                            "dex"
                        ]
                    },
                    {
                        "name": "minio",
                        "version": "5.0.13",
                        "repository": "https://charts.min.io/",
                        "condition": "minio.enabled, global.minio.enabled",
                        "tags": [
                            "minio"
                        ]
                    },
                    {
                        "name": "kubed",
                        "version": "v0.13.2",
                        "repository": "https://charts.appscode.com/stable/",
                        "condition": "kubed.enabled, global.kubed.enabled",
                        "tags": [
                            "kubed"
                        ]
                    },
                    {
                        "name": "s3gw",
                        "version": "0.14.0",
                        "repository": "https://aquarist-labs.github.io/s3gw-charts",
                        "condition": "s3gw.enabled, global.s3gw.enabled",
                        "tags": [
                            "s3gw"
                        ]
                    }
                ],
                "urls": [
                    "https://localhost:8005/v1/catalog.cattle.io.clusterrepos/epinio-repo?chartName=epinio&link=chart&version=1.10.0"
                ],
                "created": "2023-09-27T12:40:52.402503429Z",
                "digest": "5f8fcb19ed83295f481370b2c51270b29ed4be166d35398ca4f57b5c1001d00e",
                "key": "cluster/epinio-repo/epinio/1.10.0",
                "repoType": "cluster",
                "repoName": "epinio-repo"
            }
        ],
        "categories": [
            "PaaS"
        ],
        "deprecated": false,
        "hidden": false,
        "provides": [],
        "windowsIncompatible": true,
        "deploysOnWindows": false
    }
]
</code></pre>
</details>

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
![Screenshot 2023-09-29 at 10 33 58](https://github.com/rancher/dashboard/assets/5009481/2d258f6c-2c09-483f-9cb3-f8109597e029)
