### PR TITLE
Use `markRaw()` to signal non reactive data in store

### DIFF
--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import Vue, { markRaw } from 'vue';
 import { addObject, addObjects, clear, removeObject } from '@shell/utils/array';
 import { SCHEMA, COUNT } from '@shell/config/types';
 import { normalizeType, keyFieldFor } from '@shell/plugins/dashboard-store/normalize';
@@ -34,10 +34,10 @@ function registerType(state, type) {
        * Used to cancel incremental loads if the page changes during load
        */
       loadCounter:   0,
-    };
 
-    // Not enumerable so they don't get sent back to the client for SSR
-    Object.defineProperty(cache, 'map', { value: new Map() });
+      // Not enumerable so they don't get sent back to the client for SSR
+      map: markRaw(new Map()),
+    };
 
     Vue.set(state.types, type, cache);
   }

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -37,6 +37,7 @@ import { addParam } from '@shell/utils/url';
 import semver from 'semver';
 import { STORE, BLANK_CLUSTER } from '@shell/store/store-types';
 import { isDevBuild } from '@shell/utils/version';
+import { markRaw } from 'vue';
 
 // Disables strict mode for all store instances to prevent warning about changing state outside of mutations
 // because it's more efficient to do that sometimes.
@@ -247,9 +248,9 @@ export const state = () => {
     isRancherInHarvester:    false,
     targetRoute:             null,
     rootProduct:             undefined,
-    $router:                 undefined,
-    $route:                  undefined,
-    $plugin:                 undefined,
+    $router:                 markRaw(undefined),
+    $route:                  markRaw(undefined),
+    $plugin:                 markRaw(undefined),
   };
 };
 
@@ -728,15 +729,15 @@ export const mutations = {
   },
 
   setRouter(state, router) {
-    state.$router = router;
+    state.$router = markRaw(router);
   },
 
   setRoute(state, route) {
-    state.$route = route;
+    state.$route = markRaw(route);
   },
 
   setPlugin(state, pluginDefinition) {
-    state.$plugin = pluginDefinition;
+    state.$plugin = markRaw(pluginDefinition);
   }
 };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This utilizes `markRaw()` to ensure that certain properties in the Vuex store are marked as "non-reactive". 

Fixes #11098
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Upon further review of #11062, I thought that `Object.defineProperty()` was being used, in part, to mark certain properties as "non-reactive" in the Dashboard store. `$plugin`, `$router`, & `$route` really don't need reactivity associated with them.

We might want to consider following up in the future to decide if any of these properties belong in the Vuex store at all. We can achieve a similar result by utilizing a singleton or some similar pattern that will allow us to share these definitions throughout Dashboard. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Anything that accesses the $router, $route, or $plugin states stored in the store.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
