### PR TITLE
Add mergeable CI gate to check for valid approvals and milestone

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,17 @@
+version: 2
+mergeable:
+  - when: pull_request.*, pull_request_review.*
+    name: 'Approved by rancher/ui team member'
+    validate:
+      - do: approvals
+        min:
+          count: 1
+        limit:
+          teams: ['rancher/ui'] # This should work, but doesn't. It also requires users to make their membership visible
+          users: ['izaac', 'kwwii', 'rak-phillip', 'nwmac', 'cnotv', 'gaktive', 'richard-cox', 'torchiaf', 'jordojordo', 'mantis-toboggan-md', 'codyrancher', 'scures', 'aalves08', 'edenhernandez-suse', 'yonasberhe23', 'eva-vashkevich', 'momesgin']
+  - when: pull_request.*, pull_request_review.*
+    name: 'Has a milestone'
+    validate:
+      - do: milestone
+        no_empty:
+          enabled: true


### PR DESCRIPTION
> Blocked on acceptance of mergeable app permissions on repo. EIO issue created 

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Add a failed gate check if
  - There isn't an approved review from a set list of allowed users
  - There is no PR milestone
- Once this PR merges
  - Add mergeable CI checks as merge blocking
  - Apply the same file to other ui repos


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
