### PR TITLE
[2.8 Backport] Registry auth fix

### DIFF
--- a/cypress/e2e/blueprints/manager/registries-rke2-payload.ts
+++ b/cypress/e2e/blueprints/manager/registries-rke2-payload.ts
@@ -1,0 +1,24 @@
+export function machineSelectorConfigPayload(registryHost: string):Array<object> {
+  return [
+    {
+      config: {
+        'protect-kernel-defaults': false,
+        'system-default-registry': registryHost,
+      },
+    },
+  ];
+}
+
+export function registriesWithSecretPayload(registryAuthHost: string, registrySecret: string):object {
+  return {
+    configs: {
+      [registryAuthHost]: {
+        authConfigSecretName: registrySecret,
+        caBundle:             '',
+        insecureSkipVerify:   false,
+        tlsSecretName:        null
+      },
+    },
+    mirrors: {},
+  };
+}

--- a/cypress/e2e/po/components/registries-tab.po.ts
+++ b/cypress/e2e/po/components/registries-tab.po.ts
@@ -1,0 +1,35 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import RegistyConfigsPo from '@/cypress/e2e/po/components/registry-configs.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+
+export default class RegistriesTabPo extends ComponentPo {
+  constructor(selector = '.dashboard-root') {
+    super(selector);
+  }
+
+  enableRegistryCheckbox(): CheckboxInputPo {
+    return new CheckboxInputPo('[data-testid="registries-enable-checkbox"]');
+  }
+
+  clickShowAdvanced(): void {
+    this.self().find('[data-testid="registries-advanced-section"]').click();
+  }
+
+  registryHostInput(): LabeledInputPo {
+    return new LabeledInputPo('[data-testid="registry-host-input"]');
+  }
+
+  addRegistryHost(host: string): void {
+    this.registryHostInput().set(host);
+  }
+
+  registryConfigs(): RegistyConfigsPo {
+    return new RegistyConfigsPo(this.self());
+  }
+
+  clickTab(selector: string) {
+    new TabbedPo().clickTabWithSelector(selector);
+  }
+}

