### PR TITLE
add CSI suffix to all non-builtin storageClass provisioners

### DIFF
--- a/shell/models/__tests__/storage.k8s.io.storageclass.test.ts
+++ b/shell/models/__tests__/storage.k8s.io.storageclass.test.ts
@@ -6,13 +6,16 @@ describe('class StorageClass', () => {
   describe('checking if provisionerDisplay', () => {
     const provisionerDisplaySuffix = '(CSI)';
     const translationData = yaml.load(fs.readFileSync(`${ process.cwd() }/shell/assets/translations/en-us.yaml`, 'utf8'));
+    const testData = [];
 
-    it.each([
-      [PROVISIONER_OPTIONS[2].value, true],
-      [PROVISIONER_OPTIONS[6].value, true],
-      ['rancher.io/local-path', false],
-      ['some-random-string-as-provisioner', false]
-    ])('should NOT show a suffix IF they are built-in (on the PROVISIONER_OPTIONS list)', (provisioner, expectation) => {
+    PROVISIONER_OPTIONS.forEach((builtInProv) => {
+      testData.push([builtInProv.value, true]);
+    });
+
+    testData.push(['rancher.io/local-path', false]);
+    testData.push(['some-random-string-as-provisioner', false]);
+
+    it.each(testData)('should NOT show a suffix IF they are built-in (on the PROVISIONER_OPTIONS list)', (provisioner, expectation) => {
       const storageClass = new StorageClass({
         metadata: {},
         spec:     {},

--- a/shell/models/__tests__/storage.k8s.io.storageclass.test.ts
+++ b/shell/models/__tests__/storage.k8s.io.storageclass.test.ts
@@ -1,33 +1,22 @@
 import StorageClass, { PROVISIONER_OPTIONS } from '@shell/models/storage.k8s.io.storageclass';
-const yaml = require('js-yaml');
-const fs = require('fs');
 
 describe('class StorageClass', () => {
   describe('checking if provisionerDisplay', () => {
-    const provisionerDisplaySuffix = '(CSI)';
-    const translationData = yaml.load(fs.readFileSync(`${ process.cwd() }/shell/assets/translations/en-us.yaml`, 'utf8'));
-    const testData = [];
-
-    PROVISIONER_OPTIONS.forEach((builtInProv) => {
-      testData.push([builtInProv.value, true]);
-    });
-
-    testData.push(['rancher.io/local-path', false]);
-    testData.push(['some-random-string-as-provisioner', false]);
-
-    it.each(testData)('should NOT show a suffix IF they are built-in (on the PROVISIONER_OPTIONS list)', (provisioner, expectation) => {
+    it.each([
+      ['kubernetes.io/azure-disk', true],
+      ['kubernetes.io/portworx-volume', true],
+      ['rancher.io/local-path', false],
+      ['some-random-string-as-provisioner', false],
+    ])('should NOT show a suffix IF they are built-in (on the PROVISIONER_OPTIONS list)', (provisioner, expectation) => {
       const storageClass = new StorageClass({
         metadata: {},
         spec:     {},
         provisioner
       });
 
-      const transl = jest.fn((arg) => translationData[arg] || '');
-      const fb = jest.fn(() => `${ provisioner } ${ provisionerDisplaySuffix }`);
+      jest.spyOn(storageClass, '$rootGetters', 'get').mockReturnValue({ 'i18n/t': jest.fn() });
 
-      jest.spyOn(storageClass, '$rootGetters', 'get').mockReturnValue({ 'i18n/t': transl, 'i18n/withFallback': fb });
-
-      expect(!storageClass.provisionerDisplay.includes(provisionerDisplaySuffix)).toBe(expectation);
+      expect(!!PROVISIONER_OPTIONS.find((opt) => opt.value === provisioner)).toBe(expectation);
     });
   });
 });

--- a/shell/models/__tests__/storage.k8s.io.storageclass.test.ts
+++ b/shell/models/__tests__/storage.k8s.io.storageclass.test.ts
@@ -1,0 +1,30 @@
+import StorageClass, { PROVISIONER_OPTIONS } from '@shell/models/storage.k8s.io.storageclass';
+const yaml = require('js-yaml');
+const fs = require('fs');
+
+describe('class StorageClass', () => {
+  describe('checking if provisionerDisplay', () => {
+    const provisionerDisplaySuffix = '(CSI)';
+    const translationData = yaml.load(fs.readFileSync(`${ process.cwd() }/shell/assets/translations/en-us.yaml`, 'utf8'));
+
+    it.each([
+      [PROVISIONER_OPTIONS[2].value, true],
+      [PROVISIONER_OPTIONS[6].value, true],
+      ['rancher.io/local-path', false],
+      ['some-random-string-as-provisioner', false]
+    ])('should NOT show a suffix IF they are built-in (on the PROVISIONER_OPTIONS list)', (provisioner, expectation) => {
+      const storageClass = new StorageClass({
+        metadata: {},
+        spec:     {},
+        provisioner
+      });
+
+      const transl = jest.fn((arg) => translationData[arg] || '');
+      const fb = jest.fn(() => `${ provisioner } ${ provisionerDisplaySuffix }`);
+
+      jest.spyOn(storageClass, '$rootGetters', 'get').mockReturnValue({ 'i18n/t': transl, 'i18n/withFallback': fb });
+
+      expect(!storageClass.provisionerDisplay.includes(provisionerDisplaySuffix)).toBe(expectation);
+    });
+  });
+});

--- a/shell/models/storage.k8s.io.storageclass.js
+++ b/shell/models/storage.k8s.io.storageclass.js
@@ -84,7 +84,7 @@ export const PROVISIONER_OPTIONS = [
 export default class extends SteveModel {
   get provisionerDisplay() {
     const option = PROVISIONER_OPTIONS.find((o) => o.value === this.provisioner);
-    const fallback = `${ this.provisioner } ${ this.t('persistentVolume.csi.drivers.suffix') }`;
+    const fallback = `${ this.provisioner } ${ this.t('persistentVolume.csi.suffix') }`;
 
     return option ? this.t(option.labelKey) : this.$rootGetters['i18n/withFallback'](`persistentVolume.csi.drivers.${ this.provisioner.replaceAll('.', '-') }`, null, fallback);
   }

--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -71,6 +71,15 @@ module.exports = {
     config.plugins.unshift(nmrp);
 
     config.module.rules.push({
+      test: /\.ts$/,
+      use: ['ts-loader'],
+      include: baseFolder,
+      exclude: {
+        test: /\.spec\.ts$/
+      }
+    });
+
+    config.module.rules.push({
       test: /\.scss$/,
       use: ['style-loader', 'css-loader', sassLoader],
       include: baseFolder,

--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -71,13 +71,6 @@ module.exports = {
     config.plugins.unshift(nmrp);
 
     config.module.rules.push({
-      test: /\.ts$/,
-      use: ['ts-loader'],
-      include: baseFolder,
-      exclude: path.join(baseFolder, 'shell/models/__tests__')
-    });
-
-    config.module.rules.push({
       test: /\.scss$/,
       use: ['style-loader', 'css-loader', sassLoader],
       include: baseFolder,

--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -74,9 +74,7 @@ module.exports = {
       test: /\.ts$/,
       use: ['ts-loader'],
       include: baseFolder,
-      exclude: {
-        test: /\.spec\.ts$/
-      }
+      exclude: path.join(baseFolder, 'shell/models/__tests__')
     });
 
     config.module.rules.push({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9968 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add `(CSI)` suffix to all non-builtin `storageClass` provisioners
- add unit test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- follow repro steps of #9968 (it should have the suffix in the end)
- follow repro steps of #9968 BUT edit the yaml provisioner to `kubernetes.io/azure-disk` (it should not show `(CSI)` suffix)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
_Before_
![Screenshot 2024-01-29 at 15 45 48](https://github.com/rancher/dashboard/assets/97888974/8f19e9f9-a13f-413f-bce3-d34f76fa485f)

_After_
![Screenshot 2024-01-29 at 15 46 01](https://github.com/rancher/dashboard/assets/97888974/fe75eee9-bfb2-4114-be47-742bf3568dae)

