### PR TITLE
Allow for specific exception to be thrown when visiting docs page

### DIFF
--- a/cypress/e2e/tests/pages/generic/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/generic/get-support.spec.ts
@@ -1,6 +1,7 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import SupportPagePo from '@/cypress/e2e/po/pages/get-support.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import { RANCHER_PAGE_EXCEPTIONS, catchTargetPageException } from '~/cypress/support/utils/exception-utils';
 
 const burgerMenu = new BurgerMenuPo();
 const supportPage = new SupportPagePo();
@@ -26,33 +27,46 @@ describe('Support Page', () => {
     // Click the support links and verify user lands on the correct page
     beforeEach(() => {
       supportPage.goTo();
+      supportPage.waitForPage();
     });
 
     it('can click on Suse Rancher Support link', () => {
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://www.rancher.com/');
+
       supportPage.clickExternalSupportLinks(0);
+
       cy.origin('https://www.rancher.com/', () => {
         cy.url().should('include', 'support');
       });
     });
 
     it('can click on Contact us for pricing link', () => {
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://www.rancher.com/pricing');
+
       supportPage.clickExternalSupportLinks(1);
+
       cy.origin('https://www.rancher.com/pricing', () => {
         cy.url().should('include', 'pricing');
       });
     });
 
     it('can click on Docs link', () => {
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://ranchermanager.docs.rancher.com');
+
       supportPage.supportLinks().should('have.length', 5);
       supportPage.clickSupportLink(0, true);
+
       cy.origin('https://ranchermanager.docs.rancher.com', () => {
         cy.url().should('include', 'ranchermanager.docs.rancher.com');
       });
     });
 
     it('can click on Forums link', () => {
-    // click Forums link
+      catchTargetPageException('TenantFeatures', 'https://forums.rancher.com');
+
+      // click Forums link
       supportPage.clickSupportLink(1, true);
+
       cy.origin('https://forums.rancher.com', () => {
         cy.url().should('include', 'forums.rancher.com/');
       });
@@ -75,7 +89,9 @@ describe('Support Page', () => {
     });
 
     it('can click on Get Started link', () => {
-    // click Get Started link
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS);
+
+      // click Get Started link
       supportPage.clickSupportLink(4, true);
       cy.url().should('include', 'getting-started/overview');
     });

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -3,6 +3,7 @@ import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerImportGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/import/cluster-import.generic.po';
 import { PARTIAL_SETTING_THRESHOLD } from '@/cypress/support/utils/settings-utils';
+import { RANCHER_PAGE_EXCEPTIONS, catchTargetPageException } from '~/cypress/support/utils/exception-utils';
 
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
@@ -213,46 +214,58 @@ describe('Home Page', () => {
     });
 
     it('can click on Docs link', () => {
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://ranchermanager.docs.rancher.com');
+
       homePage.supportLinks().should('have.length', 6);
       homePage.clickSupportLink(0, true);
+
       cy.origin('https://ranchermanager.docs.rancher.com', () => {
         cy.url().should('include', 'ranchermanager.docs.rancher.com');
       });
     });
 
     it('can click on Forums link', () => {
-    // click Forums link
+      catchTargetPageException('TenantFeatures', 'https://forums.rancher.com');
+
+      // click Forums link
       homePage.clickSupportLink(1, true);
+
       cy.origin('https://forums.rancher.com', () => {
         cy.url().should('include', 'forums.rancher.com/');
       });
     });
 
     it('can click on Slack link', () => {
-    // click Slack link
+      // click Slack link
       homePage.clickSupportLink(2, true);
+
       cy.origin('https://slack.rancher.io', () => {
         cy.url().should('include', 'slack.rancher.io/');
       });
     });
 
     it('can click on File an Issue link', () => {
-    // click File an Issue link
+      // click File an Issue link
       homePage.clickSupportLink(3, true);
+
       cy.origin('https://github.com', () => {
         cy.url().should('include', 'github.com/login');
       });
     });
 
     it('can click on Get Started link', () => {
-    // click Get Started link
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS);
+
+      // click Get Started link
       homePage.clickSupportLink(4, true);
+
       cy.url().should('include', 'getting-started/overview');
     });
 
     it('can click on Commercial Support link', () => {
-    // click Commercial Support link
+      // click Commercial Support link
       homePage.clickSupportLink(5);
+
       cy.url().should('include', '/support');
     });
   });

--- a/cypress/support/utils/exception-utils.ts
+++ b/cypress/support/utils/exception-utils.ts
@@ -1,0 +1,35 @@
+
+export const RANCHER_PAGE_EXCEPTIONS = [
+  'TenantFeatures',
+  'DomainData'
+];
+
+/**
+ * Target page throws an error. Catch and ignore so test's generic afterAll doesn't fail
+ */
+export const catchTargetPageException = (
+  partialExceptionMessage: string | string[],
+  originUrl?: string
+): void => {
+  const catchExceptions: string[] = typeof partialExceptionMessage === 'string' ? [partialExceptionMessage] : partialExceptionMessage;
+
+  if (originUrl) {
+    cy.origin(originUrl,
+      { args: { catchExceptions } },
+      ({ catchExceptions }) => {
+        // This is a repeat of `below`... can't serialise and pass in to cy.origin
+        cy.on('uncaught:exception', (e) => {
+          if (catchExceptions.filter((m) => e.message.indexOf(m) >= 0).length) {
+            return false;
+          }
+        });
+      }
+    );
+  } else {
+    cy.on('uncaught:exception', (e) => {
+      if (catchExceptions.filter((m) => e.message.indexOf(m) >= 0).length) {
+        return false;
+      }
+    });
+  }
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Allow for specific exception to be thrown when visiting docs page

### Occurred changes and/or fixed issues
- For the two tests that go out to (roughly) https://ranchermanager.docs.rancher.com/v2.8/getting-started/overview tests fail given that page throws an error
- Solution is to ensure we don't the test if that target page has an error

See below for clean runs of test
- https://github.com/rancher/dashboard/actions/runs/8909502770/job/24467126788?pr=10928
- https://github.com/rancher/dashboard/actions/runs/8909502770/job/24467125339?pr=10928

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
