### PR TITLE
check if a user can list apps before trying to fetch the monitoring app

### DIFF
--- a/shell/components/AlertTable.vue
+++ b/shell/components/AlertTable.vue
@@ -82,14 +82,16 @@ export default {
     },
 
     async fetchDeps() {
-      try {
-        const am = await this.$store.dispatch('cluster/find', { type: ENDPOINTS, id: `${ this.monitoringNamespace }/${ this.alertServiceEndpoint }` });
+      if (this.$store.getters['cluster/canList'](ENDPOINTS)) {
+        try {
+          const am = await this.$store.dispatch('cluster/find', { type: ENDPOINTS, id: `${ this.monitoringNamespace }/${ this.alertServiceEndpoint }` });
 
-        if (!isEmpty(am) && !isEmpty(am.subsets)) {
-          this.alertManagerPoller.start();
+          if (!isEmpty(am) && !isEmpty(am.subsets)) {
+            this.alertManagerPoller.start();
+          }
+        } catch {
+
         }
-      } catch {
-
       }
     },
   }

--- a/shell/components/EtcdInfoBanner.vue
+++ b/shell/components/EtcdInfoBanner.vue
@@ -9,8 +9,18 @@ export default {
   components: { Banner, Loading },
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
-    const res = await this.$store.dispatch(`${ inStore }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
-    const monitoringVersion = res?.currentVersion;
+    let monitoringVersion = '';
+
+    if (this.$store.getters[`${ inStore }/canList}`](CATALOG.APP)) {
+      try {
+        const res = await this.$store.dispatch(`${ inStore }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+
+        monitoringVersion = res?.currentVersion;
+      } catch (err) {
+
+      }
+    }
+
     const leader = await hasLeader(monitoringVersion, this.$store.dispatch, this.currentCluster.id);
 
     this.hasLeader = leader ? this.t('generic.yes') : this.t('generic.no');

--- a/shell/components/GrafanaDashboard.vue
+++ b/shell/components/GrafanaDashboard.vue
@@ -40,13 +40,18 @@ export default {
   },
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
-    const res = await this.$store.dispatch(`${ inStore }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
 
-    this.monitoringVersion = res?.currentVersion;
+    if (this.$store.getters[`${ inStore }/canList`](CATALOG.APP)) {
+      try {
+        const res = await this.$store.dispatch(`${ inStore }/find`, { type: CATALOG.APP, id: 'cattle-monitoring-system/rancher-monitoring' });
+
+        this.monitoringVersion = res?.currentVersion;
+      } catch (err) {}
+    }
   },
   data() {
     return {
-      loading: false, error: false, interval: null, errorTimer: null, monitoringVersion: null
+      loading: false, error: false, interval: null, errorTimer: null, monitoringVersion: ''
     };
   },
   computed: {

--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -63,14 +63,13 @@ export async function allDashboardsExist(store, clusterId, embeddedUrls, storeNa
 
   let monitoringVersion = '';
 
-  if (!projectId) {
+  if (!projectId && store.getters[`${ storeName }/canList`](CATALOG.APP)) {
     try {
       res = await store.dispatch(`${ storeName }/find`, {
         type: CATALOG.APP,
         id:   'cattle-monitoring-system/rancher-monitoring'
       });
     } catch (err) {
-      return false;
     }
 
     monitoringVersion = res?.currentVersion;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9792 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the various components that use rancher monitoring's embedded grafana dashboards so they do not require that the current user can view the monitoring app.

### Technical notes summary
The local cluster's grafana dashboard url is different for some versions of monitoring. Consequently the UI attempts to fetch the monitoring app everywhere the grafana dashboard url is used. As described in #9792 it is possible for a user to have the necessary permissions to view grafana dashboards but no permission to view the monitoring app. This PR updates the grafana url-constructing logic to fall back to the grafana url that's valid for all but two monitoring versions instead of erroring out or hiding the embedded dashboards.

### Areas or cases that should be tested
Grafana links didnt work for me when running the UI locally. I tested this by building and uploading this branch and changing the `ui-dashboard-index` global setting to `https://releases.rancher.com/dashboard/nancy-dev/index.html`


As the user described in #9792, check:
* cluster dashboard metric tabs with monitoring installed
* cluster dashboard _without_ monitoring installed
* workload detail view with monitoring installed
There is a known bug with the monitoring index page: https://github.com/rancher/rancher/issues/43030
