### PR TITLE
Make rke2 clusters respect the machingConfig `addCloudCredential` property set to false

### DIFF
--- a/cypress/e2e/tests/pages/manager/mock-responses.ts
+++ b/cypress/e2e/tests/pages/manager/mock-responses.ts
@@ -1,0 +1,57 @@
+export function nodeDriveResponse(addCloudCredential: boolean): any {
+  return {
+    type:         'collection',
+    links:        { self: '/v1/management.cattle.io.nodedrivers' },
+    actions:      {},
+    resourceType: 'management.cattle.io.nodedriver',
+    count:        1,
+    data:         [
+      {
+        id:    'nutanix',
+        type:  'management.cattle.io.nodedriver',
+        links: {
+          remove: 'blocked', self: '/v1/management.cattle.io.nodedrivers/nutanix', update: 'blocked', view: '/v1/management.cattle.io.nodedrivers/nutanix'
+        },
+        apiVersion: 'management.cattle.io/v3',
+        kind:       'NodeDriver',
+        metadata:   {
+          annotations: {
+            'lifecycle.cattle.io/create.node-driver-controller': 'true', privateCredentialFields: 'password', publicCredentialFields: 'endpoint,username,port'
+          },
+          creationTimestamp: '2024-01-26T18:32:57Z',
+          fields:            ['nutanix', '10d'],
+          finalizers:        ['controller.cattle.io/node-driver-controller'],
+          generation:        5,
+          labels:            { 'cattle.io/creator': 'norman' },
+          name:              'nutanix',
+          relationships:     [{
+            toId: 'nutanixcredentialconfig', toType: 'management.cattle.io.dynamicschema', rel: 'owner', state: 'active', message: 'Resource is current'
+          }, {
+            toId: 'nutanixconfig', toType: 'management.cattle.io.dynamicschema', rel: 'owner', state: 'active', message: 'Resource is current'
+          }],
+          resourceVersion: '3117786',
+          state:           {
+            error: false, message: '', name: 'active', transitioning: false
+          },
+          uid: 'c4da5a49-ecc5-4d74-88a8-1a991a586adb'
+        },
+        spec: {
+          active: true, addCloudCredential, builtin: false, checksum: '65dbf92e2df2b4c6d1a6b1f77c542f2cb13a052a62f236eeee697a1151ede62c', description: '', displayName: 'nutanix', externalId: '', uiUrl: 'https://nutanix.github.io/rancher-ui-driver/v3.4.0/component.js', url: 'https://github.com/nutanix/docker-machine/releases/download/v3.4.0/docker-machine-driver-nutanix', whitelistDomains: ['nutanix.github.io']
+        },
+        status: {
+          appliedChecksum:             '65dbf92e2df2b4c6d1a6b1f77c542f2cb13a052a62f236eeee697a1151ede62c',
+          appliedDockerMachineVersion: '',
+          appliedURL:                  'https://github.com/nutanix/docker-machine/releases/download/v3.4.0/docker-machine-driver-nutanix',
+          conditions:                  [{
+            error: false, lastUpdateTime: '2024-02-02T22:14:36Z', status: 'True', transitioning: false, type: 'Active'
+          }, {
+            error: false, lastUpdateTime: '2024-01-26T18:32:58Z', status: 'True', transitioning: false, type: 'Inactive'
+          }, {
+            error: false, lastUpdateTime: '2024-02-02T22:14:26Z', status: 'True', transitioning: false, type: 'Downloaded'
+          }, {
+            error: false, lastUpdateTime: '2024-02-02T22:14:36Z', status: 'True', transitioning: false, type: 'Installed'
+          }]
+        }
+      }]
+  };
+}

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -305,7 +305,7 @@ export default {
 
       const templates = this.templateOptions;
       const vueKontainerTypes = getters['plugins/clusterDrivers'];
-      const machineTypes = this.nodeDrivers.filter((x) => x.spec.active && x.state === 'active').map((x) => x.spec.displayName || x.id);
+      const machineTypes = this.nodeDrivers.filter((x) => x.spec.active && x.state === 'active');
 
       this.kontainerDrivers.filter((x) => (isImport ? x.showImport : x.showCreate)).forEach((obj) => {
         if ( vueKontainerTypes.includes(obj.driverName) ) {
@@ -330,14 +330,18 @@ export default {
         });
 
         if (this.isRke1 ) {
-          machineTypes.forEach((id) => {
-            addType(id, _RKE1, false, `/g/clusters/add/launch/${ id }`, this.iconClasses[id]);
+          machineTypes.forEach((type) => {
+            const id = type.spec.displayName || type.id;
+
+            addType(id, _RKE1, false, `/g/clusters/add/launch/${ id }`, this.iconClasses[id], type);
           });
 
           addType('custom', 'custom1', false, '/g/clusters/add/launch/custom');
         } else {
-          machineTypes.forEach((id) => {
-            addType(id, _RKE2, false);
+          machineTypes.forEach((type) => {
+            const id = type.spec.displayName || type.id;
+
+            addType(id, _RKE2, false, null, undefined, type);
           });
 
           addType('custom', 'custom2', false);
@@ -392,7 +396,7 @@ export default {
         out.push(subtype);
       }
 
-      function addType(id, group, disabled = false, emberLink = null, iconClass = undefined) {
+      function addType(id, group, disabled = false, emberLink = null, iconClass = undefined, providerConfig = undefined) {
         const label = getters['i18n/withFallback'](`cluster.provider."${ id }"`, null, id);
         const description = getters['i18n/withFallback'](`cluster.providerDescription."${ id }"`, null, '');
         const tag = '';
@@ -418,7 +422,8 @@ export default {
           group,
           disabled,
           emberLink,
-          tag
+          tag,
+          providerConfig
         };
 
         out.push(subtype);
@@ -638,6 +643,7 @@ export default {
         :live-value="liveValue"
         :mode="mode"
         :provider="subType"
+        :provider-config="selectedSubType.providerConfig"
       />
       <Rke2Config
         v-else
@@ -646,6 +652,7 @@ export default {
         :live-value="liveValue"
         :mode="mode"
         :provider="subType"
+        :provider-config="selectedSubType.providerConfig"
       />
     </template>
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -126,6 +126,11 @@ export default {
       type:     String,
       required: true,
     },
+
+    providerConfig: {
+      type:    Object,
+      default: () => null
+    }
   },
 
   async fetch() {
@@ -351,7 +356,7 @@ export default {
     },
 
     needCredential() {
-      if ( this.provider === 'custom' || this.provider === 'import' || this.isElementalCluster || this.mode === _VIEW ) {
+      if ( this.provider === 'custom' || this.provider === 'import' || this.isElementalCluster || this.mode === _VIEW || (this.providerConfig?.spec?.builtin === false && this.providerConfig?.spec?.addCloudCredential === false) ) {
         return false;
       }
 
@@ -2048,11 +2053,13 @@ export default {
       :cancel="cancelCredential"
       :showing-form="showForm"
       :default-on-cancel="true"
+      data-testid="select-credential"
       class="mt-20"
     />
 
     <div
       v-if="showForm"
+      data-testid="form"
       class="mt-20"
     >
       <NameNsDescription


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ports RKE1 behavior over to RKE2 where we bypass the credential prompt when using a node driver with the `addCloudCredential` property set to false

This is achieved by having the cluster creation page pass the nodeDriver config object down to the rke2 component so the rke2 component can inspect the the property.

### Occurred changes and/or fixed issues
https://github.com/rancher/dashboard/issues/7023

### Technical notes summary
I tested this using the `Nutanix` driver instead of the `Proxmoxve` since would get stuck in a `Downloading` state for me.

### Areas or cases that should be tested
Drivers with and without the `addCloudCredential` should be tested. 

- I know Nutanix is false while Digitalocean is true.
