### PR TITLE
Error handling for contentLibrary, tag and network fields

### DIFF
--- a/shell/machine-config/__tests__/vmwarevsphere.test.ts
+++ b/shell/machine-config/__tests__/vmwarevsphere.test.ts
@@ -183,16 +183,20 @@ describe('component: vmwarevsphere', () => {
   describe('resetValueIfNecessary', () => {
     const hostsystemOptions = ['', '/Datacenter/host/Cluster/111.11.11.1'];
     const folderOptions = ['', '/Datacenter/vm', '/Datacenter/vm/sub-folder'];
+    const contentLibraryOptions = ['', 'some-content-library'];
+    const networkOptions = ['', 'some-network'];
+    const tagOptions = ['', 'some-tag'];
 
-    it('should add errors to validationError collection when values are no in the options', () => {
+    it('should add errors to validationError collection when values are NOT in the options', () => {
       const setup = {
         ...defaultEditSetup,
         propsData: {
           ...defaultEditSetup.propsData,
           value: {
             ...defaultEditSetup.propsData.value,
-            hostsystem: 'something that is not included in the options',
-            folder:     'again, something that is not included in the options'
+            hostsystem:      'something that is not included in the options',
+            folder:          'same as above',
+            constentLibrary: 'same as above'
           }
         }
       };
@@ -200,18 +204,19 @@ describe('component: vmwarevsphere', () => {
       const wrapper = mount(vmwarevsphere, setup);
 
       const hostsystemContent = wrapper.vm.mapHostOptionsToContent(hostsystemOptions);
+      const folderContent = wrapper.vm.mapHostOptionsToContent(folderOptions);
+      const contentLibraryContent = wrapper.vm.mapPathOptionsToContent(contentLibraryOptions);
 
       wrapper.vm.resetValueIfNecessary('hostsystem', hostsystemContent, hostsystemOptions);
-
-      const folderContent = wrapper.vm.mapHostOptionsToContent(folderOptions);
-
       wrapper.vm.resetValueIfNecessary('folder', folderContent, folderOptions);
+      wrapper.vm.resetValueIfNecessary('contentLibrary', contentLibraryContent, contentLibraryOptions);
 
       expect(wrapper.vm.$data.validationErrors[poolId]).toContain('hostsystem');
       expect(wrapper.vm.$data.validationErrors[poolId]).toContain('folder');
+      expect(wrapper.vm.$data.validationErrors[poolId]).toContain('contentLibrary');
     });
 
-    describe('hostsystem and folder', () => {
+    describe('hostsystem, folder, contentLibrary, network and tag', () => {
       const testCases = [null, ''];
 
       it.each(testCases)('should NOT be added to validationError collection if they are null or ""', (data) => {
@@ -221,8 +226,11 @@ describe('component: vmwarevsphere', () => {
             ...defaultEditSetup.propsData,
             value: {
               ...defaultEditSetup.propsData.value,
-              hostsystem: data,
-              folder:     data
+              hostsystem:     data,
+              folder:         data,
+              contentLibrary: data,
+              network:        [data],
+              tag:            [data]
             }
           }
         };
@@ -230,12 +238,16 @@ describe('component: vmwarevsphere', () => {
         const wrapper = mount(vmwarevsphere, setup);
 
         const hostsystemContent = wrapper.vm.mapHostOptionsToContent(hostsystemOptions);
+        const folderContent = wrapper.vm.mapHostOptionsToContent(folderOptions);
+        const contentLibraryContent = wrapper.vm.mapPathOptionsToContent(contentLibraryOptions);
+        const networkContent = wrapper.vm.mapPathOptionsToContent(networkOptions);
+        const tagContent = wrapper.vm.mapPathOptionsToContent(tagOptions);
 
         wrapper.vm.resetValueIfNecessary('hostsystem', hostsystemContent, hostsystemOptions);
-
-        const folderContent = wrapper.vm.mapHostOptionsToContent(folderOptions);
-
         wrapper.vm.resetValueIfNecessary('folder', folderContent, folderOptions);
+        wrapper.vm.resetValueIfNecessary('contentLibrary', contentLibraryContent, contentLibraryOptions);
+        wrapper.vm.resetValueIfNecessary('network', networkContent, networkOptions, true);
+        wrapper.vm.resetValueIfNecessary('tag', tagContent, tagOptions, true);
 
         expect(wrapper.vm.$data.validationErrors[poolId]).toBeUndefined();
       });

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -661,7 +661,7 @@ export default {
           [_EDIT, _VIEW].includes(this.mode) && // error messages should only be displayed in Edit or View mode
           !this.poolCreateMode && // almost identical to Create mode
           !isNullOrEmpty && // null and empty string are valid values for some fields e.g. contentLibrary, folder and hostsystem
-          !isArray; // this flag is used for network and tag fields, and should not diplay error for them
+          !isArray; // this flag is used for network and tag fields, and should not display error for them
 
         if ((this.mode === _CREATE || this.poolCreateMode) && value !== SENTINEL) {
           set(this.value, key, value);

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -16,6 +16,7 @@ import { integerString, keyValueStrings } from '@shell/utils/computed';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 
 export const SENTINEL = '__SENTINEL__';
+const NULLABLE_EMPTY_FIELDS = ['contentLibrary', 'folder', 'hostsystem'];
 const VAPP_MODE = {
   DISABLED: 'disabled',
   AUTO:     'auto',
@@ -655,9 +656,12 @@ export default {
 
       if (!isValueInContent()) {
         const value = isArray ? [] : content[0]?.value;
-        // null and "" are valid values for hostsystem and folder
-        const isNullOrEmpty = ['folder', 'hostsystem'].includes(key) && (this.value[key] === null || this.value[key] === '');
-        const shouldHandleError = [_EDIT, _VIEW].includes(this.mode) && !isNullOrEmpty && !this.poolCreateMode;
+        const isNullOrEmpty = NULLABLE_EMPTY_FIELDS.includes(key) && (this.value[key] === null || this.value[key] === '');
+        const shouldHandleError =
+          [_EDIT, _VIEW].includes(this.mode) && // error messages should only be displayed in Edit or View mode
+          !this.poolCreateMode && // almost identical to Create mode
+          !isNullOrEmpty && // null and empty string are valid values for some fields e.g. contentLibrary, folder and hostsystem
+          !isArray; // this flag is used for network and tag fields, and should not diplay error for them
 
         if ((this.mode === _CREATE || this.poolCreateMode) && value !== SENTINEL) {
           set(this.value, key, value);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10460 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
`contentLibrary` was added to the list of the fields that should be exempt from displaying errors when their value is `null` or `""`. Also found `network` and `tag` to be special cases where they're falsy

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Provisioning vSphere Clusters

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Provisioning vSphere Clusters

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="593" alt="Screenshot 2024-03-11 at 4 46 37 PM" src="https://github.com/rancher/dashboard/assets/135728925/ec4ad08f-8e84-4dac-91d0-57cd84093568">
<img width="1716" alt="Screenshot 2024-03-11 at 4 48 07 PM" src="https://github.com/rancher/dashboard/assets/135728925/7f436318-264b-4324-993d-e280e6e5f002">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
