### PR TITLE
Bump typescript to 4.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "start-server-and-test": "1.13.1",
     "style-loader": "3.3.2",
     "ts-jest": "27.1.4",
-    "typescript": "4.1.6",
+    "typescript": "4.5.5",
     "vue": "2.7.14",
     "vue-template-compiler": "2.7.14",
     "webpack-bundle-analyzer": "4.5.0",

--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -43,7 +43,7 @@
     "jsonpath-plus": "6.0.1",
     "sass": "1.55.0",
     "sass-loader": "10.2.1",
-    "typescript": "4.1.6",
+    "typescript": "4.5.5",
     "vue": "2.7.14",
     "vue-template-compiler": "2.7.14"
   },

--- a/shell/package.json
+++ b/shell/package.json
@@ -116,7 +116,7 @@
     "start-server-and-test": "1.13.1",
     "style-loader": "1.2.1",
     "ts-node": "8.10.2",
-    "typescript": "4.1.6",
+    "typescript": "4.5.5",
     "url-parse": "1.5.10",
     "v-tooltip": "2.0.3",
     "vue": "2.7.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15048,10 +15048,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
-  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
+typescript@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

I came across the following tsc warnings while working on #10104:

```
Excessive stack depth comparing types 'Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>> | HTMLElement' and 'ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, ComponentOptionsBase<any, any, any, any, any, any, any, any, any, any>> | Element | Vue<...>'.ts(2321)
Excessive stack depth comparing types 'ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, ComponentOptionsBase<any, any, any, any, any, any, any, any, any, any>> | Element | Vue<...>' and 'Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>> | HTMLElement'.ts(2321)
const ref: (ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, ComponentOptionsBase<any, any, any, any, any, any, any, any, any, any>> | Element | Vue<...>)[]
```

It appears that we are running up against the TypeScript type depth limiter while trying to infer the correct type for Vue refs. I've noted references to this changing in TypeScript from around a time that coincides with the current version that we use (4.1.6) [^1][^2].

Bumping TypeScript to 4.5.5 easily resolves this problem. I'm targeting version 4.5.5 because this is the targeted version for new Vue 2.x projects.

supports #10221

[^1]: https://github.com/microsoft/TypeScript/pull/45025
[^2]: https://github.com/microsoft/TypeScript/pull/45711 