### PR TITLE
Fleet "continous delivery dashboard" should show Clusters/Bundles/Resources in error at "mouse over"

### DIFF
--- a/cypress/e2e/tests/pages/fleet/dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/dashboard.spec.ts
@@ -23,41 +23,53 @@ describe.only('Fleet Dashboard', { tags: ['@fleet', '@adminUser'] }, () => {
   before(() => {
     cy.login();
 
-    const gitRepoCreatePage = new GitRepoCreatePo('_');
+    // const gitRepoCreatePage = new GitRepoCreatePo('_');
 
-    gitRepoCreatePage.goTo();
+    // gitRepoCreatePage.goTo();
 
-    gitRepoCreatePage.setRepoName(repoName);
-    gitRepoCreatePage.selectWorkspace('fleet-local');
-    gitRepoCreatePage.setGitRepoUrl('https://github.com/rancher/fleet-test-data.git');
-    gitRepoCreatePage.setBranchName();
-    // NB - This step is here because DOM may not be ready
-    gitRepoCreatePage.goToNext();
-    gitRepoCreatePage.create();
+    // gitRepoCreatePage.setRepoName(repoName);
+    // gitRepoCreatePage.selectWorkspace('fleet-local');
+    // gitRepoCreatePage.setGitRepoUrl('https://github.com/rancher/fleet-test-data.git');
+    // gitRepoCreatePage.setBranchName();
+    // // NB - This step is here because DOM may not be ready
+    // gitRepoCreatePage.goToNext();
+    // gitRepoCreatePage.create();
   });
 
-  it('Should display cluster status', () => {
+  it('Should display cluster status badge and hovering it should display the correct info', () => {
     // check if burguer menu nav is highlighted correctly for Fleet
     BurgerMenuPo.checkIfMenuItemLinkIsHighlighted('Continuous Delivery');
 
     const row = fleetDashboardPage.sortableTable('fleet-local').row(0);
 
     row.get('.bg-success[data-testid="clusters-ready"]').should('exist');
+    row.get('.bg-success[data-testid="clusters-ready"]').trigger('mouseenter');
+    cy.get('.clusters-ready-tooltip').should('be.visible');
+    cy.get('.clusters-ready-tooltip .tooltip-inner').contains('Ready');
+    row.get('.bg-success[data-testid="clusters-ready"]').trigger('mouseleave');
     row.get('.bg-success[data-testid="clusters-ready"] span').should('have.text', '1/1');
 
-    row.get('.bg-success[data-testid="clusters-ready"]').should('exist');
+    row.get('.bg-success[data-testid="bundles-ready"]').should('exist');
+    row.get('.bg-success[data-testid="bundles-ready"]').trigger('mouseenter');
+    cy.get('.bundles-ready-tooltip').should('be.visible');
+    cy.get('.bundles-ready-tooltip .tooltip-inner').contains('Active');
+    row.get('.bg-success[data-testid="bundles-ready"]').trigger('mouseleave');
     row.get('.bg-success[data-testid="bundles-ready"] span').should('have.text', '1/1');
 
-    row.get('.bg-success[data-testid="clusters-ready"]').should('exist');
+    row.get('.bg-success[data-testid="resources-ready"]').should('exist');
+    row.get('.bg-success[data-testid="resources-ready"]').trigger('mouseenter');
+    cy.get('.resources-ready-tooltip').should('be.visible');
+    cy.get('.resources-ready-tooltip .tooltip-inner').contains('Ready');
+    row.get('.bg-success[data-testid="resources-ready"]').trigger('mouseleave');
     row.get('.bg-success[data-testid="resources-ready"] span').should('have.text', '1/1');
   });
 
-  after(() => {
-    fleetDashboardPage = new FleetDashboardPagePo('_');
-    fleetDashboardPage.goTo();
+  // after(() => {
+  //   fleetDashboardPage = new FleetDashboardPagePo('_');
+  //   fleetDashboardPage.goTo();
 
-    const fleetLocalResourceTable = fleetDashboardPage.resourceTable('fleet-local');
+  //   const fleetLocalResourceTable = fleetDashboardPage.resourceTable('fleet-local');
 
-    fleetLocalResourceTable.sortableTable().deleteItemWithUI(repoName);
-  });
+  //   fleetLocalResourceTable.sortableTable().deleteItemWithUI(repoName);
+  // });
 });

--- a/shell/components/CompoundStatusBadge.vue
+++ b/shell/components/CompoundStatusBadge.vue
@@ -6,6 +6,10 @@ export default {
       type:    String,
       default: ''
     },
+    tooltipClass: {
+      type:    String,
+      default: ''
+    },
     badgeClass: {
       type:    String,
       default: ''
@@ -18,13 +22,13 @@ export default {
       type:    String,
       default: ''
     },
-  },
+  }
 };
 </script>
 
 <template>
   <div
-    v-clean-tooltip.bottom="tooltipText"
+    v-clean-tooltip.bottom="{content: tooltipText, classes: tooltipClass}"
     class="compound-cluster-badge"
     :class="`bg-${badgeClass}`"
   >

--- a/shell/components/form/SelectOrCreateAuthSecret.vue
+++ b/shell/components/form/SelectOrCreateAuthSecret.vue
@@ -350,7 +350,7 @@ export default {
     privateKey: 'updateKeyVal',
 
     namespace(ns) {
-      if ( ns && !this.selected.startsWith(`${ ns }/`) ) {
+      if ( ns && !this.selected?.startsWith(`${ ns }/`) ) {
         this.selected = AUTH_TYPE._NONE;
       }
     }

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -414,6 +414,7 @@ export default {
                 v-else
                 data-testid="clusters-ready"
                 :tooltip-text="getTooltipInfo('clusters', row)"
+                tooltip-class="clusters-ready-tooltip"
                 :badge-class="getStatusInfo('clusters', row).badgeClass"
                 :icon="getStatusInfo('clusters', row).icon"
                 :value="`${ row.clusterInfo.ready }/${ row.clusterInfo.total }`"
@@ -425,6 +426,7 @@ export default {
                 v-else
                 data-testid="bundles-ready"
                 :tooltip-text="getTooltipInfo('bundles', row)"
+                tooltip-class="bundles-ready-tooltip"
                 :badge-class="getStatusInfo('bundles', row).badgeClass"
                 :icon="getStatusInfo('bundles', row).icon"
                 :value="`${ row.bundlesReady.length || 0 }/${ row.bundles.length }`"
@@ -434,6 +436,7 @@ export default {
               <CompoundStatusBadge
                 data-testid="resources-ready"
                 :tooltip-text="getTooltipInfo('resources', row)"
+                tooltip-class="resources-ready-tooltip"
                 :badge-class="getStatusInfo('resources', row).badgeClass"
                 :icon="getStatusInfo('resources', row).icon"
                 :value="`${ row.status.resourceCounts.ready }/${ row.status.resourceCounts.desiredReady }`"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10339 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add tooltip showing "items" in error on Fleet Dashboard view
- Added e2e test for tooltip content on Fleet Dashboard view

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to `Fleet` -> `Git Repos` -> add the following repo `https://github.com/rancher/fleet-examples.git` + branch `master`
- Go to `Fleet` -> `Dashboard` and hover the pills/badges to display tooltip and make sure it contains the correct information

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
