### PR TITLE
Backport 2.7: Fix 'Scale Down' crash in cluster provisioning details page

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -805,7 +805,7 @@ export default {
         return false;
       }
 
-      const matchingResourceAction = resource.availableActions.find((a) => a.action === this.actionOfInterest.action);
+      const matchingResourceAction = resource.availableActions?.find((a) => a.action === this.actionOfInterest.action);
 
       return matchingResourceAction?.enabled;
     },

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -337,9 +337,10 @@ export default {
         pool._clusterSpec = mp;
 
         return {
-          poolId:     pool.id,
-          mainRowKey: 'isFake',
+          poolId:           pool.id,
+          mainRowKey:       'isFake',
           pool,
+          availableActions: []
         };
       });
     },
@@ -359,9 +360,10 @@ export default {
       const emptyNodePools = this.allNodePools.filter((x) => x.spec.clusterName === this.value.mgmtClusterId && x.spec.quantity === 0);
 
       return emptyNodePools.map((np) => ({
-        spec:       { nodePoolName: np.id.replace('/', ':') },
-        mainRowKey: 'isFake',
-        pool:       np,
+        spec:             { nodePoolName: np.id.replace('/', ':') },
+        mainRowKey:       'isFake',
+        pool:             np,
+        availableActions: []
       }));
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10062
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Cluster manage -> details page -> 'Scale Down' action