### PR TITLE
automation: add check for cluster name in tooltip

### DIFF
--- a/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
@@ -69,7 +69,7 @@ describe('Side Menu: main', () => {
       cy.url().should('include', 'https://ranchermanager.docs.rancher.com/v2.8/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences#cluster-api');
     });
 
-    it('Local cluster should show a description on the side menu and display a tooltip when hovering it show the full description', { tags: ['@navigation', '@adminUser'] }, () => {
+    it('Local cluster should show a name and description on the side menu and display a tooltip when hovering it show the full name and description', { tags: ['@navigation', '@adminUser'] }, () => {
       BurgerMenuPo.toggle();
 
       const burgerMenuPo = new BurgerMenuPo();
@@ -78,7 +78,8 @@ describe('Side Menu: main', () => {
       // truncation (text-overflow: ellipsis) is just a CSS gimick thing that adds the ... visually
       burgerMenuPo.getClusterDescription().should('include', longClusterDescription);
       burgerMenuPo.showClusterDescriptionTooltip();
-      burgerMenuPo.getClusterDescriptionTooltipContent().contains(longClusterDescription);
+      burgerMenuPo.getClusterDescriptionTooltipContent().should('include.text', 'local').and('be.visible');
+      burgerMenuPo.getClusterDescriptionTooltipContent().should('include.text', longClusterDescription).and('be.visible');
     });
   });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1240
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
