### PR TITLE
Add support for Individual banner settings

### DIFF
--- a/cypress/e2e/blueprints/settings/settings.ts
+++ b/cypress/e2e/blueprints/settings/settings.ts
@@ -3,7 +3,7 @@ const settingTemplate = {
   apiVersion: 'management.cattle.io/v3',
   kind:       'Setting',
   metadata:   { name: 'setting' },
-  value: ''
+  value:      ''
 };
 
 export type BooleanString = 'true' | 'false';

--- a/cypress/e2e/blueprints/settings/settings.ts
+++ b/cypress/e2e/blueprints/settings/settings.ts
@@ -1,0 +1,38 @@
+const settingTemplate = {
+  type:       'management.cattle.io.setting',
+  apiVersion: 'management.cattle.io/v3',
+  kind:       'Setting',
+  metadata:   { name: 'setting' },
+  value: ''
+};
+
+export type BooleanString = 'true' | 'false';
+
+export type Banner = {
+  background?: string;
+  color?: string;
+  textAlignment?: string;
+  fontWeight?: string;
+  fontStyle?: string;
+  fontSize?: string;
+  textDecoration?: string;
+  text?: string;
+};
+
+export type Banners = {
+  bannerHeader?: Banner;
+  bannerFooter?: Banner;
+  bannerConsent?: Banner;
+  showFooter: BooleanString;
+  showHeader: BooleanString;
+  showConsent: BooleanString;
+};
+
+export function makeSetting(name: string, obj: Banner): any {
+  const setting = { ...settingTemplate };
+
+  setting.metadata.name = name;
+  setting.value = JSON.stringify(obj);
+
+  return setting;
+}

--- a/cypress/e2e/po/components/fixed-banner.po.ts
+++ b/cypress/e2e/po/components/fixed-banner.po.ts
@@ -1,0 +1,19 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class FixedBannerPo extends ComponentPo {
+  // The banner content is in a div with the class 'banner'
+  // The text is in a P element within that
+
+  text() {
+    return this.self().find('.banner').first().invoke('text')
+    .then((text) => text.trim());
+  }
+
+  backgroundColor() {
+    return this.self().find('.banner').first().should('have.css', 'background-color');
+  }
+
+  color() {
+    return this.self().find('.banner').first().should('have.css', 'color');
+  }
+}

