### PR TITLE
[Workflow] Port PR: Add Milestone, Body, and Assignee to New PR

### DIFF
--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -89,12 +89,13 @@ jobs:
             gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3: $FORMATTED_ERROR_MESSAGE"
           else
               git push origin $BRANCH
-              ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body)
+              ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body,assignee)
               ORIGINAL_TITLE=$(echo "${ORIGINAL_PR}" | jq -r .title)
+              ORIGINAL_ASSIGNEE=$(echo "${ORIGINAL_PR}" | jq -r '.assignee.login // empty')
               BODY=$(mktemp)
               echo -e "This is an automated request to port PR #${ORIGINAL_ISSUE_NUMBER} by @${GITHUB_ACTOR}\n\n" > $BODY
               echo -e "Original PR body:\n\n" >> $BODY
               echo "${ORIGINAL_PR}" | jq -r .body >> $BODY
-              NEW_PR=$(gh pr create --title="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}" --body-file="${BODY}" --head "${BRANCH}" --base "${TARGET_BRANCH}" --milestone "${MILESTONE}")
+              NEW_PR=$(gh pr create --title="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}" --body-file="${BODY}" --head "${BRANCH}" --base "${TARGET_BRANCH}" --milestone "${MILESTONE}" --assignee "${ORIGINAL_ASSIGNEE}")
               echo "Port PR created: ${NEW_PR}" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -34,6 +34,7 @@ jobs:
           if gh api repos/${GITHUB_REPOSITORY}/milestones --paginate | jq -e --arg MILESTONE "$MILESTONE" '.[] | select(.title == $MILESTONE)' > /dev/null; then
               echo "Milestone exists"
               echo "milestone_exists=true" >> $GITHUB_ENV
+              echo "milestone=${MILESTONE}" >> $GITHUB_ENV
            else
               echo "Milestone ${MILESTONE} does not exist" >> $GITHUB_STEP_SUMMARY
               gh issue comment -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port issue, milestone ${MILESTONE} does not exist or is not an open milestone"

--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -94,7 +94,7 @@ jobs:
               BODY=$(mktemp)
               echo -e "This is an automated request to port PR #${ORIGINAL_ISSUE_NUMBER} by @${GITHUB_ACTOR}\n\n" > $BODY
               echo -e "Original PR body:\n\n" >> $BODY
-              echo "${ORIGINAL_ISSUE}" | jq -r .body >> $BODY
+              echo "${ORIGINAL_PR}" | jq -r .body >> $BODY
               NEW_PR=$(gh pr create --title="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}" --body-file="${BODY}" --head "${BRANCH}" --base "${TARGET_BRANCH}" --milestone "${MILESTONE}")
               echo "Port PR created: ${NEW_PR}" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This provides some additional enhancements for the Port PR workflow and includes the following

- Ensures that milestones can be added to title and assigned to backport PR
- Populates body of new PR with original PR body
- Updates the branch for the backport PR
- Add the original PR assignee to the newly created one

Fixes # 10511

### Checklist
- [X] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [X] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [X] The PR template has been filled out
- [X] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [X] The PR has a reviewer assigned
- [X] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [X] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
