### PR TITLE
Validate allocatable vGPUs number in Harvester clusters creation

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1312,6 +1312,9 @@ cluster:
         networkName: Network Name
         macAddress: Mac Address
         macFormat: 'Invalid MAC address format.'
+      vGpus:
+        errors:
+          notAllocatable: '"VGPUs" not allocatable. There are not enough [{vGpus}] devices to be allocated to each node in machine pool [{pool}]'
       volume:
         title: Volumes
         volume: Volume

--- a/shell/components/form/ArrayListSelect.vue
+++ b/shell/components/form/ArrayListSelect.vue
@@ -42,6 +42,10 @@ export default {
 
     defaultAddValue() {
       return this.options[0]?.value;
+    },
+
+    getOptionLabel() {
+      return this.selectProps?.getOptionLabel ? (opt) => (this.selectProps?.getOptionLabel(opt) || opt) : undefined;
     }
   },
 
@@ -79,6 +83,7 @@ export default {
         :value="scope.row.value"
         v-bind="selectProps"
         :options="calculateOptions(scope.row.value)"
+        :get-option-label="getOptionLabel"
         @input="updateRow(scope.i, $event)"
       />
     </template>

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -246,7 +246,7 @@ export default {
     >
       <template #option="option">
         <div @mousedown="(e) => onClickOption(option, e)">
-          {{ option.label }}
+          {{ getOptionLabel(option.label) }}
         </div>
       </template>
       <!-- Pass down templates provided by the caller -->


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10906
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Adding a validation messsage in case the number of available vGpus are less then the number of cluster nodes.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Create a new Harvester Cluster
- Assign a vGpus
- Add other nodes so their number is more then the allocatable vGPus
- Click on create button

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/rancher/dashboard/assets/26394656/e14b188e-ae7b-494c-a1b0-28af9571579b)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
