### PR TITLE
Fix Legacy / Project group

### DIFF
--- a/cypress/e2e/po/lists/management.cattle.io.feature.po.ts
+++ b/cypress/e2e/po/lists/management.cattle.io.feature.po.ts
@@ -18,11 +18,11 @@ export default class MgmtFeatureFlagListPo extends BaseResourceList {
   }
 
   clickRowActionMenuItem(name: string, itemLabel:string) {
-    return this.resourceTable().sortableTable().rowActionMenuOpen(name, 4).getMenuItem(itemLabel)
+    return this.resourceTable().sortableTable().rowActionMenuOpen(name).getMenuItem(itemLabel)
       .click();
   }
 
   getRowActionMenuItem(name: string, itemLabel:string) {
-    return this.resourceTable().sortableTable().rowActionMenuOpen(name, 4).getMenuItem(itemLabel);
+    return this.resourceTable().sortableTable().rowActionMenuOpen(name).getMenuItem(itemLabel);
   }
 }

--- a/cypress/e2e/po/pages/global-settings/feature-flags.po.ts
+++ b/cypress/e2e/po/pages/global-settings/feature-flags.po.ts
@@ -4,7 +4,6 @@ import CardPo from '@/cypress/e2e/po/components/card.po';
 import { CypressChainable } from '@/cypress/e2e/po/po.types';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
-import { Promise } from 'cypress/types/bluebird';
 
 export class FeatureFlagsPagePo extends RootClusterPage {
   static url = '/c/_/settings/management.cattle.io.feature';

--- a/cypress/e2e/po/pages/global-settings/feature-flags.po.ts
+++ b/cypress/e2e/po/pages/global-settings/feature-flags.po.ts
@@ -4,6 +4,7 @@ import CardPo from '@/cypress/e2e/po/components/card.po';
 import { CypressChainable } from '@/cypress/e2e/po/po.types';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import { Promise } from 'cypress/types/bluebird';
 
 export class FeatureFlagsPagePo extends RootClusterPage {
   static url = '/c/_/settings/management.cattle.io.feature';
@@ -65,6 +66,21 @@ export class FeatureFlagsPagePo extends RootClusterPage {
       expect(response?.statusCode).to.eq(200);
       expect(request.body.spec).to.have.property('value', value);
       expect(response?.body.spec).to.have.property('value', value);
+    });
+  }
+
+  getFeatureFlag(featureFlag: string): Cypress.Chainable<Object> {
+    return cy.getRancherResource('v1', 'management.cattle.io.features', featureFlag).then((r) => r.body);
+  }
+
+  setFeatureFlag(featureFlag: string, value: boolean) {
+    return this.getFeatureFlag(featureFlag).then((res) => {
+      const obj = {
+        ...res,
+        spec: { value }
+      };
+
+      cy.setRancherResource('v1', 'management.cattle.io.features', featureFlag, JSON.stringify(obj));
     });
   }
 }

--- a/cypress/e2e/po/pages/page.po.ts
+++ b/cypress/e2e/po/pages/page.po.ts
@@ -85,6 +85,10 @@ export default class PagePo extends ComponentPo {
     nav.navToSideMenuEntryByLabel(label);
   }
 
+  productNav(): ProductNavPo {
+    return new ProductNavPo();
+  }
+
   header() {
     return new HeaderPo();
   }

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -44,9 +44,9 @@ export default class ProductNavPo extends ComponentPo {
   }
 
   /**
-   * Check existance of menu group by label
+   * Check existence of menu group by label
    */
-  navToSideMenuGroupByLabelExistance(label: string, assertion: string): Cypress.Chainable {
+  navToSideMenuGroupByLabelExistence(label: string, assertion: string): Cypress.Chainable {
     return this.self().should('exist').contains('.accordion.has-children', label).should(assertion);
   }
 }

