### PR TITLE
Restructure longhorn UI proxy link to contain dynamic namespace

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3066,6 +3066,7 @@ longhorn:
         label: 'Longhorn'
         description: 'Manage storage system via UI'
         na: Resource Unavailable
+        uiServiceUnavailable: The Longhorn UI service is not available or you do not have permission to access it.
 
 neuvector:
   overview:

--- a/shell/pages/c/_cluster/longhorn/__tests__/longhorn.index.test.ts
+++ b/shell/pages/c/_cluster/longhorn/__tests__/longhorn.index.test.ts
@@ -60,15 +60,14 @@ describe('page: LonghornOverview', () => {
     }
 
     const wrapper = createWrapper({
-      computed: {
-        currentCluster: () => ({ id: '_' }),
-        uiServices:     () => [longhornFrontend]
-      },
-      stubs: {
+      computed: { currentCluster: () => ({ id: '_' }) },
+      stubs:    {
         Banner:    { template: '<span />' },
         LazyImage: { template: '<span />' },
       }
     });
+
+    wrapper.setData({ uiServices: [longhornFrontend] });
 
     await wrapper.vm.$nextTick();
 

--- a/shell/pages/c/_cluster/longhorn/__tests__/longhorn.index.test.ts
+++ b/shell/pages/c/_cluster/longhorn/__tests__/longhorn.index.test.ts
@@ -1,0 +1,90 @@
+import { shallowMount } from '@vue/test-utils';
+
+import IconMessage from '@shell/components/IconMessage';
+import LonghornOverview from '@shell/pages/c/_cluster/longhorn/index.vue';
+
+const longhornFrontend = {
+  id:         'default/longhorn-frontend',
+  type:       'service',
+  apiVersion: 'v1',
+  kind:       'Service',
+  metadata:   {
+    labels:    { app: 'longhorn-ui' },
+    name:      'longhorn-frontend',
+    namespace: 'default',
+  }
+};
+
+describe('page: LonghornOverview', () => {
+  const commonMocks = {
+    $fetchState: { pending: false },
+    $store:      {
+      dispatch: () => jest.fn,
+      getters:  {
+        currentProduct:      () => 'cluster',
+        'cluster/findAll':   () => jest.fn(),
+        'cluster/schemaFor': () => jest.fn(),
+        'cluster/matching':  () => jest.fn(),
+        'i18n/t':            () => jest.fn(),
+      },
+    },
+  };
+
+  const createWrapper = (overrides?: any) => {
+    return shallowMount(LonghornOverview, {
+      mocks: commonMocks,
+      ...overrides,
+    });
+  };
+
+  it('initializes externalLinks as an empty array', () => {
+    const wrapper = createWrapper({
+      stubs: {
+        IconMessage: { template: '<span />' },
+        LazyImage:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.externalLinks).toStrictEqual([]);
+  });
+
+  it('populates externalLinks proxy link correctly when uiServices contain service', async() => {
+    const proxyUrl = `/k8s/clusters/_/api/v1/namespaces/${ longhornFrontend.metadata.namespace }/services/http:longhorn-frontend:80/proxy/`;
+
+    interface LinkConfig {
+      enabled: boolean;
+      iconSrc: string;
+      label: string;
+      description: string;
+      link: string;
+    }
+
+    const wrapper = createWrapper({
+      computed: {
+        currentCluster: () => ({ id: '_' }),
+        uiServices:     () => [longhornFrontend]
+      },
+      stubs: {
+        Banner:    { template: '<span />' },
+        LazyImage: { template: '<span />' },
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+
+    const containsProxyUrl = wrapper.vm.externalLinks.find((link: LinkConfig) => link.link);
+
+    expect(containsProxyUrl).toBeTruthy();
+    expect(containsProxyUrl.link).toStrictEqual(proxyUrl);
+  });
+
+  it('displays IconMessage when externalLinks array is empty', () => {
+    const wrapper = createWrapper({ stubs: { LazyImage: { template: '<span />' } } });
+
+    expect(wrapper.vm.externalLinks).toStrictEqual([]);
+
+    const iconMessage = wrapper.findComponent(IconMessage);
+
+    expect(iconMessage.exists()).toBe(true);
+  });
+});

--- a/shell/pages/c/_cluster/longhorn/index.vue
+++ b/shell/pages/c/_cluster/longhorn/index.vue
@@ -19,12 +19,18 @@ export default {
 
   async fetch() {
     if ( this.$store.getters['cluster/schemaFor'](SERVICE) ) {
-      await this.$store.dispatch('cluster/findAll', { type: SERVICE });
+      this.uiServices = await this.$store.dispatch('cluster/findMatching', {
+        type:     SERVICE,
+        selector: 'app=longhorn-ui'
+      });
     }
   },
 
   data() {
-    return { longhornImgSrc: require('~shell/assets/images/vendor/longhorn.svg') };
+    return {
+      longhornImgSrc: require('~shell/assets/images/vendor/longhorn.svg'),
+      uiServices:     null
+    };
   },
 
   computed: {
@@ -44,10 +50,6 @@ export default {
       }
 
       return [];
-    },
-
-    uiServices() {
-      return this.$store.getters['cluster/matching'](SERVICE, 'app=longhorn-ui');
     }
   }
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10259 
<!-- Define findings related to the feature or bug issue. -->
The Longhorn frontend UI would fail to load as the `namespace` was hard-coded to `longhorn-system`. Although setting this namespace is the [recommended approach](https://longhorn.io/docs/1.5.3/deploy/install/install-with-helm/#installing-longhorn) when installing Longhorn with Helm, users may still determine their own namespace.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This adds a computed property to find the Longhorn UI based on the label `app=longhorn-ui` which is defined in the [Longhorn Helm chart](https://github.com/rancher/charts/blob/38aed06f77002690b4857d84e79252bed828dc82/charts/longhorn/103.2.1%2Bup1.5.3/templates/deployment-ui.yaml#L16). 
If the service is found, the `externalLinks` will contain the correct namespace of this service in the `link` property.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I've also added a banner to display an error when no external links have been populated.


### Screenshot/Video

https://github.com/rancher/dashboard/assets/40806497/929e5993-c8c2-40d8-9792-1b96624590d0


