### PR TITLE
Initialize i18n after plugins load more

### DIFF
--- a/shell/initialize/client.js
+++ b/shell/initialize/client.js
@@ -165,6 +165,9 @@ async function render(to, from, next) {
     // We should really make authenticated middleware do less...
     await callMiddleware.call(this, [{ options: { middleware: ['authenticated'] } }], app.context);
 
+    // We used to have i18n middleware which was called each time we called middleware. This is also needed to support harvester because of the way harvester loads as outlined in the comment above
+    await this.$store.dispatch('i18n/init');
+
     if (nextCalled) {
       return;
     }


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We previously initialized i18n on every middleware invocation. This happened to be called after harvester was loaded by the authenticated middleware which loaded it's i18n keys.

This will now call i18n/init in a 404 after the auth middleware is called and harvester pages are loaded.


### Areas or cases that should be tested
Plugin translations, mostly Harvester.

### Screenshot/Video
![Screenshot 2024-05-09 025038](https://github.com/rancher/dashboard/assets/55104481/602d8600-186f-4995-ba9e-32dc642477c6)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
