### PR TITLE
Improve Performance of many helm chart based pages

### DIFF
--- a/cypress/e2e/po/lists/chart-repositories.po.ts
+++ b/cypress/e2e/po/lists/chart-repositories.po.ts
@@ -19,4 +19,9 @@ export default class ChartRepositoriesListPo extends BaseResourceList {
   details(name: string, index: number) {
     return this.resourceTable().sortableTable().rowWithName(name).column(index);
   }
+
+  refreshRepo(repoName: string) {
+    return this.resourceTable().sortableTable().rowActionMenuOpen(repoName).getMenuItem('Refresh')
+      .click();
+  }
 }

--- a/cypress/e2e/po/pages/chart-repositories.po.ts
+++ b/cypress/e2e/po/pages/chart-repositories.po.ts
@@ -20,12 +20,22 @@ export default class ChartRepositoriesPagePo extends PagePo {
     super(ChartRepositoriesPagePo.createPath(clusterId, product));
   }
 
-  static navTo() {
+  static navTo(clusterId = '_', product: 'apps' | 'manager' = 'manager') {
     const sideNav = new ProductNavPo();
 
-    BurgerMenuPo.burgerMenuNavToMenubyLabel('Cluster Management');
-    sideNav.groups().contains('Advanced').click();
-    sideNav.navToSideMenuEntryByLabel('Repositories');
+    if (product === 'apps') {
+      const burgerMenu = new BurgerMenuPo();
+      const sideNav = new ProductNavPo();
+
+      BurgerMenuPo.toggle();
+      burgerMenu.clusters().contains(clusterId).click();
+      sideNav.navToSideMenuGroupByLabel('Apps');
+      sideNav.navToSideMenuEntryByLabel('Repositories');
+    } else {
+      BurgerMenuPo.burgerMenuNavToMenubyLabel('Cluster Management');
+      sideNav.groups().contains('Advanced').click();
+      sideNav.navToSideMenuEntryByLabel('Repositories');
+    }
   }
 
   createEditRepositories(repoName? : string): ChartRepositoriesCreateEditPo {

--- a/cypress/e2e/po/pages/explorer/charts/chart.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/chart.po.ts
@@ -1,6 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
-import { ChartsPage } from '~/cypress/e2e/po/pages/explorer/charts/charts.po';
+import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
 
 export class ChartPage extends PagePo {
   private static createPath(clusterId: string) {

--- a/cypress/e2e/po/pages/explorer/charts/charts.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/charts.po.ts
@@ -47,7 +47,7 @@ export class ChartsPage extends PagePo {
   }
 
   selectChart(name: string) {
-    cy.get('.grid .name').contains(name).click();
+    return cy.get('.grid .name').contains(name).click();
   }
 
   bannerContent() {

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -130,7 +130,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   clusters(): Cypress.Chainable {
-    return this.self().find('.body .clusters .cluster.selector.option');
+    return this.self().find('.body .clustersList .cluster.selector.option');
   }
 
   pinFirstCluster(): Cypress.Chainable {

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -130,7 +130,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   clusters(): Cypress.Chainable {
-    return this.self().find('.body .clustersList .cluster.selector.option');
+    return this.self().find('.body .clusters .cluster.selector.option');
   }
 
   pinFirstCluster(): Cypress.Chainable {

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -1,58 +1,117 @@
 import ReposListPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
+import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
 
-describe('Apps/Repositories', { tags: ['@explorer', '@adminUser'] }, () => {
-  before(() => {
-    cy.login();
+describe('Apps', () => {
+  describe('Repositories', () => {
+    describe('Add', { tags: ['@explorer', '@adminUser'] }, () => {
+      before(() => {
+        cy.login();
 
-    const appRepoList = new ReposListPagePo('local', 'apps');
+        const appRepoList = new ReposListPagePo('local', 'apps');
 
-    appRepoList.goTo();
-    appRepoList.waitForPage();
-  });
+        appRepoList.goTo();
+        appRepoList.waitForPage();
+      });
 
-  it('Should reset input values when switching from Helm index URL to Git Repo and vice versa', () => {
-    const appRepoList = new ReposListPagePo('local', 'apps');
+      it('Should reset input values when switching from Helm index URL to Git Repo and vice versa', () => {
+        const appRepoList = new ReposListPagePo('local', 'apps');
 
-    // create a new cluster repo
-    appRepoList.create();
+        // create a new cluster repo
+        appRepoList.create();
 
-    const appRepoCreate = new AppClusterRepoEditPo('local', 'create');
+        const appRepoCreate = new AppClusterRepoEditPo('local', 'create');
 
-    appRepoCreate.waitForPage();
+        appRepoCreate.waitForPage();
 
-    const helmIndexUrl = 'https://charts.rancher.io';
-    const gitRepoName = 'https://github.com/rancher/ui-plugin-examples';
-    const gitRepoBranchName = 'test-branch';
+        const helmIndexUrl = 'https://charts.rancher.io';
+        const gitRepoName = 'https://github.com/rancher/ui-plugin-examples';
+        const gitRepoBranchName = 'test-branch';
 
-    appRepoCreate.nameNsDescription().name().self().scrollIntoView()
-      .should('be.visible');
-    // fill the helm index url form
-    appRepoCreate.enterHelmIndexURL(helmIndexUrl);
-    // make sure the value is set
-    appRepoCreate.helmIndexUrl().should('eq', helmIndexUrl);
-    // select git repo option
-    appRepoCreate.selectRadioOptionGitRepo(1);
-    // switch back to helm index url option
-    appRepoCreate.selectRadioOptionGitRepo(0);
-    // test helm index value is empty
-    appRepoCreate.helmIndexUrl().should('be.empty');
+        appRepoCreate.nameNsDescription().name().self().scrollIntoView()
+          .should('be.visible');
+        // fill the helm index url form
+        appRepoCreate.enterHelmIndexURL(helmIndexUrl);
+        // make sure the value is set
+        appRepoCreate.helmIndexUrl().should('eq', helmIndexUrl);
+        // select git repo option
+        appRepoCreate.selectRadioOptionGitRepo(1);
+        // switch back to helm index url option
+        appRepoCreate.selectRadioOptionGitRepo(0);
+        // test helm index value is empty
+        appRepoCreate.helmIndexUrl().should('be.empty');
 
-    // select Git repo option
-    appRepoCreate.selectRadioOptionGitRepo(1);
-    // fill the git repo form
-    appRepoCreate.enterGitRepoName(gitRepoName);
-    appRepoCreate.enterGitBranchName(gitRepoBranchName);
-    // make sure the values are set
-    appRepoCreate.gitRepoName().should('eq', gitRepoName);
-    appRepoCreate.gitRepoBranchName().should('eq', gitRepoBranchName);
-    // select helm index url option
-    appRepoCreate.selectRadioOptionGitRepo(0);
-    // switch back to git repo option
-    appRepoCreate.selectRadioOptionGitRepo(1);
-    // test git repo value is empty
-    appRepoCreate.gitRepoName().should('be.empty');
-    // test git repo branch value is empty
-    appRepoCreate.gitRepoBranchName().should('be.empty');
+        // select Git repo option
+        appRepoCreate.selectRadioOptionGitRepo(1);
+        // fill the git repo form
+        appRepoCreate.enterGitRepoName(gitRepoName);
+        appRepoCreate.enterGitBranchName(gitRepoBranchName);
+        // make sure the values are set
+        appRepoCreate.gitRepoName().should('eq', gitRepoName);
+        appRepoCreate.gitRepoBranchName().should('eq', gitRepoBranchName);
+        // select helm index url option
+        appRepoCreate.selectRadioOptionGitRepo(0);
+        // switch back to git repo option
+        appRepoCreate.selectRadioOptionGitRepo(1);
+        // test git repo value is empty
+        appRepoCreate.gitRepoName().should('be.empty');
+        // test git repo branch value is empty
+        appRepoCreate.gitRepoBranchName().should('be.empty');
+      });
+    });
+
+    describe('Refresh', { tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+      const chartPage = new ChartPage();
+      const clusterId = 'local';
+      const appRepoList = new ReposListPagePo(clusterId, 'apps');
+
+      before(() => {
+        cy.login();
+
+        appRepoList.goTo();
+        appRepoList.waitForPage();
+      });
+
+      it('Repo Refresh results in correct api requests', () => {
+        // Root request to the Rancher helm chart repo
+        cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?*').as('rancherCharts1');
+
+        // Nav to a summary page for a specific chart
+        ChartPage.navTo(clusterId, 'Rancher Backups');
+        chartPage.waitForPage();
+        // The repo charts should have been fetched
+        cy.wait('@rancherCharts1').its('request.url').should('include', 'link=index');
+        // The specific version of the chart should be fetched
+        cy.wait('@rancherCharts1').its('request.url').should('include', 'version=');
+
+        // Nav to any other page
+        ReposListPagePo.navTo(clusterId, 'apps');
+        appRepoList.waitForPage();
+
+        // Nav back to the summary page for a specific chart
+        cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?*', cy.spy().as('rancherCharts2'));
+        ChartPage.navTo(clusterId, 'Rancher Backups');
+        chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
+        // The specific version of the chart (and any other) should NOT be fetched
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.get('@rancherCharts2').should('not.have.been.called');
+
+        // Nav to the helm chart repo page
+        ReposListPagePo.navTo(clusterId, 'apps');
+        appRepoList.waitForPage();
+
+        // Refresh the Rancher repo (clears caches)
+        cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?*').as('rancherCharts3');
+        appRepoList.list().refreshRepo('Rancher');
+        // The charts should immediately update
+        cy.wait('@rancherCharts3').its('request.url').should('include', '?link=index');
+
+        // Nav to the summary page for a specific chart
+        ChartPage.navTo(clusterId, 'Rancher Backups');
+        chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
+        // The specific version of the chart should be fetched (as the cache was cleared)
+        cy.wait('@rancherCharts3').its('request.url').should('include', 'version=');
+      });
+    });
   });
 });

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -1,10 +1,11 @@
 import ReposListPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
 import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
+import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
 
 describe('Apps', () => {
-  describe('Repositories', () => {
-    describe('Add', { tags: ['@explorer', '@adminUser'] }, () => {
+  describe('Repositories', { tags: ['@explorer', '@adminUser'] }, () => {
+    describe('Add', () => {
       before(() => {
         cy.login();
 
@@ -60,10 +61,11 @@ describe('Apps', () => {
       });
     });
 
-    describe('Refresh', { tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+    describe('Refresh', () => {
       const chartPage = new ChartPage();
       const clusterId = 'local';
       const appRepoList = new ReposListPagePo(clusterId, 'apps');
+      const chartsPage = new ChartsPage(clusterId);
 
       before(() => {
         cy.login();
@@ -77,8 +79,13 @@ describe('Apps', () => {
         cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?*').as('rancherCharts1');
 
         // Nav to a summary page for a specific chart
-        ChartPage.navTo(clusterId, 'Rancher Backups');
+        ChartsPage.navTo(clusterId);
+        chartsPage.chartsFilterReposSelect().toggle();
+        chartsPage.chartsFilterReposSelect().clickOptionWithLabelForChartReposFilter('All');
+
+        chartsPage.selectChart('Rancher Backups');
         chartPage.waitForPage();
+
         // The repo charts should have been fetched
         cy.wait('@rancherCharts1').its('request.url').should('include', 'link=index');
         // The specific version of the chart should be fetched

--- a/shell/detail/catalog.cattle.io.app.vue
+++ b/shell/detail/catalog.cattle.io.app.vue
@@ -30,7 +30,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('catalog/load', { force: true, reset: true });
+    await this.$store.dispatch('catalog/load');
 
     this.allOperations = await this.$store.dispatch('cluster/findAll', { type: CATALOG.OPERATION });
   },

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -256,7 +256,7 @@ export default {
 
   methods: {
     async fetchChart() {
-      await this.$store.dispatch('catalog/load', { force: true, reset: true }); // not the problem
+      await this.$store.dispatch('catalog/load'); // not the problem
 
       if ( this.query.appNamespace && this.query.appName ) {
         // First check the URL query for an app name and namespace.

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -37,7 +37,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('catalog/load', { force: true, reset: true });
+    await this.$store.dispatch('catalog/load');
 
     const query = this.$route.query;
 

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -1,0 +1,234 @@
+import { CATALOG } from '@shell/config/types';
+import { state, getters, actions, mutations } from '../catalog';
+import Vuex from 'vuex';
+import { createLocalVue } from '@vue/test-utils';
+import Chart from '@shell/models/chart';
+
+type getterFnsType = keyof typeof getters
+type MutationFnsType = keyof typeof mutations
+const mutationFns = Object.keys(mutations);
+
+const convert = (namespace: string, obj: any) => {
+  return Object.entries(obj).reduce((res, [key, v]) => {
+    res[`${ namespace }/${ key }`] = v;
+
+    return res;
+  }, {} as any);
+};
+
+const clusterRepo = { _key: 'testClusterRepo' };
+const repoChartName = 'abc';
+const repoChart = {
+  name:     repoChartName,
+  type:     'namespaced',
+  version:  1,
+  metadata: { name: repoChartName }
+};
+const repoCharts = [repoChart];
+const repo = {
+  metadata:   { name: 'testRepo' },
+  _key:       'testRepo',
+  links:      { index: 'fetchindex' },
+  canLoad:    true,
+  followLink: () => ({ entries: { [repoChartName]: repoCharts } })
+};
+
+const catalogStoreName = 'catalog';
+const clusterStore = 'cluster';
+
+const expectedChartKey = `namespace/${ repo._key }/${ repoChartName }`;
+const initialVersionInfo = { junk: true };
+const initialRawChartName = 'cde';
+const initialRawChart = {
+  id:       `namespace/${ repo._key }/${ initialRawChartName }`,
+  repoKey:  repo._key,
+  type:     'namespaced',
+  name:     initialRawChartName,
+  version:  1,
+  metadata: { name: initialRawChartName }
+};
+const initialRawCharts = { [initialRawChart.id]: initialRawChart };
+const initialLoadedInfo = { [repo._key]: true };
+
+describe('catalog', () => {
+  describe('load', () => {
+    const constructStore = () => {
+      const catalogStore = {
+        state: state(),
+        getters,
+        mutations,
+        actions,
+      };
+
+      const localVue = createLocalVue();
+
+      localVue.use(Vuex);
+
+      return {
+        modules: {
+          i18n: {
+            namespaced: true,
+            getters:    { withFallback: (state: any) => () => '' }
+          },
+          [catalogStoreName]: {
+            namespaced: true,
+            state:      {
+              ...catalogStore.state,
+              // Set initial state
+              // - repos have been loaded
+              // - some charts exist
+              // - some chart version info has been fetched
+              loaded:       initialLoadedInfo,
+              charts:       initialRawCharts,
+              versionInfos: initialVersionInfo,
+            },
+            mutations: catalogStore.mutations,
+            actions:   catalogStore.actions,
+            getters:   catalogStore.getters
+          },
+          [clusterStore]: {
+            namespaced: true,
+            getters:    { schemaFor: (state) => (schema: string) => ({}) },
+            actions:    {
+              findAll: (ctx, ...args: any[]) => {
+                if (args[0].type === CATALOG.CLUSTER_REPO) {
+                  return Promise.resolve([clusterRepo]);
+                }
+                if (args[0].type === CATALOG.REPO) {
+                  return Promise.resolve([repo]);
+                }
+
+                return Promise.resolve([]);
+              },
+            }
+          }
+        },
+        state:   { $plugin: { getDynamic: () => require(`@shell/models/chart`) } },
+        getters: {
+          currentCluster: () => ({ }),
+          currentProduct: () => ({ inStore: clusterStore }),
+        },
+        mutations: { },
+        actions:   { }
+      };
+    };
+
+    it('no force', async() => {
+      const localVue = createLocalVue();
+
+      localVue.use(Vuex);
+
+      const store = new Vuex.Store(constructStore());
+
+      // Validate initial state of store
+      expect(store.getters[`${ catalogStoreName }/rawCharts`]).toStrictEqual(initialRawCharts);
+      expect(store.getters[`${ catalogStoreName }/charts`]).toStrictEqual([]);
+
+      // Make the request
+      await store.dispatch(`${ catalogStoreName }/load`, {
+        force: false,
+        reset: false
+      });
+
+      // Basics should always be ok
+      expect(store.getters[`${ catalogStoreName }/inStore`]).toStrictEqual(clusterStore);
+      expect(store.getters[`${ catalogStoreName }/errors`]).toStrictEqual([]);
+      expect(store.getters[`${ catalogStoreName }/repos`]).toStrictEqual([clusterRepo, repo]);
+      expect(store.state[catalogStoreName].loaded).toStrictEqual(initialLoadedInfo);
+
+      // Store should still be in it's initial state (but charts populated)
+      expect(store.getters[`${ catalogStoreName }/rawCharts`]).toStrictEqual(initialRawCharts);
+      expect(store.getters[`${ catalogStoreName }/charts`]).toStrictEqual([initialRawChart]);
+
+      // We haven't reset the version info, so it should be unchanged
+      expect(store.state[catalogStoreName].versionInfos).toStrictEqual(initialVersionInfo);
+    });
+
+    it('force', async() => {
+      const localVue = createLocalVue();
+
+      localVue.use(Vuex);
+
+      const store = new Vuex.Store(constructStore());
+
+      // Validate initial state of store
+      let rawCharts = store.getters[`${ catalogStoreName }/rawCharts`];
+
+      expect(store.getters[`${ catalogStoreName }/rawCharts`]).toStrictEqual(initialRawCharts);
+      expect(rawCharts[initialRawChart.id]).toBeDefined();
+      expect(rawCharts[initialRawChart.id].id).toBe(initialRawChart.id);
+
+      expect(store.getters[`${ catalogStoreName }/charts`]).toStrictEqual([]);
+
+      // Make the request
+      await store.dispatch(`${ catalogStoreName }/load`, {
+        force: true, // Force such that we should get some values
+        reset: false
+      });
+
+      rawCharts = store.getters[`${ catalogStoreName }/rawCharts`];
+      const charts = store.getters[`${ catalogStoreName }/charts`];
+
+      // Basics should always be ok
+      expect(store.getters[`${ catalogStoreName }/inStore`]).toStrictEqual(clusterStore);
+      expect(store.getters[`${ catalogStoreName }/errors`]).toStrictEqual([]);
+      expect(store.getters[`${ catalogStoreName }/repos`]).toStrictEqual([clusterRepo, repo]);
+      expect(store.state[catalogStoreName].loaded).toStrictEqual(initialLoadedInfo);
+
+      // Store should have it's initial chart... and the new one
+      expect(rawCharts[initialRawChart.id]).toBeDefined();
+      expect(rawCharts[initialRawChart.id].id).toBe(initialRawChart.id);
+      expect(rawCharts[expectedChartKey]).toBeDefined();
+      expect(rawCharts[expectedChartKey].id).toBe(expectedChartKey);
+      expect(rawCharts[expectedChartKey].versions[0].version).toBe(repoChart.version);
+      expect(charts[0]).toBeDefined();
+      expect(charts[0].id).toBe(initialRawChart.id);
+      expect(charts[1]).toBeDefined();
+      expect(charts[1].id).toBe(expectedChartKey);
+
+      // Version info should be unchanged
+      expect(store.state[catalogStoreName].versionInfos).toStrictEqual(initialVersionInfo);
+    });
+
+    it('force + reset', async() => {
+      const localVue = createLocalVue();
+
+      localVue.use(Vuex);
+
+      const store = new Vuex.Store(constructStore());
+
+      // Validate initial state of store
+      expect(store.getters[`${ catalogStoreName }/rawCharts`]).toStrictEqual(initialRawCharts);
+      expect(store.getters[`${ catalogStoreName }/charts`]).toStrictEqual([]);
+
+      // Make the request
+      await store.dispatch(`${ catalogStoreName }/load`, {
+        force: true,
+        reset: true
+      });
+
+      const rawCharts = store.getters[`${ catalogStoreName }/rawCharts`];
+      const charts = store.getters[`${ catalogStoreName }/charts`];
+
+      // Basics should always be ok
+      expect(store.getters[`${ catalogStoreName }/inStore`]).toStrictEqual(clusterStore);
+      expect(store.getters[`${ catalogStoreName }/errors`]).toStrictEqual([]);
+      expect(store.getters[`${ catalogStoreName }/repos`]).toStrictEqual([clusterRepo, repo]);
+      expect(store.state[catalogStoreName].loaded).toStrictEqual(initialLoadedInfo);
+
+      // Store should NOT have it's initial chart... and should have the new one
+      expect(rawCharts[initialRawChart.id]).not.toBeDefined();
+      expect(rawCharts[expectedChartKey]).toBeDefined();
+      expect(rawCharts[expectedChartKey].id).toBe(expectedChartKey);
+      expect(rawCharts[expectedChartKey].versions[0].version).toBe(repoChart.version);
+
+      expect(charts).toHaveLength(1);
+      expect(charts[0]).toBeDefined();
+      expect(charts[0].id).toBe(expectedChartKey);
+      expect(charts[0].versions[0].version).toBe(repoChart.version);
+
+      // Version info should be changed (it's now empty given reset)
+      expect(store.state[catalogStoreName].versionInfos).toStrictEqual({ });
+    });
+  });
+});

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -2,19 +2,6 @@ import { CATALOG } from '@shell/config/types';
 import { state, getters, actions, mutations } from '../catalog';
 import Vuex from 'vuex';
 import { createLocalVue } from '@vue/test-utils';
-import Chart from '@shell/models/chart';
-
-type getterFnsType = keyof typeof getters
-type MutationFnsType = keyof typeof mutations
-const mutationFns = Object.keys(mutations);
-
-const convert = (namespace: string, obj: any) => {
-  return Object.entries(obj).reduce((res, [key, v]) => {
-    res[`${ namespace }/${ key }`] = v;
-
-    return res;
-  }, {} as any);
-};
 
 const clusterRepo = { _key: 'testClusterRepo' };
 const repoChartName = 'abc';
@@ -88,9 +75,9 @@ describe('catalog', () => {
           },
           [clusterStore]: {
             namespaced: true,
-            getters:    { schemaFor: (state) => (schema: string) => ({}) },
+            getters:    { schemaFor: (state: any) => (schema: string) => ({}) },
             actions:    {
-              findAll: (ctx, ...args: any[]) => {
+              findAll: (ctx: any, ...args: any[]) => {
                 if (args[0].type === CATALOG.CLUSTER_REPO) {
                   return Promise.resolve([clusterRepo]);
                 }
@@ -103,7 +90,10 @@ describe('catalog', () => {
             }
           }
         },
-        state:   { $plugin: { getDynamic: () => require(`@shell/models/chart`) } },
+        state: {
+          $plugin:            { getDynamic: () => require(`@shell/models/chart`) },
+          [catalogStoreName]: { } as { [key: string]: any},
+        },
         getters: {
           currentCluster: () => ({ }),
           currentProduct: () => ({ inStore: clusterStore }),

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -324,12 +324,21 @@ export const mutations = {
     }
   },
 
+  setVersions(state, versions) {
+    state.versionInfos = versions;
+  },
+
   cacheVersion(state, { key, info }) {
     state.versionInfos[key] = info;
   }
 };
 
 export const actions = {
+  /**
+   * force: Always refresh catalog's helm repo by re-fetching index.yaml
+   *
+   * reset: clear existing charts and version cache
+   */
   async load(ctx, { force, reset } = {}) {
     const {
       state, getters, rootGetters, commit, dispatch
@@ -397,6 +406,10 @@ export const actions = {
       errors,
       loaded,
     });
+
+    if (reset) {
+      commit('setVersions', {});
+    }
   },
 
   async refresh({ getters, commit, dispatch }) {

--- a/shell/utils/install-redirect.js
+++ b/shell/utils/install-redirect.js
@@ -26,7 +26,7 @@ export default function(product, chartName, defaultResourceOrRoute, install = tr
     } else if (install) {
       // The product is not installed, redirect to the details chart
 
-      await store.dispatch('catalog/load', { force: true });
+      await store.dispatch('catalog/load');
 
       const chart = store.getters['catalog/chart']({ chartName });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10448

### Occurred changes and/or fixed issues
- Reverts #7672, which was the fix for #7668. Supersedes another fix #10733
- #7672 revolved around a very outlier case where there was an update to an existing chart version (which are normally immutable) and using the 'Refresh' helm repo action failed to update it (note refreshing browser was a workaround)
- The fix for #7672 brought in a costly refresh of each helm repo at many different points in the dashboard. This impacts performance as users navigate around the dashboard, but we've also had customer's with large repos reporting timeouts which was compounded by that change. #10733 improved this by instead not caching individual chart versions and always going out and fetching them.
- See comment https://github.com/rancher/dashboard/pull/10733#issuecomment-2059034785 why this isn't so great
- This PR contains an improvement where we clear the version cache whenever we clear the chart cache

### Technical notes summary
- setting `reset` when calling catalog/load cleared the existing chart cache. This is called in four places
  - repo model's `refresh` action - force + reset
  - cluster tools visit - force + reset (not sure why we need to do this)
  - plugins page visit - reset
  - plugins page refresh button - reset + force
- now `reset` also clears the chart version cache

### Areas or cases that should be tested
- Refreshing helm repos
- Cluster tools page
- Extensions page


### Areas which could experience regressions
Areas as above

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
