### PR TITLE
[backport v2.8.next1] Revert "Aws In-tree support (#9643)"

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1864,7 +1864,6 @@ cluster:
       header: Cloud Provider Config
       defaultValue:
         label: Default - RKE2 Embedded
-      unsupported: The current Cloud Provider is not supported by this version of Kubernetes. The Cloud Provider has been changed to External. Please use the Cloud Provider Config to supply an out-of-tree configuration as needed.
     security:
       header: Security
     cis:

--- a/shell/edit/provisioning.cattle.io.cluster/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/Basics.vue
@@ -132,10 +132,6 @@ export default {
       type:     Boolean,
       required: true
     },
-    unsupportedCloudProvider: {
-      type:     Boolean,
-      required: true
-    },
     cloudProviderOptions: {
       type:     Array,
       required: true
@@ -374,7 +370,7 @@ export default {
     },
 
     canNotEditCloudProvider() {
-      const canNotEdit = this.clusterIsAlreadyCreated && !this.unsupportedCloudProvider;
+      const canNotEdit = this.clusterIsAlreadyCreated;
 
       return canNotEdit;
     },
@@ -491,12 +487,6 @@ export default {
       <div class="spacer" />
 
       <div class="col span-12">
-        <Banner
-          v-if="unsupportedCloudProvider"
-          class="error mt-5"
-        >
-          {{ t('cluster.rke2.cloudProvider.unsupported') }}
-        </Banner>
         <h3>
           {{ t('cluster.rke2.cloudProvider.header') }}
         </h3>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -249,7 +249,6 @@ export default {
       machinePoolValidation: {}, // map of validation states for each machine pool
       machinePoolErrors:     {},
       allNamespaces:         [],
-      initialCloudProvider:  this.value?.agentConfig?.['cloud-provider-name'] || '',
       extensionTabs:         getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
     };
   },
@@ -644,30 +643,8 @@ export default {
 
       const cur = this.agentConfig['cloud-provider-name'];
 
-      if (cur && !out.find((x) => x.value === cur)) {
-        // Localization missing
-        // Look up cur in the localization file
-        const label = this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ cur }".label`, null, cur);
-
-        out.unshift({
-          label:       `${ label } (Current)`,
-          value:       cur,
-          unsupported: true,
-          disabled:    true
-        });
-      }
-
-      const initial = this.initialCloudProvider;
-
-      if (cur !== initial && initial && !out.find((x) => x.value === initial)) {
-        const label = this.$store.getters['i18n/withFallback'](`cluster.cloudProvider."${ initial }".label`, null, initial);
-
-        out.unshift({
-          label:       `${ label } (Current)`,
-          value:       initial,
-          unsupported: true,
-          disabled:    true
-        });
+      if ( cur && !out.find((x) => x.value === cur) ) {
+        out.unshift({ label: `${ cur } (Current)`, value: cur });
       }
 
       return out;
@@ -781,14 +758,6 @@ export default {
       Object.values(this.machinePoolValidation).forEach((v) => (base = base && v));
 
       return validRequiredPools && base;
-    },
-    unsupportedCloudProvider() {
-      // The current cloud provider
-      const cur = this.initialCloudProvider;
-
-      const provider = cur && this.cloudProviderOptions.find((x) => x.value === cur);
-
-      return !!provider?.unsupported;
     },
   },
 
@@ -2054,18 +2023,6 @@ export default {
         if (this.isHarvesterDriver && this.mode === _CREATE && this.isHarvesterIncompatible) {
           this.setHarvesterDefaultCloudProvider();
         }
-
-        // Cloud Provider check
-        // If the cloud provider is unsupported, switch provider to 'external'
-        if (this.unsupportedCloudProvider) {
-          set(this.agentConfig, 'cloud-provider-name', 'external');
-        } else {
-          // Switch the cloud provider back to the initial value
-          // Use changed the Kubernetes version back to a version where the initial cloud provider is valid - so switch back to this one
-          // to undo the change to external that we may have made
-          // Note: Cloud Provider can only be changed on edit when the initial provider is no longer supported
-          set(this.agentConfig, 'cloud-provider-name', this.initialCloudProvider);
-        }
       }
     },
 
@@ -2338,7 +2295,6 @@ export default {
             :have-arg-info="haveArgInfo"
             :show-cni="showCni"
             :show-cloud-provider="showCloudProvider"
-            :unsupported-cloud-provider="unsupportedCloudProvider"
             :cloud-provider-options="cloudProviderOptions"
             @cilium-ipv6-changed="handleCiliumIpv6Changed"
             @enabled-system-services-changed="handleEnabledSystemServicesChanged"


### PR DESCRIPTION
This reverts changes made by  Aws In-tree support (#9643). While testing, it appears that the intent of this PR (to handle upgrade cases and display a banner) can never be triggered.

fixes #10428
backports #10426
