### PR TITLE
Fix fleet health-box in local cluster

### DIFF
--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -96,7 +96,7 @@ describe('page: cluster dashboard', () => {
       const wrapper = shallowMount(Dashboard, {
         ...options,
         data: () => ({
-          [agentId]:     isLoaded ? agent : null,
+          [agentId]:     isLoaded ? agent : 'loading',
           disconnected,
           canViewAgents: true
         })

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -412,7 +412,7 @@ export default {
         try {
           this.fleet = await this.$store.dispatch('cluster/find', {
             type: WORKLOAD_TYPES.DEPLOYMENT,
-            id:   `${ this.currentCluster.isLocal ? 'cattle-fleet-local-system' : 'cattle-fleet-system' }/fleet-agent`
+            id:   `cattle-fleet-system/${ this.currentCluster.isLocal ? 'fleet-controller' : 'fleet-agent' }`,
           });
         } catch (err) {
           this.fleet = null;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10705
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- For the local clusters, there is no fleet-agent - we are now checking the `cattle-fleet-system/fleet-controller` deployment
- Adding 400 errors handling 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Cluster's dashboard page -> health boxes

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
