### PR TITLE
automation: add check for architecture column

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke1.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke1.spec.ts
@@ -147,9 +147,13 @@ describe('Provision Node driver RKE1 cluster with AWS', { testIsolation: 'off', 
       expect(req.response?.body.rancherKubernetesEngineConfig).to.have.property('kubernetesVersion', this.k8sVersion0);
       cy.wrap(req.response?.body.id).as('clusterId');
     });
+    clusterList.waitForPage();
+
+    // check Architecture
+    // testing https://github.com/rancher/dashboard/issues/10831
+    clusterList.list().version(this.rke1Ec2ClusterName).should('contain', '—').and('not.contain', 'Unknown');
 
     // check states
-    clusterList.waitForPage();
     clusterList.list().state(this.rke1Ec2ClusterName).should('contain', 'Provisioning');
     clusterList.list().state(this.rke1Ec2ClusterName).contains('Active', { timeout: 700000 });
 

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -100,6 +100,10 @@ describe('Provision Node driver RKE2 cluster', { testIsolation: 'off', tags: ['@
     });
     clusterList.waitForPage();
 
+    // check Architecture
+    // testing https://github.com/rancher/dashboard/issues/10831
+    clusterList.list().version(this.rke2Ec2ClusterName).should('contain', '—').and('not.contain', 'Mixed');
+
     // check states
     clusterList.list().state(this.rke2Ec2ClusterName).should('contain', 'Reconciling');
     clusterList.list().state(this.rke2Ec2ClusterName).should('contain', 'Updating');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10831

add check for the architecture column in existing e2e tests RKE1/RKE2 cluster provisioning
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
