### PR TITLE
automation: disable retries in cluster prov aws/azure tests

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -6,7 +6,9 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 
 // will only run this in jenkins pipeline where cloud credentials are stored
-describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins'] }, () => {
+describe('Provision Node driver RKE2 cluster', {
+  retries: { runMode: 0 }, testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins']
+}, () => {
   const clusterList = new ClusterManagerListPagePo();
   let removeCloudCred = false;
   let cloudcredentialId = '';

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
@@ -6,7 +6,9 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 
 // will only run this in jenkins pipeline where cloud credentials are stored
-describe('Provision Node driver RKE2 cluster with Azure', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins'] }, () => {
+describe('Provision Node driver RKE2 cluster with Azure', {
+  retries: { runMode: 0 }, testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins']
+}, () => {
   const clusterList = new ClusterManagerListPagePo();
   let removeCloudCred = false;
   let cloudcredentialId = '';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
This change is needed for debugging purposes. Cluster provisioning tests (aws and azure) are failing in Jenkins nightly job but they are passing when running the tests locally which makes it difficult to debug this issue. Disabling the retries for these tests will allow us to capture the error thrown after the first attempt (not the 3rd) which will give us a better idea of what the issue is.