### PR TITLE
Update modal styles

### DIFF
--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -150,7 +150,7 @@ export default defineComponent({
       background-color: var(--modal-bg);
       border-radius: var(--border-radius);
       max-height: 95vh;
-      overflow: scroll;
+      overflow: auto;
       border: 2px solid var(--modal-border);
     }
   }

--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -27,7 +27,7 @@ export default defineComponent({
         }
 
         if (typeof value === 'string') {
-          return /^(0*(?:[1-9][0-9]*|0)\.?\d*)+(px|%)$/.test(value) && Number(value) > 0;
+          return /^(0*(?:[1-9][0-9]*|0)\.?\d*)+(px|%)$/.test(value);
         }
 
         return false;

--- a/shell/components/__tests__/AppModal.test.ts
+++ b/shell/components/__tests__/AppModal.test.ts
@@ -67,4 +67,32 @@ describe('appModal', () => {
     expect(container.exists()).toBeTruthy();
     expect(wrapper.find('.modal-container').element.style.width).toBe('50%');
   });
+
+  it('does not generate validation errors when setting a pixel width', async() => {
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    consoleErrorSpy.mockImplementation(() => {});
+
+    await wrapper.setProps({ width: '200px' });
+    const container = wrapper.find('.modal-container');
+
+    expect(container.exists()).toBeTruthy();
+    expect(wrapper.find('.modal-container').element.style.width).toBe('200px');
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('generates validation errors with an invalid string for width', async() => {
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    consoleErrorSpy.mockImplementation(() => {});
+
+    await wrapper.setProps({ width: 'FAIL' });
+    const container = wrapper.find('.modal-container');
+
+    expect(container.exists()).toBeTruthy();
+    expect(wrapper.find('.modal-container').element.style.width).toBe('600px');
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/shell/dialog/AddCustomBadgeDialog.vue
+++ b/shell/dialog/AddCustomBadgeDialog.vue
@@ -285,6 +285,10 @@ export default {
   border: 1px solid var(--default-border);
 }
 
+.text-default-text {
+  margin-bottom: 4px;
+}
+
 .prompt-badge {
   margin: 0;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This addresses a few issues with the `AppModal` component that were detailed in #10661.

Fixes #10661
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Fixes an error with the width validator when a valid string is provided
- Specifies `overflow: auto` on the modal container so that scrollbars are not present in chrome/brave
- Adjusts the bottom margin of the title in `shell/dialog/AddCustomBadgeDialog.vue` so that it appears as properly centered

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Centering of the title was not a regression introduced in #9537, but is a result of the design of the card component. More details can be found here https://github.com/rancher/dashboard/issues/10661#issuecomment-2010031758

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See the issue for more info.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![centered-title](https://github.com/rancher/dashboard/assets/835961/216c6af9-497d-4171-8062-2a9e0cd875c1)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
