### PR TITLE
Fix `updateNamespaces` to preserve compatibility with old Harvester versions

### DIFF
--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -615,7 +615,9 @@ export const mutations = {
     state.isRancherInHarvester = neu;
   },
 
-  updateNamespaces(state, { filters, all, getters }) {
+  updateNamespaces(state, opt) {
+    const { filters, all } = opt;
+
     state.namespaceFilters = filters.filter((x) => !!x);
 
     if ( all ) {
@@ -623,7 +625,7 @@ export const mutations = {
     }
     // Create map that can be used to efficiently check if a
     // resource should be displayed
-    getActiveNamespaces(state, getters);
+    getActiveNamespaces(state, opt.getters || getters);
   },
 
   changeAllNamespaces(state, namespace) {

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -615,17 +615,16 @@ export const mutations = {
     state.isRancherInHarvester = neu;
   },
 
-  updateNamespaces(state, opt) {
-    const { filters, all } = opt;
-
+  updateNamespaces(state, { filters, all, getters: optGetters }) {
     state.namespaceFilters = filters.filter((x) => !!x);
 
     if ( all ) {
       state.allNamespaces = all;
     }
-    // Create map that can be used to efficiently check if a
-    // resource should be displayed
-    getActiveNamespaces(state, opt.getters || getters);
+    // - Create map that can be used to efficiently check if a resource should be displayed.
+    // - The 'getters' parameter is required to preserve compatibility with older Harvester's versions in embedded mode.
+    //   see https://github.com/rancher/dashboard/issues/10647
+    getActiveNamespaces(state, optGetters || getters);
   },
 
   changeAllNamespaces(state, namespace) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10647
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

This fix is required when using Rancher v2.9-head with older Harvester versions (< v1.3.1)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The `getters` param is always null in Harvester store, since it is not pushing the `getters` param:

```
  commit('updateNamespaces', {
    filters: [],
    all:     getters.filterNamespace(),
    // getters
  }, { root: true });
```
and this is causing the `undefined` error in the Rancher dashboard.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
