### PR TITLE
Fix parse tag name condition to check for proper workflow types

### DIFF
--- a/shell/scripts/extension/parse-tag-name
+++ b/shell/scripts/extension/parse-tag-name
@@ -4,8 +4,8 @@ GITHUB_RELEASE_TAG=$1
 GITHUB_RUN_ID=$2
 GITHUB_WORKFLOW_TYPE=$3
 
-# Check packages for released tag name
-if [[ "${GITHUB_WORKFLOW_TYPE}" == "charts" ]]; then
+# Ensure "catalog" workflow release tag name does not match a pkg/<pkg-name>
+if [[ "${GITHUB_WORKFLOW_TYPE}" == "catalog" ]]; then
   for d in pkg/*/ ; do
     pkg=$(basename $d)
 
@@ -19,7 +19,7 @@ if [[ "${GITHUB_WORKFLOW_TYPE}" == "charts" ]]; then
     fi
   done
 else
-  # Check base extension name for tag name
+  # Ensure "charts" workflow release tag name does not match the root <pkg-name>
   BASE_EXT=$(jq -r .name package.json)
   EXT_VERSION=$(jq -r .version package.json)
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10363 
<!-- Define findings related to the feature or bug issue. -->

This changes the workflow type in `parse-tag-name` to check for `catalog` instead of `charts`. The intent of this condition is to determine if there are any naming collisions with the release tag name and any package names when releasing an Extension Catalog Image.

The `else` condition will be checking for naming collisions with the release tag name and the root package name.

