### PR TITLE
Use @rancher/icons package rather than a GH reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "marked": "4.0.17",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "@rancher/icons": "2.0.28",
+    "@rancher/icons": "2.0.29",
     "sass": "1.51.0",
     "sass-loader": "10.2.1",
     "set-cookie-parser": "2.4.6",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "marked": "4.0.17",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "rancher-icons": "rancher/icons#v2.0.25",
+    "@rancher/icons": "2.0.28",
     "sass": "1.51.0",
     "sass-loader": "10.2.1",
     "set-cookie-parser": "2.4.6",

--- a/shell/assets/styles/fonts/_icons.scss
+++ b/shell/assets/styles/fonts/_icons.scss
@@ -1,7 +1,7 @@
 
 @use "sass:math";
 
-@import "~rancher-icons/style.scss";
+@import "@rancher/icons/style.scss";
 
 // Animated Icons
 // --------------------------

--- a/shell/package.json
+++ b/shell/package.json
@@ -107,7 +107,7 @@
     "nyc": "15.1.0",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "rancher-icons": "rancher/icons#v2.0.25",
+    "@rancher/icons": "2.0.28",
     "sass": "1.51.0",
     "sass-loader": "10.2.1",
     "serve-static": "1.14.1",

--- a/shell/package.json
+++ b/shell/package.json
@@ -107,7 +107,7 @@
     "nyc": "15.1.0",
     "papaparse": "5.3.0",
     "portal-vue": "2.1.7",
-    "@rancher/icons": "2.0.28",
+    "@rancher/icons": "2.0.29",
     "sass": "1.51.0",
     "sass-loader": "10.2.1",
     "serve-static": "1.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,6 +3144,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
+"@rancher/icons@2.0.28":
+  version "2.0.28"
+  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.28.tgz#a1d8f7550a493a29da62d6d9e973472f7a37938f"
+  integrity sha512-29OtDNWBw0AYJrtdKIb5jhEQp2952EvL+yh+h6kaPhcOt3FxMo+rLo1GY1hy1jYWRZ1rFD7mTj23Sx3pe9uzzg==
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
@@ -13646,10 +13651,6 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-rancher-icons@rancher/icons#v2.0.25:
-  version "2.0.25"
-  resolved "https://codeload.github.com/rancher/icons/tar.gz/c3ac5816ee755a5c856324fe62323357fb05d421"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3144,10 +3144,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
   integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
-"@rancher/icons@2.0.28":
-  version "2.0.28"
-  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.28.tgz#a1d8f7550a493a29da62d6d9e973472f7a37938f"
-  integrity sha512-29OtDNWBw0AYJrtdKIb5jhEQp2952EvL+yh+h6kaPhcOt3FxMo+rLo1GY1hy1jYWRZ1rFD7mTj23Sx3pe9uzzg==
+"@rancher/icons@2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.29.tgz#6546d69768c706bebd66bfa73b36aef3d105987a"
+  integrity sha512-qBBqfazS9y5VjV7fJDPNXmxd9AP/2uiE05mKFWP41kpbO+tEb62RnUBXCm14XLeScDZQcOuiAKVHMmvCFzF0BA==
 
 "@sideway/address@^4.1.3":
   version "4.1.4"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7477
<!-- Define findings related to the feature or bug issue. -->

This PR fixes the above issue.

Rancher Icons is now published to npm as the package `@rancher/icons`

This PR updates the reference(s) to use this package rather than referencing GitHub.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Manual testing is needed to just check that the icons still appear correctly.

Check the app bar and explore a cluster and check the top bar - the icons should render as before, e.g. for the explorer top bar:

![image](https://github.com/rancher/dashboard/assets/1955897/51f03fa3-7f7a-4c3d-a27a-845760193acd)

We just need to validate the overall mechanism for including the icon font is not broken - so we don't need to check all icons, just that the icons still show correctly.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
