### PR TITLE
add additional configuration banner for amazon cloud provider

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1677,6 +1677,7 @@ cluster:
     haveArgInfo: Configuration information is not available for the selected Kubernetes version.  The options available on this screen will be limited; you may want to use the YAML editor.
     deprecatedPsp: Pod Security Policies are deprecated as of Kubernetes v1.21, and have been removed in Kubernetes v1.25.
     removedPsp: Pod Security Policies have been removed in Kubernetes v1.25. Use Pod Security Admission instead.
+    cloudProviderAddConfig: 'On Kubernetes 1.27 or greater, the Amazon Cloud Provider requires additional configuration. See <a href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon" target="_blank" rel="noopener noreferrer nofollow">the documentation</a> for more information.'
     machinePoolError: |-
       {count, plural,
         =1 { {pool_name}: The provided value for {fields} was not found in the list of expected values. This can happen with clusters provisioned outside of Rancher or when options for the provider have changed. }

--- a/shell/edit/provisioning.cattle.io.cluster/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/Basics.vue
@@ -377,6 +377,13 @@ export default {
       const canNotEdit = this.clusterIsAlreadyCreated && !this.unsupportedCloudProvider;
 
       return canNotEdit;
+    },
+
+    /**
+     * Display warning about additional configuration needed for cloud provider Amazon if kube >= 1.27
+     */
+    showCloudProviderAmazonAdditionalConfigWarning() {
+      return !!semver.gte(this.value.spec.kubernetesVersion, 'v1.27.0') && this.agentConfig['cloud-provider-name'] === 'aws';
     }
   },
 
@@ -412,6 +419,12 @@ export default {
       <span
         v-clean-html="t('cluster.harvester.warning.cloudProvider.incompatible', null, true)"
       />
+    </Banner>
+    <Banner
+      v-if="showCloudProviderAmazonAdditionalConfigWarning"
+      color="warning"
+    >
+      <span v-clean-html="t('cluster.banner.cloudProviderAddConfig', {}, true)" />
     </Banner>
     <div class="row mb-10">
       <div class="col span-6">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9110 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add warning banner for amazon cloud provider when kubernetes version is `gte` to `v1.27`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to `Cluster Management` -> and create a `RKE2` `Amazon EC2` cluster
- The `basics` Tab, select the combo of `kube version` at least `v1.27` + cloud provider `Amazon`
- A new banner should appear just like the screenshot

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2023-10-13 at 12 48 07](https://github.com/rancher/dashboard/assets/97888974/e3ccccef-375e-437c-83e4-ff5f6e31f2bd)
