### PR TITLE
Add certificates view to cluster dashboard

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2034,6 +2034,8 @@ clusterIndexPage:
       etcd: Etcd
       scheduler: Scheduler
       controller-manager: Controller Manager
+    certs:
+      label: Certificates
 
 configmap:
   tabs:
@@ -2343,6 +2345,7 @@ glance:
   v1MonitoringInstalled: V1 Monitoring Installed
   clusterInfo: Cluster Information
   eventsTable: Full events list
+  secretsTable: Full secrets list
 
 clusterBadge:
   addLabel: Add Cluster Badge
@@ -4769,13 +4772,26 @@ secret:
   authentication: Authentication
   certificate:
     certificate: Certificate
+    certificates: Certificates
     certificatePlaceholder: "Paste in the CA certificate, starting with -----BEGIN CERTIFICATE----"
     cn: Domain Name
     expires: Expires
+    expiresOn: Expires On
+    expiresDuration: Expires In
+    lifetime: Lifetime
     issuer: Issuer
+    paging: |-
+      {pages, plural,
+      =0 {No {pluralLabel}}
+      =1 {{count} {count, plural, =1 {{singularLabel}} other {{pluralLabel}}}}
+      other {{from} - {to} of {count} {pluralLabel}}}
     plusMore: "+ {n} more"
     privateKey: Private Key
     privateKeyPlaceholder: "Paste in the private key, typically starting with -----BEGIN RSA PRIVATE KEY-----"
+    warnings:
+      expiring: "{count} {count, plural, =1 {Certificate expires soon} other {Certificates expire soon}}"
+      expired: "{count} {count, plural, =1 {Certificate has expired} other {Certificates have expired}}"
+      filtered: ". Not all may be visible given the selected project/namespace filter"
   data: Data
   registry:
     address: Registry

