### PR TITLE
Cannot read properties of undefined (reading 'component') while loading Elemental

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -330,6 +330,14 @@ export default {
           });
         });
 
+        if (isElementalActive) {
+          // !this.subType means we are on the /create screen - we only want to show for rke2
+          // if a subType is selected, always add the ELEMENTAL_CLUSTER_PROVIDER type to cover edit scenarios
+          if ((!this.subType && !this.isRke1) || this.subType) {
+            addType(this.$plugin, ELEMENTAL_CLUSTER_PROVIDER, 'custom2', false);
+          }
+        }
+
         if (this.isRke1 ) {
           machineTypes.forEach((type) => {
             const id = type.spec.displayName || type.id;
@@ -346,10 +354,6 @@ export default {
           });
 
           addType(this.$plugin, 'custom', 'custom2', false);
-
-          if (isElementalActive) {
-            addType(this.$plugin, ELEMENTAL_CLUSTER_PROVIDER, 'custom2', false);
-          }
         }
 
         // Add from extensions


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11414 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- make sure we are adding the machine config to the `subTypes` array so that it is available while creating/editing an Elemental cluster

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The problem lies with the `edit` view of `provisioning.cattle.io.cluster` where if the preferred provisioner (RKE1 or RKE2 - toggle on cluster creation screen, which is persistent) would omit the machine config for Elemental clusters if it was toggled for RKE1. This PR makes it available always in a scenario where a subType has been selected, which will cover the create/edit Elemental cluster direct links.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Start elemental locally (install extension and operator + crds)
2. Go to `cluster management` -> hit `create` -> toggle the rke indicator to rke1
3. Go to Create Elemental cluster via `Elemental` extension -> `dashboard` -> button `Create Elemental Cluster`
4. Make sure interface loads fine and that cluster creation succeeds
5. Go to `cluster management` and edit the Elemental cluster
6.  Make sure interface loads fine and that cluster edit succeeds

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
