### PR TITLE
Cloud Credentials: Missing Credential Name 

### DIFF
--- a/cypress/e2e/po/components/async-button.po.ts
+++ b/cypress/e2e/po/components/async-button.po.ts
@@ -5,6 +5,14 @@ export default class AsyncButtonPo extends ComponentPo {
     return this.self().click({ force });
   }
 
+  expectToBeDisabled(): Cypress.Chainable {
+    return this.self().should('have.attr', 'disabled', 'disabled');
+  }
+
+  expectToBeEnabled(): Cypress.Chainable {
+    return this.self().should('not.have.attr', 'disabled');
+  }
+
   label(name: string): Cypress.Chainable {
     return this.self().contains(name);
   }

--- a/cypress/e2e/po/components/labeled-input.po.ts
+++ b/cypress/e2e/po/components/labeled-input.po.ts
@@ -36,6 +36,10 @@ export default class LabeledInputPo extends ComponentPo {
     }
   }
 
+  getAttributeValue(attr: string): Cypress.Chainable {
+    return this.input().invoke('attr', attr);
+  }
+
   clear() {
     return this.input().clear();
   }

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1220,7 +1220,7 @@ cluster:
         placeholder: Your Client Secret
     name:
       label: Credential Name
-      placeholder: Name for this credential (optional)
+      placeholder: Name for this credential
     s3:
       accessKey:
         label: Access Key

--- a/shell/edit/cloudcredential.vue
+++ b/shell/edit/cloudcredential.vue
@@ -4,7 +4,7 @@ import { MANAGEMENT, NORMAN, SCHEMA, DEFAULT_WORKSPACE } from '@shell/config/typ
 import CreateEditView from '@shell/mixins/create-edit-view';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import CruResource from '@shell/components/CruResource';
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 import Loading from '@shell/components/Loading';
 import Labels from '@shell/components/form/Labels';
 import { HIDE_SENSITIVE } from '@shell/store/prefs';
@@ -70,6 +70,11 @@ export default {
       set(this.value, '_name', '');
     }
 
+    if (this.mode === _EDIT && this.value?.name?.length) {
+      this.value._name = this.value.name;
+      this.nameRequiredValidation = true;
+    }
+
     if ( this.value.provider ) {
       this.selectType(this.value.provider);
     }
@@ -77,13 +82,19 @@ export default {
 
   data() {
     return {
-      nodeDrivers:      null,
-      kontainerDrivers: null
+      credCustomComponentValidation: false,
+      nameRequiredValidation:        false,
+      nodeDrivers:                   null,
+      kontainerDrivers:              null
     };
   },
 
   computed: {
     rke2Enabled: mapFeature(RKE2_FEATURE),
+
+    validationPassed() {
+      return this.credCustomComponentValidation && this.nameRequiredValidation;
+    },
 
     storeOverride() {
       return 'rancher';
@@ -171,6 +182,14 @@ export default {
   },
 
   methods: {
+    handleNameRequiredValidation() {
+      this.nameRequiredValidation = !!this.value?._name?.length;
+    },
+
+    createValidationChanged(passed) {
+      this.credCustomComponentValidation = passed;
+    },
+
     async saveCredential(btnCb) {
       if ( this.errors ) {
         clear(this.errors);
@@ -245,7 +264,7 @@ export default {
     <CruResource
       v-else
       :mode="mode"
-      :validation-passed="true"
+      :validation-passed="validationPassed"
       :selected-subtype="value._type"
       :resource="value"
       :errors="errors"
@@ -258,12 +277,14 @@ export default {
     >
       <NameNsDescription
         v-model="value"
+        :name-editable="true"
         name-key="_name"
         description-key="description"
         name-label="cluster.credential.name.label"
         name-placeholder="cluster.credential.name.placeholder"
         :mode="mode"
         :namespaced="false"
+        @change="handleNameRequiredValidation"
       />
       <keep-alive>
         <component
@@ -273,6 +294,7 @@ export default {
           :value="value"
           :mode="mode"
           :hide-sensitive-data="hideSensitiveData"
+          @validationChanged="createValidationChanged"
         />
       </keep-alive>
     </CruResource>

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -67,12 +67,13 @@ export default {
 
   data() {
     return {
-      allCredentials:         [],
-      nodeComponent:          null,
-      credentialId:           this.value || _NONE,
-      newCredential:          null,
-      createValidationPassed: false,
-      originalId:             this.value
+      allCredentials:                [],
+      nodeComponent:                 null,
+      credentialId:                  this.value || _NONE,
+      newCredential:                 null,
+      credCustomComponentValidation: false,
+      nameRequiredValidation:        false,
+      originalId:                    this.value
     };
   },
 
@@ -150,7 +151,7 @@ export default {
       }
 
       if ( this.credentialId === _NEW ) {
-        return this.createValidationPassed;
+        return this.credCustomComponentValidation && this.nameRequiredValidation;
       }
 
       return !!this.credentialId;
@@ -168,6 +169,10 @@ export default {
   },
 
   methods: {
+    handleNameRequiredValidation() {
+      this.nameRequiredValidation = !!this.newCredential?.name?.length;
+    },
+
     async save(btnCb) {
       if ( this.errors ) {
         clear(this.errors);
@@ -207,7 +212,7 @@ export default {
     },
 
     createValidationChanged(passed) {
-      this.createValidationPassed = passed;
+      this.credCustomComponentValidation = passed;
     },
 
     backToExisting() {
@@ -247,8 +252,8 @@ export default {
         name-key="name"
         name-label="cluster.credential.name.label"
         name-placeholder="cluster.credential.name.placeholder"
-        :name-required="false"
         mode="create"
+        @change="handleNameRequiredValidation"
       />
 
       <component


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10424 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- make name required by form validation 
- update form validation for creds that send validation from custom component 
- remove 'optional' from placeholder 
- allow editing of the 'name' prop in cloud creds 
- add tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/97888974/39fc2f8f-fbe8-460b-9942-60510ed7be8a


https://github.com/rancher/dashboard/assets/97888974/9c1a9ec6-163d-4b7c-bf62-600e1f7c0601


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
