### PR TITLE
Fix duplicate list rows on resource create race condition

### DIFF
--- a/cypress/e2e/po/components/footer.po.ts
+++ b/cypress/e2e/po/components/footer.po.ts
@@ -1,0 +1,8 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+
+export default class FooterPo extends ComponentPo {
+  create() {
+    return new AsyncButtonPo(this.self().find('.buttons .right .role-primary'));
+  }
+}

--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -144,6 +144,13 @@ export default class SortableTablePo extends ComponentPo {
   }
 
   /**
+   * Get the row element count on sortable table
+   */
+  rowCount(): Cypress.Chainable<number> {
+    return this.rowElements().then((el) => el.length);
+  }
+
+  /**
    * Check row element count on sortable table
    * @param isEmpty true if empty state expected (empty state message should display on row 1)
    * @param expected number of rows shown

--- a/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po.ts
+++ b/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po.ts
@@ -6,6 +6,7 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import SelectOrCreateAuthPo from '@/cypress/e2e/po/components/select-or-create-auth.po';
+import FooterPo from '@/cypress/e2e/po/components/footer.po';
 
 /**
  * Covers core functionality that's common to the dashboard's import or create cluster pages
@@ -115,7 +116,7 @@ export default class AppClusterRepoEditPo extends PagePo {
   }
 
   create() {
-    return this.resourceDetail().createEditView().create();
+    return new FooterPo('[data-testid="clusterrepo-footer"]').create();
   }
 
   save() {

--- a/cypress/e2e/po/edit/chart-repositories.po.ts
+++ b/cypress/e2e/po/edit/chart-repositories.po.ts
@@ -53,7 +53,7 @@ export default class ChartRepositoriesCreateEditPo extends PagePo {
     return new SelectOrCreateAuthPo(selector);
   }
 
-  clusterrepoAuthSelectOrCreate() {
+  clusterRepoAuthSelectOrCreate() {
     return this.authSelectOrCreate('[data-testid="clusterrepo-auth-secret"]');
   }
 

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -3,6 +3,8 @@ import ChartRepositoriesPagePo from '@/cypress/e2e/po/pages/chart-repositories.p
 import * as path from 'path';
 import * as jsyaml from 'js-yaml';
 
+const chartBranch = 'release-v2.9';
+
 describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, () => {
   const repositoriesPage = new ChartRepositoriesPagePo(undefined, 'manager');
   const downloadsFolder = Cypress.config('downloadsFolder');
@@ -24,7 +26,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(1);
     repositoriesPage.createEditRepositories().gitRepoUrl().set('https://github.com/rancher/charts');
-    repositoriesPage.createEditRepositories().gitBranch().set('release-v2.8');
+    repositoriesPage.createEditRepositories().gitBranch().set(chartBranch);
     repositoriesPage.createEditRepositories().saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos').its('response.statusCode').should('eq', 201);
     repositoriesPage.waitForPage();
 
@@ -126,8 +128,8 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(1);
     repositoriesPage.createEditRepositories().gitRepoUrl().set('https://github.com/rancher/charts');
-    repositoriesPage.createEditRepositories().gitBranch().set('release-v2.8');
-    repositoriesPage.createEditRepositories().clusterrepoAuthSelectOrCreate().createBasicAuth('test', 'test');
+    repositoriesPage.createEditRepositories().gitBranch().set(chartBranch);
+    repositoriesPage.createEditRepositories().clusterRepoAuthSelectOrCreate().createBasicAuth('test', 'test');
     repositoriesPage.createEditRepositories().saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos');
     repositoriesPage.waitForPage();
 
@@ -145,8 +147,8 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(1);
     repositoriesPage.createEditRepositories().gitRepoUrl().set('https://github.com/rancher/charts');
-    repositoriesPage.createEditRepositories().gitBranch().set('release-v2.8');
-    repositoriesPage.createEditRepositories().clusterrepoAuthSelectOrCreate().createSSHAuth('privateKey', 'publicKey');
+    repositoriesPage.createEditRepositories().gitBranch().set(chartBranch);
+    repositoriesPage.createEditRepositories().clusterRepoAuthSelectOrCreate().createSSHAuth('privateKey', 'publicKey');
     repositoriesPage.createEditRepositories().saveAndWaitForRequests('POST', '/v1/catalog.cattle.io.clusterrepos');
     repositoriesPage.waitForPage();
 
@@ -207,7 +209,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(2);
     repositoriesPage.createEditRepositories().ociUrl().set(ociUrl);
-    repositoriesPage.createEditRepositories().clusterrepoAuthSelectOrCreate().createBasicAuth('test', 'test');
+    repositoriesPage.createEditRepositories().clusterRepoAuthSelectOrCreate().createBasicAuth('test', 'test');
 
     cy.intercept('POST', '/v1/catalog.cattle.io.clusterrepos').as('createRepository');
 

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -269,6 +269,7 @@ export default {
     />
 
     <Footer
+      data-testid="clusterrepo-footer"
       :mode="mode"
       :errors="errors"
       @save="save"

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -104,7 +104,9 @@ export function load(state, {
     // A specific proxy instance to used was passed in (for create -> save),
     // use it instead of making a new proxy
     entry = replaceResource(existing, data, getters);
-    addObject(cache.list, entry);
+    if (!cache.list.find((e) => e[keyField] === id)) {
+      addObject(cache.list, entry);
+    }
     cache.map.set(id, entry);
     // console.log('### Mutation added from existing proxy', type, id);
   } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11151
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Resources are added to our resource map & list on resource create and on socket updates
- When resources are created..
  - the http response is usually received first, and the resource is added to both resource map and list
  - any socket updates received afterwards will then update that first resource entry
- However there are scenarios where..
  - the http response is sent, but response not yet received
  - the socket event for the created resource is then received, and resource is added to resource map and list
  - the http response is then received. the load mutator would then ADD to the list and SET in the map
  - this caused two rows for the resource to show in it's list view
- Fix is to gate adding them to the list

Also contains
- General improvements for cypress/e2e/tests/pages/manager/repositories.spec.ts test
- Reliability improvements for cypress/e2e/tests/pages/fleet/gitrepo.spec.ts test

### Areas or cases that should be tested
- As per repo steps
- Random set of other resource creates

### Areas which could experience regressions
- Anywhere we create a resource

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
  - I haven't added e2e tests for this, as existing tests (specifically repositories.spec) will fail when it occurs. Given the reproduction steps (see issue) it'll need manual test as well
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
