### PR TITLE
Bump extension api version and add tag to release-2.8 yarn publish

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "0.3.27",
+  "version": "1.2.0",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -78,7 +78,7 @@ function publish() {
   # Make a note of dependency versions, if required
   node ${SCRIPT_DIR}/record-deps.js
 
-  yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS}
+  yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS} --tag v1.2
   RET=$?
 
   popd >/dev/null


### PR DESCRIPTION
Bump extension api version and add `--tag` to release-2.8 yarn publish

PR based on our shell versioning document where `latest` releases are to be done from `master` and older releases are to be done from `release-2.8` branch in order to support pre v2.9 Rancher extensions.
