### PR TITLE
[2.7] AWS external cloud provider support

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1846,6 +1846,7 @@ cluster:
       header: Cloud Provider Config
       defaultValue:
         label: Default - RKE2 Embedded
+      unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
     security:
       header: Security
     cis:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1669,6 +1669,7 @@ cluster:
     haveArgInfo: Configuration information is not available for the selected Kubernetes version.  The options available in this screen will be limited, you may want to use the YAML editor.
     deprecatedPsp: Pod Security Policies are deprecated as of Kubernetes v1.21, and have been removed in Kubernetes v1.25.
     removedPsp: Pod Security Policies have been removed in Kubernetes v1.25, use Pod Security Admission instead.
+    cloudProviderAddConfig: 'On Kubernetes 1.27 or greater, the Amazon Cloud Provider requires additional configuration. See <a href="https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/kubernetes-clusters-in-rancher-setup/set-up-cloud-providers/amazon" target="_blank" rel="noopener noreferrer nofollow">the documentation</a> for more information.'
   rkeTemplateUpgrade: Template revision {name} available for upgrade
 
   availabilityWarnings:

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -245,6 +245,7 @@ export default {
       busy:                  false,
       machinePoolValidation: {}, // map of validation states for each machine pool
       allNamespaces:         [],
+      initialCloudProvider:  this.value?.agentConfig?.['cloud-provider-name'],
       extensionTabs:         getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
     };
   },
@@ -548,13 +549,53 @@ export default {
 
       const cur = this.agentConfig['cloud-provider-name'];
 
-      if ( cur && !out.find((x) => x.value === cur) ) {
-        out.unshift({ label: `${ cur } (Current)`, value: cur });
+      if (cur && !out.find((x) => x.value === cur)) {
+        // Localization missing
+        // Look up cur in the localization file
+        const label = this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ cur }".label`, null, cur);
+
+        out.unshift({
+          label:       `${ label } (Current)`,
+          value:       cur,
+          unsupported: true,
+          disabled:    true
+        });
+      }
+
+      const initial = this.initialCloudProvider;
+
+      if (cur !== initial && initial && !out.find((x) => x.value === initial)) {
+        const label = this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ initial }".label`, null, initial);
+
+        out.unshift({
+          label:       `${ label } (Current)`,
+          value:       initial,
+          unsupported: true,
+          disabled:    true
+        });
       }
 
       return out;
     },
 
