### PR TITLE
Fixed chart yaml scroll issue when there is an error at the bottom

### DIFF
--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -397,6 +397,7 @@ export default {
             color="error"
             :label="err"
             :closable="true"
+            class="footer-error"
             @close="errors.splice(idx, 1)"
           />
         </div>
@@ -468,7 +469,6 @@ $spacer: 10px;
   flex-direction: column;
   flex: 1;
   padding: 0;
-  height: 0;
   justify-content: flex-start;
 }
 
@@ -650,6 +650,12 @@ $spacer: 10px;
     height: 100%;
     flex: 1;
   }
+}
+
+// We have to account for the absolute position of the .controls-row
+.footer-error {
+  margin-top: -40px;
+  margin-bottom: 70px;
 }
 
   .controls-row {

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -182,6 +182,12 @@ export default {
         this.activeStep = this.visibleSteps[this.initStepIndex];
         this.goToStep(this.activeStepIndex + 1);
       }
+    },
+    errors() {
+      // Ensurce we scroll the errors into view
+      this.$nextTick(() => {
+        this.$refs.wizard.scrollTop = this.$refs.wizard.scrollHeight;
+      });
     }
   },
 
@@ -253,7 +259,10 @@ export default {
 </script>
 
 <template>
-  <div class="outer-container">
+  <div
+    ref="wizard"
+    class="outer-container"
+  >
     <Loading
       v-if="!stepsLoaded"
       mode="relative"

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1979,7 +1979,7 @@ export default {
   display: flex;
   flex-direction: column;
   padding: 0;
-  height: calc(100% - 112px);
+  overflow: auto;
 }
 
 .header {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9680
<!-- Define findings related to the feature or bug issue. -->
Added fixed from 2.8 to 2.7 head to fix chart yaml scroll issue when there is an error at the bottom.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/18264463/5046a97d-7a7a-4b58-9944-618be680002e



