### PR TITLE
Fix select does not select default storage class

### DIFF
--- a/cypress/e2e/blueprints/charts/rancher-backup-chart.ts
+++ b/cypress/e2e/blueprints/charts/rancher-backup-chart.ts
@@ -1,0 +1,35 @@
+
+// No annotatiosn - test case that broke auto-selection of the default storage class
+export const exampleStorageClass = {
+  allowVolumeExpansion: false,
+  apiVersion:           'storage.k8s.io/v1',
+  kind:                 'StorageClass',
+  metadata:             { name: 'test-no-annotations' },
+  parameters:           {
+    encrypted: 'true',
+    iopsPerGB: '0',
+    type:      'gp2'
+  },
+  provisioner:       'kubernetes.io/aws-ebs',
+  reclaimPolicy:     'Delete',
+  volumeBindingMode: 'Immediate',
+};
+
+// Example default storage class
+export const defaultStorageClass = {
+  allowVolumeExpansion: false,
+  apiVersion:           'storage.k8s.io/v1',
+  kind:                 'StorageClass',
+  metadata:             {
+    name:        'test-default-storage-class',
+    annotations: { 'storageclass.kubernetes.io/is-default-class': 'true' }
+  },
+  parameters: {
+    encrypted: 'true',
+    iopsPerGB: '0',
+    type:      'gp2'
+  },
+  provisioner:       'kubernetes.io/aws-ebs',
+  reclaimPolicy:     'Delete',
+  volumeBindingMode: 'Immediate',
+};

--- a/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
+++ b/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
@@ -1,0 +1,47 @@
+import { ChartsPage } from '@/cypress/e2e/po/pages/charts.po';
+import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
+import { exampleStorageClass, defaultStorageClass } from '@/cypress/e2e/blueprints/charts/rancher-backup-chart';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+
+const STORAGE_CLASS_RESOURCE = 'storage.k8s.io.storageclasses';
+
+describe('Charts', { tags: '@adminUser' }, () => {
+  const chartsPageUrl = '/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-charts';
+
+  describe('Rancher Backups', () => {
+    const chartsBackupPage = `${ chartsPageUrl }&chart=rancher-backup`;
+    const chartsPage: ChartsPage = new ChartsPage(chartsBackupPage);
+
+    beforeEach(() => {
+      cy.login();
+    });
+
+    describe('Rancher Backups storage class config', () => {
+      beforeEach(() => {
+        cy.createRancherResource('v1', STORAGE_CLASS_RESOURCE, defaultStorageClass);
+        cy.createRancherResource('v1', STORAGE_CLASS_RESOURCE, exampleStorageClass);
+      });
+
+      afterEach(() => {
+        cy.deleteRancherResource('v1', STORAGE_CLASS_RESOURCE, 'test-default-storage-class');
+        cy.deleteRancherResource('v1', STORAGE_CLASS_RESOURCE, 'test-no-annotations');
+      });
+
+      it('Should auto-select default storage class', () => {
+        chartsPage.goTo();
+        chartsPage.goToInstall().nextPage();
+
+        // Select the 'Use an existing storage class' option
+        const storageOptions = new RadioGroupInputPo('[chart="[chart: cluster/rancher-charts/rancher-backup]"]');
+
+        storageOptions.set(2);
+
+        // Verify that the drop-down exists and has the default storage class selected
+        const select = new LabeledSelectPo('[data-testid="backup-chart-select-existing-storage-class"]');
+
+        select.checkExists();
+        select.checkOptionSelected('test-default-storage-class');
+      });
+    });
+  });
+});

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -42,6 +42,7 @@ declare global {
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
+    createRancherResource(prefix: 'v3' | 'v1', resourceType: string): Chainable;
 
       /**
        *  Wrapper for cy.get() to simply define the data-testid value that allows you to pass a matcher to find the element.

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -42,7 +42,7 @@ declare global {
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
-    createRancherResource(prefix: 'v3' | 'v1', resourceType: string): Chainable;
+      createRancherResource(prefix: 'v3' | 'v1', resourceType: string): Chainable;
 
       /**
        *  Wrapper for cy.get() to simply define the data-testid value that allows you to pass a matcher to find the element.

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -406,6 +406,26 @@ Cypress.Commands.add('deleteRancherResource', (prefix, resourceType, resourceId)
     }
   })
     .then((resp) => {
-      expect(resp.status).to.eq(200);
+      // Either 200, or 204 (No Content)
+      expect(resp.status).to.be.oneOf([200, 204]);
+    });
+});
+
+/**
+ * create a v3 / v1 resource
+ */
+Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
+  return cy.request({
+    method:  'POST',
+    url:     `${ Cypress.env('api') }/${ prefix }/${ resourceType }`,
+    headers: {
+      'x-api-csrf': token.value,
+      Accept:       'application/json'
+    },
+    body
+  })
+    .then((resp) => {
+      // Expect 201, Created HTTP status code
+      expect(resp.status).to.eq(201);
     });
 });

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -65,7 +65,7 @@ export default {
 
   computed: {
     defaultStorageClass() {
-      return this.storageClasses.filter((sc) => sc.metadata.annotations[STORAGE.DEFAULT_STORAGE_CLASS] && sc.metadata.annotations[STORAGE.DEFAULT_STORAGE_CLASS] !== 'false' )[0] || '';
+      return this.storageClasses.filter((sc) => sc.metadata.annotations?.[STORAGE.DEFAULT_STORAGE_CLASS] && sc.metadata.annotations[STORAGE.DEFAULT_STORAGE_CLASS] !== 'false' )[0] || '';
     },
 
     availablePVs() {
@@ -200,6 +200,7 @@ export default {
                 :status="reclaimWarning ? 'warning' : null"
                 :options="storageClasses"
                 :hover-tooltip="true"
+                data-testid="backup-chart-select-existing-storage-class"
               />
             </div>
             <div class="col span-6">


### PR DESCRIPTION
Fixes #10090 

This is a simple bug fix - the UI assumed that a storage class has annotations - if it does not, the default storage class is not auto-selected on the Rancher Backups chart install page.

This used to cause a full-screen error page due to another bug that has been fixed.

This PR fixes the remaining auto-selection bug.

Added an automated e2e test to cover regression testing.