### PR TITLE
Link namespaces in mgmt cluster to local cluster

### DIFF
--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -12,6 +12,7 @@ import {
 } from '@shell/config/query-params';
 import { ExtensionPoint, PanelLocation } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
+import { BLANK_CLUSTER } from 'store/store-types';
 
 /**
  * Resource Detail Masthead component.
@@ -148,7 +149,7 @@ export default {
         return this.value.namespaceLocation || {
           name:   'c-cluster-product-resource-id',
           params: {
-            cluster:  this.$route.params.cluster,
+            cluster:  this.$route.params.cluster === BLANK_CLUSTER ? this.value?.localCluster?.id : this.$route.params.cluster,
             product:  this.$store.getters['productId'],
             resource: NAMESPACE,
             id:       this.$route.params.namespace
@@ -177,13 +178,16 @@ export default {
 
     project() {
       if (this.isNamespace) {
-        const id = (this.value?.metadata?.labels || {})[PROJECT];
-        const clusterId = this.$store.getters['currentCluster'].id;
+        const cluster = this.$store.getters['currentCluster'];
 
-        return this.$store.getters['management/byId'](MANAGEMENT.PROJECT, `${ clusterId }/${ id }`);
-      } else {
-        return null;
+        if (cluster) {
+          const id = (this.value?.metadata?.labels || {})[PROJECT];
+
+          return this.$store.getters['management/byId'](MANAGEMENT.PROJECT, `${ cluster.id }/${ id }`);
+        }
       }
+
+      return null;
     },
 
     banner() {
@@ -370,7 +374,7 @@ export default {
     },
 
     hideNamespaceLocation() {
-      return this.$store.getters['currentProduct'].hideNamespaceLocation;
+      return this.$store.getters['currentProduct'].hideNamespaceLocation || !this.value?.localCluster;
     },
   },
 

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -1,8 +1,6 @@
 <script>
 import { KUBERNETES, PROJECT } from '@shell/config/labels-annotations';
-import {
-  FLEET, NAMESPACE, MANAGEMENT, HELM, LOCAL_CLUSTER
-} from '@shell/config/types';
+import { FLEET, NAMESPACE, MANAGEMENT, HELM } from '@shell/config/types';
 import ButtonGroup from '@shell/components/ButtonGroup';
 import { BadgeState } from '@components/BadgeState';
 import { Banner } from '@components/Banner';
@@ -14,7 +12,6 @@ import {
 } from '@shell/config/query-params';
 import { ExtensionPoint, PanelLocation } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
-import { BLANK_CLUSTER } from 'store/store-types';
 
 /**
  * Resource Detail Masthead component.

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -151,7 +151,7 @@ export default {
         return this.value.namespaceLocation || {
           name:   'c-cluster-product-resource-id',
           params: {
-            cluster:  this.$route.params.cluster === BLANK_CLUSTER ? this.value?.localCluster?.id : this.$route.params.cluster,
+            cluster:  this.$route.params.cluster,
             product:  this.$store.getters['productId'],
             resource: NAMESPACE,
             id:       this.$route.params.namespace
@@ -376,7 +376,7 @@ export default {
     },
 
     hideNamespaceLocation() {
-      return this.$store.getters['currentProduct'].hideNamespaceLocation || !this.$store.getters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
+      return this.$store.getters['currentProduct'].hideNamespaceLocation || !this.value.namespaceLocation;
     },
   },
 

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -1,6 +1,8 @@
 <script>
 import { KUBERNETES, PROJECT } from '@shell/config/labels-annotations';
-import { FLEET, NAMESPACE, MANAGEMENT, HELM } from '@shell/config/types';
+import {
+  FLEET, NAMESPACE, MANAGEMENT, HELM, LOCAL_CLUSTER
+} from '@shell/config/types';
 import ButtonGroup from '@shell/components/ButtonGroup';
 import { BadgeState } from '@components/BadgeState';
 import { Banner } from '@components/Banner';
@@ -374,7 +376,7 @@ export default {
     },
 
     hideNamespaceLocation() {
-      return this.$store.getters['currentProduct'].hideNamespaceLocation || !this.value?.localCluster;
+      return this.$store.getters['currentProduct'].hideNamespaceLocation || !this.$store.getters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
     },
   },
 

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -373,7 +373,7 @@ export default {
     },
 
     hideNamespaceLocation() {
-      return this.$store.getters['currentProduct'].hideNamespaceLocation || !this.value.namespaceLocation;
+      return this.$store.getters['currentProduct'].hideNamespaceLocation || this.value.namespaceLocation === null;
     },
   },
 

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -885,14 +885,20 @@ export default class ProvCluster extends SteveModel {
   }
 
   get namespaceLocation() {
-    return {
-      name:   'c-cluster-product-resource-id',
-      params: {
-        cluster:  this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER)?.id,
-        product:  this.$rootGetters['productId'],
-        resource: NAMESPACE,
-        id:       this.namespace
-      }
-    };
+    const localCluster = this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
+
+    if (localCluster) {
+      return {
+        name:   'c-cluster-product-resource-id',
+        params: {
+          cluster:  localCluster.id,
+          product:  this.$rootGetters['productId'],
+          resource: NAMESPACE,
+          id:       this.namespace
+        }
+      };
+    }
+
+    return null;
   }
 }

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -1,5 +1,5 @@
 import {
-  CAPI, LOCAL_CLUSTER, MANAGEMENT, NORMAN, SNAPSHOT, HCI
+  CAPI, MANAGEMENT, NAMESPACE, NORMAN, SNAPSHOT, HCI, LOCAL_CLUSTER
 } from '@shell/config/types';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { findBy } from '@shell/utils/array';
@@ -884,7 +884,15 @@ export default class ProvCluster extends SteveModel {
     return this.status?.conditions?.some((condition) => condition.error === true);
   }
 
-  get localCluster() {
-    return this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
+  get namespaceLocation() {
+    return {
+      name:   'c-cluster-product-resource-id',
+      params: {
+        cluster:  this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER)?.id,
+        product:  this.$rootGetters['productId'],
+        resource: NAMESPACE,
+        id:       this.namespace
+      }
+    };
   }
 }

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -1,5 +1,5 @@
 import {
-  CAPI, MANAGEMENT, NORMAN, SNAPSHOT, HCI
+  CAPI, LOCAL_CLUSTER, MANAGEMENT, NORMAN, SNAPSHOT, HCI
 } from '@shell/config/types';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { findBy } from '@shell/utils/array';
@@ -882,5 +882,9 @@ export default class ProvCluster extends SteveModel {
 
   get hasError() {
     return this.status?.conditions?.some((condition) => condition.error === true);
+  }
+
+  get localCluster() {
+    return this.$rootGetters['management/byId'](MANAGEMENT.CLUSTER, LOCAL_CLUSTER);
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9993
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Namespace's links in ClusterManagement/Cluster Detail header are broken because the `clusterId` is missing from the `namespaceLocation` of the namespace's links.
The issue can be reproduced with any type of clusters, is not specific for Harvester clusters.

Current changes will fix the issue assuming that the namespaces are always managed from `local` cluster.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Cluster Management list -> Cluster Details -> namespace details

![image](https://github.com/rancher/dashboard/assets/26394656/2cccc5da-cb70-428b-943b-506f4edc3308)


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- `Masthead` component -> namespace links section
