### PR TITLE
[Automation] - Change local HA cluster type configuration to k3s

### DIFF
--- a/cypress/jenkins/Jenkinsfile_multi
+++ b/cypress/jenkins/Jenkinsfile_multi
@@ -60,7 +60,7 @@ node {
                                         string(name: 'RANCHER_HOST', value: ""),
                                         string(name: 'RANCHER_USERNAME', value: "${RANCHER_USERNAME}"),
                                         string(name: 'RANCHER_PASSWORD', value: "${RANCHER_PASSWORD}"),
-                                        string(name: 'RKE2_KUBERNETES_VERSION', value: "${RKE2_KUBERNETES_VERSION}"),
+                                        string(name: 'K3S_KUBERNETES_VERSION', value: "${K3S_KUBERNETES_VERSION}"),
                                         string(name: 'CERT_MANAGER_VERSION', value: "${CERT_MANAGER_VERSION}"),
                                         string(name: 'SERVER_COUNT', value: "${SERVER_COUNT}"),
                                         string(name: 'AGENT_COUNT', value: "${AGENT_COUNT}"),

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -92,11 +92,11 @@ if [[ "${JOB_TYPE}" == "recurring" ]]; then
     corral config vars set rancher_image_tag ${RANCHER_IMAGE_TAG}
   fi
   cd "${WORKSPACE}/corral-packages"
-  yq -i e ".variables.rancher_version += [\"${RANCHER_VERSION}\"] | .variables.rancher_version style=\"literal\"" packages/aws/rancher-rke2.yaml
-  yq -i e ".variables.kubernetes_version += [\"${RKE2_KUBERNETES_VERSION}\"] | .variables.kubernetes_version style=\"literal\"" packages/aws/rancher-rke2.yaml
-  yq -i e ".variables.cert_manager_version += [\"${CERT_MANAGER_VERSION}\"] | .variables.kubernetes_version style=\"literal\"" packages/aws/rancher-rke2.yaml
+  yq -i e ".variables.rancher_version += [\"${RANCHER_VERSION}\"] | .variables.rancher_version style=\"literal\"" packages/aws/rancher-k3s.yaml
+  yq -i e ".variables.kubernetes_version += [\"${K3S_KUBERNETES_VERSION}\"] | .variables.kubernetes_version style=\"literal\"" packages/aws/rancher-k3s.yaml
+  yq -i e ".variables.cert_manager_version += [\"${CERT_MANAGER_VERSION}\"] | .variables.kubernetes_version style=\"literal\"" packages/aws/rancher-k3s.yaml
 
-  cat packages/aws/rancher-rke2.yaml
+  cat packages/aws/rancher-k3s.yaml
   ls -al packages/aws/
   cat packages/aws/dashboard-tests.yaml
 
@@ -111,13 +111,13 @@ if [[ "${JOB_TYPE}" == "recurring" ]]; then
   corral config vars delete rancher_host
   RANCHER_HOST="jenkins-${prefix_random}.${AWS_ROUTE53_ZONE}"
 
-  RKE2_KUBERNETES_VERSION="${RKE2_KUBERNETES_VERSION//+/-}"
+  K3S_KUBERNETES_VERSION="${K3S_KUBERNETES_VERSION//+/-}"
   make init
   make build
   ls -al dist
-  echo "Corral Package string: ${RKE2_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
+  echo "Corral Package string: ${K3S_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
   corral create --skip-cleanup --recreate --debug rancher \
-    "dist/aws-rke2-rancher-calico-${RKE2_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
+    "dist/aws-k3s-rancher-${K3S_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
 fi
 
 if [[ "${JOB_TYPE}" == "existing" ]]; then


### PR DESCRIPTION
### Summary
This will use a k3s cluster for the Rancher installation. Originally using rke2.

This will rename the RKE2 kubernetes version variable to K3s and use a k3s corral package for the Rancher install.

### Occurred changes and/or fixed issues

This change is done to the Jenkins automation environment in order to mitigate any Rancher behavior dependent on cluster types.

Like is the case here. https://github.com/rancher/rancher/issues/28787#issuecomment-693611821 

This will require 
