### PR TITLE
Optimize active products (improves navigation performance)

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -211,6 +211,8 @@ nav:
     resourceIdNotFound: Resource { resource } with id { fqid } not found, unable to display resource details
     reload: Reload
     separator: or
+  errors:
+    noMgmtClusterSchema: Management Cluster Schema is not available
 
 product:
   apps: Apps

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -211,8 +211,6 @@ nav:
     resourceIdNotFound: Resource { resource } with id { fqid } not found, unable to display resource details
     reload: Reload
     separator: or
-  errors:
-    noMgmtClusterSchema: Management Cluster Schema is not available
 
 product:
   apps: Apps

--- a/shell/components/ResourceList/ResourceLoadingIndicator.vue
+++ b/shell/components/ResourceList/ResourceLoadingIndicator.vue
@@ -60,7 +60,9 @@ export default {
     // Total count of all of the resources for all of the resources being loaded
     count() {
       return this.resources.reduce((acc, r) => {
-        return acc + (this.$store.getters[`${ this.inStore }/all`](r) || []).length;
+        const add = !r ? 0 : (this.$store.getters[`${ this.inStore }/all`](r) || []).length;
+
+        return acc + add;
       }, 0);
     },
 

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -227,7 +227,7 @@ export default {
       const allProducts = this.$store.getters['allProducts'];
       const productMap = allProducts.reduce((acc, p) => {
         return { ...acc, [p.name]: p };
-      }, {});      
+      }, {});
 
       for (const product of allProducts) {
         if (product.rootProduct === rootProduct) {

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -164,7 +164,7 @@ export default {
 
     // Nav links are only available for explorer (via the cluster store)
     allNavLinks() {
-      const isExplorer = this.rootProduct === 'explorer';
+      const isExplorer = this.rootProduct === EXPLORER;
 
       if (!isExplorer || !this.clusterId || !this.$store.getters['cluster/schemaFor'](UI.NAV_LINK, false, false)) {
         return [];

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -133,7 +133,7 @@ export default {
       // Don't show if the header is in 'simple' mode
       const notSimple = !this.simple;
       // One of these must be enabled, otherwise t here's no component to show
-      const validFilterSettings = this.currentProduct.showNamespaceFilter || this.currentProduct.showWorkspaceSwitcher;
+      const validFilterSettings = this.currentProduct?.showNamespaceFilter || this.currentProduct?.showWorkspaceSwitcher;
 
       return validClusterOrProduct && notSimple && validFilterSettings;
     },

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -213,7 +213,9 @@ export default {
       const cluster = this.clusterId || this.$store.getters['defaultClusterId'];
 
       // TODO plugin routes
-      const entries = this.$store.getters['type-map/activeProducts']?.map((p) => {
+      // Note: Only need to look at root (top-level) products for the app bar
+      // This avoids having to re-calculate the app bar when a child product changes (e.g. within explorer)
+      const entries = this.$store.getters['type-map/activeRootProducts']?.map((p) => {
         // Try product-specific index first
         const to = p.to || {
           name:   `c-cluster-${ p.name }`,

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -297,14 +297,6 @@ export default async function({
     if (pkg && (oldPkg !== pkg || from.fullPath === route.fullPath)) {
       // Execute mandatory store actions
       await Promise.all(always);
-
-      // Execute anything optional the plugin wants to
-      await newPkgPlugin.onEnter(store, {
-        clusterId,
-        product,
-        oldProduct,
-        oldIsExt: !!oldPkg
-      });
     }
 
     if (!route.matched?.length) {
@@ -354,6 +346,17 @@ export default async function({
         targetRoute: route
       })
     ]);
+
+    // Init the package only after we have loaded the cluster store
+    if (pkg && (oldPkg !== pkg || from.fullPath === route.fullPath)) {
+      // Execute anything optional the plugin wants to
+      await newPkgPlugin.onEnter(store, {
+        clusterId,
+        product,
+        oldProduct,
+        oldIsExt: !!oldPkg
+      });
+    }
 
     if (localCheckResource) {
       const redirected = invalidResource(store, route, redirect);

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -201,6 +201,7 @@ export default {
     return out;
   },
 
+  // Are schemas loaded?
   schemasLoaded: (state) => {
     return !!state.types[SCHEMA];
   },

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -201,6 +201,10 @@ export default {
     return out;
   },
 
+  schemasLoaded: (state) => {
+    return !!state.types[SCHEMA];
+  },
+
   defaultFor: (state, getters) => (type, rootSchema, schemaDefinitions = null) => {
     let resourceFields;
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -927,6 +927,12 @@ export const actions = {
     // Try and wait until the schema exists before proceeding
     await dispatch('management/waitForSchema', { type: MANAGEMENT.CLUSTER });
 
+    // Final check, if after waiting and re-fetching schemas, we still don't have the mgmt cluster schema
+    // then show an error
+    if (!getters['management/schemaFor'](MANAGEMENT.CLUSTER)) {
+      throw new Error(getters['i18n/t']('nav.errors.noMgmtClusterSchema'));
+    }
+
     // Similar to above, we're still waiting on loadManagement to fetch required resources
     // If we don't have all mgmt clusters yet a request to fetch this cluster and then all clusters (in cleanNamespaces) is kicked off
     await dispatch('management/waitForHaveAll', { type: MANAGEMENT.CLUSTER });

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -297,7 +297,7 @@ export const getters = {
   // falls back to the explorer product and then the first active product.
   currentProduct(state, getters) {
     let product = state.productId || EXPLORER;
-    let cache = {};
+    const cache = {};
 
     // Rather than determining all active products, just check the current product (more performant)
     let res = getters['type-map/isProductActive'](product, cache);

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -293,7 +293,7 @@ export const getters = {
     return getters['management/byId'](MANAGEMENT.CLUSTER, state.clusterId);
   },
 
-  // Current product checks that the current product is active, if it is not, if
+  // Current product checks that the current product is active, if it is not, it
   // falls back to the explorer product and then the first active product.
   currentProduct(state, getters) {
     let product = state.productId || EXPLORER;

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -927,12 +927,6 @@ export const actions = {
     // Try and wait until the schema exists before proceeding
     await dispatch('management/waitForSchema', { type: MANAGEMENT.CLUSTER });
 
-    // Final check, if after waiting and re-fetching schemas, we still don't have the mgmt cluster schema
-    // then show an error
-    if (!getters['management/schemaFor'](MANAGEMENT.CLUSTER)) {
-      throw new Error(getters['i18n/t']('nav.errors.noMgmtClusterSchema'));
-    }
-
     // Similar to above, we're still waiting on loadManagement to fetch required resources
     // If we don't have all mgmt clusters yet a request to fetch this cluster and then all clusters (in cleanNamespaces) is kicked off
     await dispatch('management/waitForHaveAll', { type: MANAGEMENT.CLUSTER });

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -293,20 +293,34 @@ export const getters = {
     return getters['management/byId'](MANAGEMENT.CLUSTER, state.clusterId);
   },
 
+  // Current product checks that the current product is active, if it is not, if
+  // falls back to the explorer product and then the first active product.
   currentProduct(state, getters) {
-    const active = getters['type-map/activeProducts'];
+    let product = state.productId || EXPLORER;
+    let cache = {};
 
-    let out = findBy(active, 'name', state.productId);
+    // Rather than determining all active products, just check the current product (more performant)
+    let res = getters['type-map/isProductActive'](product, cache);
 
-    if ( !out ) {
-      out = findBy(active, 'name', EXPLORER);
+    if (!res) {
+      // Not active
+      product = EXPLORER;
+
+      res = getters['type-map/isProductActive'](product, cache);
+
+      if (!res) {
+        const allActive = getters['type-map/activeProducts'];
+
+        return allActive[0];
+      }
     }
 
-    if ( !out ) {
-      out = active[0];
-    }
+    // Lookup the product
+    return state['type-map']?.products.find((p) => p.name === product);
+  },
 
-    return out;
+  allProducts(state) {
+    return state['type-map']?.products || [];
   },
 
   // Get the root product - this is either the current product or the current product's root (if set)
@@ -666,6 +680,7 @@ export const mutations = {
     state.clusterId = neu;
   },
 
+  // Note: This is only used by the authenticated middleware to change the current product
   setProduct(state, value) {
     state.productId = value;
 
@@ -779,7 +794,6 @@ export const actions = {
 
     res = await allHash(promises);
     dispatch('i18n/init');
-    const isMultiCluster = getters['isMultiCluster'];
 
     // If the local cluster is a Harvester cluster and 'rancher-manager-support' is true, it means that the embedded Rancher is being used.
     const localCluster = res.clusters?.find((c) => c.id === 'local');
@@ -823,6 +837,9 @@ export const actions = {
       });
     }
 
+    // Should have loaded now, so can check isMultiCluster
+    const isMultiCluster = getters['isMultiCluster'];
+
     console.log(`Done loading management; isRancher=${ isRancher }; isMultiCluster=${ isMultiCluster }`); // eslint-disable-line no-console
   },
 
@@ -838,7 +855,6 @@ export const actions = {
     const sameCluster = state.clusterId && state.clusterId === id;
     const samePackage = oldPkg?.name === newPkg?.name;
     const sameProduct = oldProduct === product;
-    const isMultiCluster = getters['isMultiCluster'];
 
     const productConfig = state['type-map']?.products?.find((p) => p.name === product);
     const oldProductConfig = state['type-map']?.products?.find((p) => p.name === oldProduct);
@@ -907,7 +923,7 @@ export const actions = {
       return;
     }
 
-    console.log(`Loading ${ isMultiCluster ? 'ECM ' : '' }cluster...`); // eslint-disable-line no-console
+    console.log(`Loading cluster...`); // eslint-disable-line no-console
 
     // If we've entered a new store ensure everything has loaded correctly
     if (newPkgClusterStore) {

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -1325,7 +1325,7 @@ export const getters = {
 
   /**
    * Returns a getter for testing if the specific product is active
-   * 
+   *
    * A cache object can be passed in, so if you need to call this multiple times, the cache
    * can be re-used to avoid having to enumerate schemas to calculate knownTypes and groups
    * if required
@@ -1334,12 +1334,12 @@ export const getters = {
     // Return a named function so that we can trace it in the browser performance log
     return function isProductActive(productOrId, previousCache) {
       // Use the supplied cache object if there is one, otherwise a new local object
-      let cache = previousCache || {};
-      
+      const cache = previousCache || {};
+
       if (!cache.knownTypes) {
         cache.knownTypes = {};
       }
-      
+
       if (!cache.knownGroups) {
         cache.knownGroups = {};
       }
@@ -1353,6 +1353,7 @@ export const getters = {
       }
 
       const module = p.inStore;
+      const isDev = rootGetters['prefs/get'](VIEW_IN_API);
 
       if ( !p.public && !isDev ) {
         return false;
@@ -1392,7 +1393,7 @@ export const getters = {
       }
 
       if (p.ifHave && !ifHave(rootGetters, p.ifHave)) {
-       return false;
+        return false;
       }
 
       if (p.ifHaveType) {
@@ -1423,7 +1424,7 @@ export const getters = {
       return;
     }
 
-    let cache = {};
+    const cache = {};
 
     return state.products.filter((p) => getters['isProductActive'](p, cache));
   },
@@ -1435,7 +1436,7 @@ export const getters = {
       return;
     }
 
-    let cache = {};
+    const cache = {};
 
     return state.products.filter((p) => !p.rootProduct || p.rootProduct === p.name).filter((p) => getters['isProductActive'](p, cache));
   },

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -1431,7 +1431,7 @@ export const getters = {
 
   activeRootProducts(state, getters, rootState, rootGetters) {
     if (state.schemaGeneration < 0) {
-      // This does nothing, but makes activeProducts depend on schemaGeneration
+      // This does nothing, but makes activeRootProducts depend on schemaGeneration
       // so that it can be used to update the product list on schema change.
       return;
     }


### PR DESCRIPTION
This PR makes further optimisations to improve navigation performance - primarily optimising the behaviour of the `activeProducts` getter in the store.

Essentially, rather than always check whether every product is active, we more intelligently only check the top-level products for the app bar and the root products and its child products in the side nav.

Note, this improves performance, so there were a couple of areas where race conditions mean that things worked, where as with the improved performance, they don't.

On note is the call to `onEnter` - KubeWarden uses this and access the `cluster` store, but this was being called before `loadCluster` was called, so cluster schemas were not available.