### PR TITLE
Switch context for generic oidc provider to the genericOIDCConfig type

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -572,7 +572,7 @@ authConfig:
         title: Are you sure? This update is irreversible.
         body: '<p><b>You may need to make some additional changes</b>. Please ensure the Azure AD app has the Directory.Read.All <b>Application</b> permission added to Microsoft Graph.<br> If any endpoints were customized while configuring Azure AD authentication in Rancher, they will not be automatically updated. </p>'
   oidc:
-    oidc: Configure an OIDC account
+    genericoidc: Configure an OIDC account
     keycloakoidc: Configure a Keycloak OIDC account
     rancherUrl: Rancher URL
     clientId: Client ID
@@ -6582,7 +6582,7 @@ model:
       okta: Okta
       freeipa: FreeIPA
       googleoauth: Google
-      oidc: Generic OIDC
+      genericoidc: Generic OIDC
       keycloakoidc: Keycloak
 
   cluster:

--- a/shell/config/product/auth.js
+++ b/shell/config/product/auth.js
@@ -174,7 +174,7 @@ export function init(store) {
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/googleoauth`, 'auth/googleoauth');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/azuread`, 'auth/azuread');
   componentForType(`${ MANAGEMENT.AUTH_CONFIG }/keycloakoidc`, 'auth/oidc');
-  componentForType(`${ MANAGEMENT.AUTH_CONFIG }/oidc`, 'auth/oidc');
+  componentForType(`${ MANAGEMENT.AUTH_CONFIG }/genericoidc`, 'auth/oidc');
 
   basicType([
     'config',

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -19,14 +19,14 @@ const validScope = 'openid profile email';
 
 const mockModel = {
   enabled:      false,
-  id:           'oidc',
+  id:           'genericoidc',
   rancherUrl:   validRancherUrl,
   issuer:       validIssuer,
   authEndpoint: validAuthEndpoint,
   scope:        validScope,
   clientId:     validClientId,
   clientSecret: validClientSecret,
-  type:         'oidcConfig',
+  type:         'genericOIDCConfig',
 };
 
 const mockedAuthConfigMixin = {

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -273,7 +273,7 @@ export default {
 
         // KeyCloakOIDCConfig --> OIDCConfig
         set(this.model, 'rancherUrl', `${ serverUrl }/verify-auth`);
-        set(this.model, 'scope', BASE_SCOPES.oidc[0]);
+        set(this.model, 'scope', this.model.id === 'keycloakoidc' ? BASE_SCOPES.keycloakoidc[0] : BASE_SCOPES.genericoidc[0]);
         break;
       }
 

--- a/shell/models/management.cattle.io.authconfig.js
+++ b/shell/models/management.cattle.io.authconfig.js
@@ -15,10 +15,10 @@ export const configType = {
   local:           '',
   github:          'oauth',
   keycloakoidc:    'oidc',
-  oidc:            'oidc',
+  genericoidc:     'oidc',
 };
 
-const imageOverrides = { keycloakoidc: 'keycloak', oidc: 'openid' };
+const imageOverrides = { keycloakoidc: 'keycloak', genericoidc: 'openid' };
 
 export default class AuthConfig extends SteveModel {
   get _availableActions() {

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -13,7 +13,7 @@ export const BASE_SCOPES = {
   googleoauth:  ['openid profile email'],
   azuread:      [],
   keycloakoidc: ['openid profile email'],
-  oidc:         ['openid profile email'],
+  genericoidc:  ['openid profile email'],
 };
 
 const KEY = 'rc_nonce';

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -71,7 +71,7 @@ export const authProvidersInfo = async(store) => {
   const nonLocal = rows.filter((x) => x.name !== 'local');
   const enabled = nonLocal.filter((x) => x.enabled === true );
 
-  const supportedNonLocal = nonLocal.filter((x) => x.id !== 'genericoidc');
+  const supportedNonLocal = nonLocal.filter((x) => x.id !== 'oidc');
 
   const enabledLocation = enabled.length === 1 ? {
     name:   'c-cluster-auth-config-id',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR does not fix a targeted issue, although it is related to #11112 

This converts the provider context when using the Generic OIDC provider to use the `genericoidc` id and `genericOIDCConfig` type.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
We previously were filtering out the `genericoidc` provider and showing the `oidc` provider. This context needed to be reversed where we are using the `genericoidc` provider when selecting "Generic OIDC" as an authentication provider.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
This switches all instances of the `oidc` provider with `genericoidc`.
In `shell/mixins/auth-config.js` I added a ternary to ensure the Keycloak OIDC provider uses the related scope declared in `BASE_SCOPES.keycloakoidc`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Both Generic OIDC and Keycloak OIDC providers should be tested to ensure there are no regressions. When enabling, editing, or disabling, the following inputs will be required:
- `model.clientId`
- `model.clientSecret`
- `model.scope` contains `openid` when provider is Generic OIDC
- When Endpoints -> Generate is `Generate`
  - `oidcUrls.url`
  - `oidcUrls.realms`
- When Endpoints -> Generate is `Specify`
  - `model.rancherUrl`
  - `model.issuer`
  - `model.authEndpoint` when provider is Keycloak OIDC

A testing environment can be supplied on request.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
The Generic OIDC provider authentication needs to be thoroughly tested as this changes the fundamental type that the provider is using to authenticate.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
