### PR TITLE
Fix custom RKE2 cluster registration command's private IPv6 address.

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -55,7 +55,7 @@ export default {
       this.controlPlane && out.push('--controlplane');
       this.worker && out.push('--worker');
       this.address && out.push(`--address ${ sanitizeIP(this.address) }`);
-      this.internalAddress && out.push(`--internal-address ${ sanitizeValue(this.internalAddress) }`);
+      this.internalAddress && out.push(`--internal-address ${ sanitizeIP(this.internalAddress) }`);
       this.nodeName && out.push(`--node-name ${ sanitizeValue(this.nodeName) }`);
 
       for ( const key in this.labels ) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#9660 

### Occurred changes and/or fixed issues
- Private IPv6 sanitsation. 
- Sanitisation regex removes `:` 
- Move some functions to `utility/string.js`
- Public IPv6 already fixed in rancher/dashboard#9664

### Areas or cases that should be tested
1. Navigate to Cluster Management
2. Switch to RKE2 Clusters
3. Click on `Custom Clusters'
4. Click on create
5. On Registration tab click on `show advanced` between Step 1 and Step 2
6. In the `Node private IP` field add `2001:db8:3333:4444:5555:6666:7777:8888`
7. In step 3 registration command it should display ` --address 2001:db8:3333:4444:5555:6666:7777:8888`

### Areas which could experience regressions
- RKE2 custom cluster provisioning command

### Screenshot/Video
![image](https://github.com/rancher/dashboard/assets/1387263/8c9fdfe3-60a4-4c02-8943-eb6d417da3ac)