### PR TITLE
[backport v2.8.x] Remove v1 tools/pages under the legacy navigation item

### DIFF
--- a/shell/config/product/legacy.js
+++ b/shell/config/product/legacy.js
@@ -17,36 +17,6 @@ export function init(store) {
   });
 
   virtualType({
-    labelKey:   'legacy.alerts',
-    name:       'v1-alerts',
-    group:      'Root',
-    namespaced: true,
-    weight:     111,
-    route:      { name: 'c-cluster-legacy-pages-page', params: { page: 'alerts' } },
-    exact:      true
-  });
-
-  virtualType({
-    labelKey:   'legacy.catalogs',
-    name:       'v1-catalogs',
-    group:      'Root',
-    namespaced: true,
-    weight:     111,
-    route:      { name: 'c-cluster-legacy-pages-page', params: { page: 'catalogs' } },
-    exact:      true
-  });
-
-  virtualType({
-    labelKey:   'legacy.notifiers',
-    name:       'v1-notifiers',
-    group:      'Root',
-    namespaced: true,
-    weight:     111,
-    route:      { name: 'c-cluster-legacy-pages-page', params: { page: 'notifiers' } },
-    exact:      true
-  });
-
-  virtualType({
     ifHave:     IF_HAVE.PROJECT,
     labelKey:   'legacy.project.label',
     namespaced: true,
@@ -68,58 +38,9 @@ export function init(store) {
     overview:   false,
   });
 
-  basicType([
-    'v1-alerts',
-    'v1-catalogs',
-    'v1-notifiers',
-    'v1-project-overview'
-  ]);
+  basicType(['v1-project-overview']);
 
   // Project Pages
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.alerts',
-    namespaced: true,
-    name:       'project-alerts',
-    weight:     105,
-    route:      { name: 'c-cluster-legacy-project-page', params: { page: 'alerts' } },
-    exact:      true,
-    overview:   false,
-  });
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.apps',
-    namespaced: true,
-    name:       'project-apps',
-    weight:     110,
-    route:      { name: 'c-cluster-legacy-project-page', params: { page: 'apps' } },
-    exact:      true,
-    overview:   false,
-  });
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.catalogs',
-    namespaced: true,
-    name:       'project-catalogs',
-    weight:     105,
-    route:      { name: 'c-cluster-legacy-project-page', params: { page: 'catalogs' } },
-    exact:      true,
-    overview:   false,
-  });
-
-  virtualType({
-    ifHave:     IF_HAVE.PROJECT,
-    labelKey:   'legacy.monitoring',
-    namespaced: true,
-    name:       'project-monitoring',
-    weight:     105,
-    route:      { name: 'c-cluster-legacy-project-page', params: { page: 'monitoring' } },
-    exact:      true,
-    overview:   false,
-  });
 
   virtualType({
     ifHave:     IF_HAVE.PROJECT,
@@ -144,11 +65,7 @@ export function init(store) {
   });
 
   basicType([
-    'project-apps',
-    'project-alerts',
-    'project-catalogs',
     'project-config-maps',
-    'project-monitoring',
     'project-secrets',
   ], 'Project');
 }


### PR DESCRIPTION
### Summary
Part of these two 'epic' backports:
https://github.com/rancher/dashboard/issues/10276
https://github.com/rancher/dashboard/issues/10277

Backport of https://github.com/rancher/dashboard/issues/10489

The `feature-flag.spec.ts` does not exist in the 2.8 release branch https://github.com/rancher/dashboard/tree/release-2.8/cypress/e2e/tests/pages/global-settings. So I omitted the commit from the original pr which added those tests.