### PR TITLE
[Automation] - Refactor Jenkins Qase reporter to not use QQL endpoints and improve multi branch report creation

### DIFF
--- a/cypress/jenkins/junit_to_qase.py
+++ b/cypress/jenkins/junit_to_qase.py
@@ -135,12 +135,15 @@ skipped_cases_ids = []
 failed_cases_ids_stack = {}
 
 
-def qase_cases(project, case_id=None):
+def qase_cases(project, case_id=None, suite_id=None, limit=100):
     if case_id is not None:
         return requests.get("{0}/{1}/{2}".format(cases_url, project, case_id),
                             headers=qase_headers)
+    elif suite_id is not None:
+        return requests.get("{0}/{1}?suite_id={2}&limit={3}".format(cases_url, project, suite_id, limit),
+                            headers=qase_headers)
     else:
-        return requests.get("{0}/{1}".format(cases_url, project),
+        return requests.get("{0}/{1}?limit={2}".format(cases_url, project, limit),
                             headers=qase_headers)
 
 
@@ -160,15 +163,15 @@ def qase_update_case(project, payload, case_id):
         return None
 
 
-def qase_suites(project, suite_id=None, search_string=""):
+def qase_suites(project, suite_id=None, search_string="", limit=100):
     if search_string:
-        return requests.get("{0}/{1}?search={2}".format(suites_url, project, search_string),
+        return requests.get("{0}/{1}?search={2}&limit={3}".format(suites_url, project, search_string, limit),
                             headers=qase_headers)
     if suite_id is not None:
         return requests.get("{0}/{1}/{2}".format(suites_url, project, suite_id),
                             headers=qase_headers)
     else:
-        return requests.get("{0}/{1}".format(suites_url, project),
+        return requests.get("{0}/{1}?limit={2}".format(suites_url, project, limit),
                             headers=qase_headers)
 
 
@@ -216,17 +219,19 @@ def create_run_result(project, payload, run_id):
         return None
 
 
-def create_testcases_under_suite(all_cases_under_suite, suite_title_from_qase, suite_id):
+def create_testcases_under_suite(case_entities, suite_title_from_junit, suite_id):
     """
     Custom Fields
     - TestSource -> 14
     - AutomationTestName -> 15
     """
-    case_entities = all_cases_under_suite["result"]["entities"]
-    case_titles_from_junit = results[suite_title_from_qase].keys()
-    case_titles = [subs["title"] for subs in case_entities]
-    case_title_and_id = {subs["title"]: subs['id'] for subs in case_entities}
-    case_descriptions = [subs["description"] for subs in case_entities]
+    case_titles_from_junit = results[suite_title_from_junit].keys()
+    if len(case_entities) > 0:
+        case_titles = [subs["title"] for subs in case_entities]
+        case_title_and_id = {subs["title"]: subs['id'] for subs in case_entities}
+        case_descriptions = [subs["description"] for subs in case_entities]
+    else:
+        case_titles = []
 
     logger.debug("Titles from jUnit: {0}".format(list(case_titles_from_junit)))
     logger.debug("Titles from Qase: {0}".format(case_titles))
@@ -235,19 +240,19 @@ def create_testcases_under_suite(all_cases_under_suite, suite_title_from_qase, s
         tc_skipped = False
         if ct not in case_titles:
             # Title ct not found add it
-            logger.info("Title not found: {0}".format(ct))
+            logger.info("Case title not found in suite: {0}".format(ct))
             # if the result from junit has a description, add it
             # This part is where the error message goes if we want it in the Test Case description
-            testcase_value = results[suite_title_from_qase][ct]
+            testcase_value = results[suite_title_from_junit][ct]
             req_body = {'title': ct,
                         'is_flaky': 0,
                         'automation': 1,
                         'custom_field': {
                             "14": TEST_SOURCE,
-                            "15": "{0}/{1}".format(suite_title_from_qase, ct)},
+                            "15": "{0}/{1}".format(suite_title_from_junit, ct)},
                         "suite_id": suite_id}
             if testcase_value and testcase_value != "skipped_test":
-                req_body.update({'description': results[suite_title_from_qase][ct]})
+                req_body.update({'description': results[suite_title_from_junit][ct]})
                 failed = True
             if testcase_value == "skipped_test":
                 tc_skipped = True
@@ -257,22 +262,22 @@ def create_testcases_under_suite(all_cases_under_suite, suite_title_from_qase, s
             if tc_skipped:
                 skipped_cases_ids.append(id_to_add)
             if failed:
-                failed_cases_ids_stack[id_to_add] = results[suite_title_from_qase][ct]
+                failed_cases_ids_stack[id_to_add] = results[suite_title_from_junit][ct]
         else:
-            logger.info("Title found: {0}".format(ct))
+            logger.info("Case title found: {0}".format(ct))
             case_id_from_title = case_title_and_id[ct]
             cases_ids.append(case_id_from_title)
             req_body = {"suite_id": suite_id,
                         "custom_field": {
                                 "14": TEST_SOURCE,
-                                "15": "{0}/{1}".format(suite_title_from_qase, ct)
+                                "15": "{0}/{1}".format(suite_title_from_junit, ct)
                             },
                         }
             logger.debug("Refresh test case id {0} "
                          "to ensure it is in the correct Suite {1}".
                          format(case_id_from_title, suite_id))
             qase_update_case(qase_automation_project, req_body, case_id_from_title)
-            has_skipped_or_error = results[suite_title_from_qase][ct]
+            has_skipped_or_error = results[suite_title_from_junit][ct]
             if has_skipped_or_error:
                 logger.info("A description or skip value exist for test case")
                 if has_skipped_or_error == "skipped_test":
@@ -280,12 +285,12 @@ def create_testcases_under_suite(all_cases_under_suite, suite_title_from_qase, s
                     skipped_cases_ids.append(case_id_from_title)
                 else:
                     logger.info("Failed ID: {0} Title: {1}".format(case_id_from_title, ct))
-                    failed_cases_ids_stack[case_id_from_title] = results[suite_title_from_qase][ct]
-                    if results[suite_title_from_qase][ct] not in case_descriptions:
+                    failed_cases_ids_stack[case_id_from_title] = results[suite_title_from_junit][ct]
+                    if results[suite_title_from_junit][ct] not in case_descriptions:
                         logger.debug("A description was found that is not in Qase "
                                      "in a test case with ID: {0} Title: {1}".
                                      format(case_id_from_title, ct))
-                        req_body = {'description': results[suite_title_from_qase][ct]}
+                        req_body = {'description': results[suite_title_from_junit][ct]}
                         qase_update_case(qase_automation_project, req_body, case_id_from_title)
             else:
                 logger.info("There isn't a failure message from junit data, clear the description in qase")
@@ -299,8 +304,12 @@ check_global_suite = qase_suites(qase_automation_project, search_string=global_s
 logger.info(check_global_suite.text)
 logger.info(check_global_suite.status_code)
 suite_objects = check_global_suite.json()["result"]["entities"]
-suite_titles = [subs["title"] for subs in suite_objects]
-suite_title_and_id = {subs["title"]: subs['id'] for subs in suite_objects}
+suite_objects = sorted(suite_objects, key=lambda x: x['id'], reverse=True)
+suite_titles = [subs["title"] for subs in suite_objects
+                if subs["title"] == global_suite_id_name]
+suite_title_and_id = {subs["title"]: subs['id']
+                      for subs in suite_objects
+                      if subs["title"] == global_suite_id_name}
 
 if global_suite_id_name not in suite_titles:
     suite_post_data = {"title": global_suite_id_name}
@@ -317,34 +326,27 @@ for k in list(results.keys()):
     if suite_result["status"]:
         suite_entities = suite_result["result"]["entities"]
     else:
-        logger.error("No suites were found")
-        break
-
+        logger.error("There was an error retrieving suites")
+        sys.exit(1)
+    suite_entities = [suite_ent for suite_ent in suite_entities
+                       if suite_ent["title"] == k and suite_ent["cases_count"] > 0]
+    logger.info(suite_entities)
     if len(suite_entities) < 1:
         suite_data = {"title": k, "parent_id": global_suite_id}
         r = qase_add_suite(qase_automation_project, suite_data)
         suiteid = r.json()["result"]["id"]
-        logger.debug("Search query of suite not found:  entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
-                     format("case", qase_automation_project, k))
-        cases = qase_search_qql({"query": " entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
-                                format("case", qase_automation_project, k)})
-        cases_qql_results = cases.json()
-        create_testcases_under_suite(cases_qql_results, k, suiteid)
+        create_testcases_under_suite([], k, suiteid)
     else:
-        logger.debug("Search query of suite found:  entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
-                     format("case", qase_automation_project, k))
-        cases_qql = qase_search_qql({"query": " entity = \"{0}\" and project = \"{1}\" and suite = \"{2}\"".
-                                    format("case", qase_automation_project, k)})
-
         suiteid = None
-        for st in suite_entities:
-            if st["title"] == k:
-                suiteid = st["id"]
-                break
-
-        cases_qql_results = cases_qql.json()
-        logger.debug(cases_qql_results)
-        create_testcases_under_suite(cases_qql_results, k, suiteid)
+        suite_entities = sorted(suite_entities, key=lambda x: x['id'])
+        if suite_entities[0]:
+            suiteid = suite_entities[0]["id"]
+        if suiteid == None:
+            logger.error("There was an error getting a suite id")
+            sys.exit(1)
+        suite_cases = qase_cases(qase_automation_project, suite_id=suiteid)
+        cases_entities = suite_cases.json()["result"]["entities"]
+        create_testcases_under_suite(cases_entities, k, suiteid)
 
 formatted_date = "{0}".format(datetime.datetime.now().strftime("%m-%d-%y/%H-%M-%S"))
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

I've noticed that when running the Jenkins pipeline using the recurring Multi branch the report generated in Qase sometimes had some type of collisions and the report generated extra test cases on different branches. 

### Occurred changes and/or fixed issues

Debugging the issue I found that the QQL searches comparisons were unstable as sometimes it matched the proper string in the returned json object or not at all. 

There were some other edge cases like when either a test case or test suite returned multiple matches (duplicates) the logic wasn't smart enough to handle the differences.

To fix this I removed the QQL queries replacing them with direct calls to the `cases` and `suites` Qase API endpoints to then use the `id` and `title` to have more control over the data.

### Areas or cases that should be tested
Multi branch running of the Automation UI tests. `v2.6`, `v2.7` and `v2.8`

### Test done
Execute the multi branch pipeline and analyze the generated reports.
Validate the oldest test case or the test case with the lowest id value is used when duplicates of a test case title is detected in the results.
As a search string is used already to check for existing suites. This ensure when the count is zero means the current suite title is new.
Validate only suites with test cases get selected when looking to update a test cases. This takes care of ignoring duplicates 

