### PR TITLE
Fixing a race condition with how we update/reset the title to "Rancher" if a page doesn't set the title.

### DIFF
--- a/shell/initialize/entry-helpers.js
+++ b/shell/initialize/entry-helpers.js
@@ -264,12 +264,8 @@ export async function mountApp(appPartials, VueClass) {
 
   // Add beforeEach router hooks
   router.beforeEach(render.bind(vueApp));
-  router.beforeEach((from, to, next) => {
-    if (from?.name !== to?.name) {
-      updatePageTitle(getVendor());
-    }
-
-    next();
+  router.afterEach((from, to) => {
+    updatePageTitle(getVendor());
   });
 
   // First render on client-side


### PR DESCRIPTION

### Summary
Fixing a race condition with how we update/reset the title to "Rancher" if a page doesn't set the title.

Specifically addresses this comment https://github.com/rancher/dashboard/issues/9822#issuecomment-2078169973

Fixes #9822
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Switched from a beforeEach to an afterEach routeGuard because sometimes we'd switch back to the 'Rancher' title before changing pages which would change the title the browser recorded in history.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
