### PR TITLE
Fix for custom banner header without fontSize breaks top navigation (old obj structure)

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -72,12 +72,17 @@ export default {
       if (bannerSettings) {
         const parsed = JSON.parse(bannerSettings.value);
         const {
-          showFooter, showHeader, bannerFooter, bannerHeader
+          showFooter, showHeader, bannerFooter, bannerHeader, banner
         } = parsed;
 
+        // add defaults to accomodate older JSON structures for banner definitions without breaking the UI
+        // https://github.com/rancher/dashboard/issues/10140
+        const bannerHeaderFontSize = bannerHeader?.fontSize || banner?.fontSize || '14px';
+        const bannerFooterFontSize = bannerFooter?.fontSize || banner?.fontSize || '14px';
+
         return {
-          headerFont: showHeader === 'true' ? this.pxToEm(bannerHeader.fontSize) : '0px',
-          footerFont: showFooter === 'true' ? this.pxToEm(bannerFooter.fontSize) : '0px'
+          headerFont: showHeader === 'true' ? this.pxToEm(bannerHeaderFontSize) : '0px',
+          footerFont: showFooter === 'true' ? this.pxToEm(bannerFooterFontSize) : '0px'
         };
       }
 

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -1,5 +1,7 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import TopLevelMenu from '@shell/components/nav/TopLevelMenu';
+import { MANAGEMENT } from '@shell/config/types';
+import { SETTING } from '@shell/config/settings';
 
 // DISCLAIMER: This should not be added here, although we have several store requests which are irrelevant
 const defaultStore = {
@@ -30,6 +32,38 @@ describe('topLevelMenu', () => {
     const cluster = wrapper.find('[data-testid="top-level-menu-cluster-0"]');
 
     expect(cluster.exists()).toBe(true);
+  });
+
+  it('should not "crash" the component if the structure of banner settings is in an old format', () => {
+    const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+      mocks: {
+        $store: {
+          getters: {
+            'management/all': () => [{ name: 'whatever' },
+              // object based on https://github.com/rancher/dashboard/issues/10140#issuecomment-1883252402
+              {
+                id:    SETTING.BANNERS,
+                value: JSON.stringify({
+                  banner: {
+                    color:      '#78c9cf',
+                    background: '#27292e',
+                    text:       'Hello World!'
+                  },
+                  showHeader: 'true',
+                  showFooter: 'true'
+                })
+              }],
+            ...defaultStore
+          },
+        },
+      },
+      stubs: ['BrandImage', 'nuxt-link']
+    });
+
+    expect(wrapper.vm.globalBannerSettings).toStrictEqual({
+      headerFont: '2em',
+      footerFont: '2em'
+    });
   });
 
   describe('searching a term', () => {

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -1,6 +1,5 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import TopLevelMenu from '@shell/components/nav/TopLevelMenu';
-import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 
 // DISCLAIMER: This should not be added here, although we have several store requests which are irrelevant


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10140 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fix breaking of `TopLevelMenu` component when `ui-banner` settings has an old structure (upgrade scenario from an old version)
- update unit tests to cover regression scenario

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- `FixedBanner` component, which is responsible for the rendering of the banners already covers the above scenario (double-checked)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Edit the code for the `TopLevelMenu` component https://github.com/rancher/dashboard/blob/master/shell/components/nav/TopLevelMenu.vue#L73 so that:
```
const parsed = {
  banner: {
    color:      '#78c9cf',
    background: '#27292e',
    text:       'Hello World!'
  },
  showHeader: 'true',
  showFooter: 'false'
};
```
- Check that no error is thrown on the console or UI

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->