### PR TITLE
Add cluster description to cluster side menu and main menu

### DIFF
--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -51,7 +51,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * Check if Cluster Top Level Menu link is highlighted
    */
   static checkIfClusterMenuLinkIsHighlighted(name: string) {
-    return this.burgerMenuGetNavClusterbyLabel(name).parent().should('have.class', 'active-menu-link');
+    return this.burgerMenuGetNavClusterbyLabel(name).parent().parent().should('have.class', 'active-menu-link');
   }
 
   /**

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -156,7 +156,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   home(): Cypress.Chainable {
-    return this.self().find('.body > div > a').first();
+    return this.self().find('.body > div > div > a').first();
   }
 
   /**

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -75,11 +75,11 @@ export default class BurgerMenuPo extends ComponentPo {
     this.sideMenu().should('have.class', 'menu-close');
   }
 
-  static checkTooltipOn(): Cypress.Chainable {
+  static checkIconTooltipOn(): Cypress.Chainable {
     return cy.get('.option').get('.cluster-icon-menu').first().should('have.class', 'has-tooltip');
   }
 
-  static checkTooltipOff(): Cypress.Chainable {
+  static checkIconTooltipOff(): Cypress.Chainable {
     return cy.get('.option').get('.cluster-icon-menu').first().should('have.not.class', 'has-tooltip');
   }
 
@@ -135,6 +135,18 @@ export default class BurgerMenuPo extends ComponentPo {
 
   unpinFirstCluster(): Cypress.Chainable {
     return this.clusterPinnedList().first().find('.pin').click();
+  }
+
+  getClusterDescription(): Cypress.Chainable {
+    return this.clusters().first().find('.description').invoke('text');
+  }
+
+  showClusterDescriptionTooltip(): Cypress.Chainable {
+    return this.clusters().first().find('.description').trigger('mouseenter');
+  }
+
+  getClusterDescriptionTooltipContent(): Cypress.Chainable {
+    return cy.get('.menu-description-tooltip .tooltip-inner');
   }
 
   /**

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -10,7 +10,9 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   static toggle(): Cypress.Chainable {
-    return cy.getId('top-level-menu').should('be.visible').click({ force: true });
+    // added wait of 500ms to make time for CSS transitions to resolve (addresses tests flakiness)
+    // unfortunately there's no "easy" (and foolproof) way of waiting for transitions and 500ms is quick and does the trick
+    return cy.getId('top-level-menu').should('be.visible').click({ force: true }).wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
   }
 
   /**

--- a/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
+++ b/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
@@ -5,7 +5,7 @@ import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 
 const STORAGE_CLASS_RESOURCE = 'storage.k8s.io.storageclasses';
 
-describe('Charts', { tags: '@adminUser' }, () => {
+describe('Charts', { tags: ['@adminUser'] }, () => {
   const chartsPageUrl = '/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-charts';
 
   describe('Rancher Backups', () => {

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -91,7 +91,7 @@ describe('Home Page', () => {
       homePage.getLoginPageBanner().checkVisible();
     });
 
-    it('Can see that cluster details match those in Cluster Manangement page', { tags: '@adminUser' }, () => {
+    it('Can see that cluster details match those in Cluster Manangement page', { tags: ['@adminUser'] }, () => {
     /**
      * Get cluster details from the Home page
      * Verify that the cluster details match those on the Cluster Management page
@@ -156,7 +156,7 @@ describe('Home Page', () => {
       genericCreateClusterPage.waitForPage();
     });
 
-    it('Can filter rows in the cluster list', { tags: '@adminUser' }, () => {
+    it('Can filter rows in the cluster list', { tags: ['@adminUser'] }, () => {
     /**
      * Filter rows in the cluster list
      */
@@ -172,7 +172,7 @@ describe('Home Page', () => {
       });
     });
 
