### PR TITLE
The highlighted cluster in the App Bar retains its highlighting even when clicking on an item from the bottom category of the App Bar

### DIFF
--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -60,8 +60,10 @@ export default class BurgerMenuPo extends ComponentPo {
   /**
    * Check if Cluster Top Level Menu link is highlighted
    */
-  static checkIfClusterMenuLinkIsHighlighted(name: string) {
-    return this.burgerMenuGetNavClusterbyLabel(name).parent().parent().should('have.class', 'active-menu-link');
+  static checkIfClusterMenuLinkIsHighlighted(name: string, isHighlightedAssertion = true) {
+    const assertion = isHighlightedAssertion ? 'have.class' : 'not.have.class';
+
+    return this.burgerMenuGetNavClusterbyLabel(name).parent().parent().should(assertion, 'active-menu-link');
   }
 
   /**

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -43,7 +43,11 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.goTo();
 
     // check if burguer menu nav is highlighted correctly for extensions
+    // https://github.com/rancher/dashboard/issues/10010
     BurgerMenuPo.checkIfMenuItemLinkIsHighlighted('Extensions');
+
+    // catching regression https://github.com/rancher/dashboard/issues/10576
+    BurgerMenuPo.checkIfClusterMenuLinkIsHighlighted('local', false);
 
     // go to "add rancher repositories"
     extensionsPo.extensionMenuToggle();

--- a/cypress/e2e/tests/pages/global-settings/branding.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/branding.spec.ts
@@ -48,7 +48,11 @@ describe('Branding', { testIsolation: 'off' }, () => {
     settingsPage.waitForPageWithClusterId();
 
     // check if burguer menu nav is highlighted correctly for Global Settings
+    // https://github.com/rancher/dashboard/issues/10010
     BurgerMenuPo.checkIfMenuItemLinkIsHighlighted('Global Settings');
+
+    // catching regression https://github.com/rancher/dashboard/issues/10576
+    BurgerMenuPo.checkIfClusterMenuLinkIsHighlighted('local', false);
 
     const brandingNavItem = productMenu.visibleNavTypes().contains('Branding');
 

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -30,7 +30,11 @@ describe('Roles', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     roles.waitForPage(undefined, fragment);
 
     // check if burger menu nav is highlighted correctly for users & auth
+    // https://github.com/rancher/dashboard/issues/10010
     BurgerMenuPo.checkIfMenuItemLinkIsHighlighted('Users & Authentication');
+
+    // catching regression https://github.com/rancher/dashboard/issues/10576
+    BurgerMenuPo.checkIfClusterMenuLinkIsHighlighted('local', false);
 
     roles.listCreate('Create Global Role');
 

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -259,6 +259,40 @@ export default {
     productFromRoute() {
       return getProductFromRoute(this.$route);
     },
+
+    appBar() {
+      let activeFound = false;
+
+      const appBar = {
+        hciApps:           this.hciApps,
+        multiClusterApps:  this.multiClusterApps,
+        legacyApps:        this.legacyApps,
+        configurationApps: this.configurationApps,
+        pinFiltered:       this.pinFiltered,
+        clustersFiltered:  this.clustersFiltered,
+      };
+
+      Object.keys(appBar).forEach((menuSection) => {
+        const menuSectionItems = appBar[menuSection];
+        const isClusterCheck = menuSection === 'pinFiltered' || menuSection === 'clustersFiltered';
+
+        // need to reset active state on other menu items
+        menuSectionItems.forEach((item) => {
+          item.isMenuActive = false;
+        });
+
+        if (!activeFound) {
+          const currActiveMenu = menuSectionItems.find((item) => this.checkActiveRoute(item, isClusterCheck));
+
+          if (currActiveMenu) {
+            activeFound = true;
+            currActiveMenu.isMenuActive = true;
+          }
+        }
+      });
+
+      return appBar;
+    }
   },
 
   watch: {
@@ -527,14 +561,14 @@ export default {
               </a>
             </div>
             <div
-              v-for="a in hciApps"
+              v-for="a in appBar.hciApps"
               :key="a.label"
               @click="hide()"
             >
               <router-link
                 class="option"
                 :to="a.to"
-                :class="{'active-menu-link': checkActiveRoute(a) }"
+                :class="{'active-menu-link': a.isMenuActive }"
               >
                 <IconOrSvg
                   :icon="a.icon"
@@ -558,7 +592,7 @@ export default {
                 class="clustersPinned"
               >
                 <div
-                  v-for="c in pinFiltered"
+                  v-for="c in appBar.pinFiltered"
                   :key="c.id"
                   @click="hide()"
                 >
@@ -567,7 +601,7 @@ export default {
                     v-shortkey.push="{windows: ['alt'], mac: ['option']}"
                     :data-testid="`pinned-menu-cluster-${ c.id }`"
                     class="cluster selector option"
-                    :class="{'active-menu-link': checkActiveRoute(c, true) }"
+                    :class="{'active-menu-link': c.isMenuActive }"
                     :to="c.clusterRoute"
                     @click.prevent="clusterMenuClick($event, c)"
                     @shortkey="handleKeyComboClick"
@@ -632,7 +666,7 @@ export default {
               <!-- Clusters Search result -->
               <div class="clustersList">
                 <div
-                  v-for="(c, index) in clustersFiltered"
+                  v-for="(c, index) in appBar.clustersFiltered"
                   :key="c.id"
                   :data-testid="`top-level-menu-cluster-${index}`"
                   @click="hide()"
@@ -642,7 +676,7 @@ export default {
                     v-shortkey.push="{windows: ['alt'], mac: ['option']}"
                     :data-testid="`menu-cluster-${ c.id }`"
                     class="cluster selector option"
-                    :class="{'active-menu-link': checkActiveRoute(c, true) }"
+                    :class="{'active-menu-link': c.isMenuActive }"
                     :to="c.clusterRoute"
                     @click="clusterMenuClick($event, c)"
                     @shortkey="handleKeyComboClick"
@@ -738,13 +772,13 @@ export default {
                 </span>
               </div>
               <div
-                v-for="a in multiClusterApps"
+                v-for="a in appBar.multiClusterApps"
                 :key="a.label"
                 @click="hide()"
               >
                 <router-link
                   class="option"
-                  :class="{'active-menu-link': checkActiveRoute(a) }"
+                  :class="{'active-menu-link': a.isMenuActive }"
                   :to="a.to"
                 >
                   <IconOrSvg
@@ -766,13 +800,13 @@ export default {
                 </span>
               </div>
               <div
-                v-for="a in legacyApps"
+                v-for="a in appBar.legacyApps"
                 :key="a.label"
                 @click="hide()"
               >
                 <router-link
                   class="option"
-                  :class="{'active-menu-link': checkActiveRoute(a) }"
+                  :class="{'active-menu-link': a.isMenuActive }"
                   :to="a.to"
                 >
                   <IconOrSvg
@@ -796,13 +830,13 @@ export default {
                 </span>
               </div>
               <div
-                v-for="a in configurationApps"
+                v-for="a in appBar.configurationApps"
                 :key="a.label"
                 @click="hide()"
               >
                 <router-link
                   class="option"
-                  :class="{'active-menu-link': checkActiveRoute(a) }"
+                  :class="{'active-menu-link': a.isMenuActive }"
                   :to="a.to"
                 >
                   <IconOrSvg

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -263,6 +263,8 @@ export default {
     appBar() {
       let activeFound = false;
 
+      // order is important for the object keys here
+      // since we want to check last pinFiltered and clustersFiltered
       const appBar = {
         hciApps:           this.hciApps,
         multiClusterApps:  this.multiClusterApps,
@@ -279,7 +281,7 @@ export default {
         // need to reset active state on other menu items
         menuSectionItems.forEach((item) => {
           item.isMenuActive = false;
-          
+
           if (!activeFound && this.checkActiveRoute(item, isClusterCheck)) {
             activeFound = true;
             item.isMenuActive = true;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -279,16 +279,12 @@ export default {
         // need to reset active state on other menu items
         menuSectionItems.forEach((item) => {
           item.isMenuActive = false;
-        });
-
-        if (!activeFound) {
-          const currActiveMenu = menuSectionItems.find((item) => this.checkActiveRoute(item, isClusterCheck));
-
-          if (currActiveMenu) {
+          
+          if (!activeFound && this.checkActiveRoute(item, isClusterCheck)) {
             activeFound = true;
-            currActiveMenu.isMenuActive = true;
+            item.isMenuActive = true;
           }
-        }
+        });
       });
 
       return appBar;

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -83,6 +83,7 @@ export default {
     custom
     :to="type.route"
     :exact="type.exact"
+    :exact-path="type['exact-path']"
   >
     <li
       class="child nav-type"

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -393,15 +393,16 @@ export function init(store) {
   });
 
   virtualType({
-    labelKey:   'members.clusterAndProject',
-    group:      'cluster',
-    namespaced: false,
-    name:       VIRTUAL_TYPES.CLUSTER_MEMBERS,
-    icon:       'globe',
-    weight:     -1,
-    route:      { name: 'c-cluster-product-members' },
-    exact:      true,
-    ifHaveType: {
+    labelKey:     'members.clusterAndProject',
+    group:        'cluster',
+    namespaced:   false,
+    name:         VIRTUAL_TYPES.CLUSTER_MEMBERS,
+    icon:         'globe',
+    weight:       -1,
+    route:        { name: 'c-cluster-product-members' },
+    exact:        false,
+    'exact-path': true,
+    ifHaveType:   {
       type:  MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
       store: 'management'
     }

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -697,13 +697,14 @@ export const getters = {
         group.children.push({
           label,
           labelDisplay,
-          mode:     typeObj.mode,
-          exact:    typeObj.exact || false,
+          mode:         typeObj.mode,
+          exact:        typeObj.exact || false,
+          'exact-path': typeObj['exact-path'] || false,
           namespaced,
           route,
-          name:     typeObj.name,
-          weight:   typeObj.weight || getters.typeWeightFor(typeObj.schema?.id || label, isBasic),
-          overview: !!typeObj.overview,
+          name:         typeObj.name,
+          weight:       typeObj.weight || getters.typeWeightFor(typeObj.schema?.id || label, isBasic),
+          overview:     !!typeObj.overview,
         });
       }
 


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10576 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with double active main menu items in app bar 
- add sneaky fix for Cluster and Project Members menu item not being highlighted
- add e2e test to prevent regression

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- click on `local` cluster in app bar
- after than, go to one of the products that uses the `local` cluster for context such as `Global Settings`, `Extensions` or `Users & Authentication` and make sure the `local` cluster app bar menu is not highlighted as well.
- Try other page changes to make sure no double highlighting is occurring in the app bar

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**Before**
<img width="2406" alt="before" src="https://github.com/rancher/dashboard/assets/97888974/cd78b815-5030-4e54-8940-787a09f90e2d">

**After**
<img width="2406" alt="after" src="https://github.com/rancher/dashboard/assets/97888974/9e67c66e-bea5-40a1-8ca3-2130961266dc">

**Cluster and Project members sneaky fix**
<img width="2291" alt="Screenshot 2024-05-21 at 11 59 58" src="https://github.com/rancher/dashboard/assets/97888974/5613c2f4-570f-47e7-be1c-48d73c253af7">


### Checklist

- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
