### PR TITLE
[2.8.patch1] Port drone build tasks to gh workflows + actions

### DIFF
--- a/.github/workflows/build-and-upload-branch.yaml
+++ b/.github/workflows/build-and-upload-branch.yaml
@@ -2,8 +2,7 @@ name: Build Dashboard (Branch)
 on:
   push:
     branches:
-      - 'release-2.8*'
-      - '*-dev'
+      - 'release-2.8.patch1'
 
 jobs:
   build-validation:

--- a/.github/workflows/build-and-upload-branch.yaml
+++ b/.github/workflows/build-and-upload-branch.yaml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - release-2.8.patch1
-      # TODO: RC remove
-      - richard-cox-2.8.patch1-drone
 
 jobs:
   build-validation:

--- a/.github/workflows/build-and-upload-branch.yaml
+++ b/.github/workflows/build-and-upload-branch.yaml
@@ -2,7 +2,9 @@ name: Build Dashboard (Branch)
 on:
   push:
     branches:
-      - 'release-2.8.patch1'
+      - release-2.8.patch1
+      # TODO: RC remove
+      - richard-cox-2.8.patch1-drone
 
 jobs:
   build-validation:

--- a/.github/workflows/build-and-upload-release-2-8.yaml
+++ b/.github/workflows/build-and-upload-release-2-8.yaml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - v2.8.*
-      - richard-cox-2.8.patch1-drone-tag
 
 jobs:
   build-validation:

--- a/.github/workflows/build-and-upload-release-2-8.yaml
+++ b/.github/workflows/build-and-upload-release-2-8.yaml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - v2.8.*
+      - richard-cox-2.8.patch1-drone-tag
 
 jobs:
   build-validation:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,10 @@ name: Tests
 on:
   push:
     branches:
-      - 'release-2.8.patch1'
+      - release-2.8.patch1
   pull_request:
     branches:
-      - 'release-2.8.patch1'
+      - release-2.8.patch1
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,22 +61,6 @@ jobs:
   e2e-test:
     if: "!contains( github.event.pull_request.labels.*.name, 'ci/skip-e2e')"
     needs: e2e-ui-build
-    strategy:
-      fail-fast: false
-      matrix:
-        role: [
-          { username: 'admin', tag: '@adminUser' }, 
-          { username: 'standard_user', tag: '@standardUser' }
-        ]
-        features:  [
-         ['@navigation', '@extensions'],
-         ['@charts'],
-         ['@explorer'],
-         ['@fleet'],
-         ['@generic', '@globalSettings'],
-         ['@manager'],
-         ['@userMenu', '@usersAndAuths']
-        ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -100,6 +84,7 @@ jobs:
         with:
          name: ${{ env.E2E_BUILD_DIST_NAME }}
          path: ${{ env.E2E_BUILD_DIST_DIR }}
+
       - name: Download e2e build ember
         uses:  actions/download-artifact@v4
         with:
@@ -109,28 +94,33 @@ jobs:
       - name: Run Rancher
         run: yarn e2e:docker
       
-      - name: Setup Rancher and user
+      - name: Run admin user tests
         run: |
           yarn e2e:prod
+          mkdir -p coverage-artifacts/coverage
+          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
-          GREP_TAGS: ${{ matrix.role.tag }}Setup+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}Setup+${{ matrix.features[1] || matrix.features[0] }} --@jenkins 
+          GREP_TAGS: '@adminUser'
           TEST_USERNAME: admin
-          TEST_ONLY: setup
-      
-      - name: Run user tests
+
+
+      - name: Run standard user tests
+        if: ${{ success() || failure() }}
         run: |
           yarn e2e:prod
-          [ "$BUILD_DASHBOARD" != "false" ] || exit 0
+          yarn docker:local:stop
+          mkdir -p coverage-artifacts/coverage
+          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
         env: 
