### PR TITLE
Storybook: Fix i18n

### DIFF
--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -20,6 +20,10 @@ module.exports = {
     buildStoriesJson: true, // 👈 Enable this to build the stories.json file
   },
 
+  core: {
+    disableTelemetry: true,
+  },
+
   staticDirs: [
     'public',
     '../../shell/assets'

--- a/storybook/.storybook/preview.js
+++ b/storybook/.storybook/preview.js
@@ -19,9 +19,11 @@ import growl from './store/growl';
 import codeMirror from './store/codeMirror';
 import table from './store/table';
 
+// i18n
+import i18n from '../../shell/plugins/i18n';
 
 // Register custom i18n plugin
-require('../../shell/plugins/i18n');
+Vue.use(i18n);
 
 Vue.use(Vuex);
 Vue.use(ShortKey, { prevent: ['input', 'textarea', 'select'] });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11171 

Fixes the way i18n is used in Storybook so that the pages are not broken.

Also disables telemetry.

Issue is marked as QA/None - PR reviewer to validate locally on built Storybook - this should be sufficient - this is for the Storybook, not code that makes it into the product UI.
