### PR TITLE
Ensure extension build-pkg succeeds when extension contains form validation

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",
@@ -41,6 +41,7 @@
     "@nuxtjs/eslint-config-typescript": "6.0.1",
     "@nuxtjs/webpack-profile": "0.1.0",
     "@popperjs/core": "2.4.4",
+    "@types/is-url": "1.2.30",
     "@types/node": "16.4.3",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Ensure extension build-pkg succeeds when extension contains form validation

### Occurred changes and/or fixed issues
- if an extension uses form validation it brings in shell/utils/validators/formRules/index.ts
- that was recentely updated to import is-url (https://github.com/rancher/dashboard/pull/9701/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R149)
- is-url needs typing and will cause build-pkg to fail
- so add the typing, as per others, to shell/package dependencies

