### PR TITLE
Fixing an issue where a field can sometimes be undefined

### DIFF
--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -38,7 +38,7 @@ export default {
       if (this.hasRepoLabel) {
         const bundleResourceIds = this.bundleResourceIds;
 
-        return this.repo?.status?.resources.filter((resource) => {
+        return this.repo?.status?.resources?.filter((resource) => {
           return bundleResourceIds.includes(resource.name);
         });
       } else if (this.value?.spec?.resources?.length) {


### PR DESCRIPTION
It was reported in slack that the bundle page would error out when visiting the bundle pages due to an undefined reference. This resolves that issue.

Found the problem after replaying the user generated HAR file which yielded this in the console:
![image](https://github.com/rancher/dashboard/assets/55104481/375deae0-1f41-4d6b-ba67-93d116373ea0)
