### PR TITLE
Ensure current lack of server-side sorting/filtering on generated fields is handled

### DIFF
--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -17,15 +17,16 @@ export const STEVE_ID_COL = {
   name:     'steve-id',
   labelKey: 'tableHeaders.id',
   value:    'id',
-  sort:     ['id'],
-  search:   'id',
+  sort:     false, // sort:     ['id'], // Pending API support
+  search:   false, // search:   'id', // Pending API support
 };
 
 export const STEVE_STATE_COL = {
   ...STATE,
-  // value:  'metadata.state.name', Use the state as defined by the resource rather than converted via the model.
+  // Note, we're show the 'state' as per model, not the 'metadata.state.name' that's available in the model to remotely sort/filter
+  // Need to investigate whether we should 'dumb down' the state we show to the native one (tracked via https://github.com/rancher/dashboard/issues/8527)
   // This means we'll show something different to what we sort and filter on.
-  sort:   [], // ['metadata.state.name'], // Pending API support
+  sort:   false, // ['metadata.state.name'], // Pending API support
   search: false, // 'metadata.state.name', // Pending API support
 };
 


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to https://github.com/rancher/dashboard/issues/9545
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Currently isn't possible to sort/filter on fields like id and metadata.state.name
  - Note - Server-side pagination is not supported in production atm and is in a 'trial' state. Once ready for production these will be supported
- So for server-side lists ensure we don't sort / filter by either
  - column definitions used by server-side pagination should not define sort/filter fields
  - should not be listed as supported in validation `shell/plugins/steve/steve-pagination-utils.ts` `VALID_FIELDS` (already done)

### Technical notes summary
- This should be addressed in the next1 release (currently line item in https://github.com/rancher/rancher/issues/45635)

### Areas or cases that should be tested
- With ui-sql-cache feature flag on, and servier-side performance setting enabled
  - lists that use server-side pagination (for example pods, configmaps, customresourcedefinition) should not support sorting or filtering via state 

### Areas which could experience regressions
- As per above

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
  - test automation handled separately  
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
