### PR TITLE
[Automation] - Adding data state cleanup before running cloud-credential spec

### DIFF
--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -5,12 +5,21 @@ import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/clu
 import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
 import ClusterManagerCreateRke2AzurePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-azure.po';
 
-describe('Cloud Credential', () => {
+describe('Cloud Credential', { testIsolation: 'off' }, () => {
   const clusterList = new ClusterManagerListPagePo();
 
-  beforeEach(() => {
+  before(() => {
     cy.login();
+    cy.getRancherResource('v3', 'cloudCredentials').then((resp: Cypress.Response<any>) => {
+      const credentials = resp.body.data;
 
+      credentials.forEach( (credential) => {
+        cy.deleteRancherResource('v3', 'cloudCredentials', credential.id.trim(), false);
+      });
+    });
+  });
+
+  beforeEach(() => {
     clusterList.goTo();
   });
 

--- a/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
@@ -8,6 +8,14 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
 
   before(() => {
     cy.login();
+
+    cy.getRancherResource('v3', 'cloudCredentials').then((resp: Cypress.Response<any>) => {
+      const credentials = resp.body.data;
+
+      credentials.forEach( (credential) => {
+        cy.deleteRancherResource('v3', 'cloudCredentials', credential.id.trim(), false);
+      });
+    });
   });
 
   beforeEach(() => {


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/1335

### Occurred changes and/or fixed issues
Adding a cleanup step to the Cloud Credential spec. This will ensure the initial state of the cloud credentials data is always empty on retries.

### Areas or cases that should be tested
I've tested the remove when there are credentials linked to a cluster. I left the API check out to avoid collisions with the provisioning tests. 

### Areas which could experience regressions
E2E tests. Provisioning and Cloud credentials. Low risk.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
