### PR TITLE
Updated docs urls

### DIFF
--- a/docusaurus/docs/code-base-works/auth-providers.md
+++ b/docusaurus/docs/code-base-works/auth-providers.md
@@ -37,7 +37,7 @@ Use the steps below to set up a Keycloak instance for dev environments and confi
 
    > Double check the client has the correct checkboxes set, specifically the Mappers `group` entry.
 
-1. Using either the Ember or Vue UI set up the Keycloak auth provider by follow the instructions at [here](https://rancher.com/docs/rancher/v2.6/en/admin-settings/authentication/keycloak-saml/)
+1. Using either the Ember or Vue UI set up the Keycloak auth provider by follow the instructions at [here](https://ranchermanager.docs.rancher.com/v2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-saml)
 
    | Field              | Value                                                                                                                                                                                                                                                                                        |
    | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docusaurus/docs/code-base-works/auth-sessions-and-tokens.md
+++ b/docusaurus/docs/code-base-works/auth-sessions-and-tokens.md
@@ -47,6 +47,6 @@ We don't recommend using session storage for auth because two tabs will have dif
 
 ## Custom NavLinks
 
-To set up a link to a third-party navigation link in the left navigation bar, we recommend using the NavLink custom resource. For more information on how to configure custom NavLinks, see the [Rancher documentation.](https://rancher.com/docs/rancher/v2.6/en/admin-settings/branding/#custom-navigation-links) NavLinks open in another window or tab. You can define grouped entries in them as well.
+To set up a link to a third-party navigation link in the left navigation bar, we recommend using the NavLink custom resource. For more information on how to configure custom NavLinks, see the [Rancher documentation.](https://ranchermanager.docs.rancher.com/v2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/custom-branding#custom-navigation-links) NavLinks open in another window or tab. You can define grouped entries in them as well.
 
 A third-party app installed with a Helm chart can deploy the NavLink custom resource along with the app. When this resource is deployed, the link will be hidden for users without access to the proxy.

--- a/docusaurus/docs/getting-started/development_environment.md
+++ b/docusaurus/docs/getting-started/development_environment.md
@@ -28,12 +28,12 @@ The Dashboard is shipped with the Rancher package which contains the Rancher API
 
 ### Installing Rancher
 
-See <https://rancher.com/docs/rancher/v2.6/en/installation/>. Note: Not all Linux distros and versions are supported. To make sure your OS is compatible with Rancher, see the support maintenance terms for the specific Rancher version that you are using: https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-6-5/
+See <https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/installation-and-upgrade>. Note: Not all Linux distros and versions are supported. To make sure your OS is compatible with Rancher, see the support maintenance terms for the specific Rancher version that you are using: https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/rancher-v2-7-6/
 
 The above linked installation docs cover two methods confirmed to work with the Dashboard:
 
-- [Single Docker Container](https://rancher.com/docs/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/)
-- [Kube Cluster (via Helm)](https://rancher.com/docs/rancher/v2.6/en/installation/install-rancher-on-k8s/)
+- [Single Docker Container](https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/rancher-on-a-single-node-with-docker)
+- [Kube Cluster (via Helm)](https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/install-upgrade-on-a-kubernetes-cluster)
 
 To use the most recent version of Rancher that is actively in development, use the version tag `v2.6-head` when installing Rancher. For example, the Docker installation command would look like this:
 
@@ -63,7 +63,7 @@ You should be able to reach the older Ember UI by navigating to the Rancher API 
 ### Uninstalling Rancher
 
 - Docker - This should be a simple `docker stop` & `docker rm`
-- Kube Cluster -  Use `helm delete` as usual and then the `remove` command from [System Tools](https://rancher.com/docs/rancher/v2.6/en/system-tools/) client
+- Kube Cluster -  Use `helm delete` as usual and then the `remove` command from [System Tools](https://ranchermanager.docs.rancher.com/v2.7/reference-guides/system-tools) client
 
 ## UI Walkthrough
 
@@ -133,7 +133,7 @@ A common mistake is to accidentally work from the wrong Rancher version. Because
 
 ### Upgrading Rancher with Docker
 
-If you want to use a more long-lived Rancher instance, you may need to upgrade Rancher without just killing the container running in Docker. In that case, you can run the script `./scripts/update-docker-image`, or you can follow [these docs](https://rancher.com/docs/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-upgrades/) to upgrade Rancher with Docker.
+If you want to use a more long-lived Rancher instance, you may need to upgrade Rancher without just killing the container running in Docker. In that case, you can run the script `./scripts/update-docker-image`, or you can follow [these docs](https://ranchermanager.docs.rancher.com/v2.7/getting-started/installation-and-upgrade/other-installation-methods/rancher-on-a-single-node-with-docker/upgrade-docker-installed-rancher) to upgrade Rancher with Docker.
 
 If using the script, you will need to provide 2 arguments:
 

--- a/docusaurus/docs/getting-started/ui-walkthrough.md
+++ b/docusaurus/docs/getting-started/ui-walkthrough.md
@@ -2,7 +2,7 @@
 
 This page is intended to answer the question "What am I looking at?" for new Rancher UI developers who are navigating Rancher.
 
-This is not an exhaustive guide to Rancher. For more details, see the docs https://rancher.com/docs/rancher/v2.6/en/ or the other pages of these developer docs.
+This is not an exhaustive guide to Rancher. For more details, see the docs https://ranchermanager.docs.rancher.com/v2.7 or the other pages of these developer docs.
 
 ## 1. Home Page
 
@@ -59,7 +59,7 @@ The purpose of a project is mainly to make it easier for admins to give users pe
 
 ## 3. Cluster Provisioning
 
-One of the core features of Rancher is cluster provisioning. Rancher offers a lot of flexibility in how you can install or set up a Kubernetes cluster through the Rancher UI. There are more details in the documentation (https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/) which are too complicated to explain here, because there are many types of clusters that Rancher can manage, and Rancher can manage clusters that integrate with different technology stacks.
+One of the core features of Rancher is cluster provisioning. Rancher offers a lot of flexibility in how you can install or set up a Kubernetes cluster through the Rancher UI. There are more details in the documentation (https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/kubernetes-clusters-in-rancher-setup) which are too complicated to explain here, because there are many types of clusters that Rancher can manage, and Rancher can manage clusters that integrate with different technology stacks.
 
 In a typical use case, Rancher will take your credentials for a cloud infrastructure provider, such as AWS EC2 or Digital Ocean, and it will integrate with the API of that cloud infrastructure provider. Rancher can add new Linux servers in the cloud for you, and the cost of the resources that it provisions will be billed to the user's account associated with the cloud credentials that Rancher is using. Then Rancher installs Kubernetes on those nodes and provide a UI to add users to the cluster through Rancher, or deploy applications on the cluster, along with any other operation supported by upstream Kubernetes.
 

--- a/docusaurus/docs/guide/auth-providers.md
+++ b/docusaurus/docs/guide/auth-providers.md
@@ -33,7 +33,7 @@ Use the steps below to set up a Keycloak instance for dev environments and confi
    > Ensure that the admin user has a first name, last name and email. These fields are referenced in the Keycloak client's mappers which are then referenced in the Rancher's auth provider config.
 
    > Double check the client has the correct checkboxes set, specifically the Mappers `group` entry.
-1. Using either the Ember or Vue UI set up the Keycloak auth provider by follow the instructions at [here](https://rancher.com/docs/rancher/v2.6/en/admin-settings/authentication/keycloak-saml/)
+1. Using either the Ember or Vue UI set up the Keycloak auth provider by follow the instructions at [here](https://ranchermanager.docs.rancher.com/v2.7/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config/configure-keycloak-saml)
    
    | Field              | Value                                                                                                                                                                                                                                                                                        |
    | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2833,7 +2833,7 @@ logging:
     dockerRootDirectory: Docker Root Directory
     systemdLogPath: systemd Log Path
     tooltip: 'Some kubernetes distributions log to <code>journald</code>. In order to collect these logs the <code>systemdLogPath</code> needs to be defined. While the <code>/run/log/journal</code> directory is used by default, some Linux distributions do not default to this path.'
-    url: '<a href="https://rancher.com/docs/rancher/v2.6/en/logging/helm-chart-options/" target="_blank" rel="noopener nofollow noreferrer">Learn more</a>'
+    url: '<a href="https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/logging/logging-helm-chart-options" target="_blank" rel="noopener nofollow noreferrer">Learn more</a>'
     default: /run/log/journal
   elasticsearch:
     host: Host

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -2805,7 +2805,7 @@ logging:
     dockerRootDirectory: Docker 根目录
     systemdLogPath: systemd 日志路径
     tooltip: '某些 Kubernetes 发行版在 <code>journald</code>中记录日志。你需要定义<code>systemdLogPath</code> 以收集日志。默认路径是<code>/run/log/journal</code>，但某些 Linux 发行版不默认使用该路径。'
-    url: '<a href="https://rancher.com/docs/rancher/v2.6/en/logging/helm-chart-options/" target="_blank" rel="noopener nofollow noreferrer">了解更多</a>'
+    url: '<a href="https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/logging/logging-helm-chart-options" target="_blank" rel="noopener nofollow noreferrer">了解更多</a>'
     default: /run/log/journal
   elasticsearch:
     host: 主机

--- a/shell/config/private-label.js
+++ b/shell/config/private-label.js
@@ -3,7 +3,7 @@ import { SETTING } from './settings';
 export const ANY = 0;
 export const STANDARD = 1;
 export const CUSTOM = 2;
-export const DOCS_BASE = 'https://rancher.com/docs/rancher/v2.7/en';
+export const DOCS_BASE = 'https://ranchermanager.docs.rancher.com/v2.7';
 
 const STANDARD_VENDOR = 'Rancher';
 const STANDARD_PRODUCT = 'Explorer';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Replaced the old docs urls with the new ones. In some cases the english language code(`en`) needed to be removed from the url otherwise you would visit the "Page not found" page.

Fixes #9854 
<!-- Define findings related to the feature or bug issue. -->