### PR TITLE
Backport 2.8: Prevent mutating yaml when a header isn't found

### DIFF
--- a/shell/utils/__tests__/create-yaml.test.ts
+++ b/shell/utils/__tests__/create-yaml.test.ts
@@ -98,4 +98,26 @@ skipGeometric=true`
 
     expect(result).toStrictEqual(expectedResult);
   });
+
+  it('should not attempt to replace indicators when a header cannot be found', () => {
+    const data = {
+      a: 'a\nb\tc',
+      b: 'a\nb\tc',
+      c: `a
+b c`
+    };
+
+    const expectedResult = `a: "a\\nb\\tc"\nb: "a\\nb\\tc"\nc: |+\n  a\n  b c\n`;
+
+    const yamlModifiers = {
+      lineWidth: -1,
+      a:         { chomping: '+' },
+      b:         { chomping: '+' },
+      c:         { chomping: '+' },
+    };
+
+    const result = dumpBlock(data, yamlModifiers);
+
+    expect(result).toStrictEqual(expectedResult);
+  });
 });

--- a/shell/utils/create-yaml.js
+++ b/shell/utils/create-yaml.js
@@ -473,7 +473,9 @@ export function dumpBlock(data, options = {}) {
       /**
        * Replace the original block indicators with the ones provided in the options param
        */
-      out = out.replace(header, `${ key }: ${ scalarStyle }${ chomping }${ indentation }`);
+      if (header) {
+        out = out.replace(header, `${ key }: ${ scalarStyle }${ chomping }${ indentation }`);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10310
backports #10168

This prevents `dumpBlock()` from mutating parsed yaml when a header can't be located. More investigation might be warranted to discover why the regex used by `getBlockHeader()` isn't matching the keys when parsing the example yaml:

```
 apiVersion: v1
data:
  a: "a\nb\tc"
  b: "a\nb\tc"
kind: ConfigMap
metadata:
  name: yaml-tab-test
```

but the crux of the issue still comes down to the fact that `dumpBlock()` will indiscriminately mutate yaml output when a key can't be located; it's important that this behavior is corrected.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Stop mutating parsed yaml if the header can't be located.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Follow the repro steps left in comments on the issue:

https://github.com/rancher/dashboard/issues/9841#issuecomment-1745771047

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Any yaml editor used throughout Rancher Desktop, but I doubt there are scenarios where it would ever be valid to attempt a replace when the header is an empty string.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->