--- a/cypress/e2e/po/components/fixed-banner.po.ts
+++ b/cypress/e2e/po/components/fixed-banner.po.ts
@@ -6,7 +6,7 @@ export default class FixedBannerPo extends ComponentPo {
 
   text() {
     return this.self().find('.banner').first().invoke('text')
-    .then((text) => text.trim());
+      .then((text) => text.trim());
   }
 
   backgroundColor() {

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -20,7 +20,7 @@ function updateBannersSetting(fn) {
 
 // Common tests for Header and Footer banners
 function bannerTests(bannerName: string) {
-  it('Should not have banner', () => {
+  it('Should not have banner', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
     const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
 
     HomePagePo.goToAndWaitForGet();
@@ -28,7 +28,7 @@ function bannerTests(bannerName: string) {
     banner.checkNotExists();
   });
 
-  it('Should use banner from ui-banners setting', () => {
+  it('Should use banner from ui-banners setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
     const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
 
     HomePagePo.goToAndWaitForGet();
@@ -59,7 +59,7 @@ function bannerTests(bannerName: string) {
     banner.checkNotExists();
   });
 
-  it('Should use banner from individual setting', () => {
+  it('Should use banner from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
     const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
 
     HomePagePo.goToAndWaitForGet();
@@ -88,7 +88,7 @@ function bannerTests(bannerName: string) {
     banner.checkNotExists();
   });
 
-  it('Should prefer setting from individual setting', () => {
+  it('Should prefer setting from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
     const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
 
     HomePagePo.goToAndWaitForGet();

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -1,184 +1,447 @@
+import { BannersPagePo } from '@/cypress/e2e/po/pages/global-settings/banners.po';
 import { SettingsPagePo } from '@/cypress/e2e/po/pages/global-settings/settings.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
-import FixedBannerPo from '@/cypress/e2e/po/components/fixed-banner.po';
-import { makeSetting } from '@/cypress/e2e/blueprints/settings/settings';
+import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
+import FixedBannerPo from '~/cypress/e2e/po/components/fixed-banner.po';
+import { makeSetting } from '~/cypress/e2e/blueprints/settings/settings';
 
-function updateBannersSetting(fn) {
-  cy.getRancherResource('v1', 'management.cattle.io.settings').then((data: any) => {
-    const banners = data.body.data.find((setting) => setting.id === 'ui-banners');
-    const value = JSON.parse(banners.value);
+const bannersPage = new BannersPagePo();
+const burgerMenu = new BurgerMenuPo();
+const loginPage = new LoginPagePo();
+const bannersSettingsOriginal = [];
 
-    fn(value);
+const settings = {
+  bannerLabel:   'Rancher e2e',
+  textAlignment: {
+    original: 'Center',
+    new:      'Right'
+  },
+  fontSize: {
+    original: '14px',
+    new:      '20px'
+  },
+  textDecoration:  'Underline',
+  bannerTextColor: {
+    original: '#141419',
+    new:      '#f80dd8',
+    newRGB:   'rgb(248, 13, 216)',
+  },
+  bannerBackgroundColor: {
+    original: '#EEEFF4',
+    new:      '#ddd603',
+    newRGB:   'rgb(221, 214, 3)'
+  }
 
-    banners.value = JSON.stringify(value);
+};
 
-    cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', banners);
-  });
-}
-
-// Common tests for Header and Footer banners
-function bannerTests(bannerName: string) {
-  it('Should not have banner', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
-    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkNotExists();
-  });
-
-  it('Should use banner from ui-banners setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
-    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkNotExists();
-
-    // Update the ui-banners setting to enable the banner
-    updateBannersSetting((value) => {
-      value[`show${ bannerName }`] = 'true';
-      value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
-      value[`banner${ bannerName }`].background = '#00ff00';
-    });
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkExists();
-
-    banner.text().should('eq', 'TEST Banner (ui-banners)');
-    banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
-
-    // Turn off the banner
-    updateBannersSetting((value) => {
-      value[`show${ bannerName }`] = 'false';
-    });
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkNotExists();
-  });
-
-  it('Should use banner from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
-    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkNotExists();
-
-    // Set the banner via the individual setting
-    const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
-      text:       'Test Banner (individual setting)',
-      background: '#ff0000'
-    });
-
-    cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkExists();
-
-    banner.text().should('eq', 'Test Banner (individual setting)');
-    banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
-
-    cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkNotExists();
-  });
-
-  it('Should prefer setting from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
-    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkNotExists();
-
-    // Update the ui-banners setting to enable the banner
-    updateBannersSetting((value) => {
-      value[`show${ bannerName }`] = 'true';
-      value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
-      value[`banner${ bannerName }`].background = '#00ff00';
-    });
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkExists();
-
-    banner.text().should('eq', 'TEST Banner (ui-banners)');
-    banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
-
-    // Set the banner via the individual setting
-    const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
-      text:       'Test Banner (individual setting)',
-      background: '#ff0000'
-    });
-
-    cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkExists();
-
-    banner.text().should('eq', 'HELLO TEST');
-    banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
-
-    // Turn off the banner via the banners setting
-    updateBannersSetting((value) => {
-      value[`show${ bannerName }`] = 'false';
-    });
-
-    HomePagePo.goToAndWaitForGet();
-
-    // Banner should still exist from the individual setting
-    banner.checkExists();
-
-    banner.text().should('eq', 'Test Banner (individual setting)');
-    banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
-
-    cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
-
-    HomePagePo.goToAndWaitForGet();
-
-    banner.checkNotExists();
-  });
-}
-
-describe('Banners', { testIsolation: 'off', tags: ['@globalSettings', '@adminUser'] }, () => {
+describe('Banners', { testIsolation: 'off' }, () => {
   before(() => {
     cy.login();
-  });
+    HomePagePo.goTo();
 
-  describe('Banner Setting Page', () => {
-    it('Can navigate to Banner Settings Page', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
-      HomePagePo.goTo();
+    cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', null).then((resp: Cypress.Response<any>) => {
+      const body = resp.body;
 
-      const burgerMenu = new BurgerMenuPo();
-      const productMenu = new ProductNavPo();
-
-      BurgerMenuPo.toggle();
-
-      const globalSettingsNavItem = burgerMenu.links().contains(`Global Settings`);
-
-      globalSettingsNavItem.should('exist');
-      globalSettingsNavItem.click();
-
-      const settingsPage = new SettingsPagePo();
-
-      settingsPage.waitForPageWithClusterId();
-
-      const bannersNavItem = productMenu.visibleNavTypes().contains('Banners');
-
-      bannersNavItem.should('exist');
-      bannersNavItem.click();
-
-      // Check for title
-      cy.get('.main-layout h1').should(($el) => {
-        expect($el.text().trim()).equal('Fixed Banners');
-      });
+      bannersSettingsOriginal.push(body);
     });
   });
+
+  it('can navigate to Banners Page', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+    const productMenu = new ProductNavPo();
+
+    BurgerMenuPo.toggle();
+
+    burgerMenu.categories().contains(` Configuration `).should('exist');
+    const globalSettingsNavItem = burgerMenu.links().contains(`Global Settings`);
+
+    globalSettingsNavItem.should('exist');
+    globalSettingsNavItem.click();
+    const settingsPage = new SettingsPagePo('_');
+
+    settingsPage.waitForPageWithClusterId();
+
+    const bannersNavItem = productMenu.visibleNavTypes().contains('Banners');
+
+    bannersNavItem.should('exist');
+    bannersNavItem.click();
+
+    bannersPage.waitForPageWithClusterId();
+  });
+
+  let restoreSettings = false;
+
+  it('can show and hide Header Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    BannersPagePo.navTo();
+
+    // Show Banner
+    bannersPage.headerBannerCheckbox().set();
+    // to check custom box element width and height in order to prevent regression
+    // https://github.com/rancher/dashboard/issues/10000
+    bannersPage.headerBannerCheckbox().hasAppropriateWidth();
+    bannersPage.headerBannerCheckbox().hasAppropriateHeight();
+    bannersPage.headerInput().set(settings.bannerLabel);
+    bannersPage.textAlignmentRadioGroup('bannerHeader').set(2);
+    bannersPage.textDecorationCheckboxes('bannerHeader', 'Underline').set();
+    bannersPage.selectFontSizeByValue('bannerHeader', settings.fontSize.new);
+    bannersPage.textColorPicker(0).value().should('not.eq', settings.bannerTextColor.new);
+    bannersPage.textColorPicker(0).set(settings.bannerTextColor.new);
+    bannersPage.textColorPicker(1).value().should('not.eq', settings.bannerBackgroundColor.new);
+    bannersPage.textColorPicker(1).set(settings.bannerBackgroundColor.new);
+    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+      restoreSettings = true;
+    });
+
+    // Check in session
+    bannersPage.banner().should('be.visible').then((el) => {
+      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+    });
+    bannersPage.headerBannerCheckbox().isChecked();
+    bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
+    bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
+    bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+
+    // Check over reload
+    cy.reload();
+    bannersPage.banner().should('be.visible').then((el) => {
+      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+    });
+    bannersPage.headerBannerCheckbox().isChecked();
+    bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
+    bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
+    bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+
+    // Hide Banner
+    bannersPage.headerBannerCheckbox().set();
+    bannersPage.applyAndWait('**/ui-banners', 200);
+    bannersPage.banner().should('not.exist');
+  });
+
+  it('can show and hide Footer Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    bannersPage.goTo();
+
+    // Show Banner
+    bannersPage.footerBannerCheckbox().set();
+    bannersPage.footerInput().set(settings.bannerLabel);
+    bannersPage.textAlignmentRadioGroup('bannerFooter').set(2);
+    bannersPage.textDecorationCheckboxes('bannerFooter', 'Underline').set();
+    bannersPage.selectFontSizeByValue('bannerFooter', settings.fontSize.new);
+    bannersPage.textColorPicker(2).value().should('not.eq', settings.bannerTextColor.new);
+    bannersPage.textColorPicker(2).set(settings.bannerTextColor.new);
+    bannersPage.textColorPicker(3).value().should('not.eq', settings.bannerBackgroundColor.new);
+    bannersPage.textColorPicker(3).set(settings.bannerBackgroundColor.new);
+    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+      restoreSettings = true;
+    });
+
+    // Check in session
+    bannersPage.banner().should('be.visible').then((el) => {
+      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+    });
+    bannersPage.footerBannerCheckbox().isChecked();
+    bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
+    bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
+    bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+
+    // Check over reload
+    cy.reload();
+    bannersPage.banner().should('be.visible').then((el) => {
+      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+    });
+    bannersPage.footerBannerCheckbox().isChecked();
+    bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
+    bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
+    bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+
+    // Hide Banner
+    bannersPage.footerBannerCheckbox().set();
+    bannersPage.applyAndWait('**/ui-banners', 200);
+    bannersPage.banner().should('not.exist');
+  });
+
+  it('can show and hide Login Screen Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    cy.login(undefined, undefined, false);
+    BannersPagePo.navTo();
+
+    // Show Banner
+    bannersPage.loginScreenBannerCheckbox().checkVisible();
+    bannersPage.loginScreenBannerCheckbox().set();
+    bannersPage.loginScreenInput().set(settings.bannerLabel);
+    bannersPage.textAlignmentRadioGroup('bannerConsent').set(2);
+    bannersPage.textDecorationCheckboxes('bannerConsent', 'Underline').set();
+    bannersPage.selectFontSizeByValue('bannerConsent', settings.fontSize.new);
+    bannersPage.textColorPicker(4).value().should('not.eq', settings.bannerTextColor.new);
+    bannersPage.textColorPicker(4).set(settings.bannerTextColor.new);
+    bannersPage.textColorPicker(5).value().should('not.eq', settings.bannerBackgroundColor.new);
+    bannersPage.textColorPicker(5).set(settings.bannerBackgroundColor.new);
+    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+      restoreSettings = true;
+    });
+
+    // Check login screen
+    cy.logout();
+    loginPage.waitForPage();
+    loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
+    bannersPage.banner().should('be.visible').then((el) => {
+      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+    });
+
+    // Check after login
+    cy.login(undefined, undefined, false);
+    BannersPagePo.navTo();
+    bannersPage.loginScreenBannerCheckbox().isChecked();
+    bannersPage.textAlignmentRadioGroup('bannerConsent').isChecked(2);
+    bannersPage.textColorPicker(4).previewColor().should('eq', settings.bannerTextColor.newRGB);
+    bannersPage.textColorPicker(5).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+
+    // Hide banner
+    bannersPage.loginScreenBannerCheckbox().set();
+    bannersPage.applyAndWait('**/ui-banners', 200);
+
+    // Check login screen
+    cy.logout();
+    loginPage.waitForPage();
+    loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
+    bannersPage.banner().should('not.exist');
+  });
+
+  // Note: This test needs to be in its own `describe` with two `it` blocks for Show and Hide scenarios.
+  // 401 error is throw when the user attempts to login with valid credentials the second time
+  // which unexpectedly fails the test. This an automation specific issue it seems
+  describe('Login Failed Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    it('Show Banner', () => {
+      cy.login(undefined, undefined, false);
+      BannersPagePo.navTo();
+
+      // Show Banner
+      bannersPage.loginErrorCheckbox().checkVisible();
+      bannersPage.loginErrorCheckbox().set();
+      bannersPage.loginErrorInput().set(settings.bannerLabel);
+      bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+        expect(response?.statusCode).to.eq(200);
+        restoreSettings = true;
+      });
+
+      // Check login screen
+      cy.logout();
+      loginPage.waitForPage();
+      loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
+      loginPage.submit();
+      loginPage.waitForPage();
+      cy.contains(settings.bannerLabel).should('be.visible');
+    });
+
+    it('Hide banner', () => {
+      cy.login(undefined, undefined, false);
+      BannersPagePo.navTo();
+
+      // Hide banner
+      bannersPage.loginErrorCheckbox().checkVisible();
+      bannersPage.loginErrorCheckbox().set();
+      bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+        expect(response?.statusCode).to.eq(200);
+        restoreSettings = true;
+      });
+
+      // Check login screen
+      cy.logout();
+      loginPage.waitForPage();
+      loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
+      cy.contains(settings.bannerLabel).should('not.exist');
+    });
+  });
+
+  it('standard user has only read access to Banner page', { tags: ['@globalSettings', '@standardUser'] }, () => {
+    // verify action buttons/checkboxes etc. are disabled/hidden for standard user
+    BannersPagePo.navTo();
+    bannersPage.headerBannerCheckbox().isDisabled();
+    bannersPage.footerBannerCheckbox().isDisabled();
+    bannersPage.loginScreenBannerCheckbox().isDisabled();
+    bannersPage.loginErrorCheckbox().isDisabled();
+    bannersPage.applyButton().checkNotExists();
+  });
+
+  after('set default banners settings', () => {
+    if (restoreSettings) {
+      cy.login(undefined, undefined, true);
+
+      // get most updated version of banners info
+      cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', null).then((resp: Cypress.Response<any>) => {
+        const response = resp.body.metadata;
+
+        // update original data before sending request
+        bannersSettingsOriginal[0].metadata.resourceVersion = response.resourceVersion;
+
+        cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', bannersSettingsOriginal[0]);
+      });
+    }
+  });
+
+  // Tests for the individual banner settings behavior
+
+  function updateBannersSetting(fn) {
+    cy.getRancherResource('v1', 'management.cattle.io.settings').then((data: any) => {
+      const banners = data.body.data.find((setting) => setting.id === 'ui-banners');
+      const value = JSON.parse(banners.value);
+  
+      fn(value);
+  
+      banners.value = JSON.stringify(value);
+  
+      cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', banners);
+    });
+  }
+  
+  // Common tests for Header and Footer banners
+  function bannerTests(bannerName: string) {
+    it('Should not have banner', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+      const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkNotExists();
+    });
+  
+    it('Should use banner from ui-banners setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+      const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkNotExists();
+  
+      // Update the ui-banners setting to enable the banner
+      updateBannersSetting((value) => {
+        value[`show${ bannerName }`] = 'true';
+        value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
+        value[`banner${ bannerName }`].background = '#00ff00';
+      });
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkExists();
+  
+      banner.text().should('eq', 'TEST Banner (ui-banners)');
+      banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
+  
+      // Turn off the banner
+      updateBannersSetting((value) => {
+        value[`show${ bannerName }`] = 'false';
+      });
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkNotExists();
+    });
+  
+    it('Should use banner from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+      const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkNotExists();
+  
+      // Set the banner via the individual setting
+      const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
+        text:       'Test Banner (individual setting)',
+        background: '#ff0000'
+      });
+  
+      cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkExists();
+  
+      banner.text().should('eq', 'Test Banner (individual setting)');
+      banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
+  
+      cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkNotExists();
+    });
+  
+    it('Should prefer setting from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+      const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkNotExists();
+  
+      // Update the ui-banners setting to enable the banner
+      updateBannersSetting((value) => {
+        value[`show${ bannerName }`] = 'true';
+        value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
+        value[`banner${ bannerName }`].background = '#00ff00';
+      });
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkExists();
+  
+      banner.text().should('eq', 'TEST Banner (ui-banners)');
+      banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
+  
+      // Set the banner via the individual setting
+      const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
+        text:       'Test Banner (individual setting)',
+        background: '#ff0000'
+      });
+  
+      cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkExists();
+  
+      banner.text().should('eq', 'HELLO TEST');
+      banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
+  
+      // Turn off the banner via the banners setting
+      updateBannersSetting((value) => {
+        value[`show${ bannerName }`] = 'false';
+      });
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      // Banner should still exist from the individual setting
+      banner.checkExists();
+  
+      banner.text().should('eq', 'Test Banner (individual setting)');
+      banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
+  
+      cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
+  
+      HomePagePo.goToAndWaitForGet();
+  
+      banner.checkNotExists();
+    });
+  }
 
   describe('Header Banner', () => {
     bannerTests('Header');
@@ -188,7 +451,6 @@ describe('Banners', { testIsolation: 'off', tags: ['@globalSettings', '@adminUse
     bannerTests('Footer');
   });
 
-  describe('Login Banner', () => {
-
-  });
+  // describe('Login Banner', () => {
+  // });  
 });

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -359,6 +359,7 @@ describe('Banners', { testIsolation: 'off' }, () => {
       // Update the ui-banners setting to enable the banner
       updateBannersSetting((value) => {
         value[`show${ bannerName }`] = 'true';
+        value[`banner${ bannerName }`] = value[`banner${ bannerName }`] || {};
         value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
         value[`banner${ bannerName }`].background = '#00ff00';
       });
@@ -418,6 +419,7 @@ describe('Banners', { testIsolation: 'off' }, () => {
       // Update the ui-banners setting to enable the banner
       updateBannersSetting((value) => {
         value[`show${ bannerName }`] = 'true';
+        value[`banner${ bannerName }`] = value[`banner${ bannerName }`] || {};
         value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
         value[`banner${ bannerName }`].background = '#00ff00';
       });

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -70,7 +70,7 @@ function bannerTests(bannerName: string) {
     const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
       text:       'Test Banner (individual setting)',
       background: '#ff0000'
-    });      
+    });
 
     cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
 
@@ -146,7 +146,6 @@ function bannerTests(bannerName: string) {
 }
 
 describe('Banners', { testIsolation: 'off', tags: ['@globalSettings', '@adminUser'] }, () => {
-
   before(() => {
     cy.login();
   });
@@ -177,7 +176,7 @@ describe('Banners', { testIsolation: 'off', tags: ['@globalSettings', '@adminUse
       // Check for title
       cy.get('.main-layout h1').should(($el) => {
         expect($el.text().trim()).equal('Fixed Banners');
-      });    
+      });
     });
   });
 

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -46,199 +46,168 @@ describe('Banners', { testIsolation: 'off' }, () => {
     });
   });
 