-    it('Should show cluster description information in the cluster list', { tags: '@adminUser' }, () => {
+    it('Should show cluster description information in the cluster list', { tags: ['@adminUser'] }, () => {
       HomePagePo.navTo();
       const desc = homeClusterList.resourceTable().sortableTable().rowWithName('local').column(1)
         .get('.cluster-description');

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -6,10 +6,26 @@ import ClusterManagerImportGenericPagePo from '@/cypress/e2e/po/edit/provisionin
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
+const longClusterDescription = 'this-is-some-really-really-really-really-really-really-long-decription';
 
 describe('Home Page', () => {
   describe('Home Page', { testIsolation: 'off' }, () => {
     before(() => {
+      // since I wasn't able to fully mock a list of clusters
+      // the next best thing is to add a description to the current local cluster
+      // testing https://github.com/rancher/dashboard/issues/10441
+      cy.intercept('GET', `/v1/provisioning.cattle.io.clusters?*`, (req) => {
+        req.continue((res) => {
+          const localIndex = res.body.data.findIndex((item) => item.id.includes('/local'));
+
+          if (localIndex >= 0) {
+            res.body.data[localIndex].metadata.annotations['field.cattle.io/description'] = longClusterDescription;
+          }
+
+          res.send(res.body);
+        });
+      }).as('provClusters');
+
       cy.login();
       HomePagePo.goToAndWaitForGet();
     });
@@ -154,6 +170,14 @@ describe('Home Page', () => {
       homeClusterList.name('local').should((el) => {
         expect(el).to.contain.text('local');
       });
+    });
+
+    it('Should show cluster description information in the cluster list', { tags: '@adminUser' }, () => {
+      HomePagePo.navTo();
+      const desc = homeClusterList.resourceTable().sortableTable().rowWithName('local').column(1)
+        .get('.cluster-description');
+
+      desc.contains(longClusterDescription);
     });
   });
 

--- a/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
@@ -39,6 +39,9 @@ describe('Feature Flags', { testIsolation: 'off' }, () => {
     // Check Updated State: should be active
     featureFlagsPage.list().details('harvester', 0).should('include.text', 'Active');
 
+    // we now need to reload the page in order to catch the update of the product on the side-nav
+    cy.reload();
+
     // Check side nav
     BurgerMenuPo.toggle();
     virtualizationMgmtNavItem.should('be.visible');

--- a/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
@@ -44,7 +44,9 @@ describe('Feature Flags', { testIsolation: 'off' }, () => {
 
     // Check side nav
     BurgerMenuPo.toggle();
-    virtualizationMgmtNavItem.should('be.visible');
+    const newVirtualizationMgmtNavItem = burgerMenu.links().contains('Virtualization Management');
+
+    newVirtualizationMgmtNavItem.should('be.visible');
   });
 
   it('can toggle harvester-baremetal-container-workload feature flag', { tags: ['@globalSettings', '@adminUser'] }, () => {

--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -22,6 +22,9 @@
   // dark main text
   $lightest: #ffffff;
 
+  // menu cluster description active+hover
+  $desc-light: #EEEFF4;
+
   $secondary: $lighter;
   $disabled: $light;
 
@@ -49,6 +52,8 @@
   --body-text                  : #{$lightest};
   --scrollbar-thumb            : #{$medium};
   --scrollbar-thumb-dropdown   : #{$medium};
+
+  --side-menu-desc             : #{$desc-light};
 
   --header-bg                  : #{$darker};
   --header-border              : #{$medium};

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -511,7 +511,7 @@ export default {
                 >
                   <nuxt-link
                     v-if="c.ready"
-                    :data-testid="`menu-cluster-${ c.id }`"
+                    :data-testid="`pinned-menu-cluster-${ c.id }`"
                     class="cluster selector option"
                     :class="{'active-menu-link': checkActiveRoute(c, true) }"
                     :to="{ name: 'c-cluster-explorer', params: { cluster: c.id } }"
@@ -540,6 +540,7 @@ export default {
                   <span
                     v-else
                     class="option cluster selector disabled"
+                    :data-testid="`pinned-menu-cluster-disabled-${ c.id }`"
                   >
                     <ClusterIconMenu
                       v-tooltip="getTooltipConfig(c.label)"
@@ -611,6 +612,7 @@ export default {
                   <span
                     v-else
                     class="option cluster selector disabled"
+                    :data-testid="`menu-cluster-disabled-${ c.id }`"
                   >
                     <ClusterIconMenu
                       v-tooltip="getTooltipConfig(c.label)"

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -803,6 +803,8 @@ export default {
     // offset the tooltip a bit so it doesn't
     // overlap the pin icon and cause bad UX
     left: 35px !important;
+    white-space: pre-wrap;
+    word-wrap: break-word;
   }
 
   .localeSelector, .footer-tooltip {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -151,12 +151,8 @@ export default {
       if (sorted.length >= this.maxClustersToShow) {
         const sortedPinOut = sorted.filter((item) => !item.pinned).slice(0, this.maxClustersToShow);
 
-        console.log('sortedPinOut', sortedPinOut);
-
         return sortedPinOut;
       } else {
-        console.log('filtered clusters', sorted.filter((item) => !item.pinned));
-
         return sorted.filter((item) => !item.pinned);
       }
     },

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -127,6 +127,7 @@ export default {
           isLocal:         x.isLocal,
           isHarvester:     x.isHarvester,
           pinned:          x.pinned,
+          description:     pCluster?.description,
           pin:             () => x.pin(),
           unpin:           () => x.unpin()
         };
@@ -150,8 +151,12 @@ export default {
       if (sorted.length >= this.maxClustersToShow) {
         const sortedPinOut = sorted.filter((item) => !item.pinned).slice(0, this.maxClustersToShow);
 
+        console.log('sortedPinOut', sortedPinOut);
+
         return sortedPinOut;
       } else {
+        console.log('filtered clusters', sorted.filter((item) => !item.pinned));
+
         return sorted.filter((item) => !item.pinned);
       }
     },
@@ -504,7 +509,13 @@ export default {
                       class="rancher-provider-icon"
                     />
                     <div class="cluster-name">
-                      {{ c.label }}
+                      <p>{{ c.label }}</p>
+                      <p
+                        v-if="c.description"
+                        class="description"
+                      >
+                        {{ c.description }}
+                      </p>
                     </div>
                     <Pinned
                       :cluster="c"
@@ -519,7 +530,15 @@ export default {
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
-                    <div class="cluster-name">{{ c.label }}</div>
+                    <div class="cluster-name">
+                      <p>{{ c.label }}</p>
+                      <p
+                        v-if="c.description"
+                        class="description"
+                      >
+                        {{ c.description }}
+                      </p>
+                    </div>
                     <Pinned
                       :cluster="c"
                     />
@@ -554,7 +573,13 @@ export default {
                       class="rancher-provider-icon"
                     />
                     <div class="cluster-name">
-                      {{ c.label }}
+                      <p>{{ c.label }}</p>
+                      <p
+                        v-if="c.description"
+                        class="description"
+                      >
+                        {{ c.description }}
+                      </p>
                     </div>
                     <Pinned
                       :class="{'showPin': c.pinned}"
@@ -570,7 +595,15 @@ export default {
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
-                    <div class="cluster-name">{{ c.label }}</div>
+                    <div class="cluster-name">
+                      <p>{{ c.label }}</p>
+                      <p
+                        v-if="c.description"
+                        class="description"
+                      >
+                        {{ c.description }}
+                      </p>
+                    </div>
                     <Pinned
                       :class="{'showPin': c.pinned}"
                       :cluster="c"
@@ -745,6 +778,17 @@ export default {
       outline: 0;
     }
   }
+
+  .theme-dark .cluster-name .description {
+    color: var(--input-label) !important;
+  }
+  .theme-dark .body .option  {
+    &:hover .cluster-name .description,
+    &.router-link-active .cluster-name .description,
+    &.active-menu-link .cluster-name .description {
+      color: var(--side-menu-desc) !important;
+  }
+  }
 </style>
 
 <style lang="scss" scoped>
@@ -855,6 +899,18 @@ export default {
           }
         }
 
+        .cluster-name p {
+          max-width: 220px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+
+          &.description {
+            font-size: 12px;
+            color: var(--darker);
+          }
+        }
+
         &:hover {
           text-decoration: none;
 
@@ -868,9 +924,9 @@ export default {
           cursor: not-allowed;
 
           .rancher-provider-icon,
-          .cluster-name {
+          .cluster-name p {
             filter: grayscale(1);
-            color: var(--muted);
+            color: var(--muted) !important;
           }
 
           .pin {
@@ -912,6 +968,10 @@ export default {
           i {
             color: var(--primary-hover-text);
           }
+
+          div .description {
+            color: var(--default);
+          }
         }
 
         &:hover {
@@ -919,6 +979,10 @@ export default {
           background: var(--primary-hover-bg);
           > div {
             color: var(--primary-hover-text);
+
+            .description {
+              color: var(--default);
+            }
           }
           svg {
             fill: var(--primary-hover-text);
@@ -935,13 +999,6 @@ export default {
               display: block;
             }
           }
-        }
-
-        .cluster-name {
-          max-width: 220px;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
         }
       }
 

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -332,12 +332,15 @@ export default {
 
       let contentText = '';
       let content;
+      let classes = '';
 
       // this is scenario where we show a tooltip when we are on the expanded menu
       if (isExpandedMenuTooltip) {
         contentText = `${ item.label }<br><br>${ item.description }`;
 
         content = !this.shown || !item.description ? null : contentText;
+        // this adds a class to the tooltip container so that we can control the max width
+        classes = 'tooltip-description';
       // this is the normal tooltip scenario where we are just passing a string
       } else {
         contentText = item;
@@ -347,7 +350,8 @@ export default {
       return {
         content,
         placement:     'right',
-        popperOptions: { modifiers: { preventOverflow: { enabled: false }, hide: { enabled: false } } }
+        popperOptions: { modifiers: { preventOverflow: { enabled: false }, hide: { enabled: false } } },
+        classes
       };
     },
   }
@@ -784,6 +788,10 @@ export default {
 </template>
 
 <style lang="scss">
+  .tooltip-description {
+    max-width: 200px;
+  }
+
   .localeSelector, .footer-tooltip {
     z-index: 1000;
   }

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -324,20 +324,31 @@ export default {
       } catch {
       }
     },
-    getTooltipConfig(item) {
-      if (!this.shown && !item) {
+
+    getTooltipConfig(item, isExpandedMenuTooltip = false) {
+      if (!item) {
         return;
       }
 
-      if (!this.shown) {
-        return {
-          content:       this.shown ? null : item,
-          placement:     'right',
-          popperOptions: { modifiers: { preventOverflow: { enabled: false }, hide: { enabled: false } } }
-        };
+      let contentText = '';
+      let content;
+
+      // this is scenario where we show a tooltip when we are on the expanded menu
+      if (isExpandedMenuTooltip) {
+        contentText = `${ item.label }<br><br>${ item.description }`;
+
+        content = !this.shown || !item.description ? null : contentText;
+      // this is the normal tooltip scenario where we are just passing a string
       } else {
-        return { content: undefined };
+        contentText = item;
+        content = this.shown ? null : contentText;
       }
+
+      return {
+        content,
+        placement:     'right',
+        popperOptions: { modifiers: { preventOverflow: { enabled: false }, hide: { enabled: false } } }
+      };
     },
   }
 };
@@ -508,10 +519,13 @@ export default {
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
-                    <div class="cluster-name">
+                    <div
+                      class="cluster-name"
+                    >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
+                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}
@@ -530,10 +544,13 @@ export default {
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
-                    <div class="cluster-name">
+                    <div
+                      class="cluster-name"
+                    >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
+                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}
@@ -572,10 +589,13 @@ export default {
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
-                    <div class="cluster-name">
+                    <div
+                      class="cluster-name"
+                    >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
+                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}
@@ -595,10 +615,13 @@ export default {
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
-                    <div class="cluster-name">
+                    <div
+                      class="cluster-name"
+                    >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
+                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -402,25 +402,26 @@ export default {
         <div class="body">
           <div>
             <!-- Home button -->
-            <nuxt-link
-              class="option cluster selector home"
-              :to="{ name: 'home' }"
-            >
-              <svg
-                v-tooltip="getTooltipConfig(t('nav.home'))"
-                xmlns="http://www.w3.org/2000/svg"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-              ><path
-                d="M0 0h24v24H0z"
-                fill="none"
-              /><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" /></svg>
-              <div class="home-text">
-                {{ t('nav.home') }}
-              </div>
-            </nuxt-link>
-
+            <div @click="hide()">
+              <nuxt-link
+                class="option cluster selector home"
+                :to="{ name: 'home' }"
+              >
+                <svg
+                  v-tooltip="getTooltipConfig(t('nav.home'))"
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                ><path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                /><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" /></svg>
+                <div class="home-text">
+                  {{ t('nav.home') }}
+                </div>
+              </nuxt-link>
+            </div>
             <!-- Search bar -->
             <div
               v-if="showClusterSearch"

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -321,7 +321,7 @@ export default {
       }
     },
 
-    getTooltipConfig(item) {
+    getTooltipConfig(item, showWhenClosed = false) {
       if (!item) {
         return;
       }
@@ -337,9 +337,17 @@ export default {
 
       // this is scenario where we show a tooltip when we are on the expanded menu to show full description
       } else {
-        contentText = `${ item.label }<br><br>${ item.description }`;
+        contentText = item.label;
 
-        content = this.shown && !!item.description ? contentText : null;
+        if (item.description) {
+          contentText += `<br><br>${ item.description }`;
+        }
+
+        if (showWhenClosed) {
+          content = !this.shown ? contentText : null;
+        } else {
+          content = this.shown ? contentText : null;
+        }
 
         // this adds a class to the tooltip container so that we can control the max width
         classes = 'menu-description-tooltip';
@@ -518,7 +526,7 @@ export default {
                     :to="{ name: 'c-cluster-explorer', params: { cluster: c.id } }"
                   >
                     <ClusterIconMenu
-                      v-tooltip="getTooltipConfig(c.label)"
+                      v-tooltip="getTooltipConfig(c, true)"
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
@@ -544,7 +552,7 @@ export default {
                     :data-testid="`pinned-menu-cluster-disabled-${ c.id }`"
                   >
                     <ClusterIconMenu
-                      v-tooltip="getTooltipConfig(c.label)"
+                      v-tooltip="getTooltipConfig(c, true)"
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
@@ -589,7 +597,7 @@ export default {
                     :to="{ name: 'c-cluster-explorer', params: { cluster: c.id } }"
                   >
                     <ClusterIconMenu
-                      v-tooltip="getTooltipConfig(c.label)"
+                      v-tooltip="getTooltipConfig(c, true)"
                       :cluster="c"
                       class="rancher-provider-icon"
                     />
@@ -616,7 +624,7 @@ export default {
                     :data-testid="`menu-cluster-disabled-${ c.id }`"
                   >
                     <ClusterIconMenu
-                      v-tooltip="getTooltipConfig(c.label)"
+                      v-tooltip="getTooltipConfig(c, true)"
                       :cluster="c"
                       class="rancher-provider-icon"
                     />

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -321,7 +321,7 @@ export default {
       }
     },
 
-    getTooltipConfig(item, isExpandedMenuTooltip = false) {
+    getTooltipConfig(item) {
       if (!item) {
         return;
       }
@@ -330,17 +330,19 @@ export default {
       let content;
       let classes = '';
 
-      // this is scenario where we show a tooltip when we are on the expanded menu
-      if (isExpandedMenuTooltip) {
-        contentText = `${ item.label }<br><br>${ item.description }`;
-
-        content = !this.shown || !item.description ? null : contentText;
-        // this adds a class to the tooltip container so that we can control the max width
-        classes = 'tooltip-description';
       // this is the normal tooltip scenario where we are just passing a string
-      } else {
+      if (typeof item === 'string') {
         contentText = item;
         content = this.shown ? null : contentText;
+
+      // this is scenario where we show a tooltip when we are on the expanded menu to show full description
+      } else {
+        contentText = `${ item.label }<br><br>${ item.description }`;
+
+        content = this.shown && !!item.description ? contentText : null;
+
+        // this adds a class to the tooltip container so that we can control the max width
+        classes = 'menu-description-tooltip';
       }
 
       return {
@@ -520,12 +522,12 @@ export default {
                       class="rancher-provider-icon"
                     />
                     <div
+                      v-tooltip="getTooltipConfig(c)"
                       class="cluster-name"
                     >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
-                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}
@@ -545,12 +547,12 @@ export default {
                       class="rancher-provider-icon"
                     />
                     <div
+                      v-tooltip="getTooltipConfig(c)"
                       class="cluster-name"
                     >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
-                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}
@@ -590,12 +592,12 @@ export default {
                       class="rancher-provider-icon"
                     />
                     <div
+                      v-tooltip="getTooltipConfig(c)"
                       class="cluster-name"
                     >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
-                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}
@@ -616,12 +618,12 @@ export default {
                       class="rancher-provider-icon"
                     />
                     <div
+                      v-tooltip="getTooltipConfig(c)"
                       class="cluster-name"
                     >
                       <p>{{ c.label }}</p>
                       <p
                         v-if="c.description"
-                        v-tooltip="getTooltipConfig(c, true)"
                         class="description"
                       >
                         {{ c.description }}
@@ -784,8 +786,12 @@ export default {
 </template>
 
 <style lang="scss">
-  .tooltip-description {
+  .menu-description-tooltip {
     max-width: 200px;
+    // needs !important so that we can
+    // offset the tooltip a bit so it doesn't
+    // overlap the pin icon and cause bad UX
+    left: 35px !important;
   }
 
   .localeSelector, .footer-tooltip {
@@ -927,13 +933,14 @@ export default {
         }
 
         .cluster-name p {
-          max-width: 220px;
+          width: 199px;
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
 
           &.description {
             font-size: 12px;
+            padding-right: 8px;
             color: var(--darker);
           }
         }

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -33,6 +33,74 @@ describe('topLevelMenu', () => {
     expect(cluster.exists()).toBe(true);
   });
 
+  it('should show description if it is available on the prov cluster', async() => {
+    const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+      data: () => {
+        return { hasProvCluster: true, showPinClusters: true };
+      },
+      mocks: {
+        $store: {
+          getters: {
+            // these objs are doubling as a prov clusters
+            // from which the "description" field comes from
+            // This is triggered by the "hasProvCluster" above
+            // (check all "management/all" getters on the component code)
+            'management/all': () => [
+              // pinned ready cluster
+              {
+                name:        'whatever',
+                id:          'an-id1',
+                mgmt:        { id: 'an-id1' },
+                description: 'some-description1',
+                nameDisplay: 'some-label',
+                isReady:     true,
+                pinned:      true
+              },
+              // pinned NOT ready cluster
+              {
+                name:        'whatever',
+                id:          'an-id2',
+                mgmt:        { id: 'an-id2' },
+                description: 'some-description2',
+                nameDisplay: 'some-label',
+                pinned:      true
+              },
+              // unpinned ready cluster
+              {
+                name:        'whatever',
+                id:          'an-id3',
+                mgmt:        { id: 'an-id3' },
+                description: 'some-description3',
+                nameDisplay: 'some-label',
+                isReady:     true
+              },
+              // unpinned NOT ready cluster
+              {
+                name:        'whatever',
+                id:          'an-id4',
+                mgmt:        { id: 'an-id4' },
+                description: 'some-description4',
+                nameDisplay: 'some-label'
+              },
+            ],
+            ...defaultStore
+          },
+        },
+      },
+      stubs: ['BrandImage', 'nuxt-link']
+    });
+
+    const description1 = wrapper.find('[data-testid="pinned-menu-cluster-an-id1"] .description');
+    const description2 = wrapper.find('[data-testid="pinned-menu-cluster-disabled-an-id2"] .description');
+    const description3 = wrapper.find('[data-testid="menu-cluster-an-id3"] .description');
+    const description4 = wrapper.find('[data-testid="menu-cluster-disabled-an-id4"] .description');
+
+    expect(description1.text()).toStrictEqual('some-description1');
+    expect(description2.text()).toStrictEqual('some-description2');
+    expect(description3.text()).toStrictEqual('some-description3');
+    expect(description4.text()).toStrictEqual('some-description4');
+  });
+
   it('should not "crash" the component if the structure of banner settings is in an old format', () => {
     const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
       mocks: {

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -417,9 +417,12 @@ export default {
                   </div>
                 </template>
                 <template #col:name="{row}">
-                  <td>
+                  <td class="col-name">
                     <div class="list-cluster-name">
-                      <span v-if="row.mgmt">
+                      <p
+                        v-if="row.mgmt"
+                        class="cluster-name"
+                      >
                         <n-link
                           v-if="row.mgmt.isReady && !row.hasError"
                           :to="{ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }}"
@@ -427,12 +430,18 @@ export default {
                           {{ row.nameDisplay }}
                         </n-link>
                         <span v-else>{{ row.nameDisplay }}</span>
-                      </span>
-                      <i
-                        v-if="row.unavailableMachines"
-                        v-clean-tooltip="row.unavailableMachines"
-                        class="conditions-alert-icon icon-alert icon"
-                      />
+                        <i
+                          v-if="row.unavailableMachines"
+                          v-clean-tooltip="row.unavailableMachines"
+                          class="conditions-alert-icon icon-alert icon"
+                        />
+                      </p>
+                      <p
+                        v-if="row.description"
+                        class="cluster-description"
+                      >
+                        {{ row.description }}
+                      </p>
                     </div>
                   </td>
                 </template>
@@ -533,9 +542,23 @@ export default {
     white-space: nowrap;
   }
 
+  .col-name {
+    max-width: 280px;
+  }
+
   .list-cluster-name {
-    align-items: center;
-    display: flex;
+
+    .cluster-name {
+      display: flex;
+      align-items: center;
+    }
+
+    .cluster-description {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--muted);
+    }
 
     .conditions-alert-icon {
       color: var(--error);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10441 
Fixes #8854 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add cluster description to the `home` page cluster table
- Add cluster description to the side menu (main nav) clusters with a tooltip to display the description on hover
- Add unit and e2e tests
- Fix issue with e2e where the main side nav got into a weird state where button to toggle it was no longer visible, causing tests to fail
- Fix issue with e2e where some tests weren't running due to misusage of the `tag` property (should only accept arrays and not strings)
- Fix issue where if we were on home page and clicked on main nav link to go to home page wouldn't close the side nav
- Fix issue with e2e where asserting visibility of product (Harvester Manager) on main nav while disabling/enabling feature flag needed a page refresh


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Create/edit a couple of clusters with a long `description` field and check that the `home` cluster list show the description (truncated) and also on the side menu nav (truncated as well) with the tooltip showing the full description
https://xd.adobe.com/view/c1936434-760f-44a6-8f7a-788b16f50722-94c0/screen/d90a1157-8d66-4a70-bdfb-ce1cffe137c0?fullscreen

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1668" alt="Screenshot 2024-02-22 at 16 24 43" src="https://github.com/rancher/dashboard/assets/97888974/e90bebca-6b12-4d98-b878-55689c225713">
<img width="1668" alt="Screenshot 2024-02-22 at 16 24 52" src="https://github.com/rancher/dashboard/assets/97888974/98d914e6-6fc5-4de7-b0d4-abd3697dddd9">
<img width="1830" alt="Screenshot 2024-03-01 at 11 24 36" src="https://github.com/rancher/dashboard/assets/97888974/9bb48a7f-e048-4443-87e4-bc3d187912e0">
<img width="1830" alt="Screenshot 2024-03-01 at 11 24 49" src="https://github.com/rancher/dashboard/assets/97888974/8279d1a5-989d-473a-b831-6627cd66beef">
<img width="1830" alt="Screenshot 2024-03-01 at 11 24 51" src="https://github.com/rancher/dashboard/assets/97888974/0ec671d8-46b9-4f3f-9198-636b748fa8bf">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
