### PR TITLE
[Automation] - Use testid locators rather than positional on pagination

### DIFF
--- a/cypress/e2e/po/components/pagination.po.ts
+++ b/cypress/e2e/po/components/pagination.po.ts
@@ -6,19 +6,19 @@ export default class PaginationPo extends ComponentPo {
   }
 
   beginningButton() {
-    return this.self().find('button:nth-child(1)');
+    return this.self().find('[data-testid="pagination-first"]');
   }
 
   leftButton() {
-    return this.self().find('button:nth-child(2)');
+    return this.self().find('[data-testid="pagination-prev"]');
   }
 
   rightButton() {
-    return this.self().find('button:nth-child(4)');
+    return this.self().find('[data-testid="pagination-next"]');
   }
 
   endButton() {
-    return this.self().find('button:nth-child(5)');
+    return this.self().find('[data-testid="pagination-last"]');
   }
 
   paginationText() {

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1470,6 +1470,7 @@ export default {
       <button
         type="button"
         class="btn btn-sm role-multi-action"
+        data-testid="pagination-first"
         :disabled="page == 1 || loading"
         @click="goToPage('first')"
       >
@@ -1478,6 +1479,7 @@ export default {
       <button
         type="button"
         class="btn btn-sm role-multi-action"
+        data-testid="pagination-prev"
         :disabled="page == 1 || loading"
         @click="goToPage('prev')"
       >
@@ -1489,6 +1491,7 @@ export default {
       <button
         type="button"
         class="btn btn-sm role-multi-action"
+        data-testid="pagination-next"
         :disabled="page == totalPages || loading"
         @click="goToPage('next')"
       >
@@ -1497,6 +1500,7 @@ export default {
       <button
         type="button"
         class="btn btn-sm role-multi-action"
+        data-testid="pagination-last"
         :disabled="page == totalPages || loading"
         @click="goToPage('last')"
       >


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/1388

Positional locators aren't recommended and is a red flag on automation. Those shouldn't be used under any circumstance and is something commonly used as last resort.

### Occurred changes and/or fixed issues
Added `data-testid` for pagination navigation buttons.

### Areas or cases that should be tested
Automation is only affected and this isn't a functional change in the Vue code.

Test done: Cluster Pagination tests executed and passed.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
