### PR TITLE
Move dashboard container build to internal documentation

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -36,7 +36,6 @@ const sidebars = {
       type:  'category',
       label: 'Guide',
       items: [
-        'guide/build-for-container-registry',
         'guide/package-management',
         'guide/auth-providers',
         'guide/custom-dev-build'


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This removes the entry for [Building a dashboard image for container registries](https://rancher.github.io/dashboard/guide/build-for-container-registry) from the devkit build and replaces it into the internal documentation. Also updated the Dockerfile example for building a Rancher container with a custom dashboard.

