### PR TITLE
Update sort for numeric string values

### DIFF
--- a/shell/utils/__tests__/sort.test.ts
+++ b/shell/utils/__tests__/sort.test.ts
@@ -15,7 +15,7 @@ describe('fx: sort', () => {
       testSortBy(ary, key, expected);
     });
 
-    it.only.each([
+    it.each([
       [[{ a: '989' }, { a: '895' }, { a: '9' }], ['a'], [{ a: '9' }, { a: '895' }, { a: '989' }]],
       [[{ a: '2.55.17.196' }, { a: '2.2.17.2' }], ['a'], [{ a: '2.2.17.2' }, { a: '2.55.17.196' }]],
     ])('should sort by number', (ary, key, expected) => {

--- a/shell/utils/__tests__/sort.test.ts
+++ b/shell/utils/__tests__/sort.test.ts
@@ -15,6 +15,13 @@ describe('fx: sort', () => {
       testSortBy(ary, key, expected);
     });
 
+    it.only.each([
+      [[{ a: '989' }, { a: '895' }, { a: '9' }], ['a'], [{ a: '9' }, { a: '895' }, { a: '989' }]],
+      [[{ a: '2.55.17.196' }, { a: '2.2.17.2' }], ['a'], [{ a: '2.2.17.2' }, { a: '2.55.17.196' }]],
+    ])('should sort by number', (ary, key, expected) => {
+      testSortBy(ary, key, expected);
+    });
+
     it.each([
       [[{ a: 1, b: 1 }, { a: 9, b: 9 }], ['a', 'b'], [{ a: 1, b: 1 }, { a: 9, b: 9 }]],
       [[{ a: 2, b: 2 }, { a: 1, b: 1 }], ['a', 'b'], [{ a: 1, b: 1 }, { a: 2, b: 2 }]],

--- a/shell/utils/sort.js
+++ b/shell/utils/sort.js
@@ -96,7 +96,7 @@ export function typeOf(item) {
   }
 
   function ValidateIPaddress(ipaddress) {
-    return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress)
+    return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress);
   }
 
   let ret = TYPE_MAP[toString.call(item)] || 'object';
@@ -126,9 +126,10 @@ export function spaceship(a, b) {
 }
 
 export function octet(a, b) {
-  const num1 = Number(a.split(".").map((num) => (`000${num}`).slice(-3) ).join(""));
-  const num2 = Number(b.split(".").map((num) => (`000${num}`).slice(-3) ).join(""));
-  return num1-num2;
+  const num1 = Number(a.split('.').map((num) => (`000${ num }`).slice(-3) ).join(''));
+  const num2 = Number(b.split('.').map((num) => (`000${ num }`).slice(-3) ).join('""'));
+
+  return num1 - num2;
 }
 
 const TYPE_ORDER = {
@@ -160,7 +161,7 @@ export function compare(a, b) {
   case 'number':
     return spaceship(a, b);
   case 'octet':
-      return octet(a, b);
+    return octet(a, b);
   case 'string':
     return spaceship(a.localeCompare(b), 0);
 

--- a/shell/utils/sort.js
+++ b/shell/utils/sort.js
@@ -94,7 +94,19 @@ export function typeOf(item) {
   if (item === undefined) {
     return 'undefined';
   }
+
+  function ValidateIPaddress(ipaddress) {
+    return /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(ipaddress)
+  }
+
   let ret = TYPE_MAP[toString.call(item)] || 'object';
+
+  if (isNumeric(item)) {
+    ret = 'number';
+  }
+  if (ValidateIPaddress(item)) {
+    ret = 'octet';
+  }
 
   if (ret === 'object') {
     if (item instanceof Error) {
@@ -111,6 +123,12 @@ export function spaceship(a, b) {
   const diff = a - b;
 
   return (diff > 0) - (diff < 0);
+}
+
+export function octet(a, b) {
+  const num1 = Number(a.split(".").map((num) => (`000${num}`).slice(-3) ).join(""));
+  const num2 = Number(b.split(".").map((num) => (`000${num}`).slice(-3) ).join(""));
+  return num1-num2;
 }
 
 const TYPE_ORDER = {
@@ -141,7 +159,8 @@ export function compare(a, b) {
   case 'boolean':
   case 'number':
     return spaceship(a, b);
-
+  case 'octet':
+      return octet(a, b);
   case 'string':
     return spaceship(a.localeCompare(b), 0);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

<!-- Define findings related to the feature or bug issue. -->
- Sort numeric values as string
- Sort IP addresses in a more numerical way

Modify Sort function test for these two types of values in the table

### How to test
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
IP addresses, e.g. in Pods and Node list, should be sorted numerically-octet-wise.

For number as strings can be tested in sort.js test