-  it('can navigate to Banners Page', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
-    const productMenu = new ProductNavPo();
+  describe('Standard Banner Configuration', () => {
+    after('set default banners settings', () => {
+      if (restoreSettings) {
+        cy.login(undefined, undefined, true);
 
-    BurgerMenuPo.toggle();
+        // get most updated version of banners info
+        cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', null).then((resp: Cypress.Response<any>) => {
+          const response = resp.body.metadata;
 
-    burgerMenu.categories().contains(` Configuration `).should('exist');
-    const globalSettingsNavItem = burgerMenu.links().contains(`Global Settings`);
+          // update original data before sending request
+          bannersSettingsOriginal[0].metadata.resourceVersion = response.resourceVersion;
 
-    globalSettingsNavItem.should('exist');
-    globalSettingsNavItem.click();
-    const settingsPage = new SettingsPagePo('_');
-
-    settingsPage.waitForPageWithClusterId();
-
-    const bannersNavItem = productMenu.visibleNavTypes().contains('Banners');
-
-    bannersNavItem.should('exist');
-    bannersNavItem.click();
-
-    bannersPage.waitForPageWithClusterId();
-  });
-
-  let restoreSettings = false;
-
-  it('can show and hide Header Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    BannersPagePo.navTo();
-
-    // Show Banner
-    bannersPage.headerBannerCheckbox().set();
-    // to check custom box element width and height in order to prevent regression
-    // https://github.com/rancher/dashboard/issues/10000
-    bannersPage.headerBannerCheckbox().hasAppropriateWidth();
-    bannersPage.headerBannerCheckbox().hasAppropriateHeight();
-    bannersPage.headerInput().set(settings.bannerLabel);
-    bannersPage.textAlignmentRadioGroup('bannerHeader').set(2);
-    bannersPage.textDecorationCheckboxes('bannerHeader', 'Underline').set();
-    bannersPage.selectFontSizeByValue('bannerHeader', settings.fontSize.new);
-    bannersPage.textColorPicker(0).value().should('not.eq', settings.bannerTextColor.new);
-    bannersPage.textColorPicker(0).set(settings.bannerTextColor.new);
-    bannersPage.textColorPicker(1).value().should('not.eq', settings.bannerBackgroundColor.new);
-    bannersPage.textColorPicker(1).set(settings.bannerBackgroundColor.new);
-    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-      expect(response?.statusCode).to.eq(200);
-      restoreSettings = true;
+          cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', bannersSettingsOriginal[0]);
+        });
+      }
     });
 
-    // Check in session
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.headerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
-    bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+    it('can navigate to Banners Page', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+      const productMenu = new ProductNavPo();
 
-    // Check over reload
-    cy.reload();
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.headerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
-    bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+      BurgerMenuPo.toggle();
 
-    // Hide Banner
-    bannersPage.headerBannerCheckbox().set();
-    bannersPage.applyAndWait('**/ui-banners', 200);
-    bannersPage.banner().should('not.exist');
-  });
+      burgerMenu.categories().contains(` Configuration `).should('exist');
+      const globalSettingsNavItem = burgerMenu.links().contains(`Global Settings`);
 
-  it('can show and hide Footer Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    bannersPage.goTo();
+      globalSettingsNavItem.should('exist');
+      globalSettingsNavItem.click();
+      const settingsPage = new SettingsPagePo('_');
 
-    // Show Banner
-    bannersPage.footerBannerCheckbox().set();
-    bannersPage.footerInput().set(settings.bannerLabel);
-    bannersPage.textAlignmentRadioGroup('bannerFooter').set(2);
-    bannersPage.textDecorationCheckboxes('bannerFooter', 'Underline').set();
-    bannersPage.selectFontSizeByValue('bannerFooter', settings.fontSize.new);
-    bannersPage.textColorPicker(2).value().should('not.eq', settings.bannerTextColor.new);
-    bannersPage.textColorPicker(2).set(settings.bannerTextColor.new);
-    bannersPage.textColorPicker(3).value().should('not.eq', settings.bannerBackgroundColor.new);
-    bannersPage.textColorPicker(3).set(settings.bannerBackgroundColor.new);
-    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-      expect(response?.statusCode).to.eq(200);
-      restoreSettings = true;
+      settingsPage.waitForPageWithClusterId();
+
+      const bannersNavItem = productMenu.visibleNavTypes().contains('Banners');
+
+      bannersNavItem.should('exist');
+      bannersNavItem.click();
+
+      bannersPage.waitForPageWithClusterId();
     });
 
-    // Check in session
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.footerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
-    bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+    let restoreSettings = false;
 
-    // Check over reload
-    cy.reload();
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.footerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
-    bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+    it('can show and hide Header Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
+      BannersPagePo.navTo();
 
-    // Hide Banner
-    bannersPage.footerBannerCheckbox().set();
-    bannersPage.applyAndWait('**/ui-banners', 200);
-    bannersPage.banner().should('not.exist');
-  });
+      // Show Banner
+      bannersPage.headerBannerCheckbox().set();
+      // to check custom box element width and height in order to prevent regression
+      // https://github.com/rancher/dashboard/issues/10000
+      bannersPage.headerBannerCheckbox().hasAppropriateWidth();
+      bannersPage.headerBannerCheckbox().hasAppropriateHeight();
+      bannersPage.headerInput().set(settings.bannerLabel);
+      bannersPage.textAlignmentRadioGroup('bannerHeader').set(2);
+      bannersPage.textDecorationCheckboxes('bannerHeader', 'Underline').set();
+      bannersPage.selectFontSizeByValue('bannerHeader', settings.fontSize.new);
+      bannersPage.textColorPicker(0).value().should('not.eq', settings.bannerTextColor.new);
+      bannersPage.textColorPicker(0).set(settings.bannerTextColor.new);
+      bannersPage.textColorPicker(1).value().should('not.eq', settings.bannerBackgroundColor.new);
+      bannersPage.textColorPicker(1).set(settings.bannerBackgroundColor.new);
+      bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+        expect(response?.statusCode).to.eq(200);
+        restoreSettings = true;
+      });
 
