### PR TITLE
update backport workflow to add QA/None label to backport issues

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -60,6 +60,8 @@ jobs:
           if [[ $MILESTONE =~ (v[0-9]\.[0-9]+) ]]; then
               NEW_TITLE="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}"
           fi
+          additional_cmd+=("--label")
+          additional_cmd+=("QA/None")
           ORIGINAL_LABELS=$(gh issue view -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --json labels --jq '.labels[].name' | grep -v '^\[zube\]:' | paste -sd "," -)
           if [ -n "$ORIGINAL_LABELS" ]; then
               additional_cmd+=("--label")


### PR DESCRIPTION
Per offline conversation with @gaktive, current guidance from QA is to add the `QA/None` label to backport issues - this PR updates the issue porting workflow to do so.