### PR TITLE
Fix styles for `ResourceCancelModal`

### DIFF
--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -105,10 +105,5 @@ export default {
     & ::-webkit-scrollbar-corner {
       background: rgba(0,0,0,0);
     }
-    & .v--modal-box.v--modal {
-      width: var(--prompt-modal-width) !important;
-      left: unset !important;
-      margin: auto !important;
-    }
   }
 </style>

--- a/shell/components/ResourceCancelModal.vue
+++ b/shell/components/ResourceCancelModal.vue
@@ -50,7 +50,7 @@ export default {
 <template>
   <app-modal
     v-if="showModal"
-    class="confirm-modal"
+    customClass="confirm-modal"
     name="cancel-modal"
     :width="440"
     height="auto"
@@ -99,32 +99,27 @@ export default {
     margin: 0 10px;
   }
 
-  .v--modal-box {
-    background-color: var(--default);
-    box-shadow: none;
-    min-height: 200px;
-    .body {
-      min-height: 75px;
-      padding: 10px 0 0 15px;
-      p {
-        margin-top: 10px;
-      }
+  .body {
+    min-height: 75px;
+    padding: 10px 0 0 15px;
+    p {
+      margin-top: 10px;
     }
-    .header {
-      background-color: var(--error);
-      padding: 15px 0 0 15px;
-      height: 50px;
+  }
+  .header {
+    background-color: var(--error);
+    padding: 15px 0 0 15px;
+    height: 50px;
 
-      h4 {
-        color: white;
-      }
+    h4 {
+      color: white;
     }
-    .footer {
-      border-top: 1px solid var(--border);
-      text-align: center;
-      padding: 10px 0 0 15px;
-      height: 60px;
-    }
+  }
+  .footer {
+    border-top: 1px solid var(--border);
+    text-align: center;
+    padding: 10px 0 0 15px;
+    height: 60px;
   }
 }
 </style>

--- a/shell/dialog/RotateCertificatesDialog.vue
+++ b/shell/dialog/RotateCertificatesDialog.vue
@@ -201,25 +201,4 @@ export default {
       min-width: 260px;
     }
   }
-
-.rotate-modal ::v-deep.v--modal-box{
-  border:none;
-
-  & .card-container{
-    margin: 0;
-
-    & .card-wrap {
-      display:flex;
-      flex-direction:column;
-    }
-
-    & .card-body {
-      flex: 1;
-    }
-
-    & .card-actions{
-      align-self: center
-    };
-  }
-}
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the styles for `ResourceCancelModal.vue` so that the modal will render as it did before #10591 merged. 

Fixes #10648
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Use `customClass` prop for `app-modal`
- Remove `v--modal-box` styles - a quick review reveals that these styles weren't being applied to the original modal either, so they are not needed
- Keep styles `.header`, `.body`, and `.footer`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This can be tested as a part of any "Edit as YAML" form. For example:

1. Navigate to Local Cluster => Storage => ConfigMaps
2. Click on "Create"
3. Click on "Edit as YAML"
4. Click on "Back to Form"

Observe the design of the modal, it should match the original design from v2.8.x

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### New

![back-to-form-new](https://github.com/rancher/dashboard/assets/835961/e6d406dd-1684-43fe-a024-749763e4514b)

#### Original (v2.8.0)

![back-to-form-org](https://github.com/rancher/dashboard/assets/835961/07df36bc-6abd-4d6d-a5ed-380e669ff8f3)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
