### PR TITLE
GitHub project automation - add issue to board and change status

### DIFF
--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -331,7 +331,6 @@ async function processOpenOrEditAction() {
         if (!prjIssue[ghProject.id]) {
           console.log("Error: Could not add issue to Project Board");
           console.log(prjIssue);
-          prjIssue = undefined;
         } else {
           console.log('Added issue to the project board');
           console.log(JSON.stringify(prjIssue, null, 2));  

--- a/.github/workflows/scripts/request.js
+++ b/.github/workflows/scripts/request.js
@@ -40,8 +40,6 @@ async function ghProject(org, num) {
     }
   }`;
 
-  console.log(gQL);
-
   const res = await graphql(gQL);
 
   const prj = {};
@@ -70,6 +68,7 @@ async function ghProject(org, num) {
 
   return prj;
 }
+
 /**
  * Fetch the issue and get the project info for the issue (map of project ID to project issue ID)
  *
@@ -148,6 +147,24 @@ async function ghUpdateProjectIssueStatus(prj, prjIssueID, status) {
       }
     ) {
       projectV2Item {
+        id
+      }
+    }
+  }`;
+
+  return await graphql(gQL);
+}
+
+/**
+ * Add an issue to the GitHub Project boar4d
+ * @param {*} prj Project metadata
+ * @param {*} issue Issue metadata
+ * @returns Response from add request
+ */
+async function ghAddIssueToProject(prj, issue) {
+  const gQL = `mutation {
+    addProjectV2ItemById(input: {projectId: "${ prj.id }" contentId: "${ issue.node_id }"}) {
+      item {
         id
       }
     }
@@ -321,4 +338,5 @@ module.exports = {
     ghProjectIssue,
     ghUpdateProjectIssueStatus,
     ghFetchOpenIssues,
+    ghAddIssueToProject,
 };


### PR DESCRIPTION
This PR updates the GH Project automation.

- Adds the related issue(s) to the project board if not already there
- Sets the status of the related issue(s)