### PR TITLE
Update workload form to work with pod manifest 

### DIFF
--- a/shell/models/pod.js
+++ b/shell/models/pod.js
@@ -233,7 +233,7 @@ export default class Pod extends WorkloadService {
   save() {
     const prev = { ...this };
 
-    const { metadata, spec } = this.spec.template;
+    const { metadata, spec } = this.spec;
 
     this.spec = {
       ...this.spec,
@@ -244,8 +244,6 @@ export default class Pod extends WorkloadService {
       ...this.metadata,
       ...metadata
     };
-
-    delete this.spec.template;
 
     // IF there is an error POD world model get overwritten
     // For the workloads this need be reset back

--- a/shell/models/workload.service.js
+++ b/shell/models/workload.service.js
@@ -1,7 +1,7 @@
 
 import { findBy } from '@shell/utils/array';
 import { TARGET_WORKLOADS, UI_MANAGED, HCI as HCI_LABELS_ANNOTATIONS } from '@shell/config/labels-annotations';
-import { WORKLOAD_TYPES, SERVICE } from '@shell/config/types';
+import { WORKLOAD_TYPES, SERVICE, POD } from '@shell/config/types';
 import { clone, get } from '@shell/utils/object';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import { shortenedImage } from '@shell/utils/string';
@@ -102,9 +102,12 @@ export default class WorkloadService extends SteveModel {
 
     if (this.type === WORKLOAD_TYPES.CRON_JOB) {
       containers = get(this, 'spec.jobTemplate.spec.template.spec.containers');
+    } else if (this.type === POD) {
+      containers = get(this, 'spec.containers');
     } else {
       containers = get(this, 'spec.template.spec.containers');
     }
+
     if (containers) {
       containers.forEach((container) => {
         if (!images.includes(container.image)) {
@@ -117,6 +120,12 @@ export default class WorkloadService extends SteveModel {
   }
 
   get containers() {
+    if (this.type === POD) {
+      const { spec: { containers } } = this;
+
+      return containers;
+    }
+
     if (this.type === WORKLOAD_TYPES.CRON_JOB) {
       // cronjob pod template is nested slightly different than other types
       const { spec: { jobTemplate: { spec: { template: { spec: { containers } } } } } } = this;
@@ -134,6 +143,12 @@ export default class WorkloadService extends SteveModel {
   }
 
   get initContainers() {
+    if (this.type === POD) {
+      const { spec: { initContainers } } = this;
+
+      return initContainers;
+    }
+
     if (this.type === WORKLOAD_TYPES.CRON_JOB) {
       // cronjob pod template is nested slightly different than other types
       const { spec: { jobTemplate: { spec: { template: { spec: { initContainers } } } } } } = this;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the pod workload spec to match the expected manifest described by `kubectl explain workloads.pod.spec`. Previously, pods were treated as a Workload Resource [^1], but workload resources are meant for dealing with Deployments, Jobs, ReplicaSets, etc... It's more accurate to treat Pods as a workload, as described in [^2]

We also create a new method, `updateWorkloadManifest()`, that can properly parse a manifest for both Workloads (Pods) and Workload Resources (Jobs, Deployments, ReplicaSets, etc...). 

[^1]: https://kubernetes.io/docs/concepts/workloads/controllers/
[^2]: https://kubernetes.io/docs/concepts/workloads/pods/

Fixes #10171
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Identified and updated all instances of pod spec to generate a manifest that more closely resembles what's described by `kubectl explain workloads.pod.spec`
- Updated the `saveWorkload()` method so that it can now account for pods in addition to existing workloads

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I noted some difficulties associated with this change in https://github.com/rancher/dashboard/issues/10171#issuecomment-1866720523. In summary, the manifest for a Pod differs from Deployments, ReplicaSet, StatefulSets, etc... The tightly coupled nature of CruResource and the Yaml Editor makes it a little difficult to simply write a parser to consume the YAML as we would expect it for a pod, so we have to take a more difficult approach of updating `spec` in all the instances where we might be dealing with a pod to make sure that it adheres to the correct shape. 

With the complexity of this form, there might be edge cases that have been missed. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Creating, Reading, Updating existing workload forms, this includes:

- CronJobs
- DaemonSets
- Deployments
- Jobs
- StatefulSets
- Pods

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

![image](https://github.com/rancher/dashboard/assets/835961/1b980646-44a9-4e2d-b610-ae47ea3ba13b)

#### After

![image](https://github.com/rancher/dashboard/assets/835961/b5f1f074-99f8-423a-afce-a57555f80232)
