### PR TITLE
Add grafana resource configuration

### DIFF
--- a/cypress/e2e/tests/pages/charts/prometheus.spec.ts
+++ b/cypress/e2e/tests/pages/charts/prometheus.spec.ts
@@ -23,7 +23,7 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
       chartsPage.goTo();
     });
 
-    describe('Promethus local provisioner config', () => {
+    describe('Prometheus local provisioner config', () => {
       const provisionerVersion = 'v0.0.24';
 
       // Install the chart and navigate to the edit options page
@@ -45,15 +45,7 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
       beforeEach(() => {
         cy.login();
         chartsPage.goTo();
-        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install', {
-          statusCode: 201,
-          body:       {
-            type:               'chartActionOutput',
-            links:              {},
-            operationName:      'helm-operation-test',
-            operationNamespace: 'fleet-local'
-          }
-        }).as('prometheusChartCreation');
+        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('prometheusChartCreation');
       });
 
       it('Should not include empty prometheus selector when installing.', () => {
@@ -120,6 +112,30 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
           const monitoringChart = req.request?.body.charts.find((chart: any) => chart.chartName === 'rancher-monitoring');
 
           expect(monitoringChart.values.prometheus).to.deep.equal(prometheusSpec.values.prometheus);
+        });
+      });
+    });
+
+    describe('Grafana resource configuration', () => {
+      beforeEach(() => {
+        cy.login();
+        chartsPage.goTo();
+        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install', {
+          statusCode: 201,
+          body:       {
+            type:               'chartActionOutput',
+            links:              {},
+            operationName:      'helm-operation-test',
+            operationNamespace: 'fleet-local'
+          }
+        }).as('prometheusChartCreation');
+
+        cy.intercept('GET', '/v1/catalog.cattle.io.operations/fleet-local/helm-operation-test?*', {
+          statusCode: 200,
+          body:       {
+            id:   'fleet-local/helm-operation-test',
+            kind: 'Operation',
+          }
         });
       });
 

--- a/cypress/e2e/tests/pages/charts/prometheus.spec.ts
+++ b/cypress/e2e/tests/pages/charts/prometheus.spec.ts
@@ -45,7 +45,15 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
       beforeEach(() => {
         cy.login();
         chartsPage.goTo();
-        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('prometheusChartCreation');
+        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install', {
+          statusCode: 201,
+          body:       {
+            type:               'chartActionOutput',
+            links:              {},
+            operationName:      'helm-operation-test',
+            operationNamespace: 'fleet-local'
+          }
+        }).as('prometheusChartCreation');
       });
 
       it('Should not include empty prometheus selector when installing.', () => {

--- a/cypress/e2e/tests/pages/charts/prometheus.spec.ts
+++ b/cypress/e2e/tests/pages/charts/prometheus.spec.ts
@@ -115,42 +115,6 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
         });
       });
 
-      // Regression test for: https://github.com/rancher/dashboard/issues/10016
-      it('Should not include empty prometheus selector when installing (add/remove selector).', () => {
-        const tabbedOptions = new TabbedPo();
-
-        // Set prometheus storage class
-        chartsPage.goToInstall().nextPage().editOptions(tabbedOptions, '[data-testid="btn-prometheus"');
-
-        const enableStorageCheckbox = new CheckboxPo('[data-testid="checkbox-chart-enable-persistent-storage"]');
-
-        // Scroll into view
-        enableStorageCheckbox.checkVisible();
-
-        enableStorageCheckbox.set();
-
-        const labeledSelectPo = new LabeledSelectPo('[data-testid="select-chart-prometheus-storage-class"]');
-
-        labeledSelectPo.toggle();
-        labeledSelectPo.clickOptionWithLabel('local-path');
-
-        // Add a selector and then remove it - previously this would result in the empty selector being present
-        chartsPage.self().find(`[data-testid="input-match-expression-add-rule"]`).click();
-        chartsPage.self().find(`[data-testid="input-match-expression-remove-control-0"]`).click();
-
-        // Click on YAML. In YAML mode, the prometheus selector is present but empty
-        // It should not be sent to the API
-        chartsPage.editYaml();
-
-        chartsPage.installChart();
-
-        cy.wait('@prometheusChartCreation', { requestTimeout: 10000 }).then((req) => {
-          const monitoringChart = req.request?.body.charts.find((chart: any) => chart.chartName === 'rancher-monitoring');
-
-          expect(monitoringChart.values.prometheus).to.deep.equal(prometheusSpec.values.prometheus);
-        });
-      });
-
       it('Should allow for Grafana resource requests/limits configuration', () => {
         const tabbedOptions = new TabbedPo();
 

--- a/cypress/e2e/tests/pages/charts/prometheus.spec.ts
+++ b/cypress/e2e/tests/pages/charts/prometheus.spec.ts
@@ -149,7 +149,6 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
           expect(monitoringChart.values.prometheus).to.deep.equal(prometheusSpec.values.prometheus);
         });
       });
