### PR TITLE
now properly escaping key names prior to diffing objects

### DIFF
--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -1,5 +1,5 @@
 import {
-  clone, get, getter, isEmpty, toDictionary, remove
+  clone, get, getter, isEmpty, toDictionary, remove, diff, definedKeys
 } from '@shell/utils/object';
 
 describe('fx: get', () => {
@@ -157,6 +157,72 @@ describe('fx: remove', () => {
     [{ level1: { level2: true }, other: true }, 'level1', { other: true }],
   ])('should evaluate %p as %p', (obj, path, expected) => {
     const result = remove(obj, path);
+
+    expect(result).toStrictEqual(expected);
+  });
+});
+
+describe('fx: diff', () => {
+  it('should return an object including only the differences between two objects', () => {
+    const from = {
+      foo: 'bar',
+      baz: 'bang',
+    };
+    const to = {
+      foo:  'bar',
+      bang: 'baz'
+    };
+
+    const result = diff(from, to);
+    const expected = {
+      baz:  null,
+      bang: 'baz'
+    };
+
+    expect(result).toStrictEqual(expected);
+  });
+  it('should return an object and dot characters in object should still be respected', () => {
+    const from = {};
+    const to = { foo: { 'bar.baz': 'bang' } };
+
+    const result = diff(from, to);
+    const expected = { foo: { 'bar.baz': 'bang' } };
+
+    expect(result).toStrictEqual(expected);
+  });
+});
+
+describe('fx: definedKeys', () => {
+  it('should return an array of keys within an array', () => {
+    const obj = {
+      foo: 'bar',
+      baz: 'bang',
+    };
+
+    const result = definedKeys(obj);
+    const expected = ['"foo"', '"baz"'];
+
+    expect(result).toStrictEqual(expected);
+  });
+  it('should return an array of keys with primitive values and their full nested path', () => {
+    const obj = {
+      foo: 'bar',
+      baz: { bang: 'bop' },
+    };
+
+    const result = definedKeys(obj);
+    const expected = ['"foo"', '"baz"."bang"'];
+
+    expect(result).toStrictEqual(expected);
+  });
+  it('should return an array of keys with primitive values and their full nested path with quotation marks to escape keys with dots in them', () => {
+    const obj = {
+      foo: 'bar',
+      baz: { 'bang.bop': 'beep' },
+    };
+
+    const result = definedKeys(obj);
+    const expected = ['"foo"', '"baz"."bang.bop"'];
 
     expect(result).toStrictEqual(expected);
   });

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -178,11 +178,12 @@ export function definedKeys(obj) {
     const val = obj[key];
 
     if ( Array.isArray(val) ) {
-      return key;
+      return `"${ key }"`;
     } else if ( isObject(val) ) {
-      return ( definedKeys(val) || [] ).map((subkey) => `${ key }.${ subkey }`);
+      // no need for quotes around the subkey since the recursive call will fill that in via one of the other two statements in the if block
+      return ( definedKeys(val) || [] ).map((subkey) => `"${ key }".${ subkey }`);
     } else {
-      return key;
+      return `"${ key }"`;
     }
   });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9249 
we were incorrectly creating a nested object where we should have had a primitive value when an object's key included a period. The root cause was that we weren't properly escaping the key names by surrounding them with double-quotes so that the `set` function knows not to split the string on those particular keys. This caused the "set" function to create additional levels of nesting and to create false keys that the API was not expecting.

### Occurred changes and/or fixed issues
The `diff` utility function now wraps individual keys in quotation marks so it doesn't confuse the `set` utility function when a key in a diff includes a dot.

### Technical notes summary
It's possible that the full repro steps in the parent issue might still produce an error given the steps and depending on your environment, this mostly has to do with those steps being insufficient for creating an additional nginx ingress in some environments and isn't related to the issue fixed here.

For testing purposes, we just want to verify that the payload we're hitting the API with doesn't have an incorrectly nested value.

### Areas or cases that should be tested
For testing purposes, we just want to verify that the payload we're hitting the API with doesn't have an incorrectly nested value.

### Areas which could experience regressions
`/shell/components/ResourceDetail/index.vue` and `/shell/edit/provisioning.cattle.io.cluster/rke2.vue` both use the diff function which shouldn't have changed but it's be good to load a ResourceDetail page and edit an rke2 cluster just to make sure nothing untowards is happening outside of my test environment.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->