### PR TITLE
Handle case where issue number if empty in fixed notation

### DIFF
--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -57,7 +57,11 @@ function getReferencedIssues(body) {
   do {
     v = regexp.exec(body);
     if (v) {
-      issues.push(parseInt(v[2], 10));
+      const vNumber = parseInt(v[2], 10);
+
+      if (!isNaN(vNumber)) {
+        issues.push(vNumber);
+      }
     }
   } while (v);
   return issues;


### PR DESCRIPTION
This PR makes a small tweak to the GH Project workflow when parsing, looking for the fixes notation, to ensure an empty reference or an invalid reference is ignored (e.g. https://github.com/rancher/dashboard/pull/10922 and https://github.com/rancher/dashboard/pull/10921)

We check that the extracted issue number can be parsed as an integer and only use it, if it can.