### PR TITLE
Fix single product / standalone ui header bottom border

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -706,7 +706,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  $side-menu-logo-margin-left: 5px;
   // It would be nice to grab this from `Group.vue`, but there's margin, padding and border, which is overkill to var
   $side-menu-group-padding-left: 16px;
 
@@ -724,9 +723,11 @@ export default {
       &.isSingleProduct  {
         display: flex;
         justify-content: center;
+
         // Align the icon with the side nav menu items ($side-menu-group-padding-left)
-        // There's margin already in the icon component, so take that in to account ($side-menu-logo-margin-left)
-        margin-left: $side-menu-group-padding-left - $side-menu-logo-margin-left;
+        .side-menu-logo {
+          margin-left: $side-menu-group-padding-left;
+        }
       }
     }
 
@@ -815,7 +816,7 @@ export default {
       display: flex;
       margin-right: 8px;
       height: 55px;
-      margin-left: $side-menu-logo-margin-left;
+      margin-left: 5px;
       max-width: 200px;
       padding: 12px 0;
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Ensure the bottom border of the header goes all the way to the left when the shell is in single product / standalone mode

### Occurred changes and/or fixed issues
- move margin to icon rather than parent
- this overwrites the existing margin-left, so don't need to take that in to account

### Screenshot/Video
Before

![image](https://github.com/rancher/dashboard/assets/18697775/f5708eed-e3c8-4e8d-8217-79e4337ec59c)

After

![image](https://github.com/rancher/dashboard/assets/18697775/7b355646-c482-451e-8ce3-70175b156439)

