### PR TITLE
Fix monitoring chart version to one that works

### DIFF
--- a/cypress/e2e/po/pages/explorer/charts/chart.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/chart.po.ts
@@ -38,4 +38,8 @@ export class ChartPage extends PagePo {
   deprecationAndExperimentalWarning() {
     return new BannersPo('[data-testid="deprecation-and-experimental-banner"]', this.self());
   }
+
+  selectVersion(version: string) {
+    return this.self().find('.chart-content__right-bar__section--cVersion').contains(version).click();
+  }
 }

--- a/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
@@ -71,6 +71,9 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
 
         const tabbedOptions = new TabbedPo();
 
+        // Latest (`104.0.0+up45.31.1`) is broken (crd installs, but not actual chart), use `103.1.1+up45.31.1` instead
+        chartPage.selectVersion('103.1.1+up45.31...');
+
         // Navigate to the edit options page and Set prometheus storage class
         chartPage.goToInstall();
         installChart.nextPage().selectTab(tabbedOptions, prometheus.tabID());


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- 104.0.0+up45.31.1 is broken (crd installs, but not main chart)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
