### PR TITLE
Add possibility to set private DNS zone on AKS clusters

### DIFF
--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -130,6 +130,12 @@ aks:
     label: Set Authorized IP Ranges
   authorizedIpRanges:
     label: Authorized IP Ranges
+  privateDnsZone:
+    label: Private DNS Zone ID
+  userAssignedIdentity:
+    label: User Assigned Identity
+  managedIdentity:
+    label: Managed Identity
   errors:
     regions: 'An error occured while fetching the available regions: {e}'
     vmSizes: 
@@ -150,3 +156,4 @@ aks:
     ipv4: "{key} must be a valid ipv4 address."
     outboundType: Load Balancer SKU must be 'standard' to use user defined routing.
     availabilityZones: Availability zones are not available in the selected region.
+    privateDnsZone: The Private DNS Zone Resource ID should be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -62,7 +62,7 @@ describe('fx: privateDnsZone', () => {
     ['test-subzone.privatelink.westus.azmk8s.io', undefined],
     ['private.eastus2.azmk8s.io', undefined],
     ['privatelink.eastus2.azmk8s.io', undefined],
-    ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.privatelink.eastus2.azmk8s.io', MOCK_TRANSLATION],
+    ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.privatelink.eastus2.azmk8s.io', MOCK_TRANSLATION],
     ['privatelink.azmk8s.io', MOCK_TRANSLATION],
   ])('returns an error message if the private dns zone does not match privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io', (privateDnsZone, validatorMsg) => {
     const ctx = { ...mockCtx, normanCluster: { aksConfig: { privateDnsZone } } };

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -134,7 +134,7 @@ export const privateDnsZone = (ctx: any, labelKey: string, clusterPath: string) 
   return () :string | undefined => {
     const toValidate = get(ctx.normanCluster, clusterPath) || '';
 
-    const isValid = toValidate.match(/[a-zA-Z0-9-]{1,32}\.private(link){0,1}.[a-zA-Z0-9]+\.azmk8s\.io/);
+    const isValid = toValidate.match(/^([a-zA-Z0-9-]{1,32}\.){0,32}private(link){0,1}\.[a-zA-Z0-9]+\.azmk8s\.io$/);
 
     return isValid || !toValidate.length ? undefined : ctx.t('aks.errors.privateDnsZone', {}, true);
   };

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -128,3 +128,14 @@ export const outboundTypeUserDefined = (ctx: any, labelKey: string, clusterPath:
     return undefined;
   };
 };
+
+// https://learn.microsoft.com/en-us/azure/aks/private-clusters?tabs=azure-portal#configure-a-private-dns-zone
+export const privateDnsZone = (ctx: any, labelKey: string, clusterPath: string) => {
+  return () :string | undefined => {
+    const toValidate = get(ctx.normanCluster, clusterPath) || '';
+
+    const isValid = toValidate.match(/[a-zA-Z0-9-]{1,32}\.private(link){0,1}.[a-zA-Z0-9]+\.azmk8s\.io/);
+
+    return isValid || !toValidate.length ? undefined : ctx.t('aks.errors.privateDnsZone', {}, true);
+  };
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7163
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds privateDnsZone, userAssignedIdentity, and managedIdentity inputs to AKS cluster provisioning. These fields should only be configurable when 'private cluster' is set. 

### Screenshot/Video
![Screen Shot 2024-01-26 at 10 50 21 AM](https://github.com/rancher/dashboard/assets/42977925/73e48f81-13b7-492f-895a-bab75b3d747a)
