### PR TITLE
Handle harvester loading in a route guard to better handle the unauthenticated method.

### DIFF
--- a/shell/config/router/navigation-guards/attempt-first-login.js
+++ b/shell/config/router/navigation-guards/attempt-first-login.js
@@ -5,7 +5,7 @@ import { tryInitialSetup } from '@shell/utils/auth';
 import { routeRequiresAuthentication } from '@shell/utils/router';
 
 export function install(router, context) {
-  router.beforeEach((to, from, next) => attemptFirstLogin(to, from, next, context));
+  router.beforeEach(async(to, from, next) => await attemptFirstLogin(to, from, next, context));
 }
 
 export async function attemptFirstLogin(to, from, next, { store }) {

--- a/shell/config/router/navigation-guards/authentication.js
+++ b/shell/config/router/navigation-guards/authentication.js
@@ -2,7 +2,7 @@ import { routeRequiresAuthentication } from '@shell/utils/router';
 import { isLoggedIn, notLoggedIn, noAuth, findMe } from '@shell/utils/auth';
 
 export function install(router, context) {
-  router.beforeEach((to, from, next) => authenticate(to, from, next, context));
+  router.beforeEach(async(to, from, next) => await authenticate(to, from, next, context));
 }
 
 export async function authenticate(to, from, next, { store }) {

--- a/shell/config/router/navigation-guards/harvester.js
+++ b/shell/config/router/navigation-guards/harvester.js
@@ -1,0 +1,31 @@
+import dynamicPluginLoader from '@shell/pkg/dynamic-plugin-loader';
+import { routeRequiresAuthentication } from '@shell/utils/router';
+
+export function install(router, context) {
+  router.beforeEach((to, from, next) => loadHarvester(to, from, next, context));
+}
+
+export async function loadHarvester(to, from, next, { store }) {
+  if (!routeRequiresAuthentication(to) || to.name !== '404') {
+    return next();
+  }
+
+  try {
+    // Handle the loading of dynamic plugins (Harvester) because we only want to attempt to load those plugins and routes if we first couldn't find a page.
+    // We should probably get rid of this concept entirely and just load plugins at the start.
+    await store.dispatch('loadManagement');
+    const newLocation = await dynamicPluginLoader.check({ route: { path: window.location.pathname }, store });
+
+    // If we have a new location, double check that it's actually valid
+    const resolvedRoute = newLocation ? store.app.router.resolve(newLocation) : null;
+
+    if (resolvedRoute?.route.matched.length) {
+      // Note - don't use `redirect` or `store.app.route` (breaks feature by failing to run middleware in default layout)
+      return next(newLocation);
+    }
+  } catch (e) {
+    console.error('Failed to load harvester', e); // eslint-disable-line no-console
+  }
+
+  next();
+}

--- a/shell/config/router/navigation-guards/i18n.js
+++ b/shell/config/router/navigation-guards/i18n.js
@@ -1,5 +1,5 @@
 export function install(router, context) {
-  router.beforeEach((to, from, next) => loadI18n(to, from, next, context));
+  router.beforeEach(async(to, from, next) => await loadI18n(to, from, next, context));
 }
 
 export async function loadI18n(to, from, next, { store }) {

--- a/shell/config/router/navigation-guards/index.js
+++ b/shell/config/router/navigation-guards/index.js
@@ -1,7 +1,7 @@
 import { install as installLoadInitialSettings } from '@shell/config/router/navigation-guards/load-initial-settings';
 import { install as installAttemptFirstLogin } from '@shell/config/router/navigation-guards/attempt-first-login';
 import { install as installAuthentication } from '@shell/config/router/navigation-guards/authentication';
-import { install as installHarvester } from '@shell/config/router/navigation-guards/harvester';
+import { install as installRuntimeExtensionRoute } from '@shell/config/router/navigation-guards/runtime-extension-route';
 import { install as installI18N } from '@shell/config/router/navigation-guards/i18n';
 
 /**
@@ -11,7 +11,7 @@ export function installNavigationGuards(router, context) {
   // NOTE: the order of the installation matters.
   // Be intentional when adding, removing or modifying the guards that are installed.
 
-  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication, installHarvester, installI18N];
+  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication, installRuntimeExtensionRoute, installI18N];
 
   navigationGuardInstallers.forEach((installer) => installer(router, context));
 }

--- a/shell/config/router/navigation-guards/index.js
+++ b/shell/config/router/navigation-guards/index.js
@@ -1,6 +1,7 @@
 import { install as installLoadInitialSettings } from '@shell/config/router/navigation-guards/load-initial-settings';
 import { install as installAttemptFirstLogin } from '@shell/config/router/navigation-guards/attempt-first-login';
 import { install as installAuthentication } from '@shell/config/router/navigation-guards/authentication';
+import { install as installHarvester } from '@shell/config/router/navigation-guards/harvester';
 import { install as installI18N } from '@shell/config/router/navigation-guards/i18n';
 
 /**
@@ -10,7 +11,7 @@ export function installNavigationGuards(router, context) {
   // NOTE: the order of the installation matters.
   // Be intentional when adding, removing or modifying the guards that are installed.
 
-  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication, installI18N];
+  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication, installHarvester, installI18N];
 
   navigationGuardInstallers.forEach((installer) => installer(router, context));
 }

--- a/shell/config/router/navigation-guards/load-initial-settings.js
+++ b/shell/config/router/navigation-guards/load-initial-settings.js
@@ -1,7 +1,7 @@
 import { fetchInitialSettings } from '@shell/utils/settings';
 
 export function install(router, context) {
-  router.beforeEach((to, from, next) => loadInitialSettings(to, from, next, context));
+  router.beforeEach(async(to, from, next) => await loadInitialSettings(to, from, next, context));
 }
 
 export async function loadInitialSettings(to, from, next, { store }) {

--- a/shell/config/router/navigation-guards/runtime-extension-route.js
+++ b/shell/config/router/navigation-guards/runtime-extension-route.js
@@ -2,10 +2,10 @@ import dynamicPluginLoader from '@shell/pkg/dynamic-plugin-loader';
 import { routeRequiresAuthentication } from '@shell/utils/router';
 
 export function install(router, context) {
-  router.beforeEach((to, from, next) => loadHarvester(to, from, next, context));
+  router.beforeEach((to, from, next) => runtimeExtensionRoute(to, from, next, context));
 }
 
-export async function loadHarvester(to, from, next, { store }) {
+export async function runtimeExtensionRoute(to, from, next, { store }) {
   if (!routeRequiresAuthentication(to) || to.name !== '404') {
     return next();
   }

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -484,4 +484,12 @@ export default [
         component: () => interopDefault(import('@shell/pages/c/_cluster/_product/_resource/_namespace/_id.vue')),
         name:      'c-cluster-product-resource-namespace-id'
       }]
-  }];
+  },
+  {
+    path:      '*',
+    name:      '404',
+    component: () => interopDefault(import('@shell/pages/404.vue')),
+    meta:      { requiresAuthentication: true },
+  },
+
+];

--- a/shell/initialize/entry-helpers.js
+++ b/shell/initialize/entry-helpers.js
@@ -3,7 +3,6 @@ import { updatePageTitle } from '@shell/utils/title';
 import { getVendor } from '@shell/config/private-label';
 import middleware from '@shell/config/middleware.js';
 import { withQuery } from 'ufo';
-import dynamicPluginLoader from '@shell/pkg/dynamic-plugin-loader';
 
 // Global variable used on mount, updated on route change and used in the render function
 let app;
@@ -198,26 +197,6 @@ async function render(to, from, next) {
   // Get route's matched components
   const matches = [];
   const Components = getMatchedComponents(to, matches);
-
-  // If no Components matched, generate 404
-  if (!Components.length) {
-    // Handle the loading of dynamic plugins (Harvester) because we only want to attempt to load those plugins and routes if we first couldn't find a page.
-    // We should probably get rid of this concept entirely and just load plugins at the start.
-    await app.context.store.dispatch('loadManagement');
-    const newLocation = await dynamicPluginLoader.check({ route: { path: window.location.pathname }, store: app.context.store });
-
-    // If we have a new location, double check that it's actually valid
-    const resolvedRoute = newLocation?.path ? app.context.store.app.router.resolve({ path: newLocation.path.replace(/^\/{0,1}dashboard/, '') }) : null;
-
-    if (resolvedRoute?.route.matched.length) {
-      // Note - don't use `redirect` or `store.app.route` (breaks feature by failing to run middleware in default layout)
-      return next(resolvedRoute.resolved.path);
-    }
-
-    errorRedirect(this, new Error('404: This page could not be found'));
-
-    return next();
-  }
 
   try {
     // Call middleware

--- a/shell/pages/404.vue
+++ b/shell/pages/404.vue
@@ -1,0 +1,15 @@
+<script>
+import Brand from '@shell/mixins/brand';
+
+export default {
+  mixins: [Brand],
+  beforeMount() {
+    this.$store.commit('setError', { error: new Error('404: This page could not be found') });
+    this.$router.replace('/fail-whale');
+  }
+};
+</script>
+
+<template>
+  <div class="dashboard-root" />
+</template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This is done by providing a 404l page which is authenticated.

Fixes #11350

### Technical notes summary
We will still need the fix from https://github.com/rancher/dashboard/pull/11359/commits/be1e27b0630d32d2309c5d3969643f5fa84df014 for prod.

### Areas or cases that should be tested
404 routing.
Harvester routing.

### Screenshot/Video
Regular 404:
https://github.com/rancher/dashboard/assets/55104481/5d3d2fc8-0cbd-4d20-99e0-59dda8a0d8e3

Harvester 404:
https://github.com/rancher/dashboard/assets/55104481/310f10e4-6881-402f-8952-a55f9b846d82

I noticed a flicker of the resource page on this one. I can only reproduce this on the harvester cluster  but it's in `master` and unrelated to both this PR and harvester itself. If anyone else can reproduce this I'll resolve it as a separate issue.





### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
