### PR TITLE
Resolving an issue where resource search was reloading pages instead of navigating using vue-router

### DIFF
--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -99,7 +99,7 @@ export default {
       </TabTitle>
       <a
         :href="href"
-        @click="selectType"
+        @click="selectType(); navigate($event);"
         @mouseenter="setNear(true)"
         @mouseleave="setNear(false)"
       >


### PR DESCRIPTION
### Summary
fixes #10869
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
Depending on where/how the type component is used different events get triggered at different times. In the case of search we were navigating using the `<a href>` instead of `navigate`. 

### Areas or cases that should be tested
Resource navigation

### Screenshot/Video
https://github.com/rancher/dashboard/assets/55104481/9e562b73-9edb-4ef9-8c8d-ffe7fc9b17ae


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
