### PR TITLE
SAML SLO support

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -507,8 +507,9 @@ authConfig:
     UID: UID Field
     adfs: Configure an AD FS account
     api: '{vendor} API Host'
-    enableSlo: Enable Single-Sign Logout (SLO)
-    forceSlo: Force Single-Sign Logout (SLO)
+    sloTitle: Configure Single Logout (SLO)
+    enableSlo: Enable Single Logout
+    forceSlo: Force Single Logout
     cert:
       label: Certificate
       placeholder: Paste in the certificate, starting with -----BEGIN CERTIFICATE-----
@@ -4649,6 +4650,12 @@ promptScaleMachineDown:
   attemptingToRemove: "You are attempting to delete {count} {type}"
   retainedMachine1: At least one Machine must exist for roles Control Plane and Etcd.
   retainedMachine2: <b>{ name }</b> will remain
+
+promptSlo:
+  title: "{name} Single Logout"
+  text: "You have Single Logout enabled on { name } auth provider. Would you like to logout from Rancher or from all apps (including Rancher) that use { name }?"
+  rancher: Only Rancher
+  all: All apps
 
 promptRemove:
   title: Are you sure?

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3270,6 +3270,7 @@ login:
   welcome: Welcome to {vendor}
   loggedOut: You have been logged out.
   loggedOutFromSso: You've been logged out of Rancher, however you may still be logged in to your single sign-on identity provider.
+  loggedOutFromSlo: You've been logged out of Rancher and from your single sign-on identity provider.
   loginAgain: Log in again to continue.
   serverError:
     authFailedCreds: "Logging in failed: Check credentials, or your account may not be authorized to log in."

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -507,6 +507,8 @@ authConfig:
     UID: UID Field
     adfs: Configure an AD FS account
     api: '{vendor} API Host'
+    enableSlo: Enable Single-Sign Logout (SLO)
+    forceSlo: Force Single-Sign Logout (SLO)
     cert:
       label: Certificate
       placeholder: Paste in the certificate, starting with -----BEGIN CERTIFICATE-----

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3294,10 +3294,10 @@ login:
 
 logout:
   message: Logging Out...
-  failure: Unable to log out
-  serverError:
-    unknown: "An unknown error occurred while attempting to logout. Please contact your system administrator."
-    noResponse: "No response received"
+  error: 'An error occurred logging out: {msg}'
+  specificError:
+    unknown: Unknown.\n\nPlease contact your system administrator.
+    500: "Server-side error.\n\nPlease contact your system administrator."
 
 managementNode:
   customName: Custom Name

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -507,11 +507,11 @@ authConfig:
     UID: UID Field
     adfs: Configure an AD FS account
     api: '{vendor} API Host'
-    sloTitle: Log Out behaviour
+    sloTitle: Log Out behavior
     sloOptions:
-      onlyRancher: Only log out of Rancher
-      logoutAll: Log out of {name} (including Rancher and all other applications registered with the provider)
-      choose: Allow the user to choose in an extra step
+      onlyRancher: Log out of Rancher and not {name}
+      logoutAll: Log out of {name} (including Rancher and all other applications registered with {name})
+      choose: Allow the user to choose one of the above in an additional log out step
     cert:
       label: Certificate
       placeholder: Paste in the certificate, starting with -----BEGIN CERTIFICATE-----
@@ -4655,9 +4655,12 @@ promptScaleMachineDown:
 
 promptSlo:
   title: "Log out"
-  text: "Choose whether to log out of only Rancher, or all {name} applications."
-  rancher: Only log out of Rancher
-  all: Log out of {name}
+  text: "Log out of only Rancher, or all {name} applications."
+  rancher:
+    active: Only log out of Rancher
+  all:
+    active: Log out of {name}
+    waiting: Logging Out
 
 promptRemove:
   title: Are you sure?

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -507,8 +507,7 @@ authConfig:
     UID: UID Field
     adfs: Configure an AD FS account
     api: '{vendor} API Host'
-    sloTitle: Configure Single Logout (SLO)
-    logoutType: Log out mode
+    sloTitle: Log Out behaviour
     sloOptions:
       onlyRancher: Only log out of Rancher
       logoutAll: Log out of {name} (including Rancher and all other applications registered with the provider)

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -508,8 +508,11 @@ authConfig:
     adfs: Configure an AD FS account
     api: '{vendor} API Host'
     sloTitle: Configure Single Logout (SLO)
-    enableSlo: Enable Single Logout
-    forceSlo: Force Single Logout
+    logoutType: Log out mode
+    sloOptions:
+      onlyRancher: Only log out of Rancher
+      logoutAll: Log out of {name} (including Rancher and all other applications registered with the provider)
+      choose: Allow the user to choose in an extra step
     cert:
       label: Certificate
       placeholder: Paste in the certificate, starting with -----BEGIN CERTIFICATE-----
@@ -4652,10 +4655,10 @@ promptScaleMachineDown:
   retainedMachine2: <b>{ name }</b> will remain
 
 promptSlo:
-  title: "{name} Single Logout"
-  text: "You have Single Logout enabled on { name } auth provider. Would you like to logout from Rancher or from all apps (including Rancher) that use { name }?"
-  rancher: Only Rancher
-  all: All apps
+  title: "Log out"
+  text: "Choose whether to log out of only Rancher, or all {name} applications."
+  rancher: Only log out of Rancher
+  all: Log out of {name}
 
 promptRemove:
   title: Are you sure?

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -510,7 +510,7 @@ authConfig:
     sloTitle: Log Out behavior
     sloOptions:
       onlyRancher: Log out of Rancher and not {name}
-      logoutAll: Log out of {name} (including Rancher and all other applications registered with {name})
+      logoutAll: Log out of Rancher and {name} (includes all other applications registered with {name})
       choose: Allow the user to choose one of the above in an additional log out step
     cert:
       label: Certificate
@@ -3294,6 +3294,10 @@ login:
 
 logout:
   message: Logging Out...
+  failure: Unable to log out
+  serverError:
+    unknown: "An unknown error occurred while attempting to logout. Please contact your system administrator."
+    noResponse: "No response received"
 
 managementNode:
   customName: Custom Name

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import debounce from 'lodash/debounce';
-import { NORMAN, STEVE } from '@shell/config/types';
+import { NORMAN, STEVE, MANAGEMENT } from '@shell/config/types';
 import { ucFirst } from '@shell/utils/string';
 import { isAlternate, isMac } from '@shell/utils/platform';
 import Import from '@shell/components/Import';
@@ -20,7 +20,7 @@ import { ActionLocation, ExtensionPoint } from '@shell/core/types';
 import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
 import IconOrSvg from '@shell/components/IconOrSvg';
 import { wait } from '@shell/utils/async';
