### PR TITLE
show registration tab only on hosted providers with private endpoint/network

### DIFF
--- a/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -1,0 +1,77 @@
+import { shallowMount } from '@vue/test-utils';
+import ProvisioningCattleIoCluster from '@shell/detail/provisioning.cattle.io.cluster.vue';
+
+jest.mock('@shell/utils/clipboard', () => {
+  return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
+});
+
+describe('view: provisioning.cattle.io.cluster', () => {
+  const mockStore = {
+    getters: {
+      'management/canList':      () => true,
+      'management/schemaFor':    jest.fn(),
+      'i18n/t':                  (text: string) => text,
+      t:                         (text: string) => text,
+      currentStore:              () => 'current_store',
+      'current_store/schemaFor': jest.fn(),
+      'current_store/all':       jest.fn(),
+      workspace:                 jest.fn(),
+    },
+  };
+
+  const mocks = {
+    $store:      mockStore,
+    $fetchState: { pending: false },
+    $route:      {
+      query: { AS: '' },
+      name:  {
+        endsWith: () => {
+          return false;
+        },
+      },
+    },
+  };
+
+  describe('registration tab visibility', () => {
+    it('a hosted Kubernetes Provider with a private endpoint (network config) and cluster not ready should SHOW the registration tab', async() => {
+      const value = {
+        isHostedKubernetesProvider: true,
+        isPrivateHostedProvider:    true,
+        mgmt:                       {
+          hasLink: () => jest.fn(),
+          linkFor: () => '',
+          isReady: false
+        }
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        mocks,
+        propsData: { value },
+      });
+
+      await wrapper.setData({ clusterToken: {} });
+
+      expect(wrapper.vm.showRegistration).toStrictEqual(true);
+    });
+
+    it('a hosted Kubernetes Provider WITHOUT a private endpoint (network config) and cluster not ready should NOT SHOW the registration tab', async() => {
+      const value = {
+        isHostedKubernetesProvider: true,
+        mgmt:                       {
+          hasLink: () => jest.fn(),
+          linkFor: () => '',
+          isReady: false
+        }
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        mocks,
+        propsData: { value },
+      });
+
+      await wrapper.setData({ clusterToken: {} });
+
+      expect(wrapper.vm.showRegistration).toStrictEqual(false);
+    });
+  });
+});

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -519,7 +519,10 @@ export default {
         return this.extDetailTabs.registration;
       }
 
