### PR TITLE
fix cluster prov tests

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke1.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke1.spec.ts
@@ -244,6 +244,7 @@ describe('Provision Node driver RKE1 cluster with AWS', { testIsolation: 'off', 
   it('can delete a Amazon EC2 RKE1 cluster', function() {
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
+    clusterList.list().state(this.rke1Ec2ClusterName).contains('Active', { timeout: 120000 });
     clusterList.list().actionMenu(this.rke1Ec2ClusterName).getMenuItem('Delete').click();
 
     clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke1.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke1.spec.ts
@@ -230,7 +230,7 @@ describe('Provision Node driver RKE1 cluster with Azure', { testIsolation: 'off'
   it('can delete a Azure RKE1 cluster', function() {
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
-    clusterList.list().state(this.rke1AzureClusterName).contains('Active', { timeout: 60000 });
+    clusterList.list().state(this.rke1AzureClusterName).contains('Active', { timeout: 120000 });
     clusterList.list().actionMenu(this.rke1AzureClusterName).getMenuItem('Delete').click();
 
     clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Address failing tests in Jenkins run 
[Provision Node driver RKE1 cluster with AWS.can delete a Amazon EC2 RKE1 cluster](https://jenkins.int.rancher.io/job/rancher_qa/job/ui-automation-job/854/testReport/(root)/Provision%20Node%20driver%20RKE1%20cluster%20with%20AWS/can_delete_a_Amazon_EC2_RKE1_cluster/)
[Provision Node driver RKE1 cluster with Azure."after all" hook: clean up for "can delete a Azure RKE1 cluster"](https://jenkins.int.rancher.io/job/rancher_qa/job/ui-automation-job/854/testReport/(root)/Provision%20Node%20driver%20RKE1%20cluster%20with%20Azure/_after_all__hook__clean_up_for__can_delete_a_Azure_RKE1_cluster_/)
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