-import { authProvidersInfo } from '@shell/utils/auth';
+import { authProvidersInfo, parseAuthProvidersInfo } from '@shell/utils/auth';
 
 export default {
 
@@ -45,7 +45,8 @@ export default {
   },
 
   async fetch() {
-    this.authInfo = await authProvidersInfo(this.$store, true);
+    // fetch needed data to check if any auth provider is enabled
+    authProvidersInfo(this.$store);
   },
 
   data() {
@@ -73,8 +74,11 @@ export default {
       'currentProduct', 'rootProduct', 'backToRancherLink', 'backToRancherGlobalLink', 'pageActions', 'isSingleProduct', 'isRancherInHarvester', 'showTopLevelMenu']),
 
     authProviderEnabled() {
-      if (this.authInfo.enabled?.length) {
-        return this.authInfo.enabled[0];
+      const authProviders = this.$store.getters['management/all'](MANAGEMENT.AUTH_CONFIG);
+      const authInfo = parseAuthProvidersInfo(authProviders);
+
+      if (authInfo.enabled?.length) {
+        return authInfo.enabled[0];
       }
 
       return {};

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -45,8 +45,7 @@ export default {
   },
 
   async fetch() {
-    // TODO: this needs to be a getter in order to be reactive since the Header is always present on the UI....
-    this.authInfo = await authProvidersInfo(this.$store);
+    this.authInfo = await authProvidersInfo(this.$store, true);
   },
 
   data() {

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -81,6 +81,11 @@ export default {
     },
 
     shouldShowSloLogoutModal() {
+      if (this.isAuthLocalProvider) {
+        // If the user logged in as a local user... they cannot log out as if they were an auth config user
+        return false;
+      }
+
       const {
         logoutAllSupported, logoutAllEnabled, logoutAllForced, configType
       } = this.authProviderEnabled;

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -44,7 +44,7 @@ export default {
     }
   },
 
-  async fetch() {
+  fetch() {
     // fetch needed data to check if any auth provider is enabled
     authProvidersInfo(this.$store);
   },
@@ -77,11 +77,7 @@ export default {
       const authProviders = this.$store.getters['management/all'](MANAGEMENT.AUTH_CONFIG);
       const authInfo = parseAuthProvidersInfo(authProviders);
 
-      if (authInfo.enabled?.length) {
-        return authInfo.enabled[0];
-      }
-
-      return {};
+      return authInfo.enabled?.[0] || {};
     },
 
     shouldShowSloLogoutModal() {
@@ -240,7 +236,7 @@ export default {
       this.$store.dispatch('management/promptModal', {
         component:      'SloDialog',
         componentProps: { authProvider: this.authProviderEnabled },
-        modalWidth:     '450px'
+        modalWidth:     '500px'
       });
     },
     // Sizes the product area of the header such that it shrinks to ensure the whole header bar can be shown

--- a/shell/components/templates/home.vue
+++ b/shell/components/templates/home.vue
@@ -9,6 +9,7 @@ import AzureWarning from '@shell/components/auth/AzureWarning';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 import Inactivity from '@shell/components/Inactivity';
 import { mapState, mapGetters } from 'vuex';
+import PromptModal from '@shell/components/PromptModal';
 
 export default {
 
@@ -18,7 +19,8 @@ export default {
     GrowlManager,
     AzureWarning,
     AwsComplianceBanner,
-    Inactivity
+    Inactivity,
+    PromptModal
   },
 
   mixins: [Brand, BrowserTabVisibility],
@@ -55,7 +57,7 @@ export default {
     <Inactivity />
     <AwsComplianceBanner />
     <AzureWarning />
-
+    <PromptModal />
     <div
       class="dashboard-content"
       :class="{'dashboard-padding-left': showTopLevelMenu}"

--- a/shell/components/templates/plain.vue
+++ b/shell/components/templates/plain.vue
@@ -13,6 +13,7 @@ import AzureWarning from '@shell/components/auth/AzureWarning';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 import Inactivity from '@shell/components/Inactivity';
 import { mapGetters } from 'vuex';
+import PromptModal from '@shell/components/PromptModal';
 
 export default {
 
@@ -22,6 +23,7 @@ export default {
     Header,
     IndentedPanel,
     PromptRemove,
+    PromptModal,
     FixedBanner,
     GrowlManager,
     AwsComplianceBanner,
@@ -75,6 +77,7 @@ export default {
         </IndentedPanel>
         <ActionMenu />
         <PromptRemove />
+        <PromptModal />
         <AssignTo />
         <button
           v-if="themeShortcut"

--- a/shell/config/query-params.js
+++ b/shell/config/query-params.js
@@ -7,6 +7,7 @@ export const SETUP = 'setup';
 export const STEP = 'step';
 export const LOGGED_OUT = 'logged-out';
 export const IS_SSO = 'is-sso';
+export const IS_SLO = 'is-slo';
 export const UPGRADED = 'upgraded';
 export const TIMED_OUT = 'timed-out';
 export const AUTH_TEST = 'test';

--- a/shell/dialog/SloDialog.vue
+++ b/shell/dialog/SloDialog.vue
@@ -49,12 +49,11 @@ export default {
     class="prompt-remove"
     :show-highlight-border="false"
   >
-    <h4
-      slot="title"
-      class="text-default-text"
-    >
-      {{ t('promptSlo.title', { name }) }}
-    </h4>
+    <template #title>
+      <h4 class="text-default-text">
+        {{ t('promptSlo.title', { name }) }}
+      </h4>
+    </template>
     <div
       slot="body"
       class="pl-10 pr-10 mt-20 mb-20"

--- a/shell/dialog/SloDialog.vue
+++ b/shell/dialog/SloDialog.vue
@@ -1,8 +1,10 @@
 <script>
 import { Card } from '@components/Card';
+import AsyncButton from '@shell/components/AsyncButton';
+import { IS_SSO, LOGGED_OUT } from '@shell/config/query-params';
 
 export default {
-  components: { Card },
+  components: { Card, AsyncButton },
 
   props: {
     authProvider: {
@@ -21,16 +23,23 @@ export default {
     async doLogout(logoutAll = false) {
       const options = { force: true, provider: this.authProvider };
 
-      // Single Sign Logout for SAML
       if (logoutAll) {
+        // SLO - Single Log Out
         options.slo = true;
         options.provider = this.authProvider;
+
+        await this.$store.dispatch('auth/logout', options, { root: true });
+
+        this.$emit('close');
+      } else {
+        // Rancher Log Out (ensure we show the logging out page as per standard log out)
+        this.$router.replace({ name: 'auth-logout', query: { [LOGGED_OUT]: true, [IS_SSO]: true } });
       }
-
-      this.$emit('close');
-
-      await this.$store.dispatch('auth/logout', options, { root: true });
     },
+
+    cancel() {
+      this.$emit('close');
+    }
   }
 };
 </script>
@@ -55,18 +64,24 @@ export default {
     <template #actions>
       <div class="btn-block">
         <button
-          class="btn role-secondary mr-10"
-          @click="doLogout()"
+          class="btn role-secondary"
+          @click="cancel()"
         >
-          {{ t('promptSlo.rancher') }}
+          {{ t('generic.cancel') }}
         </button>
         <div class="spacer" />
         <button
-          class="btn ml-10 btn role-primary"
-          @click="doLogout(true)"
+          class="btn role-secondary"
+          @click="doLogout()"
         >
-          {{ t('promptSlo.all', { name }) }}
+          {{ t('promptSlo.rancher.active') }}
         </button>
+        <AsyncButton
+          class="ml-10"
+          :action-label="t('promptSlo.all.active', { name })"
+          :waiting-label="t('promptSlo.all.waiting')"
+          @click="doLogout(true)"
+        />
       </div>
     </template>
   </Card>

--- a/shell/dialog/SloDialog.vue
+++ b/shell/dialog/SloDialog.vue
@@ -1,0 +1,79 @@
+<script>
+import { Card } from '@components/Card';
+
+export default {
+  components: { Card },
+
+  props: {
+    authProvider: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  computed: {
+    name() {
+      return this.authProvider?.nameDisplay;
+    }
+  },
+
+  methods: {
+    async doLogout(logoutAll = false) {
+      const options = { force: true };
+
+      if (logoutAll) {
+        options.slo = true;
+      }
+
+      this.$emit('close');
+      await this.$store.dispatch('auth/logout', { force: true, slo: true }, { root: true });
+    },
+  }
+};
+</script>
+
+<template>
+  <Card
+    class="prompt-remove"
+    :show-highlight-border="false"
+  >
+    <h4
+      slot="title"
+      class="text-default-text"
+    >
+      {{ t('promptSlo.title', { name }) }}
+    </h4>
+    <div
+      slot="body"
+      class="pl-10 pr-10 mt-20 mb-20"
+    >
+      {{ t('promptSlo.text', { name }) }}
+    </div>
+    <template #actions>
+      <div class="btn-block">
+        <button
+          class="btn role-secondary mr-10"
+          @click="doLogout()"
+        >
+          {{ t('promptSlo.rancher') }}
+        </button>
+        <div class="spacer" />
+        <button
+          class="btn ml-10 btn role-primary"
+          @click="doLogout(true)"
+        >
+          {{ t('promptSlo.all') }}
+        </button>
+      </div>
+    </template>
+  </Card>
+</template>
+
+<style lang='scss' scoped>
+  .btn-block {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    padding: 0;
+  }
+</style>

--- a/shell/dialog/SloDialog.vue
+++ b/shell/dialog/SloDialog.vue
@@ -19,20 +19,17 @@ export default {
 
   methods: {
     async doLogout(logoutAll = false) {
-      const options = { force: true };
+      const options = { force: true, provider: this.authProvider };
 
+      // Single Sign Logout for SAML
       if (logoutAll) {
         options.slo = true;
+        options.provider = this.authProvider;
       }
 
       this.$emit('close');
 
-      await this.$store.dispatch('auth/logout',
-        {
-          force:    true,
-          slo:      true,
-          provider: this.authProvider
-        }, { root: true });
+      await this.$store.dispatch('auth/logout', options, { root: true });
     },
   }
 };
@@ -68,7 +65,7 @@ export default {
           class="btn ml-10 btn role-primary"
           @click="doLogout(true)"
         >
-          {{ t('promptSlo.all') }}
+          {{ t('promptSlo.all', { name }) }}
         </button>
       </div>
     </template>

--- a/shell/dialog/SloDialog.vue
+++ b/shell/dialog/SloDialog.vue
@@ -54,12 +54,11 @@ export default {
         {{ t('promptSlo.title', { name }) }}
       </h4>
     </template>
-    <div
-      slot="body"
-      class="pl-10 pr-10 mt-20 mb-20"
-    >
-      {{ t('promptSlo.text', { name }) }}
-    </div>
+    <template #body>
+      <div class="pl-10 pr-10 mt-20 mb-20">
+        {{ t('promptSlo.text', { name }) }}
+      </div>
+    </template>
     <template #actions>
       <div class="btn-block">
         <button

--- a/shell/dialog/SloDialog.vue
+++ b/shell/dialog/SloDialog.vue
@@ -26,7 +26,13 @@ export default {
       }
 
       this.$emit('close');
-      await this.$store.dispatch('auth/logout', { force: true, slo: true }, { root: true });
+
+      await this.$store.dispatch('auth/logout',
+        {
+          force:    true,
+          slo:      true,
+          provider: this.authProvider
+        }, { root: true });
     },
   }
 };

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -11,7 +11,6 @@ import FileSelector from '@shell/components/form/FileSelector';
 import AuthBanner from '@shell/components/auth/AuthBanner';
 import config from '@shell/edit/auth/ldap/config';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
-import { configType } from '@shell/models/management.cattle.io.authconfig';
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 
 export const SHIBBOLETH = 'shibboleth';

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -78,8 +78,8 @@ export default {
       };
     },
 
-    isSamlProvider() {
-      return configType[this.model?.id] === 'saml';
+    isLogoutAllSupported() {
+      return this.model?.logoutAllSupported;
     },
 
     sloOptions() {
@@ -186,8 +186,8 @@ export default {
             <tr><td>{{ t(`authConfig.saml.entityID`) }}: </td><td>{{ model.entityID }}</td></tr>
             <tr><td>{{ t(`authConfig.saml.api`) }}: </td><td>{{ model.rancherApiHost }}</td></tr>
             <tr><td>{{ t(`authConfig.saml.groups`) }}: </td><td>{{ model.groupsField }}</td></tr>
-            <tr v-if="isSamlProvider">
-              <td>{{ t(`authConfig.saml.logoutType`) }}: </td><td>{{ sloTypeText }}</td>
+            <tr v-if="isLogoutAllSupported">
+              <td>{{ t(`authConfig.saml.sloTitle`) }}: </td><td>{{ sloTypeText }}</td>
             </tr>
           </template>
 
@@ -362,7 +362,7 @@ export default {
 
         <!-- SLO logout -->
         <div
-          v-if="isSamlProvider"
+          v-if="isLogoutAllSupported"
           class="mt-10 mb-30"
         >
           <div class="row">

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -124,7 +124,7 @@ export default {
     sloType(neu) {
       switch (neu) {
       case SLO_OPTION_VALUES.rancher:
-        this.$set(this.model, 'logoutAllEnabled', false);
+        this.model.logoutAllEnabled = false;
         this.$set(this.model, 'logoutAllForced', false);
         break;
       case SLO_OPTION_VALUES.all:

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -1,7 +1,7 @@
 <script>
 import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
-import AuthConfig from '@shell/mixins/auth-config';
+import AuthConfig, { SLO_OPTION_VALUES } from '@shell/mixins/auth-config';
 import CruResource from '@shell/components/CruResource';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { Checkbox } from '@components/Form/Checkbox';
@@ -15,12 +15,6 @@ import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 
 export const SHIBBOLETH = 'shibboleth';
 export const OKTA = 'okta';
-
-const SLO_OPTION_VALUES = {
-  rancher: 'rancher',
-  all:     'all',
-  both:    'both',
-};
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {
@@ -63,8 +57,7 @@ export default {
   data() {
     return {
       showLdap:        false,
-      showLdapDetails: false,
-      sloOptionValues: SLO_OPTION_VALUES
+      showLdapDetails: false
     };
   },
 
@@ -83,7 +76,7 @@ export default {
 
     sloOptions() {
       return [
-        { value: SLO_OPTION_VALUES.rancher, label: this.t('authConfig.saml.sloOptions.onlyRancher') },
+        { value: SLO_OPTION_VALUES.rancher, label: this.t('authConfig.saml.sloOptions.onlyRancher', { name: this.model?.nameDisplay }) },
         { value: SLO_OPTION_VALUES.all, label: this.t('authConfig.saml.sloOptions.logoutAll', { name: this.model?.nameDisplay }) },
         { value: SLO_OPTION_VALUES.both, label: this.t('authConfig.saml.sloOptions.choose') },
       ];
@@ -92,11 +85,7 @@ export default {
     sloTypeText() {
       const sloOptionSelected = this.sloOptions.find((item) => item.value === this.sloType);
 
-      if (sloOptionSelected) {
-        return sloOptionSelected.label;
-      }
-
-      return '';
+      return sloOptionSelected?.label || '';
     },
 
     toSave() {

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -11,6 +11,7 @@ import FileSelector from '@shell/components/form/FileSelector';
 import AuthBanner from '@shell/components/auth/AuthBanner';
 import config from '@shell/edit/auth/ldap/config';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
+import { configType } from '@shell/models/management.cattle.io.authconfig';
 
 export const SHIBBOLETH = 'shibboleth';
 export const OKTA = 'okta';
@@ -66,6 +67,10 @@ export default {
         provider: this.displayName,
         username: this.principal.loginName || this.principal.name,
       };
+    },
+
+    isSamlProvider() {
+      return configType[this.model?.id] === 'saml';
     },
 
     toSave() {
@@ -142,8 +147,12 @@ export default {
             <tr><td>{{ t(`authConfig.saml.entityID`) }}: </td><td>{{ model.entityID }}</td></tr>
             <tr><td>{{ t(`authConfig.saml.api`) }}: </td><td>{{ model.rancherApiHost }}</td></tr>
             <tr><td>{{ t(`authConfig.saml.groups`) }}: </td><td>{{ model.groupsField }}</td></tr>
-            <tr><td>{{ t(`authConfig.saml.enableSlo`) }}: </td><td>{{ model.logoutAllEnabled }}</td></tr>
-            <tr><td>{{ t(`authConfig.saml.forceSlo`) }}: </td><td>{{ model.logoutAllForced }}</td></tr>
+            <tr v-if="isSamlProvider">
+              <td>{{ t(`authConfig.saml.enableSlo`) }}: </td><td>{{ model.logoutAllEnabled }}</td>
+            </tr>
+            <tr v-if="isSamlProvider">
+              <td>{{ t(`authConfig.saml.forceSlo`) }}: </td><td>{{ model.logoutAllForced }}</td>
+            </tr>
           </template>
 
           <template
@@ -316,29 +325,39 @@ export default {
         </div>
 
         <!-- SLO logout -->
-        <div class="row mb-20">
-          <div class="col span-4">
-            <Checkbox
-              v-model="model.logoutAllEnabled"
-              :mode="mode"
-              :disabled="!model.logoutAllSupported"
-              :label="t('authConfig.saml.enableSlo')"
-            />
+        <div
+          v-if="isSamlProvider"
+          class="mt-10 mb-30"
+        >
+          <div class="row">
+            <div class="col span-12">
+              <h3>{{ t('authConfig.saml.sloTitle') }}</h3>
+            </div>
           </div>
-          <div class="col span-4">
-            <Checkbox
-              v-model="model.logoutAllForced"
-              :mode="mode"
-              :disabled="!model.logoutAllSupported || !model.logoutAllEnabled"
-              :label="t('authConfig.saml.forceSlo')"
-            />
+          <div class="row">
+            <div class="col span-4">
+              <Checkbox
+                v-model="model.logoutAllEnabled"
+                :mode="mode"
+                :disabled="!model.logoutAllSupported"
+                :label="t('authConfig.saml.enableSlo')"
+              />
+            </div>
+            <div class="col span-4">
+              <Checkbox
+                v-model="model.logoutAllForced"
+                :mode="mode"
+                :disabled="!model.logoutAllSupported || !model.logoutAllEnabled"
+                :label="t('authConfig.saml.forceSlo')"
+              />
+            </div>
           </div>
         </div>
 
         <!-- LDAP search -->
         <div v-if="supportsLDAPSearch">
           <div class="row">
-            <h2>{{ t('authConfig.saml.search.title') }}</h2>
+            <h3>{{ t('authConfig.saml.search.title') }}</h3>
           </div>
           <div class="row">
             <Banner

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -99,6 +99,11 @@ export default {
         // Use a spread of config, so that if don't make changes to the defaults if the user edits them
         this.$set(this.model, 'openLdapConfig', { ...LDAP_DEFAULTS });
       }
+    },
+    'model.logoutAllEnabled'(neu) {
+      if (!neu && this.model.logoutAllForced) {
+        this.$set(this.model, 'logoutAllForced', false);
+      }
     }
   }
 };
@@ -137,6 +142,8 @@ export default {
             <tr><td>{{ t(`authConfig.saml.entityID`) }}: </td><td>{{ model.entityID }}</td></tr>
             <tr><td>{{ t(`authConfig.saml.api`) }}: </td><td>{{ model.rancherApiHost }}</td></tr>
             <tr><td>{{ t(`authConfig.saml.groups`) }}: </td><td>{{ model.groupsField }}</td></tr>
+            <tr><td>{{ t(`authConfig.saml.enableSlo`) }}: </td><td>{{ model.logoutAllEnabled }}</td></tr>
+            <tr><td>{{ t(`authConfig.saml.forceSlo`) }}: </td><td>{{ model.logoutAllForced }}</td></tr>
           </template>
 
           <template
@@ -197,6 +204,7 @@ export default {
         />
 
         <h3>{{ t(`authConfig.saml.${NAME}`) }}</h3>
+
         <div class="row mb-20">
           <div class="col span-6">
             <LabeledInput
@@ -234,6 +242,7 @@ export default {
             />
           </div>
         </div>
+
         <div class="row mb-20">
           <div
             v-if="NAME === 'keycloak' || NAME === 'ping'"
@@ -305,6 +314,28 @@ export default {
             />
           </div>
         </div>
+
+        <!-- SLO logout -->
+        <div class="row mb-20">
+          <div class="col span-4">
+            <Checkbox
+              v-model="model.logoutAllEnabled"
+              :mode="mode"
+              :disabled="!model.logoutAllSupported"
+              :label="t('authConfig.saml.enableSlo')"
+            />
+          </div>
+          <div class="col span-4">
+            <Checkbox
+              v-model="model.logoutAllForced"
+              :mode="mode"
+              :disabled="!model.logoutAllSupported || !model.logoutAllEnabled"
+              :label="t('authConfig.saml.forceSlo')"
+            />
+          </div>
+        </div>
+
+        <!-- LDAP search -->
         <div v-if="supportsLDAPSearch">
           <div class="row">
             <h2>{{ t('authConfig.saml.search.title') }}</h2>

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -102,9 +102,6 @@ export default {
         this.showLdap = true;
       }
       if (this.value.configType === 'saml') {
-        // TODO: TO BE DELETED!!!!
-        this.$set(this.model, 'logoutAllSupported', true);
-
         if (!this.model.rancherApiHost || !this.model.rancherApiHost.length) {
           this.$set(this.model, 'rancherApiHost', this.serverUrl);
         }

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -7,6 +7,21 @@ import { set } from '@shell/utils/object';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import difference from 'lodash/difference';
 
+export const SLO_OPTION_VALUES = {
+  /**
+   * Log out of only rancher, leaving auth provider logged in
+   */
+  rancher: 'rancher',
+  /**
+   * Log out of rancher AND auth provider
+   */
+  all:     'all',
+  /**
+   * Offer user chose of `rancher` or `all`
+   */
+  both:    'both',
+};
+
 export default {
   beforeCreate() {
     const { query } = this.$route;
@@ -106,14 +121,14 @@ export default {
           this.$set(this.model, 'rancherApiHost', this.serverUrl);
         }
 
-        // setting data for SLO in SAML providers
+        // setting data for SLO
         if (this.model && Object.keys(this.model).includes('logoutAllSupported')) {
           if (!this.model.logoutAllEnabled && !this.model.logoutAllForced) {
-            this.sloType = this.sloOptionValues.rancher;
+            this.sloType = SLO_OPTION_VALUES.rancher;
           } else if (this.model.logoutAllEnabled && this.model.logoutAllForced) {
-            this.sloType = this.sloOptionValues.all;
+            this.sloType = SLO_OPTION_VALUES.all;
           } else if (this.model.logoutAllEnabled && !this.model.logoutAllForced) {
-            this.sloType = this.sloOptionValues.both;
+            this.sloType = SLO_OPTION_VALUES.both;
           }
         }
       }

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -30,6 +30,7 @@ export default {
       originalModel:  null,
       principals:     [],
       authConfigName: this.$route.params.id,
+      sloType:        '',
     };
   },
 
@@ -101,17 +102,24 @@ export default {
         this.showLdap = true;
       }
       if (this.value.configType === 'saml') {
+        // TODO: TO BE DELETED!!!!
+        this.$set(this.model, 'logoutAllSupported', true);
+
         if (!this.model.rancherApiHost || !this.model.rancherApiHost.length) {
           this.$set(this.model, 'rancherApiHost', this.serverUrl);
         }
+
+        // setting data for SLO in SAML providers
+        if (this.model && Object.keys(this.model).includes('logoutAllSupported')) {
+          if (!this.model.logoutAllEnabled && !this.model.logoutAllForced) {
+            this.sloType = this.sloOptionValues.rancher;
+          } else if (this.model.logoutAllEnabled && this.model.logoutAllForced) {
+            this.sloType = this.sloOptionValues.all;
+          } else if (this.model.logoutAllEnabled && !this.model.logoutAllForced) {
+            this.sloType = this.sloOptionValues.both;
+          }
+        }
       }
-
-      // TODO: TO BE DELETED!!!!
-      this.$set(this.model, 'logoutAllSupported', true);
-      // this.$set(this.model, 'logoutAllEnabled', false);
-      // this.$set(this.model, 'logoutAllForced', false);
-
-      console.log('MODEL', this.model);
 
       if (!this.model.enabled) {
         this.applyDefaults();

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -106,10 +106,10 @@ export default {
         }
       }
 
-      // TO BE DELETED!!!!
+      // TODO: TO BE DELETED!!!!
       this.$set(this.model, 'logoutAllSupported', true);
-      this.$set(this.model, 'logoutAllEnabled', false);
-      this.$set(this.model, 'logoutAllForced', false);
+      // this.$set(this.model, 'logoutAllEnabled', false);
+      // this.$set(this.model, 'logoutAllForced', false);
 
       console.log('MODEL', this.model);
 

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -106,6 +106,13 @@ export default {
         }
       }
 
+      // TO BE DELETED!!!!
+      this.$set(this.model, 'logoutAllSupported', true);
+      this.$set(this.model, 'logoutAllEnabled', false);
+      this.$set(this.model, 'logoutAllForced', false);
+
+      console.log('MODEL', this.model);
+
       if (!this.model.enabled) {
         this.applyDefaults();
       }

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -65,6 +65,16 @@ export default {
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
 
+    loggedOutSuccessMsg() {
+      if (this.isSlo) {
+        return this.t('login.loggedOutFromSlo');
+      } else if (this.isSsoLogout) {
+        return this.t('login.loggedOutFromSso');
+      }
+
+      return this.t('login.loggedOut');
+    },
+
     singleProvider() {
       return this.providers.length === 1 ? this.providers[0] : undefined;
     },
@@ -324,7 +334,7 @@ export default {
             v-else-if="loggedOut"
             class="text-success text-center"
           >
-            {{ isSsoLogout ? t('login.loggedOutFromSso') : t('login.loggedOut') }}
+            {{ loggedOutSuccessMsg }}
           </h4>
           <h4
             v-else-if="timedOut"

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -9,7 +9,8 @@ import InfoBox from '@shell/components/InfoBox';
 import CopyCode from '@shell/components/CopyCode';
 import { Banner } from '@components/Banner';
 import {
-  LOCAL, LOGGED_OUT, TIMED_OUT, IS_SSO, _FLAGGED
+  LOCAL, LOGGED_OUT, TIMED_OUT, IS_SSO, _FLAGGED,
+  IS_SLO
 } from '@shell/config/query-params';
 import { Checkbox } from '@components/Form/Checkbox';
 import Password from '@shell/components/form/Password';
@@ -47,6 +48,7 @@ export default {
       timedOut:           this.$route.query[TIMED_OUT] === _FLAGGED,
       loggedOut:          this.$route.query[LOGGED_OUT] === _FLAGGED,
       isSsoLogout:        this.$route.query[IS_SSO] === _FLAGGED,
+      isSlo:              this.$route.query[IS_SLO] === _FLAGGED,
       err:                this.$route.query.err,
       showLocaleSelector: !process.env.loginLocaleSelector || process.env.loginLocaleSelector === 'true',
 
@@ -78,6 +80,10 @@ export default {
     },
 
     errorMessage() {
+      if (this.isSlo) {
+        return this.err?.length ? this.t('logout.error', { msg: this.err }) : '';
+      }
+
       if (this.err === LOGIN_ERRORS.CLIENT_UNAUTHORIZED) {
         return this.t('login.clientError');
       } else if (this.err === LOGIN_ERRORS.CLIENT || this.err === LOGIN_ERRORS.SERVER) {

--- a/shell/pages/auth/logout.vue
+++ b/shell/pages/auth/logout.vue
@@ -14,7 +14,9 @@ export default {
 
       if (configType === 'saml' && logoutAllSupported && logoutAllEnabled && logoutAllForced) {
         // SAML - force SLO (logout from all apps)
-        await this.$store.dispatch('auth/logout', { force: true, slo: true }, { root: true });
+        await this.$store.dispatch('auth/logout', {
+          force: true, slo: true, provider: authProvider
+        }, { root: true });
       } else {
         // simple logout
         await this.$store.dispatch('auth/logout', { force: true }, { root: true });

--- a/shell/pages/auth/logout.vue
+++ b/shell/pages/auth/logout.vue
@@ -1,8 +1,28 @@
 <script>
+import { authProvidersInfo } from '@shell/utils/auth';
 
 export default {
   async fetch() {
-    await this.$store.dispatch('auth/logout', { force: true }, { root: true });
+    const authInfo = await authProvidersInfo(this.$store);
+
+    if (authInfo.enabled?.length) {
+      const authProvider = authInfo.enabled[0];
+
+      const {
+        logoutAllSupported, logoutAllEnabled, logoutAllForced, configType
+      } = authProvider;
+
+      if (configType === 'saml' && logoutAllSupported && logoutAllEnabled && logoutAllForced) {
+        // SAML - force SLO (logout from all apps)
+        await this.$store.dispatch('auth/logout', { force: true, slo: true }, { root: true });
+      } else {
+        // simple logout
+        await this.$store.dispatch('auth/logout', { force: true }, { root: true });
+      }
+    } else {
+      // simple logout
+      await this.$store.dispatch('auth/logout', { force: true }, { root: true });
+    }
   }
 };
 </script>

--- a/shell/pages/auth/verify.vue
+++ b/shell/pages/auth/verify.vue
@@ -30,16 +30,13 @@ export default {
     const stateStr = this.$route.query[GITHUB_NONCE];
     const isSlo = this.$route.query[IS_SLO];
 
-    console.log('VERIFY route', this.$route);
-    console.log('VERIFY route query', this.$route.query);
-    console.log('VERIFY isSlo', isSlo);
-
     const {
       error, error_description: errorDescription, errorCode, errorMsg
     } = this.$route.query;
 
+    // check for existance of IS_SLO query param to
+    // differenciate between a login and a logout
     if (isSlo) {
-      console.error('IS SLO!!!');
       this.$store.dispatch('auth/uiLogout');
 
       return;
@@ -123,7 +120,6 @@ export default {
   },
 
   mounted() {
-    console.error('MOUNTED VERIFY!');
     if ( this.testing ) {
       try {
         const {

--- a/shell/pages/auth/verify.vue
+++ b/shell/pages/auth/verify.vue
@@ -1,5 +1,5 @@
 <script>
-import { GITHUB_CODE, GITHUB_NONCE, BACK_TO } from '@shell/config/query-params';
+import { GITHUB_CODE, GITHUB_NONCE, BACK_TO, IS_SLO } from '@shell/config/query-params';
 import { get } from '@shell/utils/object';
 import { base64Decode } from '@shell/utils/crypto';
 import loadPlugins from '@shell/plugins/plugin';
@@ -28,9 +28,22 @@ export default {
   async fetch() {
     const code = this.$route.query[GITHUB_CODE];
     const stateStr = this.$route.query[GITHUB_NONCE];
+    const isSlo = this.$route.query[IS_SLO];
+
+    console.log('VERIFY route', this.$route);
+    console.log('VERIFY route query', this.$route.query);
+    console.log('VERIFY isSlo', isSlo);
+
     const {
       error, error_description: errorDescription, errorCode, errorMsg
     } = this.$route.query;
+
+    if (isSlo) {
+      console.error('IS SLO!!!');
+      this.$store.dispatch('auth/uiLogout');
+
+      return;
+    }
 
     if (error || errorDescription || errorCode || errorMsg) {
       let out = errorDescription || error || errorCode;
@@ -110,6 +123,7 @@ export default {
   },
 
   mounted() {
+    console.error('MOUNTED VERIFY!');
     if ( this.testing ) {
       try {
         const {

--- a/shell/pages/auth/verify.vue
+++ b/shell/pages/auth/verify.vue
@@ -60,7 +60,7 @@ export default {
       }
     }
 
-    // check for existance of IS_SLO query param to differenciate between a login and a logout
+    // check for existence of IS_SLO query param to differentiate between a login and a logout
     if (this.isSlo) {
       this.$store.dispatch('auth/uiLogout');
 

--- a/shell/pages/auth/verify.vue
+++ b/shell/pages/auth/verify.vue
@@ -129,10 +129,9 @@ export default {
 
     const { test } = parsed;
 
-    /**
-     * Is Single Log Out
-     */
-    const isSlo = this.$route.query[IS_SLO];
+    // Is Single Log Out
+    // support just `is-slo` with no value
+    const isSlo = Object.keys(this.$route.query).includes(IS_SLO) && this.$route.query[IS_SLO] !== false;
 
     return {
       testing: test,

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -1,7 +1,6 @@
 <script>
 import { CAPI, MANAGEMENT } from '@shell/config/types';
 import AsyncButton from '@shell/components/AsyncButton';
-import PromptModal from '@shell/components/PromptModal';
 import { downloadFile } from '@shell/utils/download';
 import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/utils/cluster';
 import { sortBy } from '@shell/utils/sort';
@@ -9,7 +8,7 @@ import { sortBy } from '@shell/utils/sort';
 export default {
   name: 'Diagnostic',
 
-  components: { AsyncButton, PromptModal },
+  components: { AsyncButton },
 
   async fetch() {
     const provClusters = await this.$store.dispatch('management/findAll', { type: CAPI.RANCHER_CLUSTER });
@@ -391,8 +390,6 @@ export default {
         </table>
       </div>
     </div>
-
-    <PromptModal />
   </div>
 </template>
 

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -7,11 +7,12 @@ import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
+import PromptModal from '@shell/components/PromptModal';
 
 export default {
 
   components: {
-    BrandImage, FixedBanner, GrowlManager, Header
+    BrandImage, FixedBanner, GrowlManager, Header, PromptModal
   },
   mixins: [Brand, BrowserTabVisibility],
 
@@ -59,6 +60,7 @@ export default {
 <template>
   <div class="dashboard-root">
     <FixedBanner :header="true" />
+    <PromptModal />
     <div
       class="dashboard-content"
       :class="{'dashboard-padding-left': showTopLevelMenu}"

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -373,15 +373,12 @@ export const actions = {
     await rootState.$plugin.logout();
 
     let logoutAction = 'logout';
-    let finalRedirectUrl;
     const data = {};
 
     // SLO - Single-sign logout - will logout auth provider from all places where it's logged in
     if (options.slo) {
       logoutAction = 'logoutAll';
-      finalRedirectUrl = returnTo({ isSlo: true }, this);
-
-      data.finalRedirectUrl = finalRedirectUrl;
+      data.finalRedirectUrl = returnTo({ isSlo: true }, this);
     }
 
     try {

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -324,8 +324,6 @@ export const actions = {
   async login({ dispatch }, { provider, body }) {
     const driver = await dispatch('getAuthProvider', provider);
 
-    console.log('LOGIN BODY', body);
-
     try {
       const res = await driver.doAction('login', {
         description:  'UI session',
@@ -354,9 +352,7 @@ export const actions = {
     dispatch('onLogout', null, { root: true });
   },
 
-  async logout({
-    dispatch, commit, getters, rootState
-  }, options = {}) {
+  async logout({ dispatch, getters, rootState }, options = {}) {
     // So, we only do this check if auth has been initialized.
     //
     // It's possible to be logged in and visit auth/logout directly instead
@@ -383,17 +379,10 @@ export const actions = {
     // SLO - Single-sign logout - will logout auth provider from all places where it's logged in
     if (options.slo) {
       logoutAction = 'logoutAll';
-
-      // finalRedirectUrl = returnTo({
-      //   config: 'okta', route: '/auth/login', isSlo: true
-      // }, this);
-
       finalRedirectUrl = returnTo({ isSlo: true }, this);
 
       data.finalRedirectUrl = finalRedirectUrl;
     }
-
-    console.log('finalRedirectUrl', finalRedirectUrl);
 
     try {
       const res = await dispatch('rancher/request', {
@@ -404,13 +393,8 @@ export const actions = {
         redirectUnauthorized: false,
       }, { root: true });
 
-      console.log('LOGOUT RES', res);
-      console.log('LOGOUT RES idpRedirectUrl', res.idpRedirectUrl);
-      // debugger;
-
       // Single-sign logout for SAML providers that allow for it
       if (res.baseType === 'samlConfigLogoutOutput' && res.idpRedirectUrl) {
-        console.error('SLO REDIRECT here...', res.idpRedirectUrl);
         window.location.href = res.idpRedirectUrl;
 
         return;

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -374,14 +374,20 @@ export const actions = {
     // Unload plugins - we will load again on login
     await rootState.$plugin.logout();
 
+    // SLO - Single-sign logout - will logout auth provider from all places where it's logged in
+    const logoutAction = options.slo ? 'logoutAll' : 'logout';
+
     try {
       const res = await dispatch('rancher/request', {
-        url:                  '/v3/tokens?action=logout',
+        url:                  `/v3/tokens?action=${ logoutAction }`,
         method:               'post',
         data:                 {},
         headers:              { 'Content-Type': 'application/json' },
         redirectUnauthorized: false,
       }, { root: true });
+
+      console.log('LOGOUT RES', res);
+      // debugger;
 
       // Single-sign logout for SAML providers that allow for it
       if (res.body.type === 'samlConfigLogoutOutput' && res.body.idpRedirectUrl) {

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -410,6 +410,7 @@ export const actions = {
 
       // Single-sign logout for SAML providers that allow for it
       if (res.baseType === 'samlConfigLogoutOutput' && res.idpRedirectUrl) {
+        console.error('SLO REDIRECT here...', res.idpRedirectUrl);
         window.location.href = res.idpRedirectUrl;
 
         return;

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -2,7 +2,7 @@ import { BACK_TO } from '@shell/config/local-storage';
 import { setBrand, setVendor } from '@shell/config/private-label';
 import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import {
-  LOGGED_OUT, IS_SSO, TIMED_OUT, UPGRADED, _FLAGGED
+  LOGGED_OUT, IS_SSO, IS_SLO, TIMED_OUT, UPGRADED, _FLAGGED
 } from '@shell/config/query-params';
 import { SETTING } from '@shell/config/settings';
 import {
@@ -1160,6 +1160,9 @@ export const actions = {
 
       // adds IS_SSO query param to login route if logout came with an auth provider enabled
       QUERY += (IS_SSO in route.query) ? `&${ IS_SSO }` : '';
+
+      // adds IS_SLO query param to login route if logout came with an auth provider with Single Logout enabled
+      QUERY += (IS_SLO in route.query) ? `&${ IS_SLO }` : '';
 
       // Go back to login and force a full page reload, this ensures we unload any dangling resources the user is no longer authorized to use (like extensions).
       // We use document instead of router because router does a clunky job of visiting a new page and reloading. In this case it would cause the login page to flash before actually reloading.

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -70,17 +70,16 @@ export function returnTo(opt, vm) {
 /**
  * Determines common auth provider info as those that are available (non-local) and the location of the enabled provider
  */
-export const authProvidersInfo = async(store, addGetter = false) => {
-  let rows;
+export const authProvidersInfo = async(store) => {
+  const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
 
-  if (!addGetter) {
-    rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
-  } else {
-    // optionally add the getter to make this reactive to changes where needed
-    await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
-    rows = store.getters['management/all'](MANAGEMENT.AUTH_CONFIG);
-  }
+  return parseAuthProvidersInfo(rows);
+};
 
+/**
+ * Parses auth provider's info to return if there's an auth provider enabled
+ */
+export function parseAuthProvidersInfo(rows) {
   const nonLocal = rows.filter((x) => x.name !== 'local');
   const enabled = nonLocal.filter((x) => x.enabled === true );
 
@@ -97,7 +96,7 @@ export const authProvidersInfo = async(store, addGetter = false) => {
     enabledLocation,
     enabled
   };
-};
+}
 
 export const checkSchemasForFindAllHash = (types, store) => {
   const hash = {};

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -66,8 +66,17 @@ export function returnTo(opt, vm) {
 /**
  * Determines common auth provider info as those that are available (non-local) and the location of the enabled provider
  */
-export const authProvidersInfo = async(store) => {
-  const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
+export const authProvidersInfo = async(store, addGetter = false) => {
+  let rows;
+
+  if (!addGetter) {
+    rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
+  } else {
+    // optionally add the getter to make this reactive to changes where needed
+    await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
+    rows = store.getters['management/all'](MANAGEMENT.AUTH_CONFIG);
+  }
+
   const nonLocal = rows.filter((x) => x.name !== 'local');
   const enabled = nonLocal.filter((x) => x.enabled === true );
 

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -1,7 +1,7 @@
 import { Popup, popupWindowOptions } from '@shell/utils/window';
 import { parse as parseUrl, addParam } from '@shell/utils/url';
 import {
-  BACK_TO, SPA, _EDIT, _FLAGGED, TIMED_OUT
+  BACK_TO, SPA, _EDIT, _FLAGGED, TIMED_OUT, IS_SLO
 } from '@shell/config/query-params';
 import { MANAGEMENT, NORMAN } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
@@ -58,6 +58,10 @@ export function returnTo(opt, vm) {
 
   if (opt.config) {
     returnToUrl = addParam(returnToUrl, 'config', opt.config);
+  }
+
+  if (opt.isSlo) {
+    returnToUrl = addParam(returnToUrl, IS_SLO, _FLAGGED);
   }
 
   return returnToUrl;

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -71,9 +71,13 @@ export function returnTo(opt, vm) {
  * Determines common auth provider info as those that are available (non-local) and the location of the enabled provider
  */
 export const authProvidersInfo = async(store) => {
-  const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
+  try {
+    const rows = await store.dispatch(`management/findAll`, { type: MANAGEMENT.AUTH_CONFIG });
 
-  return parseAuthProvidersInfo(rows);
+    return parseAuthProvidersInfo(rows);
+  } catch (error) {
+    return {};
+  }
 };
 
 /**

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -1,7 +1,7 @@
 import { Popup, popupWindowOptions } from '@shell/utils/window';
 import { parse as parseUrl, addParam } from '@shell/utils/url';
 import {
-  BACK_TO, SPA, _EDIT, _FLAGGED, TIMED_OUT, IS_SLO
+  BACK_TO, SPA, _EDIT, _FLAGGED, TIMED_OUT, IS_SLO, LOGGED_OUT
 } from '@shell/config/query-params';
 import { MANAGEMENT, NORMAN } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
@@ -62,6 +62,7 @@ export function returnTo(opt, vm) {
 
   if (opt.isSlo) {
     returnToUrl = addParam(returnToUrl, IS_SLO, _FLAGGED);
+    returnToUrl = addParam(returnToUrl, LOGGED_OUT, _FLAGGED);
   }
 
   return returnToUrl;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10941 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- update SAML auth provider edit/create interface to account for setting up this new log out behaviour config
- add dialog to Header component so that user can choose log out type based on the auth provider config (will only appear if `logoutAllEnabled` && `! logoutAllForced`)
- add `PromptModal` to the `home` template so that the user can get the logout modal while browsing pages that use `home` template
- update logout action in `auth` store to account for a different logout action
- various adjustments in order to have the logout flow running in all scenarios (`normal logout` and `logout ALL`)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

To whoever is the reviewer of this PR, some notes on what each file's responsibility are:

`nav/Header.vue` -> where logout modal was added (if `logoutAllEnabled` && `! logoutAllForced`, then by clicking on the logout button, we'll get a modal to select type of logout)
`templates/home.vue` -> we were missing the `PromptModal`, so we wouldn't get the logout modal on the home screen
`SloDialog` -> actual logout modal added
`edit/auth/saml.vue` -> where the new inputs were added to setup the logout behaviour
`mixins/auth-config` -> where we handle the parsing of the model for the radio option selected in the UI for the log out behaviour. Since the mixin is responsible for fetching the necessary data, the parsing needs to be done here and not in `edit/saml.vue`
`auth/logout.vue` -> responsible for handling logout IF we aren't in a logout modal scenario (if `logoutAllForced` then we perform the logout ALL and no modal was triggered. That dispatches the logout action with different params, hence the code adjustment)
`auth/verify` -> where we handle the redirect from logout in case of a logout ALL. Still haven't been able to test this part at this point in time. Might need some adjustments here to do final "plumbing" of the whole logout cycle
`store/auth.js` - > where actual logout "action" to the backend get's triggered. logout ALL has a different logout `action` when calling the `/v3/tokens` endpoint, hence the adjustments needed
`utils/auth.js` -> helper methods. Had to add `IS_SLO` as param in the `returnTo` method so that we can differenciate a logout from a login in `auth/verify`


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Was only able to validate the whole logout cycle using Okta. Follow our docs in order to setup Okta (doc `Okta SAML setup Creation`)
- in `Users & Authentication` -> `Auth Provider` -> select `Okta` and setup everything according to the previously mentioned document. Set Log out behaviour to `Allow the user to choose in an extra step` to get access to the logout modal and therefore test both scenarios
- Should do a "normal logout" (Rancher logout only) with no problems
- Should do a "logout from ALL" (logout from all Okta apps) with no problems

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Test both normal and auth provider logins, just to be on the safe side (changes to `auth/verify`)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="2274" alt="Screenshot 2024-06-11 at 11 25 46" src="https://github.com/rancher/dashboard/assets/97888974/4becdc75-5666-4647-a594-6c0ef3ffe7b2">
<img width="2274" alt="Screenshot 2024-06-11 at 11 25 51" src="https://github.com/rancher/dashboard/assets/97888974/ec14ba21-9ba7-4dc8-84a5-42afe450cc08">
<img width="2274" alt="Screenshot 2024-06-10 at 14 53 15" src="https://github.com/rancher/dashboard/assets/97888974/3555994e-fe8e-49fc-b300-90f1df54c20f">



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