-
     });
   });
 });

--- a/cypress/e2e/tests/pages/charts/prometheus.spec.ts
+++ b/cypress/e2e/tests/pages/charts/prometheus.spec.ts
@@ -4,6 +4,7 @@ import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import { ChartsPage } from '@/cypress/e2e/po/pages/charts.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import CheckboxPo from '@/cypress/e2e/po/components/checkbox-input.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 
 import { prometheusSpec } from '@/cypress/e2e/blueprints/charts/prometheus-chart';
 
@@ -147,6 +148,53 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
           const monitoringChart = req.request?.body.charts.find((chart: any) => chart.chartName === 'rancher-monitoring');
 
           expect(monitoringChart.values.prometheus).to.deep.equal(prometheusSpec.values.prometheus);
+        });
+      });
+
+      it('Should allow for Grafana resource requests/limits configuration', () => {
+        const tabbedOptions = new TabbedPo();
+
+        // Set Grafana resource request/limits configuration
+        chartsPage.goToInstall().nextPage().editOptions(tabbedOptions, '[data-testid="btn-grafana"');
+
+        const requestsCpu = new LabeledInputPo(`[data-testid="input-grafana-requests-cpu"]`, tabbedOptions.self());
+
+        requestsCpu.checkExists();
+        requestsCpu.checkVisible();
+        requestsCpu.set('123m');
+
+        const requestsMemory = new LabeledInputPo(`[data-testid="input-grafana-requests-memory"]`, tabbedOptions.self());
+
+        requestsMemory.checkExists();
+        requestsMemory.checkVisible();
+        requestsMemory.set('567Mi');
+
+        const limitsCpu = new LabeledInputPo(`[data-testid="input-grafana-limits-cpu"]`, tabbedOptions.self());
+
+        limitsCpu.checkExists();
+        limitsCpu.checkVisible();
+        limitsCpu.set('87m');
+
+        const limitsMemory = new LabeledInputPo(`[data-testid="input-grafana-limits-memory"]`, tabbedOptions.self());
+
+        limitsMemory.checkExists();
+        limitsMemory.checkVisible();
+        limitsMemory.set('123Mi');
+
+        // Click on YAML. In YAML mode, the prometheus selector is present but empty
+        // It should not be sent to the API
+        chartsPage.editYaml();
+
+        chartsPage.installChart();
+
+        cy.wait('@prometheusChartCreation', { requestTimeout: 10000 }).then((req) => {
+          const monitoringChart = req.request?.body.charts.find((chart: any) => chart.chartName === 'rancher-monitoring');
+          const resource = monitoringChart.values.grafana.resources;
+
+          expect(resource.requests.cpu).to.equal('123m');
+          expect(resource.requests.memory).to.equal('567Mi');
+          expect(resource.limits.cpu).to.equal('87m');
+          expect(resource.limits.memory).to.equal('123Mi');
         });
       });
     });

--- a/cypress/e2e/tests/pages/charts/prometheus.spec.ts
+++ b/cypress/e2e/tests/pages/charts/prometheus.spec.ts
@@ -113,6 +113,43 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
           expect(monitoringChart.values.prometheus).to.deep.equal(prometheusSpec.values.prometheus);
         });
       });
