### PR TITLE
Add additional logging to port-issue workflow

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -31,16 +31,20 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           BODY_MILESTONE=$(echo "${COMMENT_BODY}" | awk '{ print $2 }')
+          echo "BODY_MILESTONE '${BODY_MILESTONE}'"
+
           # Sanitize input
           MILESTONE=${BODY_MILESTONE//[^a-zA-Z0-9\-\.]/}
+          echo "MILESTONE '${MILESTONE}'"
+
           if gh api repos/${GITHUB_REPOSITORY}/milestones --paginate | jq -e --arg MILESTONE "$MILESTONE" '.[] | select(.title == $MILESTONE)' > /dev/null; then
-              echo "Milestone exists"
-              echo "milestone_exists=true" >> $GITHUB_ENV
-           else
-              echo "Milestone ${MILESTONE} does not exist" >> $GITHUB_STEP_SUMMARY
-              gh issue comment -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port issue, milestone ${MILESTONE} does not exist or is not an open milestone"
-              echo "milestone_exists=false" >> $GITHUB_ENV
-           fi
+            echo "Milestone '${MILESTONE}' exists"
+            echo "milestone_exists=true" >> $GITHUB_ENV
+          else
+            echo "Milestone '${MILESTONE}' does not exist" >> $GITHUB_STEP_SUMMARY
+            gh issue comment -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port issue, milestone ${MILESTONE} does not exist or is not an open milestone"
+            echo "milestone_exists=false" >> $GITHUB_ENV
+          fi
       - name: Port issue
         if: |
           env.is_member == 'true' &&


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- This fails when there's a line break after the milestone in a comment
  - https://github.com/rancher/dashboard/actions/runs/7974403963/job/21770298336
  - Check milestone passes, Port Issue fails 
```
could not add to milestone 'v2.8.next1 ': 'v2.8.next1
' not found
Error: Process completed with exit code 1.
```
- I can't get check milestone to succeed locally with a line break in the milestone (tried a couple of different types)
- Adding better logging to see what happens if fails in future
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
