### PR TITLE
EKS - fix project network isolation checkbox

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -676,7 +676,7 @@ export default defineComponent({
       >
         <Config
           :kubernetes-version.sync="config.kubernetesVersion"
-          :enable-network-policy.sync="config.enableNetworkPolicy"
+          :enable-network-policy.sync="normanCluster.enableNetworkPolicy"
           :ebs-c-s-i-driver.sync="config.ebsCSIDriver"
           :service-role.sync="config.serviceRole"
           :kms-key.sync="config.kmsKey"
@@ -686,6 +686,7 @@ export default defineComponent({
           :eks-roles="eksRoles"
           :loading-iam="loadingIam"
           :original-version="originalVersion"
+          data-testid="eks-config-section"
           @error="e=>errors.push(e)"
         />
       </Accordion>

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -146,4 +146,30 @@ describe('eKS provisioning form', () => {
 
     expect(wrapper.vm.nodeGroups.filter((group: EKSNodeGroup) => group.version === '1.24')).toHaveLength(1);
   });
+
+  it('should configure enable network policy at the cluster level not within eksConfig', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'edit' },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper);
+
+    const configComponent = wrapper.find('[data-testid="eks-config-section"]');
+
+    configComponent.vm.$emit('update:enableNetworkPolicy', true);
+
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.normanCluster.enableNetworkPolicy).toBe(true);
+
+    configComponent.vm.$emit('update:enableNetworkPolicy', false);
+
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.normanCluster.enableNetworkPolicy).toBe(false);
+
+    wrapper.setData({ normanCluster: { ...wrapper.vm.normanCluster, enableNetworkPolicy: true } });
+    await wrapper.vm.$nextTick();
+
+    expect(configComponent.props().enableNetworkPolicy).toBe(true);
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/9905 - https://github.com/rancher/dashboard/issues/9905#issuecomment-2232680677
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
The EKS form was attempting to set `enableNetworkPolicy` (labeled "Project Network Isolation" in the UI) at the eksConfig level - it needs to be set higher in the cluster spec. 


### Areas or cases that should be tested
1. Create an EKS cluster with 'project network isolation' checked - verify that the POST request has `<norman cluster>.enableNetworkPolicy: true`
2. Edit the EKS cluster - verify that the project network isolation checkbox is checked. Uncheck it and verify that the change is persisted



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
