### PR TITLE
[Automation] - Recurring dashboard UI tests with multi branch pipeline and tags. Qase reporting

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -1,5 +1,8 @@
 #!groovy
 
+
+def upstream = !currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
+def buildtype = upstream ? "RecurringRun" : "AdHoc"
 def branch = "master"
 if ("${env.branch}" != "null" && "${env.branch}" != "") {
   branch = "${env.branch}"
@@ -20,67 +23,85 @@ node {
       params.each {
         paramsMap << "$it.key=$it.value"
       }
-      withEnv(paramsMap) {
-          stage('Checkout') {
-          deleteDir()
-          checkout([
-                      $class: 'GitSCM',
-                      branches: [[name: "*/${branch}"]],
-                      extensions: scm.extensions + [[$class: 'CleanCheckout']],
-                      userRemoteConfigs: scm.userRemoteConfigs
-                  ])
-          dir('./corral-packages') {
-              checkout([
-                $class: 'GitSCM',
-                branches: [[name: "*/${corralBranch}"]],
-                extensions: scm.extensions + [[$class: 'CleanCheckout']],
-                userRemoteConfigs: [[url: 'https://github.com/'+corralRepo]]
-              ])
-              sh 'git --no-pager branch'
-              def ciFilename = "dashboard-tests.yaml"
-              def ciConfigContents = env.CORRAL_PACKAGE_CONFIG
-              if (ciConfigContents != null) {
-                  writeFile file: "./packages/aws/"+ciFilename, text: ciConfigContents
-              }
-          }
-        }
-        try {
-          stage('Run Tests') {
-              sh 'pwd'
-              sh 'ls -al cypress/jenkins'
-              sh 'cypress/jenkins/init.sh'
-          }
-        } catch (err) {
-            echo "Error: " + err
-            currentBuild.result = 'FAILURE'
-            error()
-        }
-        try {
-          stage('Grab Results') {
-            sh "cypress/jenkins/scpget.sh dashboard/results.xml"
-            sh "cypress/jenkins/scpget.sh dashboard/results.html"
-            sh "cypress/jenkins/scpget.sh dashboard/assets"
-          }
-        } catch(err) {
-            echo "Error: " + err
-        }
-        try {
-          stage('Clean Test Environment') {  
-            sh "${WORKSPACE}/bin/corral delete ci"
-            if ("${env.JOB_TYPE}" == "recurring") {
-              sh "${WORKSPACE}/bin/corral delete rancher"
+      withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                        string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY')]) {
+        withEnv(paramsMap) {
+            stage('Checkout') {
+            deleteDir()
+            checkout([
+                        $class: 'GitSCM',
+                        branches: [[name: "*/${branch}"]],
+                        extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                        userRemoteConfigs: scm.userRemoteConfigs
+                    ])
+            dir('./corral-packages') {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: "*/${corralBranch}"]],
+                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                    userRemoteConfigs: [[url: 'https://github.com/'+corralRepo]]
+                ])
+                sh 'git --no-pager branch'
+                def ciFilename = "dashboard-tests.yaml"
+                def ciConfigContents = env.CORRAL_PACKAGE_CONFIG
+                if (ciConfigContents != null) {
+                    writeFile file: "./packages/aws/"+ciFilename, text: ciConfigContents
+                }
             }
-          }
-        } catch(err) {
-          echo "Error: " + err
-        }
-        try {
-          stage('Test Report') {
-            step([$class: 'JUnitResultArchiver', testResults: '**/results.xml'])
-          }
-        }
-        catch(err) {
-          echo "Error: " + err
+            }
+            try {
+            stage('Run Tests') {
+                sh 'pwd'
+                sh 'ls -al cypress/jenkins'
+                sh 'cypress/jenkins/init.sh'
+            }
+            } catch (err) {
+                echo "Error: " + err
+                currentBuild.result = 'FAILURE'
+                error()
+            }
+            try {
+            stage('Grab Results') {
+                sh "cypress/jenkins/scpget.sh dashboard/results.xml"
+                sh "cypress/jenkins/scpget.sh dashboard/results.html"
+                sh "cypress/jenkins/scpget.sh dashboard/assets"
+            }
+            } catch(err) {
+                echo "Error: " + err
+            }
+            if ("${env.CLEANUP}".toLowerCase() == "true") {
+                try {
+                stage('Clean Test Environment') {  
+                    sh "${WORKSPACE}/bin/corral delete ci"
+                    if ("${env.JOB_TYPE}" == "recurring") {
+                    sh "${WORKSPACE}/bin/corral delete rancher"
+                    }
+                }
+                } catch(err) {
+                echo "Error: " + err
+                }
+            }
+            try {
+            stage('Test Report') {
+                step([$class: 'JUnitResultArchiver', testResults: '**/results.xml'])
+            }
+            }
+            catch(err) {
+            echo "Error: " + err
+            }
+            if ("${env.QASE_REPORT}".toLowerCase() == "true") {
+                try {
+                    stage('Publish to TC Management') {
+                        withCredentials([ string(credentialsId: 'QASE_AUTOMATION_TOKEN', variable: 'QASE_AUTOMATION_TOKEN')]) {
+                            withEnv(["BUILDTYPE=${buildtype}"]) {
+                                sh "cypress/jenkins/transform-junit.sh"
+                            }
+                        }
+                }
+                } catch(err) {
+                    echo "Error: " + err
+                }
+            }
         }
       }
     }

