### PR TITLE
fix(detail/service): fix js error if no port is configured

### DIFF
--- a/shell/detail/__tests__/service.test.ts
+++ b/shell/detail/__tests__/service.test.ts
@@ -1,0 +1,62 @@
+import service from '@shell/detail/service.vue';
+import { shallowMount } from '@vue/test-utils';
+
+describe('view: service', () => {
+  const mockStore = {
+    getters: {
+      'cluster/schemaFor':   () => {},
+      'type-map/headersFor': jest.fn(),
+      'i18n/t':              (text: string) => text,
+    },
+  };
+
+  const mocks = { $store: mockStore };
+
+  it('should return default empty array of ports if the ports are not configured', () => {
+    const wrapper = shallowMount(service, {
+      mocks,
+      propsData: {
+        value: {
+          spec: {}, metadata: {}, pods: []
+        }
+      },
+    });
+
+    expect(wrapper.vm.ports).toStrictEqual([]);
+  });
+
+  it('should return empty array of ports if ports are set to empty array', () => {
+    const wrapper = shallowMount(service, {
+      mocks,
+      propsData: {
+        value: {
+          spec: { ports: [] }, metadata: {}, pods: []
+        }
+      },
+    });
+
+    expect(wrapper.vm.ports).toStrictEqual([]);
+  });
+
+  it('should return the correct array of ports if the ports are configured', () => {
+    const ports = [
+      {
+        name: 'test1', port: 80, protocol: 'TCP', targetPort: 80
+      },
+      {
+        name: 'test2', port: 81, protocol: 'TCP', targetPort: 81
+      }
+    ];
+
+    const wrapper = shallowMount(service, {
+      mocks,
+      propsData: {
+        value: {
+          spec: { ports }, metadata: {}, pods: []
+        }
+      },
+    });
+
+    expect(wrapper.vm.ports).toStrictEqual(ports.map((p) => ({ ...p, publicPorts: [] })));
+  });
+});

--- a/shell/detail/service.vue
+++ b/shell/detail/service.vue
@@ -110,7 +110,7 @@ export default {
         metadata: { annotations = {} },
         spec,
       } = this.value;
-      const ports = spec.ports;
+      const ports = spec.ports ?? [];
       const publicPorts = this.hasPublic ? JSON.parse(annotations[CATTLE_PUBLIC_ENDPOINTS]) : null;
 
       return ports.map((port) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes #10822

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Returns an empty array if the service port is not set, to avoid js reporting errors

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. service detail page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![test1](https://github.com/rancher/dashboard/assets/3406205/ac7d072c-cb8f-46af-a667-4feeac830f13)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
