### PR TITLE
fix flaky gitrepo test

### DIFF
--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -7,7 +7,7 @@ DASHBOARD_DIST=${DIR}/dist
 EMBER_DIST=${DIR}/dist_ember
 
 # Image version
-RANCHER_IMG_VERSION=v2.9-head
+RANCHER_IMG_VERSION=v2.9-b9ec494d4f6f1c3d6282c45a481dbb9d3c79bb6f-head
 
 docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -v ${DASHBOARD_DIST}:/usr/share/rancher/ui-dashboard/dashboard \


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

`gitrepo.spec.ts > "in git repo details view we should display the correct bundle count"` test is failing consistently in CI with an assertion error

AssertionError
Timed out retrying after 10000ms: Expected to find element: `[data-testid="gitrepo-bundle-summary"] .count`, but never found it. Queried from element: <div.dashboard-root>

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
