### PR TITLE
Ensure Azure RKE2 default region is available with selected cloud credential

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1393,6 +1393,7 @@ cluster:
         label: DNS Label
       environment:
         label: Environment
+        tooltip: The environment is configured when cloud credentials are created.
       faultDomainCount:
         help: If the availability set has already been created, the fault domain count will be ignored.
         label: Fault Domain Count

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -519,19 +519,6 @@ export default {
     <div class="row mt-20">
       <div class="col span-6">
         <LabeledSelect
-          v-model="value.environment"
-          :mode="mode"
-          :options="azureEnvironments"
-          option-key="value"
-          option-label="value"
-          :searchable="false"
-          :required="true"
-          :label="t('cluster.machineConfig.azure.environment.label')"
-          :disabled="true"
-        />
-      </div>
-      <div class="col span-6">
-        <LabeledSelect
           :value="value.location"
           :mode="mode"
           :options="locationOptionsInDropdown"
@@ -543,6 +530,17 @@ export default {
           :disabled="disabled"
           @input="setLocation"
         />
+      </div>
+      <div>
+        <label
+          v-clean-tooltip="t('cluster.machineConfig.azure.environment.tooltip')"
+          :style="{'display':'block'}"
+          class="text-label"
+        >
+          {{ t('cluster.machineConfig.azure.environment.label') }}
+          <i class="icon icon-sm icon-info" />
+        </label>
+        <span>{{ value.environment }}</span>
       </div>
     </div>
     <div class="row mt-20">

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -16,7 +16,7 @@ import { NORMAN } from '@shell/config/types';
 import { findBy } from '@shell/utils/array';
 import KeyValue from '@shell/components/form/KeyValue';
 import { RadioGroup } from '@components/Form/Radio';
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 
 export const azureEnvironments = [
   { value: 'AzurePublicCloud' },
@@ -172,20 +172,17 @@ export default {
         this.loadedCredentialIdFor = this.credentialId;
       }
 
-      // if (this.mode === _CREATE) {
-      //   this.value.location = DEFAULT_REGION;
-
-      // // when you edit an Azure cluster and add a new machine pool (edit)
-      // // the location field doesn't come populated which causes the vmSizes request
-      // // to return 200 but with a null response (also a bunch of other fields are undefined...)
-      // // so let's prefill them with the defaults
-      // } else if (this.mode === _EDIT && !this.value?.location) {
-      //   for (const key in this.defaultConfig) {
-      //     if (this.value[key] === undefined) {
-      //       this.$set(this.value, key, this.defaultConfig[key]);
-      //     }
-      //   }
-      // }
+      // when you edit an Azure cluster and add a new machine pool (edit)
+      // the location field doesn't come populated which causes the vmSizes request
+      // to return 200 but with a null response (also a bunch of other fields are undefined...)
+      // so let's prefill them with the defaults
+      if (this.mode === _EDIT && !this.value?.location) {
+        for (const key in this.defaultConfig) {
+          if (this.value[key] === undefined) {
+            this.$set(this.value, key, this.defaultConfig[key]);
+          }
+        }
+      }
 
       if (!this.value.location || !findBy(this.locationOptions, 'name', this.value.location)) {
         this.locationOptions?.length && this.setLocation(this.locationOptions[this.locationOptions.length - 1]);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9858 
Fixes #10470 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This is a remake of https://github.com/rancher/dashboard/pull/10083 which I do not have permission to push an additional fix to. This PR updates the azure machine config component to ensure that the node pool region set by default is available in the current credentail's environment (eg azure gov, azure china, azure public). 


### Areas or cases that should be tested
Create/edit azure RKE2 clusters with azurepubliccloud credentials, and with either azure china or azure gov credentials. @smallteeths has verified with azure china credentials and I verified with azure gov credentials.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
