### PR TITLE
Revert "Aws In-tree support (#9643)"

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1870,7 +1870,6 @@ cluster:
       header: Cloud Provider Config
       defaultValue:
         label: Default - RKE2 Embedded
-      unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
     security:
       header: Security
     cis:

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -103,10 +103,6 @@ export default {
       type:     Boolean,
       required: true
     },
-    unsupportedCloudProvider: {
-      type:     Boolean,
-      required: true
-    },
     cloudProviderOptions: {
       type:     Array,
       required: true
@@ -369,7 +365,7 @@ export default {
     },
 
     canNotEditCloudProvider() {
-      const canNotEdit = this.isEdit && !this.unsupportedCloudProvider;
+      const canNotEdit = this.isEdit;
 
       return canNotEdit;
     },
@@ -496,12 +492,6 @@ export default {
       <div class="spacer" />
 
       <div class="col span-12">
-        <Banner
-          v-if="unsupportedCloudProvider"
-          class="error mt-5"
-        >
-          {{ t('cluster.rke2.cloudProvider.unsupported') }}
-        </Banner>
         <h3>
           {{ t('cluster.rke2.cloudProvider.header') }}
         </h3>


### PR DESCRIPTION
This reverts changes made by  Aws In-tree support (#9643). While testing, it appears that the intent of this PR (to handle upgrade cases and display a banner) can never be triggered.

fixes #10426
