### PR TITLE
Fix Creation and Edit of Workload bases Resources

### DIFF
--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -654,14 +654,12 @@ export default class Workload extends WorkloadService {
     const val = super.cleanForSave(data);
 
     // remove fields from containers
-    if (val.spec?.template?.spec?.containers) {
-      val.spec?.template?.spec?.containers.forEach((container) => {
-        this.cleanContainerForSave(container);
-      });
-    }
+    val.spec?.template?.spec?.containers?.forEach((container) => {
+      this.cleanContainerForSave(container);
+    });
 
     // remove fields from initContainers
-    val.spec?.template?.spec?.initContainers.forEach((container) => {
+    val.spec?.template?.spec?.initContainers?.forEach((container) => {
       this.cleanContainerForSave(container);
     });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- There was a bug introduced via https://github.com/rancher/dashboard/pull/10037 that would cause workloads that did not contain init containers to fail on form save or create

### Occurred changes and/or fixed issues
- Ensure we safely check for existence of initContainer before accessing

### Technical notes summary
- Also removed if blocks in favour of `?`

### Areas or cases that should be tested
- Deployment Create/Edit via form
- Random other Workload types (not pods)