### PR TITLE
Allow extentions to redirect the user to another location if authentication fails

### DIFF
--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -8,7 +8,7 @@ import { MANAGEMENT, NORMAN, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { applyProducts } from '@shell/store/type-map';
 import { findBy } from '@shell/utils/array';
-import { ClusterNotFoundError } from '@shell/utils/error';
+import { ClusterNotFoundError, RedirectToError } from '@shell/utils/error';
 import { get } from '@shell/utils/object';
 import { setFavIcon, haveSetFavIcon } from '@shell/utils/favicon';
 import dynamicPluginLoader from '@shell/pkg/dynamic-plugin-loader';
@@ -502,8 +502,10 @@ export default async function({
       }
     }
   } catch (e) {
-    if ( e instanceof ClusterNotFoundError ) {
+    if ( e.name === ClusterNotFoundError.name ) {
       return redirect(302, '/home');
+    } if ( e.name === RedirectToError.name ) {
+      return redirect(302, e.url);
     } else {
       // Sets error 500 if lost connection to API
       store.commit('setError', { error: e, locationError: new Error(store.getters['i18n/t']('nav.failWhale.authMiddleware')) });

--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",

--- a/shell/utils/error.js
+++ b/shell/utils/error.js
@@ -1,9 +1,24 @@
 import { isArray } from '@shell/utils/array';
 
 export class ClusterNotFoundError extends Error {
+  static name = 'ClusterNotFoundError'
+
   constructor(message) {
     super(message);
-    this.name = 'ClusterNotFoundError';
+    this.name = ClusterNotFoundError.name;
+  }
+}
+
+/**
+ * An error occurred and the user should be redirected to a certain location (where this is handled)
+ */
+export class RedirectToError extends Error {
+  static name = 'RedirectToError'
+
+  constructor(message, url) {
+    super(message);
+    this.url = url;
+    this.name = RedirectToError.name;
   }
 }
 


### PR DESCRIPTION





### Occurred changes and/or fixed issues
- if entering the product, loading cluster, etc fails extensions can now throw a `RedirectToError` error
- this avoids the user being redirect to the dashboard home or fail-whale page
- example - epinio auth fails and we want to return user to the epinio cluster list

### Technical notes summary
In theory we should be able to to instanceof with something that extends error and has a `name`, unfortunately this does not work, so gone for something more manual.

Also bump shell so we can publish a new version



### Areas which could experience regressions
- user is navigated to the home page if the cluster id is unknown
