### PR TITLE
Add dropdown of ssh keys to EKS node groups

### DIFF
--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -158,10 +158,12 @@ export default defineComponent({
       type:    String,
       default: _EDIT
     },
+
     ec2Roles: {
       type:    Array as PropType<AWS.IamRole[]>,
       default: () => []
     },
+
     isNewOrUnprovisioned: {
       type:    Boolean,
       default: true
@@ -187,10 +189,16 @@ export default defineComponent({
       default: () => []
     },
 
+    sshKeyPairs: {
+      type:    Array as PropType<string[]>,
+      default: () => []
+    },
+
     normanCluster: {
       type:    Object,
       default: null
     },
+
     loadingInstanceTypes: {
       type:    Boolean,
       default: false
@@ -202,6 +210,11 @@ export default defineComponent({
     },
 
     loadingLaunchTemplates: {
+      type:    Boolean,
+      default: false
+    },
+
+    loadingSshKeyPairs: {
       type:    Boolean,
       default: false
     },
@@ -268,6 +281,15 @@ export default defineComponent({
         this.$emit('update:spotInstanceTypes', null);
       }
     },
+
+    sshKeyPairs: {
+      handler(neu) {
+        if (!neu.includes(this.ec2SshKey)) {
+          this.$emit('update:ec2SshKey', '');
+        }
+      },
+      deep: true
+    }
   },
 
   computed: {
@@ -491,7 +513,7 @@ export default defineComponent({
 
 <template>
   <div>
-    <h3>Group Details</h3>
+    <h3>{{ t('eks.nodeGroups.groupDetails') }}</h3>
     <div class="row mb-10">
       <div class="col span-6">
         <LabeledInput
@@ -583,7 +605,7 @@ export default defineComponent({
       </div>
     </div>
     <hr class="mb-20">
-    <h3>Node Template Details</h3>
+    <h3>{{ t('eks.nodeGroups.templateDetails') }}</h3>
     <Banner
       v-if="clusterWillUpgrade && !poolIsUnprovisioned"
       color="info"
@@ -745,12 +767,16 @@ export default defineComponent({
         />
       </div>
       <div class="col span-6">
-        <LabeledInput
-          type="multiline"
+        <LabeledSelect
+          :loading="loadingSshKeyPairs"
           :value="ec2SshKey"
+          :options="sshKeyPairs"
           label-key="eks.nodeGroups.ec2SshKey.label"
           :mode="mode"
           :disabled="hasUserLaunchTemplate"
+          :taggable="true"
+          :searchable="true"
+          data-testid="eks-nodegroup-ec2-key-select"
           @input="$emit('update:ec2SshKey', $event)"
         />
       </div>

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -45,6 +45,7 @@ eks:
     gpu:
       label: GPU Enabled Instance
       tooltip: This setting is ignored when using a launch template with a custom AMI defined.
+    groupDetails: Group Details
     groupLabels:
       label: Group Labels
     groupTags:
@@ -78,6 +79,7 @@ eks:
       label: Instance Resource Tags
     spotInstanceTypes:
       label: Spot Instance Types
+    templateDetails: Template Details
     title: Node Groups
     unnamed: Unnamed Node Group
     userData:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11390 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the EKS provisioning form to fetch a list of ec2 ssh keys and populate a dropdown in the node group tab.

### Technical notes summary
Functionality is copied from the Ember UI implementation: the list of ssh keys uses the `KeyName` property. The user also has the option of manually typing in a key name - in Ember, this was handled by swapping out the dropdown for a text input if no ssh keys were found. In this form, I've just allowed the user to type in their own key regardless of the list because it seems tidier.

### Areas or cases that should be tested
 1. Open the EKS cluster creation page and verify that there is a dropdown of key options in each node group. A good region to test would be `us-west-1`
 2. When switching regions, a new list of keys should be loaded
 3. After selecting an ec2 key, switch regions: if there's no key with the same name in the new region, the input should be cleared
 4. Create the EKS cluster with ec2 key defined - no errors related to the ec2 key should be shown
 5. Edit the cluster: the ec2 key dropdown should be populated. The user should be able to select a new key.
 6. Users should be able to enter their own key name


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
