### PR TITLE
10159: add e2e test

### DIFF
--- a/cypress/e2e/po/components/network-tab.po.ts
+++ b/cypress/e2e/po/components/network-tab.po.ts
@@ -1,0 +1,12 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
+
+export default class NetworkTabPo extends ComponentPo {
+  constructor(selector = '.dashboard-root') {
+    super(selector);
+  }
+
+  truncateHostnameCheckbox(): CheckboxInputPo {
+    return new CheckboxInputPo('[data-testid="network-tab-truncate-hostname"]');
+  }
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po.ts
@@ -3,6 +3,7 @@ import AgentConfigurationRke2 from '@/cypress/e2e/po/components/agent-configurat
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import RegistriesTabPo from '@/cypress/e2e/po/components/registries-tab.po';
+import NetworkTabPo from '@/cypress/e2e/po/components/network-tab.po';
 
 /**
  * Create page for an RKE2 custom cluster
@@ -38,5 +39,9 @@ export default class ClusterManagerCreateRke2CustomPagePo extends ClusterManager
 
   registries(): RegistriesTabPo {
     return new RegistriesTabPo();
+  }
+
+  network(): NetworkTabPo {
+    return new NetworkTabPo();
   }
 }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -115,7 +115,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
             name: rke2CustomName
           },
           // Test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
-          spec: { rkeConfig: { machineGlobalConfig: { cni: 'none' } } }
+          spec: { rkeConfig: { machineGlobalConfig: { cni: 'none' }, machinePoolDefaults: { hostnameLengthLimit: 15 } } }
         };
 
         cy.userPreferences();
@@ -155,6 +155,11 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         // banner with additional info about 'none' option should be visible
         cy.get('[data-testid="clusterBasics__noneOptionSelectedForCni"]').should('exist');
         // EO test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
+
+        // testing https://github.com/rancher/dashboard/issues/10159
+        cy.get('[data-testid="btn-networking"]').click();
+        createRKE2ClusterPage.network().truncateHostnameCheckbox().set();
+        // EO test for https://github.com/rancher/dashboard/issues/10159
 
         createRKE2ClusterPage.create();
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/networking/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/networking/index.vue
@@ -154,6 +154,7 @@ export default {
           :disabled="isEdit || isView || hostnameTruncationManuallySet"
           :mode="mode"
           :label="t('cluster.rke2.truncateHostnames')"
+          data-testid="network-tab-truncate-hostname"
           @input="$emit('truncate-hostname', $event)"
         />
         <Banner


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10159 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add automated test for #10159 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
