### PR TITLE
9874 remove fake cluster from daemonset test and adjust e2e

### DIFF
--- a/cypress/e2e/po/pages/explorer/workloads-daemonsets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-daemonsets.po.ts
@@ -3,6 +3,9 @@ import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import ResourceListMastheadPo from '@/cypress/e2e/po/components/ResourceList/resource-list-masthead.po';
+import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 
 export class WorkloadsDaemonsetsListPagePo extends PagePo {
   private static createPath(clusterId: string) {
@@ -15,6 +18,14 @@ export class WorkloadsDaemonsetsListPagePo extends PagePo {
 
   constructor(clusterId = 'local') {
     super(WorkloadsDaemonsetsListPagePo.createPath(clusterId));
+  }
+
+  masthead() {
+    return new ResourceListMastheadPo(this.self());
+  }
+
+  createDaemonset() {
+    return this.masthead().create();
   }
 
   goToeditItemWithName(name:string) {
@@ -53,6 +64,14 @@ export class WorkLoadsDaemonsetsEditPagePo extends PagePo {
     super(WorkLoadsDaemonsetsEditPagePo.createPath(daemonsetId, clusterId, namespaceId, queryParams));
 
     WorkLoadsDaemonsetsEditPagePo.url = WorkLoadsDaemonsetsEditPagePo.createPath(daemonsetId, clusterId, namespaceId, queryParams);
+  }
+
+  nameNsDescription() {
+    return new NameNsDescription(this.self());
+  }
+
+  containerImageInput(): LabeledInputPo {
+    return LabeledInputPo.byLabel(this.self(), 'Container Image');
   }
 
   clickTab(selector: string) {

--- a/cypress/e2e/tests/pages/explorer/workloads/daemonsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/workloads/daemonsets.spec.ts
@@ -1,47 +1,43 @@
 import { WorkloadsDaemonsetsListPagePo, WorkLoadsDaemonsetsEditPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-daemonsets.po';
-import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
-const fakeProvClusterId = 'some-fake-cluster-id';
-const fakeMgmtClusterId = 'some-fake-mgmt-id';
 
 describe('Cluster Explorer', { tags: ['@explorer', '@adminUser'] }, () => {
   beforeEach(() => {
-    generateFakeClusterDataAndIntercepts(fakeProvClusterId, fakeMgmtClusterId);
-
-    // to test payload of https://github.com/rancher/dashboard/issues/9874
-    cy.intercept('PUT', `k8s/clusters/${ fakeMgmtClusterId }/v1/apps.daemonsets/calico-system/calico-node`, (req: any) => {
-      req.reply({
-        statusCode: 200,
-        body:       {}
-      });
-    }).as('daemonsetEdit');
-
-    // to prevent error when rendering the daemonsets list after save (otherwise test will fail)
-    cy.intercept('GET', `k8s/clusters/${ fakeMgmtClusterId }/v1/nodes`, (req: any) => {
-      req.reply({
-        statusCode: 200,
-        body:       { data: [] }
-      });
-    }).as('nodesReq');
-
     cy.login();
   });
 
   describe('Workloads', () => {
     describe('Daemonsets', () => {
       it('modifying "Scaling and Upgrade Policy" to "On Delete" should use the correct property "OnDelete"', () => {
-        // same name as in blueprints/nav/k8s-schemas/apps.daemonsets
-        const daemonsetName = 'calico-node';
+        const daemonsetName = 'daemonset-test';
 
-        // list view daemonsets
-        const workloadsDaemonsetsListPage = new WorkloadsDaemonsetsListPagePo(fakeMgmtClusterId);
+        // to test payload of https://github.com/rancher/dashboard/issues/9874
+        // we need to mock the PUT reply otherwise we get 409 conflict
+        cy.intercept('PUT', `/v1/apps.daemonsets/default/${ daemonsetName }`, (req: any) => {
+          req.reply({
+            statusCode: 200,
+            body:       {}
+          });
+        }).as('daemonsetEdit');
+
+        // list view for daemonsets
+        const workloadsDaemonsetsListPage = new WorkloadsDaemonsetsListPagePo('local');
 
         workloadsDaemonsetsListPage.goTo();
+        workloadsDaemonsetsListPage.waitForPage();
+        workloadsDaemonsetsListPage.createDaemonset();
+
+        // create a new daemonset
+        const workloadsDaemonsetsEditPage = new WorkLoadsDaemonsetsEditPagePo('local');
+
+        workloadsDaemonsetsEditPage.nameNsDescription().name().set(daemonsetName);
+        workloadsDaemonsetsEditPage.containerImageInput().set('nginx');
+        workloadsDaemonsetsEditPage.saveCreateForm().click();
+
+        workloadsDaemonsetsListPage.waitForPage();
         workloadsDaemonsetsListPage.listElementWithName(daemonsetName).should('be.visible');
         workloadsDaemonsetsListPage.goToeditItemWithName(daemonsetName);
 
-        // edit view daemonsets
-        const workloadsDaemonsetsEditPage = new WorkLoadsDaemonsetsEditPagePo(fakeMgmtClusterId);
-
+        // edit daemonset
         workloadsDaemonsetsEditPage.clickTab('#DaemonSet');
         workloadsDaemonsetsEditPage.clickTab('#upgrading');
         workloadsDaemonsetsEditPage.ScalingUpgradePolicyRadioBtn().set(1);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9874 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- remove fake cluster from daemonset test and adjust e2e

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
