### PR TITLE
Only logout if the user is logged in

### DIFF
--- a/shell/pages/auth/logout.vue
+++ b/shell/pages/auth/logout.vue
@@ -2,7 +2,7 @@
 
 export default {
   async fetch() {
-    await this.$store.dispatch('auth/logout', null, { root: true });
+    await this.$store.dispatch('auth/logout', { force: true }, { root: true });
   }
 };
 </script>

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -344,7 +344,23 @@ export const actions = {
     }
   },
 
-  async logout({ dispatch, commit }) {
+  async logout({ dispatch, commit, getters }, options = {}) {
+    // So, we only do this check if auth has been initialized.
+    //
+    // It's possible to be logged in and visit auth/logout directly instead
+    // of navigating from the app while being logged in. Unfortunately auth/logout
+    // doesn't use the authenticated middleware which means auth will never be
+    // initialized and this check will be invalid. This interferes with how we sometimes
+    // logout in our e2e tests.
+    //
+    // I'm going to leave this as is because we will be modifying and removing authenticated
+    // middleware soon and we should remove `force` at that time.
+    //
+    // TODO: remove `force` once authenticated middleware is removed/made sane.
+    if (!options?.force && !getters['loggedIn']) {
+      return;
+    }
+
     // Unload plugins - we will load again on login
     await this.$plugin.logout();
 


### PR DESCRIPTION
### Summary
This prevents us from redirecting multiple times when visiting the index on login 

Fixes #10926
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
There is still a case on the logout page that we need to be able to call logout even if the user hasn't been authenticated yet because the auth pages don't use the authenticated middleware.

This caused issues with the login page in a roundabout way. 

1. On the index page we authenticate the user so we can redirect them to the appropriate page if the user is logged in.
2. If a steve api fails due to authentication (happens if the user isn't logged in when visiting the index page) we immediately log the user out and redirect them to the login page.
3. Between the index page and steve api we would redirect multiple times and we now do a full page refresh on logout to shed all of the loaded extensions. This change prevents logging out unless the user is logged in (unless they visit the logout page directly), which reduce the amount of redirecting. 

This change will also reduce the unnecessary timeout redirect we would previously see when visiting the index page.

### Areas or cases that should be tested
Logging in and logging out

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
