### PR TITLE
Add root product to improve performance of nav change within inExplorer products 

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -208,8 +208,6 @@ nav:
     resourceIdNotFound: Resource { resource } with id { fqid } not found, unable to display resource details
     reload: Reload
     separator: or
-  errors:
-    noMgmtClusterSchema: Management Cluster Schema is not available
 
 product:
   apps: Apps

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -208,6 +208,8 @@ nav:
     resourceIdNotFound: Resource { resource } with id { fqid } not found, unable to display resource details
     reload: Reload
     separator: or
+  errors:
+    noMgmtClusterSchema: Management Cluster Schema is not available
 
 product:
   apps: Apps

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -98,7 +98,8 @@ export default {
 
     rootProduct(a, b) {
       if (a?.name !== b?.name) {
-        this.queueUpdate();
+        // Immediately update because you'll see it come in later
+        this.getGroups();
       }
     },
 

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -97,8 +97,8 @@ export default {
     },
 
     rootProduct(a, b) {
-      if (a?.name === b?.name) {
-        this.getGroups();
+      if (a?.name !== b?.name) {
+        this.queueUpdate();
       }
     },
 

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -74,13 +74,6 @@ export default {
       }
     },
 
-    productId(a, b) {
-      if ( a !== b) {
-        // Immediately update because you'll see it come in later
-        this.getGroups();
-      }
-    },
-
     // Queue namespaceMode and namespaces
     // Changes to namespaceMode can also change namespaces, so keep this simple and execute both in a shortened queue
 
@@ -103,6 +96,12 @@ export default {
       }
     },
 
+    rootProduct(a, b) {
+      if (a?.name === b?.name) {
+        this.getGroups();
+      }
+    },
+
     $route(a, b) {
       this.$nextTick(() => this.syncNav());
     },
