### PR TITLE
Handle `kubelet-arg` when defined in cluster's global configurations

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1661,6 +1661,8 @@ cluster:
   advanced:
     argInfo:
       title: Additional Kubelet Args
+      machineGlobal:
+        listLabel: Add Global Argument
       machineSelector:
         label: Add Machine Selector
         listLabel: Add Argument

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1675,7 +1675,7 @@ cluster:
         titleAlt:  |-
           {count, plural,
             =1 { For all machines, use the Kubelet args: }
-            other { For any machines, use the Kubelet args: }
+            other { For machines without matched labels below: }
           }
         kubeControllerManagerTitle: Additional Controller Manager Args
         kubeApiServerTitle: Additional API Server Args

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1662,8 +1662,8 @@ cluster:
     argInfo:
       title: Additional Kubelet Args
       tooltip:
-        mixed-args: Kubelet args are defined both at Global and Machine Selector level in the YAML.<br> Click on "Add Global Argument" to add them as Global config.
-        global-args: Kubelet args are defined at Global level in the YAML.<br> Click on "Add Global Argument" to add them as Global config.
+        mixed-args: Kubelet args are defined both at Global and Machine Selector level.<br> Click on "Add Global Argument" to add them as Global config.
+        global-args: Kubelet args are defined at Global level.<br> Click on "Add Global Argument" to add them as Global config.
       machineGlobal:
         listLabel: Add Global Argument
       machineSelector:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1661,6 +1661,9 @@ cluster:
   advanced:
     argInfo:
       title: Additional Kubelet Args
