### PR TITLE
Add Fleet and Cattle health boxes in Dashboard Page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2065,6 +2065,8 @@ clusterIndexPage:
       etcd: Etcd
       scheduler: Scheduler
       controller-manager: Controller Manager
+      cattle: Cattle
+      fleet: Fleet
     certs:
       label: Certificates
 

--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -1,0 +1,113 @@
+import { clone } from '@shell/utils/object';
+import Dashboard from '@shell/pages/c/_cluster/explorer/index.vue';
+import { shallowMount } from '@vue/test-utils';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+
+describe('page: cluster dashboard', () => {
+  const mountOptions = {
+    computed: { monitoringStatus: () => ({ v1: true, v2: true }) },
+    stubs:    {
+      'n-link': true,
+      LiveDate: true
+    },
+    mocks: {
+      $store: {
+        dispatch: jest.fn(),
+        getters:  {
+          currentCluster: {
+            id:       'cluster',
+            metadata: { creationTimestamp: '' },
+            status:   { provider: 'provider' },
+          },
+          'cluster/inError':   () => false,
+          'cluster/schemaFor': jest.fn(),
+          'cluster/all':       jest.fn(),
+          'i18n/exists':       jest.fn(),
+          'i18n/t':            jest.fn(),
+        }
+      }
+    },
+  };
+
+  describe.each([
+    'etcd',
+    'scheduler',
+    'controller-manager',
+  ])('%p component health box', (componentId) => {
+    it.each([
+      [STATES_ENUM.HEALTHY, 'icon-checkmark', '', []],
+      [STATES_ENUM.HEALTHY, 'icon-checkmark', `foo`, []],
+      [STATES_ENUM.HEALTHY, 'icon-checkmark', `${ componentId }foo`, [{ status: 'True' }]],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', `${ componentId }foo`, [{ status: 'False' }]],
+    ])('should show %p status', (status, iconClass, name, conditions) => {
+      const options = clone(mountOptions);
+
+      options.mocks.$store.getters.currentCluster.status = {
+        provider:          'provider',
+        componentStatuses: [{
+          name,
+          conditions
+        }],
+      };
+
+      const wrapper = shallowMount(Dashboard, options);
+
+      const box = wrapper.find(`[data-testid="k8s-service-${ componentId }"]`);
+      const icon = box.find('i');
+
+      expect(box.element).toBeDefined();
+      expect(box.element.classList).toContain(status);
+      expect(icon.element.classList).toContain(iconClass);
+    });
+  });
+
+  describe.each([
+    ['fleet', true, [
+      [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, '', 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, [{ status: 'False' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, true, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 1],
+      [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, [{ status: 'True' }], 1, 0],
+    ]],
+    ['cattle', false, [
+      [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, '', 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, [{ status: 'False' }], 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 1],
+      [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, [{ status: 'True' }], 1, 0],
+    ]]
+  ])('%p agent health box', (agentId, isLocal, statuses) => {
+    it.each(statuses)('should show %p status', (status, iconClass, isLoaded, disconnected, conditions, readyReplicas, unavailableReplicas) => {
+      const options = clone(mountOptions);
+
+      options.mocks.$store.getters.currentCluster.isLocal = isLocal;
+
+      const agent = {
+        spec:   { replicas: 1 },
+        status: {
+          readyReplicas,
+          unavailableReplicas,
+          conditions
+        }
+      };
+
+      const wrapper = shallowMount(Dashboard, {
+        ...options,
+        data: () => ({
+          [agentId]:     isLoaded ? agent : null,
+          disconnected,
+          canViewAgents: true
+        })
+      });
+
+      const box = wrapper.find(`[data-testid="k8s-service-${ agentId }"]`);
+      const icon = box.find('i');
+
+      expect(box.element).toBeDefined();
+      expect(box.element.classList).toContain(status);
+      expect(icon.element.classList).toContain(iconClass);
+    });
+  });
+});

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -46,6 +46,7 @@ import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
 import Certificates from '@shell/components/Certificates';
 import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import TabTitle from '@shell/components/TabTitle';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 
 export const RESOURCES = [NAMESPACE, INGRESS, PV, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.DAEMON_SET, SERVICE];
 
@@ -55,13 +56,6 @@ const K8S_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/serv
 const K8S_METRICS_SUMMARY_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-k8s-components-1/rancher-kubernetes-components?orgId=1';
 const ETCD_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-etcd-nodes-1/rancher-etcd-nodes?orgId=1';
 const ETCD_METRICS_SUMMARY_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-etcd-1/rancher-etcd?orgId=1';
-
-const SERVICE_STATUS = {
-  HEALTHY:     'healthy',
-  WARNING:     'warning',
-  UNHEALTHY:   'unhealthy',
-  UNAVAILABLE: 'unavailable'
-};
 
 const CLUSTER_COMPONENTS = [
   'etcd',
@@ -153,7 +147,7 @@ export default {
       K8S_METRICS_SUMMARY_URL,
       ETCD_METRICS_DETAIL_URL,
       ETCD_METRICS_SUMMARY_URL,
-      SERVICE_STATUS,
+      STATES_ENUM,
       clusterCounts,
       selectedTab:        'cluster-events',
       extensionCards:     getApplicableExtensionEnhancements(this, ExtensionPoint.CARD, CardLocation.CLUSTER_DASHBOARD_CARD, this.$route),
@@ -433,7 +427,7 @@ export default {
 
       // If there's no matching component status, it's "healthy"
       if ( !matching.length ) {
-        return SERVICE_STATUS.HEALTHY;
+        return STATES_ENUM.HEALTHY;
       }
 
       const count = matching.reduce((acc, status) => {
@@ -443,26 +437,26 @@ export default {
       }, 0);
 
       if (!count) {
-        return SERVICE_STATUS.UNHEALTHY;
+        return STATES_ENUM.UNHEALTHY;
       }
 
-      return SERVICE_STATUS.HEALTHY;
+      return STATES_ENUM.HEALTHY;
     },
 
     getAgentStatus(agent, disconnected = false) {
       if (!agent) {
-        return SERVICE_STATUS.UNAVAILABLE;
+        return STATES_ENUM.UNAVAILABLE;
       }
 
       if (disconnected || agent.status.conditions.find((c) => c.status !== 'True')) {
-        return SERVICE_STATUS.UNHEALTHY;
+        return STATES_ENUM.UNHEALTHY;
       }
 
       if (agent.spec.replicas !== agent.status.readyReplicas || agent.status.unavailableReplicas > 0) {
-        return SERVICE_STATUS.WARNING;
+        return STATES_ENUM.WARNING;
       }
 
-      return SERVICE_STATUS.HEALTHY;
+      return STATES_ENUM.HEALTHY;
     },
 
     showActions() {
@@ -630,11 +624,11 @@ export default {
         :class="{[service.status]: true }"
       >
         <i
-          v-if="service.status === SERVICE_STATUS.UNAVAILABLE"
+          v-if="service.status === STATES_ENUM.UNAVAILABLE"
           class="icon icon-spinner icon-spin"
         />
         <i
-          v-else-if="service.status === SERVICE_STATUS.HEALTHY"
+          v-else-if="service.status === STATES_ENUM.HEALTHY"
           class="icon icon-checkmark"
         />
         <i

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -445,7 +445,7 @@ export default {
 
     getAgentStatus(agent, disconnected = false) {
       if (!agent) {
-        return STATES_ENUM.UNAVAILABLE;
+        return STATES_ENUM.IN_PROGRESS;
       }
 
       if (disconnected || agent.status.conditions.find((c) => c.status !== 'True')) {
@@ -624,7 +624,7 @@ export default {
         :class="{[service.status]: true }"
       >
         <i
-          v-if="service.status === STATES_ENUM.UNAVAILABLE"
+          v-if="service.status === STATES_ENUM.IN_PROGRESS"
           class="icon icon-spinner icon-spin"
         />
         <i

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -436,7 +436,7 @@ export default {
         return !conditions ? acc : acc + 1;
       }, 0);
 
-      if (!count) {
+      if (count > 0) {
         return STATES_ENUM.UNHEALTHY;
       }
 

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -620,8 +620,9 @@ export default {
       <div
         v-for="service in clusterServices"
         :key="service.name"
-        class="k8s-component-status"
+        class="k8s-service-status"
         :class="{[service.status]: true }"
+        :data-testid="`k8s-service-${ service.name }`"
       >
         <i
           v-if="service.status === STATES_ENUM.IN_PROGRESS"
@@ -822,7 +823,7 @@ export default {
   margin-bottom: 20px;
 }
 
-.k8s-component-status {
+.k8s-service-status {
   align-items: center;
   display: inline-flex;
   border: 1px solid;

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -122,26 +122,7 @@ export default {
         this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
       }
 
-      this.canViewAgents = !!this.$store.getters['cluster/schemaFor'](WORKLOAD_TYPES.DEPLOYMENT);
-
-      if (this.canViewAgents) {
-        if (!this.currentCluster.isLocal) {
-          this.cattle = await this.$store.dispatch('cluster/find', {
-            type: WORKLOAD_TYPES.DEPLOYMENT,
-            id:   'cattle-system/cattle-cluster-agent'
-          });
-
-          // Scaling Up/Down cattle deployment causes web sockets disconnection;
-          this.interval = setInterval(() => {
-            this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
-          }, 1000);
-        }
-
-        this.fleet = await this.$store.dispatch('cluster/find', {
-          type: WORKLOAD_TYPES.DEPLOYMENT,
-          id:   `${ this.currentCluster.isLocal ? 'cattle-fleet-local-system' : 'cattle-fleet-system' }/fleet-agent`
-        });
-      }
+      await this.loadAgents();
     }
   },
 
@@ -424,6 +405,29 @@ export default {
   },
 
   methods: {
+    async loadAgents() {
+      this.canViewAgents = !!this.$store.getters['cluster/schemaFor'](WORKLOAD_TYPES.DEPLOYMENT);
+
+      if (this.canViewAgents) {
+        if (!this.currentCluster.isLocal) {
+          this.cattle = await this.$store.dispatch('cluster/find', {
+            type: WORKLOAD_TYPES.DEPLOYMENT,
+            id:   'cattle-system/cattle-cluster-agent'
+          });
+
+          // Scaling Up/Down cattle deployment causes web sockets disconnection;
+          this.interval = setInterval(() => {
+            this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
+          }, 1000);
+        }
+
+        this.fleet = await this.$store.dispatch('cluster/find', {
+          type: WORKLOAD_TYPES.DEPLOYMENT,
+          id:   `${ this.currentCluster.isLocal ? 'cattle-fleet-local-system' : 'cattle-fleet-system' }/fleet-agent`
+        });
+      }
+    },
+
     getComponentStatus(field) {
       const matching = (this.currentCluster?.status?.componentStatuses || []).filter((s) => s.name.startsWith(field));
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10517
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We are adding 2 new boxes to show the status of `fleet` and `cattle` deployments in the Cluster's dashboard page.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- `cattle` box will be visible only for downstream clusters
- Added new `warning` status to show when the agents have replicas updating in progress.
- Added new `unavailable` status to show a spinner icon until deployments data are available; this will avoid the pop-up effect of the whole agent's boxes.
- When `cattle` is scaled up or down, the UI loses the web sockets connection; the cattle box will show an error status in this case, but we need to confirm that this is a normal behavior or is a backend bug.

### To reproduce

Fleet:

- Go to either local or downstream cluster -> Dashboard page
- Open a new browser window and Go to Workloads -> Deployments -> `fleet-agent`
- Click on Scale down button
- Check the window with Dashboard open to see Fleet box updates

Cattle:

- Go to a downstream cluster -> Dashboard page
- Open a new browser window and Go to Workloads -> Deployments -> `cattle-cluster-agent`
- Go to side menu -> Click on "Redeploy"
- Check the window with Dashboard open to see Cattle box updates

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Cluster Dashboard -> Health boxes

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Loading spinner

![image](https://github.com/rancher/dashboard/assets/26394656/cef7a999-512e-4b7b-add0-59ce22d043cc)

Fleet

![image](https://github.com/rancher/dashboard/assets/26394656/f2ceaf06-3fb2-4a41-979d-c6da44648675)

![image](https://github.com/rancher/dashboard/assets/26394656/bcb17c91-c36d-42b5-a361-3288dc717c9e)

Cattle

![image](https://github.com/rancher/dashboard/assets/26394656/07660452-c536-4f51-a0a5-6c93ccee9215)

![image](https://github.com/rancher/dashboard/assets/26394656/a0b7e028-95fe-4e00-b072-3c51b9cd13b9)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
