### PR TITLE
Improve logout message for SSO

### DIFF
--- a/cypress/e2e/tests/pages/user-menu/logout.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/logout.spec.ts
@@ -10,7 +10,7 @@ describe('User can logout of Rancher', { tags: ['@userMenu', '@adminUser', '@sta
     cy.login();
   });
 
-  it('Can logout of Rancher successfully', () => {
+  it('Can logout of Rancher successfully (normal/Rancher auth user)', () => {
     /*
     Logout of Rancher Dashboard
     Verify user lands on login page after logging out
@@ -25,5 +25,38 @@ describe('User can logout of Rancher', { tags: ['@userMenu', '@adminUser', '@sta
     HomePagePo.goTo();
     loginPage.loginPageMessage().contains('Log in again to continue.').should('be.visible');
     loginPage.waitForPage();
+  });
+
+  it('Can logout of Rancher successfully (SSO user)', () => {
+    // The "principals" resource is what tells Rancher which auth provider is being used... (mocks Github auth)
+    cy.intercept('GET', 'v3/principals', {
+      type:         'collection',
+      resourceType: 'principal',
+      data:         [
+        {
+          baseType:       'principal',
+          created:        null,
+          creatorId:      null,
+          id:             'github_user://97888974',
+          links:          { self: 'https://my-rancher-address:8005/v3/principals/github_user:%2F%2F97888974' },
+          loginName:      'some-user',
+          me:             true,
+          memberOf:       false,
+          name:           'Some Dummy User',
+          principalType:  'user',
+          profilePicture: 'https://avatars.githubusercontent.com/u/97888974?v=4',
+          provider:       'github',
+          type:           'principal'
+        }
+      ]
+    }).as('featuresGet');
+    /*
+    Logout of Rancher Dashboard using SSO method, which should display a different logout message
+    */
+    HomePagePo.goToAndWaitForGet();
+    userMenu.clickMenuItem('Log Out');
+    loginPage.waitForPage();
+    loginPage.username().checkVisible();
+    loginPage.loginPageMessage().contains("You've been logged out of Rancher, however you may still be logged in to your single sign-on identity provider.").should('be.visible');
   });
 });

--- a/cypress/e2e/tests/pages/user-menu/logout.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/logout.spec.ts
@@ -7,7 +7,9 @@ const loginPage = new LoginPagePo();
 
 describe('User can logout of Rancher', { tags: ['@userMenu', '@adminUser', '@standardUser', '@flaky'] }, () => {
   beforeEach(() => {
-    cy.login();
+    // we need to forcefully not use the cached session for this test suite, otherwise
+    // it get's into this weird state where it doesn't move past the login screen
+    cy.login(Cypress.env('username'), Cypress.env('password'), false);
   });
 
   it('Can logout of Rancher successfully (normal/Rancher auth user)', () => {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3088,6 +3088,7 @@ login:
   howdy: Howdy!
   welcome: Welcome to {vendor}
   loggedOut: You have been logged out.
+  loggedOutFromSso: You've been logged out of Rancher, however you may still be logged in to your single sign-on identity provider.
   loginAgain: Log in again to continue.
   serverError:
     authFailedCreds: "Logging in failed: Check credentials, or your account may not be authorized to log in."

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -9,7 +9,7 @@ import BrandImage from '@shell/components/BrandImage';
 import { getProduct } from '@shell/config/private-label';
 import ClusterProviderIcon from '@shell/components/ClusterProviderIcon';
 import ClusterBadge from '@shell/components/ClusterBadge';
-import { LOGGED_OUT } from '@shell/config/query-params';
+import { LOGGED_OUT, IS_SSO } from '@shell/config/query-params';
 import NamespaceFilter from './NamespaceFilter';
 import WorkspaceSwitcher from './WorkspaceSwitcher';
 import TopLevelMenu from './TopLevelMenu';
@@ -71,6 +71,14 @@ export default {
 
     authEnabled() {
       return this.$store.getters['auth/enabled'];
+    },
+
+    isAuthLocalProvider() {
+      return this.principal && this.principal.provider === 'local';
+    },
+
+    generateLogoutRoute() {
+      return this.isAuthLocalProvider ? { name: 'auth-logout', query: { [LOGGED_OUT]: true } } : { name: 'auth-logout', query: { [LOGGED_OUT]: true, [IS_SSO]: true } };
     },
 
     principal() {
@@ -693,7 +701,7 @@ export default {
               <nuxt-link
                 v-if="authEnabled"
                 tag="li"
-                :to="{name: 'auth-logout', query: { [LOGGED_OUT]: true }}"
+                :to="generateLogoutRoute"
                 class="user-menu-item"
               >
                 <a @blur="showMenu(false)">{{ t('nav.userMenu.logOut') }}</a>

--- a/shell/config/query-params.js
+++ b/shell/config/query-params.js
@@ -6,6 +6,7 @@ export const LOCAL = 'local';
 export const SETUP = 'setup';
 export const STEP = 'step';
 export const LOGGED_OUT = 'logged-out';
+export const IS_SSO = 'is-sso';
 export const UPGRADED = 'upgraded';
 export const TIMED_OUT = 'timed-out';
 export const AUTH_TEST = 'test';

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -8,7 +8,9 @@ import BrandImage from '@shell/components/BrandImage';
 import InfoBox from '@shell/components/InfoBox';
 import CopyCode from '@shell/components/CopyCode';
 import { Banner } from '@components/Banner';
-import { LOCAL, LOGGED_OUT, TIMED_OUT, _FLAGGED } from '@shell/config/query-params';
+import {
+  LOCAL, LOGGED_OUT, TIMED_OUT, IS_SSO, _FLAGGED
+} from '@shell/config/query-params';
 import { Checkbox } from '@components/Form/Checkbox';
 import Password from '@shell/components/form/Password';
 import { sortBy } from '@shell/utils/sort';
@@ -118,9 +120,10 @@ export default {
       remember: !!username,
       password: '',
 
-      timedOut:  this.$route.query[TIMED_OUT] === _FLAGGED,
-      loggedOut: this.$route.query[LOGGED_OUT] === _FLAGGED,
-      err:       this.$route.query.err,
+      timedOut:    this.$route.query[TIMED_OUT] === _FLAGGED,
+      loggedOut:   this.$route.query[LOGGED_OUT] === _FLAGGED,
+      isSsoLogout: this.$route.query[IS_SSO] === _FLAGGED,
+      err:         this.$route.query.err,
 
       providers:          [],
       providerComponents: [],
@@ -314,7 +317,7 @@ export default {
             v-else-if="loggedOut"
             class="text-success text-center"
           >
-            {{ t('login.loggedOut') }}
+            {{ isSsoLogout ? t('login.loggedOutFromSso') : t('login.loggedOut') }}
           </h4>
           <h4
             v-else-if="timedOut"

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -1,7 +1,9 @@
 import { BACK_TO } from '@shell/config/local-storage';
 import { setBrand, setVendor } from '@shell/config/private-label';
 import { NAME as EXPLORER } from '@shell/config/product/explorer';
-import { LOGGED_OUT, TIMED_OUT, UPGRADED, _FLAGGED } from '@shell/config/query-params';
+import {
+  LOGGED_OUT, IS_SSO, TIMED_OUT, UPGRADED, _FLAGGED
+} from '@shell/config/query-params';
 import { SETTING } from '@shell/config/settings';
 import {
   COUNT,
@@ -1057,7 +1059,10 @@ export const actions = {
         window.localStorage.setItem(BACK_TO, window.location.href);
       }
 
-      const QUERY = (LOGGED_OUT in route.query) ? LOGGED_OUT : TIMED_OUT;
+      let QUERY = (LOGGED_OUT in route.query) ? LOGGED_OUT : TIMED_OUT;
+
+      // adds IS_SSO query param to login route if logout came with an auth provider enabled
+      QUERY += (IS_SSO in route.query) ? `&${ IS_SSO }` : '';
 
       router.replace(`/auth/login?${ QUERY }`);
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10519 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add logic to change copy of logout screen when logging out with an auth provider different than local
- add e2e test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Enable `Github` auth provider via `Users & Authentication` -> `Auth Provider` (follow instructions displayed there)
- Do a `logout` and check that logout message is according to the issue `You've been logged out of Rancher, however you may still be logged in to your single sign-on identity provider`
- Disable `Github` auth provider, do a logout and check that message reverted to the old text

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/97888974/1a11b2c5-8a3a-4479-9679-6719ac2c67e0


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
