### PR TITLE
Avoid duplicate / surplus requests to fetch mgmt clusters

### DIFF
--- a/shell/components/LandingPagePreference.vue
+++ b/shell/components/LandingPagePreference.vue
@@ -15,10 +15,7 @@ export default {
   },
 
   async fetch() {
-    this.clusters = await this.$store.dispatch('management/findAll', {
-      type: MANAGEMENT.CLUSTER,
-      opt:  { url: MANAGEMENT.CLUSTER }
-    });
+    this.clusters = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
   },
 
   data() {

--- a/shell/components/SingleClusterInfo.vue
+++ b/shell/components/SingleClusterInfo.vue
@@ -13,10 +13,7 @@ export default {
   },
 
   async fetch() {
-    this.clusters = await this.$store.dispatch('management/findAll', {
-      type: MANAGEMENT.CLUSTER,
-      opt:  { url: MANAGEMENT.CLUSTER }
-    });
+    this.clusters = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
   },
 
   data() {

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -15,7 +15,8 @@ export const _ALL_IF_AUTHED = 'allIfAuthed';
 export const _NONE = 'none';
 
 const SCHEMA_CHECK_RETRIES = 15;
-const SCHEMA_CHECK_RETRY_LOG = 10;
+const HAVE_ALL_CHECK_RETRIES = 15;
+const RETRY_LOG = 10;
 
 export async function handleSpoofedRequest(rootGetters, schemaStore, opt, product) {
   // Handle spoofed types instead of making an actual request
@@ -617,7 +618,7 @@ export default {
       schema = getters['schemaFor'](type);
 
       if (!schema) {
-        if (tries === SCHEMA_CHECK_RETRY_LOG) {
+        if (tries === RETRY_LOG) {
           console.warn(`Schema for ${ type } not available... retrying...`); // eslint-disable-line no-console
         }
         await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -629,6 +630,27 @@ export default {
       // Ran out of tries - fetch the schemas again
       console.warn(`Schema for ${ type } still unavailable... loading schemas again...`); // eslint-disable-line no-console
       await dispatch('loadSchemas', true);
+    }
+  },
+
+  async waitForHaveAll({ getters }, { type, throwError = false, attempts = HAVE_ALL_CHECK_RETRIES }) {
+    let tries = attempts;
+    let haveAll = null;
+
+    while (!haveAll && tries > 0) {
+      haveAll = getters['haveAll'](type);
+
+      if (!haveAll) {
+        if (tries === RETRY_LOG) {
+          console.warn(`wait for all of ${ type } continuing...`); // eslint-disable-line no-console
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        tries--;
+      }
+    }
+
+    if (tries === 0 && throwError) {
+      throw new Error(`Failed to wait for all of ${ type }`);
     }
   },
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -713,10 +713,7 @@ export const actions = {
 
     const promises = {
       // Clusters guaranteed always available or your money back
-      clusters: dispatch('management/findAll', {
-        type: MANAGEMENT.CLUSTER,
-        opt:  { url: MANAGEMENT.CLUSTER }
-      }),
+      clusters: dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }),
 
       // Features checks on its own if they are available
       features: dispatch('features/loadServer'),
@@ -886,6 +883,10 @@ export const actions = {
     // This is a workaround for a timing issue where the mgmt cluster schema may not be available
     // Try and wait until the schema exists before proceeding
     await dispatch('management/waitForSchema', { type: MANAGEMENT.CLUSTER });
+
+    // Similar to above, we're still waiting on loadManagement to fetch required resources
+    // If we don't have all mgmt clusters yet a request to fetch this cluster and then all clusters (in cleanNamespaces) is kicked off
+    await dispatch('management/waitForHaveAll', { type: MANAGEMENT.CLUSTER });
 
     // See if it really exists
     try {


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10285
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- loadManagement and loadCluster run in parallel
- both make requests to fetch mgmt clusters
- normally this is fine (loadManagement fetch finishes first, loadCluster requests then use that result)
- however in scenarios where there are a lot of clusters multiple requests are made
- we now wait for the loadManagmeent request to finish

Additionally
- make requests to correct (though harmless) url path (cluster --> clusters)

### Technical notes summary
In environments where the cluster request takes multiple seconds this will knock off about 2/3 of the time when reloading / navigating directly to a ds cluster

### Areas or cases that should be tested
- cluster load on ds cluster

