### PR TITLE
Replace modal implementation in `PromptModal.vue`

### DIFF
--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -1,0 +1,109 @@
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name:  'AppModal',
+  props: {
+    /**
+     * If set to false, it will not be possible to close modal by clicking on
+     * the background or by pressing Esc key.
+     */
+    clickToClose: {
+      type:    Boolean,
+      default: true,
+    },
+    /**
+     * Width in pixels or percents (50, "50px", "50%").
+     *
+     * Supported string values are <number>% and <number>px
+     */
+    width: {
+      type:    [Number, String],
+      default: 600,
+    }
+  },
+  mounted() {
+    document.addEventListener('keydown', this.handleEscapeKey);
+  },
+  beforeDestroy() {
+    document.removeEventListener('keydown', this.handleEscapeKey);
+  },
+  methods: {
+    handleClickOutside(event: MouseEvent) {
+      if (
+        this.clickToClose &&
+        this.$refs.modalRef &&
+        !(this.$refs.modalRef as HTMLElement).contains(event.target as Node)
+      ) {
+        this.$emit('close');
+      }
+    },
+    handleEscapeKey(event: KeyboardEvent) {
+      if (this.clickToClose && event.key === 'Escape') {
+        this.$emit('close');
+      }
+    }
+  }
+});
+</script>
+
+<template>
+  <mounting-portal
+    mountTo="#modals"
+    name="source"
+    append
+  >
+    <transition
+      name="modal-fade"
+      appear
+    >
+      <div
+        class="modal-overlay"
+        @click="handleClickOutside"
+      >
+        <div
+          ref="modalRef"
+          class="modal-container"
+          :style="{ width: width }"
+          @click.stop
+        >
+          <slot><!--Empty content--></slot>
+        </div>
+      </div>
+    </transition>
+  </mounting-portal>
+</template>
+
+<style lang="scss">
+  .modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: var(--overlay-bg);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 20;
+
+    .modal-container {
+      background-color: var(--modal-bg);
+      border-radius: var(--border-radius);
+      max-height: 95vh;
+      overflow: scroll;
+      max-height: 100vh;
+      border: 2px solid var(--modal-border);
+    }
+  }
+
+  .modal-fade-enter-active,
+  .modal-fade-leave-active {
+    transition: opacity 200ms;
+  }
+
+  .modal-fade-enter,
+  .modal-fade-leave-to {
+    opacity: 0;
+  }
+</style>

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapState } from 'vuex';
 import { isArray } from '@shell/utils/array';
