### PR TITLE
AKS - fix container monitoring checkbox

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -157,7 +157,6 @@ export default defineComponent({
     }
     this.config = this.normanCluster.aksConfig;
     this.nodePools = this.normanCluster.aksConfig.nodePools;
-    this.containerMonitoring = !!(this.config.logAnalyticsWorkspaceGroup || this.config.logAnalyticsWorkspaceName);
     this.setAuthorizedIPRanges = !!(this.config?.authorizedIpRanges || []).length;
     this.nodePools.forEach((pool: AKSNodePool) => {
       this.$set(pool, '_id', randomStr());
@@ -201,7 +200,6 @@ export default defineComponent({
       loadingVersions:        false,
       loadingVmSizes:         false,
       loadingVirtualNetworks: false,
-      containerMonitoring:    false,
       setAuthorizedIPRanges:  false,
       fvFormRuleSets:         [{
         path:  'name',
@@ -793,6 +791,13 @@ export default defineComponent({
         delete this.config.privateDnsZone;
         delete this.config.userAssignedIdentity;
       }
+    },
+
+    'config.monitoring'(neu: boolean) {
+      if (!neu) {
+        this.$set(this.config, 'logAnalyticsWorkspaceGroup', null);
+        this.$set(this.config, 'logAnalyticsWorkspaceName', null);
+      }
     }
   },
 
@@ -1179,20 +1184,22 @@ export default defineComponent({
             </div>
             <div class="col span-3">
               <Checkbox
-                v-model="containerMonitoring"
+                v-model="config.monitoring"
                 :mode="mode"
                 label-key="aks.containerMonitoring.label"
+                data-testid="aks-monitoring-checkbox"
               />
             </div>
           </div>
 
           <div class="row mb-10">
-            <template v-if="containerMonitoring">
+            <template v-if="config.monitoring">
               <div class="col span-3">
                 <LabeledInput
                   v-model="config.logAnalyticsWorkspaceGroup"
                   :mode="mode"
                   label-key="aks.logAnalyticsWorkspaceGroup.label"
+                  data-testid="aks-log-analytics-workspace-group-input"
                 />
               </div>
               <div class="col span-3">
@@ -1200,6 +1207,7 @@ export default defineComponent({
                   v-model="config.logAnalyticsWorkspaceName"
                   :mode="mode"
                   label-key="aks.logAnalyticsWorkspaceName.label"
+                  data-testid="aks-log-analytics-workspace-name-input"
                 />
               </div>
             </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10965  
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
The 'container monitoring' checkbox should correspond to `aksConfig.monitoring` - previously it was just gating the visibility of the two log analytics inputs. This PR corrects that and adds a few unit tests.


### Areas or cases that should be tested
1. create an AKS cluster with container monitoring enabled, and log analytics workspace name/group set - the payload should include `aksConfig.monitoring` = true
2. edit cluster and disable container monitoring - the payload should include `aksConfig.monitoring` = false, and `aksConfig.logAnalyticsWorkspaceName` and `aksConfig.logAnalyticsWorkspaceGroup` set to null


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
