### PR TITLE
[INT] Added CAPI ui to the list of extensions to test

### DIFF
--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -218,8 +218,8 @@ function clone_repo_test_extension_build() {
 
 # Here we just add the extension that we want to include as a check (all our official extensions should be included here)
 # Don't forget to add the unit tests exception to clone_repo_test_extension_build function if a new extension has those
-clone_repo_test_extension_build "kubewarden-ui" "kubewarden"
-clone_repo_test_extension_build "elemental-ui" "elemental"
+# clone_repo_test_extension_build "kubewarden-ui" "kubewarden"
+# clone_repo_test_extension_build "elemental-ui" "elemental"
 clone_repo_test_extension_build "capi-ui-extension" "capi"
 
 echo "All done"

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -220,5 +220,6 @@ function clone_repo_test_extension_build() {
 # Don't forget to add the unit tests exception to clone_repo_test_extension_build function if a new extension has those
 clone_repo_test_extension_build "kubewarden-ui" "kubewarden"
 clone_repo_test_extension_build "elemental-ui" "elemental"
+clone_repo_test_extension_build "capi-ui-extension" "capi-ui"
 
 echo "All done"

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -220,6 +220,6 @@ function clone_repo_test_extension_build() {
 # Don't forget to add the unit tests exception to clone_repo_test_extension_build function if a new extension has those
 clone_repo_test_extension_build "kubewarden-ui" "kubewarden"
 clone_repo_test_extension_build "elemental-ui" "elemental"
-clone_repo_test_extension_build "capi-ui-extension" "capi-ui"
+clone_repo_test_extension_build "capi-ui-extension" "capi"
 
 echo "All done"

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BASE_DIR="$( cd $SCRIPT_DIR && cd ../.. & pwd)"
 SHELL_DIR=$BASE_DIR/shell/
 SHELL_VERSION="99.99.99"
-DEFAULT_YARN_REGISTRY="https://registry.npmjs.org"
+DEFAULT_YARN_REGISTRY="https://registry.yarnpkg.com/"
 VERDACCIO_YARN_REGISTRY="http://localhost:4873"
 
 echo ${SCRIPT_DIR}
@@ -209,10 +209,8 @@ function clone_repo_test_extension_build() {
   popd
 
   # delete folder
-  if [ $TEST_PERSIST_BUILD != "true" ]; then
-    echo "Removing folder ${BASE_DIR}/$REPO_NAME"
-    rm -rf ${BASE_DIR}/$REPO_NAME
-  fi
+  echo "Removing folder ${BASE_DIR}/$REPO_NAME"
+  rm -rf ${BASE_DIR}/$REPO_NAME
   yarn config set registry ${DEFAULT_YARN_REGISTRY}
 }
 

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -216,8 +216,8 @@ function clone_repo_test_extension_build() {
 
 # Here we just add the extension that we want to include as a check (all our official extensions should be included here)
 # Don't forget to add the unit tests exception to clone_repo_test_extension_build function if a new extension has those
-# clone_repo_test_extension_build "kubewarden-ui" "kubewarden"
-# clone_repo_test_extension_build "elemental-ui" "elemental"
+clone_repo_test_extension_build "kubewarden-ui" "kubewarden"
+clone_repo_test_extension_build "elemental-ui" "elemental"
 clone_repo_test_extension_build "capi-ui-extension" "capi"
 
 echo "All done"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
<!-- Define findings related to the feature or bug issue. -->
Added capi-ui-extension to the list of extensions to test with.
Fiixes #11415

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
N/A

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
N/A

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
