### PR TITLE
Increase restart modal timeout to 5 seconds

### DIFF
--- a/shell/list/management.cattle.io.feature.vue
+++ b/shell/list/management.cattle.io.feature.vue
@@ -171,7 +171,7 @@ export default {
         } catch (e) {}
 
         this.waitForBackend(btnCB, id);
-      }, 2500);
+      }, 5000);
     },
 
     async saveUrl(btnCB) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This increases the timeout for the restart modal to 5 seconds. 

Fixes #11087
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

While troubleshooting this issue, I noticed that we were receiving a 200 response from the server before the Rancher backend finished restarting. It must be that the backend is taking longer to shutdown and responding to our request when it does so.

I'm not a fan of increasing the timeout to an arbitrary number, but this is the most straightforward approach to resolve the issue at this point. The obvious issue with this approach is that we will see the same regression in the future if the backend takes any longer to shut down.

I also considered that we might be able to implement a function that initially polls at a greater duration and then incrementally steps down the timeout for each successive attempt. This would give us the flexibility to increase our timeout to something larger to give us more certainty that the backend has stopped before we first polled. I think this refactoring would be out of scope for resolving this issue. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See the description in #11087

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

See the description in #11087

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
