### PR TITLE
Fix incorrect color for text-warning

### DIFF
--- a/cypress/e2e/po/prompts/promptRemove.po.ts
+++ b/cypress/e2e/po/prompts/promptRemove.po.ts
@@ -17,4 +17,9 @@ export default class PromptRemove extends ComponentPo {
   remove() {
     return this.self().getId('prompt-remove-confirm-button').click();
   }
+
+  // Get the warning message
+  warning() {
+    return this.self().get('[warning] .text-warning');
+  }
 }

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -189,6 +189,24 @@ describe('Roles', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     roles.list().elementWithName(globalRoleName).should('not.exist');
   });
 
+  it('shows warning message when deleting the Administrator role', () => {
+    const fragment = 'GLOBAL';
+    const globalAdminRoleName = 'Administrator';
+
+    roles.goTo(undefined, fragment);
+    roles.waitForPage(undefined, fragment);
+
+    // Show delete confirmation dialog
+    roles.waitForRequests();
+    roles.list().elementWithName(globalAdminRoleName).click();
+    roles.list().delete().click();
+    const promptRemove = new PromptRemove();
+
+    promptRemove.warning().should('be.visible');
+    promptRemove.warning().shouldHaveCssVar('color', '--warning'); // Check warning message color
+    promptRemove.warning().first().should('contain.text', 'Caution:'); // Check warning message content
+  });
+
   it('Standard user with List, Get & Resources: Global Roles should be able to list users in Users and Auth', () => {
     const customRoleName = `${ runPrefix }-my-custom-role`;
     const standardUsername = `${ runPrefix }-standard-user-e2e`;

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -88,6 +88,9 @@ declare global {
        * Check if an element is visible to the user on the screen.
        */
       isVisible(): Chainable<Element>;
+
+      // Check css var
+      shouldHaveCssVar(name: string, value: string);
     }
   }
 }

--- a/cypress/support/commands/commands.ts
+++ b/cypress/support/commands/commands.ts
@@ -68,3 +68,21 @@ const runTimestamp = +new Date();
 Cypress.Commands.add('createE2EResourceName', (context) => {
   return cy.wrap(`e2e-test-${ runTimestamp }-${ context }`);
 });
+
+// See: https://stackoverflow.com/questions/74785083/how-can-i-get-a-custom-css-variable-from-any-element-cypress
+Cypress.Commands.add('shouldHaveCssVar', { prevSubject: true }, (subject, styleName, cssVarName) => {
+  cy.document().then((doc) => {
+    const dummy = doc.createElement('span');
+
+    dummy.style.setProperty(styleName, `var(${ cssVarName })`);
+    doc.body.appendChild(dummy);
+
+    const evaluatedStyle = window.getComputedStyle(dummy).getPropertyValue(styleName).trim();
+
+    dummy.remove();
+
+    cy.wrap(subject)
+      .then(($el) => window.getComputedStyle($el[0]).getPropertyValue(styleName).trim())
+      .should('eq', evaluatedStyle);
+  });
+});

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -251,7 +251,7 @@ BODY, .theme-light {
   --warning-light-bg           : #{rgba($warning, 0.05)};
 
   .text-warning {
-    color: var(--error) !important;
+    color: var(--warning) !important;
   }
 
   .bg-warning {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10018

Reverted the styling for text-warning and added e2e test. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
