### PR TITLE
Handle Cluster's snapshots pagination

### DIFF
--- a/cypress/e2e/blueprints/manager/cluster-snapshots.ts
+++ b/cypress/e2e/blueprints/manager/cluster-snapshots.ts
@@ -1,0 +1,25 @@
+export function snapshot(clusterId: string, id: string): object {
+  return {
+    annotations:  { 'lifecycle.cattle.io/create.etcdbackup-controller': 'true' },
+    backupConfig: {
+      enabled:        true,
+      intervalHours:  12,
+      retention:      6,
+      s3BackupConfig: null,
+      safeTimestamp:  false,
+      timeout:        300,
+      type:           '/v3/schemas/backupConfig'
+    },
+    baseType:    'etcdBackup',
+    clusterId,
+    created:     '2024-01-13T20:57:17Z',
+    createdTS:   1705179437000,
+    creatorId:   null,
+    filename:    `${ clusterId }-${ id }_2024-01-13T20:57:17Z.zip`,
+    id:          `${ clusterId }:${ clusterId }-${ id }`,
+    labels:      { 'cattle.io/creator': 'norman' },
+    manual:      true,
+    name:        `${ clusterId }-${ id }`,
+    namespaceId: null,
+  };
+}

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke1-custom.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke1-custom.po.ts
@@ -1,7 +1,7 @@
 import ClusterManagerDetailPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po';
 
 /**
- * Detail page for an RKE2 custom cluster
+ * Detail page for an RKE1 custom cluster
  */
 export default class ClusterManagerDetailRke1CustomPagePo extends ClusterManagerDetailPagePo {
 

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-snapshots.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-snapshots.po.ts
@@ -1,20 +1,6 @@
 import ClusterManagerDetailPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po';
-import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
-
-class SnapshotsListPo extends BaseResourceList {
-  name(snapshotName: string) {
-    return this.resourceTable().sortableTable().rowWithName(snapshotName).column(2);
-  }
-
-  selectAll() {
-    return this.self().find('[data-testid="sortable-table_check_select_all"]').find('.checkbox-container').click();
-  }
-
-  delete() {
-    return this.resourceTable().sortableTable().deleteButton().click();
-  }
-}
+import SnapshotsListPo from '@/cypress/e2e/po/lists/snapshots-list.po';
 
 /**
  * Covers core functionality of the dashboard's cluster snapshots details tab

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-snapshots.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-snapshots.po.ts
@@ -1,0 +1,38 @@
+import ClusterManagerDetailPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po';
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+
+class SnapshotsListPo extends BaseResourceList {
+  name(snapshotName: string) {
+    return this.resourceTable().sortableTable().rowWithName(snapshotName).column(2);
+  }
+
+  selectAll() {
+    return this.self().find('[data-testid="sortable-table_check_select_all"]').find('.checkbox-container').click();
+  }
+
+  delete() {
+    return this.resourceTable().sortableTable().deleteButton().click();
+  }
+}
+
+/**
+ * Covers core functionality of the dashboard's cluster snapshots details tab
+ */
+export default class ClusterManagerDetailSnapshotsPo extends ClusterManagerDetailPagePo {
+  goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo('', 'snapshots');
+  }
+
+  waitForPage(): Cypress.Chainable<string> {
+    return super.waitForPage('', 'snapshots');
+  }
+
+  create() {
+    return new AsyncButtonPo(this.self().get('[data-testid="search-box-filter-row"] > [data-testid="action-button-async-button"]')).click();
+  }
+
+  list() {
+    return new SnapshotsListPo(this.self().find('[data-testid="cluster-snapshots-list"]'));
+  }
+}

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -15,4 +15,8 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
   constructor(clusterName: string) {
     super(ClusterManagerDetailPagePo.createPath(clusterName));
   }
+
+  // waitForTabsVisible() {
+  //   return this.self().find('[data-testid="tabbed-block"]', { timeout: 50000 });
+  // }
 }

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -15,8 +15,4 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
   constructor(clusterName: string) {
     super(ClusterManagerDetailPagePo.createPath(clusterName));
   }
-
-  // waitForTabsVisible() {
-  //   return this.self().find('[data-testid="tabbed-block"]', { timeout: 50000 });
-  // }
 }

--- a/cypress/e2e/po/lists/snapshots-list.po.ts
+++ b/cypress/e2e/po/lists/snapshots-list.po.ts
@@ -1,0 +1,15 @@
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+
+export default class SnapshotsListPo extends BaseResourceList {
+  name(snapshotName: string) {
+    return this.resourceTable().sortableTable().rowWithName(snapshotName).column(2);
+  }
+
+  selectAll() {
+    return this.self().find('[data-testid="sortable-table_check_select_all"]').find('.checkbox-container').click();
+  }
+
+  delete() {
+    return this.resourceTable().sortableTable().deleteButton().click();
+  }
+}

--- a/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
@@ -23,6 +23,23 @@ export default class ClusterManagerListPagePo extends PagePo {
     BurgerMenuPo.burgerMenuNavToMenubyLabel('Cluster Management');
   }
 
+  goToAndGetClusterDetails(clusterName: string): Cypress.Chainable<{ id: string }> {
+    let clusterDetails = [];
+
+    cy.intercept({
+      method: 'GET',
+      path:   '/v3/clusters',
+    }, (req) => {
+      req.continue((res) => {
+        clusterDetails = res.body.data;
+      });
+    }).as('request');
+
+    super.goTo();
+
+    return cy.wait('@request', { timeout: 10000 }).then(() => clusterDetails.find((c) => c.name === clusterName));
+  }
+
   list(): ProvClusterListPo {
     return new ProvClusterListPo(this.self().find('[data-testid="cluster-list"]'));
   }

