### PR TITLE
Collective doc e2e: Merge links.ts into existing home-links-responses.ts

### DIFF
--- a/cypress/e2e/blueprints/global/settings/links.ts
+++ b/cypress/e2e/blueprints/global/settings/links.ts
@@ -1,5 +1,0 @@
-export const v1LinksSettingValue = {
-  version:  'v1',
-  defaults: ['docs', 'forums', 'slack', 'issues', 'getStarted', 'commercialSupport'],
-  custom:   []
-};

--- a/cypress/e2e/blueprints/global_settings/home-links-response.ts
+++ b/cypress/e2e/blueprints/global_settings/home-links-response.ts
@@ -101,3 +101,9 @@ export function removeCustomLinksResponse():object {
     value:  '{"version":"v1","defaults":["docs","forums","slack","issues","getStarted","commercialSupport"],"custom":[]}'
   };
 }
+
+export const v1LinksSettingDefaultValue = {
+  version:  'v1',
+  defaults: ['docs', 'forums', 'slack', 'issues', 'getStarted', 'commercialSupport'],
+  custom:   []
+};

--- a/cypress/e2e/tests/pages/generic/collective.spec.ts
+++ b/cypress/e2e/tests/pages/generic/collective.spec.ts
@@ -1,6 +1,6 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { HomeLinksPagePo } from '@/cypress/e2e/po/pages/global-settings/home-links.po';
-import { v1LinksSettingValue } from '@/cypress/e2e/blueprints/global/settings/links';
+import { v1LinksSettingDefaultValue } from '@/cypress/e2e/blueprints/global_settings/home-links-response';
 
 const homePage = new HomePagePo();
 const homeLinksSettingsPage = new HomeLinksPagePo();
@@ -85,7 +85,7 @@ describe('SUSE Collective Page and link', { testIsolation: 'off' }, () => {
       cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-custom-links').then((res) => {
         const obj = {
           ...res.body,
-          value: JSON.stringify(v1LinksSettingValue)
+          value: JSON.stringify(v1LinksSettingDefaultValue)
         };
 
         cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-custom-links', JSON.stringify(obj));


### PR DESCRIPTION
This is a small tidy-up.

I noticed that there was now a new `global_settings` folder in `blueprints`, so this PR moves the file added in the SUSE collective PR into that existing folder and file.