### PR TITLE
Fix docusaurus build

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -40,5 +40,8 @@
   },
   "engines": {
     "node": ">=16.14"
-  }
+  },
+  "resolutions": {
+    "image-size": "1.0"
+  }  
 }


### PR DESCRIPTION
the `image-size` library was bumped to 1.1.0 a few days ago and the node version requirement was bumped - this breaks our CI.

This PR pins image-size so we don't pick that newer version up.

I chose not to bump the node version as this has a wider impact.