### PR TITLE
Revert "Remove download cli tests"

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -111,56 +111,53 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
   //   });
   // });
 
-  // reinstate when server-version issue is corrected https://github.com/rancher/rancher/issues/46152
-  // Removed given https://github.com/rancher/rancher/issues/46068
-  // Re-instate given https://github.com/rancher/dashboard/issues/11387
-  // describe('CLI Downloads', () => {
-  //   // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
-  //   beforeEach(() => {
-  //     aboutPage.goTo();
-  //     cy.intercept('GET', 'https://releases.rancher.com/cli2/**').as('download');
-  //   });
+  describe('CLI Downloads', () => {
+    // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
+    beforeEach(() => {
+      aboutPage.goTo();
+      cy.intercept('GET', 'https://releases.rancher.com/cli2/**').as('download');
+    });
 
-  //   it('can download macOS CLI', () => {
-  //     aboutPage.getLinkDestination('rancher-darwin').then((el) => {
-  //       const macOsVersion = el.split('/')[5];
+    it('can download macOS CLI', () => {
+      aboutPage.getLinkDestination('rancher-darwin').then((el) => {
+        const macOsVersion = el.split('/')[5];
 
-  //       aboutPage.getCliDownloadLinkByLabel('rancher-darwin').then((el: any) => {
-  //         el.attr('download', '');
-  //       }).click();
-  //       cy.wait('@download').then(({ request, response }) => {
-  //         expect(response?.statusCode).to.eq(200);
-  //         expect(request.url).includes(macOsVersion);
-  //       });
-  //     });
-  //   });
+        aboutPage.getCliDownloadLinkByLabel('rancher-darwin').then((el: any) => {
+          el.attr('download', '');
+        }).click();
+        cy.wait('@download').then(({ request, response }) => {
+          expect(response?.statusCode).to.eq(200);
+          expect(request.url).includes(macOsVersion);
+        });
+      });
+    });
 
-  //   it('can download Linux CLI', () => {
-  //     aboutPage.getLinkDestination('rancher-linux').then((el) => {
-  //       const linuxVersion = el.split('/')[5];
+    it('can download Linux CLI', () => {
+      aboutPage.getLinkDestination('rancher-linux').then((el) => {
+        const linuxVersion = el.split('/')[5];
 
-  //       aboutPage.getCliDownloadLinkByLabel('rancher-linux').then((el: any) => {
-  //         el.attr('download', '');
-  //       }).click();
-  //       cy.wait('@download').then(({ request, response }) => {
-  //         expect(response?.statusCode).to.eq(200);
-  //         expect(request.url).includes(linuxVersion);
-  //       });
-  //     });
-  //   });
+        aboutPage.getCliDownloadLinkByLabel('rancher-linux').then((el: any) => {
+          el.attr('download', '');
+        }).click();
+        cy.wait('@download').then(({ request, response }) => {
+          expect(response?.statusCode).to.eq(200);
+          expect(request.url).includes(linuxVersion);
+        });
+      });
+    });
 
-  //   it('can download Windows CLI', () => {
-  //     aboutPage.getLinkDestination('rancher-windows').then((el) => {
-  //       const windowsVersion = el.split('/')[5];
+    it('can download Windows CLI', () => {
+      aboutPage.getLinkDestination('rancher-windows').then((el) => {
+        const windowsVersion = el.split('/')[5];
 
-  //       aboutPage.getCliDownloadLinkByLabel('rancher-windows').then((el: any) => {
-  //         el.attr('download', '');
-  //       }).click();
-  //       cy.wait('@download').then(({ request, response }) => {
-  //         expect(response?.statusCode).to.eq(200);
-  //         expect(request.url).includes(windowsVersion);
-  //       });
-  //     });
-  //   });
-  // });
+        aboutPage.getCliDownloadLinkByLabel('rancher-windows').then((el: any) => {
+          el.attr('download', '');
+        }).click();
+        cy.wait('@download').then(({ request, response }) => {
+          expect(response?.statusCode).to.eq(200);
+          expect(request.url).includes(windowsVersion);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This reverts commit 2b0dcd639137101fe73783c5967efec037bf6619.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11387 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR reinstates some failing e2e tests - -rc5 CLI builds appear to have been uploaded as expected, so these tests should pass now

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
