### PR TITLE
add option of 'none' for Container Network select in Basics tab of RKE2 provisioning

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -20,6 +20,7 @@ import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import { snapshot } from '@/cypress/e2e/blueprints/manager/cluster-snapshots';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { nodeDriveResponse } from '@/cypress/e2e/tests/pages/manager/mock-responses';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
 const runTimestamp = +new Date();
@@ -75,6 +76,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
             namespace,
             name: rke2CustomName
           },
+          // Test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
+          spec: { rkeConfig: { machineGlobalConfig: { cni: 'none' } } }
         };
 
         cy.userPreferences();
@@ -92,6 +95,17 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
         createRKE2ClusterPage.selectCustom(0);
         createRKE2ClusterPage.nameNsDescription().name().set(rke2CustomName);
+
+        // Test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
+        const labeledSelectPo = new LabeledSelectPo('[data-testid="cluster-rke2-cni-select"]');
+
+        labeledSelectPo.checkExists();
+        labeledSelectPo.self().scrollIntoView();
+        labeledSelectPo.toggle();
+        labeledSelectPo.clickLabel('none');
+        labeledSelectPo.checkOptionSelected('none');
+        // EO test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
+
         createRKE2ClusterPage.create();
 
         cy.wait('@createRequest').then((intercept) => {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -43,23 +43,23 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     cy.login();
   });
 
-  describe('All providers', () => {
-    providersList.forEach((prov) => {
-      prov.conditions.forEach((condition) => {
-        it(`should be able to access cluster creation for provider ${ prov.label } with rke type ${ condition.rkeType } via url`, () => {
-          const clusterCreate = new ClusterManagerCreatePagePo();
+  // describe('All providers', () => {
+  //   providersList.forEach((prov) => {
+  //     prov.conditions.forEach((condition) => {
+  //       it(`should be able to access cluster creation for provider ${ prov.label } with rke type ${ condition.rkeType } via url`, () => {
+  //         const clusterCreate = new ClusterManagerCreatePagePo();
 
-          clusterCreate.goTo(`type=${ prov.clusterProviderQueryParam }&rkeType=${ condition.rkeType }`);
-          clusterCreate.waitForPage();
+  //         clusterCreate.goTo(`type=${ prov.clusterProviderQueryParam }&rkeType=${ condition.rkeType }`);
+  //         clusterCreate.waitForPage();
 
-          const fnName = condition.loads === 'rke1' ? 'rke1PageTitle' : 'rke2PageTitle';
-          const evaluation = condition.loads === 'rke1' ? `Add Cluster - ${ condition.label ? condition.label : prov.label }` : `Create ${ condition.label ? condition.label : prov.label }`;
+  //         const fnName = condition.loads === 'rke1' ? 'rke1PageTitle' : 'rke2PageTitle';
+  //         const evaluation = condition.loads === 'rke1' ? `Add Cluster - ${ condition.label ? condition.label : prov.label }` : `Create ${ condition.label ? condition.label : prov.label }`;
 
-          clusterCreate[fnName]().should('contain', evaluation);
-        });
-      });
-    });
-  });
+  //         clusterCreate[fnName]().should('contain', evaluation);
+  //       });
+  //     });
+  //   });
+  // });
 
   describe('Created', () => {
     const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
@@ -104,6 +104,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         labeledSelectPo.toggle();
         labeledSelectPo.clickLabel('none');
         labeledSelectPo.checkOptionSelected('none');
+
+        // banner with additional info about 'none' option should be visible
+        cy.get('[data-testid="clusterBasics__noneOptionSelectedForCni"]').should('exist');
         // EO test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
 
         createRKE2ClusterPage.create();
@@ -116,103 +119,103 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         detailRKE2ClusterPage.waitForPage(undefined, 'registration');
       });
 
