### PR TITLE
Fetch only specific csp adapter helm apps... instead of all helm apps

### DIFF
--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -5,30 +5,39 @@ import { findBy } from '@shell/utils/array';
 import { createCssVars } from '@shell/utils/color';
 import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { setTitle } from '@shell/config/private-label';
+import { allHash } from '@shell/utils/promise';
 
 const cspAdaptorApp = ['rancher-csp-adapter', 'rancher-csp-billing-adapter'];
 
 export const hasCspAdapter = (apps) => {
+  // This can be removed once https://github.com/rancher/dashboard/pull/10349 merges
+  // At the moment we fetch a filtered collection... but still receive updates to all of the resources.
+  // So if any other app changes it will appear in this `apps` collection
   return apps?.find((a) => cspAdaptorApp.includes(a.metadata?.name));
 };
 
 export default {
   async fetch() {
-    // For the login page, the schemas won't be loaded - we don't need the apps in this case
     try {
-      if (this.$store.getters['management/canList'](CATALOG.APP)) {
-        this.apps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP });
-      }
-    } catch (e) {}
+      const promises = {
+        // Ensure we read the settings even when we are not authenticated
+        globalSettings: this.$store.dispatch('management/findAll', {
+          type: MANAGEMENT.SETTING,
+          opt:  {
+            load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
+          }
+        })
+      };
 
-    // Ensure we read the settings even when we are not authenticated
-    try {
-      this.globalSettings = await this.$store.dispatch('management/findAll', {
-        type: MANAGEMENT.SETTING,
-        opt:  {
-          load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
-        }
-      });
+      // For the login page, the schemas won't be loaded - we don't need the apps in this case
+      if (this.$store.getters['management/canList'](CATALOG.APP)) {
+        promises.apps = await this.$store.dispatch('management/findAll', { type: CATALOG.APP, opt: { filter: { 'metadata.name': cspAdaptorApp.join(',') } } });
+      }
+
+      const res = await allHash(promises);
+
+      this.apps = res.apps;
+      this.globalSettings = res.globalSettings;
     } catch (e) {}
 
     // Setting this up front will remove `computed` churn, and we only care that we've initialised them


### PR DESCRIPTION
- Also do in parallel with settings (though these might have already been fetched)

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10434
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fetch only required apps using new `filter` param
- Also do in parallel with settings. This is just best practise i think in all cases (logged in, not logged in) settings are fetched elsewhere)

### Technical notes summary
we still need to filter for required apps, as the socket updates don't respect filter. This will be resolved in future when https://github.com/rancher/dashboard/pull/10349 merges (it'll stop updates to resources not in the list

### Areas or cases that should be tested
Rough flow

Tab 1 - Refresh - Dashboard in standard blue brand,
Tab 2 - /v3/settings/ui-brand does not exist
Tab 3 - Install csp adatper chart (see https://github.com/rancher/dashboard/issues/9270)
Tab 1 - Without any intervention branding should change to green. 
Tab 2 - /v3/settings/ui-brand should exist and be set to `csp`
Tab 1 - Refresh - branding should remain green
Tab 3 - Uninstall csp adapter chart
Tab 1 - Branding should remain green,
Tab 2 - /v3/settings/ui-brand should exist and be set to `csp`
Tab 2 - /v3/settings/ui-brand DELETE 
Tab 1 - Without intervention brandng should be blue,
Tab 1 - Refresh - Dashboard in standard blue brand,

See https://github.com/rancher/dashboard/issues/9270 for some more detail on how to install the csp adapter chart

### Checklist
- [x The PR is linked to an issue, or one is not required. The linked issue has a Milestone
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template below has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests. The linked issue has appropriate QA labels
- [x] The PR has reviewed with UX (if required) and tested in light and dark mode
