### PR TITLE
Add ability to configure commentFieldsOptions on resource model for createYaml

### DIFF
--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -1011,6 +1011,28 @@ export default class ProvCluster extends SteveModel {
     return null;
   }
 
+  /**
+   * Gets the options for fields that should be commented out in the YAML representation
+   * of the model. This is particularly useful for conditionally commenting out certain
+   * fields based on the model's configuration.
+   *
+   * @returns {null | Array.<{path: string, key: string}>}
+   * - `path`: A dot-separated string indicating the path to the object containing the key.
+   * - `key`: The specific key within the object at the given path that should be commented out.
+   */
+  get commentFieldsOptions() {
+    if ( this.isRke2 ) {
+      return [
+        {
+          path: 'spec.rkeConfig.machineGlobalConfig',
+          key:  'profile'
+        }
+      ];
+    }
+
+    return null;
+  }
+
   // JSON Paths that should be folded in the YAML editor by default
   get yamlFolding() {
     return [

--- a/shell/utils/__tests__/create-yaml.test.ts
+++ b/shell/utils/__tests__/create-yaml.test.ts
@@ -488,3 +488,198 @@ __clone: true
     expect(actual).toStrictEqual(expected);
   });
 });
+
+describe('fx: createYaml', () => {
+  interface CommentFieldsOption {
+    path: string;
+    key: string;
+  }
+
+  const schemas = [
+    {
+      id:             'provisioning.cattle.io.cluster',
+      resourceFields: {
+        apiVersion: {
+          type:   'string',
+          create: false,
+          update: false
+        },
+        kind: {
+          type:   'string',
+          create: false,
+          update: false
+        },
+        metadata: {
+          type:   'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta',
+          create: true,
+          update: true
+        },
+        spec: {
+          type:     'provisioning.cattle.io.v1.cluster.spec',
+          nullable: true,
+          create:   true,
+          update:   true
+        }
+      }
+    },
+    {
+      id:             'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta',
+      resourceFields: {
+        annotations: {
+          type:   'map[string]',
+          create: true,
+          update: true
+        },
+        labels: {
+          type:   'map[string]',
+          create: true,
+          update: true
+        },
+        namespace: {
+          type:   'string',
+          create: true,
+          update: true
+        }
+      }
+    },
+    {
+      id:             'provisioning.cattle.io.v1.cluster.spec',
+      resourceFields: {
+        localClusterAuthEndpoint: {
+          type:     'provisioning.cattle.io.v1.cluster.spec.localClusterAuthEndpoint',
+          nullable: true,
+          create:   true,
+          update:   true
+        },
+        rkeConfig: {
+          type:     'provisioning.cattle.io.v1.cluster.spec.rkeConfig',
+          nullable: true,
+          create:   true,
+          update:   true
+        }
+      }
+    },
+    {
+      id:             'provisioning.cattle.io.v1.cluster.spec.localClusterAuthEndpoint',
+      resourceFields: {
+        caCerts: {
+          type:     'string',
+          nullable: true,
+          create:   true,
+          update:   true
+        },
+        enabled: {
+          type:     'boolean',
+          nullable: true,
+          create:   true,
+          update:   true
+        },
+        fqdn: {
+          type:     'string',
+          nullable: true,
+          create:   true,
+          update:   true
+        }
+      }
+    },
+    {
+      id:             'provisioning.cattle.io.v1.cluster.spec.rkeConfig',
+      resourceFields: {
+        additionalManifest: {
+          type:     'string',
+          nullable: true,
+          create:   true,
+          update:   true
+        },
+        chartValues: {
+          type:     'provisioning.cattle.io.v1.cluster.spec.rkeConfig.chartValues',
+          nullable: true,
+          create:   true,
+          update:   true
+        },
+        machineGlobalConfig: {
+          type:     'provisioning.cattle.io.v1.cluster.spec.rkeConfig.machineGlobalConfig',
+          nullable: true,
+          create:   true,
+          update:   true
+        }
+      }
+    },
+    {
+      id:             'provisioning.cattle.io.v1.cluster.spec.rkeConfig.chartValues',
+      resourceFields: {}
+    },
+    {
+      id:             'provisioning.cattle.io.v1.cluster.spec.rkeConfig.machineGlobalConfig',
+      resourceFields: {}
+    }
+  ];
+
+  it('should comment out fields when specific properties are defined on the model with commentFieldsOptions', () => {
+    const data = {
+      type:     'provisioning.cattle.io.cluster',
+      metadata: {
+        namespace:   'fleet-default',
+        annotations: { someannotation: 'test' },
+        labels:      {}
+      },
+      __clone: true,
+      spec:    {
+        localClusterAuthEndpoint: {
+          caCerts: '',
+          enabled: false,
+          fqdn:    ''
+        },
+        rkeConfig: {
+          machineGlobalConfig: {
+            cni:                   'calico',
+            'disable-kube-proxy':  false,
+            'etcd-expose-metrics': false,
+            profile:               null
+          },
+          chartValues: {}
+        },
+      },
+      apiVersion: 'provisioning.cattle.io/v1',
+      kind:       'Cluster'
+    };
+
+    const type = 'provisioning.cattle.io.cluster';
+    const commentFieldsOptions: CommentFieldsOption[] = [
+      { path: 'spec.rkeConfig.machineGlobalConfig', key: 'profile' },
+      { path: 'spec', key: 'localClusterAuthEndpoint' }
+    ];
+
+    // Define the expected YAML output as a string, adjusted for correct spacing
+    const expectedYaml = `
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    someannotation: test
+    #  key: string
+  labels:
+    {}
+    #  key: string
+  namespace: fleet-default
+spec:
+#  localClusterAuthEndpoint:
+    caCerts: ''
+    enabled: false
+    fqdn: ''
+  rkeConfig:
+    chartValues:
+      {}
+    machineGlobalConfig:
+      cni: calico
+      disable-kube-proxy: false
+      etcd-expose-metrics: false
+#       profile: null
+#    additionalManifest: string
+__clone: true`.trim();
+
+    const result = createYaml(schemas, type, data, true, 0, '', null, {}, commentFieldsOptions as any);
+
+    expect(result.trim()).toStrictEqual(expectedYaml);
+  });
+});

