### PR TITLE
Fix AKS private DNS zone validation

### DIFF
--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -156,5 +156,5 @@ aks:
     ipv4: "{key} must be a valid ipv4 address."
     outboundType: Load Balancer SKU must be 'standard' to use user defined routing.
     availabilityZones: Availability zones are not available in the selected region.
-    privateDnsZone: The Private DNS Zone Resource ID should be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io
+    privateDnsZone: Private DNS Zone Resource ID must be in the format /subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCEGROUP_NAME/providers/Microsoft.Network/privateDnsZones/PRIVATE_DNS_ZONE_NAME. The Private DNS Zone Resource Name must be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io
     poolName: Node pool names must be 1-12 characters long, consist only of lowercase letters and numbers, and start with a letter.

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -73,12 +73,13 @@ describe('fx: resourceGroupChars', () => {
 
 describe('fx: privateDnsZone', () => {
   it.each([
-    ['test-subzone.private.eastus2.azmk8s.io', undefined],
-    ['test-subzone.privatelink.westus.azmk8s.io', undefined],
-    ['private.eastus2.azmk8s.io', undefined],
-    ['privatelink.eastus2.azmk8s.io', undefined],
-    ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.privatelink.eastus2.azmk8s.io', MOCK_TRANSLATION],
+    ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/test-subzone.private.eastus2.azmk8s.io', undefined],
+    ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/test-subzone.privatelink.westus.azmk8s.io', undefined],
+    ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/private.eastus2.azmk8s.io', undefined],
+    ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/privatelink.eastus2.azmk8s.io', undefined],
+    ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.privatelink.eastus2.azmk8s.io', MOCK_TRANSLATION],
     ['privatelink.azmk8s.io', MOCK_TRANSLATION],
+    ['privatelink.eastus2.azmk8s.io', MOCK_TRANSLATION]
   ])('returns an error message if the private dns zone does not match privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io', (privateDnsZone, validatorMsg) => {
     const ctx = { ...mockCtx, normanCluster: { aksConfig: { privateDnsZone } } };
 

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -131,9 +131,9 @@ export const outboundTypeUserDefined = (ctx: any, labelKey: string, clusterPath:
 // https://learn.microsoft.com/en-us/azure/aks/private-clusters?tabs=azure-portal#configure-a-private-dns-zone
 export const privateDnsZone = (ctx: any, labelKey: string, clusterPath: string) => {
   return () :string | undefined => {
-    const toValidate = get(ctx.normanCluster, clusterPath) || '';
-
-    const isValid = toValidate.match(/^([a-zA-Z0-9-]{1,32}\.){0,32}private(link){0,1}\.[a-zA-Z0-9]+\.azmk8s\.io$/);
+    const toValidate = (get(ctx.normanCluster, clusterPath) || '').toLowerCase();
+    const subscriptionRegex = /^\/subscriptions\/.+\/resourcegroups\/.+\/providers\/microsoft\.network\/privatednszones\/([a-zA-Z0-9-]{1,32}\.){0,32}private(link){0,1}\.[a-zA-Z0-9]+\.azmk8s\.io$/;
+    const isValid = toValidate.match(subscriptionRegex);
 
     return isValid || !toValidate.length ? undefined : ctx.t('aks.errors.privateDnsZone', {}, true);
   };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7163 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes validation for the Private DNS Zone input field - see comments in 7163 for details. I made the validation regex pretty permissive about subscription id and resource group name because I couldn't find clear documentation on how to validate them more precisely.

### Areas or cases that should be tested
1. entering invalid private DNS zone id values should disable the 'create' button
2. private dns zone id values that pass ui validation should pass BE validation

### Areas which could experience regressions
none - changes are isolated to privateDNSZone validation


![Screenshot 2024-04-03 at 9 30 05 AM](https://github.com/rancher/dashboard/assets/42977925/f803fc64-41f0-45da-a444-b20f743f129d)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
