### PR TITLE
Bump @rancher/shell to 0.5.3

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This will bump the `@rancher/shell` package to version `0.5.3`.

There are a number of fixes for this release, but two that are rather notable:
- https://github.com/rancher/dashboard/pull/10413
- https://github.com/rancher/dashboard/pull/10008