### PR TITLE
actions on cluster tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -112,7 +112,7 @@ export default defineConfig({
       require('@cypress/code-coverage/task')(on, config);
       require('@cypress/grep/src/plugin')(config);
       // For more info: https://www.npmjs.com/package/cypress-delete-downloads-folder
-      on('task', { removeDirectory })
+      on('task', { removeDirectory });
 
       return config;
     },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'cypress';
+import { removeDirectory } from 'cypress-delete-downloads-folder';
 // Required for env vars to be available in cypress
 require('dotenv').config();
 
@@ -110,6 +111,8 @@ export default defineConfig({
       // For more info: https://docs.cypress.io/guides/tooling/code-coverage
       require('@cypress/code-coverage/task')(on, config);
       require('@cypress/grep/src/plugin')(config);
+      // For more info: https://www.npmjs.com/package/cypress-delete-downloads-folder
+      on('task', { removeDirectory })
 
       return config;
     },

--- a/cypress/e2e/po/components/shell.po.ts
+++ b/cypress/e2e/po/components/shell.po.ts
@@ -16,4 +16,12 @@ export default class Shell extends ComponentPo {
 
     return this;
   }
+
+  closeTerminal() {
+    return this.self().get('.tab .closer').click();
+  }
+
+  terminalStatus(label: string) {
+    return this.self().get('.status').contains(label);
+  }
 }

--- a/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
@@ -1,5 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import ProvClusterListPo from '@/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 
 /**
  * List page for provisioning.cattle.io.cluster resources
@@ -15,6 +16,11 @@ export default class ClusterManagerListPagePo extends PagePo {
 
   constructor(clusterId: string) {
     super(ClusterManagerListPagePo.createPath(clusterId));
+  }
+
+  static navTo() {
+    BurgerMenuPo.toggle();
+    BurgerMenuPo.burgerMenuNavToMenubyLabel('Cluster Management');
   }
 
   list(): ProvClusterListPo {

--- a/cypress/e2e/tests/pages/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/cluster-manager.spec.ts
@@ -74,18 +74,18 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
 
       it('can copy config to clipboard', () => {
         clusterList.goTo();
-    
+
         cy.intercept('POST', '*action=generateKubeconfig').as('copyKubeConfig');
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Copy KubeConfig to Clipboard').click();
         cy.wait('@copyKubeConfig');
-    
+
         // Verify confirmation message displays and is hidden after ~3 sec
         cy.get('.growl-text').contains('Copied KubeConfig to Clipboard').should('be.visible');
         cy.get('.growl-text', { timeout: 4000 }).should('not.exist');
-    
+
         // Skipping following assertion for now as it is failing due to Cypress' limitations with accessing the clipboard in Chrome browser and headless mode. Works in Electron browser
         // see https://github.com/cypress-io/cypress/issues/2752
-    
+
         // read text saved in the browser clipboard
         // cy.window().its('navigator.clipboard')
         //   .invoke('readText').should('include', rke2CustomName);
@@ -137,7 +137,7 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
       it('can download YAML', () => {
         // Delete downloads directory. Need a fresh start to avoid conflicting file names
         cy.deleteDownloadsFolder();
-        
+
         clusterList.goTo();
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download YAML').click();
 
@@ -322,6 +322,6 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
   it('can connect to kubectl shell', () => {
     clusterList.goTo();
     clusterList.list().actionMenu('local').getMenuItem('Kubectl Shell').click();
-    cy.contains('Connected').should('be.visible')
+    cy.contains('Connected').should('be.visible');
   });
 });

--- a/cypress/e2e/tests/pages/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/cluster-manager.spec.ts
@@ -12,6 +12,7 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import * as path from 'path';
 import * as jsyaml from 'js-yaml';
 import ClusterManagerCreateRke1CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke1-custom.po';
+import Shell from '@/cypress/e2e/po/components/shell.po';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
 const runTimestamp = +new Date();
@@ -27,10 +28,10 @@ const importGenericName = `${ clusterNamePartial }-import-generic`;
 
 const downloadsFolder = Cypress.config('downloadsFolder');
 
-describe('Cluster Manager', { tags: '@adminUser' }, () => {
+describe('Cluster Manager', { testIsolation: 'off', tags: '@adminUser' }, () => {
   const clusterList = new ClusterManagerListPagePo('local');
 
-  beforeEach(() => {
+  before(() => {
     cy.login();
   });
 
@@ -73,7 +74,7 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
       });
 
       it('can copy config to clipboard', () => {
-        clusterList.goTo();
+        ClusterManagerListPagePo.navTo();
 
         cy.intercept('POST', '*action=generateKubeconfig').as('copyKubeConfig');
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Copy KubeConfig to Clipboard').click();
@@ -138,7 +139,7 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
         // Delete downloads directory. Need a fresh start to avoid conflicting file names
         cy.deleteDownloadsFolder();
 
-        clusterList.goTo();
+        ClusterManagerListPagePo.navTo();
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download YAML').click();
 
         const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
@@ -320,8 +321,12 @@ describe('Cluster Manager', { tags: '@adminUser' }, () => {
   });
 
   it('can connect to kubectl shell', () => {
-    clusterList.goTo();
+    ClusterManagerListPagePo.navTo();
     clusterList.list().actionMenu('local').getMenuItem('Kubectl Shell').click();
-    cy.contains('Connected').should('be.visible');
+
+    const shellPo = new Shell();
+
+    shellPo.terminalStatus('Connected');
+    shellPo.closeTerminal();
   });
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -2,8 +2,10 @@ import '@cypress/code-coverage/support';
 import './commands/commands';
 import './commands/rancher-api-commands.ts';
 import registerCypressGrep from '@cypress/grep/src/support';
+import { addCustomCommand } from 'cypress-delete-downloads-folder';
 
 registerCypressGrep();
+addCustomCommand();
 
 // TODO handle redirection errors better?
 // we see a lot of 'error navigation cancelled' uncaught exceptions that don't actually break anything; ignore them here

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "csv-loader": "3.0.3",
     "cy2": "^4.0.6",
     "cypress": "11.1.0",
+    "cypress-delete-downloads-folder": "0.0.4",
     "eslint": "7.32.0",
     "eslint-config-standard": "16.0.3",
     "eslint-import-resolver-node": "0.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5989,6 +5989,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==
 
+cypress-delete-downloads-folder@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/cypress-delete-downloads-folder/-/cypress-delete-downloads-folder-0.0.4.tgz#00693d4d7a36b552e7a11148e49d2c4c34ed3ec3"
+  integrity sha512-0zix5YIROeMHCrCGQVmMP+jUL3KtKliAs1msSnHCPwkX8rNL4DioI8UHvbBVVghWA3vxWN6GCtV1qW+5DHi9Bg==
+
 cypress@11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.1.0.tgz#b8f16495a8a5d8f9a7dd3374ae7b2cef45e9c779"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR covers the functionality in the Cluster actions (within ellipsis)
View Test Plan https://github.com/rancher/qa-tasks/issues/753

### Technical notes summary
Between the two download tests, the kubeconfig and YAML files are created with the same name in the downloads directory which is causing failures. The easiest solution was to add the [cypress-delete-downloads-folder ](https://www.npmjs.com/package/cypress-delete-downloads-folder) npm package to delete the downloads directory to avoid the conflicting files.
Changes include adding several lines of code to our Cypress configuration files which allows the cleanup of our downloads with `cy.deleteDownloadsFolder()` command.

### Screenshots
<img width="1462" alt="Screenshot 2023-10-18 at 1 17 16 PM" src="https://github.com/rancher/dashboard/assets/127343932/05f11406-c534-4a4d-a2a9-edfbe97a1313">

