### PR TITLE
[FIX] Fixed some issues with driver pages

### DIFF
--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -84,11 +84,11 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(exampleDriver, 2).find('span').invoke('text')
+    driversPage.list().details(downloadUrl, 2).find('span').invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/kontainerDrivers/${ t }?action=deactivate`).as('deactivateDriver');
 
-        driversPage.list().actionMenu(exampleDriver).getMenuItem('Deactivate').click();
+        driversPage.list().actionMenu(downloadUrl).getMenuItem('Deactivate').click();
         const deactivateDialog = new DeactivateDriverDialogPo();
 
         deactivateDialog.deactivate();
@@ -112,11 +112,11 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(exampleDriver, 2).find('span').invoke('text')
+    driversPage.list().details(downloadUrl, 2).find('span').invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/kontainerDrivers/${ t }?action=activate`).as('activateDriver');
 
-        driversPage.list().actionMenu(exampleDriver).getMenuItem('Activate').click();
+        driversPage.list().actionMenu(downloadUrl).getMenuItem('Activate').click();
       });
     cy.wait('@activateDriver').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);
@@ -134,7 +134,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
   it('can edit a cluster driver', () => {
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().actionMenu(exampleDriver).getMenuItem('Edit Config').click();
+    driversPage.list().actionMenu(downloadUrl).getMenuItem('Edit Config').click();
     createDriverPage.downloadUrl().set(downloadUrlUpdated);
     cy.intercept('PUT', '/v3/kontainerDrivers/*').as('updateDriver');
     createDriverPage.saveCreateForm().createEditView().save();

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -19,6 +19,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
   let driverId = '';
   const oracleDriver = 'Oracle OKE';
   const linodeDriver = 'Linode LKE';
+  const exampleDriver = 'Example';
 
   before(() => {
     cy.login();
@@ -64,12 +65,8 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       driverId = response?.body.id;
     });
 
-    // Will use the below assertions until this issue is resolved https://github.com/rancher/dashboard/issues/11046.
-    // Using 'downloadUrl' instead of driver name
-    // driversPage.list().details('Example', 1).should('contain', 'Activating');
-    // driversPage.list().details('Example', 1).contains('Active', { timeout: 60000 });
-    driversPage.list().details(downloadUrl, 1).should('contain', 'Activating');
-    driversPage.list().details(downloadUrl, 1).contains('Active', { timeout: 60000 });
+    driversPage.list().details(exampleDriver, 1).should('contain', 'Activating');
+    driversPage.list().details(exampleDriver, 1).contains('Active', { timeout: 60000 });
 
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
@@ -87,11 +84,11 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(downloadUrl, 2).find('span').invoke('text')
+    driversPage.list().details(exampleDriver, 2).find('span').invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/kontainerDrivers/${ t }?action=deactivate`).as('deactivateDriver');
 
-        driversPage.list().actionMenu(downloadUrl).getMenuItem('Deactivate').click();
+        driversPage.list().actionMenu(exampleDriver).getMenuItem('Deactivate').click();
         const deactivateDialog = new DeactivateDriverDialogPo();
 
         deactivateDialog.deactivate();
@@ -115,11 +112,11 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(downloadUrl, 2).find('span').invoke('text')
+    driversPage.list().details(exampleDriver, 2).find('span').invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/kontainerDrivers/${ t }?action=activate`).as('activateDriver');
 
-        driversPage.list().actionMenu(downloadUrl).getMenuItem('Activate').click();
+        driversPage.list().actionMenu(exampleDriver).getMenuItem('Activate').click();
       });
     cy.wait('@activateDriver').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);
@@ -137,7 +134,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
   it('can edit a cluster driver', () => {
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().actionMenu(downloadUrl).getMenuItem('Edit Config').click();
+    driversPage.list().actionMenu(exampleDriver).getMenuItem('Edit Config').click();
     createDriverPage.downloadUrl().set(downloadUrlUpdated);
     cy.intercept('PUT', '/v3/kontainerDrivers/*').as('updateDriver');
     createDriverPage.saveCreateForm().createEditView().save();
@@ -180,8 +177,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     createCluster.gridElementExistanceByName(linodeDriver, 'exist');
   });
 