-  it('can show and hide Login Screen Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    cy.login(undefined, undefined, false);
-    BannersPagePo.navTo();
+      // Check in session
+      bannersPage.banner().should('be.visible').then((el) => {
+        expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+      });
+      bannersPage.headerBannerCheckbox().isChecked();
+      bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
+      bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
+      bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
 
-    // Show Banner
-    bannersPage.loginScreenBannerCheckbox().checkVisible();
-    bannersPage.loginScreenBannerCheckbox().set();
-    bannersPage.loginScreenInput().set(settings.bannerLabel);
-    bannersPage.textAlignmentRadioGroup('bannerConsent').set(2);
-    bannersPage.textDecorationCheckboxes('bannerConsent', 'Underline').set();
-    bannersPage.selectFontSizeByValue('bannerConsent', settings.fontSize.new);
-    bannersPage.textColorPicker(4).value().should('not.eq', settings.bannerTextColor.new);
-    bannersPage.textColorPicker(4).set(settings.bannerTextColor.new);
-    bannersPage.textColorPicker(5).value().should('not.eq', settings.bannerBackgroundColor.new);
-    bannersPage.textColorPicker(5).set(settings.bannerBackgroundColor.new);
-    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-      expect(response?.statusCode).to.eq(200);
-      restoreSettings = true;
-    });
+      // Check over reload
+      cy.reload();
+      bannersPage.banner().should('be.visible').then((el) => {
+        expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+      });
+      bannersPage.headerBannerCheckbox().isChecked();
+      bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
+      bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
+      bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
 
-    // Check login screen
-    cy.logout();
-    loginPage.waitForPage();
-    loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+      // Hide Banner
+      bannersPage.headerBannerCheckbox().set();
+      bannersPage.applyAndWait('**/ui-banners', 200);
+      bannersPage.banner().should('not.exist');
     });
 
-    // Check after login
-    cy.login(undefined, undefined, false);
-    BannersPagePo.navTo();
-    bannersPage.loginScreenBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerConsent').isChecked(2);
-    bannersPage.textColorPicker(4).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(5).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+    it('can show and hide Footer Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
+      bannersPage.goTo();
 
-    // Hide banner
-    bannersPage.loginScreenBannerCheckbox().set();
-    bannersPage.applyAndWait('**/ui-banners', 200);
+      // Show Banner
+      bannersPage.footerBannerCheckbox().set();
+      bannersPage.footerInput().set(settings.bannerLabel);
+      bannersPage.textAlignmentRadioGroup('bannerFooter').set(2);
+      bannersPage.textDecorationCheckboxes('bannerFooter', 'Underline').set();
+      bannersPage.selectFontSizeByValue('bannerFooter', settings.fontSize.new);
+      bannersPage.textColorPicker(2).value().should('not.eq', settings.bannerTextColor.new);
+      bannersPage.textColorPicker(2).set(settings.bannerTextColor.new);
+      bannersPage.textColorPicker(3).value().should('not.eq', settings.bannerBackgroundColor.new);
+      bannersPage.textColorPicker(3).set(settings.bannerBackgroundColor.new);
+      bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+        expect(response?.statusCode).to.eq(200);
+        restoreSettings = true;
+      });
 
-    // Check login screen
-    cy.logout();
-    loginPage.waitForPage();
-    loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-    bannersPage.banner().should('not.exist');
-  });
+      // Check in session
+      bannersPage.banner().should('be.visible').then((el) => {
+        expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+      });
+      bannersPage.footerBannerCheckbox().isChecked();
+      bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
+      bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
+      bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
 
-  // Note: This test needs to be in its own `describe` with two `it` blocks for Show and Hide scenarios.
-  // 401 error is throw when the user attempts to login with valid credentials the second time
-  // which unexpectedly fails the test. This an automation specific issue it seems
-  describe('Login Failed Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    it('Show Banner', () => {
+      // Check over reload
+      cy.reload();
+      bannersPage.banner().should('be.visible').then((el) => {
+        expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+      });
+      bannersPage.footerBannerCheckbox().isChecked();
+      bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
+      bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
+      bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
+
+      // Hide Banner
+      bannersPage.footerBannerCheckbox().set();
+      bannersPage.applyAndWait('**/ui-banners', 200);
+      bannersPage.banner().should('not.exist');
+    });
+
+    it('can show and hide Login Screen Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
       cy.login(undefined, undefined, false);
       BannersPagePo.navTo();
 
       // Show Banner
-      bannersPage.loginErrorCheckbox().checkVisible();
-      bannersPage.loginErrorCheckbox().set();
-      bannersPage.loginErrorInput().set(settings.bannerLabel);
+      bannersPage.loginScreenBannerCheckbox().checkVisible();
+      bannersPage.loginScreenBannerCheckbox().set();
+      bannersPage.loginScreenInput().set(settings.bannerLabel);
+      bannersPage.textAlignmentRadioGroup('bannerConsent').set(2);
+      bannersPage.textDecorationCheckboxes('bannerConsent', 'Underline').set();
+      bannersPage.selectFontSizeByValue('bannerConsent', settings.fontSize.new);
+      bannersPage.textColorPicker(4).value().should('not.eq', settings.bannerTextColor.new);
+      bannersPage.textColorPicker(4).set(settings.bannerTextColor.new);
+      bannersPage.textColorPicker(5).value().should('not.eq', settings.bannerBackgroundColor.new);
+      bannersPage.textColorPicker(5).set(settings.bannerBackgroundColor.new);
       bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
         expect(response?.statusCode).to.eq(200);
         restoreSettings = true;
@@ -248,56 +217,90 @@ describe('Banners', { testIsolation: 'off' }, () => {
       cy.logout();
       loginPage.waitForPage();
       loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-      loginPage.submit();
-      loginPage.waitForPage();
-      cy.contains(settings.bannerLabel).should('be.visible');
-    });
+      bannersPage.banner().should('be.visible').then((el) => {
+        expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
+        expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
+        expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
+      });
 
-    it('Hide banner', () => {
+      // Check after login
       cy.login(undefined, undefined, false);
       BannersPagePo.navTo();
+      bannersPage.loginScreenBannerCheckbox().isChecked();
+      bannersPage.textAlignmentRadioGroup('bannerConsent').isChecked(2);
+      bannersPage.textColorPicker(4).previewColor().should('eq', settings.bannerTextColor.newRGB);
+      bannersPage.textColorPicker(5).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
 
       // Hide banner
-      bannersPage.loginErrorCheckbox().checkVisible();
-      bannersPage.loginErrorCheckbox().set();
-      bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-        expect(response?.statusCode).to.eq(200);
-        restoreSettings = true;
-      });
+      bannersPage.loginScreenBannerCheckbox().set();
+      bannersPage.applyAndWait('**/ui-banners', 200);
 
       // Check login screen
       cy.logout();
       loginPage.waitForPage();
       loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-      cy.contains(settings.bannerLabel).should('not.exist');
+      bannersPage.banner().should('not.exist');
+    });
+
+    // Note: This test needs to be in its own `describe` with two `it` blocks for Show and Hide scenarios.
+    // 401 error is throw when the user attempts to login with valid credentials the second time
+    // which unexpectedly fails the test. This an automation specific issue it seems
+    describe('Login Failed Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
+      it('Show Banner', () => {
+        cy.login(undefined, undefined, false);
+        BannersPagePo.navTo();
+
+        // Show Banner
+        bannersPage.loginErrorCheckbox().checkVisible();
+        bannersPage.loginErrorCheckbox().set();
+        bannersPage.loginErrorInput().set(settings.bannerLabel);
+        bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+          expect(response?.statusCode).to.eq(200);
+          restoreSettings = true;
+        });
+
+        // Check login screen
+        cy.logout();
+        loginPage.waitForPage();
+        loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
+        loginPage.submit();
+        loginPage.waitForPage();
+        cy.contains(settings.bannerLabel).should('be.visible');
+      });
+
+      it('Hide banner', () => {
+        cy.login(undefined, undefined, false);
+        BannersPagePo.navTo();
+
+        // Hide banner
+        bannersPage.loginErrorCheckbox().checkVisible();
+        bannersPage.loginErrorCheckbox().set();
+        bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
+          expect(response?.statusCode).to.eq(200);
+          restoreSettings = true;
+        });
+
+        // Check login screen
+        cy.logout();
+        loginPage.waitForPage();
+        loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
+        cy.contains(settings.bannerLabel).should('not.exist');
+      });
+    });
+
+    it('standard user has only read access to Banner page', { tags: ['@globalSettings', '@standardUser'] }, () => {
+      // verify action buttons/checkboxes etc. are disabled/hidden for standard user
+      BannersPagePo.navTo();
+      bannersPage.headerBannerCheckbox().isDisabled();
+      bannersPage.footerBannerCheckbox().isDisabled();
+      bannersPage.loginScreenBannerCheckbox().isDisabled();
+      bannersPage.loginErrorCheckbox().isDisabled();
+      bannersPage.applyButton().checkNotExists();
     });
   });
 
