### PR TITLE
Add support for displaying error banners on configmap creation page

### DIFF
--- a/cypress/e2e/po/components/storage/config-map.po.ts
+++ b/cypress/e2e/po/components/storage/config-map.po.ts
@@ -25,6 +25,10 @@ export default class ConfigMapPo extends CreateEditViewPo {
     return LabeledInputPo.byLabel(this.self(), 'Description');
   }
 
+  errorBanner() {
+    return cy.get('#cru-errors');
+  }
+
   saveCreateForm(): AsyncButtonPo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }

--- a/cypress/e2e/tests/pages/explorer/storage/configmap.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/storage/configmap.spec.ts
@@ -59,4 +59,20 @@ skipGeometric=true`;
     // Assert the current value yaml dumps will append a newline at the end
     configMapPo.valueInput().value().should('eq', `${ expectedValue }\n`);
   });
+
+  it('should show an error banner if the api call sends back an error', () => {
+    // Navigate to Service Discovery => ConfigMaps
+    ConfigMapPagePo.navTo();
+    // Click on Create
+    configMapPage.clickCreate();
+    // Enter ConfigMap name
+    const configMapPo = new ConfigMapPo();
+
+    // Enter an invalid name so the api call fails
+    configMapPo.nameInput().set('$^$^"£%');
+    // Click on Create
+    configMapPo.saveCreateForm().click();
+    // Error banner should be displayed
+    configMapPo.errorBanner().should('exist').and('be.visible');
+  });
 });

--- a/shell/edit/configmap.vue
+++ b/shell/edit/configmap.vue
@@ -61,11 +61,17 @@ export default {
   },
 
   methods: {
-    async saveConfigMap() {
+    async saveConfigMap(saveCb) {
+      this.errors = [];
       const yaml = await this.$refs.cru.createResourceYaml(this.yamlModifiers);
 
-      await this.value.saveYaml(yaml);
-      this.done();
+      try {
+        await this.value.saveYaml(yaml);
+        this.done();
+      } catch (err) {
+        this.errors.push(err);
+        saveCb(false);
+      }
     },
 
     updateValue(val, type) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10794 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Added a try/catch block to handle errors on `configMap.vue` when saving.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Already mentioned on the original issue.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Not expected.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/rancher/dashboard/assets/135728925/45a81495-7e39-4ebb-897b-4fefe7c797a6


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