--- a/cypress/jenkins/Jenkinsfile_multi
+++ b/cypress/jenkins/Jenkinsfile_multi
@@ -1,0 +1,90 @@
+#!groovy
+
+def branch = "master"
+def test_tags = "${env.TEST_TAGS}".split(',')
+def all_cypress_tags = "${env.CYPRESS_TAGS}".split('\\|')
+if ("${env.branch}" != "null" && "${env.branch}" != "") {
+  branch = "${env.branch}"
+}
+
+if ("${env.CORRAL_PACKAGES_REPO}" != "null" && "${env.CORRAL_PACKAGES_REPO}" != "") {
+      corralRepo = "${env.CORRAL_PACKAGES_REPO}"
+}
+
+if ("${env.CORRAL_PACKAGES_BRANCH}" != "null" && "${env.CORRAL_PACKAGES_BRANCH}" != "") {
+      corralBranch = "${env.CORRAL_PACKAGES_BRANCH}"
+}
+
+node {
+  wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+    withFolderProperties {
+      paramsMap = []
+        params.each {
+          paramsMap << "$it.key=$it.value"
+      }
+        withEnv(paramsMap) {
+            stage('Checkout') {
+            deleteDir()
+            checkout([
+                        $class: 'GitSCM',
+                        branches: [[name: "*/${branch}"]],
+                        extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                        userRemoteConfigs: scm.userRemoteConfigs
+                    ])
+            }
+            try {
+                stage('Run Tests') {
+                    jobs = [:]
+                    for( String val : test_tags ) {
+                        for ( String ct : all_cypress_tags ) {
+                            params = null
+                            params = [  string(name: 'JOB_TYPE', value: "${JOB_TYPE}"),
+                                        string(name: 'CORRAL_PACKAGES_BRANCH', value: "${CORRAL_PACKAGES_BRANCH}"),
+                                        string(name: 'CORRAL_PACKAGES_REPO', value: "${CORRAL_PACKAGES_REPO}"),
+                                        text(name: 'CORRAL_PACKAGE_CONFIG', value: "${CORRAL_PACKAGE_CONFIG}"),
+                                        string(name: 'CORRAL_VERSION', value: "${CORRAL_VERSION}"),
+                                        string(name: 'AWS_SSH_USER', value: "${AWS_SSH_USER}"),
+                                        string(name: 'AWS_AMI', value: "${AWS_AMI}"),
+                                        string(name: 'AWS_REGION', value: "${AWS_REGION}"),
+                                        string(name: 'AWS_SUBNET', value: "${AWS_SUBNET}"),
+                                        string(name: 'AWS_VPC', value: "${AWS_VPC}"),
+                                        string(name: 'AWS_INSTANCE_TYPE', value: "${AWS_INSTANCE_TYPE}"),
+                                        string(name: 'AWS_VOLUME_TYPE', value: "${AWS_VOLUME_TYPE}"),
+                                        string(name: 'AWS_VOLUME_IOPS', value: "${AWS_VOLUME_IOPS}"),
+                                        string(name: 'AWS_VOLUME_SIZE', value: "${AWS_VOLUME_SIZE}"),
+                                        string(name: 'AWS_ROUTE53_ZONE', value: "${AWS_ROUTE53_ZONE}"),
+                                        string(name: 'NODEJS_VERSION', value: "${NODEJS_VERSION}"),
+                                        string(name: 'DASHBOARD_REPO', value: "${DASHBOARD_REPO}"),
+                                        string(name: 'DASHBOARD_BRANCH', value: "${DASHBOARD_BRANCH}"),
+                                        string(name: 'CYPRESS_TAGS', value: ct),
+                                        string(name: 'RANCHER_HOST', value: ""),
+                                        string(name: 'RANCHER_VERSION', value: "${RANCHER_VERSION}"),
+                                        string(name: 'RANCHER_USERNAME', value: "${RANCHER_USERNAME}"),
+                                        string(name: 'RANCHER_PASSWORD', value: "${RANCHER_PASSWORD}"),
+                                        string(name: 'RKE2_KUBERNETES_VERSION', value: "${RKE2_KUBERNETES_VERSION}"),
+                                        string(name: 'CERT_MANAGER_VERSION', value: "${CERT_MANAGER_VERSION}"),
+                                        string(name: 'SERVER_COUNT', value: "${SERVER_COUNT}"),
+                                        string(name: 'AGENT_COUNT', value: "${AGENT_COUNT}"),
+                                        string(name: 'BOOTSTRAP_PASSWORD', value: "${BOOTSTRAP_PASSWORD}"),
+                                        string(name: 'BRANCH', value: "${BRANCH}"),
+                                        string(name: 'CYPRESS_VERSION', value: "${CYPRESS_VERSION}"),
+                                        string(name: 'YARN_VERSION', value: "${YARN_VERSION}"),
+                                        string(name: 'CHROME_VERSION', value: "${CHROME_VERSION}"),
+                                        string(name: 'QASE_PROJECT', value: "${QASE_PROJECT}"),
+                                        string(name: 'QASE_REPORT', value: "${QASE_REPORT}"),
+                                        string(name: 'RANCHER_IMAGE_TAG', value: val)]
+                            echo "TAG: ${params}"
+                            build (job: 'ui-automation-job', parameters: params, propagate: false, wait: false)
+                        }
+                        
+                    }
+                }
+            } catch (err) {
+                echo "Error: " + err
+                currentBuild.result = 'FAILURE'
+                error()
+            }
+        }
+    }
+  }
+}

