### PR TITLE
Change the way we get up to date catalog information to be more performant

### DIFF
--- a/shell/detail/catalog.cattle.io.app.vue
+++ b/shell/detail/catalog.cattle.io.app.vue
@@ -30,7 +30,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('catalog/load', { force: true, reset: true });
+    await this.$store.dispatch('catalog/load');
 
     this.allOperations = await this.$store.dispatch('cluster/findAll', { type: CATALOG.OPERATION });
   },

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -256,7 +256,7 @@ export default {
 
   methods: {
     async fetchChart() {
-      await this.$store.dispatch('catalog/load', { force: true, reset: true }); // not the problem
+      await this.$store.dispatch('catalog/load'); // not the problem
 
       if ( this.query.appNamespace && this.query.appName ) {
         // First check the URL query for an app name and namespace.

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -37,7 +37,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('catalog/load', { force: true, reset: true });
+    await this.$store.dispatch('catalog/load');
 
     const query = this.$route.query;
 

--- a/shell/utils/install-redirect.js
+++ b/shell/utils/install-redirect.js
@@ -26,7 +26,7 @@ export default function(product, chartName, defaultResourceOrRoute, install = tr
     } else if (install) {
       // The product is not installed, redirect to the details chart
 
-      await store.dispatch('catalog/load', { force: true });
+      await store.dispatch('catalog/load');
 
       const chart = store.getters['catalog/chart']({ chartName });
 


### PR DESCRIPTION
### Summary
fixes: #10448
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
No longer force reload catalog in most areas. Now force reload verisonInfo in all areas.

### Technical notes summary
Digging a little deeper it became evident that the original problem was actually that we had stale versionInfo instead of catalog info. It just so happens that doing a force load of the catalog would also update the versionInfo.

This fix removes the versionInfo caching and forces a reload at that location. There was one critical path which occurs in rke2.vue but that component is already caching the versionInfo on it's own. This means that rke2 could have stale data but I'm not sure it's worth updating and if it is I think we should do it in a separate change.

![image](https://github.com/rancher/dashboard/assets/55104481/aaf517a5-6707-47f7-8564-f778bbc9954e)


### Areas or cases that should be tested
Chart installation if there's a change to the chart version. We should follow the testing instructions here https://github.com/rancher/dashboard/pull/7672

Testing if adding/removing a chart from an existing repository and the refreshing the repo will cause any issues to arise.

### Areas which could experience regressions
Same as above

### Screenshot/Video
N/A

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
