### PR TITLE
Move cluster management to top of global apps

### DIFF
--- a/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
@@ -171,7 +171,8 @@ describe('Side Menu: main', () => {
     it('Check first item in global section is Cluster Management', { tags: ['@navigation', '@adminUser', '@standardUser'] }, () => {
       HomePagePo.goTo();
       BurgerMenuPo.categoryByLabel('Global Apps').parent().parent().get('.option-link')
-        .first().should('contain.text', 'Cluster Management');
+        .first()
+        .should('contain.text', 'Cluster Management');
     });
   });
 });

--- a/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
@@ -167,5 +167,11 @@ describe('Side Menu: main', () => {
           });
       });
     });
+
+    it('Check first item in global section is Cluster Management', () => {
+      HomePagePo.goTo();
+      BurgerMenuPo.categoryByLabel('Global Apps').parent().parent().get('.option-link')
+        .first().should('contain.text', 'Cluster Management');
+    });
   });
 });

--- a/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
@@ -168,7 +168,7 @@ describe('Side Menu: main', () => {
       });
     });
 
-    it('Check first item in global section is Cluster Management', () => {
+    it('Check first item in global section is Cluster Management', { tags: ['@navigation', '@adminUser', '@standardUser'] }, () => {
       HomePagePo.goTo();
       BurgerMenuPo.categoryByLabel('Global Apps').parent().parent().get('.option-link')
         .first().should('contain.text', 'Cluster Management');

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -31,6 +31,7 @@ export function init(store) {
     icon:                'cluster-management',
     removable:           false,
     showClusterSwitcher: false,
+    weight:              -1, // Place at the top
     to:                  {
       name:   'c-cluster-product-resource',
       params: {


### PR DESCRIPTION
Fixes #10631

Moves Cluster Management to the top of the Global Apps section in the side bar and adds an e2e test to check this.

Current order in the app bar is:

![image](https://github.com/rancher/dashboard/assets/1955897/bc7d2e2e-24eb-4c55-a4e2-eae5b4ac2c1f)

With the change in this PR, these are swapped, so that Cluster Management is at the top.