### PR TITLE
Replace `createNamespace` pattern with a simple store for sharing data

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -6,7 +6,7 @@ import { SCHEMA, NAMESPACE } from '@shell/config/types';
 import ResourceYaml from '@shell/components/ResourceYaml';
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
-import { mapGetters } from 'vuex';
+import { mapGetters, mapState, mapActions } from 'vuex';
 import { stringify, exceptionToErrorsArray } from '@shell/utils/error';
 import CruResourceFooter from '@shell/components/CruResourceFooter';
 
@@ -158,19 +158,11 @@ export default {
   },
 
   data(props) {
-    this.$on('createNamespace', (e) => {
-      // When createNamespace is set to true,
-      // the UI will attempt to create a new namespace
-      // before saving the resource.
-      this.createNamespace = e;
-    });
-
     const inStore = this.$store.getters['currentStore'](this.resource);
     const schema = this.$store.getters[`${ inStore }/schemaFor`](this.resource.type);
 
     return {
       isCancelModal:   false,
-      createNamespace: false,
       showAsForm:      this.$route.query[AS] !== _YAML,
       /**
        * Initialised on demand (given that it needs to make a request to fetch schema definition)
@@ -249,6 +241,8 @@ export default {
     },
 
     ...mapGetters({ t: 'i18n/t' }),
+    ...mapState('cru-resource', ['createNamespace']),
+    ...mapActions('cru-resource', ['setCreateNamespace']),
 
     /**
      * Prevent issues for malformed types injection
@@ -275,6 +269,14 @@ export default {
     if ( this._selectedSubtype ) {
       this.$emit('select-type', this._selectedSubtype);
     }
+  },
+
+  mounted() {
+    this.$store.dispatch('cru-resource/setCreateNamespace', false);
+  },
+
+  beforeDestroy() {
+    this.$store.dispatch('cru-resource/setCreateNamespace', false);
   },
 
   methods: {

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -20,7 +20,8 @@ describe('component: CruResource', () => {
             'current_store/all':       jest.fn(),
             'i18n/t':                  jest.fn(),
             'i18n/exists':             jest.fn(),
-          }
+          },
+          dispatch: jest.fn(),
         },
         $route:  { query: { AS: _YAML } },
         $router: { applyQuery: jest.fn() },
@@ -54,7 +55,8 @@ describe('component: CruResource', () => {
             'current_store/all':       jest.fn(),
             'i18n/t':                  jest.fn(),
             'i18n/exists':             jest.fn(),
-          }
+          },
+          dispatch: jest.fn(),
         },
         $route:  { query: { AS: _YAML } },
         $router: { applyQuery: jest.fn() },
@@ -87,7 +89,8 @@ describe('component: CruResource', () => {
             'current_store/all':       jest.fn(),
             'i18n/t':                  jest.fn(),
             'i18n/exists':             jest.fn(),
-          }
+          },
+          dispatch: jest.fn(),
         },
         $route:  { query: { AS: _YAML } },
         $router: { applyQuery: jest.fn() },
@@ -126,7 +129,8 @@ describe('component: CruResource', () => {
             'current_store/all':       jest.fn(),
             'i18n/t':                  jest.fn(),
             'i18n/exists':             jest.fn(),
-          }
+          },
+          dispatch: jest.fn(),
         },
         $route:  { query: { AS: _YAML } },
         $router: { applyQuery: jest.fn() },

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -1,6 +1,6 @@
 <script>
 import Vue from 'vue';
-import { mapGetters } from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
 import { get, set } from '@shell/utils/object';
 import { sortBy } from '@shell/utils/sort';
 import { NAMESPACE } from '@shell/config/types';
@@ -215,6 +215,7 @@ export default {
 
   computed: {
     ...mapGetters(['currentProduct', 'currentCluster', 'namespaces', 'allowedNamespaces']),
+    ...mapActions('cru-resource', ['setCreateNamespace']),
     namespaceReallyDisabled() {
       return (
         !!this.forceNamespace || this.namespaceDisabled || this.mode === _EDIT
@@ -381,12 +382,18 @@ export default {
     selectNamespace(e) {
       if (!e || e.value === '') { // The blank value in the dropdown is labeled "Create a New Namespace"
         this.createNamespace = true;
-        this.$parent.$emit('createNamespace', true);
+        this.$store.dispatch(
+          'cru-resource/setCreateNamespace',
+          true,
+        );
         this.$emit('isNamespaceNew', true);
         Vue.nextTick(() => this.$refs.namespace.focus());
       } else {
         this.createNamespace = false;
-        this.$parent.$emit('createNamespace', false);
+        this.$store.dispatch(
+          'cru-resource/setCreateNamespace',
+          false,
+        );
         this.$emit('isNamespaceNew', false);
       }
     },

--- a/shell/config/store.js
+++ b/shell/config/store.js
@@ -38,6 +38,7 @@ let store = {};
   resolveStoreModules(require('../store/uiplugins.ts'), 'uiplugins.ts');
   resolveStoreModules(require('../store/wm.js'), 'wm.js');
   resolveStoreModules(require('../store/customisation.js'), 'customisation.js');
+  resolveStoreModules(require('../store/cru-resource.ts'), 'cru-resource.ts');
 
   // If the environment supports hot reloading...
 
@@ -63,7 +64,8 @@ let store = {};
       '../store/type-map.js',
       '../store/uiplugins.ts',
       '../store/wm.js',
-      '../store/customisation.js'
+      '../store/customisation.js',
+      '../store/cru-resource.ts',
     ], () => {
       // Update `root.modules` with the latest definitions.
       updateModules();

--- a/shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts
@@ -25,7 +25,18 @@ describe('view: management.cattle.io.clusterroletemplatebinding should', () => {
           'i18n/t':                  (val) => val,
           'i18n/exists':             jest.fn(),
         },
-        dispatch: jest.fn(),
+        dispatch: jest.fn((action, payload) => {
+          const actions = {
+            'management/findAll':              () => [],
+            'cru-resource/setCreateNamespace': jest.fn(),
+          };
+
+          if (actions[action]) {
+            return actions[action](payload);
+          }
+
+          throw new Error(`Unknown action: ${ action }`);
+        }),
       },
       $fetchState: { pending: false },
       $route:      { query: { AS: '' } },

--- a/shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts
@@ -25,7 +25,7 @@ describe('view: management.cattle.io.clusterroletemplatebinding should', () => {
           'i18n/t':                  (val) => val,
           'i18n/exists':             jest.fn(),
         },
-        dispatch: { 'management/findAll': () => ([]) }
+        dispatch: jest.fn(),
       },
       $fetchState: { pending: false },
       $route:      { query: { AS: '' } },

--- a/shell/edit/__tests__/management.cattle.io.setting.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.setting.test.ts
@@ -13,7 +13,8 @@ describe('view: management.cattle.io.setting should', () => {
           'current_store/all':       jest.fn(),
           'i18n/t':                  jest.fn(),
           'i18n/exists':             jest.fn(),
-        }
+        },
+        dispatch: jest.fn(),
       },
       $route:  { query: { AS: '' } },
       $router: { applyQuery: jest.fn() },

--- a/shell/store/cru-resource.ts
+++ b/shell/store/cru-resource.ts
@@ -1,0 +1,26 @@
+interface State {
+  createNamespace: boolean;
+}
+
+export const state = (): State => {
+  return { createNamespace: false };
+};
+
+export const mutations = {
+  SET_CREATE_NAMESPACE(state: State, shouldCreateNamespace: boolean): void {
+    state.createNamespace = shouldCreateNamespace;
+  }
+};
+
+export const actions = {
+  setCreateNamespace({ commit }: unknown, shouldCreateNamespace: boolean): void {
+    commit('SET_CREATE_NAMESPACE', shouldCreateNamespace);
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the pattern of `shell/components/form/NameNsDescription.vue` invoking its parent to emit the `createNamespace` event with a simple store. This store is only used to share data with `CruResource.vue` and is used to determine if a namespace should be created.  

<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I opted to use a store in this case in an effort to write something that will be Vue3 compatible without the requirement of additional libraries. An alternative would be to utilize an event bus, but that would require the addition of a dependency like mitt[^1] to remain Vue3 compatible[^2].

[^1]: https://www.npmjs.com/package/mitt
[^2]: https://v3-migration.vuejs.org/breaking-changes/events-api.html#migration-strategy

I also experimented with dynamically registering[^3] this store only when it was required by `CruResource.vue`, but this proved to be problematic; I found that the `flush()` function in `shell/plugins/steve/subscribe.js` was throwing several unhandled exceptions with stores that were not registered:

```
Error: Missing module "cru-resource" for path "cru-resource[vdt]".

...

An error occurred in hook 'getInspectorState' registered by plugin 'org.vuejs.vue2-internal' with payload:

...
```

I gave up on this approach, as it probably wasn't a good pattern in the first place. Dynamic registration is probably best left for plugin code.

[^3]: https://v3.vuex.vuejs.org/guide/modules.html#dynamic-module-registration

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This mostly changes the behavior of the components `NameNsDescription.vue` and `CruResource.vue`.

- When the Namespace dropdown includes a "Create a new namespace" option, it should create a new namespace when that option is selected
- When the Namespace dropdown should not include a new namespace when the "Create a new namespace" options is not selected
 
There are some instances of `NameNsDescription` that are not composed via `CruResource`. These cases should still function as they did before. Interacting with them should not create a new namespace. For reference:

- shell/edit/catalog.cattle.io.clusterrepo.vue
- shell/pages/c/_cluster/apps/charts/install.vue

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/rancher/dashboard/assets/835961/d6f2d6a6-8aca-421f-9cbd-abb833057ce3)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
