### PR TITLE
[backport v2.7.next1] Ensure too old messages for watches in individual resources are handled correctly

### DIFF
--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -440,8 +440,11 @@ export default {
       const watchMsg = {
         type,
         id,
-        revision: res?.metadata?.resourceVersion,
-        force:    opt.forceWatch === true,
+        // Although not used by sockets, we need this for when resyncWatch calls find... which needs namespace to construct the url
+        namespace: opt.namespaced,
+        // Override the revision. Used in cases where the resource's own revision will be too old
+        revision:  typeof opt.revision !== 'undefined' ? opt.revision : res?.metadata?.resourceVersion,
+        force:     opt.forceWatch === true,
       };
 
       const idx = id.indexOf('/');

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -442,7 +442,9 @@ export default {
         id,
         // Although not used by sockets, we need this for when resyncWatch calls find... which needs namespace to construct the url
         namespace: opt.namespaced,
-        // Override the revision. Used in cases where the resource's own revision will be too old
+        // Override the revision. Used in cases where we need to avoid using the resource's own revision which would be `too old`.
+        // For the above case opt.revision will be `null`. If left as `undefined` the subscribe mechanism will try to determine a revision
+        // from resources in store (which would be this one, with the too old revision)
         revision:  typeof opt.revision !== 'undefined' ? opt.revision : res?.metadata?.resourceVersion,
         force:     opt.forceWatch === true,
       };

--- a/shell/plugins/steve/__tests__/getters.spec.ts
+++ b/shell/plugins/steve/__tests__/getters.spec.ts
@@ -15,8 +15,8 @@ describe('steve: getters', () => {
         if (type === 'rType') {
           return { links: { collection: collectionUrl } };
         }
-        if (type === 'param') {
-          return { links: { collection: collectionUrl } };
+        if (type === 'trailingforwardslash') {
+          return { links: { collection: `${ collectionUrl }/` } };
         }
       },
       // this has its own tests so it just returns the input string
@@ -51,9 +51,14 @@ describe('steve: getters', () => {
       // With url (mostly no op)
       ['rType', undefined, { url: `${ baseUrl }/urlFoo`, namespaced: `${ namespace }` }, `${ baseUrl }/urlFoo`],
       ['rType', undefined, { url: `${ baseUrl }/urlFoo/abc`, namespaced: `${ namespace }` }, `${ baseUrl }/urlFoo/abc`],
+      ['rType', undefined, { url: `/urlFoo`, namespaced: `${ namespace }` }, `/urlFoo`],
+      ['rType', undefined, { url: `/urlFoo/abc`, namespaced: `${ namespace }` }, `/urlFoo/abc`],
 
       // multiple namespaces (no op)
       ['rType', undefined, { namespaced: [`${ namespace }`, 'nsBaz'] }, `${ collectionUrl }`],
+
+      // handle trailing space
+      ['trailingforwardslash', undefined, { namespaced: `${ namespace }` }, `${ collectionUrl }/${ namespace }`],
 
     ])("given type '%p', id '%p' and opt '%p', should get url '%p'", (type, id, opt, url) => {
       expect(urlForGetter(type, id, opt)).toBe(url);

--- a/shell/plugins/steve/__tests__/getters.spec.ts
+++ b/shell/plugins/steve/__tests__/getters.spec.ts
@@ -5,36 +5,58 @@ const { urlFor, urlOptions } = _getters;
 describe('steve: getters', () => {
   describe('steve > getters > urlFor', () => {
     // we're not testing function output based off of state or getter inputs here since they are dependencies
-    const state = { config: { baseUrl: 'protocol' } };
+    const baseUrl = '/v1';
+    const collectionUrl = 'https://abc.com/v1/urlFoo';
+    const namespace = 'myNamespace';
+    const state = { config: { baseUrl } };
     const getters = {
-      normalizeType: (type) => type,
-      schemaFor:     (type) => {
-        if (type === 'typeFoo') {
-          return { links: { collection: 'urlFoo' } };
+      normalizeType: (type: string) => type,
+      schemaFor:     (type: string) => {
+        if (type === 'rType') {
+          return { links: { collection: collectionUrl } };
+        }
+        if (type === 'param') {
+          return { links: { collection: collectionUrl } };
         }
       },
       // this has its own tests so it just returns the input string
-      urlOptions: (string) => string
+      urlOptions: (url: string, opt: any) => {
+        if (opt.addParam) {
+          url += '?param=true';
+        }
+
+        return url;
+      }
     };
 
     const urlForGetter = urlFor(state, getters);
 
     // most tests for this getter will go through the dashboard-store getters test spec, this only tests logic specific to the steve variant
 
-    it('expects urlFor to return a function', () => {
-      expect(typeof urlFor(state, getters)).toBe('function');
-    });
+    it.each([
+      ['rType', undefined, undefined, collectionUrl],
 
-    it('expects function returned by urlFor to return a string a type', () => {
-      expect(urlForGetter('typeFoo')).toBe('protocol/urlFoo');
-    });
+      // No namespace
+      ['rType', undefined, { }, `${ collectionUrl }`],
+      ['rType', undefined, { addParam: true }, `${ collectionUrl }?param=true`],
+      ['rType', 'abc', { }, `${ collectionUrl }/abc`],
+      ['rType', 'abc', { addParam: true }, `${ collectionUrl }/abc?param=true`],
 
-    it('expects function returned by urlFor to return a string containing a namespace when provided with a type and a single namespace string', () => {
-      expect(urlForGetter('typeFoo', undefined, { namespaced: 'nsBar' })).toBe('protocol/urlFoo/nsBar');
-    });
+      // With namespace
+      ['rType', undefined, { namespaced: `${ namespace }` }, `${ collectionUrl }/${ namespace }`],
+      ['rType', undefined, { addParam: true, namespaced: `${ namespace }` }, `${ collectionUrl }/${ namespace }?param=true`],
+      ['rType', 'abc', { namespaced: `${ namespace }` }, `${ collectionUrl }/${ namespace }/abc`],
+      ['rType', 'abc', { addParam: true, namespaced: `${ namespace }` }, `${ collectionUrl }/${ namespace }/abc?param=true`],
 
-    it('expects function returned by urlFor to return a string not containing a namespace when provided with a type and a multiple namespaces string', () => {
-      expect(urlForGetter('typeFoo', undefined, { namespaced: ['nsBar', 'nsBaz'] })).toBe('protocol/urlFoo');
+      // With url (mostly no op)
+      ['rType', undefined, { url: `${ baseUrl }/urlFoo`, namespaced: `${ namespace }` }, `${ baseUrl }/urlFoo`],
+      ['rType', undefined, { url: `${ baseUrl }/urlFoo/abc`, namespaced: `${ namespace }` }, `${ baseUrl }/urlFoo/abc`],
+
+      // multiple namespaces (no op)
+      ['rType', undefined, { namespaced: [`${ namespace }`, 'nsBaz'] }, `${ collectionUrl }`],
+
+    ])("given type '%p', id '%p' and opt '%p', should get url '%p'", (type, id, opt, url) => {
+      expect(urlForGetter(type, id, opt)).toBe(url);
     });
   });
   describe('steve > getters > urlOptions', () => {
@@ -42,13 +64,8 @@ describe('steve: getters', () => {
     const state = { config: { baseUrl: 'protocol' } };
     const getters = {
       normalizeType: (type) => type,
-      schemaFor:     (type) => {
-        if (type === 'typeFoo') {
-          return { links: { collection: 'urlFoo' } };
-        }
-      },
       // this has its own tests so it just returns the input string
-      urlOptions: (string) => string
+      urlOptions:    (string) => string
     };
 
     const urlOptionsGetter = urlOptions();
@@ -77,7 +94,7 @@ describe('steve: getters', () => {
     it('returns a string without an exclude statement if excludeFields is but the url does not start with "/v1/"', () => {
       expect(urlOptionsGetter('foo', { excludeFields: ['bar'] })).toBe('foo');
     });
-    it('returns a string without an exclude statement if excludeFields is an array but the URL doesnt include the "/v1/ string"', () => {
+    it('returns a string without an exclude statement if excludeFields is an array but the URL doesn\'t include the "/v1/ string"', () => {
       expect(urlOptionsGetter('foo', { excludeFields: ['bar'] })).toBe('foo');
     });
     it('returns a string with a limit applied if a limit is provided', () => {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -105,10 +105,25 @@ export default {
     // `namespaced` is either
     // - a string representing a single namespace - add restriction to the url
     // - an array of namespaces or projects - add restriction as a param
-    if (opt?.namespaced && !pAndNFiltering.isApplicable(opt)) {
-      const parts = url.split('/');
+    if (!opt?.url && opt?.namespaced && !pAndNFiltering.isApplicable(opt)) {
+      // Update path to include `namespace`, but take into account
+      // - if there is an id
+      // - if there are query params
 
-      url = `${ parts.join('/') }/${ opt.namespaced }`;
+      // Construct a url so query params / fragments are avoided
+      const urlObj = new URL(url);
+      const parts = urlObj.pathname.split('/');
+
+      if (id) {
+        // namespace should go before the id in the path
+        parts.splice(parts.length - 1, 0, opt.namespaced);
+        urlObj.pathname = parts.join('/');
+      } else {
+        // namespace should go at the end of the path
+        urlObj.pathname = `${ urlObj.pathname.split('/').join('/') }/${ opt.namespaced }`;
+      }
+
+      url = urlObj.toString();
     }
 
     return url;

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -112,6 +112,11 @@ export default {
 
       // Construct a url so query params / fragments are avoided
       const urlObj = new URL(url);
+      const path = urlObj.pathname;
+
+      if (!!path?.length && path[path.length - 1] === '/') {
+        urlObj.pathname = path.substring(0, path.length - 1);
+      }
       const parts = urlObj.pathname.split('/');
 
       if (id) {

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -151,7 +151,11 @@ export default {
 
   forgetType(state, type) {
     if ( forgetType(state, type) ) {
-      delete state.inError[keyForSubscribe({ type })];
+      Object.keys(state.inError).forEach((key) => {
+        if (key.startsWith(type)) {
+          delete state.inError[key];
+        }
+      });
     }
   },
 

--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -9,7 +9,6 @@ import {
   batchChanges,
   replace
 } from '@shell/plugins/dashboard-store/mutations';
-import { keyForSubscribe } from '@shell/plugins/steve/resourceWatcher';
 import { perfLoadAll } from '@shell/plugins/steve/performanceTesting';
 import Vue from 'vue';
 import { classify } from '@shell/plugins/dashboard-store/classify';

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -639,7 +639,13 @@ const defaultActions = {
       await dispatch('find', {
         type: resourceType,
         id,
-        opt,
+        opt:  {
+          ...opt,
+          // Pass the namespace so `find` can construct the url correctly
+          namespaced: namespace,
+          // Ensure that find calls watch with no revision (otherwise it'll use the revision from the resource which is probably stale)
+          revision:   null
+        },
       });
       commit('clearInError', params);
 

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -647,11 +647,9 @@ const defaultActions = {
           revision:   null
         },
       });
-      commit('clearInError', params);
 
       return;
     }
-
     let have, want;
 
     if ( selector ) {
@@ -856,14 +854,14 @@ const defaultActions = {
     const err = msg.data?.error?.toLowerCase();
 
     if ( err.includes('watch not allowed') ) {
-      commit('setInError', { type: msg.resourceType, reason: NO_WATCH });
+      commit('setInError', { msg, reason: NO_WATCH });
     } else if ( err.includes('failed to find schema') ) {
-      commit('setInError', { type: msg.resourceType, reason: NO_SCHEMA });
+      commit('setInError', { msg, reason: NO_SCHEMA });
     } else if ( err.includes('too old') ) {
       // Set an error for (all) subs of this type. This..
       // 1) blocks attempts by resource.stop to resub (as type is in error)
       // 2) will be cleared when resyncWatch --> watch (with force) --> resource.start completes
-      commit('setInError', { type: msg.resourceType, reason: REVISION_TOO_OLD });
+      commit('setInError', { msg, reason: REVISION_TOO_OLD });
       dispatch('resyncWatch', msg);
     }
   },
@@ -1035,10 +1033,10 @@ const defaultMutations = {
     }
   },
 
-  setInError(state, msg) {
+  setInError(state, { msg, reason }) {
     const key = keyForSubscribe(msg);
 
-    state.inError[key] = msg.reason;
+    state.inError[key] = reason;
   },
 
   clearInError(state, msg) {


### PR DESCRIPTION
This is a backport of https://github.com/rancher/dashboard/pull/10579 and only contains cherry-picked commits from that PR

Fixes #10567

> Requires a 2.7.next1 RC OR locally built rancher from `release/2.7` to validate. Apart from that steps are no different from any of the others in this chain

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes

