### PR TITLE
Add conditional depagination by native api, apply to bindings

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -155,8 +155,11 @@ export default {
       }
 
       if ( as === _YAML ) {
-        // fetch resourceFields for createYaml
-        await schema.fetchResourceFields();
+        if (schema?.fetchResourceFields) {
+          // fetch resourceFields for createYaml
+          await schema.fetchResourceFields();
+        }
+
         yaml = createYaml(schemas, resource, data);
       }
     } else {

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -30,6 +30,7 @@ import {
 
 import { COLUMN_BREAKPOINTS } from '@shell/types/store/type-map';
 import { STEVE_CACHE } from '@shell/store/features';
+import { configureConditionalDepaginate } from '@shell/store/type-map.utils';
 
 export const NAME = 'explorer';
 
@@ -57,7 +58,9 @@ export function init(store) {
     typeStoreMap:        {
       [MANAGEMENT.PROJECT]:                       'management',
       [MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING]: 'management',
-      [MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING]: 'management'
+      [MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING]: 'management',
+      [NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING]:     'rancher',
+      [NORMAN.PROJECT_ROLE_TEMPLATE_BINDING]:     'rancher',
     }
   });
 
@@ -165,12 +168,16 @@ export function init(store) {
   mapGroup(/^(.*\.)?cluster\.x-k8s\.io$/, 'clusterProvisioning');
   mapGroup(/^(aks|eks|gke|rke|rke-machine-config|rke-machine|provisioning)\.cattle\.io$/, 'clusterProvisioning');
 
+  const dePaginateBindings = configureConditionalDepaginate({ maxResourceCount: 5000 });
+  const dePaginateNormanBindings = configureConditionalDepaginate({ maxResourceCount: 5000, isNorman: true }) ;
+
   configureType(NODE, { isCreatable: false, isEditable: true });
   configureType(WORKLOAD_TYPES.JOB, { isEditable: false, match: WORKLOAD_TYPES.JOB });
-  configureType(MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, { isEditable: false });
-  configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false, depaginate: true });
+  configureType(MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, { isEditable: false, depaginate: dePaginateBindings });
+  configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false, depaginate: dePaginateBindings });
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });
-  configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: true });
+  configureType(NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING, { depaginate: dePaginateNormanBindings });
+  configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: dePaginateNormanBindings });
   configureType(SNAPSHOT, { depaginate: true });
   configureType(NORMAN.ETCD_BACKUP, { depaginate: true });
 

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -17,11 +17,11 @@ export const NORMAN = {
   ETCD_BACKUP:                   'etcdbackup',
   CLUSTER:                       'cluster',
   CLUSTER_TOKEN:                 'clusterregistrationtoken',
-  CLUSTER_ROLE_TEMPLATE_BINDING: 'clusterRoleTemplateBinding',
+  CLUSTER_ROLE_TEMPLATE_BINDING: 'clusterroletemplatebinding',
   CLOUD_CREDENTIAL:              'cloudcredential',
   FLEET_WORKSPACES:              'fleetworkspace',
-  GLOBAL_ROLE:                   'globalRole',
-  GLOBAL_ROLE_BINDING:           'globalRoleBinding',
+  GLOBAL_ROLE:                   'globalrole',
+  GLOBAL_ROLE_BINDING:           'globalrolebinding',
 
   NODE_POOL:                     'nodePool',
   // Note - This allows access to node resources, not schema's or custom components (both are accessed via 'type' which clashes with kube node)
@@ -31,11 +31,11 @@ export const NORMAN = {
   PROJECT_ROLE_TEMPLATE_BINDING: 'projectroletemplatebinding',
   SETTING:                       'setting',
   SPOOFED:                       { GROUP_PRINCIPAL: 'group.principal' },
-  ROLE_TEMPLATE:                 'roleTemplate',
+  ROLE_TEMPLATE:                 'roletemplate',
   TOKEN:                         'token',
   USER:                          'user',
-  KONTAINER_DRIVER:              'kontainerDriver',
-  NODE_DRIVER:                   'nodeDriver'
+  KONTAINER_DRIVER:              'kontainerdriver',
+  NODE_DRIVER:                   'nodedriver'
 };
 
 // Public (via Norman)

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -20,8 +20,8 @@ export const NORMAN = {
   CLUSTER_ROLE_TEMPLATE_BINDING: 'clusterroletemplatebinding',
   CLOUD_CREDENTIAL:              'cloudcredential',
   FLEET_WORKSPACES:              'fleetworkspace',
-  GLOBAL_ROLE:                   'globalrole',
-  GLOBAL_ROLE_BINDING:           'globalrolebinding',
+  GLOBAL_ROLE:                   'globalRole',
+  GLOBAL_ROLE_BINDING:           'globalRoleBinding',
 
   NODE_POOL:                     'nodePool',
   // Note - This allows access to node resources, not schema's or custom components (both are accessed via 'type' which clashes with kube node)
@@ -31,11 +31,11 @@ export const NORMAN = {
   PROJECT_ROLE_TEMPLATE_BINDING: 'projectroletemplatebinding',
   SETTING:                       'setting',
   SPOOFED:                       { GROUP_PRINCIPAL: 'group.principal' },
-  ROLE_TEMPLATE:                 'roletemplate',
+  ROLE_TEMPLATE:                 'roleTemplate',
   TOKEN:                         'token',
   USER:                          'user',
-  KONTAINER_DRIVER:              'kontainerdriver',
-  NODE_DRIVER:                   'nodedriver'
+  KONTAINER_DRIVER:              'kontainerDriver',
+  NODE_DRIVER:                   'nodeDriver'
 };
 
 // Public (via Norman)

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -645,7 +645,10 @@ export default {
     const schema = ctx.getters['schemaFor'](userData.type);
 
     if (schema) {
-      await schema.fetchResourceFields();
+      if (schema.fetchResourceFields) {
+        // fetch resourceFields for createYaml
+        await schema.fetchResourceFields();
+      }
       data = ctx.getters['defaultFor'](userData.type, schema);
     }
 

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -8,6 +8,7 @@ import { normalizeType } from './normalize';
 import garbageCollect from '@shell/utils/gc/gc';
 import { addSchemaIndexFields } from '@shell/plugins/steve/schema.utils';
 import { addParam } from '@shell/utils/url';
+import { conditionalDepaginate } from '@shell/store/type-map.utils';
 
 export const _ALL = 'all';
 export const _MERGE = 'merge';
@@ -194,7 +195,7 @@ export default {
     opt = opt || {};
     opt.url = getters.urlFor(type, null, opt);
     opt.stream = opt.stream !== false && load !== _NONE;
-    opt.depaginate = typeOptions?.depaginate;
+    opt.depaginate = conditionalDepaginate(typeOptions?.depaginate, { ctx, args: { type, opt } });
 
     let skipHaveAll = false;
 
@@ -461,7 +462,7 @@ export default {
     opt = opt || {};
     opt.labelSelector = selector;
     opt.url = getters.urlFor(type, null, opt);
-    opt.depaginate = typeOptions?.depaginate;
+    opt.depaginate = conditionalDepaginate(typeOptions?.depaginate, { ctx, args: { type, opt } });
 
     const res = await dispatch('request', { opt, type });
 

--- a/shell/store/type-map.utils.ts
+++ b/shell/store/type-map.utils.ts
@@ -2,6 +2,8 @@ import { SchemaAttribute, SchemaAttributeColumn } from '@shell/plugins/steve/sch
 import { TableColumn } from '@shell/types/store/type-map';
 import { VuexStoreGetters } from '@shell/types/store/vuex';
 import { findBy, insertAt, removeObject } from '@shell/utils/array';
+import { COUNT } from '@shell/config/types';
+import { ActionFindAllArgs } from '@shell/types/store/dashboard-store.types';
 
 const FIELD_REGEX = /^\$\.metadata\.fields\[([0-9]*)\]/;
 
@@ -181,3 +183,44 @@ export function rowValueGetter(col: SchemaAttributeColumn, asFn = true): string 
 
   return value;
 }
+
+type conditionalDepaginateArgs ={
+  ctx: { rootGetters: VuexStoreGetters},
+  args: { type: string, opt: ActionFindAllArgs},
+};
+type conditionalDepaginateFn = (args: conditionalDepaginateArgs) => boolean
+
+/**
+ * Conditionally determine if a resource should use naive kube pagination api to fetch all results
+ * (not just first page)
+ */
+export const conditionalDepaginate = (
+  depaginate?: conditionalDepaginateFn | boolean,
+  depaginateArgs?: conditionalDepaginateArgs
+): boolean => {
+  if (typeof depaginate === 'function') {
+    return !!depaginateArgs ? depaginate(depaginateArgs) : false;
+  }
+
+  return depaginate as boolean;
+};
+
+/**
+ * Setup a function that will determine if a resource should use native kube pagination api to fetch all resources
+ * (not just the first page)
+ */
+export const configureConditionalDepaginate = (
+  { maxResourceCount, isNorman = false }: { maxResourceCount: number, isNorman: boolean },
+): conditionalDepaginateFn => {
+  return (fnArgs: conditionalDepaginateArgs ): boolean => {
+    const { rootGetters } = fnArgs.ctx;
+    const { type } = fnArgs.args;
+    const safeType = isNorman ? `management.cattle.io.${ type }` : type;
+
+    const inStore = rootGetters['currentStore'](safeType);
+    const resourceCounts = rootGetters[`${ inStore }/all`](COUNT)[0]?.counts[safeType];
+    const resourceCount = resourceCounts?.summary?.count;
+
+    return resourceCount !== undefined ? resourceCount < maxResourceCount : false;
+  };
+};

--- a/shell/types/store/dashboard-store.types.ts
+++ b/shell/types/store/dashboard-store.types.ts
@@ -16,6 +16,12 @@ export interface ActionFindAllArgs extends ActionCoreFindArgs {
   incremental?: boolean,
   hasManualRefresh?: boolean,
   limit?: number,
+  /**
+   * Iterate over all pages and return all resources.
+   *
+   * This is done via the native kube pagination api, not steve
+   */
+  depaginate?: boolean,
 }
 
 /**


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11024
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Support conditionally de-paginating resource lists
- Apply conditional de-pagination to cluster and project bindings. Counts of either over 5000 will mean NO de-pagination happens
- This will ensure users with an amount of resources that the UI can reasonable fetch and cache... are fetched. For users with too many the current functionality continues (some bindings will be missing)
  - In the next feature release these changes will most probably be reverted and server-side pagination is used instead

### Technical notes summary
Main change
- change `depaginate` `type` setting from boolean to boolean | function
- depaginate function will conditionally return true
- currently condition only supports a pre-defined count (don't de-paginate if there are too many resources)

In addition / supporting changes
- fix `currentProduct(resource)` getter lookups for norman cluster and project roles (they returned `cluster` instead of `rancher`, affected by case sensitive type name)
- fix for some cases where we were creating or viewing norman resources and trying to call steve only fetchResourceFields

### Areas or cases that should be tested

Resource | Count | Expectation
----|-----|-----
Cluster Bindings | under 1k | Cluster --> Cluster and Project Roles --> Cluster Tab. All results should show (it should be enough just to check the `of X Cluster Memberships` in pagination control at bottom)
Cluster Bindings | over 1k and under 5k | Cluster --> Cluster and Project Roles --> Cluster Tab. All results should show (it should be enough just to check the `of X Cluster Memberships` in pagination control at bottom)
Cluster Bindings | over 5k | Cluster --> Cluster and Project Roles --> Cluster Tab. Only 1k results should show (it should be enough just to check the `of X Cluster Memberships` in pagination control at bottom)
Project Bindings | under 1k | Cluster --> Cluster and Project Roles --> Project Tab. All results should show (it should be enough just to check the `of X Project Memberships` in pagination control at bottom)
Project Bindings | over 1k and under 5k | Cluster --> Cluster and Project Roles --> Project Tab. All results should show (it should be enough just to check the `of X Project Memberships` in pagination control at bottom)
Project Bindings | over 5k | Cluster --> Cluster and Project Roles --> Project Tab. Only 1k results should show (it should be enough just to check the `of X Project Memberships` in pagination control at bottom)


### Areas which could experience regressions
- Create and then view any resource type, no errors in console

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
