### PR TITLE
[Automation] Added a test for credential changing the Azure environment

### DIFF
--- a/cypress/e2e/blueprints/manager/cloud-credential-create-payload.ts
+++ b/cypress/e2e/blueprints/manager/cloud-credential-create-payload.ts
@@ -20,7 +20,7 @@ export function cloudCredentialCreatePayloadAzure(credName: string, environment:
       namespace:    'fleet-default'
     },
     _name:                 credName,
-    annotations:           { 'provisioning.cattle.io/driver': 'digitalocean' },
+    annotations:           { 'provisioning.cattle.io/driver': 'azure' },
     azurecredentialConfig: {
       clientId, clientSecret, environment, subscriptionId
     },

--- a/cypress/e2e/blueprints/manager/cloud-credential-create-payload.ts
+++ b/cypress/e2e/blueprints/manager/cloud-credential-create-payload.ts
@@ -1,4 +1,4 @@
-export function cloudCredentialCreatePayload(credName: string, accessToken: string):object {
+export function cloudCredentialCreatePayloadDO(credName: string, accessToken: string):object {
   return {
     type:     'provisioning.cattle.io/cloud-credential',
     metadata: {
@@ -10,5 +10,21 @@ export function cloudCredentialCreatePayload(credName: string, accessToken: stri
     digitaloceancredentialConfig: { accessToken },
     _type:                        'provisioning.cattle.io/cloud-credential',
     name:                         credName
+  };
+}
+export function cloudCredentialCreatePayloadAzure(credName: string, environment: string, subscriptionId: string, clientId: string, clientSecret: string):object {
+  return {
+    type:     'provisioning.cattle.io/cloud-credential',
+    metadata: {
+      generateName: 'cc-',
+      namespace:    'fleet-default'
+    },
+    _name:                 credName,
+    annotations:           { 'provisioning.cattle.io/driver': 'digitalocean' },
+    azurecredentialConfig: {
+      clientId, clientSecret, environment, subscriptionId
+    },
+    _type: 'provisioning.cattle.io/cloud-credential',
+    name:  credName
   };
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-azure.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-azure.po.ts
@@ -1,6 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
-import MachinePoolRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po';
+import MachinePoolAzureRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-azure-rke2.po';
 import BasicsRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/basics-tab-rke2.po';
 import AzureCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credentials-azure.po';
 
@@ -24,8 +24,8 @@ export default class ClusterManagerCreateRke2AzurePagePo extends ClusterManagerC
     return new AzureCloudCredentialsCreateEditPo();
   }
 
-  machinePoolTab(): MachinePoolRke2 {
-    return new MachinePoolRke2();
+  machinePoolTab(): MachinePoolAzureRke2 {
+    return new MachinePoolAzureRke2();
   }
 
   basicsTab(): BasicsRke2 {

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-azure-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-azure-rke2.po.ts
@@ -1,0 +1,12 @@
+import MachinePoolRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+
+export default class MachinePoolAzureRke2 extends MachinePoolRke2 {
+  environment() {
+    return this.self().get('[data-testid="machineConfig.azure.environment.value"]');
+  }
+
+  location(): LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="machineConfig.azure.location"]');
+  }
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-azure-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-azure-rke2.po.ts
@@ -1,12 +1,13 @@
+import { CypressChainable } from '@/cypress/e2e/po/po.types';
 import MachinePoolRke2 from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 
 export default class MachinePoolAzureRke2 extends MachinePoolRke2 {
-  environment() {
-    return this.self().get('[data-testid="machineConfig.azure.environment.value"]');
+  environment(): CypressChainable {
+    return this.self().get('[data-testid="machineConfig-azure-environment-value"]'); // .find('span')
   }
 
   location(): LabeledSelectPo {
-    return new LabeledSelectPo('[data-testid="machineConfig.azure.location"]');
+    return new LabeledSelectPo('[data-testid="machineConfig-azure-location"]', this.self());
   }
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-azure-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-azure-rke2.po.ts
@@ -4,7 +4,7 @@ import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 
 export default class MachinePoolAzureRke2 extends MachinePoolRke2 {
   environment(): CypressChainable {
-    return this.self().get('[data-testid="machineConfig-azure-environment-value"]'); // .find('span')
+    return this.self().find('[data-testid="machineConfig-azure-environment-value"] span');
   }
 
   location(): LabeledSelectPo {

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -14,7 +14,7 @@ describe('Cloud Credential', () => {
     clusterList.goTo();
   });
 
-  it.skip('Editing a cluster cloud credential should work with duplicate named cloud credentials', { tags: ['@manager', '@adminUser'] }, () => {
+  it('Editing a cluster cloud credential should work with duplicate named cloud credentials', { tags: ['@manager', '@adminUser'] }, () => {
     const credsName = 'test-do-creds';
     const clusterName = 'test-cluster-digital-ocean';
     const machinePoolId = 'dummy-id';
@@ -93,7 +93,7 @@ describe('Cloud Credential', () => {
       });
     }
   });
-  it('Changing credential environment should change the list of locations when creating an Azure cluster', {}, () => {
+  it('Changing credential environment should change the list of locations when creating an Azure cluster', { tags: ['@manager', '@adminUser'] }, () => {
     const clusterName = 'test-cluster-azure';
     const machinePoolId = 'dummy-id';
 
@@ -167,9 +167,9 @@ describe('Cloud Credential', () => {
         createdCloudCredsIds.push(resp.body.id);
 
         if (i === cloudCredsToCreate.length - 1) {
-          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ createdCloudCredsIds[0] }`, { body: createdCloudCredsIds[0].body });
-          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ createdCloudCredsIds[1] }`, { body: createdCloudCredsIds[1].body });
-          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ createdCloudCredsIds[2] }`, { body: createdCloudCredsIds[1].body });
+          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ encodeURIComponent(createdCloudCredsIds[0]) }`, { body: createdCloudCredsIds[0].body });
+          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ encodeURIComponent(createdCloudCredsIds[1]) }`, { body: createdCloudCredsIds[1].body });
+          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ encodeURIComponent(createdCloudCredsIds[2]) }`, { body: createdCloudCredsIds[1].body });
 
           clusterList.checkIsCurrentPage();
           clusterList.createCluster();

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -1,19 +1,20 @@
-import { cloudCredentialCreatePayload } from '@/cypress/e2e/blueprints/manager/cloud-credential-create-payload';
+import { cloudCredentialCreatePayloadDO, cloudCredentialCreatePayloadAzure } from '@/cypress/e2e/blueprints/manager/cloud-credential-create-payload';
 import { clusterProvDigitalOceanSingleResponse } from '@/cypress/e2e/blueprints/manager/digital-ocean-cluster-provisioning-response';
 import { machinePoolConfigResponse } from '@/cypress/e2e/blueprints/manager/machine-pool-config-response';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
+import ClusterManagerCreateRke2AzurePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-azure.po';
 
 describe('Cloud Credential', () => {
   const clusterList = new ClusterManagerListPagePo();
 
-  before(() => {
+  beforeEach(() => {
     cy.login();
 
     clusterList.goTo();
   });
 
-  it('Editing a cluster cloud credential should work with duplicate named cloud credentials', { tags: ['@manager', '@adminUser'] }, () => {
+  it.skip('Editing a cluster cloud credential should work with duplicate named cloud credentials', { tags: ['@manager', '@adminUser'] }, () => {
     const credsName = 'test-do-creds';
     const clusterName = 'test-cluster-digital-ocean';
     const machinePoolId = 'dummy-id';
@@ -62,7 +63,7 @@ describe('Cloud Credential', () => {
     const createdCloudCredsIds = [];
 
     for (let i = 0; i < cloudCredsToCreate.length; i++) {
-      cy.createRancherResource('v3', 'cloudcredentials', JSON.stringify(cloudCredentialCreatePayload(cloudCredsToCreate[i].name, cloudCredsToCreate[i].token))).then((resp: Cypress.Response<any>) => {
+      cy.createRancherResource('v3', 'cloudcredentials', JSON.stringify(cloudCredentialCreatePayloadDO(cloudCredsToCreate[i].name, cloudCredsToCreate[i].token))).then((resp: Cypress.Response<any>) => {
         createdCloudCredsIds.push(resp.body.id);
 
         if (i === 0) {
@@ -88,6 +89,108 @@ describe('Cloud Credential', () => {
           cy.wait('@dummyProvClusterSave').then(({ request }) => {
             expect(request.body.spec.cloudCredentialSecretName).to.equal(createdCloudCredsIds[1]);
           });
+        }
+      });
+    }
+  });
+  it('Changing credential environment should change the list of locations when creating an Azure cluster', {}, () => {
+    const clusterName = 'test-cluster-azure';
+    const machinePoolId = 'dummy-id';
+
+    const createRKE2AzureClusterPage = new ClusterManagerCreateRke2AzurePagePo();
+
+    // prepare some intercepts of XHR requests needed for the correct flow
+    // intercept GET of machine configs and pass a mock (Azure)
+    cy.intercept('GET', `/v1/rke-machine-config.cattle.io.azureconfigs/fleet-default/*`, (req) => {
+      req.reply({
+        statusCode: 200,
+        body:       machinePoolConfigResponse(clusterName, machinePoolId),
+      });
+    }).as('dummyMachinePoolLoad1');
+
+    // create some cloud credentials with different environments
+    const cloudCredsToCreate = [
+      {
+        name:           'publicCloud',
+        environment:    'AzurePublicCloud',
+        subscriptionId: 'testSubscription',
+        clientId:       'testClientId',
+        clientSecret:   'testClientSecret',
+        body:           [
+          {
+            name:        'public',
+            displayName: 'public'
+          }
+        ]
+      },
+      {
+        name:           'chinaCloud',
+        environment:    'AzureChinaCloud',
+        subscriptionId: 'testSubscription',
+        clientId:       'testClientId',
+        clientSecret:   'testClientSecret',
+        body:           [
+          {
+            name:        'china',
+            displayName: 'china'
+          }
+        ]
+      },
+      {
+        name:           'USGovernment',
+        environment:    'AzureUSGovernmentCloud',
+        subscriptionId: 'testSubscription',
+        clientId:       'testClientId',
+        clientSecret:   'testClientSecret',
+        body:           [
+          {
+            name:        'USGovernment',
+            displayName: 'USGovernment'
+          }
+        ]
+      },
+    ];
+
+    const createdCloudCredsIds = [];
+
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+
+    for (let i = 0; i < cloudCredsToCreate.length; i++) {
+      cy.createRancherResource('v3', 'cloudcredentials', JSON.stringify(cloudCredentialCreatePayloadAzure(
+        cloudCredsToCreate[i].name,
+        cloudCredsToCreate[i].environment,
+        cloudCredsToCreate[i].subscriptionId,
+        cloudCredsToCreate[i].clientId,
+        cloudCredsToCreate[i].clientSecret,
+      ))).then((resp: Cypress.Response<any>) => {
+        createdCloudCredsIds.push(resp.body.id);
+
+        if (i === cloudCredsToCreate.length - 1) {
+          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ createdCloudCredsIds[0] }`, { body: createdCloudCredsIds[0].body });
+          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ createdCloudCredsIds[1] }`, { body: createdCloudCredsIds[1].body });
+          cy.intercept('GET', `/meta/aksLocations?cloudCredentialId=${ createdCloudCredsIds[2] }`, { body: createdCloudCredsIds[1].body });
+
+          clusterList.checkIsCurrentPage();
+          clusterList.createCluster();
+          createRKE2AzureClusterPage.rkeToggle().set('RKE2/K3s');
+          createRKE2AzureClusterPage.selectCreate(1);
+          createRKE2AzureClusterPage.rke2PageTitle().should('include', 'Create Azure');
+          createRKE2AzureClusterPage.waitForPage('type=azure&rkeType=rke2');
+          createRKE2AzureClusterPage.selectOptionForCloudCredentialWithLabel(`${ cloudCredsToCreate[0].name }`);
+
+          createRKE2AzureClusterPage.machinePoolTab().environment().should('include', cloudCredsToCreate[0].environment );
+          createRKE2AzureClusterPage.machinePoolTab().location().getOptions().should('include', cloudCredsToCreate[0].body[0].name );
+
+          createRKE2AzureClusterPage.selectOptionForCloudCredentialWithLabel(`${ cloudCredsToCreate[1].name }`);
+
+          createRKE2AzureClusterPage.machinePoolTab().environment().should('include', cloudCredsToCreate[1].environment );
+          createRKE2AzureClusterPage.machinePoolTab().location().getOptions().should('include', cloudCredsToCreate[1].body[0].name );
+
+          createRKE2AzureClusterPage.selectOptionForCloudCredentialWithLabel(`${ cloudCredsToCreate[2].name }`);
+
+          createRKE2AzureClusterPage.machinePoolTab().environment().should('include', cloudCredsToCreate[2].environment );
+          createRKE2AzureClusterPage.machinePoolTab().location().getOptions().should('include', cloudCredsToCreate[2].body[0].name );
         }
       });
     }

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -205,17 +205,17 @@ describe('Cloud Credential', () => {
           createRKE2AzureClusterPage.selectOptionForCloudCredentialWithLabel(`${ cloudCredsToCreate[0].name }`);
 
           createRKE2AzureClusterPage.machinePoolTab().location().checkOptionSelected(cloudCredsToCreate[0].body[0].name);
-          createRKE2AzureClusterPage.machinePoolTab().environment().should('include', cloudCredsToCreate[0].environment );
+          createRKE2AzureClusterPage.machinePoolTab().environment().should('have.text', cloudCredsToCreate[0].environment );
 
           createRKE2AzureClusterPage.selectOptionForCloudCredentialWithLabel(`${ cloudCredsToCreate[1].name }`);
 
-          createRKE2AzureClusterPage.machinePoolTab().environment().should('include', cloudCredsToCreate[1].environment );
-          createRKE2AzureClusterPage.machinePoolTab().location().getOptions().should('include', cloudCredsToCreate[1].body[0].name );
+          createRKE2AzureClusterPage.machinePoolTab().environment().should('have.text', cloudCredsToCreate[1].environment );
+          createRKE2AzureClusterPage.machinePoolTab().location().checkOptionSelected(cloudCredsToCreate[1].body[0].name );
 
           createRKE2AzureClusterPage.selectOptionForCloudCredentialWithLabel(`${ cloudCredsToCreate[2].name }`);
 
-          createRKE2AzureClusterPage.machinePoolTab().environment().should('include', cloudCredsToCreate[2].environment );
-          createRKE2AzureClusterPage.machinePoolTab().location().getOptions().should('include', cloudCredsToCreate[2].body[0].name );
+          createRKE2AzureClusterPage.machinePoolTab().environment().should('have.text', cloudCredsToCreate[2].environment );
+          createRKE2AzureClusterPage.machinePoolTab().location().checkOptionSelected(cloudCredsToCreate[2].body[0].name );
         }
       });
     }

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -528,6 +528,7 @@ export default {
           :required="true"
           :label="t('cluster.machineConfig.azure.location.label')"
           :disabled="disabled"
+          data-testid="machineConfig.azure.location"
           @input="setLocation"
         />
       </div>
@@ -540,7 +541,7 @@ export default {
           {{ t('cluster.machineConfig.azure.environment.label') }}
           <i class="icon icon-sm icon-info" />
         </label>
-        <span>{{ value.environment }}</span>
+        <span data-testid="machineConfig.azure.environment.value">{{ value.environment }}</span>
       </div>
     </div>
     <div class="row mt-20">

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -528,11 +528,11 @@ export default {
           :required="true"
           :label="t('cluster.machineConfig.azure.location.label')"
           :disabled="disabled"
-          data-testid="machineConfig.azure.location"
+          data-testid="machineConfig-azure-location"
           @input="setLocation"
         />
       </div>
-      <div>
+      <div data-testid="machineConfig-azure-environment-value">
         <label
           v-clean-tooltip="t('cluster.machineConfig.azure.environment.tooltip')"
           :style="{'display':'block'}"
@@ -541,7 +541,7 @@ export default {
           {{ t('cluster.machineConfig.azure.environment.label') }}
           <i class="icon icon-sm icon-info" />
         </label>
-        <span data-testid="machineConfig.azure.environment.value">{{ value.environment }}</span>
+        <span>{{ value.environment }}</span>
       </div>
     </div>
     <div class="row mt-20">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10470 
<!-- Define findings related to the feature or bug issue. -->
Added E2E test

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
N/A

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
N/A

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
N/A
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