-      it('can copy config to clipboard', () => {
-        ClusterManagerListPagePo.navTo();
+      // it('can copy config to clipboard', () => {
+      //   ClusterManagerListPagePo.navTo();
 
-        cy.intercept('POST', '*action=generateKubeconfig').as('copyKubeConfig');
-        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Copy KubeConfig to Clipboard').click();
-        cy.wait('@copyKubeConfig');
+      //   cy.intercept('POST', '*action=generateKubeconfig').as('copyKubeConfig');
+      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Copy KubeConfig to Clipboard').click();
+      //   cy.wait('@copyKubeConfig');
 
-        // Verify confirmation message displays and is hidden after ~3 sec
-        cy.get('.growl-text').contains('Copied KubeConfig to Clipboard').should('be.visible');
-        cy.get('.growl-text', { timeout: 4000 }).should('not.exist');
+      //   // Verify confirmation message displays and is hidden after ~3 sec
+      //   cy.get('.growl-text').contains('Copied KubeConfig to Clipboard').should('be.visible');
+      //   cy.get('.growl-text', { timeout: 4000 }).should('not.exist');
 
-        // Skipping following assertion for now as it is failing due to Cypress' limitations with accessing the clipboard in Chrome browser and headless mode. Works in Electron browser
-        // see https://github.com/cypress-io/cypress/issues/2752
+      //   // Skipping following assertion for now as it is failing due to Cypress' limitations with accessing the clipboard in Chrome browser and headless mode. Works in Electron browser
+      //   // see https://github.com/cypress-io/cypress/issues/2752
 
-        // read text saved in the browser clipboard
-        // cy.window().its('navigator.clipboard')
-        //   .invoke('readText').should('include', rke2CustomName);
-      });
+      //   // read text saved in the browser clipboard
+      //   // cy.window().its('navigator.clipboard')
+      //   //   .invoke('readText').should('include', rke2CustomName);
+      // });
 
-      it('can edit cluster and see changes afterwards', () => {
-        clusterList.goTo();
-        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
+      // it('can edit cluster and see changes afterwards', () => {
+      //   clusterList.goTo();
+      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
-        editCreatedClusterPage.waitForPage('mode=edit', 'basic');
-        editCreatedClusterPage.nameNsDescription().description().set(rke2CustomName);
-        editCreatedClusterPage.save();
+      //   editCreatedClusterPage.waitForPage('mode=edit', 'basic');
+      //   editCreatedClusterPage.nameNsDescription().description().set(rke2CustomName);
+      //   editCreatedClusterPage.save();
 
-        // We should be taken back to the list page if the save was successful
-        clusterList.waitForPage();
+      //   // We should be taken back to the list page if the save was successful
+      //   clusterList.waitForPage();
 
-        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
+      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
-        editCreatedClusterPage.waitForPage('mode=edit', 'basic');
-        editCreatedClusterPage.nameNsDescription().description().self().should('have.value', rke2CustomName);
-      });
+      //   editCreatedClusterPage.waitForPage('mode=edit', 'basic');
+      //   editCreatedClusterPage.nameNsDescription().description().self().should('have.value', rke2CustomName);
+      // });
 
-      it('can view cluster YAML editor', () => {
-        clusterList.goTo();
-        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit YAML').click();
+      // it('can view cluster YAML editor', () => {
+      //   clusterList.goTo();
+      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit YAML').click();
 
-        editCreatedClusterPage.waitForPage('mode=edit&as=yaml');
-        editCreatedClusterPage.resourceDetail().resourceYaml().checkVisible();
-      });
+      //   editCreatedClusterPage.waitForPage('mode=edit&as=yaml');
+      //   editCreatedClusterPage.resourceDetail().resourceYaml().checkVisible();
+      // });
 
-      it('can download KubeConfig', () => {
-        clusterList.goTo();
-        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
+      // it('can download KubeConfig', () => {
+      //   clusterList.goTo();
+      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
 
-        const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
+      //   const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
-        cy.readFile(downloadedFilename).then((buffer) => {
-          // This will throw an exception which will fail the test if not valid yaml
-          const obj = jsyaml.load(buffer);
+      //   cy.readFile(downloadedFilename).then((buffer) => {
+      //     // This will throw an exception which will fail the test if not valid yaml
+      //     const obj = jsyaml.load(buffer);
 
-          // Basic checks on the downloaded YAML
-          expect(obj.clusters.length).to.equal(1);
-          expect(obj.clusters[0].name).to.equal(rke2CustomName);
-          expect(obj.apiVersion).to.equal('v1');
-          expect(obj.kind).to.equal('Config');
-        });
-      });
+      //     // Basic checks on the downloaded YAML
+      //     expect(obj.clusters.length).to.equal(1);
+      //     expect(obj.clusters[0].name).to.equal(rke2CustomName);
+      //     expect(obj.apiVersion).to.equal('v1');
+      //     expect(obj.kind).to.equal('Config');
+      //   });
+      // });
 
