### PR TITLE
Default to unlimited line width when dumping yaml blocks

### DIFF
--- a/shell/utils/__tests__/create-yaml.test.ts
+++ b/shell/utils/__tests__/create-yaml.test.ts
@@ -133,6 +133,15 @@ b c`
 
     expect(result).toStrictEqual(expectedResult);
   });
+
+  it('should default to unlimited width for blocks', () => {
+    const block = { test: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.' };
+    const expected = 'test: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n';
+
+    const result = dumpBlock(block);
+
+    expect(result).toStrictEqual(expected);
+  });
 });
 
 describe('fx: resourceFields', () => {

--- a/shell/utils/create-yaml.js
+++ b/shell/utils/create-yaml.js
@@ -487,7 +487,7 @@ export function saferDump(obj) {
  *
  * @returns the result of jsyaml.dump with the addition of multiline indicators
  */
-export function dumpBlock(data, options = {}) {
+export function dumpBlock(data, options = { lineWidth: -1 }) {
   const parsed = jsyaml.dump(data, options);
 
   let out = parsed;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This defaults to unlimited line width when dumping yaml blocks. This should resolve issues where newline characters are inserted into yaml while using the form editor, breaking previously functional manifests.

Fixes #10589 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I don't see any situation where it would be valid to insert newline characters at the default of 80 characters. If we do want this behavior, that would be the exception and we can supply proper options for a specific field we want to target.

An alternative approach would be to specify a `lineWidth` for individual fields like `metadata.annotations`, but I thought this too specific an approach, and leaves us in a situation where future tickets will open for properties that we haven't considered.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Configmaps - See the linked issues for detailed reproduction steps.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Configmaps
- Anything that utilizes the `create-yaml` util

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
