### PR TITLE
Fix AKS node pool and node resource group validation

### DIFF
--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -126,7 +126,9 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="pool">
+  <div
+    class="pool"
+  >
     <div class="row mb-10">
       <div class="col span-3">
         <LabeledInput
@@ -136,6 +138,7 @@ export default defineComponent({
           required
           :disabled="!pool._isNewOrUnprovisioned"
           :rules="[()=>pool._validName === false ? t('aks.errors.poolName') : undefined]"
+          data-testid="pool-name"
         />
       </div>
       <div class="col span-3">

--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -52,7 +52,7 @@ export default defineComponent({
     canUseAvailabilityZones: {
       type:    Boolean,
       default: true
-    }
+    },
   },
 
   data() {
@@ -135,6 +135,7 @@ export default defineComponent({
           label-key="generic.name"
           required
           :disabled="!pool._isNewOrUnprovisioned"
+          :rules="[()=>pool._validName === false ? t('aks.errors.poolName') : undefined]"
         />
       </div>
       <div class="col span-3">

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -202,15 +202,13 @@ export default defineComponent({
         path:  'name',
         rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
       },
-      // {
-      //   path:  'resourceGroup',
-      //   rules: ['resourceGroupRequired', 'resourceGroupLength', 'resourceGroupChars', 'resourceGroupEnd'],
-      // },
+      {
+        path:  'resourceGroup',
+        rules: ['resourceGroupRequired', 'resourceGroupLength', 'resourceGroupChars', 'resourceGroupEnd'],
+      },
       {
         path:  'nodeResourceGroup',
-        rules: ['nodeResourceGroupChars'],
-
-        // rules: ['nodeResourceGroupChars', 'nodeResourceGroupLength', 'nodeResourceGroupEnd'],
+        rules: ['nodeResourceGroupChars', 'nodeResourceGroupLength', 'nodeResourceGroupEnd'],
       },
       {
         path:  'dnsPrefix',
@@ -230,7 +228,7 @@ export default defineComponent({
       },
       {
         path:  'nodePools',
-        rules: ['availabilityZoneSupport']
+        rules: ['availabilityZoneSupport', 'poolNames']
       },
       {
         path:  'nodePoolsGeneral',
@@ -325,6 +323,25 @@ export default defineComponent({
           }
 
           return undefined;
+        },
+
+        poolNames: () => {
+          let allAvailable = true;
+
+          this.nodePools.forEach((pool: AKSNodePool) => {
+            const name = pool.name || '';
+
+            if (!name.match(/^[a-zA-Z]+[a-zA-Z0-9]*$/)) {
+              this.$set(pool, '_validName', false);
+
+              allAvailable = false;
+            } else {
+              this.$set(pool, '_validName', true);
+            }
+          });
+          if (!allAvailable) {
+            return this.t('aks.errors.poolName');
+          }
         },
 
         k8sVersionAvailable: () => {
@@ -891,7 +908,7 @@ export default defineComponent({
             :key="pool._id"
             :name="pool.name"
             :label="pool.name || t('aks.nodePools.notNamed')"
-            :error="pool._validSize === false || pool._validAZ === false"
+            :error="pool._validSize === false || pool._validAZ === false || pool._validName===false"
           >
             <AksNodePool
               :mode="mode"

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -331,7 +331,7 @@ export default defineComponent({
           this.nodePools.forEach((pool: AKSNodePool) => {
             const name = pool.name || '';
 
-            if (!name.match(/^[a-zA-Z]+[a-zA-Z0-9]*$/)) {
+            if (!name.match(/^[a-z]+[a-z0-9]*$/)) {
               this.$set(pool, '_validName', false);
 
               allAvailable = false;

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -202,13 +202,15 @@ export default defineComponent({
         path:  'name',
         rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
       },
-      {
-        path:  'resourceGroup',
-        rules: ['resourceGroupRequired', 'resourceGroupLength', 'resourceGroupChars', 'resourceGroupEnd'],
-      },
+      // {
+      //   path:  'resourceGroup',
+      //   rules: ['resourceGroupRequired', 'resourceGroupLength', 'resourceGroupChars', 'resourceGroupEnd'],
+      // },
       {
         path:  'nodeResourceGroup',
-        rules: ['nodeResourceGroupChars', 'nodeResourceGroupLength', 'nodeResourceGroupEnd'],
+        rules: ['nodeResourceGroupChars'],
+
+        // rules: ['nodeResourceGroupChars', 'nodeResourceGroupLength', 'nodeResourceGroupEnd'],
       },
       {
         path:  'dnsPrefix',

--- a/pkg/aks/components/__tests__/AksNodePool.test.ts
+++ b/pkg/aks/components/__tests__/AksNodePool.test.ts
@@ -1,0 +1,57 @@
+
+import { shallowMount } from '@vue/test-utils';
+import AksNodePool from '@pkg/aks/components/AksNodePool.vue';
+
+const mockedValidationMixin = {
+  computed: {
+    fvFormIsValid:                jest.fn(),
+    type:                         jest.fn(),
+    fvUnreportedValidationErrors: jest.fn(),
+  },
+  methods: { fvGetAndReportPathRules: jest.fn() }
+};
+
+const mockedStore = () => {
+  return {
+    getters: {
+      'i18n/t':                  (text: string) => text,
+      t:                         (text: string) => text,
+      currentStore:              () => 'current_store',
+      'current_store/schemaFor': jest.fn(),
+      'current_store/all':       jest.fn(),
+      'management/schemaFor':    jest.fn(),
+      'rancher/create':          () => {}
+    },
+    dispatch: jest.fn()
+  };
+};
+
+const mockedRoute = { query: {} };
+
+const requiredSetup = () => {
+  return {
+    mixins: [mockedValidationMixin],
+    mocks:  {
+      $store:      mockedStore(),
+      $route:      mockedRoute,
+      $fetchState: {},
+    }
+  };
+};
+
+describe('aks provisioning form', () => {
+  it('should show an error if a pool has an invalid name', () => {
+    const wrapper = shallowMount(AksNodePool, {
+      propsData: { pool: {}, mode: 'create' },
+      ...requiredSetup()
+    });
+
+    const nameInput = wrapper.find(`[data-testid=pool-name]`);
+
+    expect(nameInput.exists()).toBe(true);
+    expect(nameInput.vm.rules[0]()).toBeUndefined();
+
+    wrapper.setData({ pool: { name: '123-abc', _validName: false } });
+    expect(nameInput.vm.rules[0]()).toBeDefined();
+  });
+});

--- a/pkg/aks/components/__tests__/CruAks.test.ts
+++ b/pkg/aks/components/__tests__/CruAks.test.ts
@@ -196,4 +196,20 @@ describe('aks provisioning form', () => {
     expect(wrapper.vm.config.userAssignedIdentity).toBeUndefined();
     expect(wrapper.vm.config.managedIdentity).toBeUndefined();
   });
+
+  it('should prevent saving if a node pool has an invalid name', async() => {
+    const config = {
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', nodePools: [{ name: 'abc' }]
+    };
+    const wrapper = shallowMount(CruAks, {
+      propsData: {
+        value: {}, mode: 'edit', config
+      },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper, config);
+
+    expect(wrapper.vm.fvFormIsValid).toHaveLength(0);
+  });
 });

--- a/pkg/aks/components/__tests__/CruAks.test.ts
+++ b/pkg/aks/components/__tests__/CruAks.test.ts
@@ -199,7 +199,7 @@ describe('aks provisioning form', () => {
 
   it('should prevent saving if a node pool has an invalid name', async() => {
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', nodePools: [{ name: 'abc' }]
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {
@@ -209,7 +209,17 @@ describe('aks provisioning form', () => {
     });
 
     await setCredential(wrapper, config);
+    await wrapper.setData({ nodePools: [{ name: 'abc' }] });
+    await wrapper.vm.fvExtraRules.poolNames();
+    expect(wrapper.vm.nodePools.filter((pool) => {
+      return !pool._validName;
+    })).toHaveLength(0);
 
-    expect(wrapper.vm.fvFormIsValid).toHaveLength(0);
+    await wrapper.setData({ nodePools: [{ name: '123-abc' }, { name: 'abcABC' }, { name: 'abc' }] });
+    await wrapper.vm.fvExtraRules.poolNames();
+
+    expect(wrapper.vm.nodePools.filter((pool) => {
+      return !pool._validName;
+    })).toHaveLength(2);
   });
 });

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -157,3 +157,4 @@ aks:
     outboundType: Load Balancer SKU must be 'standard' to use user defined routing.
     availabilityZones: Availability zones are not available in the selected region.
     privateDnsZone: The Private DNS Zone Resource ID should be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io
+    poolName: Node pool names must be 1-12 characters long, consist only of letters and numbers, and start with a letter.

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -157,4 +157,4 @@ aks:
     outboundType: Load Balancer SKU must be 'standard' to use user defined routing.
     availabilityZones: Availability zones are not available in the selected region.
     privateDnsZone: The Private DNS Zone Resource ID should be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io
-    poolName: Node pool names must be 1-12 characters long, consist only of letters and numbers, and start with a letter.
+    poolName: Node pool names must be 1-12 characters long, consist only of lowercase letters and numbers, and start with a letter.

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -144,7 +144,7 @@ aks:
     virtualNetworks: 'An error occured while fetching the available virtual networks: {e}'
     kubernetesVersions: 'An error occured while fetching the available kubernetes versions: {e}'
     clusterName: 
-      chars: Name may only contain alphanumerics, underscores, and hyphens.
+      chars: Name may only contain lowercase alphanumerics, underscores, and hyphens.
       startEnd: Name must start and end with an alphanumeric.
       length: Name may not exceed 63 characters.
     resourceGroup:

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -31,7 +31,7 @@ describe('fx: requiredInCluster', () => {
 describe('fx: clusterNameChars', () => {
   it.each([
     ['!!abc!!', MOCK_TRANSLATION],
-    ['123aBc-_', undefined]]
+    ['123ac-abd', undefined]]
   )('returns an error message if the cluster name contains anything other than alphanumerics, underscores, or hyphens', (name, validatorMsg) => {
     const ctx = { ...mockCtx, normanCluster: { name } };
 

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -56,6 +56,21 @@ describe('fx: clusterNameStartEnd', () => {
   });
 });
 
+describe('fx: resourceGroupChars', () => {
+  it.each([
+    ['test-test-test', undefined],
+    ['abc-DEF123-anc', undefined],
+    ['rancher-test-rancher-test-rancher-test-rancher-test-rancher-test-rancher-test-ra!', MOCK_TRANSLATION],
+    ['test-####-test', MOCK_TRANSLATION],
+  ])('returns an error message if node resource group includes invalid characters', (nodeGroupName, validatorMsg) => {
+    const ctx = { ...mockCtx, normanCluster: { aksConfig: { nodeGroupName } } };
+
+    const validator = validators.resourceGroupChars(ctx, '', 'aksConfig.nodeGroupName');
+
+    expect(validator()).toStrictEqual(validatorMsg);
+  });
+});
+
 describe('fx: privateDnsZone', () => {
   it.each([
     ['test-subzone.private.eastus2.azmk8s.io', undefined],

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -67,10 +67,9 @@ export const resourceGroupLength = (ctx: any, labelKey:string, clusterPath:strin
 export const resourceGroupChars = (ctx: any, labelKey:string, clusterPath:string) => {
   return () :string | undefined => {
     const resourceGroup = get(ctx.normanCluster, clusterPath) || '';
+    const isValid = resourceGroup.match(/^[A-Za-z0-9\p{Lu}\p{Ll}\p{Lt}\p{Lo}\p{Lm}\p{Nd}\.\-_(\)]*$/);
 
-    const isValid = resourceGroup.match(/^([A-Z]|[a-z]|\p{Lu}|\p{Ll}|\p{Lt}|\p{Lo}|\p{Lm}|\p{Nd}|\.|-|_|\(|\))*$/u);
-
-    return isValid ? undefined : ctx.t('aks.errors.resourceGroup.chars', { key: ctx.t(labelKey) });
+    return isValid || !resourceGroup.length ? undefined : ctx.t('aks.errors.resourceGroup.chars', { key: ctx.t(labelKey) });
   };
 };
 

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -28,7 +28,7 @@ export const requiredInCluster = (ctx: any, labelKey: string, clusterPath: strin
 export const clusterNameChars = (ctx: any ) => {
   return () :string | undefined => {
     const { name = '' } = get(ctx, 'normanCluster');
-    const nameIsValid = name.match(/^([A-Z]|[a-z]|[0-9]|-|_)+$/);
+    const nameIsValid = name.match(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
 
     return !needsValidation(ctx) || nameIsValid ? undefined : ctx.t('aks.errors.clusterName.chars');
   };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10462 #9433 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes the validation used for AKS node and resource group names. 

### Technical notes summary
The previous regular expression used to validate resource group characters caused catastrophic backtracking https://www.regular-expressions.info/catastrophic.html

### Areas or cases that should be tested
* resource group names containing invalid characters
* node pool names containing invalid characters/excessive length


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
