### PR TITLE
Allow extensions to override node provider icons

### DIFF
--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -264,11 +264,12 @@ export class Plugin implements IPlugin {
   }
 
   public register(type: string, name: string, fn: Function) {
+    const allowPaths = ['models', 'image'];
     const nparts = name.split('/');
 
     // Support components in a sub-folder - component_name/index.vue (and ignore other componnets in that folder)
     // Allow store-scoped models via sub-folder - pkgname/models/storename/type will be registered as storename/type to avoid overwriting shell/models/type
-    if (nparts.length === 2 && type !== 'models') {
+    if (nparts.length === 2 && !allowPaths.includes(type)) {
       if (nparts[1] !== 'index') {
         return;
       }

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -309,14 +309,14 @@ export default {
 
       this.kontainerDrivers.filter((x) => (isImport ? x.showImport : x.showCreate)).forEach((obj) => {
         if ( vueKontainerTypes.includes(obj.driverName) ) {
-          addType(obj.driverName, 'kontainer', false);
+          addType(this.$plugin, obj.driverName, 'kontainer', false);
         } else {
-          addType(obj.driverName, 'kontainer', false, (isImport ? obj.emberImportPath : obj.emberCreatePath));
+          addType(this.$plugin, obj.driverName, 'kontainer', false, (isImport ? obj.emberImportPath : obj.emberCreatePath));
         }
       });
 
       if ( isImport ) {
-        addType('import', 'custom', false);
+        addType(this.$plugin, 'import', 'custom', false);
       } else {
         templates.forEach((chart) => {
           out.push({
@@ -333,21 +333,21 @@ export default {
           machineTypes.forEach((type) => {
             const id = type.spec.displayName || type.id;
 
-            addType(id, _RKE1, false, `/g/clusters/add/launch/${ id }`, this.iconClasses[id], type);
+            addType(this.$plugin, id, _RKE1, false, `/g/clusters/add/launch/${ id }`, this.iconClasses[id]);
           });
 
-          addType('custom', 'custom1', false, '/g/clusters/add/launch/custom');
+          addType(this.$plugin, 'custom', 'custom1', false, '/g/clusters/add/launch/custom');
         } else {
           machineTypes.forEach((type) => {
             const id = type.spec.displayName || type.id;
 
-            addType(id, _RKE2, false, null, undefined, type);
+            addType(this.$plugin, id, _RKE2, false);
           });
 
-          addType('custom', 'custom2', false);
+          addType(this.$plugin, 'custom', 'custom2', false);
 
           if (isElementalActive) {
-            addType(ELEMENTAL_CLUSTER_PROVIDER, 'custom2', false);
+            addType(this.$plugin, ELEMENTAL_CLUSTER_PROVIDER, 'custom2', false);
           }
         }
 
@@ -396,16 +396,21 @@ export default {
         out.push(subtype);
       }
 
-      function addType(id, group, disabled = false, emberLink = null, iconClass = undefined, providerConfig = undefined) {
+      function addType(plugin, id, group, disabled = false, emberLink = null, iconClass = undefined, providerConfig = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
         const tag = '';
 
-        let icon;
+        // Look at extensions first
+        // An extension can override the icon for a provider with
+        // plugin.register('image', 'providers/openstack.svg', require('~shell/assets/images/providers/exoscale.svg'));
+        let icon = plugin.getDynamic('image', `providers/${ id }.svg`);
 
-        try {
-          icon = require(`~shell/assets/images/providers/${ id }.svg`);
-        } catch (e) {}
+        if (!icon) {
+          try {
+            icon = require(`~shell/assets/images/providers/${ id }.svg`);
+          } catch (e) {}
+        }
 
         if (icon) {
           iconClass = undefined;

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -333,7 +333,7 @@ export default {
           machineTypes.forEach((type) => {
             const id = type.spec.displayName || type.id;
 
-            addType(this.$plugin, id, _RKE1, false, `/g/clusters/add/launch/${ id }`, this.iconClasses[id]);
+            addType(this.$plugin, id, _RKE1, false, `/g/clusters/add/launch/${ id }`, this.iconClasses[id], type);
           });
 
           addType(this.$plugin, 'custom', 'custom1', false, '/g/clusters/add/launch/custom');
@@ -341,7 +341,7 @@ export default {
           machineTypes.forEach((type) => {
             const id = type.spec.displayName || type.id;
 
-            addType(this.$plugin, id, _RKE2, false);
+            addType(this.$plugin, id, _RKE2, false, null, undefined, type);
           });
 
           addType(this.$plugin, 'custom', 'custom2', false);


### PR DESCRIPTION
Fixes #10148

This PR allows extensions to override the icons for node providers.

This introduces the ability to override via: 

```
plugin.register('image', 'providers/openstack.svg', require('~shell/assets/images/providers/exoscale.svg'));
```

This has been tested by dev.

For QA, test when you go to the cluster creation screen, that the icons display correctly, e.g.:

![image](https://github.com/rancher/dashboard/assets/1955897/88816b5e-f408-492c-90de-3c846b86591b)

Toggle between RKE1 and RKE2 and check the icons for both are okay and that there are no broken icons.

Note: The fix is quite simple, the main change in `shell/core/plugin.ts` is to allow both `models` and `images` to contain the `/` character in their names - currently only `models` do - for the other resources, the `/` is used differently.
