### PR TITLE
Exclude kubewarden e2e test until it's possible to install extension again

### DIFF
--- a/cypress/e2e/po/lists/chart-repositories.po.ts
+++ b/cypress/e2e/po/lists/chart-repositories.po.ts
@@ -24,4 +24,8 @@ export default class ChartRepositoriesListPo extends BaseResourceList {
     return this.resourceTable().sortableTable().rowActionMenuOpen(repoName).getMenuItem('Refresh')
       .click();
   }
+
+  state(repoName: string) {
+    return this.resourceTable().sortableTable().rowWithName(repoName).column(1);
+  }
 }

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -71,7 +71,10 @@ export default class ExtensionsPagePo extends PagePo {
     appRepoCreate.gitBranch().set(branch);
 
     // save it
-    return appRepoCreate.saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos');
+    appRepoCreate.saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos');
+
+    appRepoList.waitForPage();
+    appRepoList.list().state(name).should('contain', 'Active');
   }
 
   // ------------------ extension card ------------------

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -7,7 +7,7 @@ import { catchTargetPageException } from '@/cypress/support/utils/exception-util
 
 const extensionName = 'kubewarden';
 
-describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => {
+describe('Kubewarden Extension', { tags: ['@extensions-temp-excluded', '@adminUser'] }, () => {
   before(() => {
     catchTargetPageException('Navigation cancelled');
     cy.login();


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes e2e tests

### Occurred changes and/or fixed issues
- Temporarily exclude the kubewarden extension test until it's possible to install extension (https://github.com/rancher/kubewarden-ui/pull/732 merged, new extension released
- also improve test to check the extension repo becomes active before looking for charts within

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
