### PR TITLE
App upgrade notification shown for incorrect app (corrected filters and added further tests)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
     "storageclass",
     "testid",
     "tolerations",
+    "upgrader",
     "userpreferences",
     "virtualmachine",
     "vuex",

--- a/shell/config/os.ts
+++ b/shell/config/os.ts
@@ -1,0 +1,2 @@
+export const WINDOWS = 'windows';
+export const LINUX = 'linux';

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -12,7 +12,7 @@ import { mapGetters } from 'vuex';
 import { sortBy } from '@shell/utils/sort';
 import { set } from '@shell/utils/object';
 import { mapPref, PROVISIONER, _RKE1, _RKE2 } from '@shell/store/prefs';
-import { filterAndArrangeCharts } from '@shell/store/catalog';
+import { filterAndArrangeCharts } from '@shell/utils/chart';
 import { CATALOG } from '@shell/config/labels-annotations';
 import { CAPI, MANAGEMENT, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE, RKE1_UI } from '@shell/store/features';

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -14,7 +14,7 @@ import { formatSi, parseSi } from '@shell/utils/units';
 import { CAPI, CATALOG } from '@shell/config/types';
 import { isPrerelease } from '@shell/utils/version';
 import difference from 'lodash/difference';
-import { LINUX } from '@shell/store/catalog';
+import { LINUX } from '@shell/config/os';
 import { clone } from '@shell/utils/object';
 import { merge } from 'lodash';
 

