### PR TITLE
fix issue with duplicate labels on editing a cluster cloud  credential

### DIFF
--- a/cypress/e2e/blueprints/manager/cloud-credential-create-payload.ts
+++ b/cypress/e2e/blueprints/manager/cloud-credential-create-payload.ts
@@ -1,0 +1,14 @@
+export function cloudCredentialCreatePayload(credName: string, accessToken: string):object {
+  return {
+    type:     'provisioning.cattle.io/cloud-credential',
+    metadata: {
+      generateName: 'cc-',
+      namespace:    'fleet-default'
+    },
+    _name:                        credName,
+    annotations:                  { 'provisioning.cattle.io/driver': 'digitalocean' },
+    digitaloceancredentialConfig: { accessToken },
+    _type:                        'provisioning.cattle.io/cloud-credential',
+    name:                         credName
+  };
+}

--- a/cypress/e2e/blueprints/manager/digital-ocean-cluster-provisioning-response.ts
+++ b/cypress/e2e/blueprints/manager/digital-ocean-cluster-provisioning-response.ts
@@ -1,0 +1,398 @@
+export function clusterProvDigitalOceanSingleResponse(clusterName: string, cloudCredName: string, machinePoolId: string):object {
+  return {
+    type:         'collection',
+    links:        { self: 'https://localhost:8005/v1/provisioning.cattle.io.clusters' },
+    createTypes:  { 'provisioning.cattle.io.cluster': 'https://localhost:8005/v1/provisioning.cattle.io.clusters' },
+    actions:      {},
+    resourceType: 'provisioning.cattle.io.cluster',
+    revision:     '9258713',
+    count:        9,
+    data:         [
+      {
+        id:    `fleet-default/${ clusterName }`,
+        type:  'provisioning.cattle.io.cluster',
+        links: {
+          remove: `https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/${ clusterName }`,
+          self:   `https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/${ clusterName }`,
+          update: `https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/${ clusterName }`,
+          view:   `https://localhost:8005/apis/provisioning.cattle.io/v1/namespaces/fleet-default/clusters/${ clusterName }`
+        },
+        apiVersion: 'provisioning.cattle.io/v1',
+        kind:       'Cluster',
+        metadata:   {
+          annotations:       { 'field.cattle.io/creatorId': 'user-x7q4j' },
+          creationTimestamp: '2024-01-05T14:44:50Z',
+          fields:            [
+            `${ clusterName }`,
+            'true',
+            `${ clusterName }-kubeconfig`
+          ],
+          finalizers: [
+            'wrangler.cattle.io/provisioning-cluster-remove',
+            'wrangler.cattle.io/rke-cluster-remove',
+            'wrangler.cattle.io/cloud-config-secret-remover'
+          ],
+          generation:    3,
+          name:          `${ clusterName }`,
+          namespace:     'fleet-default',
+          relationships: [
+            {
+              toId:    `fleet-default/r-cluster-${ clusterName }-view-p-lnjgz-creator-proje-67ac2`,
+              toType:  'rbac.authorization.k8s.io.rolebinding',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:    `fleet-default/crt-${ clusterName }-nodes-manage`,
+              toType:  'rbac.authorization.k8s.io.role',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:    `fleet-default/crt-${ clusterName }-cluster-owner`,
+              toType:  'rbac.authorization.k8s.io.role',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:   `fleet-default/${ clusterName }-managed-system-upgrad-53adc`,
+              toType: 'management.cattle.io.managedchart',
+              rel:    'owner',
+              state:  'waitapplied'
+            },
+            {
+              toId:    `fleet-default/r-cluster-${ clusterName }-view`,
+              toType:  'rbac.authorization.k8s.io.role',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:    `fleet-default/crt-${ clusterName }-nodes-view`,
+              toType:  'rbac.authorization.k8s.io.role',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:    `fleet-default/crt-${ clusterName }-cluster-admin`,
+              toType:  'rbac.authorization.k8s.io.role',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:    `fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }`,
+              toType:  'rke-machine-config.cattle.io.digitaloceanconfig',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:    'c-m-fbr46mrq/c-m-fbr46mrq-fleet-default-owner',
+              toType:  'management.cattle.io.clusterroletemplatebinding',
+              rel:     'applies',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:   `fleet-default/${ clusterName }`,
+              toType: 'cluster.x-k8s.io.cluster',
+              rel:    'owner',
+              state:  'provisioned'
+            },
+            {
+              toId:   `fleet-default/${ clusterName }`,
+              toType: 'fleet.cattle.io.cluster',
+              rel:    'applies',
+              state:  'waitcheckin'
+            },
+            {
+              toId:    'c-m-fbr46mrq',
+              toType:  'management.cattle.io.cluster',
+              rel:     'applies',
+              state:   'active',
+              message: 'Resource is Ready'
+            },
+            {
+              toId:    `fleet-default/crt-${ clusterName }-cluster-member`,
+              toType:  'rbac.authorization.k8s.io.role',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:   `fleet-default/${ clusterName }-managed-system-agent`,
+              toType: 'fleet.cattle.io.bundle',
+              rel:    'owner',
+              state:  'waitapplied'
+            },
+            {
+              toId:    `fleet-default/r-cluster-${ clusterName }-view-p-d27qf-creator-proje-e42dc`,
+              toType:  'rbac.authorization.k8s.io.rolebinding',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is current'
+            },
+            {
+              toId:    `fleet-default/${ clusterName }-kubeconfig`,
+              toType:  'secret',
+              rel:     'owner',
+              state:   'active',
+              message: 'Resource is always ready'
+            }
+          ],
+          resourceVersion: '9258672',
+          state:           {
+            error:         false,
+            message:       'Resource is Ready',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '99c1559a-9c6d-498b-9c8a-6735f9dd1e28'
+        },
+        spec: {
+          cloudCredentialSecretName: cloudCredName,
+          kubernetesVersion:         'v1.26.11+rke2r1',
+          localClusterAuthEndpoint:  {},
+          rkeConfig:                 {
+            chartValues: { 'rke2-calico': {} },
+            etcd:        {
+              snapshotRetention:    5,
+              snapshotScheduleCron: '0 */5 * * *'
+            },
+            machineGlobalConfig: {
+              cni:                   'calico',
+              'disable-kube-proxy':  false,
+              'etcd-expose-metrics': false
+            },
+            machinePoolDefaults: {},
+            machinePools:        [
+              {
+                controlPlaneRole:  true,
+                drainBeforeDelete: true,
+                dynamicSchemaSpec: '{"resourceFields":{"accessToken":{"type":"password","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"Digital Ocean access token"},"backups":{"type":"boolean","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"enable backups for droplet"},"image":{"type":"string","default":{"stringValue":"ubuntu-20-04-x64","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"Digital Ocean Image"},"ipv6":{"type":"boolean","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"enable ipv6 for droplet"},"monitoring":{"type":"boolean","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"enable monitoring for droplet"},"privateNetworking":{"type":"boolean","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"enable private networking for droplet"},"region":{"type":"string","default":{"stringValue":"nyc3","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"Digital Ocean region"},"size":{"type":"string","default":{"stringValue":"s-1vcpu-1gb","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"Digital Ocean size"},"sshKeyContents":{"type":"password","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"File contents for sshKeyContents"},"sshKeyFingerprint":{"type":"string","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"SSH key fingerprint"},"sshPort":{"type":"string","default":{"stringValue":"22","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"SSH port"},"sshUser":{"type":"string","default":{"stringValue":"root","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"SSH username"},"tags":{"type":"string","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"comma-separated list of tags to apply to the Droplet"},"userdata":{"type":"string","default":{"stringValue":"","intValue":0,"boolValue":false,"stringSliceValue":null},"create":true,"update":true,"description":"File contents for userdata"}}}',
+                etcdRole:          true,
+                machineConfigRef:  {
+                  kind: 'DigitaloceanConfig',
+                  name: `nc-${ clusterName }-pool1-${ machinePoolId }`
+                },
+                name:                 'pool1',
+                quantity:             1,
+                unhealthyNodeTimeout: '0s',
+                workerRole:           true
+              }
+            ],
+            machineSelectorConfig: [
+              { config: { 'protect-kernel-defaults': false } }
+            ],
+            registries:      {},
+            upgradeStrategy: {
+              controlPlaneConcurrency:  '1',
+              controlPlaneDrainOptions: {
+                deleteEmptyDirData:              true,
+                disableEviction:                 false,
+                enabled:                         false,
+                force:                           false,
+                gracePeriod:                     -1,
+                ignoreDaemonSets:                true,
+                ignoreErrors:                    false,
+                postDrainHooks:                  null,
+                preDrainHooks:                   null,
+                skipWaitForDeleteTimeoutSeconds: 0,
+                timeout:                         120
+              },
+              workerConcurrency:  '1',
+              workerDrainOptions: {
+                deleteEmptyDirData:              true,
+                disableEviction:                 false,
+                enabled:                         false,
+                force:                           false,
+                gracePeriod:                     -1,
+                ignoreDaemonSets:                true,
+                ignoreErrors:                    false,
+                postDrainHooks:                  null,
+                preDrainHooks:                   null,
+                skipWaitForDeleteTimeoutSeconds: 0,
+                timeout:                         120
+              }
+            }
+          }
+        },
+        status: {
+          agentDeployed:    true,
+          clientSecretName: `${ clusterName }-kubeconfig`,
+          clusterName:      'c-m-fbr46mrq',
+          conditions:       [
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:50:35Z',
+              status:         'False',
+              transitioning:  false,
+              type:           'Reconciling'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:44:50Z',
+              status:         'False',
+              transitioning:  false,
+              type:           'Stalled'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:52:36Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'Created'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:51:48Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'RKECluster'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:50:23Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'Connected'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:44:56Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'BackingNamespaceCreated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:44:56Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'DefaultProjectCreated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:44:56Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'SystemProjectCreated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:44:57Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'InitialRolesPopulated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:51:40Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'Updated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:51:40Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'Provisioned'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:51:40Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'Ready'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:45:05Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'CreatorMadeOwner'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:45:20Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'NoDiskPressure'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:45:20Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'NoMemoryPressure'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:45:23Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'SecretsMigrated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:45:25Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'ServiceAccountSecretsMigrated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:45:28Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'RKESecretsMigrated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:45:32Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'ACISecretsMigrated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:50:01Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'GlobalAdminsSynced'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:50:29Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'Waiting'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:52:14Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'SystemAccountCreated'
+            },
+            {
+              error:          false,
+              lastUpdateTime: '2024-01-05T14:52:31Z',
+              status:         'True',
+              transitioning:  false,
+              type:           'AgentDeployed'
+            }
+          ],
+          observedGeneration: 3,
+          ready:              true
+        }
+      }
+    ]
+  };
+}

