### PR TITLE
Fix issue where labelSelector param was incorrectly applied to filter param

### DIFF
--- a/shell/plugins/dashboard-store/__tests__/actions.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/actions.test.ts
@@ -1,127 +1,127 @@
 import _actions from '@shell/plugins/dashboard-store/actions';
 
-const { findAll } = _actions;
+const { findAll, findMatching } = _actions;
 
 describe('dashboard-store: actions', () => {
-  const setupContext = () => {
-    const commit = jest.fn();
-    const dispatch = jest.fn((...args) => {
-      switch (args[0]) {
-      case 'request':
-        return { data: ['requestData'] };
-      }
-    });
-    const state = { config: { namespace: 'unitTest' } };
-    const getters = {
-      normalizeType:    jest.fn(() => 'getters.normalizeType'),
-      typeRegistered:   jest.fn(() => false),
-      haveAll:          jest.fn(() => false),
-      haveAllNamespace: jest.fn(() => false),
-      all:              jest.fn(() => 'getters.all'),
-      urlFor:           jest.fn(() => 'getters.urlFor'), // we're not testing the urlFor getter so we don't need to do anything with opt here
-    };
-    const rootGetters = {
-      'type-map/optionsFor': jest.fn(),
-      'auth/fromHeader':     'foo'
+  describe('findAll', () => {
+    // Note - there are TS errors alll over this describe and should not have merged with them in.
+    const setupContext = () => {
+      const commit = jest.fn();
+      const dispatch = jest.fn((...args) => {
+        switch (args[0]) {
+        case 'request':
+          return { data: ['requestData'] };
+        }
+      });
+      const state = { config: { namespace: 'unitTest' } };
+      const getters = {
+        normalizeType:    jest.fn(() => 'getters.normalizeType'),
+        typeRegistered:   jest.fn(() => false),
+        haveAll:          jest.fn(() => false),
+        haveAllNamespace: jest.fn(() => false),
+        all:              jest.fn(() => 'getters.all'),
+        urlFor:           jest.fn(() => 'getters.urlFor'), // we're not testing the urlFor getter so we don't need to do anything with opt here
+      };
+      const rootGetters = {
+        'type-map/optionsFor': jest.fn(),
+        'auth/fromHeader':     'foo'
+      };
+
+      // we're not testing function output based off of state or getter inputs here since they are dependencies and should be tested independently
+      return {
+        state,
+        getters,
+        rootGetters,
+        commit,
+        dispatch
+      };
     };
 
-    // we're not testing function output based off of state or getter inputs here since they are dependencies and should be tested independently
-    return {
-      state,
-      getters,
-      rootGetters,
-      commit,
-      dispatch
-    };
-  };
-
-  const standardAssertions = {
-    returnsPromise:
-      {
+    const standardAssertions = {
+      returnsPromise: {
         assertionLabel: 'returns a promise',
         valueGetter:    ({ findAllPromise }) => typeof findAllPromise.then,
         valueExpected:  'function'
       },
-    callsAll: {
-      assertionLabel: 'calls the "all" getter with the normalizedType',
-      valueGetter:    ({ getters }) => getters.all.mock.calls[0][0],
-      valueExpected:  'getters.normalizeType'
-    },
-    returnsFromAll: {
-      assertionLabel: 'returns the value expected from the "all" getter',
-      valueGetter:    ({ findAllReturnValue }) => findAllReturnValue,
-      valueExpected:  'getters.all'
-    },
-    firstDispatchAction: {
-      assertionLabel: 'first dispatch should be the "request" action',
-      valueGetter:    ({ dispatch }) => dispatch.mock.calls[0][0],
-      valueExpected:  'request'
-    },
-    firstDispatchParams: {
-      assertionLabel: 'first dispatch parameters should be provided a normalized type and a url, streaming, and "metadata.managedFields" excluded under opt',
-      valueGetter:    ({ dispatch }) => dispatch.mock.calls[0][1],
-      valueExpected:  {
-        type: 'getters.normalizeType',
-        opt:  {
-          url:    'getters.urlFor',
-          stream: true
-        }
+      callsAll: {
+        assertionLabel: 'calls the "all" getter with the normalizedType',
+        valueGetter:    ({ getters }) => getters.all.mock.calls[0][0],
+        valueExpected:  'getters.normalizeType'
       },
-      assertionMethod: 'toMatchObject'
-    },
-    secondDispatchAction: {
-      assertionLabel: 'second dispatch should be the "watch" action',
-      valueGetter:    ({ dispatch }) => dispatch.mock.calls[1][0],
-      valueExpected:  'watch'
-    },
-    secondDispatchParams: {
-      assertionLabel:  'second dispatch parameters should have a normalized type and force set to false',
-      valueGetter:     ({ dispatch }) => dispatch.mock.calls[1][1],
-      valueExpected:   { type: 'getters.normalizeType', force: false },
-      assertionMethod: 'toMatchObject'
-    },
-    countDispatches: {
-      assertionLabel:  'should only make two dispatches',
-      valueGetter:     ({ dispatch }) => dispatch.mock.calls,
-      valueExpected:   2,
-      assertionMethod: 'toHaveLength'
-    },
-    firstCommitMutation: {
-      assertionLabel: 'first commit should be the "registerType" mutation',
-      valueGetter:    ({ commit }) => commit.mock.calls[0][0],
-      valueExpected:  'registerType'
-    },
-    firstCommitParams: {
-      assertionLabel: 'first commit parameter should be a normalized type',
-      valueGetter:    ({ commit }) => commit.mock.calls[0][1],
-      valueExpected:  'getters.normalizeType'
-    },
-    secondCommitMutation: {
-      assertionLabel: 'second commit should be the "loadAll" mutation',
-      valueGetter:    ({ commit }) => commit.mock.calls[1][0],
-      valueExpected:  'loadAll'
-    },
-    secondCommitParams: {
-      assertionLabel: 'second commit parameters should have a normalized type, ctx.state.config.namespace, data returned by request, and skipHaveAll set to false',
-      valueGetter:    ({ commit }) => commit.mock.calls[1][1],
-      valueExpected:  {
-        type:        'getters.normalizeType',
-        ctx:         { state: { config: { namespace: 'unitTest' } } },
-        data:        ['requestData'],
-        skipHaveAll: false,
+      returnsFromAll: {
+        assertionLabel: 'returns the value expected from the "all" getter',
+        valueGetter:    ({ findAllReturnValue }) => findAllReturnValue,
+        valueExpected:  'getters.all'
       },
-      assertionMethod: 'toMatchObject'
-    },
-    countCommits: {
-      assertionLabel:  'should only make two commits',
-      valueGetter:     ({ commit }) => commit.mock.calls,
-      valueExpected:   2,
-      assertionMethod: 'toHaveLength'
-    }
+      firstDispatchAction: {
+        assertionLabel: 'first dispatch should be the "request" action',
+        valueGetter:    ({ dispatch }) => dispatch.mock.calls[0][0],
+        valueExpected:  'request'
+      },
+      firstDispatchParams: {
+        assertionLabel: 'first dispatch parameters should be provided a normalized type and a url, streaming, and "metadata.managedFields" excluded under opt',
+        valueGetter:    ({ dispatch }) => dispatch.mock.calls[0][1],
+        valueExpected:  {
+          type: 'getters.normalizeType',
+          opt:  {
+            url:    'getters.urlFor',
+            stream: true
+          }
+        },
+        assertionMethod: 'toMatchObject'
+      },
+      secondDispatchAction: {
+        assertionLabel: 'second dispatch should be the "watch" action',
+        valueGetter:    ({ dispatch }) => dispatch.mock.calls[1][0],
+        valueExpected:  'watch'
+      },
+      secondDispatchParams: {
+        assertionLabel:  'second dispatch parameters should have a normalized type and force set to false',
+        valueGetter:     ({ dispatch }) => dispatch.mock.calls[1][1],
+        valueExpected:   { type: 'getters.normalizeType', force: false },
+        assertionMethod: 'toMatchObject'
+      },
+      countDispatches: {
+        assertionLabel:  'should only make two dispatches',
+        valueGetter:     ({ dispatch }) => dispatch.mock.calls,
+        valueExpected:   2,
+        assertionMethod: 'toHaveLength'
+      },
+      firstCommitMutation: {
+        assertionLabel: 'first commit should be the "registerType" mutation',
+        valueGetter:    ({ commit }) => commit.mock.calls[0][0],
+        valueExpected:  'registerType'
+      },
+      firstCommitParams: {
+        assertionLabel: 'first commit parameter should be a normalized type',
+        valueGetter:    ({ commit }) => commit.mock.calls[0][1],
+        valueExpected:  'getters.normalizeType'
+      },
+      secondCommitMutation: {
+        assertionLabel: 'second commit should be the "loadAll" mutation',
+        valueGetter:    ({ commit }) => commit.mock.calls[1][0],
+        valueExpected:  'loadAll'
+      },
+      secondCommitParams: {
+        assertionLabel: 'second commit parameters should have a normalized type, ctx.state.config.namespace, data returned by request, and skipHaveAll set to false',
+        valueGetter:    ({ commit }) => commit.mock.calls[1][1],
+        valueExpected:  {
+          type:        'getters.normalizeType',
+          ctx:         { state: { config: { namespace: 'unitTest' } } },
+          data:        ['requestData'],
+          skipHaveAll: false,
+        },
+        assertionMethod: 'toMatchObject'
+      },
+      countCommits: {
+        assertionLabel:  'should only make two commits',
+        valueGetter:     ({ commit }) => commit.mock.calls,
+        valueExpected:   2,
+        assertionMethod: 'toHaveLength'
+      }
 
-  };
+    };
 
-  describe('dashboard-store > actions > findAll', () => {
     describe('called without a cache for the type in the second param', () => {
       const {
         dispatch, commit, getters, rootGetters, state
@@ -161,5 +161,90 @@ describe('dashboard-store: actions', () => {
         }
       );
     });
+  });
+
+  describe('findMatching', () => {
+    const setupContext = () => {
+      const commit = jest.fn();
+      const dispatch = jest.fn(() => 'dispatch');
+
+      const state = { config: { namespace: 'unitTest' } };
+      const getters = {
+        normalizeType:  jest.fn((type) => type),
+        typeRegistered: jest.fn(() => true),
+        haveSelector:   jest.fn(() => false),
+        matching:       jest.fn(() => 'getters.all'),
+        urlFor:         jest.fn(() => 'getters.urlFor'),
+        urlOptions:     jest.fn(() => 'getters.urlOptions')
+      };
+      const rootGetters = { 'type-map/optionsFor': jest.fn() };
+
+      // we're not testing function output based off of state or getter inputs here since they are dependencies and should be tested independently
+      return {
+        state,
+        getters,
+        rootGetters,
+        commit,
+        dispatch
+      };
+    };
+    const genericType = 'services';
+    const genericSelector = 'a=b';
+    const genericOpt = {};
+
+    const assertionChain = [{
+      assertionLabel: 'Basic Selector',
+      input:          {
+        type:      genericType,
+        selector:  genericSelector,
+        opt:       { ...genericOpt },
+        namespace: undefined
+      },
+      output: {
+        getters: {
+          urlFor: [
+            genericType,
+            null,
+            {
+              ...genericOpt,
+              depaginate:    undefined,
+              labelSelector: genericSelector,
+              url:           'getters.urlFor',
+            }
+          ]
+        },
+        actions: {
+          request: {
+            opt:  {},
+            type: genericType
+          }
+        }
+      }
+    }];
+
+    const {
+      dispatch,
+      commit,
+      getters,
+      rootGetters,
+      state
+    } = setupContext();
+
+    it.each(assertionChain)(
+      '$assertionLabel',
+      async({ input, output }) => {
+        await findMatching(
+          {
+            dispatch,
+            getters,
+            rootGetters,
+            state,
+            commit,
+          },
+          input
+        );
+        expect(getters.urlFor).toHaveBeenCalledWith(...output.getters.urlFor);
+      }
+    );
   });
 });

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -368,10 +368,7 @@ export default {
     const typeOptions = rootGetters['type-map/optionsFor'](type);
 
     opt = opt || {};
-
-    opt.filter = opt.filter || {};
-    opt.filter['labelSelector'] = selector;
-
+    opt.labelSelector = selector;
     opt.url = getters.urlFor(type, null, opt);
     opt.depaginate = typeOptions?.depaginate;
 

--- a/shell/plugins/steve/__tests__/getters.spec.ts
+++ b/shell/plugins/steve/__tests__/getters.spec.ts
@@ -37,6 +37,7 @@ describe('steve: getters', () => {
       expect(urlForGetter('typeFoo', undefined, { namespaced: ['nsBar', 'nsBaz'] })).toBe('protocol/urlFoo');
     });
   });
+
   describe('steve > getters > urlOptions', () => {
     // we're not testing function output based off of state or getter inputs here since they are dependencies
     const state = { config: { baseUrl: 'protocol' } };
@@ -71,11 +72,20 @@ describe('steve: getters', () => {
     it('returns a string with a single filter statement applied and formatted for steve if a single filter statement is applied and the url starts with "/v1"', () => {
       expect(urlOptionsGetter('/v1/foo', { filter: { bar: 'baz' } })).toBe('/v1/foo?filter=bar=baz&exclude=metadata.managedFields');
     });
+    it('returns a string with a single filter statement applied and formatted for steve if a single filter statement is applied and the url starts with "/k8s/clusters/c-m-n4x45x4b/v1/"', () => {
+      expect(urlOptionsGetter('/k8s/clusters/c-m-n4x45x4b/v1/foo', { filter: { bar: 'baz' } })).toBe('/k8s/clusters/c-m-n4x45x4b/v1/foo?filter=bar=baz&exclude=metadata.managedFields');
+    });
     it('returns a string with a multiple filter statements applied if a single filter statement is applied', () => {
       expect(urlOptionsGetter('foo', { filter: { bar: 'baz', far: 'faz' } })).toBe('foo?bar=baz&far=faz');
     });
     it('returns a string with a multiple filter statements applied and formatted for steve if a single filter statement is applied and the url starts with "/v1"', () => {
       expect(urlOptionsGetter('/v1/foo', { filter: { bar: 'baz', far: 'faz' } })).toBe('/v1/foo?filter=bar=baz&far=faz&exclude=metadata.managedFields');
+    });
+    it('returns a string with a labelSelector and formatted for steve if the url starts with "/v1"', () => {
+      expect(urlOptionsGetter('/v1/foo', { labelSelector: 'a=b' })).toBe('/v1/foo?labelSelector=a=b&exclude=metadata.managedFields');
+    });
+    it('returns a string with a labelSelector and filter, and formatted for steve if the url starts with "/v1"', () => {
+      expect(urlOptionsGetter('/v1/foo', { labelSelector: 'a=b', filter: { bar: 'baz', far: 'faz' } })).toBe('/v1/foo?labelSelector=a=b&filter=bar=baz&far=faz&exclude=metadata.managedFields');
     });
     it('returns a string with an exclude statement for "bar" and "metadata.managedFields" if excludeFields is a single element array with the string "bar" and the url starts with "/v1/"', () => {
       expect(urlOptionsGetter('/v1/foo', { excludeFields: ['bar'] })).toBe('/v1/foo?exclude=bar&exclude=metadata.managedFields');

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -33,6 +33,12 @@ export default {
     const parsedUrl = parse(url);
     const isSteve = steveRegEx.test(parsedUrl.path);
 
+    // labelSelector
+    if ( opt.labelSelector ) {
+      url += `${ url.includes('?') ? '&' : '?' }labelSelector=${ opt.labelSelector }`;
+    }
+    // End: labelSelector
+
     // Filter
     if ( opt.filter ) {
       url += `${ (url.includes('?') ? '&' : '?') }`;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10410
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- much more detail in issue description
- the two fixes are small
  - remove labelSelector from filter param and add direct to opt in findMatching
  - explicitly add labelSelector to url in urlOptions
- add unit tests to ensure
  - findMatching action calls urlFor with correct args
  - urlOptions getter create correct url given labelSelector

### Areas or cases that should be tested
- see issue description
