### PR TITLE
Fixing the Add Repository button on the fleet cluster detail page

### DIFF
--- a/cypress/e2e/po/detail/fleet/tabs/git-repos-tab.po.ts
+++ b/cypress/e2e/po/detail/fleet/tabs/git-repos-tab.po.ts
@@ -9,4 +9,8 @@ export default class GitReposTab extends ComponentPo {
   list() {
     return new BaseResourceList('#repos [data-testid="sortable-table-list-container"]');
   }
+
+  addRepostoryButton() {
+    return this.self().get('.btn').contains('Add Repository');
+  }
 }

--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -157,6 +157,15 @@ describe('Fleet Clusters', { tags: ['@fleet', '@adminUser'] }, () => {
       });
     });
 
+    it('Git Repos Tab Add Repository button takes you to the correct page', function() {
+      const fleetClusterDetailsPage = new FleetClusterDetailsPo(namespace, this.rke2Ec2ClusterName);
+
+      fleetClusterDetailsPage.waitForPage(null, 'repos');
+      fleetClusterDetailsPage.gitReposTab().addRepostoryButton().click();
+
+      cy.url().should('include', `${ Cypress.config().baseUrl }/c/_/fleet/fleet.cattle.io.gitrepo/create`);
+    });
+
     it('adding git repo should add bundles on downstream cluster (deployments added)', function() {
       const deploymentsList = new WorkloadsDeploymentsListPagePo(this.clusterId);
 

--- a/shell/components/fleet/FleetIntro.vue
+++ b/shell/components/fleet/FleetIntro.vue
@@ -1,31 +1,25 @@
 <script>
-import { AS, _YAML } from '@shell/config/query-params';
 import { FLEET } from '@shell/config/types';
+import { NAME } from '@shell/config/product/fleet';
 
 export default {
 
   name: 'FleetIntro',
 
   data() {
-    const params = { ...this.$route.params };
-
-    const formRoute = { name: `${ this.$route.name }-create`, params };
-
-    const hasEditComponent = this.$store.getters['type-map/hasCustomEdit'](this.resource);
-
-    const yamlRoute = {
-      name:  `${ this.$route.name }-create`,
-      params,
-      query: { [AS]: _YAML },
+    const gitRepoRoute = {
+      name:   'c-cluster-product-resource-create',
+      params: {
+        product:  NAME,
+        resource: FLEET.GIT_REPO
+      },
     };
 
     const gitRepoSchema = this.$store.getters['management/schemaFor'](FLEET.GIT_REPO);
     const canCreateRepos = gitRepoSchema && gitRepoSchema.resourceMethods.includes('PUT');
 
     return {
-      formRoute,
-      yamlRoute,
-      hasEditComponent,
+      gitRepoRoute,
       canCreateRepos
     };
   },
@@ -42,7 +36,7 @@ export default {
       class="actions"
     >
       <router-link
-        :to="formRoute"
+        :to="gitRepoRoute"
         class="btn role-secondary"
       >
         {{ t('fleet.gitRepo.repo.addRepo') }}


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
rancher/dashboard#11198

### Occurred changes and/or fixed issues
We were using a broken link. This fixes that broken link.

### Areas or cases that should be tested
Just the Add Repository button.

### Screenshot/Video
https://github.com/rancher/dashboard/assets/55104481/35439b30-68db-41bf-8fe8-16106266e592

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
