### PR TITLE
Fix grafana links for rancher workload deployment 

### DIFF
--- a/shell/models/__tests__/apps.deployment.test.ts
+++ b/shell/models/__tests__/apps.deployment.test.ts
@@ -1,0 +1,93 @@
+import Deployment from '@shell/models/apps.deployment';
+import { WORKLOAD_TYPES } from '@shell/config/types';
+
+describe('class Deployment', () => {
+  describe('replicaSetId', () => {
+    it.each([{
+      relationships: [],
+      expected:      undefined,
+    }, {
+      relationships: [{
+        rel:    'owner',
+        toType: WORKLOAD_TYPES.REPLICA_SET,
+        toId:   'rel-id'
+      }],
+      expected: 'rel-id',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'ReplicaSet is available. Replicas: 1'
+      }],
+      expected: 'rel-id-1',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'ReplicaSet is available. Replicas: 1'
+      }],
+      expected: 'rel-id-2',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'Message without replicas count'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'Another message without replicas count'
+      }],
+      expected: 'rel-id-1',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }],
+      expected: 'rel-id-1',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'Message without replicas count'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }],
+      expected: 'rel-id-1',
+    }])('replicaSetId', ({ relationships, expected }) => {
+      const deploymentData = {
+        id:       'any-id',
+        type:     WORKLOAD_TYPES.DEPLOYMENT,
+        metadata: {
+          name:      'any-name',
+          namespace: 'any-namespace',
+          uid:       'any-uid',
+          relationships,
+        },
+      };
+
+      const deployment = new Deployment(deploymentData);
+
+      expect(deployment.replicaSetId).toStrictEqual(expected);
+    });
+  });
+});

--- a/shell/models/apps.deployment.js
+++ b/shell/models/apps.deployment.js
@@ -14,7 +14,8 @@ export default class Deployment extends Workload {
   get replicaSetId() {
     const set = this.metadata?.relationships?.find((relationship) => {
       return relationship.rel === 'owner' &&
-            relationship.toType === WORKLOAD_TYPES.REPLICA_SET;
+            relationship.toType === WORKLOAD_TYPES.REPLICA_SET &&
+            relationship.message.split(':')[1].trim() > 0;
     });
 
     return set?.toId?.replace(`${ this.namespace }/`, '');

--- a/shell/models/apps.deployment.js
+++ b/shell/models/apps.deployment.js
@@ -15,23 +15,23 @@ const replicasRegEx = /Replicas: (\d+)/;
 export default class Deployment extends Workload {
   get replicaSetId() {
     const relationships = this.metadata?.relationships || [];
-    
+
     // Find all relevant ReplicaSet relationships
-    const replicaSetRelationships = relationships.filter((relationship) => 
-      relationship.rel === 'owner' && relationship.toType === WORKLOAD_TYPES.REPLICA_SET
+    const replicaSetRelationships = relationships.filter((relationship) => relationship.rel === 'owner' && relationship.toType === WORKLOAD_TYPES.REPLICA_SET
     );
 
     // Filter the ReplicaSets based on replicas > 0
     const activeReplicaSet = replicaSetRelationships.find((relationship) => {
       const replicasMatch = relationship.message?.match(replicasRegEx);
       const replicas = replicasMatch ? parseInt(replicasMatch[1], 10) : 0;
+
       return replicas > 0;
     });
 
     // If no active ReplicaSet is found, fall back to the first one from the list
     const selectedReplicaSet = activeReplicaSet || replicaSetRelationships[0];
 
-    return selectedReplicaSet?.toId?.replace(`${this.namespace}/`, '');
+    return selectedReplicaSet?.toId?.replace(`${ this.namespace }/`, '');
   }
 
   async rollBack(cluster, deployment, revision) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/10236
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a condition to the `replicaSetId` getter method in the Deployment class to accurately fetch the latest replicaSetId

`relationship.message.split(':')[1].trim() > 0;`


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The issue seems to be that the get replicaSetId [method](https://github.com/rancher/dashboard/blob/master/shell/models/apps.deployment.js#L14) is not accurately identifying the correct ReplicaSet associated with the latest Deployment update. Let's say if you have multiple ReplicaSets, the logic needs to ensure it fetches the most recent one. Typically, k8s assigns ReplicaSets with a revision number, where a higher number indicates a newer ReplicaSet but we're not using them here, the current logic only fetches the first replica set id from the array... not the one with replicaset 1/1 running.
 
grafana_url from dashboard fetching the wrong replicasetid...
```
https://master-0/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-workload-pods-1/rancher-workload-pods?orgId=1&from=now-5m&to=now&refresh=30s&var-namespace=default&var-kind=ReplicaSet&var-workload=httpd-5bc8dd79b&theme=dark   

root@master-0:~# k get rs  | grep httpd
httpd-5bc8dd79b    0         0         0       5h25m
httpd-745cfdfb84   0         0         0       5h25m
httpd-7d99dfc997   1         1         1       106m
root@master-0:~# 
root@master-0:~# 
root@master-0:~# k get deployment httpd -o jsonpath='{.status.conditions[0].message} {"\n"}'
ReplicaSet "httpd-7d99dfc997" has successfully progressed. 
root@master-0:~#
```

![image](https://github.com/rancher/dashboard/assets/124564266/7a6c3605-1c10-496e-a347-76352607249a)


### Areas or cases that should be tested
- Install the latest version of Rancher.
- Deploy the latest version of the Monitoring App.
- Create nginx deployement using the `nginx:1.12.0` image.
- Create httpd application using the `httpd:latest` image.
- Upgrade the httpd deployment to the `httpd:alpine` image.
- Validate that the metrics displayed for httpd correspond to the httpd deployment.
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
