### PR TITLE
Ensure global roles are listed in a consistent order

### DIFF
--- a/cypress/e2e/po/components/global-role-binding.po.ts
+++ b/cypress/e2e/po/components/global-role-binding.po.ts
@@ -9,4 +9,10 @@ export default class GlobalRoleBindings extends ComponentPo {
   roleCheckbox(roleId: string) {
     return new CheckboxInputPo(`[data-testid="grb-checkbox-${ roleId }"]`);
   }
+
+  globalOptions() {
+    return this.self().find('.checkbox-section--global .checkbox-label-slot .checkbox-label').then((els) => {
+      return Cypress.$.makeArray(els).map((el) => el.innerText);
+    });
+  }
 }

--- a/shell/components/GlobalRoleBindings.vue
+++ b/shell/components/GlobalRoleBindings.vue
@@ -69,6 +69,7 @@ export default {
 
         const sort = (a, b) => a.nameDisplay.localeCompare(b.nameDisplay);
 
+        // global roles are not sorted
         this.sortedRoles.builtin = this.sortedRoles.builtin.sort(sort);
         this.sortedRoles.custom = this.sortedRoles.custom.sort(sort);
 
@@ -76,12 +77,33 @@ export default {
           this.globalRoleBindings = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.GLOBAL_ROLE_BINDING, opt: { force: true } });
         }
 
+        // Sort the global roles - use the order defined in 'globalPermissions' and then add the remaining roles after
+        const globalRoles = [];
+        const globalRolesAdded = {};
+
+        this.globalPermissions.forEach((id) => {
+          const role = this.sortedRoles.global.find((r) => r.id === id);
+
+          if (role) {
+            globalRoles.push(role);
+            globalRolesAdded[id] = true;
+          }
+        });
+
+        // Remaining global roles
+        const remainingGlobalRoles = this.sortedRoles.global.filter((r) => !globalRolesAdded[r.id]);
+
+        this.sortedRoles.global = globalRoles;
+        this.sortedRoles.global.push(...remainingGlobalRoles);
+        // End sort of global roles
+
         this.update();
       }
     } catch (e) { }
   },
   data() {
     return {
+      // This not only identifies global roles but the order here is the order we want to display them in the UI
       globalPermissions: [
         'admin',
         'restricted-admin',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11013

This PR fixes the above issue - it applies a sort so that the global permissions are always listed in this order:

Administrator
Restricted Admin
Standard user
User base

### Areas or cases that should be tested

An automated test is included.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
