### PR TITLE
improvements and fix flaky global settings tests

### DIFF
--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -10,7 +10,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   static toggle(): Cypress.Chainable {
-    return cy.getId('top-level-menu').should('exist').click({ force: true });
+    return cy.getId('top-level-menu').should('be.visible').click({ force: true });
   }
 
   /**

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -10,7 +10,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   static toggle(): Cypress.Chainable {
-    return cy.getId('top-level-menu').should('be.visible').click({ force: true });
+    return cy.getId('top-level-menu').should('exist').click({ force: true });
   }
 
   /**

--- a/cypress/e2e/tests/pages/global-settings/branding.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/branding.spec.ts
@@ -40,7 +40,7 @@ describe('Branding', { testIsolation: 'off' }, () => {
 
     globalSettingsNavItem.should('exist');
     globalSettingsNavItem.click();
-    const settingsPage = new SettingsPagePo('local');
+    const settingsPage = new SettingsPagePo('_');
 
     settingsPage.waitForPageWithClusterId();
 
@@ -231,7 +231,7 @@ describe('Branding', { testIsolation: 'off' }, () => {
   it('Link Color', { tags: ['@globalSettings', '@adminUser'] }, () => {
     const brandingPage = new BrandingPagePo();
 
-    BrandingPagePo.navTo();
+    brandingPage.goTo();
 
     // Set
     brandingPage.linkColorCheckbox().set();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixed branding and banners tests:
- improved banner tests by adding an `afterAll` hook to restore settings to the original state
- replaced `navTo` with `goTo` in two places where the tests were hanging and eventually failed bc the loading indicator persists and the UI is covered by it. Note: this is an automation-specific issue.
- ~~navigation tests were failing in Jenkins bc the burger menu was not visible so updating the assertion to `should('exist')` did the trick.~~

### Screenshots

Tests passing in Jenkins runs

<img width="1441" alt="Screenshot 2024-02-03 at 11 11 40 AM" src="https://github.com/rancher/dashboard/assets/127343932/375f3e0c-3c29-4757-9459-166ce79895fd">


