### PR TITLE
Ensure pods loaded by incremental loadDataPage make it to the pod by namespace cache

### DIFF
--- a/shell/plugins/dashboard-store/__tests__/mutations.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/mutations.test.ts
@@ -1,377 +1,338 @@
-import { batchChanges } from '@shell/plugins/dashboard-store/mutations.js';
+import { batchChanges, loadAdd } from '@shell/plugins/dashboard-store/mutations.js';
 import { POD, WORKLOAD_TYPES } from '@shell/config/types';
 import Resource from '@shell/plugins/dashboard-store/resource-class';
+import mutationHelpers from '@shell/plugins/steve/__tests__/utils/mutation.test.helpers';
+
+const {
+  createCtx, createCache, createNoOp, createResource, createPod, createPodResource
+} = mutationHelpers;
+
+const ctx = createCtx(); // This should be fresh per test.. not sure why it wasn't originally
 
 describe('dashboard-store: mutations', () => {
-  const ctx = {
-    rootGetters: { 'type-map/optionsFor': (type) => ({}) },
-    getters:     {
-      classify:      (resource) => Resource,
-      cleanResource: (existing, resource) => resource
-    }
-  };
-
-  const create = (type) => ({
-    id: '1',
-    type
-  });
-
-  const createResource = (type, props = {}) => new Resource({
-    ...create(type),
-    ...props
-  });
-
-  const createPod = () => create(POD);
-
-  const createPodResource = (props = {}) => createResource(POD, props);
-
-  const createCache = (props) => ({
-    generation:    0,
-    haveAll:       false,
-    haveNamespace: undefined,
-    haveSelector:  {},
-    list:          [],
-    loadCounter:   0,
-    revision:      0,
-    map:           new Map(),
-    ...props
-  });
-
-  const createNoOp = () => {
-    const emptyState = { types: {} };
-
-    return {
-      params: [emptyState, {
-        ctx,
-        batch: { }
-      }],
-      expected: { state: emptyState }
-    };
-  };
-
-  const createRegister = () => {
-    return {
-      params: [{ types: {} }, {
-        ctx,
-        batch: { [POD]: {} }
-      }],
-      expected: { types: { [POD]: createCache({ generation: 1 }) } }
-    };
-  };
-
-  const createNewEntry = () => {
-    const pod = createPod();
-
-    return {
-      params: [
-        { types: {} },
-        {
+  describe('batchChanges', () => {
+    const createRegister = () => {
+      return {
+        params: [{ types: {} }, {
           ctx,
-          batch: { [POD]: { [pod.id]: pod } }
-        }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [new Resource(pod)],
-            map:        new Map([
-              [pod.id, new Resource(pod)]
-            ])
-          })
-        }
-      }
+          batch: { [POD]: {} }
+        }],
+        expected: { types: { [POD]: createCache({ generation: 1 }) } }
+      };
     };
-  };
 
-  const createExisting = () => {
-    const existingPod = createPodResource();
-    const newPod = createPodResource({ change: true });
+    const createNewEntry = () => {
+      const pod = createPod();
 
-    return {
-      params: [
-        {
+      return {
+        params: [
+          { types: {} },
+          {
+            ctx,
+            batch: { [POD]: { [pod.id]: pod } }
+          }
+        ],
+        expected: {
           types: {
             [POD]: createCache({
-              list: [existingPod],
-              map:  new Map([
-                [existingPod.id, existingPod]
+              generation: 1,
+              list:       [new Resource(pod)],
+              map:        new Map([
+                [pod.id, new Resource(pod)]
               ])
             })
           }
-        },
-        {
-          ctx,
-          batch: { [POD]: { [newPod.id]: createPodResource({ change: true }) } }
         }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [newPod],
-            map:        new Map([
-              [newPod.id, newPod]
-            ])
-          })
-
-        },
-      }
+      };
     };
-  };
 
-  const createRemove = () => {
-    const existingPod = createPodResource();
+    const createExisting = () => {
+      const existingPod = createPodResource();
+      const newPod = createPodResource({ change: true });
 
-    return {
-      params: [
-        {
-          types: {
-            [POD]: createCache({
-              list: [existingPod],
-              map:  new Map([
-                [existingPod.id, existingPod]
-              ])
-            })
+      return {
+        params: [
+          {
+            types: {
+              [POD]: createCache({
+                list: [existingPod],
+                map:  new Map([
+                  [existingPod.id, existingPod]
+                ])
+              })
+            }
+          },
+          {
+            ctx,
+            batch: { [POD]: { [newPod.id]: createPodResource({ change: true }) } }
           }
-        },
-        {
-          ctx,
-          batch: { [POD]: { [existingPod.id]: {} } }
-        }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [],
-            map:        new Map()
-          })
-        },
-      }
-    };
-  };
-
-  const createAddRemove = () => {
-    const existingPod1 = createPodResource({ id: '1' });
-    // const newPod1 = createPodResource({ id: '1', new: true });
-    const existingPod2 = createPodResource({ id: '2' });
-
-    return {
-      params: [
-        {
+        ],
+        expected: {
           types: {
             [POD]: createCache({
-              list: [existingPod2],
-              map:  new Map([
-                [existingPod2.id, existingPod2]
+              generation: 1,
+              list:       [newPod],
+              map:        new Map([
+                [newPod.id, newPod]
               ])
             })
 
+          },
+        }
+      };
+    };
+
+    const createRemove = () => {
+      const existingPod = createPodResource();
+
+      return {
+        params: [
+          {
+            types: {
+              [POD]: createCache({
+                list: [existingPod],
+                map:  new Map([
+                  [existingPod.id, existingPod]
+                ])
+              })
+            }
+          },
+          {
+            ctx,
+            batch: { [POD]: { [existingPod.id]: {} } }
           }
-        },
-        {
-          ctx,
-          batch: {
-            [POD]: {
-              [existingPod1.id]: existingPod1,
-              [existingPod2.id]: {}
+        ],
+        expected: {
+          types: {
+            [POD]: createCache({
+              generation: 1,
+              list:       [],
+              map:        new Map()
+            })
+          },
+        }
+      };
+    };
+
+    const createAddRemove = () => {
+      const existingPod1 = createPodResource({ id: '1' });
+      // const newPod1 = createPodResource({ id: '1', new: true });
+      const existingPod2 = createPodResource({ id: '2' });
+
+      return {
+        params: [
+          {
+            types: {
+              [POD]: createCache({
+                list: [existingPod2],
+                map:  new Map([
+                  [existingPod2.id, existingPod2]
+                ])
+              })
+
+            }
+          },
+          {
+            ctx,
+            batch: {
+              [POD]: {
+                [existingPod1.id]: existingPod1,
+                [existingPod2.id]: {}
+              }
             }
           }
-        }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [existingPod1],
-            map:        new Map([
-              [existingPod1.id, existingPod1]
-            ])
-          })
-        },
-      }
-    };
-  };
-
-  const createRemoveAdd = () => {
-    const existingPod1 = createPodResource({ id: '1' });
-    // const newPod1 = createPodResource({ id: '1', new: true });
-    const existingPod2 = createPodResource({ id: '2' });
-
-    return {
-      params: [
-        {
+        ],
+        expected: {
           types: {
             [POD]: createCache({
-              list: [existingPod2],
-              map:  new Map([
-                [existingPod2.id, existingPod2]
+              generation: 1,
+              list:       [existingPod1],
+              map:        new Map([
+                [existingPod1.id, existingPod1]
               ])
             })
-          }
-        },
-        {
-          ctx,
-          batch: {
-            [POD]: {
-              [existingPod2.id]: {},
-              [existingPod1.id]: existingPod1,
+          },
+        }
+      };
+    };
+
+    const createRemoveAdd = () => {
+      const existingPod1 = createPodResource({ id: '1' });
+      // const newPod1 = createPodResource({ id: '1', new: true });
+      const existingPod2 = createPodResource({ id: '2' });
+
+      return {
+        params: [
+          {
+            types: {
+              [POD]: createCache({
+                list: [existingPod2],
+                map:  new Map([
+                  [existingPod2.id, existingPod2]
+                ])
+              })
+            }
+          },
+          {
+            ctx,
+            batch: {
+              [POD]: {
+                [existingPod2.id]: {},
+                [existingPod1.id]: existingPod1,
+              }
             }
           }
-        }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [existingPod1],
-            map:        new Map([
-              [existingPod1.id, existingPod1]
-            ])
-          })
-        },
-      }
-    };
-  };
-
-  const createAddMultipleTypes = () => {
-    const pod = createPodResource({ id: '1' });
-    const deployment = createResource({ id: '2', type: WORKLOAD_TYPES.DEPLOYMENT });
-
-    return {
-      params: [
-        {
+        ],
+        expected: {
           types: {
             [POD]: createCache({
-              list: [],
-              map:  new Map()
+              generation: 1,
+              list:       [existingPod1],
+              map:        new Map([
+                [existingPod1.id, existingPod1]
+              ])
+            })
+          },
+        }
+      };
+    };
+
+    const createAddMultipleTypes = () => {
+      const pod = createPodResource({ id: '1' });
+      const deployment = createResource({ id: '2', type: WORKLOAD_TYPES.DEPLOYMENT });
+
+      return {
+        params: [
+          {
+            types: {
+              [POD]: createCache({
+                list: [],
+                map:  new Map()
+              }),
+              [WORKLOAD_TYPES.DEPLOYMENT]: createCache({
+                list: [],
+                map:  new Map()
+              })
+            }
+          },
+          {
+            ctx,
+            batch: {
+              [POD]:                       { [pod.id]: pod },
+              [WORKLOAD_TYPES.DEPLOYMENT]: { [deployment.id]: deployment }
+            }
+          }
+        ],
+        expected: {
+          types: {
+            [POD]: createCache({
+              generation: 1,
+              list:       [pod],
+              map:        new Map([
+                [pod.id, pod]
+              ])
             }),
             [WORKLOAD_TYPES.DEPLOYMENT]: createCache({
-              list: [],
-              map:  new Map()
+              generation: 1,
+              list:       [deployment],
+              map:        new Map([[deployment.id, deployment]])
             })
-          }
-        },
-        {
-          ctx,
-          batch: {
-            [POD]:                       { [pod.id]: pod },
-            [WORKLOAD_TYPES.DEPLOYMENT]: { [deployment.id]: deployment }
-          }
+          },
         }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [pod],
-            map:        new Map([
-              [pod.id, pod]
-            ])
-          }),
-          [WORKLOAD_TYPES.DEPLOYMENT]: createCache({
-            generation: 1,
-            list:       [deployment],
-            map:        new Map([[deployment.id, deployment]])
-          })
-        },
-      }
+      };
     };
-  };
 
