### PR TITLE
Use full text label "Refresh" on refresh button instead of just icon

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -691,6 +691,15 @@ asyncButton:
     successIcon: checkmark
     waiting: ''
     waitingIcon: refresh
+  manual-refresh:
+    action: ''
+    actionIcon: refresh
+    error: ''
+    errorIcon: error
+    success: ''
+    successIcon: checkmark
+    waiting: ''
+    waitingIcon: refresh
   remove:
     action: Remove
     success: Removed

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -273,6 +273,7 @@ export default Vue.extend<{ phase: string}, any, any, any>({
     :data-testid="componentTestid + '-async-button'"
     @click="clicked"
   >
+    <span v-if="mode === 'manual-refresh'">{{ t('action.refresh') }}</span>
     <i
       v-if="displayIcon"
       v-clean-tooltip="tooltip"
@@ -285,3 +286,11 @@ export default Vue.extend<{ phase: string}, any, any, any>({
     />
   </button>
 </template>
+
+<style lang="scss" scoped>
+// refresh mode has icon + text. We need to fix the positioning of the icon and sizing
+.manual-refresh i {
+  margin: 0 0 0 8px !important;
+  font-size: 1rem !important;
+}
+</style>

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1026,9 +1026,8 @@ export default {
           <slot name="header-right" />
           <AsyncButton
             v-if="isTooManyItemsToAutoUpdate"
-            v-clean-tooltip="t('performance.manualRefresh.buttonTooltip')"
             class="manual-refresh"
-            mode="refresh"
+            mode="manual-refresh"
             :current-phase="currentPhase"
             @click="debouncedRefreshTableData"
           />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8645 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- create new `manual-refresh` action to not confuse with other refresh actions 
- update translations to match new `AsyncBtn` action
- remove tooltip from manual refresh button (we already have the text)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Go to `Settings` -> `Performance` ->  `Manual Refresh` -> and enable manual refresh with a low threshold (ex: 5)
Go to `local` cluster -> `events` -> and check that the button appears with the correct text label

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot 2023-11-13 at 12 16 56](https://github.com/rancher/dashboard/assets/97888974/0a0a4211-8aa5-4a70-a608-df59466ae5b0)
