### PR TITLE
Remove duplicate calls to mgmt settings on fresh load

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -28,6 +28,9 @@ console.log(`    Username: ${ username }`);
 if (!process.env.CATTLE_BOOTSTRAP_PASSWORD && !process.env.TEST_PASSWORD) {
   console.log(' ❌ You must provide either CATTLE_BOOTSTRAP_PASSWORD or TEST_PASSWORD');
 }
+if (process.env.CATTLE_BOOTSTRAP_PASSWORD && process.env.TEST_PASSWORD) {
+  console.log(' ❗ If both CATTLE_BOOTSTRAP_PASSWORD and TEST_PASSWORD are provided, the first will be used');
+}
 if (!skipSetup && !process.env.CATTLE_BOOTSTRAP_PASSWORD) {
   console.log(' ❌ You must provide CATTLE_BOOTSTRAP_PASSWORD when running setup tests');
 }
@@ -83,7 +86,7 @@ export default defineConfig({
     },
     api:               apiUrl,
     username,
-    password:          process.env.TEST_PASSWORD,
+    password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,
     grepTags:          process.env.GREP_TAGS,
     awsAccessKey:      process.env.AWS_ACCESS_KEY_ID, // this env var is only available to tests that run in Jenkins

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -28,9 +28,6 @@ console.log(`    Username: ${ username }`);
 if (!process.env.CATTLE_BOOTSTRAP_PASSWORD && !process.env.TEST_PASSWORD) {
   console.log(' ❌ You must provide either CATTLE_BOOTSTRAP_PASSWORD or TEST_PASSWORD');
 }
-if (process.env.CATTLE_BOOTSTRAP_PASSWORD && process.env.TEST_PASSWORD) {
-  console.log(' ❗ If both CATTLE_BOOTSTRAP_PASSWORD and TEST_PASSWORD are provided, the first will be used');
-}
 if (!skipSetup && !process.env.CATTLE_BOOTSTRAP_PASSWORD) {
   console.log(' ❌ You must provide CATTLE_BOOTSTRAP_PASSWORD when running setup tests');
 }
@@ -86,7 +83,7 @@ export default defineConfig({
     },
     api:               apiUrl,
     username,
-    password:          process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
+    password:          process.env.TEST_PASSWORD,
     bootstrapPassword: process.env.CATTLE_BOOTSTRAP_PASSWORD,
     grepTags:          process.env.GREP_TAGS,
     awsAccessKey:      process.env.AWS_ACCESS_KEY_ID, // this env var is only available to tests that run in Jenkins

--- a/cypress/e2e/po/pages/rancher-setup-configure.po.ts
+++ b/cypress/e2e/po/pages/rancher-setup-configure.po.ts
@@ -5,14 +5,14 @@ import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po'
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import PasswordPo from '@/cypress/e2e/po/components/password.po';
 
-export class RancherSetupAuthVerifyPage extends PagePo {
-  static url = '/auth/login'
+export class RancherSetupConfigurePage extends PagePo {
+  static url = '/auth/setup'
   static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
-    return super.goTo(RancherSetupAuthVerifyPage.url);
+    return super.goTo(RancherSetupConfigurePage.url);
   }
 
   constructor() {
-    super(RancherSetupAuthVerifyPage.url);
+    super(RancherSetupConfigurePage.url);
   }
 
   choosePassword(): RadioGroupInputPo {

--- a/cypress/e2e/po/pages/rancher-setup-login.po.ts
+++ b/cypress/e2e/po/pages/rancher-setup-login.po.ts
@@ -3,18 +3,25 @@ import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import FormPo from '@/cypress/e2e/po/components/form.po';
 import PasswordPo from '@/cypress/e2e/po/components/password.po';
 
-export class RancherSetupPagePo extends PagePo {
+export class RancherSetupLoginPagePo extends PagePo {
   static url = '/auth/login'
   static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
-    return super.goTo(RancherSetupPagePo.url);
+    return super.goTo(RancherSetupLoginPagePo.url);
   }
 
-  form: FormPo;
-
   constructor() {
-    super(RancherSetupPagePo.url);
+    super(RancherSetupLoginPagePo.url);
+  }
 
-    this.form = new FormPo('form', this.self());
+  form(): FormPo {
+    return new FormPo('form', this.self());
+  }
+
+  bootstrapLogin() {
+    this.canSubmit().should('eq', true);
+    this.password().set(Cypress.env('bootstrapPassword'));
+    this.canSubmit().should('eq', true);
+    this.submit();
   }
 
   hasInfoMessage() {

--- a/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
@@ -15,7 +15,10 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
   const chartsPageUrl = '/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-charts';
 
   describe('Monitoring', () => {
-    const chartsMonitoringPage = `${ chartsPageUrl }&chart=rancher-monitoring`;
+    // Ideally we should not specify this, older versions can disappear / have issues.
+    // However it seems the latest can also have issues (like no matching CRD chart)
+    const monitoringVersion = '103.0.2%2Bup45.31.1';
+    const chartsMonitoringPage = `${ chartsPageUrl }&chart=rancher-monitoring&version=${ monitoringVersion }`;
 
     const chartsPage: ChartsPage = new ChartsPage(chartsMonitoringPage);
 

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -2,6 +2,7 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerImportGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.generic.po';
+import { PARTIAL_SETTING_THRESHOLD } from '@/cypress/support/utils/settings-utils';
 
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
@@ -16,7 +17,7 @@ describe('Home Page', () => {
     homePage.goTo();
 
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).greaterThan(10);
+      expect(interception.response.body.count).greaterThan(PARTIAL_SETTING_THRESHOLD);
     });
     // Yes this is bad, but want to ensure no other settings requests are made.
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -8,6 +8,21 @@ const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
 
 describe('Home Page', () => {
+  it('Confirm correct number of settings requests made', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    cy.login();
+
+    cy.intercept('GET', '/v1/management.cattle.io.settings?exclude=metadata.managedFields').as('settingsReq');
+
+    homePage.goTo();
+
+    cy.wait('@settingsReq').then((interception) => {
+      expect(interception.response.body.count).greaterThan(10);
+    });
+    // Yes this is bad, but want to ensure no other settings requests are made.
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.get('@settingsReq.all').should('have.length', 1);
+  });
+
   describe('Home Page', { testIsolation: 'off' }, () => {
     before(() => {
       cy.login();

--- a/cypress/e2e/tests/pages/generic/login.spec.ts
+++ b/cypress/e2e/tests/pages/generic/login.spec.ts
@@ -1,5 +1,6 @@
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
-import HomePagePo from '~/cypress/e2e/po/pages/home.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import { PUBLIC_SETTING_COUNT } from '@/cypress/support/utils/settings-utils';
 
 const successStatusCode = 200;
 
@@ -12,7 +13,7 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
 
     // First request will fetch a partial list of settings
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).lessThan(10);
+      expect(interception.response.body.count).lessThan(PUBLIC_SETTING_COUNT);
     });
     cy.get('@settingsReq.all').should('have.length', 1);
 
@@ -26,7 +27,7 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
 
     // Second request (after user is logged in) will return the full list
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).greaterThan(10);
+      expect(interception.response.body.count).greaterThan(PUBLIC_SETTING_COUNT);
     });
     // Yes this is bad, but want to ensure no other settings requests are made.
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting

--- a/cypress/e2e/tests/pages/generic/login.spec.ts
+++ b/cypress/e2e/tests/pages/generic/login.spec.ts
@@ -1,8 +1,38 @@
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
+import HomePagePo from '~/cypress/e2e/po/pages/home.po';
 
 const successStatusCode = 200;
 
 describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+  it('Confirm correct number of settings requests made', () => {
+    cy.intercept('GET', '/v1/management.cattle.io.settings?exclude=metadata.managedFields').as('settingsReq');
+    const loginPage = new LoginPagePo();
+
+    loginPage.goTo();
+
+    // First request will fetch a partial list of settings
+    cy.wait('@settingsReq').then((interception) => {
+      expect(interception.response.body.count).lessThan(10);
+    });
+    cy.get('@settingsReq.all').should('have.length', 1);
+
+    loginPage.waitForPage();
+    loginPage.switchToLocal();
+    loginPage.username().set(Cypress.env('username'));
+    loginPage.password().set(Cypress.env('password'));
+    loginPage.submit();
+
+    new HomePagePo().waitForPage();
+
+    // Second request (after user is logged in) will return the full list
+    cy.wait('@settingsReq').then((interception) => {
+      expect(interception.response.body.count).greaterThan(10);
+    });
+    // Yes this is bad, but want to ensure no other settings requests are made.
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.get('@settingsReq.all').should('have.length', 2);
+  });
+
   it('Log in with valid credentials', () => {
     LoginPagePo.goTo();
     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');

--- a/cypress/e2e/tests/pages/generic/login.spec.ts
+++ b/cypress/e2e/tests/pages/generic/login.spec.ts
@@ -1,6 +1,6 @@
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
-import { PUBLIC_SETTING_COUNT } from '@/cypress/support/utils/settings-utils';
+import { PARTIAL_SETTING_THRESHOLD } from '@/cypress/support/utils/settings-utils';
 
 const successStatusCode = 200;
 
@@ -13,7 +13,7 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
 
     // First request will fetch a partial list of settings
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).lessThan(PUBLIC_SETTING_COUNT);
+      expect(interception.response.body.count).lessThan(PARTIAL_SETTING_THRESHOLD);
     });
     cy.get('@settingsReq.all').should('have.length', 1);
 
@@ -27,7 +27,7 @@ describe('Local authentication', { tags: ['@generic', '@adminUser', '@standardUs
 
     // Second request (after user is logged in) will return the full list
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).greaterThan(PUBLIC_SETTING_COUNT);
+      expect(interception.response.body.count).greaterThan(PARTIAL_SETTING_THRESHOLD);
     });
     // Yes this is bad, but want to ensure no other settings requests are made.
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -4,7 +4,6 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
-import UserMenuPo from '@/cypress/e2e/po/side-bars/user-menu.po';
 
 const bannersPage = new BannersPagePo();
 const burgerMenu = new BurgerMenuPo();

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -9,7 +9,7 @@ import UserMenuPo from '@/cypress/e2e/po/side-bars/user-menu.po';
 const bannersPage = new BannersPagePo();
 const burgerMenu = new BurgerMenuPo();
 const loginPage = new LoginPagePo();
-const bannersSettingsOrginal = [];
+const bannersSettingsOriginal = [];
 
 const settings = {
   bannerLabel:   'Rancher e2e',
@@ -43,7 +43,7 @@ describe('Banners', { testIsolation: 'off' }, () => {
     cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', null).then((resp: Cypress.Response<any>) => {
       const body = resp.body;
 
-      bannersSettingsOrginal.push(body);
+      bannersSettingsOriginal.push(body);
     });
   });
 
@@ -198,7 +198,7 @@ describe('Banners', { testIsolation: 'off' }, () => {
     });
 
     // Check login screen
-    new UserMenuPo().clickMenuItem('Log Out');
+    cy.logout();
     loginPage.waitForPage();
     loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
     bannersPage.banner().should('be.visible').then((el) => {
@@ -293,9 +293,9 @@ describe('Banners', { testIsolation: 'off' }, () => {
         const response = resp.body.metadata;
 
         // update original data before sending request
-        bannersSettingsOrginal[0].metadata.resourceVersion = response.resourceVersion;
+        bannersSettingsOriginal[0].metadata.resourceVersion = response.resourceVersion;
 
-        cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', bannersSettingsOrginal[0]);
+        cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', bannersSettingsOriginal[0]);
       });
     }
   });

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -4,6 +4,7 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
+import UserMenuPo from '@/cypress/e2e/po/side-bars/user-menu.po';
 
 const bannersPage = new BannersPagePo();
 const burgerMenu = new BurgerMenuPo();
@@ -197,7 +198,7 @@ describe('Banners', { testIsolation: 'off' }, () => {
     });
 
     // Check login screen
-    cy.logout();
+    new UserMenuPo().clickMenuItem('Log Out');
     loginPage.waitForPage();
     loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
     bannersPage.banner().should('be.visible').then((el) => {

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -1,7 +1,7 @@
 import { RancherSetupLoginPagePo } from '@/cypress/e2e/po/pages/rancher-setup-login.po';
 import { RancherSetupConfigurePage } from '~/cypress/e2e/po/pages/rancher-setup-configure.po';
 import HomePagePo from '~/cypress/e2e/po/pages/home.po';
-import { PUBLIC_SETTING_COUNT } from '~/cypress/support/utils/settings-utils';
+import { PARTIAL_SETTING_THRESHOLD } from '~/cypress/support/utils/settings-utils';
 
 // Cypress or the GrepTags avoid to run multiples times the same test for each tag used.
 // This is a temporary solution till initialization is not handled as a test
@@ -24,7 +24,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
 
     // First request will fetch a partial list of settings
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).lessThan(PUBLIC_SETTING_COUNT);
+      expect(interception.response.body.count).lessThan(PARTIAL_SETTING_THRESHOLD);
     });
     cy.get('@settingsReq.all').should('have.length', 1);
 
@@ -33,7 +33,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
 
     // Second request (after user is logged in) will return the full list
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).greaterThan(PUBLIC_SETTING_COUNT);
+      expect(interception.response.body.count).greaterThan(PARTIAL_SETTING_THRESHOLD);
     });
     rancherSetupConfigurePage.waitForPage();
 

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -1,6 +1,7 @@
 import { RancherSetupLoginPagePo } from '@/cypress/e2e/po/pages/rancher-setup-login.po';
 import { RancherSetupConfigurePage } from '~/cypress/e2e/po/pages/rancher-setup-configure.po';
 import HomePagePo from '~/cypress/e2e/po/pages/home.po';
