### PR TITLE
Fix undefined in add-issues-labels action's script

### DIFF
--- a/.github/workflows/scripts/add-issue-labels.js
+++ b/.github/workflows/scripts/add-issue-labels.js
@@ -28,7 +28,7 @@ async function processOpenAction() {
   let didUpdateLabels = false;
 
   // Check we have a QA label
-  if (!labels.includes(QA_DEV_AUTOMATION_LABEL)  && !labels.includes(QA_MANUAL_TEST_LABEL) && !labels.includes(QA_NONE_LABEL)) {
+  if (!labels.includes(QA_DEV_AUTOMATION_LABEL) && !labels.includes(QA_MANUAL_TEST_LABEL) && !labels.includes(QA_NONE_LABEL)) {
 
     // Add the appropriate QA label
     if (labels.includes(TECH_DEBT_LABEL)) {
@@ -46,18 +46,18 @@ async function processOpenAction() {
     }
 
     didUpdateLabels = true;
-}
+  }
 
-// Check we have a Zube label
-const hasZubeLabel = labels.filter((label) => label.name.indexOf('[zube]:') === 0).length > 0;
+  // Check we have a Zube label
+  const hasZubeLabel = labels.filter((label) => label.indexOf('[zube]:') === 0).length > 0;
 
-if (!hasZubeLabel) {
-  labels.push(TRIAGE_LABEL);
-  didUpdateLabels = true;
-}
+  if (!hasZubeLabel) {
+    labels.push(TRIAGE_LABEL);
+    didUpdateLabels = true;
+  }
 
-// Update the labels if we made a change
-if (didUpdateLabels) {
+  // Update the labels if we made a change
+  if (didUpdateLabels) {
     // Update the labels
     const labelsAPI = `${issue.url}/labels`;
     await request.put(labelsAPI, { labels });


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- there's some white space changes as well, auto-updated on save
- fix is `labels.filter((label) => label.name.indexOf('[zube]:') === 0)` to `labels.filter((label) => label.indexOf('[zube]:') === 0)`

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
