### PR TITLE
Bump istio chart version

### DIFF
--- a/cypress/e2e/tests/pages/charts/istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/istio.spec.ts
@@ -8,7 +8,7 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
   const chartsPageUrl = '/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-charts';
 
   describe('Istio', () => {
-    const istioVersion = '103.1.0%2Bup1.19.5';
+    const istioVersion = '104.0.0%2Bup1.18.2';
 
     const chartsIstioPage = `${ chartsPageUrl }&chart=rancher-istio&version=${ istioVersion }`;
 

--- a/cypress/e2e/tests/pages/charts/istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/istio.spec.ts
@@ -8,7 +8,7 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
   const chartsPageUrl = '/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-charts';
 
   describe('Istio', () => {
-    const istioVersion = '102.2.0%2Bup1.17.2';
+    const istioVersion = '103.1.0%2Bup1.19.5';
 
     const chartsIstioPage = `${ chartsPageUrl }&chart=rancher-istio&version=${ istioVersion }`;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- istio e2e tests are failing repeatidly
  - https://github.com/rancher/dashboard/actions/workflows/test.yaml
  - https://github.com/rancher/dashboard/actions/runs/7832204630/job/21373536327?pr=10008
- probably caused by a version thats no longer available
- we should ensure the tests gets to the wizard by the chart detail page where the latest available version is selected by default

### Checklist
- [x] The PR is linked to an issue, or one is not required. The linked issue has a Milestone
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template below has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] ~The PR has automated tests or clear instructions for manual tests. The linked issue has appropriate QA labels~
- [x] The PR has reviewed with UX (if required) and tested in light and dark mode
