### PR TITLE
Replace peaceiris/actions-gh-pages action with generic gh actions

### DIFF
--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -8,8 +8,8 @@ on:
     branches:
       - master
 jobs:
-  deploy:
-    name: Publish Docusaurus
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,19 +26,26 @@ jobs:
         run: |
           echo "extensions.rancher.io" > ./docusaurus/build/CNAME
 
-      # Popular action to deploy to GitHub Pages:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Publish Docusaurus
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.repository_owner == 'rancher' }}
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          deploy_key: ${{ secrets.GH_PAGES_DEPLOY_KEY }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./docusaurus/build
-          # Remove .gitignore from excludes
-          exclude_assets: ''
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          path: ./docusaurus/build
+
+  # Seperate the deploy job to isolate write permissions
+  deploy:
+    name: Publish
+    if: ${{ github.event_name == 'push' && github.repository_owner == 'rancher' }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    # This is required to avoid https://github.com/actions/deploy-pages/issues/271
+    environment:
+      name: github-pages
+
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docusaurus.yaml
+++ b/.github/workflows/docusaurus.yaml
@@ -27,9 +27,12 @@ jobs:
           echo "extensions.rancher.io" > ./docusaurus/build/CNAME
 
       - name: Upload artifact
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'rancher' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./docusaurus/build
+          retention-days: 10
+          compression-level: 9
 
   # Seperate the deploy job to isolate write permissions
   deploy:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to #10663
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Replace peaceiris/actions-gh-pages action with generic gh actions
- Means we have to
  - Update settings to deploy gh pages from gh actions
      - https://github.com/rancher/dashboard/settings/pages change to Source Github Actions
      - https://github.com/rancher/dashboard/settings/environments/603599194/edit add `master` as a deployment branch
  - Switch over the CI `Publish Docusaurus` gate block to the new build job
- Means we can
  - drop the gh-pages branch
  - drop GH_PAGES_DEPLOY_KEY
- See https://github.com/richard-cox/dashboard/actions/runs/9077572302 for working example (though gh pages doesn't load docusarus correctly given backed in domain name) 
- See https://github.com/richard-cox/dashboard/actions/runs/9112196237/job/25050946120 for a run from this PR

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
