### PR TITLE
Local cluster does not appear at the top of the app bar

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -281,11 +281,7 @@ export default {
         // need to reset active state on other menu items
         menuSectionItems.forEach((item) => {
           item.isMenuActive = false;
-<<<<<<< HEAD
 
-=======
-          
->>>>>>> 9b8ec51d7c (Update shell/components/nav/TopLevelMenu.vue)
           if (!activeFound && this.checkActiveRoute(item, isClusterCheck)) {
             activeFound = true;
             item.isMenuActive = true;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -141,6 +141,16 @@ export default {
       const out = search ? this.clusters.filter((item) => item.label?.toLowerCase().includes(search)) : this.clusters;
       const sorted = sortBy(out, ['ready:desc', 'label']);
 
+      // put local cluster on top of list always
+      // https://github.com/rancher/dashboard/issues/10975
+      if (sorted.findIndex((c) => c.id === 'local') > 0) {
+        const localCluster = sorted.find((c) => c.id === 'local');
+        const localIndex = sorted.findIndex((c) => c.id === 'local');
+
+        sorted.splice(localIndex, 1);
+        sorted.unshift(localCluster);
+      }
+
       if (search) {
         this.showPinClusters = false;
         this.searchActive = !sorted.length > 0;
@@ -162,6 +172,16 @@ export default {
     pinFiltered() {
       const out = this.clusters.filter((item) => item.pinned);
       const sorted = sortBy(out, ['ready:desc', 'label']);
+
+      // put local cluster on top of list always
+      // https://github.com/rancher/dashboard/issues/10975
+      if (sorted.findIndex((c) => c.id === 'local') > 0) {
+        const localCluster = sorted.find((c) => c.id === 'local');
+        const localIndex = sorted.findIndex((c) => c.id === 'local');
+
+        sorted.splice(localIndex, 1);
+        sorted.unshift(localCluster);
+      }
 
       return sorted;
     },
@@ -590,8 +610,9 @@ export default {
                 class="clustersPinned"
               >
                 <div
-                  v-for="c in appBar.pinFiltered"
+                  v-for="(c, index) in appBar.pinFiltered"
                   :key="c.id"
+                  :data-testid="`pinned-ready-cluster-${index}`"
                   @click="hide()"
                 >
                   <button

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -281,7 +281,11 @@ export default {
         // need to reset active state on other menu items
         menuSectionItems.forEach((item) => {
           item.isMenuActive = false;
+<<<<<<< HEAD
 
+=======
+          
+>>>>>>> 9b8ec51d7c (Update shell/components/nav/TopLevelMenu.vue)
           if (!activeFound && this.checkActiveRoute(item, isClusterCheck)) {
             activeFound = true;
             item.isMenuActive = true;

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -33,6 +33,234 @@ describe('topLevelMenu', () => {
     expect(cluster.exists()).toBe(true);
   });
 
+  it('should show local cluster always on top of the list of clusters (unpinned and ready clusters)', async() => {
+    const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+      data: () => {
+        return { hasProvCluster: true, showPinClusters: true };
+      },
+      mocks: {
+        $store: {
+          getters: {
+            // these objs are doubling as a prov clusters
+            // from which the "description" field comes from
+            // This is triggered by the "hasProvCluster" above
+            // (check all "management/all" getters on the component code)
+            'management/all': () => [
+              {
+                name:        'x32-cwf5-name',
+                id:          'x32-cwf5-id',
+                mgmt:        { id: 'an-id1' },
+                nameDisplay: 'c-cluster',
+                isReady:     true
+              },
+              {
+                name:        'x33-cwf5-name',
+                id:          'x33-cwf5-id',
+                mgmt:        { id: 'an-id2' },
+                nameDisplay: 'a-cluster',
+                isReady:     true
+              },
+              {
+                name:        'x34-cwf5-name',
+                id:          'x34-cwf5-id',
+                mgmt:        { id: 'an-id3' },
+                nameDisplay: 'b-cluster',
+                isReady:     true
+              },
+              {
+                name:        'local-name',
+                id:          'local',
+                mgmt:        { id: 'an-id4' },
+                nameDisplay: 'local',
+                isReady:     true
+              },
+            ],
+            ...defaultStore
+          },
+        },
+      },
+      stubs: ['BrandImage', 'router-link']
+    });
+
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-0"] .cluster-name p').text()).toStrictEqual('local');
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-1"] .cluster-name p').text()).toStrictEqual('a-cluster');
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-2"] .cluster-name p').text()).toStrictEqual('b-cluster');
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-3"] .cluster-name p').text()).toStrictEqual('c-cluster');
+  });
+
+  it('should show local cluster always on top of the list of clusters (unpinned and mix ready/unready clusters)', async() => {
+    const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+      data: () => {
+        return { hasProvCluster: true, showPinClusters: true };
+      },
+      mocks: {
+        $store: {
+          getters: {
+            // these objs are doubling as a prov clusters
+            // from which the "description" field comes from
+            // This is triggered by the "hasProvCluster" above
+            // (check all "management/all" getters on the component code)
+            'management/all': () => [
+              {
+                name:        'x32-cwf5-name',
+                id:          'x32-cwf5-id',
+                mgmt:        { id: 'an-id1' },
+                nameDisplay: 'c-cluster',
+                isReady:     true
+              },
+              {
+                name:        'x33-cwf5-name',
+                id:          'x33-cwf5-id',
+                mgmt:        { id: 'an-id2' },
+                nameDisplay: 'a-cluster',
+                isReady:     false
+              },
+              {
+                name:        'x34-cwf5-name',
+                id:          'x34-cwf5-id',
+                mgmt:        { id: 'an-id3' },
+                nameDisplay: 'b-cluster',
+                isReady:     true
+              },
+              {
+                name:        'local-name',
+                id:          'local',
+                mgmt:        { id: 'an-id4' },
+                nameDisplay: 'local',
+                isReady:     true
+              },
+            ],
+            ...defaultStore
+          },
+        },
+      },
+      stubs: ['BrandImage', 'router-link']
+    });
+
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-0"] .cluster-name p').text()).toStrictEqual('local');
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-1"] .cluster-name p').text()).toStrictEqual('b-cluster');
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-2"] .cluster-name p').text()).toStrictEqual('c-cluster');
+    expect(wrapper.find('[data-testid="top-level-menu-cluster-3"] .cluster-name p').text()).toStrictEqual('a-cluster');
+  });
+
+  it('should show local cluster always on top of the list of clusters (pinned and ready clusters)', async() => {
+    const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+      data: () => {
+        return { hasProvCluster: true, showPinClusters: true };
+      },
+      mocks: {
+        $store: {
+          getters: {
+            // these objs are doubling as a prov clusters
+            // from which the "description" field comes from
+            // This is triggered by the "hasProvCluster" above
+            // (check all "management/all" getters on the component code)
+            'management/all': () => [
+              {
+                name:        'x32-cwf5-name',
+                id:          'x32-cwf5-id',
+                mgmt:        { id: 'an-id1' },
+                nameDisplay: 'c-cluster',
+                isReady:     true,
+                pinned:      true
+              },
+              {
+                name:        'x33-cwf5-name',
+                id:          'x33-cwf5-id',
+                mgmt:        { id: 'an-id2' },
+                nameDisplay: 'a-cluster',
+                isReady:     true,
+                pinned:      true
+              },
+              {
+                name:        'x34-cwf5-name',
+                id:          'x34-cwf5-id',
+                mgmt:        { id: 'an-id3' },
+                nameDisplay: 'b-cluster',
+                isReady:     true,
+                pinned:      true
+              },
+              {
+                name:        'local-name',
+                id:          'local',
+                mgmt:        { id: 'an-id4' },
+                nameDisplay: 'local',
+                isReady:     true,
+                pinned:      true
+              },
+            ],
+            ...defaultStore
+          },
+        },
+      },
+      stubs: ['BrandImage', 'router-link']
+    });
+
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-0"] .cluster-name p').text()).toStrictEqual('local');
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-1"] .cluster-name p').text()).toStrictEqual('a-cluster');
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-2"] .cluster-name p').text()).toStrictEqual('b-cluster');
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-3"] .cluster-name p').text()).toStrictEqual('c-cluster');
+  });
+
+  it('should show local cluster always on top of the list of clusters (pinned and mix ready/unready clusters)', async() => {
+    const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+      data: () => {
+        return { hasProvCluster: true, showPinClusters: true };
+      },
+      mocks: {
+        $store: {
+          getters: {
+            // these objs are doubling as a prov clusters
+            // from which the "description" field comes from
+            // This is triggered by the "hasProvCluster" above
+            // (check all "management/all" getters on the component code)
+            'management/all': () => [
+              {
+                name:        'x32-cwf5-name',
+                id:          'x32-cwf5-id',
+                mgmt:        { id: 'an-id1' },
+                nameDisplay: 'c-cluster',
+                isReady:     true,
+                pinned:      true
+              },
+              {
+                name:        'x33-cwf5-name',
+                id:          'x33-cwf5-id',
+                mgmt:        { id: 'an-id2' },
+                nameDisplay: 'a-cluster',
+                isReady:     true,
+                pinned:      true
+              },
+              {
+                name:        'x34-cwf5-name',
+                id:          'x34-cwf5-id',
+                mgmt:        { id: 'an-id3' },
+                nameDisplay: 'b-cluster',
+                isReady:     false,
+                pinned:      true
+              },
+              {
+                name:        'local-name',
+                id:          'local',
+                mgmt:        { id: 'an-id4' },
+                nameDisplay: 'local',
+                isReady:     true,
+                pinned:      true
+              },
+            ],
+            ...defaultStore
+          },
+        },
+      },
+      stubs: ['BrandImage', 'router-link']
+    });
+
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-0"] .cluster-name p').text()).toStrictEqual('local');
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-1"] .cluster-name p').text()).toStrictEqual('a-cluster');
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-2"] .cluster-name p').text()).toStrictEqual('c-cluster');
+    expect(wrapper.find('[data-testid="pinned-ready-cluster-3"] .cluster-name p').text()).toStrictEqual('b-cluster');
+  });
+
   it('should show description if it is available on the prov cluster', async() => {
     const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
       data: () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10975 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- make sure local cluster appears always on top of pinned and unpinned cluster lists in main nav menu 
- add unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- create multiple ready clusters on DO, with names that you can distinguish easily the alphabetical ordering
- once they are all ready, make sure that they appear in alphabetical ordering (name) **BUT** with `local` cluster always on the top of the list (check pinned clusters list as well)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**Before**
<img width="2404" alt="before" src="https://github.com/rancher/dashboard/assets/97888974/16d7d17e-4dcc-4a74-9210-26bf1264f9e3">

**After**
<img width="2406" alt="after" src="https://github.com/rancher/dashboard/assets/97888974/e5905ecb-6121-4c21-8c6a-75b267859951">

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
