### PR TITLE
Replace `Vue.extend` with `defineComponent` in `LabeledInput.vue`

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -1,4 +1,3 @@
-
 import { mount } from '@vue/test-utils';
 import { LabeledInput } from './index';
 
@@ -6,7 +5,7 @@ describe('component: LabeledInput', () => {
   it('should emit input only once', () => {
     const value = '2';
     const delay = 1;
-    const wrapper = mount(LabeledInput, {
+    const wrapper = mount(LabeledInput as any, {
       propsData: { delay },
       mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } }
     });

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -101,6 +101,7 @@ export default defineComponent({
 
   setup(props, { emit }) {
     const {
+      focused,
       onFocusLabeled,
       onBlurLabeled,
       isDisabled,
@@ -110,6 +111,7 @@ export default defineComponent({
     const { isCompact } = useCompactInput(props);
 
     return {
+      focused,
       onFocusLabeled,
       onBlurLabeled,
       isDisabled,
@@ -123,7 +125,6 @@ export default defineComponent({
     return {
       updated:          false,
       validationErrors: '',
-      focused:          false,
     };
   },
 

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -6,9 +6,8 @@ import { escapeHtml } from '@shell/utils/string';
 import cronstrue from 'cronstrue';
 import { isValidCron } from 'cron-validator';
 import { debounce } from 'lodash';
-import { useLabeledFormElement } from '@shell/composables/useLabeledFormElement';
+import { useLabeledFormElement, labeledFormElementProps } from '@shell/composables/useLabeledFormElement';
 import { useCompactInput } from '@shell/composables/useCompactInput';
-import { _EDIT } from '@shell/config/query-params';
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -22,6 +21,7 @@ export default defineComponent({
   inheritAttrs: false,
 
   props: {
+    ...labeledFormElementProps,
     /**
      * The type of the Labeled Input.
      * @values text, cron, multiline, multiline-password
@@ -54,11 +54,6 @@ export default defineComponent({
     tooltip: {
       default: null,
       type:    [String, Object]
-    },
-
-    tooltipKey: {
-      type:    String,
-      default: null
     },
 
     /**
@@ -101,53 +96,6 @@ export default defineComponent({
     delay: {
       type:    Number,
       default: 0
-    },
-
-    placeholder: {
-      type:    [String, Number],
-      default: ''
-    },
-
-    placeholderKey: {
-      type:    String,
-      default: null
-    },
-
-    label: {
-      type:    String,
-      default: null
-    },
-
-    labelKey: {
-      type:    String,
-      default: null
-    },
-
-    value: {
-      type:    [String, Number, Object],
-      default: ''
-    },
-
-    mode: {
-      type:    String,
-      default: _EDIT,
-    },
-
-    rules: {
-      default:   () => [],
-      type:      Array,
-      // we only want functions in the rules array
-      validator: (rules: Array<unknown>) => rules.every((rule: unknown) => ['function'].includes(typeof rule))
-    },
-
-    required: {
-      type:    Boolean,
-      default: false,
-    },
-
-    disabled: {
-      type:    Boolean,
-      default: false,
     },
   },
 

--- a/shell/composables/useCompactInput.ts
+++ b/shell/composables/useCompactInput.ts
@@ -1,0 +1,20 @@
+import { computed, ComputedRef } from 'vue';
+
+interface CompactInputProps {
+  compact?: boolean;
+  label?: string;
+  labelKey?: string;
+}
+
+interface UseCompactInput {
+  isCompact: ComputedRef<boolean>;
+}
+
+export const useCompactInput = (props: CompactInputProps): UseCompactInput => {
+  const isCompact = computed(() => {
+    // Compact if explicitly set - otherwise compact if there is no label
+    return props.compact !== null ? !!props.compact : !(props.label || props.labelKey);
+  });
+
+  return { isCompact };
+};

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -1,6 +1,6 @@
 import { ref, computed } from 'vue';
 import type { ComputedRef } from 'vue';
-import { _VIEW } from '@shell/config/query-params';
+import { _VIEW, _EDIT } from '@shell/config/query-params';
 
 interface LabeledFormElementProps {
   mode: string;
@@ -17,6 +17,51 @@ interface UseLabeledFormElement {
   onFocusLabeled: () => void;
   onBlurLabeled: () => void;
 }
+
+export const labeledFormElementProps = {
+  tooltipKey: {
+    type:    String,
+    default: null
+  },
+  placeholder: {
+    type:    [String, Number],
+    default: ''
+  },
+  placeholderKey: {
+    type:    String,
+    default: null
+  },
+  label: {
+    type:    String,
+    default: null
+  },
+  labelKey: {
+    type:    String,
+    default: null
+  },
+  value: {
+    type:    [String, Number, Object],
+    default: ''
+  },
+  mode: {
+    type:    String,
+    default: _EDIT,
+  },
+  rules: {
+    default:   (): Array<unknown> => [],
+    type:      Array,
+    // we only want functions in the rules array
+    validator: (rules: Array<unknown>): boolean => rules.every((rule: unknown) => ['function'].includes(typeof rule))
+  },
+  required: {
+    type:    Boolean,
+    default: false,
+  },
+  disabled: {
+    type:    Boolean,
+    default: false,
+  },
+};
 
 export const useLabeledFormElement = (props: LabeledFormElementProps, emit: (event: string, ...args: any[]) => void): UseLabeledFormElement => {
   const raised = ref(props.mode === _VIEW || !!`${ props.value }`);

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -1,5 +1,4 @@
-import { ref, computed } from 'vue';
-import type { ComputedRef } from 'vue';
+import { ref, computed, ComputedRef, Ref } from 'vue';
 import { _VIEW, _EDIT } from '@shell/config/query-params';
 
 interface LabeledFormElementProps {
@@ -11,6 +10,9 @@ interface LabeledFormElementProps {
 }
 
 interface UseLabeledFormElement {
+  raised: Ref<boolean>;
+  focused: Ref<boolean>;
+  blurred: Ref<number | null>;
   requiredField: ComputedRef<any>;
   isDisabled: ComputedRef<any>;
   validationMessage: ComputedRef<any>;
@@ -124,6 +126,9 @@ export const useLabeledFormElement = (props: LabeledFormElementProps, emit: (eve
   };
 
   return {
+    raised,
+    focused,
+    blurred,
     onFocusLabeled,
     onBlurLabeled,
     isDisabled,

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -1,0 +1,88 @@
+import { ref, computed } from 'vue';
+import type { ComputedRef } from 'vue';
+import { _VIEW } from '@shell/config/query-params';
+
+interface LabeledFormElementProps {
+  mode: string;
+  value: string | number | Record<string, any>
+  required: boolean;
+  disabled: boolean;
+  rules: Array<any>;
+}
+
+interface UseLabeledFormElement {
+  requiredField: ComputedRef<any>;
+  isDisabled: ComputedRef<any>;
+  validationMessage: ComputedRef<any>;
+  onFocusLabeled: () => void;
+  onBlurLabeled: () => void;
+}
+
+export const useLabeledFormElement = (props: LabeledFormElementProps, emit: (event: string, ...args: any[]) => void): UseLabeledFormElement => {
+  const raised = ref(props.mode === _VIEW || !!`${ props.value }`);
+  const focused = ref(false);
+  const blurred = ref<number | null>(null);
+
+  const requiredField = computed(() => {
+    return props.required || props.rules?.some((rule: any) => rule?.name === 'required');
+  });
+
+  const isView = computed(() => {
+    return props.mode === _VIEW;
+  });
+
+  const isDisabled = computed(() => {
+    return props.disabled || isView.value;
+  });
+
+  const validationMessage = computed(() => {
+    const requiredRule = props.rules.find((rule: any) => rule?.name === 'required') as Function;
+    const ruleMessages = [];
+    const value = props.value;
+
+    if (requiredRule && blurred.value && !focused.value) {
+      const message = requiredRule(value);
+
+      if (!!message) {
+        return message;
+      }
+    }
+
+    for (const rule of props.rules) {
+      const message = rule(value);
+
+      if (!!message && rule.name !== 'required') {
+        ruleMessages.push(message);
+      }
+    }
+
+    if (ruleMessages.length > 0 && (blurred.value || focused.value)) {
+      return ruleMessages.join(', ');
+    } else {
+      return undefined;
+    }
+  });
+
+  const onFocusLabeled = () => {
+    raised.value = true;
+    focused.value = true;
+  };
+
+  const onBlurLabeled = () => {
+    focused.value = false;
+
+    if (!props.value) {
+      raised.value = false;
+    }
+
+    blurred.value = Date.now();
+  };
+
+  return {
+    onFocusLabeled,
+    onBlurLabeled,
+    isDisabled,
+    validationMessage,
+    requiredField
+  };
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
contributes to #10104 

Rewrote `compact-input.ts` and `labeled-form-element.ts` mixins as composables to address TypeScript issues when using mixins with `defineComponent`. The new composables are written to adhere to the conventions and best practices [^1] as best as possible, taking into consideration what's available to us in Vue 2.7.14. 

Moving to composables positions us for a smoother Vue 3 migration.

[^1]: https://vuejs.org/guide/reusability/composables.html#conventions-and-best-practices
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Any forms that utilize `LabeledInput`