-  it('standard user has only read access to Banner page', { tags: ['@globalSettings', '@standardUser'] }, () => {
-    // verify action buttons/checkboxes etc. are disabled/hidden for standard user
-    BannersPagePo.navTo();
-    bannersPage.headerBannerCheckbox().isDisabled();
-    bannersPage.footerBannerCheckbox().isDisabled();
-    bannersPage.loginScreenBannerCheckbox().isDisabled();
-    bannersPage.loginErrorCheckbox().isDisabled();
-    bannersPage.applyButton().checkNotExists();
-  });
-
-  after('set default banners settings', () => {
-    if (restoreSettings) {
-      cy.login(undefined, undefined, true);
-
-      // get most updated version of banners info
-      cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', null).then((resp: Cypress.Response<any>) => {
-        const response = resp.body.metadata;
-
-        // update original data before sending request
-        bannersSettingsOriginal[0].metadata.resourceVersion = response.resourceVersion;
-
-        cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', bannersSettingsOriginal[0]);
-      });
-    }
-  });
   // Tests for the individual banner settings behavior
 
   function updateBannersSetting(fn) {

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -1,301 +1,195 @@
-import { BannersPagePo } from '@/cypress/e2e/po/pages/global-settings/banners.po';
 import { SettingsPagePo } from '@/cypress/e2e/po/pages/global-settings/settings.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
-import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
+import FixedBannerPo from '@/cypress/e2e/po/components/fixed-banner.po';
+import { makeSetting } from '@/cypress/e2e/blueprints/settings/settings';
 
-const bannersPage = new BannersPagePo();
-const burgerMenu = new BurgerMenuPo();
-const loginPage = new LoginPagePo();
-const bannersSettingsOriginal = [];
+function updateBannersSetting(fn) {
+  cy.getRancherResource('v1', 'management.cattle.io.settings').then((data: any) => {
+    const banners = data.body.data.find((setting) => setting.id === 'ui-banners');
+    const value = JSON.parse(banners.value);
 
-const settings = {
-  bannerLabel:   'Rancher e2e',
-  textAlignment: {
-    original: 'Center',
-    new:      'Right'
-  },
-  fontSize: {
-    original: '14px',
-    new:      '20px'
-  },
-  textDecoration:  'Underline',
-  bannerTextColor: {
-    original: '#141419',
-    new:      '#f80dd8',
-    newRGB:   'rgb(248, 13, 216)',
-  },
-  bannerBackgroundColor: {
-    original: '#EEEFF4',
-    new:      '#ddd603',
-    newRGB:   'rgb(221, 214, 3)'
-  }
+    fn(value);
 
-};
+    banners.value = JSON.stringify(value);
 
-describe('Banners', { testIsolation: 'off' }, () => {
+    cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', banners);
+  });
+}
+
+// Common tests for Header and Footer banners
+function bannerTests(bannerName: string) {
+  it('Should not have banner', () => {
+    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkNotExists();
+  });
+
+  it('Should use banner from ui-banners setting', () => {
+    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkNotExists();
+
+    // Update the ui-banners setting to enable the banner
+    updateBannersSetting((value) => {
+      value[`show${ bannerName }`] = 'true';
+      value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
+      value[`banner${ bannerName }`].background = '#00ff00';
+    });
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkExists();
+
+    banner.text().should('eq', 'TEST Banner (ui-banners)');
+    banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
+
+    // Turn off the banner
+    updateBannersSetting((value) => {
+      value[`show${ bannerName }`] = 'false';
+    });
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkNotExists();
+  });
+
+  it('Should use banner from individual setting', () => {
+    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkNotExists();
+
+    // Set the banner via the individual setting
+    const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
+      text:       'Test Banner (individual setting)',
+      background: '#ff0000'
+    });      
+
+    cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkExists();
+
+    banner.text().should('eq', 'Test Banner (individual setting)');
+    banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
+
+    cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkNotExists();
+  });
+
+  it('Should prefer setting from individual setting', () => {
+    const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkNotExists();
+
+    // Update the ui-banners setting to enable the banner
+    updateBannersSetting((value) => {
+      value[`show${ bannerName }`] = 'true';
+      value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
+      value[`banner${ bannerName }`].background = '#00ff00';
+    });
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkExists();
+
+    banner.text().should('eq', 'TEST Banner (ui-banners)');
+    banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
+
+    // Set the banner via the individual setting
+    const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
+      text:       'Test Banner (individual setting)',
+      background: '#ff0000'
+    });
+
+    cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkExists();
+
+    banner.text().should('eq', 'HELLO TEST');
+    banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
+
+    // Turn off the banner via the banners setting
+    updateBannersSetting((value) => {
+      value[`show${ bannerName }`] = 'false';
+    });
+
+    HomePagePo.goToAndWaitForGet();
+
+    // Banner should still exist from the individual setting
+    banner.checkExists();
+
+    banner.text().should('eq', 'Test Banner (individual setting)');
+    banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
+
+    cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
+
+    HomePagePo.goToAndWaitForGet();
+
+    banner.checkNotExists();
+  });
+}
+
+describe('Banners', { testIsolation: 'off', tags: ['@globalSettings', '@adminUser'] }, () => {
+
   before(() => {
     cy.login();
-    HomePagePo.goTo();
+  });
 
-    cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', null).then((resp: Cypress.Response<any>) => {
-      const body = resp.body;
+  describe('Banner Setting Page', () => {
+    it('Can navigate to Banner Settings Page', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+      HomePagePo.goTo();
 
-      bannersSettingsOriginal.push(body);
+      const burgerMenu = new BurgerMenuPo();
+      const productMenu = new ProductNavPo();
+
+      BurgerMenuPo.toggle();
+
+      const globalSettingsNavItem = burgerMenu.links().contains(`Global Settings`);
+
+      globalSettingsNavItem.should('exist');
+      globalSettingsNavItem.click();
+
+      const settingsPage = new SettingsPagePo();
+
+      settingsPage.waitForPageWithClusterId();
+
+      const bannersNavItem = productMenu.visibleNavTypes().contains('Banners');
+
+      bannersNavItem.should('exist');
+      bannersNavItem.click();
+
+      // Check for title
+      cy.get('.main-layout h1').should(($el) => {
+        expect($el.text().trim()).equal('Fixed Banners');
+      });    
     });
   });
 
-  it('can navigate to Banners Page', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
-    const productMenu = new ProductNavPo();
-
-    BurgerMenuPo.toggle();
-
-    burgerMenu.categories().contains(` Configuration `).should('exist');
-    const globalSettingsNavItem = burgerMenu.links().contains(`Global Settings`);
-
-    globalSettingsNavItem.should('exist');
-    globalSettingsNavItem.click();
-    const settingsPage = new SettingsPagePo('_');
-
-    settingsPage.waitForPageWithClusterId();
-
-    const bannersNavItem = productMenu.visibleNavTypes().contains('Banners');
-
-    bannersNavItem.should('exist');
-    bannersNavItem.click();
-
-    bannersPage.waitForPageWithClusterId();
+  describe('Header Banner', () => {
+    bannerTests('Header');
   });
 
-  let restoreSettings = false;
-
-  it('can show and hide Header Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    BannersPagePo.navTo();
-
-    // Show Banner
-    bannersPage.headerBannerCheckbox().set();
-    // to check custom box element width and height in order to prevent regression
-    // https://github.com/rancher/dashboard/issues/10000
-    bannersPage.headerBannerCheckbox().hasAppropriateWidth();
-    bannersPage.headerBannerCheckbox().hasAppropriateHeight();
-    bannersPage.headerInput().set(settings.bannerLabel);
-    bannersPage.textAlignmentRadioGroup('bannerHeader').set(2);
-    bannersPage.textDecorationCheckboxes('bannerHeader', 'Underline').set();
-    bannersPage.selectFontSizeByValue('bannerHeader', settings.fontSize.new);
-    bannersPage.textColorPicker(0).value().should('not.eq', settings.bannerTextColor.new);
-    bannersPage.textColorPicker(0).set(settings.bannerTextColor.new);
-    bannersPage.textColorPicker(1).value().should('not.eq', settings.bannerBackgroundColor.new);
-    bannersPage.textColorPicker(1).set(settings.bannerBackgroundColor.new);
-    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-      expect(response?.statusCode).to.eq(200);
-      restoreSettings = true;
-    });
-
-    // Check in session
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.headerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
-    bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
-
-    // Check over reload
-    cy.reload();
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.headerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerHeader').isChecked(2);
-    bannersPage.textColorPicker(0).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(1).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
-
-    // Hide Banner
-    bannersPage.headerBannerCheckbox().set();
-    bannersPage.applyAndWait('**/ui-banners', 200);
-    bannersPage.banner().should('not.exist');
+  describe('Footer Banner', () => {
+    bannerTests('Footer');
   });
 
-  it('can show and hide Footer Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    bannersPage.goTo();
+  describe('Login Banner', () => {
 
-    // Show Banner
-    bannersPage.footerBannerCheckbox().set();
-    bannersPage.footerInput().set(settings.bannerLabel);
-    bannersPage.textAlignmentRadioGroup('bannerFooter').set(2);
-    bannersPage.textDecorationCheckboxes('bannerFooter', 'Underline').set();
-    bannersPage.selectFontSizeByValue('bannerFooter', settings.fontSize.new);
-    bannersPage.textColorPicker(2).value().should('not.eq', settings.bannerTextColor.new);
-    bannersPage.textColorPicker(2).set(settings.bannerTextColor.new);
-    bannersPage.textColorPicker(3).value().should('not.eq', settings.bannerBackgroundColor.new);
-    bannersPage.textColorPicker(3).set(settings.bannerBackgroundColor.new);
-    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-      expect(response?.statusCode).to.eq(200);
-      restoreSettings = true;
-    });
-
-    // Check in session
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.footerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
-    bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
-
-    // Check over reload
-    cy.reload();
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-    bannersPage.footerBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerFooter').isChecked(2);
-    bannersPage.textColorPicker(2).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(3).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
-
-    // Hide Banner
-    bannersPage.footerBannerCheckbox().set();
-    bannersPage.applyAndWait('**/ui-banners', 200);
-    bannersPage.banner().should('not.exist');
-  });
-
-  it('can show and hide Login Screen Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    cy.login(undefined, undefined, false);
-    BannersPagePo.navTo();
-
-    // Show Banner
-    bannersPage.loginScreenBannerCheckbox().checkVisible();
-    bannersPage.loginScreenBannerCheckbox().set();
-    bannersPage.loginScreenInput().set(settings.bannerLabel);
-    bannersPage.textAlignmentRadioGroup('bannerConsent').set(2);
-    bannersPage.textDecorationCheckboxes('bannerConsent', 'Underline').set();
-    bannersPage.selectFontSizeByValue('bannerConsent', settings.fontSize.new);
-    bannersPage.textColorPicker(4).value().should('not.eq', settings.bannerTextColor.new);
-    bannersPage.textColorPicker(4).set(settings.bannerTextColor.new);
-    bannersPage.textColorPicker(5).value().should('not.eq', settings.bannerBackgroundColor.new);
-    bannersPage.textColorPicker(5).set(settings.bannerBackgroundColor.new);
-    bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-      expect(response?.statusCode).to.eq(200);
-      restoreSettings = true;
-    });
-
-    // Check login screen
-    cy.logout();
-    loginPage.waitForPage();
-    loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-    bannersPage.banner().should('be.visible').then((el) => {
-      expect(el).to.have.attr('style').contains(`color: ${ settings.bannerTextColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`background-color: ${ settings.bannerBackgroundColor.newRGB }`);
-      expect(el).to.have.attr('style').contains(`text-align: ${ settings.textAlignment.new.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`ext-decoration: ${ settings.textDecoration.toLowerCase() }`);
-      expect(el).to.have.attr('style').contains(`font-size: ${ settings.fontSize.new }`);
-    });
-
-    // Check after login
-    cy.login(undefined, undefined, false);
-    BannersPagePo.navTo();
-    bannersPage.loginScreenBannerCheckbox().isChecked();
-    bannersPage.textAlignmentRadioGroup('bannerConsent').isChecked(2);
-    bannersPage.textColorPicker(4).previewColor().should('eq', settings.bannerTextColor.newRGB);
-    bannersPage.textColorPicker(5).previewColor().should('eq', settings.bannerBackgroundColor.newRGB);
-
-    // Hide banner
-    bannersPage.loginScreenBannerCheckbox().set();
-    bannersPage.applyAndWait('**/ui-banners', 200);
-
-    // Check login screen
-    cy.logout();
-    loginPage.waitForPage();
-    loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-    bannersPage.banner().should('not.exist');
-  });
-
-  // Note: This test needs to be in its own `describe` with two `it` blocks for Show and Hide scenarios.
-  // 401 error is throw when the user attempts to login with valid credentials the second time
-  // which unexpectedly fails the test. This an automation specific issue it seems
-  describe('Login Failed Banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    it('Show Banner', () => {
-      cy.login(undefined, undefined, false);
-      BannersPagePo.navTo();
-
-      // Show Banner
-      bannersPage.loginErrorCheckbox().checkVisible();
-      bannersPage.loginErrorCheckbox().set();
-      bannersPage.loginErrorInput().set(settings.bannerLabel);
-      bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-        expect(response?.statusCode).to.eq(200);
-        restoreSettings = true;
-      });
-
-      // Check login screen
-      cy.logout();
-      loginPage.waitForPage();
-      loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-      loginPage.submit();
-      loginPage.waitForPage();
-      cy.contains(settings.bannerLabel).should('be.visible');
-    });
-
-    it('Hide banner', () => {
-      cy.login(undefined, undefined, false);
-      BannersPagePo.navTo();
-
-      // Hide banner
-      bannersPage.loginErrorCheckbox().checkVisible();
-      bannersPage.loginErrorCheckbox().set();
-      bannersPage.applyAndWait('**/ui-banners').then(({ response }) => {
-        expect(response?.statusCode).to.eq(200);
-        restoreSettings = true;
-      });
-
-      // Check login screen
-      cy.logout();
-      loginPage.waitForPage();
-      loginPage.loginPageMessage().contains('You have been logged out.').should('be.visible');
-      cy.contains(settings.bannerLabel).should('not.exist');
-    });
-  });
-
-  it('standard user has only read access to Banner page', { tags: ['@globalSettings', '@standardUser'] }, () => {
-    // verify action buttons/checkboxes etc. are disabled/hidden for standard user
-    BannersPagePo.navTo();
-    bannersPage.headerBannerCheckbox().isDisabled();
-    bannersPage.footerBannerCheckbox().isDisabled();
-    bannersPage.loginScreenBannerCheckbox().isDisabled();
-    bannersPage.loginErrorCheckbox().isDisabled();
-    bannersPage.applyButton().checkNotExists();
-  });
-
-  after('set default banners settings', () => {
-    if (restoreSettings) {
-      cy.login(undefined, undefined, true);
-
-      // get most updated version of banners info
-      cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', null).then((resp: Cypress.Response<any>) => {
-        const response = resp.body.metadata;
-
-        // update original data before sending request
-        bannersSettingsOriginal[0].metadata.resourceVersion = response.resourceVersion;
-
-        cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', bannersSettingsOriginal[0]);
-      });
-    }
   });
 });

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -33,7 +33,6 @@ const settings = {
     new:      '#ddd603',
     newRGB:   'rgb(221, 214, 3)'
   }
