### PR TITLE
[FIX] Fixed clicking on a group header outside of text not working

### DIFF
--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -49,4 +49,11 @@ export default class ProductNavPo extends ComponentPo {
   navToSideMenuGroupByLabelExistance(label: string, assertion: string): Cypress.Chainable {
     return this.self().should('exist').contains('.accordion.has-children', label).should(assertion);
   }
+
+  /**
+   * Get expanded tab's header
+   */
+  tabHeaders(): Cypress.Chainable {
+    return this.self().find('.header');
+  }
 }

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -51,7 +51,7 @@ export default class ProductNavPo extends ComponentPo {
   }
 
   /**
-   * Get expanded tab's header
+   * Get tab headers
    */
   tabHeaders(): Cypress.Chainable {
     return this.self().find('.header');

--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
@@ -81,13 +81,16 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
 
   it('Clicking on the tab header should navigate', () => {
     const productNavPo = new ProductNavPo();
-    const group = productNavPo.groups().eq(1);
+    const group = productNavPo.groups().eq(1); // First group is 'Workloads'
 
     // Select and expand current top-level group
     group.click();
-    // Go to the second subgroup
-    productNavPo.visibleNavTypes().eq(1).click({ force: true });
-    // Click on a header and confirm it opened
-    productNavPo.tabHeaders().eq(1).click().then((els) => cy.url().should('equal', els[0].baseURI));
+
+    cy.url().then((workloadsUrl) => {
+      // Go to the second subgroup
+      productNavPo.visibleNavTypes().eq(1).click({ force: true });
+      // Clicking back should take us back to workloads
+      productNavPo.tabHeaders().eq(1).click(1, 1).then(() => cy.url().should('equal', workloadsUrl));
+    });
   });
 });

--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
@@ -74,12 +74,12 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
       productNavPo.visibleNavTypes().each((link, idx) => {
         productNavPo.visibleNavTypes().eq(idx)
           .click({ force: true })
-          .then((linkEl) => cy.url().should('equal', linkEl.prop('href')));
+          .then((linkEl) => cy.url().should('contain', linkEl.prop('href')));
       });
     });
   });
 
-  it('Clicking outside of text should still navigate', () => {
+  it('Clicking on the tab header should navigate', () => {
     const productNavPo = new ProductNavPo();
     const group = productNavPo.groups().eq(1);
 

--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
@@ -14,8 +14,7 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
     burgerMenuPo.clusters().eq(0).should('be.visible').click();
   });
 
-  // TODO: #5966: Verify cause of race condition issue making navigation link not trigger #5966
-  it.skip('Can access to first navigation link on click', () => {
+  it('Can access to first navigation link on click', () => {
     const productNavPo = new ProductNavPo();
 
     productNavPo.visibleNavTypes().eq(0).should('be.visible').click()
@@ -24,8 +23,7 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
       });
   });
 
-  // TODO: #5966: Verify cause of race condition issue making navigation link not trigger
-  it.skip('Can open second menu groups on click', () => {
+  it('Can open second menu groups on click', () => {
     const productNavPo = new ProductNavPo();
 
     productNavPo.groups().not('.expanded').eq(0)
@@ -44,8 +42,7 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
     cy.get('@openGroup').find('ul').should('have.length', 0);
   });
 
-  // TODO: #5966: Verify cause of race condition issue making navigation link not trigger
-  it.skip('Should flag second menu group as active on navigation', () => {
+  it('Should flag second menu group as active on navigation', () => {
     const productNavPo = new ProductNavPo();
 
     productNavPo.groups().not('.expanded').eq(0)
@@ -54,8 +51,7 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
     cy.get('@closedGroup').find('.router-link-active').should('have.length.gt', 0);
   });
 
-  // TODO: #5966: Verify cause of race condition issue making navigation link not trigger
-  it.skip('Should access to every navigation provided from the server link, including nested cases, without errors', () => {
+  it('Should access to every navigation provided from the server link, including nested cases, without errors', () => {
     const productNavPo = new ProductNavPo();
     // iterate through top-level groups
 
@@ -81,5 +77,17 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
           .then((linkEl) => cy.url().should('equal', linkEl.prop('href')));
       });
     });
+  });
+
+  it('Clicking outside of text should still navigate', () => {
+    const productNavPo = new ProductNavPo();
+    const group = productNavPo.groups().eq(1);
+
+    // Select and expand current top-level group
+    group.click();
+    // Go to the second subgroup
+    productNavPo.visibleNavTypes().eq(1).click({ force: true });
+    // Click on a header and confirm it opened
+    productNavPo.tabHeaders().eq(1).click().then((els) => cy.url().should('equal', els[0].baseURI));
   });
 });

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -293,7 +293,8 @@ export default {
 
     > A {
       display: block;
-      padding-left: 16px;
+      box-sizing:border-box;
+      height: 33px;
       &:hover{
         text-decoration: none;
       }
@@ -302,6 +303,7 @@ export default {
       }
       > H6 {
         text-transform: none;
+        padding: 8px 0px 8px 16px;
       }
     }
   }
@@ -313,6 +315,7 @@ export default {
         background-color: var(--primary-hover-bg);
 
         h6 {
+          padding: 8px 0px 8px 16px;
           font-weight: bold;
           color: var(--primary-hover-text);
         }
@@ -330,7 +333,6 @@ export default {
   .accordion {
     &.depth-0 {
       > .header {
-        padding: 8px 0;
 
         &.noHover {
           cursor: default;
@@ -339,6 +341,7 @@ export default {
         > H6 {
           text-transform: none;
           padding-left: 16px;
+          padding: 8px 0px 8px 16px;
         }
 
         > I {

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -294,7 +294,7 @@ export default {
     > A {
       display: block;
       box-sizing:border-box;
-      height: 33px;
+      height: 100%;
       &:hover{
         text-decoration: none;
       }
@@ -303,7 +303,7 @@ export default {
       }
       > H6 {
         text-transform: none;
-        padding: 8px 0px 8px 16px;
+        padding: 8px 0 8px 16px;
       }
     }
   }
@@ -315,7 +315,7 @@ export default {
         background-color: var(--primary-hover-bg);
 
         h6 {
-          padding: 8px 0px 8px 16px;
+          padding: 8px 0 8px 16px;
           font-weight: bold;
           color: var(--primary-hover-text);
         }
@@ -340,8 +340,7 @@ export default {
 
         > H6 {
           text-transform: none;
-          padding-left: 16px;
-          padding: 8px 0px 8px 16px;
+          padding: 8px 0 8px 16px;
         }
 
         > I {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10558
<!-- Define findings related to the feature or bug issue. -->
The link element had a padding around that wasn't clickable. Making the link the same size as the tab header fixed the problem.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
I wasn't able to create a test that was failing before the change, so manual testing is required.
Some tests in cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts were disabled pending #5966, which is now closed, so i enabled them back.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Go Local -> Workloads
2. Click on "Jobs" subgroup
3. Click back on "Workloads" below from the text
4. Workloads page should be opened

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!--Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/133266076/d0154e67-9d22-45f0-8929-06cd71f67d7c

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
