### PR TITLE
Tweaks to new cluster switch feature

### DIFF
--- a/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
@@ -85,7 +85,7 @@ describe('Side Menu: main', () => {
       sideNav.navToSideMenuEntryByLabel('Projects/Namespaces');
 
       // press key combo
-      cy.get('body').focus().type('{shift}{alt}', { release: false });
+      cy.get('body').focus().type('{alt}', { release: false });
 
       // assert that icons are displayed for the key combo
       BurgerMenuPo.burguerMenuNavClusterKeyComboIconCheck(0);

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -141,6 +141,7 @@ nav:
   takeSnapshot: Take Snapshot
   seeAllClusters: See all clusters
   seeAllClustersCollapsed: See all
+  keyComboTooltip: Switch clusters and keep location
   group:
     cluster: Cluster
     inUse: More Resources

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -16,7 +16,6 @@ import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/u
 import { getProductFromRoute } from '@shell/utils/router';
 import { isRancherPrime } from '@shell/config/version';
 import Pinned from '@shell/components/nav/Pinned';
-import isObject from 'lodash/isObject';
 
 export default {
   components: {
@@ -365,8 +364,12 @@ export default {
         content = this.shown ? null : contentText;
 
       // if key combo is pressed, then we update the tooltip as well
-      } else if (this.routeCombo && isObject(item) && item.ready) {
-        contentText = 'Switch clusters and keeps location';
+      } else if (this.routeCombo &&
+        typeof item === 'object' &&
+        !Array.isArray(item) &&
+        item !== null &&
+        item.ready) {
+        contentText = this.t('nav.keyComboTooltip');
 
         if (showWhenClosed) {
           content = !this.shown ? contentText : null;
@@ -561,7 +564,7 @@ export default {
                 >
                   <button
                     v-if="c.ready"
-                    v-shortkey.push="{windows: ['alt', 'shift'], mac: ['option', 'shift']}"
+                    v-shortkey.push="{windows: ['alt'], mac: ['option']}"
                     :data-testid="`pinned-menu-cluster-${ c.id }`"
                     class="cluster selector option"
                     :class="{'active-menu-link': checkActiveRoute(c, true) }"
@@ -636,7 +639,7 @@ export default {
                 >
                   <button
                     v-if="c.ready"
-                    v-shortkey.push="{windows: ['alt', 'shift'], mac: ['option', 'shift']}"
+                    v-shortkey.push="{windows: ['alt'], mac: ['option']}"
                     :data-testid="`menu-cluster-${ c.id }`"
                     class="cluster selector option"
                     :class="{'active-menu-link': checkActiveRoute(c, true) }"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10706 

- add missing translation to hardcoded string and adjust of copy 
- change key shortcut to `ALT` key only 
- remove lodash usage
- adjust e2e test
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

**Note:** Pressing `COMMAND + F5` opens a system-like panel in mac OS, which might lead to the "icon" getting stuck and visible. Pressing `ALT` multiple times seems to get it unstuck. We cannot prevent system key combinations from possible overrides and it's side-effects, imo. If there's additional info that might change this, let me know.


https://github.com/rancher/dashboard/assets/97888974/0cb12512-db5f-455d-a802-26003ae52e25



### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Bring up a second cluster in ready state (meaning you can navigate to cluster explorer)
- In that cluster, go to `project/namespaces`
- press the key `alt`
- while pressing the key, make sure the icons appear next to the cluster boxes in the main nav, and click on the `local` cluster
- assert that the route loaded is the `project/namespaces` but in the `local` cluster

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
