### PR TITLE
Ensure SAML providers popup closes correctly

### DIFF
--- a/shell/pages/auth/verify.vue
+++ b/shell/pages/auth/verify.vue
@@ -17,6 +17,13 @@ function reply(err, code) {
   }
 }
 
+function isSaml($route) {
+  const { query } = $route;
+  const configQuery = get(query, 'config');
+
+  return samlProviders.includes(configQuery);
+}
+
 export default {
   layout: 'unauthenticated',
 
@@ -43,9 +50,14 @@ export default {
     try {
       parsed = JSON.parse(base64Decode((stateStr)));
     } catch (err) {
+      if (isSaml(route)) {
+        // This is an ok failure. SAML has no state string so a failure is fine (see similar check in mounted).
+        // This whole file could be re-written with that in mind, but this change keeps things simple and fixes a breaking addition
+        return;
+      }
       const out = store.getters['i18n/t'](`login.error`);
 
-      console.error('Failed to parse nonce'); // eslint-disable-line no-console
+      console.error('Failed to parse nonce', stateStr, err); // eslint-disable-line no-console
 
       redirect(`/auth/login?err=${ escape(out) }`);
 
@@ -117,12 +129,8 @@ export default {
         window.close();
       }
     } else {
-      const { query } = this.$route;
-
       if ( window.opener ) {
-        const configQuery = get(query, 'config');
-
-        if ( samlProviders.includes(configQuery) ) {
+        if (isSaml(this.$route)) {
           if ( window.opener.window.onAuthTest ) {
             reply(null, null);
           } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9949
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- When configuring a SAML auth provider a popup window is shown
- The popup window allows the user to log in to the SAML provider
- The same popup window gets redirected to auth/verify to check the response of the log in
   - Normally there will be a state string. Recently code was added to show an error if this is missing
   - If SAML though there is no state, so we would incorrectly show this error. This is the bug
- Note - the auth provider was enabled, so closing the popup and refreshing the original page would continue as normal

### Technical notes summary
- See our confluence okta page on how to setup an okta provider
- This is a regression introduced in 2.7.7 via https://github.com/rancher/dashboard/pull/7623 (actual change was https://github.com/rancher/dashboard/pull/7299)

### Areas or cases that should be tested
- A saml provider like OKTA

### Areas which could experience regressions
- A non saml provider like oauth / github