+import { PUBLIC_SETTING_COUNT } from '~/cypress/support/utils/settings-utils';
 
 // Cypress or the GrepTags avoid to run multiples times the same test for each tag used.
 // This is a temporary solution till initialization is not handled as a test
@@ -23,7 +24,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
 
     // First request will fetch a partial list of settings
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).lessThan(10);
+      expect(interception.response.body.count).lessThan(PUBLIC_SETTING_COUNT);
     });
     cy.get('@settingsReq.all').should('have.length', 1);
 
@@ -32,7 +33,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
 
     // Second request (after user is logged in) will return the full list
     cy.wait('@settingsReq').then((interception) => {
-      expect(interception.response.body.count).greaterThan(10);
+      expect(interception.response.body.count).greaterThan(PUBLIC_SETTING_COUNT);
     });
     rancherSetupConfigurePage.waitForPage();
 

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -2,11 +2,6 @@ import { RancherSetupLoginPagePo } from '@/cypress/e2e/po/pages/rancher-setup-lo
 import { RancherSetupConfigurePage } from '~/cypress/e2e/po/pages/rancher-setup-configure.po';
 import HomePagePo from '~/cypress/e2e/po/pages/home.po';
 
-const user = {
-  username: Cypress.env('username'),
-  password: Cypress.env('password')
-};
-
 // Cypress or the GrepTags avoid to run multiples times the same test for each tag used.
 // This is a temporary solution till initialization is not handled as a test
 describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@setup', '@components', '@navigation', '@charts', '@explorer', '@extensions', '@fleet', '@generic', '@globalSettings', '@manager', '@userMenu', '@usersAndAuths'] }, () => {
