### PR TITLE
Replace Fleet Cluster `Nodes Ready` column 

### DIFF
--- a/shell/components/fleet/FleetClusters.vue
+++ b/shell/components/fleet/FleetClusters.vue
@@ -37,8 +37,8 @@ export default {
         STATE,
         NAME,
         {
-          name:     'nodesReady',
-          labelKey: 'tableHeaders.nodesReady',
+          name:     'bundlesReady',
+          labelKey: 'tableHeaders.bundlesReady',
           value:    'status.display.readyBundles',
           sort:     'status.summary.ready',
           search:   false,
@@ -47,7 +47,7 @@ export default {
         {
           name:     'reposReady',
           labelKey: 'tableHeaders.reposReady',
-          value:    'status.display.readyBundles',
+          value:    'status.readyGitRepos',
           sort:     'status.summary.ready',
           search:   false,
           align:    'center',
@@ -113,19 +113,19 @@ export default {
       <span v-else>{{ row.repoInfo.total }}</span>
     </template>
 
-    <template #cell:nodesReady="{row}">
+    <template #cell:bundlesReady="{row}">
       <span
-        v-if="!row.nodeInfo"
+        v-if="row.bundleInfo.noValidData"
         class="text-muted"
       >&mdash;</span>
       <span
-        v-else-if="row.nodeInfo.unready"
+        v-else-if="row.bundleInfo.ready !== row.bundleInfo.total"
         class="text-warning"
-      >{{ row.nodeInfo.ready }}/{{ row.nodeInfo.total }}</span>
+      >{{ row.bundleInfo.ready }}/{{ row.bundleInfo.total }}</span>
       <span
         v-else
-        :class="{'text-error': !row.nodeInfo.total}"
-      >{{ row.nodeInfo.total }}</span>
+        :class="{'text-error': !row.bundleInfo.total}"
+      >{{ row.bundleInfo.total }}</span>
     </template>
   </ResourceTable>
 </template>

--- a/shell/models/__tests__/fleet.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/fleet.cattle.io.cluster.test.ts
@@ -15,12 +15,14 @@ describe('class FleetCluster', () => {
   describe('should provide bundleInfo with error', () => {
     it.each([
       [''],
+      ['/'],
       ['1/'],
       ['/1'],
       ['1/1/2'],
       ['a/1'],
       ['a/b'],
-      ['any-string']
+      ['any-string'],
+      ['any-string1/string2']
     ])('with multiple scenarios of wrongful "readyBundles" data', (readyBundles) => {
       const fleetCluster = new FleetCluster({
         metadata: {},

--- a/shell/models/__tests__/fleet.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/fleet.cattle.io.cluster.test.ts
@@ -1,0 +1,34 @@
+import FleetCluster from '@shell/models/fleet.cattle.io.cluster';
+
+describe('class FleetCluster', () => {
+  it('should provide bundleInfo if correct data is present', () => {
+    const fleetCluster = new FleetCluster({
+      metadata: {},
+      spec:     {},
+      status:   { display: { readyBundles: '0/1' } },
+    });
+
+    expect(fleetCluster.bundleInfo.ready).toBe(0);
+    expect(fleetCluster.bundleInfo.total).toBe(1);
+    expect(Object.getOwnPropertyNames(fleetCluster.bundleInfo)).not.toContain('noValidData');
+  });
+  describe('should provide bundleInfo with error', () => {
+    it.each([
+      [''],
+      ['1/'],
+      ['/1'],
+      ['1/1/2'],
+      ['a/1'],
+      ['a/b'],
+      ['any-string']
+    ])('with multiple scenarios of wrongful "readyBundles" data', (readyBundles) => {
+      const fleetCluster = new FleetCluster({
+        metadata: {},
+        spec:     {},
+        status:   { display: { readyBundles } },
+      });
+
+      expect(Object.getOwnPropertyNames(fleetCluster.bundleInfo)).toContain('noValidData');
+    });
+  });
+});

--- a/shell/models/fleet.cattle.io.cluster.js
+++ b/shell/models/fleet.cattle.io.cluster.js
@@ -137,16 +137,14 @@ export default class FleetCluster extends SteveModel {
     };
     const readyBundles = this.status?.display?.readyBundles;
 
-    if (readyBundles) {
-      if (readyBundles.includes('/')) {
-        const dataArr = readyBundles.split('/');
+    if (readyBundles && readyBundles.includes('/')) {
+      const dataArr = readyBundles.split('/');
 
-        if (dataArr.length === 2 && dataArr[0].length && dataArr[1].length && parseInt(dataArr[0]) >= 0 && parseInt(dataArr[1]) >= 0) {
-          bundlesData.ready = parseInt(dataArr[0]);
-          bundlesData.total = parseInt(dataArr[1]);
+      if (dataArr.length === 2 && parseInt(dataArr[0]) >= 0 && parseInt(dataArr[1]) >= 0) {
+        bundlesData.ready = parseInt(dataArr[0]);
+        bundlesData.total = parseInt(dataArr[1]);
 
-          return bundlesData;
-        }
+        return bundlesData;
       }
     }
 

--- a/shell/models/fleet.cattle.io.cluster.js
+++ b/shell/models/fleet.cattle.io.cluster.js
@@ -119,17 +119,6 @@ export default class FleetCluster extends SteveModel {
     return this.metadata?.state?.name || 'unknown';
   }
 
-  get nodeInfo() {
-    const ready = this.status?.agent?.readyNodes || 0;
-    const unready = this.status?.agent?.nonReadyNodes || 0;
-
-    return {
-      ready,
-      unready,
-      total: ready + unready,
-    };
-  }
-
   get repoInfo() {
     const ready = this.status?.readyGitRepos || 0;
     const total = this.status?.desiredReadyGitRepos || 0;
@@ -139,6 +128,31 @@ export default class FleetCluster extends SteveModel {
       unready: total - ready,
       total,
     };
+  }
+
+  get bundleInfo() {
+    const bundlesData = {
+      ready: 0,
+      total: 0
+    };
+    const readyBundles = this.status?.display?.readyBundles;
+
+    if (readyBundles) {
+      if (readyBundles.includes('/')) {
+        const dataArr = readyBundles.split('/');
+
+        if (dataArr.length === 2 && dataArr[0].length && dataArr[1].length && parseInt(dataArr[0]) >= 0 && parseInt(dataArr[1]) >= 0) {
+          bundlesData.ready = parseInt(dataArr[0]);
+          bundlesData.total = parseInt(dataArr[1]);
+
+          return bundlesData;
+        }
+      }
+    }
+
+    bundlesData.noValidData = true;
+
+    return bundlesData;
   }
 
   get mgmt() {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #[10542](https://github.com/rancher/dashboard/issues/10542)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- replace `nodeInfo` with `bundleInfo` in fleet cluster model 
- update fleet cluster table to display `bundles ready` instead of `nodes ready` (as per https://github.com/rancher/fleet/pull/2190)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- go to fleet clusters and check that we no longer display nodes ready (replaced by bundles ready)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**Before**
<img width="2245" alt="Screenshot 2024-05-16 at 16 46 46" src="https://github.com/rancher/dashboard/assets/97888974/716c3c6e-3a96-458a-af9a-2c1dc84d9195">

**Aft
<img width="2245" alt="Screenshot 2024-05-16 at 16 41 17" src="https://github.com/rancher/dashboard/assets/97888974/ea07bc36-9478-4c9d-9f79-42dc071126de">
er**

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