--- a/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
@@ -23,7 +23,7 @@ export default class ClusterManagerListPagePo extends PagePo {
     BurgerMenuPo.burgerMenuNavToMenubyLabel('Cluster Management');
   }
 
-  goToAndGetClusterDetails(clusterName: string): Cypress.Chainable<{ id: string }> {
+  goToClusterListAndGetClusterDetails(clusterName: string): Cypress.Chainable<{ id: string }> {
     let clusterDetails = [];
 
     cy.intercept({

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -15,6 +15,7 @@ import * as jsyaml from 'js-yaml';
 import ClusterManagerCreateRke1CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke1-custom.po';
 import Shell from '@/cypress/e2e/po/components/shell.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import { snapshot } from '@/cypress/e2e/blueprints/manager/cluster-snapshots';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
 const runTimestamp = +new Date();
@@ -244,31 +245,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       });
 
       it('can show snapshots list', () => {
-        const mockSnapshotData = (clusterId: string, id: string) => ({
-          annotations:  { 'lifecycle.cattle.io/create.etcdbackup-controller': 'true' },
-          backupConfig: {
-            enabled:        true,
-            intervalHours:  12,
-            retention:      6,
-            s3BackupConfig: null,
-            safeTimestamp:  false,
-            timeout:        300,
-            type:           '/v3/schemas/backupConfig'
-          },
-          baseType:    'etcdBackup',
-          clusterId,
-          created:     '2024-01-13T20:57:17Z',
-          createdTS:   1705179437000,
-          creatorId:   null,
-          filename:    `${ clusterId }-${ id }_2024-01-13T20:57:17Z.zip`,
-          id:          `${ clusterId }:${ clusterId }-${ id }`,
-          labels:      { 'cattle.io/creator': 'norman' },
-          manual:      true,
-          name:        `${ clusterId }-${ id }`,
-          namespaceId: null,
-        });
-
-        clusterList.goToAndGetClusterDetails(rke1CustomName).then((cluster) => {
+        clusterList.goToClusterListAndGetClusterDetails(rke1CustomName).then((cluster) => {
           const snapshots = new ClusterManagerDetailSnapshotsPo(cluster.id);
 
           // We want to show 2 elements in the snapshots tab
@@ -293,7 +270,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
               };
 
               res.body.data = [
-                mockSnapshotData(cluster.id, snapshotId1),
+                snapshot(cluster.id, snapshotId1),
               ];
             });
           });
@@ -305,7 +282,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           }, (req) => {
             req.continue((res) => {
               res.body.data = [
-                mockSnapshotData(cluster.id, snapshotId2),
+                snapshot(cluster.id, snapshotId2),
               ];
             });
           });

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -240,7 +240,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterList.sortableTable().rowElementWithName(rke1CustomName).should('exist');
       });
 
-      it('can create new snapshots', () => {
+      it.skip('can create new snapshots', () => {
         clusterList.goToAndGetClusterDetails(rke1CustomName).then((cluster) => {
           const snapshots = new ClusterManagerDetailSnapshotsPo(cluster.id);
 
@@ -259,7 +259,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         });
       });
 
-      it('can show snapshots list', () => {
+      it.skip('can show snapshots list', () => {
         clusterList.goToAndGetClusterDetails(rke1CustomName).then((cluster) => {
           const snapshots = new ClusterManagerDetailSnapshotsPo(cluster.id);
 
@@ -280,7 +280,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         });
       });
 
-      it('can delete snapshots', () => {
+      it.skip('can delete snapshots', () => {
         clusterList.goToAndGetClusterDetails(rke1CustomName).then((cluster) => {
           const snapshots = new ClusterManagerDetailSnapshotsPo(cluster.id);
 

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -7,6 +7,7 @@ import {
   MANAGEMENT,
   NAMESPACE,
   NORMAN,
+  SNAPSHOT,
   VIRTUAL_TYPES,
 } from '@shell/config/types';
 
@@ -162,6 +163,8 @@ export function init(store) {
   configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false, depaginate: true });
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });
   configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: true });
+  configureType(SNAPSHOT, { depaginate: true });
+  configureType(NORMAN.ETCD_BACKUP, { depaginate: true });
 
   configureType(EVENT, { limit: 500 });
   weightType(EVENT, -1, true);

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -4,7 +4,8 @@ import {
   CATALOG,
   NORMAN,
   HCI,
-  MANAGEMENT
+  MANAGEMENT,
+  SNAPSHOT
 } from '@shell/config/types';
 import { MULTI_CLUSTER, RKE1_UI } from '@shell/store/features';
 import { DSL } from '@shell/store/type-map';
@@ -59,6 +60,9 @@ export function init(store) {
     'cloud-credentials',
     'drivers',
   ]);
+
+  configureType(SNAPSHOT, { depaginate: true });
+  configureType(NORMAN.ETCD_BACKUP, { depaginate: true });
 
   configureType(CAPI.RANCHER_CLUSTER, {
     showListMasthead: false, namespaced: false, alias: [HCI.CLUSTER]

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -1006,6 +1006,7 @@ export default {
       >
         <SortableTable
           class="snapshots"
+          :data-testid="'cluster-snapshots-list'"
           :headers="value.isRke1 ? rke1SnapshotHeaders : rke2SnapshotHeaders"
           default-sort-by="age"
           :table-actions="value.isRke1"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/9642
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`v3/etcdbackups` results are limited to `1000`, meaning that the current UI excludes results from 1000 onwards.
This change will apply `depaginate` option to the snapshots query, where a new query is run until all results are retrieved.

snapshots e2e tests set the limit to 1 and prove that depaginate flag triggers a new request to fetch the remaining results

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->