### PR TITLE
AKS - fix editing imported clusters

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -51,7 +51,6 @@ import {
   outboundTypeUserDefined,
   privateDnsZone
 } from '@pkg/aks/util/validators';
-import { isEmpty } from '@shell/utils/object';
 
 export const defaultNodePool = {
   availabilityZones:     ['1', '2', '3'],
@@ -141,18 +140,18 @@ export default defineComponent({
   async fetch() {
     const store = this.$store as Store<any>;
 
-    // id is defined when editing a cluster
     if (this.value.id) {
       const liveNormanCluster = await this.value.findNormanCluster();
 
       this.normanCluster = await store.dispatch(`rancher/clone`, { resource: liveNormanCluster });
-      // track original version on edit to ensure we don't offer k8s downgrades
-      this.originalVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
 
       // ensure any fields editable through this UI that have been altered in azure portal are shown here - see syncUpstreamConfig jsdoc for details
       if (!this.isNewOrUnprovisioned) {
         syncUpstreamConfig('aks', this.normanCluster);
       }
+
+      // track original version on edit to ensure we don't offer k8s downgrades
+      this.originalVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
     }

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -5,7 +5,7 @@ import { defineComponent } from 'vue';
 import { removeObject } from '@shell/utils/array';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { NORMAN } from '@shell/config/types';
-import { diffUpstreamSpec, syncUpstreamConfig } from '@shell/utils/kontainer';
+import { diffUpstreamSpec } from '@shell/utils/kontainer';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 
@@ -117,11 +117,6 @@ export default defineComponent({
       this.normanCluster = await store.dispatch(`rancher/clone`, { resource: liveNormanCluster });
       // track original version on edit to ensure we don't offer k8s downgrades
       this.originalVersion = this.normanCluster?.eksConfig?.kubernetesVersion || '';
-
-      // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
-      if (!this.isNewOrUnprovisioned) {
-        syncUpstreamConfig('eks', this.normanCluster);
-      }
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...DEFAULT_CLUSTER }, { root: true });
     }

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -5,7 +5,7 @@ import { defineComponent } from 'vue';
 import { removeObject } from '@shell/utils/array';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { NORMAN } from '@shell/config/types';
-import { diffUpstreamSpec } from '@shell/utils/kontainer';
+import { diffUpstreamSpec, syncUpstreamConfig } from '@shell/utils/kontainer';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 
@@ -117,6 +117,11 @@ export default defineComponent({
       this.normanCluster = await store.dispatch(`rancher/clone`, { resource: liveNormanCluster });
       // track original version on edit to ensure we don't offer k8s downgrades
       this.originalVersion = this.normanCluster?.eksConfig?.kubernetesVersion || '';
+
+      // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
+      if (!this.isNewOrUnprovisioned) {
+        syncUpstreamConfig('eks', this.normanCluster);
+      }
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...DEFAULT_CLUSTER }, { root: true });
     }

--- a/shell/utils/kontainer.ts
+++ b/shell/utils/kontainer.ts
@@ -17,7 +17,7 @@ export function syncUpstreamConfig(configPrefix: string, normanCluster: {[key: s
 
   if (!isEmpty(upstreamConfig)) {
     Object.keys(upstreamConfig).forEach((key) => {
-      if (isEmpty(rancherConfig[key]) && !isEmpty(upstreamConfig.key)) {
+      if (isEmpty(rancherConfig[key]) && !isEmpty(upstreamConfig[key])) {
         set(rancherConfig, key, upstreamConfig[key]);
       }
     });

--- a/shell/utils/kontainer.ts
+++ b/shell/utils/kontainer.ts
@@ -17,7 +17,7 @@ export function syncUpstreamConfig(configPrefix: string, normanCluster: {[key: s
 
   if (!isEmpty(upstreamConfig)) {
     Object.keys(upstreamConfig).forEach((key) => {
-      if (isEmpty(rancherConfig[key] && !isEmpty(upstreamConfig.key))) {
+      if (isEmpty(rancherConfig[key]) && !isEmpty(upstreamConfig.key)) {
         set(rancherConfig, key, upstreamConfig[key]);
       }
     });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10966 
Fixes #3872 
Fixes #8501 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR corrects editing of imported clusters by fixing the upstream syncing logic. Hosted clusters (aks eks gke) track both the configuration managed through Rancher and the configuration managed through their respective cloud provider's platform. You can read more about syncing between the two in the Rancher docs [here](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/sync-clusters). 


### Areas or cases that should be tested
When testing this PR, it should be noted that once a cluster has been updated through Rancher, it should _only_ be updated through Rancher.
To test issues with the node pool upgrade checkbox/banner stuff:
1. In the azure portal, create an AKS cluster that does not use the latest k8s version available.
2. Import the cluster into Rancher and 'edit config' - the form should be populated and save button not disabled - do _not_ edit the cluster at this stage
3. Go back to the azure portal and upgrade the k8s version of the cluster control plane only (depending on how you made your cluster you may need to disable auto upgrades to do cp-only upgrading)
4. Wait ~5 minutes for the upstream spec to sync
5. Edit the imported cluster through the Rancher UI: there should be an option to upgrade the node pool version
6. Select a new cluster-level k8s version instead: there should now be a banner telling the user they can upgrade the node pool when the cluster upgrade is done
7. Add a new node pool: it should have the same k8s version as the cluster k8s version
8. Save the cluster, let it update, and edit again: there should once again be an option to upgrade the node pool

Other stuff to check:
- Edit an imported cluster and change nothing: the cluster should not go into updating state
- The same edit options should be available for imported and rancher-provisioned AKS clusters


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