--- a/shell/utils/create-yaml.js
+++ b/shell/utils/create-yaml.js
@@ -70,13 +70,14 @@ export const ACTIVELY_REMOVE = [
 
 const INDENT = 2;
 
-export function createYamlWithOptions(schemas, type, data, options) {
+export function createYamlWithOptions(schemas, type, data, options, commentFieldsOptions) {
   return createYaml(
     schemas,
     type,
     data,
     true, 0, '', null,
-    options
+    options,
+    commentFieldsOptions
   );
 }
 

--- a/shell/utils/create-yaml.js
+++ b/shell/utils/create-yaml.js
@@ -292,7 +292,7 @@ export function createYaml(
       if ( SIMPLE_TYPES.includes(mapOf) ) {
         out += `#  key: ${ mapOf }`;
       } else {
-        // If not a simple type ie some sort of object/array, recusively build out commented fields (note data = null here) per the type's (mapOf's) schema
+        // If not a simple type ie some sort of object/array, recursively build out commented fields (note data = null here) per the type's (mapOf's) schema
         const chunk = createYaml(schemas, mapOf, null, processAlwaysAdd, depth + 1, (path ? `${ path }.${ key }` : key), rootType, dataOptions, commentFieldsOptions);
         let indented = indent(chunk);
 

--- a/shell/utils/create-yaml.js
+++ b/shell/utils/create-yaml.js
@@ -452,14 +452,17 @@ export function createYaml(
     return out;
   }
 
-  function addCommentSubFieldsOptions(commentFieldsOptions, data, path, key) {
-    if (!!commentFieldsOptions) {
-      if ( Array.isArray(commentFieldsOptions) && commentFieldsOptions.length ) {
+  /**
+   * Extends original commentFieldsOptions to cover nested objects
+   */
+  function addCommentSubFieldsOptions(options, data, path, key) {
+    if (!!options) {
+      if ( Array.isArray(options) && options.length ) {
         const currentPath = path ? `${ path }.${ key }` : key;
 
-        if ( commentFieldsOptions.some((option) => `${ option.path }.${ option.key }` === currentPath) ) {
-          commentFieldsOptions = [
-            ...commentFieldsOptions,
+        if ( options.some((option) => `${ option.path }.${ option.key }` === currentPath) ) {
+          options = [
+            ...options,
             ...Object.keys(data[key]).map((k) => ({
               path: `${ path }.${ key }`,
               key:  k
@@ -469,7 +472,7 @@ export function createYaml(
       }
     }
 
-    return commentFieldsOptions;
+    return options;
   }
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8480 
<!-- Define findings related to the feature or bug issue. -->

As the `profile` property is currently [removed before sending the request](https://github.com/rancher/dashboard/blob/7d9cea18a05807ecfe069389bdac4539ae9381e8/shell/edit/provisioning.cattle.io.cluster/rke2.vue#L1360-L1363) to the backend, this PR adds the ability to determine fields which should be commented out within a resource's YAML representation.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
I added a method on the `provisioning.cattle.io.cluster` model to return an array of field options which should be commented out, during the [creation of the yaml](https://github.com/rancher/dashboard/blob/7d9cea18a05807ecfe069389bdac4539ae9381e8/shell/edit/provisioning.cattle.io.cluster/rke2.vue#L1754-L1765), `createYaml` will fetch the `commentFieldsOptions` from the resource's model and will comment out the properties defined in the options.


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Any resource that can be created as yaml which uses the `createYaml` method. This should only apply to models which have the `commentFieldsOptions` method.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/rancher/dashboard/assets/40806497/394f8af9-dffc-418e-934b-b5b846e774e1

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes

