### PR TITLE
EKS - add validation for node group desired size

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -202,6 +202,10 @@ export default defineComponent({
         path:  'networking',
         rules: ['publicPrivateAccess']
       },
+      {
+        path:  'minMaxDesired',
+        rules: ['minMaxDesired', 'minLessThanMax']
+      },
       ],
 
       loadingInstanceTypes:   false,
@@ -281,6 +285,8 @@ export default defineComponent({
           desiredSize:            EKSValidators.desiredSize(this),
           subnets:                EKSValidators.subnets(this),
           publicPrivateAccess:    EKSValidators.publicPrivateAccess(this),
+          minMaxDesired:          EKSValidators.minMaxDesired(this),
+          minLessThanMax:         EKSValidators.minLessThanMax(this),
         };
       }
 
@@ -629,7 +635,8 @@ export default defineComponent({
               minSize: fvGetAndReportPathRules('minSize'),
               desiredSize: fvGetAndReportPathRules('desiredSize'),
               instanceType: fvGetAndReportPathRules('instanceType'),
-              diskSize: fvGetAndReportPathRules('diskSize')
+              diskSize: fvGetAndReportPathRules('diskSize'),
+              minMaxDesired: fvGetAndReportPathRules('minMaxDesired')
             }"
             :node-role.sync="node.nodeRole"
             :launch-template.sync="node.launchTemplate"

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -414,6 +414,22 @@ export default defineComponent({
       }
     },
 
+    minMaxDesiredErrors() {
+      const errs = (this.rules?.minMaxDesired || []).reduce((errs: string[], rule: Function) => {
+        const err = rule({
+          minSize: this.minSize, maxSize: this.maxSize, desiredSize: this.desiredSize
+        });
+
+        if (err) {
+          errs.push(err);
+        }
+
+        return errs;
+      }, [] as string[]);
+
+      return errs.length ? errs.join(' ') : null;
+    },
+
     isView() {
       return this.mode === _VIEW;
     }
@@ -549,7 +565,7 @@ export default defineComponent({
           label-key="eks.nodeGroups.desiredSize.label"
           :mode="mode"
           :rules="rules.desiredSize"
-          @input="$emit('update:desiredSize', $event)"
+          @input="$emit('update:desiredSize', parseInt($event))"
         />
       </div>
       <div class="col span-4">
@@ -559,7 +575,7 @@ export default defineComponent({
           label-key="eks.nodeGroups.minSize.label"
           :mode="mode"
           :rules="rules.minSize"
-          @input="$emit('update:minSize', $event)"
+          @input="$emit('update:minSize', parseInt($event))"
         />
       </div>
       <div class="col span-4">
@@ -569,10 +585,15 @@ export default defineComponent({
           label-key="eks.nodeGroups.maxSize.label"
           :mode="mode"
           :rules="rules.maxSize"
-          @input="$emit('update:maxSize', $event)"
+          @input="$emit('update:maxSize', parseInt($event))"
         />
       </div>
     </div>
+    <Banner
+      v-if="!!minMaxDesiredErrors"
+      color="error"
+      :label="minMaxDesiredErrors"
+    />
     <div class="row mb-10">
       <div class="col span-6">
         <KeyValue

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -34,6 +34,8 @@ eks:
     nodeGroups:
       nameUnique: Node group names must be unique within a cluster.
     publicOrPrivate: At least one of public or private access must be enabled.
+    minMaxDesired: The node group desired size may not be less than the minimum size nor greater than the maximum size.
+    minLessThanMax: The node group minimum size may not be greater than the maximum size.
   label: Amazon EKS
   nodeGroups:
     desiredSize:

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -100,3 +100,106 @@ describe('validate EKS node group names', () => {
     expect(res).toBe(expected);
   });
 });
+
+describe('validate EKS node group desired size', () => {
+  it('should return an error if the desired size is less than the minimum size', () => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minMaxDesired(ctx)({
+      minSize: 2, desiredSize: 1, maxSize: 2
+    });
+
+    expect(res).toBeDefined();
+  });
+
+  it('should return an error if the desired size is greater than the maximum size', () => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minMaxDesired(ctx)({
+      minSize: 1, desiredSize: 3, maxSize: 2
+    });
+
+    expect(res).toBeDefined();
+  });
+
+  it('should not return an error if the desired size is equal to the minimum and maximum sizes', () => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minMaxDesired(ctx)({
+      minSize: 1, desiredSize: 1, maxSize: 1
+    });
+
+    expect(res).toBeUndefined();
+  });
+
+  it.each([
+    [[{
+      minSize: 1, desiredSize: 1, maxSize: 1
+    }, {
+      minSize: 1, desiredSize: 3, maxSize: 1
+    }], 'eks.errors.minMaxDesired'],
+    [[{
+      minSize: 1, desiredSize: 1, maxSize: 1
+    }, {
+      minSize: 1, desiredSize: 3, maxSize: 4
+    }], undefined]
+  ])('should validate each node group in the component context if not called with specific size arguments', (nodeGroups, errMsg) => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+      nodeGroups
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minMaxDesired(ctx)();
+
+    expect(res).toBe(errMsg);
+  });
+});
+
+describe('validate EKS node group minimum and maximum size', () => {
+  it('should return an error if the minimum size is greater than the maximum size', () => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minLessThanMax(ctx)({ minSize: 2, maxSize: 1 });
+
+    expect(res).toBe('eks.errors.minLessThanMax');
+  });
+
+  it('should not return an error if the minimum and maximum sizes are equal', () => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minLessThanMax(ctx)({ minSize: 2, maxSize: 2 });
+
+    expect(res).toBeUndefined();
+  });
+
+  it.each([
+    [[{ minSize: 1, maxSize: 1 }, { minSize: 3, maxSize: 1 }], 'eks.errors.minLessThanMax'],
+    [[{ minSize: 1, maxSize: 1 }, { minSize: 1, maxSize: 4 }], undefined]
+  ])('should validate each node group in the component context if not called with specific size arguments', (nodeGroups, errMsg) => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+      nodeGroups
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minLessThanMax(ctx)();
+
+    expect(res).toBe(errMsg);
+  });
+});

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -121,6 +121,46 @@ const publicPrivateAccess = (ctx: CruEKSContext) => {
   };
 };
 
+const minMaxDesired = (ctx: CruEKSContext) => {
+  return (sizes?: {minSize: number, maxSize: number, desiredSize: number}): undefined | string => {
+    const isValid = (min = 0, max = 0, desired = 0) => {
+      if ((desired < min) || (desired > max)) {
+        return false;
+      }
+
+      return true;
+    };
+
+    if (sizes) {
+      // validate given node group - run in node group component to display error
+      return isValid(sizes.minSize, sizes.maxSize, sizes.desiredSize) ? undefined : ctx.t('eks.errors.minMaxDesired');
+    } else {
+      // validate ALL node groups - run in crueks to determine whether or not to disable save button
+      return !!ctx.nodeGroups.find((nodeGroup) => !isValid(nodeGroup.minSize, nodeGroup.maxSize, nodeGroup.desiredSize)) ? ctx.t('eks.errors.minMaxDesired') : undefined;
+    }
+  };
+};
+
+const minLessThanMax = (ctx: CruEKSContext) => {
+  return (sizes?: {minSize: number, maxSize: number}): undefined | string => {
+    const isValid = (min = 0, max = 0 ) => {
+      if ((min > max) ) {
+        return false;
+      }
+
+      return true;
+    };
+
+    if (sizes) {
+      // validate given node group - run in node group component to display error
+      return isValid(sizes.minSize, sizes.maxSize) ? undefined : ctx.t('eks.errors.minLessThanMax');
+    } else {
+      // validate ALL node groups - run in crueks to determine whether or not to disable save button
+      return !!ctx.nodeGroups.find((nodeGroup) => !isValid(nodeGroup.minSize, nodeGroup.maxSize)) ? ctx.t('eks.errors.minLessThanMax') : undefined;
+    }
+  };
+};
+
 export default {
   clusterNameRequired,
   nodeGroupNamesRequired,
@@ -131,5 +171,7 @@ export default {
   instanceType,
   desiredSize,
   subnets,
-  publicPrivateAccess
+  publicPrivateAccess,
+  minMaxDesired,
+  minLessThanMax
 };


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10510 specifically https://github.com/rancher/dashboard/issues/10510#issuecomment-2233654804
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds validation for EKS node group min/max/desired size in relation to each other. I used the form validation mixin, but I have added an error banner rather than input-level error messages because of the way the mixin functions - validators run on individual inputs only receive the context of that input, and this validation needs to cover 3 input fields in tandem. 

### Technical notes summary
Some unit tests added, but manual testing is still advisable as unit tests can't reasonably cover form validation mixin behavior. 

### Areas or cases that should be tested
1. Verify that users cannot save EKS clusters with any node groups that have:
    - min size greater than max size
    - desired size less than min size
    - desired size greater than max size
  

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
