### PR TITLE
Temporarily Remove codecov upload given caveats on `codecov/codecov-action` action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -196,32 +196,6 @@ jobs:
       - name: Run tests
         uses: ./.github/actions/lint
 
-  coverage:
-    runs-on: ubuntu-latest
-    needs:
-      - unit-test
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14.x'
-
-      - name: Download Coverage Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{github.run_number}}-${{github.run_attempt}}-coverage
-
-      - name: Upload unit test coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unit
-          files: ./coverage/coverage-unit.json
-          fail_ci_if_error: false
-
   check-e2e-tags:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to #10663
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- See https://github.com/rancher/dashboard/issues/11106 for details
- I've kept the upload of coverage artefacts as in, as soon we'll need them again


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