--- a/cypress/jenkins/cypress.sh
+++ b/cypress/jenkins/cypress.sh
@@ -16,6 +16,6 @@ NO_COLOR=1 cypress run --browser chrome \
   --reporter cypress-multi-reporters \
   --reporter-options \
     configFile=cypress/jenkins/reporter-options.json \
-  --env grepTags=CYPRESSTAGS
+  --env grepTags="CYPRESSTAGS"
 
 echo "CYPRESS EXIT CODE: $?"

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -143,6 +143,7 @@ corral config vars set bastion_ip ""
 corral config vars delete instance_type
 corral create --skip-cleanup --recreate --debug ci dist/aws-dashboard-tests-t3a.xlarge
 corral config vars -o yaml
+corral vars ci corral_private_key -o yaml
 NODE_EXTERNAL_IP="$(corral vars ci first_node_ip)"
 cd ${WORKSPACE}
 echo "${PWD}"

--- a/cypress/jenkins/junit_to_qase.py
+++ b/cypress/jenkins/junit_to_qase.py
@@ -1,0 +1,375 @@
+#!/usr/bin/python
+
+import os
+import sys
+import logging
+from urllib import parse as url_parse
+import datetime
+import requests
+from bs4 import BeautifulSoup
+
+print("ALL ENVIRONMENT VARIABLES IN PYTHON SCRIPT\n")
+for k, v in os.environ.items():
+    print("{0}={1}".format(k, v))
+
+logger = logging.getLogger('junit_to_qase')
+logger.setLevel(logging.DEBUG)
+fh = logging.FileHandler('junit_to_qase.log')
+fh.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+fh.setFormatter(formatter)
+ch.setFormatter(formatter)
+logger.addHandler(fh)
+logger.addHandler(ch)
+
+REPORT_FILENAME = "results.xml"
+TEST_SOURCE = "UIValidation"
+qase_token = ""
+qase_automation_project = ""
+build_cause = ""
+rancher_image_tag = ""
+cypress_tags = ""
+if 'QASE_AUTOMATION_TOKEN' in os.environ:
+    qase_token = os.environ['QASE_AUTOMATION_TOKEN']
+else:
+    logger.error("QASE_AUTOMATION_TOKEN NOT PROVIDED")
+    sys.exit(1)
+if 'QASE_PROJECT' in os.environ:
+    qase_automation_project = os.environ['QASE_PROJECT']
+else:
+    logger.error("QASE_PROJECT NOT PROVIDED")
+    sys.exit(1)
+if 'BUILDTYPE' in os.environ:
+    build_cause = "1" if os.environ['BUILDTYPE'] == "RecurringRun" else "2"
+else:
+    logger.info("No BUILDTYPE environment variable found. Default is AdHoc")
+    build_cause = "2"
+if 'RANCHER_IMAGE_TAG' in os.environ:
+    rancher_image_tag = os.environ['RANCHER_IMAGE_TAG']
+else:
+    logger.error("RANCHER_IMAGE_TAG NOT PROVIDED")
+    sys.exit(1)
+if 'CYPRESS_TAGS' in os.environ:
+    cypress_tags = os.environ['CYPRESS_TAGS']
+else:
+    logger.error("CYPRESS_TAGS NOT PROVIDED")
+    sys.exit(1)
+if qase_token is None or qase_token == "":
+    logger.error("NO API TOKEN PROVIDED")
+    sys.exit(1)
+
+logger.info("Qase Project: {0}".format(qase_automation_project))
+logger.info("Build cause: {0}".format(build_cause))
+
+with open(REPORT_FILENAME, 'r') as f:
+    file = f.read()
+
+soup = BeautifulSoup(file, 'lxml-xml')
+
+
+def sanitize_suite_title(string_to_clean):
+    return string_to_clean.replace("Root Suite.", "") \
+            .replace(".", " ") \
+            .replace("\"", "") \
+            .replace(":", "") \
+            .strip()
+
+
+def sanitize_testcase_title(string_to_clean):
+    return string_to_clean.replace(".", " ") \
+            .replace("\"", "") \
+            .replace(":", "") \
+            .replace("before all hook for ", "") \
+            .replace("before each hook for ", "") \
+            .replace("after all hook for ", "") \
+            .replace("after each hook for ", "") \
+            .strip()
+
+
+results = {}
+
+suite_title = soup.find_all("testsuite", {"name": True})
+for ts in suite_title:
+    testcases = ts.findChildren("testcase", recursive=False)
+    if len(testcases) > 0:
+        suite_name = ts.get("name")
+        suite_name = sanitize_suite_title(suite_name)
+        results[suite_name] = {}
+        for tc in testcases:
+            testcase_name = tc.get("name")
+            testcase_name = sanitize_testcase_title(testcase_name)
+            skipped = tc.findChildren("skipped", recursive=False)
+            failure_msgs = tc.findChildren("failure", recursive=False)
+            if len(skipped) == 1:
+                logger.debug("An skip tag was found in the test case: {0}".format(testcase_name))
+                results[suite_name][testcase_name] = "skipped_test"
+                continue
+            elif len(failure_msgs) == 1:
+                logger.debug("An error message was found in the test case: {0}".format(testcase_name))
+                results[suite_name][testcase_name] = failure_msgs[0].get("message")
+            else:
+                logger.debug("Success of test case: {0}".format(testcase_name))
+                results[suite_name][testcase_name] = None
+
+total_test_cases_in_junit = 0
+for st in results.keys():
+    total_test_cases_in_junit += len(results[st])
+logger.info("Total number of test cases in the jUnit file: {0}".format(total_test_cases_in_junit))
+
+# API Transform
+
+base_url = "https://api.qase.io/v1"
+qase_headers = {'Token': "{0}".format(qase_token), "accept": "application/json"}
+cases_url = "{0}/case".format(base_url)
+suites_url = "{0}/suite".format(base_url)
+runs_url = "{0}/run".format(base_url)
+results_url = "{0}/result".format(base_url)
+cases_ids = []
+skipped_cases_ids = []
+failed_cases_ids_stack = {}
+
+
+def qase_cases(project, case_id=None):
+    if case_id is not None:
+        return requests.get("{0}/{1}/{2}".format(cases_url, project, case_id),
+                            headers=qase_headers)
+    else:
+        return requests.get("{0}/{1}".format(cases_url, project),
+                            headers=qase_headers)
+
+
+def qase_add_case(project, payload):
+    if isinstance(payload, dict):
+        return requests.post("{0}/{1}".format(cases_url, project),
+                             json=payload, headers=qase_headers)
+    else:
+        return None
+
+
+def qase_update_case(project, payload, case_id):
+    if isinstance(payload, dict) and case_id is not None:
+        return requests.patch("{0}/{1}/{2}".format(cases_url, project, case_id),
+                              json=payload, headers=qase_headers)
+    else:
+        return None
+
+
+def qase_suites(project, suite_id=None, search_string=""):
+    if search_string:
+        return requests.get("{0}/{1}?search={2}".format(suites_url, project, search_string),
+                            headers=qase_headers)
+    if suite_id is not None:
+        return requests.get("{0}/{1}/{2}".format(suites_url, project, suite_id),
+                            headers=qase_headers)
+    else:
+        return requests.get("{0}/{1}".format(suites_url, project),
+                            headers=qase_headers)
+
+
+def qase_add_suite(project, payload):
+    if isinstance(payload, dict):
+        return requests.post("{0}/{1}".format(suites_url, project),
+                             json=payload, headers=qase_headers)
+    else:
+        return None
+
+
+def qase_update_suite(project, payload, suite_id):
+    if isinstance(payload, dict) and suite_id is not None:
+        return requests.patch("{0}/{1}/{2}".format(suites_url, project, suite_id),
+                              json=payload, headers=qase_headers)
+    else:
+        return None
+
+
+def qase_search_qql(search_query):
+    if isinstance(search_query, dict):
+        params = url_parse.urlencode(search_query, quote_via=url_parse.quote)
+        return requests.get("{0}/search".format(base_url), params=params,
+                            headers=qase_headers)
+
+
+def qase_create_run(project, payload):
+    if isinstance(payload, dict):
+        return requests.post("{0}/{1}".format(runs_url, project),
+                             json=payload, headers=qase_headers)
+    else:
+        return None
+
+
+def qase_complete_run(project, run_id):
+    return requests.post("{0}/{1}/{2}/complete".format(runs_url, project, run_id),
+                         headers=qase_headers)
+
+
+def create_run_result(project, payload, run_id):
+    if isinstance(payload, dict):
+        return requests.post("{0}/{1}/{2}".format(results_url, project, run_id),
+                             json=payload, headers=qase_headers)
+    else:
+        return None
+
+
+def create_testcases_under_suite(all_cases_under_suite, suite_title_from_qase, suite_id):
+    """
+    Custom Fields
+    - TestSource -> 14
+    - AutomationTestName -> 15
+    """
+    case_entities = all_cases_under_suite["result"]["entities"]
+    case_titles_from_junit = results[suite_title_from_qase].keys()
+    case_titles = [subs["title"] for subs in case_entities]
+    case_title_and_id = {subs["title"]: subs['id'] for subs in case_entities}
+    case_descriptions = [subs["description"] for subs in case_entities]
+
+    logger.debug("Titles from jUnit: {0}".format(list(case_titles_from_junit)))
+    logger.debug("Titles from Qase: {0}".format(case_titles))
+    for ct in case_titles_from_junit:
+        failed = False
+        tc_skipped = False
+        if ct not in case_titles:
+            # Title ct not found add it
+            logger.info("Title not found: {0}".format(ct))
+            # if the result from junit has a description, add it
+            # This part is where the error message goes if we want it in the Test Case description
+            testcase_value = results[suite_title_from_qase][ct]
+            req_body = {'title': ct,
+                        'is_flaky': 0,
+                        'automation': 1,
+                        'custom_field': {
+                            "14": TEST_SOURCE,
+                            "15": "{0}/{1}".format(suite_title_from_qase, ct)},
+                        "suite_id": suite_id}
+            if testcase_value and testcase_value != "skipped_test":
+                req_body.update({'description': results[suite_title_from_qase][ct]})
+                failed = True
+            if testcase_value == "skipped_test":
+                tc_skipped = True
+            resp = qase_add_case(qase_automation_project, req_body)
+            id_to_add = resp.json()["result"]["id"]
+            cases_ids.append(id_to_add)
+            if tc_skipped:
+                skipped_cases_ids.append(id_to_add)
+            if failed:
+                failed_cases_ids_stack[id_to_add] = results[suite_title_from_qase][ct]
+        else:
+            logger.info("Title found: {0}".format(ct))
+            case_id_from_title = case_title_and_id[ct]
+            cases_ids.append(case_id_from_title)
+            req_body = {"suite_id": suite_id,
+                        "custom_field": {
+                                "14": TEST_SOURCE,
+                                "15": "{0}/{1}".format(suite_title_from_qase, ct)
+                            },
+                        }
+            logger.debug("Refresh test case id {0} "
+                         "to ensure it is in the correct Suite {1}".
+                         format(case_id_from_title, suite_id))
+            qase_update_case(qase_automation_project, req_body, case_id_from_title)
+            has_skipped_or_error = results[suite_title_from_qase][ct]
+            if has_skipped_or_error:
+                logger.info("A description or skip value exist for test case")
+                if has_skipped_or_error == "skipped_test":
+                    logger.info("Skipped ID: {0} Title: {1}".format(case_id_from_title, ct))
+                    skipped_cases_ids.append(case_id_from_title)
+                else:
+                    logger.info("Failed ID: {0} Title: {1}".format(case_id_from_title, ct))
+                    failed_cases_ids_stack[case_id_from_title] = results[suite_title_from_qase][ct]
+                    if results[suite_title_from_qase][ct] not in case_descriptions:
+                        logger.debug("A description was found that is not in Qase "
+                                     "in a test case with ID: {0} Title: {1}".
+                                     format(case_id_from_title, ct))
+                        req_body = {'description': results[suite_title_from_qase][ct]}
+                        qase_update_case(qase_automation_project, req_body, case_id_from_title)
+            else:
+                logger.info("There isn't a failure message from junit data, clear the description in qase")
+                req_body = {'description': None}
+                qase_update_case(qase_automation_project, req_body, case_id_from_title)
+
+
+check_global_suite = qase_suites(qase_automation_project)
+logger.info(check_global_suite.text)
+logger.info(check_global_suite.status_code)
+suite_objects = check_global_suite.json()["result"]["entities"]
+suite_titles = [subs["title"] for subs in suite_objects]
+suite_title_and_id = {subs["title"]: subs['id'] for subs in suite_objects}
+global_suite_id_name = "Global UI"
+global_suite_id = None
+
+if global_suite_id_name not in suite_titles:
+    suite_post_data = {"title": global_suite_id_name}
+    suite_response = qase_add_suite(qase_automation_project, suite_post_data)
+    global_suite_id = suite_response.json()["result"]["id"]
+else:
+    global_suite_id = suite_title_and_id[global_suite_id_name]
+
+logger.info("Suite ID: {0} Name: {1}".format(global_suite_id, global_suite_id_name))
+
+for k in list(results.keys()):
+    suite = qase_suites(qase_automation_project)
+    suite_result = suite.json()
+    if suite_result["status"]:
+        suite_entities = suite_result["result"]["entities"]
+    else:
+        logger.error("No suites were found")
+        break
+
+    titles = [subs["title"] for subs in suite_entities]
+    suiteid = None
+    if k not in titles:
+        suite_data = {"title": k, "parent_id": global_suite_id}
+        r = qase_add_suite(qase_automation_project, suite_data)
+        suiteid = r.json()["result"]["id"]
+        logger.debug("Search query of suite not found:  entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
+                     format("case", qase_automation_project, k))
+        cases = qase_search_qql({"query": " entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
+                                format("case", qase_automation_project, k)})
+        cases_qql_results = cases.json()
+        create_testcases_under_suite(cases_qql_results, k, suiteid)
+    else:
+        logger.debug("Search query of suite found:  entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
+                     format("case", qase_automation_project, k))
+        cases_qql = qase_search_qql({"query": " entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
+                                    format("case", qase_automation_project, k)})
+        for st in suite_entities:
+            if st["title"] == k:
+                suiteid = st["id"]
+                break
+
+        cases_qql_results = cases_qql.json()
+        logger.debug(cases_qql_results)
+        create_testcases_under_suite(cases_qql_results, k, suiteid)
+
+formatted_date = "{0}".format(datetime.datetime.now().strftime("%m-%d-%y/%H-%M-%S"))
+
+logger.info("BUILD CAUSE: {0}".format(build_cause))
+# RunSource (16) custom field values:
+# - RecurringRun -> 1
+# - AdHoc        -> 2
+# - Manual       -> 3
+data_to_run = {"title": "UI RUN {0} - {1} - {2}".format(formatted_date, rancher_image_tag, cypress_tags),
+               "cases": cases_ids,
+               "custom_field": {"16": build_cause}
+               }
+
+logger.info("DATA FOR TEST_RUN: {0}".format(data_to_run))
+test_run_info = qase_create_run(qase_automation_project, data_to_run)
+test_run_id = test_run_info.json()["result"]["id"]
+
+test_result_data = None
+for ci in cases_ids:
+    # Skipped case id is 5 -> "skipped"  ?
+    test_result_data = {"case_id": ci}
+    if ci in failed_cases_ids_stack.keys():
+        test_result_data.update({"status": "failed", "stacktrace": failed_cases_ids_stack[ci]})
+    elif ci in skipped_cases_ids:
+        test_result_data.update({"status": "skipped"})
+    else:
+        test_result_data.update({"status": "passed"})
+    logger.info("Test Case ID: {0} Result Data {1}".format(ci, test_result_data))
+    create_run_result(qase_automation_project, test_result_data, test_run_id)
+
+qase_complete_run(qase_automation_project, test_run_id)
+logger.info("jUnit to Qase completed")

--- a/cypress/jenkins/reporter-options.json
+++ b/cypress/jenkins/reporter-options.json
@@ -9,6 +9,7 @@
   "mochaJunitReporterReporterOptions": {
     "mochaFile": "cypress/jenkins/reports/junit/junit-[hash].xml",
     "toConsole": true,
-    "jenkinsMode": true
+    "jenkinsMode": true,
+    "includePending": true
   }
 }

--- a/cypress/jenkins/scpget.sh
+++ b/cypress/jenkins/scpget.sh
@@ -4,8 +4,17 @@ set -x
 
 export PATH=$PATH:"${WORKSPACE}/bin"
 
-PRIV_KEY="${WORKSPACE}/.ssh/jenkins_ecdsa"
+
+PRIV_KEY="${WORKSPACE}/.ssh/corral_private_key"
+if [ -f "${PRIV_KEY}" ]; then 
+  chmod 700 "${PRIV_KEY}"
+else
+  echo "$(corral vars ci corral_private_key -o yaml)" > "${PRIV_KEY}"
+fi
+
+chmod 400 "${PRIV_KEY}"
+
 NODE_EXTERNAL_IP="$(corral vars ci first_node_ip)"
 
 scp -r -i ${PRIV_KEY} -o StrictHostKeyChecking=no \
-  -o UserKnownHostsFile=/dev/null "${AWS_SSH_USER}@${NODE_EXTERNAL_IP}:$1" .
+  -o UserKnownHostsFile=/dev/null "root@${NODE_EXTERNAL_IP}:$1" .

--- a/cypress/jenkins/transform-junit.sh
+++ b/cypress/jenkins/transform-junit.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -x
+
+pip3 install beautifulsoup4 requests lxml
+
+pwd
+ls -al .
+python3 cypress/jenkins/junit_to_qase.py


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This PR adds multi branch and multi tags capabilities for the existing Jenkins pipeline of UI automation.
The corral package side of this implementation can be found on these PRs:

https://github.com/rancherlabs/corral-packages/pull/19
https://github.com/rancherlabs/corral-packages/pull/26
A PR for the Jenkins configuration variables and pipeline is in a job builder private repo

### Technical notes summary

A multi Jenkinsfile pipeline that's going to be triggered with the necessary configuration variables to execute a child Pipeline with different branch and tags. On a recurring basis, that configuration is in the jenkins builder.

The child pipeline now include logic to enable Qase reporting and Cleanup resources variables. (See Jenkinsfile)


### Notes

This the next iteration of https://github.com/rancher/dashboard/pull/9726