-      it('can download YAML', () => {
-        // Delete downloads directory. Need a fresh start to avoid conflicting file names
-        cy.deleteDownloadsFolder();
+      // it('can download YAML', () => {
+      //   // Delete downloads directory. Need a fresh start to avoid conflicting file names
+      //   cy.deleteDownloadsFolder();
 
-        ClusterManagerListPagePo.navTo();
-        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download YAML').click();
+      //   ClusterManagerListPagePo.navTo();
+      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download YAML').click();
 
-        const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
+      //   const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
-        cy.readFile(downloadedFilename).then((buffer) => {
-          const obj: any = jsyaml.load(buffer);
+      //   cy.readFile(downloadedFilename).then((buffer) => {
+      //     const obj: any = jsyaml.load(buffer);
 
-          // Basic checks on the downloaded YAML
-          expect(obj.apiVersion).to.equal('provisioning.cattle.io/v1');
-          expect(obj.metadata.annotations['field.cattle.io/description']).to.equal(rke2CustomName);
-          expect(obj.kind).to.equal('Cluster');
-        });
-      });
+      //     // Basic checks on the downloaded YAML
+      //     expect(obj.apiVersion).to.equal('provisioning.cattle.io/v1');
+      //     expect(obj.metadata.annotations['field.cattle.io/description']).to.equal(rke2CustomName);
+      //     expect(obj.kind).to.equal('Cluster');
+      //   });
+      // });
 
-      it('can delete cluster', () => {
-        clusterList.goTo();
-        clusterList.sortableTable().rowElementWithName(rke2CustomName).should('exist', { timeout: 15000 });
-        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
+      // it('can delete cluster', () => {
+      //   clusterList.goTo();
+      //   clusterList.sortableTable().rowElementWithName(rke2CustomName).should('exist', { timeout: 15000 });
+      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
 
-        clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
-          const promptRemove = new PromptRemove();
+      //   clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
+      //     const promptRemove = new PromptRemove();
 
-          promptRemove.confirm(rke2CustomName);
-          promptRemove.remove();
+      //     promptRemove.confirm(rke2CustomName);
+      //     promptRemove.remove();
 
-          clusterList.waitForPage();
-          clusterList.sortableTable().checkRowCount(false, rows.length - 1);
-          clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', rke2CustomName);
-        });
-      });
+      //     clusterList.waitForPage();
+      //     clusterList.sortableTable().checkRowCount(false, rows.length - 1);
+      //     clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', rke2CustomName);
+      //   });
+      // });
     });
 
     const createClusterRKE1Page = new ClusterManagerCreateRke1CustomPagePo();

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -43,23 +43,23 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     cy.login();
   });
 
-  // describe('All providers', () => {
-  //   providersList.forEach((prov) => {
-  //     prov.conditions.forEach((condition) => {
-  //       it(`should be able to access cluster creation for provider ${ prov.label } with rke type ${ condition.rkeType } via url`, () => {
-  //         const clusterCreate = new ClusterManagerCreatePagePo();
+  describe('All providers', () => {
+    providersList.forEach((prov) => {
+      prov.conditions.forEach((condition) => {
+        it(`should be able to access cluster creation for provider ${ prov.label } with rke type ${ condition.rkeType } via url`, () => {
+          const clusterCreate = new ClusterManagerCreatePagePo();
 
-  //         clusterCreate.goTo(`type=${ prov.clusterProviderQueryParam }&rkeType=${ condition.rkeType }`);
-  //         clusterCreate.waitForPage();
+          clusterCreate.goTo(`type=${ prov.clusterProviderQueryParam }&rkeType=${ condition.rkeType }`);
+          clusterCreate.waitForPage();
 
-  //         const fnName = condition.loads === 'rke1' ? 'rke1PageTitle' : 'rke2PageTitle';
-  //         const evaluation = condition.loads === 'rke1' ? `Add Cluster - ${ condition.label ? condition.label : prov.label }` : `Create ${ condition.label ? condition.label : prov.label }`;
+          const fnName = condition.loads === 'rke1' ? 'rke1PageTitle' : 'rke2PageTitle';
+          const evaluation = condition.loads === 'rke1' ? `Add Cluster - ${ condition.label ? condition.label : prov.label }` : `Create ${ condition.label ? condition.label : prov.label }`;
 
-  //         clusterCreate[fnName]().should('contain', evaluation);
-  //       });
-  //     });
-  //   });
-  // });
+          clusterCreate[fnName]().should('contain', evaluation);
+        });
+      });
+    });
+  });
 
   describe('Created', () => {
     const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
@@ -119,103 +119,103 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         detailRKE2ClusterPage.waitForPage(undefined, 'registration');
       });
 