@@ -111,7 +110,7 @@ export default {
 
   computed: {
     ...mapState(['managementReady', 'clusterReady']),
-    ...mapGetters(['productId', 'clusterId', 'currentProduct', 'isSingleProduct', 'namespaceMode', 'isExplorer', 'isVirtualCluster']),
+    ...mapGetters(['productId', 'clusterId', 'currentProduct', 'rootProduct', 'isSingleProduct', 'namespaceMode', 'isExplorer', 'isVirtualCluster']),
     ...mapGetters({ locale: 'i18n/selectedLocaleLabel', availableLocales: 'i18n/availableLocales' }),
     ...mapGetters('type-map', ['activeProducts']),
 
@@ -124,7 +123,7 @@ export default {
     },
 
     supportLink() {
-      const product = this.currentProduct;
+      const product = this.rootProduct;
 
       if (product?.supportRoute) {
         return { ...product.supportRoute, params: { ...product.supportRoute.params, cluster: this.clusterId } };
@@ -159,7 +158,7 @@ export default {
     },
 
     isVirtualProduct() {
-      return this.currentProduct.name === HARVESTER;
+      return this.rootProduct.name === HARVESTER;
     },
 
     allNavLinks() {

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -62,7 +62,7 @@ export default {
 
   computed: {
     ...mapGetters(['clusterReady', 'isExplorer', 'isRancher', 'currentCluster',
-      'currentProduct', 'backToRancherLink', 'backToRancherGlobalLink', 'pageActions', 'isSingleProduct', 'isRancherInHarvester', 'showTopLevelMenu']),
+      'currentProduct', 'rootProduct', 'backToRancherLink', 'backToRancherGlobalLink', 'pageActions', 'isSingleProduct', 'isRancherInHarvester', 'showTopLevelMenu']),
     ...mapGetters('type-map', ['activeProducts']),
 
     appName() {
@@ -94,15 +94,15 @@ export default {
     },
 
     showKubeShell() {
-      return !this.currentProduct?.hideKubeShell;
+      return !this.rootProduct?.hideKubeShell;
     },
 
     showKubeConfig() {
-      return !this.currentProduct?.hideKubeConfig;
+      return !this.rootProduct?.hideKubeConfig;
     },
 
     showCopyConfig() {
-      return !this.currentProduct?.hideCopyConfig;
+      return !this.rootProduct?.hideCopyConfig;
     },
 
     showPreferencesLink() {
@@ -146,17 +146,17 @@ export default {
     },
 
     prod() {
-      const name = this.currentProduct.name;
+      const name = this.rootProduct.name;
 
       return this.$store.getters['i18n/withFallback'](`product."${ name }"`, null, ucFirst(name));
     },
 
     showSearch() {
-      return this.currentProduct?.inStore === 'cluster';
+      return this.rootProduct?.inStore === 'cluster';
     },
 
     showImportYaml() {
-      return this.currentProduct?.inStore !== 'harvester';
+      return this.rootProduct?.inStore !== 'harvester';
     },
 
     nameTooltip() {

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -63,7 +63,6 @@ export default {
   computed: {
     ...mapGetters(['clusterReady', 'isExplorer', 'isRancher', 'currentCluster',
       'currentProduct', 'rootProduct', 'backToRancherLink', 'backToRancherGlobalLink', 'pageActions', 'isSingleProduct', 'isRancherInHarvester', 'showTopLevelMenu']),
-    ...mapGetters('type-map', ['activeProducts']),
 
     appName() {
       return getProduct();

--- a/shell/components/templates/default.vue
+++ b/shell/components/templates/default.vue
@@ -70,7 +70,7 @@ export default {
 
   computed: {
     ...mapState(['managementReady', 'clusterReady']),
-    ...mapGetters(['clusterId', 'currentProduct', 'isRancherInHarvester', 'showTopLevelMenu']),
+    ...mapGetters(['clusterId', 'currentProduct', 'rootProduct', 'isRancherInHarvester', 'showTopLevelMenu']),
 
     afterLoginRoute: mapPref(AFTER_LOGIN_ROUTE),
 
@@ -78,7 +78,7 @@ export default {
 
     pageActions() {
       const pageActions = [];
-      const product = this.currentProduct;
+      const product = this.rootProduct;
 
       if ( !product ) {
         return [];

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -620,7 +620,7 @@ export default {
     let schema = null;
 
     while (!schema && tries > 0) {
-      // Schemas may not have been loaded, so don't error out if they aer not loaded yet
+      // Schemas may not have been loaded, so don't error out if they are not loaded yet
       // the wait here will wait for schemas to load and then for the desired schema to be available
       schema = getters['schemaFor'](type, false, false);
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -844,9 +844,9 @@ export const actions = {
 
     // Forget the cluster if we had a cluster and we have a new cluster OR if the store changed between the old and new products OR if the pkg store changed
     // Package stores are only there for UI Extensions that have their own stores (normal case is this is undefined)
-    const forgetCurrentCluster = ((state.clusterId && id)
-      || (productConfig?.inStore && productConfig.inStore !== oldProductConfig?.inStore))
-      || (oldPkgClusterStore !== newPkgClusterStore);
+    const forgetCurrentCluster = ((state.clusterId && id) ||
+      (productConfig?.inStore && productConfig.inStore !== oldProductConfig?.inStore)) ||
+      (oldPkgClusterStore !== newPkgClusterStore);
 
     // Should we leave/forget the current cluster? Only if we're going from an existing cluster to a new cluster, or the package has changed
     // (latter catches cases like nav from explorer cluster A to epinio cluster A)

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -886,12 +886,6 @@ export const actions = {
     // Try and wait until the schema exists before proceeding
     await dispatch('management/waitForSchema', { type: MANAGEMENT.CLUSTER });
 
-    // Final check, if after waiting and re-fetching schemas, we still don't have the mgmt cluster schema
-    // then show an error
-    if (!getters['management/schemaFor'](MANAGEMENT.CLUSTER)) {
-      throw new Error(getters['i18n/t']('nav.errors.noMgmtClusterSchema'));
-    }
-
     // Similar to above, we're still waiting on loadManagement to fetch required resources
     // If we don't have all mgmt clusters yet a request to fetch this cluster and then all clusters (in cleanNamespaces) is kicked off
     await dispatch('management/waitForHaveAll', { type: MANAGEMENT.CLUSTER });

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -886,6 +886,12 @@ export const actions = {
     // Try and wait until the schema exists before proceeding
     await dispatch('management/waitForSchema', { type: MANAGEMENT.CLUSTER });
 
+    // Final check, if after waiting and re-fetching schemas, we still don't have the mgmt cluster schema
+    // then show an error
+    if (!getters['management/schemaFor'](MANAGEMENT.CLUSTER)) {
+      throw new Error(getters['i18n/t']('nav.errors.noMgmtClusterSchema'));
+    }
+
     // Similar to above, we're still waiting on loadManagement to fetch required resources
     // If we don't have all mgmt clusters yet a request to fetch this cluster and then all clusters (in cleanNamespaces) is kicked off
     await dispatch('management/waitForHaveAll', { type: MANAGEMENT.CLUSTER });

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -340,7 +340,7 @@ export const getters = {
   isExplorer(state, getters) {
     const product = getters.rootProduct;
 
-    return !product ? false : product.name === EXPLORER;
+    return product?.name === EXPLORER;
   },
 
   defaultClusterId(state, getters) {

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -1529,7 +1529,7 @@ export const mutations = {
 
     // Make sure deprecated `inExplorer` is synchronized with `rootProduct` (and vice-versa)
     if (existing?.inExplorer) {
-      existing.rootProduct = existing.rootProduct || EXPLORER;
+      existing.rootProduct = EXPLORER;
     } else if (existing?.rootProduct === EXPLORER) {
       existing.inExplorer = true;
     }
@@ -1537,7 +1537,7 @@ export const mutations = {
     // We make an assumption that if the store for a product is 'cluster' it will be displayed within cluster explorer
     // Detect that here and set rootProduct and inExporer in this case
     if (!existing?.rootProduct && existing?.inStore === 'cluster') {
-      existing.rootProduct = existing.rootProduct || EXPLORER;
+      existing.rootProduct = EXPLORER;
       existing.inExplorer = (existing.rootProduct === EXPLORER);
     }
   },


### PR DESCRIPTION
Fixes #10407

This PR improves the performance when switching between child products of explorer - to test, in a downstraam cluster, install Longhorn and NeuVector from Cluster Tools - these are two simple products that sit within the Explorer product that we can use for testing, as the time taken to switch between them represents the overhead in our nav code paths.

With this PR, switching between them is much faster as the 'rootProduct' (explorer) does not change, even though the current (child) product does - this means less gets re-evaluated.

Before this change, it takes in the order of ~250ms to switch between Longhorn and NeuVector - this is primarily because our nav code believes the product has changed, so we have to call `getGroups` - with this PR, the top-level/root product does not change, so we do not have to call `getGroups` which reduces the time to change nav.

We also wire `rootProduct` into a few places to decide whether to show buttons in the header - which again don't need to be re-evaluated if the root product has not changed.

Before: ~250ms
![image](https://github.com/rancher/dashboard/assets/1955897/2def144e-1864-47da-b416-fffd18e1b3b4)

After: ~140ms
![image](https://github.com/rancher/dashboard/assets/1955897/77bae19f-5df3-43a8-b420-26dc7d427145)
