### PR TITLE
do not allow eks version upgrades >1 minor version

### DIFF
--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -160,7 +160,7 @@ export default defineComponent({
 
           if (semver.gt(coerced, withinOneMinor)) {
             versions.push({
-              value: v, label: `${ v } (minor version >1 not allowed by EKS)`, disabled: true
+              value: v, label: `${ v } ${ this.t('eks.version.upgradeWarning') }`, disabled: true
             });
           } else {
             versions.push({ value: v, label: v });

--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -4,7 +4,6 @@ import { EKSConfig, AWS } from '../types';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import semver from 'semver';
 import { Store, mapGetters } from 'vuex';
-import sortBy from 'lodash/sortBy';
 
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';

--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -4,6 +4,8 @@ import { EKSConfig, AWS } from '../types';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import semver from 'semver';
 import { Store, mapGetters } from 'vuex';
+import sortBy from 'lodash/sortBy';
+
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
@@ -145,19 +147,29 @@ export default defineComponent({
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
 
-    versionOptions(): string[] {
-      return this.allKubernetesVersions.filter((v: string) => {
+    versionOptions(): {value: string, label: string, disabled?:boolean}[] {
+      return this.allKubernetesVersions.reduce((versions, v: string) => {
         const coerced = semver.coerce(v);
 
         if (this.supportedVersionRange && !semver.satisfies(coerced, this.supportedVersionRange)) {
-          return false;
+          return versions;
         }
-        if (this.originalVersion && semver.gt(semver.coerce(this.originalVersion), coerced)) {
-          return false;
+        if (!this.originalVersion) {
+          versions.push({ value: v, label: v });
+        } else if (semver.lte(semver.coerce(this.originalVersion), coerced)) {
+          const withinOneMinor = semver.inc(semver.coerce(this.originalVersion), 'minor');
+
+          if (semver.gt(coerced, withinOneMinor)) {
+            versions.push({
+              value: v, label: `${ v } (minor version >1 not allowed by EKS)`, disabled: true
+            });
+          } else {
+            versions.push({ value: v, label: v });
+          }
         }
 
-        return true;
-      }).sort().reverse();
+        return versions;
+      }, [] as {value: string, label: string, disabled?:boolean}[]);
     },
 
     kmsOptions(): string[] {

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -685,6 +685,7 @@ export default defineComponent({
           :config="config"
           :eks-roles="eksRoles"
           :loading-iam="loadingIam"
+          :original-version="originalVersion"
           @error="e=>errors.push(e)"
         />
       </Accordion>

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -113,5 +113,6 @@ eks:
     label: Tags
   version:
     label: Kubernetes Version
+    upgradeWarning: (minor versio n >1 not allowed by EKS)
   vpcSubnet:
     label: VPC and Subnet


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11389 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR restricts users from upgrading their EKS clusters more than one minor version at a time

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
1 creating a new EKS cluster- users should be able to select versions 1.27, 1.28, 1.29 and 1.30
2. Editing an existing EKS cluster with a version >1 minor version behind the latest: users should only be able to pick the next minor version


### Screenshot/Video
![Screenshot 2024-07-10 at 1 28 38 PM](https://github.com/rancher/dashboard/assets/42977925/effeee09-37c6-48dc-9a57-1af095b3999e)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