--- a/cypress/e2e/blueprints/manager/machine-pool-config-response.ts
+++ b/cypress/e2e/blueprints/manager/machine-pool-config-response.ts
@@ -1,0 +1,85 @@
+export function machinePoolConfigResponse(clusterName:string, machinePoolId:string ):object {
+  return {
+    id:    `fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }`,
+    type:  'rke-machine-config.cattle.io.digitaloceanconfig',
+    links: {
+      remove: `https://localhost:8005/v1/rke-machine-config.cattle.io.digitaloceanconfigs/fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }`,
+      self:   `https://localhost:8005/v1/rke-machine-config.cattle.io.digitaloceanconfigs/fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }`,
+      update: `https://localhost:8005/v1/rke-machine-config.cattle.io.digitaloceanconfigs/fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }`,
+      view:   `https://localhost:8005/apis/rke-machine-config.cattle.io/v1/namespaces/fleet-default/digitaloceanconfigs/nc-${ clusterName }-pool1-${ machinePoolId }`
+    },
+    accessToken: '',
+    apiVersion:  'rke-machine-config.cattle.io/v1',
+    backups:     false,
+    image:       'ubuntu-20-04-x64',
+    ipv6:        false,
+    kind:        'DigitaloceanConfig',
+    metadata:    {
+      annotations: {
+        'field.cattle.io/creatorId': 'user-x7q4j',
+        ownerBindingsCreated:        'true'
+      },
+      creationTimestamp: '2024-01-06T10:47:28Z',
+      fields:            [
+        `nc-${ clusterName }-pool1-${ machinePoolId }`,
+        '3m36s'
+      ],
+      generateName:    `nc-${ clusterName }-pool1-`,
+      generation:      1,
+      name:            `nc-${ clusterName }-pool1-${ machinePoolId }`,
+      namespace:       'fleet-default',
+      ownerReferences: [
+        {
+          apiVersion:         'provisioning.cattle.io/v1',
+          blockOwnerDeletion: true,
+          controller:         true,
+          kind:               'Cluster',
+          name:               clusterName,
+          uid:                '6ef2f4fa-8391-405d-bb2b-f93d71a043d3'
+        }
+      ],
+      relationships: [
+        {
+          fromId:        `fleet-default/${ clusterName }`,
+          fromType:      'provisioning.cattle.io.cluster',
+          rel:           'owner',
+          state:         'updating',
+          message:       `configuring bootstrap node(s) ${ clusterName }-pool1-5486598fb8xpg8j9-dm8c5: waiting for probes: calico`,
+          transitioning: true
+        },
+        {
+          toId:    `fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }-digitaloceanconfigs-a`,
+          toType:  'rbac.authorization.k8s.io.role',
+          rel:     'owner',
+          state:   'active',
+          message: 'Resource is current'
+        },
+        {
+          toId:    `fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }-digitaloceanconfigs-a`,
+          toType:  'rbac.authorization.k8s.io.rolebinding',
+          rel:     'owner',
+          state:   'active',
+          message: 'Resource is current'
+        }
+      ],
+      resourceVersion: '9683918',
+      state:           {
+        error:         false,
+        message:       'Resource is current',
+        name:          'active',
+        transitioning: false
+      },
+      uid: '11f6e148-063a-455e-88bf-682da1ff89f1'
+    },
+    monitoring:        false,
+    privateNetworking: false,
+    region:            'sfo3',
+    size:              's-4vcpu-16gb-amd',
+    sshKeyContents:    '',
+    sshKeyFingerprint: '',
+    sshPort:           '22',
+    sshUser:           'root',
+    tags:              '',
+    userdata:          ''
+  };
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po.ts
@@ -1,6 +1,7 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
 import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 
 /**
  * Covers core functionality that's common to the dashboard's import or create cluster pages
@@ -13,6 +14,13 @@ export default abstract class ClusterManagerCreateImportPagePo extends PagePo {
   // Form
   nameNsDescription() {
     return new NameNsDescription(this.self());
+  }
+
+  selectOptionForCloudCredentialWithLabel(label: string) {
+    const cloudCredSelect = new LabeledSelectPo(`[data-testid="cluster-prov-select-credential"]`, this.self());
+
+    cloudCredSelect.toggle();
+    cloudCredSelect.clickOptionWithLabel(label);
   }
 
   create() {

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po.ts
@@ -1,4 +1,6 @@
 import ClusterManagerCreateImportPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 
 /**
  * Covers core functionality that's common to the dashboard's edit cluster pages
@@ -14,5 +16,16 @@ export default class ClusterManagerEditGenericPagePo extends ClusterManagerCreat
 
   constructor(clusterName: string) {
     super(ClusterManagerEditGenericPagePo.createPath(clusterName));
+  }
+
+  selectOptionForCloudCredentialWithLabel(label: string) {
+    const cloudCredSelect = new LabeledSelectPo(`[data-testid="cluster-prov-select-credential"]`, this.self());
+
+    cloudCredSelect.toggle();
+    cloudCredSelect.clickOptionWithLabel(label);
+  }
+
+  saveEditCluster() {
+    return new AsyncButtonPo('[data-testid="rke2-custom-create-save"]').click();
   }
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po.ts
@@ -1,12 +1,10 @@
 import ClusterManagerCreateImportPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po';
-import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
-import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 
 /**
  * Covers core functionality that's common to the dashboard's edit cluster pages
  */
 export default class ClusterManagerEditGenericPagePo extends ClusterManagerCreateImportPagePo {
-  private static createPath(clusterName: string, tab?: string) {
+  private static createPath(clusterName: string) {
     return `/c/local/manager/provisioning.cattle.io.cluster/fleet-default/${ clusterName }`;
   }
 
@@ -16,16 +14,5 @@ export default class ClusterManagerEditGenericPagePo extends ClusterManagerCreat
 
   constructor(clusterName: string) {
     super(ClusterManagerEditGenericPagePo.createPath(clusterName));
-  }
-
-  selectOptionForCloudCredentialWithLabel(label: string) {
-    const cloudCredSelect = new LabeledSelectPo(`[data-testid="cluster-prov-select-credential"]`, this.self());
-
-    cloudCredSelect.toggle();
-    cloudCredSelect.clickOptionWithLabel(label);
-  }
-
-  saveEditCluster() {
-    return new AsyncButtonPo('[data-testid="rke2-custom-create-save"]').click();
   }
 }

--- a/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
@@ -18,7 +18,7 @@ export default class ClusterManagerListPagePo extends PagePo {
     super(ClusterManagerListPagePo.createPath(clusterId));
   }
 
-  static navTo() {
+  navTo() {
     BurgerMenuPo.toggle();
     BurgerMenuPo.burgerMenuNavToMenubyLabel('Cluster Management');
   }

--- a/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
@@ -43,4 +43,8 @@ export default class ClusterManagerListPagePo extends PagePo {
     return this.list().masthead().actions().eq(1)
       .click();
   }
+
+  editCluster(name: string) {
+    this.sortableTable().rowActionMenuOpen(name).getMenuItem('Edit Config').click();
+  }
 }

--- a/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
@@ -18,7 +18,7 @@ export default class ClusterManagerListPagePo extends PagePo {
     super(ClusterManagerListPagePo.createPath(clusterId));
   }
 
-  navTo() {
+  static navTo() {
     BurgerMenuPo.toggle();
     BurgerMenuPo.burgerMenuNavToMenubyLabel('Cluster Management');
   }

--- a/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
+++ b/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
@@ -18,8 +18,8 @@ describe('Charts', { tags: '@adminUser' }, () => {
 
     describe('Rancher Backups storage class config', () => {
       beforeEach(() => {
-        cy.createRancherResource('v1', STORAGE_CLASS_RESOURCE, defaultStorageClass);
-        cy.createRancherResource('v1', STORAGE_CLASS_RESOURCE, exampleStorageClass);
+        cy.createRancherResource('v1', STORAGE_CLASS_RESOURCE, JSON.stringify(defaultStorageClass));
+        cy.createRancherResource('v1', STORAGE_CLASS_RESOURCE, JSON.stringify(exampleStorageClass));
       });
 
       afterEach(() => {

--- a/cypress/e2e/tests/pages/explorer/node-list.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/node-list.spec.ts
@@ -10,7 +10,7 @@ describe('Nodes list', { tags: ['@explorer', '@adminUser'], testIsolation: 'off'
     HomePagePo.goTo();
 
     // Add dummy node that used to cause a problem
-    cy.createRancherResource('v1', 'nodes', dummyNode);
+    cy.createRancherResource('v1', 'nodes', JSON.stringify(dummyNode));
   });
 
   after(() => {

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -82,7 +82,7 @@ describe('Cloud Credential', () => {
           const editClusterPage = new ClusterManagerEditGenericPagePo(clusterName);
 
           editClusterPage.selectOptionForCloudCredentialWithLabel(`${ credsName } (${ createdCloudCredsIds[1] })`);
-          editClusterPage.saveEditCluster();
+          editClusterPage.save();
 
           cy.wait('@dummyProvClusterSave').then(({ request }) => {
             expect(request.body.spec.cloudCredentialSecretName).to.equal(createdCloudCredsIds[1]);

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -58,7 +58,7 @@ describe('Cloud Credential', () => {
     const createdCloudCredsIds = [];
 
     for (let i = 0; i < cloudCredsToCreate.length; i++) {
-      cy.createRancherResource('v3', 'cloudcredentials', cloudCredentialCreatePayload(cloudCredsToCreate[i].name, cloudCredsToCreate[i].token)).then((resp: Cypress.Response<any>) => {
+      cy.createRancherResource('v3', 'cloudcredentials', JSON.stringify(cloudCredentialCreatePayload(cloudCredsToCreate[i].name, cloudCredsToCreate[i].token))).then((resp: Cypress.Response<any>) => {
         createdCloudCredsIds.push(resp.body.id);
 
         if (i === 0) {

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -1,0 +1,94 @@
+import { cloudCredentialCreatePayload } from '@/cypress/e2e/blueprints/manager/cloud-credential-create-payload';
+import { clusterProvDigitalOceanSingleResponse } from '@/cypress/e2e/blueprints/manager/digital-ocean-cluster-provisioning-response';
+import { machinePoolConfigResponse } from '@/cypress/e2e/blueprints/manager/machine-pool-config-response';
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
+
+describe('Cloud Credential', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('Editing a cluster cloud credential should work with duplicate named cloud credentials', { tags: ['@manager', '@adminUser'] }, () => {
+    const credsName = 'test-do-creds';
+    const clusterName = 'test-cluster-digital-ocean';
+    const machinePoolId = 'dummy-id';
+
+    // prepare some intercepts of XHR requests needed for the correct flow
+    // intercept GET of machine configs and pass a mock (Digital Ocean)
+    cy.intercept('GET', `/v1/rke-machine-config.cattle.io.digitaloceanconfigs/fleet-default/*`, (req) => {
+      req.reply({
+        statusCode: 200,
+        body:       machinePoolConfigResponse(clusterName, machinePoolId),
+      });
+    }).as('dummyMachinePoolLoad1');
+
+    // intercept PUT of machine configs and pass a mock (Digital Ocean)
+    cy.intercept('PUT', `/v1/rke-machine-config.cattle.io.digitaloceanconfigs/fleet-default/nc-${ clusterName }-pool1-${ machinePoolId }`, (req) => {
+      req.reply({
+        statusCode: 200,
+        body:       {},
+      });
+    }).as('dummyMachinePoolSave');
+
+    // intercept PUT of prov cluster save and get payload sent (Digital Ocean)
+    cy.intercept('PUT', `/v1/provisioning.cattle.io.clusters/fleet-default/${ clusterName }`, (req) => {
+      req.reply({
+        statusCode: 200,
+        body:       {},
+      });
+    }).as('dummyProvClusterSave');
+
+    // create some cloud credentials (2 with the same name + 1 with different name to populate cloud credential selection dropdown)
+    const cloudCredsToCreate = [
+      {
+        name:  credsName,
+        token: 'token1'
+      },
+      {
+        name:  credsName,
+        token: 'token2'
+      },
+      {
+        name:  `another-${ credsName }`,
+        token: 'token3'
+      },
+    ];
+
+    const createdCloudCredsIds = [];
+
+    for (let i = 0; i < cloudCredsToCreate.length; i++) {
+      cy.createRancherResource('v3', 'cloudcredentials', cloudCredentialCreatePayload(cloudCredsToCreate[i].name, cloudCredsToCreate[i].token)).then((resp: Cypress.Response<any>) => {
+        createdCloudCredsIds.push(resp.body.id);
+
+        if (i === 0) {
+          // intercept GET of list of prov clusters and pass a mock (Digital Ocean)
+          cy.intercept('GET', '/v1/provisioning.cattle.io.clusters?exclude=metadata.managedFields', (req) => {
+            req.reply({
+              statusCode: 200,
+              body:       clusterProvDigitalOceanSingleResponse(clusterName, resp.body.id, machinePoolId),
+            });
+          }).as('dummyClusterListLoad');
+        }
+
+        // code to edit cluster and final checks needs to be after all "then's" otherwise the cloud cred id's aren't stored yet on it's variable...
+        if (i === cloudCredsToCreate.length - 1) {
+          const clusterList = new ClusterManagerListPagePo('local');
+
+          clusterList.goTo();
+          clusterList.checkIsCurrentPage();
+          clusterList.editCluster(clusterName);
+
+          const editClusterPage = new ClusterManagerEditGenericPagePo(clusterName);
+
+          editClusterPage.selectOptionForCloudCredentialWithLabel(`${ credsName } (${ createdCloudCredsIds[1] })`);
+          editClusterPage.saveEditCluster();
+
+          cy.wait('@dummyProvClusterSave').then(({ request }) => {
+            expect(request.body.spec.cloudCredentialSecretName).to.equal(createdCloudCredsIds[1]);
+          });
+        }
+      });
+    }
+  });
+});

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -77,7 +77,6 @@ describe('Cloud Credential', () => {
 
         // code to edit cluster and final checks needs to be after all "then's" otherwise the cloud cred id's aren't stored yet on it's variable...
         if (i === cloudCredsToCreate.length - 1) {
-          clusterList.navTo();
           clusterList.checkIsCurrentPage();
           clusterList.editCluster(clusterName);
 

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -5,8 +5,12 @@ import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/clu
 import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
 
 describe('Cloud Credential', () => {
-  beforeEach(() => {
+  const clusterList = new ClusterManagerListPagePo('local');
+
+  before(() => {
     cy.login();
+
+    clusterList.goTo();
   });
 
   it('Editing a cluster cloud credential should work with duplicate named cloud credentials', { tags: ['@manager', '@adminUser'] }, () => {
@@ -73,9 +77,7 @@ describe('Cloud Credential', () => {
 
         // code to edit cluster and final checks needs to be after all "then's" otherwise the cloud cred id's aren't stored yet on it's variable...
         if (i === cloudCredsToCreate.length - 1) {
-          const clusterList = new ClusterManagerListPagePo('local');
-
-          clusterList.goTo();
+          clusterList.navTo();
           clusterList.checkIsCurrentPage();
           clusterList.editCluster(clusterName);
 

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -43,7 +43,6 @@ declare global {
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: string): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
-      createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
 
       /**
        *  Wrapper for cy.get() to simply define the data-testid value that allows you to pass a matcher to find the element.

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -41,6 +41,7 @@ declare global {
 
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
+      // eslint-disable-next-line
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -41,7 +41,7 @@ declare global {
 
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
-      // tslint:disable-next-line
+      // eslint-disable-next-line  @typescript-eslint/adjacent-overload-signatures
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -41,7 +41,7 @@ declare global {
 
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
-      // eslint-disable-next-line
+      // tslint:disable-next-line
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -41,6 +41,7 @@ declare global {
 
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
+      createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
 

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -41,8 +41,7 @@ declare global {
 
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
-      // eslint-disable-next-line  @typescript-eslint/adjacent-overload-signatures
-      createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
+      createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: string): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
 

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -39,7 +39,7 @@ declare global {
       createNamespace(nsName: string, projId: string): Chainable;
       createPod(nsName: string, podName: string, image: string): Chainable;
 
-      getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode: string): Chainable;
+      getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: string): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: string): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -393,6 +393,24 @@ Cypress.Commands.add('setRancherResource', (prefix, resourceType, resourceId, bo
 });
 
 /**
+ * create a v3 / v1 resource
+ */
+Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
+  return cy.request({
+    method:  'POST',
+    url:     `${ Cypress.env('api') }/${ prefix }/${ resourceType }`,
+    headers: {
+      'x-api-csrf': token.value,
+      Accept:       'application/json'
+    },
+    body
+  })
+    .then((resp) => {
+      expect(resp.status).to.eq(201);
+    });
+});
+
+/**
  * delete a v3 / v1 resource
  */
 Cypress.Commands.add('deleteRancherResource', (prefix, resourceType, resourceId) => {

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -393,24 +393,6 @@ Cypress.Commands.add('setRancherResource', (prefix, resourceType, resourceId, bo
 });
 
 /**
- * create a v3 / v1 resource
- */
-Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
-  return cy.request({
-    method:  'POST',
-    url:     `${ Cypress.env('api') }/${ prefix }/${ resourceType }`,
-    headers: {
-      'x-api-csrf': token.value,
-      Accept:       'application/json'
-    },
-    body
-  })
-    .then((resp) => {
-      expect(resp.status).to.eq(201);
-    });
-});
-
-/**
  * delete a v3 / v1 resource
  */
 Cypress.Commands.add('deleteRancherResource', (prefix, resourceType, resourceId) => {
@@ -425,25 +407,6 @@ Cypress.Commands.add('deleteRancherResource', (prefix, resourceType, resourceId)
     .then((resp) => {
       // Either 200, or 204 (No Content)
       expect(resp.status).to.be.oneOf([200, 204]);
-    });
-});
-
-/**
- * create a v3 / v1 resource
- */
-Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
-  return cy.request({
-    method:  'POST',
-    url:     `${ Cypress.env('api') }/${ prefix }/${ resourceType }`,
-    headers: {
-      'x-api-csrf': token.value,
-      Accept:       'application/json'
-    },
-    body
-  })
-    .then((resp) => {
-      // Expect 201, Created HTTP status code
-      expect(resp.status).to.eq(201);
     });
 });
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1220,7 +1220,7 @@ cluster:
         placeholder: Your Client Secret
     name:
       label: Credential Name
-      placeholder: Name for this credential (optional)
+      placeholder: Name for this credential
     s3:
       accessKey:
         label: Access Key

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1220,7 +1220,7 @@ cluster:
         placeholder: Your Client Secret
     name:
       label: Credential Name
-      placeholder: Name for this credential
+      placeholder: Name for this credential (optional)
     s3:
       accessKey:
         label: Access Key

--- a/shell/edit/cloudcredential.vue
+++ b/shell/edit/cloudcredential.vue
@@ -260,6 +260,8 @@ export default {
         v-model="value"
         name-key="_name"
         description-key="description"
+        name-label="cluster.credential.name.label"
+        name-placeholder="cluster.credential.name.placeholder"
         :mode="mode"
         :namespaced="false"
       />

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -104,7 +104,7 @@ export default {
     options() {
       const out = this.filteredCredentials.map((obj) => {
         return {
-          label: obj.nameDisplay,
+          label: `${ obj.nameDisplay }/${ obj.id }`,
           value: obj.id,
         };
       });

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -102,15 +102,17 @@ export default {
     },
 
     options() {
-      const out = this.filteredCredentials.map((obj) => {
-        const duplicateFound = this.filteredCredentials.find((filtered) => filtered.nameDisplay === obj.nameDisplay);
+      const duplicates = {};
 
-        // if credential name is duplicated we add the id to the label
-        return {
-          label: duplicateFound ? `${ obj.nameDisplay } (${ obj.id })` : obj.nameDisplay,
-          value: obj.id,
-        };
+      this.filteredCredentials.forEach((cred) => {
+        duplicates[cred.nameDisplay] = duplicates[cred.nameDisplay] === null ? true : null;
       });
+
+      const out = this.filteredCredentials.map((obj) => ({
+        // if credential name is duplicated we add the id to the label
+        label: duplicates[obj.nameDisplay] ? `${ obj.nameDisplay } (${ obj.id })` : obj.nameDisplay,
+        value: obj.id,
+      }));
 
       if ( this.originalId && !out.find((x) => x.value === this.originalId) ) {
         out.unshift({

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -102,11 +102,16 @@ export default {
     },
 
     options() {
-      const out = this.filteredCredentials.map((obj) => {
-        return {
-          label: `${ obj.nameDisplay }/${ obj.id }`,
-          value: obj.id,
-        };
+      const out = [];
+
+      this.filteredCredentials.forEach((cred) => {
+        const duplicatesArr = this.filteredCredentials.filter((filtered) => filtered.nameDisplay === cred.nameDisplay);
+
+        // if credential name is duplicated we add the id to the label
+        out.push({
+          label: duplicatesArr.length > 1 ? `${ cred.nameDisplay } (${ cred.id })` : cred.nameDisplay,
+          value: cred.id,
+        });
       });
 
       if ( this.originalId && !out.find((x) => x.value === this.originalId) ) {

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -273,6 +273,7 @@ export default {
         option-key="value"
         :mode="mode"
         :selectable="option => !option.disabled"
+        data-testid="cluster-prov-select-credential"
       />
     </div>
 

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -265,6 +265,7 @@ export default {
         v-model="credentialId"
         :label="t('cluster.credential.label')"
         :options="options"
+        option-key="value"
         :mode="mode"
         :selectable="option => !option.disabled"
       />

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -102,16 +102,14 @@ export default {
     },
 
     options() {
-      const out = [];
-
-      this.filteredCredentials.forEach((cred) => {
-        const duplicatesArr = this.filteredCredentials.filter((filtered) => filtered.nameDisplay === cred.nameDisplay);
+      const out = this.filteredCredentials.map((obj) => {
+        const duplicateFound = this.filteredCredentials.find((filtered) => filtered.nameDisplay === obj.nameDisplay);
 
         // if credential name is duplicated we add the id to the label
-        out.push({
-          label: duplicatesArr.length > 1 ? `${ cred.nameDisplay } (${ cred.id })` : cred.nameDisplay,
-          value: cred.id,
-        });
+        return {
+          label: duplicateFound ? `${ obj.nameDisplay } (${ obj.id })` : obj.nameDisplay,
+          value: obj.id,
+        };
       });
 
       if ( this.originalId && !out.find((x) => x.value === this.originalId) ) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10020 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with duplicate labels on editing a cluster cloud credential
- update label on `SelectCredential` to display combination of name and id (optional?)
- fix label and placeholder on `cloudcredential` edit view 
- fix translation for credential name placeholder 

**Note:** Cannot create e2e tests for creating cloud credentials, since we need valid tokens for any of the options available on the UI.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I’ve compared the code for `SelectCredential`  for `2.7.5` and `master` and nothing relevant changed (template and `options`  variable logic), which to me means that we’ve always had this problem.

https://github.com/rancher/dashboard/blob/release-2.7.5/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue vs https://github.com/rancher/dashboard/blob/master/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue

The fix: by default `LabeledSelect`  uses as `option-key`  the `label` property of the `options` variable. In this case the `label`  isn’t unique, we just add `option-key="value"`  to get it’s “unique” key from the `value` property.

The other thing about creating a cluster (being RKE1 or RKE2) with duplicate creds works flawlessly. Why?
That’s because the `v-model`  isn’t populated, so the component doesn’t default to the first option with the same `label` always. We are able to pick one and it works.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Create two valid credentials with the same provider, using the same name. Ex: `digital-ocean-cred`
- revert the code change that makes the label unique on `SelectCredential` (so that you can check that the fix would work for duplicate labels)
- Create a RKE2 cluster for that provider and select the first credential on the list
- Go to `view YAML` and note the cloud credential id that was "appended" to the cluster
- Edit that same cluster and select the second credential on the list 
- Go to `view YAML` again and check that the cloud credential id that was "appended" to the cluster is now the one from the edit operation

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

_Previous behaviour (while editing cluster)_

https://github.com/rancher/dashboard/assets/97888974/877a75ac-285a-4bef-9124-0a6bee80cefb

_Correct behaviour_

https://github.com/rancher/dashboard/assets/97888974/a6d6ea68-2ed7-48eb-9d96-af2d462ead38

_Fixed label and placeholder on cloud creation screen_
![Screenshot 2024-01-04 at 16 11 28](https://github.com/rancher/dashboard/assets/97888974/e37e8909-fbae-40e8-b9ce-950add4c2990)
