### PR TITLE
Making the call to i18n/init blocking to resolve a race condition

### DIFF
--- a/shell/initialize/install-plugins.js
+++ b/shell/initialize/install-plugins.js
@@ -54,6 +54,10 @@ export async function installInjectedPlugins(app, vueApp) {
 
   await Promise.all(installations);
 
+  // We had i18n/init happening asynchronously within the i18n installation method. We need this to happen synchronously otherwise we end up with race conditions where some pages won't load when translated.
+  // If there's any performance reasons this can be done concurrently with all of the installation promises above but I felt it was organizationally better to keep both i18n items together.
+  await app.store.dispatch('i18n/init');
+
   // Order matters here. This is coming after the other plugins specifically so $cookies can be installed. i18n/init relies on prefs/get which relies on $cookies.
   vueApp.use(i18n, { store: app.store });
 }

--- a/shell/plugins/i18n.js
+++ b/shell/plugins/i18n.js
@@ -58,8 +58,6 @@ export function directiveSsr(vnode, binding) {
 const i18n = {
   name:    'i18n',
   install: (Vue, _options) => {
-    _options?.store?.dispatch('i18n/init');
-
     if (Vue.prototype.t && Vue.directive('t') && Vue.component('t')) {
       // eslint-disable-next-line no-console
       console.debug('Skipping i18n install. Directive, component, and option already exist.');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/dashboard#11203

### Technical notes summary
There was a race condition where certain pages would sometimes fail to render if the language was changed. This was caused by `i18n/init` sometimes not completing before some of the page would begin to render and would ultimately lead to `loadManagement` not getting called.

### Areas or cases that should be tested
`/dashboard/c/_/fleet/fleet.cattle.io.gitrepo` in a production build. You can update the `ui-dashboard-index` global setting to `https://releases.rancher.com/dashboard/i18n-fix-dev/index.html` to test. 

I was only able to reproduce the original issue in Chrome with a production build by refreshing the gitrepo page over and over.

![image](https://github.com/rancher/dashboard/assets/55104481/0772531c-f6ab-438e-8e79-5dfa247cc0f6)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