--- a/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
@@ -15,7 +15,10 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
   const chartsPageUrl = '/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-charts';
 
   describe('Monitoring', () => {
-    const chartsMonitoringPage = `${ chartsPageUrl }&chart=rancher-monitoring`;
+    // Ideally we should not specify this, older versions can disappear / have issues.
+    // However it seems the latest can also have issues (like no matching CRD chart)
+    const monitoringVersion = '103.0.2%2Bup45.31.1';
+    const chartsMonitoringPage = `${ chartsPageUrl }&chart=rancher-monitoring&version=${ monitoringVersion }`;
 
     const chartsPage: ChartsPage = new ChartsPage(chartsMonitoringPage);
 

--- a/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
@@ -6,7 +6,7 @@ import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.
 const featureFlagsPage = new FeatureFlagsPagePo();
 let disableLegacyFlag = false;
 
-describe('Legacy: Projects', { tags: ['@explorer', '@adminUser'] }, () => {
+describe('Legacy: Projects', { tags: ['@explorer', '@adminUser'], testIsolation: 'off' }, () => {
   before(() => {
     cy.login();
 

--- a/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
@@ -1,0 +1,47 @@
+
+import { FeatureFlagsPagePo } from '@/cypress/e2e/po/pages/global-settings/feature-flags.po';
+import { ConfigMapPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
+import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.po';
+
+const featureFlagsPage = new FeatureFlagsPagePo();
+let disableLegacyFlag = false;
+
+describe('Legacy: Projects', { tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+  before(() => {
+    cy.login();
+
+    featureFlagsPage.getFeatureFlag('legacy').then((body: any) => {
+      if (!body.spec.value) {
+        return featureFlagsPage.setFeatureFlag('legacy', true).then(() => {
+          disableLegacyFlag = true;
+        });
+      }
+    });
+  });
+
+  it('Ensure legacy: projects is visible and defaults to embedded Apps page', () => {
+    const configMapPage = new ConfigMapPagePo('local');
+
+    configMapPage.goTo();
+
+    const namespacePicker = new NamespaceFilterPo();
+
+    namespacePicker.toggle();
+    namespacePicker.clickOptionByLabel('All Namespaces');
+    namespacePicker.clickOptionByLabel('Project: Default');
+    namespacePicker.closeDropdown();
+
+    configMapPage.navToSideMenuGroupByLabel('Legacy');
+    configMapPage.productNav().navToSideMenuGroupByLabelExistence('Project', 'exist');
+    configMapPage.navToSideMenuGroupByLabel('Project');
+    configMapPage.navToSideMenuEntryByLabel('Apps');
+
+    cy.iFrame().contains('.header h1', 'Apps');
+  });
+
+  after(() => {
+    if (disableLegacyFlag) {
+      featureFlagsPage.setFeatureFlag('legacy', false);
+    }
+  });
+});

--- a/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
@@ -4,6 +4,8 @@ import { ConfigMapPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
 import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.po';
 
 const featureFlagsPage = new FeatureFlagsPagePo();
+const namespacePicker = new NamespaceFilterPo();
+
 let disableLegacyFlag = false;
 
 describe('Legacy: Projects', { tags: ['@explorer', '@adminUser'], testIsolation: 'off' }, () => {
@@ -24,8 +26,6 @@ describe('Legacy: Projects', { tags: ['@explorer', '@adminUser'], testIsolation:
 
     configMapPage.goTo();
 
-    const namespacePicker = new NamespaceFilterPo();
-
     namespacePicker.toggle();
     namespacePicker.clickOptionByLabel('All Namespaces');
     namespacePicker.clickOptionByLabel('Project: Default');
@@ -43,5 +43,8 @@ describe('Legacy: Projects', { tags: ['@explorer', '@adminUser'], testIsolation:
     if (disableLegacyFlag) {
       featureFlagsPage.setFeatureFlag('legacy', false);
     }
+
+    namespacePicker.toggle();
+    namespacePicker.clickOptionByLabel('Only User Namespaces'); // This is the default
   });
 });

--- a/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
@@ -6,7 +6,7 @@ import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.
 const featureFlagsPage = new FeatureFlagsPagePo();
 let disableLegacyFlag = false;
 
-describe('Legacy: Projects', { tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+describe('Legacy: Projects', { tags: ['@explorer', '@adminUser'] }, () => {
   before(() => {
     cy.login();
 

--- a/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/legacy/projects.spec.ts
@@ -19,7 +19,7 @@ describe('Legacy: Projects', { tags: ['@explorer', '@adminUser', '@standardUser'
     });
   });
 
-  it('Ensure legacy: projects is visible and defaults to embedded Apps page', () => {
+  it('Ensure legacy: projects is visible and can nav to child entry', () => {
     const configMapPage = new ConfigMapPagePo('local');
 
     configMapPage.goTo();
@@ -34,9 +34,9 @@ describe('Legacy: Projects', { tags: ['@explorer', '@adminUser', '@standardUser'
     configMapPage.navToSideMenuGroupByLabel('Legacy');
     configMapPage.productNav().navToSideMenuGroupByLabelExistence('Project', 'exist');
     configMapPage.navToSideMenuGroupByLabel('Project');
-    configMapPage.navToSideMenuEntryByLabel('Apps');
+    configMapPage.navToSideMenuEntryByLabel('Config Maps');
 
-    cy.iFrame().contains('.header h1', 'Apps');
+    cy.iFrame().contains('.header h1', 'Config Maps');
   });
 
   after(() => {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -78,7 +78,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     const sideNav = new ProductNavPo();
 
     // check that the nav group isn't visible anymore
-    sideNav.navToSideMenuGroupByLabelExistance('RKE1 Configuration', 'not.exist');
+    sideNav.navToSideMenuGroupByLabelExistence('RKE1 Configuration', 'not.exist');
   });
 
   describe('All providers', () => {
@@ -135,7 +135,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
         const sideNav = new ProductNavPo();
 
-        sideNav.navToSideMenuGroupByLabelExistance('RKE1 Configuration', 'exist');
+        sideNav.navToSideMenuGroupByLabelExistence('RKE1 Configuration', 'exist');
         // EO test for https://github.com/rancher/dashboard/issues/9823
 
         createRKE2ClusterPage.rkeToggle().set('RKE2/K3s');

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -168,6 +168,7 @@ nav:
     RBAC: RBAC
     Scheduling: Scheduling
     Storage: Storage
+    Project: Project
   ns:
     all: All Namespaces
     clusterLevel: Only Cluster Resources

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -92,7 +92,7 @@ export default {
     },
 
     showCount() {
-      return this.count !== undefined;
+      return this.count !== undefined && this.count !== null;
     },
 
     namespaceIcon() {
@@ -170,7 +170,7 @@ export default {
         :class="{'no-icon': !type.icon}"
       />
       <span
-        v-if="showFavorite || showCount"
+        v-if="showFavorite || namespaceIcon || showCount"
         class="count"
       >
         <Favorite
@@ -179,9 +179,12 @@ export default {
         />
         <i
           v-if="namespaceIcon"
-          class="icon icon-namespace namespaced"
+          class="icon icon-namespace"
         />
-        {{ count }}
+        <span
+          v-if="showCount"
+          :class="{'namespaced': namespaceIcon}"
+        >{{ count }}</span>
       </span>
     </a>
   </n-link>
@@ -207,7 +210,7 @@ export default {
 
 <style lang="scss" scoped>
   .namespaced {
-    margin-right: 4px;
+    margin-left: 4px;
   }
 
   .child {

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -180,10 +180,10 @@ export default {
         <i
           v-if="namespaceIcon"
           class="icon icon-namespace"
+          :class="{'ns-and-icon': showCount}"
         />
         <span
           v-if="showCount"
-          :class="{'namespaced': namespaceIcon}"
         >{{ count }}</span>
       </span>
     </a>
@@ -209,8 +209,8 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .namespaced {
-    margin-left: 4px;
+  .ns-and-icon {
+    margin-right: 4px;
   }
 
   .child {

--- a/shell/config/product/legacy.js
+++ b/shell/config/product/legacy.js
@@ -8,23 +8,13 @@ export function init(store) {
     product,
     basicType,
     virtualType,
+    setGroupDefaultType,
   } = DSL(store, NAME);
 
   product({
     weight:              80,
     ifFeature:           LEGACY,
     showNamespaceFilter: true,
-  });
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.project.label',
-    namespaced: true,
-    name:       'v1-project',
-    weight:     105,
-    route:      { name: 'c-cluster-project-apps' },
-    exact:      true,
-    overview:   false,
   });
 
   virtualType({
@@ -68,4 +58,5 @@ export function init(store) {
     'project-config-maps',
     'project-secrets',
   ], 'Project');
+  setGroupDefaultType('project-config-maps', 'Project');
 }

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -938,11 +938,11 @@ export const getters = {
         const virtualTypes = state.virtualTypes[product] || [];
         const spoofedTypes = state.spoofedTypes[product] || [];
         const allTypes = [...virtualTypes, ...spoofedTypes];
-        const virtSpoofedModes = [...nonUsedModes];
 
         for ( const type of allTypes ) {
           const item = clone(type);
           const id = item.name;
+          const virtSpoofedModes = [...nonUsedModes];
 
           // Is there a virtual/spoofed type override for schema type?
           // Currently used by harvester, this should be investigated and removed if possible


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10595
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- fixed scenario exposed by the project virtual type where call to allTypes ruled out all virt / spoofed types if basic mode has an invalid entry (!groupForBasicType)
- however also removed the project virtual type. the nav item comes from `Project` group specified in `basicTypes` call)
- fixed a few things around the project group
  - add label for project group
  - explicitly set project group root of app
- fixed display of namespace icon for a menu item if there are no counts

Also
- fixed some TS errors in test
- fixed typos in tests

### Areas or cases that should be tested
- Contains e2e test that navigates to legacy --> project --> config maps

### Areas which could experience regressions
- virtual / spoof side nav menu items, like those in Global Settings

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