--- a/shell/models/__tests__/catalog.cattle.io.app.test.ts
+++ b/shell/models/__tests__/catalog.cattle.io.app.test.ts
@@ -1,0 +1,80 @@
+import CatalogApp from '@shell/models/catalog.cattle.io.app';
+
+describe('class CatalogApp', () => {
+  describe('should return upgradeAvailable for this chart', () => {
+    describe('as false to be excluded from some logic if', () => {
+      const expectation = false;
+
+      it('is fleet', () => {
+        const catalogApp = new CatalogApp({ spec: { chart: { metadata: { annotations: { 'fleet.cattle.io/bundle-id': 'anything' } } } } });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+
+      it('is managed,', () => {
+        const catalogApp = new CatalogApp({ spec: { chart: { metadata: { annotations: { 'catalog.cattle.io/managed': 'anything' } } } } });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+    });
+
+    describe('as latest version', () => {
+      it('excluding pre-releases', () => {
+        const version = '1';
+        const catalogApp = new CatalogApp({});
+
+        catalogApp.spec = { chart: { metadata: { version: '0' } } };
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => ({ versions: [{ version }] }),
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(version);
+      });
+    });
+
+    describe('as null', () => {
+      const expectation = null;
+
+      it('if no chart', () => {
+        const catalogApp = new CatalogApp({});
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => [],
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+
+      it('if no version is available', () => {
+        const catalogApp = new CatalogApp({});
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => [],
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+
+      it('if current version is the latest', () => {
+        const catalogApp = new CatalogApp({});
+
+        catalogApp.spec = { chart: { metadata: { version: '1' } } };
+
+        jest.spyOn(catalogApp, '$rootGetters', 'get').mockReturnValue({
+          'catalog/chart': () => ({ versions: [{ version: '0' }] }),
+          currentCluster:  jest.fn(),
+          'prefs/get':     () => false
+        });
+
+        expect(catalogApp.upgradeAvailable).toStrictEqual(expectation);
+      });
+    });
+  });
+});

--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -76,7 +76,7 @@ export default class CatalogApp extends SteveModel {
     const showPreRelease = this.$rootGetters['prefs/get'](SHOW_PRE_RELEASE);
     const currentChartVersion = this.spec?.chart?.metadata?.version;
     const versions = !showPreRelease
-      ? matchingChart.versions.filter((v) => !isPrerelease(v.version))
+      ? matchingChart.versions?.filter((v) => !isPrerelease(v.version))
       : compatibleVersionsFor(matchingChart, workerOSs, showPreRelease);
     const newChartVersion = versions?.[0]?.version;
     const isOlder = compare(currentChartVersion, newChartVersion) < 0;

--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -41,23 +41,10 @@ export default class CatalogApp extends SteveModel {
   }
 
   matchingChart(includeHidden) {
-    const chart = this.spec?.chart;
-
-    if ( !chart ) {
-      return;
-    }
-
-    const chartName = chart.metadata?.name;
-    const preferRepoType = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE];
-    const preferRepoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME];
-    const match = this.$rootGetters['catalog/chart']({
-      chartName,
-      preferRepoType,
-      preferRepoName,
+    return this.$rootGetters['catalog/chart']({
+      chart: this.spec?.chart,
       includeHidden
     });
-
-    return match;
   }
 
   get currentVersion() {
@@ -68,7 +55,7 @@ export default class CatalogApp extends SteveModel {
    * Return possible upgrades
    * false = does not apply (managed by fleet)
    * null = no upgrade found
-   * object = version available to upgrade to
+   * string = version available to upgrade to
    */
   get upgradeAvailable() {
     // Things managed by fleet shouldn't show upgrade available even if there might be.
@@ -79,9 +66,9 @@ export default class CatalogApp extends SteveModel {
       return false;
     }
 
-    const chart = this.matchingChart(false);
+    const matchingChart = this.matchingChart(false);
 
-    if ( !chart ) {
+    if ( !matchingChart ) {
       return null;
     }
 
@@ -89,15 +76,9 @@ export default class CatalogApp extends SteveModel {
     const showPreRelease = this.$rootGetters['prefs/get'](SHOW_PRE_RELEASE);
     const currentChartVersion = this.spec?.chart?.metadata?.version;
     const versions = !showPreRelease
-      ? chart.versions.filter((v) => !isPrerelease(v.version))
-      : compatibleVersionsFor(chart, workerOSs, showPreRelease);
-
+      ? matchingChart.versions.filter((v) => !isPrerelease(v.version))
+      : compatibleVersionsFor(matchingChart, workerOSs, showPreRelease);
     const newChartVersion = versions?.[0]?.version;
-
-    if ( !currentChartVersion || !newChartVersion ) {
-      return null;
-    }
-
     const isOlder = compare(currentChartVersion, newChartVersion) < 0;
 
     if ( isOlder ) {

--- a/shell/models/chart.js
+++ b/shell/models/chart.js
@@ -1,4 +1,4 @@
-import { compatibleVersionsFor } from '@shell/store/catalog';
+import { compatibleVersionsFor } from '@shell/utils/chart';
 import {
   REPO_TYPE, REPO, CHART, VERSION, _FLAGGED, HIDE_SIDE_NAV
 } from '@shell/config/query-params';

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -11,7 +11,7 @@ import { isEmpty } from '@shell/utils/object';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import HybridModel from '@shell/plugins/steve/hybrid-class';
-import { LINUX, WINDOWS } from '@shell/store/catalog';
+import { LINUX, WINDOWS } from '@shell/config/os';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 import { PINNED_CLUSTERS } from '@shell/store/prefs';
 import { copyTextToClipboard } from '@shell/utils/clipboard';

--- a/shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils';
+import Install from '@shell/pages/c/_cluster/apps/charts/install.vue';
+import { DefaultProps } from 'vue/types/options';
+import { ExtendedVue, Vue } from 'vue/types/vue';
+
+describe('view (Charts) Install should', () => {
+  it('automatically select current version by matching available charts and query parameter', async() => {
+    const version = '123';
+    const wrapper = mount(Install as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      data() {
+        return { existing: false };
+      },
+      computed: {
+        chart:          () => ({ versions: [{ version }] }), // Charts provided by the store
+        diffMode:       () => false, // Not used by the dropdown
+        targetVersion:  () => 'targetVersion', // Not used by the dropdown
+        currentVersion: () => 'currentVersion', // Not used by the dropdown
+        showPreRelease: () => false, // Not used by the dropdown
+      },
+      mocks: {
+        $fetchState: {},
+        $route:      {
+          query: {
+            tools:       true,
+            versionName: 'versionName', // The name is actually the version, so this is not relevant although required in computation
+            version, // Required for displaying chart versions dropdown
+          }
+        },
+        $store: {
+          getters: {
+            'i18n/withFallback': jest.fn(),
+            'i18n/t':            jest.fn(),
+            'catalog/repo':      () => 'catalog/repo', // Used as optional filter
+            currentCluster:      'currentCluster', // Not used by the dropdown
+            isRancher:           true,
+          }
+        }
+      },
+      stubs: {
+        Wizard:            { template: '<div><slot name="basics"></slot></div>' }, // Required to render the slot content
+        TypeDescription:   true,
+        NameNsDescription: { template: '<div></div>' },
+      }
+    });
+
+    // Override computed data after fetch initialization (we cannot mock async fetch hook atm)
+    await wrapper.setData({ value: {} });
+
+    const versionEl = wrapper.find('[data-testid="chart-install-existing-version"]');
+
+    expect((versionEl.vm as any).value).toStrictEqual(version);
+  });
+});

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -8,7 +8,7 @@ import DateFormatter from '@shell/components/formatter/Date';
 import isEqual from 'lodash/isEqual';
 import { CHART, REPO, REPO_TYPE, VERSION } from '@shell/config/query-params';
 import { mapGetters } from 'vuex';
-import { compatibleVersionsFor } from '@shell/store/catalog';
+import { compatibleVersionsFor } from '@shell/utils/chart';
 import TypeDescription from '@shell/components/TypeDescription';
 export default {
   components: {

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -16,7 +16,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import Select from '@shell/components/form/Select';
 import { mapPref, HIDE_REPOS, SHOW_PRE_RELEASE, SHOW_CHART_MODE } from '@shell/store/prefs';
 import { removeObject, addObject, findBy } from '@shell/utils/array';
-import { compatibleVersionsFor, filterAndArrangeCharts } from '@shell/store/catalog';
+import { compatibleVersionsFor, filterAndArrangeCharts } from '@shell/utils/chart';
 import { CATALOG } from '@shell/config/labels-annotations';
 import { isUIPlugin } from '@shell/config/uiplugins';
 

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -36,7 +36,7 @@ import { ignoreVariables } from './install.helpers';
 import { findBy, insertAt } from '@shell/utils/array';
 import Vue from 'vue';
 import { saferDump } from '@shell/utils/create-yaml';
-import { LINUX, WINDOWS } from '@shell/store/catalog';
+import { LINUX, WINDOWS } from '@shell/config/os';
 
 const VALUES_STATE = {
   FORM: 'FORM',

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1380,6 +1380,8 @@ export default {
           </label>
         </div>
       </template>
+
+      <!-- This Wizard step (template) is always present in the wizard for any chart -->
       <template #basics>
         <div class="step__basic">
           <Banner
@@ -1422,10 +1424,12 @@ export default {
             class="row mb-20"
           >
             <div class="col span-4">
+              <!-- Chart versions, automatically selected from query version, here renamed as query versionName -->
               <!-- We have a chart for the app, let the user select a new version -->
               <LabeledSelect
                 v-if="chart"
                 :label="t('catalog.install.version')"
+                data-testid="chart-install-existing-version"
                 :value="query.versionName"
                 :options="filteredVersions"
                 :selectable="version => !version.disabled"
@@ -1436,6 +1440,7 @@ export default {
                 v-else
                 :label="t('catalog.install.chart')"
                 :value="chart"
+                data-testid="chart-install-new-version"
                 :options="charts"
                 :selectable="option => !option.disabled"
                 :get-option-label="opt => getOptionLabel(opt)"

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -2,7 +2,7 @@
 import { mapGetters } from 'vuex';
 import Loading from '@shell/components/Loading';
 import { _FLAGGED, DEPRECATED, HIDDEN, FROM_TOOLS } from '@shell/config/query-params';
-import { filterAndArrangeCharts } from '@shell/store/catalog';
+import { filterAndArrangeCharts } from '@shell/utils/chart';
 import { CATALOG, MANAGEMENT, NORMAN } from '@shell/config/types';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import LazyImage from '@shell/components/LazyImage';

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -1,0 +1,83 @@
+import { getters } from '../catalog';
+
+describe('getters', () => {
+  describe('chart', () => {
+    describe('should return latest version of matching chart for', () => {
+      it('given parameters', () => {
+        const options = {
+          chartName: 'chartName',
+          repoType:  'repoType',
+          repoName:  'repoName',
+        };
+        const common = { deprecated: false };
+        const chart1 = {
+          ...options,
+          ...common
+        };
+        const chart2 = {
+          ...options,
+          ...common,
+          repoName: 'somethingElse'
+        };
+        const state = {};
+        const stateGetters = { charts: [chart2, chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)(options);
+
+        expect(result).toStrictEqual(chart1);
+      });
+
+      it('given key', () => {
+        const key = 'repoType/repoName/chartName';
+        const chart1 = {
+          chartName:  'chartName',
+          repoType:   'repoType',
+          repoName:   'repoName',
+          deprecated: false
+        };
+        const chart2 = {
+          ...chart1,
+          repoName: 'somethingElse'
+        };
+        const state = {};
+        const stateGetters = { charts: [chart2, chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)({ key });
+
+        expect(result).toStrictEqual(chart1);
+      });
+
+      it.each([
+        {
+          metadata: {
+            name:        'chartName',
+            annotations: {
+              'catalog.cattle.io/ui-source-repo-type': 'repoType',
+              'catalog.cattle.io/ui-source-repo':      'repoName'
+            }
+          }
+        }
+      ])('given chart with same name %p', (chart) => {
+        const chart1 = {
+          chartName:  'chartName',
+          repoType:   'repoType',
+          repoName:   'repoName',
+          deprecated: false
+        };
+        const chart2 = {
+          ...chart1,
+          repoName: 'somethingElse'
+        };
+        const state = {};
+        const stateGetters = { charts: [chart2, chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)({ chart });
+
+        expect(result).toStrictEqual(chart1);
+      });
+    });
+  });
+});

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -64,6 +64,11 @@ describe('getters', () => {
               'catalog.cattle.io/ui-source-repo':      'repoName'
             }
           }
+        },
+        {
+          metadata: { name: 'chartName' },
+          repoType: 'repoType',
+          repoName: 'repoName',
         }
       ])('given chart with same name %p', (chart) => {
         const chart1 = {

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -61,6 +61,31 @@ describe('getters', () => {
         expect(result).toStrictEqual(chart1);
       });
 
+      it.each([
+        {
+          chartName: 'rancher-alerting-drivers',
+          repoType:  'cluster',
+          repoName:  'rancher-charts',
+        },
+        { chartName: 'rancher-alerting-drivers' },
+        { repoType: 'cluster' },
+        { repoName: 'rancher-charts' },
+      ])('given any matching parameter %p', (options) => {
+        const chart1 = {
+          chartName:  'rancher-alerting-drivers',
+          repoType:   'cluster',
+          repoName:   'rancher-charts',
+          deprecated: false
+        };
+        const state = {};
+        const stateGetters = { charts: [chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)(options);
+
+        expect(result).toStrictEqual(chart1);
+      });
+
       it('given key', () => {
         const key = 'repoType/repoName/chartName';
         const chart1 = {
@@ -104,6 +129,38 @@ describe('getters', () => {
 
         // NOTE: Getters arguments are actually optional
         const result = (getters.chart as any)(state, stateGetters)({ chart });
+
+        expect(result).toStrictEqual(chart1);
+      });
+
+      it('given only all matching parameters if provided', () => {
+        const options = {
+          chartName: 'epinio',
+          repoType:  'cluster',
+          repoName:  'rancher-charts',
+        };
+        const common = {
+          chartName:  'epinio',
+          repoType:   'cluster',
+          deprecated: false
+        };
+        const chart1 = {
+          repoName: 'rancher-charts',
+          ...common
+        };
+        const chart2 = {
+          repoName: 'epinio-repo',
+          ...common,
+        };
+        const chart3 = {
+          repoName: 'epinio-extension',
+          ...common,
+        };
+        const state = {};
+        const stateGetters = { charts: [chart2, chart3, chart1] };
+
+        // NOTE: Getters arguments are actually optional
+        const result = (getters.chart as any)(state, stateGetters)(options);
 
         expect(result).toStrictEqual(chart1);
       });

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -2,6 +2,12 @@ import { getters } from '../catalog';
 
 describe('getters', () => {
   describe('chart', () => {
+    it('should return nothing if no parameter is passed', () => {
+      const result = (getters.chart as any)({}, {})({});
+
+      expect(result).toBeUndefined();
+    });
+
     describe('should return latest version of matching chart for', () => {
       it('given parameters', () => {
         const options = {

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -2,10 +2,37 @@ import { getters } from '../catalog';
 
 describe('getters', () => {
   describe('chart', () => {
-    it('should return nothing if no parameter is passed', () => {
-      const result = (getters.chart as any)({}, {})({});
+    describe('should return nothing and avoid mismatches', () => {
+      it('if no parameter is passed', () => {
+        const result = (getters.chart as any)({}, {})({});
 
-      expect(result).toBeUndefined();
+        expect(result).toBeUndefined();
+      });
+
+      it.each([
+        {
+          repoType:  'repoType',
+          repoName:  'repoName',
+          chartName: undefined,
+        },
+        {
+          repoType:  undefined,
+          repoName:  'repoName',
+          chartName: 'chartName',
+        },
+        {
+          repoType:  'repoType',
+          repoName:  undefined,
+          chartName: 'chartName',
+        },
+      ])('if missing arguments for filtering', (options) => {
+        const result = (getters.chart as any)({}, {})({
+          key: undefined,
+          ...options
+        });
+
+        expect(result).toBeUndefined();
+      });
     });
 
     describe('should return latest version of matching chart for', () => {
@@ -56,15 +83,6 @@ describe('getters', () => {
       });
 
       it.each([
-        {
-          metadata: {
-            name:        'chartName',
-            annotations: {
-              'catalog.cattle.io/ui-source-repo-type': 'repoType',
-              'catalog.cattle.io/ui-source-repo':      'repoName'
-            }
-          }
-        },
         {
           metadata: { name: 'chartName' },
           repoType: 'repoType',

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -25,7 +25,7 @@ describe('getters', () => {
           repoName:  undefined,
           chartName: 'chartName',
         },
-      ])('if missing arguments for filtering', (options) => {
+      ])('if missing arguments for filtering %p', (options) => {
         const result = (getters.chart as any)({}, {})({
           key: undefined,
           ...options

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -115,13 +115,8 @@ export const getters = {
         repoName = chart.repoName;
       }
 
-      // Return nothing if cannot filter the charts, to avoid mismatches
-      if (!(key || (repoType && repoName && chartName))) {
-        return;
-      }
-
       // Get data as key of the retrieved Charts (currently same as ID)
-      if ( key && !repoType && !repoName && !chartName) {
+      if ( key && !(repoType && repoName && chartName)) {
         const keyParts = key.split('/');
 
         repoType = keyParts[0];
@@ -140,6 +135,7 @@ export const getters = {
         matchingCharts = matchingCharts.filter((x) => !x.hidden);
       }
 
+      //  No charts found
       if ( !matchingCharts.length ) {
         return;
       }

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -100,7 +100,11 @@ export const getters = {
    */
   chart(state, getters) {
     return ({
-      chart, key, repoType, repoName, chartName, preferRepoType, preferRepoName, includeHidden
+      chart, // to extract parameters
+      key, // filtering mode 1
+      repoType, repoName, chartName, // filtering mode 2
+      preferRepoType, preferRepoName, // sorting
+      includeHidden
     }) => {
       // Get data from the Chart
       if ( chart && !key && !repoType && !repoName && !chartName) {
@@ -109,6 +113,11 @@ export const getters = {
         preferRepoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME];
         repoType = chart.repoType;
         repoName = chart.repoName;
+      }
+
+      // Return nothing if cannot filter the charts, to avoid mismatches
+      if (!(key || (repoType && repoName && chartName))) {
+        return;
       }
 
       // Get data as key of the retrieved Charts (currently same as ID)
@@ -135,6 +144,7 @@ export const getters = {
         return;
       }
 
+      // Sorting by preference
       if ( preferRepoType && preferRepoName ) {
         preferSameRepo(matchingCharts, preferRepoType, preferRepoName);
       }

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -107,6 +107,8 @@ export const getters = {
         chartName = chart.metadata?.name;
         preferRepoType = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE];
         preferRepoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME];
+        repoType = chart.repoType;
+        repoName = chart.repoName;
       }
 
       // Get data as key of the retrieved Charts (currently same as ID)

--- a/shell/types/catalog.ts
+++ b/shell/types/catalog.ts
@@ -1,0 +1,30 @@
+export interface IChartVersions {
+  annotations?: Record<string, any>,
+  version: string,
+}
+
+export interface IChart {
+  versions: IChartVersions[];
+  deprecated: boolean;
+  hidden: boolean;
+  repoKey: string;
+  chartType: string;
+  chartName: string;
+  categories: string[];
+  chartDescription: string;
+  chartNameDisplay: string;
+}
+
+export interface IChartOptions {
+  clusterProvider?: string;
+  operatingSystems?: string | string[];
+  category?: string;
+  searchQuery?: string;
+  showDeprecated?: boolean;
+  showHidden?: boolean;
+  showPrerelease?: boolean;
+  hideRepos?: string[];
+  showRepos?: string[];
+  showTypes?: string[];
+  hideTypes?: string[];
+}

--- a/shell/utils/__tests__/array.test.ts
+++ b/shell/utils/__tests__/array.test.ts
@@ -323,6 +323,11 @@ describe('fx: filterBy', () => {
         expected: { key: 'qux', booleanKey: true }
       },
       {
+        case:     'including part of declared keys and values',
+        keyOrObj: { key: 'qux' },
+        expected: { key: 'qux', booleanKey: true }
+      },
+      {
         case:     'including a matching key',
         keyOrObj: { booleanKey: undefined },
         expected: { key: 'qux', booleanKey: true }

--- a/shell/utils/__tests__/version.test.ts
+++ b/shell/utils/__tests__/version.test.ts
@@ -1,4 +1,40 @@
-import { isDevBuild } from '@shell/utils/version';
+import { isDevBuild, compare } from '@shell/utils/version';
+
+describe('fx: compare', () => {
+  it('should return null if no value is provided', () => {
+    const expectation = null;
+
+    const result = compare();
+
+    expect(result).toStrictEqual(expectation);
+  });
+
+  describe('should return -1', () => {
+    const expectation = -1;
+
+    it('given bigger first value', () => {
+      const result = compare(1, 0);
+
+      expect(result).toStrictEqual(expectation);
+    });
+  });
+
+  describe('should return 1', () => {
+    const expectation = 1;
+
+    it('given 0 to both values', () => {
+      const result = compare(0, 0);
+
+      expect(result).toStrictEqual(expectation);
+    });
+
+    it('given bigger second value', () => {
+      const result = compare(0, 1);
+
+      expect(result).toStrictEqual(expectation);
+    });
+  });
+});
 
 describe('fx: isDevBuild', () => {
   it.each([

--- a/shell/utils/chart.ts
+++ b/shell/utils/chart.ts
@@ -2,7 +2,7 @@ import difference from 'lodash/difference';
 import { isArray } from '@shell/utils/array';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { LINUX } from '@shell/config/os';
-import { isPrerelease } from 'utils/version';
+import { isPrerelease } from '@shell/utils/version';
 import { ensureRegex } from '@shell/utils/string';
 import { sortBy } from '@shell/utils/sort';
 import { IChart, IChartVersions, IChartOptions } from 'types/catalog';

--- a/shell/utils/chart.ts
+++ b/shell/utils/chart.ts
@@ -1,0 +1,91 @@
+import difference from 'lodash/difference';
+import { isArray } from '@shell/utils/array';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { LINUX } from '@shell/config/os';
+import { isPrerelease } from 'utils/version';
+import { ensureRegex } from '@shell/utils/string';
+import { sortBy } from '@shell/utils/sort';
+import { IChart, IChartVersions, IChartOptions } from 'types/catalog';
+
+/*
+catalog.cattle.io/deploys-on-os: OS -> requires global.cattle.OS.enabled: true
+  default: nothing
+catalog.cattle.io/permits-os: OS -> will break on clusters containing nodes that are not OS
+  default if not found: catalog.cattle.io/permits-os: linux
+*/
+export function compatibleVersionsFor(chart: IChart, os?: string | string[], includePrerelease = true): IChartVersions[] {
+  const versions = chart.versions;
+
+  if (os && !isArray(os)) {
+    os = [os as string];
+  }
+
+  return versions.filter((ver) => {
+    const osPermitted = (ver?.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || LINUX).split(',');
+
+    if ( !includePrerelease && isPrerelease(ver.version) ) {
+      return false;
+    }
+
+    if ( !os || difference(os, osPermitted).length === 0) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
+export function filterAndArrangeCharts(charts: IChart[], {
+  clusterProvider = '',
+  operatingSystems,
+  category,
+  searchQuery,
+  showDeprecated = false,
+  showHidden = false,
+  showPrerelease = true,
+  hideRepos = [],
+  showRepos = [],
+  showTypes = [],
+  hideTypes = [],
+}: IChartOptions = {}): IChart[] {
+  const out = charts.filter((c) => {
+    if (
+      ( c.deprecated && !showDeprecated ) ||
+      ( c.hidden && !showHidden ) ||
+      ( hideRepos?.length && hideRepos.includes(c.repoKey) ) ||
+      ( showRepos?.length && !showRepos.includes(c.repoKey) ) ||
+      ( hideTypes?.length && hideTypes.includes(c.chartType) ) ||
+      ( showTypes?.length && !showTypes.includes(c.chartType) ) ||
+      (c.chartName === 'rancher-wins-upgrader' && clusterProvider === 'rke2')
+    ) {
+      return false;
+    }
+
+    if (compatibleVersionsFor(c, operatingSystems, showPrerelease).length <= 0) {
+      // There's no versions compatible with the specified os
+      return false;
+    }
+
+    if ( category && !c.categories.includes(category) ) {
+      // The category filter doesn't match
+      return false;
+    }
+
+    if ( searchQuery ) {
+      // The search filter doesn't match
+      const searchTokens = searchQuery.split(/\s*[, ]\s*/).map((x) => ensureRegex(x, false));
+
+      for ( const token of searchTokens ) {
+        const chartDescription = c.chartDescription || '';
+
+        if ( !c.chartNameDisplay.match(token) && !chartDescription.match(token) ) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  });
+
+  return sortBy(out, ['certifiedSort', 'repoName', 'chartNameDisplay']);
+}

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -21,6 +21,10 @@ export function sortable(str) {
 }
 
 export function compare(in1, in2) {
+  if (in1 === undefined && in2 === undefined) {
+    return null;
+  }
+
   if ( !in1 ) {
     return 1;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9613

Changes are the same of https://github.com/rancher/dashboard/pull/9806, except that `repoType`, `repoName`, `chartName` are not mandatory anymore, as they will just return no charts if none of the criteria is provided.
If parameters are provided, only charts with all of them will be returned.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Added tests for:
- Chart match logic
  - Check `given only all matching parameters if provided` for Epinio case.
  - Check `given any matching parameter` for returning always charts if anything matches (reason this is reopened).
- Chart install view version selection

#### Kubewarden installation
I have a 2 breaking errors when I try locally with master to install Kubewarden to reproduce the mentioned case:
- Copy to clipboard says function does not exists
- `addChart` says the `repo` is actually `null`

After setting conditional variables it works, although I keep it for another time, since my PR covered already more than needed and the error is on master as well (also just when running locally). 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<img width="1569" alt="Screenshot 2023-12-18 at 19 59 31" src="https://github.com/rancher/dashboard/assets/5009481/f5deb3c3-9e16-49dc-bf8c-67bd2e80568b">
