### PR TITLE
fix Project Resource Quotas Fields Appear to Clear Once Focus has Moved

### DIFF
--- a/shell/components/__tests__/ProjectRow.test.ts
+++ b/shell/components/__tests__/ProjectRow.test.ts
@@ -1,0 +1,63 @@
+import ProjectRow from '@shell/components/form/ResourceQuota/ProjectRow.vue';
+import { RANCHER_TYPES } from '@shell/components/form/ResourceQuota/shared';
+import { shallowMount } from '@vue/test-utils';
+import Vue from 'vue';
+
+const CONFIGMAP_STRING = RANCHER_TYPES[0].value;
+
+describe('component: ProjectRow.vue', () => {
+  const wrapper = shallowMount(ProjectRow,
+    {
+      propsData: {
+        mode:  'edit',
+        types: RANCHER_TYPES,
+        type:  CONFIGMAP_STRING,
+        value: {
+          spec: {
+            namespaceDefaultResourceQuota: { limit: {} },
+            resourceQuota:                 { limit: {} }
+          }
+        }
+      }
+    });
+
+  it('should render the correct input fields and set the correct computed values, based on the provided data', () => {
+    const typeInput = wrapper.find(`[data-testid="projectrow-type-input"]`);
+    const projectQuotaInput = wrapper.find(`[data-testid="projectrow-project-quota-input"]`);
+    const namespaceQuotaInput = wrapper.find(`[data-testid="projectrow-namespace-quota-input"]`);
+
+    expect(typeInput.exists()).toBe(true);
+    expect(projectQuotaInput.exists()).toBe(true);
+    expect(namespaceQuotaInput.exists()).toBe(true);
+    expect(wrapper.vm.resourceQuotaLimit).toStrictEqual({});
+    expect(wrapper.vm.namespaceDefaultResourceQuotaLimit).toStrictEqual({});
+  });
+
+  it('triggering "updateQuotaLimit" should trigger Vue.set with the correct data', () => {
+    const vueSet = jest.spyOn(Vue, 'set');
+
+    wrapper.vm.updateQuotaLimit('resourceQuota', CONFIGMAP_STRING, 10);
+
+    expect(vueSet).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.value).toStrictEqual({
+      spec: {
+        namespaceDefaultResourceQuota: { limit: {} },
+        resourceQuota:                 { limit: { [`${ CONFIGMAP_STRING }`]: 10 } }
+      }
+    });
+  });
+
+  it('triggering "updateType" with the same type that existed should clear limits and trigger emit', () => {
+    wrapper.vm.updateType(CONFIGMAP_STRING);
+
+    expect(wrapper.vm.value).toStrictEqual({
+      spec: {
+        namespaceDefaultResourceQuota: { limit: {} },
+        resourceQuota:                 { limit: {} }
+      }
+    });
+
+    expect(wrapper.emitted('type-change')).toBeTruthy();
+    expect(wrapper.emitted('type-change')[0]).toStrictEqual([CONFIGMAP_STRING]);
+  });
+});

--- a/shell/components/form/ResourceQuota/ProjectRow.vue
+++ b/shell/components/form/ResourceQuota/ProjectRow.vue
@@ -2,6 +2,7 @@
 import Select from '@shell/components/form/Select';
 import UnitInput from '@shell/components/form/UnitInput';
 import { ROW_COMPUTED } from './shared';
+import Vue from 'vue';
 
 export default {
   components: { Select, UnitInput },
@@ -57,10 +58,10 @@ export default {
 
     updateQuotaLimit(prop, type, val) {
       if (!this.value.spec[prop]) {
-        this.value.spec[prop] = { limit: { } };
+        Vue.set(this.value.spec, prop, { limit: { } });
       }
 
-      this.value.spec[prop].limit[type] = val;
+      Vue.set(this.value.spec[prop].limit, type, val);
     }
   },
 };
@@ -75,6 +76,7 @@ export default {
       :mode="mode"
       :value="type"
       :options="types"
+      data-testid="projectrow-type-input"
       @input="updateType($event)"
     />
     <UnitInput
@@ -86,6 +88,7 @@ export default {
       :input-exponent="typeOption.inputExponent"
       :base-unit="typeOption.baseUnit"
       :output-modifier="true"
+      data-testid="projectrow-project-quota-input"
       @input="updateQuotaLimit('resourceQuota', type, $event)"
     />
     <UnitInput
@@ -96,6 +99,7 @@ export default {
       :input-exponent="typeOption.inputExponent"
       :base-unit="typeOption.baseUnit"
       :output-modifier="true"
+      data-testid="projectrow-namespace-quota-input"
       @input="updateQuotaLimit('namespaceDefaultResourceQuota', type, $event)"
     />
   </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9795 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Use `Vue.set` on `ProjectRow` component `updateQuotaLimit` method so that values aren't cleared from the inputs (they weren't being properly set)
- Add unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Create a project under your `local` cluster (no other configs other than `name`)
- Edit the above created project using `Edit config`
- Click >>> `Resource Qoutas` >>> `Add Resource` >>> `Config Maps` >>>
- set `Project Limit` to 200
- set `Namespace Default Limit` to 20
- Check that on blur, the fields remain with the correct value
- Click `Save` and check that the project `Resource Quotas` contains the correct values after save

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/97888974/00fe3a08-a167-4dd1-a4b0-9d99be25936b

