### PR TITLE
add node pool name length validation and refactor to allow unit tests

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -50,8 +50,9 @@ import {
   ipv4WithOrWithoutCidr,
   ipv4WithCidr,
   outboundTypeUserDefined,
-  privateDnsZone
-} from '@pkg/aks/util/validators';
+  privateDnsZone,
+  nodePoolNames
+} from '../util/validators';
 
 export const defaultNodePool = {
   availabilityZones:     ['1', '2', '3'],
@@ -334,6 +335,7 @@ export default defineComponent({
         dockerBridgeCidr:        ipv4WithCidr(this, 'aks.dockerBridgeCidr.label', 'aksConfig.dockerBridgeCidr'),
         outboundType:            outboundTypeUserDefined(this, 'aks.outboundType.label', 'aksConfig.outboundType'),
         privateDnsZone:          privateDnsZone(this, 'aks.privateDnsZone.label', 'aksConfig.privateDnsZone'),
+        poolNames:               nodePoolNames(this),
 
         vmSizeAvailable: () => {
           if (this.touchedVmSize) {
@@ -423,29 +425,6 @@ export default defineComponent({
           }
 
           return this.canUseAvailabilityZones || !isUsingAvailabilityZones ? undefined : this.t('aks.errors.availabilityZones');
-        },
-
-        poolNames: (poolName?: string) => {
-          let allAvailable = true;
-
-          if (poolName || poolName === '') {
-            return poolName.match(/^[a-z]+[a-z0-9]*$/) ? undefined : this.t('aks.errors.poolName');
-          } else {
-            this.nodePools.forEach((pool: AKSNodePool) => {
-              const name = pool.name || '';
-
-              if (!name.match(/^[a-z]+[a-z0-9]*$/)) {
-                this.$set(pool._validation, '_validName', false);
-
-                allAvailable = false;
-              } else {
-                this.$set(pool._validation, '_validName', true);
-              }
-            });
-            if (!allAvailable) {
-              return this.t('aks.errors.poolName');
-            }
-          }
         },
 
         poolCount: (count?: number) => {

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -5,7 +5,7 @@
  */
 
 import { get } from '@shell/utils/object';
-import { LoadBalancerSku, OutboundType } from '@pkg/aks/types';
+import { LoadBalancerSku, OutboundType, AKSNodePool } from '../types';
 
 // no need to try to validate any fields if the user is still selecting a credential and the rest of the form isn't visible
 export const needsValidation = (ctx: any): Boolean => {
@@ -136,5 +136,32 @@ export const privateDnsZone = (ctx: any, labelKey: string, clusterPath: string) 
     const isValid = toValidate.match(subscriptionRegex) || toValidate === 'system';
 
     return isValid || !toValidate.length ? undefined : ctx.t('aks.errors.privateDnsZone', {}, true);
+  };
+};
+
+export const nodePoolNames = (ctx: any) => {
+  return (poolName:string) :string | undefined => {
+    let allAvailable = true;
+
+    const isValid = (name:string) => name.match(/^[a-z]+[a-z0-9]*$/) && name.length <= 12;
+
+    if (poolName || poolName === '') {
+      return isValid(poolName) ? undefined : ctx.t('aks.errors.poolName');
+    } else {
+      ctx.nodePools.forEach((pool: AKSNodePool) => {
+        const name = pool.name || '';
+
+        if (!isValid(name)) {
+          ctx.$set(pool._validation, '_validName', false);
+
+          allAvailable = false;
+        } else {
+          ctx.$set(pool._validation, '_validName', true);
+        }
+      });
+      if (!allAvailable) {
+        return ctx.t('aks.errors.poolName');
+      }
+    }
   };
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11405 - see comments for expected behavior

### Occurred changes and/or fixed issues
This PR updates the node pool name validator to check length as well as characters.


### Areas or cases that should be tested
Open the AKS provisioning form and enter a pool name with >12 characters 
1. You should be prevented from saving
2. There should be an error icon in the node pool name input
3. If you add another pool and switch pool tabs, the inactive tab with validation error should have an error icon


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
