### PR TITLE
[AUTOMATION] Added E2E test to confirm that imported cluster displays provider correctly

### DIFF
--- a/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
@@ -32,6 +32,11 @@ export default class ProvClusterListPo extends BaseResourceList {
     return this.resourceTable().sortableTable().rowWithName(clusterName).column(4);
   }
 
+  providerSubType(clusterName: string) {
+    return this.resourceTable().sortableTable().rowWithName(clusterName).column(4)
+      .find(`.text-muted`);
+  }
+
   machines(clusterName: string) {
     return this.resourceTable().sortableTable().rowWithName(clusterName).column(5);
   }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -486,6 +486,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterList.list().state(importGenericName).should('contain', 'Pending');
         clusterList.list().state(importGenericName).should('contain', 'Waiting');
         clusterList.list().state(importGenericName).contains('Active', { timeout: 700000 });
+        // Issue #6836: Provider field on Imported clusters states "Imported" instead of cluster type
+        clusterList.list().provider(importGenericName).should('contain', 'Imported');
+        clusterList.list().providerSubType(importGenericName).should('contain', 'RKE2');
       });
 
       it('can navigate to cluster edit page', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6836 
<!-- Define findings related to the feature or bug issue. -->
Added E2E test to check that imported cluster displays provider type.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a E2E test. Unit tests were a part of the original change.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
N/A

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
