### PR TITLE
Fix bug with container log formatting

### DIFF
--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -276,7 +276,7 @@ export default {
       this.socket.addEventListener(EVENT_MESSAGE, (e) => {
         const data = base64Decode(e.detail.data);
 
-        // Websocket message may contain multiple lines - loop through each line, one by one 
+        // Websocket message may contain multiple lines - loop through each line, one by one
         data.split('\n').forEach((line) => {
           let msg = line;
           let time = null;

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -274,33 +274,36 @@ export default {
       });
 
       this.socket.addEventListener(EVENT_MESSAGE, (e) => {
-        const line = base64Decode(e.detail.data);
+        const data = base64Decode(e.detail.data);
 
-        let msg = line;
-        let time = null;
+        // Websocket message may contain multiple lines - loop through each line, one by one 
+        data.split('\n').forEach((line) => {
+          let msg = line;
+          let time = null;
 
-        const idx = line.indexOf(' ');
+          const idx = line.indexOf(' ');
 
-        if ( idx > 0 ) {
-          const timeStr = line.substr(0, idx);
-          const date = new Date(timeStr);
+          if ( idx > 0 ) {
+            const timeStr = line.substr(0, idx);
+            const date = new Date(timeStr);
 
-          if ( !isNaN(date.getSeconds()) ) {
-            time = date.toISOString();
-            msg = line.substr(idx + 1);
+            if ( !isNaN(date.getSeconds()) ) {
+              time = date.toISOString();
+              msg = line.substr(idx + 1);
+            }
           }
-        }
 
-        const parsedLine = {
-          id:     lastId++,
-          msg:    ansiup.ansi_to_html(msg),
-          rawMsg: msg,
-          time,
-        };
+          const parsedLine = {
+            id:     lastId++,
+            msg:    ansiup.ansi_to_html(msg),
+            rawMsg: msg,
+            time,
+          };
 
-        Object.freeze(parsedLine);
+          Object.freeze(parsedLine);
 
-        this.backlog.push(parsedLine);
+          this.backlog.push(parsedLine);
+        });
       });
 
       this.socket.connect();


### PR DESCRIPTION
Fixes #9437
Fixes #9931 

The container logs can end up not formatting correctly when including new-lines.

We assume that each websocket message only includes a single error message - this no longer seems to be the case and we can now get multiple lines.

The fix here is to split on newline and iterate through each line.

To test:

Create a pod from the image `nwmac/logtest` - this is a simple container that logs single and multiline messages.

Examine the container logs for this pod.

Prior to this fix, the output would look like this:

![image](https://github.com/rancher/dashboard/assets/1955897/aec59105-43e0-433d-8838-06f64d996557)

With this fix, the output now looks like this:

![image](https://github.com/rancher/dashboard/assets/1955897/d54d5135-b966-4d1b-839f-b5064791148b)
