### PR TITLE
Harvester i18n and page reload fixes

### DIFF
--- a/cypress/e2e/tests/pages/generic/loading.spec.ts
+++ b/cypress/e2e/tests/pages/generic/loading.spec.ts
@@ -2,13 +2,13 @@
 describe('Theme of loading indicator', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
   it('should have dark color', () => {
     cy.setCookie('R_THEME', 'dark');
-    cy.visit(`${ Cypress.config().baseUrl }/public/index.html`);
+    cy.visit(`${ Cypress.config().baseUrl }`);
 
     cy.get('head style').should('contain', '--loading-bg-color: #1b1c21');
   });
   it('should have light color', () => {
     cy.setCookie('R_THEME', 'light');
-    cy.visit(`${ Cypress.config().baseUrl }/public/index.html`);
+    cy.visit(`${ Cypress.config().baseUrl }`);
 
     cy.get('head style').should('contain', '--loading-bg-color: #FFF');
   });

--- a/shell/config/router/navigation-guards/i18n.js
+++ b/shell/config/router/navigation-guards/i18n.js
@@ -1,0 +1,13 @@
+export function install(router, context) {
+  router.beforeEach((to, from, next) => loadI18n(to, from, next, context));
+}
+
+export async function loadI18n(to, from, next, { store }) {
+  try {
+    await store.dispatch('i18n/init');
+  } catch (e) {
+    console.error('Failed to initialize i18n', e); // eslint-disable-line no-console
+  }
+
+  next();
+}

--- a/shell/config/router/navigation-guards/index.js
+++ b/shell/config/router/navigation-guards/index.js
@@ -1,6 +1,7 @@
 import { install as installLoadInitialSettings } from '@shell/config/router/navigation-guards/load-initial-settings';
 import { install as installAttemptFirstLogin } from '@shell/config/router/navigation-guards/attempt-first-login';
 import { install as installAuthentication } from '@shell/config/router/navigation-guards/authentication';
+import { install as installI18N } from '@shell/config/router/navigation-guards/i18n';
 
 /**
  * Install our router navigation guards. i.e. router.beforeEach(), router.afterEach()
@@ -9,7 +10,7 @@ export function installNavigationGuards(router, context) {
   // NOTE: the order of the installation matters.
   // Be intentional when adding, removing or modifying the guards that are installed.
 
-  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication];
+  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication, installI18N];
 
   navigationGuardInstallers.forEach((installer) => installer(router, context));
 }

--- a/shell/initialize/entry-helpers.js
+++ b/shell/initialize/entry-helpers.js
@@ -204,9 +204,6 @@ async function render(to, from, next) {
     // We should really make authenticated middleware do less...
     await callMiddleware.call(this, [{ options: { middleware: ['authenticated'] } }], app.context);
 
-    // We used to have i18n middleware which was called each time we called middleware. This is also needed to support harvester because of the way harvester loads as outlined in the comment above
-    await this.$store.dispatch('i18n/init');
-
     if (nextCalled) {
       return;
     }

--- a/shell/middleware/authenticated.js
+++ b/shell/middleware/authenticated.js
@@ -2,7 +2,6 @@ import { DEFAULT_WORKSPACE } from '@shell/config/types';
 import { applyProducts } from '@shell/store/type-map';
 import { ClusterNotFoundError, RedirectToError } from '@shell/utils/error';
 import { get } from '@shell/utils/object';
-import dynamicPluginLoader from '@shell/pkg/dynamic-plugin-loader';
 import { AFTER_LOGIN_ROUTE, WORKSPACE } from '@shell/store/prefs';
 import { BACK_TO } from '@shell/config/local-storage';
 import { NAME as FLEET_NAME } from '@shell/config/product/fleet.js';
@@ -105,24 +104,6 @@ export default async function({
         oldProduct,
         oldIsExt: !!oldPkg
       });
-    }
-
-    if (!route.matched?.length) {
-      // If there are no matching routes we could be trying to nav to a page belonging to a dynamic plugin which needs loading
-      await Promise.all([
-        ...always,
-      ]);
-
-      // If a plugin claims the route and is loaded correctly we'll get a route back
-      const newLocation = await dynamicPluginLoader.check({ route, store });
-
-      // If we have a new location, double check that it's actually valid
-      const resolvedRoute = newLocation ? store.app.router.resolve(newLocation) : null;
-
-      if (resolvedRoute?.route.matched.length) {
-        // Note - don't use `redirect` or `store.app.route` (breaks feature by failing to run middleware in default layout)
-        return next(newLocation);
-      }
     }
 
     // Ensure that the activeNamespaceCache is updated given the change of context either from or to a place where it uses workspaces


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves two issues around harvester i18n and harvester cluster page reload failures.

Fixes #11349
Fixes #11350




### Technical notes summary

- i18n
  - i18n we needed to ensure that `i18n/init` was invoked after the harvester plugin was loaded and added it's own strings. Previously this was done in authenticated middleware which was run before each (nearly every) page was rendered. This is now done as a part of a router navigation guard and is ran just as frequently as it used to be,
- Page refresh
  - There was compounding factors which caused this but effectively we were no longer loading dynamic plugins in the authenticated middleware on 404s. I pulled the logic out of the authenticated middleware and put it in our render method. We probably want to get rid of this concept all together.

### Areas or cases that should be tested
Harvester cluster pages

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
