### PR TITLE
Fix parse-tag-name script to use correct GITHUB_WORKFLOW_TYPE

### DIFF
--- a/.github/workflows/build-extension-catalog.yml
+++ b/.github/workflows/build-extension-catalog.yml
@@ -35,14 +35,6 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Parse Extension Name
-        if: github.ref_type == 'tag'
-        id: parsed-name
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          yarn parse-tag-name ${{ inputs.tagged_release }} ${{ github.run_id }} "catalog"
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -76,6 +68,14 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+
+      - name: Parse Extension Name
+        if: github.ref_type == 'tag'
+        id: parsed-name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          yarn parse-tag-name ${{ inputs.tagged_release }} ${{ github.run_id }} "catalog"
 
       - name: Build and push UI image
         run: |

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -37,14 +37,6 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Parse Extension Name
-        if: github.ref_type == 'tag'
-        id: parsed-name
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          yarn parse-tag-name ${{ inputs.tagged_release }} ${{ github.run_id }} "charts"
-
       - name: Setup Helm
         uses: azure/setup-helm@v3
         with:
@@ -71,6 +63,14 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+
+      - name: Parse Extension Name
+        if: github.ref_type == 'tag'
+        id: parsed-name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          yarn parse-tag-name ${{ inputs.tagged_release }} ${{ github.run_id }} "charts"
 
       - name: Run build script
         shell: bash

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -85,7 +85,7 @@ jobs:
           $publish
 
       - name: Upload charts artifact
-        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || (github.ref == 'refs/heads/main' && github.event_name != 'pull_request')
         uses: actions/upload-artifact@v3
         with:
           name: charts

--- a/shell/scripts/extension/parse-tag-name
+++ b/shell/scripts/extension/parse-tag-name
@@ -5,7 +5,7 @@ GITHUB_RUN_ID=$2
 GITHUB_WORKFLOW_TYPE=$3
 
 # Check packages for released tag name
-if [[ "${GITHUB_WORKFLOW_TYPE}" == "container" ]]; then
+if [[ "${GITHUB_WORKFLOW_TYPE}" == "charts" ]]; then
   for d in pkg/*/ ; do
     pkg=$(basename $d)
 


### PR DESCRIPTION
build-extension-charts.yml workflow passes "charts" as GITHUB_WORKFLOW_TYPE build-extension-catalog.yaml workflow passes "catalog" as GITHUB_WORKFLOW_TYPE

This change utilizes correct workflow types in the parse-tag-name script. For charts it checks against package.json in pkg and for catalog it checks against root package.json

Examples of failing workflows:
https://github.com/suse-edge/dashboard-extensions/actions/runs/7554197375
https://github.com/suse-edge/dashboard-extensions/actions/runs/7554197372
