### PR TITLE
Trying forcing the Cypress binary install due to erros in CI

### DIFF
--- a/cypress/jenkins/cypress.sh
+++ b/cypress/jenkins/cypress.sh
@@ -13,7 +13,9 @@ kubectl get nodes
 node -v
 yarn add --dev -W mocha mochawesome mochawesome-merge \
   mochawesome-report-generator cypress-multi-reporters \
-  mocha-junit-reporter 
+  mocha-junit-reporter
+
+./node_modules/.bin/cypress install --force
 
 NO_COLOR=1 CYPRESS_grepTags="CYPRESSTAGS" cypress run --browser chrome \
   --reporter cypress-multi-reporters \


### PR DESCRIPTION
### Summary
Fixes CI

### Occurred changes and/or fixed issues
Fixing cypress not found on tests running on 2.7

### Technical notes summary
this will force cypress to be installed before executing

### Areas or cases that should be tested
Jenkins

