### PR TITLE
Remove `event` data from store when leaving Events tab

### DIFF
--- a/cypress/e2e/tests/pages/explorer/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-dashboard.spec.ts
@@ -153,9 +153,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
   const projName = `project${ +new Date() }`;
   const nsName = `namespace${ +new Date() }`;
 
-  // Note: This test fails due to https://github.com/rancher/dashboard/issues/10265
-  // skipping this tests until issue has been resolved
-  it.skip('can view events', () => {
+  it('can view events', () => {
     // Create a pod to trigger events
 
     // get user id

--- a/shell/pages/c/_cluster/explorer/EventsTable.vue
+++ b/shell/pages/c/_cluster/explorer/EventsTable.vue
@@ -43,7 +43,7 @@ export default {
   },
 
   mounted() {
-    this.$router.beforeEach(this.onRouteChange);
+    this.dismissRouteHandler = this.$router.beforeEach(this.onRouteChange);
   },
 
   methods: {
@@ -54,6 +54,10 @@ export default {
 
       next();
     }
+  },
+
+  beforeDestroy() {
+    this.dismissRouteHandler();
   }
 };
 </script>

--- a/shell/pages/c/_cluster/explorer/EventsTable.vue
+++ b/shell/pages/c/_cluster/explorer/EventsTable.vue
@@ -40,6 +40,20 @@ export default {
       events: [],
       eventHeaders,
     };
+  },
+
+  mounted() {
+    this.$router.beforeEach(this.onRouteChange);
+  },
+
+  methods: {
+    async onRouteChange(to, from, next) {
+      if (this.$route.name !== to.name) {
+        await this.$store.dispatch('cluster/forgetType', EVENT);
+      }
+
+      next();
+    }
   }
 };
 </script>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10265
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

The Events tab inside Cluster Dashboard page - `/c/local/explorer#cluster-events` - fetches and saves the events as a new `fetchedType` into the store.

We are removing the event type from the store before the Events tab is unmounted, so the events can be fetched again when navigating to Cluster/Events page.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The same result can be achieved by using a custom list component for the Cluster/Events page; it seems that, using a new component and calling the `$fetchType` after the component is rendered, it fetches again the event resource. This is likely caused by an async behavior inside `resource-fetch.js` mixin and needs further investigations.
- it is not possible to call `cluster/forgetType` directly in the `beforeDestroy` because it is async and it would be called after the new Events page is rendered.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Cluster/Events page.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
