### PR TITLE
EKS - do not allow upgrades if any node groups would fall more than one minor version behind

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -656,6 +656,7 @@ export default defineComponent({
             :request-spot-instances.sync="node.requestSpotInstances"
             :labels.sync="node.labels"
             :version.sync="node.version"
+            :pool-is-upgrading.sync="node._isUpgrading"
             :cluster-version="config.kubernetesVersion"
             :original-cluster-version="originalVersion"
             :region="config.region"

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -199,6 +199,11 @@ export default defineComponent({
       default: null
     },
 
+    poolIsUpgrading: {
+      type:    Boolean,
+      default: false
+    },
+
     loadingInstanceTypes: {
       type:    Boolean,
       default: false
@@ -408,8 +413,10 @@ export default defineComponent({
       set(neu: boolean) {
         if (neu) {
           this.$emit('update:version', this.clusterVersion);
+          this.$emit('update:poolIsUpgrading', true);
         } else {
           this.$emit('update:version', this.originalNodeVersion);
+          this.$emit('update:poolIsUpgrading', false);
         }
       }
     },

--- a/pkg/eks/components/__tests__/NodeGroup.test.ts
+++ b/pkg/eks/components/__tests__/NodeGroup.test.ts
@@ -351,6 +351,63 @@ describe('eks node groups: edit', () => {
     expect(wrapper.emitted('update:version')?.[0]?.[0]).toBe('1.24');
   });
 
+  it('should report that a pool is being upgraded when the upgrade checkbox is checked', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        version:                '1.23',
+        clusterVersion:         '1.24',
+        originalClusterVersion: '1.24',
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    expect(wrapper.emitted('update:poolIsUpgrading')).toBeUndefined();
+
+    const upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    upgradeVersionCheckbox.vm.$emit('input', true);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:poolIsUpgrading')?.[0]?.[0]).toBe(true);
+  });
+
+  it('should report that a pool is NOT being upgraded when the upgrade checkbox is unchecked', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(NodeGroup, {
+      propsData: {
+        launchTemplate:         {},
+        region:                 'foo',
+        amazonCredentialSecret: 'bar',
+        version:                '1.23',
+        clusterVersion:         '1.24',
+        originalClusterVersion: '1.24',
+        isNewOrUnprovisioned:   false
+      },
+      ...setup
+    });
+
+    expect(wrapper.emitted('update:poolIsUpgrading')).toBeUndefined();
+
+    const upgradeVersionCheckbox = wrapper.find('[data-testid="eks-version-upgrade-checkbox"]');
+
+    wrapper.setProps({ version: '1.24' });
+    await wrapper.vm.$nextTick();
+
+    expect(upgradeVersionCheckbox.props().value).toBe(true);
+
+    upgradeVersionCheckbox.vm.$emit('input', false);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:poolIsUpgrading')?.[0]?.[0]).toBe(false);
+  });
+
   it('should revert the node version to its original version when the upgrade checkbox is unchecked', async() => {
     const setup = requiredSetup();
 

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -118,6 +118,7 @@ eks:
     label: Tags
   version:
     label: Kubernetes Version
-    upgradeWarning: (minor versio n >1 not allowed by EKS)
+    upgradeWarning: (minor version >1 not allowed by EKS)
+    upgradeDisallowed: "EKS only allows upgrades of one minor version: you must upgrade all node group versions before upgrading the cluster version."
   vpcSubnet:
     label: VPC and Subnet

--- a/pkg/eks/types/index.d.ts
+++ b/pkg/eks/types/index.d.ts
@@ -36,6 +36,7 @@ export interface EKSNodeGroup {
   version?: string
   __nameUnique?: boolean
   _isNew?: boolean,
+  _isUpgrading: boolean
 }
 
 export interface EKSConfig {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11460 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the EKS provisioning form to prevent users from upgrading the cluster (control plane) k8s version more than one minor version ahead of any node groups in the cluster.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
1. Create an EKS cluster with an older version eg 1.27, upgrade it & edit it again - the version input should be disabled with a warning about node groups
2. Check all nodegroup upgrade checkboxes - the cluster version dropdown should stay disabled
3. Save the cluster
4. Edit again - now that nodegroups are the same version as the cluster, you should be able to upgrade the cluster again

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
![Screenshot 2024-07-18 at 12 47 31 PM](https://github.com/user-attachments/assets/85bf5330-d862-4c42-8ad9-1166473a0045)
![Screenshot 2024-07-18 at 12 47 48 PM](https://github.com/user-attachments/assets/48049b3f-5300-4659-bc4b-388d5e1e2ff6)
![Screenshot 2024-07-18 at 12 47 55 PM](https://github.com/user-attachments/assets/fda14d45-d536-4b77-a139-dc12d7f5ec25)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
