### PR TITLE
fix(service): reset clusterIP(s) field  when clone a service

### DIFF
--- a/shell/edit/__tests__/service.test.ts
+++ b/shell/edit/__tests__/service.test.ts
@@ -1,0 +1,89 @@
+import { shallowMount, Wrapper } from '@vue/test-utils';
+
+import { _CLONE } from '@shell/config/query-params';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
+
+import ServicePage from '@shell/edit/service.vue';
+
+const createEditViewMock = {
+  data() {
+    return { errors: [] };
+  },
+  computed: {
+    isCreate:     () => false,
+    isEdit:       () => true,
+    isView:       () => false,
+    schema:       () => ({}),
+    isNamespaced: () => false,
+    labels:       {
+      get: jest.fn(() => ({})),
+      set: jest.fn(),
+    },
+    annotations: {
+      get: jest.fn(() => ({})),
+      set: jest.fn(),
+    },
+    doneRoute:  () => 'mockedRoute',
+    doneParams: () => ({}),
+  },
+  methods: {
+    done:         jest.fn(),
+    conflict:     jest.fn(() => Promise.resolve([])),
+    save:         jest.fn(() => Promise.resolve()),
+    actuallySave: jest.fn(() => Promise.resolve()),
+    setErrors:    jest.fn()
+  }
+};
+
+const formValidationMock = {};
+
+describe('service edit', () => {
+  let wrapper: Wrapper<InstanceType<typeof ServicePage>>;
+
+  const createComponent = (propsData: any) => {
+    wrapper = shallowMount(ServicePage,
+      {
+        propsData,
+        mixins: [createEditViewMock, formValidationMock],
+        mocks:  {
+          $store: {
+            getters: {
+              'management/all': jest.fn(),
+              'i18n/t':         jest.fn()
+            }
+          }
+        },
+        computed:   { provisioningCluster: jest.fn() },
+        directives: { cleanHtmlDirective },
+      }
+    );
+  };
+
+  it('sets clusterIP to an empty string and deletes clusterIPs when in clone mode', () => {
+    const value = {
+      spec: {
+        clusterIP:  '10.43.1.1',
+        clusterIPs: ['10.43.1.1', '10.43.1.2'],
+      }
+    };
+
+    createComponent({ realMode: _CLONE, value });
+
+    expect(wrapper.vm.value.spec.clusterIP).toBe('');
+    expect(wrapper.vm.value.spec.clusterIPs).toBeUndefined();
+  });
+
+  it('does not change clusterIP and clusterIPs when not in clone mode', () => {
+    const value = {
+      spec: {
+        clusterIP:  '10.43.1.1',
+        clusterIPs: ['10.43.1.1', '10.43.1.2'],
+      }
+    };
+
+    createComponent({ realMode: 'someOtherMode', value });
+
+    expect(wrapper.vm.value.spec.clusterIP).toBe('10.43.1.1');
+    expect(wrapper.vm.value.spec.clusterIPs).toStrictEqual(['10.43.1.1', '10.43.1.2']);
+  });
+});

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -26,6 +26,7 @@ import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { allHash } from '@shell/utils/promise';
 import { isHarvesterSatisfiesVersion } from '@shell/utils/cluster';
 import { Port } from '@shell/utils/validators/formRules';
+import { _CLONE } from '@shell/config/query-params';
 
 const SESSION_AFFINITY_ACTION_VALUES = {
   NONE:     'None',
@@ -72,6 +73,17 @@ export default {
           ports:           [],
           sessionAffinity: 'None',
         });
+      }
+    }
+
+    // Set clusterIP to an empty string, if it exists and the value is not None when clone a service
+    // Remove clusterIPs if it exists when clone a service
+    if (this.realMode === _CLONE) {
+      if (this.value?.spec?.clusterIP && this.value?.spec?.clusterIP !== 'None') {
+        this.value.spec.clusterIP = '';
+      }
+      if (this.value?.spec?.clusterIPs) {
+        this.$delete(this.value.spec, 'clusterIPs');
       }
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10252
<!-- Define findings related to the feature or bug issue. -->

1. Set clusterIP to an empty string, if it exists and the value is not None when clone a service
2. Remove clusterIPs if it exists when clone a service

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->