### PR TITLE
add e2e test to test issue 10056

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -31,6 +31,14 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
     return new ToggleSwitchPo('.toggle-container', this.self());
   }
 
+  rkeToggleExistance(assertion: string) {
+    this.self().find('.toggle-container').should(assertion);
+  }
+
+  gridElementExistance(groupIndex = 0, itemIndex = 0, assertion: string) {
+    this.self().find(`[data-testid="cluster-manager-create-grid-${ groupIndex }-${ itemIndex }"]`).should(assertion);
+  }
+
   selectKubeProvider(index: number) {
     return this.resourceDetail().cruResource().selectSubType(0, index).click();
   }

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -42,4 +42,11 @@ export default class ProductNavPo extends ComponentPo {
     return this.self().should('exist').find('.child.nav-type a .label').contains(label)
       .click({ force: true });
   }
+
+  /**
+   * Check existance of menu group by label
+   */
+  navToSideMenuGroupByLabelExistance(label: string, assertion: string): Cypress.Chainable {
+    return this.self().should('exist').contains('.accordion.has-children', label).should(assertion);
+  }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10056 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add e2e test to to improve test coverage of #10056 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
