### PR TITLE
[Automation] - Adding support for RKE2 custom cluster provisioning

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -94,7 +94,9 @@ export default defineConfig({
     awsSecretKey:        process.env.AWS_SECRET_ACCESS_KEY,
     azureSubscriptionId: process.env.AZURE_AKS_SUBSCRIPTION_ID,
     azureClientId:       process.env.AZURE_CLIENT_ID,
-    azureClientSecret:   process.env.AZURE_CLIENT_SECRET
+    azureClientSecret:   process.env.AZURE_CLIENT_SECRET,
+    customNodeIp:        process.env.CUSTOM_NODE_IP,
+    customNodeKey:       process.env.CUSTOM_NODE_KEY
   },
   e2e: {
     fixturesFolder: 'cypress/e2e/blueprints',

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -52,4 +52,16 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
   selectCustom(index: number) {
     return this.resourceDetail().cruResource().selectSubType(2, index).click();
   }
+
+  commandFromCustomClusterUI() {
+    return this.self().get('code').contains('--insecure');
+  }
+
+  activateInsecureRegistrationCommandFromUI() {
+    return this.self().get('.checkbox-label').contains('Insecure:');
+  }
+
+  customClusterRegistrationCmd(cmd: string) {
+    return `ssh -i custom_node.key -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" root@${ Cypress.env('customNodeIp') } \"nohup ${ cmd }\"`;
+  }
 }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -103,7 +103,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
     const detailRKE2ClusterPage = new ClusterManagerDetailRke2CustomPagePo(undefined, rke2CustomName);
 
-    describe('RKE2 Custom', () => {
+    describe('RKE2 Custom', { tags: ['@jenkins', '@customCluster'] }, () => {
       const editCreatedClusterPage = new ClusterManagerEditRke2CustomPagePo(undefined, rke2CustomName);
 
       it('can create new cluster', () => {
@@ -115,7 +115,10 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
             name: rke2CustomName
           },
           // Test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
-          spec: { rkeConfig: { machineGlobalConfig: { cni: 'none' }, machinePoolDefaults: { hostnameLengthLimit: 15 } } }
+          // The test validate the warning when selecting none, but now this get back to calico.
+          // A CNI is mandatory to get the cluster active otherwise manual intervention is needed or
+          // the use of a cloud provider but that's not in scope.
+          spec: { rkeConfig: { machineGlobalConfig: { cni: 'calico' }, machinePoolDefaults: { hostnameLengthLimit: 15 } } }
         };
 
         cy.userPreferences();
@@ -156,6 +159,10 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         cy.get('[data-testid="clusterBasics__noneOptionSelectedForCni"]').should('exist');
         // EO test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
 
+        labeledSelectPo.toggle();
+        labeledSelectPo.clickLabel('calico');
+        labeledSelectPo.checkOptionSelected('calico');
+
         // testing https://github.com/rancher/dashboard/issues/10159
         cy.get('[data-testid="btn-networking"]').click();
         createRKE2ClusterPage.network().truncateHostnameCheckbox().set();
@@ -169,6 +176,32 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         });
 
         detailRKE2ClusterPage.waitForPage(undefined, 'registration');
+
+        createRKE2ClusterPage.activateInsecureRegistrationCommandFromUI().click();
+        createRKE2ClusterPage.commandFromCustomClusterUI().then(($value) => {
+          const registrationCommand = $value.text();
+
+          cy.exec(`echo ${ Cypress.env('customNodeKey') } | base64 -d > custom_node.key && chmod 600 custom_node.key`).then((result) => {
+            cy.log('Creating the custom_node.key');
+            cy.log(result.stderr);
+            cy.log(result.stdout);
+            expect(result.code).to.eq(0);
+          });
+          cy.exec(`head custom_node.key`).then((result) => {
+            cy.log(result.stdout);
+            cy.log(result.stderr);
+            expect(result.code).to.eq(0);
+          });
+          cy.exec(createRKE2ClusterPage.customClusterRegistrationCmd(registrationCommand)).then((result) => {
+            cy.log(result.stderr);
+            cy.log(result.stdout);
+            expect(result.code).to.eq(0);
+          });
+        });
+        ClusterManagerListPagePo.navTo();
+        clusterList.waitForPage();
+        clusterList.list().state(rke2CustomName).should('contain', 'Updating');
+        clusterList.list().state(rke2CustomName).contains('Active', { timeout: 700000 });
       });
 
       it('can copy config to clipboard', () => {


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/749

### Occurred changes and/or fixed issues
Similar to the imported cluster tests updates to use real nodes for clusters. This adds a node to use on Custom Cluster provisioning. Using an instance to later register it as an all roles node for a cluster.

### Technical notes summary

- Adds a node
- Provisioning with the `can create cluster` under `RKE2 Custom`
- Remote connects with ssh and runs the registration command.
- Wait until the cluster become Active

Add tags to only run on Jenkins

### Areas or cases that should be tested
Jenkins pipelines

### Areas which could experience regressions
Jenkins pipelines


### Checklist
- [ x ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ x ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ x ] The PR template has been filled out
- [ x ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ x ] The PR has a reviewer assigned
- [ x ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ x ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
