### PR TITLE
Fix console errors in Harvester cluster's provisioning page

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
@@ -51,6 +51,35 @@ describe('component: DirectoryConfig', () => {
     expect(k8sDistroInput.exists()).toBe(false);
   });
 
+  it('should render the component with configuration being an empty object, without errors', () => {
+    const newMountOptions = clone(mountOptions);
+
+    newMountOptions.propsData.value = {};
+
+    wrapper = mount(
+      DirectoryConfig,
+      newMountOptions
+    );
+
+    const title = wrapper.find('h3');
+    const checkbox = wrapper.find('[data-testid="rke2-directory-config-individual-config-checkbox"]');
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    expect(title.exists()).toBe(true);
+    expect(checkbox.exists()).toBe(true);
+    // for the default config, checkbox should be checked
+    expect(wrapper.vm.isSettingCommonConfig).toBe(true);
+    expect(commonInput.exists()).toBe(true);
+
+    // since we have all of the vars empty, then the individual inputs should not be there
+    expect(systemAgentInput.exists()).toBe(false);
+    expect(provisioningInput.exists()).toBe(false);
+    expect(k8sDistroInput.exists()).toBe(false);
+  });
+
   it('updating common config path should set the correct values on each data dir variable', async() => {
     wrapper = mount(
       DirectoryConfig,

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -171,12 +171,26 @@ export default {
       });
     }
 
+    // default for dataDirectories configuration obj
     if (!this.value.spec.rkeConfig.dataDirectories) {
       set(this.value.spec.rkeConfig, 'dataDirectories', {
         systemAgent:  '',
         provisioning: '',
         k8sDistro:    '',
       });
+    }
+
+    // default for dataDirectories configuration systemAgent config
+    if (!this.value.spec.rkeConfig.dataDirectories.systemAgent) {
+      set(this.value.spec.rkeConfig.dataDirectories, 'systemAgent', '');
+    }
+    // default for dataDirectories configuration provisioning config
+    if (!this.value.spec.rkeConfig.dataDirectories.provisioning) {
+      set(this.value.spec.rkeConfig.dataDirectories, 'provisioning', '');
+    }
+    // default for dataDirectories configuration k8sDistro config
+    if (!this.value.spec.rkeConfig.dataDirectories.k8sDistro) {
+      set(this.value.spec.rkeConfig.dataDirectories, 'k8sDistro', '');
     }
 
     if (!this.value.spec.rkeConfig.machineGlobalConfig) {

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -25,17 +25,17 @@ export default {
     let atLeastOneDirWithAnIdentifier = false;
     let allDirsWithSameIdentifier = false;
 
-    if (this.value.systemAgent.length || this.value.provisioning.length || this.value.k8sDistro.length) {
+    if (this.value?.systemAgent?.length || this.value?.provisioning?.length || this.value?.k8sDistro?.length) {
       atLeastOneDirWithAnIdentifier = true;
-      if (this.value.systemAgent === this.value.provisioning && this.value.provisioning === this.value.k8sDistro &&
-      this.value.systemAgent === this.value.k8sDistro) {
+      if (this.value?.systemAgent === this.value?.provisioning && this.value?.provisioning === this.value?.k8sDistro &&
+      this.value?.systemAgent === this.value?.k8sDistro) {
         allDirsWithSameIdentifier = true;
       }
     }
 
     return {
       isSettingCommonConfig: !(atLeastOneDirWithAnIdentifier && !allDirsWithSameIdentifier),
-      commonConfig:          allDirsWithSameIdentifier ? this.value.systemAgent : '',
+      commonConfig:          allDirsWithSameIdentifier ? this.value?.systemAgent : '',
     };
   },
   watch: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11397 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with dataDirectories object being empty by initializing missing properties and adding optional chaining for increased code resilience
- add unit test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Connect this PR's branch to the shared env and edit the cluster `fra-vgpu-allocation` and make sure there are no console errors and that edit succeeds.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/rancher/dashboard/assets/97888974/244f45ae-0c80-414b-ab55-874bd19f1246



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
