### PR TITLE
Chore/refactor store modules

### DIFF
--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -215,6 +215,7 @@ export default {
         'digitalocean',
         'linode',
         'targetRoute', // contains circular references, isn't useful (added later to store)
+        '$router', // also contains a circular reference to $store, not useful for diagnostics
       ];
 
       const clearListsKeys = [

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -344,7 +344,9 @@ export const actions = {
     }
   },
 
-  async logout({ dispatch, commit, getters }, options = {}) {
+  async logout({
+    dispatch, commit, getters, rootState
+  }, options = {}) {
     // So, we only do this check if auth has been initialized.
     //
     // It's possible to be logged in and visit auth/logout directly instead
@@ -362,7 +364,7 @@ export const actions = {
     }
 
     // Unload plugins - we will load again on login
-    await this.$plugin.logout();
+    await rootState.$plugin.logout();
 
     try {
       await dispatch('rancher/request', {

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -1128,13 +1128,6 @@ export const actions = {
     }
   },
 
-  nuxtServerInit({ dispatch, rootState }, nuxt) {
-    // Models in SSR server mode have no way to get to the route or router, so hack one in...
-    Object.defineProperty(rootState, '$router', { value: nuxt.app.router });
-    Object.defineProperty(rootState, '$route', { value: nuxt.route });
-    dispatch('prefs/loadCookies');
-  },
-
   nuxtClientInit({ dispatch, rootState }, nuxt) {
     Object.defineProperty(rootState, '$router', { value: nuxt.app.router });
     Object.defineProperty(rootState, '$route', { value: nuxt.route });

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -247,6 +247,9 @@ export const state = () => {
     isRancherInHarvester:    false,
     targetRoute:             null,
     rootProduct:             undefined,
+    $router:                 undefined,
+    $route:                  undefined,
+    $plugin:                 undefined,
   };
 };
 
@@ -722,6 +725,18 @@ export const mutations = {
 
   targetRoute(state, route) {
     state.targetRoute = route;
+  },
+
+  setRouter(state, router) {
+    state.$router = router;
+  },
+
+  setRoute(state, route) {
+    state.$route = route;
+  },
+
+  setPlugin(state, pluginDefinition) {
+    state.$plugin = pluginDefinition;
   }
 };
 
@@ -1128,11 +1143,10 @@ export const actions = {
     }
   },
 
-  nuxtClientInit({ dispatch, rootState }, nuxt) {
-    Object.defineProperty(rootState, '$router', { value: nuxt.app.router });
-    Object.defineProperty(rootState, '$route', { value: nuxt.route });
-    Object.defineProperty(rootState, '$plugin', { value: nuxt.app.$plugin });
-    Object.defineProperty(this, '$plugin', { value: nuxt.app.$plugin });
+  nuxtClientInit({ dispatch, commit, rootState }, nuxt) {
+    commit('setRouter', nuxt.app.router);
+    commit('setRoute', nuxt.route);
+    commit('setPlugin', nuxt.app.$plugin);
 
     dispatch('management/rehydrateSubscribe');
     dispatch('cluster/rehydrateSubscribe');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This refactors the `nuxtClientInit` action so that mutations are explicitly invoked in the store instead of utilizing `Object.defineProperty()` to modify the root state. 

Fixes #11081
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Vue 3 wraps the store's state object with a proxy to make it reactive, and the proxy's target object has its properties marked as non-writable and non-configurable. In order to resolve this issue, we make use of accepted Vuex patterns for modifying state.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This is the core store module, so we will need to test anything that utilizes the `$router`, `$route`, and `$plugin` state that's defined within the store.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Anything that accesses the `$router`, `$route`, or `$plugin` states stored in the store.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
