### PR TITLE
Add vGpus field in Harvester clusters provision

### DIFF
--- a/pkg/harvester-manager/l10n/en-us.yaml
+++ b/pkg/harvester-manager/l10n/en-us.yaml
@@ -20,3 +20,7 @@ harvesterManager:
     addLabel: Add Workload Selector
     topologyKey:
       placeholder: 'topology.kubernetes.io/zone'
+  vGpu:
+    title: VGPUs
+    label: VGPU type
+    placeholder: 'Please select a VGPU'

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -1307,6 +1307,7 @@ export default {
         <div>
           <ArrayListSelect
             v-model="vGpus"
+            class="mt-20"
             :array-list-props="{ addAllowed: true, mode, disabled }"
             :select-props="{ mode, disabled }"
             :options="vGpuOptions"

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -1307,13 +1307,10 @@ export default {
         <div>
           <ArrayListSelect
             v-model="vGpus"
-            :array-list-props="{ addAllowed: true }"
-            :mode="mode"
-            :disabled="disabled"
+            :array-list-props="{ addAllowed: true, mode, disabled }"
+            :select-props="{ mode, disabled }"
             :options="vGpuOptions"
-            :clearable="true"
             label-key="harvesterManager.vGpu.label"
-            :placeholder="t('harvesterManager.vGpu.placeholder')"
             @input="updateVGpu"
           />
         </div>

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -11,6 +11,7 @@ import InfoBox from '@shell/components/InfoBox';
 import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import ArrayListSelect from '@shell/components/form/ArrayListSelect';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import UnitInput from '@shell/components/form/UnitInput';
 import YamlEditor from '@shell/components/YamlEditor';
@@ -79,11 +80,13 @@ const SOURCE_TYPE = {
   IMAGE:  'image',
 };
 
+const VGPU_PREFIX = { NVIDIA: 'nvidia.com/' };
+
 export default {
   name: 'ConfigComponentHarvester',
 
   components: {
-    Checkbox, draggable, Loading, LabeledSelect, LabeledInput, UnitInput, Banner, YamlEditor, NodeAffinity, PodAffinity, InfoBox
+    ArrayListSelect, Checkbox, draggable, Loading, LabeledSelect, LabeledInput, UnitInput, Banner, YamlEditor, NodeAffinity, PodAffinity, InfoBox
   },
 
   mixins: [CreateEditView],
@@ -321,6 +324,7 @@ export default {
 
     vmAffinity = { affinity: clone(vmAffinityObj) };
 
+    let vGpus = [];
     let networkData = '';
     let userData = '';
     let installAgent;
@@ -348,6 +352,12 @@ export default {
         networkDataIsBase64 = false;
         networkData = this.value.networkData;
       }
+    }
+
+    if (this.value.vgpuInfo) {
+      const vGPURequests = JSON.parse(this.value.vgpuInfo)?.vGPURequests;
+
+      vGpus = vGPURequests?.map((r) => r.deviceName?.replace(VGPU_PREFIX.NVIDIA, '')).filter((r) => r) || [];
     }
 
     return {
@@ -378,7 +388,8 @@ export default {
       userDataIsBase64,
       networkDataIsBase64,
       vmAffinityIsBase64,
-      SOURCE_TYPE
+      SOURCE_TYPE,
+      vGpus,
     };
   },
 
@@ -448,6 +459,21 @@ export default {
         topologyKeyPlaceholder: this.t('harvesterManager.affinity.topologyKey.placeholder')
       };
     },
+
+    vGpuOptions() {
+      const vGpus = this.allNodeObjects.reduce((acc, node) => {
+        const nodeVGpus = Object.keys(node.status.allocatable || {})
+          .filter((k) => k.startsWith(VGPU_PREFIX.NVIDIA) && node.status.allocatable[k] > 0)
+          .map((k) => k.replace(VGPU_PREFIX.NVIDIA, '')) || [];
+
+        return [
+          ...acc,
+          ...nodeVGpus
+        ];
+      }, []);
+
+      return vGpus.filter((x) => !this.vGpus.includes(x));
+    }
   },
 
   watch: {
@@ -810,6 +836,19 @@ export default {
           message: this.t('harvesterManager.rke.templateError')
         }, { root: true });
       }
+    },
+
+    updateVGpu() {
+      const vGPURequests = this.vGpus?.filter((name) => name).reduce((acc, name, i) => ([
+        ...acc,
+        {
+          name:       `vgpu${ i + 1 }`,
+          deviceName: `${ VGPU_PREFIX.NVIDIA }${ name }`
+        }
+      ])
+      , []);
+
+      this.value.vgpuInfo = vGPURequests.length > 0 ? JSON.stringify({ vGPURequests }) : '';
     },
 
     addCloudConfigComment(value) {
@@ -1262,6 +1301,23 @@ export default {
       </button>
 
       <portal :to="'advanced-'+uuid">
+        <h3 class="mt-20">
+          {{ t("harvesterManager.vGpu.title") }}
+        </h3>
+        <div>
+          <ArrayListSelect
+            v-model="vGpus"
+            :array-list-props="{ addAllowed: true }"
+            :mode="mode"
+            :disabled="disabled"
+            :options="vGpuOptions"
+            :clearable="true"
+            label-key="harvesterManager.vGpu.label"
+            :placeholder="t('harvesterManager.vGpu.placeholder')"
+            @input="updateVGpu"
+          />
+        </div>
+
         <h3 class="mt-20">
           {{ t("cluster.credential.harvester.userData.title") }}
         </h3>

--- a/shell/components/form/ArrayListSelect.vue
+++ b/shell/components/form/ArrayListSelect.vue
@@ -87,6 +87,6 @@ export default {
 
 <style lang="scss" scoped>
 ::v-deep .unlabeled-select {
-    height: 61px;
-}
+  height: 61px;
+  }
 </style>

--- a/shell/components/form/ArrayListSelect.vue
+++ b/shell/components/form/ArrayListSelect.vue
@@ -37,7 +37,7 @@ export default {
     },
 
     addAllowed() {
-      return this.filteredOptions.length > 0;
+      return this.arrayListProps?.addAllowed || this.filteredOptions.length > 0;
     },
 
     defaultAddValue() {
@@ -48,7 +48,7 @@ export default {
   methods: {
     updateRow(index, value) {
       this.value.splice(index, 1, value);
-      this.$emit(value);
+      this.$emit('input', this.value);
     },
     calculateOptions(value) {
       const valueOption = this.options.find((o) => o.value === value);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10588
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We are adding the possibility to select a list of `vGpus` to assign to Harvester clusters. The list of available vGpus needs to be enabled in Harvester first.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It will also fix a bug in ArrayListSelect component when emitting new `input` event.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

`harvester.vue` component

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/rancher/dashboard/assets/26394656/4ea018a1-c31a-4f76-a667-7579fe9c3dcf)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
