### PR TITLE
Remove version number from side nav and update app bar to show it instead

### DIFF
--- a/cypress/e2e/po/components/version-number.po.ts
+++ b/cypress/e2e/po/components/version-number.po.ts
@@ -1,0 +1,16 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class VersionNumberPo extends ComponentPo {
+
+  checkVersion(version: string) {
+    return this.self().should('contain.text', version);
+  }
+
+  checkNormalText() {
+    return this.self().should('not.have.class', 'version-small');
+  }
+
+  checkSmallText() {
+    return this.self().should('have.class', 'version-small');
+  }
+}

--- a/cypress/e2e/po/components/version-number.po.ts
+++ b/cypress/e2e/po/components/version-number.po.ts
@@ -1,7 +1,6 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class VersionNumberPo extends ComponentPo {
-
   checkVersion(version: string) {
     return this.self().should('contain.text', version);
   }

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -1,4 +1,5 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import VersionNumberPo from '~/cypress/e2e/po/components/version-number.po';
 
 export default class ProductNavPo extends ComponentPo {
   constructor() {
@@ -55,5 +56,12 @@ export default class ProductNavPo extends ComponentPo {
    */
   tabHeaders(): Cypress.Chainable {
     return this.self().find('.header');
+  }
+
+  /**
+   * Get version number
+   */
+  version() {
+    return new VersionNumberPo('.side-menu .version');
   }
 }

--- a/cypress/e2e/tests/pages/generic/version.spec.ts
+++ b/cypress/e2e/tests/pages/generic/version.spec.ts
@@ -1,0 +1,69 @@
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+
+function interceptAndChangeVersion(version) {
+  return cy.intercept('GET', '/v1/management.cattle.io.settings?exclude=metadata.managedFields', (req) => {
+    req.continue((res) => {
+      console.log(res.body);
+
+      const serverVersion = res.body.data.find((setting) => setting.id === 'server-version');
+
+      serverVersion.value = version;
+    });
+  });
+}
+
+describe('App Bar Version Number', { testIsolation: 'off', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+  const nav = new ProductNavPo();
+
+  before(() => {
+    cy.login();
+  });
+
+  it('app bar shows version number', () => {
+    HomePagePo.goTo();
+
+    nav.version().checkExists();
+    nav.version().checkVisible();
+  });
+
+  it('app bar shows short version number', () => {
+    interceptAndChangeVersion('v2.9.0');
+    HomePagePo.goTo();
+
+    nav.version().checkExists();
+    nav.version().checkVisible();
+    nav.version().checkVersion('v2.9');
+    nav.version().checkNormalText();
+  });
+
+  it('app bar shows full version number', () => {
+    interceptAndChangeVersion('v2.9.1');
+    HomePagePo.goTo();
+
+    nav.version().checkExists();
+    nav.version().checkVisible();
+    nav.version().checkVersion('v2.9.1');
+    nav.version().checkNormalText();
+  });
+
+  it('app bar shows "About" for dev version', () => {
+    interceptAndChangeVersion('12345678');
+    HomePagePo.goTo();
+
+    nav.version().checkExists();
+    nav.version().checkVisible();
+    nav.version().checkVersion('About');
+    nav.version().checkNormalText();
+  });
+
+  it('app bar uses smaller text for longer version', () => {
+    interceptAndChangeVersion('v2.10.11');
+    HomePagePo.goTo();
+
+    nav.version().checkExists();
+    nav.version().checkVisible();
+    nav.version().checkVersion('v2.10.11');
+    nav.version().checkSmallText();
+  });     
+});

--- a/cypress/e2e/tests/pages/generic/version.spec.ts
+++ b/cypress/e2e/tests/pages/generic/version.spec.ts
@@ -4,8 +4,6 @@ import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 function interceptAndChangeVersion(version) {
   return cy.intercept('GET', '/v1/management.cattle.io.settings?exclude=metadata.managedFields', (req) => {
     req.continue((res) => {
-      console.log(res.body);
-
       const serverVersion = res.body.data.find((setting) => setting.id === 'server-version');
 
       serverVersion.value = version;
@@ -65,5 +63,5 @@ describe('App Bar Version Number', { testIsolation: 'off', tags: ['@generic', '@
     nav.version().checkVisible();
     nav.version().checkVersion('v2.10.11');
     nav.version().checkSmallText();
-  });     
+  });
 });

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -433,7 +433,7 @@ export default {
       >
         {{ displayVersion }}
       </span>
-      
+
       <!-- locale selector -->
       <span v-if="isSingleProduct">
         <v-popover
@@ -549,7 +549,7 @@ export default {
     .version {
       cursor: default;
       margin: 0 10px 10px 10px;
-    }    
+    }
 
     .footer {
       margin: 20px;
@@ -575,7 +575,7 @@ export default {
       .version {
         cursor: default;
         margin: 0px;
-      }      
+      }
 
       .locale-chooser {
         cursor: pointer;

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -433,7 +433,7 @@ export default {
       >
         {{ displayVersion }}
       </span>
-
+      
       <!-- locale selector -->
       <span v-if="isSingleProduct">
         <v-popover
@@ -478,7 +478,6 @@ export default {
         {{ displayVersion }}
       </router-link>
       <template v-else>
-        <span>{{ displayVersion }}</span>
         <span
           v-if="isVirtualCluster && isExplorer"
           v-tooltip="{content: harvesterVersion, placement: 'top'}"
@@ -550,7 +549,7 @@ export default {
     .version {
       cursor: default;
       margin: 0 10px 10px 10px;
-    }
+    }    
 
     .footer {
       margin: 20px;
@@ -576,7 +575,7 @@ export default {
       .version {
         cursor: default;
         margin: 0px;
-      }
+      }      
 
       .locale-chooser {
         cursor: pointer;

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -280,6 +280,21 @@ export default {
       return getProductFromRoute(this.$route);
     },
 
+    aboutText() {
+      // If a version number (starts with 'v') then use that
+      if (this.displayVersion.startsWith('v')) {
+        // Don't show the '.0' for a minor release (e.g. 2.8.0, 2.9.0 etc)
+        return !this.displayVersion.endsWith('.0') ? this.displayVersion : this.displayVersion.substr(0, this.displayVersion.length - 2);
+      }
+
+      // Default fallback to 'About'
+      return this.t('about.title');
+    },
+
+    largeAboutText() {
+      return this.aboutText.length > 6;
+    }
+
     appBar() {
       let activeFound = false;
 
@@ -887,12 +902,13 @@ export default {
           </div>
           <div
             class="version"
+            :class="{'version-small': largeAboutText}"
             @click="hide()"
           >
             <router-link
               :to="{ name: 'about' }"
             >
-              {{ t('about.title') }}
+              {{ aboutText }}
             </router-link>
           </div>
         </div>
@@ -1379,14 +1395,19 @@ export default {
       }
 
       .footer {
-        margin: 20px 15px;
+        margin: 20px 10px;
+        width: 50px;
 
         .support {
           display: none;
         }
 
         .version{
-          text-align: left;
+          text-align: center;
+
+          &.version-small {
+            font-size: 12px;
+          }
         }
       }
     }

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -293,7 +293,7 @@ export default {
 
     largeAboutText() {
       return this.aboutText.length > 6;
-    }
+    },
 
     appBar() {
       let activeFound = false;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11137

This PR removes the version from the bottom of the side nav and replaces the 'About' text in the app bar with the version number.

### Technical notes summary

If the version number starts with 'v', we show that version - if it ends with '.0' - i.e. is a minor release, we remove that, so we show (e.g.) `v2.9`.

For development versions, we show 'About'

For long version numbers (e.g. `v2.10.11` we reduce the font size slightly so that it looks better) 

### Areas or cases that should be tested

Automated tests added for the cases above.

### Screenshot/Video

![image](https://github.com/rancher/dashboard/assets/1955897/efbfb5df-b09c-48bb-9f43-b18ee8a757b2)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
