### PR TITLE
EKS - add ability to specify additional security groups

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -699,6 +699,7 @@ export default defineComponent({
           :private-access.sync="config.privateAccess"
           :public-access-sources.sync="config.publicAccessSources"
           :subnets.sync="config.subnets"
+          :security-groups.sync="config.securityGroups"
           :mode="mode"
           :region="config.region"
           :amazon-credential-secret="config.amazonCredentialSecret"

--- a/pkg/eks/components/Networking.vue
+++ b/pkg/eks/components/Networking.vue
@@ -345,6 +345,7 @@ export default defineComponent({
           :options="securityGroupOptions"
           :multiple="true"
           :value="securityGroups"
+          :loading="loadingSecurityGroups"
           data-testid="eks-security-groups-dropdown"
           @input="$emit('update:securityGroups', $event)"
         />

--- a/pkg/eks/components/Networking.vue
+++ b/pkg/eks/components/Networking.vue
@@ -43,6 +43,11 @@ export default defineComponent({
       default: () => []
     },
 
+    securityGroups: {
+      type:    Array as PropType<string[]>,
+      default: () => []
+    },
+
     publicAccess: {
       type:    Boolean,
       default: false
@@ -74,6 +79,7 @@ export default defineComponent({
       handler(neu) {
         if (neu && !this.isView) {
           this.fetchVpcs();
+          this.fetchSecurityGroups();
         }
       },
       immediate: true
@@ -82,6 +88,7 @@ export default defineComponent({
       handler(neu ) {
         if (neu && !this.isView) {
           this.fetchVpcs();
+          this.fetchSecurityGroups();
         }
       },
       immediate: true
@@ -91,16 +98,24 @@ export default defineComponent({
       if (!neu) {
         this.$emit('update:subnets', []);
       }
+    },
+
+    selectedVpc(neu: string, old: string) {
+      if (!!old) {
+        this.$emit('update:securityGroups', []);
+      }
     }
 
   },
 
   data() {
     return {
-      loadingVpcs:  false,
-      vpcInfo:      {} as {Vpcs: AWS.VPC[]},
-      subnetInfo:   {} as {Subnets: AWS.Subnet[]},
-      chooseSubnet: !!this.subnets && !!this.subnets.length
+      loadingVpcs:           false,
+      loadingSecurityGroups: false,
+      vpcInfo:               {} as {Vpcs: AWS.VPC[]},
+      subnetInfo:            {} as {Subnets: AWS.Subnet[]},
+      securityGroupInfo:     {} as {SecurityGroups: AWS.SecurityGroup[]},
+      chooseSubnet:          !!this.subnets && !!this.subnets.length
     };
   },
 
@@ -142,7 +157,8 @@ export default defineComponent({
             const subnetFormOption = {
               key:       SubnetId,
               label:     `${ nameTag } (${ SubnetId })`,
-              _isSubnet: true
+              _isSubnet: true,
+              disabled:  this.selectedVpc && VpcId !== this.selectedVpc
             };
 
             out.push(subnetFormOption);
@@ -151,6 +167,22 @@ export default defineComponent({
       });
 
       return out;
+    },
+
+    securityGroupOptions() {
+      const allGroups = this.securityGroupInfo?.SecurityGroups || [];
+
+      return allGroups.reduce((opts, sg) => {
+        if (sg.VpcId !== this.selectedVpc) {
+          return opts;
+        }
+        opts.push({
+          label: `${ sg.GroupName } (${ sg.GroupId })`,
+          value: sg.GroupId
+        });
+
+        return opts;
+      }, [] as {label: string, value: string}[]);
     },
 
     displaySubnets: {
@@ -163,6 +195,14 @@ export default defineComponent({
       set(neu: {key:string, label:string, _isSubnet?:boolean, kind?:string}[]) {
         this.$emit('update:subnets', neu.map((s) => s.key));
       }
+    },
+
+    selectedVpc() {
+      if (!this.chooseSubnet) {
+        return null;
+      }
+
+      return (this.subnetInfo?.Subnets || []).find((s) => this.subnets.includes(s.SubnetId))?.VpcId;
     },
 
     isNew(): boolean {
@@ -193,6 +233,24 @@ export default defineComponent({
       }
       this.loadingVpcs = false;
     },
+
+    async fetchSecurityGroups() {
+      this.loadingSecurityGroups = true;
+      const { region, amazonCredentialSecret } = this;
+
+      if (!region || !amazonCredentialSecret) {
+        return;
+      }
+      const store: Store<any> = this.$store;
+      const ec2Client = await store.dispatch('aws/ec2', { region, cloudCredentialId: amazonCredentialSecret });
+
+      try {
+        this.securityGroupInfo = await ec2Client.describeSecurityGroups({ });
+      } catch (err) {
+        this.$emit('error', err);
+      }
+      this.loadingSecurityGroups = false;
+    }
   }
 });
 </script>
@@ -250,6 +308,10 @@ export default defineComponent({
           :disabled="!isNew"
         />
       </div>
+    </div>
+    <div
+      class="row mb-10"
+    >
       <div
         v-if="chooseSubnet || !isNew"
         class="col span-6"
@@ -270,6 +332,21 @@ export default defineComponent({
             <span :class="{'pl-30': option._isSubnet}">{{ option.label }}</span>
           </template>
         </LabeledSelect>
+      </div>
+      <div
+        v-if="chooseSubnet"
+        class="col span-6"
+      >
+        <LabeledSelect
+          :mode="mode"
+          :disabled="!isNew"
+          label-key="eks.securityGroups.label"
+          :tooltip="t('eks.securityGroups.tooltip')"
+          :options="securityGroupOptions"
+          :multiple="true"
+          :value="securityGroups"
+          @input="$emit('update:securityGroups', $event)"
+        />
       </div>
     </div>
   </div>

--- a/pkg/eks/components/Networking.vue
+++ b/pkg/eks/components/Networking.vue
@@ -158,7 +158,7 @@ export default defineComponent({
               key:       SubnetId,
               label:     `${ nameTag } (${ SubnetId })`,
               _isSubnet: true,
-              disabled:  this.selectedVpc && VpcId !== this.selectedVpc
+              disabled:  !!this.selectedVpc && VpcId !== this.selectedVpc
             };
 
             out.push(subnetFormOption);
@@ -345,6 +345,7 @@ export default defineComponent({
           :options="securityGroupOptions"
           :multiple="true"
           :value="securityGroups"
+          data-testid="eks-security-groups-dropdown"
           @input="$emit('update:securityGroups', $event)"
         />
       </div>

--- a/pkg/eks/components/__mocks__/describeSecurityGroups.js
+++ b/pkg/eks/components/__mocks__/describeSecurityGroups.js
@@ -1,0 +1,19 @@
+export default {
+  SecurityGroups: [
+    {
+      GroupName: 'group0-name',
+      GroupId:   'group0-id',
+      VpcId:     'vpc-1234'
+    },
+    {
+      GroupName: 'group1-name',
+      GroupId:   'group1-id',
+      VpcId:     'vpc-1234'
+    },
+    {
+      GroupName: 'group2-name',
+      GroupId:   'group2-id',
+      VpcId:     'vpc-12345'
+    },
+  ]
+};

--- a/pkg/eks/components/__mocks__/describeSubnets.js
+++ b/pkg/eks/components/__mocks__/describeSubnets.js
@@ -189,7 +189,7 @@ export default {
       MapCustomerOwnedIpOnLaunch:  false,
       State:                       'available',
       SubnetId:                    'subnet-12',
-      VpcId:                       'vpc-1234',
+      VpcId:                       'vpc-12',
       OwnerId:                     '1234',
       AssignIpv6AddressOnCreation: false,
       Ipv6CidrBlockAssociationSet: [],

--- a/pkg/eks/components/__tests__/Networking.test.ts
+++ b/pkg/eks/components/__tests__/Networking.test.ts
@@ -4,6 +4,10 @@ import { _CREATE, _EDIT } from '@shell/config/query-params';
 import { shallowMount } from '@vue/test-utils';
 import Networking from '../Networking.vue';
 
+import SecurityGroupData from '../__mocks__/describeSecurityGroups.js';
+import SubnetData from '../__mocks__/describeSubnets';
+import VpcData from '../__mocks__/describeVpcs';
+
 const mockedValidationMixin = {
   computed: {
     fvFormIsValid:                jest.fn(),
@@ -89,5 +93,178 @@ describe('eKS Networking', () => {
     expect(subnetDropdown.exists()).toBe(true);
 
     expect(subnetDropdown.props().value).toStrictEqual(['bc', 'def']);
+  });
+
+  // this tests dropdown visibility - contents of dropdown are tested further down
+  it('should show a dropdown of security groups when the select from existing subnets radio option is selected', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(Networking, {
+      propsData: { mode: _CREATE },
+      ...setup
+    });
+
+    wrapper.setData({ chooseSubnet: true });
+    await wrapper.vm.$nextTick();
+    const sgDropDown = wrapper.find('[data-testid="eks-security-groups-dropdown"]');
+
+    expect(sgDropDown.exists()).toBe(true);
+
+    wrapper.setData({ chooseSubnet: false });
+    await wrapper.vm.$nextTick();
+    expect(sgDropDown.exists()).toBe(false);
+  });
+
+  it('should fetch VPCs and securityGroups when a credential is provided or changes', async() => {
+    const setup = requiredSetup();
+
+    // eslint-disable-next-line prefer-const
+    let wrapper: any;
+
+    const fetchGroupsSpy = jest.spyOn(Networking.methods, 'fetchSecurityGroups').mockImplementation(() => {
+      wrapper.setData({ securityGroupInfo: SecurityGroupData });
+    });
+
+    const fetchVpcsSpy = jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
+      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+    });
+
+    wrapper = shallowMount(Networking, {
+      propsData: { mode: _CREATE },
+      ...setup
+    });
+
+    wrapper.setProps({ amazonCredentialSecret: 'abc' });
+    await wrapper.vm.$nextTick();
+
+    expect(fetchGroupsSpy).toHaveBeenCalledTimes(1);
+    expect(fetchVpcsSpy).toHaveBeenCalledTimes(1);
+
+    wrapper.setProps({ amazonCredentialSecret: 'def' });
+    await wrapper.vm.$nextTick();
+
+    expect(fetchGroupsSpy).toHaveBeenCalledTimes(2);
+    expect(fetchVpcsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should populate the security group dropdown with groups in the same vpc as the selected subnet', async() => {
+    const setup = requiredSetup();
+
+    // eslint-disable-next-line prefer-const
+    let wrapper: any;
+
+    jest.spyOn(Networking.methods, 'fetchSecurityGroups').mockImplementation(() => {
+      wrapper.setData({ securityGroupInfo: SecurityGroupData });
+    });
+
+    jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
+      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+    });
+
+    wrapper = shallowMount(Networking, {
+      propsData: { mode: _CREATE },
+      ...setup
+    });
+
+    wrapper.setProps({ amazonCredentialSecret: 'abc' });
+    wrapper.setData({ chooseSubnet: true });
+
+    await wrapper.vm.$nextTick();
+
+    const sgDropDown = wrapper.find('[data-testid="eks-security-groups-dropdown"]');
+
+    expect(sgDropDown.props().options).toStrictEqual([]);
+
+    wrapper.setProps({ subnets: ['subnet-1234'] });
+    await wrapper.vm.$nextTick();
+    expect(sgDropDown.props().options).toStrictEqual([{ label: 'group0-name (group0-id)', value: 'group0-id' }, { label: 'group1-name (group1-id)', value: 'group1-id' }]);
+
+    wrapper.setProps({ subnets: ['subnet-4321'] });
+    await wrapper.vm.$nextTick();
+    expect(sgDropDown.props().options).toStrictEqual([{ label: 'group2-name (group2-id)', value: 'group2-id' }]);
+  });
+
+  it('should clear any selected security groups when the selected vpc changes', async() => {
+    const setup = requiredSetup();
+
+    // eslint-disable-next-line prefer-const
+    let wrapper: any;
+
+    jest.spyOn(Networking.methods, 'fetchSecurityGroups').mockImplementation(() => {
+      wrapper.setData({ securityGroupInfo: SecurityGroupData });
+    });
+
+    jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
+      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+    });
+
+    wrapper = shallowMount(Networking, {
+      propsData: {
+        mode: _CREATE, subnets: ['subnet-1234'], securityGroups: ['group0-id']
+      },
+      ...setup
+    });
+
+    wrapper.setProps({ amazonCredentialSecret: 'abc' });
+    wrapper.setData({ chooseSubnet: true });
+
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('update:securityGroups')).toBeUndefined();
+
+    wrapper.setProps({ subnets: ['subnet-12345'] });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:securityGroups')[0][0]).toStrictEqual([]);
+  });
+
+  it('should not allow the user to select subnets in different vpcs', async() => {
+    const setup = requiredSetup();
+
+    // eslint-disable-next-line prefer-const
+    let wrapper: any;
+
+    jest.spyOn(Networking.methods, 'fetchSecurityGroups').mockImplementation(() => {
+      wrapper.setData({ securityGroupInfo: SecurityGroupData });
+    });
+
+    jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
+      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+    });
+
+    wrapper = shallowMount(Networking, {
+      propsData: { mode: _CREATE, subnets: ['subnet-1234'] },
+      ...setup
+    });
+
+    wrapper.setProps({ amazonCredentialSecret: 'abc' });
+    wrapper.setData({ chooseSubnet: true });
+
+    await wrapper.vm.$nextTick();
+    const subnetDropdown = wrapper.find('[data-testid="eks-subnets-dropdown"]');
+
+    let subnetOpts = subnetDropdown.props().options;
+
+    expect(subnetOpts.filter((opt) => !opt.disabled && opt.kind !== 'group')).toHaveLength(2);
+
+    // check that adding a subnet in the same vpc doesnt change the selectable subnet options
+    wrapper.setProps({ subnets: ['subnet-4321', 'subnet-1234'] });
+    await wrapper.vm.$nextTick();
+
+    subnetOpts = subnetDropdown.props().options;
+    expect(subnetOpts.filter((opt) => !opt.disabled && opt.kind !== 'group')).toHaveLength(2);
+
+    // check that when subnets are empty, no options are disabled
+    wrapper.setProps({ subnets: [] });
+    await wrapper.vm.$nextTick();
+
+    subnetOpts = subnetDropdown.props().options;
+    expect(subnetOpts.filter((opt) => opt.disabled && opt.kind !== 'group')).toHaveLength(0);
+
+    // check that selecting a subnet in a different vpc changes which options are disabled
+    wrapper.setProps({ subnets: ['subnet-12'] });
+    await wrapper.vm.$nextTick();
+
+    subnetOpts = subnetDropdown.props().options;
+    expect(subnetOpts.filter((opt) => opt.disabled && opt.kind !== 'group')).toHaveLength(5);
   });
 });

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -100,6 +100,9 @@ eks:
   scheduler:
     label: Scheduler
     tooltip: The scheduler component manages when and where to run pods in your cluster.
+  securityGroups:
+    label: Additional Security Groups
+    tooltip: EKS creates a security group for your cluster by default. You may choose additional security groups that will be applied to your EKS cluster. Only the default security group will be set on the nodes unless the launch template specified contains security groups to override them.
   serviceRole:
     label: Service Role
     options:

--- a/pkg/eks/types/aws-sdk.d.ts
+++ b/pkg/eks/types/aws-sdk.d.ts
@@ -103,3 +103,10 @@ export interface EKSAddon {
 export interface EC2Region {
   RegionName: string
 }
+
+// ec2 describeSecurityGroups
+export interface SecurityGroup {
+  GroupId: string,
+  GroupName: string,
+  VpcId: string
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11412 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds a dropdown to select security groups when selecting an existing subnet. It also prevents the user from selecting subnets from different VPCs. I noticed the Ember UI doesn't have that restriction but EKS throws an error if you try to create a cluster using multiple VPCs. Security groups are scoped by VPC so allowing the user to select multiple VPCs would undermine the security group feature... Consequently, I fixed the multi-VPC issue as part of this PR, despite that not being explicitly called out in #11412 



### Areas or cases that should be tested
1. Creating EKS cluster - verify that you can select security groups and their GroupId shows up in the network request under eksConfig.securityGroups
2. Edit EKS cluster - verify that, while you can't edit security groups the dropdown still shows previously selected groups
3. EKS cluster detail view - the dropdown should still show selected security groups

Other aspects of the feature should be pretty well covered by/described in unit tests



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
