### PR TITLE
EKS fix validation when no credential is found, cluster name display

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -255,23 +255,23 @@ export default defineComponent({
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
 
-    needsValidation() {
-      return !!this.config.amazonCredentialSecret;
-    },
+    fvExtraRules(): {[key:string]: Function} {
+      if (this.hasCredential) {
+        return {
+          nameRequired:           EKSValidators.clusterNameRequired(this),
+          nodeGroupNamesRequired: EKSValidators.nodeGroupNamesRequired(this),
+          nodeGroupNamesUnique:   EKSValidators.nodeGroupNamesUnique(this),
+          maxSize:                EKSValidators.maxSize(this),
+          minSize:                EKSValidators.minSize(this),
+          diskSize:               EKSValidators.diskSize(this),
+          instanceType:           EKSValidators.instanceType(this),
+          desiredSize:            EKSValidators.desiredSize(this),
+          subnets:                EKSValidators.subnets(this),
+          publicPrivateAccess:    EKSValidators.publicPrivateAccess(this),
+        };
+      }
 
-    fvExtraRules() {
-      return {
-        nameRequired:           EKSValidators.clusterNameRequired(this),
-        nodeGroupNamesRequired: EKSValidators.nodeGroupNamesRequired(this),
-        nodeGroupNamesUnique:   EKSValidators.nodeGroupNamesUnique(this),
-        maxSize:                EKSValidators.maxSize(this),
-        minSize:                EKSValidators.minSize(this),
-        diskSize:               EKSValidators.diskSize(this),
-        instanceType:           EKSValidators.instanceType(this),
-        desiredSize:            EKSValidators.desiredSize(this),
-        subnets:                EKSValidators.subnets(this),
-        publicPrivateAccess:    EKSValidators.publicPrivateAccess(this),
-      };
+      return {};
     },
 
     // upstreamSpec will be null if the user created a cluster with some invalid options such that it ultimately fails to create anything in aks

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -525,9 +525,10 @@ export default defineComponent({
         <LabeledInput
           required
           label-key="eks.clusterName.label"
-          :value="normanCluster.name"
+          :value="config.displayName"
           :mode="mode"
           :rules="fvGetAndReportPathRules('name')"
+          data-testid="eks-name-input"
           @input="setClusterName"
         />
       </div>

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -25,6 +25,7 @@ import Logging from './Logging.vue';
 import Config from './Config.vue';
 import Networking from './Networking.vue';
 import AccountAccess from './AccountAccess.vue';
+import EKSValidators from '../util/validators';
 
 const DEFAULT_CLUSTER = {
   dockerRootDir:                       '/var/lib/docker',
@@ -162,7 +163,8 @@ export default defineComponent({
       },
       {
         path:  'nodegroupNames',
-        rules: ['nodeGroupNamesUnique', 'nodeGroupNamesRequired']
+        rules: ['nodeGroupNamesRequired', 'nodeGroupNamesUnique']
+
       },
       {
         path:  'maxSize',
@@ -253,122 +255,22 @@ export default defineComponent({
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
 
-    needsValidaation() {
+    needsValidation() {
       return !!this.config.amazonCredentialSecret;
     },
 
     fvExtraRules() {
       return {
-        nameRequired: () => {
-          return this.needsValidation && !this.config.displayName ? this.t('validation.required', { key: this.t('nameNsDescription.name.label') }) : null;
-        },
-        nodeGroupNamesRequired: (node: EKSNodeGroup) => {
-          if (!this.needsValidation) {
-            return;
-          }
-          if (node) {
-            return !!node.nodegroupName ? this.t('validation.required', { key: this.t('eks.nodeGroups.name.label') }) : null;
-          }
-
-          return !!this.nodeGroups.find((group) => !group.nodegroupName) ? this.t('validation.required', { key: this.t('eks.nodeGroups.name.label') }) : null;
-        },
-        nodeGroupNamesUnique: (node: EKSNodeGroup): null | string => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          if (node) {
-            return node.__nameUnique === false ? this.t('eks.errors.nodeGroups.nameUnique') : null;
-          }
-          let out = null as null|string;
-
-          const names = this.nodeGroups.map((node) => node.nodegroupName);
-
-          this.nodeGroups.forEach((group) => {
-            const name = group.nodegroupName;
-
-            if (names.filter((n) => n === name).length > 1) {
-              this.$set(group, '__nameUnique', false);
-              if (!out) {
-                out = this.t('eks.errors.nodeGroups.nameUnique');
-              }
-            }
-          });
-
-          return out;
-        },
-        maxSize: (size: number) => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          const msg = this.t('eks.errors.greaterThanZero', { key: this.t('eks.nodeGroups.maxSize.label') });
-
-          if (size !== undefined) {
-            return size > 0 ? null : msg;
-          }
-
-          return !!this.nodeGroups.find((group) => !group.maxSize || group.maxSize <= 0) ? msg : null;
-        },
-        minSize: (size: number) => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          const msg = this.t('eks.errors.greaterThanZero', { key: this.t('eks.nodeGroups.minSize.label') });
-
-          if (size !== undefined) {
-            return size > 0 ? null : msg;
-          }
-
-          return !!this.nodeGroups.find((group) => !group.minSize || group.minSize <= 0) ? msg : null;
-        },
-        diskSize: (type: string) => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          if (type || type === '') {
-            return !type ? this.t('validation.required', { key: this.t('eks.nodeGroups.diskSize.label') }) : null;
-          }
-
-          return !!this.nodeGroups.find((group: EKSNodeGroup) => !group.diskSize ) ? this.t('validation.required', { key: this.t('eks.nodeGroups.instanceType.label') }) : null;
-        },
-        instanceType: (type: string) => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          if (type || type === '') {
-            return !type ? this.t('validation.required', { key: this.t('eks.nodeGroups.instanceType.label') }) : null;
-          }
-
-          return !!this.nodeGroups.find((group: EKSNodeGroup) => !group.instanceType && !group.requestSpotInstances) ? this.t('validation.required', { key: this.t('eks.nodeGroups.instanceType.label') }) : null;
-        },
-        desiredSize: (size: number) => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          const msg = this.t('eks.errors.greaterThanZero', { key: this.t('eks.nodeGroups.desiredSize.label') });
-
-          if (size !== undefined) {
-            return size > 0 ? null : msg;
-          }
-
-          return !!this.nodeGroups.find((group) => !group.desiredSize || group.desiredSize <= 0) ? msg : null;
-        },
-        subnets: (val: string[]) => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          const subnets = val || this.config.subnets;
-
-          return subnets && subnets.length === 1 ? this.t('eks.errors.minimumSubnets') : undefined;
-        },
-        publicPrivateAccess: (): string | undefined => {
-          if (!this.needsValidation) {
-            return null;
-          }
-          const { publicAccess, privateAccess } = this.config;
-
-          return publicAccess || privateAccess ? undefined : this.t('eks.errors.publicOrPrivate');
-        },
-
+        nameRequired:           EKSValidators.clusterNameRequired(this),
+        nodeGroupNamesRequired: EKSValidators.nodeGroupNamesRequired(this),
+        nodeGroupNamesUnique:   EKSValidators.nodeGroupNamesUnique(this),
+        maxSize:                EKSValidators.maxSize(this),
+        minSize:                EKSValidators.minSize(this),
+        diskSize:               EKSValidators.diskSize(this),
+        instanceType:           EKSValidators.instanceType(this),
+        desiredSize:            EKSValidators.desiredSize(this),
+        subnets:                EKSValidators.subnets(this),
+        publicPrivateAccess:    EKSValidators.publicPrivateAccess(this),
       };
     },
 
@@ -664,7 +566,8 @@ export default defineComponent({
         <Tab
           v-for="(node, i) in nodeGroups"
           :key="i"
-          :name="node.nodegroupName"
+          :label="node.nodegroupName || t('eks.nodeGroups.unnamed')"
+          :name="`${node.nodegroupName} ${i}`"
         >
           <NodeGroup
             :rules="{

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -253,12 +253,19 @@ export default defineComponent({
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
 
+    needsValidaation() {
+      return !!this.config.amazonCredentialSecret;
+    },
+
     fvExtraRules() {
       return {
         nameRequired: () => {
-          return !this.config.displayName ? this.t('validation.required', { key: this.t('nameNsDescription.name.label') }) : null;
+          return this.needsValidation && !this.config.displayName ? this.t('validation.required', { key: this.t('nameNsDescription.name.label') }) : null;
         },
         nodeGroupNamesRequired: (node: EKSNodeGroup) => {
+          if (!this.needsValidation) {
+            return;
+          }
           if (node) {
             return !!node.nodegroupName ? this.t('validation.required', { key: this.t('eks.nodeGroups.name.label') }) : null;
           }
@@ -266,6 +273,9 @@ export default defineComponent({
           return !!this.nodeGroups.find((group) => !group.nodegroupName) ? this.t('validation.required', { key: this.t('eks.nodeGroups.name.label') }) : null;
         },
         nodeGroupNamesUnique: (node: EKSNodeGroup): null | string => {
+          if (!this.needsValidation) {
+            return null;
+          }
           if (node) {
             return node.__nameUnique === false ? this.t('eks.errors.nodeGroups.nameUnique') : null;
           }
@@ -287,6 +297,9 @@ export default defineComponent({
           return out;
         },
         maxSize: (size: number) => {
+          if (!this.needsValidation) {
+            return null;
+          }
           const msg = this.t('eks.errors.greaterThanZero', { key: this.t('eks.nodeGroups.maxSize.label') });
 
           if (size !== undefined) {
@@ -296,6 +309,9 @@ export default defineComponent({
           return !!this.nodeGroups.find((group) => !group.maxSize || group.maxSize <= 0) ? msg : null;
         },
         minSize: (size: number) => {
+          if (!this.needsValidation) {
+            return null;
+          }
           const msg = this.t('eks.errors.greaterThanZero', { key: this.t('eks.nodeGroups.minSize.label') });
 
           if (size !== undefined) {
@@ -305,6 +321,9 @@ export default defineComponent({
           return !!this.nodeGroups.find((group) => !group.minSize || group.minSize <= 0) ? msg : null;
         },
         diskSize: (type: string) => {
+          if (!this.needsValidation) {
+            return null;
+          }
           if (type || type === '') {
             return !type ? this.t('validation.required', { key: this.t('eks.nodeGroups.diskSize.label') }) : null;
           }
@@ -312,6 +331,9 @@ export default defineComponent({
           return !!this.nodeGroups.find((group: EKSNodeGroup) => !group.diskSize ) ? this.t('validation.required', { key: this.t('eks.nodeGroups.instanceType.label') }) : null;
         },
         instanceType: (type: string) => {
+          if (!this.needsValidation) {
+            return null;
+          }
           if (type || type === '') {
             return !type ? this.t('validation.required', { key: this.t('eks.nodeGroups.instanceType.label') }) : null;
           }
@@ -319,6 +341,9 @@ export default defineComponent({
           return !!this.nodeGroups.find((group: EKSNodeGroup) => !group.instanceType && !group.requestSpotInstances) ? this.t('validation.required', { key: this.t('eks.nodeGroups.instanceType.label') }) : null;
         },
         desiredSize: (size: number) => {
+          if (!this.needsValidation) {
+            return null;
+          }
           const msg = this.t('eks.errors.greaterThanZero', { key: this.t('eks.nodeGroups.desiredSize.label') });
 
           if (size !== undefined) {
@@ -328,11 +353,17 @@ export default defineComponent({
           return !!this.nodeGroups.find((group) => !group.desiredSize || group.desiredSize <= 0) ? msg : null;
         },
         subnets: (val: string[]) => {
+          if (!this.needsValidation) {
+            return null;
+          }
           const subnets = val || this.config.subnets;
 
           return subnets && subnets.length === 1 ? this.t('eks.errors.minimumSubnets') : undefined;
         },
         publicPrivateAccess: (): string | undefined => {
+          if (!this.needsValidation) {
+            return null;
+          }
           const { publicAccess, privateAccess } = this.config;
 
           return publicAccess || privateAccess ? undefined : this.t('eks.errors.publicOrPrivate');

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -71,4 +71,31 @@ describe('eKS provisioning form', () => {
     await setCredential(wrapper);
     expect(wrapper.find(formSelector).exists()).toBe(true);
   });
+
+  it('should update both cluster.name and config.displayName when the name input is altered', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'create' },
+      ...requiredSetup()
+    });
+
+    const formSelector = '[data-testid="crueks-form"]';
+
+    expect(wrapper.find(formSelector).exists()).toBe(false);
+
+    await setCredential(wrapper);
+
+    const nameInput = wrapper.find('[data-testid="eks-name-input"]');
+
+    nameInput.vm.$emit('input', 'abc');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.config.displayName).toStrictEqual('abc');
+    expect(wrapper.vm.normanCluster.name).toStrictEqual('abc');
+    expect(nameInput.props().value).toStrictEqual('abc');
+
+    nameInput.vm.$emit('input', 'def');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.config.displayName).toStrictEqual('def');
+    expect(wrapper.vm.normanCluster.name).toStrictEqual('def');
+    expect(nameInput.props().value).toStrictEqual('def');
+  });
 });

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -72,6 +72,24 @@ describe('eKS provisioning form', () => {
     expect(wrapper.find(formSelector).exists()).toBe(true);
   });
 
+  it('should not use form validation if no credential is selected', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'create' },
+      ...requiredSetup()
+    });
+
+    let fvRules = wrapper.vm.fvExtraRules;
+
+    expect(fvRules).toStrictEqual({});
+
+    await setCredential(wrapper);
+    await wrapper.vm.$nextTick();
+
+    fvRules = wrapper.vm.fvExtraRules;
+
+    expect(Object.keys(fvRules).length).toBeGreaterThan(0);
+  });
+
   it('should update both cluster.name and config.displayName when the name input is altered', async() => {
     const wrapper = shallowMount(CruEKS, {
       propsData: { value: {}, mode: 'create' },

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -90,7 +90,7 @@ eks:
     addEndpoint: Add Endpoint
     label: Public Access Endpoints
   region:
-    label: RegionW
+    label: Region
   scheduler:
     label: Scheduler
     tooltip: The scheduler component manages when and where to run pods in your cluster.

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -75,6 +75,7 @@ eks:
     spotInstanceTypes:
       label: Spot Instance Types
     title: Node Groups
+    unnamed: Unnamed Node Group
     userData:
       label: User Data
       tooltip: Pass user data to <a href="https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data" target="_blank">Amazon using cloud-init</a> to automate common operations.
@@ -89,7 +90,7 @@ eks:
     addEndpoint: Add Endpoint
     label: Public Access Endpoints
   region:
-    label: Region
+    label: RegionW
   scheduler:
     label: Scheduler
     tooltip: The scheduler component manages when and where to run pods in your cluster.

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -76,7 +76,7 @@ describe('validate EKS node group names', () => {
       t:               mockTranslation,
       needsValidation: true
     } as any as CruEKSContext, 'validation.required'],
-  ])('should validate all node groups if not passed a specific node group', (ctx, expected) => {
+  ])('should validate that all node groups have names if not passed a specific node group', (ctx, expected) => {
     const res = EKSValidators.nodeGroupNamesRequired(ctx)(undefined);
 
     expect(res).toBe(expected);
@@ -122,8 +122,4 @@ describe('validate EKS node group names', () => {
 
     expect(res).toBe(expected);
   });
-});
-
-describe('validate EKS node group max size', () => {
-
 });

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -1,0 +1,129 @@
+import EKSValidators, { CruEKSContext } from '../validators';
+
+const mockTranslation = (key: string) => key;
+
+describe('validate EKS Cluster name', () => {
+  it('should return an error if displayName is an empty string or undefined', () => {
+    const ctx = {
+      config:          { displayName: '' },
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.clusterNameRequired(ctx)();
+
+    expect(res).toBeDefined();
+  });
+
+  it('should not return an error if cruEKS needsValidation is false', () => {
+    const ctx = {
+      config:          { displayName: '' },
+      t:               mockTranslation,
+      needsValidation: false
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.clusterNameRequired(ctx)();
+
+    expect(res).toBeNull();
+  });
+
+  it('should not return an error if name is defined', () => {
+    const ctx = {
+      config:          { displayName: 'abc' },
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.clusterNameRequired(ctx)();
+
+    expect(res).toBeNull();
+  });
+});
+
+describe('validate EKS node group names', () => {
+  it('should return an error if the current node name is empty', () => {
+    const ctx = {
+      nodeGroups:      [],
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.nodeGroupNamesRequired(ctx)('');
+
+    expect(res).toBeDefined();
+  });
+
+  it('should not return an error if the current node name is defined', () => {
+    const ctx = {
+      nodeGroups:      [],
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.nodeGroupNamesRequired(ctx)('abc');
+
+    expect(res).toBeDefined();
+  });
+
+  it.each([
+    [{
+      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext, null],
+    [{
+      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: '' }],
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext, 'validation.required'],
+  ])('should validate all node groups if not passed a specific node group', (ctx, expected) => {
+    const res = EKSValidators.nodeGroupNamesRequired(ctx)(undefined);
+
+    expect(res).toBe(expected);
+  });
+
+  it.each([
+    [{
+      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext, 'abc', null],
+    [{
+      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext, 'abc', 'eks.errors.nodeGroups.nameUnique'],
+    [{
+      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:               mockTranslation,
+      needsValidation: true
+    } as any as CruEKSContext, 'def', null],
+  ])('should return an error if the node group name passed in is not unique within ctx', (ctx, nodeGroupName, expected) => {
+    const res = EKSValidators.nodeGroupNamesUnique(ctx)(nodeGroupName);
+
+    expect(res).toBe(expected);
+  });
+
+  it.each([
+    [{
+      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:               mockTranslation,
+      needsValidation: true,
+      $set:            () => {}
+    } as any as CruEKSContext, null],
+    [{
+      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:               mockTranslation,
+      needsValidation: true,
+      $set:            () => {}
+    } as any as CruEKSContext, 'eks.errors.nodeGroups.nameUnique']
+  ])('should return an error if any node group within ctx has non-unique name, if not passed a name', (ctx, expected) => {
+    const res = EKSValidators.nodeGroupNamesUnique(ctx)(undefined);
+
+    expect(res).toBe(expected);
+  });
+});
+
+describe('validate EKS node group max size', () => {
+
+});

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -15,18 +15,6 @@ describe('validate EKS Cluster name', () => {
     expect(res).toBeDefined();
   });
 
-  it('should not return an error if cruEKS needsValidation is false', () => {
-    const ctx = {
-      config:          { displayName: '' },
-      t:               mockTranslation,
-      needsValidation: false
-    } as any as CruEKSContext;
-
-    const res = EKSValidators.clusterNameRequired(ctx)();
-
-    expect(res).toBeNull();
-  });
-
   it('should not return an error if name is defined', () => {
     const ctx = {
       config:          { displayName: 'abc' },

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -5,9 +5,8 @@ const mockTranslation = (key: string) => key;
 describe('validate EKS Cluster name', () => {
   it('should return an error if displayName is an empty string or undefined', () => {
     const ctx = {
-      config:          { displayName: '' },
-      t:               mockTranslation,
-      needsValidation: true
+      config: { displayName: '' },
+      t:      mockTranslation,
     } as any as CruEKSContext;
 
     const res = EKSValidators.clusterNameRequired(ctx)();
@@ -17,9 +16,8 @@ describe('validate EKS Cluster name', () => {
 
   it('should not return an error if name is defined', () => {
     const ctx = {
-      config:          { displayName: 'abc' },
-      t:               mockTranslation,
-      needsValidation: true
+      config: { displayName: 'abc' },
+      t:      mockTranslation,
     } as any as CruEKSContext;
 
     const res = EKSValidators.clusterNameRequired(ctx)();
@@ -31,9 +29,8 @@ describe('validate EKS Cluster name', () => {
 describe('validate EKS node group names', () => {
   it('should return an error if the current node name is empty', () => {
     const ctx = {
-      nodeGroups:      [],
-      t:               mockTranslation,
-      needsValidation: true
+      nodeGroups: [],
+      t:          mockTranslation,
     } as any as CruEKSContext;
 
     const res = EKSValidators.nodeGroupNamesRequired(ctx)('');
@@ -43,9 +40,8 @@ describe('validate EKS node group names', () => {
 
   it('should not return an error if the current node name is defined', () => {
     const ctx = {
-      nodeGroups:      [],
-      t:               mockTranslation,
-      needsValidation: true
+      nodeGroups: [],
+      t:          mockTranslation,
     } as any as CruEKSContext;
 
     const res = EKSValidators.nodeGroupNamesRequired(ctx)('abc');
@@ -55,14 +51,12 @@ describe('validate EKS node group names', () => {
 
   it.each([
     [{
-      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:               mockTranslation,
-      needsValidation: true
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:          mockTranslation,
     } as any as CruEKSContext, null],
     [{
-      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: '' }],
-      t:               mockTranslation,
-      needsValidation: true
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: '' }],
+      t:          mockTranslation,
     } as any as CruEKSContext, 'validation.required'],
   ])('should validate that all node groups have names if not passed a specific node group', (ctx, expected) => {
     const res = EKSValidators.nodeGroupNamesRequired(ctx)(undefined);
@@ -72,19 +66,16 @@ describe('validate EKS node group names', () => {
 
   it.each([
     [{
-      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:               mockTranslation,
-      needsValidation: true
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:          mockTranslation,
     } as any as CruEKSContext, 'abc', null],
     [{
-      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:               mockTranslation,
-      needsValidation: true
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:          mockTranslation,
     } as any as CruEKSContext, 'abc', 'eks.errors.nodeGroups.nameUnique'],
     [{
-      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:               mockTranslation,
-      needsValidation: true
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:          mockTranslation,
     } as any as CruEKSContext, 'def', null],
   ])('should return an error if the node group name passed in is not unique within ctx', (ctx, nodeGroupName, expected) => {
     const res = EKSValidators.nodeGroupNamesUnique(ctx)(nodeGroupName);
@@ -94,16 +85,14 @@ describe('validate EKS node group names', () => {
 
   it.each([
     [{
-      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:               mockTranslation,
-      needsValidation: true,
-      $set:            () => {}
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:          mockTranslation,
+      $set:       () => {}
     } as any as CruEKSContext, null],
     [{
-      nodeGroups:      [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
-      t:               mockTranslation,
-      needsValidation: true,
-      $set:            () => {}
+      nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
+      t:          mockTranslation,
+      $set:       () => {}
     } as any as CruEKSContext, 'eks.errors.nodeGroups.nameUnique']
   ])('should return an error if any node group within ctx has non-unique name, if not passed a name', (ctx, expected) => {
     const res = EKSValidators.nodeGroupNamesUnique(ctx)(undefined);

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -5,24 +5,16 @@ export interface CruEKSContext {
   t: Function,
   config: EKSConfig,
   nodeGroups: EKSNodeGroup[],
-  needsValidation: boolean
 }
 
 const clusterNameRequired = (ctx: CruEKSContext) => {
   return (): string | null => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
-
     return !ctx.config.displayName ? ctx.t('validation.required', { key: ctx.t('nameNsDescription.name.label') }) : null;
   };
 };
 
 const nodeGroupNamesRequired = (ctx: CruEKSContext) => {
   return (nodeName: string | undefined): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     if (nodeName !== undefined) {
       return nodeName === '' ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.name.label') }) : null;
     }
@@ -33,9 +25,6 @@ const nodeGroupNamesRequired = (ctx: CruEKSContext) => {
 
 const nodeGroupNamesUnique = (ctx: CruEKSContext) => {
   return (nodeName: string | undefined): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     let out = null as null|string;
 
     const names = ctx.nodeGroups.map((node) => node.nodegroupName);
@@ -62,9 +51,6 @@ const nodeGroupNamesUnique = (ctx: CruEKSContext) => {
 
 const maxSize = (ctx: CruEKSContext) => {
   return (size: number): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     const msg = ctx.t('eks.errors.greaterThanZero', { key: ctx.t('eks.nodeGroups.maxSize.label') });
 
     if (size !== undefined) {
@@ -77,9 +63,6 @@ const maxSize = (ctx: CruEKSContext) => {
 
 const minSize = (ctx: CruEKSContext) => {
   return (size: number): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     const msg = ctx.t('eks.errors.greaterThanZero', { key: ctx.t('eks.nodeGroups.minSize.label') });
 
     if (size !== undefined) {
@@ -92,9 +75,6 @@ const minSize = (ctx: CruEKSContext) => {
 
 const diskSize = (ctx: CruEKSContext) => {
   return (size: string): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     if (size || size === '') {
       return !size ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.diskSize.label') }) : null;
     }
@@ -105,9 +85,6 @@ const diskSize = (ctx: CruEKSContext) => {
 
 const instanceType = (ctx: CruEKSContext) => {
   return (type: string): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     if (type || type === '') {
       return !type ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.instanceType.label') }) : null;
     }
@@ -118,9 +95,6 @@ const instanceType = (ctx: CruEKSContext) => {
 
 const desiredSize = (ctx: CruEKSContext) => {
   return (size: number): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     const msg = ctx.t('eks.errors.greaterThanZero', { key: ctx.t('eks.nodeGroups.desiredSize.label') });
 
     if (size !== undefined) {
@@ -133,9 +107,6 @@ const desiredSize = (ctx: CruEKSContext) => {
 
 const subnets = (ctx: CruEKSContext) => {
   return (val: string[]): null | string => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     const subnets = val || ctx.config.subnets;
 
     return subnets && subnets.length === 1 ? ctx.t('eks.errors.minimumSubnets') : undefined;
@@ -144,9 +115,6 @@ const subnets = (ctx: CruEKSContext) => {
 
 const publicPrivateAccess = (ctx: CruEKSContext) => {
   return (): string | null => {
-    if (!ctx.needsValidation) {
-      return null;
-    }
     const { publicAccess, privateAccess } = ctx.config;
 
     return publicAccess || privateAccess ? undefined : ctx.t('eks.errors.publicOrPrivate');

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -1,0 +1,167 @@
+import { EKSConfig, EKSNodeGroup } from 'types';
+
+export interface CruEKSContext {
+  $set: Function,
+  t: Function,
+  config: EKSConfig,
+  nodeGroups: EKSNodeGroup[],
+  needsValidation: boolean
+}
+
+const clusterNameRequired = (ctx: CruEKSContext) => {
+  return (): string | null => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+
+    return !ctx.config.displayName ? ctx.t('validation.required', { key: ctx.t('nameNsDescription.name.label') }) : null;
+  };
+};
+
+const nodeGroupNamesRequired = (ctx: CruEKSContext) => {
+  return (nodeName: string | undefined): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    if (nodeName !== undefined) {
+      return nodeName === '' ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.name.label') }) : null;
+    }
+
+    return !!ctx.nodeGroups.find((group) => !group.nodegroupName) ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.name.label') }) : null;
+  };
+};
+
+const nodeGroupNamesUnique = (ctx: CruEKSContext) => {
+  return (nodeName: string | undefined): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    let out = null as null|string;
+
+    const names = ctx.nodeGroups.map((node) => node.nodegroupName);
+
+    if (nodeName !== undefined) {
+      const matchingNames = names.filter((n) => n === nodeName);
+
+      return matchingNames.length > 1 ? ctx.t('eks.errors.nodeGroups.nameUnique') : null;
+    }
+    ctx.nodeGroups.forEach((group) => {
+      const name = group.nodegroupName;
+
+      if (names.filter((n) => n === name).length > 1) {
+        ctx.$set(group, '__nameUnique', false);
+        if (!out) {
+          out = ctx.t('eks.errors.nodeGroups.nameUnique');
+        }
+      }
+    });
+
+    return out;
+  };
+};
+
+const maxSize = (ctx: CruEKSContext) => {
+  return (size: number): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    const msg = ctx.t('eks.errors.greaterThanZero', { key: ctx.t('eks.nodeGroups.maxSize.label') });
+
+    if (size !== undefined) {
+      return size > 0 ? null : msg;
+    }
+
+    return !!ctx.nodeGroups.find((group) => !group.maxSize || group.maxSize <= 0) ? msg : null;
+  };
+};
+
+const minSize = (ctx: CruEKSContext) => {
+  return (size: number): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    const msg = ctx.t('eks.errors.greaterThanZero', { key: ctx.t('eks.nodeGroups.minSize.label') });
+
+    if (size !== undefined) {
+      return size > 0 ? null : msg;
+    }
+
+    return !!ctx.nodeGroups.find((group) => !group.minSize || group.minSize <= 0) ? msg : null;
+  };
+};
+
+const diskSize = (ctx: CruEKSContext) => {
+  return (size: string): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    if (size || size === '') {
+      return !size ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.diskSize.label') }) : null;
+    }
+
+    return !!ctx.nodeGroups.find((group: EKSNodeGroup) => !group.diskSize ) ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.instanceType.label') }) : null;
+  };
+};
+
+const instanceType = (ctx: CruEKSContext) => {
+  return (type: string): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    if (type || type === '') {
+      return !type ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.instanceType.label') }) : null;
+    }
+
+    return !!ctx.nodeGroups.find((group: EKSNodeGroup) => !group.instanceType && !group.requestSpotInstances) ? ctx.t('validation.required', { key: ctx.t('eks.nodeGroups.instanceType.label') }) : null;
+  };
+};
+
+const desiredSize = (ctx: CruEKSContext) => {
+  return (size: number): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    const msg = ctx.t('eks.errors.greaterThanZero', { key: ctx.t('eks.nodeGroups.desiredSize.label') });
+
+    if (size !== undefined) {
+      return size > 0 ? null : msg;
+    }
+
+    return !!ctx.nodeGroups.find((group) => !group.desiredSize || group.desiredSize <= 0) ? msg : null;
+  };
+};
+
+const subnets = (ctx: CruEKSContext) => {
+  return (val: string[]): null | string => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    const subnets = val || ctx.config.subnets;
+
+    return subnets && subnets.length === 1 ? ctx.t('eks.errors.minimumSubnets') : undefined;
+  };
+};
+
+const publicPrivateAccess = (ctx: CruEKSContext) => {
+  return (): string | null => {
+    if (!ctx.needsValidation) {
+      return null;
+    }
+    const { publicAccess, privateAccess } = ctx.config;
+
+    return publicAccess || privateAccess ? undefined : ctx.t('eks.errors.publicOrPrivate');
+  };
+};
+
+export default {
+  clusterNameRequired,
+  nodeGroupNamesRequired,
+  nodeGroupNamesUnique,
+  maxSize,
+  minSize,
+  diskSize,
+  instanceType,
+  desiredSize,
+  subnets,
+  publicPrivateAccess
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11199 (see comment for details)
#11105 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates EKS form validators to not run until the form has renders. It also updates which name property is displayed in the name input, see https://github.com/rancher/dashboard/issues/11199#issuecomment-2163774098. This PR also has some tweaks to tab name/labels so there are no console errors thrown if the user tries to use duplicate node group names.

### Technical notes summary
Validators have been moved out of CruEKS to  write unit tests without having to test form validation mixin functionality.

### Areas or cases that should be tested
1. Create a cluster and verify that the POST request has correctly set both `cluster.name` and `cluster.eksConfig.displayName`
2. Edit the cluster and update the name; verify that both `cluster.name` and `cluster.eksConfig.displayName` are updated

Node groups:
1. Add a node pool and give it the same name as the first pool: the save button should be greyed out and an input-level error displayed. No console errors from tabbed.
2. Clear a node group's name: save button should be disabled and an input-level error shown. No console errors from tabbed. The tab should be labeled 'unnamed node group'



### Checklist
- [ x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
