### PR TITLE
EKS: edit imported clusters, and clusters with exclusively self-managed nodes

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -418,7 +418,7 @@ export default defineComponent({
     },
 
     async actuallySave(): Promise<void> {
-      if (!this.isNewOrUnprovisioned && !this.nodeGroups.length) {
+      if (!this.isNewOrUnprovisioned && !this.nodeGroups.length && !!this.normanCluster?.eksConfig?.nodeGroups) {
         delete this.normanCluster.eksConfig.nodeGroups;
       }
       await this.normanCluster.save();

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -530,7 +530,6 @@ export default defineComponent({
     :done-route="doneRoute"
     :errors="fvUnreportedValidationErrors"
     :validation-passed="fvFormIsValid"
-    data-testid="eks-cruresource"
     @error="e=>errors=e"
     @finish="save"
     @cancel="done"

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -119,7 +119,7 @@ export default defineComponent({
       const liveNormanCluster = await this.value.findNormanCluster();
 
       this.normanCluster = await store.dispatch(`rancher/clone`, { resource: liveNormanCluster });
-      // ensure any fields editable through this UI that have been altered in azure portal are shown here - see syncUpstreamConfig jsdoc for details
+      // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
       if (!this.isNewOrUnprovisioned) {
         syncUpstreamConfig('eks', this.normanCluster);
       }
@@ -419,7 +419,7 @@ export default defineComponent({
 
     async actuallySave(): Promise<void> {
       if (!this.isNewOrUnprovisioned && !this.nodeGroups.length && !!this.normanCluster?.eksConfig?.nodeGroups) {
-        delete this.normanCluster.eksConfig.nodeGroups;
+        this.$set(this.normanCluster.eksConfig, 'nodeGroups', null);
       }
       await this.normanCluster.save();
 

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -5,7 +5,7 @@ import { defineComponent } from 'vue';
 import { removeObject } from '@shell/utils/array';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { NORMAN } from '@shell/config/types';
-import { diffUpstreamSpec } from '@shell/utils/kontainer';
+import { diffUpstreamSpec, syncUpstreamConfig } from '@shell/utils/kontainer';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 
@@ -119,6 +119,10 @@ export default defineComponent({
       const liveNormanCluster = await this.value.findNormanCluster();
 
       this.normanCluster = await store.dispatch(`rancher/clone`, { resource: liveNormanCluster });
+      // ensure any fields editable through this UI that have been altered in azure portal are shown here - see syncUpstreamConfig jsdoc for details
+      if (!this.isNewOrUnprovisioned) {
+        syncUpstreamConfig('aks', this.normanCluster);
+      }
       // track original version on edit to ensure we don't offer k8s downgrades
       this.originalVersion = this.normanCluster?.eksConfig?.kubernetesVersion || '';
     } else {

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -307,6 +307,11 @@ export default defineComponent({
       return this.value?.id || null;
     },
 
+    // used to display VPC/subnet information in the networking tab for imported clusters and clusters with the 'create a vpc and subnets automatically' option selected
+    statusSubnets(): string[] {
+      return this.normanCluster?.eksStatus?.subnets || [];
+    },
+
     canManageMembers(): boolean {
       return canViewClusterMembershipEditor(this.$store);
     },
@@ -665,6 +670,7 @@ export default defineComponent({
           :mode="mode"
           :region="config.region"
           :amazon-credential-secret="config.amazonCredentialSecret"
+          :status-subnets="statusSubnets"
           :rules="{subnets:fvGetAndReportPathRules('subnets')}"
         />
       </Accordion>

--- a/pkg/eks/components/Logging.vue
+++ b/pkg/eks/components/Logging.vue
@@ -33,13 +33,13 @@ export default defineComponent({
 
   methods: {
     typeEnabled(type: string) {
-      return this.loggingTypes.includes(type);
+      return (this.loggingTypes || []).includes(type);
     },
 
     toggleType(type:string) {
-      const out = [...this.loggingTypes];
+      const out = [...(this.loggingTypes || [])];
 
-      if (this.loggingTypes.includes(type)) {
+      if (out.includes(type)) {
         removeObject(out, type);
       } else {
         out.push(type);

--- a/pkg/eks/components/Networking.vue
+++ b/pkg/eks/components/Networking.vue
@@ -89,7 +89,7 @@ export default defineComponent({
       loadingVpcs:  false,
       vpcInfo:      {} as {Vpcs: AWS.VPC[]},
       subnetInfo:   {} as {Subnets: AWS.Subnet[]},
-      chooseSubnet: this.subnets && !!this.subnets.length
+      chooseSubnet: !!this.subnets && !!this.subnets.length
     };
   },
 

--- a/pkg/eks/components/__tests__/Networking.test.ts
+++ b/pkg/eks/components/__tests__/Networking.test.ts
@@ -1,5 +1,6 @@
 
 /* eslint-disable jest/no-mocks-import */
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 import { shallowMount } from '@vue/test-utils';
 import Networking from '../Networking.vue';
 
@@ -56,7 +57,7 @@ describe('eKS Networking', () => {
     const setup = requiredSetup();
 
     const wrapper = shallowMount(Networking, {
-      propsData: { },
+      propsData: { mode: _CREATE },
       ...setup
     });
 
@@ -69,5 +70,24 @@ describe('eKS Networking', () => {
     wrapper.setData({ chooseSubnet: false });
     await wrapper.vm.$nextTick();
     expect(subnetDropdown.exists()).toBe(false);
+  });
+
+  it('should show a list of subnets in use if a cluster has already provisioned and the \'create automatically\' vpc option was selected', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(Networking, {
+      propsData: {
+        mode: _EDIT, subnets: [], statusSubnets: ['bc', 'def']
+      },
+      ...setup
+    });
+
+    await wrapper.vm.$nextTick();
+
+    const subnetDropdown = wrapper.find('[data-testid="eks-subnets-dropdown"]');
+
+    expect(subnetDropdown.exists()).toBe(true);
+
+    expect(subnetDropdown.props().value).toStrictEqual(['bc', 'def']);
   });
 });

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -36,7 +36,7 @@ import debounce from 'lodash/debounce';
 import {
   clusterNameChars, clusterNameStartEnd, requiredInCluster, ipv4WithCidr, ipv4oripv6WithCidr
 } from '../util/validators';
-import { diffUpstreamSpec } from '@shell/utils/kontainer';
+import { diffUpstreamSpec, syncUpstreamConfig } from '@shell/utils/kontainer';
 
 const defaultMachineType = 'n1-standard-2';
 
@@ -174,6 +174,10 @@ export default defineComponent({
       this.originalVersion = this.normanCluster?.gkeConfig?.kubernetesVersion;
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
+    }
+    // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
+    if (!this.isNewOrUnprovisioned) {
+      syncUpstreamConfig('gke', this.normanCluster);
     }
     if (!this.normanCluster.gkeConfig) {
       this.$set(this.normanCluster, 'gkeConfig', { ...defaultGkeConfig });

--- a/shell/utils/__tests__/kontainer.test.ts
+++ b/shell/utils/__tests__/kontainer.test.ts
@@ -96,12 +96,6 @@ describe('fx: syncUpstreamSpec', () => {
     const upstream = {
       string:                 'def',
       'other-string':         '123',
-      emptyArray:             [],
-      emptyObject:            {},
-      nonEmptyArray:          [1, 2, 3],
-      nonEmptyObject:         { foo: 'bar' },
-      falseBoolean:           false,
-      trueBoolean:            true,
       alreadySet:             'abc',
       alreadySetArray:        [2, 3, 4],
       alreadySetBooleanFalse: false,
@@ -117,12 +111,62 @@ describe('fx: syncUpstreamSpec', () => {
     const expected = {
       string:                 'def',
       'other-string':         '123',
-      nonEmptyArray:          [1, 2, 3],
-      nonEmptyObject:         { foo: 'bar' },
-      falseBoolean:           false,
-      trueBoolean:            true,
       alreadySet:             'def',
       alreadySetArray:        [1, 2, 3],
+      alreadySetBooleanFalse: false,
+      alreadySetBooleanTrue:  true
+    };
+
+    const testCluster = { eksConfig: local, eksStatus: { upstreamSpec: upstream } };
+
+    syncUpstreamConfig( 'eks', testCluster);
+
+    expect(testCluster.eksConfig).toStrictEqual(expected);
+  });
+
+  it('should not set empty objects or arrays from upstream spec', () => {
+    const upstream = {
+      emptyArray:      [],
+      emptyObject:     {},
+      nonEmptyArray:   [1, 2, 3],
+      nonEmptyObject:  { foo: 'bar' },
+      alreadySet:      'abc',
+      alreadySetArray: [2, 3, 4],
+    };
+    const local = {
+      alreadySet:      'def',
+      alreadySetArray: [1, 2, 3],
+    };
+
+    const expected = {
+      nonEmptyArray:   [1, 2, 3],
+      nonEmptyObject:  { foo: 'bar' },
+      alreadySet:      'def',
+      alreadySetArray: [1, 2, 3],
+    };
+
+    const testCluster = { eksConfig: local, eksStatus: { upstreamSpec: upstream } };
+
+    syncUpstreamConfig( 'eks', testCluster);
+
+    expect(testCluster.eksConfig).toStrictEqual(expected);
+  });
+
+  it('should not overwrite boolean values explicitly set false', () => {
+    const upstream = {
+      falseBoolean:           false,
+      trueBoolean:            true,
+      alreadySetBooleanFalse: true,
+      alreadySetBooleanTrue:  false
+    };
+    const local = {
+      alreadySetBooleanFalse: false,
+      alreadySetBooleanTrue:  true
+    };
+
+    const expected = {
+      falseBoolean:           false,
+      trueBoolean:            true,
       alreadySetBooleanFalse: false,
       alreadySetBooleanTrue:  true
     };

--- a/shell/utils/__tests__/kontainer.test.ts
+++ b/shell/utils/__tests__/kontainer.test.ts
@@ -1,4 +1,4 @@
-import { diffUpstreamSpec } from '@shell/utils/kontainer';
+import { diffUpstreamSpec, syncUpstreamConfig } from '@shell/utils/kontainer';
 
 describe('fx: diffUpstreamSpec', () => {
   it.each([
@@ -88,5 +88,49 @@ describe('fx: diffUpstreamSpec', () => {
     [{ labels: { a: 'a', b: 'b' } }, { labels: { a: 'a', b: 'b' } }, {}],
   ])('should include all of tags and labels unless upstream and local are deeply equal', (upstream, local, diff) => {
     expect(diffUpstreamSpec(upstream, local)).toStrictEqual(diff);
+  });
+});
+
+describe('fx: syncUpstreamSpec', () => {
+  it('should set any fields defined in upstream spec and not local spec', () => {
+    const upstream = {
+      string:                 'def',
+      'other-string':         '123',
+      emptyArray:             [],
+      emptyObject:            {},
+      nonEmptyArray:          [1, 2, 3],
+      nonEmptyObject:         { foo: 'bar' },
+      falseBoolean:           false,
+      trueBoolean:            true,
+      alreadySet:             'abc',
+      alreadySetArray:        [2, 3, 4],
+      alreadySetBooleanFalse: false,
+      alreadySetBooleanTrue:  true
+    };
+    const local = {
+      alreadySet:             'def',
+      alreadySetArray:        [1, 2, 3],
+      alreadySetBooleanFalse: false,
+      alreadySetBooleanTrue:  true
+    };
+
+    const expected = {
+      string:                 'def',
+      'other-string':         '123',
+      nonEmptyArray:          [1, 2, 3],
+      nonEmptyObject:         { foo: 'bar' },
+      falseBoolean:           false,
+      trueBoolean:            true,
+      alreadySet:             'def',
+      alreadySetArray:        [1, 2, 3],
+      alreadySetBooleanFalse: false,
+      alreadySetBooleanTrue:  true
+    };
+
+    const testCluster = { eksConfig: local, eksStatus: { upstreamSpec: upstream } };
+
+    syncUpstreamConfig( 'eks', testCluster);
+
+    expect(testCluster.eksConfig).toStrictEqual(expected);
   });
 });

--- a/shell/utils/kontainer.ts
+++ b/shell/utils/kontainer.ts
@@ -17,7 +17,11 @@ export function syncUpstreamConfig(configPrefix: string, normanCluster: {[key: s
 
   if (!isEmpty(upstreamConfig)) {
     Object.keys(upstreamConfig).forEach((key) => {
-      if (isEmpty(rancherConfig[key]) && !isEmpty(upstreamConfig[key])) {
+      if (typeof upstreamConfig[key] === 'object') {
+        if (isEmpty(rancherConfig[key]) && !isEmpty(upstreamConfig[key])) {
+          set(rancherConfig, key, upstreamConfig[key]);
+        }
+      } else if ((rancherConfig[key] === null || rancherConfig[key] === undefined) && upstreamConfig[key] !== null && upstreamConfig[key] !== undefined) {
         set(rancherConfig, key, upstreamConfig[key]);
       }
     });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11100 
Fixes #11104 
Fixes #10335 
Fixes #11291 

### Occurred changes and/or fixed issues
This PR updates EKS provisioning to incorporate the same upstream syncing behavior as AKS - see https://github.com/rancher/dashboard/pull/11120 for some background on why this is needed. This PR adds some fixes to the syncing utility as well as unit tests around the problems I found while working on the PR. There are also some minor fixes around the EKS components to correct console errors shown when editing an imported cluster.

Special notes about EKS:
- imported clusters with no nodeGroups are valid (they may have self-managed nodes)
- After following aws instructions to create an EKS cluster with default values and importing it into Rancher, the subnet/virtual network configuration is indistinguishable from an EKS cluster provisioned in Rancher with the 'Create a new VPC and subnet automatically' option selected. The old UI just shows that option selected for imported clusters. 
- In this PR I updated the networking tab to use the subnets from the upstream status instead, so the user can see which VPC/subnets are in use by the current cluster.


### Areas or cases that should be tested
1. Edit an imported cluster with exclusively self-managed nodes (no node groups)
     - no console errors shown
     - user should be able to save the cluster without having added node groups
     - ~user should be able to add and remove node groups~
     EDIT: removing all node groups is causing issues due to backend validation, issue filed here https://github.com/rancher/dashboard/issues/11336
2. Edit an imported cluster with node groups
    - user should be able to make all the same changes as they can with a Rancher-provisioned EKS cluster
    - the networking tab should show a list of selected subnets


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
