### PR TITLE
update logic of `WorkloadDetailEndpoints` to consider hostname as a valid link if there is an `ingress` associated

### DIFF
--- a/shell/components/formatter/WorkloadDetailEndpoints.vue
+++ b/shell/components/formatter/WorkloadDetailEndpoints.vue
@@ -35,7 +35,7 @@ export default {
               protocol = 'https';
             }
 
-            const linkDefaultDisplay = endpoint.port ? `${ endpoint.port }${ endpoint.protocol }` : endpoint.protocol;
+            const linkDefaultDisplay = endpoint.port ? `${ endpoint.port }/${ endpoint.protocol }` : endpoint.protocol;
 
             // If there's an ingress and it has a hostname, we use the hostname address instead
             // https://github.com/rancher/dashboard/issues/8087

--- a/shell/components/formatter/WorkloadDetailEndpoints.vue
+++ b/shell/components/formatter/WorkloadDetailEndpoints.vue
@@ -35,14 +35,19 @@ export default {
               protocol = 'https';
             }
 
+            const linkDefaultDisplay = endpoint.port ? `${ endpoint.port }${ endpoint.protocol }` : endpoint.protocol;
+
             // If there's an ingress and it has a hostname, we use the hostname address instead
             // https://github.com/rancher/dashboard/issues/8087
             if (endpoint.ingressName && endpoint.hostname) {
               endpoint.link = `${ protocol }://${ endpoint.hostname }${ endpoint.path }`;
+              endpoint.linkDisplay = endpoint.link;
             } else if (endpoint.addresses && endpoint.addresses.length) {
               endpoint.link = `${ protocol }://${ endpoint.addresses[0] }:${ endpoint.port }`;
+              endpoint.linkDisplay = linkDefaultDisplay;
             } else if (externalIp) {
               endpoint.link = `${ protocol }://${ externalIp }:${ endpoint.port }`;
+              endpoint.linkDisplay = linkDefaultDisplay;
             } else {
               endpoint.display = `[${ this.t('servicesPage.anyNode') }]:${ endpoint.port }`;
             }
@@ -75,7 +80,7 @@ export default {
         :href="endpoint.link"
         target="_blank"
         rel="nofollow noopener noreferrer"
-      >{{ endpoint.link }}</a>
+      >{{ endpoint.linkDisplay }}</a>
     </template>
   </span>
 </template>

--- a/shell/components/formatter/__tests__/WorkloadDetailEndpoints.test.ts
+++ b/shell/components/formatter/__tests__/WorkloadDetailEndpoints.test.ts
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import WorkloadDetailEndpoints from '@shell/components/formatter/WorkloadDetailEndpoints.vue';
+import Tag from '@shell/components/Tag';
+
+describe('component: WorkloadDetailEndpoints', () => {
+  const withIngressAndHostname = [{
+    addresses: [
+      '172.18.0.3'
+    ],
+    port:        80,
+    protocol:    'HTTP',
+    serviceName: 'kube-public:tetris',
+    ingressName: 'kube-public:tetris',
+    hostname:    'tetris.kube-public.172.18.0.3.sslip.io',
+    path:        '/',
+    allNodes:    false,
+  }];
+
+  const withoutIngress = [
+    {
+      addresses: [
+        '172.18.0.3'
+      ],
+      port:        80,
+      protocol:    'TCP',
+      serviceName: 'kube-system:traefik',
+      allNodes:    false
+    },
+    {
+      addresses: [
+        '172.18.0.3'
+      ],
+      port:        443,
+      protocol:    'TCP',
+      serviceName: 'kube-system:traefik',
+      allNodes:    false
+    }
+  ];
+
+  const withoutAddresses = [
+    {
+      port:        443,
+      protocol:    'TCP',
+      serviceName: 'kube-system:traefik',
+      allNodes:    false
+    }
+  ];
+
+  const basicNodesOutput = [
+    { externalIp: 'some-external-ip' }
+  ];
+
+  it.each([
+    [withIngressAndHostname, [], ['http://tetris.kube-public.172.18.0.3.sslip.io/']],
+    [withoutIngress, [], ['http://172.18.0.3:80', 'https://172.18.0.3:443']],
+    [withoutAddresses, basicNodesOutput, ['https://some-external-ip:443']],
+  ])('should display a link given the appropriate conditions', (value:any[], nodesOutput:any[], expectationArr:any[]) => {
+    const wrapper = mount(WorkloadDetailEndpoints, {
+      propsData: { value: JSON.stringify(value) },
+      mocks:     { $store: { getters: { 'cluster/all': () => nodesOutput } } }
+    });
+
+    wrapper.vm.parsed.forEach((endpoint:{[key: string]: string}, i:number) => {
+      expect(endpoint.link).toBe(expectationArr[i]);
+    });
+  });
+
+  it.each([
+    [withoutAddresses, [], ['[some-translation]:443']],
+  ])('should render a Tag component with the appropriate content', (value:any[], nodesOutput:any[], expectationArr:any[]) => {
+    const wrapper = mount(WorkloadDetailEndpoints, {
+      propsData: { value: JSON.stringify(value) },
+      mocks:     { $store: { getters: { 'cluster/all': () => nodesOutput, 'i18n/t': () => 'some-translation' } } }
+    });
+
+    wrapper.vm.parsed.forEach((endpoint:{[key: string]: string}, i:number) => {
+      expect(endpoint.display).toBe(expectationArr[i]);
+      expect(wrapper.findComponent(Tag).exists()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8087 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- update logic of `WorkloadDetailEndpoints` to consider hostname as a valid link if there is an `ingress` associated
- formatter code cleanup (unused computed property)
- add unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Install repository as `git repo` -> `https://github.com/bashofmann/rodeo` - branch `master` in `apps` - `repositories` on `local` cluster
- in `apps` - `chart` on `local` cluster, find a card for `tetris` app that comes from the repo added on the step before and install it
- on `local` cluster, `workloads` - `deployments`, find the deployment associated with the deployment of `tetris`
- On the details in the top of the page, check that the `endpoints` link points to the hostname `tetris.kube-public.172.18.0.3` as per the changes on this PR 


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**Before**
 
![before](https://github.com/rancher/dashboard/assets/97888974/f6f180fb-c8e2-4250-899f-e620dce4b177)


**After**


![after](https://github.com/rancher/dashboard/assets/97888974/b95899d8-e282-4c4d-b597-00408c2bdabb)

