### PR TITLE
Sort by raw value instead of string value

### DIFF
--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -403,7 +403,7 @@ export const USER_LAST_LOGIN = {
   labelKey:  'tableHeaders.userLastLogin',
   value:     'userLastLogin',
   formatter: 'LiveDate',
-  sort:      'user-last-login',
+  sort:      'userLastLogin',
 };
 
 export const USER_DISABLED_IN = {
@@ -411,7 +411,7 @@ export const USER_DISABLED_IN = {
   labelKey:  'tableHeaders.userDisabledIn',
   value:     'userDisabledIn',
   formatter: 'LiveDate',
-  sort:      'user-disabled-in',
+  sort:      'userDisabledIn',
 };
 
 export const USER_DELETED_IN = {
@@ -419,7 +419,7 @@ export const USER_DELETED_IN = {
   labelKey:  'tableHeaders.userDeletedIn',
   value:     'userDeletedIn',
   formatter: 'LiveDate',
-  sort:      'user-deleted-in',
+  sort:      'userDeletedIn',
 };
 
 export const USER_ID = {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensures that the Last Login, Disabled In, & Deleted In columns in the Users table are sorted by their epoch time values instead of the string representation. 

Fixes #10821
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Updates the sort key for `userLastLogin`, `userDisabledIn`, & `userDeletedIn`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Sorting of the users table

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
