### PR TITLE
Fix gitrepo detail view bundle count

### DIFF
--- a/shell/components/fleet/FleetBundles.vue
+++ b/shell/components/fleet/FleetBundles.vue
@@ -26,7 +26,9 @@ export default {
   },
 
   async fetch() {
-    this.allFleet = await this.$store.getters['management/all'](FLEET.CLUSTER);
+    if (this.$store.getters['management/schemaFor']( FLEET.CLUSTER )) {
+      this.allFleet = await this.$store.getters['management/all'](FLEET.CLUSTER);
+    }
   },
 
   data() {
@@ -97,6 +99,11 @@ export default {
       return out;
     },
   },
+  methods: {
+    displayWarning(row) {
+      return !!row.status?.summary && (row.status.summary.desiredReady !== row.status.summary.ready);
+    }
+  }
 };
 </script>
 
@@ -116,11 +123,11 @@ export default {
       >
         <template #cell:deploymentsReady="{row}">
           <span
-            v-if="row.status.summary.desiredReady != row.status.summary.ready"
+            v-if="displayWarning(row)"
             class="text-warning"
           >
             {{ row.status.summary.ready }}/{{ row.status.summary.desiredReady }}</span>
-          <span v-else>{{ row.status.summary.desiredReady }}</span>
+          <span v-else-if="row.status">{{ row.status.summary.desiredReady }}</span>
         </template>
       </ResourceTable>
     </div>

--- a/shell/components/fleet/FleetBundles.vue
+++ b/shell/components/fleet/FleetBundles.vue
@@ -26,9 +26,7 @@ export default {
   },
 
   async fetch() {
-    if (this.$store.getters['management/schemaFor']( FLEET.CLUSTER )) {
-      this.allFleet = await this.$store.getters['management/all'](FLEET.CLUSTER);
-    }
+    this.allFleet = await this.$store.getters['management/all'](FLEET.CLUSTER);
   },
 
   data() {
@@ -37,8 +35,8 @@ export default {
 
   computed: {
 
-    allBundles() {
-      // gitrepo model has getter for bundles.
+    allBundlesInRepo() {
+      // gitrepo model has getter for its bundles.
       return this.value.bundles || [];
     },
 
@@ -65,13 +63,7 @@ export default {
     bundles() {
       const harvester = this.harvesterClusters;
 
-      return this.allBundles.filter((bundle) => {
-        const isRepoBundle = bundle.metadata.name.startsWith(`${ this.value.metadata.name }-`);
-
-        if (!isRepoBundle) {
-          return false;
-        }
-
+      return this.allBundlesInRepo.filter((bundle) => {
         const targets = bundle.spec?.targets || [];
 
         // Filter out any bundle that has one target whose cluster is a harvester cluster
@@ -84,7 +76,7 @@ export default {
     },
 
     hidden() {
-      return this.allBundles.length - this.bundles.length;
+      return this.allBundlesInRepo.length - this.bundles.length;
     },
 
     headers() {
@@ -105,14 +97,9 @@ export default {
       return out;
     },
   },
-
-  methods: {
-    displayWarning(row) {
-      return !!row.status?.summary && (row.status.summary.desiredReady !== row.status.summary.ready);
-    }
-  }
 };
 </script>
+
 <template>
   <div>
     <Loading v-if="$fetchState.pending" />
@@ -129,11 +116,11 @@ export default {
       >
         <template #cell:deploymentsReady="{row}">
           <span
-            v-if="displayWarning(row)"
+            v-if="row.status.summary.desiredReady != row.status.summary.ready"
             class="text-warning"
           >
             {{ row.status.summary.ready }}/{{ row.status.summary.desiredReady }}</span>
-          <span v-else-if="row.status">{{ row.status.summary.desiredReady }}</span>
+          <span v-else>{{ row.status.summary.desiredReady }}</span>
         </template>
       </ResourceTable>
     </div>

--- a/shell/components/fleet/FleetSummary.vue
+++ b/shell/components/fleet/FleetSummary.vue
@@ -1,5 +1,4 @@
 <script>
-import capitalize from 'lodash/capitalize';
 import { STATES, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import FleetStatus from '@shell/components/fleet/FleetStatus';
 
@@ -174,7 +173,6 @@ export default {
 
   },
 
-  methods: { capitalize },
 };
 </script>
 
@@ -185,11 +183,13 @@ export default {
       title="Bundles"
       :values="bundleCounts"
       value-key="count"
+      data-testid="gitrepo-bundle-summary"
     />
     <FleetStatus
       title="Resources"
       :values="resourceCounts"
       value-key="count"
+      data-testid="gitrepo-deployment-summary"
     />
   </div>
 </template>

--- a/shell/components/fleet/FleetSummary.vue
+++ b/shell/components/fleet/FleetSummary.vue
@@ -80,7 +80,7 @@ export default {
     },
 
     bundleCounts() {
-      const resources = this.bundles.filter((item) => item.metadata.name.startsWith(`${ this.repoName }-`));
+      const resources = this.bundles.filter((item) => item.repoName === this.repoName);
 
       if (!resources.length) {
         return [];

--- a/shell/components/fleet/__tests__/FleetSummary.test.ts
+++ b/shell/components/fleet/__tests__/FleetSummary.test.ts
@@ -1,0 +1,316 @@
+import { mount } from '@vue/test-utils';
+import FleetSummary from '@shell/components/fleet/FleetSummary.vue';
+
+const REPO_NAME = 'testrepo';
+
+const REPO_NAME_VARIANT = 'testrepo-again';
+
+const CLUSTER_NAME = 'testcluster';
+
+const mockedBundlesInRepo = [{
+  id:         `fleet-default/${ REPO_NAME }-${ CLUSTER_NAME }-1234`,
+  type:       'fleet.cattle.io.bundle',
+  apiVersion: 'fleet.cattle.io/v1alpha1',
+  kind:       'Bundle',
+  repoName:   REPO_NAME,
+  metadata:   {
+    labels: {
+      'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
+      'fleet.cattle.io/repo-name': REPO_NAME
+    },
+
+    name:      `${ REPO_NAME }-${ CLUSTER_NAME }-1234`,
+    namespace: 'fleet-default',
+    state:     {
+      error:         false,
+      message:       'Resource is Ready',
+      name:          'active',
+      transitioning: false
+    },
+  },
+  spec: {
+    correctDrift:        { },
+    forceSyncGeneration: 2,
+    ignore:              { },
+    namespace:           'custom-namespace-name',
+    resources:           [
+      {
+        content: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: configmap-test\n  annotations:\n    {}\n#    key: string\n  labels:\n    {}\n#    key: string\ndata:\n  key1: val1\n  key2: val2\n  key3: val3',
+        name:    'test-configmap.yaml'
+      }
+    ],
+    targets: [
+      {
+        clusterName: 'nb-cluster0-28',
+        namespace:   'custom-namespace-name'
+      }
+    ]
+  }
+},
+{
+  id:         `fleet-default/${ REPO_NAME }-${ CLUSTER_NAME }-5678`,
+  type:       'fleet.cattle.io.bundle',
+  apiVersion: 'fleet.cattle.io/v1alpha1',
+  kind:       'Bundle',
+  repoName:   REPO_NAME,
+  metadata:   {
+    labels: {
+      'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
+      'fleet.cattle.io/repo-name': REPO_NAME
+    },
+
+    name:      `${ REPO_NAME }-${ CLUSTER_NAME }-5678`,
+    namespace: 'fleet-default',
+    state:     {
+      error:         false,
+      message:       'Resource is Ready',
+      name:          'active',
+      transitioning: false
+    },
+  },
+  spec: {
+    correctDrift:        { },
+    forceSyncGeneration: 2,
+    ignore:              { },
+    namespace:           'custom-namespace-name',
+    resources:           [
+      {
+        content: 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx-cluster0\n  labels:\n    app: nginx\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: nginx\n  template:\n    metadata:\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - name: nginx\n        image: nginx:latest\n        ports:\n        - containerPort: 80',
+        name:    'nginx.yml'
+      },
+    ],
+    targets: [
+      {
+        clusterName: 'nb-cluster0-28',
+        namespace:   'custom-namespace-name'
+      }
+    ]
+  }
+}];
+
+const mockedBundlesOutOfRepo = [{
+  id:         `fleet-default/${ REPO_NAME_VARIANT }-${ CLUSTER_NAME }-1234`,
+  type:       'fleet.cattle.io.bundle',
+  apiVersion: 'fleet.cattle.io/v1alpha1',
+  kind:       'Bundle',
+  repoName:   REPO_NAME_VARIANT,
+  metadata:   {
+    labels: {
+      'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
+      'fleet.cattle.io/repo-name': REPO_NAME_VARIANT
+    },
+
+    name:      `${ REPO_NAME_VARIANT }-${ CLUSTER_NAME }-1234`,
+    namespace: 'fleet-default',
+    state:     {
+      error:         false,
+      message:       'Resource is Ready',
+      name:          'active',
+      transitioning: false
+    },
+  },
+  spec: {
+    correctDrift:        { },
+    forceSyncGeneration: 2,
+    ignore:              { },
+    namespace:           'custom-namespace-name',
+    resources:           [
+      {
+        content: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: configmap-test\n  annotations:\n    {}\n#    key: string\n  labels:\n    {}\n#    key: string\ndata:\n  key1: val1\n  key2: val2\n  key3: val3',
+        name:    'test-configmap.yaml'
+      }
+    ],
+    targets: [
+      {
+        clusterName: 'nb-cluster0-28',
+        namespace:   'custom-namespace-name'
+      }
+    ]
+  }
+},
+{
+  id:         `fleet-default/${ REPO_NAME_VARIANT }-${ CLUSTER_NAME }-5678`,
+  type:       'fleet.cattle.io.bundle',
+  apiVersion: 'fleet.cattle.io/v1alpha1',
+  kind:       'Bundle',
+  repoName:   REPO_NAME_VARIANT,
+  metadata:   {
+    labels: {
+      'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
+      'fleet.cattle.io/repo-name': REPO_NAME_VARIANT
+    },
+
+    name:      `${ REPO_NAME_VARIANT }-${ CLUSTER_NAME }-5678`,
+    namespace: 'fleet-default',
+    state:     {
+      error:         false,
+      message:       'Resource is Ready',
+      name:          'active',
+      transitioning: false
+    },
+  },
+  spec: {
+    correctDrift:        { },
+    forceSyncGeneration: 2,
+    ignore:              { },
+    namespace:           'custom-namespace-name',
+    resources:           [
+      {
+        content: 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: nginx-cluster0\n  labels:\n    app: nginx\nspec:\n  replicas: 1\n  selector:\n    matchLabels:\n      app: nginx\n  template:\n    metadata:\n      labels:\n        app: nginx\n    spec:\n      containers:\n      - name: nginx\n        image: nginx:latest\n        ports:\n        - containerPort: 80',
+        name:    'nginx.yml'
+      },
+    ],
+    targets: [
+      {
+        clusterName: 'nb-cluster0-28',
+        namespace:   'custom-namespace-name'
+      }
+    ]
+  }
+}];
+
+const mockRepo = {
+  id:         `fleet-default/${ REPO_NAME }`,
+  type:       'fleet.cattle.io.gitrepo',
+  apiVersion: 'fleet.cattle.io/v1alpha1',
+  kind:       'GitRepo',
+  metadata:   {
+
+    name:      `${ REPO_NAME }`,
+    namespace: 'fleet-default',
+    state:     {
+      error:         false,
+      message:       'Resource is Ready',
+      name:          'active',
+      transitioning: false
+    },
+  },
+  spec: {
+    branch:                'main',
+    correctDrift:          { enabled: false },
+    forceSyncGeneration:   2,
+    insecureSkipTLSVerify: false,
+    paths:                 [
+      './cluster0'
+    ],
+    repo:            'https://github.com/testuser/testrepo.git',
+    targetNamespace: 'custom-namespace-name',
+    targets:         [
+      { clusterName: `${ CLUSTER_NAME }` }
+    ]
+  },
+  status: {
+    commit:     '3640888439d1b7b6a53dbeee291a533eea2632ab',
+    conditions: [
+      {
+        error:          false,
+        lastUpdateTime: '2023-10-05T18:06:27Z',
+        status:         'True',
+        transitioning:  false,
+        type:           'Ready'
+      },
+      {
+        error:          false,
+        lastUpdateTime: '2023-10-05T20:35:07Z',
+        status:         'True',
+        transitioning:  false,
+        type:           'Accepted'
+      },
+      {
+        error:          false,
+        lastUpdateTime: '2023-10-05T18:05:09Z',
+        status:         'True',
+        transitioning:  false,
+        type:           'ImageSynced'
+      },
+      {
+        error:          false,
+        lastUpdateTime: '2023-10-05T18:06:22Z',
+        status:         'False',
+        transitioning:  false,
+        type:           'Reconciling'
+      },
+      {
+        error:          false,
+        lastUpdateTime: '2023-10-05T18:05:09Z',
+        status:         'False',
+        transitioning:  false,
+        type:           'Stalled'
+      },
+      {
+        error:          false,
+        lastUpdateTime: '2023-10-05T20:35:07Z',
+        status:         'True',
+        transitioning:  false,
+        type:           'Synced'
+      }
+    ],
+    desiredReadyClusters:    1,
+    display:                 { readyBundleDeployments: '2/2' },
+    gitJobStatus:            'Current',
+    lastSyncedImageScanTime: null,
+    observedGeneration:      2,
+    readyClusters:           1,
+    resourceCounts:          {
+      desiredReady: 2,
+      missing:      0,
+      modified:     0,
+      notReady:     0,
+      orphaned:     0,
+      ready:        2,
+      unknown:      0,
+      waitApplied:  0
+    },
+    resources: [
+      {
+        apiVersion: 'apps/v1',
+        id:         'custom-namespace-name/nginx-cluster0',
+        kind:       'Deployment',
+        name:       'nginx-cluster0',
+        namespace:  'custom-namespace-name',
+        state:      'Ready',
+        type:       'apps.deployment'
+      },
+      {
+        apiVersion: 'v1',
+        id:         'custom-namespace-name/configmap-test',
+        kind:       'ConfigMap',
+        name:       'configmap-test',
+        namespace:  'custom-namespace-name',
+        state:      'Ready',
+        type:       'configmap'
+      }
+    ],
+    summary: {
+      desiredReady: 1,
+      ready:        1
+    }
+  }
+};
+
+const mockStore = { getters: { 'i18n/withFallback': (key, opt, fallback) => fallback } };
+
+describe('component: FleetSummary', () => {
+  it.each([
+    [[...mockedBundlesInRepo, ...mockedBundlesOutOfRepo], '2'],
+    [mockedBundlesInRepo, '2'],
+  ])('displays the number of bundles associated with the current gitrepo', (bundles: any[], bundleCount: string) => {
+    const wrapper = mount(FleetSummary, { propsData: { bundles, value: mockRepo }, mocks: { $store: mockStore } });
+
+    const bundleCountEl = wrapper.find('[data-testid="gitrepo-bundle-summary"] .count');
+
+    expect(bundleCountEl.text()).toBe(bundleCount);
+  });
+
+  it.each([
+    [[...mockedBundlesInRepo, ...mockedBundlesOutOfRepo], '2'],
+    [mockedBundlesInRepo, '2'],
+
+  ])('displays the number of deployments associated with the current gitrepo', (bundles: any[], bundleCount: string) => {
+    const wrapper = mount(FleetSummary, { propsData: { bundles, value: mockRepo }, mocks: { $store: mockStore } });
+
+    const bundleCountEl = wrapper.find('[data-testid="gitrepo-deployment-summary"] .count');
+
+    expect(bundleCountEl.text()).toBe(bundleCount);
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9866 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the bundle-filtering logic in FleetSummary to use the `repoName` getter, which references an annotation of the associated repo's name, instead of a regex. This is imiliar to a previous fix: https://github.com/rancher/dashboard/pull/5348

### Technical notes summary
Also cleaned up misleading unnecessary filtering in FleetBundles -- the bundles there are already filtered by repo.

### Areas or cases that should be tested
1. Gitrepo detail view when repos have similar names



### Screenshot/Video
before and after:
![Screen Shot 2023-10-06 at 8 35 00 AM](https://github.com/rancher/dashboard/assets/42977925/605a2fe8-c151-4a2c-97fe-b244655ea50a)
![Screen Shot 2023-10-06 at 8 49 27 AM](https://github.com/rancher/dashboard/assets/42977925/c0b99ce4-6ccf-4c7d-b105-eb0695f3b65e)
