### PR TITLE
GKE: fix node pool taint effect options

### DIFF
--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -474,6 +474,8 @@ export default defineComponent({
           :mode="mode"
           :value="taints"
           :disabled="!isNew"
+          :effect-values="{NO_SCHEDULE:'NoSchedule', PREFER_NO_SCHEDULE: 'PreferNoSchedule', NO_EXECUTE: 'NoExecute'}"
+          data-testid="gke-taints-comp"
           @input="$emit('update:taints', $event)"
         />
       </div>

--- a/pkg/gke/components/__tests__/GKENodePool.test.ts
+++ b/pkg/gke/components/__tests__/GKENodePool.test.ts
@@ -151,7 +151,7 @@ describe('gke node pool', () => {
       ...setup
     });
 
-    const taints = wrapper.find('data-testid="gke-taints-comp"');
+    const taints = wrapper.find('[data-testid="gke-taints-comp"]');
 
     // the effectValues prop functionality is tested in the Taints component's unit tests
     expect(taints.props().effectValues).toStrictEqual({

--- a/pkg/gke/components/__tests__/GKENodePool.test.ts
+++ b/pkg/gke/components/__tests__/GKENodePool.test.ts
@@ -139,4 +139,23 @@ describe('gke node pool', () => {
 
     expect(wrapper.emitted()?.['update:version']?.[1][0]).toBe('1.20.4');
   });
+
+  it('should use NO_SCHEDULE, PREFER_NO_SCHEDULE, and NO_EXECUTE for taint values', async() => {
+    const setup = requiredSetup();
+    const wrapper = shallowMount(GKENodePool, {
+      propsData: {
+        clusterKubernetesVersion: '1.23.4',
+        version:                  '1.20.4',
+        mode:                     _EDIT
+      },
+      ...setup
+    });
+
+    const taints = wrapper.find('data-testid="gke-taints-comp"');
+
+    // the effectValues prop functionality is tested in the Taints component's unit tests
+    expect(taints.props().effectValues).toStrictEqual({
+      NO_SCHEDULE: 'NoSchedule', PREFER_NO_SCHEDULE: 'PreferNoSchedule', NO_EXECUTE: 'NoExecute'
+    });
+  });
 });

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -758,6 +758,7 @@ export default {
             :name="'col:' + c"
             :row="row"
             :queue-update="queueUpdate"
+            :i="i"
           />
         </div>
         <div

--- a/shell/components/form/Taints.vue
+++ b/shell/components/form/Taints.vue
@@ -3,10 +3,10 @@ import KeyValue from '@shell/components/form/KeyValue';
 import { _VIEW } from '@shell/config/query-params';
 import Select from '@shell/components/form/Select';
 
-const EFFECT_VALUES = {
-  NO_SCHEDULE:        'NoSchedule',
-  PREFER_NO_SCHEDULE: 'PreferNoSchedule',
-  NO_EXECUTE:         'NoExecute',
+const DEFAULT_EFFECT_VALUES = {
+  NoSchedule:       'NoSchedule',
+  PreferNoSchedule: 'PreferNoSchedule',
+  NoExecute:        'NoExecute',
 };
 
 export default {
@@ -24,11 +24,15 @@ export default {
     disabled: {
       default: false,
       type:    Boolean
+    },
+    effectValues: {
+      type:    Object,
+      default: () => DEFAULT_EFFECT_VALUES
     }
   },
 
   data() {
-    return { effectOptions: Object.values(EFFECT_VALUES).map((v) => ({ label: v, value: v })) };
+    return { effectOptions: Object.keys(this.effectValues).map((k) => ({ label: this.effectValues[k], value: k })) };
   },
 
   computed: {
@@ -43,7 +47,7 @@ export default {
     },
 
     defaultAddData() {
-      return { effect: EFFECT_VALUES.NO_SCHEDULE };
+      return { effect: this.effectOptions[0] };
     }
   }
 };
@@ -53,6 +57,7 @@ export default {
   <div class="taints">
     <KeyValue
       v-model="localValue"
+      data-testid="taints-keyvalue"
       :title="t('tableHeaders.taints')"
       :mode="mode"
       :as-map="false"
@@ -69,9 +74,10 @@ export default {
         {{ t('tableHeaders.effect') }}
       </template>
 
-      <template #col:effect="{row, queueUpdate}">
+      <template #col:effect="{row, queueUpdate, i}">
         <Select
           v-model="row.effect"
+          :data-testid="`taints-effect-row-${i}`"
           :options="effectOptions"
           :disabled="disabled"
           class="compact-select"

--- a/shell/components/form/Taints.vue
+++ b/shell/components/form/Taints.vue
@@ -47,7 +47,7 @@ export default {
     },
 
     defaultAddData() {
-      return { effect: this.effectOptions[0] };
+      return { effect: this.effectOptions[0].value };
     }
   }
 };

--- a/shell/components/form/__tests__/Taints.test.ts
+++ b/shell/components/form/__tests__/Taints.test.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils';
+import Taints from '@shell/components/form/Taints.vue';
+
+describe('component: Taints', () => {
+  it('should accept custom effect values', async() => {
+    const customEffects = { FOO_EFFECT: 'foo', BAR_EFFECT: 'bar' };
+
+    const wrapper = mount(Taints, {
+      propsData: {
+        value:        [{ effect: 'FOO_EFFECT', value: 'abc' }],
+        effectValues: customEffects
+      }
+    });
+
+    const firstEffectInput = wrapper.find('[data-testid="taints-effect-row-0"]');
+
+    expect(firstEffectInput.exists()).toBe(true);
+
+    expect(firstEffectInput.props().value).toBe('FOO_EFFECT');
+    expect(firstEffectInput.props().options).toStrictEqual([{ value: 'FOO_EFFECT', label: 'foo' }, { value: 'BAR_EFFECT', label: 'bar' }]);
+
+    const taintKV = wrapper.find('[data-testid="taints-keyvalue"]');
+
+    taintKV.vm.add();
+    await wrapper.vm.$nextTick();
+
+    const secondEffectInput = wrapper.find('[data-testid="taints-effect-row-1"]');
+
+    expect(secondEffectInput.exists()).toBe(true);
+
+    expect(secondEffectInput.props().value).toStrictEqual({ label: 'foo', value: 'FOO_EFFECT' });
+  });
+
+  it('should use default effect values of NoSchedule, PreferNoSchedule, and PreferNoExecute', async() => {
+    const expectedEffectOptions = [
+      { label: 'NoSchedule', value: 'NoSchedule' },
+      { label: 'PreferNoSchedule', value: 'PreferNoSchedule' },
+
+      { label: 'NoExecute', value: 'NoExecute' },
+
+    ];
+
+    const wrapper = mount(Taints, { propsData: { value: [{ effect: '', value: 'abc' }] } });
+
+    const firstEffectInput = wrapper.find('[data-testid="taints-effect-row-0"]');
+
+    expect(firstEffectInput.exists()).toBe(true);
+
+    expect(firstEffectInput.props().value).toBe('');
+    expect(firstEffectInput.props().options).toStrictEqual(expectedEffectOptions);
+
+    const taintKV = wrapper.find('[data-testid="taints-keyvalue"]');
+
+    taintKV.vm.add();
+    await wrapper.vm.$nextTick();
+
+    const secondEffectInput = wrapper.find('[data-testid="taints-effect-row-1"]');
+
+    expect(secondEffectInput.exists()).toBe(true);
+
+    expect(secondEffectInput.props().value).toStrictEqual({ label: 'NoSchedule', value: 'NoSchedule' });
+  });
+});

--- a/shell/components/form/__tests__/Taints.test.ts
+++ b/shell/components/form/__tests__/Taints.test.ts
@@ -28,7 +28,8 @@ describe('component: Taints', () => {
 
     expect(secondEffectInput.exists()).toBe(true);
 
-    expect(secondEffectInput.props().value).toStrictEqual({ label: 'foo', value: 'FOO_EFFECT' });
+    expect(secondEffectInput.props().value).toStrictEqual('FOO_EFFECT');
+    expect(wrapper.vm.defaultAddData).toStrictEqual({ effect: 'FOO_EFFECT' });
   });
 
   it('should use default effect values of NoSchedule, PreferNoSchedule, and PreferNoExecute', async() => {
@@ -48,16 +49,22 @@ describe('component: Taints', () => {
 
     expect(firstEffectInput.props().value).toBe('');
     expect(firstEffectInput.props().options).toStrictEqual(expectedEffectOptions);
+  });
+
+  it('should set the effect value to NoSchedule by default', async() => {
+    const wrapper = mount(Taints, { propsData: { value: [] } });
 
     const taintKV = wrapper.find('[data-testid="taints-keyvalue"]');
 
     taintKV.vm.add();
     await wrapper.vm.$nextTick();
 
-    const secondEffectInput = wrapper.find('[data-testid="taints-effect-row-1"]');
+    const effectInput = wrapper.find('[data-testid="taints-effect-row-0"]');
 
-    expect(secondEffectInput.exists()).toBe(true);
+    expect(effectInput.exists()).toBe(true);
 
-    expect(secondEffectInput.props().value).toStrictEqual({ label: 'NoSchedule', value: 'NoSchedule' });
+    expect(effectInput.props().value).toStrictEqual('NoSchedule');
+
+    expect(wrapper.vm.defaultAddData).toStrictEqual({ effect: 'NoSchedule' });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11293 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes GKE node pool taints. The underlying issue appears to be the effect options' values, which should be uppercase snake case instead of camel case.

### Technical notes summary
The PR expands functionality of the Taints component and adds unit tests to verify that default behavior is unaltered.

### Areas or cases that should be tested
Verify new behavior in GKE provisioning following the steps in #11293 
Verify default Taints.vue behavior still works by creating an RKE2 cluster with taints 
    - taints appear in the advanced section of the machine pool form
    - they will show up in the request to create the provisioning cluster object under `spec.rkeConfig.machinePools[].taints`


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
