### PR TITLE
Add e2e test for resource search and namespace filter issue

### DIFF
--- a/cypress/e2e/po/dialog/ResourceSearchDialog.po.ts
+++ b/cypress/e2e/po/dialog/ResourceSearchDialog.po.ts
@@ -1,17 +1,17 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 const CMD_K_KEY = {
-  'key':      'k',
-  'keyCode':  75,
-  'which':    75,
-  'code':    'KeyK',
-  'location': 0,
-  'altKey':   false,
-  'ctrlKey':  false,
-  'metaKey':  true,
-  'shiftKey': false,
-  'repeat':   false
- };
+  key:      'k',
+  keyCode:  75,
+  which:    75,
+  code:     'KeyK',
+  location: 0,
+  altKey:   false,
+  ctrlKey:  false,
+  metaKey:  true,
+  shiftKey: false,
+  repeat:   false
+};
 
 export default class ResourceSearchDialog extends ComponentPo {
   constructor() {

--- a/cypress/e2e/po/dialog/ResourceSearchDialog.po.ts
+++ b/cypress/e2e/po/dialog/ResourceSearchDialog.po.ts
@@ -1,0 +1,36 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+const CMD_K_KEY = {
+  'key':      'k',
+  'keyCode':  75,
+  'which':    75,
+  'code':    'KeyK',
+  'location': 0,
+  'altKey':   false,
+  'ctrlKey':  false,
+  'metaKey':  true,
+  'shiftKey': false,
+  'repeat':   false
+ };
+
+export default class ResourceSearchDialog extends ComponentPo {
+  constructor() {
+    super('[data-modal="searchModal"]');
+  }
+
+  open() {
+    cy.keyboardControls(CMD_K_KEY, 1);
+  }
+
+  close() {
+    cy.get('body').click(10, 10); // Click outside of the search modal
+  }
+
+  searchBox() {
+    return this.self().get('input.search');
+  }
+
+  results() {
+    return this.self().get('.results li.child .label');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
@@ -41,4 +41,8 @@ export default class ClusterDashboardPagePo extends PagePo {
   fullEventsLink() {
     return cy.get('.events-table-link').contains('Full events list');
   }
+
+  resourceSearchButton(): Cypress.Chainable {
+    return cy.get('[data-testid="header-resource-search"]');
+  }
 }

--- a/cypress/e2e/tests/pages/explorer/resource-search.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/resource-search.spec.ts
@@ -1,0 +1,66 @@
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import ResourceSearchDialog from  '@/cypress/e2e/po/dialog/ResourceSearchDialog.po';
+import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.po';
+import { ConfigMapPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
+
+const clusterDashboard = new ClusterDashboardPagePo('local');
+
+describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+  before(() => {
+    cy.login();
+    HomePagePo.goTo();
+
+    ClusterDashboardPagePo.navTo();
+  });
+
+  it('can show resource search dialog', () => {
+    // Open the resource search
+    clusterDashboard.resourceSearchButton().click();
+
+    const dialog = new ResourceSearchDialog();
+
+    dialog.checkExists();
+    dialog.checkVisible();
+
+    dialog.searchBox().type('ConfigMap');
+
+    dialog.results().should('have.length', 1);
+    dialog.results().first().should('have.text', 'ConfigMaps');
+
+    dialog.close();
+
+    dialog.checkNotExists();
+  });
+
+  it('can show resource dialog when namespace chooser is open', () => {
+    const namespacePicker = new NamespaceFilterPo();
+
+    namespacePicker.toggle();
+    namespacePicker.clickOptionByLabel('Only User Namespaces');
+    namespacePicker.isChecked('Only User Namespaces');
+
+    // Namespace filter is still open
+    const dialog = new ResourceSearchDialog();
+
+    // Open the resource search
+    dialog.open();
+
+    dialog.checkExists();
+    dialog.checkVisible();
+
+    dialog.searchBox().type('ConfigMap');
+
+    dialog.results().should('have.length', 1);
+    dialog.results().first().should('have.text', 'ConfigMaps');
+
+    dialog.results().first().click();
+
+    const configMapPage = new ConfigMapPagePo('local');
+
+    configMapPage.waitForPage();
+
+    dialog.checkNotExists();
+  });
+});
+

--- a/cypress/e2e/tests/pages/explorer/resource-search.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/resource-search.spec.ts
@@ -1,6 +1,6 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
-import ResourceSearchDialog from  '@/cypress/e2e/po/dialog/ResourceSearchDialog.po';
+import ResourceSearchDialog from '@/cypress/e2e/po/dialog/ResourceSearchDialog.po';
 import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.po';
 import { ConfigMapPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
 
@@ -63,4 +63,3 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     dialog.checkNotExists();
   });
 });
-

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -540,6 +540,7 @@ export default {
           v-shortkey="{windows: ['ctrl', 'k'], mac: ['meta', 'k']}"
           type="button"
           class="btn header-btn role-tertiary"
+          data-testid="header-resource-search"
           @shortkey="openSearch()"
           @click="openSearch()"
         >


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8656

Adds e2e tests for the issue where the resource search dialog appeared below the namespace filter when opened using the keyboard shortcut.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
