### PR TITLE
Improve LabeledSelect performance

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -153,18 +153,6 @@ export default {
         return;
       }
 
-      // This check is only needed if its possible for an option's label to change without the option's value changing - we can skip this if options are just strings or numbers
-      // HOWEVER even if strings are passed to v-select the 'option' in the slot is normalized to {label: <option>} so we have to check the options prop here instead of the 'option' itself
-      if (typeof this.options[0] === 'object') {
-        const newOption = this.getUpdatedOption(option);
-
-        if (newOption) {
-          const label = get(newOption, this.optionLabel);
-
-          return this.localizedLabel ? this.$store.getters['i18n/t'](label) || label : label;
-        }
-      }
-
       if (this.$attrs['get-option-label']) {
         return this.$attrs['get-option-label'](option);
       }
@@ -179,14 +167,6 @@ export default {
       } else {
         return option;
       }
-    },
-
-    // If the option's label changed in parent but value did not, the label wont be automatically updated here
-    // Ensure that the label being shown is still present in the options prop and find the new one if not
-    getUpdatedOption(option) {
-      const isOutdated = this.options && !this.options.find((opt) => option[this.optionLabel] === opt[this.optionLabel]);
-
-      return isOutdated ? this.options.find((opt) => isEqual(this.reduce(option), this.reduce(opt))) : undefined;
     },
 
     positionDropdown(dropdownList, component, { width }) {

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -5,7 +5,6 @@ import { get } from '@shell/utils/object';
 import { LabeledTooltip } from '@components/LabeledTooltip';
 import VueSelectOverrides from '@shell/mixins/vue-select-overrides';
 import { onClickOption, calculatePosition } from '@shell/utils/select';
-import isEqual from 'lodash/isEqual';
 
 export default {
   name: 'LabeledSelect',

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -133,24 +133,6 @@ describe('component: LabeledSelect', () => {
         // Component is from a library and class is not going to be changed
         expect(wrapper.find('.vs__selected').text()).toBe(translation);
       });
-
-      it.each([
-        [['a'], 'b', 0],
-        [[{ value: 'a', label: 'A' }], { value: 'a', label: 'B' }, 4]
-      ])('should only check for a new label if options are objects', async(options: any[], newOption, checkUpdateCalled: number) => {
-        const spyUpdatedOption = jest.spyOn(LabeledSelect.methods, 'getUpdatedOption');
-
-        const wrapper = mount(LabeledSelect, {
-          propsData: {
-            value: 'a',
-            options
-          }
-        });
-
-        await wrapper.setProps({ options: [newOption] });
-
-        expect(spyUpdatedOption).toHaveBeenCalledTimes(checkUpdateCalled);
-      });
     });
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -589,6 +589,7 @@ export default {
       <div class="col span-6">
         <!-- PSA template selector -->
         <LabeledSelect
+          :key="defaultPsaOptionLabel"
           v-model="value.spec.defaultPodSecurityAdmissionConfigurationTemplateName"
           :mode="mode"
           data-testid="rke2-custom-edit-psa"


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9668 

This PR re-introduces https://github.com/rancher/dashboard/issues/8149 

### Occurred changes and/or fixed issues
This PR removes code added to make LabeledSelect option labels more dynamic because it causes a substantial performance hit. I have attempted a partial fix in the past; see https://github.com/rancher/dashboard/pull/9689 for details. Previously I was reluctant to re-introduce #8149 so I improved labeledselect performance only when the options provided are strings, not objects...this solution turns out to be inadequate, as we have some more complex dropdown options in EC2 and EKS

As this PR removes code added to fix #8133 I have added an alternative fix, supplying that LabeledSelect with a key which will force it to re-render if the option label changes. Though it was added for the psa dropdown, it is possible that other code is relying on the functionality in #8149 -- it has been in master for over a year now -- I did my best to look through the codebase but LabeledSelect is used in so many places it is virtually impossible to be certain I haven't broken something. (hence my reluctance to make this change when I looked at the issue previously)

### Areas or cases that should be tested
RKE2 ec2 cluster instance type dropdown is a good example of a massive list


### Areas which could experience regressions
Ensure https://github.com/rancher/dashboard/pull/8133 has not been re-introduced


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
