### PR TITLE
Fix to extension bugs

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -311,7 +311,7 @@ export default {
         product: this.currentProduct.name,
         cluster: this.currentCluster,
       };
-      const enabled = action.enabled ? action.enabled.apply(this, [opts]) : true;
+      const enabled = action.enabled ? action.enabled.apply(this, [this.ctx]) : true;
 
       if (fn && enabled) {
         fn.apply(this, [opts, [], { $route: this.$route }]);

--- a/shell/core/plugin-helpers.js
+++ b/shell/core/plugin-helpers.js
@@ -7,13 +7,11 @@ import {
 import { getProductFromRoute } from '@shell/middleware/authenticated';
 import { isEqual } from '@shell/utils/object';
 
-function checkRouteProduct({ name, params, query }, locationConfigParam) {
-  const product = getProductFromRoute({
-    name, params, query
-  });
+function checkRouteProduct($route, locationConfigParam) {
+  const product = getProductFromRoute($route);
 
   // alias for the homepage
-  if (locationConfigParam === 'home' && name === 'home') {
+  if (locationConfigParam === 'home' && $route.name === 'home') {
     return true;
   } else if (locationConfigParam === product) {
     return true;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

- Ensure `checkRouteProduct` works with route meta object
  - `getProductFromRoute` falls back on product in route meta object
  - in `checkRouteProduct` this was not passed through
- Ensure header action button enabled fn gets the same args
  -  `handleExtensionAction` was `action.enabled.apply(this, [opts])`
  - but in the template it is `action.enabled(ctx)`
  - fix is to pass in ctx in `handleExtensionAction`
