### PR TITLE
[Automation] - Fixing logic for running Jenkins tests on existing Rancher

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -117,6 +117,12 @@ if [[ "${JOB_TYPE}" == "recurring" ]]; then
     "dist/aws-rke2-rancher-calico-${RKE2_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
 fi
 
+if [[ "${JOB_TYPE}" == "existing" ]]; then
+  RANCHER_TYPE="existing"
+fi
+
+echo "Rancher type: ${RANCHER_TYPE}"
+
 corral config vars set rancher_type ${RANCHER_TYPE}
 corral config vars set nodejs_version ${NODEJS_VERSION}
 corral config vars set dashboard_repo ${DASHBOARD_REPO}


### PR DESCRIPTION
### Summary
Fixes:

An issue when configuring the Jenkins tests to run on an `existing` Rancher. The test was doing the `local` type instead.
`recurring` is unaffected.

### Areas or cases that should be tested
Jenkins jobs execution using an existing Rancher, running the job on demand.