-
 };
 
 describe('Banners', { testIsolation: 'off' }, () => {
@@ -307,138 +306,138 @@ describe('Banners', { testIsolation: 'off' }, () => {
     cy.getRancherResource('v1', 'management.cattle.io.settings').then((data: any) => {
       const banners = data.body.data.find((setting) => setting.id === 'ui-banners');
       const value = JSON.parse(banners.value);
-  
+
       fn(value);
-  
+
       banners.value = JSON.stringify(value);
-  
+
       cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-banners', banners);
     });
   }
-  
+
   // Common tests for Header and Footer banners
   function bannerTests(bannerName: string) {
     it('Should not have banner', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
       const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkNotExists();
     });
-  
+
     it('Should use banner from ui-banners setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
       const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkNotExists();
-  
+
       // Update the ui-banners setting to enable the banner
       updateBannersSetting((value) => {
         value[`show${ bannerName }`] = 'true';
         value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
         value[`banner${ bannerName }`].background = '#00ff00';
       });
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkExists();
-  
+
       banner.text().should('eq', 'TEST Banner (ui-banners)');
       banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
-  
+
       // Turn off the banner
       updateBannersSetting((value) => {
         value[`show${ bannerName }`] = 'false';
       });
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkNotExists();
     });
-  
+
     it('Should use banner from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
       const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkNotExists();
-  
+
       // Set the banner via the individual setting
       const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
         text:       'Test Banner (individual setting)',
         background: '#ff0000'
       });
-  
+
       cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkExists();
-  
+
       banner.text().should('eq', 'Test Banner (individual setting)');
       banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
-  
+
       cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkNotExists();
     });
-  
+
     it('Should prefer setting from individual setting', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
       const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkNotExists();
-  
+
       // Update the ui-banners setting to enable the banner
       updateBannersSetting((value) => {
         value[`show${ bannerName }`] = 'true';
         value[`banner${ bannerName }`].text = 'TEST Banner (ui-banners)';
         value[`banner${ bannerName }`].background = '#00ff00';
       });
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkExists();
-  
+
       banner.text().should('eq', 'TEST Banner (ui-banners)');
       banner.backgroundColor().should('eq', 'rgb(0, 255, 0)');
-  
+
       // Set the banner via the individual setting
       const bannerSetting = makeSetting(`ui-banner-${ bannerName.toLowerCase() }`, {
         text:       'Test Banner (individual setting)',
         background: '#ff0000'
       });
-  
+
       cy.createRancherResource('v1', 'management.cattle.io.settings', JSON.stringify(bannerSetting));
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkExists();
-  
+
       banner.text().should('eq', 'HELLO TEST');
       banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
-  
+
       // Turn off the banner via the banners setting
       updateBannersSetting((value) => {
         value[`show${ bannerName }`] = 'false';
       });
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       // Banner should still exist from the individual setting
       banner.checkExists();
-  
+
       banner.text().should('eq', 'Test Banner (individual setting)');
       banner.backgroundColor().should('eq', 'rgb(255, 0, 0)');
-  
+
       cy.deleteRancherResource('k8s', 'clusters/local/apis/management.cattle.io/v3/settings', `ui-banner-${ bannerName.toLowerCase() }`);
-  
+
       HomePagePo.goToAndWaitForGet();
-  
+
       banner.checkNotExists();
     });
   }
@@ -452,5 +451,5 @@ describe('Banners', { testIsolation: 'off' }, () => {
   });
 
   // describe('Login Banner', () => {
-  // });  
+  // });
 });

--- a/cypress/e2e/tests/pages/global-settings/banners.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/banners.spec.ts
@@ -338,7 +338,7 @@ describe('Banners', { testIsolation: 'off' }, () => {
       HomePagePo.goTo();
     });
 
