### PR TITLE
[Automation] Added test to validate that Create button is disabled when attempting to create a project but name is not provided

### DIFF
--- a/cypress/e2e/tests/pages/explorer/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/project-namespace.spec.ts
@@ -19,6 +19,19 @@ describe('Projects/Namespaces', { tags: ['@explorer', '@adminUser'] }, () => {
     projectsNamespacesPage.nsProject().checkExists();
   });
 
+  describe('Create Project validation', () => {
+    beforeEach(() => {
+      projectsNamespacesPage.goTo();
+    });
+    // Issue 5975: create button should be disabled unless name is filled in
+    it('Create button becomes available if the name is filled in', () => {
+      projectsNamespacesPage.createProjectButtonClick();
+      projectsNamespacesPage.buttonSubmit().expectToBeDisabled();
+      projectsNamespacesPage.name().set('test-1234');
+      projectsNamespacesPage.buttonSubmit().expectToBeEnabled();
+    });
+  });
+
   describe('Create Project Error Banner', () => {
     beforeEach(() => {
       projectsNamespacesPage.goTo();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5975 
<!-- Define findings related to the feature or bug issue. -->
Added a test case

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
N/A

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Added a test

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
