### PR TITLE
Revert "Include Kubewarden extension tests"

### DIFF
--- a/cypress/e2e/po/pages/extensions/kubewarden.po.ts
+++ b/cypress/e2e/po/pages/extensions/kubewarden.po.ts
@@ -1,5 +1,5 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
-import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
+// import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
 
 export default class KubewardenExtensionPo extends PagePo {
   private static createPath(clusterId: string) {
@@ -15,15 +15,15 @@ export default class KubewardenExtensionPo extends PagePo {
   }
 
   /** add ui-plugin-charts repository */
-  addChartsRepoIfNeeded(): void {
-    const extensionsPo: ExtensionsPagePo = new ExtensionsPagePo();
+  // addChartsRepoIfNeeded(): void {
+  //   const extensionsPo: ExtensionsPagePo = new ExtensionsPagePo();
 
-    extensionsPo.waitForPage();
+  //   extensionsPo.waitForPage();
 
-    cy.get('body').then(($body: any) => {
-      if ( $body.find('[data-testid="extension-card-kubewarden"]').length === 0 ) {
-        extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-charts', 'main', 'rancher-extensions');
-      }
-    });
-  }
+  //   cy.get('body').then(($body: any) => {
+  //     if ( $body.find('[data-testid="extension-card-kubewarden"]').length === 0 ) {
+  //       extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-charts', 'main', 'rancher-extensions');
+  //     }
+  //   });
+  // }
 }

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -7,19 +7,18 @@ import { catchTargetPageException } from '@/cypress/support/utils/exception-util
 
 const extensionName = 'kubewarden';
 
-describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => {
+describe('Kubewarden Extension', { tags: ['@extensions-temp-excluded', '@adminUser'] }, () => {
   before(() => {
     catchTargetPageException('Navigation cancelled');
     cy.login();
 
     const extensionsPo = new ExtensionsPagePo();
-    const kubewardenPo = new KubewardenExtensionPo();
 
     extensionsPo.goTo();
     extensionsPo.waitForPage();
 
     // install the ui-plugin-charts repo
-    kubewardenPo.addChartsRepoIfNeeded();
+    extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-charts', 'main', 'rancher-extensions');
   });
 
   beforeEach(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This reverts commit c4900df9c562ea6f4f224288158a5f80c5fe516a.
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The kubewarden tests are failing on the pipeline causing all PRs to fail the checks needed to be merged. Reverting the commit that replaced those tests will at the very least allow other PRs to pass while a proper fix can be implemented.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Debugging the Kubewarden tests locally shows zero issues.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![fail-test](https://github.com/rancher/dashboard/assets/40806497/7848a8bf-cca9-4530-8f99-c679e26f52cc)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
