### PR TITLE
Add automated tests to confirm Role's can be `default`

### DIFF
--- a/cypress/e2e/po/components/global-role-binding.po.ts
+++ b/cypress/e2e/po/components/global-role-binding.po.ts
@@ -1,0 +1,12 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import CheckboxInputPo from '~/cypress/e2e/po/components/checkbox-input.po';
+
+export default class GlobalRoleBindings extends ComponentPo {
+  constructor(selector = '.global-permissions') {
+    super(selector);
+  }
+
+  roleCheckbox(roleId: string) {
+    return new CheckboxInputPo(`[data-testid="grb-checkbox-${ roleId }"]`);
+  }
+}

--- a/cypress/e2e/po/components/global-role-binding.po.ts
+++ b/cypress/e2e/po/components/global-role-binding.po.ts
@@ -1,5 +1,5 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
-import CheckboxInputPo from '~/cypress/e2e/po/components/checkbox-input.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 
 export default class GlobalRoleBindings extends ComponentPo {
   constructor(selector = '.global-permissions') {

--- a/cypress/e2e/po/edit/management.cattle.io.user.po.ts
+++ b/cypress/e2e/po/edit/management.cattle.io.user.po.ts
@@ -3,7 +3,7 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import { CypressChainable } from '@/cypress/e2e/po/po.types';
-import GlobalRoleBindings from '~/cypress/e2e/po/components/global-role-binding.po';
+import GlobalRoleBindings from '@/cypress/e2e/po/components/global-role-binding.po';
 
 export default class MgmtUserEditPo extends PagePo {
   private static createPath(clusterId: string, userId?: string ) {

--- a/cypress/e2e/po/edit/management.cattle.io.user.po.ts
+++ b/cypress/e2e/po/edit/management.cattle.io.user.po.ts
@@ -3,6 +3,7 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import { CypressChainable } from '@/cypress/e2e/po/po.types';
+import GlobalRoleBindings from '~/cypress/e2e/po/components/global-role-binding.po';
 
 export default class MgmtUserEditPo extends PagePo {
   private static createPath(clusterId: string, userId?: string ) {
@@ -85,5 +86,9 @@ export default class MgmtUserEditPo extends PagePo {
     this.saveCreateForm().click();
 
     return (multipleCalls ? cy.wait(['@request', '@request'], { timeout: 10000 }) : cy.wait('@request', { timeout: 10000 }));
+  }
+
+  globalRoleBindings(): GlobalRoleBindings {
+    return new GlobalRoleBindings();
   }
 }

--- a/cypress/e2e/po/lists/role-list.po.ts
+++ b/cypress/e2e/po/lists/role-list.po.ts
@@ -20,4 +20,24 @@ export default class RoleListPo extends BaseResourceList {
   details(name: string, index: number) {
     return this.resourceTable().sortableTable().rowWithName(name).column(index);
   }
+
+  checkBuiltIn(name: string, isBuiltIn = true) {
+    const element = this.details(name, 4).find('span i.icon-checkmark');
+
+    if (isBuiltIn) {
+      element.should('exist');
+    } else {
+      element.should('not.exist');
+    }
+  }
+
+  checkDefault(name: string, isDefault = true) {
+    const element = this.details(name, 5).find('span i.icon-checkmark');
+
+    if (isDefault) {
+      element.should('exist');
+    } else {
+      element.should('not.exist');
+    }
+  }
 }

--- a/cypress/e2e/po/pages/users-and-auth/users.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/users.po.ts
@@ -2,6 +2,8 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import MgmtUsersListPo from '@/cypress/e2e/po/lists/management.cattle.io.user.po';
 import MgmtUserEditPo from '@/cypress/e2e/po/edit/management.cattle.io.user.po';
 import MgmtUserResourceDetailPo from '@/cypress/e2e/po/detail/management.cattle.io.user.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 
 export default class UsersPo extends PagePo {
   private static createPath(clusterId: string) {
@@ -10,6 +12,13 @@ export default class UsersPo extends PagePo {
 
   static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
     throw new Error('invalid');
+  }
+
+  static navTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    BurgerMenuPo.checkIfMenuItemLinkIsHighlighted('Users & Authentication');
+    const sideNav = new ProductNavPo();
+
+    return sideNav.navToSideMenuEntryByLabel('Users');
   }
 
   constructor(private clusterId = '_') {

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -9,6 +9,7 @@ import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 const roles = new RolesPo('_');
 const usersPo = new UsersPo('_');
 const userCreate = usersPo.createEdit();
+const sideNav = new ProductNavPo();
 
 const runTimestamp = +new Date();
 const runPrefix = `e2e-test-${ runTimestamp }`;
@@ -28,7 +29,7 @@ describe('Roles', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     roles.goTo(undefined, fragment);
     roles.waitForPage(undefined, fragment);
 
-    // check if burguer menu nav is highlighted correctly for users & auth
+    // check if burger menu nav is highlighted correctly for users & auth
     BurgerMenuPo.checkIfMenuItemLinkIsHighlighted('Users & Authentication');
 
     roles.listCreate('Create Global Role');
@@ -51,7 +52,7 @@ describe('Roles', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
       // testing https://github.com/rancher/dashboard/issues/9800
       // confirming that the globalRole created is not flagged as built-in
-      roles.list().details(globalRoleName, 4).should('not.contain', 'i.icon-checkmark');
+      roles.list().checkBuiltIn(globalRoleName, false);
       // eo test
 
       roles.list().details(globalRoleName, 2).find('a').click();
@@ -61,11 +62,17 @@ describe('Roles', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       globalRoleDetails.waitForPage();
       globalRoleDetails.mastheadTitle().should('include', `${ globalRoleName }`);
 
-      const sideNav = new ProductNavPo();
-
       sideNav.navToSideMenuEntryByLabel('Role Templates');
-
       roles.waitForPage(undefined, fragment);
+
+      // testing https://github.com/rancher/dashboard/issues/5291
+      roles.list().checkDefault(globalRoleName, true);
+      UsersPo.navTo();
+      usersPo.list().create();
+      userCreate.waitForPage();
+      userCreate.globalRoleBindings().roleCheckbox(globalRoleId).checkVisible();
+      userCreate.globalRoleBindings().roleCheckbox(globalRoleId).isChecked();
+      sideNav.navToSideMenuEntryByLabel('Role Templates');
 
       // testing https://github.com/rancher/dashboard/issues/9800
       roles.goToEditYamlPage(globalRoleName);
@@ -112,6 +119,7 @@ describe('Roles', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
       // view role details
       roles.waitForPage(undefined, fragment);
+      roles.list().checkDefault(clusterRoleName, true);
       roles.list().details(clusterRoleName, 2).find('a').click();
 
       const clusterRoleDetails = roles.detailRole(clusterRoleId);
@@ -145,6 +153,7 @@ describe('Roles', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
       // view role details
       roles.waitForPage(undefined, fragment);
+      roles.list().checkDefault(projectRoleName, true);
       roles.list().details(projectRoleName, 2).find('a').click();
 
       const projectRoleDetails = roles.detailRole(projectRoleId);

--- a/shell/components/GlobalRoleBindings.vue
+++ b/shell/components/GlobalRoleBindings.vue
@@ -338,6 +338,7 @@ export default {
                   :label="role.nameDisplay"
                   :description="role.descriptionDisplay"
                   :mode="mode"
+                  :data-testId="'grb-checkbox-' + role.id"
                   @input="checkboxChanged"
                 >
                   <template #label>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5291
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- There were some existing e2e tests that create various roles
- Added checks to confirm that the setting is saved correctly and in the case of global roles is applied when creating a user


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
