### PR TITLE
automation: fix provisioning tests by disabling global-settings -> server-url test and adding fallback 

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -27,15 +27,11 @@ describe('Settings', { testIsolation: 'off' }, () => {
     });
   });
 
-<<<<<<< Updated upstream
-  it('can update server-url', { tags: ['@globalSettings', '@adminUser'] }, () => {
-=======
   it.skip('can update server-url', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Note: this test fails due to https://github.com/rancher/dashboard/issues/10613
     // This issue is causing e2e provisioning tests to fail
     // skipping this test until issue is resolved
 
->>>>>>> Stashed changes
     // Update setting
     SettingsPagePo.navTo();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://zube.io/rancher/rancher/c/64071
This pr disables server-url test and adds fallback to reset server-url via API call in case the test fails to prevent existing AWS/Azure provisioning tests from failing in the Jenkins pipeline. In the server-url test, the server-url is updated to a bogus url and because of a bug, the test fails to reset the server-url to its original state.

Fix includes:
- disabling the failing server-url test until the bug is fixed https://github.com/rancher/dashboard/issues/10613.
- putting in a fail-safe in an after() hook just in case the test fails in the future to prevent this from happening again.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
