### PR TITLE
[Automation] - Add specific viewport size for Bulk Actions element to show 

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -373,7 +373,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editImportedClusterPage.waitForPage('mode=edit');
       });
 
-      it('can delete cluster by bulk actions', () => {
+      it('can delete cluster by bulk actions', { viewportHeight: 1000, viewportWidth: 660 }, () => {
         clusterList.goTo();
         clusterList.sortableTable().rowElementWithName(importGenericName).should('exist', { timeout: 15000 });
         clusterList.sortableTable().rowSelectCtlWithName(importGenericName).set();


### PR DESCRIPTION
### Summary
Fixes #
The bulk actions element seems to only appear below certain browser screen size. On Jenkins the viewport is of a more standard or real user screen which is larger than the default. To run the tests. 

### Occurred changes and/or fixed issue

Fix:
```
- Imported
  - Generic
    - can delete cluster by bulk actions
```

### Areas which could experience regressions
E2E tests execution on Jenkins pipeline.


Results on dockerized execution:

```
Imported
      Generic
        ✓ can create new cluster (15092ms)
        ✓ can navigate to cluster edit page (6259ms)
        ✓ can delete cluster by bulk actions (8633ms)


<testsuite name="Root Suite.Cluster Manager.Imported.Generic" timestamp="2024-02-01T16:05:24" tests="3" time="30.439" failures="0">
    <testcase name="can create new cluster" time="15.092" classname="Cluster Manager.Imported.Generic">
    </testcase>
    <testcase name="can navigate to cluster edit page" time="6.259" classname="Cluster Manager.Imported.Generic">
    </testcase>
    <testcase name="can delete cluster by bulk actions" time="8.633" classname="Cluster Manager.Imported.Generic">
    </testcase>
  </testsuite>
</testsuites>

```