### PR TITLE
Improve keyboard mapping display

### DIFF
--- a/cypress/e2e/po/components/keyboard-mapping-indicator.po.ts
+++ b/cypress/e2e/po/components/keyboard-mapping-indicator.po.ts
@@ -7,7 +7,7 @@ export default class KeyboardMappingIndicatorPo extends ComponentPo {
 
   showTooltip(): Cypress.Chainable {
     return this.self().trigger('mouseenter');
-  }  
+  }
 
   getTooltipContent(): Cypress.Chainable {
     return cy.get('.tooltip.vue-tooltip-theme .tooltip-inner');

--- a/cypress/e2e/po/components/keyboard-mapping-indicator.po.ts
+++ b/cypress/e2e/po/components/keyboard-mapping-indicator.po.ts
@@ -1,0 +1,15 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class KeyboardMappingIndicatorPo extends ComponentPo {
+  constructor() {
+    super('[data-testid="code-mirror-keymap"]');
+  }
+
+  showTooltip(): Cypress.Chainable {
+    return this.self().trigger('mouseenter');
+  }  
+
+  getTooltipContent(): Cypress.Chainable {
+    return cy.get('.tooltip.vue-tooltip-theme .tooltip-inner');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/yaml-editor.po.ts
+++ b/cypress/e2e/po/pages/explorer/yaml-editor.po.ts
@@ -1,0 +1,21 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import KeyboardMappingIndicatorPo from '@/cypress/e2e/po/components/keyboard-mapping-indicator.po';
+
+export default class ResourceYamlEditorPagePo extends PagePo {
+  private static createPath(resourceId: string, clusterId = 'local') {
+    return `/c/${ clusterId }/explorer/${ resourceId }/create?as=yaml`;
+  }
+
+  static goTo(resourceId: string, clusterId = 'local'): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(ResourceYamlEditorPagePo.createPath(resourceId, clusterId));
+  }
+
+  constructor(resourceId: string, clusterId = 'local') {
+    super(ResourceYamlEditorPagePo.createPath(resourceId, clusterId));
+  }
+
+  // Get the keyboard mapping indicator that can app[ear in the top-right
+  keyboardMappingIndicator() {
+    return new KeyboardMappingIndicatorPo();
+  }
+}

--- a/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
@@ -6,6 +6,7 @@ import RepositoriesPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+import ResourceYamlEditorPagePo from '@/cypress/e2e/po/pages/explorer/yaml-editor.po';
 
 // import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 
@@ -14,6 +15,11 @@ const prefPage = new PreferencesPagePo();
 const repoListPage = new RepositoriesPagePo('_', 'manager');
 const repoList = repoListPage.list();
 // const clusterManagerPage = new ClusterManagerListPagePo('_');
+
+const VIM = 'Vim'
+const NORMAL_HUMAN = 'Normal human';
+
+const RESOURCE_FOR_CREATE_YAML = 'resourcequota';
 
 describe('User can update their preferences', () => {
   beforeEach(() => {
@@ -405,6 +411,46 @@ describe('User can update their preferences', () => {
       });
       prefPage.keymapButtons().isSelected(key);
     }
+  });
+
+  describe('Check keyboard mapping on YAML Editor',{ tags: ['@userMenu', '@adminUser', '@standardUser'] }, () => {
+    it('does not show any indicator for default keyboard mapping', () => {
+      prefPage.goTo();
+      prefPage.keymapButtons().checkVisible();
+
+      const yamlEditor = new ResourceYamlEditorPagePo(RESOURCE_FOR_CREATE_YAML);
+
+      yamlEditor.goTo();
+      yamlEditor.waitForPage();
+
+      yamlEditor.keyboardMappingIndicator().checkNotExists();
+    });
+
+    it('does show any indicator for non-default keyboard mapping', () => {
+      prefPage.goTo();
+      prefPage.keymapButtons().checkVisible();
+
+      prefPage.keymapButtons().set(VIM);
+      prefPage.keymapButtons().isSelected(VIM);
+
+      const yamlEditor = new ResourceYamlEditorPagePo(RESOURCE_FOR_CREATE_YAML);
+
+      yamlEditor.goTo();
+      yamlEditor.waitForPage();
+
+      yamlEditor.keyboardMappingIndicator().checkExists();
+      yamlEditor.keyboardMappingIndicator().checkVisible();
+
+      yamlEditor.keyboardMappingIndicator().showTooltip();
+      yamlEditor.keyboardMappingIndicator().getTooltipContent().should('be.visible');
+      yamlEditor.keyboardMappingIndicator().getTooltipContent().contains('Key mapping: Vim');
+
+      // Reset keyboard mapping
+      prefPage.goTo();
+      prefPage.keymapButtons().checkVisible();
+
+      prefPage.keymapButtons().set(NORMAL_HUMAN);
+    });
   });
 
   it('Can select a Helm Charts option', { tags: ['@userMenu', '@adminUser', '@standardUser'] }, () => {

--- a/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
@@ -16,7 +16,7 @@ const repoListPage = new RepositoriesPagePo('_', 'manager');
 const repoList = repoListPage.list();
 // const clusterManagerPage = new ClusterManagerListPagePo('_');
 
-const VIM = 'Vim'
+const VIM = 'Vim';
 const NORMAL_HUMAN = 'Normal human';
 
 const RESOURCE_FOR_CREATE_YAML = 'resourcequota';
@@ -413,7 +413,7 @@ describe('User can update their preferences', () => {
     }
   });
 
-  describe('Check keyboard mapping on YAML Editor',{ tags: ['@userMenu', '@adminUser', '@standardUser'] }, () => {
+  describe('Check keyboard mapping on YAML Editor', { tags: ['@userMenu', '@adminUser', '@standardUser'] }, () => {
     it('does not show any indicator for default keyboard mapping', () => {
       prefPage.goTo();
       prefPage.keymapButtons().checkVisible();

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2160,6 +2160,7 @@ resource:
 codeMirror:
   keymap:
     tooltip: Key mapping preference.
+    indicatorToolip: "Key mapping: {name}"
 
 cruResource:
   backToForm: Back to Form

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -233,7 +233,7 @@ export default {
         &:hover {
           border: 1px solid var(--primary);
           border-radius: var(--border-radius);;
-          
+
           .close-indicator {
             margin-left: -6px;
             width: auto;

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -33,10 +33,9 @@ export default {
 
   data() {
     return {
-      codeMirrorRef:       null,
-      loaded:              false,
-      showKeyMapCloseIcon: false,
-      removeKeyMapBox:     false,
+      codeMirrorRef:   null,
+      loaded:          false,
+      removeKeyMapBox: false,
     };
   },
 
@@ -76,9 +75,19 @@ export default {
       return out;
     },
 
-    keyMapText() {
-      return this.combinedOptions?.keyMap ? this.t(`prefs.keymap.${ this.combinedOptions.keyMap }`) : null;
+    keyMapTooltip() {
+      if (this.combinedOptions?.keyMap) {
+        const name = this.t(`prefs.keymap.${ this.combinedOptions.keyMap }`);
+
+        return this.t('codeMirror.keymap.indicatorToolip', { name });
+      }
+
+      return null;
     },
+
+    isNonDefaultKeyMap() {
+      return this.combinedOptions?.keyMap !== 'sublime';
+    }
   },
 
   created() {
@@ -138,10 +147,6 @@ export default {
     closeKeyMapInfo() {
       this.removeKeyMapBox = true;
     },
-
-    onKeyMapMouseOver(v) {
-      this.showKeyMapCloseIcon = v;
-    }
   }
 };
 </script>
@@ -153,24 +158,19 @@ export default {
   >
     <div v-if="loaded">
       <div
-        v-if="showKeyMapBox && !removeKeyMapBox && keyMapText"
+        v-if="showKeyMapBox && !removeKeyMapBox && keyMapTooltip && isNonDefaultKeyMap"
         class="keymap overlay"
       >
         <div
-          v-clean-tooltip="t('codeMirror.keymap.tooltip')"
-          class="label"
+          v-clean-tooltip="keyMapTooltip"
+          class="keymap-indicator"
           data-testid="code-mirror-keymap"
-          @mouseover="onKeyMapMouseOver(true)"
-          @mouseleave="onKeyMapMouseOver(false)"
+          @click="closeKeyMapInfo"
         >
-          <span>
-            {{ keyMapText }}
-          </span>
-          <i
-            v-if="showKeyMapCloseIcon"
-            class="icon icon-close icon-sm"
-            @click="closeKeyMapInfo"
-          />
+          <i class="icon icon-keyboard keymap-icon" />
+          <div class="close-indicator">
+            <i class="icon icon-close icon-sm" />
+          </div>
         </div>
       </div>
       <codemirror
@@ -195,26 +195,53 @@ export default {
   .code-mirror {
     z-index: 0;
 
-    .overlay {
-      position: sticky;
-      display: grid;
-      top: 0;
-      float: right;
-      height: 0;
+    // Keyboard mapping overlap
+    .keymap.overlay {
+      position: absolute;
+      display: flex;
+      top: 7px;
+      right: 7px;
       z-index: 1;
+      cursor: pointer;
 
-      .label {
-        border-radius: 2px;
-        border-style: dashed;
-        border-width: 0.1px;
-        margin: 7px 7px 0 0;
-        padding: 7px;
+      .keymap-indicator {
+        width: 48px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid transparent;
         color: var(--darker);
         background-color: var(--overlay-bg);
         font-size: 12px;
 
-        .icon {
-          cursor: pointer;
+        .icon-close {
+          opacity: 0;
+        }
+
+        .keymap-icon {
+          font-size: 24px;
+          opacity: 0.8;
+        }
+
+        &:hover {
+          border: 1px solid var(--primary);
+          border-radius: 4px;
+
+          .icon-close {
+            opacity: 1;
+          }
+
+          .keymap-icon {
+            opacity: 0.6;
+          }
+        }
+
+        .icon-close {
+          color: var(--primary);
+          position: absolute;
+          right: 3px;
+          top: 3px;
         }
       }
     }

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -192,6 +192,8 @@ export default {
 </template>
 
 <style lang="scss">
+  $code-mirror-animation-time: 0.1s;
+
   .code-mirror {
     z-index: 0;
 
@@ -227,7 +229,7 @@ export default {
         .keymap-icon {
           font-size: 24px;
           opacity: 0.8;
-          transition: margin-right 0.2s ease-in-out;
+          transition: margin-right $code-mirror-animation-time ease-in-out;
         }
 
         &:hover {
@@ -240,7 +242,7 @@ export default {
 
             .icon-close {
               opacity: 1;
-              transition: opacity 0.25s ease-in-out 0.2s; // Only animate when being shown
+              transition: opacity $code-mirror-animation-time ease-in-out $code-mirror-animation-time; // Only animate when being shown
             }
           }
 

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -215,33 +215,39 @@ export default {
         background-color: var(--overlay-bg);
         font-size: 12px;
 
-        .icon-close {
-          opacity: 0;
+        .close-indicator {
+          width: 0;
+
+          .icon-close {
+            color: var(--primary);
+            opacity: 0;
+          }
         }
 
         .keymap-icon {
           font-size: 24px;
           opacity: 0.8;
+          transition: margin-right 0.2s ease-in-out;
         }
 
         &:hover {
           border: 1px solid var(--primary);
-          border-radius: 4px;
+          border-radius: var(--border-radius);;
+          
+          .close-indicator {
+            margin-left: -6px;
+            width: auto;
 
-          .icon-close {
-            opacity: 1;
+            .icon-close {
+              opacity: 1;
+              transition: opacity 0.25s ease-in-out 0.2s; // Only animate when being shown
+            }
           }
 
           .keymap-icon {
             opacity: 0.6;
+            margin-right: 10px;
           }
-        }
-
-        .icon-close {
-          color: var(--primary);
-          position: absolute;
-          right: 3px;
-          top: 3px;
         }
       }
     }

--- a/shell/components/__tests__/CodeMirror.test.ts
+++ b/shell/components/__tests__/CodeMirror.test.ts
@@ -66,23 +66,6 @@ describe('component: CodeMirror.vue', () => {
       expect(closeIcon.element).toBeDefined();
     });
 
-    it(`should show keyMap close icon on mouse over`, async() => {
-      await wrapper.vm.$nextTick();
-
-      let keyMapBox = wrapper.find('[data-testid="code-mirror-keymap"]');
-
-      keyMapBox.trigger('mouseenter');
-      await wrapper.vm.$nextTick();
-
-      const closeIcon = keyMapBox.find('.icon-close');
-
-      expect(closeIcon.element).toBeDefined();
-
-      keyMapBox = wrapper.find('[data-testid="code-mirror-keymap"]');
-
-      expect(keyMapBox.element.className).toContain('.tooltip-open');
-    });
-
     it(`should remove keyMap box`, async() => {
       await wrapper.vm.$nextTick();
 

--- a/shell/components/__tests__/CodeMirror.test.ts
+++ b/shell/components/__tests__/CodeMirror.test.ts
@@ -59,23 +59,28 @@ describe('component: CodeMirror.vue', () => {
       await wrapper.vm.$nextTick();
 
       const keyMapBox = wrapper.find('[data-testid="code-mirror-keymap"]');
-      const closeIcon = keyMapBox.find('.icon');
+      const keyboardIcon = keyMapBox.find('.keymap-indicator');
+      const closeIcon = keyMapBox.find('.icon-close');
 
-      expect(keyMapBox.element.textContent).toContain('Vim');
-      expect(closeIcon.element).toBeUndefined();
+      expect(keyboardIcon.element).toBeDefined();
+      expect(closeIcon.element).toBeDefined();
     });
 
     it(`should show keyMap close icon on mouse over`, async() => {
       await wrapper.vm.$nextTick();
 
-      const keyMapBox = wrapper.find('[data-testid="code-mirror-keymap"]');
+      let keyMapBox = wrapper.find('[data-testid="code-mirror-keymap"]');
 
-      keyMapBox.trigger('mouseover');
+      keyMapBox.trigger('mouseenter');
       await wrapper.vm.$nextTick();
 
-      const closeIcon = keyMapBox.find('.icon');
+      const closeIcon = keyMapBox.find('.icon-close');
 
       expect(closeIcon.element).toBeDefined();
+
+      keyMapBox = wrapper.find('[data-testid="code-mirror-keymap"]');
+
+      expect(keyMapBox.element.className).toContain('.tooltip-open');
     });
 
     it(`should remove keyMap box`, async() => {
@@ -83,10 +88,10 @@ describe('component: CodeMirror.vue', () => {
 
       let keyMapBox = wrapper.find('[data-testid="code-mirror-keymap"]');
 
-      keyMapBox.trigger('mouseover');
+      keyMapBox.trigger('mouseenter');
       await wrapper.vm.$nextTick();
 
-      const closeIcon = keyMapBox.find('.icon');
+      const closeIcon = keyMapBox.find('.icon-close');
 
       closeIcon.element.click();
       await wrapper.vm.$nextTick();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11092

This PR fixes the above issue.

Instead of always showing the current keyboard mapping overlay on the yaml editor, we only show it when set to something other that the default (i.e. Emacs or Vim). The default is called 'Norman Human', so showing it just looks weird.

When shown now, the display has been changed to only show an icon with a tooltip, so that even when shown, it is less intrusive.

Was:

![image](https://github.com/rancher/dashboard/assets/1955897/1358f492-d271-47fb-a391-bc60fbbaddf9)

Now:

![image](https://github.com/rancher/dashboard/assets/1955897/28e4f97a-1a26-436b-813f-1f5b13779140)

With the exiting UI/UX, the close icon appears and the label jolts as a result. With this change, subtle animations have been applied to make this is a nicer transition that is less jarry.

### Areas or cases that should be tested

Automated tests are included.

Video before:
![Keyboard_mapping_existing](https://github.com/rancher/dashboard/assets/1955897/9828f7f2-3af6-4559-807e-ac4a57ba94a2)

Video with this change:
![Keyboard_mapping_new](https://github.com/rancher/dashboard/assets/1955897/5bd9deea-b56a-4fc4-a494-e5537b44cc5d)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
