### PR TITLE
Resync resources with ws errors

### DIFF
--- a/cypress/e2e/tests/pages/explorer/cluster-tools.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/cluster-tools.spec.ts
@@ -43,7 +43,7 @@ describe('Cluster Tools', { tags: ['@explorer', '@adminUser'] }, () => {
     });
   });
 
-  it.skip('can edit chart successfully', () => {
+  it('can edit chart successfully', () => {
     // Note: this test fails due to https://github.com/rancher/dashboard/issues/9940
     // skipping this test until issue is resolved
     clusterTools.goTo();
@@ -61,7 +61,7 @@ describe('Cluster Tools', { tags: ['@explorer', '@adminUser'] }, () => {
     cy.contains('Connected');
   });
 
-  it.skip('can uninstall chart successfully', () => {
+  it('can uninstall chart successfully', () => {
     // Note: this test fails due to https://github.com/rancher/dashboard/issues/9940
     // skipping this test until issue is resolved
     clusterTools.goTo();

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -847,7 +847,7 @@ const defaultActions = {
       commit('setInError', { type: msg.resourceType, reason: NO_WATCH });
     } else if ( err.includes('failed to find schema') ) {
       commit('setInError', { type: msg.resourceType, reason: NO_SCHEMA });
-    } else if ( err.includes('too old') ) {
+    } else if ( err.includes('too old') || err.includes('unable to decode an event') ) {
       // Set an error for (all) subs of this type. This..
       // 1) blocks attempts by resource.stop to resub (as type is in error)
       // 2) will be cleared when resyncWatch --> watch (with force) --> resource.start completes


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
DO NOT MERGE
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
