### PR TITLE
Fix fleet status calculation

### DIFF
--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -306,11 +306,15 @@ export default {
     },
 
     fleetStatus() {
-      const resources = [this.fleetStatefulSet];
-
-      if (this.currentCluster.isLocal) {
-        resources.push(this.fleetDeployment);
-      }
+      const resources = this.currentCluster.isLocal ? [
+        /**
+         * 'fleetStatefulSet' could take a while to be created by rancher.
+         * During that startup period, only 'fleetDeployment' will be used to calculate the fleet agent status.
+         */
+        ...(this.fleetStatefulSet ? [this.fleetStatefulSet, this.fleetDeployment] : [this.fleetDeployment]),
+      ] : [
+        this.fleetStatefulSet
+      ];
 
       if (resources.find((r) => r === 'loading')) {
         return STATES_ENUM.IN_PROGRESS;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/11181
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

When Rancher is freshly installed, it takes some time to create `cattle-fleet-local-system/fleet-agent` StatefulSet in `local` cluster. 
We are excluding it from` fleet agent` health checks during this startup period.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

During the startup period:
 - `cattle-fleet-local-system/fleet-agent` is null
 - Rancher is able to create and communicate with new downstream clusters
 - `cattle-fleet-system/fleet-controller` is OK
 
 So it's reasonable to calculate the fleet agent status using only `cattle-fleet-system/fleet-controller` and include `cattle-fleet-local-system/fleet-agent` when available.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- cluster explorer -> local -> Dashboard page -> Health boxes -> fleet

### How to test
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Install Rancher 2.9.x
- Check the fleet health box (see screenshot)
- `cattle-fleet-local-system/fleet-agent is created by Rancher after ~5/10 minutes (docker installation)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/rancher/dashboard/assets/26394656/e85a1606-1080-4e03-a37c-0c5b671f75be)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
