### PR TITLE
[Automation] - Adding Cluster Details and Snapshot tab check

### DIFF
--- a/cypress/e2e/po/components/resource-table.po.ts
+++ b/cypress/e2e/po/components/resource-table.po.ts
@@ -9,4 +9,8 @@ export default class ResourceTablePo extends ComponentPo {
   downloadYamlButton() {
     return cy.getId('sortable-table-download');
   }
+
+  snapshotNowButton() {
+    return cy.get('[data-testid="action-button-async-button"').last();
+  }
 }

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -3,7 +3,9 @@ import MachinePoolsListPo from '@/cypress/e2e/po/lists/machine-pools-list.po';
 import ClusterConditionsListPo from '~/cypress/e2e/po/lists/cluster-conditions-list.po';
 import ClusterProvisioningLogPo from '~/cypress/e2e/po/lists/cluster-provisioning-log.po';
 import ClusterReferredToListPo from '~/cypress/e2e/po/lists/cluster-referred-to-list.po';
+import ClusterSnapshotsListPo from '~/cypress/e2e/po/lists/cluster-snapshots-list.po';
 import TabbedPo from '~/cypress/e2e/po/components/tabbed.po';
+import ClusterRecentEventsListPo from '~/cypress/e2e/po/lists/cluster-recent-events-list.po';
 
 /**
  * Covers core functionality that's common to the dashboard's cluster detail pages
@@ -45,6 +47,14 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
 
   referredToList() {
     return new ClusterReferredToListPo(this.self().find('[data-testid="sortable-table-list-container"]'));
+  }
+
+  snapshotsList() {
+    return new ClusterSnapshotsListPo(this.self().get('[data-testid="cluster-snapshots-list"]'));
+  }
+
+  recentEventsList() {
+    return new ClusterRecentEventsListPo(this.self().get('.sortable-table'));
   }
 
   selectTab(options: TabbedPo, selector: string) {

--- a/cypress/e2e/po/lists/cluster-recent-events-list.po.ts
+++ b/cypress/e2e/po/lists/cluster-recent-events-list.po.ts
@@ -1,0 +1,11 @@
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+
+export default class ClusterRecentEventsListPo extends BaseResourceList {
+  details(name: string, index: number) {
+    return this.resourceTable().sortableTable().rowWithPartialName(name).column(index);
+  }
+
+  checkTableIsEmpty() {
+    return this.resourceTable().sortableTable().rowWithPartialName('There are no rows to show.');
+  }
+}

--- a/cypress/e2e/po/lists/cluster-snapshots-list.po.ts
+++ b/cypress/e2e/po/lists/cluster-snapshots-list.po.ts
@@ -1,0 +1,19 @@
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+
+export default class ClusterSnapshotsListPo extends BaseResourceList {
+  details(name: string, index: number) {
+    return this.resourceTable().sortableTable().rowWithPartialName(name).column(index);
+  }
+
+  checkTableIsEmpty() {
+    return this.resourceTable().sortableTable().checkRowCount(true, 1);
+  }
+
+  clickOnSnapshotNow() {
+    return this.resourceTable().snapshotNowButton().click();
+  }
+
+  checkSnapshotExist(name: string) {
+    return this.resourceTable().sortableTable().rowWithPartialName(name);
+  }
+}


### PR DESCRIPTION
### Summary
Related task: 

https://github.com/rancher/qa-tasks/issues/759
https://github.com/rancher/qa-tasks/issues/757

### Occurred changes and/or fixed issues
Adding checks to provisioned RKE2 clusters to validate Recent Event tabs and Snapshots on cluster details.


### Technical notes summary
These two tabs are only visible on cluster driver provisioned clusters. These aren't shown on the local cluster details which is an Imported cluster

Those other checks are in this PR: https://github.com/rancher/dashboard/pull/10867

### Areas or cases that should be tested
Jenkins pipelines

### Areas which could experience regressions
provisioning tests on Jenkins

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