+
+      // Regression test for: https://github.com/rancher/dashboard/issues/10016
+      it('Should not include empty prometheus selector when installing (add/remove selector).', () => {
+        const tabbedOptions = new TabbedPo();
+
+        // Set prometheus storage class
+        chartsPage.goToInstall().nextPage().editOptions(tabbedOptions, '[data-testid="btn-prometheus"');
+
+        const enableStorageCheckbox = new CheckboxPo('[data-testid="checkbox-chart-enable-persistent-storage"]');
+
+        // Scroll into view
+        enableStorageCheckbox.checkVisible();
+
+        enableStorageCheckbox.set();
+
+        const labeledSelectPo = new LabeledSelectPo('[data-testid="select-chart-prometheus-storage-class"]');
+
+        labeledSelectPo.toggle();
+        labeledSelectPo.clickOptionWithLabel('local-path');
+
+        // Add a selector and then remove it - previously this would result in the empty selector being present
+        chartsPage.self().find(`[data-testid="input-match-expression-add-rule"]`).click();
+        chartsPage.self().find(`[data-testid="input-match-expression-remove-control-0"]`).click();
+
+        // Click on YAML. In YAML mode, the prometheus selector is present but empty
+        // It should not be sent to the API
+        chartsPage.editYaml();
+
+        chartsPage.installChart();
+
+        cy.wait('@prometheusChartCreation', { requestTimeout: 10000 }).then((req) => {
+          const monitoringChart = req.request?.body.charts.find((chart: any) => chart.chartName === 'rancher-monitoring');
+
+          expect(monitoringChart.values.prometheus).to.deep.equal(prometheusSpec.values.prometheus);
+        });
+      });
+
     });
   });
 });

--- a/shell/chart/monitoring/grafana/index.vue
+++ b/shell/chart/monitoring/grafana/index.vue
@@ -87,6 +87,9 @@ export default {
 
       return (storageClasses || []).length >= 1;
     },
+    showGrafanaResourceConfig() {
+      return this.value?.grafana?.resources?.requests && this.value?.grafana?.resources?.limits;
+    }
   },
   watch: {
     persistentStorageType(newType, oldType) {
@@ -172,6 +175,58 @@ export default {
       <h3>{{ t('monitoring.grafana.title') }}</h3>
     </div>
     <div class="grafana-config">
+      <!-- Request and Limits -->
+      <!-- Note, we use the same labels for resource config as Prometheus since they are generic -->
+      <div
+        v-if="showGrafanaResourceConfig"
+        class="row"
+      >
+        <div class="col span-12 mt-5">
+          <h4 class="mb-0">
+            {{ t('monitoring.prometheus.config.resourceLimits') }}
+          </h4>
+        </div>
+      </div>
+      <div
+        v-if="showGrafanaResourceConfig"
+        class="row"
+      >
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.grafana.resources.requests.cpu"
+            data-testid="input-grafana-requests-cpu"
+            :label="t('monitoring.prometheus.config.requests.cpu')"
+            :mode="mode"
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.grafana.resources.requests.memory"
+            data-testid="input-grafana-requests-memory"
+            :label="t('monitoring.prometheus.config.requests.memory')"
+            :mode="mode"
+          />
+        </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.grafana.resources.limits.cpu"
+            data-testid="input-grafana-limits-cpu"
+            :label="t('monitoring.prometheus.config.limits.cpu')"
+            :mode="mode"
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.grafana.resources.limits.memory"
+            data-testid="input-grafana-limits-memory"
+            :label="t('monitoring.prometheus.config.limits.memory')"
+            :mode="mode"
+          />
+        </div>
+      </div>
+
       <div class="row pt-10 pb-10">
         <div class="col span-12 persistent-storage-config">
           <RadioGroup

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -435,7 +435,7 @@ export default {
           border-radius: var(--border-radius);
           line-height: 12px;
           font-size: 10px;
-          width: 12px;
+          width: 14px;
           align-self: center;
           display: flex;
           justify-content: center;

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -435,14 +435,15 @@ export default {
           border-radius: var(--border-radius);
           line-height: 12px;
           font-size: 10px;
-          width: 14px;
+          width: 12px;
           align-self: center;
           display: flex;
           justify-content: center;
 
           &:hover {
             border-color: var(--link-border);
-            color: var(--link-border);
+            color: var(--link-active-text);
+            border-color: var(--link-border);
           }
         }
       }

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -442,8 +442,7 @@ export default {
 
           &:hover {
             border-color: var(--link-border);
-            color: var(--link-active-text);
-            border-color: var(--link-border);
+            color: var(--link-border);
           }
         }
       }


### PR DESCRIPTION
Fixes #10042

NOTE: This PR is based on top of https://github.com/rancher/dashboard/pull/10085, which needs to be reviewed and merged first.

This PR adds Grafana resource configuration fields to the UI for the Monitoring installation chart:

![image](https://github.com/rancher/dashboard/assets/1955897/22818208-0e4c-48f5-95d8-49fa69c868a8)

Also added an e2e test to verify that the values are correctly wired in to the relevant backend API request.