### PR TITLE
skip failing cluster events test

### DIFF
--- a/cypress/e2e/tests/pages/explorer/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-dashboard.spec.ts
@@ -140,7 +140,9 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
   const projName = `project${ +new Date() }`;
   const nsName = `namespace${ +new Date() }`;
 
-  it('can view events', () => {
+  // Note: This test fails due to https://github.com/rancher/dashboard/issues/10265
+  // skipping this tests until issue has been resolved
+  it.skip('can view events', () => {
     // Create a pod to trigger events
 
     // get user id


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Skipping cluster events test until this issue has been resolved https://github.com/rancher/dashboard/issues/10265 to avoid PR CI from failing and blocking merging of PRs.