### PR TITLE
Adding noAuth extension loading

### DIFF
--- a/cypress/e2e/po/pages/page.po.ts
+++ b/cypress/e2e/po/pages/page.po.ts
@@ -92,4 +92,8 @@ export default class PagePo extends ComponentPo {
   header() {
     return new HeaderPo();
   }
+
+  extensionScriptImport(name: string) {
+    return this.self().get(`[data-purpose="extension"]`).get(`[id*="${ name }"]`);
+  }
 }

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4194,6 +4194,7 @@ plugins:
   manageRepos: Manage Repositories
   addRancherRepos: Add Rancher Repositories
   manageCharts: Manage Extension Charts
+  warnNoAuth: This version of the extension will be loaded before authentication and will have access to the login process.
   manageCatalog:
     label: Manage Extension Catalogs
     title: Extension

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -4,7 +4,7 @@ import semver from 'semver';
 export const UI_PLUGIN_API_VERSION = '1.2.0';
 export const UI_PLUGIN_HOST_APP = 'rancher-manager';
 
-export const UI_PLUGIN_BASE_URL = '/api/v1/namespaces/cattle-ui-plugin-system/services/http:ui-plugin-operator:80/proxy';
+export const UI_PLUGIN_BASE_URL = '/v1/uiplugins';
 
 export const UI_PLUGIN_NAMESPACE = 'cattle-ui-plugin-system';
 

--- a/shell/plugins/plugin.js
+++ b/shell/plugins/plugin.js
@@ -32,7 +32,7 @@ export default async function(context) {
     // Fetch list of installed plugins from endpoint
     try {
       const res = await context.store.dispatch('management/request', {
-        url:                  `${ UI_PLUGIN_BASE_URL }/index.json`,
+        url:                  `${ UI_PLUGIN_BASE_URL }`,
         method:               'GET',
         headers:              { accept: 'application/json' },
         redirectUnauthorized: false,

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -1106,8 +1106,8 @@ export const actions = {
       QUERY += (IS_SSO in route.query) ? `&${ IS_SSO }` : '';
 
       // Go back to login and force a full page reload, this ensures we unload any dangling resources the user is no longer authorized to use (like extensions).
-      await router.replace(`/auth/login?${ QUERY }`);
-      router.go(0);
+      // We use document instead of router because router does a clunky job of visiting a new page and reloading. In this case it would cause the login page to flash before actually reloading.
+      document.location.href = `/auth/login?${ QUERY }`;
     }
   },
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -1107,7 +1107,9 @@ export const actions = {
 
       // Go back to login and force a full page reload, this ensures we unload any dangling resources the user is no longer authorized to use (like extensions).
       // We use document instead of router because router does a clunky job of visiting a new page and reloading. In this case it would cause the login page to flash before actually reloading.
-      document.location.href = `/auth/login?${ QUERY }`;
+      const base = process.env.routerBase || '/';
+
+      document.location.href = `${ base }auth/login?${ QUERY }`;
     }
   },
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -1105,7 +1105,9 @@ export const actions = {
       // adds IS_SSO query param to login route if logout came with an auth provider enabled
       QUERY += (IS_SSO in route.query) ? `&${ IS_SSO }` : '';
 
-      router.replace(`/auth/login?${ QUERY }`);
+      // Go back to login and force a full page reload, this ensures we unload any dangling resources the user is no longer authorized to use (like extensions).
+      await router.replace(`/auth/login?${ QUERY }`);
+      router.go(0);
     }
   },
 


### PR DESCRIPTION
### Summary
Adding noAuth extension loading. This will allow specific extensions (such as extensions locale or login page modifications) to load even if the user isn't authenticated.

Fixes #9814
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
- When extensions are installed
- Extensions before a user logs in
- Extensions after a user logs in
- Extensions after a user logs out
- A cluster with 2 versions of harvester and navigating between the two separate instances

### Areas which could experience regressions
- When extensions are installed
- Extensions before a user logs in
- Extensions after a user logs in
- Extensions after a user logs out
- A cluster with 2 versions of harvester and navigating between the two separate instances

### Screenshot/Video
To test you can used the extensions in this repo https://github.com/rancher/ui-plugin-charts.
The uk-locale extension is one that can be loaded without authentication.

To verify you can check to see if the locale is present at the login screen:
![image](https://github.com/rancher/dashboard/assets/55104481/da6d51b4-0f19-4252-aa27-b4eb8e2d2f35)

You can also verify that the script tags are present in the head tag:
![image](https://github.com/rancher/dashboard/assets/55104481/57eeb51d-ae7c-446c-b8b7-a3a9d7ecfb39)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
