### PR TITLE
Add new cache states to determine plugin init

### DIFF
--- a/shell/models/catalog.cattle.io.uiplugin.js
+++ b/shell/models/catalog.cattle.io.uiplugin.js
@@ -1,6 +1,10 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
 
-const CACHED_STATUS = 'cached';
+const CACHE_STATE = Object.freeze({
+  CACHED:   'cached',
+  DISABLED: 'disabled',
+  PENDING:  'pending',
+});
 
 export default class UIPlugin extends SteveModel {
   get name() {
@@ -15,13 +19,8 @@ export default class UIPlugin extends SteveModel {
     return this.spec?.plugin?.version;
   }
 
-  get willBeCached() {
-    return this.spec?.plugin?.noCache === false;
-  }
-
-  // Has the plugin been cached?
-  get isCached() {
-    return !this.willBeCached || (this.willBeCached && this.status?.cacheState === CACHED_STATUS);
+  get isInitialized() {
+    return this.status?.cacheState !== CACHE_STATE.PENDING;
   }
 
   get pluginMetadata() {

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -461,7 +461,7 @@ export default {
       neu.forEach((plugin) => {
         const existing = installed.find((p) => !p.removed && p.name === plugin.name && p.version === plugin.version);
 
-        if (!existing && plugin.isCached) {
+        if (!existing && plugin.isInitialized) {
           if (!this.uiErrors[plugin.name]) {
             changes++;
           }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This expands the cases of using the cache state to determine if a plugin has been initialized or not; an initialized plugin can either be in a "cached" or "disabled" state.

Fixes #10639
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- This also removes the getters for `willBeCached()` and `isCached()` as they are unused by Dashboard with this change
- `noCache` can be manually set in the CRD so this isn't a good indicator for determining plugin initialization

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Managing plugins should remain unchanged
- Installing plugins should succeed when cache is disabled.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
