### PR TITLE
Show specific providers when creating RKE2 cluster in OVH

### DIFF
--- a/shell/store/plugins.js
+++ b/shell/store/plugins.js
@@ -100,12 +100,13 @@ export const suffixFields = [
 
 // Machine driver to cloud provider mapping
 const driverToCloudProviderMap = {
-  amazonec2:     'aws',
-  azure:         'azure',
-  digitalocean:  '', // Show restricted options
-  harvester:     'harvester',
-  linode:        '', // Show restricted options
-  vmwarevsphere: 'rancher-vsphere',
+  amazonec2:           'aws',
+  azure:               'azure',
+  digitalocean:        '', // Show restricted options
+  harvester:           'harvester',
+  linode:              '', // Show restricted options
+  vmwarevsphere:       'rancher-vsphere',
+  ovhcloudpubliccloud: '',
 
   custom: undefined // Show all options
 };


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When creating a custom node driver for OVHCloud, the UI shows all possible choices for cloud providers, including `aws` , `azure`, etc.

In order to restrict the choice to only, `rke2-embedded` and `external`, an entry to the map `driverToCloudProvider`, with an an empty string as a value, has to be added for `ovhcloudpubliccloud` key.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Only change is adding an `ovhcloudpubliccloud` entry to a hard-coded map.

### Technical notes summary


### Areas or cases that should be tested
- Check that when creating a node driver cluster using the UI, the traditional node drivers show the usual values in the list `Cloud Providers`
- Check that when creating an `ovhcloudpubliccloud` node driver cluster, the choice list is only `rke2-embedded` or `external` .

### Areas which could experience regressions
Probably node.

