### PR TITLE
Fixing an azuread test where the wrong auth provider is being selected

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -37,10 +37,6 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
     this.self().find('.toggle-container').should(assertion);
   }
 
-  gridElementExistance(groupIndex = 0, itemIndex = 0, assertion: string) {
-    this.self().find(`[data-testid="cluster-manager-create-grid-${ groupIndex }-${ itemIndex }"]`).should(assertion);
-  }
-
   gridElementExistanceByName(name: string, assertion: string) {
     return this.self().contains('.grid .name', name, { timeout: 10000 }).should(assertion);
   }

--- a/cypress/e2e/po/pages/users-and-auth/authProvider.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/authProvider.po.ts
@@ -27,6 +27,6 @@ export default class AuthProviderPo extends PagePo {
   }
 
   selectAzureAd() {
-    return this.self().find('[data-testid="select-icon-grid-3"]').click();
+    return this.self().find('[data-testid="select-icon-grid-AzureAD"]').click();
   }
 }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -73,7 +73,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
     // seems like the waitForPage does await for full DOM render, so let's wait for a simple assertion
     // like "gridElementExists" to make sure we aren't creating a fake assertion with the toggle
-    clusterCreate.gridElementExistance(0, 0, 'exist');
+    clusterCreate.gridElementExistanceByName('Linode', 'exist');
     clusterCreate.rkeToggleExistance('not.exist');
 
     const sideNav = new ProductNavPo();

--- a/shell/components/SelectIconGrid.vue
+++ b/shell/components/SelectIconGrid.vue
@@ -106,7 +106,7 @@ export default {
       :target="get(r, targetField)"
       :rel="rel"
       class="item"
-      :data-testid="componentTestid + '-' + idx"
+      :data-testid="componentTestid + '-' + get(r, nameField)"
       :class="{
         'has-description': !!get(r, descriptionField),
         'has-side-label': !!get(r, sideLabelField), [colorFor(r, idx)]: true, disabled: get(r, disabledField) === true

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -627,7 +627,7 @@ export default {
           name-field="label"
           side-label-field="tag"
           :color-for="colorFor"
-          :component-testid="'cluster-manager-create-grid-' + i"
+          component-testid="cluster-manager-create-grid"
           @clicked="clickedType"
         />
       </div>


### PR DESCRIPTION
Turns out that the order of the providers has changed (changes all the time?) so this broke the reliance on looking up elements based on index.

### Technical notes summary
This change makes the relevant tests more robust by relying on names instead of indices.

### Areas which could experience regressions
Only our tests


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
