### PR TITLE
Relative mode for the loading component will make it appear full screen

### DIFF
--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -288,7 +288,10 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
+  <Loading
+    v-if="$fetchState.pending"
+    mode="relative"
+  />
   <main
     v-else
     class="main-layout login"

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -276,7 +276,10 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
+  <Loading
+    v-if="$fetchState.pending"
+    mode="relative"
+  />
   <form
     v-else
     class="setup"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes an issue where we were rendering the wrong loading screen layout. It was just a little jarring if the page took some time to load. I think we should actually work on just having the spinner show until the page fully loads but that's beyond the scope of this fix.

We want the loading component relative in these two areas because they aren't a part of our clusters and don't use that layout.

This issue was introduced in https://github.com/rancher/dashboard/commit/7d282bf1d0201f68eb034c3a5e669298dc1902cf



### Technical notes summary

### Areas which could experience regressions
Login and setup pages.

### Screenshot/Video
Broken:

https://github.com/rancher/dashboard/assets/55104481/e30ed1bf-c736-4961-bcb2-86743b34bb35


Fixed:

https://github.com/rancher/dashboard/assets/55104481/11fc256c-06c7-40d9-a90c-6c20b451e134


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
