### PR TITLE
Ingresses List warns pathExistsInSchema has been used without fetching the schema definition

### DIFF
--- a/cypress/e2e/po/pages/explorer/ingress.po.ts
+++ b/cypress/e2e/po/pages/explorer/ingress.po.ts
@@ -1,0 +1,44 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+
+export class IngressPagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/explorer/networking.k8s.io.ingress`;
+  }
+
+  urlPath(clusterId = 'local') {
+    return IngressPagePo.createPath(clusterId);
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(IngressPagePo.createPath(clusterId));
+  }
+
+  static navTo(clusterId = 'local') {
+    const burgerMenu = new BurgerMenuPo();
+    const sideNav = new ProductNavPo();
+
+    BurgerMenuPo.toggle();
+    burgerMenu.clusters().contains(clusterId).click();
+    sideNav.navToSideMenuGroupByLabel('Service Discovery');
+    sideNav.navToSideMenuEntryByLabel('Ingresses');
+  }
+
+  constructor(clusterId = 'local') {
+    super(IngressPagePo.createPath(clusterId));
+  }
+
+  list() {
+    return new BaseResourceList(this.self());
+  }
+
+  clickCreate() {
+    return this.list().masthead().create();
+  }
+
+  listElementWithName(name:string) {
+    return this.list().resourceTable().sortableTable().rowElementWithName(name);
+  }
+}

--- a/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
@@ -1,0 +1,25 @@
+import { IngressPagePo } from '@/cypress/e2e/po/pages/explorer/ingress.po';
+
+const ingressPagePo = new IngressPagePo();
+
+describe('ConfigMap', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('does not show console warning due to lack of secondary schemas needed to load data on list view', () => {
+    // pattern as per https://docs.cypress.io/faq/questions/using-cypress-faq#How-do-I-spy-on-consolelog
+    cy.visit(ingressPagePo.urlPath(), {
+      onBeforeLoad(win) {
+        cy.stub(win.console, 'warn').as('consoleWarn');
+      },
+    });
+
+    cy.title().should('eq', 'Rancher - local - Ingresses');
+
+    const warnMsg = "pathExistsInSchema requires schema networking.k8s.io.ingress to have resources fields via schema definition but none were found. has the schema 'fetchResourceFields' been called?";
+
+    // testing https://github.com/rancher/dashboard/issues/11086
+    cy.get('@consoleWarn').should('not.be.calledWith', warnMsg);
+  });
+});

--- a/shell/components/formatter/IngressTarget.vue
+++ b/shell/components/formatter/IngressTarget.vue
@@ -43,7 +43,7 @@ export default {
 
 <template>
   <div
-    v-if="value"
+    v-if="value && !$fetchState.pending"
     class="ingress-target"
     :reactivity="workloads.length"
   >

--- a/shell/list/networking.k8s.io.ingress.vue
+++ b/shell/list/networking.k8s.io.ingress.vue
@@ -1,0 +1,36 @@
+<script>
+import ResourceTable from '@shell/components/ResourceTable';
+import ResourceFetch from '@shell/mixins/resource-fetch';
+export default {
+  components: { ResourceTable },
+  mixins:     [ResourceFetch],
+  props:      {
+    resource: {
+      type:     String,
+      required: true,
+    },
+    schema: {
+      type:     Object,
+      required: true,
+    },
+    useQueryParamsForSimpleFiltering: {
+      type:    Boolean,
+      default: false
+    }
+  },
+  async fetch() {
+    // pathExistsInSchema requires schema networking.k8s.io.ingress to have resources fields via schema definition but none were found. has the schema 'fetchResourceFields' been called?
+    await Promise.all([this.schema.fetchResourceFields(), this.$fetchType(this.resource)]);
+  }
+};
+</script>
+
+<template>
+  <ResourceTable
+    :schema="schema"
+    :rows="rows"
+    :loading="loading"
+    :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+    :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
+  />
+</template>


### PR DESCRIPTION
 <!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11086 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add fix for missing secondary schemas in ingress list view
- add e2e test


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to `Ingress` list view and make sure we don't have the console warn related to `pathExistsInSchema`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Before**
<img width="2184" alt="before" src="https://github.com/rancher/dashboard/assets/97888974/58058f89-b369-476e-8dbe-29095be4433e">
**After**
<img width="2253" alt="after" src="https://github.com/rancher/dashboard/assets/97888974/73611cfe-0dfa-4197-bb75-474be421ca78">

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