+    unsupportedCloudProvider() {
+      // The current cloud provider
+      const cur = this.initialCloudProvider;
+
+      const provider = cur && this.cloudProviderOptions.find((x) => x.value === cur);
+
+      return !!provider?.unsupported;
+    },
+
+    canNotEditCloudProvider() {
+      const canNotEdit = this.clusterIsAlreadyCreated && !this.unsupportedCloudProvider;
+
+      return canNotEdit;
+    },
+
+    /**
+     * Kube Version
+     */
     selectedVersion() {
       const str = this.value.spec.kubernetesVersion;
 
@@ -1164,6 +1205,18 @@ export default {
         this.allPSAs = res.allPSAs || [];
         this.rke2Versions = res.rke2Versions.data || [];
         this.k3sVersions = res.k3sVersions.data || [];
+
+        // For testing ---------------------------------------------------------------------------------------------
+        // Fake a 1.27 version by copying the latest version (1.26) and remove the aws cloud provider from it
+        // const add = JSON.parse(JSON.stringify(this.rke2Versions[this.rke2Versions.length -1]));
+
+        // add.id = 'v1.27.0+rke2r1';
+        // add.version = add.id;
+        // add.agentArgs['cloud-provider-name'].options = add.agentArgs['cloud-provider-name'].options.filter((a) => a !== 'aws'); // Remove the aws cloud provider
+
+        // this.rke2Versions.push(add);
+
+        /// ^^^ End of code that should be removed ---------------------------------------------------------------------------------------
 
         if (!defaultRke2) {
           const rke2Channels = res.rke2Channels.data || [];
@@ -2226,6 +2279,18 @@ export default {
         if (this.isHarvesterDriver && this.mode === _CREATE && this.isHarvesterIncompatible) {
           this.setHarvesterDefaultCloudProvider();
         }
+
+        // Cloud Provider check
+        // If the cloud provider is unsupported, switch provider to 'external'
+        if (this.unsupportedCloudProvider) {
+          set(this.agentConfig, 'cloud-provider-name', 'external');
+        } else {
+          // Switch the cloud provider back to the initial value
+          // Use changed the Kubernetes version back to a version where the initial cloud provider is valid - so switch back to this one
+          // to undo the change to external that we may have made
+          // Note: Cloud Provider can only be changed on edit when the initial provider is no longer supported
+          set(this.agentConfig, 'cloud-provider-name', this.initialCloudProvider);
+        }
       }
     },
 
@@ -2444,7 +2509,7 @@ export default {
               <LabeledSelect
                 v-model="agentConfig['cloud-provider-name']"
                 :mode="mode"
-                :disabled="clusterIsAlreadyCreated"
+                :disabled="canNotEditCloudProvider"
                 :options="cloudProviderOptions"
                 :label="t('cluster.rke2.cloudProvider.label')"
               />
@@ -2485,6 +2550,12 @@ export default {
             <div class="spacer" />
 
             <div class="col span-12">
+              <Banner
+                v-if="unsupportedCloudProvider"
+                class="error mt-5"
+              >
+                {{ t('cluster.rke2.cloudProvider.unsupported') }}
+              </Banner>
               <h3>
                 {{ t('cluster.rke2.cloudProvider.header') }}
               </h3>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -594,6 +594,13 @@ export default {
     },
 
     /**
+     * Display warning about additional configuration needed for cloud provider Amazon if kube >= 1.27
+     */
+    showCloudProviderAmazonAdditionalConfigWarning() {
+      return !!semver.gte(this.value.spec.kubernetesVersion, 'v1.27.0') && this.agentConfig['cloud-provider-name'] === 'aws';
+    },
+
+    /**
      * Kube Version
      */
     selectedVersion() {
@@ -2473,6 +2480,12 @@ export default {
             <span
               v-clean-html="t('cluster.harvester.warning.cloudProvider.incompatible', null, true)"
             />
+          </Banner>
+          <Banner
+            v-if="showCloudProviderAmazonAdditionalConfigWarning"
+            color="warning"
+          >
+            <span v-clean-html="t('cluster.banner.cloudProviderAddConfig', {}, true)" />
           </Banner>
           <div class="row mb-10">
             <div class="col span-6">

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1206,18 +1206,6 @@ export default {
         this.rke2Versions = res.rke2Versions.data || [];
         this.k3sVersions = res.k3sVersions.data || [];
 
-        // For testing ---------------------------------------------------------------------------------------------
-        // Fake a 1.27 version by copying the latest version (1.26) and remove the aws cloud provider from it
-        // const add = JSON.parse(JSON.stringify(this.rke2Versions[this.rke2Versions.length -1]));
-
-        // add.id = 'v1.27.0+rke2r1';
-        // add.version = add.id;
-        // add.agentArgs['cloud-provider-name'].options = add.agentArgs['cloud-provider-name'].options.filter((a) => a !== 'aws'); // Remove the aws cloud provider
-
-        // this.rke2Versions.push(add);
-
-        /// ^^^ End of code that should be removed ---------------------------------------------------------------------------------------
-
         if (!defaultRke2) {
           const rke2Channels = res.rke2Channels.data || [];
 


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/10299
Fixes https://github.com/rancher/dashboard/issues/10266

This is a backport of https://github.com/rancher/dashboard/pull/9643 and https://github.com/rancher/dashboard/pull/9914

### Summary
UX for these issues changed from what was originally outlined in the above issues. The initial plan was to remove the aws cloud provider option for k8s versions >=1.27 (rke2 cloud provider options come from an api call, so no need to explicitly remove the option in the UI). Generalized UI code was added to handle the possibility that a user is upgrading a cluster with a cloud provider that is no longer supported. 

The plan for aws external cloud provider support changed, and new UX involves selecting the 'aws' cloud provider option then adding some extra configuration. #9914 adds a banner warning the user that they need to do this.

### Technical notes summary
Per offline conversations w/ Neil and Gary we're keeping the code from #9643 in our backports - though no longer relevant, it doesn't cause bugs.

### Areas or cases that should be tested
When upgrading a cluster using the aws cloud provider to >=1.27, a banner should appear warning the user that they will need to supply some extra configration for the external aws cloud provider. The same banner should appear when creating a new >=1.27 cluster with the aws cloud provider selected.

2.-7head doesn't have a k8s 1.27 option available yet. You fake a 1.27 version option for testing purposes by adding code [here](https://github.com/rancher/dashboard/blob/1c09fbd83dbc18de148487ef74c28175d5bd3455/shell/edit/provisioning.cattle.io.cluster/rke2.vue#L1215)

```
const add = JSON.parse(JSON.stringify(this.rke2Versions[this.rke2Versions.length -1]));
add.id = 'v1.27.0+rke2r1';
add.version = add.id;
this.rke2Versions.push(add);
 ```