### PR TITLE
Adding fix for table rows groups name validation

### DIFF
--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -76,6 +76,10 @@ export default class SortableTablePo extends ComponentPo {
   // sortable-table
   //
 
+  groupElementWithName(name: string) {
+    return this.self().contains('tr.group-row div', name);
+  }
+
   rowElements(options?: any) {
     return this.self().find('tbody tr:not(.sub-row)', options);
   }

--- a/cypress/e2e/tests/pages/explorer/namespace-picker.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/namespace-picker.spec.ts
@@ -35,7 +35,10 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.clickOptionByLabel('cattle-fleet-local-system');
     namespacePicker.isChecked('cattle-fleet-local-system');
     namespacePicker.closeDropdown();
-    workloadsPodPage.sortableTable().rowElementWithName('cattle-fleet-local-system').should('be.visible').and('have.length', 1);
+    workloadsPodPage.sortableTable()
+      .groupElementWithName('cattle-fleet-local-system')
+      .scrollIntoView().should('be.visible')
+      .and('have.length', 1);
 
     // clear selection: from dropdown controller
     namespacePicker.toggle();
@@ -47,8 +50,8 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.clickOptionByLabel('Project: System');
     namespacePicker.isChecked('Project: System');
     namespacePicker.closeDropdown();
-    workloadsPodPage.sortableTable().rowElementWithName('kube-system').should('be.visible');
-    workloadsPodPage.sortableTable().rowElementWithName('cattle-fleet-local-system').scrollIntoView().should('be.visible');
+    workloadsPodPage.sortableTable().groupElementWithName('kube-system').scrollIntoView().should('be.visible');
+    workloadsPodPage.sortableTable().groupElementWithName('cattle-fleet-local-system').scrollIntoView().should('be.visible');
   });
 
   it('can select only one of the top 5 resource filters at a time', { tags: ['@adminUser', '@standardUser'] }, () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
Namespaces groups title name validation on tests running on Jenkins and local.

### Occurred changes and/or fixed issues
Added a method to the `SortableTablePo` to look for specific namespace groups. Also added `scrollIntoView()` method in case the viewport has a small height.

### Areas or cases that should be tested
Tests that are related to namespace picker. Validate pass on Jenkins.

### Docker run

```
Running:  namespace-picker.spec.ts                                                       (4 of 12)


  Namespace picker
    ✓ can filter workloads by project/namespace from the picker dropdown (13279ms)
    ✓ can select only one of the top 5 resource filters at a time
    ✓ can select multiple projects/namespaces
    ✓ can deselect options
    ✓ can filter options by name
    ✓ newly created project/namespace appears in namespace picker (27672ms)


  6 passing (49s)

<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Mocha Tests" time="49.110" tests="6" failures="0">
  <testsuite name="" timestamp="2024-01-29T18:49:07" tests="0" file="cypress/e2e/tests/pages/explorer/namespace-picker.spec.ts" time="0.000" failures="0">
  </testsuite>
  <testsuite name="Root Suite.Namespace picker" timestamp="2024-01-29T18:49:07" tests="6" time="49.093" failures="0">
    <testcase name="can filter workloads by project/namespace from the picker dropdown" time="13.279" classname="Namespace picker">
    </testcase>
    <testcase name="can select only one of the top 5 resource filters at a time" time="2.209" classname="Namespace picker">
    </testcase>
    <testcase name="can select multiple projects/namespaces" time="2.064" classname="Namespace picker">
    </testcase>
    <testcase name="can deselect options" time="1.726" classname="Namespace picker">
    </testcase>
    <testcase name="can filter options by name" time="1.709" classname="Namespace picker">
    </testcase>
    <testcase name="newly created project/namespace appears in namespace picker" time="27.672" classname="Namespace picker">
    </testcase>
  </testsuite>
</testsuites>
[mochawesome] Report JSON saved to /e2e/dashboard/cypress/jenkins/reports/mochawesome/mochawesome_003.json


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        6                                                                                │
  │ Passing:      6                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     49 seconds                                                                       │
  │ Spec Ran:     namespace-picker.spec.ts                                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘

```