-  it.skip('can deactivate drivers in bulk', () => {
-    // Skipping this test until issue is resolved https://github.com/rancher/dashboard/issues/10718
+  it('can deactivate drivers in bulk', () => {
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
     driversPage.list().details(oracleDriver, 1).should('contain', 'Active');

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -84,15 +84,13 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(downloadUrl, 2).find('span').invoke('text')
-      .then((t) => {
-        cy.intercept('POST', `/v3/kontainerDrivers/${ t }?action=deactivate`).as('deactivateDriver');
 
-        driversPage.list().actionMenu(downloadUrl).getMenuItem('Deactivate').click();
-        const deactivateDialog = new DeactivateDriverDialogPo();
+    cy.intercept('POST', `/v3/kontainerDrivers/*?action=deactivate`).as('deactivateDriver');
 
-        deactivateDialog.deactivate();
-      });
+    driversPage.list().actionMenu(downloadUrl).getMenuItem('Deactivate').click();
+    const deactivateDialog = new DeactivateDriverDialogPo();
+
+    deactivateDialog.deactivate();
 
     cy.wait('@deactivateDriver').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);
@@ -112,12 +110,11 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(downloadUrl, 2).find('span').invoke('text')
-      .then((t) => {
-        cy.intercept('POST', `/v3/kontainerDrivers/${ t }?action=activate`).as('activateDriver');
 
-        driversPage.list().actionMenu(downloadUrl).getMenuItem('Activate').click();
-      });
+    cy.intercept('POST', `/v3/kontainerDrivers/*?action=activate`).as('activateDriver');
+
+    driversPage.list().actionMenu(downloadUrl).getMenuItem('Activate').click();
+
     cy.wait('@activateDriver').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);
       expect(isMatch(request.body, requestData)).to.equal(true);

--- a/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
@@ -80,7 +80,7 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       expect(isMatch(request.body, requestData)).to.equal(true);
       driverId = response.body.id;
     });
-    driversPage.list().details(downloadUrl1, 1).should('contain', 'Active');
+    driversPage.list().details(cloudCaDriver, 1).should('contain', 'Active');
   });
 
   it('can edit a node driver', () => {
@@ -112,12 +112,8 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       expect(isMatch(request.body, requestData)).to.equal(true);
     });
 
-    // Will use the below assertions until this issue is resolved https://github.com/rancher/dashboard/issues/11046.
-    // Using 'downloadUrl' instead of driver name
-    // driversPage.list().details(cloudCaDriver, 1).should('contain', 'Downloading');
-    // driversPage.list().details(cloudCaDriver, 1).contains('Active', { timeout: 15000 });
-    driversPage.list().details(downloadUrl2, 1).should('contain', 'Downloading');
-    driversPage.list().details(downloadUrl2, 1).contains('Active', { timeout: 60000 });
+    driversPage.list().details(cloudCaDriver, 1).should('contain', 'Downloading');
+    driversPage.list().details(cloudCaDriver, 1).contains('Active', { timeout: 15000 });
 
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
@@ -135,13 +131,13 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     NodeDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(downloadUrl2, 1).should('contain', 'Active');
-    driversPage.list().details(downloadUrl2, 2).find('span')
+    driversPage.list().details(cloudCaDriver, 1).should('contain', 'Active');
+    driversPage.list().details(cloudCaDriver, 2).find('span')
       .invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/nodeDrivers/${ t }?action=deactivate`).as('deactivateDriver');
 
-        driversPage.list().actionMenu(downloadUrl2).getMenuItem('Deactivate').click();
+        driversPage.list().actionMenu(cloudCaDriver).getMenuItem('Deactivate').click();
         const deactivateDialog = new DeactivateDriverDialogPo();
 
         deactivateDialog.deactivate();
@@ -165,11 +161,11 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     NodeDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(downloadUrl2, 2).find('span').invoke('text')
+    driversPage.list().details(cloudCaDriver, 2).find('span').invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/nodeDrivers/${ t }?action=activate`).as('activateDriver');
 
