### PR TITLE
Fix selection of default storage class

### DIFF
--- a/shell/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim.vue
+++ b/shell/edit/workload/storage/persistentVolumeClaim/persistentvolumeclaim.vue
@@ -78,7 +78,8 @@ export default {
      * Required to initialize with default SC on creation
      */
     defaultStorageClassName() {
-      return this.storageClasses.find((sc) => sc.metadata?.annotations?.['storageclass.beta.kubernetes.io/is-default-class'] || sc.metadata?.annotations?.['storageclass.kubernetes.io/is-default-class'])?.metadata.name;
+      return this.storageClasses.find((sc) => sc.metadata?.annotations?.['storageclass.beta.kubernetes.io/is-default-class'] === 'true' ||
+        sc.metadata?.annotations?.['storageclass.kubernetes.io/is-default-class'] === 'true')?.metadata.name ;
     },
 
     availablePVs() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes ~# 9717~ This is the 2.8next1 PR
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- default storage class is set via annotation
- annotations can be `"true"` or `"false"`
- previously we only checked for truthy when finding default
- this mean `"false"` counted as true
