### PR TITLE
Fix warning messages in Harvester embedded view

### DIFF
--- a/shell/components/formatter/ImagePercentageBar.vue
+++ b/shell/components/formatter/ImagePercentageBar.vue
@@ -37,10 +37,6 @@ export default {
       }];
     },
 
-    state() {
-      return this.row.stateDisplay;
-    },
-
     completed() {
       return Number.parseFloat(this.value) === 100 && !this.failed;
     },

--- a/shell/initialize/App.js
+++ b/shell/initialize/App.js
@@ -37,7 +37,11 @@ export default {
     window.$globalApp = this;
     Object.defineProperty(window, '$nuxt', {
       get() {
-        console.warn('window.$nuxt is deprecated. It would be best to stop using globalState all together. For an alternative you can use window.$globalApp.'); // eslint-disable-line no-console
+        const isHarvester = this.$globalApp?.$store.getters['currentCluster']?.isHarvester;
+
+        if (!isHarvester) {
+          console.warn('window.$nuxt is deprecated. It would be best to stop using globalState all together. For an alternative you can use window.$globalApp.'); // eslint-disable-line no-console
+        }
 
         return window.$globalApp;
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10681
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

We are disabling nuxt warning messages for Harvester clusters / fixing image's error message.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Virtualization Management / Dashboard -> console
- Virtualization Management / Images -> console

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