--- a/cypress/e2e/po/components/registry-configs.po.ts
+++ b/cypress/e2e/po/components/registry-configs.po.ts
@@ -1,0 +1,23 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import SelectOrCreateAuthPo from '@/cypress/e2e/po/components/select-or-create-auth.po';
+
+export default class RegistyConfigsPo extends ComponentPo {
+  registryAuthHost(index: number): LabeledInputPo {
+    return new LabeledInputPo(`[data-testid="registry-auth-host-input-${ index }"]`);
+  }
+
+  addRegistryAuthHost(index: number, host: string): void {
+    this.registryAuthHost(index).set(host);
+  }
+
+  authSelectOrCreate(selector: string): SelectOrCreateAuthPo {
+    return new SelectOrCreateAuthPo(selector);
+  }
+
+  registryAuthSelectOrCreate(index: number): SelectOrCreateAuthPo {
+    return this.authSelectOrCreate(
+      `[data-testid="registry-auth-select-or-create-${ index }"]`
+    );
+  }
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
@@ -1,6 +1,7 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import AgentConfigurationRke2 from '@/cypress/e2e/po/components/agent-configuration-rke2.po';
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
+import RegistriesTabPo from '@/cypress/e2e/po/components/registries-tab.po';
 
 /**
  * Create page for an RKE2 custom cluster
@@ -21,5 +22,9 @@ export default class ClusterManagerCreateRke2CustomPagePo extends ClusterManager
 
   agentConfiguration(): AgentConfigurationRke2 {
     return new AgentConfigurationRke2();
+  }
+
+  registries(): RegistriesTabPo {
+    return new RegistriesTabPo();
   }
 }

--- a/cypress/e2e/tests/pages/registries.spec.ts
+++ b/cypress/e2e/tests/pages/registries.spec.ts
@@ -1,0 +1,71 @@
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import ClusterManagerCreateRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po';
+import { machineSelectorConfigPayload, registriesWithSecretPayload } from '@/cypress/e2e/blueprints/manager/registries-rke2-payload';
+
+const registryHost = 'docker.io';
+const registryAuthHost = 'a.registry.com';
+const clusterName = `test-cluster-${ Math.random().toString(36).substr(2, 6) }`;
+
+describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('Should send the correct payload to the server', () => {
+    const clusterList = new ClusterManagerListPagePo('local');
+    const createCustomClusterPage = new ClusterManagerCreateRke2CustomPagePo();
+
+    clusterList.goTo();
+
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+
+    createCustomClusterPage.waitForPage();
+    createCustomClusterPage.rkeToggle().set('RKE2/K3s');
+
+    createCustomClusterPage.selectCustom(0);
+
+    // intercepts
+    cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('customRKE2ClusterCreation');
+    cy.intercept('POST', 'v1/secrets/fleet-default').as('registrySecretCreation');
+
+    // cluster name
+    createCustomClusterPage.nameNsDescription().name().set(clusterName);
+    // navigate to Registries tab
+    createCustomClusterPage.registries().clickTab('#registry');
+    // enable registry
+    createCustomClusterPage.registries().enableRegistryCheckbox().set();
+    // add host
+    createCustomClusterPage.registries().addRegistryHost(registryHost);
+    // click show advanced
+    createCustomClusterPage.registries().clickShowAdvanced();
+    // scroll down to registry auth
+    createCustomClusterPage.registries().registryConfigs().registryAuthHost(0).self()
+      .scrollIntoView();
+    // add url
+    createCustomClusterPage.registries().registryConfigs().addRegistryAuthHost(0, registryAuthHost);
+    // create basic secret
+    createCustomClusterPage.registries().registryConfigs().registryAuthSelectOrCreate(0).createBasicAuth('test-user', 'test-pass');
+    // save
+    createCustomClusterPage.create();
+
+    let registrySecret;
+
+    // need to do a wait to make sure intercept doesn't fail on cy.wait for request
+    // ci/cd pipelines are notoriously slow... let's wait longer than usual
+    cy.wait('@registrySecretCreation', { requestTimeout: 10000 }).then((req) => {
+      expect(req.response?.statusCode).to.equal(201);
+      registrySecret = req.response?.body?.metadata?.name;
+    });
+    cy.wait('@customRKE2ClusterCreation', { requestTimeout: 10000 }).then((req) => {
+      expect(req.response?.statusCode).to.equal(201);
+      expect(req.request?.body?.spec.rkeConfig.machineSelectorConfig).to.deep.equal(machineSelectorConfigPayload(registryHost));
+      expect(req.request?.body?.spec.rkeConfig.registries).to.deep.equal(
+        registriesWithSecretPayload(
+          registryAuthHost,
+          registrySecret
+        ));
+      expect(req.request?.body?.spec.rkeConfig.registries.configs[registryHost]).to.equal(undefined);
+    });
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/RegistryConfigs.vue
@@ -138,13 +138,14 @@ export default {
       :mode="mode"
       @input="update"
     >
-      <template #default="{row}">
+      <template #default="{row, i}">
         <div class="row">
           <div class="col span-6">
             <LabeledInput
               v-model="row.value.hostname"
               label="Registry Hostname"
               :mode="mode"
+              :data-testid="`registry-auth-host-input-${i}`"
             />
 
             <SelectOrCreateAuthSecret
@@ -158,6 +159,7 @@ export default {
               :namespace="value.metadata.namespace"
               :mode="mode"
               generate-name="registryconfig-auth-"
+              :data-testid="`registry-auth-select-or-create-${i}`"
             />
           </div>
           <div class="col span-6">

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1720,8 +1720,7 @@ export default {
         set(regs, 'mirrors', {});
       }
 
-      const hostname = Object.keys(regs.configs)[0];
-      const config = regs.configs[hostname];
+      const config = regs.configs[this.registryHost];
 
       if ( config ) {
         registrySecret = config.authConfigSecretName;
@@ -2632,6 +2631,7 @@ export default {
               v-model="showCustomRegistryInput"
               class="mb-20"
               :label="t('cluster.privateRegistry.label')"
+              data-testid="registries-enable-checkbox"
               @input="toggleCustomRegistry"
             />
           </div>
@@ -2644,6 +2644,7 @@ export default {
                 v-model="registryHost"
                 label-key="catalog.chart.registry.custom.inputLabel"
                 placeholder-key="catalog.chart.registry.custom.placeholder"
+                data-testid="registry-host-input"
                 :min-height="30"
               />
               <SelectOrCreateAuthSecret
@@ -2669,6 +2670,7 @@ export default {
                 class="col span-12 advanced"
                 :is-open-by-default="showCustomRegistryAdvancedInput"
                 :mode="mode"
+                data-testid="registries-advanced-section"
               >
                 <Banner
                   :closable="false"


### PR DESCRIPTION
Fixes #10514  and #10337 

Backport of PR to 2.8 => https://github.com/rancher/dashboard/pull/10397

Note: The folder re-structuring around `rke2.vue` doesn't exist in 2.8 so the changes ported to 2.8 a bit differently. Also some minor changes needed to make the e2e tests work.