### PR TITLE
Fix reload on chart install page

### DIFF
--- a/shell/mixins/__tests__/chart.test.ts
+++ b/shell/mixins/__tests__/chart.test.ts
@@ -24,8 +24,9 @@ describe('chartMixin', () => {
   localVue.mixin(ChartMixin);
 
   it.each(testCases.opa)(
-    'should add OPA deprecation warning properly', (chartId, expected) => {
+    'should add OPA deprecation warning properly', async(chartId, expected) => {
       const store = new Vuex.Store({
+        actions: { 'catalog/load': () => {} },
         getters: {
           currentCluster: () => {},
           isRancher:      () => true,
@@ -43,6 +44,8 @@ describe('chartMixin', () => {
       const instance = new vm({ store });
 
       instance.$route = { query: { chart: 'chart_name' } };
+
+      await instance.fetchChart();
 
       const warnings = instance.warnings;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11126
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- When refreshing or navigating directly to the chart install page the chart was missing
- This was caused by the chart install page's mixin's computed property `chart` value never populating
  - The computed method would be called, but before charts were loaded
  - When charts loaded the computed property did not trigger again
  - Whenever this.chart was used it would contain the stale value (falsy)
- Fix
  - `chart` value must now be manually populated,
  - this happens via existing `fetchChart`
  - should be safe, given it's called by both `chart install` and `chart detail` page's $fetch

### Areas or cases that should be tested
- Navigating to via dashboard links, also refreshing directly on the following pages
  - Cluster tools --> Install App
  - Cluster tools --> Upgrade App
  - Apps --> Charts --> chart
  - Apps --> Charts --> chart --> chart version
  - Apps --> Installed Apps --> app upgrade

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
