### PR TITLE
Pin rancher backend image version for e2e tests

### DIFF
--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -6,6 +6,9 @@ DIR=$(cd $(dirname $0)/..; pwd)
 DASHBOARD_DIST=${DIR}/dist
 EMBER_DIST=${DIR}/dist_ember
 
+# Image version
+RANCHER_IMG_VERSION=v2.9-2deb6a1e64956e35d02aeaa5e179090ebfeb0d6a-linux-amd64
+
 docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -v ${DASHBOARD_DIST}:/usr/share/rancher/ui-dashboard/dashboard \
   -v ${EMBER_DIST}:/usr/share/rancher/ui \
@@ -14,7 +17,7 @@ docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -e CATTLE_PASSWORD_MIN_LENGTH=3 \
   --name cypress \
   --privileged \
-  rancher/rancher:v2.9-head
+  rancher/rancher:${RANCHER_IMG_VERSION}
 
 docker ps
 

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -7,7 +7,7 @@ DASHBOARD_DIST=${DIR}/dist
 EMBER_DIST=${DIR}/dist_ember
 
 # Image version
-RANCHER_IMG_VERSION=v2.9-2deb6a1e64956e35d02aeaa5e179090ebfeb0d6a-linux-amd64
+RANCHER_IMG_VERSION=v2.9-c9be13b09329bbee60a5f6419d500198f83c44d1-head
 
 docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -v ${DASHBOARD_DIST}:/usr/share/rancher/ui-dashboard/dashboard \


### PR DESCRIPTION
Testing pinning backend image to older version.

Note, done in file rather than via a var on the repository, so it is very clear what version is being used and so that to change it, we have to use a PR, which will itself go through the gates.