+import AppModal from '@shell/components/AppModal.vue';
 
 /**
  * @name PromptModal
@@ -8,6 +9,8 @@ import { isArray } from '@shell/utils/array';
  */
 export default {
   name: 'PromptModal',
+
+  components: { AppModal },
 
   data() {
     return { opened: false, backgroundClosing: null };
@@ -50,13 +53,7 @@ export default {
 
   watch: {
     showModal(show) {
-      if (show) {
-        this.opened = true;
-        this.$modal.show('promptModal');
-      } else {
-        this.opened = false;
-        this.$modal.hide('promptModal');
-      }
+      this.opened = show;
     },
   },
 
@@ -71,6 +68,8 @@ export default {
       if (this.backgroundClosing) {
         this.backgroundClosing();
       }
+
+      this.opened = false;
     },
 
     // We're using register instead of just making use of $refs because the $refs is always undefined when referencing the component
@@ -82,24 +81,20 @@ export default {
 </script>
 
 <template>
-  <modal
-    class="promptModal-modal"
-    name="promptModal"
-    :styles="`background-color: var(--nav-bg); border-radius: var(--border-radius); ${stickyProps} max-height: 95vh; ${cssProps}`"
-    height="auto"
-    :scrollable="true"
+  <app-modal
+    v-if="opened && component"
     :click-to-close="closeOnClickOutside"
-    @closed="close()"
+    :width="modalWidth"
+    @close="close()"
   >
     <component
       v-bind="modalData.componentProps || {}"
       :is="component"
-      v-if="opened && component"
       :resources="resources"
       :register-background-closing="registerBackgroundClosing"
       @close="close()"
     />
-  </modal>
+  </app-modal>
 </template>
 
 <style lang='scss'>

--- a/shell/components/__tests__/AppModal.test.ts
+++ b/shell/components/__tests__/AppModal.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable jest/no-hooks */
+import { shallowMount, Wrapper } from '@vue/test-utils';
+import AppModal from '@shell/components/AppModal.vue';
+
+let wrapper: Wrapper<InstanceType<typeof AppModal>>;
+
+describe('appModal', () => {
+  beforeEach(() => {
+    wrapper = shallowMount(AppModal, {
+      propsData: {
+        clickToClose: true,
+        width:        600,
+      },
+      slots: { default: '<div class="content">Modal content</div>' }
+    });
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  it('renders modal content', () => {
+    expect(wrapper.find('.content').exists()).toBeTruthy();
+  });
+
+  it('emits close event when clicked outside', async() => {
+    const overlay = wrapper.find('.modal-overlay');
+
+    await overlay.trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits close event when escape key is pressed', async() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key:     'Escape',
+      keyCode: 27,
+    }));
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('does not emit close event when clickToClose is false', async() => {
+    await wrapper.setProps({ clickToClose: false });
+    const overlay = wrapper.find('.modal-overlay');
+
+    await overlay.trigger('click');
+    expect(wrapper.emitted('close')).toBeFalsy();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key:     'Escape',
+      keyCode: 27,
+    }));
+
+    expect(wrapper.emitted('close')).toBeFalsy();
+  });
+});

--- a/shell/dialog/RollbackWorkloadDialog.vue
+++ b/shell/dialog/RollbackWorkloadDialog.vue
@@ -163,11 +163,11 @@ export default {
       return option.label;
     },
     sizeDialog() {
-      const dialogs = document.getElementsByClassName('v--modal');
+      const dialogs = document.getElementsByClassName('modal-container');
       const width = this.showDiff ? '85%' : '600px';
 
       if (dialogs.length === 1) {
-        dialogs[0].style.setProperty('--prompt-modal-width', width);
+        dialogs[0].style.setProperty('width', width);
       }
     },
     sanitizeYaml(obj, path = '') {

--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -67,6 +67,7 @@
             <i class="initial-load-spinner"></i>
         </div>
     </div>
+    <div id="modals"><!--Portal content here--></div>
 </body>
 
 </html>

--- a/storybook/stories/components/AppModal.stories.mdx
+++ b/storybook/stories/components/AppModal.stories.mdx
@@ -1,0 +1,49 @@
+import { Canvas, Meta, Story, ArgsTable, Source } from '@storybook/addon-docs';
+import AppModal from '@shell/components/AppModal';
+
+<Meta 
+  title="Components/AppModal" 
+  component={AppModal}
+/>
+
+export const Template = (args, { argTypes }) => ({
+  components: { AppModal },
+  props:      Object.keys(argTypes),
+  template:   '<app-modal v-bind="$props">Modal content goes here</app-modal>',
+})
+
+# Modal 
+The <code>AppModal</code> component is a reusable Vue modal component that provides a simple way to display content in a modal overlay.
+
+<br/>
+
+### Description
+
+<strong>Note:</strong> AppModal renders modal content outside of the control of Vue, via <code>&lt;div id="modals" /&gt;</code> located within <code>index.html</code>. This allows Dashboard to position the modal as the very last node in the page's <code>body</code>, making styling and positioning much easier and less error-prone. 
+
+<Canvas>
+  <Story
+    name="Default"
+    args={{
+      clickToClose: true,
+      width: 800,
+    }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Import
+
+<Source
+  language='js'
+  light
+  format={false}
+  code={`
+     import AppModal from '@shell/components/AppModal';
+  `}
+/>
+
+### Props table
+
+<ArgsTable of={AppModal} />
+


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This is the first of PRs to replace the existing `vue-js-modal` package with something that we can use to more easily transition Rancher Dashboard over to Vue 3.

The scope of this change is limited to `PromptModal.vue`; there are still instances of the `<modal>` component used throughout Rancher Dashboard. I find that it's best to limit the scope of this change to ensure that we cover all of the use cases for the `PromptModal`, which is widely used throughout Rancher Dashboard. 

Supports #8207
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

This PR adds a new `AppModal` component that serves as a replacement for the features that we rely on from `vue-js-modal`: displaying and sizing modal dialogs. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I chose `portal-vue` as a replacement for `vue-js-modal` for the following reasons:

- Existing `vue-js-modal` is fairly simple and readily reproduced using portals
- `portal-vue` provides us with a supported upgrade path from Vue 2 to Vue 3
- We can eventually remove the `portal-vue` dependency after completing the Vue 3 migration if we desire

I'm still considering some key points related to the design of this new component

- I'm finding that we need to include a `portal-target` in each of our top-level pages that requires the modal. I'm considering if it makes sense to utilize `portal-vue`'s ability to render a portal target outside of the vue app[^1]
- I opted out of implementing a global `this.$modal` option that would allow the `AppModal` to control its own display, instead preferring to allow the caller to conditionally render `AppModal` as needed. I think that this design has the potential to be more straightforward, but I am willing to change this if desired. 

[^1]: https://v2.portal-vue.linusb.org/guide/advanced.html#rendering-outside-of-the-vue-app

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The scope of this change involves the following Modal Layouts used throughout Rancher Dashboard

## Modal Layouts

These can be considered layouts that are used to populate other `PromptModal.vue`. They are dispatched via Vuex actions.
### AddClusterMemberDialog.vue

It is dispatched via `shell/components/form/Members/MembershipEditor.vue` using the action

```
      this.$store.dispatch('cluster/promptModal', {
        component:      this.addMemberDialogName,
        componentProps: { onAdd: this.onAddMember },
        modalSticky:    this.modalSticky
});
```

### AddCustomBadgeDialog.vue

It is dispatched via `shell/pages/c/_cluster/explorer/ConfigBadge.vue` using the action

```
this.$store.dispatch('cluster/promptModal', { component: 'AddCustomBadgeDialog' });
```

### AddonConfigConfirmationDialog.vue

It is dispatched via `shell/edit/provisioning.cattle.io.cluster/rke2.vue` using the action
> 📄 NOTE
> 
> Can't get this one to trigger in app

```
        this.$store.dispatch('cluster/promptModal', {
          component: 'AddonConfigConfirmationDialog',
          resources: [(value) => resolve(value)]
        });
```

### AddProjectMemberDialog.vue

It is dispatched via `shell/components/ExplorerMembers.vue` using the action

```
      this.$store.dispatch('cluster/promptModal', {
        component:      'AddProjectMemberDialog',
        componentProps: {
          projectId:   group.group.key.replace('/', ':'),
          saveInModal: true
        },
        modalSticky: true
      });
```

It is also passed as a prop to `MembershipEditor` in `shell/components/form/Members/ProjectMembershipEditor.vue`, where it is used to populate PromptModal.vue using the action

```      this.$store.dispatch('cluster/promptModal', {
        component:      this.addMemberDialogName,
        componentProps: { onAdd: this.onAddMember },
        modalSticky:    this.modalSticky
      });
```

### DiagnosticsTimingsDialog.vue

It is dispatched via `shell/pages/diagnostic.vue` using the action

```
this.$store.dispatch('management/promptModal', {
          component:      'DiagnosticTimingsDialog',
          componentProps: {
            downloadData:        this.downloadData,
            gatherResponseTimes: this.gatherResponseTimes
          }
        })
```

### DrainNode.vue

It is dispatched via `shell/models/cluster/node.js` using the action

```
    this.$dispatch('promptModal', {
      component:      'DrainNode',
      componentProps: {
        kubeNodes:    resources || [this],
        normanNodeId: this.normanNodeId
      }
    });
```

### ForceMachineRemoveDialog.vue

It is dispatched via `shell/models/cluster.x-k8s.io.machine.js` using the action

```
    this.$dispatch('promptModal', {
      componentProps: { machine: resources },
      component:      'ForceMachineRemoveDialog'
    });
```

### GenericPrompt.vue

It is dispatched via

- `shell/chart/monitoring/steps/uninstall-v1.vue`
- `shell/edit/auth/azuread.vue`
- `shell/edit/provisioning.cattle.io.cluster/rke2.vue`
- `shell/pages/c/_cluster/settings/performance.vue`

### RollbackWorkloadDialog.vue

It is dispatched via `shell/models/workload.js` using the action

```
    this.$dispatch('promptModal', {
      componentProps: { workload },
      component:      'RollbackWorkloadDialog'
    });
```

### RotateCertificatesDialog.vue

It is dispatched via `shell/models/provisioning.cattle.io.cluster.js` using the action

```
    this.$dispatch('promptModal', {
      componentProps: { cluster },

      component: 'RotateCertificatesDialog'
    });
```

### RotateEncryptionKeyDialog.vue

It is dispatched vie `shell/models/provisioning.cattle.io.cluster.js` using the action

```
    this.$dispatch('promptModal', {
      componentProps: { cluster },
      component:      'RotateEncryptionKeyDialog'
    });
```

### SaveAsRKETemplateDialog.vue

It is dispatched via `shell/models/provisioning.cattle.io.cluster.js` using the action

```
    this.$dispatch('promptModal', {
      componentProps: { cluster },
      component:      'SaveAsRKETemplateDialog'
    });
```

### ScaleMachineDownDialog.vue

It is dispatched via

- `shell/models/cluster.x-k8s.io.machine.js`
- `shell/models/management.cattle.io.node.js`

### ScalePoolDownDialog.vue

It is dispatched via `shell/detail/provisioning.cattle.io.cluster.vue` using the action

```  
this.$store.dispatch('management/promptModal', {
          component:  'ScalePoolDownDialog',
          resources,
          modalWidth: '450px'
        });
```

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### New

![cluster-badge-new](https://github.com/rancher/dashboard/assets/835961/99f857a6-1984-409a-a975-2f06c47f7096)

![diagnostics-new](https://github.com/rancher/dashboard/assets/835961/917ea991-b5fd-456e-a3ea-789149e4144c)

#### Original

![cluster-badge-org](https://github.com/rancher/dashboard/assets/835961/11d23651-340f-4e75-aa59-14617447f6d8)

![diagnostics-org](https://github.com/rancher/dashboard/assets/835961/e4295afe-6ac0-4f78-8692-dd074716ded6)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
