### PR TITLE
AKS - fix tab component behavior when there are duplicate node pool names

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -51,7 +51,8 @@ import {
   ipv4WithCidr,
   outboundTypeUserDefined,
   privateDnsZone,
-  nodePoolNames
+  nodePoolNames,
+  nodePoolNamesUnique
 } from '../util/validators';
 
 export const defaultNodePool = {
@@ -243,6 +244,10 @@ export default defineComponent({
         rules: ['poolNames']
       },
       {
+        path:  'poolNamesUnique',
+        rules: ['poolNamesUnique']
+      },
+      {
         path:  'poolAZ',
         rules: ['availabilityZoneSupport']
       },
@@ -336,6 +341,7 @@ export default defineComponent({
         outboundType:            outboundTypeUserDefined(this, 'aks.outboundType.label', 'aksConfig.outboundType'),
         privateDnsZone:          privateDnsZone(this, 'aks.privateDnsZone.label', 'aksConfig.privateDnsZone'),
         poolNames:               nodePoolNames(this),
+        poolNamesUnique:         nodePoolNamesUnique(this),
 
         vmSizeAvailable: () => {
           if (this.touchedVmSize) {
@@ -1093,7 +1099,7 @@ export default defineComponent({
           <Tab
             v-for="(pool, i) in nodePools"
             :key="pool._id"
-            :name="pool.name"
+            :name="pool._id || pool.name"
             :label="pool.name || t('aks.nodePools.notNamed')"
             :error="!poolIsValid(pool)"
           >

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -168,3 +168,4 @@ aks:
     poolMin: The minimum number of nodes must be greater than 0 and at most 100.
     poolMax: The maximum number of nodes must be greater than 0 and at most 100.
     poolTaints: Taints must have both a key and value defined.
+    poolNamesUnique: Node pool names must be unique.

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -165,3 +165,15 @@ export const nodePoolNames = (ctx: any) => {
     }
   };
 };
+
+export const nodePoolNamesUnique = (ctx: any) => {
+  return () :string | undefined => {
+    const poolNames = (ctx.nodePools || []).map((pool: AKSNodePool) => pool.name);
+
+    const hasDuplicates = poolNames.some((name: string, idx: number) => poolNames.indexOf(name) !== idx);
+
+    if (hasDuplicates) {
+      return ctx.t('aks.errors.poolNamesUnique');
+    }
+  };
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11406 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the AKS provisioning form to correct an issue with `Tab` props - duplicate pool names caused a problem due to tabs not having unique keys. This PR also adds validation for AKS pool name uniqueness. 

It's pretty easy to wind up with duplicate pool names here. In an effort to avoid adding QA burden to the fast-approaching 2.9.0 release I've filed a separate issue to improve node pool/group default naming more generally in a later release (https://github.com/rancher/dashboard/issues/11451), as technically, that is not a release-blocker (the workaround is immediately obvious: manually re-name any duplicate pools you've inadvertently created).


### Technical notes summary
To clarify the `Tab` props in play here: in `CruAKS` `Tab` components need a `key` prop because they're part of a `v-for `loop...`Tabs` within the `Tabbed` are _also_ part of a `v-for` loop and the `key` used there is the `Tab` `name` prop. Arguably `Tabbed` should re-use the `key` prop when it is defined but it felt outside the scope of this issue to mess with such a widely used component.

### Areas or cases that should be tested
 1. Create a new AKS cluster, add and remove node pools and/or manually enter duplicate pool names - the tab components should work as expected
 2. There should be an error banner and the save button should be disabled if there are duplicate pool names
 3. Edit the AKS cluster - pool names and tab titles should all still work as expected
 


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
