### PR TITLE
Add agent tls mode to global settings

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -258,6 +258,34 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-token-max-ttl-minutes').contains(settings['auth-token-max-ttl-minutes'].original);
   });
 
+  it('can update agent-tls-mode', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    // Update setting
+    SettingsPagePo.navTo();
+    settingsPage.editSettingsByLabel('agent-tls-mode');
+
+    const settingsEdit = settingsPage.editSettings('local', 'agent-tls-mode');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
+    settingsEdit.selectSettingsByLabel('System Store');
+    settingsEdit.saveAndWait('agent-tls-mode');
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('agent-tls-mode').contains('System Store');
+
+    // Reset
+    SettingsPagePo.navTo();
+    settingsPage.waitForPage();
+    settingsPage.editSettingsByLabel('agent-tls-mode');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
+    settingsEdit.useDefaultButton().click();
+    settingsEdit.saveAndWait('agent-tls-mode');
+
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('agent-tls-mode').contains('Strict');
+  });
+
   it('can update kubeconfig-default-token-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
@@ -375,33 +403,5 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(obj.apiVersion).to.equal('v1');
       expect(obj.kind).to.equal('Config');
     });
-  });
-
-  it('can update agent-tls-mode', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    // Update setting
-    SettingsPagePo.navTo();
-    settingsPage.editSettingsByLabel('agent-tls-mode');
-
-    const settingsEdit = settingsPage.editSettings('local', 'agent-tls-mode');
-
-    settingsEdit.waitForPage();
-    settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
-    settingsEdit.selectSettingsByLabel('System Store');
-    settingsEdit.saveAndWait('agent-tls-mode');
-    settingsPage.waitForPage();
-    settingsPage.settingsValue('agent-tls-mode').contains('System Store');
-
-    // Reset
-    SettingsPagePo.navTo();
-    settingsPage.waitForPage();
-    settingsPage.editSettingsByLabel('agent-tls-mode');
-
-    settingsEdit.waitForPage();
-    settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
-    settingsEdit.useDefaultButton().click();
-    settingsEdit.saveAndWait('agent-tls-mode');
-
-    settingsPage.waitForPage();
-    settingsPage.settingsValue('agent-tls-mode').contains('Strict');
   });
 });

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -376,4 +376,32 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(obj.kind).to.equal('Config');
     });
   });
+
+  it('can update agent-tls-mode', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    // Update setting
+    SettingsPagePo.navTo();
+    settingsPage.editSettingsByLabel('agent-tls-mode');
+
+    const settingsEdit = settingsPage.editSettings('local', 'agent-tls-mode');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
+    settingsEdit.selectSettingsByLabel('System Store');
+    settingsEdit.saveAndWait('agent-tls-mode');
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('agent-tls-mode').contains('System Store');
+
+    // Reset
+    SettingsPagePo.navTo();
+    settingsPage.waitForPage();
+    settingsPage.editSettingsByLabel('agent-tls-mode');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
+    settingsEdit.useDefaultButton().click();
+    settingsEdit.saveAndWait('agent-tls-mode');
+
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('agent-tls-mode').contains('Strict');
+  });
 });

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7331,6 +7331,9 @@ advancedSettings:
     'ui-default-landing': 'The default page users land on after login.'
     'brand': Folder name for an alternative theme defined in '/assets/brand'
     'hide-local-cluster': Hide the local cluster
+    'agent-tls-mode': 'TLS mode for agent communication.'
+  warnings:
+    'agent-tls-mode': 'Changing this setting will cause all agents to be redeployed.'
   editHelp:
     'ui-banners': This setting takes a JSON object containing 3 root parameters; <code>banner</code>, <code>showHeader</code>, <code>showFooter</code>. <code>banner</code> is an object containing; <code>textColor</code>, <code>background</code>, and <code>text</code>, where <code>textColor</code> and <code>background</code> are any valid CSS color value.
   enum:
@@ -7353,6 +7356,9 @@ advancedSettings:
       info: Info
       debug: Debug
       trace: Trace
+    'agent-tls-mode':
+      strict: 'Strict'
+      system-store: 'System Store'
 
 featureFlags:
   label: Feature Flags

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7331,7 +7331,7 @@ advancedSettings:
     'ui-default-landing': 'The default page users land on after login.'
     'brand': Folder name for an alternative theme defined in '/assets/brand'
     'hide-local-cluster': Hide the local cluster
-    'agent-tls-mode': 'TLS mode for agent communication.'
+    'agent-tls-mode': "Rancher Certificate Verification. In `strict` mode the agents (system, cluster, fleet, etc) will only trust Rancher installations which are using a certificate signed by the CABundle in the `cacerts` setting. When the mode is system-store, the agents will trust any certificate signed by a CABundle in the operating system’s trust store."
   warnings:
     'agent-tls-mode': 'Changing this setting will cause all agents to be redeployed.'
   editHelp:

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -20,7 +20,8 @@ interface GlobalSetting {
     /**
      * Function used from the form validation
      */
-     ruleSet?: GlobalSettingRuleset[],
+    ruleSet?: GlobalSettingRuleset[],
+    warning?: string
   };
 }
 
@@ -96,8 +97,9 @@ export const SETTING = {
   FLEET_AGENT_DEFAULT_AFFINITY:         'fleet-agent-default-affinity',
   /**
    * manage rancher repositories in extensions (official, partners repos)
-   */
+  */
   ADD_EXTENSION_REPOS_BANNER_DISPLAY:   'display-add-extension-repos-banner',
+  AGENT_TLS_MODE:                       'agent-tls-mode',
   /**
    * User retention settings
    */
@@ -158,6 +160,11 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
     options: ['prompt', 'in', 'out']
   },
   [SETTING.HIDE_LOCAL_CLUSTER]: { kind: 'boolean' },
+  [SETTING.AGENT_TLS_MODE]:     {
+    kind:    'enum',
+    options: ['strict', 'system-store'],
+    warning: 'agent-tls-mode'
+  },
 };
 
 /**

--- a/shell/edit/management.cattle.io.setting.vue
+++ b/shell/edit/management.cattle.io.setting.vue
@@ -79,6 +79,10 @@ export default {
       return isServerUrl(this.value.id) && isLocalhost(this.value.value);
     },
 
+    showWarningBanner() {
+      return this.setting?.warning;
+    },
+
     validationPassed() {
       return this.fvFormIsValid && this.fvGetPathErrors(['value']).length === 0;
     }
@@ -141,6 +145,13 @@ export default {
     @finish="saveSettings"
     @cancel="done"
   >
+    <Banner
+      v-if="showWarningBanner"
+      color="warning"
+      :label="t(`advancedSettings.warnings.${ setting.warning }`)"
+      data-testid="advanced_settings_warning_banner"
+    />
+
     <h4>{{ description }}</h4>
 
     <h5


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11138 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This will add the `agent-tls-mode` setting to the Global Settings page, as well as a new optional property `warning` on the `GlobalSettings` interface that will display a warning banner when editing the setting.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The setting is an `enum` with two values: `strict` and `system-store`

To add a warning to the setting, the `advancedSettings.warnings` translation will require a property named after the setting, in this case `agent-tls-mode`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Testing the setting works with both values, ensure the warning banner shows.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![1](https://github.com/rancher/dashboard/assets/40806497/e67dfd30-e6a5-4f28-bc32-9a2802378907)

![2](https://github.com/rancher/dashboard/assets/40806497/b108c748-d9fc-4af9-8ca5-3767a7aeabd2)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
