### PR TITLE
fix flaky cluster-project-members.spec test 

### DIFF
--- a/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
@@ -32,9 +32,15 @@ export default class ClusterProjectMembersPo extends PagePo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 
-  listElementWithName(name:string) {
-    const baseResourceList = new BaseResourceList(this.self());
+  resourcesList() {
+    return new BaseResourceList(this.self());
+  }
 
-    return baseResourceList.resourceTable().sortableTable().rowElementWithName(name);
+  sortableTable() {
+    return this.resourcesList().resourceTable().sortableTable();
+  }
+
+  listElementWithName(name:string) {
+    return this.sortableTable().rowElementWithName(name);
   }
 }

--- a/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
@@ -39,8 +39,8 @@ describe('Cluster Project and Members', { tags: ['@adminUser', '@debug'] }, () =
     cy.wait('@createClusterMembership');
 
     clusterMembership.waitForPageWithExactUrl();
-    clusterMembership.sortableTable().noRowsText().then((el) => {
-      if (el.find('span').is(':visible')) {
+    cy.get('body tbody').then((el) => {
+      if (el.find('tr.no-rows').is(':visible')) {
         cy.reload();
       }
       clusterMembership.listElementWithName(username).should('exist');

--- a/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
@@ -34,7 +34,9 @@ describe('Cluster Project and Members', { tags: ['@adminUser'] }, () => {
     clusterMembership.navToSideMenuEntryByLabel('Cluster and Project Members');
     clusterMembership.triggerAddClusterOrProjectMemberAction();
     clusterMembership.selectClusterOrProjectMember(username);
+    cy.intercept('POST', '/v3/clusterroletemplatebindings').as('createClusterMembership');
     clusterMembership.saveCreateForm().click();
+    cy.wait('@createClusterMembership');
 
     clusterMembership.waitForPageWithExactUrl();
     clusterMembership.listElementWithName(username).should('exist');

--- a/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
@@ -7,7 +7,7 @@ const runPrefix = `e2e-test-${ runTimestamp }`;
 const username = `${ runPrefix }-cluster-proj-member`;
 const standardPassword = 'standard-password';
 
-describe('Cluster Project and Members', { tags: ['@adminUser'] }, () => {
+describe('Cluster Project and Members', { tags: ['@adminUser', '@debug'] }, () => {
   it('Members added to both Cluster Membership should not show "Loading..." next to their names', () => {
     const usersAdmin = new UsersPo('_');
     const userCreate = usersAdmin.createEdit();
@@ -39,15 +39,19 @@ describe('Cluster Project and Members', { tags: ['@adminUser'] }, () => {
     cy.wait('@createClusterMembership');
 
     clusterMembership.waitForPageWithExactUrl();
-    clusterMembership.listElementWithName(username).should('exist');
-
-    clusterMembership.listElementWithName(username).find('.principal .name').invoke('text').then((t) => {
+    clusterMembership.sortableTable().noRowsText().then((el) => {
+      if (el.find('span').is(':visible')) {
+        cy.reload();
+      }
+      clusterMembership.listElementWithName(username).should('exist');
+      clusterMembership.listElementWithName(username).find('.principal .name').invoke('text').then((t) => {
       // clear new line chars and white spaces
-      const sanitizedName = t.trim().replace(/^\n|\n$/g, '');
+        const sanitizedName = t.trim().replace(/^\n|\n$/g, '');
 
-      // no string "loading..." next to name
-      // usecase https://github.com/rancher/dashboard/issues/8804
-      expect(sanitizedName).to.equal(username);
+        // no string "loading..." next to name
+        // usecase https://github.com/rancher/dashboard/issues/8804
+        expect(sanitizedName).to.equal(username);
+      });
     });
   });
 });

--- a/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
@@ -7,7 +7,7 @@ const runPrefix = `e2e-test-${ runTimestamp }`;
 const username = `${ runPrefix }-cluster-proj-member`;
 const standardPassword = 'standard-password';
 
-describe('Cluster Project and Members', { tags: ['@adminUser', '@debug'] }, () => {
+describe('Cluster Project and Members', { tags: ['@adminUser'] }, () => {
   it('Members added to both Cluster Membership should not show "Loading..." next to their names', () => {
     const usersAdmin = new UsersPo('_');
     const userCreate = usersAdmin.createEdit();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
fix flaky cluster-project-members.spec test by adding intercept logic and conditional statement.
addresses failure where cluster member does not display on Cluster and Project Members page: http://139.59.134.103/instance/6a70d355-1f33-4fc9-9816-7bd065185315/test/r3