-      // it('can copy config to clipboard', () => {
-      //   ClusterManagerListPagePo.navTo();
+      it('can copy config to clipboard', () => {
+        ClusterManagerListPagePo.navTo();
 
-      //   cy.intercept('POST', '*action=generateKubeconfig').as('copyKubeConfig');
-      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Copy KubeConfig to Clipboard').click();
-      //   cy.wait('@copyKubeConfig');
+        cy.intercept('POST', '*action=generateKubeconfig').as('copyKubeConfig');
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Copy KubeConfig to Clipboard').click();
+        cy.wait('@copyKubeConfig');
 
-      //   // Verify confirmation message displays and is hidden after ~3 sec
-      //   cy.get('.growl-text').contains('Copied KubeConfig to Clipboard').should('be.visible');
-      //   cy.get('.growl-text', { timeout: 4000 }).should('not.exist');
+        // Verify confirmation message displays and is hidden after ~3 sec
+        cy.get('.growl-text').contains('Copied KubeConfig to Clipboard').should('be.visible');
+        cy.get('.growl-text', { timeout: 4000 }).should('not.exist');
 
-      //   // Skipping following assertion for now as it is failing due to Cypress' limitations with accessing the clipboard in Chrome browser and headless mode. Works in Electron browser
-      //   // see https://github.com/cypress-io/cypress/issues/2752
+        // Skipping following assertion for now as it is failing due to Cypress' limitations with accessing the clipboard in Chrome browser and headless mode. Works in Electron browser
+        // see https://github.com/cypress-io/cypress/issues/2752
 
-      //   // read text saved in the browser clipboard
-      //   // cy.window().its('navigator.clipboard')
-      //   //   .invoke('readText').should('include', rke2CustomName);
-      // });
+        // read text saved in the browser clipboard
+        // cy.window().its('navigator.clipboard')
+        //   .invoke('readText').should('include', rke2CustomName);
+      });
 
-      // it('can edit cluster and see changes afterwards', () => {
-      //   clusterList.goTo();
-      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
+      it('can edit cluster and see changes afterwards', () => {
+        clusterList.goTo();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
-      //   editCreatedClusterPage.waitForPage('mode=edit', 'basic');
-      //   editCreatedClusterPage.nameNsDescription().description().set(rke2CustomName);
-      //   editCreatedClusterPage.save();
+        editCreatedClusterPage.waitForPage('mode=edit', 'basic');
+        editCreatedClusterPage.nameNsDescription().description().set(rke2CustomName);
+        editCreatedClusterPage.save();
 
-      //   // We should be taken back to the list page if the save was successful
-      //   clusterList.waitForPage();
+        // We should be taken back to the list page if the save was successful
+        clusterList.waitForPage();
 
-      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
-      //   editCreatedClusterPage.waitForPage('mode=edit', 'basic');
-      //   editCreatedClusterPage.nameNsDescription().description().self().should('have.value', rke2CustomName);
-      // });
+        editCreatedClusterPage.waitForPage('mode=edit', 'basic');
+        editCreatedClusterPage.nameNsDescription().description().self().should('have.value', rke2CustomName);
+      });
 
-      // it('can view cluster YAML editor', () => {
-      //   clusterList.goTo();
-      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit YAML').click();
+      it('can view cluster YAML editor', () => {
+        clusterList.goTo();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit YAML').click();
 
-      //   editCreatedClusterPage.waitForPage('mode=edit&as=yaml');
-      //   editCreatedClusterPage.resourceDetail().resourceYaml().checkVisible();
-      // });
+        editCreatedClusterPage.waitForPage('mode=edit&as=yaml');
+        editCreatedClusterPage.resourceDetail().resourceYaml().checkVisible();
+      });
 
-      // it('can download KubeConfig', () => {
-      //   clusterList.goTo();
-      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
+      it('can download KubeConfig', () => {
+        clusterList.goTo();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
 
-      //   const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
+        const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
-      //   cy.readFile(downloadedFilename).then((buffer) => {
-      //     // This will throw an exception which will fail the test if not valid yaml
-      //     const obj = jsyaml.load(buffer);
+        cy.readFile(downloadedFilename).then((buffer) => {
+          // This will throw an exception which will fail the test if not valid yaml
+          const obj = jsyaml.load(buffer);
 
-      //     // Basic checks on the downloaded YAML
-      //     expect(obj.clusters.length).to.equal(1);
-      //     expect(obj.clusters[0].name).to.equal(rke2CustomName);
-      //     expect(obj.apiVersion).to.equal('v1');
-      //     expect(obj.kind).to.equal('Config');
-      //   });
-      // });
+          // Basic checks on the downloaded YAML
+          expect(obj.clusters.length).to.equal(1);
+          expect(obj.clusters[0].name).to.equal(rke2CustomName);
+          expect(obj.apiVersion).to.equal('v1');
+          expect(obj.kind).to.equal('Config');
+        });
+      });
 