--- a/shell/components/Certificates.vue
+++ b/shell/components/Certificates.vue
@@ -55,7 +55,7 @@ export default Vue.extend<Data, any, any, any>({
         }, {
           name:        'cert-expires2',
           labelKey:    'secret.certificate.expiresDuration',
-          value:       (row: Secret) => row.certInfo?.notAfter.valueOf(),
+          value:       (row: Secret) => row.timeTilExpirationDate,
           formatter:   'LiveDate',
           sort:        ['timeTilExpiration'],
           search:      ['timeTilExpiration'],

--- a/shell/components/Certificates.vue
+++ b/shell/components/Certificates.vue
@@ -1,0 +1,165 @@
+<script lang="ts">
+import Vue from 'vue';
+import { mapGetters } from 'vuex';
+import ResourceTable from '@shell/components/ResourceTable';
+import { SECRET } from '@shell/config/types';
+import { NAME as NAME_COL, NAMESPACE as NAMESPACE_COL, AGE, STATE } from '@shell/config/table-headers';
+import Secret, { TYPES } from '@shell/models/secret';
+import { Banner } from '@components/Banner';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+import { BadgeState } from '@components/BadgeState';
+
+interface Data {
+  schema: Object,
+  headers: Object[],
+  certs: Secret[],
+  pagingParams: {
+    pluralLabel: string,
+    singularLabel: string
+  }
+}
+
+export default Vue.extend<Data, any, any, any>({
+  components: {
+    ResourceTable, Banner, BadgeState
+  },
+
+  async fetch() {
+    // We're fetching secrets with a filter, this will clash with secrets in other contexts
+    this.$store.dispatch('cluster/forgetType', SECRET);
+
+    this.certs = await this.fetchCerts();
+  },
+
+  data(): Data {
+    return {
+      schema:  this.$store.getters['cluster/schemaFor'](SECRET),
+      headers: [
+        {
+          ...STATE,
+          formatter: null,
+          name:      'certState',
+          sort:      ['certState', 'nameSort'],
+          value:     'certState',
+        },
+        NAME_COL,
+        NAMESPACE_COL,
+        {
+          name:     'cn',
+          labelKey: 'secret.certificate.cn',
+          value:    (row: Secret) => {
+            return row.cn + (row.unrepeatedSans.length ? ` ${ this.t('secret.certificate.plusMore', { n: row.unrepeatedSans.length }) }` : '');
+          },
+          sort:   ['cn'],
+          search: ['cn'],
+        }, {
+          name:        'cert-expires2',
+          labelKey:    'secret.certificate.expiresDuration',
+          value:       (row: Secret) => row.certInfo?.notAfter.valueOf(),
+          formatter:   'LiveDate',
+          sort:        ['timeTilExpiration'],
+          search:      ['timeTilExpiration'],
+          defaultSort: true,
+          width:       100
+        }, {
+          name:      'cert-expires',
+          labelKey:  'secret.certificate.expiresOn',
+          value:     'certInfo.notAfter',
+          formatter: 'Date',
+          sort:      ['certInfo.notAfter'],
+          search:    ['certInfo.notAfter'],
+        }, {
+          name:     'cert-lifetime',
+          labelKey: 'secret.certificate.lifetime',
+          value:    (row: Secret) => row.certLifetime,
+          sort:     ['certLifetime'],
+          search:   ['certLifetime'],
+        },
+        AGE
+      ],
+      certs:        [],
+      pagingParams: {
+        pluralLabel:   this.t('secret.certificate.certificates'),
+        singularLabel: this.t('secret.certificate.certificate')
+      }
+    };
+  },
+
+  computed: {
+    ...mapGetters(['isAllNamespaces']),
+
+    expiredData() {
+      let expiring = 0;
+      let expired = 0;
+
+      for (let i = 0; i < this.certs.length; i++) {
+        const cert = this.certs[i];
+
+        if (cert.certState === STATES_ENUM.EXPIRING) {
+          expiring++;
+        }
+        if (cert.certState === STATES_ENUM.EXPIRED) {
+          expired++;
+        }
+      }
+
+      const filterWarning = !this.isAllNamespaces ? this.t('secret.certificate.warnings.filtered') : '';
+
+      return {
+        expiring: expiring ? this.t('secret.certificate.warnings.expiring', { count: expiring, filtered: !this.isAllNamespaces }) + filterWarning : '',
+        expired:  expired ? this.t('secret.certificate.warnings.expired', { count: expired, filtered: !this.isAllNamespaces }) + filterWarning : '',
+      };
+    }
+  },
+
+  beforeDestroy() {
+    // We're fetching secrets with a filter, clear it so as to not clash with other contexts
+    this.$store.dispatch('cluster/forgetType', SECRET);
+  },
+
+  methods: {
+    async fetchCerts() {
+      return await this.$store.dispatch('cluster/findAll', {
+        type: SECRET,
+        opt:  {
+          watch:  false,
+          // Note - urlOptions handles filter in a weird way
+          filter: { 'metadata.fields.1': TYPES.TLS }
+        }
+      });
+    },
+  }
+});
+</script>
+
+<template>
+  <div>
+    <Banner
+      v-if="expiredData.expiring"
+      color="warning"
+      :label="expiredData.expiring"
+    />
+    <Banner
+      v-if="expiredData.expired"
+      color="error"
+      :label="expiredData.expired"
+    />
+    <ResourceTable
+      :loading="$fetchState.pending"
+      :schema="schema"
+      :headers="headers"
+      :rows="certs"
+      :paging-label="'secret.certificate.paging'"
+      :paging-params="pagingParams"
+    >
+      <template #col:certState="{row}">
+        <td>
+          <BadgeState
+            :color="row.certStateBackground"
+            :label="row.certStateDisplay"
+          />
+        </td>
+      </template>
+    </ResourceTable>
+  </div>
+</template>

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -97,6 +97,14 @@ export default {
       default: 'sortableTable.paging.resource',
     },
 
+    /**
+     * Additional params to pass to the pagingLabel translation
+     */
+    pagingParams: {
+      type:    Object,
+      default: null,
+    },
+
     rowActions: {
       type:    Boolean,
       default: true,
@@ -392,7 +400,11 @@ export default {
       return standard.concat(this.listGroups);
     },
 
-    pagingParams() {
+    parsedPagingParams() {
+      if (this.pagingParams) {
+        return this.pagingParams;
+      }
+
       if ( !this.schema ) {
         return {
           singularLabel: '',
@@ -482,7 +494,7 @@ export default {
     :group-options="groupOptions"
     :search="search"
     :paging="true"
-    :paging-params="pagingParams"
+    :paging-params="parsedPagingParams"
     :paging-label="pagingLabel"
     :row-actions="rowActions"
     :table-actions="_showBulkActions"

--- a/shell/components/formatter/LiveDuration.vue
+++ b/shell/components/formatter/LiveDuration.vue
@@ -57,7 +57,7 @@ export default {
       const now = day();
 
       from = from || now;
-      const seconds = Math.abs(value.diff(now, 'seconds'));
+      const seconds = Math.abs(value.diff(from, 'seconds'));
 
       return elapsedTime(seconds);
     },

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -293,9 +293,7 @@ export default class Secret extends SteveModel {
         issuer, notBefore, notAfter, cn, sans
       };
 
-      this._cachedCertInfo = certInfo;
-
-      return this._cachedCertInfo;
+      return certInfo;
     }
 
     return null;
@@ -323,7 +321,7 @@ export default class Secret extends SteveModel {
         return displaySans;
       }
 
-      return certInfo?.sans || [];
+      return certInfo?.sans?.array || certInfo?.sans || [];
     }
 
     return null;
@@ -333,7 +331,7 @@ export default class Secret extends SteveModel {
     if (this._type === TYPES.TLS) {
       const certInfo = this.cachedCertInfo;
 
-      if (!certInfo.notAfter) {
+      if (!certInfo?.notAfter) {
         return null;
       }
 
@@ -350,7 +348,7 @@ export default class Secret extends SteveModel {
   }
 
   get timeTilExpirationDate() {
-    return this.timeTilExpiration > 0 ? this.cachedCertInfo.notAfter.valueOf() : null;
+    return this.timeTilExpiration > 0 ? this.cachedCertInfo?.notAfter?.valueOf() : null;
   }
 
   get decodedData() {

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -7,7 +7,7 @@ import { set } from '@shell/utils/object';
 import { NAME as MANAGER } from '@shell/config/product/manager';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { colorForState, stateDisplay, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
-import { diffFrom } from 'utils/time';
+import { diffFrom } from '@shell/utils/time';
 import day from 'dayjs';
 
 export const TYPES = {

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -15,6 +15,7 @@ import {
   WORKLOAD_TYPES,
   COUNT,
   CATALOG,
+  SECRET
 } from '@shell/config/types';
 import { setPromiseResult } from '@shell/utils/promise';
 import AlertTable from '@shell/components/AlertTable';
@@ -42,6 +43,8 @@ import { fetchClusterResources } from './explorer-utils';
 import SimpleBox from '@shell/components/SimpleBox';
 import { ExtensionPoint, CardLocation } from '@shell/core/types';
 import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
+import Certificates from '@shell/components/Certificates';
+import { NAME as EXPLORER } from '@shell/config/product/explorer';
 
 export const RESOURCES = [NAMESPACE, INGRESS, PV, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.DAEMON_SET, SERVICE];
 
@@ -74,6 +77,7 @@ export default {
     ConfigBadge,
     EventsTable,
     SimpleBox,
+    Certificates
   },
 
   mixins: [metricPoller],
@@ -348,8 +352,18 @@ export default {
       return {
         name:   'c-cluster-product-resource',
         params: {
-          product:  'explorer',
-          resource: 'event',
+          product:  EXPLORER,
+          resource: EVENT,
+        }
+      };
+    },
+
+    allSecretsLink() {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          product:  EXPLORER,
+          resource: SECRET,
         }
       };
     }
@@ -580,6 +594,18 @@ export default {
           :weight="1"
         >
           <AlertTable v-if="selectedTab === 'cluster-alerts'" />
+        </Tab>
+        <Tab
+          name="cluster-certs"
+          :label="t('clusterIndexPage.sections.certs.label')"
+          :weight="1"
+        >
+          <span class="events-table-link">
+            <n-link :to="allSecretsLink">
+              <span>{{ t('glance.secretsTable') }}</span>
+            </n-link>
+          </span>
+          <Certificates v-if="selectedTab === 'cluster-certs'" />
         </Tab>
       </Tabbed>
     </div>

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -105,6 +105,7 @@ export const STATES_ENUM = {
   ERRORING:         'erroring',
   ERRORS:           'errors',
   EXPIRED:          'expired',
+  EXPIRING:         'expiring',
   FAIL:             'fail',
   FAILED:           'failed',
   HEALTHY:          'healthy',
@@ -253,7 +254,10 @@ export const STATES = {
     color: 'error', icon: 'error', label: 'Errors', compoundIcon: 'error'
   },
   [STATES_ENUM.EXPIRED]: {
-    color: 'warning', icon: 'error', label: 'Expired', compoundIcon: 'warning'
+    color: 'error', icon: 'error', label: 'Expired', compoundIcon: 'warning'
+  },
+  [STATES_ENUM.EXPIRING]: {
+    color: 'warning', icon: 'error', label: 'Expiring', compoundIcon: 'error'
   },
   [STATES_ENUM.FAIL]: {
     color: 'error', icon: 'error', label: 'Fail', compoundIcon: 'error'

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -24,11 +24,14 @@ const GC_IGNORE_TYPES = {
   [UI.NAV_LINK]: true,
 };
 
+// Include calls to /v1 AND /k8s/clusters/<cluster id>/v1
+const steveRegEx = new RegExp('(/v1)|(\/k8s\/clusters\/[a-z0-9-]+\/v1)');
+
 export default {
   urlOptions: () => (url, opt) => {
     opt = opt || {};
     const parsedUrl = parse(url);
-    const isSteve = parsedUrl.path.startsWith('/v1');
+    const isSteve = steveRegEx.test(parsedUrl.path);// .startsWith('/v1');
 
     // Filter
     if ( opt.filter ) {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -31,7 +31,7 @@ export default {
   urlOptions: () => (url, opt) => {
     opt = opt || {};
     const parsedUrl = parse(url);
-    const isSteve = steveRegEx.test(parsedUrl.path);// .startsWith('/v1');
+    const isSteve = steveRegEx.test(parsedUrl.path);
 
     // Filter
     if ( opt.filter ) {

--- a/shell/utils/time.js
+++ b/shell/utils/time.js
@@ -10,7 +10,7 @@ export function diffFrom(value, from, t) {
   const now = day();
 
   from = from || now;
-  const diff = value.diff(now, 'seconds');
+  const diff = value.diff(from, 'seconds');
 
   let absDiff = Math.abs(diff);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10025
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Add a new tab, next to events, in the cluster dashboard
- Tab shows a list of all secrets of cert type
- List allows users to see which certs are expiring soon, how long they've lived etc
- Tab also shows a notification if certs are expiring or have expired
- Related fixes
  - plumb in option list paging params (so we can show X of Y Certificates in pagination controls)
  - fix usages of from = from || now
  - Count requests to kube steve (`/k8s/cluster/<clusterid>/v1`) as steve requests (alongside local steve requests `/v1`)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
- Cluster --> new `Certificates` Tab
- Certificates that are expiring
- Certificates that have expired

### Areas which could experience regressions
- General API requests made to the cluster when in explorer view
- Secrets List 
  - Certs that are expiring should show have a red date (should be yellow - covered by https://github.com/rancher/dashboard/issues/10018)
  - Certs that have expired should show have a red date
- Secrets Detail View
  - Dates should be coloured as per list 
- Switching between the secrets and certs list (start on one, switch to another, ensure list entries are correct) 

### Screenshot/Video

![image](https://github.com/rancher/dashboard/assets/18697775/7efca2f2-2503-488b-9e54-da1ea10a2b58)
