### PR TITLE
Fix for Monitoring Helm chart sometimes adds empty selector

### DIFF
--- a/cypress/e2e/po/components/kubectl.po.ts
+++ b/cypress/e2e/po/components/kubectl.po.ts
@@ -16,6 +16,10 @@ export default class Kubectl extends ComponentPo {
     return this;
   }
 
+  closeTerminal() {
+    this.self().get('[data-testid="wm-tab-close-button"]').click();
+  }
+
   /**
    *
    * @param command Kube command without the 'kubectl'

--- a/cypress/e2e/tests/pages/charts/prometheus.spec.ts
+++ b/cypress/e2e/tests/pages/charts/prometheus.spec.ts
@@ -113,7 +113,6 @@ describe('Charts', { tags: '@adminUser' }, () => {
           expect(monitoringChart.values.prometheus).to.deep.equal(prometheusSpec.values.prometheus);
         });
       });
-
     });
   });
 });

--- a/shell/chart/monitoring/prometheus/index.vue
+++ b/shell/chart/monitoring/prometheus/index.vue
@@ -185,7 +185,7 @@ export default {
       // We want to ensure we remove .selector.matchExpressions, .selector.matchLabels, and .selector if empty
       // See: https://github.com/rancher/dashboard/issues/10016
 
-      if (storageSpec.selector.matchExpressions?.length == 0) {
+      if (storageSpec.selector.matchExpressions?.length === 0) {
         delete storageSpec.selector.matchExpressions;
       }
 
@@ -195,7 +195,7 @@ export default {
 
       if (Object.keys(storageSpec.selector).length === 0) {
         delete storageSpec.selector;
-      }      
+      }
     },
   },
 };

--- a/shell/chart/monitoring/prometheus/index.vue
+++ b/shell/chart/monitoring/prometheus/index.vue
@@ -179,6 +179,23 @@ export default {
 
       this.$set(storageSpec.selector, 'matchLabels', matchLabels);
       this.$set(storageSpec.selector, 'matchExpressions', matchExpressions);
+
+      // Remove an empty selector object if present
+      // User can add a selector and then remove the selector - this will leave an empty structure as above
+      // We want to ensure we remove .selector.matchExpressions, .selector.matchLabels, and .selector if empty
+      // See: https://github.com/rancher/dashboard/issues/10016
+
+      if (storageSpec.selector.matchExpressions?.length == 0) {
+        delete storageSpec.selector.matchExpressions;
+      }
+
+      if (storageSpec.selector.matchLabels && Object.keys(storageSpec.selector.matchLabels).length === 0) {
+        delete storageSpec.selector.matchLabels;
+      }
+
+      if (Object.keys(storageSpec.selector).length === 0) {
+        delete storageSpec.selector;
+      }      
     },
   },
 };

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -443,7 +443,7 @@ export default {
           border-radius: var(--border-radius);
           line-height: 12px;
           font-size: 10px;
-          width: 12px;
+          width: 14px;
           align-self: center;
           display: flex;
           justify-content: center;

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -342,7 +342,8 @@ export default {
         />
         <span class="tab-label"> {{ tab.label }}</span>
         <i
-          class="closer icon icon-fw icon-x"
+          data-testid="wm-tab-close-button"
+          class="closer icon icon-fw icon-x wm-closer-button"
           @click.stop="close(tab.id)"
         />
       </div>
@@ -440,9 +441,17 @@ export default {
           margin-left: 5px;
           border: 1px solid var(--body-text);
           border-radius: var(--border-radius);
+          line-height: 12px;
+          font-size: 10px;
+          width: 12px;
+          align-self: center;
+          display: flex;
+          justify-content: center;
 
           &:hover {
             background-color: var(--wm-closer-hover-bg);
+            color: var(--link-active-text);
+            border-color: var(--link-border);
           }
         }
       }
@@ -502,4 +511,5 @@ export default {
       border-right: var(--nav-border-size) solid var(--nav-border);
     }
   }
+
 </style>

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -449,9 +449,8 @@ export default {
           justify-content: center;
 
           &:hover {
-            background-color: var(--wm-closer-hover-bg);
-            color: var(--link-active-text);
             border-color: var(--link-border);
+            color: var(--link-border);
           }
         }
       }


### PR DESCRIPTION
Fixes #10016

This PR fixes an issue with the monitoring helm chart with Prometheus persistent storage config, where when you add a selector, we add in empty selector, matchLabels and mathExpressions into the Helm values - if you then remove the selectors, this empty structure is left, which causes issues.

1. This PR removes the empty structure
2. Added an e2e test to test this behaviour and verified the test fails with the existing code
3. Minor change to the close icon size/style on the window manager - the close icon was resized some time ago and it loos quite big in the window manager - sized this down slightly and added hover behaviour.
4. Updated e2e test to set larger viewport size and to close the terminal window and scroll into view, so its easier to see what is going on when running locally in dev

New style
![image](https://github.com/rancher/dashboard/assets/1955897/ca035997-caf1-43d6-ba34-63505e791162)

New style (hover):
![image](https://github.com/rancher/dashboard/assets/1955897/c6f054a6-bb34-42de-8476-f8d60c6c32ac)

Existing sizing/style:

![image](https://github.com/rancher/dashboard/assets/1955897/6a722c05-3f54-4dc0-97a9-a86494a261ee)

