### PR TITLE
Fix RBAC issue with workload create/edit screen

### DIFF
--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -146,10 +146,20 @@ export default {
 
   async fetch() {
     // TODO Should remove these lines
-    await allHash({
-      rancherClusters:  this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER }),
-      harvesterConfigs: this.$store.dispatch('management/findAll', { type: HCI.HARVESTER_CONFIG }),
-    });
+    // ? The results aren't stored, so don't know why we fetch?
+
+    // User might not have access to these resources - so check before trying to fetch
+    const fetches = {};
+
+    if (this.$store.getters[`management/canList`](CAPI.RANCHER_CLUSTER)) {
+      fetches.rancherClusters = this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
+    }
+
+    if (this.$store.getters[`management/canList`](HCI.HARVESTER_CONFIG)) {
+      fetches.harvesterConfigs = this.$store.dispatch('management/findAll', { type: HCI.HARVESTER_CONFIG });
+    }
+
+    await allHash(fetches);
 
     // don't block UI for these resources
     this.resourceManagerFetchSecondaryResources(this.secondaryResourceData);


### PR DESCRIPTION
Fixes #9863 

The workload create/edit screen assumes access to two resources that the user might not have access to - in that case, the fetch errors out and we do not fetch secrets etc, so the form does not operate correctly.

Hard to automate test as this requires RBAC setup.

To test:

- As admin, create a user with user-base
- Create a project and add a namespace
- Create an image pull secret (registry secret) int this new namespace
- Give the new user member access to the project
- Login as the new user
- Go to create a new workload in the namespace in the project and in general, check the 'Pull Secrets' dropdown in the Image section - with this bug, this will be empty. With this fix, the list should show the secret that was created.

![image](https://github.com/rancher/dashboard/assets/1955897/7dad3dec-ba4c-435c-9c5b-6e37be7f75f1)
