### PR TITLE
Disable e2e tests that rely on the server-version setting

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -85,6 +85,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
       aboutPage.goTo();
     });
 
+  // reinstate when server-version issue is corrected https://github.com/rancher/rancher/issues/46152
   //   it('can download Linux Image List', () => {
   //     // Download txt and verify file exists
   //     const downloadedFilename = path.join(downloadsFolder, 'rancher-linux-images.txt');
@@ -110,6 +111,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
   //   });
   // });
 
+  // reinstate when server-version issue is corrected https://github.com/rancher/rancher/issues/46152
   // Removed given https://github.com/rancher/rancher/issues/46068
   // Re-instate given https://github.com/rancher/dashboard/issues/11387
   // describe('CLI Downloads', () => {

--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -1,10 +1,10 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import AboutPagePo from '@/cypress/e2e/po/pages/about.po';
 import DiagnosticsPagePo from '@/cypress/e2e/po/pages/diagnostics.po';
-import * as path from 'path';
+// import * as path from 'path';
 
 const aboutPage = new AboutPagePo();
-const downloadsFolder = Cypress.config('downloadsFolder');
+// const downloadsFolder = Cypress.config('downloadsFolder');
 
 describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
   before(() => {

--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -80,10 +80,10 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     });
   });
 
-  describe('Image List', () => {
-    before(() => {
-      aboutPage.goTo();
-    });
+  // describe('Image List', () => {
+  //   before(() => {
+  //     aboutPage.goTo();
+  //   });
 
   // reinstate when server-version issue is corrected https://github.com/rancher/rancher/issues/46152
   //   it('can download Linux Image List', () => {

--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -85,30 +85,30 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
       aboutPage.goTo();
     });
 
-    it('can download Linux Image List', () => {
-      // Download txt and verify file exists
-      const downloadedFilename = path.join(downloadsFolder, 'rancher-linux-images.txt');
+  //   it('can download Linux Image List', () => {
+  //     // Download txt and verify file exists
+  //     const downloadedFilename = path.join(downloadsFolder, 'rancher-linux-images.txt');
 
-      aboutPage.getLinuxDownloadLink().click();
+  //     aboutPage.getLinuxDownloadLink().click();
 
-      cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
-        const rancherVersion = resp.body['value'];
+  //     cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
+  //       const rancherVersion = resp.body['value'];
 
-        cy.readFile(downloadedFilename).should('contain', rancherVersion);
-      });
-    });
+  //       cy.readFile(downloadedFilename).should('contain', rancherVersion);
+  //     });
+  //   });
 
-    it('can download Windows Image List', () => {
-      const downloadedFilename = path.join(downloadsFolder, 'rancher-windows-images.txt');
+  //   it('can download Windows Image List', () => {
+  //     const downloadedFilename = path.join(downloadsFolder, 'rancher-windows-images.txt');
 
-      aboutPage.getWindowsDownloadLink().click();
-      cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
-        const rancherVersion = resp.body['value'];
+  //     aboutPage.getWindowsDownloadLink().click();
+  //     cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
+  //       const rancherVersion = resp.body['value'];
 
-        cy.readFile(downloadedFilename).should('contain', rancherVersion);
-      });
-    });
-  });
+  //       cy.readFile(downloadedFilename).should('contain', rancherVersion);
+  //     });
+  //   });
+  // });
 
   // Removed given https://github.com/rancher/rancher/issues/46068
   // Re-instate given https://github.com/rancher/dashboard/issues/11387

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -47,7 +47,7 @@ describe('Home Page', () => {
         const rancherVersion = resp.body['value'].split('-', 1)[0].slice(1);
 
         homePage.changelog().self().contains('Learn more about the improvements and new capabilities in this version.');
-        homePage.whatsNewBannerLink().contains(`What's new in ${ rancherVersion }`);
+        // homePage.whatsNewBannerLink().contains(`What's new in ${ rancherVersion }`);
 
         homePage.whatsNewBannerLink().invoke('attr', 'href').then((releaseNotesUrl) => {
           cy.request(releaseNotesUrl).then((res) => {

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -44,7 +44,7 @@ describe('Home Page', () => {
       homePage.restoreAndWait();
 
       cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
-        const rancherVersion = resp.body['value'].split('-', 1)[0].slice(1);
+        // const rancherVersion = resp.body['value'].split('-', 1)[0].slice(1);
 
         homePage.changelog().self().contains('Learn more about the improvements and new capabilities in this version.');
         // reinstate when server-version issue is corrected https://github.com/rancher/rancher/issues/46152

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -47,6 +47,7 @@ describe('Home Page', () => {
         const rancherVersion = resp.body['value'].split('-', 1)[0].slice(1);
 
         homePage.changelog().self().contains('Learn more about the improvements and new capabilities in this version.');
+        // reinstate when server-version issue is corrected https://github.com/rancher/rancher/issues/46152
         // homePage.whatsNewBannerLink().contains(`What's new in ${ rancherVersion }`);
 
         homePage.whatsNewBannerLink().invoke('attr', 'href').then((releaseNotesUrl) => {


### PR DESCRIPTION
We have a few e2e tests failing because the server-version setting is set to `dev` instead of the usual version + commit id (eg `v2.9-3c4ccdc5bc9fde3510089153b5ad58fdbe604880-head`). Could be tied to this release blocker https://github.com/rancher/rancher/issues/46160