### PR TITLE
fix capi machine canScaleDown getter when machine' provisioning cluster is undefined.

### DIFF
--- a/shell/models/cluster.x-k8s.io.machine.js
+++ b/shell/models/cluster.x-k8s.io.machine.js
@@ -231,7 +231,7 @@ export default class CapiMachine extends SteveModel {
       return false;
     }
 
-    return notOnlyOfRole(this, this.cluster.machines);
+    return notOnlyOfRole(this, this.cluster?.machines);
   }
 
   get roles() {


### PR DESCRIPTION
Fixes #9973 
<!-- Define findings related to the feature or bug issue. -->

See the issue for more details - the fix here is just to ensure `canScaleDown` doesn't break if `this.cluster` is undefined. I hit this bug with rancher turtles specifically; I can provide a test setup to repro the bug if needed.