### PR TITLE
Fix TypeError when registries are added to cluster in Edit as YAML mode

### DIFF
--- a/shell/utils/__tests__/create-yaml.test.ts
+++ b/shell/utils/__tests__/create-yaml.test.ts
@@ -2,6 +2,7 @@ import {
   getBlockDescriptor,
   dumpBlock,
 } from '@shell/utils/create-yaml';
+import jsyaml from 'js-yaml';
 
 const key = 'example';
 const randomData = '\n      foo\n      bar\n';
@@ -59,6 +60,15 @@ describe('fx: dumpBlock', () => {
         });
       });
     });
+  });
+
+  it('should not create a data block when the value of a key is not a string', () => {
+    const data = { key: { test: 'test' } };
+
+    const expectedResult = jsyaml.dump(data);
+    const result = dumpBlock(data);
+
+    expect(result).toStrictEqual(expectedResult);
   });
 
   it('should retain line breaks when a line longer than 80 characters exists', () => {

--- a/shell/utils/create-yaml.js
+++ b/shell/utils/create-yaml.js
@@ -465,7 +465,11 @@ export function dumpBlock(data, options = {}) {
 
   let out = parsed;
 
-  const blockFields = Object.keys(data).filter((k) => data[k].includes('\n'));
+  const blockFields = Object.keys(data).filter((k) => {
+    if (typeof data[k] === 'string') {
+      return data[k].includes('\n');
+    }
+  });
 
   if (blockFields.length) {
     for (const key of blockFields) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10371 

### Occurred changes and/or fixed issues
`dumpBlock` always expects to receive strings but in the case of registry configs/mirrors the value is an object. This change checks for string type before creating blocks in `dumpBlock`.

<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Areas or cases that should be tested
All the registries section functionalities.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/rancher/dashboard/assets/135728925/ec8c69fa-f94d-4bc6-8866-462730b0adc7

