### PR TITLE
Removed slide numbers from the titles, other small fix

### DIFF
--- a/shell/components/Carousel.vue
+++ b/shell/components/Carousel.vue
@@ -181,7 +181,7 @@ export default {
               :label="slide.repoName"
               color="slider-badge mb-20"
             />
-            <h1>{{ slide.chartNameDisplay }} {{ i + 1 }}</h1>
+            <h1>{{ slide.chartNameDisplay }}</h1>
             <p>{{ slide.chartDescription }}</p>
           </div>
         </div>
@@ -282,6 +282,7 @@ export default {
   .slide-content {
     display: flex;
     padding: 30px;
+    height: 100%;
 
     .slide-img {
       width: 150px;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9975
<!-- Define findings related to the feature or bug issue. -->
- Removed slide numbers from the titles
- Adjusted dividing line height in all the slides



### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Adjusted dividing line height in all the slides

**Before:**
<img width="1026" alt="Screenshot 2023-10-30 at 14 56 12" src="https://github.com/rancher/dashboard/assets/18264463/e3095831-2808-43ed-9964-59f1c7013151">

<img width="942" alt="Screenshot 2023-10-30 at 16 08 07" src="https://github.com/rancher/dashboard/assets/18264463/84beb367-823f-4bd3-9276-74e83f21769e">


**After:**

<img width="954" alt="Screenshot 2023-10-30 at 14 56 20" src="https://github.com/rancher/dashboard/assets/18264463/6194f6b8-4233-42aa-b3be-8213ce57aae4">

<img width="944" alt="Screenshot 2023-10-30 at 16 07 54" src="https://github.com/rancher/dashboard/assets/18264463/aaa86b23-870b-4f55-970c-70dc51169984">