-          TEST_SKIP: setup
-          GREP_TAGS: ${{ matrix.role.tag }}+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}+${{ matrix.features[1] || matrix.features[0] }} --@jenkins
-          TEST_USERNAME: ${{ matrix.role.username }}
-          
+          GREP_TAGS: '@standardUser'
+          TEST_USERNAME: standard_user
+
       - name: Upload screenshots
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
-          name: ${{github.run_number}}-${{github.run_attempt}}-screenshots-${{ matrix.role.tag }}+${{ matrix.features[0] }}
+          name: ${{github.run_number}}-${{github.run_attempt}}-screenshots
           path: cypress/screenshots
 
   unit-test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,10 @@ name: Tests
 on:
   push:
     branches:
-      - 'release-2.8*'
+      - 'release-2.8.patch1'
   pull_request:
     branches:
-      - 'release-2.8*'
+      - 'release-2.8.patch1'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,22 @@ jobs:
   e2e-test:
     if: "!contains( github.event.pull_request.labels.*.name, 'ci/skip-e2e')"
     needs: e2e-ui-build
+    strategy:
+      fail-fast: false
+      matrix:
+        role: [
+          { username: 'admin', tag: '@adminUser' }, 
+          { username: 'standard_user', tag: '@standardUser' }
+        ]
+        features:  [
+         ['@navigation', '@extensions'],
+         ['@charts'],
+         ['@explorer'],
+         ['@fleet'],
+         ['@generic', '@globalSettings'],
+         ['@manager'],
+         ['@userMenu', '@usersAndAuths']
+        ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -94,33 +110,28 @@ jobs:
       - name: Run Rancher
         run: yarn e2e:docker
       
-      - name: Run admin user tests
+      - name: Setup Rancher and user
         run: |
           yarn e2e:prod
-          mkdir -p coverage-artifacts/coverage
-          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
-          cp -r coverage/e2e/ coverage-artifacts/coverage/e2e/
         env: 
-          GREP_TAGS: '@adminUser'
+          GREP_TAGS: ${{ matrix.role.tag }}Setup+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}Setup+${{ matrix.features[1] || matrix.features[0] }} --@jenkins 
           TEST_USERNAME: admin
-
-
-      - name: Run standard user tests
-        if: ${{ success() || failure() }}
+          TEST_ONLY: setup
+      
+      - name: Run user tests
         run: |
           yarn e2e:prod
-          yarn docker:local:stop
-          mkdir -p coverage-artifacts/coverage
-          cp coverage/e2e/coverage-final.json coverage-artifacts/coverage/coverage-e2e.json
+          [ "$BUILD_DASHBOARD" != "false" ] || exit 0
         env: 
-          GREP_TAGS: '@standardUser'
-          TEST_USERNAME: standard_user
-
+          TEST_SKIP: setup
+          GREP_TAGS: ${{ matrix.role.tag }}+${{ matrix.features[0] }} --@jenkins ${{ matrix.role.tag }}+${{ matrix.features[1] || matrix.features[0] }} --@jenkins
+          TEST_USERNAME: ${{ matrix.role.username }}
+          
       - name: Upload screenshots
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
-          name: ${{github.run_number}}-${{github.run_attempt}}-screenshots
+          name: ${{github.run_number}}-${{github.run_attempt}}-screenshots-${{ matrix.role.tag }}+${{ matrix.features[0] }}
           path: cypress/screenshots
 
   unit-test:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->

### Occurred changes and/or fixed issues
- This is the backport of https://github.com/rancher/dashboard/pull/11018
- It also includes the change 
  - to split e2e build into a separate job (this will reduce runner load) https://github.com/rancher/dashboard/pull/10691
  - remove stale docker files / references https://github.com/rancher/dashboard/pull/9763
  
Examples
- building from branch (with uploaded bits) -  https://github.com/rancher/dashboard/actions/runs/9159052158
- building from tag (with uploaded bit) - https://github.com/rancher/dashboard/actions/runs/9160038772


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes