### PR TITLE
Fix VSCode typescript warning for components that have mixins which use ChildHook

### DIFF
--- a/shell/components/PromptRestore.vue
+++ b/shell/components/PromptRestore.vue
@@ -30,10 +30,6 @@ export default {
 
   name: 'PromptRestore',
 
-  mixins: [
-    ChildHook,
-  ],
-
   data() {
     return {
       errors:           [],
@@ -98,6 +94,8 @@ export default {
   },
 
   methods: {
+    ...ChildHook.methods,
+
     close() {
       this.errors = [];
       this.labels = {};

--- a/shell/mixins/create-edit-view/impl.js
+++ b/shell/mixins/create-edit-view/impl.js
@@ -10,8 +10,6 @@ export default {
 
   name: 'CreateEditView',
 
-  mixins: [ChildHook],
-
   data() {
     // Keep label and annotation filters in data so each resource CRUD page can alter individually
     return { errors: [] };
@@ -90,6 +88,8 @@ export default {
   },
 
   methods: {
+    ...ChildHook.methods,
+
     done() {
       if ( this.doneEvent ) {
         this.$emit('done');

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -76,7 +76,6 @@ export default {
   },
 
   mixins: [
-    ChildHook,
     ChartMixin
   ],
 
@@ -839,6 +838,8 @@ export default {
   },
 
   methods: {
+    ...ChildHook.methods,
+
     async getClusterRegistry() {
       const hasPermissionToSeeProvCluster = this.$store.getters[`management/schemaFor`](CAPI.RANCHER_CLUSTER);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Fix VSCode typescript warning for components that have mixins which use ChildHook
```
Argument of type ' ... ' is not assignable to parameter of type 'never'.ts(2345)
```

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
