### PR TITLE
Add GH Action to ensure new issues have a QA label

### DIFF
--- a/.github/workflows/add-qa-label.yaml
+++ b/.github/workflows/add-qa-label.yaml
@@ -1,4 +1,3 @@
-# Docs for this workflow are here https://github.com/github/issue-labeler
 name: Add QA Label
 on:
   issues:

--- a/.github/workflows/add-qa-label.yaml
+++ b/.github/workflows/add-qa-label.yaml
@@ -1,0 +1,21 @@
+# Docs for this workflow are here https://github.com/github/issue-labeler
+name: Add QA Label
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_qa_label_to_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '16.x'
+    - name: script
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: node .github/workflows/scripts/add-qa-label.js

--- a/.github/workflows/scripts/add-qa-label.js
+++ b/.github/workflows/scripts/add-qa-label.js
@@ -6,6 +6,9 @@ const QA_DEV_AUTOMATION_LABEL = 'QA/dev-automation';
 const QA_MANUAL_TEST_LABEL = 'QA/manual-test';
 const QA_NONE_LABEL = 'QA/None';
 
+const EMBER_LABEL = 'ember';
+const TECH_DEBT_LABEL = 'kind/tech-debt';
+
 // The event object
 const event = require(process.env.GITHUB_EVENT_PATH);
 
@@ -21,11 +24,21 @@ async function processOpenAction() {
 
   // Check we have a QA label
   if (!labels.includes(QA_DEV_AUTOMATION_LABEL)  && !labels.includes(QA_MANUAL_TEST_LABEL) && !labels.includes(QA_NONE_LABEL)) {
-    // Need to add the Dev Automation label
 
-    labels.push(QA_DEV_AUTOMATION_LABEL);
+    // Add the appropriate QA label
+    if (labels.includes(EMBER_LABEL)) {
+      console.log('    Issue does not have a QA label, adding manual test label (as issue is marked as ember)');
 
-    console.log('    Issue does not a QA label, adding ...');
+      labels.push(QA_MANUAL_TEST_LABEL);
+    } else if (labels.includes(TECH_DEBT_LABEL)) {
+      console.log('    Issue does not have a QA label, adding QA/None label (as issue is marked as tech-debt)');
+
+      labels.push(QA_NONE_LABEL);
+    } else {
+      console.log('    Issue does not have a QA label, adding dev-automation label');
+
+      labels.push(QA_DEV_AUTOMATION_LABEL);
+    }
 
     // Update the labels
     const labelsAPI = `${issue.url}/labels`;

--- a/.github/workflows/scripts/add-qa-label.js
+++ b/.github/workflows/scripts/add-qa-label.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const request = require('./request');
+
+const QA_DEV_AUTOMATION_LABEL = 'QA/dev-automation';
+const QA_MANUAL_TEST_LABEL = 'QA/manual-test';
+
+// The event object
+const event = require(process.env.GITHUB_EVENT_PATH);
+
+async function processOpenAction() {
+  const issue = event.issue;
+
+  console.log('======');
+  console.log('Processing Opened Issue #' + issue.number + ' : ' + issue.title);
+  console.log('======');
+
+  // Get an array of labels
+  const labels = issue.labels.map((label) => label.name);
+
+  // Check we have a QA label
+  if (!labels.includes(QA_DEV_AUTOMATION_LABEL) && !labels.includes(QA_MANUAL_TEST_LABEL)) {
+    // Need to add the Dev Automation label
+
+    labels.push(QA_DEV_AUTOMATION_LABEL);
+
+    console.log('    Issue does not a QA label, adding ...');
+
+    // Update the labels
+    const labelsAPI = `${issue.url}/labels`;
+    await request.put(labelsAPI, { labels });
+
+    console.log('    Issue has been updated with QA label');
+  } else {
+    console.log('    Issue already has a QA label, nothing to do');
+  }
+}
+
+// Debugging
+// console.log(JSON.stringify(event, null, 2));
+
+// Look at the action
+if (event.action === 'opened') {
+  processOpenAction();
+} else {
+  console.log(`Unsupported action: ${event.action}`);
+}

--- a/.github/workflows/scripts/add-qa-label.js
+++ b/.github/workflows/scripts/add-qa-label.js
@@ -4,6 +4,7 @@ const request = require('./request');
 
 const QA_DEV_AUTOMATION_LABEL = 'QA/dev-automation';
 const QA_MANUAL_TEST_LABEL = 'QA/manual-test';
+const QA_NONE_LABEL = 'QA/None';
 
 // The event object
 const event = require(process.env.GITHUB_EVENT_PATH);
@@ -19,7 +20,7 @@ async function processOpenAction() {
   const labels = issue.labels.map((label) => label.name);
 
   // Check we have a QA label
-  if (!labels.includes(QA_DEV_AUTOMATION_LABEL) && !labels.includes(QA_MANUAL_TEST_LABEL)) {
+  if (!labels.includes(QA_DEV_AUTOMATION_LABEL)  && !labels.includes(QA_MANUAL_TEST_LABEL) && !labels.includes(QA_NONE_LABEL)) {
     // Need to add the Dev Automation label
 
     labels.push(QA_DEV_AUTOMATION_LABEL);

--- a/.github/workflows/scripts/add-qa-label.js
+++ b/.github/workflows/scripts/add-qa-label.js
@@ -26,14 +26,14 @@ async function processOpenAction() {
   if (!labels.includes(QA_DEV_AUTOMATION_LABEL)  && !labels.includes(QA_MANUAL_TEST_LABEL) && !labels.includes(QA_NONE_LABEL)) {
 
     // Add the appropriate QA label
-    if (labels.includes(EMBER_LABEL)) {
-      console.log('    Issue does not have a QA label, adding manual test label (as issue is marked as ember)');
-
-      labels.push(QA_MANUAL_TEST_LABEL);
-    } else if (labels.includes(TECH_DEBT_LABEL)) {
+    if (labels.includes(TECH_DEBT_LABEL)) {
       console.log('    Issue does not have a QA label, adding QA/None label (as issue is marked as tech-debt)');
 
       labels.push(QA_NONE_LABEL);
+    } else if (labels.includes(EMBER_LABEL)) {
+      console.log('    Issue does not have a QA label, adding manual test label (as issue is marked as ember)');
+
+      labels.push(QA_MANUAL_TEST_LABEL);
     } else {
       console.log('    Issue does not have a QA label, adding dev-automation label');
 


### PR DESCRIPTION
Fixes #10573

This PR adds a new GitHub action that runs when new issues are created and ensures that the issue has a QA label if it has none of these labels:

- `QA/dev-automation`
- `QA/manual-test`
- `QA/None`

The label that is added is chosen as follows:

1. If the issue has the `kind/tech-debt` label then we use `QA/None`
2. Otherwise, If the issue has the `ember` label then we use `QA/manual-test`
3. Otherwise we use `QA/dev-automation`


This action has been tested on a separate test repository and does not need QA.