### PR TITLE
Improve vGPU allocation

### DIFF
--- a/pkg/harvester-manager/l10n/en-us.yaml
+++ b/pkg/harvester-manager/l10n/en-us.yaml
@@ -24,3 +24,5 @@ harvesterManager:
     title: VGPUs
     label: VGPU type
     placeholder: 'Please select a VGPU'
+    allocatable: allocatable
+    allocatableUnknown: missing allocation info

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -933,12 +933,12 @@ export default {
     },
 
     updateVGpu() {
-      /**
-       * We are assigning the first vGpu profile found for each vGpu type selected by the user.
-       * This will not work if we will remove the limit of only one vGpu assignable to each cluster.
-       */
       const vGPURequests = this.vGpus?.filter((f) => f).map((deviceName) => ({
-        name: Object.values(this.vGpuDevices).filter((f) => f.type === deviceName)?.[0]?.id || '',
+        /**
+         * 'provisioned' is a placeholder.
+         * The real vGpu name is assigned to the provisioned VM by the backend and saved in 'harvesterhci.io/deviceAllocationDetails' annotation.
+         */
+        name: 'provisioned',
         deviceName,
       })) || [];
 

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -701,7 +701,7 @@ export default {
       if (clusterId) {
         const url = `/k8s/clusters/${ clusterId }/v1`;
 
-        const vGpus = await this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.VGPU_DEVICE }s` });
+        const vGpus = await this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.VGPU_DEVICE }` });
         const harvesterCluster = await this.$store.dispatch('cluster/request', { url: `${ url }/harvester/cluster/local` });
 
         let deviceCapacity = {};

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1357,6 +1357,9 @@ cluster:
         networkName: Network Name
         macAddress: Mac Address
         macFormat: 'Invalid MAC address format.'
+      vGpus:
+        errors:
+          notAllocatable: '[{vGpu}] vGPU device is not allocatable; required: {allocated}, allocatable: {allocatable}'
       volume:
         title: Volumes
         volume: Volume

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1357,9 +1357,6 @@ cluster:
         networkName: Network Name
         macAddress: Mac Address
         macFormat: 'Invalid MAC address format.'
-      vGpus:
-        errors:
-          notAllocatable: '"VGPUs" not allocatable. There are not enough [{vGpus}] devices to be allocated to each node in machine pool [{pool}]'
       volume:
         title: Volumes
         volume: Volume


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Related issue https://github.com/harvester/harvester/issues/5774
Blocked by https://github.com/harvester/dashboard/pull/1154
Blocked by https://github.com/harvester/pcidevices/pull/91
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- https://github.com/harvester/harvester/pull/6096 introduced the new `/v1/harvester/cluster` endpoint to provide available Harvester resources; we are now using those information to get the allocatable number for each vGpu device.
- Fixing the vGpu validation; We are now counting the `nodePools` x `machineCount` to check if there are enough  vGpu devices to be assigned to each machine.
- In legacy Harvester versions - `/v1/harvester/cluster` endpoint is not available and the UI will not be able to calculate the `allocatable` label. We will leave it empty - see screenshots-  and add some notes in the documentations to inform the users to upgrade their Harvester 1.3.x to 1.3.2.   
- https://github.com/rancher/dashboard/pull/11399/commits/965287d0f53bf0a8a0deab773f6b177208170a89 - Based on offline discussion with @a110605 and @ibrokethecloud we are removing the vGpu `profile` id from option labels, since it is meaningless from users perspective.
  -  vGpu options `key` in the 'vGPUs' dropdown element is now the vGpu type.
  - The request payload still requires the vGpu profile id (Name) along the vGpu type (deviceName); The first profile Id for each vGpu type will be used when assigning vGpus in the request.
  
  ![image](https://github.com/user-attachments/assets/58d28bd1-df25-483f-9174-6722341ee6de)
  - This means Harvester clusters will use always the same vGpu profile when assigning new vGpus.

### How to tests

Create a new Harvester cluster

- 1 Go to Cluster Management
- 2 Create a new Harvester cluster
- 3 Click on 'Advanced'
- 4 Add 1 or more vGPus

Create another Harvester Cluster

- Go at step 4
- Check if available vGPUs are changed. The UI should remove vGPUs allocated in first cluster, based on `allocatable` number - the backend should update this number after cluster creation.

Edit a Harvester Cluster

- Click on Edit Config to edit an existent Harvester Cluster
- Click on vGPU dropdown. The UI should show only available vGPU + the one already assigned to the cluster, based on `allocatable` number - the backend should update this number after saving.

Create multiple nodes Clusters

- Repeat above steps, assigning more than 1 node pools to the new cluster.
- Repeat above steps, assigning more than 1 Machines to each node pool.
  - For each vGpu , should get validation error if there are not enough devices for node pools x machine counts.

 
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Harvester clusters, create/edit page.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Harvester 1.3.2

![image](https://github.com/user-attachments/assets/3dd6c915-0f8a-47e9-832a-01751f933935)

Harvester legacy versions

![image](https://github.com/user-attachments/assets/276d8a52-7cd1-4a34-b8d1-9fb7f704020d)

Validation

![image](https://github.com/user-attachments/assets/9e72b82c-ea48-4a66-b8cd-2fcbe966a986)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
