### PR TITLE
Fetch `statefulset` resource to calculate fleet agent status

### DIFF
--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -63,30 +63,33 @@ describe('page: cluster dashboard', () => {
 
   describe.each([
     ['fleet', true, [
-      [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, '', 0, 0],
-      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, [{ status: 'False' }], 0, 0],
-      [STATES_ENUM.WARNING, 'icon-warning', true, true, [{ status: 'True' }], 0, 0],
-      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 0],
-      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 1],
-      [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, [{ status: 'True' }], 1, 0],
+      [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, '', 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, false, [{ status: 'False' }], 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, true, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, true, false, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, false, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, false, [{ status: 'True' }], 0, 1],
+      [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, false, [{ status: 'True' }], 1, 0],
     ]],
     ['cattle', false, [
-      [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, '', 0, 0],
-      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, [{ status: 'False' }], 0, 0],
-      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, [{ status: 'True' }], 0, 0],
-      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 0],
-      [STATES_ENUM.WARNING, 'icon-warning', true, false, [{ status: 'True' }], 0, 1],
-      [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, [{ status: 'True' }], 1, 0],
+      [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, '', 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, false, [{ status: 'False' }], 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, false, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, true, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, false, [{ status: 'True' }], 0, 0],
+      [STATES_ENUM.WARNING, 'icon-warning', true, false, false, [{ status: 'True' }], 0, 1],
+      [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, false, [{ status: 'True' }], 1, 0],
     ]]
   ])('%p agent health box', (agentId, isLocal, statuses) => {
-    it.each(statuses)('should show %p status', (status, iconClass, isLoaded, disconnected, conditions, readyReplicas, unavailableReplicas) => {
+    it.each(statuses)('should show %p status', (status, iconClass, isLoaded, disconnected, error, conditions, readyReplicas, unavailableReplicas) => {
       const options = clone(mountOptions);
 
       options.mocks.$store.getters.currentCluster.isLocal = isLocal;
 
       const agent = {
-        spec:   { replicas: 1 },
-        status: {
+        metadata: { state: { error } },
+        spec:     { replicas: 1 },
+        status:   {
           readyReplicas,
           unavailableReplicas,
           conditions

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -411,7 +411,15 @@ export default {
 
         try {
           this.fleet = await this.$store.dispatch('cluster/find', {
-            type: WORKLOAD_TYPES.DEPLOYMENT,
+            /**
+             * local cluster
+             *  - deployment:  cattle-fleet-system/fleet-controller
+             *  - statefulset: cattle-fleet-local-system/fleet-agent
+             * downstream rke2 cluster
+             *  - deployment:  none
+             *  - statefulset: cattle-fleet-system/fleet-agent
+             */
+            type: this.currentCluster.isLocal ? WORKLOAD_TYPES.DEPLOYMENT : WORKLOAD_TYPES.STATEFUL_SET,
             id:   `cattle-fleet-system/${ this.currentCluster.isLocal ? 'fleet-controller' : 'fleet-agent' }`,
           });
         } catch (err) {
@@ -446,7 +454,7 @@ export default {
         return STATES_ENUM.IN_PROGRESS;
       }
 
-      if (!agent || disconnected || agent.status.conditions.find((c) => c.status !== 'True')) {
+      if (!agent || disconnected || agent.status.conditions?.find((c) => c.status !== 'True') || agent.metadata.state?.error) {
         return STATES_ENUM.UNHEALTHY;
       }
 

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -83,7 +83,7 @@ export default {
 
   mixins: [metricPoller],
 
-  async fetch() {
+  fetch() {
     fetchClusterResources(this.$store, NODE);
 
     if (this.currentCluster) {
@@ -117,7 +117,7 @@ export default {
       this.canViewAgents = this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET);
 
       if (this.canViewAgents) {
-        await this.loadAgents();
+        this.loadAgents();
       }
     }
   },
@@ -444,13 +444,13 @@ export default {
   },
 
   methods: {
-    async loadAgents() {
+    loadAgents() {
       if (this.currentCluster.isLocal) {
-        await this.setAgentResource('fleetDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-fleet-system/fleet-controller');
-        await this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-local-system/fleet-agent');
+        this.setAgentResource('fleetDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-fleet-system/fleet-controller');
+        this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-local-system/fleet-agent');
       } else {
-        await this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-system/fleet-agent');
-        await this.setAgentResource('cattleDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-system/cattle-cluster-agent');
+        this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-system/fleet-agent');
+        this.setAgentResource('cattleDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-system/cattle-cluster-agent');
 
         // Scaling Up/Down cattle deployment causes web sockets disconnection;
         this.interval = setInterval(() => {

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -278,13 +278,7 @@ export default {
       }
 
       for (const resource of resources) {
-        if (!resource) {
-          return STATES_ENUM.UNHEALTHY;
-        }
-      }
-
-      for (const resource of resources) {
-        if (resource.status.conditions?.find((c) => c.status !== 'True') || resource.metadata.state?.error) {
+        if (!resource || resource.status.conditions?.find((c) => c.status !== 'True') || resource.metadata.state?.error) {
           return STATES_ENUM.UNHEALTHY;
         }
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10738
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We are adding the fleet's StatefulSet in agent status calculation, for downstream clusters.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- local clusters:
  - using both StatefulSet and Deployment
- rke2 downstream clusters:
  - using StatefulSet since the deployment does not exist.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- cluster's dashboard -> healthboxes.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### To test

See https://github.com/rancher/dashboard/pull/10614 description.
  - there is a known issue when scaling/redeploying fleet StatefulSet; it can be done using kubectl, see https://github.com/rancher/dashboard/issues/10762

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