-    it('Should not have banner', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+    it('Should not have banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
       const banner = new FixedBannerPo(`#banner-${ bannerName.toLowerCase() }`);
 
       HomePagePo.goToAndWaitForGet();
@@ -482,7 +482,7 @@ describe('Banners', { testIsolation: 'off' }, () => {
       HomePagePo.goTo();
     });
 
-    it('Should not have banner', { tags: ['@globalSettings', '@adminUser', '@standardUser'] }, () => {
+    it('Should not have banner', { tags: ['@globalSettings', '@adminUser'] }, () => {
       const banner = new FixedBannerPo('#banner-consent');
 
       cy.logout();

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -68,7 +68,7 @@ declare global {
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
-      deleteRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;
+      deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;
       deleteNodeTemplate(nodeTemplateId: string, timeout?: number)
 
       /**

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -443,18 +443,15 @@ Cypress.Commands.add('deleteRancherResource', (prefix, resourceType, resourceId,
 /**
  * create a v3 / v1 resource
  */
-Cypress.Commands.add('createRancherResource', (prefix, resourceType, body?) => {
-  const url = !!body ? `${ prefix }/${ resourceType }` : prefix;
-  const b = !!body ? body : resourceType;
-
+Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
   return cy.request({
     method:  'POST',
-    url:     `${ Cypress.env('api') }/${ url }`,
+    url:     `${ Cypress.env('api') }/${ prefix }/${ resourceType }`,
     headers: {
       'x-api-csrf': token.value,
       Accept:       'application/json'
     },
-    body: b
+    body
   })
     .then((resp) => {
       // Expect 201, Created HTTP status code

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -443,15 +443,18 @@ Cypress.Commands.add('deleteRancherResource', (prefix, resourceType, resourceId,
 /**
  * create a v3 / v1 resource
  */
-Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
+Cypress.Commands.add('createRancherResource', (prefix, resourceType, body?) => {
+  const url = !!body ? `${ prefix }/${ resourceType }` : prefix;
+  const b = !!body ? body : resourceType;
+
   return cy.request({
     method:  'POST',
-    url:     `${ Cypress.env('api') }/${ prefix }/${ resourceType }`,
+    url:     `${ Cypress.env('api') }/${ url }`,
     headers: {
       'x-api-csrf': token.value,
       Accept:       'application/json'
     },
-    body
+    body: b
   })
     .then((resp) => {
       // Expect 201, Created HTTP status code

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7385,6 +7385,7 @@ banner:
     label: 'Font Size'
   consent: Consent Banner
   consentFootnote: "Tip: Use \\n character for line break"
+  individualSetting: 'This banner is managed by the setting "{name}" and can not be modified in the UI'
 
 branding:
   label: Branding

--- a/shell/components/FixedBanner.vue
+++ b/shell/components/FixedBanner.vue
@@ -22,11 +22,11 @@ export default {
 
   data() {
     return {
-      showDialog:         true,
-      showHeader:         false,
-      showFooter:         false,
-      showConsent:        false,
-      banner:             {},
+      showDialog:  true,
+      showHeader:  false,
+      showFooter:  false,
+      showConsent: false,
+      banner:      {},
     };
   },
 
@@ -52,11 +52,10 @@ export default {
   },
 
   computed: {
-
     uiBannerIndividual() {
       return getIndividualBanners(this.$store);
     },
-    
+
     bannerSetting() {
       return this.$store.getters['management/all'](MANAGEMENT.SETTING).find((s) => s.id === SETTING.BANNERS);
     },
@@ -127,7 +126,6 @@ export default {
               bannerHeader, bannerFooter, bannerConsent, banner, showHeader, showFooter, showConsent
             } = parsed;
             let bannerContent = parsed?.banner || {};
-
 
             if (isEmpty(banner)) {
               if (showHeader && this.header) {

--- a/shell/components/FixedBanner.vue
+++ b/shell/components/FixedBanner.vue
@@ -2,6 +2,7 @@
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import isEmpty from 'lodash/isEmpty';
+import { getIndividualBanners, overlayIndividualBanners } from '@shell/utils/banners';
 
 export default {
   props: {
@@ -21,11 +22,11 @@ export default {
 
   data() {
     return {
-      showDialog:  true,
-      showHeader:  false,
-      showFooter:  false,
-      showConsent: false,
-      banner:      {},
+      showDialog:         true,
+      showHeader:         false,
+      showFooter:         false,
+      showConsent:        false,
+      banner:             {},
     };
   },
 
@@ -51,6 +52,11 @@ export default {
   },
 
   computed: {
+
+    uiBannerIndividual() {
+      return getIndividualBanners(this.$store);
+    },
+    
     bannerSetting() {
       return this.$store.getters['management/all'](MANAGEMENT.SETTING).find((s) => s.id === SETTING.BANNERS);
     },
@@ -114,10 +120,14 @@ export default {
         if (neu?.value && neu.value !== '') {
           try {
             const parsed = JSON.parse(neu.value);
+
+            overlayIndividualBanners(parsed, this.uiBannerIndividual);
+
             const {
               bannerHeader, bannerFooter, bannerConsent, banner, showHeader, showFooter, showConsent
             } = parsed;
             let bannerContent = parsed?.banner || {};
+
 
             if (isEmpty(banner)) {
               if (showHeader && this.header) {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -16,6 +16,7 @@ import { filterOnlyKubernetesClusters, filterHiddenLocalCluster } from '@shell/u
 import { getProductFromRoute } from '@shell/utils/router';
 import { isRancherPrime } from '@shell/config/version';
 import Pinned from '@shell/components/nav/Pinned';
+import { getGlobalBannerFontSizes } from '@shell/utils/banners';
 
 export default {
   components: {
@@ -59,35 +60,14 @@ export default {
       },
     },
     sideMenuStyle() {
+      const globalBannerSettings = getGlobalBannerFontSizes(this.$store);
+
       return {
-        marginBottom: this.globalBannerSettings?.footerFont,
-        marginTop:    this.globalBannerSettings?.headerFont
+        marginBottom: globalBannerSettings?.footerFont,
+        marginTop:    globalBannerSettings?.headerFont
       };
     },
 
-    globalBannerSettings() {
-      const settings = this.$store.getters['management/all'](MANAGEMENT.SETTING);
-      const bannerSettings = settings?.find((s) => s.id === SETTING.BANNERS);
-
-      if (bannerSettings) {
-        const parsed = JSON.parse(bannerSettings.value);
-        const {
-          showFooter, showHeader, bannerFooter, bannerHeader, banner
-        } = parsed;
-
-        // add defaults to accomodate older JSON structures for banner definitions without breaking the UI
-        // https://github.com/rancher/dashboard/issues/10140
-        const bannerHeaderFontSize = bannerHeader?.fontSize || banner?.fontSize || '14px';
-        const bannerFooterFontSize = bannerFooter?.fontSize || banner?.fontSize || '14px';
-
-        return {
-          headerFont: showHeader === 'true' ? this.pxToEm(bannerHeaderFontSize) : '0px',
-          footerFont: showFooter === 'true' ? this.pxToEm(bannerFooterFontSize) : '0px'
-        };
-      }
-
-      return undefined;
-    },
     legacyEnabled() {
       return this.features(LEGACY);
     },
@@ -343,19 +323,6 @@ export default {
   },
 
   methods: {
-    /**
-     * Converts a pixel value to an em value based on the default font size.
-     * @param {number} elementFontSize - The font size of the element in pixels.
-     * @param {number} [defaultFontSize=14] - The default font size in pixels.
-     * @returns {string} The converted value in em units.
-     */
-    pxToEm(elementFontSize, defaultFontSize = 14) {
-      const lineHeightInPx = 2 * parseInt(elementFontSize);
-      const lineHeightInEm = lineHeightInPx / defaultFontSize;
-
-      return `${ lineHeightInEm }em`;
-    },
-
     checkActiveRoute(obj, isClusterRoute) {
       // for Cluster links in main nav: check if route is a cluster explorer one + check if route cluster matches cluster obj id + check if curr product matches route product
       if (isClusterRoute) {

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -420,9 +420,9 @@ describe('topLevelMenu', () => {
       stubs: ['BrandImage', 'router-link']
     });
 
-    expect(wrapper.vm.globalBannerSettings).toStrictEqual({
-      headerFont: '2em',
-      footerFont: '2em'
+    expect(wrapper.vm.sideMenuStyle).toStrictEqual({
+      marginBottom: '2em',
+      marginTop: '2em'
     });
   });
 

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -422,7 +422,7 @@ describe('topLevelMenu', () => {
 
     expect(wrapper.vm.sideMenuStyle).toStrictEqual({
       marginBottom: '2em',
-      marginTop: '2em'
+      marginTop:    '2em'
     });
   });
 

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -28,6 +28,7 @@ import {
 } from '@shell/config/private-label';
 import loadPlugins from '@shell/plugins/plugin';
 import Loading from '@shell/components/Loading';
+import { getGlobalBannerFontSizes } from '@shell/utils/banners';
 
 export default {
   name:       'Login',
@@ -104,8 +105,14 @@ export default {
 
     hasLoginMessage() {
       return this.errorToDisplay || this.loggedOut || this.timedOut;
-    }
+    },
 
+    // Apply bottom margin so that the locale secletor control lifts up to avoid the footer fixed banner, if it is shown
+    localeSelectorStyle() {
+      const globalBannerSettings = getGlobalBannerFontSizes(this.$store);
+
+      return { marginBottom: globalBannerSettings?.footerFont };
+    }
   },
 
   async fetch() {
@@ -470,9 +477,12 @@ export default {
         </template>
         <div
           v-if="showLocaleSelector"
-          class="locale-elector"
+          class="locale-selector"
         >
-          <LocaleSelector mode="login" />
+          <LocaleSelector
+            :style="localeSelectorStyle"
+            mode="login"
+          />
         </div>
       </div>
       <BrandImage
@@ -545,7 +555,7 @@ export default {
       place-content: center;
     }
   }
-  .locale-elector {
+  .locale-selector {
     position: absolute;
     bottom: 30px;
   }

--- a/shell/pages/c/_cluster/settings/banners.vue
+++ b/shell/pages/c/_cluster/settings/banners.vue
@@ -105,6 +105,7 @@ export default {
       if (this.uiBannerIndividual.bannerFooter) {
         return _VIEW;
       }
+
       return this.bannerVal?.showFooter === 'true' ? _EDIT : _VIEW;
     },
     consentMode() {
@@ -112,6 +113,7 @@ export default {
       if (this.uiBannerIndividual.bannerConsent) {
         return _VIEW;
       }
+
       return this.bannerVal?.showConsent === 'true' ? _EDIT : _VIEW;
     }
   },
@@ -207,9 +209,15 @@ export default {
         <!-- Header Settings -->
         <h2 class="mt-40 mb-10 setting-title">
           {{ t('banner.headerBanner') }}
-          <i v-if="!!uiBannerIndividual.bannerHeader" class="icon icon-lock" />
+          <i
+            v-if="!!uiBannerIndividual.bannerHeader"
+            class="icon icon-lock"
+          />
         </h2>
-        <div v-if="!!uiBannerIndividual.bannerHeader" class="row mb-10">
+        <div
+          v-if="!!uiBannerIndividual.bannerHeader"
+          class="row mb-10"
+        >
           <Banner
             color="warning"
             class="mt-0"
@@ -236,9 +244,15 @@ export default {
         <!-- Footer settings -->
         <h2 class="mt-40 mb-10 setting-title">
           {{ t('banner.footerBanner') }}
-          <i v-if="!!uiBannerIndividual.bannerFooter" class="icon icon-lock" />
+          <i
+            v-if="!!uiBannerIndividual.bannerFooter"
+            class="icon icon-lock"
+          />
         </h2>
-        <div v-if="!!uiBannerIndividual.bannerFooter" class="row mb-10">
+        <div
+          v-if="!!uiBannerIndividual.bannerFooter"
+          class="row mb-10"
+        >
           <Banner
             color="warning"
             class="mt-0"
@@ -266,9 +280,15 @@ export default {
       <!-- Consent settings -->
       <h2 class="mt-40 mb-10 setting-title">
         {{ t('banner.loginScreenBanner') }}
-        <i v-if="!!uiBannerIndividual.bannerConsent" class="icon icon-lock" />
+        <i
+          v-if="!!uiBannerIndividual.bannerConsent"
+          class="icon icon-lock"
+        />
       </h2>
-      <div v-if="!!uiBannerIndividual.bannerConsent" class="row mb-10">
+      <div
+        v-if="!!uiBannerIndividual.bannerConsent"
+        class="row mb-10"
+      >
         <Banner
           color="warning"
           class="mt-0"

--- a/shell/utils/banners.js
+++ b/shell/utils/banners.js
@@ -1,0 +1,47 @@
+import { MANAGEMENT } from '@shell/config/types';
+
+const BANNER_HEADER = 'bannerHeader';
+const BANNER_FOOTER = 'bannerFooter';
+const BANNER_LOGIN = 'bannerConsent';
+
+const INDIVIDUAL_BANNERS = {
+  'ui-banner-header': BANNER_HEADER,
+  'ui-banner-footer': BANNER_FOOTER,
+  'ui-banner-login-consent': BANNER_LOGIN,
+};
+
+const BANNER_SHOW_KEY_MAP = {
+  [BANNER_HEADER]: 'showHeader',
+  [BANNER_FOOTER]: 'showFooter',
+  [BANNER_LOGIN]: 'showConsent',
+};
+
+export function getIndividualBanners(store) {
+  const banners = {};
+
+  // We fetch all settings, so we can check for individual banner setting resources
+  // We will have already fetched all settings, so there is no performance impact doing this versus fetching individual settings
+  const allSettings = store.getters['management/all'](MANAGEMENT.SETTING);
+
+  allSettings.forEach((setting) => {
+    if (setting.value && !!INDIVIDUAL_BANNERS[setting.id]) {
+      const settingId = INDIVIDUAL_BANNERS[setting.id];
+
+      banners[settingId] = setting;
+    }
+  });
+
+  return banners;
+}
+
+export function overlayIndividualBanners(parsedBanner, banners) {
+  Object.keys(banners).forEach((id) => {
+    try {
+        const parsedIndvBanner = JSON.parse(banners[id].value);
+        const shownID = BANNER_SHOW_KEY_MAP[id];
+
+        parsedBanner[id] = parsedIndvBanner;
+        parsedBanner[shownID] = 'true'; // If there is an individual banner setting, then banner is shown
+    } catch {}
+  });  
+}

--- a/shell/utils/banners.js
+++ b/shell/utils/banners.js
@@ -1,26 +1,35 @@
+/**
+ *
+ * Helper utilities for the fixed banners that can be configured to show on pages
+ *
+ */
+
 import { MANAGEMENT } from '@shell/config/types';
+import { SETTING } from '@shell/config/settings';
 
 const BANNER_HEADER = 'bannerHeader';
 const BANNER_FOOTER = 'bannerFooter';
 const BANNER_LOGIN = 'bannerConsent';
 
 const INDIVIDUAL_BANNERS = {
-  'ui-banner-header': BANNER_HEADER,
-  'ui-banner-footer': BANNER_FOOTER,
+  'ui-banner-header':        BANNER_HEADER,
+  'ui-banner-footer':        BANNER_FOOTER,
   'ui-banner-login-consent': BANNER_LOGIN,
 };
 
 const BANNER_SHOW_KEY_MAP = {
   [BANNER_HEADER]: 'showHeader',
   [BANNER_FOOTER]: 'showFooter',
-  [BANNER_LOGIN]: 'showConsent',
+  [BANNER_LOGIN]:  'showConsent',
 };
 
+/**
+ * Get the individual banner settings
+ */
 export function getIndividualBanners(store) {
   const banners = {};
 
-  // We fetch all settings, so we can check for individual banner setting resources
-  // We will have already fetched all settings, so there is no performance impact doing this versus fetching individual settings
+  // Go through all settings looking for the individual settings
   const allSettings = store.getters['management/all'](MANAGEMENT.SETTING);
 
   allSettings.forEach((setting) => {
@@ -34,14 +43,61 @@ export function getIndividualBanners(store) {
   return banners;
 }
 
+/**
+ * Overlay settings from the individual banner settings onto the single banner setting
+ */
 export function overlayIndividualBanners(parsedBanner, banners) {
   Object.keys(banners).forEach((id) => {
     try {
-        const parsedIndvBanner = JSON.parse(banners[id].value);
-        const shownID = BANNER_SHOW_KEY_MAP[id];
+      const parsedIndividualBanner = JSON.parse(banners[id].value);
+      const shownID = BANNER_SHOW_KEY_MAP[id];
 
-        parsedBanner[id] = parsedIndvBanner;
-        parsedBanner[shownID] = 'true'; // If there is an individual banner setting, then banner is shown
+      parsedBanner[id] = parsedIndividualBanner;
+      parsedBanner[shownID] = 'true'; // If there is an individual banner setting, then banner is shown
     } catch {}
-  });  
+  });
+}
+
+/**
+ * Converts a pixel value to an em value based on the default font size.
+ * @param {number} elementFontSize - The font size of the element in pixels.
+ * @param {number} [defaultFontSize=14] - The default font size in pixels.
+ * @returns {string} The converted value in em units.
+ */
+function pxToEm(elementFontSize, defaultFontSize = 14) {
+  const lineHeightInPx = 2 * parseInt(elementFontSize);
+  const lineHeightInEm = lineHeightInPx / defaultFontSize;
+
+  return `${ lineHeightInEm }em`;
+}
+
+/**
+ * Get banner font sizes - used to add margins when header and footer banners are present
+ **/
+export function getGlobalBannerFontSizes(store) {
+  const settings = store.getters['management/all'](MANAGEMENT.SETTING);
+  const bannerSettings = settings?.find((s) => s.id === SETTING.BANNERS);
+  const individualBannerSettings = getIndividualBanners(store);
+
+  if (bannerSettings) {
+    const parsed = JSON.parse(bannerSettings.value);
+
+    overlayIndividualBanners(parsed, individualBannerSettings);
+
+    const {
+      showFooter, showHeader, bannerFooter, bannerHeader, banner
+    } = parsed;
+
+    // add defaults to accommodate older JSON structures for banner definitions without breaking the UI
+    // https://github.com/rancher/dashboard/issues/10140
+    const bannerHeaderFontSize = bannerHeader?.fontSize || banner?.fontSize || '14px';
+    const bannerFooterFontSize = bannerFooter?.fontSize || banner?.fontSize || '14px';
+
+    return {
+      headerFont: showHeader === 'true' ? pxToEm(bannerHeaderFontSize) : '0px',
+      footerFont: showFooter === 'true' ? pxToEm(bannerFooterFontSize) : '0px'
+    };
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7366

This PR addresses the above new feature.

We now allow for individual banner settings:

- `ui-banner-header`
- `ui-banner-footer`
- `ui-banner-login-consent`

When configured, these will be used in preference to the configuration in the existing single banner setting `ui-banners` - this makes it easier for users wishing to configure these banners independently.

When configured by the individual settings, the UI prevents editing of the banners for simplicity - e.g.

![image](https://github.com/rancher/dashboard/assets/1955897/30f467e5-c082-4ae8-9c0a-57e69b73ac30)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This PR included automated e2e tests to validate the existing behaviour and the new settings in various scenarios.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Banner configuration via the banner settings.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

See above for the banner settings page when individual banner settings are present.

Banners should appear on pages exactly the same as when configured via the single `ui-banners` setting.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
