### PR TITLE
[Automation] - Use the latest Rancher chart to use during the Rancher installation when the Jenkins job is recurring.

### DIFF
--- a/cypress/jenkins/Jenkinsfile_multi
+++ b/cypress/jenkins/Jenkinsfile_multi
@@ -58,7 +58,6 @@ node {
                                         string(name: 'DASHBOARD_BRANCH', value: "${DASHBOARD_BRANCH}"),
                                         string(name: 'CYPRESS_TAGS', value: ct),
                                         string(name: 'RANCHER_HOST', value: ""),
-                                        string(name: 'RANCHER_VERSION', value: "${RANCHER_VERSION}"),
                                         string(name: 'RANCHER_USERNAME', value: "${RANCHER_USERNAME}"),
                                         string(name: 'RANCHER_PASSWORD', value: "${RANCHER_PASSWORD}"),
                                         string(name: 'RKE2_KUBERNETES_VERSION', value: "${RKE2_KUBERNETES_VERSION}"),


### PR DESCRIPTION
Rancher installation when the Jenkins job type
is recurring.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

When the Job type is recurring in Jenkins get the latest Rancher chart to be used during the Rancher installation done by Corral.
This will allow to use the latest chart with the current *-head image.
The latest chart will be filtered by Rancher version 2.x (2.6, 2.7, 2.8 ..)

### Technical notes summary

This change will allow the Dashboard tests package use the latest Rancher chart available, release candidate or release. This will allow using the more recent Rancher Image during helm install.

### Areas which could experience regressions
Jenkins pipeline setup.