### PR TITLE
Make cluster dashboard certificates list ns filter agnostic

### DIFF
--- a/shell/components/Certificates.vue
+++ b/shell/components/Certificates.vue
@@ -150,6 +150,7 @@ export default defineComponent({
       :rows="certs"
       :paging-label="'secret.certificate.paging'"
       :paging-params="pagingParams"
+      :ignoreFilter="true"
     >
       <template #col:certState="{row}">
         <td>


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Related to https://github.com/rancher/dashboard/issues/10025 / https://github.com/rancher/dashboard/pull/10024

### Occurred changes and/or fixed issues
- The cluster dashboard page contains tabs
- Tabs contain lists
- One tab shows lists of events (non-namespaced resource), the other certificates (namespaced resource)
- By default lists will filter rows of namespaced resources by the namespaces selected in the header filter
- This works fine for root lists, and is ignored for lists with in the detail page of resources (as they're showing resources associated with the primary resource)
- For lists that are in overview pages though we don't have a pattern
- For this context and use case it feels discombobulating to filter by namespace
  - navigating to the local cluster and viewing cert list will by default not show any due to the `user only` namespaces filter



### Areas or cases that should be tested
- cluster dashboard --> certificates tab
- entries do not change given the value of the ns filter


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
