### PR TITLE
e2e test for large extension that disables cache

### DIFF
--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -4,7 +4,8 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
 
-const DISABLED_CACHE_EXTENSION_NAME = 'clock-large';
+const DISABLED_CACHE_EXTENSION_NAME = 'large-extension';
+const DISABLED_CACHE_EXTENSION_MENU_LABEL = 'Large-extension';
 const UNAUTHENTICATED_EXTENSION_NAME = 'uk-locale';
 const EXTENSION_NAME = 'clock';
 const UI_PLUGINS_PARTNERS_REPO_URL = 'https://github.com/rancher/partner-extensions';
@@ -284,9 +285,8 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.extensionDetailsCloseClick();
 
     // check if extension is working fine
-    BurgerMenuPo.burgerMenuNavToMenubyLabel('Clock-large');
-    // this checks if all 26 images are there, making sure extension is working
-    cy.get('.clock.outlet').find('img').should('have.length', 26);
+    BurgerMenuPo.burgerMenuNavToMenubyLabel(DISABLED_CACHE_EXTENSION_MENU_LABEL);
+    cy.get('h1').should('have.text', 'Large extension demo');
   });
 
   it('Should respect authentication when importing extension scripts', () => {

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -342,10 +342,12 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.extensionCardUninstallClick(EXTENSION_NAME);
     extensionsPo.extensionUninstallModal().should('be.visible');
     extensionsPo.uninstallModaluninstallClick();
+    extensionsPo.extensionReloadBanner().should('be.visible');
 
     extensionsPo.extensionCardUninstallClick(UNAUTHENTICATED_EXTENSION_NAME);
     extensionsPo.extensionUninstallModal().should('be.visible');
     extensionsPo.uninstallModaluninstallClick();
+    extensionsPo.extensionReloadBanner().should('be.visible');
 
     extensionsPo.extensionCardUninstallClick(DISABLED_CACHE_EXTENSION_NAME);
     extensionsPo.extensionUninstallModal().should('be.visible');

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -4,6 +4,7 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
 
+const DISABLED_CACHE_EXTENSION_NAME = 'clock-large';
 const UNAUTHENTICATED_EXTENSION_NAME = 'uk-locale';
 const EXTENSION_NAME = 'clock';
 const UI_PLUGINS_PARTNERS_REPO_URL = 'https://github.com/rancher/partner-extensions';
@@ -258,6 +259,36 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.extensionCard(EXTENSION_NAME).should('be.visible');
   });
 
+  it('An extension larger than 20mb, which will trigger chacheState disabled, should install and work fine', () => {
+    const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.goTo();
+
+    extensionsPo.extensionTabAvailableClick();
+
+    // click on install button on card
+    extensionsPo.extensionCardInstallClick(DISABLED_CACHE_EXTENSION_NAME);
+    extensionsPo.extensionInstallModal().should('be.visible');
+
+    // click install
+    extensionsPo.installModalInstallClick();
+
+    // let's check the extension reload banner and reload the page
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    // make sure extension card is in the installed tab
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCardClick(DISABLED_CACHE_EXTENSION_NAME);
+    extensionsPo.extensionDetailsTitle().should('contain', DISABLED_CACHE_EXTENSION_NAME);
+    extensionsPo.extensionDetailsCloseClick();
+
+    // check if extension is working fine
+    BurgerMenuPo.burgerMenuNavToMenubyLabel('Clock-large');
+    // this checks if all 26 images are there, making sure extension is working
+    cy.get('.clock.outlet').find('img').should('have.length', 26);
+  });
+
   it('Should respect authentication when importing extension scripts', () => {
     const extensionsPo = new ExtensionsPagePo();
 
@@ -312,6 +343,10 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.uninstallModaluninstallClick();
 
     extensionsPo.extensionCardUninstallClick(UNAUTHENTICATED_EXTENSION_NAME);
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
+
+    extensionsPo.extensionCardUninstallClick(DISABLED_CACHE_EXTENSION_NAME);
     extensionsPo.extensionUninstallModal().should('be.visible');
     extensionsPo.uninstallModaluninstallClick();
 

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -6,6 +6,7 @@ import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
 
 const DISABLED_CACHE_EXTENSION_NAME = 'large-extension';
 const DISABLED_CACHE_EXTENSION_MENU_LABEL = 'Large-extension';
+const DISABLED_CACHE_EXTENSION_TITLE = 'Large extension demo (> 20mb) - cache testing';
 const UNAUTHENTICATED_EXTENSION_NAME = 'uk-locale';
 const EXTENSION_NAME = 'clock';
 const UI_PLUGINS_PARTNERS_REPO_URL = 'https://github.com/rancher/partner-extensions';
@@ -286,7 +287,7 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
 
     // check if extension is working fine
     BurgerMenuPo.burgerMenuNavToMenubyLabel(DISABLED_CACHE_EXTENSION_MENU_LABEL);
-    cy.get('h1').should('have.text', 'Large extension demo');
+    cy.get('h1').should('have.text', DISABLED_CACHE_EXTENSION_TITLE);
   });
 
   it('Should respect authentication when importing extension scripts', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10639 
<!-- Define findings related to the feature or bug issue. -->

**TO TEST/REVIEW THIS LOCALLY IT'S NEEDED:**
- https://github.com/rancher/dashboard/pull/11036 **to be merged** (done!)
- **needs Rancher backend 2.9-head from 24th May, 2024 minimum** -> tied to https://github.com/rancher/rancher/pull/45521

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add e2e test to check that extensions with `cacheState: disabled` work on Rancher Dashboard

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Add git repo to Rancher for extension examples: local -> apps -> repositories
type: `git repo`
repo: `https://github.com/rancher/ui-plugin-examples`
branch: `main`
- Install extension `Large-extension` and make sure it works (top-level extension -> main nav)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
