### PR TITLE
Add default label to Fleet Secrets to enable BRO backups

### DIFF
--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -52,15 +52,18 @@ describe('Git Repo', { tags: ['@fleet', '@adminUser'] }, () => {
 
       // First request is for creating credentials
       let secretName = '';
-      let secretLabels = {};
+      let requestLabels = null;
+      let secretLabels = null;
 
       cy.wait('@interceptSecret')
         .then(({ request, response }) => {
+          requestLabels = request.body.metadata.labels;
+          expect(requestLabels).to.not.be.null.and.to.have.property('fleet.cattle.io/managed').with.value('true');
           expect(response.statusCode).to.eq(201);
           secretName = response.body.metadata.name;
           secretLabels = response.body.metadata.labels;
           expect(secretName).not.to.eq('');
-          expect(secretLabels).to.have.property('fleet.cattle.io/managed').with.value('true');
+          expect(secretLabels).to.not.be.null.and.to.have.property('fleet.cattle.io/managed').with.value('true');
 
           // Second request is for creating the git repo
           return cy.wait('@interceptGitRepo');

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -58,12 +58,12 @@ describe('Git Repo', { tags: ['@fleet', '@adminUser'] }, () => {
       cy.wait('@interceptSecret')
         .then(({ request, response }) => {
           requestLabels = request.body.metadata.labels;
-          expect(requestLabels).to.not.be.null.and.to.have.property('fleet.cattle.io/managed').with.value('true');
+          expect(requestLabels).to.be.an('object').and.to.have.property('fleet.cattle.io/managed').that.equals('true');
           expect(response.statusCode).to.eq(201);
           secretName = response.body.metadata.name;
           secretLabels = response.body.metadata.labels;
           expect(secretName).not.to.eq('');
-          expect(secretLabels).to.not.be.null.and.to.have.property('fleet.cattle.io/managed').with.value('true');
+          expect(secretLabels).to.be.an('object').and.to.have.property('fleet.cattle.io/managed').that.equals('true');
 
           // Second request is for creating the git repo
           return cy.wait('@interceptGitRepo');

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -52,12 +52,15 @@ describe('Git Repo', { tags: ['@fleet', '@adminUser'] }, () => {
 
       // First request is for creating credentials
       let secretName = '';
+      let secretLabels = {};
 
       cy.wait('@interceptSecret')
         .then(({ request, response }) => {
           expect(response.statusCode).to.eq(201);
           secretName = response.body.metadata.name;
+          secretLabels = response.body.metadata.labels;
           expect(secretName).not.to.eq('');
+          expect(secretLabels).to.have.property('fleet.cattle.io/managed').with.value('true');
 
           // Second request is for creating the git repo
           return cy.wait('@interceptGitRepo');

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -22,7 +22,7 @@ import { base64Decode, base64Encode } from '@shell/utils/crypto';
 import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret';
 import { _CREATE } from '@shell/config/query-params';
 import { isHarvesterCluster } from '@shell/utils/cluster';
-import { CAPI, CATALOG } from '@shell/config/labels-annotations';
+import { CAPI, CATALOG, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
 import { SECRET_TYPES } from '@shell/config/secret';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
@@ -414,7 +414,7 @@ export default {
           metadata: {
             namespace:    this.value.metadata.namespace,
             generateName: 'auth-',
-            labels:       { 'fleet.cattle.io/managed': 'true' }
+            labels:       { [FLEET_LABELS.MANAGED]: 'true' }
           }
         });
 

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -413,8 +413,9 @@ export default {
           type:     SECRET,
           metadata: {
             namespace:    this.value.metadata.namespace,
-            generateName: 'auth-'
-          },
+            generateName: 'auth-',
+            labels:       { 'fleet.cattle.io/managed': 'true' }
+          }
         });
 
         let type, publicField, privateField;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR fixes SURE-6919
Fixes https://github.com/rancher/dashboard/issues/11211
<!-- Define findings related to the feature or bug issue. -->

There were recent fixes to the BRO codebase that corrected a bug which backed up far more data than it should have been backing up. In other terms, the resourceset filters BRO uses to collect resources for backups are properly followed now.

As such, the only fleet secrets that get backed up would be ones with the `"fleet.cattle.io/managed=true"` label. Since that is the existing rule defined for fleet within the resoruceset.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
This PR aims to make sure that the secrets being created by the fleet UI are labeled as managed by fleet. This in turn will allow BROs rules to collect the secrets for backup.

This change is not retroactive - any existing secrets should be updated by Rancher admins to include the correct label.

Additionally, we are intentionally not addressing when users select a secret created outside of the UI for fleet. This maybe worth looking into expanding on later, but for now the BRO team perspective is that those would be "user-created" (and managed) resources; not something Rancher created for them.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Create a GitRepo and define a new secret via the GitRepo UI,
2. Find the secrets name after creation,
3. Explore secrets in the local cluster to find new secret,
4. Observe it currently lacks the expected label.

After this PR it should be observed that the secret will have the expected label.
Once complete this will allow testing of the main issue per direction on https://github.com/rancher/dashboard/issues/11211

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Unlikely to occur.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
N/A. There are no visual UX changes.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or **there are no UX changes**