-      // it('can download YAML', () => {
-      //   // Delete downloads directory. Need a fresh start to avoid conflicting file names
-      //   cy.deleteDownloadsFolder();
+      it('can download YAML', () => {
+        // Delete downloads directory. Need a fresh start to avoid conflicting file names
+        cy.deleteDownloadsFolder();
 
-      //   ClusterManagerListPagePo.navTo();
-      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download YAML').click();
+        ClusterManagerListPagePo.navTo();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download YAML').click();
 
-      //   const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
+        const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
-      //   cy.readFile(downloadedFilename).then((buffer) => {
-      //     const obj: any = jsyaml.load(buffer);
+        cy.readFile(downloadedFilename).then((buffer) => {
+          const obj: any = jsyaml.load(buffer);
 
-      //     // Basic checks on the downloaded YAML
-      //     expect(obj.apiVersion).to.equal('provisioning.cattle.io/v1');
-      //     expect(obj.metadata.annotations['field.cattle.io/description']).to.equal(rke2CustomName);
-      //     expect(obj.kind).to.equal('Cluster');
-      //   });
-      // });
+          // Basic checks on the downloaded YAML
+          expect(obj.apiVersion).to.equal('provisioning.cattle.io/v1');
+          expect(obj.metadata.annotations['field.cattle.io/description']).to.equal(rke2CustomName);
+          expect(obj.kind).to.equal('Cluster');
+        });
+      });
 
-      // it('can delete cluster', () => {
-      //   clusterList.goTo();
-      //   clusterList.sortableTable().rowElementWithName(rke2CustomName).should('exist', { timeout: 15000 });
-      //   clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
+      it('can delete cluster', () => {
+        clusterList.goTo();
+        clusterList.sortableTable().rowElementWithName(rke2CustomName).should('exist', { timeout: 15000 });
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
 
-      //   clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
-      //     const promptRemove = new PromptRemove();
+        clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
+          const promptRemove = new PromptRemove();
 
-      //     promptRemove.confirm(rke2CustomName);
-      //     promptRemove.remove();
+          promptRemove.confirm(rke2CustomName);
+          promptRemove.remove();
 
-      //     clusterList.waitForPage();
-      //     clusterList.sortableTable().checkRowCount(false, rows.length - 1);
-      //     clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', rke2CustomName);
-      //   });
-      // });
+          clusterList.waitForPage();
+          clusterList.sortableTable().checkRowCount(false, rows.length - 1);
+          clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', rke2CustomName);
+        });
+      });
     });
 
     const createClusterRKE1Page = new ClusterManagerCreateRke1CustomPagePo();

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1862,6 +1862,7 @@ cluster:
       header: System Services
     cni:
       label: Container Network
+      cniNoneBanner: When CNI is set to 'none' an <a href="https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration#additionalmanifest" target="_blank" rel="noopener noreferrer nofollow">Additional Manifest</a> deploying an alternate CNI must be specified for successful cluster provisioning.
       cilium:
         BandwidthManager:
           enable: Enable Bandwidth Manager

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -330,6 +330,26 @@ export default {
 
       const out = findBy(this.versionOptions, 'value', str);
 
+      // Adding the option 'none' to Container Network select (used it Basics component)
+      // https://github.com/rancher/dashboard/issues/10338
+      if (!out.serverArgs) {
+        out.serverArgs = {};
+      }
+
+      if (!out.serverArgs.cni) {
+        out.serverArgs.cni = {};
+      }
+
+      if (!out.serverArgs.cni?.options) {
+        out.serverArgs.cni.options = [];
+      }
+
+      // there's an update loop on refresh that might include 'none'
+      // multiple times... Prevent that
+      if (!out.serverArgs.cni.options.includes('none')) {
+        out.serverArgs.cni.options.push('none');
+      }
+
       return out;
     },
 
