### PR TITLE
Add `[zube]: Backlog` label to backported issues

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -62,6 +62,8 @@ jobs:
           fi
           additional_cmd+=("--label")
           additional_cmd+=("QA/None")
+          additional_cmd+=("--label")
+          additional_cmd+=("[zube]: Backlog")
           ORIGINAL_LABELS=$(gh issue view -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --json labels --jq '.labels[].name' | grep -v '^\[zube\]:' | paste -sd "," -)
           if [ -n "$ORIGINAL_LABELS" ]; then
               additional_cmd+=("--label")


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Backport issues created by the backport bot don't automatically have the `[Zube]: Triage` label. The workflow https://github.com/rancher/dashboard/blob/master/.github/workflows/port-issue.yaml uses a github token to create the issue, which doesn't trigger the `opened` event in https://github.com/rancher/dashboard/blob/master/.github/workflows/add-to-triage-label.yaml which adds the zube label (https://github.com/orgs/community/discussions/24953).

### Occurred changes and/or fixed issues
Update the port-issue workflow to add the `[zube]: Backlog` label (as this is more appropriate than triage)
