### PR TITLE
Wrong rendering of Markdown files

### DIFF
--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -20,9 +20,14 @@ export default {
 
   computed: {
     html() {
-      return this.marked.parse(this.value, {
+      console.log('HTML', this.marked.parse(this.value, {
         renderer: this.markedRenderer,
         breaks:   true
+      }));
+
+      return this.marked.parse(this.value, {
+        renderer: this.markedRenderer,
+        // breaks:   true
       });
     },
   },
@@ -87,8 +92,20 @@ export default {
 }
 
 .markdown {
+    blockquote {
+      color: rgb(101, 109, 118);
+      border-left: 0.25em solid rgb(208, 215, 222);
+      padding: 0 1em;
+      margin-bottom: 16px;
+    }
+
+    table {
+      border-collapse: collapse;
+    }
+
     TH {
       text-align: left;
+      border: 1px solid #e3e7eb;
     }
 
     table tr th {
@@ -109,6 +126,7 @@ export default {
       text-align: left;
       margin: 0;
       padding: 6px 13px;
+      border: 1px solid #e3e7eb;
     }
 
     table tr th :first-child, table tr td :first-child {

--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -20,14 +20,9 @@ export default {
 
   computed: {
     html() {
-      console.log('HTML', this.marked.parse(this.value, {
-        renderer: this.markedRenderer,
-        breaks:   true
-      }));
-
       return this.marked.parse(this.value, {
         renderer: this.markedRenderer,
-        // breaks:   true
+        breaks:   true
       });
     },
   },

--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -15,7 +15,6 @@ export default {
     return {
       loaded:    false,
       marked:    null,
-      dompurify: null,
     };
   },
 
@@ -26,15 +25,10 @@ export default {
         breaks:   true
       });
     },
-
-    sanitized() {
-      return this.dompurify.sanitize(this.html);
-    },
   },
 
   async mounted() {
     const marked = (await import(/* webpackChunkName: "markdown" */ 'marked'));
-    const dompurify = (await import(/* webpackChunkName: "markdown" */ 'dompurify')).default;
 
     const renderer = new marked.Renderer();
     const linkRenderer = renderer.link;
@@ -63,11 +57,8 @@ export default {
       return rendered;
     };
 
-    dompurify.setConfig({ ADD_ATTR: ['target'] });
-
     this.marked = marked;
     this.markedRenderer = renderer;
-    this.dompurify = dompurify;
     this.loaded = true;
     this.$emit('loaded', true);
   }
@@ -77,7 +68,7 @@ export default {
 <template>
   <div
     v-if="loaded"
-    v-clean-html="sanitized"
+    v-clean-html="html"
     class="markdown"
   />
   <Loading v-else />

--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -13,8 +13,8 @@ export default {
 
   data() {
     return {
-      loaded:    false,
-      marked:    null,
+      loaded: false,
+      marked: null,
     };
   },
 

--- a/shell/plugins/clean-html.js
+++ b/shell/plugins/clean-html.js
@@ -15,6 +15,19 @@ const ALLOWED_TAGS = [
   'i',
   'em',
   'strong',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'table',
+  'thead',
+  'tr',
+  'th',
+  'tbody',
+  'td',
+  'blockquote'
 ];
 
 // Allow 'A' tags to keep the target=_blank attribute if they have it


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9951 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- remove `DOMpurify` from markdown component (`v-clean-html` does exactly this, so need to duplicate it)
- add missing `html` tags to allowed tags in `v-clean-html` so that markdown content is rendered correctly

**NOTE:** links in markdown won't open in a new tab unless https://github.com/rancher/dashboard/pull/9928 is merged as well.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to `https://<!--- RANCHER BASE URL --->/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-partner-charts&chart=tomcat&version=10.10.10` and check that markdown is rendered correctly

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2023-10-20 at 11 07 18](https://github.com/rancher/dashboard/assets/97888974/9401733f-7992-492e-97af-1b2972bacd3a)
![Screenshot 2023-10-20 at 11 07 22](https://github.com/rancher/dashboard/assets/97888974/2831a674-2d1d-4191-b838-a04fa843ff74)
