### PR TITLE
[Automation] - Adding Cluster Events table tests

### DIFF
--- a/cypress/e2e/blueprints/explorer/cluster/events.ts
+++ b/cypress/e2e/blueprints/explorer/cluster/events.ts
@@ -1,3 +1,14 @@
+// GET /v1/events - return empty events data
+const eventsGetEmptyEventsSet = {
+  type:         'collection',
+  links:        { self: `${ Cypress.env('api') }/v1/events` },
+  createTypes:  { event: `${ Cypress.env('api') }/v1/events` },
+  actions:      {},
+  resourceType: 'event',
+  revision:     '95942',
+  data:         []
+};
+
 // GET /v1/events - small set of events data
 const eventsGetResponseSmallSet = {
   type:         'collection',
@@ -3902,6 +3913,10 @@ function reply(statusCode: number, body: any) {
       body
     });
   };
+}
+
+export function eventsNoDataset(): Cypress.Chainable<Response> {
+  return cy.intercept('GET', '/v1/events?*', reply(200, eventsGetEmptyEventsSet)).as('eventsNoData');
 }
 
 export function generateEventsDataSmall(): Cypress.Chainable<Response> {

--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -8,7 +8,7 @@ import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/
 import { NodesPagePo } from '@/cypress/e2e/po/pages/explorer/nodes.po';
 import { EventsPagePo } from '@/cypress/e2e/po/pages/explorer/events.po';
 import * as path from 'path';
-import { generateEventsDataLarge, generateEventsDataSmall } from '@/cypress/e2e/blueprints/explorer/cluster/events';
+import { generateEventsDataLarge, generateEventsDataSmall, eventsNoDataset } from '@/cypress/e2e/blueprints/explorer/cluster/events';
 import { groupByPayload } from '@/cypress/e2e/blueprints/user_preferences/group_by';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
@@ -366,6 +366,41 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
       events.sortableTable().checkRowCount(false, 3);
       events.sortableTable().pagination().checkNotExists();
     });
+  });
+  it('can view events table empty if no events', { tags: ['@vai'] }, () => {
+    const events = new EventsPagePo('local');
+
+    HomePagePo.goTo();
+
+    eventsNoDataset();
+    ClusterDashboardPagePo.navTo();
+    cy.wait('@eventsNoData');
+    clusterDashboard.waitForPage(undefined, 'cluster-events');
+
+    clusterDashboard.eventsList().resourceTable().sortableTable().checkRowCount(true, 1);
+
+    const expectedHeaders = ['Reason', 'Object', 'Message', 'Name', 'Date'];
+
+    clusterDashboard.eventsList().resourceTable().sortableTable().tableHeaderRow()
+      .find('.table-header-container .content')
+      .each((el, i) => {
+        expect(el.text().trim()).to.eq(expectedHeaders[i]);
+      });
+
+    clusterDashboard.fullEventsLink().click();
+    cy.wait('@eventsNoData');
+    events.waitForPage();
+
+    events.eventslist().resourceTable().sortableTable().checkRowCount(true, 1);
+
+    const expectedFullHeaders = ['State', 'Last Seen', 'Type', 'Reason', 'Object',
+      'Subobject', 'Source', 'Message', 'First Seen', 'Count', 'Name', 'Namespace'];
+
+    events.eventslist().resourceTable().sortableTable().tableHeaderRow()
+      .find('.table-header-container .content')
+      .each((el, i) => {
+        expect(el.text().trim()).to.eq(expectedFullHeaders[i]);
+      });
   });
 
   after(function() {


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/1384

### Occurred changes and/or fixed issues
Updating the Cluster Dashboard events tests to include table headers validations. It currently does basic data validation.

- This is validating the empty table scenario.
- A basic table with data scenario already exist in the suite.
- Pagination is done in a separate PR https://github.com/rancher/dashboard/pull/11234

### Areas or cases that should be tested
Automation pipeline

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
