### PR TITLE
Fix default values not being set when a new pool is added in edit mode

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2100,6 +2100,7 @@ export default {
                 :machine-pools="machinePools"
                 :busy="busy"
                 :pool-id="obj.id"
+                :pool-create-mode="obj.create"
                 @error="handleMachinePoolError"
                 @validationChanged="v=>machinePoolValidationChanged(obj.id, v)"
               />

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -69,6 +69,12 @@ export default {
     poolId: {
       type:     String,
       required: true,
+    },
+
+    // this is a useful info when in edit mode you add a new pool, example of use in vmwarevsphere.vue
+    poolCreateMode: {
+      type:     Boolean,
+      required: true,
     }
   },
 
@@ -269,6 +275,7 @@ export default {
       :credential-id="credentialId"
       :pool-index="idx"
       :pool-id="poolId"
+      :pool-create-mode="value.create"
       :machine-pools="machinePools"
       :busy="busy"
       @error="emitError"

--- a/shell/machine-config/__tests__/vmwarevsphere.test.ts
+++ b/shell/machine-config/__tests__/vmwarevsphere.test.ts
@@ -23,66 +23,82 @@ describe('component: vmwarevsphere', () => {
     ...baseSetup,
     propsData: {
       ...baseSetup.propsData,
-      mode:  'create',
-      value: { initted: false },
+      mode:           'create',
+      poolCreateMode: true,
+      value:          { initted: false },
     }
   };
   const defaultEditSetup = {
     ...baseSetup,
     propsData: {
       ...baseSetup.propsData,
-      mode:  'edit',
-      value: { initted: false },
+      mode:           'edit',
+      poolCreateMode: false,
+      value:          { initted: false },
+    }
+  };
+  const editModeWithPoolInCreateModeSetup = {
+    ...defaultEditSetup,
+    propsData: {
+      ...defaultEditSetup.propsData,
+      poolCreateMode: true
     }
   };
 
-  it('should mount successfully with correct default values', () => {
-    const wrapper = mount(vmwarevsphere, defaultCreateSetup);
+  describe('default values', () => {
+    const testCases = [
+      defaultCreateSetup,
+      editModeWithPoolInCreateModeSetup
+    ];
 
-    const dataCenterElement = wrapper.find(`[data-testid="datacenter"]`).element;
-    const resourcePoolElement = wrapper.find(`[data-testid="resourcePool"]`).element;
-    const dataStoreElement = wrapper.find(`[data-testid="dataStore"]`).element;
-    const folderElement = wrapper.find(`[data-testid="folder"]`).element;
-    const hostElement = wrapper.find(`[data-testid="host"]`).element;
-    const gracefulShutdownTimeoutElement = wrapper.find(`[data-testid="gracefulShutdownTimeout"]`).element;
+    it.each(testCases)('should mount successfully with correct default values', (setup) => {
+      const wrapper = mount(vmwarevsphere, setup);
 
-    expect(dataCenterElement).toBeDefined();
-    expect(resourcePoolElement).toBeDefined();
-    expect(dataStoreElement).toBeDefined();
-    expect(folderElement).toBeDefined();
-    expect(hostElement).toBeDefined();
-    expect(gracefulShutdownTimeoutElement).toBeDefined();
+      const dataCenterElement = wrapper.find(`[data-testid="datacenter"]`).element;
+      const resourcePoolElement = wrapper.find(`[data-testid="resourcePool"]`).element;
+      const dataStoreElement = wrapper.find(`[data-testid="dataStore"]`).element;
+      const folderElement = wrapper.find(`[data-testid="folder"]`).element;
+      const hostElement = wrapper.find(`[data-testid="host"]`).element;
+      const gracefulShutdownTimeoutElement = wrapper.find(`[data-testid="gracefulShutdownTimeout"]`).element;
 
-    const {
-      cpuCount: defaultCpuCount,
-      diskSize: defaultDiskSize,
-      memorySize: defaultMemorySize,
-      hostsystem: defaultHostsystem,
-      cloudConfig: defaultCloudConfig,
-      gracefulShutdownTimeout: defaultGracefulShutdownTimeout,
-      cfgparam: defaultCfgparam,
-      os: defaultOs
-    } = DEFAULT_VALUES;
+      expect(dataCenterElement).toBeDefined();
+      expect(resourcePoolElement).toBeDefined();
+      expect(dataStoreElement).toBeDefined();
+      expect(folderElement).toBeDefined();
+      expect(hostElement).toBeDefined();
+      expect(gracefulShutdownTimeoutElement).toBeDefined();
 
-    const {
-      cpuCount,
-      diskSize,
-      memorySize,
-      hostsystem,
-      cloudConfig,
-      gracefulShutdownTimeout,
-      cfgparam,
-      os
-    } = wrapper.vm.$options.propsData.value;
+      const {
+        cpuCount: defaultCpuCount,
+        diskSize: defaultDiskSize,
+        memorySize: defaultMemorySize,
+        hostsystem: defaultHostsystem,
+        cloudConfig: defaultCloudConfig,
+        gracefulShutdownTimeout: defaultGracefulShutdownTimeout,
+        cfgparam: defaultCfgparam,
+        os: defaultOs
+      } = DEFAULT_VALUES;
 
-    expect(cpuCount).toStrictEqual(defaultCpuCount);
-    expect(diskSize).toStrictEqual(defaultDiskSize);
-    expect(memorySize).toStrictEqual(defaultMemorySize);
-    expect(hostsystem).toStrictEqual(defaultHostsystem);
-    expect(cloudConfig).toStrictEqual(defaultCloudConfig);
-    expect(gracefulShutdownTimeout).toStrictEqual(defaultGracefulShutdownTimeout);
-    expect(cfgparam).toStrictEqual(defaultCfgparam);
-    expect(os).toStrictEqual(defaultOs);
+      const {
+        cpuCount,
+        diskSize,
+        memorySize,
+        hostsystem,
+        cloudConfig,
+        gracefulShutdownTimeout,
+        cfgparam,
+        os
+      } = wrapper.vm.$options.propsData.value;
+
+      expect(cpuCount).toStrictEqual(defaultCpuCount);
+      expect(diskSize).toStrictEqual(defaultDiskSize);
+      expect(memorySize).toStrictEqual(defaultMemorySize);
+      expect(hostsystem).toStrictEqual(defaultHostsystem);
+      expect(cloudConfig).toStrictEqual(defaultCloudConfig);
+      expect(gracefulShutdownTimeout).toStrictEqual(defaultGracefulShutdownTimeout);
+      expect(cfgparam).toStrictEqual(defaultCfgparam);
+      expect(os).toStrictEqual(defaultOs);
+    });
   });
 
   describe('mapPathOptionsToContent', () => {

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -650,15 +650,16 @@ export default {
       };
 
       if (!isValueInContent()) {
-        if (this.mode === _CREATE) {
-          const value = isArray ? [] : content[0]?.value;
+        const value = isArray ? [] : content[0]?.value;
+        // null and "" values are valid for hostsystem and folder
+        const isFolderNull = key === 'folder' && (this.value.folder === null || this.value.folder === '');
+        const isHostsystemNull = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
 
-          if (value !== SENTINEL) {
-            set(this.value, key, value);
-          }
+        if (this.mode === _CREATE && value !== SENTINEL) {
+          set(this.value, key, value);
         }
 
-        if ([_EDIT, _VIEW].includes(this.mode)) {
+        if ([_EDIT, _VIEW].includes(this.mode) && !isFolderNull && !isHostsystemNull) {
           this.manageErrors(errorActions.CREATE, key);
         }
       } else {

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -651,15 +651,15 @@ export default {
 
       if (!isValueInContent()) {
         const value = isArray ? [] : content[0]?.value;
-        // null and "" values are valid for hostsystem and folder
-        const isFolderNull = key === 'folder' && (this.value.folder === null || this.value.folder === '');
-        const isHostsystemNull = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
+        // null and "" are valid values for hostsystem and folder
+        const isFolderNullOrEmpty = key === 'folder' && (this.value.folder === null || this.value.folder === '');
+        const isHostsystemNullOrEmpty = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
 
         if (this.mode === _CREATE && value !== SENTINEL) {
           set(this.value, key, value);
         }
 
-        if ([_EDIT, _VIEW].includes(this.mode) && !isFolderNull && !isHostsystemNull) {
+        if ([_EDIT, _VIEW].includes(this.mode) && !isFolderNullOrEmpty && !isHostsystemNullOrEmpty) {
           this.manageErrors(errorActions.CREATE, key);
         }
       } else {

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -656,9 +656,8 @@ export default {
       if (!isValueInContent()) {
         const value = isArray ? [] : content[0]?.value;
         // null and "" are valid values for hostsystem and folder
-        const isFolderNullOrEmpty = key === 'folder' && (this.value.folder === null || this.value.folder === '');
-        const isHostsystemNullOrEmpty = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
-        const shouldHandleError = [_EDIT, _VIEW].includes(this.mode) && !isFolderNullOrEmpty && !isHostsystemNullOrEmpty && !this.poolCreateMode;
+        const isNullOrEmpty = ['folder', 'hostsystem'].includes(key) && (this.value[key] === null || this.value[key] === '');
+        const shouldHandleError = [_EDIT, _VIEW].includes(this.mode) && !isNullOrEmpty && !this.poolCreateMode;
 
         if ((this.mode === _CREATE || this.poolCreateMode) && value !== SENTINEL) {
           set(this.value, key, value);

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -168,7 +168,11 @@ export default {
     },
     disabled: {
       type:    Boolean,
-      default: false
+      default: false,
+    },
+    poolCreateMode: {
+      type:     Boolean,
+      required: true,
     },
   },
 
@@ -223,7 +227,7 @@ export default {
       },
     ];
 
-    if (this.mode === _CREATE && !this.value.initted) {
+    if ((this.mode === _CREATE || this.poolCreateMode) && !this.value.initted) {
       Object.defineProperty(this.value, 'initted', { value: true, enumerable: false });
 
       const {
@@ -444,13 +448,13 @@ export default {
       const valueInContent = content.find((c) => c.value === this.value.datacenter );
 
       if (!valueInContent) {
-        if (this.mode === _CREATE) {
+        if (this.mode === _CREATE || this.poolCreateMode) {
           set(this.value, 'datacenter', options[0]);
           set(this.value, 'cloneFrom', undefined);
           set(this.value, 'useDataStoreCluster', false);
         }
 
-        if ([_EDIT, _VIEW].includes(this.mode)) {
+        if ([_EDIT, _VIEW].includes(this.mode) && !this.poolCreateMode) {
           this.manageErrors(errorActions.CREATE, 'datacenter');
         }
       } else {
@@ -654,12 +658,13 @@ export default {
         // null and "" are valid values for hostsystem and folder
         const isFolderNullOrEmpty = key === 'folder' && (this.value.folder === null || this.value.folder === '');
         const isHostsystemNullOrEmpty = key === 'hostsystem' && (this.value.hostsystem === null || this.value.hostsystem === '');
+        const shouldHandleError = [_EDIT, _VIEW].includes(this.mode) && !isFolderNullOrEmpty && !isHostsystemNullOrEmpty && !this.poolCreateMode;
 
-        if (this.mode === _CREATE && value !== SENTINEL) {
+        if ((this.mode === _CREATE || this.poolCreateMode) && value !== SENTINEL) {
           set(this.value, key, value);
         }
 
-        if ([_EDIT, _VIEW].includes(this.mode) && !isFolderNullOrEmpty && !isHostsystemNullOrEmpty) {
+        if (shouldHandleError) {
           this.manageErrors(errorActions.CREATE, key);
         }
       } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10476 

Note: Better to be merged after [this PR](https://github.com/rancher/dashboard/pull/10473).

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Previously `vmwarevsphere.vue` relied only on `this.mode === _CREATE` to populate default values, but in Edit mode if you add a new pool you want the same behaviour. In order to detect this state `poolCreateMode` is passed as a prop to `vmwarevsphere.vue`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Provisioning vSphere cluster with multiple pools.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Provisioning vSphere cluster.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/135728925/00180e5f-139c-4ab0-9efb-68c524aaacbd

