### PR TITLE
Allow cluster provisioning extensions to define cluster-importing support

### DIFF
--- a/cypress/e2e/blueprints/manager/clusterProviderUrlCheck.ts
+++ b/cypress/e2e/blueprints/manager/clusterProviderUrlCheck.ts
@@ -14,8 +14,8 @@ export const providersList = [
     ]
   },
   {
-    clusterProviderQueryParam: 'AKS',
-    label:                     'AKS',
+    clusterProviderQueryParam: 'azureaks',
+    label:                     'Azure AKS',
     conditions:                [
       {
         rkeType: 'rke2',
@@ -84,8 +84,8 @@ export const providersList = [
     ]
   },
   {
-    clusterProviderQueryParam: 'AKS',
-    label:                     'AKS',
+    clusterProviderQueryParam: 'azureaks',
+    label:                     'Azure AKS',
     conditions:                [
       {
         rkeType: 'rke2',

--- a/pkg/aks/provisioner.ts
+++ b/pkg/aks/provisioner.ts
@@ -4,7 +4,7 @@ import { mapDriver } from '@shell/store/plugins';
 import { Component } from 'vue/types/umd';
 
 export class AKSProvisioner implements IClusterProvisioner {
-  static ID = 'AKS'
+  static ID = 'azureaks'
 
   constructor(private context: ClusterProvisionerContext) {
     mapDriver(this.id, 'azure' );

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -115,6 +115,12 @@ export interface IClusterProvisioner {
    */
   tag?: string;
 
+  /**
+   * Also show the provider card in the cluster importing flow
+   * If not set, the card will only be shown in the cluster creation page
+   */
+  showImport?: boolean
+
   /* --------------------------------------------------------------------------------------
    * Custer Details View
    * --------------------------------------------------------------------------------------- */

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -60,6 +60,7 @@ export interface IClusterProvisioner {
 
   /**
    * Unique ID of the Cluster Provisioner
+   * If this overlaps with the name of an existing provisioner (seen in the type query param while creating a cluster) this provisioner will overwrite the built-in ui
    */
   id: string;
 

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -301,7 +301,7 @@ export default {
       const getters = this.$store.getters;
       const isImport = this.isImport;
       const isElementalActive = !!this.activeProducts.find((item) => item.name === ELEMENTAL_PRODUCT_NAME);
-      const out = [];
+      let out = [];
 
       const templates = this.templateOptions;
       const vueKontainerTypes = getters['plugins/clusterDrivers'];
@@ -348,12 +348,18 @@ export default {
         }
 
         // Add from extensions
-        // if th rke toggle is set to rke1, don't add extensions that specify rke2 group
-        // default group is rke2
         this.extensions.forEach((ext) => {
+          // if the rke toggle is set to rke1, don't add extensions that specify rke2 group
+          // default group is rke2
           if (!this.isRke2 && (ext.group === _RKE2 || !ext.group)) {
             return;
           }
+          // Do not show the extension provisioner on the import cluster page unless its explicitly set to do so
+          if (isImport && !ext.showImport) {
+            return;
+          }
+          // Allow extensions to overwrite provisioners with the same id
+          out = out.filter((type) => type.id !== ext.id);
           addExtensionType(ext, getters);
         });
       }

--- a/shell/models/management.cattle.io.kontainerdriver.js
+++ b/shell/models/management.cattle.io.kontainerdriver.js
@@ -1,6 +1,5 @@
 import HybridModel from '@shell/plugins/steve/hybrid-class';
 
-// const HIDDEN = ['rke', 'rancherkubernetesengine', 'azureaks'];
 const HIDDEN = ['rke', 'rancherkubernetesengine'];
 
 const V2 = ['amazoneks', 'googlegke', 'azureaks'];

--- a/shell/models/management.cattle.io.kontainerdriver.js
+++ b/shell/models/management.cattle.io.kontainerdriver.js
@@ -1,6 +1,8 @@
 import HybridModel from '@shell/plugins/steve/hybrid-class';
 
-const HIDDEN = ['rke', 'rancherkubernetesengine', 'azureaks'];
+// const HIDDEN = ['rke', 'rancherkubernetesengine', 'azureaks'];
+const HIDDEN = ['rke', 'rancherkubernetesengine'];
+
 const V2 = ['amazoneks', 'googlegke', 'azureaks'];
 const IMPORTABLE = ['amazoneks', 'googlegke', 'azureaks'];
 


### PR DESCRIPTION
### Summary
Fixes #10302
This PR expands provisioning extension functionality to allow them to:
* overwrite existing node/machine/kontainer driver UI
* define support for importing clusters, with the default being that they do not

Previously the AKS provisioning extension replaced the old UI by marking the AKS kontainer driver as 'hidden' - this update allows prov extensions to replace builtin ui without further updating dashboard code.

I'm not confident that the way extensions may overwrite existing UI is clear enough: In this context the subtype `id` that needs to line up doesn't necessarily map to a driver resource's `id` as you might expect; kontainer drivers have this hard-coded mapping to align with Ember urls: https://github.com/rancher/dashboard/blob/871d059043c5a4b42c085ff944a53ecc0763e2b6/shell/models/management.cattle.io.kontainerdriver.js#L10-L31