### PR TITLE
Add shim for `defineComponent` for better backwards compatibility

### DIFF
--- a/shell/pkg/define-component-plugin.js
+++ b/shell/pkg/define-component-plugin.js
@@ -1,0 +1,42 @@
+/**
+ * Custom WebPack plugin that will detect 'defineComponent' imports from Vue and
+ * replace those with references to our shim - which will either use the Vue
+ * definition if avialble or it will use a fallback.
+ */
+
+const path = require('path');
+const PLUGIN_NAME = 'rancherDefineComponentPlugin';
+
+class RancherDefineComponentPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      PLUGIN_NAME,
+      (compilation, { normalModuleFactory }) => {
+        const handler = (parser) => {
+          parser.hooks.program.tap(PLUGIN_NAME, (ast) => {
+            // Go through the complication abstract syntax tree and look for import statements
+            ast.body.forEach((node) => {
+              if (node.type === 'ImportDeclaration') {
+                if (node.source.value === 'vue' && node.specifiers) {
+                  // When we import defineComponent in the shim, we use a different local name, which ensures we don't end up in a recursive loop
+                  const isDefineComponent = node.specifiers.find((node) => node.local.name === 'defineComponent' && node.imported.name === 'defineComponent');
+
+                  if (isDefineComponent) {
+                    // Replace the import to use the shim
+                    node.source.value = path.join(__dirname, 'define-component-shim.js');
+                  }
+                }
+              }
+            });
+          });
+        };
+
+        normalModuleFactory.hooks.parser.for('javascript/auto').tap('UseStrictPlugin', handler);
+        normalModuleFactory.hooks.parser.for('javascript/dynamic').tap('UseStrictPlugin', handler);
+        normalModuleFactory.hooks.parser.for('javascript/esm').tap('UseStrictPlugin', handler);
+      }
+    );
+  }
+}
+
+module.exports = RancherDefineComponentPlugin;

--- a/shell/pkg/define-component-shim.js
+++ b/shell/pkg/define-component-shim.js
@@ -1,0 +1,13 @@
+// Shim that ensures that defineComponent is available
+
+import { defineComponent as vueDefineComponent } from 'vue';
+
+export function defineComponent(opts) {
+  // Use the function from Vue, if available
+  if (vueDefineComponent) {
+    return vueDefineComponent(opts);
+  }
+
+  // Otherwise, just return the opts
+  return opts;
+}

--- a/shell/pkg/vue.config.js
+++ b/shell/pkg/vue.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 const webpack = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const VirtualModulesPlugin = require('webpack-virtual-modules');
+const RancherDefineComponentPlugin = require('./define-component-plugin');
 const { generateTypeImport } = require('./auto-import');
 
 module.exports = function(dir) {
@@ -77,6 +78,8 @@ module.exports = function(dir) {
       config.plugins.unshift(dynamicImporterOverride);
       config.plugins.unshift(modelLoaderImporterOverride);
       config.plugins.unshift(autoImportPlugin);
+      config.plugins.unshift(new RancherDefineComponentPlugin());
+
       // config.plugins.unshift(debug);
 
       // These modules will be externalised and not included with the build of a package library


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

This PR adds a shim for `defineComponent`.

This means that extensions built with the newer shell will be able to be loaded into older versions of Rancher (2.8.0, 2.8.1, 2.8.2, 2.8.3 and 2.7).

The main benefit of `defineComponent` is in the typing - the actual implementation simply returns the options it is passed.

Note: The AsyncButton uses the `inject` function from `vue` - this is the only other use of function exports from Vue, so to be complete, we would need to replace the use of inject there (temporarily) - it is not easy to shim the `inject` function.

This change doesn't need to go into a Rancher release as such - it needs to be published into a shell version, which will then mean extensions built with that shell will work in older versions if they use components declared with `defineComponent`.

The implementation is a WebPack plugin - during compilation we process the abstract syntax tree looking at import statements - any from `vue` for `defineComponent` are updated to refer to a small shim, rather than the `vue` module.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
