### PR TITLE
Add cluster architecture info

### DIFF
--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -9,6 +9,8 @@ const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
 const longClusterDescription = 'this-is-some-really-really-really-really-really-really-long-decription';
 
+const rowDetails = (text) => text.split('\n').map((r) => r.trim()).filter((f) => f);
+
 describe('Home Page', () => {
   it('Confirm correct number of settings requests made', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
     cy.login();
@@ -109,11 +111,11 @@ describe('Home Page', () => {
       });
 
       homeClusterList.version('local').invoke('text').then((el) => {
-        clusterDetails.push(el.trim());
+        clusterDetails.push(rowDetails(el));
       });
 
       homeClusterList.provider('local').invoke('text').then((el) => {
-        clusterDetails.push(el.trim());
+        clusterDetails.push(rowDetails(el));
       });
 
       provClusterList.goTo();
@@ -127,11 +129,17 @@ describe('Home Page', () => {
       });
 
       provClusterList.list().version('local').should((el) => {
-        expect(el).to.include.text(clusterDetails[2]);
+        const version = rowDetails(el.text());
+
+        expect(version[0]).eq(clusterDetails[2][0]);
+        expect(version[1]).eq(clusterDetails[2][1]);
       });
 
       provClusterList.list().provider('local').should((el) => {
-        expect(el).to.include.text(clusterDetails[3]);
+        const provider = rowDetails(el.text());
+
+        expect(provider[0]).eq(clusterDetails[3][0]);
+        expect(provider[1]).eq(clusterDetails[3][1]);
       });
     });
 

--- a/shell/assets/styles/fonts/_icons.scss
+++ b/shell/assets/styles/fonts/_icons.scss
@@ -61,8 +61,8 @@ $icon-inverse:          #fff !default;
   position: relative;
   display: inline-block;
   // width: 2em;
-  height: 2em;
-  line-height: 2em;
+  height: 1em;
+  line-height: 1em;
   vertical-align: middle;
 }
 .icon-stack-1x, .icon-stack-2x {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2423,6 +2423,7 @@ glance:
   pods: Pods
   provider: Provider
   version: Kubernetes Version
+  architecture: Architecture
   monitoringDashboard: Monitoring Dashboard
   installMonitoring: Install Monitoring
   clusterInfo: Cluster Information

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2831,7 +2831,9 @@ landing:
   clusters:
     title: Clusters
     provider: Provider
+    distro: Distro
     kubernetesVersion: Kubernetes Version
+    architecture: Architecture
     explorer: Explorer
     explore: Explore
     cores: |-

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1726,6 +1726,11 @@ cluster:
       }
   rkeTemplateUpgrade: Template revision {name} available for upgrade
 
