### PR TITLE
[Workflow] Port PR: Fix issues with assignees and relaying error messages

### DIFF
--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -80,13 +80,11 @@ jobs:
           git config --global user.email "rancherdashboardportbot@suse.com"
           git config --global user.name "Rancher Dashboard Port Bot"
           git checkout -b $BRANCH
-          git am -3 "$PATCH_FILE" 2> error.log
-          GIT_AM_EXIT_CODE=$?
 
-          if [ "$GIT_AM_EXIT_CODE" -ne 0 ]; then
-            ERROR_MESSAGE=$(cat error.log)
-            FORMATTED_ERROR_MESSAGE=$(printf "\n```\n%s\n```" "$ERROR_MESSAGE")
-            gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3: $FORMATTED_ERROR_MESSAGE"
+          if ! git am -3 "$PATCH_FILE" > error.log 2>&1; then
+              ERROR_MESSAGE=$(cat error.log)
+              FORMATTED_ERROR_MESSAGE=$(printf "\n\`\`\`\n%s\n\`\`\`" "$ERROR_MESSAGE")
+              gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3: $FORMATTED_ERROR_MESSAGE"
           else
               git push origin $BRANCH
               ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body,assignees)

--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -89,13 +89,31 @@ jobs:
             gh issue comment ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port PR, there was an error running git am -3: $FORMATTED_ERROR_MESSAGE"
           else
               git push origin $BRANCH
-              ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body,assignee)
+              ORIGINAL_PR=$(gh pr view ${ORIGINAL_ISSUE_NUMBER} --json title,body,assignees)
               ORIGINAL_TITLE=$(echo "${ORIGINAL_PR}" | jq -r .title)
               ORIGINAL_ASSIGNEE=$(echo "${ORIGINAL_PR}" | jq -r '.assignee.login // empty')
               BODY=$(mktemp)
               echo -e "This is an automated request to port PR #${ORIGINAL_ISSUE_NUMBER} by @${GITHUB_ACTOR}\n\n" > $BODY
               echo -e "Original PR body:\n\n" >> $BODY
               echo "${ORIGINAL_PR}" | jq -r .body >> $BODY
-              NEW_PR=$(gh pr create --title="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}" --body-file="${BODY}" --head "${BRANCH}" --base "${TARGET_BRANCH}" --milestone "${MILESTONE}" --assignee "${ORIGINAL_ASSIGNEE}")
+              ASSIGNEES=$(echo "${ORIGINAL_PR}" | jq -r .assignees[].login)
+              if [ -n "$ASSIGNEES" ]; then
+                  echo "Checking if assignee is member before assigning"
+                  DELIMITER=""
+                  NEW_ASSIGNEES=""
+                  for ASSIGNEE in $ASSIGNEES; do
+                      if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
+                          echo "${ASSIGNEE} is a member, adding to assignees"
+                          NEW_ASSIGNEES="${NEW_ASSIGNEES}${DELIMITER}${ASSIGNEE}"
+                          DELIMITER=","
+                      fi
+                  done
+                  if [ -n "$NEW_ASSIGNEES" ]; then
+                      echo "Assignees for new issue: ${NEW_ASSIGNEES}"
+                      additional_cmd+=("--assignee")
+                      additional_cmd+=("${NEW_ASSIGNEES}")
+                  fi
+              fi
+              NEW_PR=$(gh pr create --title="[${TYPE} ${MILESTONE}] ${ORIGINAL_TITLE}" --body-file="${BODY}" --head "${BRANCH}" --base "${TARGET_BRANCH}" --milestone "${MILESTONE}" "${additional_cmd[@]}")
               echo "Port PR created: ${NEW_PR}" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This fixes some issues with relaying error messages and transferring assignees when backporting a PR.

- Properly relay an error message in the original PR when there is a problem running `git am` (example located in my fork [^1])
- Properly append the list of assignees (code taken from Port Issue [^2])

Fixes #10511

[^1]: https://github.com/rak-phillip/dashboard/pull/42#issuecomment-1967315236
[^2]: https://github.com/rancher/dashboard/blob/dbe99ccb00e294811d8938fa529e6b0bb8120c86/.github/workflows/port-issue.yaml#L77-L94
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
