### PR TITLE
Fix `Conditions` tab, and Fleet Cluster `Resources` column

### DIFF
--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -73,12 +73,13 @@ export default {
     const inStore = this.$store.getters['currentStore'](EVENT);
 
     return {
-      hasEvents:     this.$store.getters[`${ inStore }/schemaFor`](EVENT), // @TODO be smarter about which resources actually ever have events
-      allEvents:     [],
-      selectedTab:   this.defaultTab,
-      didLoadEvents: false,
-      extensionTabs: getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.RESOURCE_DETAIL, this.$route, this, this.extensionParams),
+      hasEvents:      this.$store.getters[`${ inStore }/schemaFor`](EVENT), // @TODO be smarter about which resources actually ever have events
+      allEvents:      [],
+      selectedTab:    this.defaultTab,
+      didLoadEvents:  false,
+      extensionTabs:  getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.RESOURCE_DETAIL, this.$route, this, this.extensionParams),
       inStore,
+      showConditions: false,
     };
   },
 
@@ -86,33 +87,13 @@ export default {
     this.$store.dispatch('cluster/forgetType', EVENT);
   },
 
+  fetch() {
+    // By this stage the `value` should be set. Taking a chance that this is true
+    // The alternative is have an expensive watch on the `value` and trigger there (as well)
+    this.setShowConditions();
+  },
+
   computed: {
-    /**
-     * Sync checks for showing the conditions tab
-     */
-    preShowConditions() {
-      return this.isView && this.needConditions && this.value?.type;
-    },
-
-    /**
-    * Conditions come from a resource's `status`. They are used by both core resources like workloads as well as those from CRDs
-    *
-    * Check here if the resource type contains conditions via the schema resourceFields
-    */
-    showConditions() {
-      if (!this.preShowConditions) {
-        return false;
-      }
-
-      if (!this.schema.hasResourceFields) {
-        console.warn('Schema does not contain resourceFields, unable to check for status.conditions'); // eslint-disable-line no-console
-
-        return false;
-      }
-
-      return this.$store.getters[`${ this.inStore }/pathExistsInSchema`](this.value.type, 'status.conditions');
-    },
-
     showEvents() {
       return this.isView && this.needEvents && this.hasEvents;
     },
@@ -184,7 +165,24 @@ export default {
           this.didLoadEvents = true;
         });
       }
-    }
+    },
+
+    /**
+    * Conditions come from a resource's `status`. They are used by both core resources like workloads as well as those from CRDs
+    * - Workloads
+    * - Nodes
+    * - Fleet git repo
+    * - Cluster (provisioning)
+    *
+    * Check here if the resource type contains conditions via the schema resourceFields
+    */
+    async setShowConditions() {
+      if (this.isView && this.needConditions && !!this.value?.type && !!this.schema?.fetchResourceFields) {
+        await this.schema.fetchResourceFields();
+
+        this.showConditions = this.$store.getters[`${ this.inStore }/pathExistsInSchema`](this.value.type, 'status.conditions');
+      }
+    },
   }
 };
 </script>

--- a/shell/components/formatter/FleetSummaryGraph.vue
+++ b/shell/components/formatter/FleetSummaryGraph.vue
@@ -3,6 +3,7 @@ import ProgressBarMulti from '@shell/components/ProgressBarMulti';
 import { ucFirst } from '@shell/utils/string';
 import { colorForState, stateSort } from '@shell/plugins/dashboard-store/resource-class';
 import { sortBy } from '@shell/utils/sort';
+import { FLEET } from '@shell/config/types';
 
 export default {
   components: { ProgressBarMulti },
@@ -32,7 +33,7 @@ export default {
     },
 
     show() {
-      return this.stateParts.length > 0 && this.row.targetClusters?.length;
+      return this.stateParts.length > 0 && (this.row.type === FLEET.CLUSTER || this.row.targetClusters?.length);
     },
 
     stateParts() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11154
Fixes #11155
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
1. Unreleased Regression - Ensure the Resource Tabs Conditions tab correctly shows
   - The `Conditions` tab shows when the resource's schema says the resource contains conditions
   - Following the schema diet change this info isn't in the base schema, so we need to fetch the resources schema definition
   - If not found we currently only print a warning to indicate the owning component needs to call `fetchResourceFields`. This was done to avoid making the request for every resource detail page. This resulted though in a number missed places (nodes, some fleet resources, etc)
   - To avoid this we'll now make the request to fetch schema definitions on every resource tabs usages (with some caveats)
2. Legacy broken feature - Fleet Cluster List `Resources` column failed to show the summary graph

### Areas or cases that should be tested
- Detail page for cluster, node, deployments and fleet fgit repo resources all show the Conditions
- Fleet Cluster List `Resources` column should show summary graph

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
  - @yonasberhe23 Will be covering automated tests separately 
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
