### PR TITLE
[2.7] Adding ovhcloudpubliccloud to the driverToCloudProvider map in order to restrict options for Cloud Provider

### DIFF
--- a/shell/store/plugins.js
+++ b/shell/store/plugins.js
@@ -100,12 +100,13 @@ export const suffixFields = [
 
 // Machine driver to cloud provider mapping
 const driverToCloudProviderMap = {
-  amazonec2:     'aws',
-  azure:         'azure',
-  digitalocean:  '', // Show restricted options
-  harvester:     'harvester',
-  linode:        '', // Show restricted options
-  vmwarevsphere: 'rancher-vsphere',
+  amazonec2:           'aws',
+  azure:               'azure',
+  digitalocean:        '', // Show restricted options
+  harvester:           'harvester',
+  linode:              '', // Show restricted options
+  vmwarevsphere:       'rancher-vsphere',
+  ovhcloudpubliccloud: '',
 
   custom: undefined // Show all options
 };


### PR DESCRIPTION
Summary
This is a backport of https://github.com/rancher/dashboard/pull/10313. For details see description

> ~Currently blocked on target branch version~