### PR TITLE
Annotations display redesign

### DIFF
--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -31,6 +31,22 @@
 
   $drag-over: #DCDEE7;
 
+  // Status colors Yaml
+  $cm-meta: #FFFFFF;
+  $cm-string: #5CE6FF;
+  $cm-number: #63F7C1;
+  $cm-keyword: #FF9C9C;
+  $cm-atom: #CC8DBF;
+  $cm-comment: #E78957;
+
+  // Status colors Yaml variables
+  --cm-meta: #{$cm-meta};
+  --cm-string: #{$cm-string};
+  --cm-number: #{$cm-number};
+  --cm-keyword: #{$cm-keyword};
+  --cm-atom: #{$cm-atom};
+  --cm-comment: #{$cm-comment};
+
   --default                    : #{$dark};
   --default-text               : #{$light};
   --default-hover-bg           : #{darken($dark, 10%)};

--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -31,7 +31,9 @@
 
   $drag-over: #DCDEE7;
 
-  // Status colors Yaml
+  // The library that decorates the code blocks in CodeMirror uses the same colours for light and dark themes.
+  // This causes a contrast and accessibility issues.
+  // To fix the issues we have added new colors to the code blocks in CodeMirror for light and dark themes.
   $cm-meta: #FFFFFF;
   $cm-string: #5CE6FF;
   $cm-number: #63F7C1;
@@ -227,4 +229,5 @@
 
   --product-icon               : #{$lighter};
   --product-icon-active        : #{$lightest};