-        driversPage.list().actionMenu(downloadUrl2).getMenuItem('Activate').click();
+        driversPage.list().actionMenu(cloudCaDriver).getMenuItem('Activate').click();
       });
     cy.wait('@activateDriver').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);
@@ -246,8 +242,7 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     createCluster.gridElementExistanceByName(openStackDriver, 'not.exist');
   });
 
-  it.skip('can delete drivers in bulk', () => {
-    // Skipping this test until issue is resolved https://github.com/rancher/dashboard/issues/10718
+  it('can delete drivers in bulk', () => {
     NodeDriversPagePo.navTo();
     driversPage.waitForPage();
     driversPage.list().resourceTable().sortableTable().rowSelectCtlWithName(oracleDriver)

--- a/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
@@ -80,7 +80,7 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       expect(isMatch(request.body, requestData)).to.equal(true);
       driverId = response.body.id;
     });
-    driversPage.list().details(cloudCaDriver, 1).should('contain', 'Active');
+    driversPage.list().details(downloadUrl1, 1).should('contain', 'Active');
   });
 
   it('can edit a node driver', () => {
@@ -131,13 +131,13 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     NodeDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(cloudCaDriver, 1).should('contain', 'Active');
-    driversPage.list().details(cloudCaDriver, 2).find('span')
+    driversPage.list().details(downloadUrl2, 1).should('contain', 'Active');
+    driversPage.list().details(downloadUrl2, 2).find('span')
       .invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/nodeDrivers/${ t }?action=deactivate`).as('deactivateDriver');
 
-        driversPage.list().actionMenu(cloudCaDriver).getMenuItem('Deactivate').click();
+        driversPage.list().actionMenu(downloadUrl2).getMenuItem('Deactivate').click();
         const deactivateDialog = new DeactivateDriverDialogPo();
 
         deactivateDialog.deactivate();
@@ -161,11 +161,11 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
 
     NodeDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(cloudCaDriver, 2).find('span').invoke('text')
+    driversPage.list().details(downloadUrl2, 2).find('span').invoke('text')
       .then((t) => {
         cy.intercept('POST', `/v3/nodeDrivers/${ t }?action=activate`).as('activateDriver');
 
-        driversPage.list().actionMenu(cloudCaDriver).getMenuItem('Activate').click();
+        driversPage.list().actionMenu(downloadUrl2).getMenuItem('Activate').click();
       });
     cy.wait('@activateDriver').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2225,7 +2225,22 @@ drivers:
     refresh: Refresh Kubernetes Metadata
   deactivate:
     title: Are you sure?
-    warning: You will no longer be able to edit the configuration of clusters using {name} driver. Resources in the provider will not be automatically removed.
+    andOthers: |-
+      {count, plural,
+      =0 {}
+      =1 { and <b>one other </b>}
+      other { and <b>{count} other </b>}
+      }
+    warningDrivers: |-
+      {count, plural,
+      =1 { You will no longer be able to edit the configuration of clusters using {names} driver.}
+      other { You will no longer be able to edit the configuration of clusters using {names} drivers.}
+      }
+    warning: |-
+      {count, plural,
+      =1 { {warningDrivers} Resources in the corresponding provider will not be automatically removed.}
+      other { {warningDrivers} Resources in the corresponding providers will not be automatically removed.}
+      }
 
 detailText:
   collapse: Hide

--- a/shell/dialog/DeactivateDriverDialog.vue
+++ b/shell/dialog/DeactivateDriverDialog.vue
@@ -51,14 +51,12 @@ export default {
     },
     async apply(buttonDone) {
       try {
-        await Promise.all(this.drivers.map((driver) => {
-          const url = `v3/${ this.driverType }/${ escape(driver.id) }?action=deactivate`;
-
-          this.$store.dispatch('rancher/request', {
-            url,
+        await Promise.all(this.drivers.map(
+          (driver) => this.$store.dispatch('rancher/request', {
+            url: `v3/${ this.driverType }/${ escape(driver.id) }?action=deactivate`,
             method: 'POST'
-          });
-        }));
+          })
+        ));
 
         this.close(buttonDone);
       } catch (err) {

--- a/shell/dialog/DeactivateDriverDialog.vue
+++ b/shell/dialog/DeactivateDriverDialog.vue
@@ -53,7 +53,7 @@ export default {
       try {
         await Promise.all(this.drivers.map(
           (driver) => this.$store.dispatch('rancher/request', {
-            url: `v3/${ this.driverType }/${ escape(driver.id) }?action=deactivate`,
+            url:    `v3/${ this.driverType }/${ escape(driver.id) }?action=deactivate`,
             method: 'POST'
           })
         ));

--- a/shell/dialog/DeactivateDriverDialog.vue
+++ b/shell/dialog/DeactivateDriverDialog.vue
@@ -3,6 +3,8 @@ import AsyncButton from '@shell/components/AsyncButton';
 import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
 import { exceptionToErrorsArray } from '@shell/utils/error';
+import { resourceNames } from '@shell/utils/string';
+import { mapGetters } from 'vuex';
 
 export default {
   components: {
@@ -12,20 +14,35 @@ export default {
   },
 
   props: {
-    url: {
-      type:    String,
-      default: null,
+    drivers: {
+      type:     Array,
+      required: true
     },
-    name: {
-      type:    String,
-      default: null,
+    driverType: {
+      type:     String,
+      required: true
     }
   },
 
   data() {
     return { errors: [] };
   },
+  computed: {
+    formattedText() {
+      const namesSliced = this.drivers.map((obj) => obj.nameDisplay).slice(0, 5);
+      const remaining = this.drivers.length - namesSliced.length;
+
+      const plusMore = this.t('drivers.deactivate.andOthers', { count: remaining });
+      const names = resourceNames(namesSliced, plusMore, this.t);
+      const count = remaining || namesSliced.length;
+      const warningDrivers = this.t('drivers.deactivate.warningDrivers', { names, count });
+
+      return this.t('drivers.deactivate.warning', { warningDrivers, count: namesSliced.length });
+    },
+    ...mapGetters({ t: 'i18n/t' }),
+  },
   methods: {
+    resourceNames,
     close(buttonDone) {
       if (buttonDone && typeof buttonDone === 'function') {
         buttonDone(true);
@@ -34,10 +51,14 @@ export default {
     },
     async apply(buttonDone) {
       try {
-        await this.$store.dispatch('rancher/request', {
-          url:    this.url,
-          method: 'post'
-        });
+        await Promise.all(this.drivers.map((driver) => {
+          const url = `v3/${ this.driverType }/${ escape(driver.id) }?action=deactivate`;
+
+          this.$store.dispatch('rancher/request', {
+            url,
+            method: 'POST'
+          });
+        }));
 
         this.close(buttonDone);
       } catch (err) {
@@ -64,7 +85,7 @@ export default {
     <template #body>
       <div class="pl-10 pr-10">
         <div class="text info mb-10 mt-20">
-          <span v-clean-html="t('drivers.deactivate.warning', {name})" />
+          <span v-clean-html="formattedText" />
         </div>
         <Banner
           v-for="(err, i) in errors"

--- a/shell/models/driver.js
+++ b/shell/models/driver.js
@@ -1,6 +1,7 @@
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 import NormanModel from '@shell/plugins/steve/norman-class';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
+import capitalize from 'lodash/capitalize';
 
 export default class Driver extends NormanModel {
   get canViewYaml() {
@@ -20,12 +21,12 @@ export default class Driver extends NormanModel {
       }
     }
 
-    return KONTAINER_TO_DRIVER[this.id] || this.id;
+    return KONTAINER_TO_DRIVER[this.id] || this.name || this.id;
   }
 
   get nameDisplay() {
     const path = `cluster.provider.${ this.driverName }`;
-    const label = this.driverName || this.name || this.id;
+    const label = capitalize(this.driverName);
 
     return this.$rootGetters['i18n/withFallback'](path, label);
   }

--- a/shell/models/kontainerdriver.js
+++ b/shell/models/kontainerdriver.js
@@ -8,19 +8,21 @@ export default class KontainerDriver extends Driver {
   get _availableActions() {
     const out = [
       {
-        action:   'activate',
-        label:    'Activate',
-        icon:     'icon icon-play',
-        bulkable: true,
-        enabled:  !!this.links.update && !this.active
+        action:     'activate',
+        label:      'Activate',
+        icon:       'icon icon-play',
+        bulkable:   true,
+        bulkAction: 'activateBulk',
+        enabled:    !!this.links.update && !this.active
       },
       {
-        action:   'deactivate',
-        label:    'Deactivate',
-        icon:     'icon icon-pause',
-        bulkable: true,
-        enabled:  !!this.links.update && !!this.active,
-        weight:   -1
+        action:     'deactivate',
+        label:      'Deactivate',
+        icon:       'icon icon-pause',
+        bulkable:   true,
+        bulkAction: 'deactivateBulk',
+        enabled:    !!this.links.update && !!this.active,
+        weight:     -1
       },
       { divider: true },
       {
@@ -52,9 +54,16 @@ export default class KontainerDriver extends Driver {
     return out;
   }
 
-  deactivate() {
+  deactivate(resources = [this]) {
     this.$dispatch('promptModal', {
-      componentProps: { url: `v3/kontainerDrivers/${ escape(this.id) }?action=deactivate`, name: this.nameDisplay },
+      componentProps: { drivers: resources, driverType: 'kontainerDrivers' },
+      component:      'DeactivateDriverDialog'
+    });
+  }
+
+  deactivateBulk(resources) {
+    this.$dispatch('promptModal', {
+      componentProps: { drivers: resources, driverType: 'kontainerDrivers' },
       component:      'DeactivateDriverDialog'
     });
   }
@@ -64,5 +73,13 @@ export default class KontainerDriver extends Driver {
       url:    `v3/kontainerDrivers/${ escape(this.id) }?action=activate`,
       method: 'post',
     }, { root: true });
+  }
+
+  async activateBulk(resources) {
+    await Promise.all(resources.map((resource) => this.$dispatch('rancher/request', {
+      url:    `v3/kontainerDrivers/${ escape(resource.id) }?action=activate`,
+      method: 'post',
+    }, { root: true }
+    )));
   }
 }

--- a/shell/models/kontainerdriver.js
+++ b/shell/models/kontainerdriver.js
@@ -9,7 +9,7 @@ export default class KontainerDriver extends Driver {
     const out = [
       {
         action:     'activate',
-        label:      'Activate',
+        label:      this.t('action.activate'),
         icon:       'icon icon-play',
         bulkable:   true,
         bulkAction: 'activateBulk',
@@ -17,7 +17,7 @@ export default class KontainerDriver extends Driver {
       },
       {
         action:     'deactivate',
-        label:      'Deactivate',
+        label:      this.t('action.deactivate'),
         icon:       'icon icon-pause',
         bulkable:   true,
         bulkAction: 'deactivateBulk',

--- a/shell/models/nodedriver.js
+++ b/shell/models/nodedriver.js
@@ -9,7 +9,7 @@ export default class NodeDriver extends Driver {
     const out = [
       {
         action:     'activate',
-        label:      'Activate',
+        label:      this.t('action.activate'),
         icon:       'icon icon-play',
         bulkable:   true,
         bulkAction: 'activateBulk',
@@ -17,7 +17,7 @@ export default class NodeDriver extends Driver {
       },
       {
         action:     'deactivate',
-        label:      'Deactivate',
+        label:      this.t('action.deactivate'),
         icon:       'icon icon-pause',
         bulkable:   true,
         bulkAction: 'deactivateBulk',

--- a/shell/models/nodedriver.js
+++ b/shell/models/nodedriver.js
@@ -8,19 +8,21 @@ export default class NodeDriver extends Driver {
   get _availableActions() {
     const out = [
       {
-        action:   'activate',
-        label:    'Activate',
-        icon:     'icon icon-play',
-        bulkable: true,
-        enabled:  !!this.actions.activate && this.state === 'inactive',
+        action:     'activate',
+        label:      'Activate',
+        icon:       'icon icon-play',
+        bulkable:   true,
+        bulkAction: 'activateBulk',
+        enabled:    !!this.actions.activate && this.state === 'inactive',
       },
       {
-        action:   'deactivate',
-        label:    'Deactivate',
-        icon:     'icon icon-pause',
-        bulkable: true,
-        enabled:  !!this.actions.deactivate && this.state === 'active',
-        weight:   -1,
+        action:     'deactivate',
+        label:      'Deactivate',
+        icon:       'icon icon-pause',
+        bulkable:   true,
+        bulkAction: 'deactivateBulk',
+        enabled:    !!this.actions.deactivate && this.state === 'active',
+        weight:     -1,
       },
       { divider: true },
       {
@@ -52,9 +54,16 @@ export default class NodeDriver extends Driver {
     return out;
   }
 
-  deactivate() {
+  deactivate(resources = [this]) {
     this.$dispatch('promptModal', {
-      componentProps: { url: `v3/nodeDrivers/${ escape(this.id) }?action=deactivate`, name: this.nameDisplay },
+      componentProps: { drivers: resources, driverType: 'nodeDrivers' },
+      component:      'DeactivateDriverDialog'
+    });
+  }
+
+  deactivateBulk(resources) {
+    this.$dispatch('promptModal', {
+      componentProps: { drivers: resources, driverType: 'nodeDrivers' },
       component:      'DeactivateDriverDialog'
     });
   }
@@ -64,5 +73,13 @@ export default class NodeDriver extends Driver {
       url:    `v3/nodeDrivers/${ escape(this.id) }?action=activate`,
       method: 'post',
     }, { root: true });
+  }
+
+  async activateBulk(resources) {
+    await Promise.all(resources.map((resource) => this.$dispatch('rancher/request', {
+      url:    `v3/nodeDrivers/${ escape(resource.id) }?action=activate`,
+      method: 'post',
+    }, { root: true }
+    )));
   }
 }

--- a/shell/pages/c/_cluster/manager/drivers/kontainerDriver/index.vue
+++ b/shell/pages/c/_cluster/manager/drivers/kontainerDriver/index.vue
@@ -44,9 +44,6 @@ export default {
         buttonDone(false);
       }
     }
-  },
-  mounted() {
-    window.c = this;
   }
 };
 </script>

--- a/shell/pages/c/_cluster/manager/drivers/nodeDriver/index.vue
+++ b/shell/pages/c/_cluster/manager/drivers/nodeDriver/index.vue
@@ -26,10 +26,7 @@ export default {
     rows() {
       return this.allDrivers || [];
     },
-  },
-  mounted() {
-    window.c = this;
-  },
+  }
 };
 </script>
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11046
Fixes #10718 
<!-- Define findings related to the feature or bug issue. -->
Fixed deactivate driver bulk action, fixed displaying driver id instead of name for drivers that do not have translation.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Additionally, changed bulk activation action to follow pattern similar to other models.
When provisioning a cluster, driver name is used instead of the id.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
[] Test that driver name is shown instead of id for non-builtin driver
[] Test that driver can be activated on its own
[] Test that drivers can be activated in bulk
[] Test that driver can be deactivated on its own
[] Test that drivers can be deactivated in bulk 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Driver name is displayed instead of id inside of the cluster creation wizard.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
