### PR TITLE
add `data directory` configuration component to advanced tab in rke2 create/edit cluster interface

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1395,6 +1395,21 @@ cluster:
   name:
     label: Cluster Name
     placeholder: A unique name for the cluster
+  directoryConfig:
+    title: Data directory configuration
+    checkboxText: Use the same path for System-agent, Provisioning and K8s Distro data directories configuration
+    common: 
+      label: Data directory configuration path
+      tooltip: Data directory configuration for System-agent, Provisioning and K8s Distro
+    systemAgent: 
+      label: System-agent directory path
+      tooltip: Data directory for the system-agent connection info and plans
+    provisioning: 
+      label: Provisioning directory path
+      tooltip: Data directory for provisioning related files
+    k8sDistro: 
+      label: K8s Distro directory path
+      tooltip: Data directory for the k8s distro
   machineConfig:
     banner:
       updateInfo: Create a new pool to update machine configs

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
@@ -26,7 +26,7 @@ describe('component: DirectoryConfig', () => {
     }
   };
 
-  it(`should render the component with its default configuration (create scenario)`, () => {
+  it('should render the component with its default configuration (create scenario)', () => {
     wrapper = mount(
       DirectoryConfig,
       mountOptions
@@ -51,7 +51,7 @@ describe('component: DirectoryConfig', () => {
     expect(k8sDistroInput.exists()).toBe(false);
   });
 
-  it(`updating common config path should set the correct values on each data dir variable`, async() => {
+  it('updating common config path should set the correct values on each data dir variable', async() => {
     wrapper = mount(
       DirectoryConfig,
       mountOptions
@@ -68,7 +68,7 @@ describe('component: DirectoryConfig', () => {
     expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath);
   });
 
-  it(`updating each individual data dir should set the correct values on each data dir variable`, async() => {
+  it('updating each individual data dir should set the correct values on each data dir variable', async() => {
     wrapper = mount(
       DirectoryConfig,
       mountOptions
@@ -97,7 +97,7 @@ describe('component: DirectoryConfig', () => {
     expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath);
   });
 
-  it(`checkbox should be checked if all data dir values are the same (with all data dir values filled)`, () => {
+  it('checkbox should be checked if all data dir values are the same (with all data dir values filled)', () => {
     const newMountOptions = clone(mountOptions);
     const inputPath = 'some-data-dir';
 
@@ -130,7 +130,7 @@ describe('component: DirectoryConfig', () => {
     expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath);
   });
 
-  it(`checkbox should NOT be checked if some data dir values are the different (with all data dir values filled)`, () => {
+  it('checkbox should NOT be checked if some data dir values are the different (with all data dir values filled)', () => {
     const newMountOptions = clone(mountOptions);
     const inputPath1 = 'some-data-dir1';
     const inputPath2 = 'some-data-dir2';
@@ -162,7 +162,7 @@ describe('component: DirectoryConfig', () => {
     expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath3);
   });
 
-  it(`on a mode different than _CREATE all visible inputs should be disabled (with common config)`, () => {
+  it('on a mode different than _CREATE all visible inputs should be disabled (with common config)', () => {
     const newMountOptions = clone(mountOptions);
     const inputPath = 'some-data-dir';
 
@@ -192,7 +192,7 @@ describe('component: DirectoryConfig', () => {
     expect(commonInput.attributes('disabled')).toBe('disabled');
   });
 
-  it(`on a mode different than _CREATE all visible inputs should be disabled (with different values)`, () => {
+  it('on a mode different than _CREATE all visible inputs should be disabled (with different values)', () => {
     const newMountOptions = clone(mountOptions);
     const inputPath1 = 'some-data-dir1';
     const inputPath2 = 'some-data-dir2';

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
@@ -1,0 +1,228 @@
+/* eslint-disable jest/no-hooks */
+import { mount, Wrapper } from '@vue/test-utils';
+import DirectoryConfig from '@shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue';
+import { _EDIT, _CREATE } from '@shell/config/query-params';
+import { clone } from '@shell/utils/object';
+
+describe('component: DirectoryConfig', () => {
+  let wrapper: Wrapper<InstanceType<typeof DirectoryConfig>>;
+
+  const mountOptions = {
+    propsData: {
+      value: {
+        systemAgent:  '',
+        provisioning: '',
+        k8sDistro:    '',
+      },
+      mode: _CREATE,
+    },
+    mocks: {
+      $store: {
+        getters: {
+          'i18n/t':      jest.fn(),
+          'i18n/exists': jest.fn(),
+        }
+      },
+    }
+  };
+
+  it(`should render the component with its default configuration (create scenario)`, () => {
+    wrapper = mount(
+      DirectoryConfig,
+      mountOptions
+    );
+
+    const title = wrapper.find('h3');
+    const checkbox = wrapper.find('[data-testid="rke2-directory-config-individual-config-checkbox"]');
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    expect(title.exists()).toBe(true);
+    expect(checkbox.exists()).toBe(true);
+    // for the default config, checkbox should be checked
+    expect(wrapper.vm.isSettingCommonConfig).toBe(true);
+    expect(commonInput.exists()).toBe(true);
+
+    // since we have all of the vars empty, then the individual inputs should not be there
+    expect(systemAgentInput.exists()).toBe(false);
+    expect(provisioningInput.exists()).toBe(false);
+    expect(k8sDistroInput.exists()).toBe(false);
+  });
+
+  it(`updating common config path should set the correct values on each data dir variable`, async() => {
+    wrapper = mount(
+      DirectoryConfig,
+      mountOptions
+    );
+
+    const inputPath = 'some-data-dir';
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+
+    commonInput.setValue(inputPath);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(inputPath);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(inputPath);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath);
+  });
+
+  it(`updating each individual data dir should set the correct values on each data dir variable`, async() => {
+    wrapper = mount(
+      DirectoryConfig,
+      mountOptions
+    );
+
+    const inputPath = 'some-data-dir';
+    const checkbox = wrapper.find('[data-testid="rke2-directory-config-individual-config-checkbox"]');
+
+    await checkbox.find('label').trigger('click');
+    await checkbox.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.isSettingCommonConfig).toBe(false);
+
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    systemAgentInput.setValue(inputPath);
+    provisioningInput.setValue(inputPath);
+    k8sDistroInput.setValue(inputPath);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(inputPath);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(inputPath);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath);
+  });
+
+  it(`checkbox should be checked if all data dir values are the same (with all data dir values filled)`, () => {
+    const newMountOptions = clone(mountOptions);
+    const inputPath = 'some-data-dir';
+
+    newMountOptions.propsData.value.systemAgent = inputPath;
+    newMountOptions.propsData.value.provisioning = inputPath;
+    newMountOptions.propsData.value.k8sDistro = inputPath;
+
+    wrapper = mount(
+      DirectoryConfig,
+      newMountOptions
+    );
+
+    const checkbox = wrapper.find('[data-testid="rke2-directory-config-individual-config-checkbox"]');
+
+    expect(checkbox.exists()).toBe(true);
+    expect(wrapper.vm.isSettingCommonConfig).toBe(true);
+
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    expect(commonInput.exists()).toBe(true);
+    expect(systemAgentInput.exists()).toBe(false);
+    expect(provisioningInput.exists()).toBe(false);
+    expect(k8sDistroInput.exists()).toBe(false);
+
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(inputPath);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(inputPath);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath);
+  });
+
+  it(`checkbox should NOT be checked if some data dir values are the different (with all data dir values filled)`, () => {
+    const newMountOptions = clone(mountOptions);
+    const inputPath1 = 'some-data-dir1';
+    const inputPath2 = 'some-data-dir2';
+    const inputPath3 = 'some-data-dir3';
+
+    newMountOptions.propsData.value.systemAgent = inputPath1;
+    newMountOptions.propsData.value.provisioning = inputPath2;
+    newMountOptions.propsData.value.k8sDistro = inputPath3;
+
+    wrapper = mount(
+      DirectoryConfig,
+      newMountOptions
+    );
+
+    expect(wrapper.vm.isSettingCommonConfig).toBe(false);
+
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    expect(commonInput.exists()).toBe(false);
+    expect(systemAgentInput.exists()).toBe(true);
+    expect(provisioningInput.exists()).toBe(true);
+    expect(k8sDistroInput.exists()).toBe(true);
+
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(inputPath1);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(inputPath2);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath3);
+  });
+
+  it(`on a mode different than _CREATE all visible inputs should be disabled (with common config)`, () => {
+    const newMountOptions = clone(mountOptions);
+    const inputPath = 'some-data-dir';
+
+    newMountOptions.propsData.value.systemAgent = inputPath;
+    newMountOptions.propsData.value.provisioning = inputPath;
+    newMountOptions.propsData.value.k8sDistro = inputPath;
+    newMountOptions.propsData.mode = _EDIT;
+
+    wrapper = mount(
+      DirectoryConfig,
+      newMountOptions
+    );
+
+    const checkbox = wrapper.find('[data-testid="rke2-directory-config-individual-config-checkbox"]');
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    expect(checkbox.exists()).toBe(true);
+    expect(commonInput.exists()).toBe(true);
+    expect(systemAgentInput.exists()).toBe(false);
+    expect(provisioningInput.exists()).toBe(false);
+    expect(k8sDistroInput.exists()).toBe(false);
+
+    expect(checkbox.find('label').classes('disabled')).toBe(true);
+    expect(commonInput.attributes('disabled')).toBe('disabled');
+  });
+
+  it(`on a mode different than _CREATE all visible inputs should be disabled (with different values)`, () => {
+    const newMountOptions = clone(mountOptions);
+    const inputPath1 = 'some-data-dir1';
+    const inputPath2 = 'some-data-dir2';
+    const inputPath3 = 'some-data-dir3';
+
+    newMountOptions.propsData.value.systemAgent = inputPath1;
+    newMountOptions.propsData.value.provisioning = inputPath2;
+    newMountOptions.propsData.value.k8sDistro = inputPath3;
+    newMountOptions.propsData.mode = _EDIT;
+
+    wrapper = mount(
+      DirectoryConfig,
+      newMountOptions
+    );
+
+    const checkbox = wrapper.find('[data-testid="rke2-directory-config-individual-config-checkbox"]');
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    expect(checkbox.exists()).toBe(true);
+    expect(commonInput.exists()).toBe(false);
+    expect(systemAgentInput.exists()).toBe(true);
+    expect(provisioningInput.exists()).toBe(true);
+    expect(k8sDistroInput.exists()).toBe(true);
+
+    expect(checkbox.find('label').classes('disabled')).toBe(true);
+    expect(systemAgentInput.attributes('disabled')).toBe('disabled');
+    expect(provisioningInput.attributes('disabled')).toBe('disabled');
+    expect(k8sDistroInput.attributes('disabled')).toBe('disabled');
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/utils/cluster.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/utils/cluster.ts
@@ -60,6 +60,11 @@ export const PROV_CLUSTER = {
         configs: {},
         mirrors: {}
       },
+      dataDirectories: {
+        systemAgent:  '',
+        provisioning: '',
+        k8sDistro:    '',
+      }
     },
     defaultPodSecurityAdmissionConfigurationTemplateName: '',
   },

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -171,6 +171,14 @@ export default {
       });
     }
 
+    if (!this.value.spec.rkeConfig.dataDirectories) {
+      set(this.value.spec.rkeConfig, 'dataDirectories', {
+        systemAgent:  '',
+        provisioning: '',
+        k8sDistro:    '',
+      });
+    }
+
     if (!this.value.spec.rkeConfig.machineGlobalConfig) {
       set(this.value.spec, 'rkeConfig.machineGlobalConfig', {});
     }

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -6,6 +6,7 @@ import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 import MatchExpressions from '@shell/components/form/MatchExpressions';
 import ArrayList from '@shell/components/form/ArrayList';
 import { Checkbox } from '@components/Form/Checkbox';
+import DirectoryConfig from '@shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue';
 
 export default {
   components: {
@@ -13,7 +14,8 @@ export default {
     ArrayListGrouped,
     MatchExpressions,
     ArrayList,
-    Checkbox
+    Checkbox,
+    DirectoryConfig
   },
 
   props: {
@@ -91,6 +93,10 @@ export default {
 <template>
   <div>
     <template v-if="haveArgInfo">
+      <DirectoryConfig
+        v-model="value.spec.rkeConfig.dataDirectories"
+        :mode="mode"
+      />
       <h3>{{ t('cluster.advanced.argInfo.title') }}</h3>
       <ArrayListGrouped
         v-if="agentArgs['kubelet-arg']"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -25,17 +25,17 @@ export default {
     let atLeastOneDirWithAnIdentifier = false;
     let allDirsWithSameIdentifier = false;
 
-    if (this.value?.systemAgent?.length || this.value?.provisioning?.length || this.value?.k8sDistro?.length) {
+    if (this.value.systemAgent.length || this.value.provisioning.length || this.value.k8sDistro.length) {
       atLeastOneDirWithAnIdentifier = true;
-      if (this.value?.systemAgent === this.value?.provisioning && this.value?.provisioning === this.value?.k8sDistro &&
-      this.value?.systemAgent === this.value?.k8sDistro) {
+      if (this.value.systemAgent === this.value.provisioning && this.value.provisioning === this.value.k8sDistro &&
+      this.value.systemAgent === this.value.k8sDistro) {
         allDirsWithSameIdentifier = true;
       }
     }
 
     return {
       isSettingCommonConfig: !(atLeastOneDirWithAnIdentifier && !allDirsWithSameIdentifier),
-      commonConfig:          allDirsWithSameIdentifier ? this.value?.systemAgent : '',
+      commonConfig:          allDirsWithSameIdentifier ? this.value.systemAgent : '',
     };
   },
   watch: {

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -25,10 +25,10 @@ export default {
     let atLeastOneDirWithAnIdentifier = false;
     let allDirsWithSameIdentifier = false;
 
-    if (this.value.systemAgent.length || this.value.provisioning.length || this.value.k8sDistro.length) {
+    if (this.value?.systemAgent?.length || this.value?.provisioning?.length || this.value?.k8sDistro?.length) {
       atLeastOneDirWithAnIdentifier = true;
-      if (this.value.systemAgent === this.value.provisioning && this.value.provisioning === this.value.k8sDistro &&
-      this.value.systemAgent === this.value.k8sDistro) {
+      if (this.value?.systemAgent === this.value?.provisioning && this.value?.provisioning === this.value?.k8sDistro &&
+      this.value?.systemAgent === this.value?.k8sDistro) {
         allDirsWithSameIdentifier = true;
       }
     }

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -1,0 +1,132 @@
+
+<script>
+import { Checkbox } from '@components/Form/Checkbox';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import { _CREATE } from '@shell/config/query-params';
+
+export default {
+  name:       'DirectoryConfig',
+  components: {
+    Checkbox,
+    LabeledInput,
+  },
+  props: {
+    mode: {
+      type:     String,
+      required: true,
+    },
+
+    value: {
+      type:     Object,
+      required: true,
+    },
+  },
+  data() {
+    let atLeastOneDirWithAnIdentifier = false;
+    let allDirsWithSameIdentifier = false;
+
+    if (this.value?.systemAgent?.length || this.value?.provisioning?.length || this.value?.k8sDistro?.length) {
+      atLeastOneDirWithAnIdentifier = true;
+      if (this.value?.systemAgent === this.value?.provisioning && this.value?.provisioning === this.value?.k8sDistro &&
+      this.value?.systemAgent === this.value?.k8sDistro) {
+        allDirsWithSameIdentifier = true;
+      }
+    }
+
+    return {
+      isSettingCommonConfig: !(atLeastOneDirWithAnIdentifier && !allDirsWithSameIdentifier),
+      commonConfig:          allDirsWithSameIdentifier ? this.value?.systemAgent : '',
+    };
+  },
+  watch: {
+    commonConfig(neu) {
+      if (neu && neu.length && this.isSettingCommonConfig) {
+        this.value.systemAgent = neu;
+        this.value.provisioning = neu;
+        this.value.k8sDistro = neu;
+      }
+    }
+  },
+  computed: {
+    disableEditInput() {
+      return this.mode !== _CREATE;
+    }
+  },
+  methods: {
+    handleCommonConfig(val) {
+      this.isSettingCommonConfig = val;
+
+      if (val) {
+        this.value.systemAgent = '';
+        this.value.provisioning = '';
+        this.value.k8sDistro = '';
+      } else {
+        this.commonConfig = '';
+      }
+    }
+  },
+};
+</script>
+
+<template>
+  <div class="row">
+    <div class="col span-8">
+      <h3 class="mb-20">
+        {{ t('cluster.directoryConfig.title') }}
+      </h3>
+      <Checkbox
+        class="mb-10"
+        :value="isSettingCommonConfig"
+        :mode="mode"
+        :label="t('cluster.directoryConfig.checkboxText')"
+        :disabled="disableEditInput"
+        data-testid="rke2-directory-config-individual-config-checkbox"
+        @input="handleCommonConfig"
+      />
+      <LabeledInput
+        v-if="isSettingCommonConfig"
+        v-model="commonConfig"
+        class="mb-20"
+        :mode="mode"
+        :label="t('cluster.directoryConfig.common.label')"
+        :tooltip="t('cluster.directoryConfig.common.tooltip')"
+        :disabled="disableEditInput"
+        data-testid="rke2-directory-config-common-data-dir"
+      />
+      <div v-if="!isSettingCommonConfig">
+        <LabeledInput
+          v-model="value.systemAgent"
+          class="mb-20"
+          :mode="mode"
+          :label="t('cluster.directoryConfig.systemAgent.label')"
+          :tooltip="t('cluster.directoryConfig.systemAgent.tooltip')"
+          :disabled="disableEditInput"
+          data-testid="rke2-directory-config-systemAgent-data-dir"
+        />
+        <LabeledInput
+          v-model="value.provisioning"
+          class="mb-20"
+          :mode="mode"
+          :label="t('cluster.directoryConfig.provisioning.label')"
+          :tooltip="t('cluster.directoryConfig.provisioning.tooltip')"
+          :disabled="disableEditInput"
+          data-testid="rke2-directory-config-provisioning-data-dir"
+        />
+        <LabeledInput
+          v-model="value.k8sDistro"
+          class="mb-20"
+          :mode="mode"
+          :label="t('cluster.directoryConfig.k8sDistro.label')"
+          :tooltip="t('cluster.directoryConfig.k8sDistro.tooltip')"
+          :disabled="disableEditInput"
+          data-testid="rke2-directory-config-k8sDistro-data-dir"
+        />
+      </div>
+      <div class="mb-40" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+
+</style>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -25,10 +25,10 @@ export default {
     let atLeastOneDirWithAnIdentifier = false;
     let allDirsWithSameIdentifier = false;
 
-    if (this.value?.systemAgent?.length || this.value?.provisioning?.length || this.value?.k8sDistro?.length) {
+    if (this.value.systemAgent.length || this.value.provisioning.length || this.value.k8sDistro.length) {
       atLeastOneDirWithAnIdentifier = true;
-      if (this.value?.systemAgent === this.value?.provisioning && this.value?.provisioning === this.value?.k8sDistro &&
-      this.value?.systemAgent === this.value?.k8sDistro) {
+      if (this.value.systemAgent === this.value.provisioning && this.value.provisioning === this.value.k8sDistro &&
+      this.value.systemAgent === this.value.k8sDistro) {
         allDirsWithSameIdentifier = true;
       }
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10824 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add `data directory configuration` component to advanced tab in rke2 create/edit cluster interface 
- add unit test for `data directory configuration` component

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- full manual test is dependent on https://github.com/rancher/rancher/issues/45038

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to RKE2 cluster creation interface and make sure the `data configuration` area is present on the `Advanced` tab of Cluster Configuration
- Make sure data persists and all works fine
- Make sure that cluster editing, the `data configuration` is disabled (not allowed to change the values)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**NOTE:** this video still doesn't cover the edit scenario properly, since we still don't have the changes needed on the backend to persist the data, but it proves the payload sent is correct

https://github.com/rancher/dashboard/assets/97888974/2f09bc61-8c02-4927-8ebf-98257261fc6d


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
