### PR TITLE
[Workflow] Port PR: Use `[...]` to evaluate conditional expression

### DIFF
--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -82,11 +82,10 @@ jobs:
           git am -3 "$PATCH_FILE" 2> error.log
           GIT_AM_EXIT_CODE=$?
 
-          if "$GIT_AM_EXIT_CODE" -ne 0; then
+          if [ "$GIT_AM_EXIT_CODE" -ne 0 ]; then
             ERROR_MESSAGE=$(cat error.log)
             FORMATTED_ERROR_MESSAGE=$(printf "\n```\n%s\n```" "$ERROR_MESSAGE")
             gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3: $FORMATTED_ERROR_MESSAGE"
-
           else
               git push origin $BRANCH
               ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body)


### PR DESCRIPTION
It looks like the Port PR workflow is now failing[^1] after attempting to better relay error messages in #10494. We should be using `test`[^2] to evaluate the conditional expression properly. This PR uses the `[...]` form.

[^1]: https://github.com/rancher/dashboard/actions/runs/8008010814/job/21874248633
[^2]: https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html#index-test