### PR TITLE
Ensure home page `Get Started` link uses correct docs link

### DIFF
--- a/cypress/e2e/tests/pages/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/get-support.spec.ts
@@ -77,7 +77,7 @@ describe('Support Page', () => {
     it('can click on Get Started link', () => {
     // click Get Started link
       supportPage.clickSupportLink(4, true);
-      cy.url().should('include', 'ranchermanager.docs.rancher.com/getting-started/overview');
+      cy.url().should('include', 'getting-started/overview');
     });
   });
 });

--- a/cypress/e2e/tests/pages/home.spec.ts
+++ b/cypress/e2e/tests/pages/home.spec.ts
@@ -199,7 +199,7 @@ describe('Home Page', () => {
     it('can click on Get Started link', () => {
     // click Get Started link
       homePage.clickSupportLink(4, true);
-      cy.url().should('include', 'ranchermanager.docs.rancher.com/getting-started/overview');
+      cy.url().should('include', 'getting-started/overview');
     });
 
     it('can click on Commercial Support link', () => {

--- a/shell/config/home-links.js
+++ b/shell/config/home-links.js
@@ -26,7 +26,7 @@ const DEFAULT_LINKS = [
   },
   {
     key:     'getStarted',
-    value:   'https://ranchermanager.docs.rancher.com/getting-started/overview',
+    value:   `${ DOCS_BASE }/getting-started/overview`,
     enabled: true,
   },
 ];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Expands Fix for #9855
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- There's already a link ``Docs` that uses a var containing the correct root url
- This PR updates the link to the docs overview page to use the same root
- This means home page links to docs site go out to `https://ranchermanager.docs.rancher.com/v2.8`