### PR TITLE
Improve getGroups performance

### DIFF
--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -53,7 +53,7 @@ export default {
       }
     },
 
-    allNavLinksKey(a, b) {
+    allNavLinksIds(a, b) {
       if ( !sameContents(a, b) ) {
         this.queueUpdate();
       }
@@ -186,7 +186,7 @@ export default {
       return this.$store.getters['activeNamespaceCache'];
     },
 
-    allNavLinksKey() {
+    allNavLinksIds() {
       return this.allNavLinks.map((a) => a.id);
     },
   },

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -31,7 +31,8 @@ export default {
   },
 
   created() {
-    this.queueUpdate = debounce(this.getGroups, 250);
+    // Ensure that changes to resource that change often don't resort to spamming redraw of the side nav
+    this.queueUpdate = debounce(this.getGroups, 500);
 
     this.getGroups();
   },

--- a/shell/components/nav/Jump.vue
+++ b/shell/components/nav/Jump.vue
@@ -2,7 +2,8 @@
 import debounce from 'lodash/debounce';
 import Group from '@shell/components/nav/Group';
 import { isMac } from '@shell/utils/platform';
-import { BOTH, ALL } from '@shell/store/type-map';
+import { BOTH, TYPE_MODES } from '@shell/store/type-map';
+import { COUNT } from '@shell/config/types';
 
 export default {
   components: { Group },
@@ -31,17 +32,26 @@ export default {
   methods: {
     updateMatches() {
       const clusterId = this.$store.getters['clusterId'];
-      const isAllNamespaces = this.$store.getters['isAllNamespaces'];
-      const product = this.$store.getters['productId'];
+      const productId = this.$store.getters['productId'];
+      const product = this.$store.getters['currentProduct'];
 
-      let namespaces = null;
+      const allTypesByMode = this.$store.getters['type-map/allTypes'](productId, [TYPE_MODES.ALL]) || {};
+      const allTypes = allTypesByMode[TYPE_MODES.ALL];
+      const out = this.$store.getters['type-map/getTree'](productId, TYPE_MODES.ALL, allTypes, clusterId, BOTH, null, this.value);
 
-      if ( !isAllNamespaces ) {
-        namespaces = Object.keys(this.$store.getters['activeNamespaceCache']);
-      }
+      // Suplement the output with count info. Usualy the `Type` component would handle this individualy... but scales real so give it some
+      // help
+      const counts = this.$store.getters[`${ product.inStore }/all`](COUNT)?.[0]?.counts || {};
 
-      const allTypes = this.$store.getters['type-map/allTypes'](product) || {};
-      const out = this.$store.getters['type-map/getTree'](product, ALL, allTypes, clusterId, BOTH, namespaces, null, this.value);
+      out.forEach((o) => {
+        o.children?.forEach((t) => {
+          const count = counts[t.name];
+
+          t.count = count ? count.summary.count || 0 : null;
+          t.byNamespace = count ? count.namespaces : {};
+          t.revision = count ? count.revision : null;
+        });
+      });
 
       this.groups = out;
 

--- a/shell/components/nav/Jump.vue
+++ b/shell/components/nav/Jump.vue
@@ -39,8 +39,8 @@ export default {
       const allTypes = allTypesByMode[TYPE_MODES.ALL];
       const out = this.$store.getters['type-map/getTree'](productId, TYPE_MODES.ALL, allTypes, clusterId, BOTH, null, this.value);
 
-      // Suplement the output with count info. Usualy the `Type` component would handle this individualy... but scales real so give it some
-      // help
+      // Suplement the output with count info. Usualy the `Type` component would handle this individualy... but scales real bad so give it
+      // some help
       const counts = this.$store.getters[`${ product.inStore }/all`](COUNT)?.[0]?.counts || {};
 
       out.forEach((o) => {

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -1,8 +1,8 @@
 <script>
 import Favorite from '@shell/components/nav/Favorite';
-import { FAVORITE, USED } from '@shell/store/type-map';
+import { TYPE_MODES } from '@shell/store/type-map';
 
-const showFavoritesFor = [FAVORITE, USED];
+const showFavoritesFor = [TYPE_MODES.FAVORITE, TYPE_MODES.USED];
 
 export default {
 
@@ -90,12 +90,23 @@ export default {
     },
 
     showCount() {
-      return typeof this.type.count !== 'undefined';
+      return typeof this.count !== 'undefined';
     },
 
     namespaceIcon() {
       return this.type.namespaced;
     },
+
+    count() {
+      if (typeof this.type.count !== 'undefined') {
+        return this.type.count;
+      }
+
+      const inStore = this.$store.getters['currentStore'](this.type.name);
+
+      return this.$store.getters[`${ inStore }/count`]({ name: this.type.name });
+    }
+
   },
 
   methods: {
@@ -162,7 +173,7 @@ export default {
           v-if="namespaceIcon"
           class="icon icon-namespace namespaced"
         />
-        {{ type.count }}
+        {{ count }}
       </span>
     </a>
   </n-link>

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -90,7 +90,7 @@ export default {
     },
 
     showCount() {
-      return typeof this.count !== 'undefined';
+      return this.count !== undefined;
     },
 
     namespaceIcon() {
@@ -98,7 +98,7 @@ export default {
     },
 
     count() {
-      if (typeof this.type.count !== 'undefined') {
+      if (this.type.count !== undefined) {
         return this.type.count;
       }
 

--- a/shell/components/nav/__tests__/Type.test.ts
+++ b/shell/components/nav/__tests__/Type.test.ts
@@ -16,6 +16,12 @@ describe('component: Type', () => {
         mocks:     {
           $route:  { path: 'whatever' },
           $router: { resolve: () => ({ route: { path: 'whatever' } }) },
+          $store:  {
+            getters: {
+              currentStore:    () => 'cluster',
+              'cluster/count': () => 1,
+            }
+          }
         },
       });
 
@@ -31,6 +37,12 @@ describe('component: Type', () => {
         mocks:     {
           $route:  { hash: 'whatever' },
           $router: { resolve: () => ({ route: { path: 'whatever' } }) },
+          $store:  {
+            getters: {
+              currentStore:    () => 'cluster',
+              'cluster/count': () => 1,
+            }
+          }
         },
       });
 
@@ -67,6 +79,12 @@ describe('component: Type', () => {
             path: 'whatever',
           },
           $router: { resolve: () => ({ route: { path: 'many/parts' } }) },
+          $store:  {
+            getters: {
+              currentStore:    () => 'cluster',
+              'cluster/count': () => 1,
+            }
+          }
         },
       });
 
@@ -101,6 +119,12 @@ describe('component: Type', () => {
             path: currentPath,
           },
           $router: { resolve: () => ({ route: { path: menuPath } }) },
+          $store:  {
+            getters: {
+              currentStore:    () => 'cluster',
+              'cluster/count': () => 1,
+            }
+          }
         },
       });
 
@@ -126,6 +150,12 @@ describe('component: Type', () => {
             path: currentPath,
           },
           $router: { resolve: () => ({ route: { path: menuPath } }) },
+          $store:  {
+            getters: {
+              currentStore:    () => 'cluster',
+              'cluster/count': () => 1,
+            }
+          }
         },
       });
 

--- a/shell/store/__tests__/type-map.test.ts
+++ b/shell/store/__tests__/type-map.test.ts
@@ -1,0 +1,1122 @@
+/* eslint-disable jest/max-nested-describe */
+
+import { TYPE_MODES, getters } from '../type-map';
+import { NAME as EXPLORER } from '@shell/config/product/explorer';
+import {
+  COUNT,
+  SCHEMA,
+} from '@shell/config/types';
+
+/**
+ * types in the store
+ */
+const types = {
+  virtual: { name: 'virt' },
+  spoof:   { name: 'spoof' }
+};
+
+const schemas = {
+  pod: {
+    id:         'pod',
+    type:       SCHEMA,
+    attributes: { kind: 'pod' },
+  },
+  /**
+   * Represents a group
+   */
+  podNoAttributes: {
+    id:   'pod',
+    type: SCHEMA,
+  },
+  secret: {
+    id:         'secret',
+    type:       SCHEMA,
+    attributes: { kind: 'secret' },
+  },
+  topLevel: {
+    id:   'toplevel',
+    type: SCHEMA,
+  }
+};
+
+/**
+ * counts in the store
+ */
+const counts = {
+  pod: {
+    summary:    { count: 1 },
+    revision:   'abc',
+    namespaces: { a: true }
+  },
+  toplevel: {
+    summary:    { count: 1 },
+    revision:   'abc',
+    namespaces: { a: true }
+  },
+  secret: {
+    summary:    { count: 1 },
+    revision:   'abc',
+    namespaces: { a: true }
+  }
+};
+
+/**
+ * Some of the objects that we expect to be returned by allTypes
+ */
+const expectedMenuItems = {
+  podWithoutAttribute: {
+    label:      'Pod',
+    name:       'pod',
+    namespaced: true,
+    route:      'cde',
+    schema:     schemas.podNoAttributes,
+    weight:     1,
+  },
+  podWithAttribute: {
+    label:      'Pod',
+    name:       'pod',
+    namespaced: true,
+    route:      'cde',
+    schema:     schemas.pod,
+    weight:     1,
+  },
+  secretWithAttribute: {
+    label:      'Secret',
+    name:       'secret',
+    namespaced: true,
+    route:      'cde',
+    schema:     schemas.secret,
+    weight:     1,
+  },
+  virtual: {
+    label:  'virt',
+    name:   'virt',
+    weight: 1,
+  },
+  spoof: {
+    label:  'spoof',
+    name:   'spoof',
+    weight: 1,
+  },
+  topLevel: {
+    label:      'Pod',
+    mode:       'basic',
+    name:       'toplevel',
+    namespaced: true,
+    route:      'cde',
+    schema:     schemas.topLevel,
+    weight:     1,
+  }
+};
+
+describe('type-map', () => {
+  describe('getters', () => {
+    describe('allTypes', () => {
+      /**
+       * Stick in the required mode param to the expected menu items
+       */
+      const setTypeMode = (modes, resourcesById) => {
+        return modes.reduce((res, mode) => {
+          const newResource = { };
+
+          Object.entries(resourcesById).forEach(([id, resource]: [string, any]) => {
+            newResource[id] = {
+              ...resource,
+              mode,
+            };
+          });
+          res[mode] = newResource;
+
+          return res;
+        }, {});
+      };
+
+      /** All basic ctx properties and helpers */
+      const generateDefaults = (productName = EXPLORER, productStore = 'cluster', modes = [TYPE_MODES.BASIC]) => {
+        return {
+          productName,
+          productStore,
+
+          state: {
+            products: [{
+              name:    EXPLORER,
+              inStore: productStore,
+            }],
+            virtualTypes: { [productName]: [] },
+            spoofedTypes: { [productName]: [] }
+          },
+          typeMapGetters: {
+            labelFor:          (schema, count) => '',
+            optionsFor:        (schema) => {},
+            groupForBasicType: () => {},
+            typeWeightFor:     (label, isBasic) => 1
+          },
+          rootState:   {},
+          rootGetters: {
+            [`${ productStore }/all`]: (schema: string) => {
+              return [];
+            },
+            'prefs/get': (pref) => {},
+
+          },
+
+          modes
+        };
+      };
+
+      /**
+       * When there are no schema, spoofed or virtual types there's no menu types
+       */
+      it('empty', () => {
+        const {
+          state, typeMapGetters, rootState, rootGetters, productName, modes
+        } = generateDefaults();
+
+        const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+        expect(groups).toStrictEqual({});
+      });
+
+      describe('product: Explorer', () => {
+        /**
+         * Extend generateDefaults with env to return a pod type
+         */
+        const createEnvBasicPod = (modes = [TYPE_MODES.BASIC], expected = true) => {
+          const defaults = generateDefaults(EXPLORER, `cluster`, [TYPE_MODES.BASIC]);
+          const { typeMapGetters, rootGetters, productStore } = defaults;
+
+          const testRootGetters = {
+            ...rootGetters,
+            [`${ productStore }/all`]: (resource: string) => {
+              switch (resource) {
+              case SCHEMA:
+                return [schemas.pod];
+              case COUNT:
+                return [{ counts: { pod: counts.pod } }];
+              }
+
+              return [];
+            },
+          };
+
+          const testTypeMapGetters = {
+            ...typeMapGetters,
+            labelFor:          (schema, count) => 'Pod',
+            groupForBasicType: () => true,
+            optionsFor:        (schema) => ({
+              namespaced:  true,
+              customRoute: 'cde'
+            }),
+            isFavorite: () => false,
+          };
+
+          return {
+            ...defaults,
+            typeMapGetters: testTypeMapGetters,
+            rootGetters:    testRootGetters,
+
+            modes,
+
+            expectedTypes: expected ? setTypeMode(modes, { pod: expectedMenuItems.podWithAttribute }) : {}
+          };
+        };
+
+        /**
+         * Extend generateDefaults with env to return a virtual type
+         */
+        const createEnvBasicVirtual = (modes = [TYPE_MODES.BASIC], expected = true) => {
+          const defaults = generateDefaults();
+          const { state, typeMapGetters, productName } = defaults;
+
+          const testState = {
+            ...state,
+            virtualTypes: { [productName]: [types.virtual] }
+          };
+
+          const testTypeMapGetters = {
+            ...typeMapGetters,
+            groupForBasicType: () => true,
+          };
+
+          return {
+            ...defaults,
+            state:          testState,
+            typeMapGetters: testTypeMapGetters,
+
+            modes,
+
+            expectedTypes: expected ? setTypeMode(modes, { virt: expectedMenuItems.virtual }) : {}
+          };
+        };
+
+        /**
+         * Extend generateDefaults with env to return a spoof type
+         */
+        const createEnvBasicSpoof = (modes = [TYPE_MODES.BASIC], expected = true) => {
+          const defaults = generateDefaults();
+          const { state, typeMapGetters, productName } = defaults;
+
+          const testState = {
+            ...state,
+            spoofedTypes: { [productName]: [types.spoof] }
+          };
+
+          const testTypeMapGetters = {
+            ...typeMapGetters,
+            groupForBasicType: () => true,
+          };
+
+          return {
+            ...defaults,
+            state:          testState,
+            typeMapGetters: testTypeMapGetters,
+
+            modes,
+
+            expectedTypes: expected ? setTypeMode(modes, { spoof: expectedMenuItems.spoof }) : {}
+          };
+        };
+
+        describe('mode: BASIC', () => {
+          it('one entry', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+            } = createEnvBasicPod();
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('one entry (explicitly test basic mode with a schema without `kind`)', () => {
+            // This is odd, but it should be clear that in basic mode schemas without a kind are ok)
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, modes, productStore
+            } = createEnvBasicPod();
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.podNoAttributes];
+                case COUNT:
+                  return [{ counts: { pod: counts.pod } }];
+                }
+
+                return [];
+              },
+            };
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(setTypeMode([TYPE_MODES.BASIC], { pod: expectedMenuItems.podWithoutAttribute }));
+          });
+
+          it('no entry (basic but no group)', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+            } = createEnvBasicPod([TYPE_MODES.BASIC], false);
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              groupForBasicType: (product, id) => false
+            };
+
+            const groups = getters.allTypes(state, testTypeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          describe('virtual types', () => {
+            it('one entry', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createEnvBasicVirtual();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+
+            it('no entry (group not basic)', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createEnvBasicVirtual([TYPE_MODES.BASIC], false);
+
+              const testTypeMapGetters = {
+                ...typeMapGetters,
+                groupForBasicType: () => false,
+              };
+
+              const groups = getters.allTypes(state, testTypeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+          });
+
+          describe('spoof types', () => {
+            it('one entry', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createEnvBasicSpoof();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+
+            it('no entry (group not basic)', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createEnvBasicSpoof([TYPE_MODES.BASIC], false);
+
+              const testTypeMapGetters = {
+                ...typeMapGetters,
+                groupForBasicType: () => false,
+              };
+
+              const groups = getters.allTypes(state, testTypeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+          });
+        });
+
+        describe('mode: ALL', () => {
+          /**
+          * Extend createEnvBasicPod with env to return a pod type for mode TYPE_MODES.ALL
+          */
+          const createEnvAllPod = (expected = true) => {
+            const defaults = createEnvBasicPod([TYPE_MODES.ALL]);
+            const { rootGetters, productStore } = defaults;
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.pod];
+                case COUNT:
+                  return [{ counts: { pod: counts.pod } }];
+                }
+
+                return [];
+              },
+            };
+
+            return {
+              ...defaults,
+              rootGetters: testRootGetters,
+
+              expectedTypes: expected ? setTypeMode([TYPE_MODES.ALL], { pod: expectedMenuItems.podWithAttribute }) : { }
+            };
+          };
+
+          /**
+          * Extend createEnvBasicVirtual with env to return a virtual type for mode TYPE_MODES.ALL
+          */
+          const createAllVirtualType = () => {
+            return createEnvBasicVirtual([TYPE_MODES.ALL]);
+          };
+
+          /**
+          * Extend createEnvBasicSpoof with env to return a spoof type for mode TYPE_MODES.ALL
+          */
+          const createAllSpoofedType = () => {
+            return createEnvBasicSpoof([TYPE_MODES.ALL]);
+          };
+
+          it('one entry', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+            } = createEnvAllPod();
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('no entry (schema without a kind)', () => {
+            const {
+              state, typeMapGetters, productStore, rootGetters, productName, modes, rootState, expectedTypes
+            } = createEnvAllPod(false);
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.podNoAttributes];
+                case COUNT:
+                  return [{ counts: { pod: counts.pod } }];
+                }
+
+                return [];
+              },
+            };
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('no entry (needs rancher cluster)', () => {
+            const {
+              state, typeMapGetters, rootGetters, productName, modes, rootState, expectedTypes
+            } = createEnvAllPod(false);
+
+            const testRootGetters = {
+              ...rootGetters,
+              isRancher: false
+            };
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              optionsFor: (schema) => ({
+                namespaced:       true,
+                customRoute:      'cde',
+                ifRancherCluster: true
+              }),
+            };
+
+            const groups = getters.allTypes(state, testTypeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('no entry (shouldn\'t be rancher cluster)', () => {
+            const {
+              state, typeMapGetters, rootGetters, productName, modes, rootState, expectedTypes
+            } = createEnvAllPod(false);
+
+            const testRootGetters = {
+              ...rootGetters,
+              isRancher: true
+            };
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              optionsFor: (schema) => ({
+                namespaced:       true,
+                customRoute:      'cde',
+                ifRancherCluster: false
+              }),
+            };
+
+            const groups = getters.allTypes(state, testTypeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('one entry (needs rancher cluster)', () => {
+            const {
+              state, typeMapGetters, rootGetters, productName, modes, rootState, expectedTypes
+            } = createEnvAllPod();
+
+            const testRootGetters = {
+              ...rootGetters,
+              isRancher: true
+            };
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              optionsFor: (schema) => ({
+                namespaced:       true,
+                customRoute:      'cde',
+                ifRancherCluster: true
+              }),
+            };
+
+            const groups = getters.allTypes(state, testTypeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('no entry (local only)', () => {
+            const {
+              state, typeMapGetters, rootGetters, productName, modes, rootState, expectedTypes
+            } = createEnvAllPod(false);
+
+            const testRootGetters = {
+              ...rootGetters,
+              currentCluster: { isLocal: false }
+            };
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              optionsFor: (schema) => ({
+                namespaced:  true,
+                customRoute: 'cde',
+                localOnly:   true
+              }),
+            };
+
+            const groups = getters.allTypes(state, testTypeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('one entry (local only)', () => {
+            const {
+              state, typeMapGetters, rootGetters, productName, modes, rootState, expectedTypes
+            } = createEnvAllPod();
+
+            const testRootGetters = {
+              ...rootGetters,
+              currentCluster: { isLocal: true }
+            };
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              optionsFor: (schema) => ({
+                namespaced:  true,
+                customRoute: 'cde',
+                localOnly:   true
+              }),
+            };
+
+            const groups = getters.allTypes(state, testTypeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          describe('virtual types', () => {
+            it('one entry', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createAllVirtualType();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+          });
+
+          describe('spoof types', () => {
+            it('one entry', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createAllSpoofedType();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+          });
+        });
+
+        describe('mode: FAVORITE', () => {
+          /**
+          * Extend generateDefaults with env to return a pod type for mode TYPE_MODES.FAVORITE
+          */
+          const generateDefaultsForFavourite = (expected = true) => {
+            const defaults = generateDefaults();
+            const { typeMapGetters, rootGetters, productStore } = defaults;
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.secret];
+                case COUNT:
+                  return [{ counts: { secret: counts.secret } }];
+                }
+
+                return [];
+              },
+            };
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              labelFor:          (schema, count) => 'Secret',
+              groupForBasicType: () => true,
+              optionsFor:        (schema) => ({
+                namespaced:  true,
+                customRoute: 'cde'
+              }),
+              isFavorite: () => true,
+            };
+
+            return {
+              ...defaults,
+              modes:          [TYPE_MODES.FAVORITE],
+              typeMapGetters: testTypeMapGetters,
+              rootGetters:    testRootGetters,
+
+              expectedTypes: expected ? setTypeMode([TYPE_MODES.FAVORITE], { secret: expectedMenuItems.secretWithAttribute }) : {}
+            };
+          };
+
+          /**
+          * Extend generateDefaultsForFavourite with env to return a virtual type for mode TYPE_MODES.FAVORITE
+          */
+          const createDefaultsForFavouriteVirtualType = (expected = true) => {
+            const defaults = generateDefaults();
+            const defaultsFavourites = generateDefaultsForFavourite();
+            const { state, productName } = defaultsFavourites;
+
+            const testState = {
+              ...state,
+              virtualTypes: { [productName]: [types.virtual] }
+            };
+
+            return {
+              ...defaultsFavourites,
+              state:       testState,
+              rootGetters: defaults.rootGetters,
+
+              expectedTypes: expected ? setTypeMode([TYPE_MODES.FAVORITE], { virt: expectedMenuItems.virtual }) : {}
+            };
+          };
+
+          /**
+          * Extend generateDefaultsForFavourite with env to return a spoof type for mode TYPE_MODES.FAVORITE
+          */
+          const createDefaultsForFavouriteSpoofType = (expected = true) => {
+            const defaults = generateDefaults();
+            const defaultsFavourites = generateDefaultsForFavourite();
+            const { state, productName } = defaultsFavourites;
+
+            const testState = {
+              ...state,
+              spoofedTypes: { [productName]: [types.spoof] }
+            };
+
+            return {
+              ...defaultsFavourites,
+              state:       testState,
+              rootGetters: defaults.rootGetters,
+
+              expectedTypes: expected ? setTypeMode([TYPE_MODES.FAVORITE], { spoof: expectedMenuItems.spoof }) : {}
+            };
+          };
+
+          it('one entry', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+            } = generateDefaultsForFavourite();
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('no entry (not favourite)', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+            } = generateDefaultsForFavourite(false);
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              isFavorite: () => false,
+            };
+
+            const groups = getters.allTypes(state, testTypeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          describe('virtual types', () => {
+            it('one entry', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createDefaultsForFavouriteVirtualType();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+
+            it('no entry (not favourite)', () => {
+              const expectedGroups = { };
+
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes
+              } = createDefaultsForFavouriteVirtualType();
+
+              const testTypeMapGetters = {
+                ...typeMapGetters,
+                isFavorite: () => false,
+              };
+
+              const groups = getters.allTypes(state, testTypeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedGroups);
+            });
+          });
+
+          describe('spoof types', () => {
+            it('one entry', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createDefaultsForFavouriteSpoofType();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+
+            it('no entry (not favourite)', () => {
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName, modes, expectedTypes
+              } = createDefaultsForFavouriteSpoofType(false);
+
+              const testTypeMapGetters = {
+                ...typeMapGetters,
+                isFavorite: () => false,
+              };
+
+              const groups = getters.allTypes(state, testTypeMapGetters, rootState, rootGetters)(productName, modes);
+
+              expect(groups).toStrictEqual(expectedTypes);
+            });
+          });
+        });
+
+        describe('mode: USED', () => {
+          /**
+          * Extend createEnvBasicPod with env to return a pod for mode TYPE_MODES.USED
+          */
+          const createUsedPod = () => {
+            const defaults = createEnvBasicPod([TYPE_MODES.USED]);
+            const { rootGetters, productStore } = defaults;
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.pod];
+                case COUNT:
+                  return [{ counts: { pod: counts.pod } }];
+                }
+
+                return [];
+              },
+            };
+
+            return {
+              ...defaults,
+              rootGetters: testRootGetters
+            };
+          };
+
+          it('one entry', () => {
+            const expectedGroups = setTypeMode([TYPE_MODES.USED], { pod: expectedMenuItems.podWithAttribute });
+
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, modes
+            } = createUsedPod();
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedGroups);
+          });
+
+          describe('virtual types', () => {
+            it('no entry (used not included)', () => {
+              const expectedGroups = { };
+
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName
+              } = createEnvBasicVirtual();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, [TYPE_MODES.USED]);
+
+              expect(groups).toStrictEqual(expectedGroups);
+            });
+          });
+
+          describe('spoof types', () => {
+            it('no entry (used not included)', () => {
+              const expectedGroups = { };
+
+              const {
+                state, typeMapGetters, rootState, rootGetters, productName
+              } = createEnvBasicSpoof();
+
+              const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, [TYPE_MODES.USED]);
+
+              expect(groups).toStrictEqual(expectedGroups);
+            });
+          });
+        });
+
+        describe('mode: multiple', () => {
+          // Covers getProductsGroups use cases
+          const modes = [TYPE_MODES.BASIC, TYPE_MODES.FAVORITE, TYPE_MODES.USED];
+
+          const createAllOfTheThings = () => {
+            const defaults = generateDefaults(EXPLORER, 'cluster', modes);
+            const {
+              state, typeMapGetters, rootGetters, productName, productStore
+            } = defaults;
+
+            const testState = {
+              ...state,
+              virtualTypes: { [productName]: [types.virtual] },
+              spoofedTypes: { [productName]: [types.spoof] }
+            };
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.topLevel, schemas.pod, schemas.secret];
+                case COUNT:
+                  return [{
+                    counts: {
+                      toplevel: counts.toplevel,
+                      pod:      counts.pod,
+                      secret:   counts.secret
+                    }
+                  }];
+                }
+
+                return [];
+              },
+            };
+
+            const testTypeMapGetters = {
+              ...typeMapGetters,
+              labelFor: (schema, count) => {
+                switch (schema.id) {
+                case 'secret':
+                  return 'Secret';
+                default:
+                  return 'Pod';
+                }
+              },
+              groupForBasicType: () => true,
+              optionsFor:        (schema) => ({
+                namespaced:  true,
+                customRoute: 'cde'
+              }),
+              isFavorite: (id) => id === 'secret',
+            };
+
+            return {
+              ...defaults,
+              typeMapGetters: testTypeMapGetters,
+              rootGetters:    testRootGetters,
+              state:          testState,
+
+              modes,
+              expectedTypes: {
+                ...setTypeMode([TYPE_MODES.BASIC], {
+                  // A resource that's favourite should still appear in the basic side nav
+                  // fav: {
+                  secret: expectedMenuItems.secretWithAttribute,
+
+                  // A basic resource
+                  pod: expectedMenuItems.podWithAttribute,
+
+                  // A top level resource with an invalid schema (no kind)
+                  toplevel: expectedMenuItems.topLevel,
+
+                  virt: expectedMenuItems.virtual,
+
+                  spoof: expectedMenuItems.spoof
+                }),
+                ...setTypeMode([TYPE_MODES.FAVORITE], { secret: expectedMenuItems.secretWithAttribute }),
+                ...setTypeMode([TYPE_MODES.USED], {
+                  // A resource that's favourite should still appear in the basic side nav
+                  secret: expectedMenuItems.secretWithAttribute,
+                  // A basic resource
+                  pod:    expectedMenuItems.podWithAttribute,
+                }),
+              }
+            };
+          };
+
+          it('no entries', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName
+            } = generateDefaults(EXPLORER, 'cluster', modes);
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual({});
+          });
+
+          it('one entry each', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, expectedTypes
+            } = createAllOfTheThings();
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(expectedTypes);
+          });
+
+          it('limited basic type', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, productStore
+            } = createAllOfTheThings();
+
+            const testState = {
+              ...state,
+              virtualTypes: { },
+              spoofedTypes: { }
+            };
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.secret];
+                case COUNT:
+                  return [{ counts: { secret: counts.secret } }];
+                }
+
+                return [];
+              },
+            };
+
+            const testExpectedTypes = {
+              ...setTypeMode([TYPE_MODES.BASIC], { secret: expectedMenuItems.secretWithAttribute }),
+              ...setTypeMode([TYPE_MODES.FAVORITE], { secret: expectedMenuItems.secretWithAttribute }),
+              ...setTypeMode([TYPE_MODES.USED], { secret: expectedMenuItems.secretWithAttribute }),
+            };
+
+            const groups = getters.allTypes(testState, typeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(testExpectedTypes);
+          });
+
+          it('no favourite type', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName, productStore
+            } = createAllOfTheThings();
+
+            const testRootGetters = {
+              ...rootGetters,
+              [`${ productStore }/all`]: (resource: string) => {
+                switch (resource) {
+                case SCHEMA:
+                  return [schemas.topLevel, schemas.pod];
+                case COUNT:
+                  return [{
+                    counts: {
+                      toplevel: counts.toplevel,
+                      pod:      counts.pod,
+                    }
+                  }];
+                }
+
+                return [];
+              },
+            };
+
+            const testExpectedTypes = {
+              ...setTypeMode([TYPE_MODES.BASIC], {
+                // A basic resource
+                pod: expectedMenuItems.podWithAttribute,
+
+                // A top level resource with an invalid schema (no kind)
+                toplevel: expectedMenuItems.topLevel,
+
+                virt: expectedMenuItems.virtual,
+
+                spoof: expectedMenuItems.spoof
+              }),
+              ...setTypeMode([TYPE_MODES.USED], {
+                // A basic resource
+                pod: expectedMenuItems.podWithAttribute,
+              }),
+            };
+
+            const groups = getters.allTypes(state, typeMapGetters, rootState, testRootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(testExpectedTypes);
+          });
+
+          it('no used type / no virtual type', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName
+            } = createAllOfTheThings();
+
+            const testState = {
+              ...state,
+              spoofedTypes: { [productName]: [types.spoof] },
+              virtualTypes: { [productName]: [] },
+            };
+
+            const testExpectedTypes = {
+              ...setTypeMode([TYPE_MODES.BASIC], {
+                // A resource that's favourite should still appear in the basic side nav
+                // fav: {
+                secret: expectedMenuItems.secretWithAttribute,
+
+                // A basic resource
+                pod: expectedMenuItems.podWithAttribute,
+
+                // A top level resource with an invalid schema (no kind)
+                toplevel: expectedMenuItems.topLevel,
+
+                spoof: expectedMenuItems.spoof
+              }),
+              ...setTypeMode([TYPE_MODES.FAVORITE], { secret: expectedMenuItems.secretWithAttribute }),
+              ...setTypeMode([TYPE_MODES.USED], {
+                // A resource that's favourite should still appear in the basic side nav
+                secret: expectedMenuItems.secretWithAttribute,
+                // A basic resource
+                pod:    expectedMenuItems.podWithAttribute,
+              }),
+            };
+
+            const groups = getters.allTypes(testState, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(testExpectedTypes);
+          });
+
+          it('no used type / no spoofed type', () => {
+            const {
+              state, typeMapGetters, rootState, rootGetters, productName
+            } = createAllOfTheThings();
+
+            const testState = {
+              ...state,
+              spoofedTypes: { [productName]: [] },
+              virtualTypes: { [productName]: [types.virtual] },
+            };
+
+            const testExpectedTypes = {
+              ...setTypeMode([TYPE_MODES.BASIC], {
+                // A resource that's favourite should still appear in the basic side nav
+                // fav: {
+                secret: expectedMenuItems.secretWithAttribute,
+
+                // A basic resource
+                pod: expectedMenuItems.podWithAttribute,
+
+                // A top level resource with an invalid schema (no kind)
+                toplevel: expectedMenuItems.topLevel,
+
+                virt: expectedMenuItems.virtual,
+
+              }),
+              ...setTypeMode([TYPE_MODES.FAVORITE], { secret: expectedMenuItems.secretWithAttribute }),
+              ...setTypeMode([TYPE_MODES.USED], {
+                // A resource that's favourite should still appear in the basic side nav
+                secret: expectedMenuItems.secretWithAttribute,
+                // A basic resource
+                pod:    expectedMenuItems.podWithAttribute,
+              }),
+            };
+
+            const groups = getters.allTypes(testState, typeMapGetters, rootState, rootGetters)(productName, modes);
+
+            expect(groups).toStrictEqual(testExpectedTypes);
+          });
+        });
+      });
+    });
+  });
+});
+
+// getTree - Remove ignored schemas, not-applicable to ns filter

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -604,7 +604,7 @@ export const mutations = {
     state.isRancherInHarvester = neu;
   },
 
