### PR TITLE
Add e2e test to check default grafana storage size for statefulset type

### DIFF
--- a/cypress/e2e/po/pages/explorer/charts/tabs/grafana-tab.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/tabs/grafana-tab.po.ts
@@ -1,5 +1,6 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
 
 export class GrafanaTab extends ComponentPo {
   constructor(selector = '.dashboard-root') {
@@ -20,5 +21,13 @@ export class GrafanaTab extends ComponentPo {
 
   memoryLimit(): LabeledInputPo {
     return new LabeledInputPo('[data-testid="input-grafana-limits-memory"]');
+  }
+
+  storageOptions(): RadioGroupInputPo {
+    return new RadioGroupInputPo('[data-testid="radio-group-input-grafana-storage"');
+  }
+
+  storageStatefulsetSizeInput(): LabeledInputPo {
+    return new LabeledInputPo('[data-testid="grafana-storage-statefulset-size"');
   }
 }

--- a/cypress/e2e/po/pages/explorer/charts/tabs/grafana-tab.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/tabs/grafana-tab.po.ts
@@ -27,6 +27,10 @@ export class GrafanaTab extends ComponentPo {
     return new RadioGroupInputPo('[data-testid="radio-group-input-grafana-storage"');
   }
 
+  storagePvcSizeInput(): LabeledInputPo {
+    return new LabeledInputPo('[data-testid="grafana-storage-pvc-size"');
+  }
+
   storageStatefulsetSizeInput(): LabeledInputPo {
     return new LabeledInputPo('[data-testid="grafana-storage-statefulset-size"');
   }

--- a/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
@@ -9,7 +9,7 @@ import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
 import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
 import { PrometheusTab } from '@/cypress/e2e/po/pages/explorer/charts/tabs/prometheus-tab.po';
 import { GrafanaTab } from '@/cypress/e2e/po/pages/explorer/charts/tabs/grafana-tab.po';
-import { DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE } from '@shell/config/types.js';
+import { DEFAULT_GRAFANA_STORAGE_SIZE } from '@shell/config/types.js';
 
 describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
   const chartsPage = new ChartsPage();
@@ -173,11 +173,18 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
         grafana.memoryLimit().checkVisible();
         grafana.memoryLimit().set('123Mi');
 
-        // Check default Grafana statefulset storage value
+        // Check default Grafana storage value for pvc and statefulset types
+        // pvc
+        grafana.storageOptions().set(2);
+        grafana.storagePvcSizeInput().checkExists();
+        grafana.storagePvcSizeInput().checkVisible();
+        grafana.storagePvcSizeInput().self().invoke('val').should('equal', DEFAULT_GRAFANA_STORAGE_SIZE);
+        // statefulset
         grafana.storageOptions().set(3);
         grafana.storageStatefulsetSizeInput().checkExists();
         grafana.storageStatefulsetSizeInput().checkVisible();
-        grafana.storageStatefulsetSizeInput().self().invoke('val').should('equal', DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE);
+        grafana.storageStatefulsetSizeInput().self().invoke('val').should('equal', DEFAULT_GRAFANA_STORAGE_SIZE);
+        // back to disabled
         grafana.storageOptions().set(0);
 
         // Click on YAML. In YAML mode, the prometheus selector is present but empty

--- a/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
@@ -9,6 +9,7 @@ import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
 import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
 import { PrometheusTab } from '@/cypress/e2e/po/pages/explorer/charts/tabs/prometheus-tab.po';
 import { GrafanaTab } from '@/cypress/e2e/po/pages/explorer/charts/tabs/grafana-tab.po';
+import { DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE } from '@shell/config/types.js';
 
 describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
   const chartsPage = new ChartsPage();
@@ -171,6 +172,13 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
         grafana.memoryLimit().checkExists();
         grafana.memoryLimit().checkVisible();
         grafana.memoryLimit().set('123Mi');
+
+        // Check default Grafana statefulset storage value
+        grafana.storageOptions().set(3);
+        grafana.storageStatefulsetSizeInput().checkExists();
+        grafana.storageStatefulsetSizeInput().checkVisible();
+        grafana.storageStatefulsetSizeInput().self().invoke('val').should('equal', DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE);
+        grafana.storageOptions().set(0);
 
         // Click on YAML. In YAML mode, the prometheus selector is present but empty
         // It should not be sent to the API

--- a/shell/chart/monitoring/grafana/index.vue
+++ b/shell/chart/monitoring/grafana/index.vue
@@ -5,6 +5,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import KeyValue from '@shell/components/form/KeyValue';
 import ArrayList from '@shell/components/form/ArrayList';
 import StorageClassSelector from '@shell/chart/monitoring/StorageClassSelector';
+import { DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE } from '@shell/config/types';
 
 export default {
   components: {
@@ -151,7 +152,7 @@ export default {
         newValsOut = {
           accessModes:      null,
           storageClassName: null,
-          size:             '10Gi',
+          size:             DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE,
           subPath:          null,
           type:             'statefulset',
           enabled:          true,
@@ -236,6 +237,7 @@ export default {
             :labels="persistentStorageTypeLabels"
             :mode="mode"
             :options="persistentStorageTypes"
+            data-testid="radio-group-input-grafana-storage"
           />
         </div>
       </div>
@@ -325,6 +327,7 @@ export default {
               v-model="value.grafana.persistence.size"
               :label="t('monitoring.grafana.storage.size')"
               :mode="mode"
+              data-testid="grafana-storage-statefulset-size"
             />
           </div>
           <div class="col span-6">

--- a/shell/chart/monitoring/grafana/index.vue
+++ b/shell/chart/monitoring/grafana/index.vue
@@ -5,7 +5,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import KeyValue from '@shell/components/form/KeyValue';
 import ArrayList from '@shell/components/form/ArrayList';
 import StorageClassSelector from '@shell/chart/monitoring/StorageClassSelector';
-import { DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE } from '@shell/config/types';
+import { DEFAULT_GRAFANA_STORAGE_SIZE } from '@shell/config/types';
 
 export default {
   components: {
@@ -140,7 +140,7 @@ export default {
         newValsOut = {
           accessModes:      null,
           storageClassName: null,
-          size:             '10Gi',
+          size:             DEFAULT_GRAFANA_STORAGE_SIZE,
           subPath:          null,
           type:             'pvc',
           annotations:      null,
@@ -152,7 +152,7 @@ export default {
         newValsOut = {
           accessModes:      null,
           storageClassName: null,
-          size:             DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE,
+          size:             DEFAULT_GRAFANA_STORAGE_SIZE,
           subPath:          null,
           type:             'statefulset',
           enabled:          true,
@@ -261,6 +261,7 @@ export default {
               v-model="value.grafana.persistence.size"
               :label="t('monitoring.grafana.storage.size')"
               :mode="mode"
+              data-testid="grafana-storage-pvc-size"
             />
           </div>
           <div class="col span-6">

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -314,4 +314,4 @@ export const AUTH_TYPE = {
 
 export const LOCAL_CLUSTER = 'local';
 
-export const DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE = '10Gi';
+export const DEFAULT_GRAFANA_STORAGE_SIZE = '10Gi';

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -313,3 +313,5 @@ export const AUTH_TYPE = {
 };
 
 export const LOCAL_CLUSTER = 'local';
+
+export const DEFAULT_GRAFANA_STATEFULSET_STORAGE_SIZE = '10Gi';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #2615 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
