### PR TITLE
[FEAT] Added validation to AzureAD

### DIFF
--- a/cypress/e2e/po/edit/auth/azuread.po.ts
+++ b/cypress/e2e/po/edit/auth/azuread.po.ts
@@ -1,0 +1,113 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+
+export default class AzureadPo extends PagePo {
+  private static createPath(clusterId: string, id?: string ) {
+    return `/c/${ clusterId }/auth/config/azuread?mode=edit`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(AzureadPo.createPath(clusterId));
+  }
+
+  constructor(clusterId: string) {
+    super(AzureadPo.createPath(clusterId));
+  }
+
+  static navTo() {
+    const sideNav = new ProductNavPo();
+
+    BurgerMenuPo.burgerMenuNavToMenubyLabel('Users & Authentication');
+    sideNav.navToSideMenuEntryByLabel('Auth Provider');
+  }
+
+  endpointsRadioBtn(): RadioGroupInputPo {
+    return new RadioGroupInputPo('[data-testid="endpoints-radio-input"]');
+  }
+
+  selectEndpointsOption(index: number): Cypress.Chainable {
+    const radioButton = new RadioGroupInputPo('[data-testid="endpoints-radio-input"]');
+
+    return radioButton.set(index);
+  }
+
+  clickEdit(): Cypress.Chainable {
+    return this.self().find(`[data-testid="edit-auth-button"]`).click();
+  }
+
+  tenantIdInputField() {
+    return this.self().get('[data-testid="input-azureAD-tenantId"]').invoke('val');
+  }
+
+  enterTenantId(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-tenantId"]').set(name);
+  }
+
+  applicationIdInputField() {
+    return this.self().get('[data-testid="input-azureAD-applcationId"]').invoke('val');
+  }
+
+  enterApplicationId(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-applcationId"]').set(name);
+  }
+
+  applicationSecretInputField() {
+    return this.self().get('[data-testid="input-azureAD-applicationSecret"]').invoke('val');
+  }
+
+  enterApplicationSecret(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-applicationSecret"]').set(name);
+  }
+
+  endpointInputField() {
+    return this.self().get('[data-testid="input-azureAD-endpoint"]').invoke('val');
+  }
+
+  enterEndpoint(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-endpoint"]').set(name);
+  }
+
+  graphEndpointInputField() {
+    return this.self().get('[data-testid="input-azureAD-graphEndpoint"]').invoke('val');
+  }
+
+  enterGraphEndpoint(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-graphEndpoint"]').set(name);
+  }
+
+  tokenEndpointInputField() {
+    return this.self().get('[data-testid="input-azureAD-tokenEndpoint"]').invoke('val');
+  }
+
+  enterTokenEndpoint(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-tokenEndpoint"]').set(name);
+  }
+
+  authEndpointInputField() {
+    return this.self().get('[data-testid="input-azureAD-authEndpoint"]').invoke('val');
+  }
+
+  enterAuthEndpoint(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-authEndpoint"]').set(name);
+  }
+
+  deviceAuthEndpointInputField() {
+    return this.self().get('[data-testid="input-azureAD-deviceAuthEndpoint"]').invoke('val');
+  }
+
+  enterDeviceAuthEndpoint(name: string) {
+    return new LabeledInputPo('[data-testid="input-azureAD-deviceAuthEndpoint"]').set(name);
+  }
+
+  saveButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="form-save"]', this.self());
+  }
+
+  save() {
+    return new AsyncButtonPo('[data-testid="form-save"]').click();
+  }
+}

--- a/cypress/e2e/po/edit/auth/azuread.po.ts
+++ b/cypress/e2e/po/edit/auth/azuread.po.ts
@@ -35,9 +35,6 @@ export default class AzureadPo extends PagePo {
     return radioButton.set(index);
   }
 
