### PR TITLE
Fix storage class not being selected properly

### DIFF
--- a/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
+++ b/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
@@ -2,6 +2,7 @@ import { ChartsPage } from '@/cypress/e2e/po/pages/charts.po';
 import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
 import { exampleStorageClass, defaultStorageClass } from '@/cypress/e2e/blueprints/charts/rancher-backup-chart';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 
 const STORAGE_CLASS_RESOURCE = 'storage.k8s.io.storageclasses';
 
@@ -39,6 +40,14 @@ describe('Charts', { tags: ['@adminUser'] }, () => {
         // Verify that the drop-down exists and has the default storage class selected
         const select = new LabeledSelectPo('[data-testid="backup-chart-select-existing-storage-class"]');
 
+        select.checkExists();
+        select.checkOptionSelected('test-default-storage-class');
+
+        // Verify that changing tabs doesn't change the selected storage class option
+        chartsPage.editYaml();
+        const tabbedOptions = new TabbedPo();
+        chartsPage.editOptions(tabbedOptions, '[data-testid="button-group-child-0"]');
+        
         select.checkExists();
         select.checkOptionSelected('test-default-storage-class');
       });

--- a/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
+++ b/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
@@ -6,7 +6,7 @@ import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 
 const STORAGE_CLASS_RESOURCE = 'storage.k8s.io.storageclasses';
 
