### PR TITLE
Adding missing tags to tests

### DIFF
--- a/cypress/e2e/tests/pages/explorer/cluster-tools.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-tools.spec.ts
@@ -5,7 +5,7 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 
 const clusterTools = new ClusterToolsPagePo('local');
 
-describe('Cluster Tools', { tags: '@adminUser' }, () => {
+describe('Cluster Tools', { tags: ['@explorer', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer/storage/configmap.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/storage/configmap.spec.ts
@@ -1,7 +1,7 @@
 import { ConfigMapPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
 import ConfigMapPo from '@/cypress/e2e/po/components/storage/config-map.po';
 
-describe('ConfigMap', () => {
+describe('ConfigMap', { tags: ['@explorer', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
Adding tags to a couple of e2e specs (`/explorer/cluster-tools.spec`, `/explorer/storage/configmap.spec`) that aren't running in CI as they're missing their group/user tag.
