### PR TITLE
correct port-issue workflow github_token vars

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check org membership
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
               echo "${GITHUB_ACTOR} is a member"
@@ -26,7 +26,7 @@ jobs:
       - name: Check milestone
         if: env.is_member == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
@@ -46,7 +46,7 @@ jobs:
           env.is_member == 'true' &&
           env.milestone_exists == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |


### PR DESCRIPTION
The port-issue workflow isn't working, see https://github.com/rancher/dashboard/actions/runs/6578593068/job/17872661826

I tested this change on a personal repo and it appears to fix the workflow.