### PR TITLE
[Extensions] Expose UMD Builds of Vue to the `window` Object

### DIFF
--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -1,7 +1,7 @@
 import semver from 'semver';
 
 // Version of the plugin API supported
-export const UI_PLUGIN_API_VERSION = '1.1.0';
+export const UI_PLUGIN_API_VERSION = '1.2.0';
 export const UI_PLUGIN_HOST_APP = 'rancher-manager';
 
 export const UI_PLUGIN_BASE_URL = '/api/v1/namespaces/cattle-ui-plugin-system/services/http:ui-plugin-operator:80/proxy';

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -400,7 +400,7 @@ module.exports = function(dir, _appConfig) {
       config.resolve.alias['@pkg'] = path.join(dir, 'pkg');
       config.resolve.alias['./node_modules'] = path.join(dir, 'node_modules');
       config.resolve.alias['@components'] = COMPONENTS_DIR;
-      config.resolve.alias['vue$'] = dev ? path.resolve(process.cwd(), 'node_modules', 'vue') : 'vue';
+      config.resolve.alias['vue$'] = path.resolve(process.cwd(), 'node_modules', 'vue', 'dist', dev ? 'vue.js' : 'vue.min.js');
       config.resolve.modules.push(__dirname);
       config.plugins.push(virtualModules);
       config.plugins.push(autoImport);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This resolves an error where importing extensions that utilize backported features will throw the error `object(...) is not a function` by explicitly importing `vue.runtime` to ensure that Dashboard is always exposing the UMD builds of Vue to the `window` object. This error originally occurred because different builds of Vue (ESM vs. UMD) are used depending on the environment; there are differences in how backported Vue 3 features are exposed in Vue 2.7[^1], so it's important that the intended build is explicitly attached to the `window` object so that extensions can be imported without error. 

For more information on different builds that are available to us, see the vue documentation for explanation of different builds [^2].

This also bumps the `UI_PLUGIN_API_VERSION` to signal that upcoming changes to UI extensions will be incompatible with older versions of Dashboard. A version of 1.2.0 or higher will be required for extensions that utilize backported Vue 3 features that are available in Vue 2.7.

[^2]: https://v2.vuejs.org/v2/guide/installation#Explanation-of-Different-Builds
[^1]: https://v2.vuejs.org/v2/guide/migration-vue-2-7.html#Notes-on-API-exposure

Fixes #10543 
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Loading an interacting with existing extensions does not regress
- Loading extensions that utilize backported Vue 3 features behaves the same as existing extensions 
- Development & Production builds of Dashboard should behave the same when loading and interacting with extensions
- No new errors are logged as a result of this change


### Screenshots
https://github.com/rancher/dashboard/assets/97888974/be6b12c9-fbd9-4c9b-abed-008337485b65


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
