### PR TITLE
[Automation] - Adding real cluster support for Imported Generic tests

### DIFF
--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -21,6 +21,10 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
     return this.self().find('.primaryheader h1');
   }
 
+  kubectlCommandForImported() {
+    return this.self().get('code').contains('--insecure');
+  }
+
   machinePoolsList() {
     return new MachinePoolsListPo(this.self().find('[data-testid="sortable-table-list-container"]'));
   }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -405,7 +405,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     });
   });
 
-  describe('Imported', () => {
+  describe('Imported', { tags: ['@jenkins', '@importedCluster'] }, () => {
     const importClusterPage = new ClusterManagerImportGenericPagePo();
 
     describe('Generic', () => {
@@ -435,8 +435,22 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
             spec: {}
           });
         });
-
         detailClusterPage.waitForPage(undefined, 'registration');
+        detailClusterPage.kubectlCommandForImported().then(($value) => {
+          const kubectlCommand = $value.text();
+
+          cy.log(kubectlCommand);
+          cy.exec(kubectlCommand, { failOnNonZeroExit: false }).then((result) => {
+            cy.log(result.stderr);
+            cy.log(result.stdout);
+            expect(result.code).to.eq(0);
+          });
+        });
+        ClusterManagerListPagePo.navTo();
+        clusterList.waitForPage();
+        clusterList.list().state(importGenericName).should('contain', 'Pending');
+        clusterList.list().state(importGenericName).should('contain', 'Waiting');
+        clusterList.list().state(importGenericName).contains('Active', { timeout: 700000 });
       });
 
       it('can navigate to cluster edit page', () => {

--- a/cypress/jenkins/Dockerfile.ci
+++ b/cypress/jenkins/Dockerfile.ci
@@ -1,3 +1,17 @@
 FROM cypress/factory
 
+ARG KUBECTL_VERSION=v1.27.10
+ARG CURL_VERSION=v8.6.0
+
+RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
+    mv kubectl /bin/kubectl && \
+    chmod +x /bin/kubectl
+RUN mkdir -p /root/.kube
+
+RUN wget https://github.com/moparisthebest/static-curl/releases/download/$CURL_VERSION/curl-amd64 && \
+    mv curl-amd64 /bin/curl && \
+    chmod +x /bin/curl
+
+COPY dashboard/imported_config /root/.kube/config
+
 ENTRYPOINT ["bash", "dashboard/cypress/jenkins/cypress.sh"]

--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -76,10 +76,8 @@ node {
             if ("${env.CLEANUP}".toLowerCase() == "true") {
                 try {
                   stage('Clean Test Environment') {  
-                    sh "${WORKSPACE}/bin/corral delete ci"
-                    if ("${env.JOB_TYPE}" == "recurring") {
-                      sh "${WORKSPACE}/bin/corral delete rancher"
-                    }
+                    sh "corrals=\$(${WORKSPACE}/bin/corral list | grep -v \"NAME\" | grep -v \"-\" | cut -d' ' -f 2)" +
+                    "&& for corral in \$corrals; do ${WORKSPACE}/bin/corral delete \$corral; done"
                   }
                 } catch(err) {
                   echo "Error: " + err

--- a/cypress/jenkins/cypress.sh
+++ b/cypress/jenkins/cypress.sh
@@ -7,6 +7,9 @@ pwd
 ls -al
 cd "dashboard"
 
+kubectl version --client=true
+kubectl get nodes
+
 node -v
 yarn add --dev -W mocha mochawesome mochawesome-merge \
   mochawesome-report-generator cypress-multi-reporters \


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
Adds support for using a real cluster during imported cluster tests.

### Occurred changes and/or fixed issues
Updating the `init.sh` script to use a k3s cluster package to create a single node cluster. The information is then stored in the `corral` configuration for later use.

### Technical notes summary
After creating the cluster[ the updates to the corral package](https://github.com/rancherlabs/corral-packages/pull/44) will allow the imported cluster create test to use it. 

Both PRs depend on each other.
https://github.com/rancher/dashboard/pull/10726

### Areas or cases that should be tested
Jenkins pipeline


### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed 
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
