### PR TITLE
EKS: fix node group versioning and name input

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -566,7 +566,6 @@ export default defineComponent({
         class="mb-20"
         :side-tabs="true"
         :show-tabs-add-remove="mode !== VIEW"
-        data-testid="eks-node-group-tabbed"
         @removeTab="removeGroup($event)"
         @addTab="addGroup()"
       >

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -59,6 +59,7 @@ export const DEFAULT_NODE_GROUP_CONFIG = {
   tags:                 {},
   type:                 'nodeGroup',
   userData:             '',
+  _isNew:               true,
 };
 
 const DEFAULT_EKS_CONFIG = {
@@ -599,7 +600,8 @@ export default defineComponent({
             :region="config.region"
             :amazon-credential-secret="config.amazonCredentialSecret"
             :is-new-or-unprovisioned="isNewOrUnprovisioned"
-            :mode="mode"
+            :pool-is-new="node._isNew"
+            :mode="mode"s
             :instance-type-options="instanceTypeOptions"
             :spot-instance-type-options="spotInstanceTypeOptions"
             :launch-templates="launchTemplates"

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -249,7 +249,11 @@ export default defineComponent({
     },
 
     'config.kubernetesVersion'(neu) {
-      this.nodeGroups.forEach((group: EKSNodeGroup) => this.$set(group, 'version', neu));
+      this.nodeGroups.forEach((group: EKSNodeGroup) => {
+        if (group._isNew) {
+          this.$set(group, 'version', neu);
+        }
+      });
     }
   },
 
@@ -562,6 +566,7 @@ export default defineComponent({
         class="mb-20"
         :side-tabs="true"
         :show-tabs-add-remove="mode !== VIEW"
+        data-testid="eks-node-group-tabbed"
         @removeTab="removeGroup($event)"
         @addTab="addGroup()"
       >
@@ -597,11 +602,14 @@ export default defineComponent({
             :max-size.sync="node.maxSize"
             :request-spot-instances.sync="node.requestSpotInstances"
             :labels.sync="node.labels"
+            :version.sync="node.version"
+            :cluster-version="config.kubernetesVersion"
+            :original-cluster-version="originalVersion"
             :region="config.region"
             :amazon-credential-secret="config.amazonCredentialSecret"
             :is-new-or-unprovisioned="isNewOrUnprovisioned"
             :pool-is-new="node._isNew"
-            :mode="mode"s
+            :mode="mode"
             :instance-type-options="instanceTypeOptions"
             :spot-instance-type-options="spotInstanceTypeOptions"
             :launch-templates="launchTemplates"

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -151,6 +151,11 @@ export default defineComponent({
       default: true
     },
 
+    poolIsNew: {
+      type:    Boolean,
+      default: true
+    },
+
     instanceTypeOptions: {
       type:    Array,
       default: () => []
@@ -343,6 +348,10 @@ export default defineComponent({
 
     userDataPlaceholder() {
       return DEFAULT_USER_DATA;
+    },
+
+    poolIsUnprovisioned() {
+      return this.isNewOrUnprovisioned || this.poolIsNew;
     }
   },
 
@@ -447,7 +456,7 @@ export default defineComponent({
           :value="nodegroupName"
           label-key="eks.nodeGroups.name.label"
           :mode="mode"
-          :disabled="!isNewOrUnprovisioned"
+          :disabled="!poolIsUnprovisioned"
           :rules="rules.nodegroupName"
           data-testid="eks-nodegroup-name"
           required
@@ -463,7 +472,7 @@ export default defineComponent({
           :options="[defaultNodeRoleOption, ...ec2Roles]"
           option-label="RoleName"
           option-key="Arn"
-          :disabled="!isNewOrUnprovisioned"
+          :disabled="!poolIsUnprovisioned"
           :loading="loadingRoles"
         />
       </div>
@@ -541,7 +550,7 @@ export default defineComponent({
           :options="launchTemplateOptions"
           option-label="LaunchTemplateName"
           option-key="LaunchTemplateId"
-          :disabled="!isNewOrUnprovisioned"
+          :disabled="!poolIsUnprovisioned"
           :loading="loadingLaunchTemplates"
           data-testid="eks-launch-template-dropdown"
         />

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -391,13 +391,17 @@ export default defineComponent({
         }
       }
     },
+
+    isView() {
+      return this.mode === _VIEW;
+    }
   },
 
   methods: {
     async fetchLaunchTemplateVersionInfo(launchTemplate: AWS.LaunchTemplate) {
       const { region, amazonCredentialSecret } = this;
 
-      if (!region || !amazonCredentialSecret || this.mode === _VIEW) {
+      if (!region || !amazonCredentialSecret || this.isView) {
         return;
       }
       const store = this.$store as Store<any>;
@@ -600,6 +604,7 @@ export default defineComponent({
           v-model="willUpgrade"
           :label="t('eks.nodeGroups.kubernetesVersion.upgrade', {from: originalNodeVersion, to: clusterVersion})"
           data-testid="eks-version-upgrade-checkbox"
+          :disabled="isView"
         />
       </div>
       <div class="col span-4">

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -691,6 +691,7 @@ export default defineComponent({
           :disabled="hasUserLaunchTemplate"
           :read-allowed="false"
           :as-map="true"
+          @input="$emit('update:resourceTags', $event)"
         >
           <template #title>
             <label class="text-label">{{ t('eks.nodeGroups.resourceTags.label') }}</label>

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -1,5 +1,5 @@
 import flushPromises from 'flush-promises';
-import { mount, shallowMount, Wrapper } from '@vue/test-utils';
+import { shallowMount, Wrapper } from '@vue/test-utils';
 import { EKSConfig, EKSNodeGroup } from 'types';
 import CruEKS from '@pkg/eks/components/CruEKS.vue';
 
@@ -130,7 +130,7 @@ describe('eKS provisioning form', () => {
     expect(wrapper.vm.nodeGroups.filter((group: EKSNodeGroup) => !group._isNew)).toHaveLength(1);
   });
 
-  it('should update new node pool\s version when cluster version is updated', async() => {
+  it('should update new node pools\' version when cluster version is updated', async() => {
     const wrapper = shallowMount(CruEKS, {
       propsData: { value: {}, mode: 'edit' },
       ...requiredSetup()

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -1,6 +1,6 @@
 import flushPromises from 'flush-promises';
-import { shallowMount, Wrapper } from '@vue/test-utils';
-import { EKSConfig } from 'types';
+import { mount, shallowMount, Wrapper } from '@vue/test-utils';
+import { EKSConfig, EKSNodeGroup } from 'types';
 import CruEKS from '@pkg/eks/components/CruEKS.vue';
 
 const mockedValidationMixin = {
@@ -115,5 +115,35 @@ describe('eKS provisioning form', () => {
     expect(wrapper.vm.config.displayName).toStrictEqual('def');
     expect(wrapper.vm.normanCluster.name).toStrictEqual('def');
     expect(nameInput.props().value).toStrictEqual('def');
+  });
+
+  it('should set _isNew to true when a pool is added', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'edit' },
+      ...requiredSetup()
+    });
+
+    wrapper.setData({ nodeGroups: [{ name: 'abc' }] });
+    wrapper.vm.addGroup();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.nodeGroups).toHaveLength(2);
+    expect(wrapper.vm.nodeGroups.filter((group: EKSNodeGroup) => !group._isNew)).toHaveLength(1);
+  });
+
+  it('should update new node pool\s version when cluster version is updated', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'edit' },
+      ...requiredSetup()
+    });
+
+    wrapper.setData({ nodeGroups: [{ name: 'abc' }] });
+    wrapper.vm.addGroup();
+    await wrapper.vm.$nextTick();
+
+    wrapper.setData({ config: { kubernetesVersion: '1.24' } });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.nodeGroups.filter((group: EKSNodeGroup) => group.version === '1.24')).toHaveLength(1);
   });
 });

--- a/pkg/eks/components/__tests__/NodeGroup.test.ts
+++ b/pkg/eks/components/__tests__/NodeGroup.test.ts
@@ -42,7 +42,7 @@ const requiredSetup = () => {
   };
 };
 
-describe('eKS Node Groups', () => {
+describe('eKS Node Groups: create', () => {
   it('should load template-controlled fields when a template version is selected', async() => {
     const setup = requiredSetup();
 
@@ -207,5 +207,214 @@ describe('eKS Node Groups', () => {
     latest = (diskSizeUpdates[diskSizeUpdates.length - 1] || [])[0];
 
     expect(latest).toBe(20);
+  });
+
+  it('should show a disabled text input with kubernetes version', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        version:                '1.23',
+        clusterVersion:         '1.23'
+      },
+      ...setup
+    });
+
+    const versionDisplay = wrapper.find('[data-testid="eks-version-display"]');
+    const upgradeVersionBanner = wrapper.find('[data-testid="eks-version-upgrade-banner"]');
+    const upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    expect(versionDisplay.isVisible()).toBe(true);
+    expect(versionDisplay.props().value).toBe('1.23');
+    expect(upgradeVersionBanner.exists()).toBe(false);
+    expect(upgradeVersionCheckbox.exists()).toBe(false);
+  });
+
+  it('should update resource tags', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+      },
+      ...setup
+    });
+
+    const tagsInput = wrapper.find('[data-testid="eks-resource-tags-input"]');
+
+    expect(tagsInput.props().value).toStrictEqual({});
+
+    tagsInput.vm.$emit('input', { abc: 'def' });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:tags')?.[0]?.[0]).toStrictEqual({ abc: 'def' });
+    // no need to test that emitting 'update:tags' will set this prop as its built-in vue functionality
+    wrapper.setProps({ tags: { abc: 'def' } });
+
+    await wrapper.vm.$nextTick();
+    expect(tagsInput.props().value).toStrictEqual({ abc: 'def' });
+  });
+});
+
+describe('eks node groups: edit', () => {
+  it('should show an info banner telling the user they can upgrade the node version after the cluster upgrade finishes', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        version:                '1.23',
+        clusterVersion:         '1.23',
+        originalClusterVersion: '1.23',
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    const versionDisplay = wrapper.find('[data-testid="eks-version-display"]');
+    let upgradeVersionBanner = wrapper.find('[data-testid="eks-version-upgrade-banner"]');
+    let upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    expect(versionDisplay.isVisible()).toBe(true);
+    expect(upgradeVersionBanner.exists()).toBe(false);
+    expect(upgradeVersionCheckbox.exists()).toBe(false);
+
+    wrapper.setProps({ clusterVersion: '1.24' });
+
+    await wrapper.vm.$nextTick();
+
+    upgradeVersionBanner = wrapper.find('[data-testid="eks-version-upgrade-banner"]');
+    upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    expect(versionDisplay.isVisible()).toBe(true);
+    expect(versionDisplay.props().value).toBe('1.23');
+
+    expect(upgradeVersionBanner.exists()).toBe(true);
+    expect(upgradeVersionCheckbox.exists()).toBe(false);
+  });
+
+  it('should show the user a checkbox to upgrade the node version if the cluster version is ahead of node version and not currently being changed', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        version:                '1.23',
+        clusterVersion:         '1.24',
+        originalClusterVersion: '1.24',
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    const versionDisplay = wrapper.find('[data-testid="eks-version-display"]');
+    const upgradeVersionBanner = wrapper.find('[data-testid="eks-version-upgrade-banner"]');
+    const upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    expect(versionDisplay.exists()).toBe(false);
+    expect(upgradeVersionBanner.exists()).toBe(false);
+    expect(upgradeVersionCheckbox.exists()).toBe(true);
+  });
+
+  it('should update the node version to match the cluster version when the upgrade checkbox is checked', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        version:                '1.23',
+        clusterVersion:         '1.24',
+        originalClusterVersion: '1.24',
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    const upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    upgradeVersionCheckbox.vm.$emit('input', true);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:version')?.[0]?.[0]).toBe('1.24');
+  });
+
+  it('should revert the node version to its original version when the upgrade checkbox is unchecked', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        version:                '1.23',
+        clusterVersion:         '1.24',
+        originalClusterVersion: '1.24',
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    const upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    wrapper.setProps({ version: '1.24' });
+    await wrapper.vm.$nextTick();
+
+    expect(upgradeVersionCheckbox.props().value).toBe(true);
+
+    upgradeVersionCheckbox.vm.$emit('input', false);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:version')?.[0]?.[0]).toBe('1.23');
+  });
+
+  // poolIsNew is tested in crueks.test.ts
+  it('should allow the node group name to be changed if poolIsNew is true', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        poolIsNew:              true,
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    const nameInput = wrapper.find('[data-testid="eks-nodegroup-name"]');
+
+    expect(nameInput.props().disabled).toBe(false);
+  });
+
+  it('should allow the node group name to be changed if poolIsNew is false', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        poolIsNew:              false,
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    const nameInput = wrapper.find('[data-testid="eks-nodegroup-name"]');
+
+    expect(nameInput.props().disabled).toBe(true);
   });
 });

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -55,6 +55,10 @@ eks:
     instanceType:
       label: Instance Type
       tooltip: Instance Type will not be sent when requesting spot instances. You must include Spot Instance Types instead.
+    kubernetesVersion:
+      clusterWillUpgrade: A new control plane Kubernetes version has been selected. Once that upgrade is complete, you can come back and upgrade the node group.
+      label: Node Kubernetes Version
+      upgrade: Upgrade the node Kubernetes version from {from} to {to}
     launchTemplate:
       label: Launch Template
       rancherManaged: '{name} (Rancher-managed)'

--- a/pkg/eks/types/index.d.ts
+++ b/pkg/eks/types/index.d.ts
@@ -35,6 +35,7 @@ export interface EKSNodeGroup {
   userData?: string,
   version?: string
   __nameUnique?: boolean
+  _isNew?: boolean,
 }
 
 export interface EKSConfig {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11102 
Fixes #11202 
Fixes #11103


### Occurred changes and/or fixed issues
This PR updates the EKS node group component to disable inputs when the cluster is new _or_ when the current group is being added to a new cluster. It also adds version upgrading functionality in line with AKS  - node groups' versioning.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
Create a new cluster with a kubernetes version less than the latest available:
1. Verify that the node group name is editable
2. Verify that adding data to 'instance tags' is reflected in the node group's spec when saving
3. Verify that there is a disabled input whose value aligns with the cluster kubernetes version 
Once that cluster has provisioned, go to edit it and verify that:
1. The name of the existing node group is not editable
2. When a new node group is added, its name is editable
3. When a new node group is added, it has a disabled kubernetes version input whose value aligns with the cluster version
4. if a new cluster kubernetes version is selected, the existing node group should have an info banner informing the user that they can upgrade when the cluster has been upgraded
After upgrading the cluster, go back to edit and verify that:
1. The old node group has a checkbox telling the user that they can upgrade the version
2. The checkbox should go away if the cluster version is upgraded again




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
