### PR TITLE
Revert vue-js-modal removal as required in Harvester

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "url-parse": "1.5.10",
     "v-tooltip": "2.0.3",
     "vue-codemirror": "4.0.6",
+    "vue-js-modal": "1.3.35",
     "vue-resize": "0.4.5",
     "vue-router": "3.6.5",
     "vue-select": "3.18.3",

--- a/shell/initialize/plugins.js
+++ b/shell/initialize/plugins.js
@@ -2,6 +2,7 @@ import '@shell/plugins/extend-router';
 import '@shell/plugins/formatters';
 import '@shell/plugins/global-formatters';
 import '@shell/plugins/i18n';
+import '@shell/plugins/vue-js-modal';
 import '@shell/plugins/js-yaml';
 import '@shell/plugins/portal-vue.js';
 import '@shell/plugins/resize';

--- a/shell/package.json
+++ b/shell/package.json
@@ -122,6 +122,7 @@
     "vue": "2.7.14",
     "clipboard-polyfill": "4.0.1",
     "vue-codemirror": "4.0.6",
+    "vue-js-modal": "1.3.35",
     "vue-resize": "0.4.5",
     "vue-select": "3.18.3",
     "vue-server-renderer": "2.7.14",

--- a/shell/plugins/vue-js-modal.js
+++ b/shell/plugins/vue-js-modal.js
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+import VModal from 'vue-js-modal/dist/ssr.index';
+
+Vue.use(VModal);

--- a/shell/plugins/vue-js-modal.js
+++ b/shell/plugins/vue-js-modal.js
@@ -1,4 +1,4 @@
 import Vue from 'vue';
-import VModal from 'vue-js-modal/dist/ssr.index';
+import VModal from 'vue-js-modal';
 
 Vue.use(VModal);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15387,6 +15387,11 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
+vue-js-modal@1.3.35:
+  version "1.3.35"
+  resolved "https://registry.yarnpkg.com/vue-js-modal/-/vue-js-modal-1.3.35.tgz#5f54de1a30a5f977121bfe6b2a1a5498bce2752a"
+  integrity sha512-DKtxUCW/oprM/ndn9h/cnVgsmqjQ/ARy5rH4q/11Pas04og2td+sltl91H/rlwXTwJIqWyt+lJizK5o4ErjWIQ==
+
 "vue-loader-v16@npm:vue-loader@^16.1.0":
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.8.3.tgz#d43e675def5ba9345d6c7f05914c13d861997087"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10675
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Modal dialogs in Harvester embedded-mode require vue-js-modal package.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
