### PR TITLE
Wire in Feature Flag and Performance Settings for Server-Side Pagination

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7248,7 +7248,7 @@ performance:
       When enabled, resources will appear more quickly, but it may take slightly longer to load the entire set of resources. This setting only applies to resources that come from the Kubernetes API
     checkboxLabel: Enable incremental loading
     inputLabel: Resource Threshold
-    incompatibleDescription: "Incremental Loading is incomaptible with Namespace/Project filtering. Enabling this will disable it."
+    incompatibleDescription: "Incremental Loading is incomaptible with Namespace/Project filtering and Server-side Pagination. Enabling this will disable them."
   manualRefresh:
     label: Manual Refresh
     setting: You can configure a threshold above which manual refresh will be enabled.
@@ -7257,7 +7257,7 @@ performance:
       When enabled, list data will not auto-update but instead the user must manually trigger a list-view refresh. This setting only applies to resources that come from the Kubernetes API
     checkboxLabel: Enable manual refresh of data for lists
     inputLabel: Resource Threshold
-    incompatibleDescription: "Manual Refresh is incomaptible with Namespace/Project filtering. Enabling this will disable it."
+    incompatibleDescription: "Manual Refresh is incomaptible with Namespace/Project filtering and Server-side Pagination. Enabling this will disable them."
   websocketNotification:
     label: Websocket Notifications
     description: |-
@@ -7300,8 +7300,13 @@ performance:
     information: To change the automatic logout behaviour, edit the authorisation and/or session token timeout values (<code>auth-user-session-ttl-minutes</code> and <code>auth-token-max-ttl-minutes</code>) in the Settings page.
     description: When enabled and the user is inactive past the specified timeout, the UI will no longer fresh page content and the user must reload the page to continue.
     authUserTTL: This timeout cannot be higher than the user session timeout auth-user-session-ttl-minutes, which is currently {current} minutes.
-
-
+  serverPagination:
+    label: Server-side Pagination
+    description: By default Lists will fetch all resources and paginate in the browser (create the page given sorting and filtering settings). Change this setting to enable pagination server-side. This should help the responsiveness of the UI in systems with a lot of resources.
+    checkboxLabel: Enable Server-side Pagination
+    applicable: "This applies to the following resource types"
+    incompatibleDescription: "Server-side Pagination is incomaptible with Manual Refresh and Incremental Loading. Enabling this will disable them."
+    featureFlag: The Feature Flag `on-disk-steve-cache` must be enabled to use this feature
 banner:
   label: Fixed Banners
   settingName: Banners

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7306,7 +7306,10 @@ performance:
     checkboxLabel: Enable Server-side Pagination
     applicable: "This applies to the following resource types"
     incompatibleDescription: "Server-side Pagination is incomaptible with Manual Refresh and Incremental Loading. Enabling this will disable them."
-    featureFlag: The Feature Flag `on-disk-steve-cache` must be enabled to use this feature
+    featureFlag: The <a href="{ffUrl}">Feature Flag</a> `on-disk-steve-cache` must be enabled to use this feature
+    resources:
+      generic: most resources in the cluster's 'More Resources' section
+      all: All Resources
 banner:
   label: Fixed Banners
   settingName: Banners

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -1,5 +1,6 @@
 // Settings
 import { GC_DEFAULTS, GC_PREFERENCES } from '@shell/utils/gc/gc-types';
+import { PaginationSettings } from '@shell/types/resources/settings';
 
 interface GlobalSettingRuleset {
   name: string,
@@ -189,6 +190,7 @@ export interface PerfSettings {
   forceNsFilterV2: any;
   advancedWorker: {};
   kubeAPI: PerfSettingsKubeApi;
+  serverPagination: PaginationSettings;
 }
 
 export const DEFAULT_PERF_SETTING: PerfSettings = {
@@ -224,5 +226,20 @@ export const DEFAULT_PERF_SETTING: PerfSettings = {
        */
       notificationBlockList: ['299 - unknown field']
     }
+  },
+  serverPagination: {
+    enabled: false,
+    stores:  {
+      cluster: {
+        resources: {
+          enableAll:  false,
+          enableSome: {
+            enabled: ['configmap', 'secret', 'pod', 'node'],
+            generic: true,
+          }
+        }
+      }
+    }
   }
+
 };

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -9,6 +9,7 @@ import { DEFAULT_PERF_SETTING, SETTING } from '@shell/config/settings';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import UnitInput from '@shell/components/form/UnitInput';
 import { STEVE_CACHE } from '@shell/store/features';
