### PR TITLE
[2.7] show harvester cluster in fleet page

### DIFF
--- a/shell/list/fleet.cattle.io.cluster.vue
+++ b/shell/list/fleet.cattle.io.cluster.vue
@@ -1,7 +1,7 @@
 <script>
 import FleetClusters from '@shell/components/fleet/FleetClusters';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
-import { isHarvesterCluster } from '@shell/utils/cluster';
+import { filterOnlyKubernetesClusters } from '@shell/utils/cluster';
 import { Banner } from '@components/Banner';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 
@@ -56,7 +56,7 @@ export default {
     },
 
     filteredRows() {
-      return this.fleetClusters.filter((c) => !isHarvesterCluster(c));
+      return filterOnlyKubernetesClusters(this.fleetClusters, this.$store);
     },
 
     fleetClusters() {

--- a/shell/utils/cluster.js
+++ b/shell/utils/cluster.js
@@ -8,7 +8,7 @@ export function filterOnlyKubernetesClusters(mgmtClusters, store) {
   const openHarvesterContainerWorkload = store.getters['features/get']('harvester-baremetal-container-workload');
 
   return mgmtClusters.filter((c) => {
-    return openHarvesterContainerWorkload ? true : !c.isHarvester;
+    return openHarvesterContainerWorkload ? true : !isHarvesterCluster(c);
   });
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/harvester/harvester/issues/5546
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
