### PR TITLE
RKE2 Amazon EC2 cluster provisioning tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           yarn e2e:prod
         env: 
-          GREP_TAGS: ${{ matrix.role.tag }}Setup+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}Setup+${{ matrix.features[1] || matrix.features[0] }} --@jenkins
+          GREP_TAGS: ${{ matrix.role.tag }}Setup+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}Setup+${{ matrix.features[1] || matrix.features[0] }} --@jenkins 
           TEST_USERNAME: admin
           TEST_ONLY: setup
       

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           yarn e2e:prod
         env: 
-          GREP_TAGS: ${{ matrix.role.tag }}Setup+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}Setup+${{ matrix.features[1] || matrix.features[0] }} --@jenkins 
+          GREP_TAGS: ${{ matrix.role.tag }}Setup+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}Setup+${{ matrix.features[1] || matrix.features[0] }} --@jenkins
           TEST_USERNAME: admin
           TEST_ONLY: setup
       

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -81,8 +81,8 @@ export default defineConfig({
     password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,
     grepTags:          process.env.GREP_TAGS,
-    awsAccessKey:      process.env.AWS_ACCESS_KEY_ID,
-    awsSecretKey:      process.env.AWS_SECRET_ACCESS_KEY
+    awsAccessKey:      process.env.AWS_ACCESS_KEY_ID, // this env var is only available to test that run in Jenkins
+    awsSecretKey:      process.env.AWS_SECRET_ACCESS_KEY // this env var is only available to test that run in Jenkins
   },
   e2e: {
     fixturesFolder: 'cypress/e2e/blueprints',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -81,8 +81,8 @@ export default defineConfig({
     password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,
     grepTags:          process.env.GREP_TAGS,
-    awsAccessKey:      process.env.AWS_ACCESS_KEY_ID, // this env var is only available to test that run in Jenkins
-    awsSecretKey:      process.env.AWS_SECRET_ACCESS_KEY // this env var is only available to test that run in Jenkins
+    awsAccessKey:      process.env.AWS_ACCESS_KEY_ID, // this env var is only available to tests that run in Jenkins
+    awsSecretKey:      process.env.AWS_SECRET_ACCESS_KEY // this env var is only available to tests that run in Jenkins
   },
   e2e: {
     fixturesFolder: 'cypress/e2e/blueprints',

--- a/cypress/e2e/po/components/cru-resource.po.ts
+++ b/cypress/e2e/po/components/cru-resource.po.ts
@@ -20,7 +20,9 @@ export default class CruResourcePo extends ComponentPo {
   saveAndWaitForRequests(method, endpoint: string, statusCode?: number): Cypress.Chainable {
     cy.intercept(method, endpoint).as(endpoint);
     this.saveOrCreate().click();
+    /* eslint-disable cypress/no-assigning-return-values */
+    const wait = cy.wait(`@${ endpoint }`, { timeout: 10000 });
 
-    return statusCode ? cy.wait(`@${ endpoint }`, { timeout: 10000 }).its('response.statusCode').should('eq', statusCode) : cy.wait(`@${ endpoint }`, { timeout: 10000 });
+    return statusCode ? wait.its('response.statusCode').should('eq', statusCode) : wait;
   }
 }

--- a/cypress/e2e/po/components/cru-resource.po.ts
+++ b/cypress/e2e/po/components/cru-resource.po.ts
@@ -17,10 +17,17 @@ export default class CruResourcePo extends ComponentPo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 
-  saveAndWaitForRequests(method: string, url: string) {
-    cy.intercept(method, url).as('request');
+  // saveAndWaitForRequests(method: string, url: string) {
+  //   cy.intercept(method, url).as('request');
+  //   this.saveOrCreate().click();
+
+  //   return cy.wait('@request', { timeout: 10000 });
+  // }
+
+  saveAndWaitForRequests(method, endpoint: string, statusCode?: number): Cypress.Chainable {
+    cy.intercept(method, endpoint).as(endpoint);
     this.saveOrCreate().click();
 
-    return cy.wait('@request', { timeout: 10000 });
+    return statusCode ? cy.wait(`@${ endpoint }`, { timeout: 10000 }).its('response.statusCode').should('eq', statusCode) : cy.wait(`@${ endpoint }`, { timeout: 10000 });
   }
 }

--- a/cypress/e2e/po/components/cru-resource.po.ts
+++ b/cypress/e2e/po/components/cru-resource.po.ts
@@ -17,13 +17,6 @@ export default class CruResourcePo extends ComponentPo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 
-  // saveAndWaitForRequests(method: string, url: string) {
-  //   cy.intercept(method, url).as('request');
-  //   this.saveOrCreate().click();
-
-  //   return cy.wait('@request', { timeout: 10000 });
-  // }
-
   saveAndWaitForRequests(method, endpoint: string, statusCode?: number): Cypress.Chainable {
     cy.intercept(method, endpoint).as(endpoint);
     this.saveOrCreate().click();

--- a/cypress/e2e/po/components/loading.po.ts
+++ b/cypress/e2e/po/components/loading.po.ts
@@ -1,0 +1,5 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class LoadingPo extends ComponentPo {
+
+}

--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -88,8 +88,16 @@ export default class SortableTablePo extends ComponentPo {
     return this.self().contains('tbody tr', new RegExp(` ${ name } `));
   }
 
+  rowElementWithPartialName(name: string) {
+    return this.self().contains('tbody tr', name);
+  }
+
   row(index: number) {
     return new ListRowPo(this.rowElements().eq(index));
+  }
+
+  rowWithPartialName(name: string) {
+    return new ListRowPo(this.rowElementWithPartialName(name));
   }
 
   rowWithName(name: string) {

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po.ts
@@ -1,0 +1,15 @@
+import ClusterManagerDetailPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po';
+import MachinePoolsListPo from '@/cypress/e2e/po/lists/machine-pools-list.po';
+
+/**
+ * Detail page for an RKE2 amazon EC2 cluster
+ */
+export default class ClusterManagerDetailRke2AmazonEc2PagePo extends ClusterManagerDetailPagePo {
+  title() {
+    return this.self().find('.primaryheader h1');
+  }
+
+  machinePoolsList() {
+    return new MachinePoolsListPo(this.self().find('[data-testid="sortable-table-list-container"]'));
+  }
+}

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po.ts
@@ -1,15 +1,11 @@
 import ClusterManagerDetailPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po';
-import MachinePoolsListPo from '@/cypress/e2e/po/lists/machine-pools-list.po';
+import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
 
 /**
  * Detail page for an RKE2 amazon EC2 cluster
  */
 export default class ClusterManagerDetailRke2AmazonEc2PagePo extends ClusterManagerDetailPagePo {
-  title() {
-    return this.self().find('.primaryheader h1');
-  }
-
-  machinePoolsList() {
-    return new MachinePoolsListPo(this.self().find('[data-testid="sortable-table-list-container"]'));
+  resourceDetail() {
+    return new ResourceDetailPo(this.self());
   }
 }

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -4,15 +4,15 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
  * Covers core functionality that's common to the dashboard's cluster detail pages
  */
 export default abstract class ClusterManagerDetailPagePo extends PagePo {
-  private static createPath(clusterName: string, tab?: string) {
-    return `/c/local/manager/provisioning.cattle.io.cluster/fleet-default/${ clusterName }`;
+  private static createPath(clusterId: string, clusterName: string, tab?: string) {
+    return `/c/${ clusterId }/manager/provisioning.cattle.io.cluster/fleet-default/${ clusterName }`;
   }
 
-  static goTo(clusterName: string): Cypress.Chainable<Cypress.AUTWindow> {
-    return super.goTo(ClusterManagerDetailPagePo.createPath(clusterName));
+  static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
+    throw new Error('invalid');
   }
 
-  constructor(clusterName: string) {
-    super(ClusterManagerDetailPagePo.createPath(clusterName));
+  constructor(clusterId = '_', clusterName: string) {
+    super(ClusterManagerDetailPagePo.createPath(clusterId, clusterName));
   }
 }

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -1,4 +1,5 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
+import MachinePoolsListPo from '@/cypress/e2e/po/lists/machine-pools-list.po';
 
 /**
  * Covers core functionality that's common to the dashboard's cluster detail pages
@@ -14,5 +15,13 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
 
   constructor(clusterId = '_', clusterName: string) {
     super(ClusterManagerDetailPagePo.createPath(clusterId, clusterName));
+  }
+
+  title() {
+    return this.self().find('.primaryheader h1');
+  }
+
+  machinePoolsList() {
+    return new MachinePoolsListPo(this.self().find('[data-testid="sortable-table-list-container"]'));
   }
 }

--- a/cypress/e2e/po/edit/base-cloud-credentials.po.ts
+++ b/cypress/e2e/po/edit/base-cloud-credentials.po.ts
@@ -1,5 +1,7 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import CruResourcePo from '@/cypress/e2e/po/components/cru-resource.po';
+import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
 
 export default class BaseCloudCredentialsPo extends PagePo {
   private static createPath(clusterId: string, id?: string ) {
@@ -18,5 +20,13 @@ export default class BaseCloudCredentialsPo extends PagePo {
 
   cloudServiceOptions(): CruResourcePo {
     return new CruResourcePo('[data-testid="cru-form"]');
+  }
+
+  nameNsDescription() {
+    return new NameNsDescription(this.self());
+  }
+
+  saveCreateForm(): ResourceDetailPo {
+    return new ResourceDetailPo(this.self());
   }
 }

--- a/cypress/e2e/po/edit/cloud-credentials-amazon.po.ts
+++ b/cypress/e2e/po/edit/cloud-credentials-amazon.po.ts
@@ -1,13 +1,7 @@
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import BaseCloudCredentialsPo from '@/cypress/e2e/po/edit/base-cloud-credentials.po';
-import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
-import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
 export default class AmazonCloudCredentialsCreateEditPo extends BaseCloudCredentialsPo {
-  nameNsDescription() {
-    return new NameNsDescription(this.self());
-  }
-
   accessKey(): LabeledInputPo {
     return LabeledInputPo.byLabel(this.self(), 'Access Key');
   }
@@ -18,9 +12,5 @@ export default class AmazonCloudCredentialsCreateEditPo extends BaseCloudCredent
 
   defaultRegion(): LabeledSelectPo {
     return new LabeledSelectPo('.vs__dropdown-toggle');
-  }
-
-  saveCreateForm(): ResourceDetailPo {
-    return new ResourceDetailPo(this.self());
   }
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po.ts
@@ -1,0 +1,35 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
+import MachinePoolRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po';
+import BasicsRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po';
+import AmazonCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credentials-amazon.po';
+
+/**
+ * Create page for an RKE2 Amazon EC2 cluster
+ */
+export default class ClusterManagerCreateRke2AmazonPagePo extends ClusterManagerCreatePagePo {
+  static url = `${ ClusterManagerCreatePagePo.url }/create?type=amazonec2#basic`
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return PagePo.goTo(ClusterManagerCreateRke2AmazonPagePo.url);
+  }
+
+  goToAmazonClusterCreation(): Cypress.Chainable<Cypress.AUTWindow> {
+    return PagePo.goTo(`${ ClusterManagerCreatePagePo.url }?type=amazonec2#basic`);
+  }
+
+  title(): Cypress.Chainable<string> {
+    return this.self().find('.primaryheader h1').invoke('text');
+  }
+
+  cloudCredentialsForm(): AmazonCloudCredentialsCreateEditPo {
+    return new AmazonCloudCredentialsCreateEditPo();
+  }
+
+  machinePoolTab(): MachinePoolRke2 {
+    return new MachinePoolRke2();
+  }
+
+  basicsTab(): BasicsRke2 {
+    return new BasicsRke2();
+  }
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po.ts
@@ -17,10 +17,6 @@ export default class ClusterManagerCreateRke2AmazonPagePo extends ClusterManager
     return PagePo.goTo(`${ ClusterManagerCreatePagePo.url }?type=amazonec2#basic`);
   }
 
-  title(): Cypress.Chainable<string> {
-    return this.self().find('.primaryheader h1').invoke('text');
-  }
-
   cloudCredentialsForm(): AmazonCloudCredentialsCreateEditPo {
     return new AmazonCloudCredentialsCreateEditPo();
   }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
@@ -1,7 +1,7 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import AgentConfigurationRke2 from '@/cypress/e2e/po/components/agent-configuration-rke2.po';
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
-import TabbedPo from '~/cypress/e2e/po/components/tabbed.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 
 /**
  * Create page for an RKE2 custom cluster

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po.ts
@@ -1,4 +1,3 @@
-/* eslint-disable cypress/no-unnecessary-waiting */
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po.ts
@@ -1,0 +1,18 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+
+export default class BasicsRke2 extends ComponentPo {
+  constructor(selector = '.dashboard-root') {
+    super(selector);
+  }
+
+  nameNsDescription() {
+    return new NameNsDescription(this.self());
+  }
+
+  kubernetesVersions(): LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="clusterBasics__kubernetesVersions"]');
+  }
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
@@ -1,4 +1,3 @@
-/* eslint-disable cypress/no-unnecessary-waiting */
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
@@ -1,0 +1,18 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+
+export default class MachinePoolRke2 extends ComponentPo {
+  constructor(selector = '.dashboard-root') {
+    super(selector);
+  }
+
+  nameNsDescription() {
+    return new NameNsDescription(this.self());
+  }
+
+  networks(): LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="amazonEc2__selectedNetwork"]');
+  }
+}

--- a/cypress/e2e/po/edit/resource-detail.po.ts
+++ b/cypress/e2e/po/edit/resource-detail.po.ts
@@ -15,4 +15,8 @@ export default class ResourceDetailPo extends ComponentPo {
   resourceYaml() {
     return new ResourceYamlPo(this.self());
   }
+
+  title(): Cypress.Chainable<string> {
+    return this.self().find('.primaryheader h1').invoke('text');
+  }
 }

--- a/cypress/e2e/po/lists/machine-pools-list.po.ts
+++ b/cypress/e2e/po/lists/machine-pools-list.po.ts
@@ -1,0 +1,7 @@
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+
+export default class MachinePoolsListPo extends BaseResourceList {
+  details(name: string, index: number) {
+    return this.resourceTable().sortableTable().rowWithPartialName(name).column(index);
+  }
+}

--- a/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
@@ -32,6 +32,10 @@ export default class ProvClusterListPo extends BaseResourceList {
     return this.resourceTable().sortableTable().rowWithName(clusterName).column(4);
   }
 
+  machines(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(5);
+  }
+
   explore(clusterName: string) {
     return this.resourceTable().sortableTable().rowWithName(clusterName).column(7)
       .find('.btn');

--- a/cypress/e2e/po/pages/cluster-manager/cloud-credentials.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cloud-credentials.po.ts
@@ -34,6 +34,6 @@ export default class CloudCredentialsPagePo extends PagePo {
   }
 
   list(): CloudCredentialsListPo {
-    return new CloudCredentialsListPo('[data-testid="cluster-list-container"]');
+    return new CloudCredentialsListPo('[data-testid="sortable-table-list-container"]');
   }
 }

--- a/cypress/e2e/po/pages/cluster-manager/machine-deployments.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/machine-deployments.po.ts
@@ -35,7 +35,7 @@ export default class MachineDeploymentsPagePo extends PagePo {
   }
 
   list(): MachineDeploymentsListPo {
-    return new MachineDeploymentsListPo('[data-testid="cluster-list-container"]');
+    return new MachineDeploymentsListPo('[data-testid="sortable-table-list-container"]');
   }
 
   yamlEditor(): CodeMirrorPo {

--- a/cypress/e2e/po/pages/cluster-manager/machine-sets.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/machine-sets.po.ts
@@ -36,7 +36,7 @@ export default class MachineSetsPagePo extends PagePo {
   }
 
   list(): MachineSetsListPo {
-    return new MachineSetsListPo('[data-testid="cluster-list-container"]');
+    return new MachineSetsListPo('[data-testid="sortable-table-list-container"]');
   }
 
   yamlEditor(): CodeMirrorPo {

--- a/cypress/e2e/po/pages/cluster-manager/machines.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/machines.po.ts
@@ -36,7 +36,7 @@ export default class MachinesPagePo extends PagePo {
   }
 
   list(): MachinesListPo {
-    return new MachinesListPo('[data-testid="cluster-list-container"]');
+    return new MachinesListPo('[data-testid="sortable-table-list-container"]');
   }
 
   yamlEditor(): CodeMirrorPo {

--- a/cypress/e2e/po/pages/cluster-manager/pod-security-admissions.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/pod-security-admissions.po.ts
@@ -34,6 +34,6 @@ export default class PodSecurityAdmissionsPagePo extends PagePo {
   }
 
   list(): PodSecurityAdmissionListPo {
-    return new PodSecurityAdmissionListPo('[data-testid="cluster-list-container"]');
+    return new PodSecurityAdmissionListPo('[data-testid="sortable-table-list-container"]');
   }
 }

--- a/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
@@ -35,7 +35,7 @@ export default class ClusterDashboardPagePo extends PagePo {
   }
 
   eventslist(): EventsListPo {
-    return new EventsListPo('[data-testid="cluster-list-container"]');
+    return new EventsListPo('[data-testid="sortable-table-list-container"]');
   }
 
   fullEventsLink() {

--- a/cypress/e2e/po/pages/explorer/events.po.ts
+++ b/cypress/e2e/po/pages/explorer/events.po.ts
@@ -15,6 +15,6 @@ export class EventsPagePo extends PagePo {
   }
 
   eventslist(): EventsListPo {
-    return new EventsListPo('[data-testid="cluster-list-container"]');
+    return new EventsListPo('[data-testid="sortable-table-list-container"]');
   }
 }

--- a/cypress/e2e/po/pages/explorer/nodes.po.ts
+++ b/cypress/e2e/po/pages/explorer/nodes.po.ts
@@ -15,6 +15,6 @@ export class NodesPagePo extends PagePo {
   }
 
   nodesList(): NodesListPo {
-    return new NodesListPo('[data-testid="cluster-list-container"]');
+    return new NodesListPo('[data-testid="sortable-table-list-container"]');
   }
 }

--- a/cypress/e2e/po/pages/explorer/workloads-pods.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-pods.po.ts
@@ -26,7 +26,7 @@ export class WorkloadsPodsListPagePo extends PagePo {
   }
 
   list(): PodsListPo {
-    return new PodsListPo('[data-testid="cluster-list-container"]');
+    return new PodsListPo('[data-testid="sortable-table-list-container"]');
   }
 
   sortableTable() {

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -62,7 +62,7 @@ export default class HomePagePo extends PagePo {
   }
 
   list(): HomeClusterListPo {
-    return new HomeClusterListPo('[data-testid="cluster-list-container"]');
+    return new HomeClusterListPo('[data-testid="sortable-table-list-container"]');
   }
 
   manageButton() {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -60,7 +60,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
   describe('Created', () => {
     const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
-    const detailRKE2ClusterPage = new ClusterManagerDetailRke2CustomPagePo(rke2CustomName);
+    const detailRKE2ClusterPage = new ClusterManagerDetailRke2CustomPagePo('local', rke2CustomName);
 
     describe('RKE2 Custom', () => {
       const editCreatedClusterPage = new ClusterManagerEditRke2CustomPagePo(rke2CustomName);
@@ -266,7 +266,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
       it('can show snapshots list', () => {
         clusterList.goToClusterListAndGetClusterDetails(rke1CustomName).then((cluster) => {
-          const snapshots = new ClusterManagerDetailSnapshotsPo(cluster.id);
+          const snapshots = new ClusterManagerDetailSnapshotsPo('local', cluster.id);
 
           // We want to show 2 elements in the snapshots tab
           const snapshotId1 = 'ml-mkhz4';
@@ -332,14 +332,14 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     });
   });
 
-  describe('Imported', () => {
+  describe.only('Imported', () => {
     const importClusterPage = new ClusterManagerImportGenericPagePo('local');
 
     describe('Generic', () => {
       const editImportedClusterPage = new ClusterManagerEditGenericPagePo(importGenericName);
 
       it('can create new cluster', () => {
-        const detailClusterPage = new ClusterManagerDetailImportedGenericPagePo(importGenericName);
+        const detailClusterPage = new ClusterManagerDetailImportedGenericPagePo('local', importGenericName);
 
         cy.intercept('POST', `/v1/${ type }s`).as('importRequest');
 

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -332,7 +332,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     });
   });
 
-  describe.only('Imported', () => {
+  describe('Imported', () => {
     const importClusterPage = new ClusterManagerImportGenericPagePo('local');
 
     describe('Generic', () => {

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -36,8 +36,8 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
     cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'), true);
     cloudCredForm.defaultRegion().toggle();
     cloudCredForm.defaultRegion().clickOptionWithLabel('us-west-2');
-    cloudCredForm.saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials')
-      .then((req) => {
+    cloudCredForm.saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials').then((req) => {
+        expect(req.response?.statusCode).to.equal(201);
         cloudcredentialId = req.response?.body.id;
         removeCloudCred = true;
       });

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -29,7 +29,7 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
     clusterList.createCluster();
     createRKE2ClusterPage.rkeToggle().set('RKE2/K3s');
     createRKE2ClusterPage.selectCreate(0);
-    createRKE2ClusterPage.title().should('include', 'Create Amazon EC2');
+    createRKE2ClusterPage.rke2PageTitle().should('include', 'Create Amazon EC2');
 
     // create amazon ec2 cloud credential
     cloudCredForm.nameNsDescription().name().set(this.ec2CloudCredentialName);
@@ -88,7 +88,7 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
     // check cluster details page > machine pools
     clusterList.list().name(this.rke2Ec2ClusterName).click();
     clusterDetails.waitForPage(null, 'machine-pools');
-    clusterDetails.mastheadTitle().should('contain', this.rke2Ec2ClusterName);
+    clusterDetails.resourceDetail().title().should('contain', this.rke2Ec2ClusterName);
     clusterDetails.machinePoolsList().details(`${ this.rke2Ec2ClusterName }-pool1-`, 1).should('contain', 'Running');
   });
 

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -37,10 +37,10 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
     cloudCredForm.defaultRegion().toggle();
     cloudCredForm.defaultRegion().clickOptionWithLabel('us-west-2');
     cloudCredForm.saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials').then((req) => {
-        expect(req.response?.statusCode).to.equal(201);
-        cloudcredentialId = req.response?.body.id;
-        removeCloudCred = true;
-      });
+      expect(req.response?.statusCode).to.equal(201);
+      cloudcredentialId = req.response?.body.id;
+      removeCloudCred = true;
+    });
 
     cy.waitForLoadingIndicator();
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -3,6 +3,7 @@ import ClusterManagerCreateRke2AmazonPagePo from '@/cypress/e2e/po/edit/provisio
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerDetailRke2AmazonEc2PagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
+import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 
 // will only run this in jenkins pipeline where cloud credentials are stored
 describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins'] }, () => {
@@ -42,7 +43,9 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
       removeCloudCred = true;
     });
 
-    cy.waitForLoadingIndicator();
+    const loadingPo = new LoadingPo('.loading-indicator');
+
+    loadingPo.checkNotExists();
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
     createRKE2ClusterPage.nameNsDescription().description().set(`${ this.rke2Ec2ClusterName }-description`);
 

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -1,0 +1,116 @@
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ClusterManagerCreateRke2AmazonPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po';
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import ClusterManagerDetailRke2AmazonEc2PagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po';
+import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
+
+// will only run this in jenkins pipeline where cloud credentials are stored
+describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@manager', '@jenkins'] }, () => {
+  const clusterList = new ClusterManagerListPagePo('_');
+  let removeCloudCred = false;
+  let cloudcredentialId = '';
+
+  before(() => {
+    cy.login();
+    HomePagePo.goTo();
+    cy.createE2EResourceName('rke2ec2cluster').as('rke2Ec2ClusterName');
+    cy.createE2EResourceName('ec2cloudcredential').as('ec2CloudCredentialName');
+  });
+
+  it('can provision a Amazon EC2 RKE2 cluster with Amazon cloud provider', function() {
+    const createRKE2ClusterPage = new ClusterManagerCreateRke2AmazonPagePo();
+    const clusterDetails = new ClusterManagerDetailRke2AmazonEc2PagePo('_', this.rke2Ec2ClusterName);
+
+    // create cluster
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+    clusterList.createCluster();
+    createRKE2ClusterPage.rkeToggle().set('RKE2/K3s');
+    createRKE2ClusterPage.selectCreate(0);
+    createRKE2ClusterPage.title().should('include', 'Create Amazon EC2');
+
+    // create amazon ec2 cloud credential
+    createRKE2ClusterPage.cloudCredentialsForm().nameNsDescription().name().set(this.ec2CloudCredentialName);
+    createRKE2ClusterPage.cloudCredentialsForm().accessKey().set(Cypress.env('awsAccessKey'));
+    createRKE2ClusterPage.cloudCredentialsForm().secretKey().set(Cypress.env('awsSecretKey'), true);
+    createRKE2ClusterPage.cloudCredentialsForm().defaultRegion().toggle();
+    createRKE2ClusterPage.cloudCredentialsForm().defaultRegion().clickOptionWithLabel('us-west-2');
+    createRKE2ClusterPage.cloudCredentialsForm().saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials')
+      .then((req) => {
+        cloudcredentialId = req.response?.body.id;
+        cy.log(cloudcredentialId);
+        removeCloudCred = true;
+      });
+    cy.log(cloudcredentialId);
+
+    createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
+    createRKE2ClusterPage.nameNsDescription().description().set(`${ this.rke2Ec2ClusterName }-description`);
+
+    // Get kubernetes version options and store them in variables
+    createRKE2ClusterPage.basicsTab().kubernetesVersions().toggle();
+    createRKE2ClusterPage.basicsTab().kubernetesVersions().getOptions().each((el, index) => {
+      cy.wrap(el.text().trim()).as(`k8sVersion${ index }`);
+    });
+    createRKE2ClusterPage.basicsTab().kubernetesVersions().clickOption(1);
+
+    createRKE2ClusterPage.machinePoolTab().networks().toggle();
+    createRKE2ClusterPage.machinePoolTab().networks().clickOption(3);
+
+    cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('createRke2Cluster');
+    createRKE2ClusterPage.create();
+    cy.wait('@createRke2Cluster').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201);
+      expect(response?.body).to.have.property('kind', 'Cluster');
+      expect(response?.body.metadata).to.have.property('name', this.rke2Ec2ClusterName);
+      expect(response?.body.spec).to.have.property('kubernetesVersion', this.k8sVersion1);
+    });
+    clusterList.waitForPage();
+
+    // check states
+    clusterList.list().state(this.rke2Ec2ClusterName).should('contain', 'Reconciling');
+    clusterList.list().state(this.rke2Ec2ClusterName).should('contain', 'Updating');
+    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', { timeout: 400000 });
+
+    // check k8s version
+    clusterList.list().version(this.rke2Ec2ClusterName).then(function(el) {
+      expect(el.text().trim()).contains(this.k8sVersion1);
+    });
+
+    // check provider
+    clusterList.list().provider(this.rke2Ec2ClusterName).should('contain', 'Amazon EC2');
+
+    // check machines
+    clusterList.list().machines(this.rke2Ec2ClusterName).should('contain', 1);
+
+    // check cluster details page > machine pools
+    clusterList.list().name(this.rke2Ec2ClusterName).click();
+    clusterDetails.waitForPage(null, 'machine-pools');
+    clusterDetails.mastheadTitle().should('contain', this.rke2Ec2ClusterName);
+    clusterDetails.machinePoolsList().details(`${ this.rke2Ec2ClusterName }-pool1-`, 1).should('contain', 'Running');
+  });
+
+  it('can delete a Amazon EC2 RKE2 cluster', function() {
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+    clusterList.list().actionMenu(this.rke2Ec2ClusterName).getMenuItem('Delete').click();
+
+    clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
+      const promptRemove = new PromptRemove();
+
+      promptRemove.confirm(this.rke2Ec2ClusterName);
+      promptRemove.remove();
+
+      clusterList.waitForPage();
+      clusterList.list().state(this.rke2Ec2ClusterName).should('contain', 'Removing');
+      clusterList.sortableTable().checkRowCount(false, rows.length - 1);
+      clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', this.rke2Ec2ClusterName);
+    });
+  });
+
+  after('clean up', () => {
+    if (removeCloudCred) {
+      //  delete cloud cred
+      cy.deleteRancherResource('v3', 'cloudCredentials', cloudcredentialId);
+    }
+  });
+});

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -30,6 +30,7 @@ declare global {
       logout(): Chainable;
       byLabel(label: string): Chainable<Element>;
       createE2EResourceName(context: string): Chainable<Element>;
+      waitForLoadingIndicator(): Chainable;
 
       createUser(params: CreateUserParams): Chainable;
       setGlobalRoleBinding(userId: string, role: string): Chainable;

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -30,7 +30,6 @@ declare global {
       logout(): Chainable;
       byLabel(label: string): Chainable<Element>;
       createE2EResourceName(context: string): Chainable<Element>;
-      waitForLoadingIndicator(): Chainable;
 
       createUser(params: CreateUserParams): Chainable;
       setGlobalRoleBinding(userId: string, role: string): Chainable;

--- a/cypress/support/commands/commands.ts
+++ b/cypress/support/commands/commands.ts
@@ -1,5 +1,4 @@
 import { Matcher } from '@/cypress/support/types';
-import LoadingPo from '~/cypress/e2e/po/components/loading.po';
 
 /**
  * Get input field for given label

--- a/cypress/support/commands/commands.ts
+++ b/cypress/support/commands/commands.ts
@@ -68,3 +68,10 @@ const runTimestamp = +new Date();
 Cypress.Commands.add('createE2EResourceName', (context) => {
   return cy.wrap(`e2e-test-${ runTimestamp }-${ context }`);
 });
+
+/*
+* Wait for loading indicator to disappear
+*/
+Cypress.Commands.add('waitForLoadingIndicator', () => {
+  return cy.get('.loading-indicator').should('not.exist', { timeout: 10000 });
+});

--- a/cypress/support/commands/commands.ts
+++ b/cypress/support/commands/commands.ts
@@ -1,4 +1,5 @@
 import { Matcher } from '@/cypress/support/types';
+import LoadingPo from '~/cypress/e2e/po/components/loading.po';
 
 /**
  * Get input field for given label
@@ -67,11 +68,4 @@ const runTimestamp = +new Date();
 
 Cypress.Commands.add('createE2EResourceName', (context) => {
   return cy.wrap(`e2e-test-${ runTimestamp }-${ context }`);
-});
-
-/*
-* Wait for loading indicator to disappear
-*/
-Cypress.Commands.add('waitForLoadingIndicator', () => {
-  return cy.get('.loading-indicator').should('not.exist', { timeout: 10000 });
 });

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -906,7 +906,7 @@ export default {
 <template>
   <div
     ref="container"
-    data-testid="cluster-list-container"
+    :data-testid="componentTestid + '-list-container'"
   >
     <div
       :class="{'titled': $slots.title && $slots.title.length}"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -427,6 +427,7 @@ export default {
           v-model="value.spec.kubernetesVersion"
           :mode="mode"
           :options="versionOptions"
+          data-testid="clusterBasics__kubernetesVersions"
           label-key="cluster.kubernetesVersion.label"
           @input="$emit('kubernetes-changed', $event)"
         />

--- a/shell/machine-config/amazonec2.vue
+++ b/shell/machine-config/amazonec2.vue
@@ -475,6 +475,7 @@ export default {
               :disabled="disabled"
               :placeholder="t('cluster.machineConfig.amazonEc2.selectedNetwork.placeholder')"
               :label="t('cluster.machineConfig.amazonEc2.selectedNetwork.label')"
+              data-testid="amazonEc2__selectedNetwork"
               option-key="value"
               @input="updateNetwork($event)"
             >


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
Tests cover the creation and deletion of an RKE2 Amazon EC2 cluster. See the test plan [here](https://github.com/rancher/qa-tasks/issues/748)

### Technical notes summary

- This PR relies on a code change in the corral-packages repo which gives our tests access to AWS cloud credentials https://github.com/rancherlabs/corral-packages/pull/33 (I will not merge this PR until the associated PR is approved/merged).
- These tests will only be run in the Jenkins pipeline for two reasons: 1) the tests rely on access/secret keys stored in Jenkins and 2) the provisioning process takes 7+ minutes, hence the `{timeout: 400000}`, to complete.
- I've created a custom command that waits for the 'Loading' indicator to not exist in the DOM before executing the following code. 

### Screenshots
Tests passing in Jenkins Pipeline
<img width="1203" alt="Screenshot 2024-02-01 at 1 40 14 PM" src="https://github.com/rancher/dashboard/assets/127343932/5713168b-35c8-4643-9658-1d016217bb9e">


