### PR TITLE
add new feature flag to gate workspace change on fleet clusters

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -105,7 +105,7 @@ export default {
       }
 
       return kubeClusters.map((x) => {
-        const pCluster = pClusters?.find((c) => c.mgmt.id === x.id);
+        const pCluster = pClusters?.find((c) => c.mgmt?.id === x.id);
 
         return {
           id:              x.id,

--- a/shell/models/fleet.cattle.io.cluster.js
+++ b/shell/models/fleet.cattle.io.cluster.js
@@ -86,7 +86,7 @@ export default class FleetCluster extends SteveModel {
       return false;
     }
     // https://github.com/rancher/dashboard/issues/9730
-    if (this.isRKE2) {
+    if (this.isRke2) {
       return this.$rootGetters['features/get'](FLEET_WORKSPACE_BACK);
     }
 

--- a/shell/models/fleet.cattle.io.cluster.js
+++ b/shell/models/fleet.cattle.io.cluster.js
@@ -82,9 +82,13 @@ export default class FleetCluster extends SteveModel {
 
   get canChangeWorkspace() {
     // https://github.com/rancher/dashboard/issues/7745
-    if (this.isLocal) return false;
+    if (this.isLocal) {
+      return false;
+    }
     // https://github.com/rancher/dashboard/issues/9730
-    if (this.isRKE2) return this.$rootGetters['features/get'](FLEET_WORKSPACE_BACK);
+    if (this.isRKE2) {
+      return this.$rootGetters['features/get'](FLEET_WORKSPACE_BACK);
+    }
 
     return true;
   }

--- a/shell/models/fleet.cattle.io.cluster.js
+++ b/shell/models/fleet.cattle.io.cluster.js
@@ -5,6 +5,7 @@ import SteveModel from '@shell/plugins/steve/steve-class';
 import { escapeHtml } from '@shell/utils/string';
 import { insertAt } from '@shell/utils/array';
 import jsyaml from 'js-yaml';
+import { FLEET_WORKSPACE_BACK } from '@shell/store/features';
 
 export default class FleetCluster extends SteveModel {
   get _availableActions() {
@@ -80,7 +81,12 @@ export default class FleetCluster extends SteveModel {
   }
 
   get canChangeWorkspace() {
-    return !this.isRke2 && !this.isLocal;
+    // https://github.com/rancher/dashboard/issues/7745
+    if (this.isLocal) return false;
+    // https://github.com/rancher/dashboard/issues/9730
+    if (this.isRKE2) return this.$rootGetters['features/get'](FLEET_WORKSPACE_BACK);
+
+    return true;
   }
 
   get isLocal() {

--- a/shell/store/features.js
+++ b/shell/store/features.js
@@ -31,6 +31,7 @@ export const UNSUPPORTED_STORAGE_DRIVERS = create('unsupported-storage-drivers',
 export const FLEET = create('continuous-delivery', true);
 export const HARVESTER = create('harvester', true);
 export const HARVESTER_CONTAINER = create('harvester-baremetal-container-workload', false);
+export const FLEET_WORKSPACE_BACK = create('provisioningv2-fleet-workspace-back-population', false);
 
 // Not currently used.. no point defining ones we don't use
 // export const EMBEDDED_CLUSTER_API = create('embedded-cluster-api', true);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9730 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add new feature flag to gate workspace change on fleet clusters
- sneaky fix for `id` bug encountered on `provisioning.cattle.io.clusters` list view after deleting clusters

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Cannot repro this because to this date on `v2.8-head` the feature flag `provisioningv2-fleet-workspace-back-population` isn't found.

- Navigate to cluster management and create a RKE2 cluster
- Navigate to Continuous delivery
- Ensure correct workspace with the clusters selected.
- Click on each cluster action
- RKE2 dropdown should have Change workspace action IF it RKE2 and feature flag `provisioningv2-fleet-workspace-back-population` is `true`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/97888974/f604e54d-1f3f-44e7-a791-1998f0cb206e

_sneaky fix screenshots_
![Screenshot 2023-09-29 at 17 02 46](https://github.com/rancher/dashboard/assets/97888974/4b6a89e5-5d1b-4965-8950-291e5fd5c655)
![Screenshot 2023-09-29 at 17 02 57](https://github.com/rancher/dashboard/assets/97888974/251a6db2-d153-40da-beba-47e1c429e1f6)
