### PR TITLE
Disallow reset of server url

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -376,4 +376,18 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(obj.kind).to.equal('Config');
     });
   });
+
+  // The server-url can not be reset as there is no default - so check that is the case
+  it('can not reset server url', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    SettingsPagePo.navTo();
+    settingsPage.editSettingsByLabel('server-url');
+
+    const settingsEdit = settingsPage.editSettings('local', 'server-url');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: server-url').should('be.visible');
+
+    settingsEdit.useDefaultButton().should('be.visible');
+    settingsEdit.useDefaultButton().should('be.disabled');
+  });
 });

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -382,7 +382,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('server-url');
 
-    const settingsEdit = settingsPage.editSettings('local', 'server-url');
+    const settingsEdit = settingsPage.editSettings('_', 'server-url');
 
     settingsEdit.waitForPage();
     settingsEdit.title().contains('Setting: server-url').should('be.visible');

--- a/shell/edit/management.cattle.io.setting.vue
+++ b/shell/edit/management.cattle.io.setting.vue
@@ -52,6 +52,12 @@ export default {
       path:  'value',
       rules: this.setting.ruleSet.map(({ name }) => name)
     }] : [];
+
+    // Don't allow the user to reset the server URL if there is no default
+    // helps to ensure that a value is always set
+    if (isServerUrl(this.value.id) && !this.value.default) {
+      this.canReset = false;
+    }
   },
 
   computed: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10613

This PR updates the global settings edit page for `server-url` to make it so that you can not reset if to the default, since there is no default value.

Also adds an e2e test to verify this behaviour.

### Areas or cases that should be tested

Handled by automated e2e test - checks that when you go to edit the `server-url` setting, that the `Reset to Default` button is not enabled.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