-  const removeNonExisting = () => {
-    const pod1 = createPodResource({ id: '1' });
-    const pod2 = createPodResource({ id: '2' });
+    const removeNonExisting = () => {
+      const pod1 = createPodResource({ id: '1' });
+      const pod2 = createPodResource({ id: '2' });
 
-    return {
-      params: [
-        {
+      return {
+        params: [
+          {
+            types: {
+              [POD]: createCache({
+                list: [pod1],
+                map:  new Map([[pod1.id, pod1]])
+              }),
+            }
+          },
+          {
+            ctx,
+            batch: { [POD]: { [pod2.id]: {} } }
+          }
+        ],
+        expected: {
           types: {
             [POD]: createCache({
-              list: [pod1],
-              map:  new Map([[pod1.id, pod1]])
+              generation: 1,
+              list:       [pod1],
+              map:        new Map([[pod1.id, pod1]])
             }),
-          }
-        },
-        {
-          ctx,
-          batch: { [POD]: { [pod2.id]: {} } }
+          },
         }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [pod1],
-            map:        new Map([[pod1.id, pod1]])
-          }),
-        },
-      }
+      };
     };
-  };
 
-  const muchMuchChange = () => {
-    const pod1NoChange = createPodResource({ id: '1' });
+    const muchMuchChange = () => {
+      const pod1NoChange = createPodResource({ id: '1' });
 
-    const pod2Add = createPodResource({ id: '2' });
-    const pod3Remove = createPodResource({ id: '3' });
-    const pod4RemoveNoneExistant = createPodResource({ id: '4' });
-    const pod5Add = createPodResource({ id: '5' });
-    const pod6Original = createPodResource({ id: '6' });
-    const pod6WithChange = createPodResource({ id: '6', change: true }); // Cannot be same reference
-    const pod6WithChangeRef = createPodResource({ id: '6', change: true });
+      const pod2Add = createPodResource({ id: '2' });
+      const pod3Remove = createPodResource({ id: '3' });
+      const pod4RemoveNoneExistant = createPodResource({ id: '4' });
+      const pod5Add = createPodResource({ id: '5' });
+      const pod6Original = createPodResource({ id: '6' });
+      const pod6WithChange = createPodResource({ id: '6', change: true }); // Cannot be same reference
+      const pod6WithChangeRef = createPodResource({ id: '6', change: true });
 
-    expect(pod6Original.id).toBe('6');
-    expect(pod6WithChange.id).toBe('6');
-    expect(pod6WithChangeRef.id).toBe('6');
+      expect(pod6Original.id).toBe('6');
+      expect(pod6WithChange.id).toBe('6');
+      expect(pod6WithChangeRef.id).toBe('6');
 
-    return {
-      params: [
-        {
+      return {
+        params: [
+          {
+            types: {
+              [POD]: createCache({
+                list: [pod1NoChange, pod3Remove, pod6Original],
+                map:  new Map([
+                  [pod1NoChange.id, pod1NoChange],
+                  [pod3Remove.id, pod3Remove],
+                  [pod6Original.id, pod6Original],
+                ])
+              }),
+            }
+          },
+          {
+            ctx,
+            batch: {
+              [POD]: {
+                [pod2Add.id]:                pod2Add,
+                [pod3Remove.id]:             {},
+                [pod4RemoveNoneExistant.id]: {},
+                [pod5Add.id]:                pod5Add,
+                [pod6WithChangeRef.id]:      pod6WithChange // Cannot be same reference,
+              },
+            }
+          }
+        ],
+        expected: {
           types: {
             [POD]: createCache({
-              list: [pod1NoChange, pod3Remove, pod6Original],
-              map:  new Map([
+              generation: 1,
+              list:       [pod1NoChange, pod6WithChangeRef, pod2Add, pod5Add], // Order important
+              map:        new Map([
                 [pod1NoChange.id, pod1NoChange],
-                [pod3Remove.id, pod3Remove],
-                [pod6Original.id, pod6Original],
+                [pod2Add.id, pod2Add],
+                [pod5Add.id, pod5Add],
+                [pod6WithChangeRef.id, pod6WithChangeRef],
+
               ])
             }),
-          }
-        },
-        {
-          ctx,
-          batch: {
-            [POD]: {
-              [pod2Add.id]:                pod2Add,
-              [pod3Remove.id]:             {},
-              [pod4RemoveNoneExistant.id]: {},
-              [pod5Add.id]:                pod5Add,
-              [pod6WithChangeRef.id]:      pod6WithChange // Cannot be same reference,
-            },
-          }
+          },
         }
-      ],
-      expected: {
-        types: {
-          [POD]: createCache({
-            generation: 1,
-            list:       [pod1NoChange, pod6WithChangeRef, pod2Add, pod5Add], // Order important
-            map:        new Map([
-              [pod1NoChange.id, pod1NoChange],
-              [pod2Add.id, pod2Add],
-              [pod5Add.id, pod5Add],
-              [pod6WithChangeRef.id, pod6WithChangeRef],
-
-            ])
-          }),
-        },
-      }
+      };
     };
-  };
 
-  describe('batchChanges', () => {
     it.each([['No change', createNoOp()]])('%s', (_, run) => {
       batchChanges(...run.params);
 
@@ -401,6 +362,28 @@ describe('dashboard-store: mutations', () => {
         expect(cacheState).toStrictEqual(expected);
         expect(cacheMap).toStrictEqual(expectedMap);
       });
+    });
+  });
+
+  describe('loadAdd', () => {
+    it.each([['No change', mutationHelpers.loadAll.createNoOp()]])('%s', (_, run) => {
+      loadAdd(...run.params);
+
+      expect(run.params[0]).toStrictEqual(run.expected.state);
+    });
+
+    it.each([
+      ['Add a new pod', mutationHelpers.loadAll.createNewEntry()],
+    ])('%s', (_, run) => { // eslint-disable-line jest/no-identical-title
+      loadAdd(...run.params);
+      const { map: cacheMap, ...cacheState } = run.params[0].types?.[POD] || {};
+      const { map: expectedMap, ...expected } = run.expected.types?.[POD];
+
+      expect(cacheMap).toBeDefined();
+      expect(expectedMap).toBeDefined();
+
+      expect(cacheState).toStrictEqual(expected);
+      expect(cacheMap).toStrictEqual(expectedMap);
     });
   });
 });

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -200,6 +200,8 @@ export default {
     // on for a limit of 100, to quickly show data
     // another one with 1st page of the subset of the resource we are fetching
     // the default is 4 pages, but it can be changed on mixin/resource-fetch.js
+    let pageFetchOpts;
+
     if (opt.incremental) {
       commit('incrementLoadCounter', type);
 
@@ -207,7 +209,7 @@ export default {
         dispatch('resource-fetch/updateManualRefreshIsLoading', true, { root: true });
       }
 
-      const pageFetchOpts = {
+      pageFetchOpts = {
         ...opt,
         url: addParam(opt.url, 'limit', `${ opt.incremental }`),
       };
@@ -223,8 +225,6 @@ export default {
       if (opt.force) {
         commit('forgetType', type);
       }
-
-      dispatch('loadDataPage', { type, opt: pageFetchOpts });
     }
 
     let streamStarted = false;
@@ -318,6 +318,11 @@ export default {
           skipHaveAll,
           namespace: opt.namespaced
         });
+      }
+
+      if (opt.incremental) {
+        // This needs to come after the loadAll (which resets state) so supplements via loadDataPage aren't lost
+        dispatch('loadDataPage', { type, opt: pageFetchOpts });
       }
     }
 

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -298,6 +298,24 @@ export function loadAll(state, {
   return proxies;
 }
 
+/**
+ * Add a set of resources to the store for a given type
+ *
+ * Don't mark the 'haveAll' field - this is used for incremental loading
+ */
+export function loadAdd(state, { type, data: allLatest, ctx }) {
+  const { getters } = ctx;
+  const keyField = getters.keyFieldForType(type);
+
+  allLatest.forEach((entry) => {
+    const existing = state.types[type].map.get(entry[keyField]);
+
+    load(state, {
+      data: entry, ctx, existing
+    });
+  });
+}
+
 export default {
   registerType,
   load,
@@ -358,20 +376,7 @@ export default {
     });
   },
 
-  // Add a set of resources to the store for a given type
-  // Don't mark the 'haveAll' field - this is used for incremental loading
-  loadAdd(state, { type, data: allLatest, ctx }) {
-    const { getters } = ctx;
-    const keyField = getters.keyFieldForType(type);
-
-    allLatest.forEach((entry) => {
-      const existing = state.types[type].map.get(entry[keyField]);
-
-      load(state, {
-        data: entry, ctx, existing
-      });
-    });
-  },
+  loadAdd,
 
   forgetAll(state, { type }) {
     const cache = registerType(state, type);

--- a/shell/plugins/steve/__tests__/mutations.test.ts
+++ b/shell/plugins/steve/__tests__/mutations.test.ts
@@ -1,0 +1,49 @@
+import mutations from '@shell/plugins/steve/mutations.js';
+import { POD } from '@shell/config/types';
+import Resource from '@shell/plugins/dashboard-store/resource-class';
+import mutationHelpers from '@shell/plugins/steve/__tests__/utils/mutation.test.helpers';
+
+describe('steve-store: mutations', () => {
+  describe('loadAdd', () => {
+    const createNewEntry = () => {
+      const res = mutationHelpers.loadAll.createNewEntry();
+      const pod = res.params[1].data[0];
+
+      res.params[0].podsByNamespace = {};
+      res.expected.podsByNamespace = {
+        [pod.namespace]: {
+          list: [new Resource(pod)],
+          map:  new Map([
+            [pod.id, new Resource(pod)]
+          ])
+        }
+      };
+
+      return res;
+    };
+
+    it.each([['No change', mutationHelpers.loadAll.createNoOp()]])('%s', (_, run) => {
+      mutations.loadAdd(...run.params);
+
+      expect(run.params[0]).toStrictEqual(run.expected.state);
+    });
+
+    it.each([
+      ['Add a new pod', createNewEntry()],
+    ])('%s', (_, run) => { // eslint-disable-line jest/no-identical-title
+      mutations.loadAdd(...run.params);
+      const { map: cacheMap, ...cacheState } = run.params[0].types?.[POD] ;
+      const cachePodsByNamespace = run.params[0].podsByNamespace ;
+      const { map: expectedMap, ...expected } = run.expected.types?.[POD];
+      const expectedPodsByNamespace = run.expected.podsByNamespace ;
+
+      expect(cacheMap).toBeDefined();
+      expect(expectedMap).toBeDefined();
+
+      expect(cacheState).toStrictEqual(expected);
+      expect(cacheMap).toStrictEqual(expectedMap);
+
+      expect(cachePodsByNamespace).toStrictEqual(expectedPodsByNamespace);
+    });
+  });
+});

--- a/shell/plugins/steve/__tests__/utils/mutation.test.helpers.ts
+++ b/shell/plugins/steve/__tests__/utils/mutation.test.helpers.ts
@@ -1,0 +1,104 @@
+import { POD } from '@shell/config/types';
+import Resource from '@shell/plugins/dashboard-store/resource-class';
+
+const createCtx = () => ({
+  rootGetters: { 'type-map/optionsFor': (type: string) => ({}) },
+  getters:     {
+    classify:        (resource: any) => Resource,
+    cleanResource:   (existing: Resource, resource: any) => resource,
+    keyFieldForType: () => 'id',
+  }
+});
+
+const create = (type: string) => ({
+  id: '1',
+  type,
+});
+
+const createResource = (type: string, props = {}) => new Resource({
+  ...create(type),
+  ...props
+});
+
+const createPod = () => create(POD);
+
+const createPodResource = (props = {}) => createResource(POD, props);
+
+const createCache = (props: any) => ({
+  generation:    0,
+  haveAll:       false,
+  haveNamespace: undefined,
+  haveSelector:  {},
+  list:          [],
+  loadCounter:   0,
+  revision:      0,
+  map:           new Map(),
+  ...props
+});
+
+const createNoOp = () => {
+  const emptyState = { types: {} };
+
+  return {
+    params: [emptyState, {
+      ctx:   createCtx(),
+      batch: { }
+    }],
+    expected: { state: emptyState }
+  };
+};
+
+const loadAllCreateNoOp = () => {
+  const emptyState = { types: {} };
+
+  return {
+    params: [
+      emptyState,
+      {
+        ctx:  createCtx(),
+        type: POD,
+        data: [],
+      }],
+    expected: { state: emptyState }
+  };
+};
+
+const loadAllCreateNewEntry = () => {
+  const pod = createPodResource({ namespace: 'namespace' } );
+
+  return {
+    params: [
+      { types: { [POD]: createCache({}) } },
+      {
+        ctx:  createCtx(),
+        type: POD,
+        data: [pod]
+      }
+    ],
+    expected: {
+      types: {
+        [POD]: createCache({
+          generation: 1,
+          list:       [new Resource(pod)],
+          map:        new Map([
+            [pod.id, new Resource(pod)]
+          ])
+        })
+      },
+      podsByNamespace: {},
+    }
+  };
+};
+
+export default {
+  createCtx,
+  createCache,
+  createNoOp,
+  createResource,
+  createPod,
+  createPodResource,
+  loadAll: {
+    createNewEntry: loadAllCreateNewEntry,
+    createNoOp:     loadAllCreateNoOp
+  }
+};

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -7,7 +7,8 @@ import {
   load,
   remove,
   batchChanges,
-  replace
+  replace,
+  loadAdd
 } from '@shell/plugins/dashboard-store/mutations';
 import { keyForSubscribe } from '@shell/plugins/steve/resourceWatcher';
 import { perfLoadAll } from '@shell/plugins/steve/performanceTesting';
@@ -179,6 +180,16 @@ export default {
         addObject(cache.list, resource);
         cache.map.set(resource.id, resource);
       }
+    }
+  },
+
+  loadAdd(state, { type, data: allLatest, ctx }) {
+    loadAdd(state, {
+      type, data: allLatest, ctx
+    });
+
+    if (allLatest.length && allLatest[0].type === POD) {
+      updatePodsByNamespaceCache(state, ctx, allLatest, false);
     }
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10479
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Ensure loadDataPage --> loadAdd updates pod by namespace cache
- Also address a possible race condition made more likely by change

### Technical notes summary
- The bug can be tricky to reproduce, as the initial fetch of 100 pods which calls loadAll populates cache ok... it's the subsequent loadDataPage results which won't. So the deployment detail page needs to show pods that weren't fetched in the initial 100 pods. There's a tweak in code to make this easier to reproduce (by dropping 100 pod limit down), see issue description

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
As per issue (ensure exact env setup or hack using instructions in Additional context)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
General incremental loading mechanism


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
