### PR TITLE
add retry logic for failing user creation network request

### DIFF
--- a/cypress/e2e/po/edit/management.cattle.io.user.po.ts
+++ b/cypress/e2e/po/edit/management.cattle.io.user.po.ts
@@ -57,19 +57,22 @@ export default class MgmtUserEditPo extends PagePo {
 
     this.saveCreateForm().click();
 
+    // Based on issue https://github.com/rancher/dashboard/issues/10260
     // main xhr request for user creation
     cy.wait('@userCreation').then(({ response }) => {
       if (response?.statusCode !== 201) {
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(1500); // eslint-disable-line cypress/no-unnecessary-waiting
 
         return this.saveCreateWithErrorRetry(++attempt);
       }
 
+      const userId = response.body?.id;
+
       // also covers globalrolebindings fail upon user creation
-      // https://github.com/rancher/dashboard/issues/10260
       cy.wait('@globalRoleBindingsCreation').then(({ response }) => {
         if (response?.statusCode !== 201) {
-          cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+          cy.deleteRancherResource('v3', 'users', userId); // we need to delete the user previously created
+          cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
 
           return this.saveCreateWithErrorRetry(++attempt);
         }

--- a/cypress/e2e/po/edit/management.cattle.io.user.po.ts
+++ b/cypress/e2e/po/edit/management.cattle.io.user.po.ts
@@ -3,7 +3,6 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import { CypressChainable } from '@/cypress/e2e/po/po.types';
-import BannersPo from '@/cypress/e2e/po/components/banners.po';
 
 export default class MgmtUserEditPo extends PagePo {
   private static createPath(clusterId: string, userId?: string ) {

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -175,8 +175,4 @@ export class WorkloadsCreatePageBasePo extends PagePo {
   createWithKubectl(blueprintJson: string | Object, wait = 6000) {
     this.workload().createWithKubectl(blueprintJson, wait);
   }
-
-  // waitForCreate() {
-  //   cy.interceptAny
-  // }
 }

--- a/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-project-members.spec.ts
@@ -22,7 +22,7 @@ describe('Cluster Project and Members', { tags: ['@explorer', '@adminUser'] }, (
     userCreate.username().set(username);
     userCreate.newPass().set(standardPassword);
     userCreate.confirmNewPass().set(standardPassword);
-    userCreate.saveCreateForm().click();
+    userCreate.saveCreateWithErrorRetry();
     usersAdmin.waitForPageWithExactUrl();
 
     // add user to Cluster membership

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -435,6 +435,7 @@ export default {
           v-for="(err, i) in errors"
           :key="i"
           color="error"
+          :data-testid="`error-banner${i}`"
           :label="stringify(mappedErrors[err].message)"
           :icon="mappedErrors[err].icon"
           :closable="true"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10260 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add retry logic for failing user creation network request

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
This is a video, with a couple of changes on the code in order to visualise the fix:

https://github.com/rancher/dashboard/assets/97888974/930a162d-7deb-4e82-8028-594d7282793d

