### PR TITLE
Bump extension max versions

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",

--- a/shell/scripts/extension/helm/charts/ui-plugin-server/Chart.yaml
+++ b/shell/scripts/extension/helm/charts/ui-plugin-server/Chart.yaml
@@ -1,10 +1,10 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.28.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.29.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows
-  catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.9.0-0'
   catalog.cattle.io/scope: management
   catalog.cattle.io/ui-component: plugins
 apiVersion: v2


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Ensures charts that build from 2.8 code have a max version that includes 2.8
