### PR TITLE
Remove yq install from build-extension-x workflows

### DIFF
--- a/.github/workflows/build-extension-catalog.yml
+++ b/.github/workflows/build-extension-catalog.yml
@@ -47,11 +47,6 @@ jobs:
         with:
           version: v3.8.0
 
-      - name: Setup yq
-        uses: chrisdickinson/setup-yq@v1.0.1
-        with:
-          yq-version: v4.34.2
-
       - name: Setup Nodejs and npm
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -42,11 +42,6 @@ jobs:
         with:
           version: v3.8.0
 
-      - name: Setup yq
-        uses: chrisdickinson/setup-yq@v1.0.1
-        with:
-          yq-version: v4.34.2
-
       - name: Setup Nodejs and npm
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to #10663

### Occurred changes and/or fixed issues
- yq should come as default
  - https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
- Tested via repo containing pkgs pointing at workflows from this PR's branch
  - https://github.com/richard-cox/extension-testing/actions/runs/9060291972
  - https://github.com/richard-cox/extension-testing/actions/runs/9060291974/job/24889695939
- The output i think is all in https://github.com/richard-cox/extension-testing/tree/gh-pages
  - I've tested https://richard-cox.github.io/extension-testing can be added as a repo and the extension installed
  - This requires a thorough confirmation still though

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
