### PR TITLE
Update port-issue workflow permissions

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -11,6 +11,8 @@ jobs:
   port-issue:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/backport') || contains(github.event.comment.body, '/forwardport')
+    permissions:
+      issues: write
     steps:
       - name: Check org membership
         env:


### PR DESCRIPTION
I hit two issues with the backport workflow that didn't come up in my own testing repo initially:
1. The workflow needs permission to write issues, see https://github.com/rancher/dashboard/blob/master/.github/workflows/add-to-triage-label.yaml#L10
2. My membership in the Rancher org was set to private. I updated my membership setting (`https://github.com/orgs/rancher/people?query=<GITHUB LOGIN>`), not sure if there's an alternative workkaround that could be added to this workflow. 