### PR TITLE
Update `source.fixAll.eslint` and specify `typescript.tsdk` in `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
   "eslint.packageManager": "yarn",
   "eslint.validate": ["vue","html","javascript","typescript"],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.workingDirectories": ["./", "./pkg/rancher-components/"],
   "javascript.preferences.importModuleSpecifier": "non-relative",
@@ -54,5 +54,6 @@
     "virtualmachine",
     "vuex",
     "whatsnew"
-  ]
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This updates the value for `source.fixAll.eslint` to `explicit` instead of `true`. It looks like vscode released an update in September 2023 that deprecated using boolean values in favor of the string representation [^1].  

This also configures vscode to use the typescript version specified in `package.json` instead of what vscode used by default [^2].

[^1]: https://code.visualstudio.com/updates/v1_83#_code-actions-on-save-and-auto-save
[^2]: https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript