### PR TITLE
[Automation] - Fix the Helm installation using the bin tarball

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -30,6 +30,7 @@ DASHBOARD_REPO="${DASHBOARD_REPO:-rancher/dashboard.git}"
 DASHBOARD_BRANCH="${DASHBOARD_BRANCH:-master}"
 GITHUB_URL="https://github.com/"
 RANCHER_TYPE="${RANCHER_TYPE:-local}"
+HELM_VERSION="${HELM_VERSION:-3.13.2}"
 NODEJS_VERSION="${NODEJS_VERSION:-14.19.1}"
 CYPRESS_VERSION="${CYPRESS_VERSION:-13.2.0}"
 YARN_VERSION="${YARN_VERSION:-1.22.19}"
@@ -78,7 +79,9 @@ corral config vars set volume_iops ${AWS_VOLUME_IOPS}
 if [[ "${JOB_TYPE}" == "recurring" ]]; then 
   RANCHER_TYPE="recurring"
   if [[ -n "${RANCHER_IMAGE_TAG}" ]]; then
-    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+    TARFILE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+    curl -L -o ${TARFILE} "https://get.helm.sh/${TARFILE}"
+    tar -C "${WORKSPACE}/bin" --strip-components=1 -xzf ${TARFILE}
     helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
     helm repo update
     version_string=$(echo "${RANCHER_IMAGE_TAG}" | cut -f1 -d"-")


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

The Jenkins pipeline is failing intermittently. The the official helm installation docs script makes this step in the pipeline unstable.
I am opting to make the manual binary install of helm on Linux when the Job type is recurring (automated)


### Areas which could experience regressions
Jenkins automation pipeline

### Testing done

Running the setup and E2E execution of the recurring pipeline.
