### PR TITLE
Disable project fetch in ClusterTools page when MCM is disabled

### DIFF
--- a/shell/pages/c/_cluster/explorer/tools/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/tools/__tests__/index.test.ts
@@ -4,53 +4,21 @@ import { shallowMount } from '@vue/test-utils';
 import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
 import { MANAGEMENT } from '@shell/config/types';
 
-const options = () => [
-  {
-    chart: {
-      key:              'cluster/rancher-charts/rancher-alerting-drivers',
-      type:             'chart',
-      id:               'cluster/rancher-charts/rancher-alerting-drivers',
-      certified:        'rancher',
-      sideLabel:        null,
-      repoType:         'cluster',
-      repoName:         'rancher-charts',
-      repoNameDisplay:  'Rancher',
-      certifiedSort:    1,
-      icon:             '',
-      iconName:         'dot',
-      color:            'rancher',
-      chartType:        'cluster-tool',
-      chartName:        'rancher-alerting-drivers',
-      chartNameDisplay: 'Alerting Drivers',
-      chartDescription: 'The manager for third-party webhook receivers used in Prometheus Alertmanager',
-      repoKey:          '1',
-      categories:       [
-        'Monitoring'
-      ],
-    },
-    app: {
-      id:         'default/rancher-alerting-drivers',
-      type:       'catalog.cattle.io.app',
-      apiVersion: 'catalog.cattle.io/v1',
-      kind:       'App',
-      metadata:   {
-        name:      'rancher-alerting-drivers',
-        namespace: 'default',
-      },
-      spec: {
-        chart:     { metadata: { name: 'rancher-alerting-drivers' } },
-        name:      'rancher-alerting-drivers',
-        namespace: 'default',
-      },
-    }
-  }
-];
-
 describe('page: cluster tools', () => {
   const mountOptions = {
     directives: { cleanHtmlDirective },
-    computed:   { options },
-    mocks:      {
+    computed:   {
+      options: () => [
+        {
+          chart: {
+            id:       'cluster/rancher-charts/rancher-alerting-drivers',
+            iconName: 'icon',
+          },
+          app: {}
+        }
+      ]
+    },
+    mocks: {
       $route:      { query: {} },
       $fetchState: {
         pending: false, error: true, timestamp: Date.now()

--- a/shell/pages/c/_cluster/explorer/tools/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/tools/__tests__/index.test.ts
@@ -1,0 +1,103 @@
+import { clone } from '@shell/utils/object';
+import ClusterTools from '@shell/pages/c/_cluster/explorer/tools/index.vue';
+import { shallowMount } from '@vue/test-utils';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
+import { MANAGEMENT } from '@shell/config/types';
+
+const options = () => [
+  {
+    chart: {
+      key:              'cluster/rancher-charts/rancher-alerting-drivers',
+      type:             'chart',
+      id:               'cluster/rancher-charts/rancher-alerting-drivers',
+      certified:        'rancher',
+      sideLabel:        null,
+      repoType:         'cluster',
+      repoName:         'rancher-charts',
+      repoNameDisplay:  'Rancher',
+      certifiedSort:    1,
+      icon:             '',
+      iconName:         'dot',
+      color:            'rancher',
+      chartType:        'cluster-tool',
+      chartName:        'rancher-alerting-drivers',
+      chartNameDisplay: 'Alerting Drivers',
+      chartDescription: 'The manager for third-party webhook receivers used in Prometheus Alertmanager',
+      repoKey:          '1',
+      categories:       [
+        'Monitoring'
+      ],
+    },
+    app: {
+      id:         'default/rancher-alerting-drivers',
+      type:       'catalog.cattle.io.app',
+      apiVersion: 'catalog.cattle.io/v1',
+      kind:       'App',
+      metadata:   {
+        name:      'rancher-alerting-drivers',
+        namespace: 'default',
+      },
+      spec: {
+        chart:     { metadata: { name: 'rancher-alerting-drivers' } },
+        name:      'rancher-alerting-drivers',
+        namespace: 'default',
+      },
+    }
+  }
+];
+
+describe('page: cluster tools', () => {
+  const mountOptions = {
+    directives: { cleanHtmlDirective },
+    computed:   { options },
+    mocks:      {
+      $route:      { query: {} },
+      $fetchState: {
+        pending: false, error: true, timestamp: Date.now()
+      },
+      $store: {
+        dispatch: (schema: string, opt: { type: string }) => {
+          if (schema === 'management/findAll' && opt.type === MANAGEMENT.PROJECT) {
+            return [];
+          }
+        },
+        getters: {
+          'features/get':         () => true,
+          'management/schemaFor': (schema: string) => {
+            if (schema === MANAGEMENT.PROJECT) {
+              return true;
+            }
+          },
+          currentCluster: { id: 'cluster', status: { provider: 'provider' } },
+          'i18n/t':       jest.fn(),
+        }
+      }
+    },
+  };
+
+  it('should show apps catalog', async() => {
+    const wrapper = shallowMount(ClusterTools, mountOptions);
+
+    await (ClusterTools as any).fetch.call(wrapper.vm);
+    const cards = wrapper.find('[data-testid^="cluster-tools-app"]');
+
+    expect(cards.exists()).toBe(true);
+  });
+
+  it('should show apps catalog when no permissions to `project` schema', async() => {
+    const options = clone(mountOptions);
+
+    options.mocks.$store.dispatch = (schema: string, opt: { type: string }) => {
+      if (schema === 'management/findAll' && opt.type === MANAGEMENT.PROJECT) {
+        return null;
+      }
+    };
+
+    const wrapper = shallowMount(ClusterTools, options);
+
+    await (ClusterTools as any).fetch.call(wrapper.vm);
+    const cards = wrapper.find('[data-testid^="cluster-tools-app"]');
+
+    expect(cards.exists()).toBe(true);
+  });
+});


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10458
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

For Clusters having  `multi-cluster-management=false` the `project` schema is not available. 
We are avoiding to fetch `project` schema when `multi-cluster-management` is disabled.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Install a new Rancher cluster with `multi-cluster-management=false`, https://github.com/rancher/dashboard/issues/10458#issuecomment-1959603429
- Go to `ClusterTools` page


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
