### PR TITLE
Prevent errors in existing cases binding props with v-model

### DIFF
--- a/shell/mixins/model-value.js
+++ b/shell/mixins/model-value.js
@@ -1,0 +1,27 @@
+/**
+ * Allow to maintain current 2 way binding behavior for v-model in Vue 3.
+ * In Vue 3, props mutation is not allowed since they are read-only.
+ * v-model="foo" is short for :model-value="foo" @update:model-value="foo = $event"
+ * Docs: https://vuejs.org/guide/components/props.html#one-way-data-flow
+ * Linter: https://eslint.vuejs.org/rules/no-mutating-props.html
+ * IMPORTANT: This mixin is temporary and the logic should be replaced with something to be defined in the future.
+ */
+export default {
+  props: {
+    modelValue: {
+      type:     Object,
+      required: true,
+      default:  () => {}
+    }
+  },
+  computed: {
+    value: {
+      get() {
+        return this.modelValue;
+      },
+      set(value) {
+        this.$emit('update:modelValue', value);
+      }
+    }
+  }
+};

--- a/shell/scripts/vue-migrate.js
+++ b/shell/scripts/vue-migrate.js
@@ -612,7 +612,7 @@ const replaceCases = (fileType, files, replacementCases, printText) => {
         // Regex case
         // TODO: Fix issue not replacing all
         if (text.test(content) && replacement) {
-          content = content.replace(new RegExp(text, 'g'), replacement);
+          content = content.replace(new RegExp(text, 'g'), replacement === removePlaceholder ? '' : replacement);
           if (!matchedCases.includes(`${ text }, ${ replacement }, ${ notes }`)) {
             matchedCases.push(`${ text }, ${ replacement }, ${ notes }`);
           }

--- a/shell/scripts/vue-migrate.js
+++ b/shell/scripts/vue-migrate.js
@@ -360,7 +360,8 @@ const vueSyntaxUpdates = () => {
     // TODO: Add missing import
 
     [/( {4,}default)\(\)\s*\{([\s\S]*?)this\.([\s\S]*?\}\s*\})/g, (_, before, middle, after) => `${ before }(props) {${ middle }props.${ after }`, 'https://v3-migration.vuejs.org/breaking-changes/props-default-this.html'],
-    [`value=`, `modelValue=`],
+    // [`value=`, `modelValue=`],
+    [/value:\s*{[\s\S]*?},?\s*/g, removePlaceholder, 'Read issue for more info https://github.com/rancher/dashboard/issues/11029'],
     [`@input=`, `@update:modelValue=`],
     // [`v-bind.sync=`, `:modelValue=`, `https://v3-migration.vuejs.org/breaking-changes/v-model.html#using-v-bind-sync`],
     // ['v-model=', ':modelValue=', ''],

--- a/shell/scripts/vue-migrate.js
+++ b/shell/scripts/vue-migrate.js
@@ -360,12 +360,15 @@ const vueSyntaxUpdates = () => {
     // TODO: Add missing import
 
     [/( {4,}default)\(\)\s*\{([\s\S]*?)this\.([\s\S]*?\}\s*\})/g, (_, before, middle, after) => `${ before }(props) {${ middle }props.${ after }`, 'https://v3-migration.vuejs.org/breaking-changes/props-default-this.html'],
-    // [`value=`, `modelValue=`],
-    [/value:\s*{[\s\S]*?},?\s*/g, removePlaceholder, 'Read issue for more info https://github.com/rancher/dashboard/issues/11029'],
+
+    // [/value:\s*{[\s\S]*?},?\s*/g, removePlaceholder, 'Read issue for more info https://github.com/rancher/dashboard/issues/11029'],
+    [/value:\s*{[\s\S]*?},?\s*/g, (match) => match.replace(/value/g, 'modelValue'), 'Read issue for more info https://github.com/rancher/dashboard/issues/11029'],
+
     [`@input=`, `@update:modelValue=`],
     // [`v-bind.sync=`, `:modelValue=`, `https://v3-migration.vuejs.org/breaking-changes/v-model.html#using-v-bind-sync`],
-    // ['v-model=', ':modelValue=', ''],
+
     [/:([a-z-0-9]+)\.sync/g, (_, propName) => `v-model:${ propName }`, `https://v3-migration.vuejs.org/breaking-changes/v-model.html#migration-strategy`],
+
     [`click.native`, `click`, `https://v3-migration.vuejs.org/breaking-changes/v-model.html#using-v-bind-sync`],
     [`v-on="$listeners"`, removePlaceholder, `removed and integrated with $attrs https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html`],
     [`:listeners="$listeners"`, `:v-bind="$attrs"`, `removed and integrated with $attrs https://v3-migration.vuejs.org/breaking-changes/listeners-removed.html`],


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11029
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
