### PR TITLE
Replace default values of props using global variables with computed case

### DIFF
--- a/shell/components/KeyValueView.vue
+++ b/shell/components/KeyValueView.vue
@@ -36,7 +36,7 @@ export default {
     keyLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.key');
+        return this.t('generic.key');
       },
     },
 
@@ -54,7 +54,7 @@ export default {
     valueLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.value');
+        return this.t('generic.value');
       },
     },
 

--- a/shell/components/KeyValueView.vue
+++ b/shell/components/KeyValueView.vue
@@ -35,6 +35,7 @@ export default {
 
     keyLabel: {
       type: String,
+      default: '',
     },
 
     separatorLabel: {
@@ -50,6 +51,7 @@ export default {
 
     valueLabel: {
       type: String,
+      default: '',
     },
 
     valueBase64: {

--- a/shell/components/KeyValueView.vue
+++ b/shell/components/KeyValueView.vue
@@ -34,7 +34,7 @@ export default {
     },
 
     keyLabel: {
-      type: String,
+      type:    String,
       default: '',
     },
 
@@ -50,7 +50,7 @@ export default {
     },
 
     valueLabel: {
-      type: String,
+      type:    String,
       default: '',
     },
 

--- a/shell/components/KeyValueView.vue
+++ b/shell/components/KeyValueView.vue
@@ -35,9 +35,6 @@ export default {
 
     keyLabel: {
       type: String,
-      default() {
-        return this.t('generic.key');
-      },
     },
 
     separatorLabel: {
@@ -53,9 +50,6 @@ export default {
 
     valueLabel: {
       type: String,
-      default() {
-        return this.t('generic.value');
-      },
     },
 
     valueBase64: {
@@ -70,6 +64,14 @@ export default {
   },
 
   computed: {
+    _keyLabel() {
+      return this.keyLabel || this.t('generic.key');
+    },
+
+    _valueLabel() {
+      return this.valueLabel || this.t('generic.value');
+    },
+
     threeColumns() {
       return this.showRemove;
     },
@@ -157,10 +159,10 @@ export default {
       :class="{'extra-column':threeColumns}"
     >
       <label class="text-label">
-        {{ keyLabel }}
+        {{ _keyLabel }}
       </label>
       <label class="text-label">
-        {{ valueLabel }}
+        {{ _valueLabel }}
       </label>
       <span v-if="threeColumns" />
 

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -49,7 +49,7 @@ export default {
     addLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.add');
+        return this.t('generic.add');
       },
     },
     addAllowed: {
@@ -59,7 +59,7 @@ export default {
     removeLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.remove');
+        return this.t('generic.remove');
       },
     },
     removeAllowed: {

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -47,7 +47,7 @@ export default {
       default: false,
     },
     addLabel: {
-      type: String,
+      type:    String,
       default: '',
     },
     addAllowed: {
@@ -55,7 +55,7 @@ export default {
       default: true,
     },
     removeLabel: {
-      type: String,
+      type:    String,
       default: '',
     },
     removeAllowed: {

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -48,9 +48,6 @@ export default {
     },
     addLabel: {
       type: String,
-      default() {
-        return this.t('generic.add');
-      },
     },
     addAllowed: {
       type:    Boolean,
@@ -58,9 +55,6 @@ export default {
     },
     removeLabel: {
       type: String,
-      default() {
-        return this.t('generic.remove');
-      },
     },
     removeAllowed: {
       type:    Boolean,
@@ -101,6 +95,13 @@ export default {
     return { rows, lastUpdateWasFromValue: false };
   },
   computed: {
+    _addLabel() {
+      return this.addLabel || this.t('generic.add');
+    },
+    _removeLabel() {
+      return this.removeLabel || this.t('generic.remove');
+    },
+
     isView() {
       return this.mode === _VIEW;
     },
@@ -311,7 +312,7 @@ export default {
               :data-testid="`remove-item-${idx}`"
               @click="remove(row, idx)"
             >
-              {{ removeLabel }}
+              {{ _removeLabel }}
             </button>
           </slot>
         </div>
@@ -347,7 +348,7 @@ export default {
             v-if="loading"
             class="mr-5 icon icon-spinner icon-spin icon-lg"
           />
-          {{ addLabel }}
+          {{ _addLabel }}
         </button>
       </slot>
     </div>

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -48,6 +48,7 @@ export default {
     },
     addLabel: {
       type: String,
+      default: '',
     },
     addAllowed: {
       type:    Boolean,
@@ -55,6 +56,7 @@ export default {
     },
     removeLabel: {
       type: String,
+      default: '',
     },
     removeAllowed: {
       type:    Boolean,

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -255,13 +255,13 @@ export default {
       return this.keyLabel || this.t('generic.key');
     },
     _keyPlaceholder() {
-      return this._keyPlaceholder || this.t('keyValue.keyPlaceholder');
+      return this.keyPlaceholder || this.t('keyValue.keyPlaceholder');
     },
     _valueLabel() {
       return this.valueLabel || this.t('generic.value');
     },
     _valuePlaceholder() {
-      return this._valuePlaceholder || this.t('keyValue.valuePlaceholder');
+      return this.valuePlaceholder || this.t('keyValue.valuePlaceholder');
     },
     _addLabel() {
       return this.addLabel || this.t('generic.add');

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -59,6 +59,7 @@ export default {
 
     protip: {
       type: [String, Boolean],
+      default: '',
     },
     // For asMap=false, the name of the field that goes into the row objects
     keyName: {
@@ -67,6 +68,7 @@ export default {
     },
     keyLabel: {
       type: String,
+      default: '',
     },
     keyEditable: {
       type:    Boolean,
@@ -88,6 +90,7 @@ export default {
     },
     keyPlaceholder: {
       type: String,
+      default: '',
     },
     /**
      * List of keys which needs to be disabled and hidden based on toggler
@@ -114,9 +117,11 @@ export default {
     },
     valueLabel: {
       type: String,
+      default: '',
     },
     valuePlaceholder: {
       type: String,
+      default: '',
     },
     valueCanBeEmpty: {
       type:    Boolean,
@@ -170,6 +175,7 @@ export default {
     },
     addLabel: {
       type: String,
+      default: '',
     },
     addIcon: {
       type:    String,

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -58,7 +58,7 @@ export default {
     },
 
     protip: {
-      type: [String, Boolean],
+      type:    [String, Boolean],
       default: '',
     },
     // For asMap=false, the name of the field that goes into the row objects
@@ -67,7 +67,7 @@ export default {
       default: 'key',
     },
     keyLabel: {
-      type: String,
+      type:    String,
       default: '',
     },
     keyEditable: {
@@ -89,7 +89,7 @@ export default {
       default: false,
     },
     keyPlaceholder: {
-      type: String,
+      type:    String,
       default: '',
     },
     /**
@@ -116,11 +116,11 @@ export default {
       default: 'value',
     },
     valueLabel: {
-      type: String,
+      type:    String,
       default: '',
     },
     valuePlaceholder: {
-      type: String,
+      type:    String,
       default: '',
     },
     valueCanBeEmpty: {
@@ -174,7 +174,7 @@ export default {
       default: () => {},
     },
     addLabel: {
-      type: String,
+      type:    String,
       default: '',
     },
     addIcon: {

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -60,7 +60,7 @@ export default {
     protip: {
       type: [String, Boolean],
       default() {
-        return this.$store.getters['i18n/t']('keyValue.protip', null, true);
+        return this.t('keyValue.protip', null, true);
       },
     },
     // For asMap=false, the name of the field that goes into the row objects
@@ -71,7 +71,7 @@ export default {
     keyLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.key');
+        return this.t('generic.key');
       },
     },
     keyEditable: {
@@ -95,7 +95,7 @@ export default {
     keyPlaceholder: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('keyValue.keyPlaceholder');
+        return this.t('keyValue.keyPlaceholder');
       },
     },
     /**
@@ -124,13 +124,13 @@ export default {
     valueLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.value');
+        return this.t('generic.value');
       },
     },
     valuePlaceholder: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('keyValue.valuePlaceholder');
+        return this.t('keyValue.valuePlaceholder');
       },
     },
     valueCanBeEmpty: {
@@ -186,7 +186,7 @@ export default {
     addLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.add');
+        return this.t('generic.add');
       },
     },
     addIcon: {
@@ -200,7 +200,7 @@ export default {
     readLabel: {
       type: String,
       default() {
-        return this.$store.getters['i18n/t']('generic.readFromFile');
+        return this.t('generic.readFromFile');
       },
     },
     readIcon: {
@@ -266,6 +266,9 @@ export default {
   },
 
   computed: {
+    _keyPlaceholder() {
+      return this.keyPlaceholder || this.t('keyValue.keyPlaceholder');
+    },
     isView() {
       return this.mode === _VIEW;
     },

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -59,9 +59,6 @@ export default {
 
     protip: {
       type: [String, Boolean],
-      default() {
-        return this.t('keyValue.protip', null, true);
-      },
     },
     // For asMap=false, the name of the field that goes into the row objects
     keyName: {
@@ -70,9 +67,6 @@ export default {
     },
     keyLabel: {
       type: String,
-      default() {
-        return this.t('generic.key');
-      },
     },
     keyEditable: {
       type:    Boolean,
@@ -94,9 +88,6 @@ export default {
     },
     keyPlaceholder: {
       type: String,
-      default() {
-        return this.t('keyValue.keyPlaceholder');
-      },
     },
     /**
      * List of keys which needs to be disabled and hidden based on toggler
@@ -123,15 +114,9 @@ export default {
     },
     valueLabel: {
       type: String,
-      default() {
-        return this.t('generic.value');
-      },
     },
     valuePlaceholder: {
       type: String,
-      default() {
-        return this.t('keyValue.valuePlaceholder');
-      },
     },
     valueCanBeEmpty: {
       type:    Boolean,
@@ -185,9 +170,6 @@ export default {
     },
     addLabel: {
       type: String,
-      default() {
-        return this.t('generic.add');
-      },
     },
     addIcon: {
       type:    String,
@@ -196,12 +178,6 @@ export default {
     addAllowed: {
       type:    Boolean,
       default: true,
-    },
-    readLabel: {
-      type: String,
-      default() {
-        return this.t('generic.readFromFile');
-      },
     },
     readIcon: {
       type:    String,
@@ -266,9 +242,25 @@ export default {
   },
 
   computed: {
-    _keyPlaceholder() {
-      return this.keyPlaceholder || this.t('keyValue.keyPlaceholder');
+    _protip() {
+      return this.protip || this.t('keyValue.protip', null, true);
     },
+    _keyLabel() {
+      return this.keyLabel || this.t('generic.key');
+    },
+    _keyPlaceholder() {
+      return this._keyPlaceholder || this.t('keyValue.keyPlaceholder');
+    },
+    _valueLabel() {
+      return this.valueLabel || this.t('generic.value');
+    },
+    _valuePlaceholder() {
+      return this._valuePlaceholder || this.t('keyValue.valuePlaceholder');
+    },
+    _addLabel() {
+      return this.addLabel || this.t('generic.add');
+    },
+
     isView() {
       return this.mode === _VIEW;
     },
@@ -590,15 +582,15 @@ export default {
     >
       <template v-if="rows.length || isView">
         <label class="text-label">
-          {{ keyLabel }}
+          {{ _keyLabel }}
           <i
-            v-if="protip && !isView && addAllowed"
-            v-clean-tooltip="protip"
+            v-if="_protip && !isView && addAllowed"
+            v-clean-tooltip="_protip"
             class="icon icon-info"
           />
         </label>
         <label class="text-label">
-          {{ valueLabel }}
+          {{ _valueLabel }}
         </label>
         <label
           v-for="c in extraColumns"
@@ -656,7 +648,7 @@ export default {
               ref="key"
               v-model="row[keyName]"
               :disabled="isView || disabled || !keyEditable || isProtected(row.key)"
-              :placeholder="keyPlaceholder"
+              :placeholder="_keyPlaceholder"
               :data-testid="`input-kv-item-key-${i}`"
               @input="queueUpdate"
               @paste="onPaste(i, $event)"
@@ -707,7 +699,7 @@ export default {
                 :class="{'conceal': valueConcealed}"
                 :disabled="disabled || isProtected(row.key)"
                 :mode="mode"
-                :placeholder="valuePlaceholder"
+                :placeholder="_valuePlaceholder"
                 :min-height="40"
                 :spellcheck="false"
                 @input="queueUpdate"
@@ -717,7 +709,7 @@ export default {
                 v-model="row[valueName]"
                 :disabled="isView || disabled || isProtected(row.key)"
                 :type="valueConcealed ? 'password' : 'text'"
-                :placeholder="valuePlaceholder"
+                :placeholder="_valuePlaceholder"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false"
@@ -787,7 +779,7 @@ export default {
           <i
             v-if="loading"
             class="mr-5 icon icon-spinner icon-spin icon-lg"
-          /> {{ addLabel }}
+          /> {{ _addLabel }}
         </button>
         <FileSelector
           v-if="readAllowed"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10829

As mentioned in the issue, this is a safe migration to Vue3 with limited use cases.
Using computed values based on props using i18n default values should be sufficient to not break anywhere.

A first attempt to use the global variable `t` has been carried out, unfortunately, it's not exposed in a prop scope and cannot be used.

Finally, as you can see by the commits and logs, it's mandatory to set a default empty value regardless, to not break existing logic.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