-describe('Charts', { tags: ['@adminUser'] }, () => {
+describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
   const chartsPageUrl = '/c/local/apps/charts/chart?repo-type=cluster&repo=rancher-charts';
 
   describe('Rancher Backups', () => {

--- a/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
+++ b/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
@@ -46,8 +46,9 @@ describe('Charts', { tags: ['@adminUser'] }, () => {
         // Verify that changing tabs doesn't change the selected storage class option
         chartsPage.editYaml();
         const tabbedOptions = new TabbedPo();
+
         chartsPage.editOptions(tabbedOptions, '[data-testid="button-group-child-0"]');
-        
+
         select.checkExists();
         select.checkOptionSelected('test-default-storage-class');
       });

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -94,7 +94,11 @@ export default {
         this.value.persistence.enabled = true;
         this.value.s3.enabled = false;
         if (this.value.persistence.storageClass) {
-          this.storageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
+          const matchedStorageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
+
+          if (matchedStorageClass) {
+            this.storageClass = matchedStorageClass;
+          }
         }
         if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
           this.value.persistence.storageClass = this.defaultStorageClass.id;

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -93,6 +93,9 @@ export default {
       case 'pickSC':
         this.value.persistence.enabled = true;
         this.value.s3.enabled = false;
+        if (this.value.persistence.storageClass) {
+          this.storageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
+        }
         if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
           this.value.persistence.storageClass = this.defaultStorageClass.id;
           this.storageClass = this.defaultStorageClass;

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -88,14 +88,18 @@ export default {
   },
 
   watch: {
-    storageClasses: 'updateStorageClass',
-
     storageSource(neu) {
       switch (neu) {
       case 'pickSC':
         this.value.persistence.enabled = true;
         this.value.s3.enabled = false;
-        this.updateStorageClass();
+        if (this.value.persistence.storageClass) {
+          const matchedStorageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
+
+          if (matchedStorageClass) {
+            this.storageClass = matchedStorageClass;
+          }
+        }
         if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
           this.value.persistence.storageClass = this.defaultStorageClass.id;
           this.storageClass = this.defaultStorageClass;
@@ -159,15 +163,6 @@ export default {
     updatePageValid(update) {
       this.$emit('valid', update);
     },
-    updateStorageClass() {
-      if (this.value.persistence.storageClass) {
-        const matchedStorageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
-
-        if (matchedStorageClass) {
-          this.storageClass = matchedStorageClass;
-        }
-      }
-    }
   },
   get
 };

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -88,26 +88,12 @@ export default {
   },
 
   watch: {
+    storageClasses: 'updatePickSCValues',
+
     storageSource(neu) {
       switch (neu) {
       case 'pickSC':
-        this.value.persistence.enabled = true;
-        this.value.s3.enabled = false;
-        if (this.value.persistence.storageClass) {
-          const matchedStorageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
-
-          if (matchedStorageClass) {
-            this.storageClass = matchedStorageClass;
-          }
-        }
-        if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
-          this.value.persistence.storageClass = this.defaultStorageClass.id;
-          this.storageClass = this.defaultStorageClass;
-        }
-        if (this.storageClass?.reclaimPolicy === 'Delete') {
-          this.reclaimWarning = true;
-        }
-        delete this.value.persistence.volumeName;
+        this.updatePickSCValues();
         break;
       case 'pickPV':
         this.value.persistence.enabled = true;
@@ -162,6 +148,25 @@ export default {
     },
     updatePageValid(update) {
       this.$emit('valid', update);
+    },
+    updatePickSCValues() {
+      this.value.persistence.enabled = true;
+      this.value.s3.enabled = false;
+      if (this.value.persistence.storageClass) {
+        const matchedStorageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
+
+        if (matchedStorageClass) {
+          this.storageClass = matchedStorageClass;
+        }
+      }
+      if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
+        this.value.persistence.storageClass = this.defaultStorageClass.id;
+        this.storageClass = this.defaultStorageClass;
+      }
+      if (this.storageClass?.reclaimPolicy === 'Delete') {
+        this.reclaimWarning = true;
+      }
+      delete this.value.persistence.volumeName;
     }
   },
   get

--- a/shell/chart/rancher-backup/index.vue
+++ b/shell/chart/rancher-backup/index.vue
@@ -88,12 +88,22 @@ export default {
   },
 
   watch: {
-    storageClasses: 'updatePickSCValues',
+    storageClasses: 'updateStorageClass',
 
     storageSource(neu) {
       switch (neu) {
       case 'pickSC':
-        this.updatePickSCValues();
+        this.value.persistence.enabled = true;
+        this.value.s3.enabled = false;
+        this.updateStorageClass();
+        if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
+          this.value.persistence.storageClass = this.defaultStorageClass.id;
+          this.storageClass = this.defaultStorageClass;
+        }
+        if (this.storageClass?.reclaimPolicy === 'Delete') {
+          this.reclaimWarning = true;
+        }
+        delete this.value.persistence.volumeName;
         break;
       case 'pickPV':
         this.value.persistence.enabled = true;
@@ -149,9 +159,7 @@ export default {
     updatePageValid(update) {
       this.$emit('valid', update);
     },
-    updatePickSCValues() {
-      this.value.persistence.enabled = true;
-      this.value.s3.enabled = false;
+    updateStorageClass() {
       if (this.value.persistence.storageClass) {
         const matchedStorageClass = this.storageClasses.find((sc) => sc.id === this.value.persistence.storageClass);
 
@@ -159,14 +167,6 @@ export default {
           this.storageClass = matchedStorageClass;
         }
       }
-      if (this.defaultStorageClass && (!this.value.persistence.storageClass || this.value.persistence.storageClass === '-' )) {
-        this.value.persistence.storageClass = this.defaultStorageClass.id;
-        this.storageClass = this.defaultStorageClass;
-      }
-      if (this.storageClass?.reclaimPolicy === 'Delete') {
-        this.reclaimWarning = true;
-      }
-      delete this.value.persistence.volumeName;
     }
   },
   get


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10765 
<!-- Define findings related to the feature or bug issue. -->
The current logic pre-selects the storage class if a default storage class exists(i.e. it has `annotations: {'storageclass.kubernetes.io/is-default-class': 'true'}`) and no storage class is already set. Two scenarios needed to be addressed:

1. You've saved a storage class different from the default one and are currently viewing it
2. During editing, you've selected a storage class and switched tabs

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
In the summary^.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
n/a
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/rancher/dashboard/assets/135728925/a31b5df5-50c4-46c5-ba48-fb7e7666e9c7


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
