### PR TITLE
Add zube migration script (WIP)

### DIFF
--- a/.github/workflows/pr-gh-project.yaml
+++ b/.github/workflows/pr-gh-project.yaml
@@ -1,0 +1,19 @@
+name: gh-project-integration
+on:
+  pull_request_target:
+    types: [ opened, reopened, edited, closed ]
+
+jobs:
+  rancher_zube:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '16.x'
+    - name: script
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_PROJECT: ${{ secrets.PR_PROJECT }}
+      run: node .github/workflows/scripts/pr-gh-project.js

--- a/.github/workflows/pr-gh-project.yaml
+++ b/.github/workflows/pr-gh-project.yaml
@@ -4,7 +4,7 @@ on:
     types: [ opened, reopened, edited, closed ]
 
 jobs:
-  rancher_zube:
+  rancher_gh_project:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pr-zube.yaml
+++ b/.github/workflows/pr-zube.yaml
@@ -11,6 +11,8 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
+        node-version: '16.x'
     - name: script
-      run: node .github/workflows/scripts/pr.js "${{ secrets.GITHUB_TOKEN }}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: node .github/workflows/scripts/pr.js

--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+/**
+ * PR workflow to move issues to the appropriate lanes on the Github project board
+ */
+
+const request = require('./request');
+
+const TRIAGE_LABEL = '[zube]: To Triage';
+const IN_REVIEW_LABEL = '[zube]: Review';
+const IN_TEST_LABEL = '[zube]: To Test';
+const DONE_LABEL = '[zube]: Done';
+const BACKEND_BLOCKED_LABEL = '[zube]: Backend Blocked';
+const QA_REVIEW_LABEL = '[zube]: QA Review';
+const TECH_DEBT_LABEL = 'kind/tech-debt';
+const DEV_VALIDATE_LABEL = 'status/dev-validate';
+const QA_NONE_LABEL = 'QA/None';
+const QA_DEV_AUTOMATION_LABEL = 'QA/dev-automation'
+
+const GH_PRJ_TRIAGE = 'Triage';
+
+const GH_PRJ_TO_TEST = 'To Test';
+const GH_PRJ_QA_REVIEW = 'QA Review';
+const GH_PRJ_IN_REVIEW = 'In Review';
+
+// Check required environment variables
+if (!process.env.GH_TOKEN) {
+  console.log('You must set a GitHub token in the GH_TOKEN environment variable');
+
+  return;
+}
+
+if (!process.env.PR_PROJECT) {
+  console.log('You must set the GitHub project in the PR_PROJECT environment variable (format org#number)');
+
+  return;
+}
+
+// Check the format
+const ghProjectId = process.env.PR_PROJECT.split('#');
+
+if (ghProjectId.length !== 2) {
+  console.log('Error: PR_PROJECT is not in the correct format (format org#number)');
+
+  return;
+}
+
+const ghProject = await request.ghProject(ghProjectId[0], ghProjectId[1]);
+
+if (!ghProject) {
+  console.log('Error: Can not fetch GitHub Project metadata');
+
+  return; 
+}
+
+console.log(JSON.stringify(ghProject, null, 2));
+
+// The event object
+const event = require(process.env.GITHUB_EVENT_PATH);
+
+function getReferencedIssues(body) {
+  // https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+  const regexp = /[Ff]ix(es|ed)?\s*#([0-9]*)|[Cc]lose(s|d)?\s*#([0-9]*)|[Rr]esolve(s|d)?\s*#([0-9]*)/g;
+  var v;
+  const issues = [];
+  do {
+    v = regexp.exec(body);
+    if (v) {
+      issues.push(parseInt(v[2], 10));
+    }
+  } while (v);
+  return issues;
+}
+
+function hasLabel(issue, label) {
+  const labels = issue.labels || [];
+
+  return !!(labels.find(l => l.name.toLowerCase() === label.toLowerCase()));
+}
+
+function moveIssueToProjectState(issue, state) {
+  console.log(`moveIssueToProjectState ${ state }`);
+
+  console.log(JSON.stringify(issue, null, 2));
+}
+
+/**
+ * Remove Zube labels
+ */
+async function removeZubeLabels(issue, label) {
+  // Remove all Zube labels
+  let cleanLabels = labels.filter(l => l.name.indexOf('[zube]') === -1);
+
+  cleanLabels = cleanLabels.map((v) => {
+    return v.name;
+  });
+
+  // Turn the array of labels into just their names
+  console.log(`    Current Labels: ${cleanLabels}`);
+
+  // Add the 'to test' label
+  cleanLabels.push(label);
+  console.log(`    New Labels    : ${cleanLabels}`);
+
+  // Update the labels
+  const labelsAPI = `${issue.url}/labels`;
+  return request.put(labelsAPI, { labels: cleanLabels });
+}
+
+async function waitForLabel(issue, label) {
+  let tries = 0;
+  while (!hasLabel(issue, label) && tries < 10) {
+    console.log(`  Waiting for issue to have the label ${label} (${tries})`);
+
+    // Wait 10 seconds
+    await new Promise(r => setTimeout(r, 10000));
+
+    // Refetch the issue
+    issue = await request.fetch(issue.url);
+
+    tries++;
+  }
+
+  if (tries > 10) {
+    console.log('WARNING: Timed out waiting for issue to have the Done label');
+  } else {
+    console.log('  Issue has the done label');
+  }
+}
+
+async function processClosedAction() {
+  const pr = event.pull_request;
+  const body = pr.body;
+
+  console.log('======');
+  console.log('Processing Closed PR #' + pr.number + ' : ' + pr.title);
+  console.log('======');
+
+  // Check that the issue was merged and not just closed
+  if (!pr.merged) {
+    console.log('  PR was closed without merging - ignoring');
+    return;
+  }
+
+  const issues = getReferencedIssues(body);
+  if (issues.length > 0) {
+    console.log('  This PR fixes issues: ' + issues.join(', '));
+  } else {
+    console.log("  This PR does not fix any issues");
+    return;
+  }
+
+  // Need to get all open PRs to see if any other references the same issues that this PR says it fixes
+  const openPRs = event.repository.url + '/pulls?state=open&per_page=100';
+  const r = await request.fetch(openPRs);
+  const issueMap = issues.reduce((prev, issue) => { prev[issue] = true; return prev; }, {})
+
+  // Go through all of the Open PRs and see if they fix any of the same issues that this PR does
+  // If not, then the issue has been completed, so we can process it
+  r.forEach(openPR => {
+    const fixed = getReferencedIssues(openPR.body);
+    fixed.forEach(issue => issueMap[issue] = false);
+  });
+
+  // Filter down the list of issues that should be closed because this PR was merged
+  const fixed = Object.keys(issueMap).filter(key => !!issueMap[key]);
+  console.log('');
+
+  Object.keys(issueMap).forEach(k => {
+    if (k && !issueMap[k]) {
+      console.log(`  Issue #${k} will be ignored as another open PR also states that it fixes this issue`);
+    }
+  });
+
+  // GitHub will do the closing, so we expect each issue to already be closed
+  // We will fetch each issue in turn, expecting it to be closed
+  // We will re-open the issue and label it as ready to test
+  fixed.forEach(async (i) => {
+    const detail = event.repository.url + '/issues/' + i;
+    const iss = await request.fetch(detail);
+    console.log('')
+    console.log('Processing Issue #' + i + ' - ' + iss.title);
+
+    // If the issue is a tech debt issue or says dev will validate then don't move it to 'To Test'
+    if (hasLabel(iss, TECH_DEBT_LABEL) || hasLabel(iss, DEV_VALIDATE_LABEL) || hasLabel(iss, QA_NONE_LABEL)) {
+      console.log('  Issue is tech debt/dev validate/qa none - ignoring');
+    } else {
+      // Put this in when we remove the Zube workflow
+      // A single workflow needs to re-open the issue after GH closes it
+      // console.log('  Waiting for Zube to mark the issue as done ...');
+
+      // // Output labels
+      // const labels = iss.labels || [];
+
+      // console.log(labels.join(', '));
+
+      // // console.log(JSON.stringify(iss, null, 2));
+
+      // // The Zube Integration will label the issue with the Done label
+      // // Since it runs via a webhook, it should have done that well before our GitHub action
+      // // is scheduled and has run, but we will check it has the label and wait if not
+      // await waitForLabel(iss, DONE_LABEL);
+
+      // // Wait
+      // await new Promise(r => setTimeout(r, 10000));
+      // // Re-open the issue if it is closed
+      // if (iss.state === 'closed') {
+      //   console.log('  Re-opening issue');
+      //   await request.patch(detail, { state: 'open' });
+      // } else {
+      //   console.log('  Expecting issue to be closed, but it is not');
+      // }
+
+      // console.log('  Waiting for Zube to mark the issue as in triage ...');
+
+      // // The Zube Integration will label the issue as To Triage now that is has been re-opened
+      // // Wait for that and then we can move it to test
+      // await waitForLabel(iss, TRIAGE_LABEL);
+
+      // Move to QA Review if the issue has the label that dev wrote automated tests
+      if (hasLabel(iss, QA_DEV_AUTOMATION_LABEL)) {
+        console.log('  Updating GitHub Project to move issue to QA Review');
+
+        console.log(JSON.stringify(iss, null, 2));
+
+        // await moveIssueToProjectState(iss, GH_PRJ_QA_REVIEW);
+        // Uncomment when we switch off Zube 
+        // await removeZubeLabels(iss);
+      } else {
+        console.log('  Updating GitHub Project to move issue to Test');
+
+        console.log(JSON.stringify(iss, null, 2));
+
+        // await moveIssueToProjectState(iss, GH_PRJ_TO_TEST);
+        // Uncomment when we switch off Zube 
+        // await removeZubeLabels(iss);
+      }
+    }
+
+    console.log('');
+  });
+}
+
+async function processOpenAction() {
+  const pr = event.pull_request;
+
+  // Check that an assignee has been set
+  if (pr.assignees.length === 0) {
+    console.log('======');
+    console.log('Processing Opened PR #' + pr.number + ' : ' + pr.title);
+    console.log('======');
+
+    console.log(`  Adding assignee to the PR: ${pr.user.login}`);
+
+    // Update the assignees
+    const assigneesAPI = `${event.repository.url}/issues/${pr.number}/assignees`;
+    await request.post(assigneesAPI, { assignees: [pr.user.login] });
+  }
+}
+
+async function processOpenOrEditAction() {
+  console.log('======');
+  console.log('Processing Opened/Edited PR #' + event.pull_request.number + ' : ' + event.pull_request.title);
+  console.log('======');
+
+  const pr = event.pull_request;
+  const body = pr.body;
+  const issues = getReferencedIssues(body);
+  if (issues.length > 0) {
+    console.log('+ This PR fixes issues: #' + issues.join(', '));
+  } else {
+    console.log("+ This PR does not fix any issues");
+  }
+
+  const milestones = {};
+
+  for (i of issues) {
+    const detail = `${event.repository.url}/issues/${i}`;
+    const iss = await request.fetch(detail);
+    console.log('')
+    console.log('Processing Issue #' + i + ' - ' + iss.title);
+
+    if (pr.draft) {
+      console.log('    Issue will not be moved to In Review (Draft PR)');
+    } else if (hasLabel(iss, BACKEND_BLOCKED_LABEL)) {
+      console.log('    Issue will not be moved to In Review (Backend Blocked)');
+    } else {
+      await moveIssueToProjectState(iss, GH_PRJ_IN_REVIEW);
+    }
+
+    if (iss.milestone) {
+      milestones[iss.milestone.title] = iss.milestone.number;
+    }
+  }
+
+  const keys = Object.keys(milestones);
+  if (keys.length === 0) {
+    console.log('No milestones on issue(s) for this PR');
+  } else if (keys.length > 1) {
+    console.log('More than one milestone on issues for this PR');
+  } else {
+    // There is exactly 1 milestone, so use that for the PR
+    const milestoneNumber = milestones[keys[0]];
+
+    if (event.pull_request.milestone?.number !== milestoneNumber) {
+      console.log('Updating PR with milestone: ' + keys[0]);
+      await request.patch(event.pull_request.issue_url, { milestone: milestoneNumber });
+    } else {
+      console.log('PR is already assigned to milestone ' + keys[0]);
+    }
+  }
+}
+
+// Debugging
+console.log(JSON.stringify(event, null, 2));
+
+// Look at the action
+if (event.action === 'opened' || event.action === 'reopened') {
+  processOpenAction();
+  processOpenOrEditAction();
+} else if (event.action === 'edited') {
+  processOpenOrEditAction();
+} else if (event.action === 'closed') {
+  processClosedAction();
+}

