### PR TITLE
update shell version to be up to par with latest published version for 2.8

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",


### PR DESCRIPTION
update shell version to be up to par with latest published version for 2.8

We are now in version `1.2.3` released from `release-2.8` branch

https://www.npmjs.com/package/@rancher/shell?activeTab=versions