### PR TITLE
Better logging for failed plugin loads

### DIFF
--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -68,7 +68,7 @@ export default async function(context) {
       const res = pluginLoads[name];
 
       if (res?.status === 'rejected') {
-        console.error(`Failed to load plugin: ${ name }`); // eslint-disable-line no-console
+        console.error(`Failed to load plugin: ${ name }. `, res.reason || 'Unknown reason'); // eslint-disable-line no-console
 
         // Record error in the uiplugins store, so that we can show this to the user
         context.store.dispatch('uiplugins/setError', { name, error: 'plugins.error.load' });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Output the actual error that caused the plugin to not load. This will help debugging a lot in user land

### Occurred changes and/or fixed issues
- track the reason the promise failed


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
