### PR TITLE
address jenkins failures for manager and users tests

### DIFF
--- a/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
@@ -8,6 +8,9 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
 
   before(() => {
     cy.login();
+  });
+
+  beforeEach(() => {
     cy.createE2EResourceName('cloudCredential').as('cloudCredentialName');
   });
 

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -467,9 +467,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     ClusterManagerListPagePo.navTo();
     clusterList.list().resourceTable().sortableTable().rowElementWithName('local')
       .click();
-    clusterList.list().openBulkActionDropdown();
     cy.intercept('POST', '/v3/clusters/local?action=generateKubeconfig').as('generateKubeConfig');
-    clusterList.list().bulkActionButton('Download KubeConfig').click({ force: true });
+    clusterList.list().downloadKubeConfig().click({ force: true });
     cy.wait('@generateKubeConfig').its('response.statusCode').should('eq', 200);
     const downloadedFilename = path.join(downloadsFolder, 'local.yaml');
 

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -165,13 +165,15 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
       it('can download KubeConfig', () => {
         clusterList.goTo();
+        cy.intercept('POST', '/v3/clusters/**').as('generateKubeconfig');
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
+        cy.wait('@generateKubeconfig').its('response.statusCode').should('eq', 200);
 
         const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
         cy.readFile(downloadedFilename).then((buffer) => {
           // This will throw an exception which will fail the test if not valid yaml
-          const obj = jsyaml.load(buffer);
+          const obj: any = jsyaml.load(buffer);
 
           // Basic checks on the downloaded YAML
           expect(obj.clusters.length).to.equal(1);
@@ -392,7 +394,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editImportedClusterPage.waitForPage('mode=edit');
       });
 
-      it('can delete cluster by bulk actions', { viewportHeight: 1000, viewportWidth: 660 }, () => {
+      it('can delete cluster by bulk actions', () => {
         clusterList.goTo();
         clusterList.sortableTable().rowElementWithName(importGenericName).should('exist', { timeout: 15000 });
         clusterList.sortableTable().rowSelectCtlWithName(importGenericName).set();
@@ -445,7 +447,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     clusterList.list().resourceTable().sortableTable().rowElementWithName('local')
       .click();
     clusterList.list().openBulkActionDropdown();
-    clusterList.list().bulkActionButton('Download YAML').click();
+    clusterList.list().bulkActionButton('Download YAML').click({ force: true });
     const downloadedFilename = path.join(downloadsFolder, `local.yaml`);
 
     cy.readFile(downloadedFilename).then((buffer) => {
@@ -466,7 +468,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     clusterList.list().resourceTable().sortableTable().rowElementWithName('local')
       .click();
     clusterList.list().openBulkActionDropdown();
-    clusterList.list().bulkActionButton('Download KubeConfig').click();
+    cy.intercept('POST', '/v3/clusters/local?action=generateKubeconfig').as('generateKubeConfig');
+    clusterList.list().bulkActionButton('Download KubeConfig').click({ force: true });
+    cy.wait('@generateKubeConfig').its('response.statusCode').should('eq', 200);
     const downloadedFilename = path.join(downloadsFolder, 'local.yaml');
 
     cy.readFile(downloadedFilename).then((buffer) => {

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -14,6 +14,9 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
   before(() => {
     cy.login();
     HomePagePo.goTo();
+  });
+
+  beforeEach(() => {
     cy.createE2EResourceName('rke2ec2cluster').as('rke2Ec2ClusterName');
     cy.createE2EResourceName('ec2cloudcredential').as('ec2CloudCredentialName');
   });
@@ -36,7 +39,9 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
     cloudCredForm.accessKey().set(Cypress.env('awsAccessKey'));
     cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'), true);
     cloudCredForm.defaultRegion().toggle();
-    cloudCredForm.defaultRegion().clickOptionWithLabel('us-west-2');
+    cloudCredForm.defaultRegion().clickOptionWithLabel('us-west-1');
+
+    cy.intercept('GET', '/v1/management.cattle.io.users?exclude=metadata.managedFields').as('pageLoad');
     cloudCredForm.saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials').then((req) => {
       expect(req.response?.statusCode).to.equal(201);
       cloudcredentialId = req.response?.body.id;
@@ -45,6 +50,7 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
 
     const loadingPo = new LoadingPo('.loading-indicator');
 
+    cy.wait('@pageLoad').its('response.statusCode').should('eq', 200);
     loadingPo.checkNotExists();
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
     createRKE2ClusterPage.nameNsDescription().description().set(`${ this.rke2Ec2ClusterName }-description`);
@@ -57,7 +63,7 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
     createRKE2ClusterPage.basicsTab().kubernetesVersions().clickOption(1);
 
     createRKE2ClusterPage.machinePoolTab().networks().toggle();
-    createRKE2ClusterPage.machinePoolTab().networks().clickOption(3);
+    createRKE2ClusterPage.machinePoolTab().networks().clickOptionWithLabel('maxdualstack-vpc');
 
     cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('createRke2Cluster');
     createRKE2ClusterPage.create();

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -14,6 +14,21 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
   before(() => {
     cy.login();
     HomePagePo.goTo();
+
+    // clean up cloud credentials
+    cy.getRancherResource('v3', 'cloudcredentials', null, null).then((resp: Cypress.Response<any>) => {
+      const body = resp.body;
+
+      if (body.pagination['total'] > 0) {
+        for (const i in body.data) {
+          const id = body.data[i]['id'];
+
+          cy.deleteRancherResource('v3', 'cloudcredentials', id);
+        }
+      } else {
+        cy.log('There are no existing cloud credentials to delete');
+      }
+    });
   });
 
   beforeEach(() => {

--- a/cypress/e2e/tests/pages/manager/drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/drivers.spec.ts
@@ -27,6 +27,7 @@ describe('Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, 
       const downloadUrl = 'https://github.com/rancher-plugins/kontainer-engine-driver-example/releases/download/v0.2.3/kontainer-engine-driver-example-copy1-linux-amd64';
 
       RkeDriversPagePo.navTo();
+      driversPage.waitForPage();
       driversPage.addClusterDriver().click();
       driversPage.createEditClusterDriver().formInput(2).set(downloadUrl);
       cy.intercept('POST', '/v3/kontainerdriver').as('createDriver');
@@ -40,6 +41,7 @@ describe('Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, 
       const downloadUrl = 'https://github.com/rancher-plugins/kontainer-engine-driver-example/releases/download/v0.2.3/kontainer-engine-driver-example-copy2-linux-amd64';
 
       RkeDriversPagePo.navTo();
+      driversPage.waitForPage();
       driversPage.list().rowActionMenuOpen(`Example`);
       driversPage.actionMenu().selectMenuItemByLabel(`Edit`);
       driversPage.createEditClusterDriver().formInput(2).set(downloadUrl);
@@ -50,7 +52,8 @@ describe('Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, 
     });
 
     it('can deactivate a cluster driver', () => {
-      driversPage.goTo();
+      RkeDriversPagePo.navTo();
+      driversPage.waitForPage();
       driversPage.list().rowActionMenuOpen(`Example`);
       driversPage.actionMenu().selectMenuItemByLabel(`Deactivate`);
       cy.intercept('POST', '/v3/kontainerDrivers/*').as('deactivateDriver');
@@ -61,6 +64,7 @@ describe('Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, 
 
     it('can activate a cluster driver', () => {
       RkeDriversPagePo.navTo();
+      driversPage.waitForPage();
       driversPage.list().rowActionMenuOpen(`Example`);
       cy.intercept('POST', '/v3/kontainerDrivers/*').as('activateDriver');
       driversPage.actionMenu().selectMenuItemByLabel(`Activate`);
@@ -70,6 +74,7 @@ describe('Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, 
 
     it('can delete a cluster driver', () => {
       RkeDriversPagePo.navTo();
+      driversPage.waitForPage();
       driversPage.list().rowActionMenuOpen(`Example`);
       driversPage.actionMenu().selectMenuItemByLabel(`Delete`);
       cy.intercept('DELETE', '/v3/kontainerDrivers/*').as('deleteDriver');

--- a/cypress/e2e/tests/pages/manager/drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/drivers.spec.ts
@@ -50,7 +50,7 @@ describe('Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, 
     });
 
     it('can deactivate a cluster driver', () => {
-      RkeDriversPagePo.navTo();
+      driversPage.goTo();
       driversPage.list().rowActionMenuOpen(`Example`);
       driversPage.actionMenu().selectMenuItemByLabel(`Deactivate`);
       cy.intercept('POST', '/v3/kontainerDrivers/*').as('deactivateDriver');

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -106,7 +106,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
 
   it('can download YAML', function() {
     MachineDeploymentsPagePo.navTo();
-    machineDeploymentsPage.list().actionMenu(this.machineDeploymentsName).getMenuItem('Download YAML').click();
+    machineDeploymentsPage.list().actionMenu(this.machineDeploymentsName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.machineDeploymentsName }.yaml`);
 

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -15,6 +15,9 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
 
   before(() => {
     cy.login();
+  });
+
+  beforeEach(() => {
     cy.createE2EResourceName('machinedeployments').as('machineDeploymentsName');
   });
 

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -15,6 +15,9 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
 
   before(() => {
     cy.login();
+  });
+
+  beforeEach(() => {
     cy.createE2EResourceName('machinesets').as('machineSetName');
   });
 

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -103,7 +103,7 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
 
   it('can download YAML', function() {
     MachineSetsPagePo.navTo();
-    machineSetsPage.list().actionMenu(this.machineSetName).getMenuItem('Download YAML').click();
+    machineSetsPage.list().actionMenu(this.machineSetName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.machineSetName }.yaml`);
 

--- a/cypress/e2e/tests/pages/manager/machines.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machines.spec.ts
@@ -15,6 +15,9 @@ describe('Machines', { testIsolation: 'off', tags: ['@manager', '@adminUser'] },
 
   before(() => {
     cy.login();
+  });
+
+  beforeEach(() => {
     cy.createE2EResourceName('machines').as('machineName');
   });
 

--- a/cypress/e2e/tests/pages/manager/machines.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machines.spec.ts
@@ -84,7 +84,7 @@ describe('Machines', { testIsolation: 'off', tags: ['@manager', '@adminUser'] },
 
   it('can download YAML', function() {
     MachinesPagePo.navTo();
-    machinesPage.list().actionMenu(this.machineName).getMenuItem('Download YAML').click();
+    machinesPage.list().actionMenu(this.machineName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.machineName }.yaml`);
 

--- a/cypress/e2e/tests/pages/manager/node-templates.spec.ts
+++ b/cypress/e2e/tests/pages/manager/node-templates.spec.ts
@@ -11,12 +11,12 @@ describe('Node Templates', { testIsolation: 'off', tags: ['@manager', '@jenkins'
 
   before(() => {
     cy.login();
-    cy.createE2EResourceName('nodeTemplates').as('nodeTemplateName');
-    cy.createE2EResourceName('cloudCredential').as('cloudCredentialName');
   });
 
   beforeEach(() => {
-    cy.viewport(1380, 720);
+    cy.viewport(1440, 900);
+    cy.createE2EResourceName('nodeTemplates').as('nodeTemplateName');
+    cy.createE2EResourceName('cloudCredential').as('cloudCredentialName');
   });
 
   let removeCloudCred = false;
@@ -66,7 +66,7 @@ describe('Node Templates', { testIsolation: 'off', tags: ['@manager', '@jenkins'
   });
 
   it('can edit a node template', function() {
-    NodeTemplatesPagePo.navTo();
+    nodeTemplatesPage.goTo();
     nodeTemplatesPage.list().rowWithName(this.nodeTemplateName).should('be.visible');
     nodeTemplatesPage.list().rowActionMenuOpen(this.nodeTemplateName);
     nodeTemplatesPage.list().actionMenu().selectMenuItemByLabel('Edit');

--- a/cypress/e2e/tests/pages/manager/node-templates.spec.ts
+++ b/cypress/e2e/tests/pages/manager/node-templates.spec.ts
@@ -66,7 +66,8 @@ describe('Node Templates', { testIsolation: 'off', tags: ['@manager', '@jenkins'
   });
 
   it('can edit a node template', function() {
-    nodeTemplatesPage.goTo();
+    NodeTemplatesPagePo.navTo();
+    nodeTemplatesPage.waitForPage();
     nodeTemplatesPage.list().rowWithName(this.nodeTemplateName).should('be.visible');
     nodeTemplatesPage.list().rowActionMenuOpen(this.nodeTemplateName);
     nodeTemplatesPage.list().actionMenu().selectMenuItemByLabel('Edit');
@@ -84,6 +85,8 @@ describe('Node Templates', { testIsolation: 'off', tags: ['@manager', '@jenkins'
 
   it('can clone a node template', function() {
     NodeTemplatesPagePo.navTo();
+    nodeTemplatesPage.waitForPage();
+
     nodeTemplatesPage.list().rowWithName(`${ this.nodeTemplateName }-edit`).should('be.visible');
     nodeTemplatesPage.list().rowActionMenuOpen(`${ this.nodeTemplateName }-edit`);
     nodeTemplatesPage.list().actionMenu().selectMenuItemByLabel('Clone');
@@ -101,6 +104,7 @@ describe('Node Templates', { testIsolation: 'off', tags: ['@manager', '@jenkins'
 
   it('can delete a node template', function() {
     NodeTemplatesPagePo.navTo();
+    nodeTemplatesPage.waitForPage();
 
     // delete clone node template
     nodeTemplatesPage.list().rowWithName(`${ this.nodeTemplateName }-clone`).should('be.visible');
@@ -120,6 +124,7 @@ describe('Node Templates', { testIsolation: 'off', tags: ['@manager', '@jenkins'
 
   it('can delete a node template via bulk actions', function() {
     NodeTemplatesPagePo.navTo();
+    nodeTemplatesPage.waitForPage();
 
     // delete original node template
     nodeTemplatesPage.list().rowWithName(`${ this.nodeTemplateName }-edit`).click();

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -17,6 +17,7 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
 
   beforeEach(() => {
     cy.viewport(1380, 720);
+    cy.createE2EResourceName('podsecurityadmissions').as('podSecurityAdmissionsName');
   });
 
   it('can create a policy security admission', function() {

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -93,7 +93,7 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
 
   it('can download YAML for a policy security admission', function() {
     PodSecurityAdmissionsPagePo.navTo();
-    podSecurityAdmissionsPage.list().actionMenu(this.podSecurityAdmissionsName).getMenuItem('Download YAML').click();
+    podSecurityAdmissionsPage.list().actionMenu(this.podSecurityAdmissionsName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.podSecurityAdmissionsName }.yaml`);
 

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -12,7 +12,6 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
 
   before(() => {
     cy.login();
-    cy.createE2EResourceName('podsecurityadmissions').as('podSecurityAdmissionsName');
   });
 
   beforeEach(() => {

--- a/cypress/e2e/tests/pages/manager/pod-security-policy-templates.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-policy-templates.spec.ts
@@ -8,11 +8,11 @@ describe.skip('Pod Security Policy Templates', { testIsolation: 'off', tags: ['@
 
   before(() => {
     cy.login();
-    cy.createE2EResourceName('podsecuritytemplate').as('podSecurityTemplateName');
   });
 
   beforeEach(() => {
     cy.viewport(1380, 720);
+    cy.createE2EResourceName('podsecuritytemplate').as('podSecurityTemplateName');
   });
 
   it('can create a policy template', function() {

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -9,6 +9,9 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
 
   before(() => {
     cy.login();
+  });
+
+  beforeEach(() => {
     cy.createE2EResourceName('repo').as('repoName');
   });
 

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -74,7 +74,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
 
   it('can download YAML', function() {
     ChartRepositoriesPagePo.navTo();
-    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Download YAML').click();
+    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.repoName }.yaml`);
 

--- a/cypress/e2e/tests/pages/manager/rke-templates.spec.ts
+++ b/cypress/e2e/tests/pages/manager/rke-templates.spec.ts
@@ -49,7 +49,8 @@ describe('RKE Templates', { testIsolation: 'off', tags: ['@manager', '@adminUser
   });
 
   it('can disable RKE template revision', function() {
-    rkeTemplatesPage.goTo();
+    RkeTemplatesPagePo.navTo();
+    rkeTemplatesPage.waitForPage();
     rkeTemplatesPage.mainRow().rowActionMenuOpen(this.rkeRevisionName);
     cy.intercept('POST', '/v3/clusterTemplateRevisions/*').as('disableTemplateRevision');
     rkeTemplatesPage.actionMenu().selectMenuItemByLabel('Disable');
@@ -60,6 +61,7 @@ describe('RKE Templates', { testIsolation: 'off', tags: ['@manager', '@adminUser
 
   it('can enable RKE template revision', function() {
     RkeTemplatesPagePo.navTo();
+    rkeTemplatesPage.waitForPage();
     rkeTemplatesPage.mainRow().rowActionMenuOpen(this.rkeRevisionName);
     cy.intercept('POST', '/v3/clusterTemplateRevisions/*').as('enableTemplateRevision');
     rkeTemplatesPage.actionMenu().selectMenuItemByLabel('Enable');
@@ -70,6 +72,7 @@ describe('RKE Templates', { testIsolation: 'off', tags: ['@manager', '@adminUser
 
   it('can clone RKE template revision', function() {
     RkeTemplatesPagePo.navTo();
+    rkeTemplatesPage.waitForPage();
     rkeTemplatesPage.groupRow().groupRowWithName(this.rkeTemplateName).should('be.visible');
     rkeTemplatesPage.mainRow().rowActionMenuOpen(this.rkeRevisionName);
     rkeTemplatesPage.actionMenu().selectMenuItemByLabel('Clone Revision');
@@ -82,6 +85,7 @@ describe('RKE Templates', { testIsolation: 'off', tags: ['@manager', '@adminUser
 
   it('can delete RKE template revision', function() {
     RkeTemplatesPagePo.navTo();
+    rkeTemplatesPage.waitForPage();
     rkeTemplatesPage.mainRow().rowActionMenuOpen(`${ this.rkeRevisionName }-2`);
     rkeTemplatesPage.actionMenu().selectMenuItemByLabel(`Delete`);
     cy.intercept('DELETE', '/v3/clusterTemplateRevisions/*').as('deleteTemplateRevision');
@@ -92,6 +96,7 @@ describe('RKE Templates', { testIsolation: 'off', tags: ['@manager', '@adminUser
 
   it('can delete RKE template group', function() {
     RkeTemplatesPagePo.navTo();
+    rkeTemplatesPage.waitForPage();
     rkeTemplatesPage.groupRow().groupRowActionMenuOpen(this.rkeTemplateName);
     rkeTemplatesPage.actionMenu().selectMenuItemByLabel(`Delete`);
     cy.intercept('DELETE', '/v3/clusterTemplates/*').as('deleteTemplate');

--- a/cypress/e2e/tests/pages/manager/rke-templates.spec.ts
+++ b/cypress/e2e/tests/pages/manager/rke-templates.spec.ts
@@ -10,12 +10,12 @@ describe('RKE Templates', { testIsolation: 'off', tags: ['@manager', '@adminUser
 
   before(() => {
     cy.login();
-    cy.createE2EResourceName('rkeTemplate').as('rkeTemplateName');
-    cy.createE2EResourceName('rkeRevision').as('rkeRevisionName');
   });
 
   beforeEach(() => {
-    cy.viewport(1380, 720);
+    cy.viewport(1440, 900);
+    cy.createE2EResourceName('rkeTemplate').as('rkeTemplateName');
+    cy.createE2EResourceName('rkeRevision').as('rkeRevisionName');
   });
 
   it('can create RKE template and should display on RKE1 cluster creation page', function() {
@@ -49,7 +49,7 @@ describe('RKE Templates', { testIsolation: 'off', tags: ['@manager', '@adminUser
   });
 
   it('can disable RKE template revision', function() {
-    RkeTemplatesPagePo.navTo();
+    rkeTemplatesPage.goTo();
     rkeTemplatesPage.mainRow().rowActionMenuOpen(this.rkeRevisionName);
     cy.intercept('POST', '/v3/clusterTemplateRevisions/*').as('disableTemplateRevision');
     rkeTemplatesPage.actionMenu().selectMenuItemByLabel('Disable');

--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -208,7 +208,7 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       usersPo.list().openBulkActionDropdown();
 
       cy.intercept('GET', '/v1/management.cattle.io.users/*').as('downloadYaml');
-      usersPo.list().bulkActionButton('Download YAML').click();
+      usersPo.list().bulkActionButton('Download YAML').click({ force: true });
       cy.wait('@downloadYaml', { timeout: 10000 }).its('response.statusCode').should('eq', 200);
       const downloadedFilename = path.join(downloadsFolder, 'resources.zip');
 
@@ -220,7 +220,7 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       usersPo.waitForRequests();
       usersPo.list().elementWithName(userBaseUsername).click();
       usersPo.list().openBulkActionDropdown();
-      usersPo.list().bulkActionButton('Delete').click();
+      usersPo.list().bulkActionButton('Delete').click({ force: true });
       const promptRemove = new PromptRemove();
 
       cy.intercept('DELETE', '/v3/users/*').as('deleteUser');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
This PR addresses test failures/flaky tests in the Jenkins pipeline for manager and users tests

- Cypress clears aliases between tests; after the first test `undefined` is returned so I've moved the variables into beforeEach hook.
- rke2 aws cluster provisioning test was failing bc subnets were no longer available in the network that was previously selected. I've updated the selection to use a reliable VPC/subnet network.
- ~~change navTos to goTos in one test in each of these specs to prevent failures (drivers, rke templates, and node template tests)~~
- when using default viewport values, the download kubeconfig button should not appear in the bulk action menu dropdown. The fix here is to use `downloadKubeConfig` fn instead of clicking on it from the dropdown menu.
- set viewport values to defaults (width: 1000, height: 660) in Jenkins pipeline - update is in corral-packages repo https://github.com/rancherlabs/corral-packages/pull/38

### Screenshot/Video

### Checklist
- [ ] ~~The PR is linked to an issue, or one is not required. The linked issue has a Milestone~~
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template below has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] ~~The PR has automated tests or clear instructions for manual tests. The linked issue has appropriate QA labels~~
- [ ] ~~The PR has reviewed with UX (if required) and tested in light and dark mode~~
