### PR TITLE
Hide provider labels for Harvester clusters

### DIFF
--- a/shell/config/harvester-manager-types.js
+++ b/shell/config/harvester-manager-types.js
@@ -1,1 +1,3 @@
 export const NAME = 'harvesterManager';
+
+export const KIND = { MACHINE_TEMPLATE: 'HarvesterMachineTemplate' };

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -775,10 +775,10 @@ export default {
                   v-clean-html="t('resourceTable.groupLabel.notInANodePool')"
                 />
                 <div
-                  v-if="group.ref && group.ref.template"
+                  v-if="group.ref && group.ref.providerSummary"
                   class="description text-muted text-small"
                 >
-                  {{ group.ref.providerDisplay }} &ndash;  {{ group.ref.providerLocation }} / {{ group.ref.providerSize }} ({{ group.ref.providerName }})
+                  {{ group.ref.providerSummary }}
                 </div>
               </div>
               <div

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -7,6 +7,7 @@ import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
 import { MACHINE_ROLES } from '@shell/config/labels-annotations';
 import { notOnlyOfRole } from '@shell/models/cluster.x-k8s.io.machine';
 import { KIND } from '../config/elemental-types';
+import { KIND as HARVESTER_KIND } from '../config/harvester-manager-types';
 
 export default class CapiMachineDeployment extends SteveModel {
   get cluster() {
@@ -67,6 +68,19 @@ export default class CapiMachineDeployment extends SteveModel {
 
   get providerSize() {
     return this.template?.providerSize || this.t('node.list.poolDescription.noSize');
+  }
+
+  get providerSummary() {
+    if (this.template) {
+      switch (this.infrastructureRefKind) {
+      case HARVESTER_KIND.MACHINE_TEMPLATE:
+        return null;
+      default:
+        return `${ this.providerDisplay } \u2013  ${ this.providerLocation } / ${ this.providerSize } (${ this.providerName })`;
+      }
+    }
+
+    return null;
   }
 
   get desired() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9892
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
`isHarvester` could be also calculated by checking the provider name of the cluster.
Other solution to show the label: find required information for Harvester machine pools = `this.machines.pool`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Clusters details page