+import { NAME as SETTING_PRODUCT } from '@shell/config/product/settings';
 
 const incompatible = {
   incrementalLoading: ['forceNsFilterV2', 'serverPagination'],
@@ -67,6 +68,13 @@ export default {
       errors:                     [],
       gcStartedEnabled:           null,
       isInactivityThresholdValid: false,
+      ffUrl:                      this.$router.resolve({
+        name:   'c-cluster-product-resource',
+        params: {
+          product:  SETTING_PRODUCT,
+          resource: MANAGEMENT.FEATURE
+        }
+      }).href
     };
   },
 
@@ -92,13 +100,13 @@ export default {
         const resources = [];
 
         if (settings.resources.enableAll) {
-          resources.push('All resources');
+          resources.push(this.t('performance.serverPagination.resources.all'));
         } else {
           settings.resources.enableSome.enabled.forEach((resource) => {
             resources.push(resource);
           });
           if (settings.resources.enableSome.generic) {
-            resources.push('generic lists');
+            resources.push(this.t('performance.serverPagination.resources.generic', {}, true));
           }
         }
 
@@ -380,8 +388,9 @@ export default {
           <Banner
             v-if="!steveCacheEnabled"
             color="warning"
-            label-key="performance.serverPagination.featureFlag"
-          />
+          >
+            <span v-clean-html="t(`performance.serverPagination.featureFlag`, { ffUrl }, true)" />
+          </Banner>
           <Checkbox
             v-model="value.serverPagination.enabled"
             :mode="mode"

--- a/shell/plugins/steve/__tests__/subscribe.spec.ts
+++ b/shell/plugins/steve/__tests__/subscribe.spec.ts
@@ -10,7 +10,10 @@ describe('steve: subscribe', () => {
         inError:       () => false,
         watchStarted:  () => false,
       };
-      const rootGetters = { 'type-map/isSpoofed': () => false };
+      const rootGetters = {
+        'type-map/isSpoofed': () => false,
+        'features/get':       () => false,
+      };
 
       const type = 'test';
       const selector = undefined;

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -403,14 +403,14 @@ const sharedActions = {
       return;
     }
 
-    // This is temporary and will be removed once Part 3 of https://github.com/rancher/dashboard/pull/10349 is resolved by abckend
+    // This is temporary and will be removed once Part 3 of https://github.com/rancher/dashboard/pull/10349 is resolved by backend
     // Steve cache backed api does not return a revision, so `revision` here is always undefined
     // Which means we find a revision within a resource itself and use it in the watch
     // That revision is probably too old and results in a watch error
     // Watch errors mean we make a http request to get latest revision (which is still missing) and try to re-watch with it...
     // etc
-    if (!rootGetters['features/get']?.(STEVE_CACHE) && typeof revision === 'undefined') {
-      return undefined;
+    if (typeof revision === 'undefined' && !rootGetters['features/get']?.(STEVE_CACHE)) {
+      revision = getters.nextResourceVersion(type, id);
     }
     // if ( typeof revision === 'undefined' ) {
     //   revision = getters.nextResourceVersion(type, id);

--- a/shell/store/features.js
+++ b/shell/store/features.js
@@ -2,8 +2,8 @@ import { MANAGEMENT } from '@shell/config/types';
 
 const definitions = {};
 
-export const create = function(name, def) {
-  definitions[name] = { def };
+export const create = function(name, defaultValue) {
+  definitions[name] = { def: defaultValue };
 
   return name;
 };
@@ -33,6 +33,7 @@ export const FLEET = create('continuous-delivery', true);
 export const HARVESTER = create('harvester', true);
 export const HARVESTER_CONTAINER = create('harvester-baremetal-container-workload', false);
 export const FLEET_WORKSPACE_BACK = create('provisioningv2-fleet-workspace-back-population', false);
+export const STEVE_CACHE = create('on-disk-steve-cache', false);
 
 // Not currently used.. no point defining ones we don't use
 // export const EMBEDDED_CLUSTER_API = create('embedded-cluster-api', true);

--- a/shell/utils/pagination-utils.ts
+++ b/shell/utils/pagination-utils.ts
@@ -44,7 +44,7 @@ class PaginationUtils {
     const settings = this.getSettings({ rootGetters });
 
     // Cache must be enabled to support pagination api
-    if (!rootGetters['features/get'](STEVE_CACHE)) {
+    if (!rootGetters['features/get']?.(STEVE_CACHE)) {
       return false;
     }
 

--- a/shell/utils/pagination-utils.ts
+++ b/shell/utils/pagination-utils.ts
@@ -12,22 +12,8 @@ import {
 import { PaginationArgs, PaginationParam, PaginationSort } from '@shell/types/store/pagination.types';
 import { sameArrayObjects } from '@shell/utils/array';
 import { isEqual } from '@shell/utils/object';
-
-// This are hardcoded atm, but will be changed via the `Performance` settings
-const settings: PaginationSettings = {
-  enabled: false,
-  stores:  {
-    cluster: {
-      resources: {
-        enableAll:  false,
-        enableSome: {
-          enabled: ['configmap', 'secret', 'pod', 'node'],
-          generic: true,
-        }
-      }
-    }
-  }
-};
+import { STEVE_CACHE } from '@shell/store/features';
+import { getPerformanceSetting } from '@shell/utils/settings';
 
 /**
  * Helper functions for server side pagination
@@ -40,6 +26,12 @@ class PaginationUtils {
    */
   validNsProjectFilters = [ALL, ALL_SYSTEM, ALL_USER, ALL_SYSTEM, NAMESPACE_FILTER_KINDS.NAMESPACE, NAMESPACE_FILTER_KINDS.PROJECT, NAMESPACED_YES, NAMESPACED_NO];
 
+  private getSettings({ rootGetters }: any): PaginationSettings {
+    const perf = getPerformanceSetting(rootGetters);
+
+    return perf.serverPagination;
+  }
+
   /**
    * Is pagination enabled at a global level or for a specific resource
    */
@@ -49,6 +41,13 @@ class PaginationUtils {
       id: string,
     }
   }) {
+    const settings = this.getSettings({ rootGetters });
+
+    // Cache must be enabled to support pagination api
+    if (!rootGetters['features/get'](STEVE_CACHE)) {
+      return false;
+    }
+
     // No setting, not enabled
     if (!settings?.enabled) {
       return false;


### PR DESCRIPTION
~Blocked on https://github.com/rancher/dashboard/pull/10761~

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to https://github.com/rancher/dashboard/issues/9545



### Occurred changes and/or fixed issues
Gate server side pagination on 
- `on-disk-steve-cache` feature flag
  - There's a backend in progress item to resolve a `revision` issue, so when this is enabled... disable watching on revisions
- new Global Settings - Performance - Server Side Pagination Setting
  - Added new setting to enable server side pagination
  - this is incompatible with two other performance settings

Also fix add temporary fix for an issue Bullseye team are working on
- new steve vai cache api does not return a revision number when we fetch resources
- this means the UI will watch resource using a revision from the resources themselves, which is often `too old`
- watch will fail given `too old`... we fetch resources again to get latest and a correct revision
- revision is missing, so we use from resources themselves
- repeat ad nauseam. 
The fix is to not use a revision from resources themselves. This is temporary, blocked backend, and tracked in https://github.com/rancher/dashboard/issues/9545

### Areas or cases that should be tested
- Lists are not server-side paginated until both settings are enabled
- Incremental Loading and Manual Refresh are incompatible with server-side pagination and their settings should not apply at the same time

### Areas which could experience regressions
- Lists show server-side paginated when they shouldn't 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
  - Automated tests for server-side pagination will come in as part of https://github.com/rancher/dashboard/issues/9545
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
