### PR TITLE
Resolve issues with user last login fields

### DIFF
--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -108,11 +108,11 @@ describe('Users', { tags: '@adminUser' }, () => {
       // Deactivate user and check state is Inactive
       usersPo.goTo();
       usersPo.list().clickRowActionMenuItem(standardUsername, 'Deactivate');
-      usersPo.list().details(standardUsername, 1).should('include.text', 'Inactive');
+      usersPo.list().details(standardUsername, 1).should('include.text', 'Disabled');
 
       // Activate user and check state is Active
       usersPo.list().clickRowActionMenuItem(standardUsername, 'Activate');
-      usersPo.list().details(standardUsername, 1).should('include.text', 'Active');
+      usersPo.list().details(standardUsername, 1).should('include.text', 'Enabled');
     });
 
     it('can Refresh Group Memberships', () => {
@@ -191,14 +191,14 @@ describe('Users', { tags: '@adminUser' }, () => {
       usersPo.list().selectAll().set();
       usersPo.list().deactivate().click();
       cy.wait('@updateUsers');
-      cy.contains('Inactive');
-      usersPo.list().details('admin', 1).should('include.text', 'Active');
-      usersPo.list().details(userBaseUsername, 1).should('include.text', 'Inactive');
+      cy.contains('Disabled');
+      usersPo.list().details('admin', 1).should('include.text', 'Enabled');
+      usersPo.list().details(userBaseUsername, 1).should('include.text', 'Disabled');
 
       // Activate user and check state is Active
       usersPo.list().activate().click();
       cy.wait('@updateUsers');
-      usersPo.list().details(userBaseUsername, 1).should('include.text', 'Active');
+      usersPo.list().details(userBaseUsername, 1).should('include.text', 'Enabled');
     });
 
     it('can Download YAML', () => {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5599,6 +5599,10 @@ target:
     placeholder: Select a version
 
 user:
+  state:
+    active: 'Enabled'
+    inactive: 'Disabled'
+    unknown: 'Unknown'
   detail:
     username: Username
     globalPermissions:

--- a/shell/components/formatter/LiveDate.vue
+++ b/shell/components/formatter/LiveDate.vue
@@ -34,6 +34,16 @@ export default {
     showTooltip: {
       type:    Boolean,
       default: true
+    },
+
+    /**
+     * Determines if the live date should behave like a countdown by comparing
+     * the provided value and the current date. When the countdown reaches 0, a
+     * "-" is rendered.
+     */
+    isCountdown: {
+      type:    Boolean,
+      default: false,
     }
   },
 
@@ -100,6 +110,12 @@ export default {
         if (this.label !== '-') {
           this.label = '-';
         }
+
+        return 300;
+      }
+
+      if (this.isCountdown && now.valueOf() > this.dayValue?.valueOf()) {
+        this.label = '-';
 
         return 300;
       }

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -399,11 +399,12 @@ export const USER_PROVIDER = {
 };
 
 export const USER_LAST_LOGIN = {
-  name:      'user-last-login',
-  labelKey:  'tableHeaders.userLastLogin',
-  value:     'userLastLogin',
-  formatter: 'LiveDate',
-  sort:      'userLastLogin',
+  name:          'user-last-login',
+  labelKey:      'tableHeaders.userLastLogin',
+  value:         'userLastLogin',
+  formatter:     'LiveDate',
+  formatterOpts: { addSuffix: true },
+  sort:          'userLastLogin',
 };
 
 export const USER_DISABLED_IN = {

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -407,19 +407,21 @@ export const USER_LAST_LOGIN = {
 };
 
 export const USER_DISABLED_IN = {
-  name:      'user-disabled-in',
-  labelKey:  'tableHeaders.userDisabledIn',
-  value:     'userDisabledIn',
-  formatter: 'LiveDate',
-  sort:      'userDisabledIn',
+  name:          'user-disabled-in',
+  labelKey:      'tableHeaders.userDisabledIn',
+  value:         'userDisabledIn',
+  formatter:     'LiveDate',
+  formatterOpts: { isCountdown: true },
+  sort:          'userDisabledIn',
 };
 
 export const USER_DELETED_IN = {
-  name:      'user-deleted-in',
-  labelKey:  'tableHeaders.userDeletedIn',
-  value:     'userDeletedIn',
-  formatter: 'LiveDate',
-  sort:      'userDeletedIn',
+  name:          'user-deleted-in',
+  labelKey:      'tableHeaders.userDeletedIn',
+  value:         'userDeletedIn',
+  formatter:     'LiveDate',
+  formatterOpts: { isCountdown: true },
+  sort:          'userDeletedIn',
 };
 
 export const USER_ID = {

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -409,7 +409,7 @@ export const USER_LAST_LOGIN = {
 export const USER_DISABLED_IN = {
   name:          'user-disabled-in',
   labelKey:      'tableHeaders.userDisabledIn',
-  value:         'userDisabledIn',
+  value:         'userDisabledInDisplay',
   formatter:     'LiveDate',
   formatterOpts: { isCountdown: true },
   sort:          'userDisabledIn',

--- a/shell/models/management.cattle.io.user.js
+++ b/shell/models/management.cattle.io.user.js
@@ -132,6 +132,19 @@ export default class User extends HybridModel {
     return this.metadata?.state?.name || 'unknown';
   }
 
+  get stateDisplay() {
+    switch (this.state) {
+    case 'inactive':
+      return this.t('user.state.inactive');
+    case 'active':
+      return this.t('user.state.active');
+    case 'unknown':
+      return this.t('user.state.unknown');
+    default:
+      return this.state;
+    }
+  }
+
   get description() {
     return this._description;
   }

--- a/shell/models/management.cattle.io.user.js
+++ b/shell/models/management.cattle.io.user.js
@@ -244,14 +244,16 @@ export default class User extends HybridModel {
         content:       this.userLastLogin,
       },
       {
-        label:     this.t('tableHeaders.userDisabledIn'),
-        formatter: 'LiveDate',
-        content:   this.userDisabledIn,
+        label:         this.t('tableHeaders.userDisabledIn'),
+        formatter:     'LiveDate',
+        formatterOpts: { isCountdown: true },
+        content:       this.userDisabledIn,
       },
       {
-        label:     this.t('tableHeaders.userDeletedIn'),
-        formatter: 'LiveDate',
-        content:   this.userDeletedIn,
+        label:         this.t('tableHeaders.userDeletedIn'),
+        formatter:     'LiveDate',
+        formatterOpts: { isCountdown: true },
+        content:       this.userDeletedIn,
       },
       ...this._details
     ];

--- a/shell/models/management.cattle.io.user.js
+++ b/shell/models/management.cattle.io.user.js
@@ -117,6 +117,14 @@ export default class User extends HybridModel {
   }
 
   /**
+   * Provides a display value for the userDisabledIn date based on the user
+   * state.
+   */
+  get userDisabledInDisplay() {
+    return this.state === 'inactive' ? null : this.userDisabledIn;
+  }
+
+  /**
    * Gets the delete-after label in milliseconds
    * @returns {number}
    */
@@ -260,7 +268,7 @@ export default class User extends HybridModel {
         label:         this.t('tableHeaders.userDisabledIn'),
         formatter:     'LiveDate',
         formatterOpts: { isCountdown: true },
-        content:       this.userDisabledIn,
+        content:       this.userDisabledInDisplay,
       },
       {
         label:         this.t('tableHeaders.userDeletedIn'),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This addresses several issues identified with new Login fields added to the users table

- When Disable/Delete After fields reach 0, the relative date would start counting up
- When a user is disabled, there is no need to display a value for Disable After
- Update the user states to reach Enabled/Disabled instead of Active/Inactive
- Add a suffix to the last login column 

Fixes #11074
Fixes #11071
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I originally attempted to expose the live date components through the cell slots for the table, but I found that the `LiveDate` component no longer works with this change. It appears that `LiveDate` is receiving updates via the prop on a regular basis while rendering from within the table, but that relationship is broken when data is exposed through a slot. I opted to add a new prop to the `LiveDate` component, but we can also consider creating a new component to handle a countdown like this if we would prefer.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Users List
- User Details

Set a short time (2 minutes) for disable/delete after. Watch the timer countdown.

Alternatively, disable a user before the countdown reaches zero.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
