### PR TITLE
Fix incorrect spec structure for cilium ipv6 configuration

### DIFF
--- a/cypress/e2e/po/components/checkbox-input.po.ts
+++ b/cypress/e2e/po/components/checkbox-input.po.ts
@@ -16,7 +16,7 @@ export default class CheckboxInputPo extends ComponentPo {
    * @returns
    */
   set(): Cypress.Chainable {
-    return this.input().click({ force: true });
+    return this.self().find('.checkbox-custom').click();
   }
 
   /**

--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -25,7 +25,9 @@ export default class LabeledSelectPo extends ComponentPo {
    * @returns
    */
   checkOptionSelected(label: string): Cypress.Chainable {
-    return this.self().should('contain.text', label);
+    return this.self().find('.vs__selected-options > span.vs__selected').should((elm) => {
+      expect(elm.text().trim()).to.equal(label);
+    });
   }
 
   /**

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
@@ -15,6 +15,10 @@ export default class ClusterManagerCreateRke2CustomPagePo extends ClusterManager
     return PagePo.goTo(`${ ClusterManagerCreatePagePo.url }?type=custom#basic`);
   }
 
+  goToDigitalOceanCreation(): Cypress.Chainable<Cypress.AUTWindow> {
+    return PagePo.goTo(`${ ClusterManagerCreatePagePo.url }?type=digitalocean#basic`);
+  }
+
   title(): Cypress.Chainable<string> {
     return this.self().find('.primaryheader h1').invoke('text');
   }

--- a/cypress/e2e/tests/pages/manager/cilium-ipv6.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cilium-ipv6.spec.ts
@@ -1,0 +1,96 @@
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import ClusterManagerCreateRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import CheckboxInputPo from '~/cypress/e2e/po/components/checkbox-input.po';
+
+const cloudCredentialsResponse = {
+  type:         'collection',
+  resourceType: 'cloudCredential',
+  data:         [
+    {
+      annotations:                  { 'provisioning.cattle.io/driver': 'digitalocean' },
+      baseType:                     'cloudCredential',
+      created:                      '2023-05-17T12:03:44Z',
+      createdTS:                    1684325024000,
+      creatorId:                    'user-8ajxt',
+      digitaloceancredentialConfig: {},
+      id:                           'cattle-global-data:cc-zzz2l',
+      labels:                       { 'cattle.io/creator': 'norman' },
+      name:                         'cypress-do',
+      type:                         'cloudCredential',
+      uuid:                         'abc6bb3f-0876-4e0f-8057-04d2cc8bdd17'
+    }
+  ]
+};
+
+// Simple helper for reply with a 200 status code
+function reply(statusCode: number, body: any): any {
+  return (req: any) => {
+    req.reply({
+      statusCode,
+      body
+    });
+  };
+}
+
+describe('RKE2 Cilium CNI IPV6', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('ipv6 configuration is sent correctly on cluster create', { tags: ['@manager', '@adminUser'] }, () => {
+    cy.intercept('GET', '/v3/cloudcredentials', reply(200, cloudCredentialsResponse)).as('cloudCredentials');
+
+    const clusterList = new ClusterManagerListPagePo('local');
+    const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
+    const clusterName = 'test-do-cilium';
+
+    clusterList.goTo();
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+
+    createRKE2ClusterPage.rkeToggle().set('RKE2/K3s');
+    createRKE2ClusterPage.goToDigitalOceanCreation();
+    createRKE2ClusterPage.waitForPage();
+    createRKE2ClusterPage.nameNsDescription().name().set(clusterName);
+
+    cy.wait('@cloudCredentials');
+
+    cy.intercept('POST', `/v1/rke-machine-config.cattle.io.digitaloceanconfigs/fleet-default`, reply(201, {})).as('dummyMachinePoolSave');
+    cy.intercept('POST', `/v1/provisioning.cattle.io.clusters`, reply(201, {})).as('dummyProvClusterSave');
+
+    const labeledSelectPo = new LabeledSelectPo('[data-testid="cluster-rke2-cni-select"]');
+
+    labeledSelectPo.checkExists();
+    labeledSelectPo.self().scrollIntoView();
+
+    labeledSelectPo.checkOptionSelected('calico');
+
+    const ipv6 = new CheckboxInputPo('[data-testid="cluster-rke2-cni-ipv6-checkbox"]');
+
+    ipv6.checkNotExists();
+
+    // Change to 'cilium'
+    labeledSelectPo.toggle();
+    labeledSelectPo.clickLabel('cilium');
+    labeledSelectPo.checkOptionSelected('cilium');
+    labeledSelectPo.isClosed();
+
+    // Check that the ipv6 checkbox shows up and is not selected
+    ipv6.checkExists();
+    ipv6.isUnchecked();
+
+    // Check the ipv6 checkbox to enable ipv6 support
+    ipv6.set();
+    ipv6.isChecked();
+
+    createRKE2ClusterPage.create();
+
+    cy.wait('@dummyMachinePoolSave');
+
+    // If we create the cluster now, check that the model is sent correctly for the new ipv6 format
+    cy.wait('@dummyProvClusterSave').then(({ request }) => {
+      expect(request.body.spec.rkeConfig.chartValues['rke2-cilium'].ipv6.enabled).to.equal(true);
+    });
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts
@@ -1,11 +1,18 @@
 import { mount } from '@vue/test-utils';
 import Basics from '@shell/edit/provisioning.cattle.io.cluster/tabs/Basics';
+import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 
 const defaultStubs = {
   Banner:        true,
   LabeledSelect: true,
   YamlEditor:    true,
   Checkbox:      true
+};
+
+const defaultCiliumStubs = {
+  Banner:        true,
+  LabeledSelect: true,
+  YamlEditor:    true,
 };
 
 const defaultComputed = {
@@ -65,6 +72,62 @@ const defaultSpec = {
   rkeConfig:   { etcd: { disableSnapshots: false }, machineGlobalConfig: { cni: 'calico' } },
   chartValues: {},
 };
+
+const defaultCiliumSpec = {
+  rkeConfig:   { etcd: { disableSnapshots: false }, machineGlobalConfig: { cni: 'cilium' } },
+  chartValues: {},
+};
+
+const legacyOnValue = { cilium: { ipv6: { enabled: true } } };
+const legacyOffValue = { cilium: { ipv6: { enabled: false } } };
+const newOnValue = { ipv6: { enabled: true } };
+const newOffValue = { ipv6: { enabled: false } };
+
+function createBasicsTab(version, userChartValues) {
+  const k8s = mockVersionOptions.find((v) => v.id === version) || mockVersionOptions[0];
+  const label = 'whatever';
+  const wrapper = mount(Basics, {
+    propsData: {
+      mode:  'create',
+      value: {
+        spec: {
+          ...defaultCiliumSpec,
+          defaultPodSecurityAdmissionConfigurationTemplateName: label,
+          kubernetesVersion:                                    k8s.value
+        },
+        agentConfig: { 'cloud-provider-name': '' },
+      },
+      addonVersions:               [],
+      provider:                    'custom',
+      userChartValues:             userChartValues || {},
+      cisOverride:                 false,
+      cisPsaChangeBanner:          true,
+      allPsas:                     [],
+      selectedVersion:             k8s,
+      versionOptions:              mockVersionOptions,
+      isHarvesterDriver:           false,
+      isHarvesterIncompatible:     false,
+      showDeprecatedPatchVersions: false,
+      clusterIsAlreadyCreated:     false,
+      isElementalCluster:          false,
+      hasPsaTemplates:             false,
+      isK3s:                       false,
+      haveArgInfo:                 false,
+      showCni:                     true,
+      showCloudProvider:           false,
+      unsupportedCloudProvider:    false,
+      cloudProviderOptions:        [{ label: 'Default - RKE2 Embedded', value: '' }],
+    },
+    computed: defaultComputed,
+    mocks:    {
+      ...defaultMocks,
+      $store: { getters: defaultGetters },
+    },
+    stubs: defaultCiliumStubs
+  });
+
+  return wrapper;
+}
 
 describe('component: Basics', () => {
   /**
@@ -224,5 +287,96 @@ describe('component: Basics', () => {
     const select = wrapper.find('[data-testid="rke2-custom-edit-psa"]');
 
     expect((select.vm as unknown as any).disabled).toBe(disabled);
+  });
+
+  describe('cilium CNI', () => {
+    it('should toggle ipv6 on/off with the legacy structure', async() => {
+      const wrapper = createBasicsTab('v1.23.0+rke2r1', {});
+      const ipv6Checkbox = wrapper.find('[data-testid="cluster-rke2-cni-ipv6-checkbox"]');
+
+      expect(ipv6Checkbox.exists()).toBe(true);
+      expect(ipv6Checkbox.isVisible()).toBe(true);
+
+      // Click the checkbox - should enable ipv6
+      await ipv6Checkbox.find('label').trigger('click');
+      await ipv6Checkbox.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      // Check and update user values with the emitted value
+      let latest = (wrapper.emitted()['cilium-ipv6-changed'] || [])[0][0];
+
+      expect(JSON.stringify(latest)).toStrictEqual(JSON.stringify(legacyOnValue));
+
+      await wrapper.setProps({ userChartValues: { 'rke2-cilium': latest } });
+
+      // Click the checkbox to turn ipv6 off again
+      await ipv6Checkbox.find('label').trigger('click');
+      await ipv6Checkbox.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      // Update from the emitted value
+      latest = (wrapper.emitted()['cilium-ipv6-changed'] || [])[1][0];
+
+      expect(JSON.stringify(latest)).toStrictEqual(JSON.stringify(legacyOffValue));
+    });
+
+    it('should toggle ipv6 on/off with the new structure', async() => {
+      const wrapper = createBasicsTab('v1.25.0+rke2r1', {});
+      const ipv6Checkbox = wrapper.find('[data-testid="cluster-rke2-cni-ipv6-checkbox"]');
+
+      expect(ipv6Checkbox.exists()).toBe(true);
+      expect(ipv6Checkbox.isVisible()).toBe(true);
+
+      // Click the checkbox - should enable ipv6
+      await ipv6Checkbox.find('label').trigger('click');
+      await ipv6Checkbox.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      // Check and update user values with the emitted value
+      let latest = (wrapper.emitted()['cilium-ipv6-changed'] || [])[0][0];
+
+      expect(JSON.stringify(latest)).toStrictEqual(JSON.stringify(newOnValue));
+
+      await wrapper.setProps({ userChartValues: { 'rke2-cilium': latest } });
+
+      // Click the checkbox to turn ipv6 off again
+      await ipv6Checkbox.find('label').trigger('click');
+      await ipv6Checkbox.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      // Update from the emitted value
+      latest = (wrapper.emitted()['cilium-ipv6-changed'] || [])[1][0];
+
+      expect(JSON.stringify(latest)).toStrictEqual(JSON.stringify(newOffValue));
+    });
+
+    it('should migrate when the k8s version is changed', async() => {
+      const userChartValues = { 'rke2-cilium': { ipv6: { enabled: true } } };
+      const wrapper = createBasicsTab('v1.25.0+rke2r1', userChartValues);
+
+      // Check that the checkbox is checked
+      const ipv6Checkbox = wrapper.find('[data-testid="cluster-rke2-cni-ipv6-checkbox"]') as Checkbox;
+
+      expect(ipv6Checkbox.exists()).toBe(true);
+      expect(ipv6Checkbox.isVisible()).toBe(true);
+      expect(ipv6Checkbox.vm.value).toBe(true);
+
+      // Change the kubernetes version that needs the legacy format
+      const k8s123 = mockVersionOptions.find((v) => v.id === 'v1.23.0+rke2r1');
+
+      await wrapper.setProps({ selectedVersion: k8s123 });
+
+      let latest = (wrapper.emitted()['cilium-ipv6-changed'] || [])[0][0];
+
+      expect(JSON.stringify(latest)).toStrictEqual(JSON.stringify(legacyOnValue));
+
+      // Change back the version so that the new format should be used
+      const k8s125 = mockVersionOptions.find((v) => v.id === 'v1.25.0+rke2r1');
+
+      await wrapper.setProps({ selectedVersion: k8s125 });
+
+      latest = (wrapper.emitted()['cilium-ipv6-changed'] || [])[1][0];
+      expect(JSON.stringify(latest)).toStrictEqual(JSON.stringify(newOnValue));
+    });
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/CustomCommand.test.ts
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import CustomCommand from '@shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
 });
+
 describe('component: CustomCommand', () => {
   const token = 'MY_TOKEN';
   const ip = 'MY_IP';
@@ -37,6 +39,8 @@ describe('component: CustomCommand', () => {
       taints:          [],
       worker:          true,
     }),
+
+    directives: { cleanHtmlDirective }
   });
 
   it('should return linux commands with the right flags based on cluster information', () => {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1857,7 +1857,7 @@ export default {
     /**
      * Handle k8s changes side effects, like PSA resets
      */
-    handleKubernetesChange(value) {
+    handleKubernetesChange(value, old) {
       if (value) {
         this.togglePsaDefault();
 
@@ -1896,22 +1896,17 @@ export default {
     handleEnabledSystemServicesChanged(val) {
       set(this.serverConfig, 'disable', val);
     },
+
     handleCiliumIpv6Changed(neu) {
+      if (neu === undefined) {
+        return;
+      }
+
       const name = this.chartVersionKey('rke2-cilium');
-      const values = this.userChartValues[name];
 
       set(this, 'userChartValues', {
         ...this.userChartValues,
-        [name]: {
-          ...values,
-          cilium: {
-            ...values?.cilium,
-            ipv6: {
-              ...values?.cilium?.ipv6,
-              enabled: neu
-            }
-          }
-        }
+        [name]: { ...neu }
       });
     },
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -113,6 +113,15 @@ export default {
     }
   },
 
+  watch: {
+    selectedVersion(neu, old) {
+      if (neu?.value !== old?.value && this.ciliumIpv6) {
+        // Re-assign so that the setter updates the structure for the new k8s version if needed
+        this.ciliumIpv6 = !!this.ciliumIpv6;
+      }
+    }
+  },
+
   computed: {
     ...mapGetters({ features: 'features/get' }),
 
@@ -289,10 +298,46 @@ export default {
         // eslint-disable-next-line no-unused-vars
         const cni = this.serverConfig.cni; // force this property to recalculate if cni was changed away from cilium and chartValues['rke-cilium'] deleted
 
-        return this.userChartValues[this.chartVersionKey('rke2-cilium')]?.cilium?.ipv6?.enabled || false;
+        const chart = this.userChartValues[this.chartVersionKey('rke2-cilium')];
+
+        return chart?.cilium?.ipv6?.enabled || chart?.ipv6?.enabled || false;
       },
-      set(val) {
-        this.$emit('cilium-ipv6-changed', val);
+      set(neu) {
+        const name = this.chartVersionKey('rke2-cilium');
+        const values = this.userChartValues[name];
+
+        // RKE2 older than 1.23.5 uses different Helm chart values structure - need to take that into account
+        const version = this.selectedVersion.value;
+        let ciliumValues = {};
+
+        if (semver.gt(version, '1.23.5')) {
+          // New style
+          ciliumValues = {
+            ...values,
+            ipv6: {
+              ...values?.ipv6,
+              enabled: neu
+            }
+          };
+
+          delete ciliumValues.cilium;
+        } else {
+          // Old style
+          ciliumValues = {
+            ...values,
+            cilium: {
+              ...values?.cilium,
+              ipv6: {
+                ...values?.cilium?.ipv6,
+                enabled: neu
+              }
+            }
+          };
+
+          delete ciliumValues.ipv6;
+        }
+
+        this.$emit('cilium-ipv6-changed', ciliumValues);
       }
     },
 
@@ -391,6 +436,7 @@ export default {
       <div class="col span-6">
         <LabeledSelect
           v-model="serverConfig.cni"
+          data-testid="cluster-rke2-cni-select"
           :mode="mode"
           :disabled="isEdit"
           :options="serverArgs.cni.options"
@@ -403,6 +449,7 @@ export default {
       >
         <Checkbox
           v-model="ciliumIpv6"
+          data-testid="cluster-rke2-cni-ipv6-checkbox"
           :mode="mode"
           :label="t('cluster.rke2.address.ipv6.enable')"
         />


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/10047

Supersedes https://github.com/rancher/dashboard/pull/10048

This PR fixes the IPv6 support for RKE2 + Cilium.

It ensures migration of the setting in the case that a 1.23 cluster is upgraded and it adds automated tests.

Notes:
- Changed the `Basics.vue` Tab component to take care of the structure and emit the change for the parent `rke2.vue` to update the model with.
- Renames two e2e test to `.test.st` from `.tests.ts` so that the typescript imports work correctly in vscode
- Updated checkbox and labeled select POs to make them more reliable
- Added a single e2e test that validates the changes made to `Basics.vue` that setting ipv6 is correctly wired into the request sent to create a cluster.
- Added unit tests to cover the various cases - focused on `Basics.vue` - ensuring that the correct structrue is used depending on if the k8s version > 1.23.5. Also checks that the settings are migrated back and forward when you change the k8s version