### PR TITLE
Add missing routing segments or query parameters for cluster creation with RKE1/2

### DIFF
--- a/cypress/e2e/blueprints/manager/clusterProviderUrlCheck.ts
+++ b/cypress/e2e/blueprints/manager/clusterProviderUrlCheck.ts
@@ -1,0 +1,172 @@
+export const providersList = [
+  {
+    clusterProviderQueryParam: 'amazoneks',
+    label:                     'Amazon EKS',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke1'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'AKS',
+    label:                     'AKS',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke2'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'googlegke',
+    label:                     'Google GKE',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke1'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'amazonec2',
+    label:                     'Amazon EC2',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'azure',
+    label:                     'Azure',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'digitalocean',
+    label:                     'DigitalOcean',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'AKS',
+    label:                     'AKS',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke2'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'harvester',
+    label:                     'Harvester',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'linode',
+    label:                     'Linode',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'azure',
+    label:                     'Azure',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'vmwarevsphere',
+    label:                     'VMware vSphere',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2',
+        label:   'VMware vSphere',
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1',
+        label:   'vSphere',
+      },
+    ]
+  },
+  {
+    clusterProviderQueryParam: 'custom',
+    label:                     'Custom',
+    conditions:                [
+      {
+        rkeType: 'rke2',
+        loads:   'rke2'
+      },
+      {
+        rkeType: 'rke1',
+        loads:   'rke1'
+      },
+    ]
+  },
+];

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -4,11 +4,27 @@ import ClusterManagerCreateImportPagePo from '@/cypress/e2e/po/edit/provisioning
 /**
  * Covers core functionality that's common to the dashboard's create cluster pages
  */
-export default abstract class ClusterManagerCreatePagePo extends ClusterManagerCreateImportPagePo {
+export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImportPagePo {
   static url = '/c/local/manager/provisioning.cattle.io.cluster/create'
 
-  constructor() {
-    super(ClusterManagerCreatePagePo.url);
+  private static createPath(queryParams?: string) {
+    return `${ ClusterManagerCreatePagePo.url }${ queryParams ? `?${ queryParams }` : '' }`;
+  }
+
+  static goTo(queryParams?: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(ClusterManagerCreatePagePo.createPath(queryParams));
+  }
+
+  constructor(queryParams?: string) {
+    super(ClusterManagerCreatePagePo.createPath(queryParams));
+  }
+
+  rke1PageTitle(): Cypress.Chainable<string> {
+    return cy.iFrame().find('.header h1').invoke('text');
+  }
+
+  rke2PageTitle(): Cypress.Chainable<string> {
+    return this.self().find('.primaryheader h1').invoke('text');
   }
 
   rkeToggle() {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -1,5 +1,7 @@
 import { isMatch } from 'lodash';
 
+import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
+import { providersList } from '@/cypress/e2e/blueprints/manager/clusterProviderUrlCheck';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
 import ClusterManagerDetailRke2CustomPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-custom.po';
@@ -34,6 +36,24 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
   before(() => {
     cy.login();
+  });
+
+  describe('All providers', () => {
+    providersList.forEach((prov) => {
+      prov.conditions.forEach((condition) => {
+        it(`should be able to access cluster creation for provider ${ prov.label } with rke type ${ condition.rkeType } via url`, () => {
+          const clusterCreate = new ClusterManagerCreatePagePo();
+
+          clusterCreate.goTo(`type=${ prov.clusterProviderQueryParam }&rkeType=${ condition.rkeType }`);
+          clusterCreate.waitForPage();
+
+          const fnName = condition.loads === 'rke1' ? 'rke1PageTitle' : 'rke2PageTitle';
+          const evaluation = condition.loads === 'rke1' ? `Add Cluster - ${ condition.label ? condition.label : prov.label }` : `Create ${ condition.label ? condition.label : prov.label }`;
+
+          clusterCreate[fnName]().should('contain', evaluation);
+        });
+      });
+    });
   });
 
   describe('Created', () => {

--- a/shell/config/query-params.js
+++ b/shell/config/query-params.js
@@ -50,6 +50,7 @@ export const _SPLIT = 'split';
 
 // CruResource
 export const SUB_TYPE = 'type';
+export const RKE_TYPE = 'rkeType';
 
 // App launch
 export const REPO_TYPE = 'repo-type';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6299 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add query param `rkeType` to cluster creation url
- add logic to take into consideration `rkeType` query param when reading cluster provisioning create url
- replace some strings for consts in `edit/provisioning.cattle.io.cluster`
- add e2e test


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- enter the url `c/local/manager/provisioning.cattle.io.cluster/create?type=digitalocean&rkeType=rke1` and make sure it loads the ember interface
- enter the url `c/local/manager/provisioning.cattle.io.cluster/create?type=digitalocean&rkeType=rke2` and make sure it loads the vue interface


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->