+  architecture:
+    label:
+      unknown: Unknown
+      mixed: Mixed
+
   availabilityWarnings:
     node: Node {name} is inactive
     machine: Machine {name} is inactive

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -237,11 +237,22 @@ export default {
           class="table-header-container"
           :class="{ 'not-filterable': hasAdvancedFiltering && !col.isFilter }"
         >
-          <span
-            v-if="col.sort"
+          <div
             v-clean-tooltip="tooltip(col)"
+            class="content"
           >
             <span v-clean-html="labelFor(col)" />
+            <span
+              v-if="col.subLabel"
+              class="text-muted"
+            >
+              {{ col.subLabel }}
+            </span>
+          </div>
+          <div
+            v-if="col.sort"
+            class="sort"
+          >
             <i
               v-show="hasAdvancedFiltering && !col.isFilter"
               v-clean-tooltip="t('sortableTable.tableHeader.noFilter')"
@@ -258,11 +269,7 @@ export default {
                 class="icon icon-sort-up icon-stack-1x"
               />
             </span>
-          </span>
-          <span
-            v-else
-            v-clean-tooltip="tooltip(col)"
-          >{{ labelFor(col) }}</span>
+          </div>
         </div>
       </th>
       <th
@@ -413,11 +420,11 @@ export default {
       color: var(--body-text);
 
       .table-header-container {
-        display: inherit;
+        display: flex;
 
-        > span {
+        .content {
           display: flex;
-          align-items: center;
+          flex-direction: column;
         }
 
         &.not-filterable {

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -14,6 +14,7 @@ export const CREATOR_ID = 'field.cattle.io/creatorId';
 export const RESOURCE_QUOTA = 'field.cattle.io/resourceQuota';
 export const AZURE_MIGRATED = 'auth.cattle.io/azuread-endpoint-migrated';
 export const WORKSPACE_ANNOTATION = 'objectset.rio.cattle.io/id';
+export const NODE_ARCHITECTURE = 'kubernetes.io/arch';
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -169,6 +169,7 @@ export function init(store) {
     {
       name:     'kubernetesVersion',
       labelKey: 'tableHeaders.version',
+      subLabel: 'architecture',
       value:    'kubernetesVersion',
       sort:     'kubernetesVersion',
       search:   'kubernetesVersion',
@@ -176,6 +177,7 @@ export function init(store) {
     {
       name:      'provider',
       labelKey:  'tableHeaders.provider',
+      subLabel:  'distro',
       value:     'machineProvider',
       sort:      ['machineProvider', 'provisioner'],
       formatter: 'ClusterProvider',

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -169,7 +169,7 @@ export function init(store) {
     {
       name:     'kubernetesVersion',
       labelKey: 'tableHeaders.version',
-      subLabel: 'architecture',
+      subLabel: 'Architecture',
       value:    'kubernetesVersion',
       sort:     'kubernetesVersion',
       search:   'kubernetesVersion',
@@ -177,7 +177,7 @@ export function init(store) {
     {
       name:      'provider',
       labelKey:  'tableHeaders.provider',
-      subLabel:  'distro',
+      subLabel:  'Distro',
       value:     'machineProvider',
       sort:      ['machineProvider', 'provisioner'],
       formatter: 'ClusterProvider',

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -231,8 +231,11 @@ export default {
           <span>
             {{ row.kubernetesVersion }}
           </span>
-          <div class="text-muted">
-            {{ row.architecture }}
+          <div
+            v-clean-tooltip="{content: row.architecture.tooltip, placement: 'left'}"
+            class="text-muted"
+          >
+            {{ row.architecture.label }}
           </div>
         </td>
       </template>

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -226,6 +226,16 @@ export default {
       <template #cell:summary="{row}">
         <span v-if="!row.stateParts.length">{{ row.nodes.length }}</span>
       </template>
+      <template #col:kubernetesVersion="{row}">
+        <td class="col-name">
+          <span>
+            {{ row.kubernetesVersion }}
+          </span>
+          <div class="text-muted">
+            {{ row.architecture }}
+          </div>
+        </td>
+      </template>
       <template #cell:explorer="{row}">
         <router-link
           v-if="row.mgmt && row.mgmt.isReady && !row.hasError"

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -9,7 +9,7 @@ import { ucFirst } from '@shell/utils/string';
 import { compare } from '@shell/utils/version';
 import { AS, MODE, _VIEW, _YAML } from '@shell/config/query-params';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
-import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { CAPI as CAPI_ANNOTATIONS, NODE_ARCHITECTURE } from '@shell/config/labels-annotations';
 
 /**
  * Class representing Cluster resource.
@@ -401,6 +401,18 @@ export default class ProvCluster extends SteveModel {
 
   get providerLogo() {
     return this.mgmt?.providerLogo;
+  }
+
+  get architecture() {
+    return this.nodes?.reduce((acc, node) => {
+      const arch = node.status?.nodeLabels?.[NODE_ARCHITECTURE];
+
+      if (acc && acc !== arch) {
+        return 'mixed';
+      }
+
+      return arch;
+    }, '');
   }
 
   get kubernetesVersion() {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -408,11 +408,11 @@ export default class ProvCluster extends SteveModel {
     const obj = {};
 
     this.nodes?.forEach((node) => {
-      const key = capitalize(node.status?.nodeLabels?.[NODE_ARCHITECTURE] || '');
+      const architecture = node.status?.nodeLabels?.[NODE_ARCHITECTURE];
 
-      if (key) {
-        obj[key] = (obj[key] || 0) + 1;
-      }
+      const key = architecture ? capitalize(architecture) : this.t('cluster.architecture.label.unknown');
+
+      obj[key] = (obj[key] || 0) + 1;
     });
 
     return obj;
@@ -422,7 +422,7 @@ export default class ProvCluster extends SteveModel {
     const keys = Object.keys(this.nodesArchitecture);
 
     return {
-      label:   keys.length === 1 ? keys[0] : 'Mixed',
+      label:   keys.length === 1 ? keys[0] : this.t('cluster.architecture.label.mixed'),
       tooltip: keys.length === 1 ? undefined : keys.reduce((acc, k) => `${ acc }${ k }: ${ this.nodesArchitecture[k] }<br>`, '')
     };
   }

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -10,6 +10,7 @@ import { compare } from '@shell/utils/version';
 import { AS, MODE, _VIEW, _YAML } from '@shell/config/query-params';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { CAPI as CAPI_ANNOTATIONS, NODE_ARCHITECTURE } from '@shell/config/labels-annotations';
+import capitalize from 'lodash/capitalize';
 
 /**
  * Class representing Cluster resource.
@@ -404,7 +405,7 @@ export default class ProvCluster extends SteveModel {
   }
 
   get architecture() {
-    return this.nodes?.reduce((acc, node) => {
+    const arch = this.nodes?.reduce((acc, node) => {
       const arch = node.status?.nodeLabels?.[NODE_ARCHITECTURE];
 
       if (acc && acc !== arch) {
@@ -413,6 +414,8 @@ export default class ProvCluster extends SteveModel {
 
       return arch;
     }, '');
+
+    return capitalize(arch);
   }
 
   get kubernetesVersion() {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -404,18 +404,27 @@ export default class ProvCluster extends SteveModel {
     return this.mgmt?.providerLogo;
   }
 
-  get architecture() {
-    const arch = this.nodes?.reduce((acc, node) => {
-      const arch = node.status?.nodeLabels?.[NODE_ARCHITECTURE];
+  get nodesArchitecture() {
+    const obj = {};
 
-      if (acc && acc !== arch) {
-        return 'mixed';
+    this.nodes?.forEach((node) => {
+      const key = capitalize(node.status?.nodeLabels?.[NODE_ARCHITECTURE] || '');
+
+      if (key) {
+        obj[key] = (obj[key] || 0) + 1;
       }
+    });
 
-      return arch;
-    }, '');
+    return obj;
+  }
 
-    return capitalize(arch);
+  get architecture() {
+    const keys = Object.keys(this.nodesArchitecture);
+
+    return {
+      label:   keys.length === 1 ? keys[0] : 'Mixed',
+      tooltip: keys.length === 1 ? undefined : keys.reduce((acc, k) => `${ acc }${ k }: ${ this.nodesArchitecture[k] }<br>`, '')
+    };
   }
 
   get kubernetesVersion() {

--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -160,7 +160,7 @@ describe('page: cluster dashboard', () => {
       ['clusterProvider', [], 'other'],
       ['kubernetesVersion', [], '0.0.0 k3s'],
       ['created', [], 'glance.created'],
-      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }, { labels: { [NODE_ARCHITECTURE]: '' } }], 'Mixed'],
+      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }, { labels: { [NODE_ARCHITECTURE]: 'intel' } }], 'Mixed'],
       ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }], 'Amd64'],
     ])('should show %p label', (label, nodes, text) => {
       const options = clone(mountOptions);

--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -160,8 +160,8 @@ describe('page: cluster dashboard', () => {
       ['clusterProvider', [], 'other'],
       ['kubernetesVersion', [], '0.0.0 k3s'],
       ['created', [], 'glance.created'],
-      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }, { labels: { [NODE_ARCHITECTURE]: '' } }], 'mixed'],
-      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }], 'amd64'],
+      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }, { labels: { [NODE_ARCHITECTURE]: '' } }], 'Mixed'],
+      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }], 'Amd64'],
     ])('should show %p label', (label, nodes, text) => {
       const options = clone(mountOptions);
 

--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -160,8 +160,10 @@ describe('page: cluster dashboard', () => {
       ['clusterProvider', [], 'other'],
       ['kubernetesVersion', [], '0.0.0 k3s'],
       ['created', [], 'glance.created'],
-      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }, { labels: { [NODE_ARCHITECTURE]: 'intel' } }], 'Mixed'],
+      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }, { labels: { [NODE_ARCHITECTURE]: 'intel' } }], 'mixed'],
+      ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }, { labels: { } }], 'mixed'],
       ['architecture', [{ labels: { [NODE_ARCHITECTURE]: 'amd64' } }], 'Amd64'],
+      ['architecture', [{ labels: { } }], 'unknown'],
     ])('should show %p label', (label, nodes, text) => {
       const options = clone(mountOptions);
 

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -47,6 +47,7 @@ import Certificates from '@shell/components/Certificates';
 import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import TabTitle from '@shell/components/TabTitle';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+import capitalize from 'lodash/capitalize';
 
 export const RESOURCES = [NAMESPACE, INGRESS, PV, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.DAEMON_SET, SERVICE];
 
@@ -200,7 +201,7 @@ export default {
     },
 
     architecture() {
-      return this.nodes?.reduce((acc, node) => {
+      const arch = this.nodes?.reduce((acc, node) => {
         const arch = node.labels?.[NODE_ARCHITECTURE];
 
         if (acc && acc !== arch) {
@@ -209,6 +210,8 @@ export default {
 
         return arch;
       }, '');
+
+      return capitalize(arch);
     },
 
     isHarvesterCluster() {

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -204,11 +204,11 @@ export default {
       const obj = {};
 
       this.nodes?.forEach((node) => {
-        const key = capitalize(node.labels?.[NODE_ARCHITECTURE] || '');
+        const architecture = node.labels?.[NODE_ARCHITECTURE];
 
-        if (key) {
-          obj[key] = (obj[key] || 0) + 1;
-        }
+        const key = architecture ? capitalize(architecture) : this.t('cluster.architecture.label.unknown');
+
+        obj[key] = (obj[key] || 0) + 1;
       });
 
       return obj;
@@ -218,7 +218,7 @@ export default {
       const keys = Object.keys(this.nodesArchitecture);
 
       return {
-        label:   keys.length === 1 ? keys[0] : 'Mixed',
+        label:   keys.length === 1 ? keys[0] : this.t('cluster.architecture.label.mixed'),
         tooltip: keys.length === 1 ? undefined : keys.reduce((acc, k) => `${ acc }${ k }: ${ this.nodesArchitecture[k] }<br>`, '')
       };
     },

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -17,6 +17,7 @@ import {
   CATALOG,
   SECRET
 } from '@shell/config/types';
+import { NODE_ARCHITECTURE } from '@shell/config/labels-annotations';
 import { setPromiseResult } from '@shell/utils/promise';
 import AlertTable from '@shell/components/AlertTable';
 import { Banner } from '@components/Banner';
@@ -196,6 +197,18 @@ export default {
       }
 
       return this.t(`cluster.provider.${ provider }`);
+    },
+
+    architecture() {
+      return this.nodes?.reduce((acc, node) => {
+        const arch = node.labels?.[NODE_ARCHITECTURE];
+
+        if (acc && acc !== arch) {
+          return 'mixed';
+        }
+
+        return arch;
+      }, '');
     },
 
     isHarvesterCluster() {
@@ -529,7 +542,7 @@ export default {
     <div
       class="cluster-dashboard-glance"
     >
-      <div>
+      <div data-testid="clusterProvider__label">
         <label>{{ t('glance.provider') }}: </label>
         <span v-if="isHarvesterCluster">
           <a
@@ -543,7 +556,7 @@ export default {
           {{ displayProvider }}
         </span>
       </div>
-      <div>
+      <div data-testid="kubernetesVersion__label">
         <label>{{ t('glance.version') }}: </label>
         <span>{{ currentCluster.kubernetesVersionBase }}</span>
         <span
@@ -551,7 +564,14 @@ export default {
           style="font-size: 0.75em"
         >{{ currentCluster.kubernetesVersionExtension }}</span>
       </div>
-      <div>
+      <div
+        v-if="nodes.length > 0"
+        data-testid="architecture__label"
+      >
+        <label>{{ t('glance.architecture') }}: </label>
+        <span>{{ architecture }}</span>
+      </div>
+      <div data-testid="created__label">
         <label>{{ t('glance.created') }}: </label>
         <span><LiveDate
           :value="currentCluster.metadata.creationTimestamp"

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -200,18 +200,27 @@ export default {
       return this.t(`cluster.provider.${ provider }`);
     },
 
-    architecture() {
-      const arch = this.nodes?.reduce((acc, node) => {
-        const arch = node.labels?.[NODE_ARCHITECTURE];
+    nodesArchitecture() {
+      const obj = {};
 
-        if (acc && acc !== arch) {
-          return 'mixed';
+      this.nodes?.forEach((node) => {
+        const key = capitalize(node.labels?.[NODE_ARCHITECTURE] || '');
+
+        if (key) {
+          obj[key] = (obj[key] || 0) + 1;
         }
+      });
 
-        return arch;
-      }, '');
+      return obj;
+    },
 
-      return capitalize(arch);
+    architecture() {
+      const keys = Object.keys(this.nodesArchitecture);
+
+      return {
+        label:   keys.length === 1 ? keys[0] : 'Mixed',
+        tooltip: keys.length === 1 ? undefined : keys.reduce((acc, k) => `${ acc }${ k }: ${ this.nodesArchitecture[k] }<br>`, '')
+      };
     },
 
     isHarvesterCluster() {
@@ -572,7 +581,9 @@ export default {
         data-testid="architecture__label"
       >
         <label>{{ t('glance.architecture') }}: </label>
-        <span>{{ architecture }}</span>
+        <span v-clean-tooltip="architecture.tooltip">
+          {{ architecture.label }}
+        </span>
       </div>
       <div data-testid="created__label">
         <label>{{ t('glance.created') }}: </label>

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -451,8 +451,11 @@ export default {
                     <span>
                       {{ row.kubernetesVersion }}
                     </span>
-                    <div class="text-muted">
-                      {{ row.architecture }}
+                    <div
+                      v-clean-tooltip="{content: row.architecture.tooltip, placement: 'left'}"
+                      class="text-muted"
+                    >
+                      {{ row.architecture.label }}
                     </div>
                   </td>
                 </template>

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -166,15 +166,16 @@ export default {
         },
         {
           label:     this.t('landing.clusters.provider'),
+          subLabel:  this.t('landing.clusters.distro'),
           value:     'mgmt.status.provider',
           name:      'Provider',
           sort:      ['mgmt.status.provider'],
           formatter: 'ClusterProvider'
         },
         {
-          label: this.t('landing.clusters.kubernetesVersion'),
-          value: 'kubernetesVersion',
-          name:  'Kubernetes Version'
+          label:    this.t('landing.clusters.kubernetesVersion'),
+          subLabel: this.t('landing.clusters.architecture'),
+          name:     'kubernetesVersion',
         },
         {
           label: this.t('tableHeaders.cpu'),
@@ -442,6 +443,16 @@ export default {
                       >
                         {{ row.description }}
                       </p>
+                    </div>
+                  </td>
+                </template>
+                <template #col:kubernetesVersion="{row}">
+                  <td class="col-name">
+                    <span>
+                      {{ row.kubernetesVersion }}
+                    </span>
+                    <div class="text-muted">
+                      {{ row.architecture }}
                     </div>
                   </td>
                 </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10382
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Adding cluster `architecture` info in various places:

- Homepage, Clusters table
  - adding 'Distro' sub-label to Provider column.
  - adding 'Architecture' sub-label to Kubernetes Version column.
  - adding architecture info in Kubernetes Version cells
- Cluster Management, Clusters table
  - same
- Cluster Dashboard, for each cluster
  - adding the new 'Architecture' on top of the page.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- `SortableTable` component: fixed css -> header's alignment for tables containing columns with `subLabel`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Clusters tables

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- SortableTable component

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Homepage

![image](https://github.com/rancher/dashboard/assets/26394656/56986680-8616-4df1-bb13-3f475637bcf9)

Cluster Management

![image](https://github.com/rancher/dashboard/assets/26394656/c80cae1f-40bd-43e2-b70e-c4a4c166d05e)

Cluster Dashboard (local)

![image](https://github.com/rancher/dashboard/assets/26394656/ad5b7b94-9f8c-455a-ad2d-a1afc92b7ec0)

Tooltips

- mixed

![image](https://github.com/rancher/dashboard/assets/26394656/770ad9e9-4477-4231-aa62-20ee364b015b)

![image](https://github.com/rancher/dashboard/assets/26394656/8c93eb32-842f-46d0-addc-b028c7ea6779)


- mixed, one is unknown

![image](https://github.com/rancher/dashboard/assets/26394656/ca6aa54c-5063-4699-ad5b-4bdd48e396c6)

![image](https://github.com/rancher/dashboard/assets/26394656/2d984021-1456-4d97-8976-3a540e78c98c)

- all are unknown

![image](https://github.com/rancher/dashboard/assets/26394656/656d769e-06cf-482e-a9ef-f0cc8c12f3bd)

![image](https://github.com/rancher/dashboard/assets/26394656/e36d8c4e-de30-4991-91ce-b07fa573ce55)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
