### PR TITLE
add hook to re-add `target _blank` to external links cleaned by v-clean-directive

### DIFF
--- a/shell/plugins/clean-html-directive.js
+++ b/shell/plugins/clean-html-directive.js
@@ -17,6 +17,14 @@ const ALLOWED_TAGS = [
   'strong',
 ];
 
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  // set all elements owning target to target=_blank if rel property includes the correct values, making it safe
+  // Solution based on https://github.com/cure53/DOMPurify/issues/317
+  if ('rel' in node && node.rel.includes('noopener') && node.rel.includes('noreferrer') && node.rel.includes('nofollow')) {
+    node.setAttribute('target', '_blank');
+  }
+});
+
 export const purifyHTML = (value) => DOMPurify.sanitize(value, { ALLOWED_TAGS });
 
 export const cleanHtmlDirective = {


### PR DESCRIPTION
add hook to re-add `target _blank` to external links cleaned by v-clean-directive

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9920 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add hook to re-add `target _blank` to external links cleaned by v-clean-directive

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Add a HTML element to a Vue view like (just as an example... find another translation string with an anchor `<a>` inside:
```
<p
    v-if="role.id === 'restricted-admin'"
    v-clean-html="t('rbac.globalRoles.role.restricted-admin.deprecation', { releaseNotesUrl }, true)"
    class="deprecation-notice"
  />
```
click on it via the UI
Make sure the link is opened in a new tab

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->