### PR TITLE
Replace settings strings with constants

### DIFF
--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -66,7 +66,7 @@ export default class HciCluster extends ProvCluster {
 
     if (uiOfflinePreferred === 'dynamic') {
       // We shouldn't need to worry about the version of the dashboard when embedded in harvester (aka in isSingleProduct)
-      const version = this.$rootGetters['management/byId'](MANAGEMENT.SETTING, 'server-version')?.value;
+      const version = this.$rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.VERSION_RANCHER)?.value;
 
       if (version.endsWith('-head')) {
         uiOfflinePreferred = 'false';

--- a/shell/edit/token.vue
+++ b/shell/edit/token.vue
@@ -13,6 +13,7 @@ import Select from '@shell/components/form/Select';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { diffFrom } from '@shell/utils/time';
 import { filterHiddenLocalCluster, filterOnlyKubernetesClusters } from '@shell/utils/cluster';
+import { SETTING } from '@shell/config/settings';
 
 export default {
   components: {
@@ -29,7 +30,7 @@ export default {
 
   data() {
     // Get the setting that defines the max token TTL allowed (in minutes)
-    const maxTTLSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, 'auth-token-max-ttl-minutes');
+    const maxTTLSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.AUTH_TOKEN_MAX_TTL_MINUTES);
     let maxTTL = 0;
 
     try {

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -37,6 +37,7 @@ import { findBy, insertAt } from '@shell/utils/array';
 import Vue from 'vue';
 import { saferDump } from '@shell/utils/create-yaml';
 import { LINUX, WINDOWS } from '@shell/store/catalog';
+import { SETTING } from '@shell/config/settings';
 
 const VALUES_STATE = {
   FORM: 'FORM',
@@ -126,7 +127,7 @@ export default {
     try {
       this.serverUrlSetting = await this.$store.dispatch('management/find', {
         type: MANAGEMENT.SETTING,
-        id:   'server-url'
+        id:   SETTING.SERVER_URL,
       });
     } catch (e) {
       console.error('Unable to fetch `server-url` setting: ', e); // eslint-disable-line no-console
@@ -888,7 +889,7 @@ export default {
       // runtime will pull images from docker.io.
       const globalRegistry = await this.$store.dispatch('management/find', {
         type: MANAGEMENT.SETTING,
-        id:   'system-default-registry'
+        id:   SETTING.SYSTEM_DEFAULT_REGISTRY,
       });
 
       return globalRegistry.value;

--- a/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
+++ b/shell/pages/c/_cluster/uiplugins/InstallDialog.vue
@@ -6,6 +6,7 @@ import { CATALOG, MANAGEMENT } from '@shell/config/types';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { UI_PLUGIN_NAMESPACE } from '@shell/config/uiplugins';
 import Banner from '@components/Banner/Banner.vue';
+import { SETTING } from '@shell/config/settings';
 
 // Note: This dialog handles installation and update of a plugin
 
@@ -20,7 +21,7 @@ export default {
   async fetch() {
     this.defaultRegistrySetting = await this.$store.dispatch('management/find', {
       type: MANAGEMENT.SETTING,
-      id:   'system-default-registry'
+      id:   SETTING.SYSTEM_DEFAULT_REGISTRY,
     });
   },
 

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -594,7 +594,7 @@ export const getters = {
   },
 
   releaseNotesUrl(state, getters) {
-    const version = getters['management/byId'](MANAGEMENT.SETTING, 'server-version')?.value;
+    const version = getters['management/byId'](MANAGEMENT.SETTING, SETTING.VERSION_RANCHER)?.value;
 
     const base = 'https://github.com/rancher/rancher/releases';
 

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -2,6 +2,7 @@ import { sortableNumericSuffix } from '@shell/utils/sort';
 import semver from 'semver';
 import { MANAGEMENT } from '@shell/config/types';
 import { READ_WHATS_NEW, SEEN_WHATS_NEW } from '@shell/store/prefs';
+import { SETTING } from '@shell/config/settings';
 
 export function parse(str) {
   str = `${ str }`;
@@ -82,7 +83,7 @@ export function isDevBuild(version) {
 }
 
 export function getVersionInfo(store) {
-  const setting = store.getters['management/byId'](MANAGEMENT.SETTING, 'server-version');
+  const setting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.VERSION_RANCHER);
   const fullVersion = setting?.value || 'unknown';
   let displayVersion = fullVersion;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This fixes a few instances where settings are referenced without using the constants. These were discovered while reviewing and validating changes for rancher/rancher#45894

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
