### PR TITLE
update docs for noAuth annotation

### DIFF
--- a/docusaurus/docs/extensions/extensions-configuration.md
+++ b/docusaurus/docs/extensions/extensions-configuration.md
@@ -72,6 +72,7 @@ It's possible that different products will use the same kubernetes resource, but
 | `catalog.cattle.io/ui-extensions-version` | `Range` | Determines the Extensions API version that is compatible with the Extension package. |
 | `catalog.cattle.io/ui-version` | `Range` | Determines the Rancher UI version that is compatible with the Extension package. |
 | `catalog.cattle.io/display-name` | `String` | Specifies the Display Name for an Extension package's card on the "Extensions" page. |
+| `noAuth` | `String` | Boolean in string format. If `noAuth` is set to `"true"` then the extension will be loaded even when the user is logged out. (Rancher 2.9 - Extensions API 2.0) |
 
 ## Example Configuration
 
@@ -89,7 +90,8 @@ ___`./pkg/my-package/package.json`___
       "catalog.cattle.io/rancher-version": ">= 2.7.7-0 < 2.9.0-0",
       "catalog.cattle.io/ui-extensions-version": ">= 1.1.0",
       "catalog.cattle.io/ui-version": ">= 2.7.7-0 < 2.9.0-0",
-      "catalog.cattle.io/display-name": "My Super Great Extension"
+      "catalog.cattle.io/display-name": "My Super Great Extension",
+      "noAuth": "true"
     }
   },
   ...

--- a/docusaurus/docs/extensions/extensions-configuration.md
+++ b/docusaurus/docs/extensions/extensions-configuration.md
@@ -96,7 +96,7 @@ ___`./pkg/my-package/package.json`___
       "catalog.cattle.io/ui-version": ">= 2.7.7-0 < 2.9.0-0",
       "catalog.cattle.io/display-name": "My Super Great Extension"
     },
-    "noAuth": "true"
+    "noAuth": true
   },
   ...
 }

--- a/docusaurus/docs/extensions/extensions-configuration.md
+++ b/docusaurus/docs/extensions/extensions-configuration.md
@@ -72,7 +72,11 @@ It's possible that different products will use the same kubernetes resource, but
 | `catalog.cattle.io/ui-extensions-version` | `Range` | Determines the Extensions API version that is compatible with the Extension package. |
 | `catalog.cattle.io/ui-version` | `Range` | Determines the Rancher UI version that is compatible with the Extension package. |
 | `catalog.cattle.io/display-name` | `String` | Specifies the Display Name for an Extension package's card on the "Extensions" page. |
-| `noAuth` | `String` | Boolean in string format. If `noAuth` is set to `"true"` then the extension will be loaded even when the user is logged out. (Rancher 2.9 - Extensions API 2.0) |
+
+## Other configuration properties
+| Property | Value | Description |
+| ------ | :------: | --------------|
+| `noAuth` | `Boolean` | If `noAuth` is set to `true` then the extension will be loaded even when the user is logged out. (Rancher 2.9 - Extensions API 2.0) |
 
 ## Example Configuration
 
@@ -90,9 +94,9 @@ ___`./pkg/my-package/package.json`___
       "catalog.cattle.io/rancher-version": ">= 2.7.7-0 < 2.9.0-0",
       "catalog.cattle.io/ui-extensions-version": ">= 1.1.0",
       "catalog.cattle.io/ui-version": ">= 2.7.7-0 < 2.9.0-0",
-      "catalog.cattle.io/display-name": "My Super Great Extension",
-      "noAuth": "true"
-    }
+      "catalog.cattle.io/display-name": "My Super Great Extension"
+    },
+    "noAuth": "true"
   },
   ...
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- update docs for noAuth annotation

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
