### PR TITLE
hide embedded grafana graphs on cluster index when the user cant view grafana endpoint

### DIFF
--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -4,7 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import InstallRedirect from '@shell/utils/install-redirect';
 import AlertTable from '@shell/components/AlertTable';
 import { NAME, CHART_NAME } from '@shell/config/product/monitoring';
-import { CATALOG, ENDPOINTS, MONITORING } from '@shell/config/types';
+import { CATALOG, MONITORING } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
 import { findBy } from '@shell/utils/array';
 import { getClusterPrefix } from '@shell/utils/grafana';

--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -11,9 +11,7 @@ import { getClusterPrefix } from '@shell/utils/grafana';
 import { Banner } from '@components/Banner';
 import LazyImage from '@shell/components/LazyImage';
 import SimpleBox from '@shell/components/SimpleBox';
-import { haveV1MonitoringWorkloads } from '@shell/utils/monitoring';
-
-const CATTLE_MONITORING_NAMESPACE = 'cattle-monitoring-system';
+import { haveV1MonitoringWorkloads, canViewAlertManagerLink, canViewGrafanaLink, canViewPrometheusLink } from '@shell/utils/monitoring';
 
 export default {
   components: {
@@ -101,52 +99,36 @@ export default {
       if ($store.getters['cluster/canList'](CATALOG.APP)) {
         hash.apps = $store.dispatch('cluster/findAll', { type: CATALOG.APP });
       }
-      if ($store.getters['cluster/schemaFor'](ENDPOINTS)) {
-        hash.endpoints = $store.dispatch('cluster/findAll', { type: ENDPOINTS });
-      }
       const res = await allHash(hash);
 
-      if (res.endpoints && !isEmpty(res.endpoints)) {
-        const amMatch = findBy(externalLinks, 'group', 'alertmanager');
-        const grafanaMatch = findBy(externalLinks, 'group', 'grafana');
-        const promeMatch = externalLinks.filter(
-          (el) => el.group === 'prometheus'
-        );
+      const canViewAlertManager = await canViewAlertManagerLink(this.$store);
+      const canViewGrafana = await canViewGrafanaLink(this.$store);
+      const canViewPrometheus = await canViewPrometheusLink(this.$store);
 
+      if (canViewAlertManager) {
+        const amMatch = findBy(externalLinks, 'group', 'alertmanager');
+
+        amMatch.enabled = true;
+      }
+      if (canViewGrafana) {
+        const grafanaMatch = findBy(externalLinks, 'group', 'grafana');
         // Generate Grafana link
         const currentCluster = this.$store.getters['currentCluster'];
         const rancherMonitoring = !isEmpty(res.apps) ? findBy(res.apps, 'id', 'cattle-monitoring-system/rancher-monitoring') : '';
         const clusterPrefix = getClusterPrefix(rancherMonitoring?.currentVersion || '', currentCluster.id);
 
         grafanaMatch.link = `${ clusterPrefix }/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/`;
+        grafanaMatch.enabled = true;
+      }
 
-        const alertmanager = findBy(
-          res.endpoints,
-          'id',
-          `${ CATTLE_MONITORING_NAMESPACE }/rancher-monitoring-alertmanager`
-        );
-        const grafana = findBy(
-          res.endpoints,
-          'id',
-          `${ CATTLE_MONITORING_NAMESPACE }/rancher-monitoring-grafana`
-        );
-        const prometheus = findBy(
-          res.endpoints,
-          'id',
-          `${ CATTLE_MONITORING_NAMESPACE }/rancher-monitoring-prometheus`
+      if (canViewPrometheus) {
+        const promeMatch = externalLinks.filter(
+          (el) => el.group === 'prometheus'
         );
 
-        if (!isEmpty(alertmanager) && !isEmpty(alertmanager.subsets)) {
-          amMatch.enabled = true;
-        }
-        if (!isEmpty(grafana) && !isEmpty(grafana.subsets)) {
-          grafanaMatch.enabled = true;
-        }
-        if (!isEmpty(prometheus) && !isEmpty(prometheus.subsets)) {
-          promeMatch.forEach((match) => {
-            match.enabled = true;
-          });
-        }
+        promeMatch.forEach((match) => {
+          match.enabled = true;
+        });
       }
     },
   },

--- a/shell/utils/monitoring.js
+++ b/shell/utils/monitoring.js
@@ -1,6 +1,6 @@
 // Helpers for determining if V2 or v1 Monitoring are installed
 
-import { SCHEMA, MONITORING, WORKLOAD_TYPES } from '@shell/config/types';
+import { SCHEMA, MONITORING, WORKLOAD_TYPES, ENDPOINTS } from '@shell/config/types';
 import { normalizeType } from '@shell/plugins/dashboard-store/normalize';
 import { findBy } from '@shell/utils/array';
 import { isEmpty } from '@shell/utils/object';
@@ -63,6 +63,30 @@ export async function haveV1MonitoringWorkloads(store) {
 
     return Promise.resolve(false);
   }
+}
+
+async function hasEndpointSubsets(store, id) {
+  if (store.getters['cluster/schemaFor'](ENDPOINTS)) {
+    const endpoints = await store.dispatch('cluster/findAll', { type: ENDPOINTS }) || [];
+
+    const endpoint = endpoints.find((ep) => ep.id === id);
+
+    return endpoint && !isEmpty(endpoint) && !isEmpty(endpoint.subsets);
+  }
+
+  return false;
+}
+
+export async function canViewGrafanaLink(store) {
+  return await hasEndpointSubsets(store, `${ CATTLE_MONITORING_NAMESPACE }/rancher-monitoring-grafana`);
+}
+
+export async function canViewAlertManagerLink(store) {
+  return await hasEndpointSubsets(store, `${ CATTLE_MONITORING_NAMESPACE }/rancher-monitoring-alertmanager`);
+}
+
+export async function canViewPrometheusLink(store) {
+  return await hasEndpointSubsets(store, `${ CATTLE_MONITORING_NAMESPACE }/rancher-monitoring-prometheus`);
 }
 
 // Other ways we check for monitoring:


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9792 - (look at latest comments for explanation)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the cluster index to only show metrics tabs when the user can view the grafana endpoint. Prevously we checked if the relevant grafana links worked: this doesn't match the monitoring-ui-view permissions described in the docs  (https://github.com/rancher/dashboard/issues/9792#issuecomment-1766808320)

### Technical notes summary
This matches the logic already in place on the monitoring index page so I moved that code to a utility.

### Areas or cases that should be tested
Original repro steps in the issue 

### Areas which could experience regressions
Links on the monitoring index view

