### PR TITLE
[Automation] - adding fix for empty RANCHER_VERSION string

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -86,6 +86,9 @@ if [[ "${JOB_TYPE}" == "recurring" ]]; then
     helm repo update
     version_string=$(echo "${RANCHER_IMAGE_TAG}" | cut -f1 -d"-")
     RANCHER_VERSION=$(helm search repo rancher-latest --devel --versions | grep ${version_string} | head -n 1 | cut -f2 | tr -d '[:space:]')
+    if [[ -z "${RANCHER_VERSION}" ]]; then
+        RANCHER_VERSION=$(helm search repo rancher-latest --devel --versions | sed -n '1!p' | head -1 | cut -f2 | tr -d '[:space:]')
+    fi
     corral config vars set rancher_image_tag ${RANCHER_IMAGE_TAG}
   fi
   cd "${WORKSPACE}/corral-packages"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
This adds a fix for when a RANCHER_VERSION variable is empty. Then we just pull the latest Rancher chart version to use during the Rancher install. This happens in the window where a RANCHER_IMAGE_TAG has the latest in development version but there's still not chart released.

### Areas or cases that should be tested
Jenkins pipeline.

### Areas which could experience regressions
Jenkins environment setup. Recurring jobs
