### PR TITLE
Include Kubewarden extension tests

### DIFF
--- a/cypress/e2e/po/pages/extensions/kubewarden.po.ts
+++ b/cypress/e2e/po/pages/extensions/kubewarden.po.ts
@@ -1,5 +1,5 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
-// import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
+import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
 
 export default class KubewardenExtensionPo extends PagePo {
   private static createPath(clusterId: string) {
@@ -15,15 +15,15 @@ export default class KubewardenExtensionPo extends PagePo {
   }
 
   /** add ui-plugin-charts repository */
-  // addChartsRepoIfNeeded(): void {
-  //   const extensionsPo: ExtensionsPagePo = new ExtensionsPagePo();
+  addChartsRepoIfNeeded(): void {
+    const extensionsPo: ExtensionsPagePo = new ExtensionsPagePo();
 
-  //   extensionsPo.waitForPage();
+    extensionsPo.waitForPage();
 
-  //   cy.get('body').then(($body: any) => {
-  //     if ( $body.find('[data-testid="extension-card-kubewarden"]').length === 0 ) {
-  //       extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-charts', 'main', 'rancher-extensions');
-  //     }
-  //   });
-  // }
+    cy.get('body').then(($body: any) => {
+      if ( $body.find('[data-testid="extension-card-kubewarden"]').length === 0 ) {
+        extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-charts', 'main', 'rancher-extensions');
+      }
+    });
+  }
 }

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -7,18 +7,19 @@ import { catchTargetPageException } from '@/cypress/support/utils/exception-util
 
 const extensionName = 'kubewarden';
 
-describe('Kubewarden Extension', { tags: ['@extensions-temp-excluded', '@adminUser'] }, () => {
+describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => {
   before(() => {
     catchTargetPageException('Navigation cancelled');
     cy.login();
 
     const extensionsPo = new ExtensionsPagePo();
+    const kubewardenPo = new KubewardenExtensionPo();
 
     extensionsPo.goTo();
     extensionsPo.waitForPage();
 
     // install the ui-plugin-charts repo
-    extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-charts', 'main', 'rancher-extensions');
+    kubewardenPo.addChartsRepoIfNeeded();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the Kubewarden extension tests that were [excluded previously](https://github.com/rancher/dashboard/pull/11149) due to an incorrect Kubernetes version in the chart annotation of the extension.

The Kubernetes version has been updated in the [Kubewarden dashboard repo](https://github.com/rancher/kubewarden-ui/pull/732) and a release has been merged in the [`ui-plugin-charts` repo](https://github.com/rancher/ui-plugin-charts/pull/54)

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Removed the `-temp-excluded` tag kubewarden.spec.ts
- Replaced the `addChartsRepoIfNeeded` method from kubewarden page object
- Added wait to repository creation to ensure the repo is cached before continuing the tests.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![cypress](https://github.com/rancher/dashboard/assets/40806497/804c0437-4486-4e3e-b564-85ffafdbfee6)


### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
