### PR TITLE
Relay an error message when the backport fails

### DIFF
--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -79,8 +79,14 @@ jobs:
           git config --global user.email "rancherdashboardportbot@suse.com"
           git config --global user.name "Rancher Dashboard Port Bot"
           git checkout -b $BRANCH
-          if ! git am -3 "$PATCH_FILE"; then
-              gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3"
+          git am -3 "$PATCH_FILE" 2> error.log
+          GIT_AM_EXIT_CODE=$?
+
+          if "$GIT_AM_EXIT_CODE" -ne 0; then
+            ERROR_MESSAGE=$(cat error.log)
+            FORMATTED_ERROR_MESSAGE=$(printf "\n```\n%s\n```" "$ERROR_MESSAGE")
+            gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3: $FORMATTED_ERROR_MESSAGE"
+
           else
               git push origin $BRANCH
               ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body)


### PR DESCRIPTION
This is a follow-up to #10478

The goal of this PR is to relay an error message when the Port PR action fails to apply a patch. The current behavior isn't very helpful and requires digging through logs for actions when a failure occurs. For example

![image](https://github.com/rancher/dashboard/assets/835961/bfc3ae8e-e01f-4967-82d8-49e79d013ed6)
| 