-      if ( this.value.isHostedKubernetesProvider && !this.isClusterReady ) {
+      // Hosted kubernetes providers with private endpoints need the registration tab
+      // https://github.com/rancher/dashboard/issues/6036
+      // https://github.com/rancher/dashboard/issues/4545
+      if ( this.value.isHostedKubernetesProvider && this.value.isPrivateHostedProvider && !this.isClusterReady ) {
         return this.extDetailTabs.registration;
       }
 
@@ -552,6 +555,18 @@ export default {
 
     snapshotsGroupBy() {
       return 'backupLocation';
+    },
+
+    extDetailTabsRelated() {
+      return this.extDetailTabs?.related;
+    },
+
+    extDetailTabsEvents() {
+      return this.extDetailTabs?.events;
+    },
+
+    extDetailTabsConditions() {
+      return this.extDetailTabs?.conditions;
     }
   },
 
@@ -725,9 +740,9 @@ export default {
       :default-tab="defaultTab"
       :need-related="hasLocalAccess"
       :extension-params="extCustomParams"
-      :needRelated="extDetailTabs.related"
-      :needEvents="extDetailTabs.events"
-      :needConditions="extDetailTabs.conditions"
+      :needRelated="extDetailTabsRelated"
+      :needEvents="extDetailTabsEvents"
+      :needConditions="extDetailTabsConditions"
     >
       <Tab
         v-if="showMachines"

--- a/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -26,6 +26,56 @@ describe('class ProvCluster', () => {
     clusterName: 'test', provisioner: 'rke2', mgmt: { isLocal: false, providerForEmberParam: 'import' }, spec: { rkeConfig: {} }
   };
 
+  const gkeClusterWithPrivateEndpoint = {
+    clusterName: 'test',
+    provisioner: 'GKE',
+    spec:        { rkeConfig: {} },
+    mgmt:        { spec: { gkeConfig: { privateClusterConfig: { enablePrivateEndpoint: true } } } }
+  };
+
+  const eksClusterWithPrivateEndpoint = {
+    clusterName: 'test',
+    provisioner: 'EKS',
+    spec:        { rkeConfig: {} },
+    mgmt:        { spec: { eksConfig: { privateAccess: true } } }
+  };
+
+  const aksClusterWithPrivateEndpoint = {
+    clusterName: 'test',
+    provisioner: 'AKS',
+    spec:        { rkeConfig: {} },
+    mgmt:        { spec: { aksConfig: { privateCluster: true } } }
+  };
+
+  // Related to https://github.com/rancher/dashboard/issues/9402
+  describe('isHostedKubernetesProvider + isPrivateHostedProvider', () => {
+    const testCases = [
+      [gkeClusterWithPrivateEndpoint, true],
+      [eksClusterWithPrivateEndpoint, true],
+      [aksClusterWithPrivateEndpoint, true],
+    ];
+    const resetMocks = () => {
+      // Clear all mock function calls:
+      jest.clearAllMocks();
+    };
+
+    it.each(testCases)('should return the isHostedKubernetesProvider and isPrivateHostedProvider values properly based on the props data', (clusterData: Object, expected: Boolean) => {
+      const cluster = new ProvCluster({ spec: clusterData.spec });
+
+      jest.spyOn(cluster, 'mgmt', 'get').mockReturnValue(
+        clusterData.mgmt
+      );
+      jest.spyOn(cluster, 'provisioner', 'get').mockReturnValue(
+        clusterData.provisioner
+      );
+
+      expect(cluster.isRke2).toBe(expected);
+      expect(cluster.isHostedKubernetesProvider).toBe(expected);
+      expect(cluster.isPrivateHostedProvider).toBe(expected);
+      resetMocks();
+    });
+  });
+
   describe('isImported', () => {
     const testCases = [
       [importedClusterInfo, true],
@@ -84,7 +134,6 @@ describe('class ProvCluster', () => {
 
       expect(cluster.mgmt).toBe(expected);
       resetMocks();
-    }
-    );
+    });
   });
 });

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -249,6 +249,25 @@ export default class ProvCluster extends SteveModel {
     return providers.includes(this.provisioner);
   }
 
+  get isPrivateHostedProvider() {
+    if (this.isHostedKubernetesProvider && this.mgmt) {
+      const provisionerSmallCase = this.provisioner ? this.provisioner.toLowerCase() : '';
+
+      switch (provisionerSmallCase) {
+      case 'gke':
+        return this.mgmt.spec?.gkeConfig?.privateClusterConfig?.enablePrivateEndpoint;
+      case 'eks':
+        return this.mgmt.spec?.eksConfig?.privateAccess;
+      case 'aks':
+        return this.mgmt.spec?.aksConfig?.privateCluster;
+      default:
+        return false;
+      }
+    }
+
+    return false;
+  }
+
   get isLocal() {
     return this.mgmt?.isLocal;
   }

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -250,18 +250,14 @@ export default class ProvCluster extends SteveModel {
   }
 
   get isPrivateHostedProvider() {
-    if (this.isHostedKubernetesProvider && this.mgmt) {
-      const provisionerSmallCase = this.provisioner ? this.provisioner.toLowerCase() : '';
-
-      switch (provisionerSmallCase) {
+    if (this.isHostedKubernetesProvider && this.mgmt && this.provisioner) {
+      switch (this.provisioner.toLowerCase()) {
       case 'gke':
         return this.mgmt.spec?.gkeConfig?.privateClusterConfig?.enablePrivateEndpoint;
       case 'eks':
         return this.mgmt.spec?.eksConfig?.privateAccess;
       case 'aks':
         return this.mgmt.spec?.aksConfig?.privateCluster;
-      default:
-        return false;
       }
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9402 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- change condition to show registration tab only on hosted providers with private endpoint/network on `detail/provisioning.cattle.io.cluster`
- add unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to Cluster Management - Create - Select `Google GKE` hosted provider
- Move forward on the cluster creation until you get the `Cluster Options` tab
- On `Cluster Options` tab select `show advanced options` on the bottom-right corner
- After expanding, select `Enable Private Endpoint` and finish the creation process
- Go to that cluster details and make sure the `registration` tab appears

- Repeat the steps above to create another but WITHOUT enabling `Private endpoint`
- Check the details for this last cluster and make sure that the `registration` tab doesn't appear

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->