+  --annotations-hover-bg       : #{$darkest};
 }

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -42,7 +42,10 @@ $selected: rgba(#3D98D3, .5);
 
 $drag-over: #DCDEE7;
 
-// Status colors Yaml
+
+// The library that decorates the code blocks in CodeMirror uses the same colours for light and dark themes.
+// This causes a contrast and accessibility issues.
+// To fix the issues we have added new colors to the code blocks in CodeMirror for light and dark themes.
 $cm-meta: #141419;
 $cm-string: #00529F;
 $cm-number: #005E3B;
@@ -556,4 +559,6 @@ BODY, .theme-light {
 
   --product-icon               : #{$darker};
   --product-icon-active        : #{$darkest};
+
+  --annotations-hover-bg       : #{$lighter};
 }

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -42,6 +42,14 @@ $selected: rgba(#3D98D3, .5);
 
 $drag-over: #DCDEE7;
 
+// Status colors Yaml
+$cm-meta: #141419;
+$cm-string: #00529F;
+$cm-number: #005E3B;
+$cm-keyword: #B94545;
+$cm-atom: #921E80;
+$cm-comment: #8F5536;
+
 BODY, .theme-light {
 
   --primary                    : #{$primary};
@@ -54,6 +62,14 @@ BODY, .theme-light {
   --primary-banner-bg          : #{rgba($primary, 0.15)};
   --primary-light-bg           : #{rgba($primary, 0.05)};
 
+
+  // Status colors Yaml variables
+  --cm-meta: #{$cm-meta};
+  --cm-string: #{$cm-string};
+  --cm-number: #{$cm-number};
+  --cm-keyword: #{$cm-keyword};
+  --cm-atom: #{$cm-atom};
+  --cm-comment: #{$cm-comment};
 
   .text-primary {
     color: var(--primary) !important;
@@ -84,7 +100,6 @@ BODY, .theme-light {
   --link-border             : #{$link};
   --link-banner-bg          : #{rgba($link, 0.15)};
   --link-light-bg           : #{rgba($link, 0.05)};
-
 
 
   .text-link {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -111,6 +111,8 @@ generic:
           =1 {Matches 1 of {total, number}: "{sample}"}
           other {Matches {matched, number} of {total, number}, including "{sample}"}
         }
+  copyValue: Copy value
+  valueCopied: Value copied!
 
 locale:
   en-us: English

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -166,7 +166,7 @@ export default {
     .cm-s-base16-light .cm-atom {
       color: var(--cm-atom);
     }
-     
+
     .cm-meta {
       color: var(--cm-meta);
     }

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -162,6 +162,34 @@ export default {
       height: initial;
       background: none
     }
+    .cm-s-base16-dark .cm-atom,
+    .cm-s-base16-light .cm-atom {
+      color: var(--cm-atom);
+    }
+     
+    .cm-meta {
+      color: var(--cm-meta);
+    }
+
+    .cm-s-base16-dark .cm-comment,
+    .cm-s-base16-light .cm-comment {
+      color: var(--cm-meta);
+    }
+
+    .cm-s-base16-dark .cm-string,
+    .cm-s-base16-light .cm-string {
+      color: var(--cm-string);
+    }
+
+    .cm-s-base16-dark span.cm-keyword,
+    .cm-s-base16-light span.cm-keyword {
+      color: var(--cm-keyword);
+    }
+
+    .cm-s-base16-dark span.cm-number,
+    .cm-s-base16-light span.cm-number {
+      color: var(--cm-number);
+    }
 
     &.as-text-area {
       min-height: 40px;

--- a/shell/components/CopyToClipboardText.vue
+++ b/shell/components/CopyToClipboardText.vue
@@ -1,5 +1,4 @@
 <script>
-import { VTooltip } from 'v-tooltip';
 export default {
   props: {
     text: {
@@ -23,11 +22,7 @@ export default {
   },
 
   data() {
-    return {
-      copied: false,
-      text: "Copy to invite",
-      copyText: ''
-    };
+    return { copied: false };
   },
 
   methods: {
@@ -38,12 +33,14 @@ export default {
         this.copied = true;
 
         let t = event.target;
+
         if (t.tagName === 'I') {
           t = t.parentElement || t;
         }
+
         setTimeout(() => {
           this.copied = false;
-        }, 1000);
+        }, 800);
       }
     },
     reset() {
@@ -54,38 +51,39 @@ export default {
 </script>
 
 <template>
-  <div>
-    <a
-      class="copy-to-clipboard-text"
-      :class="{ 'copied': copied, 'plain': plain}"
-      href="#"
-      @click="clicked"
+  <a
+    v-tooltip="toolTip ? {content: 'Copy value'} : {content: null}"
+    class="copy-to-clipboard-text"
+    :class="{ 'copied': copied, 'plain': plain}"
+    href="#"
+    @click="clicked"
+  >
+    <span v-if="showLabel">{{ text }}</span>
+    <v-popover
+      popover-class="clipboard-text-copied"
+      placement="top"
+      :trigger="toolTip ? 'click' : ''"
+      :open="copied && toolTip"
     >
-      <span v-if="showLabel">{{ text }}</span>
       <i
         class="icon"
         :class="{ 'icon-copy': !copied, 'icon-checkmark': copied}"
       />
-    </a>
-    <v-popover
-      popover-class="localeSelector"
-      placement="top"
-      @click="clicked"
-      @mouseout="reset" 
-    >
-      {{copied}}
-      <a
-        data-testid="locale-selector"
-        class="locale-chooser"
-      >
-        <i class="icon icon-copy" />
-      </a>
       <template slot="popover">
-        <span>test</span>
+        <span>Value copied!</span>
       </template>
     </v-popover>
-  </div>
+  </a>
 </template>
+<style lang="scss">
+  .clipboard-text-copied {
+    .wrapper {
+      .popover-inner {
+        background: var(--tooltip-bg);
+      }
+    }
+  }
+</style>
 <style lang="scss" scoped>
   .copy-to-clipboard-text {
     &.plain {

--- a/shell/components/CopyToClipboardText.vue
+++ b/shell/components/CopyToClipboardText.vue
@@ -43,9 +43,6 @@ export default {
         }, 800);
       }
     },
-    reset() {
-      this.copyText = this.text;
-    }
   }
 };
 </script>

--- a/shell/components/CopyToClipboardText.vue
+++ b/shell/components/CopyToClipboardText.vue
@@ -10,14 +10,10 @@ export default {
       type:    Boolean,
       default: false
     },
-    // Show label before copy-to-clipboard icon
+    // If false Show toolTip instead of label before copy-to-clipboard icon
     showLabel: {
       type:    Boolean,
       default: true
-    },
-    toolTip: {
-      type:    Boolean,
-      default: false
     },
   },
 
@@ -42,14 +38,14 @@ export default {
           this.copied = false;
         }, 800);
       }
-    },
+    }
   }
 };
 </script>
 
 <template>
   <a
-    v-tooltip="toolTip ? {content: 'Copy value'} : {content: null}"
+    v-tooltip="!showLabel ? {content: $store.getters['i18n/t']('generic.copyValue')} : {content: null}"
     class="copy-to-clipboard-text"
     :class="{ 'copied': copied, 'plain': plain}"
     href="#"
@@ -59,15 +55,15 @@ export default {
     <v-popover
       popover-class="clipboard-text-copied"
       placement="top"
-      :trigger="toolTip ? 'click' : ''"
-      :open="copied && toolTip"
+      :trigger="!showLabel ? 'click' : ''"
+      :open="copied && !showLabel"
     >
       <i
         class="icon"
         :class="{ 'icon-copy': !copied, 'icon-checkmark': copied}"
       />
       <template slot="popover">
-        <span>Value copied!</span>
+        <span>{{ t('generic.valueCopied') }}</span>
       </template>
     </v-popover>
   </a>

--- a/shell/components/CopyToClipboardText.vue
+++ b/shell/components/CopyToClipboardText.vue
@@ -1,4 +1,5 @@
 <script>
+import { VTooltip } from 'v-tooltip';
 export default {
   props: {
     text: {
@@ -9,11 +10,24 @@ export default {
     plain: {
       type:    Boolean,
       default: false
-    }
+    },
+    // Show label before copy-to-clipboard icon
+    showLabel: {
+      type:    Boolean,
+      default: true
+    },
+    toolTip: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   data() {
-    return { copied: false };
+    return {
+      copied: false,
+      text: "Copy to invite",
+      copyText: ''
+    };
   },
 
   methods: {
@@ -24,31 +38,53 @@ export default {
         this.copied = true;
 
         let t = event.target;
-
         if (t.tagName === 'I') {
           t = t.parentElement || t;
         }
         setTimeout(() => {
           this.copied = false;
-        }, 500);
+        }, 1000);
       }
     },
+    reset() {
+      this.copyText = this.text;
+    }
   }
 };
 </script>
 
 <template>
-  <a
-    class="copy-to-clipboard-text"
-    :class="{ 'copied': copied, 'plain': plain}"
-    href="#"
-    @click="clicked"
-  >
-    {{ text }} <i
-      class="icon"
-      :class="{ 'icon-copy': !copied, 'icon-checkmark': copied}"
-    />
-  </a>
+  <div>
+    <a
+      class="copy-to-clipboard-text"
+      :class="{ 'copied': copied, 'plain': plain}"
+      href="#"
+      @click="clicked"
+    >
+      <span v-if="showLabel">{{ text }}</span>
+      <i
+        class="icon"
+        :class="{ 'icon-copy': !copied, 'icon-checkmark': copied}"
+      />
+    </a>
+    <v-popover
+      popover-class="localeSelector"
+      placement="top"
+      @click="clicked"
+      @mouseout="reset" 
+    >
+      {{copied}}
+      <a
+        data-testid="locale-selector"
+        class="locale-chooser"
+      >
+        <i class="icon icon-copy" />
+      </a>
+      <template slot="popover">
+        <span>test</span>
+      </template>
+    </v-popover>
+  </div>
 </template>
 <style lang="scss" scoped>
   .copy-to-clipboard-text {

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -2,13 +2,15 @@
 import { mapGetters } from 'vuex';
 import { asciiLike, nlToBr } from '@shell/utils/string';
 import { HIDE_SENSITIVE } from '@shell/store/prefs';
-import CopyToClipboard from '@shell/components/CopyToClipboard';
 import CodeMirror from '@shell/components/CodeMirror';
 import { binarySize } from '@shell/utils/crypto';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 
 export default {
-  components: { CopyToClipboardText, CopyToClipboard, CodeMirror },
+  components: {
+    CopyToClipboardText,
+    CodeMirror
+  },
 
   props: {
     label: {
@@ -155,8 +157,8 @@ export default {
       <CopyToClipboardText
         v-if="copy && !isBinary"
         :text="value"
+        :toolTip="true"
         :showLabel="false"
-        
         action-color=""
       />
       <span

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -157,7 +157,6 @@ export default {
       <CopyToClipboardText
         v-if="copy && !isBinary"
         :text="value"
-        :toolTip="true"
         :showLabel="false"
         action-color=""
       />
@@ -219,7 +218,7 @@ export default {
   padding: 8px 20px;
 
   &:hover {
-    background: var(--sortable-table-header-bg);
+    background: var(--annotations-hover-bg);
   }
 }
 </style>

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -168,7 +168,7 @@ export default {
       <span
         v-else-if="isBinary"
         class="text-italic "
-      >{{ body }}te</span>
+      >{{ body }}</span>
 
       <CodeMirror
         v-else-if="jsonStr"

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -5,9 +5,10 @@ import { HIDE_SENSITIVE } from '@shell/store/prefs';
 import CopyToClipboard from '@shell/components/CopyToClipboard';
 import CodeMirror from '@shell/components/CodeMirror';
 import { binarySize } from '@shell/utils/crypto';
+import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 
 export default {
-  components: { CopyToClipboard, CodeMirror },
+  components: { CopyToClipboardText, CopyToClipboard, CodeMirror },
 
   props: {
     label: {
@@ -150,55 +151,57 @@ export default {
       {{ label }}
     </h5>
 
-    <span
-      v-if="isEmpty"
-      v-t="'detailText.empty'"
-      class="text-italic"
-    />
-    <span
-      v-else-if="isBinary"
-      class="text-italic"
-    >{{ body }}</span>
+    <div class="value-wrapper">
+      <CopyToClipboardText
+        v-if="copy && !isBinary"
+        :text="value"
+        :showLabel="false"
+        
+        action-color=""
+      />
+      <span
+        v-if="isEmpty"
+        v-t="'detailText.empty'"
+        class="text-italic"
+      />
+      <span
+        v-else-if="isBinary"
+        class="text-italic "
+      >{{ body }}te</span>
 
-    <CodeMirror
-      v-else-if="jsonStr"
-      :options="{mode:{name:'javascript', json:true}, lineNumbers:false, foldGutter:false, readOnly:true}"
-      :value="jsonStr"
-      :class="{'conceal': concealed}"
-    />
+      <CodeMirror
+        v-else-if="jsonStr"
+        :options="{mode:{name:'javascript', json:true}, lineNumbers:false, foldGutter:false, readOnly:true}"
+        :value="jsonStr"
+        :class="{'conceal': concealed}"
+      />
 
-    <span
-      v-else
-      v-clean-html="bodyHtml"
-      data-testid="detail-top_html"
-      :class="{'conceal': concealed, 'monospace': monospace && !isBinary}"
-    />
+      <span
+        v-else
+        v-clean-html="bodyHtml"
+        data-testid="detail-top_html"
+        :class="{'conceal': concealed, 'monospace': monospace && !isBinary}"
+      />
 
-    <template v-if="!isBinary && !jsonStr && isLong && !expanded">
-      <a
-        href="#"
-        @click.prevent="expand"
-      >{{ plusMore }}</a>
-    </template>
-
-    <CopyToClipboard
-      v-if="copy && !isBinary"
-      :text="value"
-      class="role-tertiary"
-      action-color=""
-    />
+      <template v-if="!isBinary && !jsonStr && isLong && !expanded">
+        <a
+          href="#"
+          @click.prevent="expand"
+        >{{ plusMore }}</a>
+      </template>
+    </div>
   </div>
 </template>
 
 <style lang='scss' scoped>
 .with-copy {
-  border: solid 1px var(--border);
-  border-radius: var(--border-radius);
-  padding: 10px;
+  // border: solid 1px var(--border);
+  // border-radius: var(--border-radius);
+  padding: 8px 0;
   position: relative;
   background-color: var(--input-bg);
-  border-radius: var(--border-radius);
-  border: solid var(--border-width) var(--input-border);
+  // border-radius: var(--border-radius);
+  // border: solid var(--border-width) var(--input-border);
 
   > button {
     position: absolute;
@@ -211,5 +214,14 @@ export default {
 .monospace {
   white-space: pre-wrap;
   word-wrap: break-all
+}
+
+.value-wrapper {
+  display: flex;
+  padding: 8px 20px;
+
+  &:hover {
+    background: var(--sortable-table-header-bg);
+  }
 }
 </style>

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -197,13 +197,9 @@ export default {
 
 <style lang='scss' scoped>
 .with-copy {
-  // border: solid 1px var(--border);
-  // border-radius: var(--border-radius);
   padding: 8px 0;
   position: relative;
   background-color: var(--input-bg);
-  // border-radius: var(--border-radius);
-  // border: solid var(--border-width) var(--input-border);
 
   > button {
     position: absolute;

--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -341,7 +341,7 @@ export default {
         font-weight: bold;
         margin-left: 20px;
       }
-       
+
       .icon {
         margin-right: 10px;
       }

--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -336,6 +336,19 @@ export default {
 
     .annotation {
       margin-top: 10px;
+
+      h5 {
+        font-weight: bold;
+        margin-left: 20px;
+      }
+       
+      .icon {
+        margin-right: 10px;
+      }
+
+      .CodeMirror-lines {
+        margin: 0;
+      }
     }
 
     .label {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9321
Fixes #9320

<!-- Define findings related to the feature or bug issue. -->
Fixed contrast issues in annotations and the YAML editor for light and dark themes.

### How to test
- Go to any YAML editor section that should have new colors for the light/dark theme 
- got to the node > annotations section should have a new design for the Annotations display section

### XD ref:
Annotations display:  https://xd.adobe.com/view/a9174e68-1483-4027-bca3-d5fb284fd35c-fc44/specs/
YAML new colors: https://xd.adobe.com/view/a2eb73f7-2a3c-4b21-a564-a5f95f4e5dce-f7b8/

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
====== Annotations display ======
<img width="1595" alt="Screenshot 2023-10-03 at 16 35 31" src="https://github.com/rancher/dashboard/assets/18264463/88715f0f-81e7-4b65-83de-f37da251283d">


<img width="1308" alt="Screenshot 2023-10-03 at 16 35 36" src="https://github.com/rancher/dashboard/assets/18264463/a4d80c83-c6ee-4ae1-b1f8-4efdb3e5ffe3">


====== Annotations display light theme ======
<img width="1529" alt="Screenshot 2023-10-03 at 16 36 02" src="https://github.com/rancher/dashboard/assets/18264463/62bb0157-b8a4-40d9-98c2-6515b5ceb8f2">
====== YAML light theme ======
<img width="971" alt="Screenshot 2023-10-03 at 16 36 32" src="https://github.com/rancher/dashboard/assets/18264463/6038c0e0-9cf5-42c5-b9b2-6f65269291c5">
====== YAML dark theme ======
<img width="1422" alt="Screenshot 2023-10-03 at 16 36 43" src="https://github.com/rancher/dashboard/assets/18264463/ad08a838-dd91-48a0-ac05-a6ccbd8e331a">
