### PR TITLE
Add Logo for OVHCloud (both RKE2 and Managed Kubernetes)

### DIFF
--- a/shell/assets/images/providers/ovhcloudmks.svg
+++ b/shell/assets/images/providers/ovhcloudmks.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 24.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 348.92935 163.69999"
+   xml:space="preserve"
+   sodipodi:docname="OVHcloud_stacked_R_logo_fullcolor_RGB.svg"
+   width="348.92935"
+   height="163.7"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"><metadata
+   id="metadata35"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs33" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="2499"
+   inkscape:window-height="1376"
+   id="namedview31"
+   showgrid="false"
+   inkscape:zoom="2.1519241"
+   inkscape:cx="381.9839"
+   inkscape:cy="25.915451"
+   inkscape:window-x="1981"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#000E9C;}
+	.st1{fill:#000E9C;}
+</style>
+<g
+   id="g24"
+   transform="translate(-49.4,-37.8)">
+	<path
+   class="st0"
+   d="m 272.4,42.2 c 12.8,23.1 10.4,51.6 -6.1,72.2 H 231.5 L 242.2,95.5 H 228 L 244.8,66 h 14.3 z m -68.7,72.2 H 168.2 C 151.5,93.8 149,65.1 162.1,42 l 23,40 25.4,-44.2 h 37.3 z"
+   id="path4"
+   inkscape:connector-curvature="0"
+   style="clip-rule:evenodd;fill:#000e9c;fill-rule:evenodd" />
+	<g
+   id="g22">
+		<path
+   class="st1"
+   d="m 49.4,171.3 c 0,-20.4 10.2,-30.2 26.9,-30.2 16.7,0 26.9,9.8 26.9,30.2 0,20.2 -10.2,30.1 -26.9,30.1 -16.7,0.1 -26.9,-9.9 -26.9,-30.1 z m 6.1,0 c 0,16.8 7.7,24.8 20.8,24.8 13.2,0 20.8,-8 20.8,-24.8 0,-16.9 -7.7,-24.9 -20.8,-24.9 -13.2,0 -20.8,8 -20.8,24.9 z"
+   id="path6"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 147.1,143.5 c 0.3,-0.7 1.1,-1.9 2.8,-1.9 1.6,0 2.9,1.3 2.9,2.9 0,0.5 -0.2,1 -0.3,1.3 L 132.4,199 c -0.4,1.2 -1.6,2 -2.8,2 -1.1,0 -2.3,-0.8 -2.8,-2 l -20.2,-53.1 c -0.1,-0.3 -0.3,-0.8 -0.3,-1.3 0,-1.6 1.3,-2.9 2.9,-2.9 1.6,0 2.5,1.2 2.8,1.9 l 17.5,46.3 z"
+   id="path8"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="M 165,173.2 V 198 c 0,1.6 -1.3,2.9 -2.9,2.9 -1.6,0 -2.9,-1.4 -2.9,-2.9 v -53.5 c 0,-1.6 1.3,-2.9 2.9,-2.9 1.6,0 2.9,1.4 2.9,2.9 v 23.3 h 30 v -23.3 c 0,-1.6 1.3,-2.9 2.9,-2.9 1.6,0 2.9,1.4 2.9,2.9 V 198 c 0,1.6 -1.3,2.9 -2.9,2.9 -1.6,0 -2.9,-1.4 -2.9,-2.9 v -24.8 z"
+   id="path10"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 228.5,159.9 c 7.7,0 11.9,4 13.3,5.9 0.4,0.6 0.6,1 0.6,1.6 0,1.5 -1.1,2.5 -2.5,2.5 -0.9,0 -1.5,-0.3 -2.1,-1 -1.3,-1.5 -3.6,-4 -9.3,-4 -7.9,0 -12.1,5.1 -12.1,15.7 0,10.8 4.2,15.8 12.1,15.8 5,0 8,-2.2 10,-3.7 0.6,-0.4 1,-0.6 1.6,-0.6 1.4,0 2.5,1.1 2.5,2.5 0,0.8 -0.3,1.4 -1.1,2.2 -1.9,1.6 -6,4.7 -13,4.7 -11.1,0 -17.7,-6.6 -17.7,-20.8 -0.1,-14.2 6.6,-20.8 17.7,-20.8 z"
+   id="path12"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 255.9,141.7 v 49.2 c 0,3.4 1.1,4.9 3.4,4.9 1.4,0 2.6,1.1 2.6,2.6 0,1.5 -1.2,2.6 -2.6,2.6 -5.8,0 -9,-3.4 -9,-10.1 v -49.2 c 0,-1.5 1.3,-2.8 2.8,-2.8 1.6,0 2.8,1.3 2.8,2.8 z"
+   id="path14"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 302.9,180.6 c 0,14.1 -6.9,20.8 -18.1,20.8 -11.1,0 -18.1,-6.6 -18.1,-20.8 0,-14.1 7,-20.7 18.1,-20.7 11.2,0 18.1,6.6 18.1,20.7 z m -5.6,0 c 0,-10.9 -4.6,-15.7 -12.5,-15.7 -7.9,0 -12.5,4.8 -12.5,15.7 0,11 4.6,15.8 12.5,15.8 7.9,0 12.5,-4.8 12.5,-15.8 z"
+   id="path16"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 316.1,163.2 v 22.5 c 0,5.6 1.8,10.4 10.5,10.4 8.7,0 10.5,-4.8 10.5,-10.4 v -22.5 c 0,-1.6 1.3,-2.8 2.8,-2.8 1.5,0 2.7,1.2 2.7,2.8 v 22.5 c 0,8.2 -2.7,15.7 -16,15.7 -13.3,0 -16,-7.5 -16,-15.7 v -22.5 c 0,-1.6 1.2,-2.8 2.8,-2.8 1.4,0.1 2.7,1.3 2.7,2.8 z"
+   id="path18"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 379.4,165.5 v -23.9 c 0,-1.6 1.2,-2.8 2.8,-2.8 1.6,0 2.8,1.2 2.8,2.8 v 42.7 c 0,11.4 -7.1,17 -16.9,17 -11.1,0 -17.7,-6.6 -17.7,-20.8 0,-14.1 6.2,-20.7 17.3,-20.7 5.5,0.1 9.7,3 11.7,5.7 z m 0,7 c 0,0 -3.3,-7.6 -11.4,-7.6 -7.8,0 -12.1,5.1 -12.1,15.7 0,10.8 4.2,15.8 12.1,15.8 6.6,0 11.4,-3.8 11.4,-12 z"
+   id="path20"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+	</g>
+</g>
+<g
+   id="g28"
+   transform="translate(-51.570659,-37.8)">
+	<path
+   class="st1"
+   d="m 395.3,152.8 c -0.7,0 -1.4,-0.1 -2,-0.4 -0.6,-0.3 -1.2,-0.6 -1.7,-1.1 -0.5,-0.5 -0.9,-1.1 -1.1,-1.8 -0.3,-0.7 -0.4,-1.5 -0.4,-2.3 0,-0.9 0.1,-1.6 0.4,-2.3 0.3,-0.7 0.7,-1.3 1.1,-1.8 0.5,-0.5 1,-0.9 1.7,-1.1 0.6,-0.3 1.3,-0.4 2,-0.4 0.7,0 1.4,0.1 2,0.4 0.6,0.3 1.2,0.7 1.7,1.1 0.5,0.5 0.9,1.1 1.1,1.8 0.3,0.7 0.4,1.5 0.4,2.3 0,0.9 -0.1,1.6 -0.4,2.3 -0.3,0.7 -0.7,1.3 -1.1,1.8 -0.5,0.5 -1,0.9 -1.7,1.1 -0.6,0.2 -1.3,0.4 -2,0.4 z m 0,-0.9 c 0.6,0 1.2,-0.1 1.7,-0.4 0.5,-0.2 1,-0.6 1.4,-1 0.4,-0.4 0.7,-0.9 0.9,-1.5 0.2,-0.6 0.3,-1.2 0.3,-1.9 0,-0.7 -0.1,-1.3 -0.3,-1.9 -0.2,-0.6 -0.5,-1.1 -0.9,-1.5 -0.4,-0.4 -0.9,-0.8 -1.4,-1 -0.5,-0.2 -1.1,-0.4 -1.7,-0.4 -0.6,0 -1.2,0.1 -1.7,0.4 -0.5,0.2 -1,0.6 -1.4,1 -0.4,0.4 -0.7,0.9 -0.9,1.5 -0.2,0.6 -0.3,1.2 -0.3,1.9 0,0.7 0.1,1.3 0.3,1.9 0.2,0.6 0.5,1.1 0.9,1.5 0.4,0.4 0.8,0.7 1.4,1 0.5,0.3 1.1,0.4 1.7,0.4 z m -2,-1.9 v -6 h 2 c 0.3,0 0.6,0 0.8,0.1 0.3,0.1 0.5,0.2 0.7,0.3 0.2,0.1 0.4,0.3 0.5,0.6 0.1,0.2 0.2,0.5 0.2,0.9 0,0.4 -0.1,0.7 -0.3,1 -0.2,0.3 -0.5,0.5 -0.8,0.6 l 1.4,2.5 h -1.1 l -1.1,-2.2 h -1.4 v 2.2 z m 1,-2.9 h 0.8 c 0.4,0 0.8,-0.1 1.1,-0.2 0.3,-0.2 0.4,-0.4 0.4,-0.8 0,-0.3 -0.1,-0.6 -0.3,-0.8 -0.2,-0.2 -0.6,-0.3 -1.1,-0.3 h -0.9 z"
+   id="path26"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+</g>
+</svg>

--- a/shell/assets/images/providers/ovhcloudpubliccloud.svg
+++ b/shell/assets/images/providers/ovhcloudpubliccloud.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 24.2.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 348.92935 163.69999"
+   xml:space="preserve"
+   sodipodi:docname="OVHcloud_stacked_R_logo_fullcolor_RGB.svg"
+   width="348.92935"
+   height="163.7"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"><metadata
+   id="metadata35"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs33" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="2499"
+   inkscape:window-height="1376"
+   id="namedview31"
+   showgrid="false"
+   inkscape:zoom="2.1519241"
+   inkscape:cx="381.9839"
+   inkscape:cy="25.915451"
+   inkscape:window-x="1981"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#000E9C;}
+	.st1{fill:#000E9C;}
+</style>
+<g
+   id="g24"
+   transform="translate(-49.4,-37.8)">
+	<path
+   class="st0"
+   d="m 272.4,42.2 c 12.8,23.1 10.4,51.6 -6.1,72.2 H 231.5 L 242.2,95.5 H 228 L 244.8,66 h 14.3 z m -68.7,72.2 H 168.2 C 151.5,93.8 149,65.1 162.1,42 l 23,40 25.4,-44.2 h 37.3 z"
+   id="path4"
+   inkscape:connector-curvature="0"
+   style="clip-rule:evenodd;fill:#000e9c;fill-rule:evenodd" />
+	<g
+   id="g22">
+		<path
+   class="st1"
+   d="m 49.4,171.3 c 0,-20.4 10.2,-30.2 26.9,-30.2 16.7,0 26.9,9.8 26.9,30.2 0,20.2 -10.2,30.1 -26.9,30.1 -16.7,0.1 -26.9,-9.9 -26.9,-30.1 z m 6.1,0 c 0,16.8 7.7,24.8 20.8,24.8 13.2,0 20.8,-8 20.8,-24.8 0,-16.9 -7.7,-24.9 -20.8,-24.9 -13.2,0 -20.8,8 -20.8,24.9 z"
+   id="path6"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 147.1,143.5 c 0.3,-0.7 1.1,-1.9 2.8,-1.9 1.6,0 2.9,1.3 2.9,2.9 0,0.5 -0.2,1 -0.3,1.3 L 132.4,199 c -0.4,1.2 -1.6,2 -2.8,2 -1.1,0 -2.3,-0.8 -2.8,-2 l -20.2,-53.1 c -0.1,-0.3 -0.3,-0.8 -0.3,-1.3 0,-1.6 1.3,-2.9 2.9,-2.9 1.6,0 2.5,1.2 2.8,1.9 l 17.5,46.3 z"
+   id="path8"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="M 165,173.2 V 198 c 0,1.6 -1.3,2.9 -2.9,2.9 -1.6,0 -2.9,-1.4 -2.9,-2.9 v -53.5 c 0,-1.6 1.3,-2.9 2.9,-2.9 1.6,0 2.9,1.4 2.9,2.9 v 23.3 h 30 v -23.3 c 0,-1.6 1.3,-2.9 2.9,-2.9 1.6,0 2.9,1.4 2.9,2.9 V 198 c 0,1.6 -1.3,2.9 -2.9,2.9 -1.6,0 -2.9,-1.4 -2.9,-2.9 v -24.8 z"
+   id="path10"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 228.5,159.9 c 7.7,0 11.9,4 13.3,5.9 0.4,0.6 0.6,1 0.6,1.6 0,1.5 -1.1,2.5 -2.5,2.5 -0.9,0 -1.5,-0.3 -2.1,-1 -1.3,-1.5 -3.6,-4 -9.3,-4 -7.9,0 -12.1,5.1 -12.1,15.7 0,10.8 4.2,15.8 12.1,15.8 5,0 8,-2.2 10,-3.7 0.6,-0.4 1,-0.6 1.6,-0.6 1.4,0 2.5,1.1 2.5,2.5 0,0.8 -0.3,1.4 -1.1,2.2 -1.9,1.6 -6,4.7 -13,4.7 -11.1,0 -17.7,-6.6 -17.7,-20.8 -0.1,-14.2 6.6,-20.8 17.7,-20.8 z"
+   id="path12"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 255.9,141.7 v 49.2 c 0,3.4 1.1,4.9 3.4,4.9 1.4,0 2.6,1.1 2.6,2.6 0,1.5 -1.2,2.6 -2.6,2.6 -5.8,0 -9,-3.4 -9,-10.1 v -49.2 c 0,-1.5 1.3,-2.8 2.8,-2.8 1.6,0 2.8,1.3 2.8,2.8 z"
+   id="path14"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 302.9,180.6 c 0,14.1 -6.9,20.8 -18.1,20.8 -11.1,0 -18.1,-6.6 -18.1,-20.8 0,-14.1 7,-20.7 18.1,-20.7 11.2,0 18.1,6.6 18.1,20.7 z m -5.6,0 c 0,-10.9 -4.6,-15.7 -12.5,-15.7 -7.9,0 -12.5,4.8 -12.5,15.7 0,11 4.6,15.8 12.5,15.8 7.9,0 12.5,-4.8 12.5,-15.8 z"
+   id="path16"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 316.1,163.2 v 22.5 c 0,5.6 1.8,10.4 10.5,10.4 8.7,0 10.5,-4.8 10.5,-10.4 v -22.5 c 0,-1.6 1.3,-2.8 2.8,-2.8 1.5,0 2.7,1.2 2.7,2.8 v 22.5 c 0,8.2 -2.7,15.7 -16,15.7 -13.3,0 -16,-7.5 -16,-15.7 v -22.5 c 0,-1.6 1.2,-2.8 2.8,-2.8 1.4,0.1 2.7,1.3 2.7,2.8 z"
+   id="path18"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+		<path
+   class="st1"
+   d="m 379.4,165.5 v -23.9 c 0,-1.6 1.2,-2.8 2.8,-2.8 1.6,0 2.8,1.2 2.8,2.8 v 42.7 c 0,11.4 -7.1,17 -16.9,17 -11.1,0 -17.7,-6.6 -17.7,-20.8 0,-14.1 6.2,-20.7 17.3,-20.7 5.5,0.1 9.7,3 11.7,5.7 z m 0,7 c 0,0 -3.3,-7.6 -11.4,-7.6 -7.8,0 -12.1,5.1 -12.1,15.7 0,10.8 4.2,15.8 12.1,15.8 6.6,0 11.4,-3.8 11.4,-12 z"
+   id="path20"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+	</g>
+</g>
+<g
+   id="g28"
+   transform="translate(-51.570659,-37.8)">
+	<path
+   class="st1"
+   d="m 395.3,152.8 c -0.7,0 -1.4,-0.1 -2,-0.4 -0.6,-0.3 -1.2,-0.6 -1.7,-1.1 -0.5,-0.5 -0.9,-1.1 -1.1,-1.8 -0.3,-0.7 -0.4,-1.5 -0.4,-2.3 0,-0.9 0.1,-1.6 0.4,-2.3 0.3,-0.7 0.7,-1.3 1.1,-1.8 0.5,-0.5 1,-0.9 1.7,-1.1 0.6,-0.3 1.3,-0.4 2,-0.4 0.7,0 1.4,0.1 2,0.4 0.6,0.3 1.2,0.7 1.7,1.1 0.5,0.5 0.9,1.1 1.1,1.8 0.3,0.7 0.4,1.5 0.4,2.3 0,0.9 -0.1,1.6 -0.4,2.3 -0.3,0.7 -0.7,1.3 -1.1,1.8 -0.5,0.5 -1,0.9 -1.7,1.1 -0.6,0.2 -1.3,0.4 -2,0.4 z m 0,-0.9 c 0.6,0 1.2,-0.1 1.7,-0.4 0.5,-0.2 1,-0.6 1.4,-1 0.4,-0.4 0.7,-0.9 0.9,-1.5 0.2,-0.6 0.3,-1.2 0.3,-1.9 0,-0.7 -0.1,-1.3 -0.3,-1.9 -0.2,-0.6 -0.5,-1.1 -0.9,-1.5 -0.4,-0.4 -0.9,-0.8 -1.4,-1 -0.5,-0.2 -1.1,-0.4 -1.7,-0.4 -0.6,0 -1.2,0.1 -1.7,0.4 -0.5,0.2 -1,0.6 -1.4,1 -0.4,0.4 -0.7,0.9 -0.9,1.5 -0.2,0.6 -0.3,1.2 -0.3,1.9 0,0.7 0.1,1.3 0.3,1.9 0.2,0.6 0.5,1.1 0.9,1.5 0.4,0.4 0.8,0.7 1.4,1 0.5,0.3 1.1,0.4 1.7,0.4 z m -2,-1.9 v -6 h 2 c 0.3,0 0.6,0 0.8,0.1 0.3,0.1 0.5,0.2 0.7,0.3 0.2,0.1 0.4,0.3 0.5,0.6 0.1,0.2 0.2,0.5 0.2,0.9 0,0.4 -0.1,0.7 -0.3,1 -0.2,0.3 -0.5,0.5 -0.8,0.6 l 1.4,2.5 h -1.1 l -1.1,-2.2 h -1.4 v 2.2 z m 1,-2.9 h 0.8 c 0.4,0 0.8,-0.1 1.1,-0.2 0.3,-0.2 0.4,-0.4 0.4,-0.8 0,-0.3 -0.1,-0.6 -0.3,-0.8 -0.2,-0.2 -0.6,-0.3 -1.1,-0.3 h -0.9 z"
+   id="path26"
+   inkscape:connector-curvature="0"
+   style="fill:#000e9c" />
+</g>
+</svg>


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes: #10064

Adds a logo for OVHCloud, a major cloud provider in Europe who wants to develop their own Rancher Node Drivers.
<!-- Define findings related to the feature or bug issue. -->

