### PR TITLE
EKS: fix k8s version selection

### DIFF
--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -135,7 +135,7 @@ export default defineComponent({
     versionOptions: {
       handler(neu) {
         if (neu && neu.length && !this.kubernetesVersion) {
-          this.$emit('update:kubernetesVersion', neu[0]);
+          this.$emit('update:kubernetesVersion', neu[0].value);
         }
       },
       immediate: true

--- a/pkg/eks/components/__mocks__/describeAddonVersions.js
+++ b/pkg/eks/components/__mocks__/describeAddonVersions.js
@@ -17,6 +17,13 @@ export default {
           ],
           compatibilities: [
             {
+              clusterVersion:   '2.0',
+              defaultVersion:   false,
+              platformVersions: [
+                '*'
+              ]
+            },
+            {
               clusterVersion:   '1.29',
               defaultVersion:   false,
               platformVersions: [


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11438 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
#11438 reports an issue with the formatting of the node group version. It looks like the default value of the cluster kubernetes version was formatted incorrectly, leading to the node group version being wrong too.

### Technical notes summary
The root cause of #11438 is a change in the structure of the list of k8s versions shown in the UI, done as part of https://github.com/rancher/dashboard/pull/11411. I've added unit tests that explicitly check that the kubernetes version is set with the right format when it is initially set. 

### Areas or cases that should be tested
Create a new EKS cluster without changing the cluster kubernetes version and verify that:
1. The node group version is displayed correctly 
2. The POST request to create the cluster includes the correct `eksConfig.kubernetesVersion` (should be "1.30" at this time)



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
