### PR TITLE
Fix displaying false vsphere errors

### DIFF
--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -650,15 +650,16 @@ export default {
       };
 
       if (!isValueInContent()) {
-        if (this.mode === _CREATE) {
-          const value = isArray ? [] : content[0]?.value;
+        const value = isArray ? [] : content[0]?.value;
+        // null and "" values are valid for hostsystem and folder
+        const isFolderNull = key === 'folder' && (this.value.folder === null || this.value.folder === '');
+        const isHostsystemNull = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
 
-          if (value !== SENTINEL) {
-            set(this.value, key, value);
-          }
+        if (this.mode === _CREATE && value !== SENTINEL) {
+          set(this.value, key, value);
         }
 
-        if ([_EDIT, _VIEW].includes(this.mode)) {
+        if ([_EDIT, _VIEW].includes(this.mode) && !isFolderNull && !isHostsystemNull) {
           this.manageErrors(errorActions.CREATE, key);
         }
       } else {

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -651,15 +651,15 @@ export default {
 
       if (!isValueInContent()) {
         const value = isArray ? [] : content[0]?.value;
-        // null and "" values are valid for hostsystem and folder
-        const isFolderNull = key === 'folder' && (this.value.folder === null || this.value.folder === '');
-        const isHostsystemNull = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
+        // null and "" are valid values for hostsystem and folder
+        const isFolderNullOrEmpty = key === 'folder' && (this.value.folder === null || this.value.folder === '');
+        const isHostsystemNullOrEmpty = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
 
         if (this.mode === _CREATE && value !== SENTINEL) {
           set(this.value, key, value);
         }
 
-        if ([_EDIT, _VIEW].includes(this.mode) && !isFolderNull && !isHostsystemNull) {
+        if ([_EDIT, _VIEW].includes(this.mode) && !isFolderNullOrEmpty && !isHostsystemNullOrEmpty) {
           this.manageErrors(errorActions.CREATE, key);
         }
       } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10460 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
`hostsystem` and `folder` can be `null` or `""`, this PR adds this into consideration before displaying error banners.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Provisioning vSphere Clusters

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/135728925/de64f2e2-058c-46f8-9379-3de0aceb94a6



