### PR TITLE
Bump rancher-components to v0.1.5-alpha.0

### DIFF
--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -2,7 +2,7 @@
   "name": "@rancher/components",
   "repository": "git://github.com:rancher/dashboard.git",
   "license": "Apache-2.0",
-  "version": "0.1.4",
+  "version": "0.1.5-alpha.0",
   "module": "./main.js",
   "main": "./dist/@rancher/components.umd.min.js",
   "files": [


### PR DESCRIPTION
This bumps Rancher Components to `v0.1.5-alpha.0`.