--- a/.github/workflows/scripts/request.js
+++ b/.github/workflows/scripts/request.js
@@ -12,8 +12,16 @@ const https = require('https');
  * @returns Project Info (ID and Status Field info)
  */
 async function ghProject(org, num) {
+  let orgOrUser = org;
+
+  if (orgOrUser.startsWith('@')) {
+    orgOrUser = orgOrUser.substr(1);
+  }
+
+  const type = orgOrUser !== org ? 'user' : 'organization';
+  
   const gQL = `query {
-    organization(login: "${ org }") {
+    ${ type }(login: "${ orgOrUser }") {
       projectV2(number: ${ num }) {
         id
         fields(first:100) {
@@ -31,6 +39,8 @@ async function ghProject(org, num) {
       }
     }
   }`;
+
+  console.log(gQL);
 
   const res = await graphql(gQL);
 
@@ -264,11 +274,11 @@ function patch(url, data) {
 }
 
 function graphql(data) {
-    return write(GRAPHQL, data, 'POST')
+    return write(GRAPHQL, { query: data }, 'POST')
 }
 
 function write(url, data, method) {
-    const json = JSON.stringify({ query: data });
+    const json = JSON.stringify(data);
     const opts = {
         method: method || 'POST',
         headers: {

--- a/.github/workflows/scripts/request.js
+++ b/.github/workflows/scripts/request.js
@@ -1,7 +1,227 @@
 const USER_AGENT = 'PR Action'
-const TOKEN = process.argv.length > 2 ? process.argv[2] : process.env.TOKEN;
+const TOKEN = process.env.TOKEN || process.env.GH_TOKEN;
+const GRAPHQL = 'https://api.github.com/graphql';
 
 const https = require('https');
+
+/**
+ * Get the Project Information for the specified GH project
+ *
+ * @param org GitHub Organization
+ * @param num Project number
+ * @returns Project Info (ID and Status Field info)
+ */
+async function ghProject(org, num) {
+  const gQL = `query {
+    organization(login: "${ org }") {
+      projectV2(number: ${ num }) {
+        id
+        fields(first:100) {
+        	nodes {
+            ... on ProjectV2SingleSelectField {
+            	id
+              name
+              options {
+                id
+                name
+              }
+            }
+        	}
+      	}        
+      }
+    }
+  }`;
+
+  const res = await graphql(gQL);
+
+  const prj = {};
+
+  if (res.data?.organization?.projectV2) {
+    const v2Project = res.data?.organization?.projectV2;
+
+    prj.id = v2Project.id;
+
+    const statusField = v2Project.fields?.nodes.find((node) => node.name === 'Status');
+
+    if (statusField) {
+      const optionMap = {};
+      statusField.options.forEach((opt) => {
+        optionMap[opt.name] = opt.id;
+      });
+
+      prj.statusField = {
+        id: statusField.id,
+        options: optionMap
+      };
+    }
+  } else {
+    console.log(res);
+  }
+
+  return prj;
+}
+/**
+ * Fetch the issue and get the project info for the issue (map of project ID to project issue ID)
+ *
+ * @param org GitHub Organization
+ * @param repo GitHub Repository
+ * @param num Project number
+ * @returns Project Issue Map metadata
+ */
+async function ghProjectIssue(org, repo, num) {
+  const gQL = `query {
+    repository(name:"${ repo }", owner:"${ org }") {
+      issue(number: ${ num }) {
+        title,
+        labels(first: 100) {
+          nodes {
+          	name
+          }
+        }        
+        projectItems(first:100){
+          nodes {
+            id
+            project {
+              id
+              title
+            }
+          }
+        }
+      }
+    }
+  }`;
+
+  const res = await graphql(gQL);
+
+  if (res.data?.repository?.issue?.projectItems) {
+    const projectItems = res.data?.repository?.issue?.projectItems?.nodes;
+    const projectMap = {};
+
+    // Map of project ID to the Issue ID within that project
+    projectItems.forEach((item) => {
+      projectMap[item.project.id] = item.id;
+    });
+
+    return projectMap;
+  }
+
+  return undefined;
+}
+
+/**
+ * Change the status of an issue on a project board
+ *
+ * @param prj Project metadata
+ * @param prjIssueID Issue ID in project
+ * @param status New status name
+ * @returns 
+ */
+async function ghUpdateProjectIssueStatus(prj, prjIssueID, status) {
+  // Check status exists
+  const statusOptionID = prj.statusField?.options?.[status];
+
+  if (!statusOptionID) {
+    console.log(`Can not find status ${ status } as a valid option for the project's status field`);
+
+    return false;
+  }
+
+  const gQL = `mutation {
+    updateProjectV2ItemFieldValue(
+      input: {
+        projectId: "${ prj.id }"
+        itemId: "${ prjIssueID }"
+        fieldId: "${ (prj.statusField.id) }"
+        value: { 
+          singleSelectOptionId: "${ statusOptionID }"
+        }
+      }
+    ) {
+      projectV2Item {
+        id
+      }
+    }
+  }`;
+
+  return await graphql(gQL);
+}
+
+/**
+ * Fetch the open issues for the given org/repo with the given milestone and label
+ *
+ */
+async function ghFetchOpenIssues(org, repo, milestone, label, previous) {
+  let extra = milestone ? `milestone:${ milestone }` : '';
+
+  if (label) {
+    extra += ` label:\\"${label}\\"`;
+  }
+
+  let after = '';
+
+  if (previous && previous.pageInfo?.endCursor) {
+    after = `after: "${ previous.pageInfo.endCursor }",`;
+  }
+
+  const gQL = `query {
+    search(first:100, ${after} type:ISSUE, query:"is:open is:issue repo:${org}/${repo} ${extra}") {
+      issueCount,
+      pageInfo {
+        startCursor
+        hasNextPage
+        endCursor
+      }
+        nodes {
+        ...on Issue {
+          id
+          number
+          state
+          title
+          labels(first: 100) {
+            nodes {
+              name
+            }
+          }        
+          projectItems(first:100) {
+            totalCount
+            nodes {
+              id
+              project {
+                id
+              }
+              status: fieldValueByName(name: "Status") {
+                ...on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }`;
+
+  const res = await graphql(gQL);
+
+  if (res.data?.search) {
+    if (previous) {
+      // Copy in the previous issues
+      res.data.search.nodes = [
+        ...previous.nodes,
+        ...res.data.search.nodes,
+      ];
+    }
+
+    if (res.data.search.pageInfo.hasNextPage) {
+      return await ghFetchOpenIssues(org, repo, milestone, label, res.data.search)
+    }
+
+    return res.data.search.nodes;
+  }
+
+  return false;
+}
 
 function fetch (url) {
     const opts = {
@@ -43,8 +263,12 @@ function patch(url, data) {
     return write(url, data, 'PATCH');
 }
 
+function graphql(data) {
+    return write(GRAPHQL, data, 'POST')
+}
+
 function write(url, data, method) {
-    const json = JSON.stringify(data);
+    const json = JSON.stringify({ query: data });
     const opts = {
         method: method || 'POST',
         headers: {
@@ -82,4 +306,9 @@ module.exports = {
     post,
     put,
     patch,
+    graphql,
+    ghProject,
+    ghProjectIssue,
+    ghUpdateProjectIssueStatus,
+    ghFetchOpenIssues,
 };

--- a/scripts/github/zube-migration
+++ b/scripts/github/zube-migration
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+// Migrate Zube labels to GitHub Project Statuses
+
+const request = require('../../.github/workflows/scripts/request');
+
+console.log('GH Issues: Zube > GitHub Project Migrator');
+console.log('=========================================');
+console.log('');
+
+const STATUS_MAP = {
+  'Backlog': 'Backlog',
+  'To Triage': 'To Triage',
+  'Groomed': 'Groomed',
+};
+
+// Options
+// -m = milestone - only migrate issues with the given milestone
+// -z = zube_status - only migrate issues with the given zube label
+// -p = project - GH project in the format 'org#number'
+// -a = apply - make the changes (default is dry-run that shows which changes will be made)
+
+// Parse the options
+
+// Arguments are after the process name and script name
+const options = {
+  args: [...process.argv.slice(2)],
+  milestone: undefined,
+  zubeStatus: undefined,
+  project: undefined,
+  repo: undefined,
+  apply: false,
+};
+
+function handleOption(options, optName, flag, hasValue) {
+  const provided = options.args.findIndex((item) => item === flag);
+
+  if (provided >= 0) {
+    // Remove the arg that was found
+    options.args.splice(provided, 1);
+
+    if (hasValue) {
+      if (options.args.length < (provided + 1)) {
+        console.log(`You need to provide a value for the ${ flag } option`);
+        return;
+      } else {
+        options[optName] = options.args[provided];
+        options.args.splice(provided, 1);
+      }
+    } else {
+      options[optName] = true;
+    }
+  }
+}
+
+handleOption(options, 'project', '-p', true);
+handleOption(options, 'repo', '-r', true);
+handleOption(options, 'milestone', '-m', true);
+handleOption(options, 'zubeStatus', '-z', true);
+handleOption(options, 'apply', '-a', false);
+
+if (!process.env.TOKEN || !process.env.GH_TOKEN) {
+  console.log('You must set a GitHub token in either the TOKEN or GH_TOKEN environment variables');
+
+  return;
+}
+
+if (!options.project) {
+  console.log('You must provide a GitHub project with the -p flag in the form org#number');
+
+  return;
+} else {
+  const pParts = options.project.split('#');
+
+  if (pParts.length !== 2) {
+    console.log('GitHub project must be in the form org#number');
+
+    return;
+  }
+
+  options.project = pParts;
+}
+
+if (!options.repo) {
+  console.log('You must provide a GitHub repository with the -r flag in the form org/name');
+
+  return;
+}
+
+if (!options.milestone) {
+  console.log('You must provide a GitHub milestone with the -m flag');
+
+  return;
+}
+
+if (options.zubeStatus && !options.zubeStatus.startsWith('[zube')) {
+  options.zubeStatus = `[zube]: ${ options.zubeStatus }`;
+}
+
+// console.log(options);
+
+async function run() {
+  // Fetch the GitHub Project board
+  const project = await request.ghProject(options.project[0], options.project[1]);
+
+  if (!project || Object.keys(project).length === 0) {
+    console.log('Unable to fetch ID for specified project');
+
+    return;
+  }
+
+  // console.log(project);
+
+  // Fetch all of the matching issues
+  const issues = await request.ghFetchOpenIssues('rancher', 'dashboard', options.milestone, options.zubeStatus);
+
+  if (!issues) {
+    console.log('Unable to fetch issues');
+
+    return;
+  }
+
+  console.log(`Fetched ${ issues.length } issue(s)`);
+  console.log('');
+
+  // Process the issues and figure out which ones need updating
+
+  const updates = [];
+
+  issues.forEach((issue) => {
+    const projectInfo = issue.projectItems.nodes.find((pItem) => pItem.project.id === project.id);
+
+    // Determine the current issue state from the Zube label
+    const labels = (issue.labels?.nodes || []).filter((label) => label.name.startsWith('[zube]: ')).map((label) => label.name);
+
+    if (labels.length > 1) {
+      console.log(`Warning: Issue ${ issue.number } has more than one Zube label - ignoring`);
+    } else if (labels.length < 1) {
+      console.log(`Warning: Issue ${ issue.number } does not have a Zube label - ignoring`);
+    } else {
+      const ghStatus = STATUS_MAP[labels[0].substr(8)];
+      const statusChange = projectInfo?.status?.name !== ghStatus;
+
+      if (statusChange) {
+        updates.push({
+          ...issue,
+          idInProject: projectInfo?.id,
+          currentStatus: projectInfo?.status?.name || 'No Status',
+          status: ghStatus,
+          statusChange,
+        });
+      }
+    }
+  });
+
+  console.log(`#ISSUE ${ 'TITLE'.padEnd(80) } CHANGE   NOTE`);
+  console.log(`------ ${ '-'.padEnd(80, '-') } -------- ----`);
+
+  updates.forEach((update) => {
+    let change = ''
+    let note = ''
+    if (!update.idInProject) {
+      change = 'ADD     ';
+      note = `${update.status}`;
+    } else if (update.statusChange) {
+      change = `UPDATE  `;
+      note = `${update.currentStatus} -> ${update.status}`;
+    }
+
+    const number = `${ update.number }`.padStart(6);
+
+    console.log(`${ number } ${ update.title.substr(0,80).padEnd(80)} ${ change } ${ note }`);
+  });
+
+  console.log('');
+  console.log(`${ updates.length} issue(s) require updating out of ${ issues.length }`);
+  
+  const add = updates.filter((update) => !update.idInProject);
+
+  if (options.apply && add.length) {
+    let gQL = 'mutation {\n';
+
+    // Add all of the missing items to the project in one go
+    add.forEach((update) => {
+      gQL += `issue${ update.number }: addProjectV2ItemById(input: {projectId: "${ project.id }" contentId: "${ update.id }"}) {
+          item {
+            id
+          }
+        }\n`;
+    });
+
+    gQL += '}';
+
+    const res = await request.graphql(gQL);
+
+    if (!res.data) {
+      console.log('Error updating');
+      console.log(res);
+
+      return;
+    }
+
+    if (res.data) {
+      Object.keys(res.data).forEach((itemName) => {
+        const itemRes = res.data[itemName]?.item;
+        const number = parseInt(itemName.substr(5), 10);
+        const existingUpdate = updates.find((update) => update.number === number);
+  
+        if (existingUpdate) {
+          existingUpdate.statusChange = true;
+          existingUpdate.idInProject = itemRes.id;
+        }
+      });
+    }
+  }
+
+  // Apply all of the status changes
+  const statusChanges = updates.filter((update) => (update.idInProject && update.statusChange));
+
+  if (options.apply && statusChanges.length) {
+    let statusQL = `mutation {\n`;
+
+    statusChanges.forEach((update) => {
+      if (update.idInProject && update.statusChange) {
+        // Get the optionId for the new status
+        const optionId = project.statusField.options[update.status];
+
+        if (!optionId) {
+          console.log(`Warning: Can not find status ${ update.status } in the GitHub Project`);
+        } else {
+          statusQL += `issue${update.number}: updateProjectV2ItemFieldValue(input: {
+              projectId: "${ project.id }"
+              itemId: "${ update.idInProject }"
+              fieldId: "${ project.statusField.id }"
+              value: { 
+                singleSelectOptionId: "${ optionId }"
+              }
+            }) {
+              projectV2Item {
+                id
+              }
+            }\n`
+        }
+      }
+    });
+
+    statusQL += '}';
+
+    const statusRes = await request.graphql(statusQL);
+
+    if (!statusRes.data) {
+      console.log('Error updating statuses of issues');
+      console.log(statusRes);
+
+      return;
+    }    
+  }
+
+  if (!updates.length && !statusChanges.length) {
+    console.log('');
+    console.log('All issues are up to date - nothing to do');
+  } else {
+    console.log('');
+
+    if (options.apply) {
+      console.log('Updates applied');
+    } else {
+      console.log('To apply updates, run again with the -a flag');
+    }
+  }
+
+  console.log('');
+}
+
+run();


### PR DESCRIPTION
This PR adds a script to migrate the swimline from the Zube label on a GH issue to the GitHub Project.

It also adds a new workflow to move linked issues to the appropriate column in the GH Project.

Note:

- This is currently not complete, but needs to be merged, so I can test the permissions that the GH_TOKEN has, to understand if it can read the GH project.