### PR TITLE
add e2e test for issue 9923

### DIFF
--- a/cypress/e2e/po/other-products/v2-monitoring.po.ts
+++ b/cypress/e2e/po/other-products/v2-monitoring.po.ts
@@ -7,6 +7,7 @@ import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
 import UnitInputPo from '@/cypress/e2e/po/components/unit-input.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 
 export default class V2MonitoringPo extends PagePo {
   static createPath(clusterId: string) {
@@ -23,6 +24,10 @@ export default class V2MonitoringPo extends PagePo {
 
   create(): Cypress.Chainable {
     return this.list().masthead().actions().contains('Create');
+  }
+
+  createChinese(): Cypress.Chainable {
+    return this.list().masthead().actions().contains('创建');
   }
 
   createFromYaml(): Cypress.Chainable {
@@ -81,6 +86,22 @@ export default class V2MonitoringPo extends PagePo {
 
   prometheusRulesRecordPromQl(index: number): CodeMirrorPo {
     return CodeMirrorPo.bySelector(cy.get(`body [id=group-${ index }]`), '[data-testid="v2-monitoring-prom-rules-recording-promql"]');
+  }
+
+  prometheusRulesAddAlert(index: number) {
+    return cy.get(`[id=group-${ index }] [data-testid="v2-monitoring-add-alert"]`);
+  }
+
+  alertingRuleSeveritySelect(index: number) {
+    return new LabeledSelectPo(`[id=group-${ index }] [data-testid="v2-monitoring-alerting-rules-severity"]`, this.self());
+  }
+
+  prometheusRulesAlertName(index: number) {
+    return new LabeledInputPo(cy.get(`[id=group-${ index }] [data-testid="v2-monitoring-alerting-rules-alert-name"]`));
+  }
+
+  prometheusRulesAlertPromQl(index: number): CodeMirrorPo {
+    return CodeMirrorPo.bySelector(cy.get(`body [id=group-${ index }]`), '[data-testid="v2-monitoring-alerting-rules-promql"]');
   }
 
   goToDetailsPage(elemName: string) {

--- a/cypress/e2e/tests/pages/charts/v2-monitoring.spec.ts
+++ b/cypress/e2e/tests/pages/charts/v2-monitoring.spec.ts
@@ -145,6 +145,7 @@ describe('V2 monitoring Chart', { tags: ['@charts', '@adminUser'] }, () => {
 
       const prefPage = new PreferencesPagePo();
 
+      // change language to chinese
       prefPage.goTo();
       prefPage.languageDropdownMenu().checkVisible();
       prefPage.languageDropdownMenu().toggle();

--- a/cypress/e2e/tests/pages/charts/v2-monitoring.spec.ts
+++ b/cypress/e2e/tests/pages/charts/v2-monitoring.spec.ts
@@ -1,5 +1,6 @@
 import { generateV2MonitoringForLocalCluster } from '@/cypress/e2e/blueprints/other-products/v2-monitoring.js';
 import V2Monitoring from '@/cypress/e2e/po/other-products/v2-monitoring.po';
+import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
 
 describe('V2 monitoring Chart', { tags: ['@charts', '@adminUser'] }, () => {
   beforeEach(() => {
@@ -129,6 +130,63 @@ describe('V2 monitoring Chart', { tags: ['@charts', '@adminUser'] }, () => {
             }
           ]
         });
+      });
+    });
+
+    // testing https://github.com/rancher/dashboard/issues/9923
+    it('Alerting Rules "Severity" select should NOT be translating the values to Chinese', () => {
+      // this intercept is for the payload of the creation of prometheusrules, which is what we want to test
+      cy.intercept('POST', 'k8s/clusters/local/v1/monitoring.coreos.com.prometheusrules', (req: any) => {
+        req.reply({
+          statusCode: 201,
+          body:       {}
+        });
+      }).as('prometheusRulesCreation');
+
+      const prefPage = new PreferencesPagePo();
+
+      prefPage.goTo();
+      prefPage.languageDropdownMenu().checkVisible();
+      prefPage.languageDropdownMenu().toggle();
+      prefPage.languageDropdownMenu().isOpened();
+      prefPage.languageDropdownMenu().getOptions().should('have.length', 2);
+      prefPage.languageDropdownMenu().clickOption(2);
+      prefPage.languageDropdownMenu().isClosed();
+
+      const v2Monitoring = new V2Monitoring('local');
+
+      // go to v2 monitoring on local cluster
+      v2Monitoring.goTo();
+      v2Monitoring.waitForPage();
+
+      // // open Advanced group (default is PrometheusRules)
+      v2Monitoring.navToSideMenuGroupByLabel('Advanced');
+      v2Monitoring.waitForPage();
+
+      // create a new PrometheusRule
+      v2Monitoring.createChinese().click();
+      v2Monitoring.waitForPage();
+
+      v2Monitoring.nameNsDescription().name().set('some-prom-rules');
+
+      v2Monitoring.prometheusRuleGroupName(0).self().scrollIntoView();
+      v2Monitoring.prometheusRuleGroupName(0).set('group-name-0');
+      v2Monitoring.prometheusRuleGroupInterval(0).setValue('60');
+
+      v2Monitoring.prometheusRulesAddAlert(0).click();
+      v2Monitoring.prometheusRulesAlertName(0).self().scrollIntoView();
+      v2Monitoring.prometheusRulesAlertName(0).set('record-0');
+      v2Monitoring.prometheusRulesAlertPromQl(0).self().scrollIntoView();
+      v2Monitoring.prometheusRulesAlertPromQl(0).set('promql-0');
+
+      // critical option
+      v2Monitoring.alertingRuleSeveritySelect(0).toggle();
+      v2Monitoring.alertingRuleSeveritySelect(0).clickOption(1);
+
+      v2Monitoring.saveCreateForm().click();
+
+      cy.wait('@prometheusRulesCreation', { requestTimeout: 4000 }).then((req) => {
+        expect(req.request.body.spec.groups[0].rules[0].labels.severity).to.equal('critical');
       });
     });
   });

--- a/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
@@ -285,6 +285,7 @@ export default {
           :label="t('prometheusRule.alertingRules.name')"
           :required="true"
           :mode="mode"
+          data-testid="v2-monitoring-alerting-rules-alert-name"
         />
       </div>
       <div class="col span-6">
@@ -314,6 +315,7 @@ export default {
                 foldGutter: false,
                 readOnly: mode === 'view',
               }"
+              data-testid="v2-monitoring-alerting-rules-promql"
               @onInput="queueUpdate"
             />
           </template>
@@ -353,6 +355,7 @@ export default {
             :label="t('prometheusRule.alertingRules.labels.severity.choices.label')"
             :localized-label="false"
             :options="severityOptions"
+            data-testid="v2-monitoring-alerting-rules-severity"
           />
         </div>
       </div>

--- a/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/GroupRules.vue
@@ -194,6 +194,7 @@ export default {
             :disabled="disableAddAlert"
             type="button"
             class="btn role-tertiary"
+            data-testid="v2-monitoring-add-alert"
             @click="addRule('alert')"
           >
             <t k="prometheusRule.alertingRules.addLabel" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9923 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add e2e test to prevent regression of issue #9923 where changing language to chinese should **NOT** affect value of severity in `PrometheusRules`


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
