### PR TITLE
fix flaky tests - manager and explorer

### DIFF
--- a/cypress/e2e/tests/pages/explorer/namespace-picker.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/namespace-picker.spec.ts
@@ -206,8 +206,8 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
         // check ns picker
         cy.reload();
         namespacePicker.toggle();
-        cy.contains(projName).should('not.exist');
-        cy.contains(nsName).should('not.exist');
+        cy.contains(projName, { timeout: 10000 }).should('not.exist');
+        cy.contains(nsName, { timeout: 10000 }).should('not.exist');
       });
     });
   });

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -52,7 +52,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
 
   it('can edit a MachineDeployments', function() {
     MachineDeploymentsPagePo.navTo();
-
+    machineDeploymentsPage.waitForPage();
     machineDeploymentsPage.list().actionMenu(this.machineDeploymentsName).getMenuItem('Edit YAML').click();
     machineDeploymentsPage.createEditMachineDeployment(nsName, this.machineDeploymentsName).waitForPage('mode=edit&as=yaml');
 
@@ -82,7 +82,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
 
   it('can clone a MachineDeployments', function() {
     MachineDeploymentsPagePo.navTo();
-
+    machineDeploymentsPage.waitForPage();
     machineDeploymentsPage.list().actionMenu(this.machineDeploymentsName).getMenuItem('Clone').click();
     machineDeploymentsPage.createEditMachineDeployment(nsName, this.machineDeploymentsName).waitForPage('mode=clone&as=yaml');
 
@@ -106,6 +106,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
 
   it('can download YAML', function() {
     MachineDeploymentsPagePo.navTo();
+    machineDeploymentsPage.waitForPage();
     machineDeploymentsPage.list().actionMenu(this.machineDeploymentsName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.machineDeploymentsName }.yaml`);
@@ -122,6 +123,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
 
   it('can delete a MachineDeployments', function() {
     MachineDeploymentsPagePo.navTo();
+    machineDeploymentsPage.waitForPage();
 
     // delete original cloned MachineSet
     machineDeploymentsPage.list().actionMenu(`${ this.machineDeploymentsName }-clone`).getMenuItem('Delete').click();
@@ -140,6 +142,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
 
   it('can delete MachineDeployments via bulk actions', function() {
     MachineDeploymentsPagePo.navTo();
+    machineDeploymentsPage.waitForPage();
 
     // delete original MachineSet
     machineDeploymentsPage.list().resourceTable().sortableTable().rowSelectCtlWithName(`${ this.machineDeploymentsName }`)

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -51,6 +51,7 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
 
   it('can edit a MachineSet', function() {
     MachineSetsPagePo.navTo();
+    machineSetsPage.waitForPage();
     machineSetsPage.list().actionMenu(this.machineSetName).getMenuItem('Edit YAML').click();
     machineSetsPage.createEditMachineSet(nsName, this.machineSetName).waitForPage('mode=edit&as=yaml');
 
@@ -80,6 +81,7 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
 
   it('can clone a MachineSet', function() {
     MachineSetsPagePo.navTo();
+    machineSetsPage.waitForPage();
     machineSetsPage.list().actionMenu(this.machineSetName).getMenuItem('Clone').click();
     machineSetsPage.createEditMachineSet(nsName, this.machineSetName).waitForPage('mode=clone&as=yaml');
 
@@ -103,6 +105,7 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
 
   it('can download YAML', function() {
     MachineSetsPagePo.navTo();
+    machineSetsPage.waitForPage();
     machineSetsPage.list().actionMenu(this.machineSetName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.machineSetName }.yaml`);
@@ -119,6 +122,7 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
 
   it('can delete a MachineSet', function() {
     MachineSetsPagePo.navTo();
+    machineSetsPage.waitForPage();
 
     // delete original cloned MachineSet
     machineSetsPage.list().actionMenu(`${ this.machineDeploymentsName }-clone`).getMenuItem('Delete').click();
@@ -137,6 +141,7 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
 
   it('can delete MachineSet via bulk actions', function() {
     MachineSetsPagePo.navTo();
+    machineSetsPage.waitForPage();
 
     // delete original MachineSet
     machineSetsPage.list().resourceTable().sortableTable().rowSelectCtlWithName(this.machineSetName)

--- a/cypress/e2e/tests/pages/manager/machines.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machines.spec.ts
@@ -55,6 +55,7 @@ describe('Machines', { testIsolation: 'off', tags: ['@manager', '@adminUser'] },
 
   it('can edit a Machine', function() {
     MachinesPagePo.navTo();
+    machinesPage.waitForPage();
     machinesPage.list().actionMenu(this.machineName).getMenuItem('Edit YAML').click();
     machinesPage.createEditMachines(nsName, this.machineName).waitForPage('mode=edit&as=yaml');
 
@@ -84,6 +85,7 @@ describe('Machines', { testIsolation: 'off', tags: ['@manager', '@adminUser'] },
 
   it('can download YAML', function() {
     MachinesPagePo.navTo();
+    machinesPage.waitForPage();
     machinesPage.list().actionMenu(this.machineName).getMenuItem('Download YAML').click({ force: true });
 
     const downloadedFilename = path.join(downloadsFolder, `${ this.machineName }.yaml`);
@@ -100,6 +102,7 @@ describe('Machines', { testIsolation: 'off', tags: ['@manager', '@adminUser'] },
 
   it('can delete a Machine', function() {
     MachinesPagePo.navTo();
+    machinesPage.waitForPage();
     machinesPage.list().actionMenu(this.machineName).getMenuItem('Delete').click();
 
     const promptRemove = new PromptRemove();

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -112,36 +112,50 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
   it('can delete a policy security admission', function() {
     PodSecurityAdmissionsPagePo.navTo();
     podSecurityAdmissionsPage.waitForPage();
-    podSecurityAdmissionsPage.list().actionMenu(`${ this.podSecurityAdmissionsName }-clone`).getMenuItem('Delete').click();
-
-    const promptRemove = new PromptRemove();
-
-    cy.intercept('DELETE', `/v1/management.cattle.io.podsecurityadmissionconfigurationtemplates/${ this.podSecurityAdmissionsName }-clone`).as('deletePolicyAdmission');
-
-    promptRemove.remove();
-    cy.wait('@deletePolicyAdmission');
-    podSecurityAdmissionsPage.waitForPage();
 
     // check list details
-    cy.contains(`${ this.podSecurityAdmissionsName }-clone`).should('not.exist');
+    podSecurityAdmissionsPage.list().resourceTable().sortableTable().rowNames()
+      .then((names) => {
+        if (names.filter((name) => name === `${ this.podSecurityAdmissionsName }-clone`).length > 1) {
+          cy.reload(); // need page reload here in case multiple entries are created. reload should resolve the duplicate issue
+        }
+
+        podSecurityAdmissionsPage.list().actionMenu(`${ this.podSecurityAdmissionsName }-clone`).getMenuItem('Delete').click();
+
+        const promptRemove = new PromptRemove();
+
+        cy.intercept('DELETE', `/v1/management.cattle.io.podsecurityadmissionconfigurationtemplates/${ this.podSecurityAdmissionsName }-clone`).as('deletePolicyAdmission');
+
+        promptRemove.remove();
+        cy.wait('@deletePolicyAdmission').its('response.statusCode').should('eq', 204);
+        podSecurityAdmissionsPage.waitForPage();
+        cy.contains(`${ this.podSecurityAdmissionsName }-clone`).should('not.exist');
+      });
   });
 
   it('can delete a policy security admission via bulk actions', function() {
     PodSecurityAdmissionsPagePo.navTo();
     podSecurityAdmissionsPage.waitForPage();
-    podSecurityAdmissionsPage.list().details(this.podSecurityAdmissionsName, 0).click();
-    podSecurityAdmissionsPage.list().resourceTable().sortableTable().deleteButton()
-      .click();
-
-    const promptRemove = new PromptRemove();
-
-    cy.intercept('DELETE', `/v1/management.cattle.io.podsecurityadmissionconfigurationtemplates/${ this.podSecurityAdmissionsName }`).as('deletePolicyAdmission');
-
-    promptRemove.remove();
-    cy.wait('@deletePolicyAdmission');
-    podSecurityAdmissionsPage.waitForPage();
 
     // check list details
-    cy.contains(this.podSecurityAdmissionsName).should('not.exist');
+    podSecurityAdmissionsPage.list().resourceTable().sortableTable().rowNames()
+      .then((names) => {
+        if (names.filter((name) => name === this.podSecurityAdmissionsName).length > 1) {
+          cy.reload(); // need page reload here in case multiple entries are created. reload should resolve the duplicate issue
+        }
+        podSecurityAdmissionsPage.list().details(this.podSecurityAdmissionsName, 0).click();
+        podSecurityAdmissionsPage.list().resourceTable().sortableTable().deleteButton()
+          .click();
+
+        const promptRemove = new PromptRemove();
+
+        cy.intercept('DELETE', `/v1/management.cattle.io.podsecurityadmissionconfigurationtemplates/${ this.podSecurityAdmissionsName }`).as('deletePolicyAdmission');
+
+        promptRemove.remove();
+        cy.wait('@deletePolicyAdmission').its('response.statusCode').should('eq', 204);
+
+        podSecurityAdmissionsPage.waitForPage();
+        cy.contains(this.podSecurityAdmissionsName).should('not.exist');
+      });
   });
 });

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -18,31 +18,18 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
   it('can create a repository', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
-    repositoriesPage.waitForGoTo('/v1/catalog.cattle.io.clusterrepos?exclude=metadata.managedFields');
     repositoriesPage.create();
     repositoriesPage.createEditRepositories().waitForPage();
     repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.repoName);
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(1);
-    repositoriesPage.createEditRepositories().gitRepoUrl().set('https://git.rancher.io/charts');
+    repositoriesPage.createEditRepositories().gitRepoUrl().set('https://github.com/rancher/charts');
     repositoriesPage.createEditRepositories().gitBranch().set('release-v2.8');
-    repositoriesPage.createEditRepositories().saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos');
+    repositoriesPage.createEditRepositories().saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos').its('response.statusCode').should('eq', 201);
     repositoriesPage.waitForPage();
 
     // check list details
     repositoriesPage.list().details(this.repoName, 2).should('be.visible');
-    repositoriesPage.list().details(this.repoName, 1).contains('In Progress').should('be.visible');
-    repositoriesPage.list().details(this.repoName, 1).contains('Active').should('be.visible');
-  });
-
-  it('can refresh a repository', function() {
-    ChartRepositoriesPagePo.navTo();
-    repositoriesPage.waitForPage();
-    cy.intercept('PUT', `/v1/catalog.cattle.io.clusterrepos/${ this.repoName }`).as('refreshRepo');
-    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Refresh').click();
-    cy.wait('@refreshRepo').its('response.statusCode').should('eq', 200);
-
-    // check list details
     repositoriesPage.list().details(this.repoName, 1).contains('In Progress').should('be.visible');
     repositoriesPage.list().details(this.repoName, 1).contains('Active').should('be.visible');
   });
@@ -92,11 +79,30 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     });
   });
 
+  it('can refresh a repository', function() {
+    ChartRepositoriesPagePo.navTo();
+    repositoriesPage.waitForPage();
+    cy.intercept('PUT', `/v1/catalog.cattle.io.clusterrepos/${ this.repoName }`).as('refreshRepo');
+    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Refresh').click();
+    cy.wait('@refreshRepo').its('response.statusCode').should('eq', 200);
+
+    // check list details
+    repositoriesPage.list().details(this.repoName, 1).contains('In Progress').should('be.visible');
+    repositoriesPage.list().details(this.repoName, 1).contains('Active').should('be.visible');
+  });
+
   it('can delete a repository', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
 
-    // delete original cloned Repository
+    // delete cloned Repository
+    repositoriesPage.list().resourceTable().sortableTable().rowNames()
+      .then((names) => {
+        if (names.filter((name) => name === `${ this.repoName }-clone`).length > 1) {
+          cy.reload(); // need page reload here in case multiple entries are created. reload should resolve the duplicate issue
+        }
+      });
+
     repositoriesPage.list().actionMenu(`${ this.repoName }-clone`).getMenuItem('Delete').click();
 
     const promptRemove = new PromptRemove();
@@ -111,89 +117,81 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     cy.contains(`${ this.repoName }-clone`).should('not.exist');
   });
 
-  it('can delete a repository via bulk actions', function() {
-    ChartRepositoriesPagePo.navTo();
-    repositoriesPage.waitForPage();
-
-    // delete original Repository
-    repositoriesPage.list().resourceTable().sortableTable().rowSelectCtlWithName(this.repoName)
-      .set();
-    repositoriesPage.list().openBulkActionDropdown();
-
-    cy.intercept('DELETE', `v1/catalog.cattle.io.clusterrepos/${ this.repoName }`).as('deleteRepository');
-    repositoriesPage.list().bulkActionButton('Delete').click();
-
-    const promptRemove = new PromptRemove();
-
-    promptRemove.remove();
-    cy.wait('@deleteRepository');
-    repositoriesPage.waitForPage();
-
-    // check list details
-    cy.contains(this.repoName).should('not.exist');
-  });
-
   it('can create a repository with basic auth', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
-    repositoriesPage.waitForGoTo('/v1/catalog.cattle.io.clusterrepos?exclude=metadata.managedFields');
     repositoriesPage.create();
     repositoriesPage.createEditRepositories().waitForPage();
-    repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.repoName);
+    repositoriesPage.createEditRepositories().nameNsDescription().name().set(`${ this.repoName }basic`);
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(1);
-    repositoriesPage.createEditRepositories().gitRepoUrl().set('https://git.rancher.io/charts');
+    repositoriesPage.createEditRepositories().gitRepoUrl().set('https://github.com/rancher/charts');
     repositoriesPage.createEditRepositories().gitBranch().set('release-v2.8');
     repositoriesPage.createEditRepositories().clusterrepoAuthSelectOrCreate().createBasicAuth('test', 'test');
     repositoriesPage.createEditRepositories().saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos');
     repositoriesPage.waitForPage();
 
     // check list details
-    repositoriesPage.list().details(this.repoName, 2).should('be.visible');
-    repositoriesPage.list().details(this.repoName, 1).contains('In Progress').should('be.visible');
-    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Delete').click();
-
-    const promptRemove = new PromptRemove();
-
-    cy.intercept('DELETE', `v1/catalog.cattle.io.clusterrepos/${ this.repoName }`).as('deleteRepository');
-
-    promptRemove.remove();
-    cy.wait('@deleteRepository');
-    repositoriesPage.waitForPage();
-
-    // check list details
-    cy.contains(this.repoName).should('not.exist');
+    repositoriesPage.list().details(`${ this.repoName }basic`, 2).should('be.visible');
+    repositoriesPage.list().details(`${ this.repoName }basic`, 1).contains('Active').should('be.visible');
   });
 
   it('can create a repository with SSH key', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
-    repositoriesPage.waitForGoTo('/v1/catalog.cattle.io.clusterrepos?exclude=metadata.managedFields');
     repositoriesPage.create();
     repositoriesPage.createEditRepositories().waitForPage();
-    repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.repoName);
+    repositoriesPage.createEditRepositories().nameNsDescription().name().set(`${ this.repoName }ssh`);
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(1);
-    repositoriesPage.createEditRepositories().gitRepoUrl().set('https://git.rancher.io/charts');
+    repositoriesPage.createEditRepositories().gitRepoUrl().set('https://github.com/rancher/charts');
     repositoriesPage.createEditRepositories().gitBranch().set('release-v2.8');
     repositoriesPage.createEditRepositories().clusterrepoAuthSelectOrCreate().createSSHAuth('privateKey', 'publicKey');
     repositoriesPage.createEditRepositories().saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos');
     repositoriesPage.waitForPage();
 
     // check list details
-    repositoriesPage.list().details(this.repoName, 2).should('be.visible');
+    repositoriesPage.list().details(`${ this.repoName }ssh`, 2).should('be.visible');
+    repositoriesPage.list().details(`${ this.repoName }ssh`, 1).contains('Active').should('be.visible');
+  });
 
-    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Delete').click();
+  it('can delete repositories via bulk actions', function() {
+    ChartRepositoriesPagePo.navTo();
+    repositoriesPage.waitForPage();
+
+    // delete Repositories
+    repositoriesPage.list().resourceTable().sortableTable().rowNames()
+      .then((names) => {
+        if (names.filter((name1) => name1 === (this.repoName || `${ this.repoName }basic` || `${ this.repoName }ssh`)).length > 1) {
+          cy.reload(); // need page reload here in case multiple entries are created. reload should resolve the duplicate issue
+        }
+      });
+
+    repositoriesPage.list().resourceTable().sortableTable().rowSelectCtlWithName(this.repoName)
+      .set();
+    repositoriesPage.list().resourceTable().sortableTable().rowSelectCtlWithName(`${ this.repoName }basic`)
+      .set();
+    repositoriesPage.list().resourceTable().sortableTable().rowSelectCtlWithName(`${ this.repoName }ssh`)
+      .set();
+    repositoriesPage.list().openBulkActionDropdown();
+
+    cy.intercept('DELETE', `v1/catalog.cattle.io.clusterrepos/${ this.repoName }`).as('deleteRepository');
+    cy.intercept('DELETE', `v1/catalog.cattle.io.clusterrepos/${ this.repoName }basic`).as('deleteRepositoryBasic');
+    cy.intercept('DELETE', `v1/catalog.cattle.io.clusterrepos/${ this.repoName }ssh`).as('deleteRepositorySsh');
+
+    repositoriesPage.list().bulkActionButton('Delete').click();
 
     const promptRemove = new PromptRemove();
 
-    cy.intercept('DELETE', `v1/catalog.cattle.io.clusterrepos/${ this.repoName }`).as('deleteRepository');
-
     promptRemove.remove();
     cy.wait('@deleteRepository');
+    cy.wait('@deleteRepositoryBasic');
+    cy.wait('@deleteRepositorySsh');
     repositoriesPage.waitForPage();
 
     // check list details
     cy.contains(this.repoName).should('not.exist');
+    cy.contains(`${ this.repoName }basic`).should('not.exist');
+    cy.contains(`${ this.repoName }ssh`).should('not.exist');
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
- Most of these issues addressed in this PR are timing issues so adding `.waitForPage()` should help with flakiness 
- Pod Security Admissions and Repositories tests, it was discovered that duplicate entries were being created (when creating/cloning) so adding a page reload when multiple entries with the same name exist to resolve this.

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
