### PR TITLE
Ensure blank cluster does not have a cluster namespace context

### DIFF
--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -392,6 +392,10 @@ export default {
    *
    * This takes into account if the type is namespaced.
    *
+   * Used in currently two places
+   * - Type
+   * - getTree
+   *
    * @param typeObj see inners for properties. must have at least `name` (resource type)
    *
    */
@@ -408,6 +412,7 @@ export default {
       const counts = getters.all(COUNT)?.[0]?.counts || {};
       const count = counts[type];
 
+      // This object aligns with `Type.vue` `type`
       _typeObj = {
         count:       count ? count.summary.count || 0 : null,
         byNamespace: count ? count.namespaces : {},
@@ -416,7 +421,7 @@ export default {
       };
     }
 
-    const namespaces = Object.keys(rootGetters.activeNamespaceCache || {});
+    const namespaces = _typeObj?.namespaced ? Object.keys(rootGetters.activeNamespaceCache || {}) : [];
 
     return matchingCounts(_typeObj, namespaces.length ? namespaces : null);
   },

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -146,7 +146,7 @@ const getReadOnlyActiveNamespaces = (namespaces, activeNamespaces) => {
 };
 
 /**
- * Collect all the namespaces grouped by category, project or single pick
+ * Collect all the namespaces for the current cluster grouped by category, project or single pick
  * @returns Record<string, true>
  */
 const getActiveNamespaces = (state, getters, readonly = false) => {
@@ -401,6 +401,9 @@ export const getters = {
     return !filters[0].startsWith(NAMESPACE_FILTER_NS_FULL_PREFIX);
   },
 
+  /**
+   * Namespace/Project filter for the current cluster
+   */
   namespaceFilters(state) {
     const filters = state.namespaceFilters.filter((x) => !!x && !`${ x }`.startsWith(NAMESPACED_PREFIX));
 
@@ -453,6 +456,9 @@ export const getters = {
     return state.namespaceFilters;
   },
 
+  /**
+   * All namespaces in the current cluster
+   */
   allNamespaces(state) {
     return state.allNamespaces;
   },
@@ -619,6 +625,9 @@ export const mutations = {
     state.isRancherInHarvester = neu;
   },
 
+  /**
+   * Updates cluster specific ns settings, including the selected ns cache `activeNamespaceCache`
+   */
   updateNamespaces(state, { filters, all, getters: optGetters }) {
     state.namespaceFilters = filters.filter((x) => !!x);
 
@@ -898,6 +907,13 @@ export const actions = {
 
       // Use a pseudo cluster ID to pretend we have a cluster... to ensure some screens that don't care about a cluster but 'require' one to show
       if (id === BLANK_CLUSTER) {
+        // Remove previous cluster context from cached namespaces
+        commit('updateNamespaces', {
+          filters: [],
+          all:     [],
+          getters
+        });
+
         commit('clusterReady', true);
 
         return;

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -644,7 +644,7 @@ export const getters = {
           continue;
         } else if ( mode === TYPE_MODES.USED && count <= 0 ) {
           // If there's none of this type, ignore this entry when viewing only in-use types
-          // Note: count is sometimes null, which is <= 0.
+          // Note: count is sometimes null, in js `null <= 0` is `true`.
           continue;
         }
 


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10803
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- when we change cluster we change state via `loadCluster`
- `loadCluster` with call `updateNamespaces` with current cluster filters and namespaces
- this was not happening when switching to a blank cluster, so anything that cached namespaces still had the old cluster's context
- also
  - small optimisation to `count` getter (if not namespaced, don't mess around with ns cache)
  - added comments to places

### Technical notes summary
- considered updating the `count` function to ignore the cached namespaces if the current product does not show the ns filter... but that felt like more of a workaround and left us open to anything else that used the cached namespaces

### Areas or cases that should be tested
- switching between local cluster, downstream cluster, back and forth, refresh at different points, etc


### Areas which could experience regressions
- areas that depends on namespaces within cluster management. in theory these should all look at management namespaces and thus shouldn't regress

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
  - Note - I burned a few hours trying to find a nice way to unit test the loadCluster action and specific root store properties that hold cached namespaces. Specifically creating a root mock store that handled all getters, mutators and actions ... alternatively creating a geniune store and overriding the required getters, mutators and actions. Both introduced a LOT of hackey code. Altenative is to return to this with an e2e test where we intercept calls to clusters, namespaces, etc (we would need to intercept enough to get to the dashboard page of a downstream cluster and filter by a namespace)
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
