### PR TITLE
update loadCluster to account for extensions adding to existing products

### DIFF
--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -804,14 +804,14 @@ export const actions = {
     commit('targetRoute', targetRoute);
     const sameCluster = state.clusterId && state.clusterId === id;
     const samePackage = oldPkg?.name === newPkg?.name;
+    const sameProduct = oldProduct === product;
     const isMultiCluster = getters['isMultiCluster'];
 
-    // Are we in the same cluster and package?
-    if ( sameCluster && samePackage) {
+    // Are we in the same cluster and package or product?
+    if ( sameCluster && (samePackage || sameProduct)) {
       // Do nothing, we're already connected/connecting to this cluster
       return;
     }
-
     const oldPkgClusterStore = oldPkg?.stores.find(
       (s) => getters[`${ s.storeName }/isClusterStore`]
     )?.storeName;
@@ -832,7 +832,6 @@ export const actions = {
       // so that the nav and header stay the same when going to things like prefs
       commit('clusterReady', false);
       commit('clusterId', undefined);
-
       await dispatch('cluster/unsubscribe');
       commit('cluster/reset');
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9733 

An extension can add to an existing product by nesting its routes, see https://github.com/rancher/capi-ui-extension/pull/3; however, if the product is cluster-scoped `loadCluster` will re-run when navigating into/out of the extension which causes a noticeable delay.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
Locally build and load the capi extension, navigate to `c/local/manager` (note the cluster-scoping), navigate into/out of the capi section and use existing console logs to verify that the cluster store isn't re-initializing (attempting to subscribe to socket; re-loading schemas)


### Areas which could experience regressions
* navigating to a new package but same cluster id eg between epinio and cluster explorer
* navigating to an extension that adds a product to cluster explorer eg kubewarden
