### PR TITLE
Automation: No matching clusters msg fix

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -131,9 +131,7 @@ export default {
 
     clustersFiltered() {
       const search = (this.clusterFilter || '').toLowerCase();
-
       const out = search ? this.clusters.filter((item) => item.label?.toLowerCase().includes(search)) : this.clusters;
-
       const sorted = sortBy(out, ['ready:desc', 'label']);
 
       if (search) {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -132,7 +132,7 @@ export default {
     clustersFiltered() {
       const search = (this.clusterFilter || '').toLowerCase();
 
-      const out = search ? this.clusters.filter((item) => item.label.toLowerCase().includes(search)) : this.clusters;
+      const out = search ? this.clusters.filter((item) => item.label?.toLowerCase().includes(search)) : this.clusters;
 
       const sorted = sortBy(out, ['ready:desc', 'label']);
 
@@ -508,8 +508,9 @@ export default {
               <!-- Clusters Search result -->
               <div class="clustersList">
                 <div
-                  v-for="c in clustersFiltered"
+                  v-for="(c, index) in clustersFiltered"
                   :key="c.id"
+                  :data-testid="`top-level-menu-cluster-${index}`"
                   @click="hide()"
                 >
                   <nuxt-link

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -321,12 +321,14 @@ export default {
 </script>
 <template>
   <div>
+    <!-- Overlay -->
     <div
       v-if="shown"
       class="side-menu-glass"
       @click="hide()"
     />
     <transition name="fade">
+      <!-- Side menu -->
       <div
         data-testid="side-menu"
         class="side-menu"
@@ -334,6 +336,7 @@ export default {
         :style="sideMenuStyle"
         tabindex="-1"
       >
+        <!-- Logo and name -->
         <div class="title">
           <div
             data-testid="top-level-menu"
@@ -355,8 +358,11 @@ export default {
             <BrandImage file-name="rancher-logo.svg" />
           </div>
         </div>
+
+        <!-- Menu body -->
         <div class="body">
           <div>
+            <!-- Home button -->
             <nuxt-link
               class="option cluster selector home"
               :to="{ name: 'home' }"
@@ -375,6 +381,8 @@ export default {
                 {{ t('nav.home') }}
               </div>
             </nuxt-link>
+
+            <!-- Search bar -->
             <div
               v-if="showClusterSearch"
               class="clusters-search"
@@ -404,6 +412,8 @@ export default {
               </div>
             </div>
           </div>
+
+          <!-- Harvester extras -->
           <template v-if="hciApps.length">
             <div class="category" />
             <div>
@@ -420,7 +430,6 @@ export default {
                 </div>
               </a>
             </div>
-
             <div
               v-for="a in hciApps"
               :key="a.label"
@@ -439,12 +448,14 @@ export default {
             </div>
           </template>
 
+          <!-- Cluster menu -->
           <template v-if="clusters && !!clusters.length">
             <div
               ref="clusterList"
               class="clusters"
               :style="pinnedClustersHeight"
             >
+              <!-- Pinned Clusters -->
               <div
                 v-if="showPinClusters && pinFiltered.length"
                 class="clustersPinned"
@@ -494,6 +505,8 @@ export default {
                   <hr>
                 </div>
               </div>
+
+              <!-- Clusters Search result -->
               <div class="clustersList">
                 <div
                   v-for="c in clustersFiltered"
@@ -536,6 +549,8 @@ export default {
                   </span>
                 </div>
               </div>
+
+              <!-- No clusters message -->
               <div
                 v-if="(clustersFiltered.length === 0 || pinFiltered.length === 0) && searchActive"
                 data-testid="top-level-menu-no-results"
@@ -545,6 +560,7 @@ export default {
               </div>
             </div>
 
+            <!-- See all clusters -->
             <nuxt-link
               v-if="clusters.length > maxClustersToShow"
               class="clusters-all"
@@ -616,6 +632,8 @@ export default {
                 </nuxt-link>
               </div>
             </template>
+
+            <!-- App menu -->
             <template v-if="configurationApps.length">
               <div
                 class="category-title"
@@ -645,6 +663,8 @@ export default {
             </template>
           </div>
         </div>
+
+        <!-- Footer -->
         <div
           class="footer"
         >

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -59,6 +59,13 @@ export default {
       },
     },
 
+    sideMenuStyle() {
+      return {
+        marginBottom: this.globalBannerSettings?.footerFont,
+        marginTop:    this.globalBannerSettings?.headerFont
+      };
+    },
+
     globalBannerSettings() {
       const settings = this.$store.getters['management/all'](MANAGEMENT.SETTING);
       const bannerSettings = settings?.find((s) => s.id === SETTING.BANNERS);
@@ -104,7 +111,7 @@ export default {
         kubeClusters = kubeClusters.filter((c) => !!available[c]);
       }
 
-      return kubeClusters.map((x) => {
+      return kubeClusters?.map((x) => {
         const pCluster = pClusters?.find((c) => c.mgmt?.id === x.id);
 
         return {
@@ -120,7 +127,7 @@ export default {
           pin:             () => x.pin(),
           unpin:           () => x.unpin()
         };
-      });
+      }) || [];
     },
 
     clustersFiltered() {
@@ -324,10 +331,7 @@ export default {
         data-testid="side-menu"
         class="side-menu"
         :class="{'menu-open': shown, 'menu-close':!shown}"
-        :style="{
-          'marginBottom': globalBannerSettings.footerFont,
-          'marginTop': globalBannerSettings.headerFont
-        }"
+        :style="sideMenuStyle"
         tabindex="-1"
       >
         <div class="title">

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -324,10 +324,10 @@ export default {
         data-testid="side-menu"
         class="side-menu"
         :class="{'menu-open': shown, 'menu-close':!shown}"
-        :style="{'marginBottom':
-                   globalBannerSettings?.footerFont,
-                 'marginTop':
-                   globalBannerSettings?.headerFont}"
+        :style="{
+          'marginBottom': globalBannerSettings.footerFont,
+          'marginTop': globalBannerSettings.headerFont
+        }"
         tabindex="-1"
       >
         <div class="title">

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -50,7 +50,6 @@ export default {
   computed: {
     ...mapGetters(['clusterId']),
     ...mapGetters(['clusterReady', 'isRancher', 'currentCluster', 'currentProduct', 'isRancherInHarvester']),
-    ...mapGetters('type-map', ['activeProducts']),
     ...mapGetters({ features: 'features/get' }),
 
     value: {
@@ -210,7 +209,7 @@ export default {
       const cluster = this.clusterId || this.$store.getters['defaultClusterId'];
 
       // TODO plugin routes
-      const entries = this.activeProducts?.map((p) => {
+      const entries = this.$store.getters['type-map/activeProducts']?.map((p) => {
         // Try product-specific index first
         const to = p.to || {
           name:   `c-cluster-${ p.name }`,

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -210,7 +210,7 @@ export default {
       const cluster = this.clusterId || this.$store.getters['defaultClusterId'];
 
       // TODO plugin routes
-      const entries = this.activeProducts.map((p) => {
+      const entries = this.activeProducts?.map((p) => {
         // Try product-specific index first
         const to = p.to || {
           name:   `c-cluster-${ p.name }`,

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -61,7 +61,7 @@ export default {
 
     globalBannerSettings() {
       const settings = this.$store.getters['management/all'](MANAGEMENT.SETTING);
-      const bannerSettings = settings.find((s) => s.id === SETTING.BANNERS);
+      const bannerSettings = settings?.find((s) => s.id === SETTING.BANNERS);
 
       if (bannerSettings) {
         const parsed = JSON.parse(bannerSettings.value);
@@ -534,6 +534,7 @@ export default {
               </div>
               <div
                 v-if="(clustersFiltered.length === 0 || pinFiltered.length === 0) && searchActive"
+                data-testid="top-level-menu-no-results"
                 class="none-matching"
               >
                 {{ t('nav.search.noResults') }}

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -1,0 +1,120 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import TopLevelMenu from '@shell/components/nav/TopLevelMenu';
+
+// DISCLAIMER: This should not be added here, although we have several store requests which are irrelevant
+const defaultStore = {
+  'management/byId':         jest.fn(),
+  'management/schemaFor':    jest.fn(),
+  'i18n/t':                  jest.fn(),
+  'features/get':            jest.fn(),
+  'prefs/theme':             jest.fn(),
+  defaultClusterId:          jest.fn(),
+  clusterId:                 jest.fn(),
+  'type-map/activeProducts': [],
+};
+
+describe('topLevelMenu', () => {
+  it('should display clusters', () => {
+    const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+      mocks: {
+        $store: {
+          getters: {
+            'management/all': () => [{ name: 'whatever' }],
+            ...defaultStore
+          },
+        },
+      },
+      stubs: ['BrandImage', 'nuxt-link']
+    });
+
+    const cluster = wrapper.find('[data-testid="top-level-menu-cluster-0"]');
+
+    expect(cluster.exists()).toBe(true);
+  });
+
+  describe('searching a term', () => {
+    describe('should displays a no results message if have clusters but', () => {
+      it('given no matching clusters', () => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          data:  () => ({ clusterFilter: 'whatever' }),
+          mocks: {
+            $store: {
+              getters: {
+                'management/all': () => [{ nameDisplay: 'something else' }],
+                ...defaultStore
+              },
+            },
+          },
+          stubs: ['BrandImage', 'nuxt-link']
+        });
+
+        const noResults = wrapper.find('[data-testid="top-level-menu-no-results"]');
+
+        expect(noResults.exists()).toBe(true);
+      });
+
+      it('given no matched pinned clusters', () => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          data:  () => ({ clusterFilter: 'whatever' }),
+          mocks: {
+            $store: {
+              getters: {
+                'management/all': () => [{ nameDisplay: 'something else', pinned: true }],
+                ...defaultStore
+              },
+            },
+          },
+          stubs: ['BrandImage', 'nuxt-link']
+        });
+
+        const noResults = wrapper.find('[data-testid="top-level-menu-no-results"]');
+
+        expect(noResults.exists()).toBe(true);
+      });
+    });
+
+    describe('should not displays a no results message', () => {
+      it('given matching clusters', () => {
+        const search = 'you found me';
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          data:  () => ({ clusterFilter: search }),
+          mocks: {
+            $store: {
+              getters: {
+                'management/all': () => [{ nameDisplay: search }],
+                ...defaultStore
+              },
+            },
+          },
+          stubs: ['BrandImage', 'nuxt-link']
+        });
+
+        const noResults = wrapper.find('[data-testid="top-level-menu-no-results"]');
+
+        expect(wrapper.vm.clustersFiltered).toHaveLength(1);
+        expect(noResults.exists()).toBe(false);
+      });
+
+      it('given clusters with status pinned', () => {
+        const search = 'you found me';
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          data:  () => ({ clusterFilter: search }),
+          mocks: {
+            $store: {
+              getters: {
+                'management/all': () => [{ nameDisplay: search, pinned: true }],
+                ...defaultStore
+              },
+            },
+          },
+          stubs: ['BrandImage', 'nuxt-link']
+        });
+
+        const noResults = wrapper.find('[data-testid="top-level-menu-no-results"]');
+
+        expect(wrapper.vm.pinFiltered).toHaveLength(1);
+        expect(noResults.exists()).toBe(false);
+      });
+    });
+  });
+});

--- a/shell/utils/cluster.js
+++ b/shell/utils/cluster.js
@@ -7,7 +7,7 @@ import { SETTING } from '@shell/config/settings';
 export function filterOnlyKubernetesClusters(mgmtClusters, store) {
   const openHarvesterContainerWorkload = store.getters['features/get']('harvester-baremetal-container-workload');
 
-  return mgmtClusters.filter((c) => {
+  return mgmtClusters?.filter((c) => {
     return openHarvesterContainerWorkload ? true : !isHarvesterCluster(c);
   });
 }

--- a/shell/utils/sort.js
+++ b/shell/utils/sort.js
@@ -184,7 +184,7 @@ export function sortBy(ary, keys, desc) {
     keys = [keys];
   }
 
-  return ary.slice().sort((objA, objB) => {
+  return (ary || []).slice().sort((objA, objB) => {
     for ( let i = 0 ; i < keys.length ; i++ ) {
       const parsed = parseField(keys[i]);
       const a = get(objA, parsed.field);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9683
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

### Technical notes summary
- Added tests
- Added several fallbacks
  - Removed conditional chaining in some styling
  - `SortBy()` utility if missing argument
  - `filterOnlyKubernetesClusters()` if missing mgmt Clusters
  - Several cases in the sidebar
- Changed getter map flavor due issues while mocking method
- Added comments to the markup to match to the UI

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->