### PR TITLE
remove rancher-components folder to prevent releasing outdated version of shell pkg on a manual release

### DIFF
--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -67,6 +67,7 @@ function publish() {
   # For now, copy the rancher components into the shell and ship them with it
   if [ "$NAME" == "Shell" ]; then
     echo "Adding Rancher Components"
+    rm -rf ./rancher-components
     cp -R ${BASE_DIR}/pkg/rancher-components/src/components ./rancher-components/
   fi
 


### PR DESCRIPTION
remove rancher-components folder to prevent releasing outdated version of shell pkg on a manual release