### PR TITLE
Extensions: Add support for noAuth in publish script

### DIFF
--- a/shell/scripts/extension/helm/charts/ui-plugin-server/templates/cr.yaml
+++ b/shell/scripts/extension/helm/charts/ui-plugin-server/templates/cr.yaml
@@ -10,4 +10,5 @@ spec:
     version: {{ (semver (default .Chart.AppVersion .Values.plugin.versionOverride)).Original }}
     endpoint: http://{{ include "extension-server.fullname" . }}.{{ .Release.Namespace }}.svc
     noCache: {{ .Values.plugin.noCache }}
+    noAuth: {{ .Values.plugin.noAuth }}
     metadata: {{ include "extension-server.pluginMetadata" . | indent 6 }}

--- a/shell/scripts/extension/helm/charts/ui-plugin-server/values.yaml
+++ b/shell/scripts/extension/helm/charts/ui-plugin-server/values.yaml
@@ -4,4 +4,5 @@ plugin:
   enabled: true
   versionOverride: ""
   noCache: false
+  noAuth: false
   metadata: {}

--- a/shell/scripts/extension/helm/scripts/patch
+++ b/shell/scripts/extension/helm/scripts/patch
@@ -58,9 +58,16 @@ ICON=$(cat ${PACKAGE_JSON} | jq ".icon" | tr -d '"')
 KEYWORDS=$(cat ${PACKAGE_JSON} | jq ".keywords")
 HOME=$(cat ${PACKAGE_JSON} | jq ".homepage" | tr -d '"')
 ANNOTATIONS=""
+NO_AUTH="false"
 
 if jq -e '.rancher.annotations | objects' ${PACKAGE_JSON} > /dev/null 2>&1; then
     ANNOTATIONS=$(jq -r '.rancher.annotations | to_entries[] | @base64' < ${PACKAGE_JSON})
+fi
+
+# Check if the package file specifies noAuth
+if jq -e '.rancher.noAuth' ${PACKAGE_JSON} > /dev/null 2>&1; then
+    NO_AUTH=$(jq -r '.rancher.noAuth' < ${PACKAGE_JSON})
+    echo "noAuth: ${NO_AUTH}"
 fi
 
 if [[ -z ${ORG} ]] || [[ -z ${REPO} ]] || [[ -z ${TAG} ]]; then
@@ -113,4 +120,9 @@ if [[ -n "${ANNOTATIONS}" ]]; then
 
         yq -i eval ".plugin.metadata[\"${key}\"] = \"${value}\"" $CHART/values.yaml
     done
+fi
+
+# If the extension has noAuth as true then patch this into the values.yaml to override the default of false
+if [ "${NO_AUTH}" == "true" ]; then
+    yq -i eval ".plugin.noAuth=true" $CHART/values.yaml
 fi

--- a/shell/scripts/extension/publish
+++ b/shell/scripts/extension/publish
@@ -23,7 +23,7 @@ GITHUB_SOURCE=$(git config --get remote.origin.url | sed -e 's/^git@.*:\([[:grap
 GITHUB_BRANCH="main"
 
 usage() {
-  echo "Usage: $0 [<options>] [plugins]"
+  echo "Usage: $0 [<options>] [extensions]"
   echo " options:"
   echo "  -s <repo>    Specify destination GitHub repository (org/name) - defaults to the git origin"
   echo "  -b <branch>  Specify destination GitHub branch"
@@ -86,7 +86,7 @@ shift $((OPTIND-1))
 PLUGINS=( "$@" )
 BUILT="false"
 
-echo -e "${CYAN}${BOLD}Publishing UI Plugins${RESET}"
+echo -e "${CYAN}${BOLD}Publishing UI Extensions${RESET}"
 
 pushd ${BASE_DIR} > /dev/null
 
@@ -184,7 +184,7 @@ if [ "${GITHUB_BUILD}" == "false" ]; then
   if [ "${PODMAN_CONTAINER}" == "false" ]; then
     docker images > /dev/null
     if [ $? -ne 0 ]; then
-      echo "docker is not running - this is required to build container images for the UI Plugins"
+      echo "docker is not running - this is required to build container images for the UI Extensions"
       exit 1
     fi
   fi
@@ -229,7 +229,7 @@ for d in pkg/*/ ; do
       continue
     fi
 
-    echo -e "${CYAN}${BOLD}Building plugin: ${pkg} (${PKG_VERSION}) ${RESET}"
+    echo -e "${CYAN}${BOLD}Building extension: ${pkg} (${PKG_VERSION}) ${RESET}"
 
     echo "Package version: ${PKG_VERSION}"
     echo "Package folder:  ${PKG_NAME}"
@@ -237,10 +237,10 @@ for d in pkg/*/ ; do
     # --------------------------------------------------------------------------------
     # Build the plugin from source
     # --------------------------------------------------------------------------------
-    echo -e "${CYAN}Building plugin from source code${RESET}"
+    echo -e "${CYAN}Building extension from source code${RESET}"
     FORCE_COLOR=1 yarn build-pkg $pkg | cat
 
-    echo -e "${CYAN}Adding plugin code ...${RESET}"
+    echo -e "${CYAN}Adding extension code ...${RESET}"
 
     EXT_FOLDER=${BASE_DIR}/extensions/${pkg}/${PKG_VERSION}
     PKG_DIST="${BASE_DIR}/dist-pkg/${PKG_NAME}"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11219
<!-- Define findings related to the feature or bug issue. -->

Updates the extension publish script so that if the extension's `package.json` file specifies `noAuth` then this will be wired into the extension Helm package.

Note: I also updated some of the log statements to refer to Extensions rather than Plugins.

### Areas or cases that should be tested

No manual testing - we will test this as part of Extensions development.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
