### PR TITLE
Change the order we evaluate isImported with isCustom

### DIFF
--- a/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -73,5 +73,47 @@ describe('view: provisioning.cattle.io.cluster', () => {
 
       expect(wrapper.vm.showRegistration).toStrictEqual(false);
     });
+
+    it('should SHOW if custom/imported cluster and the cluster is active', async() => {
+      const value = {
+        isCustom:   true,
+        isImported: true,
+        mgmt:       {
+          hasLink: () => jest.fn(),
+          linkFor: () => '',
+          isReady: true
+        }
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        mocks,
+        propsData: { value },
+      });
+
+      await wrapper.setData({ clusterToken: {} });
+
+      expect(wrapper.vm.showRegistration).toStrictEqual(true);
+    });
+
+    it('should NOT show if imported cluster and the cluster is active', async() => {
+      const value = {
+        isCustom:   false,
+        isImported: true,
+        mgmt:       {
+          hasLink: () => jest.fn(),
+          linkFor: () => '',
+          isReady: true
+        }
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        mocks,
+        propsData: { value },
+      });
+
+      await wrapper.setData({ clusterToken: {} });
+
+      expect(wrapper.vm.showRegistration).toStrictEqual(false);
+    });
   });
 });

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -512,12 +512,12 @@ export default {
         return false;
       }
 
-      if ( this.value.isImported ) {
-        return !this.value.mgmt?.isReady && this.extDetailTabs.registration;
-      }
-
       if ( this.value.isCustom ) {
         return this.extDetailTabs.registration;
+      }
+
+      if ( this.value.isImported ) {
+        return !this.value.mgmt?.isReady && this.extDetailTabs.registration;
       }
 
       // Hosted kubernetes providers with private endpoints need the registration tab


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Both isImported and isCustom end up being true when using a custom cluster. There's some prior art which seems to indicate swapping the evaluation is acceptable.

Fixes #11160
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
The root cause was the change in the definition of [isImported()](https://github.com/rancher/dashboard/commit/6d4f75afafe9c0ac43a69c93fd6f085730048c97#diff-d888082c4e23d876ed1154a65f0abf824000d685eda426eee3512d88318f7d2bR246-R259).

I noticed that the provider correctly selected 'custom' on the list page
![image](https://github.com/rancher/dashboard/assets/55104481/3fe1982f-f669-4b11-acae-98dc7a7a71c7)

And that we invert the evaluation of `isImported()` and `isCustom()` in this context so I did the same here.
https://github.com/rancher/dashboard/blob/master/shell/components/formatter/ClusterProvider.vue#L28-L33

### Areas or cases that should be tested
Original case described in the issue

### Screenshot/Video
![image](https://github.com/rancher/dashboard/assets/55104481/4844a944-a201-4e30-b845-34dea3fc36d4)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