@@ -61,12 +56,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     cy.intercept('PUT', '/v1/userpreferences/*').as('firstLoginReq');
 
     rancherSetupConfigurePage.waitForPage();
-
     rancherSetupConfigurePage.canSubmit().should('eq', false);
-    rancherSetupConfigurePage.choosePassword().set(1);
-    rancherSetupConfigurePage.password().set(user.password);
-    rancherSetupConfigurePage.confirmPassword().set(user.password);
-
     rancherSetupConfigurePage.termsAgreement().set();
     rancherSetupConfigurePage.canSubmit().should('eq', true);
     rancherSetupConfigurePage.submit();
@@ -80,7 +70,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
   });
 
   it('Create standard user', () => {
-    cy.login(user.username, user.password);
+    cy.login();
 
     // Note: the username argument here should match the TEST_USERNAME env var used when running non-admin tests
     cy.createUser({

--- a/cypress/support/utils/settings-utils.ts
+++ b/cypress/support/utils/settings-utils.ts
@@ -1,9 +1,8 @@
 /**
- * There's a small amount of mgmt settings that are public and will be returned when the user in unauthed.
- *
- * This represents that number.
+ * There's a small amount of mgmt settings that are public and will be returned when the user in unauthed. This represents that number.
  *
  * It doesn't need to be exact but should always be equal or more than the actual amount
+ * (tests will check that the pre-authed setting count is less than this, and the post-authed count is greater than)
  *
  */
-export const PUBLIC_SETTING_COUNT = 12;
+export const PARTIAL_SETTING_THRESHOLD = 12;

--- a/cypress/support/utils/settings-utils.ts
+++ b/cypress/support/utils/settings-utils.ts
@@ -1,0 +1,9 @@
+/**
+ * There's a small amount of mgmt settings that are public and will be returned when the user in unauthed.
+ *
+ * This represents that number.
+ *
+ * It doesn't need to be exact but should always be equal or more than the actual amount
+ *
+ */
+export const PUBLIC_SETTING_COUNT = 12;

--- a/shell/components/FixedBanner.vue
+++ b/shell/components/FixedBanner.vue
@@ -19,18 +19,13 @@ export default {
     },
   },
 
-  async fetch() {
-    this.bannerSetting = await this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BANNERS);
-  },
-
   data() {
     return {
-      showDialog:    true,
-      showHeader:    false,
-      showFooter:    false,
-      showConsent:   false,
-      banner:        {},
-      bannerSetting: null
+      showDialog:  true,
+      showHeader:  false,
+      showFooter:  false,
+      showConsent: false,
+      banner:      {},
     };
   },
 
@@ -56,6 +51,10 @@ export default {
   },
 
   computed: {
+    bannerSetting() {
+      return this.$store.getters['management/all'](MANAGEMENT.SETTING).find((s) => s.id === SETTING.BANNERS);
+    },
+
     bannerStyle() {
       return {
         color:              this.banner.color,
@@ -74,7 +73,7 @@ export default {
       };
     },
     showBanner() {
-      if (!this.banner.text && !this.banner.background) {
+      if (!this.banner?.text && !this.banner?.background) {
         return false;
       }
 
@@ -110,34 +109,38 @@ export default {
   },
 
   watch: {
-    bannerSetting(neu) {
-      if (neu?.value && neu.value !== '') {
-        try {
-          const parsed = JSON.parse(neu.value);
-          const {
-            bannerHeader, bannerFooter, bannerConsent, banner, showHeader, showFooter, showConsent
-          } = parsed;
-          let bannerContent = parsed?.banner || {};
+    bannerSetting: {
+      handler(neu) {
+        if (neu?.value && neu.value !== '') {
+          try {
+            const parsed = JSON.parse(neu.value);
+            const {
+              bannerHeader, bannerFooter, bannerConsent, banner, showHeader, showFooter, showConsent
+            } = parsed;
+            let bannerContent = parsed?.banner || {};
 
-          if (isEmpty(banner)) {
-            if (showHeader && this.header) {
-              bannerContent = bannerHeader || {};
-            } else if (showConsent && this.consent) {
-              bannerContent = this.handleLineBreaksConsentText(bannerConsent) || {};
-            } else if (showFooter && this.footer) {
-              bannerContent = bannerFooter || {};
-            } else {
-              bannerContent = {};
+            if (isEmpty(banner)) {
+              if (showHeader && this.header) {
+                bannerContent = bannerHeader || {};
+              } else if (showConsent && this.consent) {
+                bannerContent = this.handleLineBreaksConsentText(bannerConsent) || {};
+              } else if (showFooter && this.footer) {
+                bannerContent = bannerFooter || {};
+              } else {
+                bannerContent = {};
+              }
             }
-          }
 
-          this.showHeader = showHeader === 'true';
-          this.showFooter = showFooter === 'true';
-          this.showConsent = showConsent === 'true';
-          this.banner = bannerContent;
-        } catch {}
-      }
-    }
+            this.showHeader = showHeader === 'true';
+            this.showFooter = showFooter === 'true';
+            this.showConsent = showConsent === 'true';
+            this.banner = bannerContent;
+          } catch {}
+        }
+      },
+      immediate: true
+    },
+
   }
 };
 </script>

--- a/shell/components/__tests__/FixedBanner.test.ts
+++ b/shell/components/__tests__/FixedBanner.test.ts
@@ -2,6 +2,7 @@ import { shallowMount } from '@vue/test-utils';
 import FixedBanner from '@shell/components/FixedBanner.vue';
 import { ExtendedVue, Vue } from 'vue/types/vue';
 import { DefaultProps } from 'vue/types/options';
+import { SETTING } from '@shell/config/settings';
 
 const SETTING_NO_CONSENT = { value: '{"loginError":{"message":"","showMessage":"false"},"bannerHeader":{"background":" #EEEFF4","color":" #141419","textAlignment":"center","fontWeight":null,"fontStyle":null,"fontSize":"14px","textDecoration":null,"text":"SOME HEADER TEXT"},"bannerFooter":{"background":" #EEEFF4","color":" #141419","textAlignment":"center","fontWeight":null,"fontStyle":null,"fontSize":"14px","textDecoration":null,"text":"SOME FOOTER TEXT"},"bannerConsent":{"background":" #EEEFF4","color":" #141419","textAlignment":"center","fontWeight":null,"fontStyle":null,"fontSize":"14px","textDecoration":null,"text":null,"button":null},"showHeader":"true","showFooter":"true","showConsent":"false"}' };
 const SETTING_WITH_CONSENT = { value: '{"loginError":{"message":"","showMessage":"false"},"bannerHeader":{"background":" #EEEFF4","color":" #141419","textAlignment":"center","fontWeight":null,"fontStyle":null,"fontSize":"14px","textDecoration":null,"text":"SOME HEADER TEXT"},"bannerFooter":{"background":" #EEEFF4","color":" #141419","textAlignment":"center","fontWeight":null,"fontStyle":null,"fontSize":"14px","textDecoration":null,"text":"SOME FOOTER TEXT"},"bannerConsent":{"background":" #EEEFF4","color":" #141419","textAlignment":"center","fontWeight":null,"fontStyle":null,"fontSize":"14px","textDecoration":null,"text":"SOME CONSENT TEXT" ,"button": "some-button-label"},"showHeader":"true","showFooter":"true","showConsent":"true"}' };
@@ -30,12 +31,8 @@ describe('component: FixedBanner', () => {
   it('should render HEADER fixed banner correctly', async() => {
     const wrapper = shallowMount(FixedBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { header: true },
-      mocks:     { $store: { getters: { 'management/byId': jest.fn() } } }
+      mocks:     { $store: { getters: { 'management/byId': jest.fn(), 'management/all': () => [{ id: SETTING.BANNERS, ...SETTING_NO_CONSENT }] } } }
     });
-
-    wrapper.setData({ bannerSetting: SETTING_NO_CONSENT });
-
-    await wrapper.vm.$nextTick();
 
     expect(wrapper.vm.bannerStyle).toStrictEqual(parsedBannerStyle);
 
@@ -54,12 +51,8 @@ describe('component: FixedBanner', () => {
   it('should render FOOTER fixed banner, as text array (newline char), correctly', async() => {
     const wrapper = shallowMount(FixedBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { footer: true },
-      mocks:     { $store: { getters: { 'management/byId': jest.fn() } } }
+      mocks:     { $store: { getters: { 'management/byId': jest.fn(), 'management/all': () => [{ id: SETTING.BANNERS, ...SETTING_NO_CONSENT }] } } }
     });
-
-    wrapper.setData({ bannerSetting: SETTING_NO_CONSENT });
-
-    await wrapper.vm.$nextTick();
 
     expect(wrapper.vm.bannerStyle).toStrictEqual(parsedBannerStyle);
 
@@ -78,12 +71,8 @@ describe('component: FixedBanner', () => {
   it('should render CONSENT as a DIALOG correctly', async() => {
     const wrapper = shallowMount(FixedBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { consent: true },
-      mocks:     { $store: { getters: { 'management/byId': jest.fn() } } }
+      mocks:     { $store: { getters: { 'management/byId': jest.fn(), 'management/all': () => [{ id: SETTING.BANNERS, ...SETTING_WITH_CONSENT }] } } }
     });
-
-    wrapper.setData({ bannerSetting: SETTING_WITH_CONSENT });
-
-    await wrapper.vm.$nextTick();
 
     expect(wrapper.vm.bannerStyle).toStrictEqual(parsedBannerStyle);
 
@@ -109,12 +98,8 @@ describe('component: FixedBanner', () => {
   it('clicking dialog button should hide dialog', async() => {
     const wrapper = shallowMount(FixedBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { consent: true },
-      mocks:     { $store: { getters: { 'management/byId': jest.fn() } } }
+      mocks:     { $store: { getters: { 'management/byId': jest.fn(), 'management/all': () => [{ id: SETTING.BANNERS, ...SETTING_WITH_CONSENT }] } } }
     });
-
-    wrapper.setData({ bannerSetting: SETTING_WITH_CONSENT });
-
-    await wrapper.vm.$nextTick();
 
     const buttonDialog = wrapper.find('.banner-dialog button');
     const spy = jest.spyOn(wrapper.vm, 'hideDialog');

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -29,6 +29,7 @@ export const NORMAN = {
   PRINCIPAL:                     'principal',
   PROJECT:                       'project',
   PROJECT_ROLE_TEMPLATE_BINDING: 'projectroletemplatebinding',
+  SETTING:                       'setting',
   SPOOFED:                       { GROUP_PRINCIPAL: 'group.principal' },
   ROLE_TEMPLATE:                 'roleTemplate',
   TOKEN:                         'token',

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -91,9 +91,7 @@ export default async function({
     // Load settings, which will either be just the public ones if not logged in, or all if you are
     await store.dispatch('management/findAll', {
       type: MANAGEMENT.SETTING,
-      opt:  {
-        load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
-      }
+      opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
     });
 
     // Set the favicon - use custom one from store if set

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -13,7 +13,7 @@ import { BACK_TO } from '@shell/config/local-storage';
 import { NAME as FLEET_NAME } from '@shell/config/product/fleet.js';
 import { canViewResource } from '@shell/utils/auth';
 import { getClusterFromRoute, getProductFromRoute, getPackageFromRoute, getResourceFromRoute } from '@shell/utils/router';
-import { fetchInitialSettings } from 'utils/settings';
+import { fetchInitialSettings } from '@shell/utils/settings';
 
 let beforeEachSetup = false;
 

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -2,7 +2,6 @@ import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import { SETUP, TIMED_OUT } from '@shell/config/query-params';
 import { SETTING } from '@shell/config/settings';
 import { MANAGEMENT, NORMAN, DEFAULT_WORKSPACE } from '@shell/config/types';
-import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { applyProducts } from '@shell/store/type-map';
 import { findBy } from '@shell/utils/array';
 import { ClusterNotFoundError, RedirectToError } from '@shell/utils/error';
@@ -14,6 +13,7 @@ import { BACK_TO } from '@shell/config/local-storage';
 import { NAME as FLEET_NAME } from '@shell/config/product/fleet.js';
 import { canViewResource } from '@shell/utils/auth';
 import { getClusterFromRoute, getProductFromRoute, getPackageFromRoute, getResourceFromRoute } from '@shell/utils/router';
+import { fetchInitialSettings } from 'utils/settings';
 
 let beforeEachSetup = false;
 
@@ -89,10 +89,7 @@ export default async function({
 
   try {
     // Load settings, which will either be just the public ones if not logged in, or all if you are
-    await store.dispatch('management/findAll', {
-      type: MANAGEMENT.SETTING,
-      opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
-    });
+    await fetchInitialSettings(store);
 
     // Set the favicon - use custom one from store if set
     if (!haveSetFavIcon()) {
@@ -113,7 +110,7 @@ export default async function({
   if ( firstLogin === null ) {
     try {
       const res = await store.dispatch('rancher/find', {
-        type: 'setting',
+        type: NORMAN.SETTING,
         id:   SETTING.FIRST_LOGIN,
         opt:  { url: `/v3/settings/${ SETTING.FIRST_LOGIN }` }
       });
@@ -121,7 +118,7 @@ export default async function({
       firstLogin = res?.value === 'true';
 
       const plSetting = await store.dispatch('rancher/find', {
-        type: 'setting',
+        type: NORMAN.SETTING,
         id:   SETTING.PL,
         opt:  { url: `/v3/settings/${ SETTING.PL }` }
       });

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -186,6 +186,8 @@ export default async function({
       isLoggedIn(me);
     } else if ( fromHeader === 'false' ) {
       notLoggedIn();
+
+      return;
     } else {
       // Older versions look at principals and see what happens
       try {

--- a/shell/middleware/unauthenticated.js
+++ b/shell/middleware/unauthenticated.js
@@ -11,9 +11,7 @@ export default async function({ store }) {
     // Load settings, which will either be just the public ones if not logged in, or all if you are
     await store.dispatch('management/findAll', {
       type: MANAGEMENT.SETTING,
-      opt:  {
-        load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
-      }
+      opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
     });
 
     // Set the favicon - use custom one from store if set

--- a/shell/middleware/unauthenticated.js
+++ b/shell/middleware/unauthenticated.js
@@ -1,6 +1,5 @@
 import { setFavIcon, haveSetFavIcon } from '@shell/utils/favicon';
-import { MANAGEMENT } from '@shell/config/types';
-import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
+import { fetchInitialSettings } from '@shell/utils/settings';
 
 export default async function({ store }) {
   if (haveSetFavIcon()) {
@@ -9,12 +8,11 @@ export default async function({ store }) {
 
   try {
     // Load settings, which will either be just the public ones if not logged in, or all if you are
-    await store.dispatch('management/findAll', {
-      type: MANAGEMENT.SETTING,
-      opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
-    });
-
-    // Set the favicon - use custom one from store if set
-    setFavIcon(store);
+    fetchInitialSettings(store)
+      // Don't block everything on fetching settings, just update when they come in
+      .then(() => {
+        // Set the favicon - use custom one from store if set
+        setFavIcon(store);
+      });
   } catch (e) {}
 }

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -2,8 +2,8 @@ import { mapGetters } from 'vuex';
 import { CATALOG, MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import { createCssVars } from '@shell/utils/color';
-import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { setTitle } from '@shell/config/private-label';
+import { fetchInitialSettings } from '@shell/utils/settings';
 
 const cspAdaptorApp = ['rancher-csp-adapter', 'rancher-csp-billing-adapter'];
 
@@ -22,10 +22,7 @@ export default {
 
     // Ensure we read the settings even when we are not authenticated
     try {
-      this.globalSettings = await this.$store.dispatch('management/findAll', {
-        type: MANAGEMENT.SETTING,
-        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
-      });
+      this.globalSettings = await fetchInitialSettings(this.$store);
     } catch (e) {}
 
     // Setting this up front will remove `computed` churn, and we only care that we've initialised them

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -1,7 +1,6 @@
 import { mapGetters } from 'vuex';
 import { CATALOG, MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
-import { findBy } from '@shell/utils/array';
 import { createCssVars } from '@shell/utils/color';
 import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { setTitle } from '@shell/config/private-label';
@@ -25,9 +24,7 @@ export default {
     try {
       this.globalSettings = await this.$store.dispatch('management/findAll', {
         type: MANAGEMENT.SETTING,
-        opt:  {
-          load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
-        }
+        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
       });
     } catch (e) {}
 
@@ -45,25 +42,25 @@ export default {
     ...mapGetters({ loggedIn: 'auth/loggedIn' }),
 
     brand() {
-      const setting = findBy(this.globalSettings, 'id', SETTING.BRAND);
+      const setting = this.globalSettings?.find((gs) => gs.id === SETTING.BRAND);
 
       return setting?.value;
     },
 
     color() {
-      const setting = findBy(this.globalSettings, 'id', SETTING.PRIMARY_COLOR);
+      const setting = this.globalSettings?.find((gs) => gs.id === SETTING.PRIMARY_COLOR);
 
       return setting?.value;
     },
 
     linkColor() {
-      const setting = findBy(this.globalSettings, 'id', SETTING.LINK_COLOR);
+      const setting = this.globalSettings?.find((gs) => gs.id === SETTING.LINK_COLOR);
 
       return setting?.value;
     },
 
     theme() {
-      const setting = findBy(this.globalSettings, 'id', SETTING.THEME);
+      const setting = this.globalSettings?.find((gs) => gs.id === SETTING.THEME);
 
       // This handles cases where the settings update after the page loads (like on log out)
       if (setting?.value) {
@@ -127,7 +124,7 @@ export default {
       // The brand setting will only get updated if...
       if (neu && !this.brand) {
         // 1) There should be a brand... but there's no brand setting
-        const brandSetting = findBy(this.globalSettings, 'id', SETTING.BRAND);
+        const brandSetting = this.globalSettings?.find((gs) => gs.id === SETTING.BRAND);
 
         if (brandSetting) {
           brandSetting.value = 'csp';

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -26,7 +26,7 @@ import {
   setVendor
 } from '@shell/config/private-label';
 import loadPlugins from '@shell/plugins/plugin';
-import { fetchInitialSettings } from '~/shell/utils/settings';
+import { fetchInitialSettings } from '@shell/utils/settings';
 
 export default {
   name:       'Login',

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -14,7 +14,7 @@ import Password from '@shell/components/form/Password';
 import { sortBy } from '@shell/utils/sort';
 import { configType } from '@shell/models/management.cattle.io.authconfig';
 import { mapGetters } from 'vuex';
-import { _ALL_IF_AUTHED, _MULTI } from '@shell/plugins/dashboard-store/actions';
+import { _MULTI } from '@shell/plugins/dashboard-store/actions';
 import { MANAGEMENT, NORMAN } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import { LOGIN_ERRORS } from '@shell/store/auth';
@@ -26,6 +26,7 @@ import {
   setVendor
 } from '@shell/config/private-label';
 import loadPlugins from '@shell/plugins/plugin';
+import { fetchInitialSettings } from '~/shell/utils/settings';
 
 export default {
   name:       'Login',
@@ -51,10 +52,7 @@ export default {
     // For newer versions this will return all settings if you are somehow logged in,
     // and just the public ones if you aren't.
     try {
-      await store.dispatch('management/findAll', {
-        type: MANAGEMENT.SETTING,
-        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false },
-      });
+      await fetchInitialSettings(store);
 
       firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);
       plSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.PL);
@@ -62,19 +60,19 @@ export default {
     } catch (e) {
       // Older versions used Norman API to get these
       firstLoginSetting = await store.dispatch('rancher/find', {
-        type: 'setting',
+        type: NORMAN.SETTING,
         id:   SETTING.FIRST_LOGIN,
         opt:  { url: `/v3/settings/${ SETTING.FIRST_LOGIN }` }
       });
 
       plSetting = await store.dispatch('rancher/find', {
-        type: 'setting',
+        type: NORMAN.SETTING,
         id:   SETTING.PL,
         opt:  { url: `/v3/settings/${ SETTING.PL }` }
       });
 
       brand = await store.dispatch('rancher/find', {
-        type: 'setting',
+        type: NORMAN.SETTING,
         id:   SETTING.BRAND,
         opt:  { url: `/v3/settings/${ SETTING.BRAND }` }
       });

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -53,9 +53,7 @@ export default {
     try {
       await store.dispatch('management/findAll', {
         type: MANAGEMENT.SETTING,
-        opt:  {
-          load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
-        },
+        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false },
       });
 
       firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -57,9 +57,7 @@ export default {
     try {
       await store.dispatch('management/findAll', {
         type: MANAGEMENT.SETTING,
-        opt:  {
-          load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
-        }
+        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
       });
     } catch (e) {
     }
@@ -107,9 +105,7 @@ export default {
     try {
       await store.dispatch('management/findAll', {
         type: MANAGEMENT.SETTING,
-        opt:  {
-          load: _ALL_IF_AUTHED, url: `/v1/${ MANAGEMENT.SETTING }`, redirectUnauthorized: false
-        },
+        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false },
       });
 
       plSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.PL);

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -9,9 +9,8 @@ import { findBy } from '@shell/utils/array';
 import { Checkbox } from '@components/Form/Checkbox';
 import { getVendor, getProduct, setVendor } from '@shell/config/private-label';
 import { RadioGroup } from '@components/Form/Radio';
-import { setSetting } from '@shell/utils/settings';
+import { fetchInitialSettings, setSetting } from '@shell/utils/settings';
 import { SETTING } from '@shell/config/settings';
-import { _ALL_IF_AUTHED } from '@shell/plugins/dashboard-store/actions';
 import { isDevBuild } from '@shell/utils/version';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import Password from '@shell/components/form/Password';
@@ -55,14 +54,11 @@ export default {
 
   async middleware({ store, redirect, route } ) {
     try {
-      await store.dispatch('management/findAll', {
-        type: MANAGEMENT.SETTING,
-        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false }
-      });
+      await fetchInitialSettings(store);
     } catch (e) {
     }
 
-    const isFirstLogin = await calcIsFirstLogin(store);
+    const isFirstLogin = calcIsFirstLogin(store);
     const mustChangePassword = await calcMustChangePassword(store);
 
     if (isFirstLogin) {
@@ -103,16 +99,13 @@ export default {
     let plSetting;
 
     try {
-      await store.dispatch('management/findAll', {
-        type: MANAGEMENT.SETTING,
-        opt:  { load: _ALL_IF_AUTHED, redirectUnauthorized: false },
-      });
+      await fetchInitialSettings(store);
 
       plSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.PL);
     } catch (e) {
       // Older versions used Norman API to get these
       plSetting = await store.dispatch('rancher/find', {
-        type: 'setting',
+        type: NORMAN.SETTING,
         id:   SETTING.PL,
         opt:  { url: `/v3/settings/${ SETTING.PL }` }
       });

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -12,7 +12,6 @@ import { addParam } from '@shell/utils/url';
 export const _ALL = 'all';
 export const _MERGE = 'merge';
 export const _MULTI = 'multi';
-export const _ALL_IF_AUTHED = 'allIfAuthed';
 export const _NONE = 'none';
 
 const SCHEMA_CHECK_RETRIES = 15;
@@ -176,14 +175,6 @@ export default {
 
     if ( opt.load === false || opt.load === _NONE ) {
       load = _NONE;
-    } else if ( opt.load === _ALL_IF_AUTHED ) {
-      const header = rootGetters['auth/fromHeader'];
-
-      if ( `${ header }` === 'true' || `${ header }` === 'none' ) {
-        load = _ALL;
-      } else {
-        load = _MULTI;
-      }
     }
 
     const typeOptions = rootGetters['type-map/optionsFor'](type);

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -396,4 +396,14 @@ export default {
     return matchingCounts(_typeObj, namespaces.length ? namespaces : null);
   },
 
+  generation: (state, getters) => (type) => {
+    type = getters.normalizeType(type);
+    const entry = state.types[type];
+
+    if ( entry ) {
+      return entry.generation;
+    }
+
+    return undefined;
+  }
 };

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -37,7 +37,7 @@ export const state = function() {
 };
 
 export const getters = {
-  fromHeader() {
+  fromHeader(state) {
     return state.fromHeader;
   },
 

--- a/shell/utils/settings.ts
+++ b/shell/utils/settings.ts
@@ -50,6 +50,8 @@ export const fetchSetting = async(store: Store<any>, id: string): Promise<any> =
  */
 export const fetchInitialSettings = async(store: Store<any>): Promise<any> => {
   const generation = store.getters['management/generation'](MANAGEMENT.SETTING);
+  // We use this as it copies the previous mechanism this was based on (in findAll)
+  // There is the getter `auth/loggedInAs` (which is set given `fromHeader`), but that's initialised after the first call to here (see `authenticated`)
   const header = store.getters['auth/fromHeader'];
   const authed = `${ header }` === 'true' || `${ header }` === 'none';
 

--- a/shell/utils/settings.ts
+++ b/shell/utils/settings.ts
@@ -1,6 +1,8 @@
 import { MANAGEMENT } from '@shell/config/types';
 import { Store } from 'vuex';
 import { DEFAULT_PERF_SETTING, PerfSettings, SETTING } from '@shell/config/settings';
+import { pluralize } from '@shell/utils/string';
+import { _MULTI } from '@shell/plugins/dashboard-store/actions';
 
 export const fetchOrCreateSetting = async(store: Store<any>, id: string, val: string, save = true): Promise<any> => {
   let setting;
@@ -32,6 +34,48 @@ export const fetchSetting = async(store: Store<any>, id: string): Promise<any> =
   const setting = (all || []).find((setting: any) => setting.id === id);
 
   return setting;
+};
+
+/**
+ * Carefully fetch mgmt settings
+ *
+ * Ensures that
+ * - Concurrent calls to this function will only result in a single http request
+ * - Subsequent calls, when either logged in or logged out, will only result in a single http request
+ * - Logged out call will fetch partial settings, after logging in another call will fetch all settings
+ *
+ * Will be used in many places, particularly multiple times when loading the dashboard
+ *
+ * Note - We need to specify the url for cases where it can't be determined (i.e. we haven't fetched schemas)
+ */
+export const fetchInitialSettings = async(store: Store<any>): Promise<any> => {
+  const generation = store.getters['management/generation'](MANAGEMENT.SETTING);
+  const header = store.getters['auth/fromHeader'];
+  const authed = `${ header }` === 'true' || `${ header }` === 'none';
+
+  if (authed) {
+    // We're authed, we will always get the full list
+    return await store.dispatch('management/findAll', {
+      type: MANAGEMENT.SETTING,
+      opt:  { url: `/v1/${ pluralize(MANAGEMENT.SETTING) }` }
+    } );
+  }
+
+  if (!generation) {
+    // We're not authed, and haven't previously fetched settings (no generation)
+    // Fetch settings, put them in the store, but don't say we've got all yet (so subsequent calls will run)
+    return await store.dispatch('management/findAll', {
+      type: MANAGEMENT.SETTING,
+      opt:  {
+        url:                  `/v1/${ pluralize(MANAGEMENT.SETTING) }`,
+        load:                 _MULTI,
+        redirectUnauthorized: false
+      }
+    });
+  }
+
+  // We're not authed, but have a previous value, no need to make a http request to fetch again
+  return store.getters['management/all'](MANAGEMENT.SETTING);
 };
 
 export const setSetting = async(store: Store<any>, id: string, val: string): Promise<any> => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9304
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
1. Concurrent calls to findAll would always result in two requests
   - when findAll runs we cache running results with key JSON.stringify(headers) + method + opt.url
   - if a request is made with a matching key we return the promise associated with the first request (thus negating a second request)
   - when mgmt settings were fetched with a hardcoded url ... url contains singular setting
   - when mgmt settings are fetched without hardcoded url ... url contains plural settings
   - therefore the second call to findAll was not using the cached promise from the first call.... resulting in a second request

After the above is fixed, noticed two other issues

2. When making a request we checked the response headers for a specific auth header which we pushed to the auth store.... however the getter for this was broken and always returned undefined
   - This meant even with fix number 1 from above an additional requests was still made
   - i.e first request fetches a partial response which is set in store via loadMulti... second request fetches full response however it was treated as partial so stored via loadMulti, so next findAll didn't know it had all and made a new request which did eventually store with loadAll)
3. The fix for number 1 above handled the case when two concurrent calls to findAll occurred. If the api returns quickly the findAll requests become sequential. Sequential findAlls with `_ALL_IF_AUTHED` always resulted in individual requests.
   - findAll when _ALL_IF_AUTHED and not logged in results in loadMutli mutation. next call to findAll doesn't find a running request... and makes another one. 

The above is addressed by removing _ALL_IF_AUTHED (it's only used for settings) and using a new `fetchInitialSettings` helper function which
1. if auth'd uses usual mechanism of findAll with no flags. if any previous call existing with partial results this means a new call for all results will be made. if a call is currently happening it'll use the same promise.
2. if not auth'd and haven't previously fetched results... fetch them and ensure we persist to store via loadMulti (so future findAll calls, once authed, result in new request)
3. if not auth'd and HAVE previous fetched results... just returned them
 
Also
- in unauthed world don't block loading of dashboard on fetching setting for favicon, this speeds up load of login page
- replaced findBy with .find in some places
- `'settings'` to NORMAN.SETTINGS
- Fix issue where now populated `fromHeader` can be `false`
- ~Don't mix up CATTLE_BOOTSTRAP_PASSWORD and TEST_PASSWORD, this causes issues in the setup flow when they're different~ e2e tests bring up rancher with CATTLE_BOOTSTRAP_PASSWORD... and if so the fields to change password are hidden. this breaks the change i made to setup admin user's password with TEST_PASSWORD and not CATTLE_BOOTSTRAP_PASSWORD
- Refactor setup test, re-enable check at end

### Areas or cases that should be tested
- Refresh on setup page
  - One request, partial response
  - Previously this was three blocking http requests
- Refresh on log in page
  - One request, partial response
  - Previously this was three blocking http requests
- Refresh on home page
  - One request, full response
  - Previously this was two blocking http requests (settings/setting)
- Refresh on log in page, log in
  - Two requests, one partial and the second one full
  - Previously this was five blocking http requests
  - ![image](https://github.com/rancher/dashboard/assets/18697775/6042eef9-c156-40f3-a0dc-fa338df93b07)


PR includes automated tests that cover the above cases

### Areas which could experience regressions
As per sections above, but with no branding and then with branding (colour scheme et all is correct)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes