### PR TITLE
GKE - allow user to edit master authorized network in provisioned clusters

### DIFF
--- a/pkg/gke/components/Networking.vue
+++ b/pkg/gke/components/Networking.vue
@@ -781,7 +781,6 @@ export default defineComponent({
           class="col span-6"
         >
           <KeyValue
-
             :label="t('gke.masterAuthorizedNetwork.cidrBlocks.label')"
             :mode="mode"
             :as-map="false"
@@ -794,7 +793,6 @@ export default defineComponent({
             :read-allowed="false"
             :add-label="t('gke.masterAuthorizedNetwork.cidrBlocks.add')"
             :initial-empty-row="true"
-            :disabled="!isNewOrUnprovisioned"
             data-testid="gke-master-authorized-network-cidr-keyvalue"
             @input="$emit('update:masterAuthorizedNetworkCidrBlocks', $event)"
           />

--- a/pkg/gke/components/__tests__/Networking.test.ts
+++ b/pkg/gke/components/__tests__/Networking.test.ts
@@ -361,4 +361,37 @@ describe('gke Networking', () => {
     masterAuthorizedNetworkCidrInput = wrapper.find('[data-testid="gke-master-authorized-network-cidr-keyvalue"]');
     expect(masterAuthorizedNetworkCidrInput.isVisible()).toBe(true);
   });
+
+  it('should allow the user to edit the master authorized network cidr block list for new or existing node pools', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(Networking, {
+      propsData: {
+        zone:                          'test-zone',
+        region:                        'test-region',
+        cloudCredentialId:             '',
+        projectId:                     'test-project',
+        enablePrivateNodes:            false,
+        enableMasterAuthorizedNetwork: true,
+        isNewOrUnprovisioned:          false,
+      },
+      ...setup
+    });
+
+    wrapper.setProps({ cloudCredentialId: 'abc' });
+    await flushPromises();
+
+    wrapper.setData({ showAdvanced: true });
+    await wrapper.vm.$nextTick();
+
+    const masterAuthorizedNetworkCidrInput = wrapper.find('[data-testid="gke-master-authorized-network-cidr-keyvalue"]');
+
+    expect(masterAuthorizedNetworkCidrInput.isVisible()).toBe(true);
+    expect(masterAuthorizedNetworkCidrInput.props().disabled).toBe(false);
+
+    wrapper.setProps({ isNewOrUnprovisioned: true });
+    await wrapper.vm.$nextTick();
+
+    expect(masterAuthorizedNetworkCidrInput.props().disabled).toBe(false);
+  });
 });


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11391 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the GKE networking component to allow editing the master authorized network cidr block keyvalue input. Per #11391, that keyvalue should be editable all the time but when a cluster is provisioned the master authorized checkbox  should not be editable.


### Areas or cases that should be tested
1. Provision a GKE cluster - under the 'advanced' section in networking you should be able to enable master authorized networks and add some cidr blocks
2. Once the cluster has finished provisioning, edit it and verify that you can update the list of cidr blocks


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
