### PR TITLE
Ensure count shown in side nav is correct

### DIFF
--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -429,7 +429,7 @@ export default {
       };
     }
 
-    const namespaces = _typeObj?.namespaced ? Object.keys(rootGetters.activeNamespaceCache || {}) : [];
+    const namespaces = _typeObj?.namespaced && !rootGetters.isAllNamespaces ? Object.keys(rootGetters.activeNamespaceCache || {}) : [];
 
     return matchingCounts(_typeObj, namespaces.length ? namespaces : null);
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to https://github.com/rancher/dashboard/issues/7773
<!-- Define findings related to the feature or bug issue. -->

When `all` namespace filter selected the counts shown in side nav excluded resources in 'obscure' namespaces (c-, p-, user-, local-). However lists would show them (counts missaligned).

When anything other than `all` namespace filter is selected resources in obscure namespaces were filtered out from both side nav and list (counts align).

This is only visible for resources that are in those obscure namespaces, which isn't many


### Occurred changes and/or fixed issues
- A new `counts` getter was created to improve performance of the side nav (specifically Type component)
  - https://github.com/rancher/dashboard/commit/48d5695359c60c2ba28d266adff0eeb803f1d357#diff-53d2b9025f17bb20287d00cbf1b9de5d7d43bd21b4c7d74c86ae2085e07936c6R381
- This contained the functionality from
  - SideNav (count came from typemap https://github.com/rancher/dashboard/commit/48d5695359c60c2ba28d266adff0eeb803f1d357#diff-3ad9f7560480743de6a82ac01d6f961c5c8674095bf5a27c65287d4946b88fc3L581)
  - Jump (count came from typemap AND itself https://github.com/rancher/dashboard/commit/48d5695359c60c2ba28d266adff0eeb803f1d357#diff-38a7ef0c623e19def1d9489f91f35089ceabf49da206a3fc298327d3eccfb584L44)
- Previously in both cases if all namespaces were selected it didn't pass in a list of namespaces when calculating the total count
- This was missed, so we were passing in a restrictive set of namespaces (sans obscure) to calc the resource count

### Technical notes summary
- I thought this might be a bug in our activeNamespaceCache (list not filtering out obscure namespaces), however this was intentional https://github.com/rancher/dashboard/issues/5088#issuecomment-1185712798

### Areas or cases that should be tested
- Counts in side nav match resource count in menu for a cross section of resource types
  - pods, deployments, service accounts, 


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
