### PR TITLE
Display user dates in the resource detail subheader

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -243,6 +243,7 @@ suffix:
   ib: iB
   mib: MiB
   gb: GB
+  ago: ago
   revisions: |-
     {count, plural,
       =1 { Revision }

--- a/shell/models/management.cattle.io.user.js
+++ b/shell/models/management.cattle.io.user.js
@@ -235,6 +235,21 @@ export default class User extends HybridModel {
         formatter: 'CopyToClipboard',
         content:   this.username
       },
+      {
+        label:     this.t('tableHeaders.userLastLogin'),
+        formatter: 'LiveDate',
+        content:   this.userLastLogin,
+      },
+      {
+        label:     this.t('tableHeaders.userDisabledIn'),
+        formatter: 'LiveDate',
+        content:   this.userDisabledIn,
+      },
+      {
+        label:     this.t('tableHeaders.userDeletedIn'),
+        formatter: 'LiveDate',
+        content:   this.userDeletedIn,
+      },
       ...this._details
     ];
   }

--- a/shell/models/management.cattle.io.user.js
+++ b/shell/models/management.cattle.io.user.js
@@ -1,5 +1,6 @@
 import { NORMAN } from '@shell/config/types';
 import HybridModel, { cleanHybridResources } from '@shell/plugins/steve/hybrid-class';
+import day from 'dayjs';
 
 export default class User extends HybridModel {
   // Preserve description
@@ -235,10 +236,12 @@ export default class User extends HybridModel {
         formatter: 'CopyToClipboard',
         content:   this.username
       },
+      { separator: true },
       {
-        label:     this.t('tableHeaders.userLastLogin'),
-        formatter: 'LiveDate',
-        content:   this.userLastLogin,
+        label:         this.t('tableHeaders.userLastLogin'),
+        formatter:     'LiveDate',
+        formatterOpts: { addSuffix: true, suffix: `${ this.t('suffix.ago') } (${ day(this.userLastLogin) })` },
+        content:       this.userLastLogin,
       },
       {
         label:     this.t('tableHeaders.userDisabledIn'),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds the user last login, disabled in, & deleted in values to the user detail page. 

Fixes #10820
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Adds new fields to the DetailTop of users detail page

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Adding a customized suffix via the `formatterOpts` feels a little clunky, but it's sufficient for customizing the display format so that we can more closely match the design. Alternatives probably include building a new formatter, but this is too much given what we are trying to achieve.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Users Details Page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Users Details Page

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![user-last-login](https://github.com/rancher/dashboard/assets/835961/87377928-eecf-4662-b866-fd365ab4fa05)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