-  updateNamespaces(state, { filters, all }) {
+  updateNamespaces(state, { filters, all, getters }) {
     state.namespaceFilters = filters.filter((x) => !!x);
 
     if ( all ) {
@@ -957,6 +957,7 @@ export const actions = {
     commit('updateNamespaces', {
       filters: filters || [ALL_USER],
       all:     allNamespaces,
+      getters
     });
 
     if (getters['currentCluster'] && getters['currentCluster'].isHarvester) {
@@ -979,7 +980,7 @@ export const actions = {
       }
     });
 
-    commit('updateNamespaces', { filters: ids });
+    commit('updateNamespaces', { filters: ids, getters });
   },
 
   async cleanNamespaces({ getters, dispatch }) {

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -573,13 +573,11 @@ export const getters = {
   },
 
   getTree(state, getters, rootState, rootGetters) {
-    // Name the function so it's easily discernible on performance tracing
+    // Name the function so it's easily identifiable when performance tracing
     return function getTree(productId, mode, allTypes, clusterId, namespaceMode, currentType, search) {
       // getTree has four modes:
-      // - `basic` matches data types that should always be shown even if there
-      //    are 0 of them.
-      // - `used` matches the data types where there are more than 0 of them
-      //    in the current set of namespaces.
+      // - `basic` matches data types that should always be shown (even if there are 0 of them).
+      // - `used` matches the data types where there are more than 0 of them in the current set of namespaces.
       // - `all` matches all types.
       // - `favorite` matches starred types.
       // namespaceMode: 'namespaced', 'cluster', or 'both'
@@ -852,12 +850,11 @@ export const getters = {
 
   /**
    * Given many things, create a list of menu items per schema given the mode
-   *
    */
   allTypes(state, getters, rootState, rootGetters) {
-    // Name the function so it's easily discernible on performance tracing
+    // Name the function so it's easily identifiable when performance tracing
     return function allTypes(product, modes = [TYPE_MODES.ALL]) {
-      const module = findBy(state.products, 'name', product)?.inStore;
+      const module = state.products.find((p) => p.name === product)?.inStore;
       const schemas = rootGetters[`${ module }/all`](SCHEMA);
       const isLocal = !rootGetters.currentCluster?.isLocal;
       const isRancher = rootGetters.isRancher;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7773
<!-- Define findings related to the feature or bug issue. -->

> The general refactor of the side nav is covered by https://github.com/rancher/dashboard/issues/5607

### Occurred changes and/or fixed issues
- getGroups creates the entries used in the side nav (and the explorer resource search modal)
- This previously was triggered often and on large / slow systems can run slowly, both impacting UI performance
- This PR improves this performance in two ways
  - Improve performance of allTypes fn
    - This consumed the majority of time within getGroups
    - PR reduces execution time by a half
    - It does this by 
      - calculating entries for a product given all modes requests... rather than one per product per mode
      - skip calling the costly labelFor fn unless we actually need to
  - Reduce the amount of times getGroups is called
    - don't trigger on changes to counts (which changes often). Instead show counts via the component itself
      - to do this i added a dashboard store `count` getter which is now used in a couple of places
      - note - for explorer search stick them in again, as in that context it negatively impacts performance
    - only trigger of new / removed schemas, instead of any changes to schemas
      - this is more costly to calc up front, but saves an even more costly getGroups cal
    - queue up getGroup calls for namespace and namespaceMode changes... instead of executing immediately
      - on some change of mode the namespace list changes also, this results in x2 execution. i think we might even be able to remove changes on ns mode change... but chickened out in this PR
    - Fixed a bug where `updateNamespaces` used the wrong getters... which meant namespace cache was set to an empty object and then set to the correct value (which caused x2 calls to getGroups)   
- The PR also
  - Adds lots of comments
  - Adds unit tests for the new allTypes fn
  - set named functions for allTypes and getTree so they show up in performance logs
  - removed a watch on `product`, which didn't exist. there is a watch on `productId`

### Technical notes summary
- Added unit tests for allTypes
- Ensured `diff` between previous and new allTypes output matched. The only diff is the counts stuff which has now been left out


#### Tested at scale (7.5k schemas, 2k namespaces)
- Different global products (user management, fleet, cluster management, harvester manager)
- Different explorer products (cis benchmark, kubewarden, legacy)

Product - Mode | Old | New
-- | -- | --
Explorer - basic | 169.247314453125 ms
Explorer - favorite | 162.413330078125 ms
Explorer - used | 114.866943359375 ms
Explorer - all modes | | 150.678955078125 ms
Apps - basic | 111.8642578125 ms | 63.146728515625 ms
CIS - basic | 147.37890625 ms | 62.5 ms
Legacy - basic  | 109.410888671875 ms | 60.7373046875 ms
Kubewarden - basic | 115.473876953125 ms | 61.5009765625 ms
TOTAL (getProductsGroups) |  1042.572998046875 ms | 509.0517578125 ms

#### Observations
- Explorer product requests three modes
  - BASIC
    - returns configured types (probably as per product definition)
  - FAVORITE
    - user favs
  - USED
    - types that have resources. if a resource has no count at all, it won't be in this list
- Non-explorer products just request the BASIC mode
- allTypes always used with getTree and vice-versa. These might have been split at some point? Used in extension?
- labelFor getter performs much worse when passed number instead of random & invalid `counts` object.
- labelFor with a cold cache is expensive (need to cache strings... create and cache regex)
- doesn't scale with more products (though impact is now limited

### Areas or cases that should be tested
- Side nav content for each burger menu item, including a cluster. Check
  - same menu items as old
  - counts are correct, given namespace filter
  - inline products such as CIS benchmark, kubewarden, legacy  
  - favourites
  - custom nav entries
- Side nav updates given
  - new/removed resources (made via another browser) changes resource count
  - namespace/project filter changes (made in same browser) changes resource counts
- Cluster explorer search resource modal
  - same items as old
  - counts show correctly