### PR TITLE
Fix removing array type values in machine pool configs

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -26,7 +26,7 @@ import {
 } from '@shell/utils/object';
 import { allHash } from '@shell/utils/promise';
 import { sortBy } from '@shell/utils/sort';
-import { customMerge } from '@shell/utils/custom-merge';
+import { vspherePoolConfigMerge } from '@shell/machine-config/vmwarevsphere-pool-config-merge';
 
 import { compare, sortable } from '@shell/utils/version';
 import { isHarvesterSatisfiesVersion } from '@shell/utils/cluster';
@@ -66,6 +66,8 @@ import ClusterAppearance from '@shell/components/form/ClusterAppearance';
 const HARVESTER = 'harvester';
 const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
 const NETBIOS_TRUNCATION_LENGTH = 15;
+
+const VMWARE_VSPHERE = 'vmwarevsphere';
 
 /**
  * Classes to be adopted by the node badges in Machine pools
@@ -1105,7 +1107,7 @@ export default {
         },
       };
 
-      if (this.provider === 'vmwarevsphere') {
+      if (this.provider === VMWARE_VSPHERE) {
         pool.pool.machineOS = 'linux';
       }
 
@@ -1150,7 +1152,12 @@ export default {
         // We don't allow the user to edit any of the fields in metadata from the UI so it's safe to override it with the
         // metadata defined by the latest backend value. This is primarily used to ensure the resourceVersion is up to date.
         delete clonedCurrentConfig.metadata;
-        machinePool.config = customMerge(clonedLatestConfig, clonedCurrentConfig);
+
+        if (this.provider === VMWARE_VSPHERE) {
+          machinePool.config = vspherePoolConfigMerge(clonedLatestConfig, clonedCurrentConfig);
+        } else {
+          machinePool.config = merge(clonedLatestConfig, clonedCurrentConfig);
+        }
       }
     },
 

--- a/shell/machine-config/__tests__/vmwarevsphere-pool-config-merge.test.ts
+++ b/shell/machine-config/__tests__/vmwarevsphere-pool-config-merge.test.ts
@@ -1,6 +1,6 @@
-import { customMerge } from '@shell/utils/custom-merge';
+import { vspherePoolConfigMerge } from '@shell/machine-config/vmwarevsphere-pool-config-merge';
 
-describe('customMerge', () => {
+describe('vspherePoolConfigMerge', () => {
   const testCases: Array<[object?, object?, object?]> = [
     // Some array test cases, an array from the first object should be replaced with the array from the second object
     [{ a: ['one'] }, { a: [] }, { a: [] }],
@@ -23,7 +23,7 @@ describe('customMerge', () => {
   ];
 
   it.each(testCases)('should merge properly', (obj1, obj2, expected) => {
-    const result = customMerge(obj1, obj2);
+    const result = vspherePoolConfigMerge(obj1, obj2);
 
     expect(result).toStrictEqual(expected);
   });

--- a/shell/machine-config/vmwarevsphere-pool-config-merge.ts
+++ b/shell/machine-config/vmwarevsphere-pool-config-merge.ts
@@ -16,7 +16,7 @@ import mergeWith from 'lodash/mergeWith';
  *
  * This helper function addresses the issue by always replacing the old array with the new array during the merge process.
  */
-export function customMerge(obj1 = {}, obj2 = {}): Object {
+export function vspherePoolConfigMerge(obj1 = {}, obj2 = {}): Object {
   return mergeWith(obj1, obj2, (obj1Value, obj2Value) => {
     if (Array.isArray(obj1Value) && Array.isArray(obj2Value)) {
       return obj2Value;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10693 
<!-- Define findings related to the feature or bug issue. -->
In `rke2.vue`, before saving the new changes made to the machine pools configuration we run `syncMachineConfigWithLatest` function, it gets the latest(last saved) config from the BE, then uses Lodash `merge` function to update it with the current changes made by the user. The problem is that if the user removes an item from an array type config value(e.g. network in vSphere), it will never work due to the default behaviour of Lodash `merge` function. Example:

```
const lastSavedConfigFromBE = { a: ["test"] };
const currentConfigByUser = { a: [] };

merge(lastSavedConfigFromBE, currentConfigByUser) // { a: ["test"] }
```

A new helper function `customMerge` is created to address the issue by correctly replacing the old array values with the new values during the merge process.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
This change is not limited to vSphere's machine pool config, any array type values for any provider's machine pool config will be affected. I haven't found any examples so far, but I believe the removing issue exists for any provider's array type value in their machine pool config, and this PR should fix them too.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Same as above.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/135728925/35beeba1-5198-4010-8b02-3c1f9d3717f1


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
