### PR TITLE
Migrate the usage of asyncData to fetch

### DIFF
--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -23,112 +23,49 @@ import { LOGIN_ERRORS } from '@shell/store/auth';
 import {
   getBrand,
   getVendor,
-  getProduct,
   setBrand,
   setVendor
 } from '@shell/config/private-label';
 import loadPlugins from '@shell/plugins/plugin';
 import { fetchInitialSettings } from '@shell/utils/settings';
+import Loading from '@shell/components/Loading';
 
 export default {
   name:       'Login',
   components: {
-    LabeledInput, AsyncButton, Checkbox, BrandImage, Banner, InfoBox, CopyCode, Password, LocaleSelector
+    LabeledInput, AsyncButton, Checkbox, BrandImage, Banner, InfoBox, CopyCode, Password, LocaleSelector, Loading
   },
 
-  async asyncData({ route, redirect, store }) {
-    const drivers = await store.dispatch('auth/getAuthProviders');
-    const providers = sortBy(drivers.map((x) => x.id), ['id']);
-
-    const hasLocal = providers.includes('local');
-    const hasOthers = hasLocal && !!providers.find((x) => x !== 'local');
-
-    if ( hasLocal ) {
-      // Local is special and handled here so that it can be toggled
-      removeObject(providers, 'local');
-    }
-
-    let firstLoginSetting, plSetting, brand;
-
-    // Load settings.
-    // For newer versions this will return all settings if you are somehow logged in,
-    // and just the public ones if you aren't.
-    try {
-      await fetchInitialSettings(store);
-
-      firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);
-      plSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.PL);
-      brand = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BRAND);
-    } catch (e) {
-      // Older versions used Norman API to get these
-      firstLoginSetting = await store.dispatch('rancher/find', {
-        type: NORMAN.SETTING,
-        id:   SETTING.FIRST_LOGIN,
-        opt:  { url: `/v3/settings/${ SETTING.FIRST_LOGIN }` }
-      });
-
-      plSetting = await store.dispatch('rancher/find', {
-        type: NORMAN.SETTING,
-        id:   SETTING.PL,
-        opt:  { url: `/v3/settings/${ SETTING.PL }` }
-      });
-
-      brand = await store.dispatch('rancher/find', {
-        type: NORMAN.SETTING,
-        id:   SETTING.BRAND,
-        opt:  { url: `/v3/settings/${ SETTING.BRAND }` }
-      });
-    }
-
-    if (plSetting.value?.length && plSetting.value !== getVendor()) {
-      setVendor(plSetting.value);
-    }
-
-    if (brand?.value?.length && brand.value !== getBrand()) {
-      setBrand(brand.value);
-    }
-
-    let singleProvider;
-
-    if (providers.length === 1) {
-      singleProvider = providers[0];
-    }
+  data() {
+    const username = this.$cookies.get(USERNAME, { parseJSON: false }) || '';
 
     return {
-      vendor:             getVendor(),
-      providers,
-      hasOthers,
-      hasLocal,
-      showLocal:          !hasOthers || (route.query[LOCAL] === _FLAGGED),
-      firstLogin:         firstLoginSetting?.value === 'true',
-      singleProvider,
-      showLocaleSelector: !process.env.loginLocaleSelector || process.env.loginLocaleSelector === 'true'
-    };
-  },
-
-  data({ $cookies }) {
-    const username = $cookies.get(USERNAME, { parseJSON: false }) || '';
-
-    return {
-      product: getProduct(),
-
       username,
       remember: !!username,
       password: '',
 
-      timedOut:    this.$route.query[TIMED_OUT] === _FLAGGED,
-      loggedOut:   this.$route.query[LOGGED_OUT] === _FLAGGED,
-      isSsoLogout: this.$route.query[IS_SSO] === _FLAGGED,
-      err:         this.$route.query.err,
+      timedOut:           this.$route.query[TIMED_OUT] === _FLAGGED,
+      loggedOut:          this.$route.query[LOGGED_OUT] === _FLAGGED,
+      isSsoLogout:        this.$route.query[IS_SSO] === _FLAGGED,
+      err:                this.$route.query.err,
+      showLocaleSelector: !process.env.loginLocaleSelector || process.env.loginLocaleSelector === 'true',
 
+      hasLocal:           false,
+      showLocal:          false,
       providers:          [],
       providerComponents: [],
-      customLoginError:   {}
+      customLoginError:   {},
+      firstLogin:         false,
+      vendor:             getVendor()
     };
   },
 
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
+
+    singleProvider() {
+      return this.providers.length === 1 ? this.providers[0] : undefined;
+    },
 
     nonLocalPrompt() {
       if (this.singleProvider) {
@@ -179,12 +116,24 @@ export default {
   },
 
   async fetch() {
+    const { firstLoginSetting } = await this.loadInitialSettings();
     const { value } = await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.BANNERS });
+    const drivers = await this.$store.dispatch('auth/getAuthProviders');
+    const providers = sortBy(drivers.map((x) => x.id), ['id']);
+    const hasLocal = providers.includes('local');
+    const hasOthers = hasLocal && !!providers.find((x) => x !== 'local');
 
+    if ( hasLocal ) {
+      // Local is special and handled here so that it can be toggled
+      removeObject(providers, 'local');
+    }
+
+    this.vendor = getVendor();
+    this.providers = providers;
+    this.hasLocal = hasLocal;
+    this.showLocal = !hasOthers || (this.$route.query[LOCAL] === _FLAGGED);
     this.customLoginError = JSON.parse(value).loginError;
-  },
-
-  mounted() {
+    this.firstLogin = firstLoginSetting?.value === 'true';
     this.username = this.firstLogin ? 'admin' : this.username;
     this.$nextTick(() => {
       this.focusSomething();
@@ -192,6 +141,52 @@ export default {
   },
 
   methods: {
+    async loadInitialSettings() {
+      let firstLoginSetting, plSetting, brand;
+
+      // Load settings.
+      // For newer versions this will return all settings if you are somehow logged in,
+      // and just the public ones if you aren't.
+      try {
+        await fetchInitialSettings(this.$store);
+
+        firstLoginSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);
+        plSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.PL);
+        brand = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.BRAND);
+      } catch (e) {
+        // Older versions used Norman API to get these
+        firstLoginSetting = await this.$store.dispatch('rancher/find', {
+          type: NORMAN.SETTING,
+          id:   SETTING.FIRST_LOGIN,
+          opt:  { url: `/v3/settings/${ SETTING.FIRST_LOGIN }` }
+        });
+
+        plSetting = await this.$store.dispatch('rancher/find', {
+          type: NORMAN.SETTING,
+          id:   SETTING.PL,
+          opt:  { url: `/v3/settings/${ SETTING.PL }` }
+        });
+
+        brand = await this.$store.dispatch('rancher/find', {
+          type: NORMAN.SETTING,
+          id:   SETTING.BRAND,
+          opt:  { url: `/v3/settings/${ SETTING.BRAND }` }
+        });
+      }
+
+      if (plSetting.value?.length && plSetting.value !== getVendor()) {
+        setVendor(plSetting.value);
+      }
+
+      if (brand?.value?.length && brand.value !== getBrand()) {
+        setBrand(brand.value);
+      }
+
+      return {
+        firstLoginSetting, plSetting, brand
+      };
+    },
+
     displayName(provider) {
       return this.t(`model.authConfig.provider.${ provider }`);
     },
@@ -290,7 +285,11 @@ export default {
 </script>
 
 <template>
-  <main class="main-layout login">
+  <Loading v-if="$fetchState.pending" />
+  <main
+    v-else
+    class="main-layout login"
+  >
     <div class="row gutless mb-20">
       <div class="col span-6 p-20">
         <p class="text-center">
@@ -480,7 +479,6 @@ export default {
           <LocaleSelector mode="login" />
         </div>
       </div>
-
       <BrandImage
         class="col span-6 landscape"
         data-testid="login-landscape__img"

--- a/shell/pages/auth/logout.vue
+++ b/shell/pages/auth/logout.vue
@@ -1,8 +1,8 @@
 <script>
 
 export default {
-  async asyncData({ redirect, store, router }) {
-    await store.dispatch('auth/logout', null, { root: true });
+  async fetch() {
+    await this.$store.dispatch('auth/logout', null, { root: true });
   }
 };
 </script>

--- a/shell/pages/c/_cluster/auth/config/index.vue
+++ b/shell/pages/c/_cluster/auth/config/index.vue
@@ -5,18 +5,22 @@ import { sortBy } from '@shell/utils/sort';
 import { MODE, _EDIT } from '@shell/config/query-params';
 import { authProvidersInfo } from '@shell/utils/auth';
 import { Banner } from '@components/Banner';
+import Loading from '@shell/components/Loading';
 
 export default {
-  components: { SelectIconGrid, Banner },
+  components: {
+    SelectIconGrid, Banner, Loading
+  },
 
-  async asyncData({ store, redirect }) {
-    const authProvs = await authProvidersInfo(store);
+  async fetch() {
+    const authProvs = await authProvidersInfo(this.$store);
 
     if (!!authProvs.enabledLocation) {
-      redirect(authProvs.enabledLocation);
+      return this.$router.replace(authProvs.enabledLocation);
     }
 
-    return { nonLocal: authProvs.nonLocal, enabled: authProvs.enabled };
+    this.$set(this, 'enabled', authProvs.enabled);
+    this.$set(this, 'nonLocal', authProvs.nonLocal);
   },
 
   data() {
@@ -34,6 +38,7 @@ export default {
       hasEditComponent,
 
       // Provided by asyncData later
+      enabled:  false,
       nonLocal: null,
     };
   },
@@ -82,7 +87,8 @@ export default {
 </script>
 
 <template>
-  <div>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
     <h1 class="m-0">
       {{ displayName }}
     </h1>

--- a/shell/pages/c/_cluster/auth/roles/index.vue
+++ b/shell/pages/c/_cluster/auth/roles/index.vue
@@ -36,14 +36,12 @@ export default {
     Tab, Tabbed, ResourceTable, Loading, Banner
   },
 
-  async asyncData({ store }) {
-    const globalRoleSchema = store.getters[`management/schemaFor`](MANAGEMENT.GLOBAL_ROLE);
-    const roleTemplatesSchema = store.getters[`management/schemaFor`](MANAGEMENT.ROLE_TEMPLATE);
+  async fetch() {
+    const globalRoleSchema = this.$store.getters[`management/schemaFor`](MANAGEMENT.GLOBAL_ROLE);
+    const roleTemplatesSchema = this.$store.getters[`management/schemaFor`](MANAGEMENT.ROLE_TEMPLATE);
 
-    return {
-      globalRoles:   globalRoleSchema ? await store.dispatch(`management/findAll`, { type: MANAGEMENT.GLOBAL_ROLE }) : [],
-      roleTemplates: roleTemplatesSchema ? await store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }) : [],
-    };
+    this.$set(this, 'globalRoles', globalRoleSchema ? await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.GLOBAL_ROLE }) : []);
+    this.$set(this, 'roleTemplates', roleTemplatesSchema ? await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.ROLE_TEMPLATE }) : []);
   },
 
   data() {
@@ -158,7 +156,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="!globalRoles || !roleTemplates" />
+  <Loading v-if="$fetchState.pending" />
   <div v-else>
     <header>
       <div class="title">


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Migrate the usage of asyncData to fetch. I'll remove the nuxt implementation of asyncData in a separate pr (https://github.com/rancher/dashboard/pull/10896/commits/3cdf3eceb4468eb7e4433cfcab07c1ff7d2569cd).

This will give us one less thing that we have to consider while working on Vue3. After the migration we will then remove all of the initialization code. 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
The affected pages are, login, logout, setup, auth/config, and auth/roles.

All of these pages appear to be exercised through existing e2e tests.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