@@ -1405,7 +1425,9 @@ export default {
       for ( const chartName of this.addonNames ) {
         const entry = this.chartVersions[chartName];
 
-        if ( this.versionInfo[chartName] ) {
+        // prevent fetching of addon config for 'none' CNI option
+        // https://github.com/rancher/dashboard/issues/10338
+        if ( this.versionInfo[chartName] || chartName.includes('none')) {
           continue;
         }
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -334,7 +334,7 @@ export default {
       // https://github.com/rancher/dashboard/issues/10338
       // there's an update loop on refresh that might include 'none'
       // multiple times... Prevent that
-      if (out.serverArgs.cni?.options && !out.serverArgs.cni.options.includes('none')) {
+      if (out.serverArgs?.cni?.options && !out.serverArgs?.cni?.options.includes('none')) {
         out.serverArgs.cni.options.push('none');
       }
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -330,23 +330,11 @@ export default {
 
       const out = findBy(this.versionOptions, 'value', str);
 
-      // Adding the option 'none' to Container Network select (used it Basics component)
+      // Adding the option 'none' to Container Network select (used in Basics component)
       // https://github.com/rancher/dashboard/issues/10338
-      if (!out.serverArgs) {
-        out.serverArgs = {};
-      }
-
-      if (!out.serverArgs.cni) {
-        out.serverArgs.cni = {};
-      }
-
-      if (!out.serverArgs.cni?.options) {
-        out.serverArgs.cni.options = [];
-      }
-
       // there's an update loop on refresh that might include 'none'
       // multiple times... Prevent that
-      if (!out.serverArgs.cni.options.includes('none')) {
+      if (out.serverArgs.cni?.options && !out.serverArgs.cni.options.includes('none')) {
         out.serverArgs.cni.options.push('none');
       }
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -213,14 +213,6 @@ export default {
       });
     },
 
-    cniOptions() {
-      const serverCniOptions = this.serverArgs.cni?.options || [];
-
-      serverCniOptions.push('none');
-
-      return serverCniOptions;
-    },
-
     serverArgs() {
       return this.selectedVersion?.serverArgs || {};
     },
@@ -468,7 +460,7 @@ export default {
           data-testid="cluster-rke2-cni-select"
           :mode="mode"
           :disabled="isEdit"
-          :options="cniOptions"
+          :options="serverArgs.cni.options"
           :label="t('cluster.rke2.cni.label')"
         />
       </div>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -213,6 +213,14 @@ export default {
       });
     },
 
+    cniOptions() {
+      const serverCniOptions = this.serverArgs.cni?.options || [];
+
+      serverCniOptions.push('none');
+
+      return serverCniOptions;
+    },
+
     serverArgs() {
       return this.selectedVersion?.serverArgs || {};
     },
@@ -460,7 +468,7 @@ export default {
           data-testid="cluster-rke2-cni-select"
           :mode="mode"
           :disabled="isEdit"
-          :options="serverArgs.cni.options"
+          :options="cniOptions"
           :label="t('cluster.rke2.cni.label')"
         />
       </div>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -420,6 +420,7 @@ export default {
     <Banner
       v-if="serverConfig.cni === 'none'"
       color="warning"
+      data-testid="clusterBasics__noneOptionSelectedForCni"
     >
       <span v-clean-html="t('cluster.rke2.cni.cniNoneBanner', {}, true)" />
     </Banner>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -417,6 +417,12 @@ export default {
     >
       <span v-clean-html="t('cluster.banner.cloudProviderAddConfig', {}, true)" />
     </Banner>
+    <Banner
+      v-if="serverConfig.cni === 'none'"
+      color="warning"
+    >
+      <span v-clean-html="t('cluster.rke2.cni.cniNoneBanner', {}, true)" />
+    </Banner>
     <div class="row mb-10">
       <div class="col span-6">
         <LabeledSelect


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10338 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add option of 'none' for Container Network select in Basics tab of RKE2 provisioning
- add e2e test to check that option is available and can be selected

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Under `Cluster Management`, create a `RKE2 custom` cluster
- On the `Basics` tab, `Container Network` select, select the option `none`
- Check that on the network request payload has been sent with `none` and check YAML after creation to confirm as well

`spec.rkeConfig.machineGlobalConfig.cni`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**Confirmation of data after cluster creation**
![Screenshot 2024-02-02 at 13 30 52](https://github.com/rancher/dashboard/assets/97888974/d3737b4e-61bf-4e79-be68-3390f2ff08a3)

<img width="1662" alt="Screenshot 2024-02-14 at 17 48 16" src="https://github.com/rancher/dashboard/assets/97888974/cc2cce4e-5b73-4d19-ade3-ab129b00958c">


