### PR TITLE
Add GitLab support for extensions

### DIFF
--- a/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml
+++ b/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml
@@ -1,0 +1,50 @@
+.podman-setup: &podman-setup
+  - zypper --non-interactive install jq podman
+  - usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $(id -nu)
+  - podman login -u $REGISTRY_USER -p $REGISTRY_PASSWORD $REGISTRY
+
+check_version_collisions:
+  stage: check_version
+  rules:
+    - changes:
+        - package.json
+  script:
+    - *podman-setup
+    - |
+      PACKAGE_VERSION=`jq -r .version package.json`
+      PACKAGE_NAME=`jq -r .name package.json`
+
+      readarray -t VERSIONS < <(podman search $REGISTRY/$IMAGE_NAMESPACE/ui-extension-$PACKAGE_NAME --list-tags --format {{.Tag}})
+
+      echo -e "Checking for version collisions with Extension version: ${PACKAGE_VERSION}"
+      for version in ${VERSIONS[@]}; do
+        if [[ ${version} == ${PACKAGE_VERSION} ]]; then
+          echo "Cannot overwrite production image version ${version} since it already exists."
+          podman logout $REGISTRY
+          exit 1
+        fi
+      done
+
+      echo -e "Published image not found for version ${PACKAGE_VERSION}, continuing build..."
+  tags:
+    - linux
+
+build_and_release:
+  stage: build_catalog
+  rules:
+    - changes:
+        - package.json
+  script:
+    - *podman-setup
+    - zypper addrepo https://download.opensuse.org/repositories/devel:languages:nodejs/SLE_12_SP5/devel:languages:nodejs.repo
+    - zypper --non-interactive --no-gpg-checks refresh
+    - zypper --non-interactive install go git nodejs14 npm helm
+    - YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.35.2/yq_linux_amd64"
+    - curl -sLf ${YQ_URL} -o /usr/bin/yq && chmod +x /usr/bin/yq
+    - npm install -g --unsafe-perm yarn
+    - yarn
+    - yarn publish-pkgs -cl -r $REGISTRY -o $IMAGE_NAMESPACE
+    - podman push `podman images -f reference!=registry.suse.com/bci/bci-base --format "{{index .Names 0}}"`
+    - podman logout $REGISTRY
+  tags:
+    - linux

--- a/docusaurus/docs/extensions/extensions-configuration.md
+++ b/docusaurus/docs/extensions/extensions-configuration.md
@@ -32,10 +32,10 @@ ___`./pkg/my-package/package.json`___
   "version": "0.1.0",
   "rancher": {
     "annotations": {
-      "catalog.cattle.io/kube-version": ">= v1.26.0-0 < v1.28.0-0",
-      "catalog.cattle.io/rancher-version": ">= 2.7.7-0 < 2.8.0-0",
+      "catalog.cattle.io/kube-version": ">= v1.26.0-0 < v1.29.0-0",
+      "catalog.cattle.io/rancher-version": ">= 2.7.7-0 < 2.9.0-0",
       "catalog.cattle.io/ui-extensions-version": ">= 1.1.0",
-      "catalog.cattle.io/ui-version": ">= 2.7.7-0 < 2.8.0-0",
+      "catalog.cattle.io/ui-version": ">= 2.7.7-0 < 2.9.0-0",
       "catalog.cattle.io/display-name": "My Super Great Extension"
     }
   },

--- a/docusaurus/docs/extensions/extensions-getting-started.md
+++ b/docusaurus/docs/extensions/extensions-getting-started.md
@@ -22,7 +22,7 @@ Rancher publishes two npm packages to help bootstrap the creation of the app and
 Create a new folder and run:
 
 ```sh
-yarn create @rancher/app my-app
+yarn create @rancher/app my-app [OPTIONS]
 cd my-app
 ```
 
@@ -31,6 +31,16 @@ This will create a new folder `my-app` and populate it with the minimum files ne
 > Note: If you don't want to create a new folder, but instead want the files created in an existing folder, use `yarn create @rancher/app .`
 
 > Note: The skeleton application references the Rancher dashboard code via the `@rancher/shell` npm module.
