### PR TITLE
AKS: fix node labels and errors when saving the cluster fails immediately

### DIFF
--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -447,11 +447,12 @@ export default defineComponent({
           />
         </div>
         <KeyValue
-          v-model="pool.labels"
+          v-model="pool.nodeLabels"
           :mode="mode"
           :value-can-be-empty="true"
-          add-label-key="Add Label"
+          :add-label="t('aks.nodePools.labels.add')"
           :read-allowed="false"
+          data-testid="aks-node-labels-input"
         />
       </div>
     </div>

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -299,7 +299,6 @@ export default defineComponent({
     const registerBeforeHook = this.registerBeforeHook as Function;
     const registerAfterHook = this.registerAfterHook as Function;
 
-    registerBeforeHook(this.cleanPoolsForSave);
     registerBeforeHook(this.removeUnchangedConfigFields);
     registerAfterHook(this.saveRoleBindings, 'save-role-bindings');
   },

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -983,17 +983,6 @@ export default defineComponent({
       }
     },
 
-    // these fields are used purely in UI, to track individual nodepool components
-    cleanPoolsForSave(): void {
-      this.nodePools.forEach((pool: AKSNodePool) => {
-        Object.keys(pool).forEach((key: string) => {
-          if (key.startsWith('_')) {
-            delete pool[key as keyof AKSNodePool];
-          }
-        });
-      });
-    },
-
     // only save values that differ from upstream aks spec - see diffUpstreamSpec comments for details
     removeUnchangedConfigFields(): void {
       const upstreamConfig = this.normanCluster?.status?.aksStatus?.upstreamSpec;

--- a/pkg/aks/components/__tests__/AksNodePool.test.ts
+++ b/pkg/aks/components/__tests__/AksNodePool.test.ts
@@ -16,8 +16,8 @@ const mockedValidationMixin = {
 const mockedStore = () => {
   return {
     getters: {
-      'i18n/t': (text: string, v = {}) => {
-        return `${ text }${ Object.values(v) }`;
+      'i18n/t': (text: string, v: {[key:string]: string}) => {
+        return `${ text }${ Object.values(v || {}) }`;
       },
       t:                         (text: string) => text,
       currentStore:              () => 'current_store',
@@ -203,5 +203,27 @@ describe('aks node pool component', () => {
 
     // above verifies that the form is showing the right thing: also verify that the node pool spec has been updated to remove the taint
     expect(wrapper.props().pool.nodeTaints).toStrictEqual([initialTaints[1]]);
+  });
+
+  it('should add nodeLabels to the pool spec when the labels keyvalue is edited', async() => {
+    const labels = { abc: 'def', efg: 'hij' };
+    const newLabels = { abc: 'def' };
+    const wrapper = mount(AksNodePool, {
+      propsData: {
+        pool: { ...defaultPool, nodeLabels: { ...labels } },
+
+        mode: _EDIT
+      },
+      ...requiredSetup()
+
+    });
+    const labelInput = wrapper.find('[data-testid="aks-node-labels-input"]');
+
+    expect(labelInput.props().value).toStrictEqual(labels);
+
+    labelInput.vm.$emit('input', newLabels);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.props().pool.nodeLabels).toStrictEqual(newLabels);
   });
 });

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -66,6 +66,7 @@ aks:
       label: Mode
     labels:
       tooltip: Configure labels for all nodes in this Node Pool.
+      add: Add Label
     orchestratorVersion: 
       label: Node Pool Kubernetes Version
       upgrade: Upgrade node pool Kubernetes version from {from} to {to}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10952 
Fixes #11084 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes an issue with node labels not being saved - the wrong key was used it should be `nodeLabels`, see `<rancher url>v3/schemas/aksNodePool`. This PR also corrects an issue with the form when saving throws an error ( see the issue for an example misconfiguration - many incorrect cluster configurations either throw inline form validation errors before saving or show up after saving when the user is taken back to the cluster list view)

### Technical notes summary
The problem in #11084 appears to be related to the before save hook removing ui-only fields from AKS node pools. With the `__validation` property missing, some form validators start throwing errors; this sends the whole form out of whack (eg cluster name no longer being editable. idk). I realized as well that the ui-only fields need to be preserved so that when editing a provisioned cluster to add new node pools, the UI keeps track of which pools are new and keeps all their input fields editable.

### Areas or cases that should be tested
1. Create a cluster with node labels defined and verify that they're saved
2. Edit the cluster; verify that the previously-configured labels are shown, and that labels can be added and removed.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