+      tooltip:
+        mixed-args: Kubelet args are defined both at Global and Machine Selector level in the YAML.<br> Click on "Add Global Argument" to add them as Global config.
+        global-args: Kubelet args are defined at Global level in the YAML.<br> Click on "Add Global Argument" to add them as Global config.
       machineGlobal:
         listLabel: Add Global Argument
       machineSelector:

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -317,14 +317,15 @@ export default {
         </div>
       </div>
     </template>
-    <div
-      v-else-if="mode==='view'"
-      class="text-muted"
-    >
-      &mdash;
-    </div>
     <div v-else>
-      <slot name="empty" />
+      <slot name="empty">
+        <div
+          v-if="mode==='view'"
+          class="text-muted"
+        >
+          &mdash;
+        </div>
+      </slot>
     </div>
     <div
       v-if="showAdd && !isView"

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jest/no-hooks */
 import { mount, Wrapper } from '@vue/test-utils';
 import Advanced from '@shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue';
-import { _YAML, _VIEW } from '@shell/config/query-params';
+import { _EDIT, _YAML, _VIEW } from '@shell/config/query-params';
 import { clone } from '@shell/utils/object';
 import { PROV_CLUSTER, VERSION_CLUSTER } from '@shell/edit/provisioning.cattle.io.cluster/__tests__/utils/cluster';
 
@@ -46,6 +46,23 @@ describe('component: Advanced', () => {
       const inputElem = wrapper.find('[data-testid="array-list-box0"]').element as HTMLElement;
 
       expect(inputElem).toBeUndefined();
+    });
+
+    it(`should support undefined machineSelectorConfig.config`, () => {
+      const value = clone(PROV_CLUSTER);
+
+      value.spec.rkeConfig.machineSelectorConfig[0].config = undefined;
+
+      mountOptions.propsData.value = value;
+
+      wrapper = mount(
+        Advanced,
+        mountOptions
+      );
+
+      const inputElem = wrapper.find('[data-testid="array-list-box0"]').element as HTMLElement;
+
+      expect(inputElem.textContent).toContain('—');
     });
 
     describe(`'protect-kernel-defaults'`, () => {
@@ -106,6 +123,153 @@ describe('component: Advanced', () => {
         const checkbox = wrapper.find('[data-testid="protect-kernel-defaults"]').find('[type="checkbox"]').element as HTMLInputElement;
 
         expect(checkbox.value).toBe('true');
+      });
+    });
+
+    describe(`'kubelet-arg'`, () => {
+      describe.each([
+        _VIEW,
+        _EDIT
+      ])(`mode: %s`, (mode) => {
+        it(`should show value from machineSelectorConfig only`, () => {
+          const value = clone(PROV_CLUSTER);
+
+          value.spec.rkeConfig.machineSelectorConfig[0].config['kubelet-arg'] = ['config-from-machineSelectorConfig'];
+
+          mountOptions.propsData.mode = mode;
+          mountOptions.propsData.value = value;
+
+          wrapper = mount(
+            Advanced,
+            mountOptions
+          );
+
+          const globalContainer = wrapper.find('[data-testid="global-kubelet-arg"]');
+          const selectorContainer = wrapper.find('[data-testid="selector-kubelet-arg"]');
+
+          const globalInputElem = globalContainer.element as HTMLInputElement;
+          const selectorInputElem = selectorContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+
+          expect(globalInputElem).toBeUndefined();
+          expect(selectorInputElem.value).toContain('config-from-machineSelectorConfig');
+        });
+
+        it(`should show value from machineGlobalConfig only`, () => {
+          const value = clone(PROV_CLUSTER);
+
+          value.spec.rkeConfig.machineGlobalConfig['kubelet-arg'] = ['config-from-machineGlobalConfig'];
+
+          mountOptions.propsData.mode = mode;
+          mountOptions.propsData.value = value;
+
+          wrapper = mount(
+            Advanced,
+            mountOptions
+          );
+
+          const globalContainer = wrapper.find('[data-testid="global-kubelet-arg"]');
+          const selectorContainer = wrapper.find('[data-testid="selector-kubelet-arg"]');
+
+          const selectorInputElem = selectorContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+          const globalInputElem = globalContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+
+          expect(selectorInputElem).toBeUndefined();
+          expect(globalInputElem.value).toContain('config-from-machineGlobalConfig');
+        });
+
+        it(`should show value from machineGlobalConfig and machineSelectorConfig`, () => {
+          const value = clone(PROV_CLUSTER);
+
+          value.spec.rkeConfig.machineSelectorConfig[0].config['kubelet-arg'] = ['config-from-machineSelectorConfig'];
+          value.spec.rkeConfig.machineGlobalConfig['kubelet-arg'] = ['config-from-machineGlobalConfig'];
+
+          mountOptions.propsData.mode = mode;
+          mountOptions.propsData.value = value;
+
+          wrapper = mount(
+            Advanced,
+            mountOptions
+          );
+
+          const globalContainer = wrapper.find('[data-testid="global-kubelet-arg"]');
+          const selectorContainer = wrapper.find('[data-testid="selector-kubelet-arg"]');
+
+          const selectorInputElem = selectorContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+          const globalInputElem = globalContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+
+          expect(selectorInputElem.value).toContain('config-from-machineSelectorConfig');
+          expect(globalInputElem.value).toContain('config-from-machineGlobalConfig');
+        });
+      });
+
+      it(`mode: edit, should show empty value'`, () => {
+        const value = clone(PROV_CLUSTER);
+
+        value.spec.rkeConfig.machineSelectorConfig[0].config['kubelet-arg'] = [];
+        value.spec.rkeConfig.machineGlobalConfig['kubelet-arg'] = [];
+
+        mountOptions.propsData.mode = 'view';
+        mountOptions.propsData.value = value;
+
+        wrapper = mount(
+          Advanced,
+          mountOptions
+        );
+
+        const globalContainer = wrapper.find('[data-testid="global-kubelet-arg"]');
+        const selectorContainer = wrapper.find('[data-testid="selector-kubelet-arg"]');
+
+        const selectorInputElem = selectorContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+        const globalInputElem = globalContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+
+        const emptyCharacter = wrapper.find('.info-box').find('.text-muted').element;
+
+        const globalAddButton = globalContainer.find('[data-testid="array-list-button"]').element;
+        const selectorAddButton = selectorContainer.find('[data-testid="array-list-button"]').element;
+
+        const removeButtonConfig = globalContainer.find('[data-testid="remove-item-0"]').element;
+
+        expect(selectorInputElem).toBeUndefined();
+        expect(globalInputElem).toBeUndefined();
+        expect(globalAddButton).toBeUndefined();
+        expect(selectorAddButton).toBeUndefined();
+        expect(emptyCharacter).toBeDefined();
+        expect(removeButtonConfig).toBeFalsy();
+      });
+
+      it(`mode: view, should show empty value'`, () => {
+        const value = clone(PROV_CLUSTER);
+
+        value.spec.rkeConfig.machineSelectorConfig[0].config['kubelet-arg'] = [];
+        value.spec.rkeConfig.machineGlobalConfig['kubelet-arg'] = [];
+
+        mountOptions.propsData.mode = 'edit';
+        mountOptions.propsData.value = value;
+
+        wrapper = mount(
+          Advanced,
+          mountOptions
+        );
+
+        const globalContainer = wrapper.find('[data-testid="global-kubelet-arg"]');
+        const selectorContainer = wrapper.find('[data-testid="selector-kubelet-arg"]');
+
+        const selectorInputElem = selectorContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+        const globalInputElem = globalContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+
+        const emptyCharacter = wrapper.find('.info-box').find('.text-muted').element;
+
+        const globalAddButton = globalContainer.find('[data-testid="array-list-button"]').element;
+        const selectorAddButton = selectorContainer.find('[data-testid="array-list-button"]').element;
+
+        const removeButtonConfig = globalContainer.find('[data-testid="remove-item-0"]').element;
+
+        expect(selectorInputElem).toBeUndefined();
+        expect(globalInputElem).toBeUndefined();
+        expect(globalAddButton).toBeDefined();
+        expect(selectorAddButton).toBeDefined();
+        expect(emptyCharacter).toBeUndefined();
+        expect(removeButtonConfig).toBeFalsy();
       });
     });
   });

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
@@ -170,7 +170,7 @@ describe('component: Advanced', () => {
           const globalContainer = wrapper.find('[data-testid="global-kubelet-arg"]');
           const selectorContainer = wrapper.find('[data-testid="selector-kubelet-arg"]');
 
-          const selectorInputElem = selectorContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
+          const selectorInputElem = selectorContainer.element as HTMLInputElement;
           const globalInputElem = globalContainer.find('[data-testid="input-0"]').element as HTMLInputElement;
 
           expect(selectorInputElem).toBeUndefined();

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -64,6 +64,13 @@ export default {
     },
     protectKernelDefaults() {
       return (this.agentConfig || this.serverConfig)['protect-kernel-defaults'];
+    },
+    kubeletArgTooltip() {
+      if (this.serverConfig?.['kubelet-arg']) {
+        return this.t(`cluster.advanced.argInfo.tooltip.${ this.agentConfig?.['kubelet-arg'] ? 'mixed-args' : 'global-args' }`, null, { raw: true });
+      }
+
+      return null;
     }
   },
 
@@ -108,6 +115,11 @@ export default {
           </template>
           <h3 v-else>
             {{ advancedTitleAlt }}
+            <i
+              v-if="kubeletArgTooltip"
+              v-clean-tooltip="kubeletArgTooltip"
+              class="icon icon-info"
+            />
           </h3>
 
           <ArrayList

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -1,5 +1,6 @@
 <script>
 import Vue from 'vue';
+import { _VIEW } from '@shell/config/query-params';
 import { Banner } from '@components/Banner';
 import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 import MatchExpressions from '@shell/components/form/MatchExpressions';
@@ -38,6 +39,9 @@ export default {
   },
 
   computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
     rkeConfig() {
       return this.value.spec.rkeConfig;
     },
@@ -136,7 +140,7 @@ export default {
           </ArrayList>
 
           <div
-            v-if="i === 0 && mode==='view' && showEmptyKubeletArg(row.value.config)"
+            v-if="i === 0 && isView && showEmptyKubeletArg(row.value.config)"
             class="text-muted"
           >
             &mdash;

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -136,7 +136,7 @@ export default {
           </ArrayList>
 
           <ArrayList
-            v-if="row.value.config && ((agentConfig || {})['kubelet-arg'] || !serverConfig['kubelet-arg'])"
+            v-if="row.value.config && (row.value.config['kubelet-arg'] || !serverConfig['kubelet-arg'])"
             v-model="row.value.config['kubelet-arg']"
             data-testid="selector-kubelet-arg"
             :mode="mode"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -124,7 +124,7 @@ export default {
           </ArrayList>
 
           <ArrayList
-            v-if="row.value.config"
+            v-if="row.value.config && (row.value.config['kubelet-arg'] || !serverConfig['kubelet-arg'])"
             v-model="row.value.config['kubelet-arg']"
             data-testid="selector-kubelet-arg"
             :mode="mode"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -136,7 +136,7 @@ export default {
           </ArrayList>
 
           <ArrayList
-            v-if="row.value.config && (row.value.config['kubelet-arg'] || !serverConfig['kubelet-arg'])"
+            v-if="row.value.config && ((agentConfig || {})['kubelet-arg'] || !serverConfig['kubelet-arg'])"
             v-model="row.value.config['kubelet-arg']"
             data-testid="selector-kubelet-arg"
             :mode="mode"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -194,7 +194,7 @@ export default {
      * Check if current CIS profile is required and listed in the options
      */
     isCisSupported() {
-      const cisProfile = this.serverConfig.profile || this.agentConfig.profile;
+      const cisProfile = this.serverConfig?.profile || this.agentConfig?.profile;
 
       return !cisProfile || this.profileOptions.map((option) => option.value).includes(cisProfile);
     },
@@ -458,7 +458,7 @@ export default {
         class="col span-6"
       >
         <LabeledSelect
-          v-if="serverArgs && serverArgs.profile"
+          v-if="serverArgs && serverArgs.profile && serverConfig"
           v-model="serverConfig.profile"
           :mode="mode"
           :options="profileOptions"
@@ -466,7 +466,7 @@ export default {
           @input="$emit('cis-changed')"
         />
         <LabeledSelect
-          v-else-if="agentArgs && agentArgs.profile"
+          v-else-if="agentArgs && agentArgs.profile && agentConfig"
           v-model="agentConfig.profile"
           data-testid="rke2-custom-edit-cis-agent"
           :mode="mode"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10045

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Rancher UI expects to find the `kubelet-arg` configuration in `spec.rkeConfig.machineSelectorConfig[0].config` where it can also be defined in `spec.rkeConfig.machineGlobalConfig`, see docs https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration#machineselectorconfig.

We are assuming the UI should take the kubelet-arg value from machineGlobalConfig when defined and display it in the same panel where it shows the kubelet-arg from machineSelectorConfig.

Use cases scenarios:

- Create:
    -  only `machineSelectorConfig` is used
- Edit / View:
    - in the case that ONLY machineSelectorConfig in the Yaml, UI can only add/modify kubelet-arg in machineSelectorConfig.
    - in the case that ONLY machineGlobalConfig is defined in the Yaml, UI can only add/modify kubelet-arg in machineGlobalConfig.
    - in the case that BOTH machineSelectorConfig and machineGlobalConfig are defined, the UI handles both and existing args will be updated from where they came from.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Save the `kubelet-arg` in machineGlobalConfig by manually edit and save cluster's YAML .
- Put the `kubelet-arg` in machineGlobalConfig by Terraform configs, sample file is attached below:

<details><summary>Terraform block</summary>
<p>

```

terraform {
 required_providers {
    rancher2 = {
    source = "rancher/rancher2"
    version = "3.2.0"
    }
  }
}

# Provider bootstrap config
provider "rancher2" {
 api_url = # your rancher url
 insecure = true
 access_key = # your access_key token
 secret_key = # your secret_key token
}

resource "rancher2_machine_config_v2" "rancher2_machine_config_v2" {
 generate_name   = "cfg-terraform"
 digitalocean_config {
  image  = "ubuntu-20-04-x64"
  region  = "nyc1"
  size   = "s-4vcpu-8gb"
 }
}

# Create a new rancher2 RKE2 Cluster
resource "rancher2_cluster_v2" "cfg-terraform" {
 name = "pr-10255-terraform"
 kubernetes_version = "v1.26.10+rke2r2"
 enable_network_policy = false
 default_cluster_role_for_project_members = "admin"
 rke_config {
  # machine_selector_config {
  #   machine_label_selector{
  #     match_labels = {
  #       "key" = "value"
  #     }
  #   }
  # }
  # machine_global_config = <<EOF
  #   kubelet-arg:
  #     - pippo
  # EOF
  machine_pools {
   name = "pool1"
   # this is important
   cloud_credential_secret_name = # DO cluster credentials
   control_plane_role = true
   etcd_role = true
   worker_role = true
   quantity = 1
   machine_config {
    kind = rancher2_machine_config_v2.rancher2_machine_config_v2.kind
    name = rancher2_machine_config_v2.rancher2_machine_config_v2.name
   }
  }
 }
}

```

</p>
</details> 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Yaml configs

![image](https://github.com/rancher/dashboard/assets/26394656/daab6079-0466-4f7e-8006-e331ea471282)

UI

![image](https://github.com/rancher/dashboard/assets/26394656/44b61e41-b0fd-4595-9aef-0f26833bcf4a)


