### PR TITLE
[FIX] Fixed broken test in product-side-nav.spec

### DIFF
--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
@@ -1,6 +1,7 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 
 Cypress.config();
 describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, () => {
@@ -84,15 +85,16 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
     const group = productNavPo.groups().eq(1); // First group is 'Workloads'
 
     // Select and expand current top-level group
-    group.click().then((workloadsGroup) => {
-      const workloadsUrl = (workloadsGroup.find('a')[0] as HTMLAnchorElement).href;
+    group.click();
+    const workloads = new WorkloadPagePo();
 
+    workloads.waitForPage();
+
+    cy.url().then((workloadsUrl) => {
       // Go to the second subgroup
       productNavPo.visibleNavTypes().eq(1).click({ force: true });
       // Clicking back should take us back to workloads
-      productNavPo.tabHeaders().eq(1).click(1, 1).then(() => {
-        cy.url().should('equal', workloadsUrl);
-      });
+      productNavPo.tabHeaders().eq(1).click(1, 1).then(() => cy.url().should('equal', workloadsUrl));
     });
   });
 });

--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
@@ -84,13 +84,15 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
     const group = productNavPo.groups().eq(1); // First group is 'Workloads'
 
     // Select and expand current top-level group
-    group.click();
+    group.click().then((workloadsGroup) => {
+      const workloadsUrl = (workloadsGroup.find('a')[0] as HTMLAnchorElement).href;
 
-    cy.url().then((workloadsUrl) => {
       // Go to the second subgroup
       productNavPo.visibleNavTypes().eq(1).click({ force: true });
       // Clicking back should take us back to workloads
-      productNavPo.tabHeaders().eq(1).click(1, 1).then(() => cy.url().should('equal', workloadsUrl));
+      productNavPo.tabHeaders().eq(1).click(1, 1).then(() => {
+        cy.url().should('equal', workloadsUrl);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10558
<!-- Define findings related to the feature or bug issue. -->
Needed to wait for the page to load before getting the URL.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
