### PR TITLE
[Automation] - Move network labelselect to BasicRke2 create tab

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po.ts
@@ -2,6 +2,8 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
 import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import BasicsRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po';
+import TabbedPo from '~/cypress/e2e/po/components/tabbed.po';
 
 /**
  * Covers core functionality that's common to the dashboard's import or create cluster pages
@@ -23,6 +25,12 @@ export default abstract class ClusterManagerCreateImportPagePo extends PagePo {
     cloudCredSelect.clickOptionWithLabel(label);
   }
 
+  selectTab(options: TabbedPo, selector: string) {
+    options.clickTabWithSelector(selector);
+
+    return this;
+  }
+
   create() {
     return this.resourceDetail().createEditView().create();
   }
@@ -33,5 +41,9 @@ export default abstract class ClusterManagerCreateImportPagePo extends PagePo {
 
   saveAndWait() {
     return this.resourceDetail().createEditView().saveAndWait();
+  }
+
+  basicsTab(): BasicsRke2 {
+    return new BasicsRke2();
   }
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po.ts
@@ -1,6 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import { CypressChainable } from '@/cypress/e2e/po/po.types';
 
 export default class BasicsRke2 extends ComponentPo {
   constructor(selector = '.dashboard-root') {
@@ -13,5 +14,13 @@ export default class BasicsRke2 extends ComponentPo {
 
   kubernetesVersions(): LabeledSelectPo {
     return new LabeledSelectPo('[data-testid="clusterBasics__kubernetesVersions"]');
+  }
+
+  networks(): LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="cluster-rke2-cni-select"]');
+  }
+
+  networkNoneSelectedForCni(): CypressChainable {
+    return cy.get('[data-testid="clusterBasics__noneOptionSelectedForCni"]');
   }
 }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -21,7 +21,6 @@ import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import { snapshot } from '@/cypress/e2e/blueprints/manager/cluster-snapshots';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { nodeDriveResponse } from '@/cypress/e2e/tests/pages/manager/mock-responses';
-import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 
@@ -104,6 +103,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
   describe('Created', () => {
     const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
     const detailRKE2ClusterPage = new ClusterManagerDetailRke2CustomPagePo(undefined, rke2CustomName);
+    const tabbedPo = new TabbedPo('[data-testid="tabbed-block"]');
 
     describe('RKE2 Custom', { tags: ['@jenkins', '@customCluster'] }, () => {
       const editCreatedClusterPage = new ClusterManagerEditRke2CustomPagePo(undefined, rke2CustomName);
@@ -149,24 +149,22 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         createRKE2ClusterPage.nameNsDescription().name().set(rke2CustomName);
 
         // Test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
-        const labeledSelectPo = new LabeledSelectPo('[data-testid="cluster-rke2-cni-select"]');
-
-        labeledSelectPo.checkExists();
-        labeledSelectPo.self().scrollIntoView();
-        labeledSelectPo.toggle();
-        labeledSelectPo.clickLabel('none');
-        labeledSelectPo.checkOptionSelected('none');
+        createRKE2ClusterPage.basicsTab().networks().checkExists();
+        createRKE2ClusterPage.basicsTab().networks().self().scrollIntoView();
+        createRKE2ClusterPage.basicsTab().networks().toggle();
+        createRKE2ClusterPage.basicsTab().networks().clickOptionWithLabel('none');
+        createRKE2ClusterPage.basicsTab().networks().checkOptionSelected('none');
 
         // banner with additional info about 'none' option should be visible
-        cy.get('[data-testid="clusterBasics__noneOptionSelectedForCni"]').should('exist');
+        createRKE2ClusterPage.basicsTab().networkNoneSelectedForCni().should('exist');
         // EO test for https://github.com/rancher/dashboard/issues/10338 (added option 'none' for CNI)
 
-        labeledSelectPo.toggle();
-        labeledSelectPo.clickLabel('calico');
-        labeledSelectPo.checkOptionSelected('calico');
+        createRKE2ClusterPage.basicsTab().networks().toggle();
+        createRKE2ClusterPage.basicsTab().networks().clickOptionWithLabel('calico');
+        createRKE2ClusterPage.basicsTab().networks().checkOptionSelected('calico');
 
         // testing https://github.com/rancher/dashboard/issues/10159
-        cy.get('[data-testid="btn-networking"]').click();
+        createRKE2ClusterPage.selectTab(tabbedPo, '[data-testid="btn-networking"]');
         createRKE2ClusterPage.network().truncateHostnameCheckbox().set();
         // EO test for https://github.com/rancher/dashboard/issues/10159
 


### PR DESCRIPTION
### Summary
Task #
https://github.com/rancher/qa-tasks/issues/1284

Refactor labelselect to be used from the BasicRke2 cluster create tab.
Use the TabbedPo to click on the Networking tab,

### Occurred changes and/or fixed issues
Refactor to organize a couple of `cy.get` to POs

### Areas or cases that should be tested
Custom Cluster create test

### Areas which could experience regressions
Test Pipeline

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
