### PR TITLE
[Automation] - Use the grepTags as environment variable

### DIFF
--- a/cypress/jenkins/cypress.sh
+++ b/cypress/jenkins/cypress.sh
@@ -12,10 +12,9 @@ yarn add --dev -W mocha mochawesome mochawesome-merge \
   mochawesome-report-generator cypress-multi-reporters \
   mocha-junit-reporter 
 
-NO_COLOR=1 cypress run --browser chrome \
+NO_COLOR=1 CYPRESS_grepTags="CYPRESSTAGS" cypress run --browser chrome \
   --reporter cypress-multi-reporters \
   --reporter-options \
-    configFile=cypress/jenkins/reporter-options.json \
-  --env grepTags="CYPRESSTAGS"
+    configFile=cypress/jenkins/reporter-options.json
 
 echo "CYPRESS EXIT CODE: $?"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes: An small fix to use an environment variable instead of an `--env` flag for `grepTags`. Using `--env` was unstable when using tags separated by commas.

### Areas or cases that should be tested
Jenkins pipeline

### Areas which could experience regressions
N/A
