### PR TITLE
Fix default values for exponentialBackOffValues

### DIFF
--- a/cypress/e2e/po/edit/chart-repositories.po.ts
+++ b/cypress/e2e/po/edit/chart-repositories.po.ts
@@ -37,6 +37,14 @@ export default class ChartRepositoriesCreateEditPo extends PagePo {
     return LabeledInputPo.byLabel(this.self(), 'OCI Repository Host URL');
   }
 
+  ociMinWaitInput() {
+    return new LabeledInputPo('[data-testid="clusterrepo-oci-min-wait-input"]');
+  }
+
+  ociMaxWaitInput() {
+    return new LabeledInputPo('[data-testid="clusterrepo-oci-max-wait-input"]');
+  }
+
   authentication(): LabeledSelectPo {
     return new LabeledSelectPo('.vs__dropdown-toggle');
   }

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -204,12 +204,19 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.create();
     repositoriesPage.createEditRepositories().waitForPage();
     const ociUrl = 'oci://test.rancher.io/charts/mychart';
+    const ociMinWait = '2';
+    const expectedOciMinWaitInPayload = 2;
+    const ociMaxWait = '7';
 
     repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.repoName);
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().repoRadioBtn().set(2);
     repositoriesPage.createEditRepositories().ociUrl().set(ociUrl);
     repositoriesPage.createEditRepositories().clusterRepoAuthSelectOrCreate().createBasicAuth('test', 'test');
+    repositoriesPage.createEditRepositories().ociMinWaitInput().set(ociMinWait);
+    // setting a value and removing it so in the intercept we test that the key(e.g. maxWait) is not included in the request
+    repositoriesPage.createEditRepositories().ociMaxWaitInput().set(ociMaxWait);
+    repositoriesPage.createEditRepositories().ociMaxWaitInput().clear();
 
     cy.intercept('POST', '/v1/catalog.cattle.io.clusterrepos').as('createRepository');
 
@@ -218,6 +225,8 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     cy.wait('@createRepository', { requestTimeout: 10000 }).then((req) => {
       expect(req.response?.statusCode).to.equal(201);
       expect(req.request?.body?.spec.url).to.equal(ociUrl);
+      expect(req.request?.body?.spec.exponentialBackOffValues.minWait).to.equal(expectedOciMinWaitInPayload);
+      expect(req.request?.body?.spec.exponentialBackOffValues.maxWait).to.equal(undefined);
       // insecurePlainHttp should always be included in the payload for oci repo creation
       expect(req.request?.body?.spec.insecurePlainHttp).to.equal(false);
     });

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -61,45 +61,54 @@ export default {
       // reset input fields when switching options
       switch (clusterRepoType) {
       case CLUSTER_REPO_TYPES.GIT_REPO:
-        Vue.set(this.value.spec, 'url', '');
-        Vue.set(this.value.spec, 'clientSecret', null);
         this.resetOciValues();
+        this.resetHelmValues();
         break;
       case CLUSTER_REPO_TYPES.OCI_URL:
-        Vue.set(this.value.spec, 'url', '');
         // set insecurePlainHttp to false as a secondary flag, alongside checking for 'oci://' in the URL, to determine OCI type later
         Vue.set(this.value.spec, 'insecurePlainHttp', false);
-        Vue.set(this.value.spec, 'gitRepo', '');
-        Vue.set(this.value.spec, 'clientSecret', null);
-        if (!!this.value.spec.gitBranch) {
-          Vue.set(this.value.spec, 'gitBranch', '');
-        }
+        this.resetGitRepoValues();
+        this.resetHelmValues();
         break;
       case CLUSTER_REPO_TYPES.HELM_URL:
-        Vue.set(this.value.spec, 'url', '');
-        Vue.set(this.value.spec, 'gitRepo', '');
-        Vue.set(this.value.spec, 'clientSecret', null);
         this.resetOciValues();
-        if (!!this.value.spec.gitBranch) {
-          Vue.set(this.value.spec, 'gitBranch', '');
-        }
+        this.resetGitRepoValues();
         break;
       }
+      this.resetClientSecret();
     },
     updateExponentialBackOffValues(key, newVal) {
       if (!Object.prototype.hasOwnProperty.call(this.value.spec, 'exponentialBackOffValues')) {
         Vue.set(this.value.spec, 'exponentialBackOffValues', {});
       }
+      // when user removes the value we remove the key too, backend will set the default value
+      if (newVal === '') {
+        Vue.delete(this.value.spec.exponentialBackOffValues, key);
+
+        return;
+      }
+
       Vue.set(this.value.spec.exponentialBackOffValues, key, Number(newVal));
     },
+    resetGitRepoValues() {
+      Vue.delete(this.value.spec, 'gitRepo');
+      Vue.delete(this.value.spec, 'gitBranch');
+    },
     resetOciValues() {
+      Vue.delete(this.value.spec, 'url');
       Vue.delete(this.value.spec, 'insecurePlainHttp');
       Vue.delete(this.value.spec, 'insecureSkipTLSVerify');
       Vue.delete(this.value.spec, 'caBundle');
-      Vue.set(this.value.spec, 'exponentialBackOffValues', {});
+      Vue.delete(this.value.spec, 'exponentialBackOffValues');
       this.ociMinWait = undefined;
       this.ociMaxWait = undefined;
       this.ociMaxRetries = undefined;
+    },
+    resetHelmValues() {
+      Vue.delete(this.value.spec, 'url');
+    },
+    resetClientSecret() {
+      Vue.set(this.value.spec, 'clientSecret', null);
     }
   },
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11123 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The main fix for this issue is done by the backend in [this PR](https://github.com/rancher/rancher/pull/45672), but there were some issues on the UI side too, such as sending unnecessary data to the backend e.g. sending `gitRepo: ''` when creating a helm/oci repos. Also setting a value for any inputs of `exponentialBackOffValues` and then clearing it was leading to send `0` which is fixed in this PR.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Added an E2E test to type a value for `exponentialBackOffValues` and then clearing it to check that the key of that input(e.g. `maxWait`) is not sent in the payload.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Creating git/helm repos should be checked just in case if the removal of some unnecessary data in the payload might have caused a regression. The current automation could be sufficient enough probably?

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
