### PR TITLE
AKS - update privateDNSZone validator to allow 'system' value

### DIFF
--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -78,6 +78,7 @@ describe('fx: privateDnsZone', () => {
     ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/test-subzone.privatelink.westus.azmk8s.io', undefined],
     ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/private.eastus2.azmk8s.io', undefined],
     ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/privatelink.eastus2.azmk8s.io', undefined],
+    ['system', undefined],
     ['/subscriptions/abcdef123/resourceGroups/abcdef123/providers/Microsoft.Network/privateDnsZones/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.privatelink.eastus2.azmk8s.io', MOCK_TRANSLATION],
     ['privatelink.azmk8s.io', MOCK_TRANSLATION],
     ['privatelink.eastus2.azmk8s.io', MOCK_TRANSLATION]

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -133,7 +133,7 @@ export const privateDnsZone = (ctx: any, labelKey: string, clusterPath: string) 
   return () :string | undefined => {
     const toValidate = (get(ctx.normanCluster, clusterPath) || '').toLowerCase();
     const subscriptionRegex = /^\/subscriptions\/.+\/resourcegroups\/.+\/providers\/microsoft\.network\/privatednszones\/([a-zA-Z0-9-]{1,32}\.){0,32}private(link){0,1}\.[a-zA-Z0-9]+\.azmk8s\.io$/;
-    const isValid = toValidate.match(subscriptionRegex);
+    const isValid = toValidate.match(subscriptionRegex) || toValidate === 'system';
 
     return isValid || !toValidate.length ? undefined : ctx.t('aks.errors.privateDnsZone', {}, true);
   };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11381 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the AKS PrivateDNSZone validator to allow the value 'system' as well as a private dns zone resource id (previously validated per https://github.com/rancher/dashboard/issues/7163

### Technical notes summary
If an AKS cluster with private cluster is created with PrivateDNSZone left blank, it will be auto-filled with 'system' when the cluster is successfully provisioned, see the first bullet-point here: https://learn.microsoft.com/en-us/azure/aks/private-clusters?tabs=azure-portal#configure-a-private-dns-zone

### Areas or cases that should be tested
1. Create a private AKS cluster with PrivateDNSZone left empty.
2. Navigate to the cluster's detail page and copy the command shown
3. Open the azure portal ui, navigate to 'kubernetes services' and select the cluster you just created
4. Once the cluster is 'running' use the 'run command' ui to run the command from step 2
5. Once the cluster becomes active (mine showed an error for a few minutes https://github.com/rancher/rancher/issues/43772) edit the cluster and verify that the save button is available.

I also tested supplying the value 'system' during creation as this change now allows that, too. It seems to work as well.

### Areas which could experience regressions
None - very self-contained fix

### Screenshot/Video
![Screenshot 2024-07-08 at 1 07 39 PM](https://github.com/rancher/dashboard/assets/42977925/7e6d6074-7f16-4ad5-b67f-b4d60e18e373)

Azure portal kubernetes cluster detail view:
![Screenshot 2024-07-08 at 1 02 53 PM](https://github.com/rancher/dashboard/assets/42977925/3c90c3e4-8c5e-4b9a-b005-97832aad3d99)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