-  clickEdit(): Cypress.Chainable {
-    return this.self().find(`[data-testid="edit-auth-button"]`).click();
-  }
 
   tenantIdInputField() {
     return this.self().get('[data-testid="input-azureAD-tenantId"]').invoke('val');
@@ -93,14 +90,6 @@ export default class AzureadPo extends PagePo {
 
   enterAuthEndpoint(name: string) {
     return new LabeledInputPo('[data-testid="input-azureAD-authEndpoint"]').set(name);
-  }
-
-  deviceAuthEndpointInputField() {
-    return this.self().get('[data-testid="input-azureAD-deviceAuthEndpoint"]').invoke('val');
-  }
-
-  enterDeviceAuthEndpoint(name: string) {
-    return new LabeledInputPo('[data-testid="input-azureAD-deviceAuthEndpoint"]').set(name);
   }
 
   saveButton(): AsyncButtonPo {

--- a/cypress/e2e/po/edit/auth/azuread.po.ts
+++ b/cypress/e2e/po/edit/auth/azuread.po.ts
@@ -35,7 +35,6 @@ export default class AzureadPo extends PagePo {
     return radioButton.set(index);
   }
 
-
   tenantIdInputField() {
     return this.self().get('[data-testid="input-azureAD-tenantId"]').invoke('val');
   }

--- a/cypress/e2e/po/pages/users-and-auth/authProvider.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/authProvider.po.ts
@@ -1,0 +1,32 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+
+export default class AuthProviderPo extends PagePo {
+  private static createPath(clusterId: string, id?: string ) {
+    return `/c/${ clusterId }/auth/config`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(AuthProviderPo.createPath(clusterId));
+  }
+
+  constructor(clusterId: string) {
+    super(AuthProviderPo.createPath(clusterId));
+  }
+
+  static navTo() {
+    const sideNav = new ProductNavPo();
+
+    BurgerMenuPo.burgerMenuNavToMenubyLabel('Users & Authentication');
+    sideNav.navToSideMenuEntryByLabel('Auth Provider');
+  }
+
+  goToAzureADCreation(clusterId = '_'): Cypress.Chainable<Cypress.AUTWindow> {
+    return PagePo.goTo(`/c/${ clusterId }/auth/config/azuread?mode=edit`);
+  }
+
+  selectAzureAd() {
+    return this.self().find('[data-testid="select-icon-grid-3"]').click();
+  }
+}

--- a/cypress/e2e/tests/pages/users-and-auth/azuread.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/azuread.spec.ts
@@ -1,0 +1,95 @@
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import AzureadPo from '@/cypress/e2e/po/edit/auth/azuread.po';
+import AuthProviderPo from '@/cypress/e2e/po/pages/users-and-auth/authProvider.po';
+
+const authProviderPo = new AuthProviderPo('local');
+const azureadPo = new AzureadPo('local');
+
+const tenantId = '564b6f53-ebf4-43c3-8077-44c56a44990a';
+const applicationId = '18cca356-170e-4bd9-a4a4-2e349855f96b';
+const appSecret = 'test';
+const defaultEndpoint = 'https://login.microsoftonline.com/';
+const defaultAuthEndpoint = 'https://login.microsoftonline.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/authorize';
+const defaultTokenEndpoint = 'https://login.microsoftonline.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/token';
+const defaultGraphEndpoint = 'https://graph.microsoft.com';
+const endpoint = 'https://login.test.com/';
+const authEndpoint = 'https://login.test.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/authorize';
+const tokenEndpoint = 'https://login.test.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/token';
+const graphEndpoint = 'https://graph.test.com';
+const deviceAuthEndpoint = 'https://login.test.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/devicecode';
+
+const mockStatusCode = 200;
+const mockBody = {};
+
+describe('AzureAD', { tags: ['@adminUser'] }, () => {
+  beforeEach(() => {
+    cy.login();
+    HomePagePo.goToAndWaitForGet();
+    AuthProviderPo.navTo();
+    authProviderPo.waitForPage();
+    authProviderPo.selectAzureAd();
+    azureadPo.waitForPage();
+  });
+
+  it('can navigate Auth Provider and select AzureAD', () => {
+    azureadPo.mastheadTitle().should('include', `AzureAD`);
+  });
+
+  it('sends correct request to create standard Azure AD', () => {
+    cy.intercept('POST', 'v3/azureADConfigs/azuread?action=configureTest', (req) => {
+      expect(req.body.tenantId).to.equal(tenantId);
+      expect(req.body.applicationId).to.equal(applicationId);
+      expect(req.body.applicationSecret).to.equal(appSecret);
+      expect(req.body.endpoint).to.equal(defaultEndpoint);
+      expect(req.body.authEndpoint).to.equal(defaultAuthEndpoint);
+      expect(req.body.tokenEndpoint).to.equal(defaultTokenEndpoint);
+      expect(req.body.graphEndpoint).to.equal(defaultGraphEndpoint);
+
+      req.reply(mockStatusCode, mockBody);
+    }).as('configureTest');
+
+    // save should be disabled before values are filled
+    azureadPo.saveButton().expectToBeDisabled();
+    azureadPo.enterTenantId(tenantId);
+    azureadPo.enterApplicationId(applicationId);
+    azureadPo.enterApplicationSecret(appSecret);
+    // save should be enabled after values are filled
+    azureadPo.saveButton().expectToBeEnabled();
+    azureadPo.save();
+    cy.wait('@configureTest');
+  });
+
+  it('sends correct request to create custom Azure AD', () => {
+    cy.intercept('POST', 'v3/azureADConfigs/azuread?action=configureTest', (req) => {
+      expect(req.body.tenantId).to.equal(tenantId);
+      expect(req.body.applicationId).to.equal(applicationId);
+      expect(req.body.applicationSecret).to.equal(appSecret);
+      expect(req.body.endpoint).to.equal(endpoint);
+      expect(req.body.authEndpoint).to.equal(authEndpoint);
+      expect(req.body.tokenEndpoint).to.equal(tokenEndpoint);
+      expect(req.body.graphEndpoint).to.equal(graphEndpoint);
+      expect(req.body.deviceAuthEndpoint).to.equal(deviceAuthEndpoint);
+
+      req.reply(mockStatusCode, mockBody);
+    }).as('configureTest');
+
+    // save should be disabled before values are filled
+    azureadPo.saveButton().expectToBeDisabled();
+    azureadPo.enterTenantId(tenantId);
+    azureadPo.enterApplicationId(applicationId);
+    azureadPo.enterApplicationSecret(appSecret);
+
+    azureadPo.selectEndpointsOption(2);
+
+    azureadPo.enterEndpoint(endpoint);
+    azureadPo.enterTokenEndpoint(tokenEndpoint);
+    azureadPo.enterGraphEndpoint(graphEndpoint);
+    azureadPo.enterAuthEndpoint(authEndpoint);
+    azureadPo.enterDeviceAuthEndpoint(deviceAuthEndpoint);
+
+    // save should be enabled after values are filled
+    azureadPo.saveButton().expectToBeEnabled();
+    azureadPo.save();
+    cy.wait('@configureTest');
+  });
+});

--- a/cypress/e2e/tests/pages/users-and-auth/azuread.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/azuread.spec.ts
@@ -16,7 +16,6 @@ const endpoint = 'https://login.test.com/';
 const authEndpoint = 'https://login.test.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/authorize';
 const tokenEndpoint = 'https://login.test.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/token';
 const graphEndpoint = 'https://graph.test.com';
-const deviceAuthEndpoint = 'https://login.test.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/devicecode';
 
 const mockStatusCode = 200;
 const mockBody = {};
@@ -68,7 +67,6 @@ describe('AzureAD', { tags: ['@adminUser'] }, () => {
       expect(req.body.authEndpoint).to.equal(authEndpoint);
       expect(req.body.tokenEndpoint).to.equal(tokenEndpoint);
       expect(req.body.graphEndpoint).to.equal(graphEndpoint);
-      expect(req.body.deviceAuthEndpoint).to.equal(deviceAuthEndpoint);
 
       req.reply(mockStatusCode, mockBody);
     }).as('configureTest');
@@ -85,7 +83,6 @@ describe('AzureAD', { tags: ['@adminUser'] }, () => {
     azureadPo.enterTokenEndpoint(tokenEndpoint);
     azureadPo.enterGraphEndpoint(graphEndpoint);
     azureadPo.enterAuthEndpoint(authEndpoint);
-    azureadPo.enterDeviceAuthEndpoint(deviceAuthEndpoint);
 
     // save should be enabled after values are filled
     azureadPo.saveButton().expectToBeEnabled();

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -552,7 +552,7 @@ authConfig:
     authEndpoint: 
       label: Auth Endpoint
     deviceAuthEndpoint: 
-      label: Auth Endpoint
+      label: Device Auth Endpoint
     reply:
       info: 'Azure AD requires a whitelisted URL for your Rancher server before beginning this setup. Please ensure that the following URL is set in the Reply URL section of your Azure Portal. Please note that it may take up to 5 minutes for the whitelisted URL to propagate.'
       label: Reply URL

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -551,8 +551,6 @@ authConfig:
       label: Token Endpoint
     authEndpoint: 
       label: Auth Endpoint
-    deviceAuthEndpoint: 
-      label: Device Auth Endpoint
     reply:
       info: 'Azure AD requires a whitelisted URL for your Rancher server before beginning this setup. Please ensure that the following URL is set in the Reply URL section of your Azure Portal. Please note that it may take up to 5 minutes for the whitelisted URL to propagate.'
       label: Reply URL

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -529,12 +529,30 @@ authConfig:
       show: Show details
       hide: Hide details
   azuread:
-    tenantId: Tenant ID
-    applicationId: Application ID
-    endpoint: Endpoint
-    graphEndpoint: Graph Endpoint
-    tokenEndpoint: Token Endpoint
-    authEndpoint: Auth Endpoint
+    tenantId: 
+      label: Tenant ID
+      tooltip: From the Azure AD portal
+      placeholder: A long UUID string
+    applicationId: 
+      label: Application ID
+      placeholder: A long UUID string
+    applicationSecret:
+      label: Application Secret
+    endpoint: 
+      label: Endpoint
+    endpoints: 
+      label: Endpoints
+      standard: Standard
+      china: China
+      custom: Custom
+    graphEndpoint: 
+      label: Graph Endpoint
+    tokenEndpoint: 
+      label: Token Endpoint
+    authEndpoint: 
+      label: Auth Endpoint
+    deviceAuthEndpoint: 
+      label: Auth Endpoint
     reply:
       info: 'Azure AD requires a whitelisted URL for your Rancher server before beginning this setup. Please ensure that the following URL is set in the Reply URL section of your Azure Portal. Please note that it may take up to 5 minutes for the whitelisted URL to propagate.'
       label: Reply URL

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -54,7 +54,6 @@ export default {
       <button
         type="button"
         class="btn-sm role-primary"
-        data-testid="edit-auth-button"
         @click="edit"
       >
         {{ t('action.edit') }}

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -54,6 +54,7 @@ export default {
       <button
         type="button"
         class="btn-sm role-primary"
+        data-testid="edit-auth-button"
         @click="edit"
       >
         {{ t('action.edit') }}

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -83,57 +83,131 @@ describe('edit: azureAD should', () => {
 
     expect(saveButton.disabled).toBe(true);
   });
-  it('have "Create" button enabled and disabled depending on validation results when endpoint is standard', async() => {
+
+  it.each([
+    {
+      tenantId:          '',
+      applicationId:     '',
+      applicationSecret: '',
+      result:            true
+    },
+    {
+      tenantId:          '',
+      applicationId:     validApplicationId,
+      applicationSecret: validAppSecret,
+      result:            true
+    },
+    {
+      tenantId:          validTenantId,
+      applicationId:     '',
+      applicationSecret: validAppSecret,
+      result:            true
+    },
+    {
+      tenantId:          validTenantId,
+      applicationId:     validApplicationId,
+      applicationSecret: '',
+      result:            true
+    },
+    {
+      tenantId:          validTenantId,
+      applicationId:     validApplicationId,
+      applicationSecret: validAppSecret,
+      result:            false
+    },
+  ])('has "Create" button enabled and disabled depending on validation results when endpoint is standard', async(testCase) => {
     const tenantIdInputField = wrapper.find('[data-testid="input-azureAD-tenantId"]').find('input');
     const applicationIdInputField = wrapper.find('[data-testid="input-azureAD-applcationId"]').find('input');
     const applicationSecretInputField = wrapper.find('[data-testid="input-azureAD-applicationSecret"]').find('input');
     const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-    const testCases = [
-      {
-        tenantId:          '',
-        applicationId:     '',
-        applicationSecret: '',
-        result:            true
-      },
-      {
-        tenantId:          '',
-        applicationId:     validApplicationId,
-        applicationSecret: validAppSecret,
-        result:            true
-      },
-      {
-        tenantId:          validTenantId,
-        applicationId:     '',
-        applicationSecret: validAppSecret,
-        result:            true
-      },
-      {
-        tenantId:          validTenantId,
-        applicationId:     validApplicationId,
-        applicationSecret: '',
-        result:            true
-      },
-      {
-        tenantId:          validTenantId,
-        applicationId:     validApplicationId,
-        applicationSecret: validAppSecret,
-        result:            false
-      },
-    ];
+    tenantIdInputField.setValue(testCase.tenantId);
+    applicationIdInputField.setValue(testCase.applicationId);
+    applicationSecretInputField.setValue(testCase.applicationSecret);
+    await wrapper.vm.$nextTick();
 
-    for (const testCase of testCases) {
-      tenantIdInputField.setValue(testCase.tenantId);
-      await wrapper.vm.$nextTick();
-      applicationIdInputField.setValue(testCase.applicationId);
-      await wrapper.vm.$nextTick();
-      applicationSecretInputField.setValue(testCase.applicationSecret);
-      await wrapper.vm.$nextTick();
-
-      expect(saveButton.disabled).toBe(testCase.result);
-    }
+    expect(saveButton.disabled).toBe(testCase.result);
   });
-  it('have "Create" button enabled and disabled depending on validation results when endpoint is custom', async() => {
+
+  it.each([
+    {
+      endpoint:      '',
+      graphEndpoint: '',
+      tokenEndpoint: '',
+      authEndpoint:  '',
+      result:        true
+    },
+    {
+      endpoint:      invalidEndpoint,
+      graphEndpoint: invalidGraphEndpoint,
+      tokenEndpoint: invalidTokenEndpoint,
+      authEndpoint:  invalidAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      '',
+      graphEndpoint: validGraphEndpoint,
+      tokenEndpoint: validTokenEndpoint,
+      authEndpoint:  validAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      invalidEndpoint,
+      graphEndpoint: validGraphEndpoint,
+      tokenEndpoint: validTokenEndpoint,
+      authEndpoint:  validAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      validEndpoint,
+      graphEndpoint: '',
+      tokenEndpoint: validTokenEndpoint,
+      authEndpoint:  validAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      validEndpoint,
+      graphEndpoint: invalidGraphEndpoint,
+      tokenEndpoint: validTokenEndpoint,
+      authEndpoint:  validAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      validEndpoint,
+      graphEndpoint: validGraphEndpoint,
+      tokenEndpoint: '',
+      authEndpoint:  validAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      validEndpoint,
+      graphEndpoint: validGraphEndpoint,
+      tokenEndpoint: invalidTokenEndpoint,
+      authEndpoint:  validAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      validEndpoint,
+      graphEndpoint: validGraphEndpoint,
+      tokenEndpoint: validTokenEndpoint,
+      authEndpoint:  '',
+      result:        true
+    },
+    {
+      endpoint:      validEndpoint,
+      graphEndpoint: validGraphEndpoint,
+      tokenEndpoint: validTokenEndpoint,
+      authEndpoint:  invalidAuthEndpoint,
+      result:        true
+    },
+    {
+      endpoint:      validEndpoint,
+      graphEndpoint: validGraphEndpoint,
+      tokenEndpoint: validTokenEndpoint,
+      authEndpoint:  validAuthEndpoint,
+      result:        false
+    }
+  ])('has "Create" button enabled and disabled depending on validation results when endpoint is custom', async(testCase) => {
     const tenantIdInputField = wrapper.find('[data-testid="input-azureAD-tenantId"]').find('input');
     const applicationIdInputField = wrapper.find('[data-testid="input-azureAD-applcationId"]').find('input');
     const applicationSecretInputField = wrapper.find('[data-testid="input-azureAD-applicationSecret"]').find('input');
@@ -142,91 +216,9 @@ describe('edit: azureAD should', () => {
     const customButton = endpointsRG.findAll('.radio-label').at(2);
     const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-    const testCases = [
-      {
-        endpoint:      '',
-        graphEndpoint: '',
-        tokenEndpoint: '',
-        authEndpoint:  '',
-        result:        true
-      },
-      {
-        endpoint:      invalidEndpoint,
-        graphEndpoint: invalidGraphEndpoint,
-        tokenEndpoint: invalidTokenEndpoint,
-        authEndpoint:  invalidAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      '',
-        graphEndpoint: validGraphEndpoint,
-        tokenEndpoint: validTokenEndpoint,
-        authEndpoint:  validAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      invalidEndpoint,
-        graphEndpoint: validGraphEndpoint,
-        tokenEndpoint: validTokenEndpoint,
-        authEndpoint:  validAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      validEndpoint,
-        graphEndpoint: '',
-        tokenEndpoint: validTokenEndpoint,
-        authEndpoint:  validAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      validEndpoint,
-        graphEndpoint: invalidGraphEndpoint,
-        tokenEndpoint: validTokenEndpoint,
-        authEndpoint:  validAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      validEndpoint,
-        graphEndpoint: validGraphEndpoint,
-        tokenEndpoint: '',
-        authEndpoint:  validAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      validEndpoint,
-        graphEndpoint: validGraphEndpoint,
-        tokenEndpoint: invalidTokenEndpoint,
-        authEndpoint:  validAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      validEndpoint,
-        graphEndpoint: validGraphEndpoint,
-        tokenEndpoint: validTokenEndpoint,
-        authEndpoint:  '',
-        result:        true
-      },
-      {
-        endpoint:      validEndpoint,
-        graphEndpoint: validGraphEndpoint,
-        tokenEndpoint: validTokenEndpoint,
-        authEndpoint:  invalidAuthEndpoint,
-        result:        true
-      },
-      {
-        endpoint:      validEndpoint,
-        graphEndpoint: validGraphEndpoint,
-        tokenEndpoint: validTokenEndpoint,
-        authEndpoint:  validAuthEndpoint,
-        result:        false
-      }
-    ];
-
     // populate fields tested in previous test first
     tenantIdInputField.setValue(validTenantId);
-    await wrapper.vm.$nextTick();
     applicationIdInputField.setValue(validApplicationId);
-    await wrapper.vm.$nextTick();
     applicationSecretInputField.setValue(validAppSecret);
     await wrapper.vm.$nextTick();
 
@@ -240,17 +232,12 @@ describe('edit: azureAD should', () => {
     const tokenEndpointInputField = wrapper.find('[data-testid="input-azureAD-tokenEndpoint"]').find('input');
     const authEndpointInputField = wrapper.find('[data-testid="input-azureAD-authEndpoint"]').find('input');
 
-    for (const testCase of testCases) {
-      endpointInputField.setValue(testCase.endpoint);
-      await wrapper.vm.$nextTick();
-      graphEndpointInputField.setValue(testCase.graphEndpoint);
-      await wrapper.vm.$nextTick();
-      tokenEndpointInputField.setValue(testCase.tokenEndpoint);
-      await wrapper.vm.$nextTick();
-      authEndpointInputField.setValue(testCase.authEndpoint);
-      await wrapper.vm.$nextTick();
+    endpointInputField.setValue(testCase.endpoint);
+    graphEndpointInputField.setValue(testCase.graphEndpoint);
+    tokenEndpointInputField.setValue(testCase.tokenEndpoint);
+    authEndpointInputField.setValue(testCase.authEndpoint);
+    await wrapper.vm.$nextTick();
 
-      expect(saveButton.disabled).toBe(testCase.result);
-    }
+    expect(saveButton.disabled).toBe(testCase.result);
   });
 });

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -1,0 +1,286 @@
+/* eslint-disable jest/no-hooks */
+import { mount } from '@vue/test-utils';
+import AzureAD from '@shell/edit/auth/azuread.vue';
+import { _EDIT } from '@shell/config/query-params';
+import { cleanHtmlDirective } from '@shell/plugins/clean-html-directive';
+
+jest.mock('@shell/utils/clipboard', () => {
+  return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
+});
+
+const validTenantId = '564b6f53-ebf4-43c3-8077-44c56a44990a';
+const validApplicationId = '18cca356-170e-4bd9-a4a4-2e349855f96b';
+const validAppSecret = 'test';
+const validEndpoint = 'https://login.microsoftonline.com/';
+const validAuthEndpoint = 'https://login.microsoftonline.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/authorize';
+const validTokenEndpoint = 'https://login.microsoftonline.com/564b6f53-ebf4-43c3-8077-44c56a44990a/oauth2/v2.0/token';
+const validGraphEndpoint = 'https://graph.microsoft.com';
+
+const invalidEndpoint = 'aaaaBBBBaaaa';
+const invalidAuthEndpoint = 'aaa';
+const invalidTokenEndpoint = 'aaaaBBBBaaaa';
+const invalidGraphEndpoint = 'aaaaBBBBaaaa';
+
+const mockModel = {
+  enabled:  true,
+  id:       'azuread',
+  endpoint: 'https://login.microsoftonline.com/',
+  type:     'azureADConfig',
+};
+
+const mockedAuthConfigMixin = {
+  data() {
+    return {
+      sEnabling:      false,
+      editConfig:     false,
+      model:          { mockModel },
+      serverSetting:  null,
+      errors:         [],
+      originalModel:  null,
+      principals:     [],
+      authConfigName: 'azuread',
+    };
+  },
+  computed: {},
+  methods:  {}
+};
+
+describe('edit: azureAD should', () => {
+  let wrapper: any;
+  const requiredSetup = () => ({
+    mixins: [mockedAuthConfigMixin],
+    mocks:  {
+      $fetchState: { pending: false },
+      $store:      {
+        getters: {
+          currentStore:              () => 'current_store',
+          'current_store/schemaFor': jest.fn(),
+          'current_store/all':       jest.fn(),
+          'i18n/t':                  (val: string) => val,
+          'i18n/exists':             jest.fn(),
+        },
+        dispatch: jest.fn()
+      },
+      $route:  { query: { AS: '' }, params: { id: 'azure' } },
+      $router: { applyQuery: jest.fn() },
+    },
+    propsData: {
+      value: { applicationSecret: '' },
+      mode:  _EDIT,
+    },
+    directives: { cleanHtmlDirective },
+  });
+
+  beforeEach(() => {
+    wrapper = mount(AzureAD, { ...requiredSetup() });
+  });
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  it('have "Create" button disabled before fields are filled in', () => {
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+    expect(saveButton.disabled).toBe(true);
+  });
+  it('have "Create" button enabled and disabled depending on validation results when endpoint is standard', async() => {
+    const tenantIdInputField = wrapper.find('[data-testid="input-azureAD-tenantId"]').find('input');
+    const applicationIdInputField = wrapper.find('[data-testid="input-azureAD-applcationId"]').find('input');
+    const applicationSecretInputField = wrapper.find('[data-testid="input-azureAD-applicationSecret"]').find('input');
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+    const testCases = [
+      {
+        tenantId:          '',
+        applicationId:     '',
+        applicationSecret: '',
+        result:            true
+      },
+      {
+        tenantId:          '',
+        applicationId:     validApplicationId,
+        applicationSecret: validAppSecret,
+        result:            true
+      },
+      {
+        tenantId:          validTenantId,
+        applicationId:     '',
+        applicationSecret: validAppSecret,
+        result:            true
+      },
+      {
+        tenantId:          validTenantId,
+        applicationId:     validApplicationId,
+        applicationSecret: '',
+        result:            true
+      },
+      {
+        tenantId:          validTenantId,
+        applicationId:     validApplicationId,
+        applicationSecret: validAppSecret,
+        result:            false
+      },
+    ];
+
+    for (const testCase of testCases) {
+      tenantIdInputField.setValue(testCase.tenantId);
+      await wrapper.vm.$nextTick();
+      applicationIdInputField.setValue(testCase.applicationId);
+      await wrapper.vm.$nextTick();
+      applicationSecretInputField.setValue(testCase.applicationSecret);
+      await wrapper.vm.$nextTick();
+
+      expect(saveButton.disabled).toBe(testCase.result);
+    }
+  });
+  it('have "Create" button enabled and disabled depending on validation results when endpoint is custom', async() => {
+    const tenantIdInputField = wrapper.find('[data-testid="input-azureAD-tenantId"]').find('input');
+    const applicationIdInputField = wrapper.find('[data-testid="input-azureAD-applcationId"]').find('input');
+    const applicationSecretInputField = wrapper.find('[data-testid="input-azureAD-applicationSecret"]').find('input');
+
+    const endpointsRG = wrapper.find('[data-testid="endpoints-radio-input"]');
+    const customButton = endpointsRG.findAll('.radio-label').at(2);
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+    const testCases = [
+      {
+        endpoint:           '',
+        graphEndpoint:      '',
+        tokenEndpoint:      '',
+        authEndpoint:       '',
+        deviceAuthEndpoint: '',
+        result:             true
+      },
+      {
+        endpoint:           invalidEndpoint,
+        graphEndpoint:      invalidAuthEndpoint,
+        tokenEndpoint:      invalidTokenEndpoint,
+        authEndpoint:       invalidAuthEndpoint,
+        deviceAuthEndpoint: invalidGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           '',
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           invalidEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      '',
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      invalidAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      '',
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      invalidTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       '',
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       invalidAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: invalidGraphEndpoint,
+        result:             true
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: '', // this field is not mandatory
+        result:             false
+      },
+      {
+        endpoint:           validEndpoint,
+        graphEndpoint:      validAuthEndpoint,
+        tokenEndpoint:      validTokenEndpoint,
+        authEndpoint:       validAuthEndpoint,
+        deviceAuthEndpoint: validGraphEndpoint,
+        result:             false
+      }
+    ];
+
+    // populate fields tested in previous test first
+    tenantIdInputField.setValue(validTenantId);
+    await wrapper.vm.$nextTick();
+    applicationIdInputField.setValue(validApplicationId);
+    await wrapper.vm.$nextTick();
+    applicationSecretInputField.setValue(validAppSecret);
+    await wrapper.vm.$nextTick();
+
+    expect(saveButton.disabled).toBe(false);
+    customButton.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(saveButton.disabled).toBe(true);
+
+    const endpointInputField = wrapper.find('[data-testid="input-azureAD-endpoint"]').find('input');
+    const graphEndpointInputField = wrapper.find('[data-testid="input-azureAD-graphEndpoint"]').find('input');
+    const tokenEndpointInputField = wrapper.find('[data-testid="input-azureAD-tokenEndpoint"]').find('input');
+    const authEndpointInputField = wrapper.find('[data-testid="input-azureAD-authEndpoint"]').find('input');
+    const deviceAuthEndpointInputField = wrapper.find('[data-testid="input-azureAD-deviceAuthEndpoint"]').find('input');
+
+    for (const testCase of testCases) {
+      endpointInputField.setValue(testCase.endpoint);
+      await wrapper.vm.$nextTick();
+      graphEndpointInputField.setValue(testCase.graphEndpoint);
+      await wrapper.vm.$nextTick();
+      tokenEndpointInputField.setValue(testCase.tokenEndpoint);
+      await wrapper.vm.$nextTick();
+      authEndpointInputField.setValue(testCase.authEndpoint);
+      await wrapper.vm.$nextTick();
+      deviceAuthEndpointInputField.setValue(testCase.deviceAuthEndpoint);
+      await wrapper.vm.$nextTick();
+
+      expect(saveButton.disabled).toBe(testCase.result);
+    }
+  });
+});

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -144,81 +144,81 @@ describe('edit: azureAD should', () => {
 
     const testCases = [
       {
-        endpoint:           '',
-        graphEndpoint:      '',
-        tokenEndpoint:      '',
-        authEndpoint:       '',
-        result:             true
+        endpoint:      '',
+        graphEndpoint: '',
+        tokenEndpoint: '',
+        authEndpoint:  '',
+        result:        true
       },
       {
-        endpoint:           invalidEndpoint,
-        graphEndpoint:      invalidGraphEndpoint,
-        tokenEndpoint:      invalidTokenEndpoint,
-        authEndpoint:       invalidAuthEndpoint,
-        result:             true
+        endpoint:      invalidEndpoint,
+        graphEndpoint: invalidGraphEndpoint,
+        tokenEndpoint: invalidTokenEndpoint,
+        authEndpoint:  invalidAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           '',
-        graphEndpoint:      validGraphEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        result:             true
+        endpoint:      '',
+        graphEndpoint: validGraphEndpoint,
+        tokenEndpoint: validTokenEndpoint,
+        authEndpoint:  validAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           invalidEndpoint,
-        graphEndpoint:      validGraphEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        result:             true
+        endpoint:      invalidEndpoint,
+        graphEndpoint: validGraphEndpoint,
+        tokenEndpoint: validTokenEndpoint,
+        authEndpoint:  validAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           validEndpoint,
-        graphEndpoint:      '',
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        result:             true
+        endpoint:      validEndpoint,
+        graphEndpoint: '',
+        tokenEndpoint: validTokenEndpoint,
+        authEndpoint:  validAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           validEndpoint,
-        graphEndpoint:      invalidGraphEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        result:             true
+        endpoint:      validEndpoint,
+        graphEndpoint: invalidGraphEndpoint,
+        tokenEndpoint: validTokenEndpoint,
+        authEndpoint:  validAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           validEndpoint,
-        graphEndpoint:      validGraphEndpoint,
-        tokenEndpoint:      '',
-        authEndpoint:       validAuthEndpoint,
-        result:             true
+        endpoint:      validEndpoint,
+        graphEndpoint: validGraphEndpoint,
+        tokenEndpoint: '',
+        authEndpoint:  validAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           validEndpoint,
-        graphEndpoint:      validGraphEndpoint,
-        tokenEndpoint:      invalidTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        result:             true
+        endpoint:      validEndpoint,
+        graphEndpoint: validGraphEndpoint,
+        tokenEndpoint: invalidTokenEndpoint,
+        authEndpoint:  validAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           validEndpoint,
-        graphEndpoint:      validGraphEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       '',
-        result:             true
+        endpoint:      validEndpoint,
+        graphEndpoint: validGraphEndpoint,
+        tokenEndpoint: validTokenEndpoint,
+        authEndpoint:  '',
+        result:        true
       },
       {
-        endpoint:           validEndpoint,
-        graphEndpoint:      validGraphEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       invalidAuthEndpoint,
-        result:             true
+        endpoint:      validEndpoint,
+        graphEndpoint: validGraphEndpoint,
+        tokenEndpoint: validTokenEndpoint,
+        authEndpoint:  invalidAuthEndpoint,
+        result:        true
       },
       {
-        endpoint:           validEndpoint,
-        graphEndpoint:      validGraphEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        result:             false
+        endpoint:      validEndpoint,
+        graphEndpoint: validGraphEndpoint,
+        tokenEndpoint: validTokenEndpoint,
+        authEndpoint:  validAuthEndpoint,
+        result:        false
       }
     ];
 

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -148,31 +148,27 @@ describe('edit: azureAD should', () => {
         graphEndpoint:      '',
         tokenEndpoint:      '',
         authEndpoint:       '',
-        deviceAuthEndpoint: '',
         result:             true
       },
       {
         endpoint:           invalidEndpoint,
-        graphEndpoint:      invalidAuthEndpoint,
+        graphEndpoint:      invalidGraphEndpoint,
         tokenEndpoint:      invalidTokenEndpoint,
         authEndpoint:       invalidAuthEndpoint,
-        deviceAuthEndpoint: invalidGraphEndpoint,
         result:             true
       },
       {
         endpoint:           '',
-        graphEndpoint:      validAuthEndpoint,
+        graphEndpoint:      validGraphEndpoint,
         tokenEndpoint:      validTokenEndpoint,
         authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
         endpoint:           invalidEndpoint,
-        graphEndpoint:      validAuthEndpoint,
+        graphEndpoint:      validGraphEndpoint,
         tokenEndpoint:      validTokenEndpoint,
         authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
@@ -180,71 +176,48 @@ describe('edit: azureAD should', () => {
         graphEndpoint:      '',
         tokenEndpoint:      validTokenEndpoint,
         authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
         endpoint:           validEndpoint,
-        graphEndpoint:      invalidAuthEndpoint,
+        graphEndpoint:      invalidGraphEndpoint,
         tokenEndpoint:      validTokenEndpoint,
         authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
         endpoint:           validEndpoint,
-        graphEndpoint:      validAuthEndpoint,
+        graphEndpoint:      validGraphEndpoint,
         tokenEndpoint:      '',
         authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
         endpoint:           validEndpoint,
-        graphEndpoint:      validAuthEndpoint,
+        graphEndpoint:      validGraphEndpoint,
         tokenEndpoint:      invalidTokenEndpoint,
         authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
         endpoint:           validEndpoint,
-        graphEndpoint:      validAuthEndpoint,
+        graphEndpoint:      validGraphEndpoint,
         tokenEndpoint:      validTokenEndpoint,
         authEndpoint:       '',
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
         endpoint:           validEndpoint,
-        graphEndpoint:      validAuthEndpoint,
+        graphEndpoint:      validGraphEndpoint,
         tokenEndpoint:      validTokenEndpoint,
         authEndpoint:       invalidAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             true
       },
       {
         endpoint:           validEndpoint,
-        graphEndpoint:      validAuthEndpoint,
+        graphEndpoint:      validGraphEndpoint,
         tokenEndpoint:      validTokenEndpoint,
         authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: invalidGraphEndpoint,
-        result:             true
-      },
-      {
-        endpoint:           validEndpoint,
-        graphEndpoint:      validAuthEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: '', // this field is not mandatory
-        result:             false
-      },
-      {
-        endpoint:           validEndpoint,
-        graphEndpoint:      validAuthEndpoint,
-        tokenEndpoint:      validTokenEndpoint,
-        authEndpoint:       validAuthEndpoint,
-        deviceAuthEndpoint: validGraphEndpoint,
         result:             false
       }
     ];
@@ -266,7 +239,6 @@ describe('edit: azureAD should', () => {
     const graphEndpointInputField = wrapper.find('[data-testid="input-azureAD-graphEndpoint"]').find('input');
     const tokenEndpointInputField = wrapper.find('[data-testid="input-azureAD-tokenEndpoint"]').find('input');
     const authEndpointInputField = wrapper.find('[data-testid="input-azureAD-authEndpoint"]').find('input');
-    const deviceAuthEndpointInputField = wrapper.find('[data-testid="input-azureAD-deviceAuthEndpoint"]').find('input');
 
     for (const testCase of testCases) {
       endpointInputField.setValue(testCase.endpoint);
@@ -276,8 +248,6 @@ describe('edit: azureAD should', () => {
       tokenEndpointInputField.setValue(testCase.tokenEndpoint);
       await wrapper.vm.$nextTick();
       authEndpointInputField.setValue(testCase.authEndpoint);
-      await wrapper.vm.$nextTick();
-      deviceAuthEndpointInputField.setValue(testCase.deviceAuthEndpoint);
       await wrapper.vm.$nextTick();
 
       expect(saveButton.disabled).toBe(testCase.result);

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -49,8 +49,7 @@ const ENDPOINT_MAPPING = {
     endpoint:           'https://login.microsoftonline.com/',
     graphEndpoint:      '',
     tokenEndpoint:      '',
-    authEndpoint:       '',
-    deviceAuthEndpoint: ''
+    authEndpoint:       ''
   }
 };
 
@@ -93,7 +92,6 @@ export default {
         { path: 'graphEndpoint', rules: ['graphEndpointRequired', 'graphEndpointMustBeURL'] },
         { path: 'tokenEndpoint', rules: ['tokenEndpointRequired', 'tokenEndpointMustBeURL'] },
         { path: 'authEndpoint', rules: ['authEndpointRequired', 'authEndpointMustBeURL'] },
-        { path: 'deviceAuthEndpoint', rules: ['deviceAuthEndpointMustBeURL'] },
       ]
     };
   },
@@ -112,8 +110,7 @@ export default {
         tokenEndpointRequired:       this.modelFieldRequired('tokenEndpoint', 'authConfig.azuread.tokenEndpoint.label'),
         tokenEndpointMustBeURL:      this.modelFieldURL('tokenEndpoint'),
         authEndpointRequired:        this.modelFieldRequired('authEndpoint', 'authConfig.azuread.authEndpoint.label'),
-        authEndpointMustBeURL:       this.modelFieldURL('authEndpoint'),
-        deviceAuthEndpointMustBeURL: this.modelFieldURL('deviceAuthEndpoint'),
+        authEndpointMustBeURL:       this.modelFieldURL('authEndpoint')
       };
     },
 
@@ -348,10 +345,6 @@ export default {
               <td>{{ t(`authConfig.azuread.authEndpoint.label`) }}:</td>
               <td>{{ model.authEndpoint }}</td>
             </tr>
-            <tr v-if="model.deviceAuthEndpoint">
-              <td>{{ t(`authConfig.azuread.deviceAuthEndpoint.label`) }}:</td>
-              <td>{{ model.deviceAuthEndpoint }}</td>
-            </tr>
           </template>
           <template
             v-if="needsUpdate"
@@ -490,17 +483,6 @@ export default {
                 :rules="fvGetAndReportPathRules('authEndpoint')"
                 :mode="mode"
                 data-testid="input-azureAD-authEndpoint"
-              />
-            </div>
-          </div>
-          <div class="row mb-20">
-            <div class="col span-6">
-              <LabeledInput
-                v-model="model.deviceAuthEndpoint"
-                :label="t('authConfig.azuread.deviceAuthEndpoint.label')"
-                :mode="mode"
-                :rules="fvGetAndReportPathRules('deviceAuthEndpoint')"
-                data-testid="input-azureAD-deviceAuthEndpoint"
               />
             </div>
           </div>

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -277,12 +277,12 @@ export default {
     },
     modelFieldRequired(path, label) {
       return () => {
-        return !this.model[path] ? `${ this.t(label) } is required` : undefined;
+        return !this.model[path] ? `${ this.t('validation.required', { key: this.t(label) }) }` : undefined;
       };
     },
     applicationSecretRequired() {
       return () => {
-        return !this.editMemberConfig && !this.model.applicationSecret ? `${ this.t('authConfig.azuread.applicationSecret.label') } is required` : undefined;
+        return !this.editMemberConfig && !this.model.applicationSecret ? `${ this.t('validation.required', { key: this.t('authConfig.azuread.applicationSecret.label') }) }` : undefined;
       };
     },
     modelFieldURL(path) {

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -2,6 +2,7 @@
 import isEqual from 'lodash/isEqual';
 import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
+import FormValidation from '@shell/mixins/form-validation';
 import CruResource from '@shell/components/CruResource';
 import InfoBox from '@shell/components/InfoBox';
 import { RadioGroup } from '@components/Form/Radio';
@@ -13,6 +14,7 @@ import AuthConfig from '@shell/mixins/auth-config';
 import { AZURE_MIGRATED } from '@shell/config/labels-annotations';
 import { get } from '@shell/utils/object';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
+import formRulesGenerator from '@shell/utils/validators/formRules/index';
 
 const TENANT_ID_TOKEN = '__[[TENANT_ID]]__';
 
@@ -44,10 +46,11 @@ const ENDPOINT_MAPPING = {
     authEndpoint:  `https://login.partner.microsoftonline.cn/${ TENANT_ID_TOKEN }/oauth2/v2.0/authorize`
   },
   custom: {
-    endpoint:      'https://login.microsoftonline.com/',
-    graphEndpoint: '',
-    tokenEndpoint: '',
-    authEndpoint:  ''
+    endpoint:           'https://login.microsoftonline.com/',
+    graphEndpoint:      '',
+    tokenEndpoint:      '',
+    authEndpoint:       '',
+    deviceAuthEndpoint: ''
   }
 };
 
@@ -64,7 +67,7 @@ export default {
     AuthProviderWarningBanners
   },
 
-  mixins: [CreateEditView, AuthConfig],
+  mixins: [CreateEditView, AuthConfig, FormValidation],
 
   async fetch() {
     await this.reloadModel();
@@ -81,11 +84,39 @@ export default {
 
       // Storing the applicationSecret is necessary because norman doesn't support returning secrets and when we
       // override the steve authconfig with a norman config the applicationSecret is lost
-      applicationSecret: this.value.applicationSecret
+      applicationSecret: this.value.applicationSecret,
+      fvFormRuleSets:    [
+        { path: 'tenantId', rules: ['tenantIdRequired'] },
+        { path: 'applicationId', rules: ['applicationIdRequired'] },
+        { path: 'applicationSecret', rules: ['applicationSecretRequired'] },
+        { path: 'endpoint', rules: ['endpointRequired', 'endpointMustBeURL'] },
+        { path: 'graphEndpoint', rules: ['graphEndpointRequired', 'graphEndpointMustBeURL'] },
+        { path: 'tokenEndpoint', rules: ['tokenEndpointRequired', 'tokenEndpointMustBeURL'] },
+        { path: 'authEndpoint', rules: ['authEndpointRequired', 'authEndpointMustBeURL'] },
+        { path: 'deviceAuthEndpoint', rules: ['deviceAuthEndpointMustBeURL'] },
+      ]
     };
   },
 
   computed: {
+    // Cannot pass this.model as a rootObject because it is undefined at that point, so had to use a workaround
+    fvExtraRules() {
+      return {
+        tenantIdRequired:            this.modelFieldRequired('tenantId', 'authConfig.azuread.tenantId.label'),
+        applicationIdRequired:       this.modelFieldRequired('applicationId', 'authConfig.azuread.applicationId.label'),
+        applicationSecretRequired:   this.applicationSecretRequired(),
+        endpointRequired:            this.modelFieldRequired('endpoint', 'authConfig.azuread.endpoint.label'),
+        endpointMustBeURL:           this.modelFieldURL('endpoint'),
+        graphEndpointRequired:       this.modelFieldRequired('graphEndpoint', 'authConfig.azuread.graphEndpoint.label'),
+        graphEndpointMustBeURL:      this.modelFieldURL('graphEndpoint'),
+        tokenEndpointRequired:       this.modelFieldRequired('tokenEndpoint', 'authConfig.azuread.tokenEndpoint.label'),
+        tokenEndpointMustBeURL:      this.modelFieldURL('tokenEndpoint'),
+        authEndpointRequired:        this.modelFieldRequired('authEndpoint', 'authConfig.azuread.authEndpoint.label'),
+        authEndpointMustBeURL:       this.modelFieldURL('authEndpoint'),
+        deviceAuthEndpointMustBeURL: this.modelFieldURL('deviceAuthEndpoint'),
+      };
+    },
+
     tArgs() {
       return {
         baseUrl:  this.baseUrl,
@@ -131,6 +162,9 @@ export default {
         title:       this.t('authConfig.azuread.updateEndpoint.modal.title'),
         body:        this.t('authConfig.azuread.updateEndpoint.modal.body', null, { raw: true })
       };
+    },
+    editMemberConfig() {
+      return this.model.enabled && !this.isEnabling && !this.editConfig;
     }
   },
 
@@ -243,6 +277,23 @@ export default {
             btnCB(false);
           });
       }
+    },
+    modelFieldRequired(path, label) {
+      return () => {
+        return !this.model[path] ? `${ this.t(label) } is required` : undefined;
+      };
+    },
+    applicationSecretRequired() {
+      return () => {
+        return !this.editMemberConfig && !this.model.applicationSecret ? `${ this.t('authConfig.azuread.applicationSecret.label') } is required` : undefined;
+      };
+    },
+    modelFieldURL(path) {
+      return () => {
+        const rule = formRulesGenerator(this.$store.getters['i18n/t'], {}).url;
+
+        return rule(this.model[path]);
+      };
     }
   }
 };
@@ -256,17 +307,17 @@ export default {
       :mode="mode"
       :resource="model"
       :subtypes="[]"
-      :validation-passed="true"
+      :validation-passed="fvFormIsValid"
       :finish-button-mode="model && model.enabled ? 'edit' : 'enable'"
       :can-yaml="false"
       :errors="errors"
       :show-cancel="showCancel"
       :cancel-event="true"
-      @error="e => (errors = e)"
+      @error="e=>errors = e"
       @finish="save"
       @cancel="cancel"
     >
-      <template v-if="model.enabled && !isEnabling && !editConfig">
+      <template v-if="editMemberConfig">
         <AuthBanner
           :t-args="tArgs"
           :disable="disable"
@@ -274,27 +325,27 @@ export default {
         >
           <template slot="rows">
             <tr>
-              <td>{{ t(`authConfig.azuread.tenantId`) }}:</td>
+              <td>{{ t(`authConfig.azuread.tenantId.label`) }}:</td>
               <td>{{ model.tenantId }}</td>
             </tr>
             <tr>
-              <td>{{ t(`authConfig.azuread.applicationId`) }}:</td>
+              <td>{{ t(`authConfig.azuread.applicationId.label`) }}:</td>
               <td>{{ model.applicationId }}</td>
             </tr>
             <tr>
-              <td>{{ t(`authConfig.azuread.endpoint`) }}:</td>
+              <td>{{ t(`authConfig.azuread.endpoint.label`) }}:</td>
               <td>{{ model.endpoint }}</td>
             </tr>
             <tr>
-              <td>{{ t(`authConfig.azuread.graphEndpoint`) }}:</td>
+              <td>{{ t(`authConfig.azuread.graphEndpoint.label`) }}:</td>
               <td>{{ model.graphEndpoint }}</td>
             </tr>
             <tr>
-              <td>{{ t(`authConfig.azuread.tokenEndpoint`) }}:</td>
+              <td>{{ t(`authConfig.azuread.tokenEndpoint.label`) }}:</td>
               <td>{{ model.tokenEndpoint }}</td>
             </tr>
             <tr>
-              <td>{{ t(`authConfig.azuread.authEndpoint`) }}:</td>
+              <td>{{ t(`authConfig.azuread.authEndpoint.label`) }}:</td>
               <td>{{ model.authEndpoint }}</td>
             </tr>
           </template>
@@ -346,11 +397,13 @@ export default {
             <LabeledInput
               id="tenant-id"
               v-model="model.tenantId"
-              label="Tenant ID"
+              :label="t('authConfig.azuread.tenantId.label')"
               :mode="mode"
               :required="true"
-              tooltip="From the Azure AD portal"
-              placeholder="A long UUID string"
+              :rules="fvGetAndReportPathRules('tenantId')"
+              :tooltip="t('authConfig.azuread.tenantId.tooltip')"
+              :placeholder="t('authConfig.azuread.tenantId.placeholder')"
+              data-testid="input-azureAD-tenantId"
             />
           </div>
         </div>
@@ -359,10 +412,12 @@ export default {
             <LabeledInput
               id="application-id"
               v-model="model.applicationId"
-              label="Application ID"
+              :label="t('authConfig.azuread.applicationId.label')"
               :mode="mode"
               :required="true"
-              placeholder="A long UUID string"
+              :rules="fvGetAndReportPathRules('applicationId')"
+              :placeholder="t('authConfig.azuread.applicationId.placeholder')"
+              data-testid="input-azureAD-applcationId"
             />
           </div>
           <div class="col span-6">
@@ -370,9 +425,11 @@ export default {
               id="application-secret"
               v-model="model.applicationSecret"
               type="password"
-              label="Application Secret"
+              :label="t('authConfig.azuread.applicationSecret.label')"
               :required="true"
+              :rules="fvGetAndReportPathRules('applicationSecret')"
               :mode="mode"
+              data-testid="input-azureAD-applicationSecret"
             />
           </div>
         </div>
@@ -380,28 +437,33 @@ export default {
           v-model="endpoint"
           class="mb-20"
           :required="true"
-          label="Endpoints"
+          :label="t('authConfig.azuread.endpoints.label')"
           name="endpoints"
           :options="['standard', 'china', 'custom']"
           :mode="mode"
-          :labels="['Standard', 'China', 'Custom']"
+          :labels="[t('authConfig.azuread.endpoints.standard'), t('authConfig.azuread.endpoints.china'), t('authConfig.azuread.endpoints.custom')]"
+          data-testid="endpoints-radio-input"
         />
         <div v-if="endpoint === 'custom'">
           <div class="row mb-20">
             <div class="col span-6">
               <LabeledInput
                 v-model="model.endpoint"
-                label="Endpoint"
+                :label="t('authConfig.azuread.endpoint.label')"
                 :mode="mode"
                 :required="true"
+                :rules="fvGetAndReportPathRules('endpoint')"
+                data-testid="input-azureAD-endpoint"
               />
             </div>
             <div class="col span-6">
               <LabeledInput
                 v-model="model.graphEndpoint"
-                label="Graph Endpoint"
+                :label="t('authConfig.azuread.graphEndpoint.label')"
                 :required="true"
+                :rules="fvGetAndReportPathRules('graphEndpoint')"
                 :mode="mode"
+                data-testid="input-azureAD-graphEndpoint"
               />
             </div>
           </div>
@@ -409,17 +471,32 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model="model.tokenEndpoint"
-                label="Token Endpoint"
+                :label="t('authConfig.azuread.tokenEndpoint.label')"
                 :mode="mode"
                 :required="true"
+                :rules="fvGetAndReportPathRules('tokenEndpoint')"
+                data-testid="input-azureAD-tokenEndpoint"
               />
             </div>
             <div class="col span-6">
               <LabeledInput
                 v-model="model.authEndpoint"
-                label="Auth Endpoint"
+                :label="t('authConfig.azuread.authEndpoint.label')"
                 :required="true"
+                :rules="fvGetAndReportPathRules('authEndpoint')"
                 :mode="mode"
+                data-testid="input-azureAD-authEndpoint"
+              />
+            </div>
+          </div>
+          <div class="row mb-20">
+            <div class="col span-6">
+              <LabeledInput
+                v-model="model.deviceAuthEndpoint"
+                :label="t('authConfig.azuread.deviceAuthEndpoint.label')"
+                :mode="mode"
+                :rules="fvGetAndReportPathRules('deviceAuthEndpoint')"
+                data-testid="input-azureAD-deviceAuthEndpoint"
               />
             </div>
           </div>

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -348,6 +348,10 @@ export default {
               <td>{{ t(`authConfig.azuread.authEndpoint.label`) }}:</td>
               <td>{{ model.authEndpoint }}</td>
             </tr>
+            <tr v-if="model.deviceAuthEndpoint">
+              <td>{{ t(`authConfig.azuread.deviceAuthEndpoint.label`) }}:</td>
+              <td>{{ model.deviceAuthEndpoint }}</td>
+            </tr>
           </template>
           <template
             v-if="needsUpdate"

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -46,10 +46,10 @@ const ENDPOINT_MAPPING = {
     authEndpoint:  `https://login.partner.microsoftonline.cn/${ TENANT_ID_TOKEN }/oauth2/v2.0/authorize`
   },
   custom: {
-    endpoint:           'https://login.microsoftonline.com/',
-    graphEndpoint:      '',
-    tokenEndpoint:      '',
-    authEndpoint:       ''
+    endpoint:      'https://login.microsoftonline.com/',
+    graphEndpoint: '',
+    tokenEndpoint: '',
+    authEndpoint:  ''
   }
 };
 
@@ -100,17 +100,17 @@ export default {
     // Cannot pass this.model as a rootObject because it is undefined at that point, so had to use a workaround
     fvExtraRules() {
       return {
-        tenantIdRequired:            this.modelFieldRequired('tenantId', 'authConfig.azuread.tenantId.label'),
-        applicationIdRequired:       this.modelFieldRequired('applicationId', 'authConfig.azuread.applicationId.label'),
-        applicationSecretRequired:   this.applicationSecretRequired(),
-        endpointRequired:            this.modelFieldRequired('endpoint', 'authConfig.azuread.endpoint.label'),
-        endpointMustBeURL:           this.modelFieldURL('endpoint'),
-        graphEndpointRequired:       this.modelFieldRequired('graphEndpoint', 'authConfig.azuread.graphEndpoint.label'),
-        graphEndpointMustBeURL:      this.modelFieldURL('graphEndpoint'),
-        tokenEndpointRequired:       this.modelFieldRequired('tokenEndpoint', 'authConfig.azuread.tokenEndpoint.label'),
-        tokenEndpointMustBeURL:      this.modelFieldURL('tokenEndpoint'),
-        authEndpointRequired:        this.modelFieldRequired('authEndpoint', 'authConfig.azuread.authEndpoint.label'),
-        authEndpointMustBeURL:       this.modelFieldURL('authEndpoint')
+        tenantIdRequired:          this.modelFieldRequired('tenantId', 'authConfig.azuread.tenantId.label'),
+        applicationIdRequired:     this.modelFieldRequired('applicationId', 'authConfig.azuread.applicationId.label'),
+        applicationSecretRequired: this.applicationSecretRequired(),
+        endpointRequired:          this.modelFieldRequired('endpoint', 'authConfig.azuread.endpoint.label'),
+        endpointMustBeURL:         this.modelFieldURL('endpoint'),
+        graphEndpointRequired:     this.modelFieldRequired('graphEndpoint', 'authConfig.azuread.graphEndpoint.label'),
+        graphEndpointMustBeURL:    this.modelFieldURL('graphEndpoint'),
+        tokenEndpointRequired:     this.modelFieldRequired('tokenEndpoint', 'authConfig.azuread.tokenEndpoint.label'),
+        tokenEndpointMustBeURL:    this.modelFieldURL('tokenEndpoint'),
+        authEndpointRequired:      this.modelFieldRequired('authEndpoint', 'authConfig.azuread.authEndpoint.label'),
+        authEndpointMustBeURL:     this.modelFieldURL('authEndpoint')
       };
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#10771
<!-- Define findings related to the feature or bug issue. -->
Added validation to AzureAD configuration 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Fixed validation for AzureAD
- Replaced labels with translations

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Had to use fvExtraRules() for validation since this.model() is used to set the values and it is undefined when data() is run, so default validation would be using this.value instead, which is incorrect.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to Users & Authentication -> Auth provider ->AzureAD
- 'Enable' button should be disabled before any information is entered
- 'Enable' button should be enabled once Tenant ID, Application ID, and Application Secret are populated
- Switch 'Endpoints' to 'Custom'
- 'Enable' button should be disabled before any information is entered
- 'Enable' button should be enabled once Endpoint, Graph Endpoint, Token Endpoint, and Auth Endpoint are populated
- Press enable and finish the setup. Azure AD should be successfully enabled.
- Check that the steps from above apply to edit.

### Areas which could experience regressions
Editing the list of users who have access can be affected

### Screenshot/Video

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