+
+#### ___Extension Options___
+
+There is one option available to be passed as an argument to the `@rancher/app` script:
+
+| Option | Description |
+| :---: | ------ |
+| `-l` | This will automatically add the [`.gitlab-ci.yml`](https://github.com/rancher/dashboard/blob/master/shell/creators/app/files/.gitlab-ci.yml) pipeline file for integration with GitLab |
+
+---
 
 You can run the app with:
 
@@ -60,11 +70,14 @@ yarn create @rancher/pkg test [OPTIONS]
 
 This will create a new UI Package in the `./pkg/test` folder.
 
-#### ___Extension Options___
+#### ___Extension Package Options___
 
 There are two options that can be passed to the `@rancher/pkg` script:
-- `-t`: Creates additional boilerplate directories for types, including: 'l10n', 'models', 'edit', 'list', and 'detail'
-- `-w`: Creates a workflow file ('build-extension.yml') to be used as a Github action. This will automatically build your extension and release a Helm chart.
+
+| Option | Description |
+| :---: | ------ |
+| `-t` | Creates additional boilerplate directories for types, including: 'l10n', 'models', 'edit', 'list', and 'detail'. |
+| `-w` | Creates the workflow files [`build-extension-catalog.yml`, `build-extension-charts.yml`](https://github.com/rancher/dashboard/tree/master/shell/creators/pkg/files/.github/workflows) to be used as Github actions. This will automatically build your extension and release a Helm chart and Extension Catalog Image. |
 
 > Note: Using the `-w` option to create an automated workflow will require additonal prequesites, see the [Release](#creating-a-release) section.
 
@@ -210,9 +223,11 @@ You'll notice that if you reload the Rancher UI, the extension is not persistent
 
 Creating a Release for your extension is the official avenue for loading extensions into any Rancher instance. As mentioned in the [Introduction](./introduction.md), the extension can be packaged into a Helm chart and added as a Helm repository to be easily accessible from your Rancher Manager.
 
-We have created [a workflow](https://github.com/rancher/dashboard/tree/master/shell/creators/pkg/files/.github/workflows) for [Github Actions](https://docs.github.com/en/actions) which will automatically build, package, and release your extension as a Helm chart for use within your Github repository, and an [Extension Catalog Image](./advanced/air-gapped-environments) (ECI) which is published into a specified container registry (`ghcr.io` by default). Depending on the use case, you can utilize the Github repository as a [Helm repository](https://helm.sh/docs/topics/chart_repository/) endpoint which we can use to consume the chart in Rancher, or you can import the ECI into the Extension Catalog list and serve the Helm charts locally.
+We have created [workflows](https://github.com/rancher/dashboard/tree/master/shell/creators/pkg/files/.github/workflows) for [Github Actions](https://docs.github.com/en/actions) which will automatically build, package, and release your extension as a Helm chart for use within your Github repository, and an [Extension Catalog Image](./advanced/air-gapped-environments) (ECI) which is published into a specified container registry (`ghcr.io` by default). Depending on the use case, you can utilize the Github repository as a [Helm repository](https://helm.sh/docs/topics/chart_repository/) endpoint which we can use to consume the chart in Rancher, or you can import the ECI into the Extension Catalog list and serve the Helm charts locally.
 
-> Note: If you wish to build and publish the Helm chart or the ECI manually or with specific configurations, you can follow the steps listed in the [Publishing an Extension](./publishing) section.
+> **Note:** GitLab support is offered through leverging the ECI build. For configuration instructions, follow the setps in the [Gitlab Integration](./publishing#gitlab-integration) section.
+
+> **Note:** If you wish to build and publish the Helm chart or the ECI manually or with specific configurations, you can follow the steps listed in the [Publishing an Extension](./publishing) section.
 
 ### Release Prerequisites
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -77,7 +77,7 @@ const sidebars = {
       items: [
         'extensions/introduction',
         'extensions/extensions-getting-started',
-        // 'extensions/extensions-configuration',
+        'extensions/extensions-configuration',
         {
           type:  'category',
           label: 'Extensions API',

--- a/shell/creators/app/files/.gitlab-ci.yml
+++ b/shell/creators/app/files/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+image: registry.suse.com/bci/bci-base:latest
+
+stages:
+  - check_version
+  - build_catalog
+
+variables:
+  REGISTRY: $CI_REGISTRY
+  REGISTRY_USER: $CI_REGISTRY_USER
+  REGISTRY_PASSWORD: $CI_REGISTRY_PASSWORD
+  IMAGE_NAMESPACE: $CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME
+
+include:
+  - remote: 'https://raw.githubusercontent.com/rancher/dashboard/master/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml'

--- a/shell/creators/app/init
+++ b/shell/creators/app/init
@@ -34,6 +34,25 @@ if (args.length === 3) {
   fs.ensureDirSync(appFolder);
 }
 
+let addGitlabWorkflow = false;
+
+// Check for Gitlab integration option
+if ( args.length > 3 ) {
+  for (let i = 3; i < args.length; i++) {
+    switch (args[i]) {
+    case '-l':
+      addGitlabWorkflow = true;
+      break;
+    default:
+      break;
+    }
+  }
+}
+
+if ( addGitlabWorkflow ) {
+  files.push('.gitlab-ci.yml');
+}
+
 // Check that there is a package file
 
 let setName = false;

--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.26",
+  "version": "0.4.0",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",

--- a/shell/scripts/extension/bundle
+++ b/shell/scripts/extension/bundle
@@ -16,6 +16,7 @@ REGISTRY="${3}"
 REGISTRY_ORG="${4}"
 IMAGE_PREFIX="${5}"
 PUSH="${6}"
+PODMAN_CONTAINER="${7}"
 
 PKG_NAME="${PKG}-${PKG_VERSION}"
 
@@ -48,12 +49,15 @@ for d in ${BASE_DIR}/dist-pkg/*; do
   cp -R ${BASE_DIR}/dist-pkg/${pkg} ${TMP}/container/plugin
 done
 
-# Build the docker image
-pushd ${TMP}/container > /dev/null
-echo -e "${CYAN}Building container image ...${RESET}"
+package() {
+  if [ "${PODMAN_CONTAINER}" == "true" ]; then
+    RUNTIME="podman"
+  else
+    RUNTIME="docker"
+  fi
+  echo -e "Container build: ${RUNTIME}"
 
-if [ ! -z "${REGISTRY}" ]; then
-  REGISTRY=${REGISTRY} ORG=${REGISTRY_ORG} REPO=${IMAGE_PREFIX}${PKG} TAG=${PKG_VERSION} ./scripts/package
+  REGISTRY=${REGISTRY} ORG=${REGISTRY_ORG} REPO=${IMAGE_PREFIX}${PKG} TAG=${PKG_VERSION} RUNTIME=${RUNTIME} ./scripts/package
 
   if [ "${PUSH}" == "--push" ]; then
     echo -e "${CYAN}Pushing container image ...${RESET}"
@@ -61,14 +65,22 @@ if [ ! -z "${REGISTRY}" ]; then
     # Ensure that you do not overwrite production images
     if [[ "${REGISTRY_ORG}" == "rancher" ]]; then
       IMAGE=${REGISTRY}${REGISTRY_ORG}/${IMAGE_PREFIX}${PKG}:${PKG_VERSION}
-      if docker manifest inspect 2>&1 1>/dev/null; then
+      if ${RUNTIME} manifest inspect ${IMAGE} 2>&1 1>/dev/null; then
         echo -e "${RED}${BOLD}Cannot overwrite production image ${IMAGE_PREFIX}${PKG} since it already exists${RESET}"
         exit 1
       fi
     fi
 
-    docker push ${REGISTRY}${REGISTRY_ORG}/${IMAGE_PREFIX}${PKG}:${PKG_VERSION}
+    ${RUNTIME} push ${REGISTRY}${REGISTRY_ORG}/${IMAGE_PREFIX}${PKG}:${PKG_VERSION}
   fi
+}
+
+# Build the container image
+pushd ${TMP}/container > /dev/null
+echo -e "${CYAN}Building container image ...${RESET}"
+
+if [ ! -z "${REGISTRY}" ]; then
+  package
 fi
 
 popd > /dev/null

--- a/shell/scripts/extension/helm/scripts/package
+++ b/shell/scripts/extension/helm/scripts/package
@@ -5,8 +5,8 @@ source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
-if [[ -z ${ORG} ]] || [[ -z ${REPO} ]] || [[ -z ${TAG} ]]; then
-    echo "Usage: [REGISTRY=] ORG= REPO= TAG= ./scripts/package"
+if [[ -z ${ORG} ]] || [[ -z ${REPO} ]] || [[ -z ${TAG} ]] || [[ -z ${RUNTIME} ]]; then
+    echo "Usage: [REGISTRY=] ORG= REPO= TAG= RUNTIME= ./scripts/package"
     exit 1
 fi
 
@@ -19,5 +19,13 @@ if [ -e ${DOCKERFILE}.${ARCH} ]; then
     DOCKERFILE=${DOCKERFILE}.${ARCH}
 fi
 
-docker build -f ${DOCKERFILE} -t ${IMAGE} .
+BUILD="${RUNTIME} build -f ${DOCKERFILE} -t ${IMAGE}"
+
+if [[ ${RUNTIME} == "podman" ]]; then
+    BUILD="$BUILD -v /var/lib/containers:/var/lib/containers ."
+else
+    BUILD="$BUILD ."
+fi
+
+$BUILD
 echo Built ${IMAGE}

--- a/shell/scripts/extension/publish
+++ b/shell/scripts/extension/publish
@@ -17,6 +17,7 @@ IMAGE_PREFIX="ui-extension-"
 FORCE="false"
 GITHUB_BUILD="true"
 GITHUB_RELEASE_TAG=""
+PODMAN_CONTAINER="false"
 
 GITHUB_SOURCE=$(git config --get remote.origin.url | sed -e 's/^git@.*:\([[:graph:]]*\).git/\1/')
 GITHUB_BRANCH="main"
@@ -33,10 +34,11 @@ usage() {
   echo "  -r <name>    Specify destination container registry for built images"
   echo "  -o <name>    Specify destination container registry organization for built images"
   echo "  -i <prefix>  Specify prefix for the built container image (default: 'ui-extension-')"
+  echo "  -l           Specify Podman container build"
   exit 1
 }
 
-while getopts "hvr:o:pi:fcb:t:s:" opt; do
+while getopts "hvr:o:pi:fcb:t:s:l" opt; do
   case $opt in
     h)
       usage
@@ -69,6 +71,9 @@ while getopts "hvr:o:pi:fcb:t:s:" opt; do
       ;;
     t)
       GITHUB_RELEASE_TAG="${OPTARG}"
+      ;;
+    l)
+      PODMAN_CONTAINER="true"
       ;;
     *)
       usage
@@ -126,7 +131,11 @@ fi
 
 COMMANDS=("node" "jq" "yq" "git" "helm" "yarn")
 if [ "${GITHUB_BUILD}" == "false" ]; then
-  COMMANDS+=("docker")
+  if [ "${PODMAN_CONTAINER}" == "true" ]; then
+    COMMANDS+=("podman")
+  else
+    COMMANDS+=("docker")
+  fi
 fi
 
 HAVE_COMMANDS="true"
@@ -172,10 +181,12 @@ if [ "${GITHUB_BUILD}" == "false" ]; then
     exit 1
   fi
 
-  docker images > /dev/null
-  if [ $? -ne 0 ]; then
-    echo "docker is not running - this is required to build container images for the UI Plugins"
-    exit 1
+  if [ "${PODMAN_CONTAINER}" == "false" ]; then
+    docker images > /dev/null
+    if [ $? -ne 0 ]; then
+      echo "docker is not running - this is required to build container images for the UI Plugins"
+      exit 1
+    fi
   fi
 fi
 
@@ -354,8 +365,8 @@ if [ "${GITHUB_BUILD}" == "false" ]; then
   echo -e "${CYAN}Base extension: ${BASE_EXT}${RESET}"
   echo -e "${CYAN}Extension version: ${EXT_VERSION}${RESET}"
 
-  # Build the docker image
-  ${SCRIPT_DIR}/bundle ${BASE_EXT} ${EXT_VERSION} ${REGISTRY} ${REGISTRY_ORG} ${IMAGE_PREFIX} ${PUSH}
+  # Build the container image
+  ${SCRIPT_DIR}/bundle "${BASE_EXT}" "${EXT_VERSION}" "${REGISTRY}" "${REGISTRY_ORG}" "${IMAGE_PREFIX}" "${PUSH}" "${PODMAN_CONTAINER}"
 else
   rm -rf ${CHART_TEMPLATE}
 fi
@@ -386,5 +397,5 @@ fi
 rm -rf ${CHART_TMP}
 
 if [ "${GITHUB_BUILD}" == "false" ]; then
-  rm -rf ${TMP}
+  rm -rf ${TMP} ${ASSETS} ${CHARTS} ${BASE_DIR}/extensions ${BASE_DIR}/dist-pkg ${ROOT_INDEX}
 fi


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8314 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
In order for the `ui-plugin-operator` to easily consume extensions housed in GitLab, going with the approach of adding an extension catalog image to a container registry is a simple solution. This adds a reusable pipeline configuration to build the ECI within a gitlab pipeline, and by default will push to the gitlab container registry for a given project.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
When creating an extension, you can now supply an argument to add the pipeline with `yarn create @rancher/app my-app -l`, this will add the `.gitlab-ci.yml` file to the root directory of an extension. This file links to the actual job configurations in `build-extension-catalog.gitlab-ci.yml` which will be housed in the `.gitlab/workflows` directory of the Dashboard repo which allows us to continuously iterate on the stages if needed.

The pipeline will build the catalog image using `podman` rather than `docker`, which will enable us to become more oci compliant in the future. With this, the publish scripts have been updated to accommodate using a different runtime. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Building an extension with podman
- Building an extension with docker
- Building extension charts 

---

An example of this use case can be found in a [test repository on Gitlab](https://gitlab.com/jordonleach/rancher-ext), this used the scripts in a relevant location rather than calling `yarn publish-pkgs`. For testing I placed the reusable pipeline file in [this repo](https://github.com/jordojordo/ui-chart-workflow/blob/main/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml) 