### PR TITLE
Fix iframe overlap

### DIFF
--- a/shell/components/EmberPage.vue
+++ b/shell/components/EmberPage.vue
@@ -597,11 +597,11 @@ export default {
 
   .ember-iframe {
     border: 0;
-    left: var(--nav-width);
+    left: calc(var(--nav-width) + $app-bar-collapsed-width);
     height: calc(100vh - var(--header-height));
     position: absolute;
     top: var(--header-height);
-    width: calc(100vw - var(--nav-width));
+    width: calc(100vw - var(--nav-width) - $app-bar-collapsed-width);
     visibility: show;
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Takeing the app bar's width into account so the iframe section doesn't overlap.

Fixes #9904 
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
Before:
<img width="1718" alt="image" src="https://github.com/rancher/dashboard/assets/135728925/80d1f047-48fe-4471-8272-5aa5f08b3b10">

After:
<img width="1717" alt="image" src="https://github.com/rancher/dashboard/assets/135728925/f8cac48f-36c7-4754-aa28-fdb07c284cf1">

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->