### PR TITLE
Introduce additional form validation for User Retention

### DIFF
--- a/cypress/e2e/tests/pages/users-and-auth/index.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/index.spec.ts
@@ -48,7 +48,7 @@ describe('Auth Index', { testIsolation: 'off', tags: ['@explorer', '@adminUser']
     const userRetentionPo = new UserRetentionPo();
 
     userRetentionPo.disableAfterPeriodCheckbox().set();
-    userRetentionPo.disableAfterPeriodInput().set('30d');
+    userRetentionPo.disableAfterPeriodInput().set('300h');
     userRetentionPo.userRetentionCron().set('0 0 1 1 *');
 
     userRetentionPo.saveButton().expectToBeEnabled();

--- a/shell/composables/useI18n.ts
+++ b/shell/composables/useI18n.ts
@@ -21,6 +21,6 @@ export const useI18n = (vuexStore: Store<any>): { t: typeof t } => {
  * @param raw - A boolean determining if the string returned is a raw representation.
  * @returns A translated string or the raw value if the raw parameter is set to true.
  */
-const t = (key: string, args?: unknown, raw?: boolean): unknown => {
+const t = (key: string, args?: unknown, raw?: boolean): string => {
   return stringFor(store, key, args, raw);
 };

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -104,8 +104,10 @@ export const useLabeledFormElement = (props: LabeledFormElementProps, emit: (eve
     }
 
     if (ruleMessages.length > 0 && (blurred.value || focused.value)) {
+      emit('update:validation', false);
       return ruleMessages.join(', ');
     } else {
+      emit('update:validation', true);
       return undefined;
     }
   });

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -7,6 +7,7 @@ interface LabeledFormElementProps {
   required: boolean;
   disabled: boolean;
   rules: Array<any>;
+  requireDirty?: boolean;
 }
 
 interface UseLabeledFormElement {
@@ -63,6 +64,10 @@ export const labeledFormElementProps = {
     type:    Boolean,
     default: false,
   },
+  requireDirty: {
+    default: true,
+    type:    Boolean
+  }
 };
 
 export const useLabeledFormElement = (props: LabeledFormElementProps, emit: (event: string, ...args: any[]) => void): UseLabeledFormElement => {
@@ -91,6 +96,8 @@ export const useLabeledFormElement = (props: LabeledFormElementProps, emit: (eve
       const message = requiredRule(value);
 
       if (!!message) {
+        emit('update:validation', false);
+
         return message;
       }
     }
@@ -103,11 +110,13 @@ export const useLabeledFormElement = (props: LabeledFormElementProps, emit: (eve
       }
     }
 
-    if (ruleMessages.length > 0 && (blurred.value || focused.value)) {
+    if (ruleMessages.length > 0 && (blurred.value || focused.value || !props.requireDirty)) {
       emit('update:validation', false);
+
       return ruleMessages.join(', ');
     } else {
       emit('update:validation', true);
+
       return undefined;
     }
   });

--- a/shell/composables/useUserRetentionValidation.test.ts
+++ b/shell/composables/useUserRetentionValidation.test.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
-import { useUserRetentionValidation, Setting } from './useUserRetentionValidation';
+import { useUserRetentionValidation } from './useUserRetentionValidation';
+import type { Setting } from '@shell/types/resources/settings';
 
 const mockStore = { dispatch: jest.fn() };
 

--- a/shell/composables/useUserRetentionValidation.test.ts
+++ b/shell/composables/useUserRetentionValidation.test.ts
@@ -1,0 +1,99 @@
+import { ref } from 'vue';
+import { useUserRetentionValidation, Setting } from './useUserRetentionValidation';
+
+const mockStore = {
+  dispatch: jest.fn(),
+}
+jest.mock('@shell/composables/useStore', () => ({
+  useStore: () => mockStore,
+}))
+
+const mockAuthUserSessionTtlMinutes: Setting = {
+  apiVersion: 'management.cattle.io/v3',
+  customized: false,
+  default: '960',
+  id: 'auth-user-session-ttl-minutes',
+  kind: 'Setting',
+  links: {
+    remove: 'mock-remove-link',
+    self: 'mock-self-link',
+    update: 'mock-update-link',
+    view: 'mock-view-link',
+  },
+  metadata: {
+    creationTimestamp: 'mock-creation-timestamp',
+    fields: ['mock-field'],
+    generation: 1,
+    managedFields: [
+      {
+        apiVersion: 'mock-api-version',
+        fieldsType: 'mock-fields-type',
+        fieldsV1: {
+          'f:customized': {},
+          'f:default': {},
+          'f:source': {},
+          'f:value': {},
+        },
+        manager: 'mock-manager',
+        operation: 'mock-operation',
+        time: 'mock-time',
+      },
+    ],
+    name: 'mock-name',
+    relationships: null,
+    resourceVersion: 'mock-resource-version',
+    state: {
+      error: false,
+      message: 'mock-message',
+      name: 'mock-name',
+      transitioning: false,
+    },
+    uid: 'mock-uid',
+  },
+  source: '',
+  type: 'management.cattle.io.setting',
+  value: '960',
+  save: () => {},
+}
+
+describe('validateDurationAgainstAuthUserSession', () => {
+  it('should return an error message when the  duration is less than the auth user session TTL', () => {
+    const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
+    
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
+
+    const result = validateDurationAgainstAuthUserSession('59m')
+
+    expect(result).toEqual('Invalid value: "59m": must be at least auth-user-session-ttl-minutes (960m)');
+  });
+
+  it('should return undefined when the duration is equal to the auth user session TTL', () => {
+    const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
+    
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
+
+    const result = validateDurationAgainstAuthUserSession('960m')
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when the duration is greater than the auth user session TTL', () => {
+    const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
+    
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
+
+    const result = validateDurationAgainstAuthUserSession('961m')
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should throw an error when the duration is in an invalid format', () => {
+    const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
+    
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
+
+    const result = validateDurationAgainstAuthUserSession('960')
+
+    expect(result).toEqual('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
+  });
+})

--- a/shell/composables/useUserRetentionValidation.test.ts
+++ b/shell/composables/useUserRetentionValidation.test.ts
@@ -155,13 +155,13 @@ describe('validateDurationAgainstAuthUserSession', () => {
   });
 });
 
-describe('validateDuration', () => {
+describe('validateDurations', () => {
   it('should return an errror message when the duration is in an invalid format', () => {
     const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
 
-    const { validateDuration } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
+    const { validateDeleteInactiveUserAfterDuration } = useUserRetentionValidation(ref(false), ref(true), authUserSessionTtlMinutes);
 
-    const result = validateDuration('960');
+    const result = validateDeleteInactiveUserAfterDuration('960');
 
     expect(result).toStrictEqual('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
   });
@@ -169,9 +169,9 @@ describe('validateDuration', () => {
   it('should return undefined with a valid duration string', () => {
     const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
 
-    const { validateDuration } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
+    const { validateDeleteInactiveUserAfterDuration } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
 
-    const result = validateDuration('960m');
+    const result = validateDeleteInactiveUserAfterDuration('960m');
 
     expect(result).toBeUndefined();
   });

--- a/shell/composables/useUserRetentionValidation.test.ts
+++ b/shell/composables/useUserRetentionValidation.test.ts
@@ -121,14 +121,6 @@ describe('validateDeleteInactiveUserAfter', () => {
 
     expect(result).toBeUndefined();
   });
-
-  it('should throw an error when the duration is in an invalid format', () => {
-    const { validateDeleteInactiveUserAfter } = useUserRetentionValidation(ref(false), ref(false), ref(null));
-
-    const result = validateDeleteInactiveUserAfter('500');
-
-    expect(result).toStrictEqual('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
-  });
 });
 
 describe('validateDurationAgainstAuthUserSession', () => {
@@ -161,14 +153,26 @@ describe('validateDurationAgainstAuthUserSession', () => {
 
     expect(result).toBeUndefined();
   });
+});
 
-  it('should throw an error when the duration is in an invalid format', () => {
+describe('validateDuration', () => {
+  it('should return an errror message when the duration is in an invalid format', () => {
     const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
 
-    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
+    const { validateDuration } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
 
-    const result = validateDurationAgainstAuthUserSession('960');
+    const result = validateDuration('960');
 
     expect(result).toStrictEqual('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
+  });
+
+  it('should return undefined with a valid duration string', () => {
+    const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
+
+    const { validateDuration } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
+
+    const result = validateDuration('960m');
+
+    expect(result).toBeUndefined();
   });
 });

--- a/shell/composables/useUserRetentionValidation.test.ts
+++ b/shell/composables/useUserRetentionValidation.test.ts
@@ -1,99 +1,173 @@
 import { ref } from 'vue';
 import { useUserRetentionValidation, Setting } from './useUserRetentionValidation';
 
-const mockStore = {
-  dispatch: jest.fn(),
-}
-jest.mock('@shell/composables/useStore', () => ({
-  useStore: () => mockStore,
-}))
+const mockStore = { dispatch: jest.fn() };
+
+jest.mock('@shell/composables/useStore', () => ({ useStore: () => mockStore }));
+
+const mockI18n = { t: (key: string) => key };
+
+jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => mockI18n }));
 
 const mockAuthUserSessionTtlMinutes: Setting = {
   apiVersion: 'management.cattle.io/v3',
   customized: false,
-  default: '960',
-  id: 'auth-user-session-ttl-minutes',
-  kind: 'Setting',
-  links: {
+  default:    '960',
+  id:         'auth-user-session-ttl-minutes',
+  kind:       'Setting',
+  links:      {
     remove: 'mock-remove-link',
-    self: 'mock-self-link',
+    self:   'mock-self-link',
     update: 'mock-update-link',
+
     view: 'mock-view-link',
   },
   metadata: {
     creationTimestamp: 'mock-creation-timestamp',
-    fields: ['mock-field'],
-    generation: 1,
-    managedFields: [
+    fields:            ['mock-field'],
+    generation:        1,
+    managedFields:     [
       {
         apiVersion: 'mock-api-version',
         fieldsType: 'mock-fields-type',
-        fieldsV1: {
+        fieldsV1:   {
           'f:customized': {},
-          'f:default': {},
-          'f:source': {},
-          'f:value': {},
+          'f:default':    {},
+          'f:source':     {},
+          'f:value':      {},
         },
-        manager: 'mock-manager',
+        manager:   'mock-manager',
         operation: 'mock-operation',
-        time: 'mock-time',
+        time:      'mock-time',
       },
     ],
-    name: 'mock-name',
-    relationships: null,
+    name:            'mock-name',
+    relationships:   null,
     resourceVersion: 'mock-resource-version',
-    state: {
-      error: false,
-      message: 'mock-message',
-      name: 'mock-name',
+    state:           {
+      error:         false,
+      message:       'mock-message',
+      name:          'mock-name',
       transitioning: false,
     },
     uid: 'mock-uid',
   },
   source: '',
-  type: 'management.cattle.io.setting',
-  value: '960',
-  save: () => {},
-}
+  type:   'management.cattle.io.setting',
+  value:  '960',
+  save:   () => {},
+};
+
+describe('validateUserRetentionCron', () => {
+  it('should return undefined when disableAfterPeriod and deleteAfterPeriod are false', () => {
+    const disableAfterPeriod = ref(false);
+    const deleteAfterPeriod = ref(false);
+    const authUserSessionTtlMinutes = ref(null);
+
+    const { validateUserRetentionCron } = useUserRetentionValidation(disableAfterPeriod, deleteAfterPeriod, authUserSessionTtlMinutes);
+
+    const result = validateUserRetentionCron(null);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return an error message when cronSetting is invalid', () => {
+    const disableAfterPeriod = ref(true);
+    const deleteAfterPeriod = ref(false);
+    const authUserSessionTtlMinutes = ref(null);
+
+    const { validateUserRetentionCron } = useUserRetentionValidation(disableAfterPeriod, deleteAfterPeriod, authUserSessionTtlMinutes);
+
+    const result = validateUserRetentionCron(null);
+
+    expect(result).toStrictEqual('user.retention.edit.form.cron.errorMessage');
+  });
+
+  it('should return undefined when cronSetting is valid', () => {
+    const disableAfterPeriod = ref(true);
+    const deleteAfterPeriod = ref(false);
+    const authUserSessionTtlMinutes = ref(null);
+
+    const { validateUserRetentionCron } = useUserRetentionValidation(disableAfterPeriod, deleteAfterPeriod, authUserSessionTtlMinutes);
+
+    const result = validateUserRetentionCron('0 0 1 1 *');
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('validateDeleteInactiveUserAfter', () => {
+  it('should return an error message when the duration is less than 336 hours', () => {
+    const { validateDeleteInactiveUserAfter } = useUserRetentionValidation(ref(false), ref(false), ref(null));
+
+    const result = validateDeleteInactiveUserAfter('335h');
+
+    expect(result).toStrictEqual('Invalid value: "335h": must be at least 336h0m0s');
+  });
+
+  it('should return undefined when the duration is equal to 336 hours', () => {
+    const { validateDeleteInactiveUserAfter } = useUserRetentionValidation(ref(false), ref(false), ref(null));
+
+    const result = validateDeleteInactiveUserAfter('336h');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when the duration is greater than 336 hours', () => {
+    const { validateDeleteInactiveUserAfter } = useUserRetentionValidation(ref(false), ref(false), ref(null));
+
+    const result = validateDeleteInactiveUserAfter('500h');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should throw an error when the duration is in an invalid format', () => {
+    const { validateDeleteInactiveUserAfter } = useUserRetentionValidation(ref(false), ref(false), ref(null));
+
+    const result = validateDeleteInactiveUserAfter('500');
+
+    expect(result).toStrictEqual('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
+  });
+});
 
 describe('validateDurationAgainstAuthUserSession', () => {
   it('should return an error message when the  duration is less than the auth user session TTL', () => {
     const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
-    
-    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
 
-    const result = validateDurationAgainstAuthUserSession('59m')
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
 
-    expect(result).toEqual('Invalid value: "59m": must be at least auth-user-session-ttl-minutes (960m)');
+    const result = validateDurationAgainstAuthUserSession('59m');
+
+    expect(result).toStrictEqual('Invalid value: "59m": must be at least auth-user-session-ttl-minutes (960m)');
   });
 
   it('should return undefined when the duration is equal to the auth user session TTL', () => {
     const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
-    
-    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
 
-    const result = validateDurationAgainstAuthUserSession('960m')
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
+
+    const result = validateDurationAgainstAuthUserSession('960m');
 
     expect(result).toBeUndefined();
   });
 
   it('should return undefined when the duration is greater than the auth user session TTL', () => {
     const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
-    
-    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
 
-    const result = validateDurationAgainstAuthUserSession('961m')
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
+
+    const result = validateDurationAgainstAuthUserSession('961m');
 
     expect(result).toBeUndefined();
   });
 
   it('should throw an error when the duration is in an invalid format', () => {
     const authUserSessionTtlMinutes = ref<Setting>(mockAuthUserSessionTtlMinutes);
-    
-    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes)
 
-    const result = validateDurationAgainstAuthUserSession('960')
+    const { validateDurationAgainstAuthUserSession } = useUserRetentionValidation(ref(false), ref(false), authUserSessionTtlMinutes);
 
-    expect(result).toEqual('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
+    const result = validateDurationAgainstAuthUserSession('960');
+
+    expect(result).toStrictEqual('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
   });
-})
+});

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -12,6 +12,7 @@ dayjs.extend(duration);
 
 interface UseUserRetentionValidation {
   validateUserRetentionCron: (cronSetting: string | null) => string | undefined;
+  validateDuration: (duration: string) => string | undefined;
   validateDeleteInactiveUserAfter: (duration: string) => string | undefined;
   validateDurationAgainstAuthUserSession: (duration: string) => string | undefined;
   setValidation: (formField: string, isValid: boolean) => void;
@@ -98,6 +99,14 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     }
   };
 
+  const validateDuration = (duration: string): string | undefined => {
+    try {
+      parseDuration(duration);
+    } catch (error: any) {
+      return error.message;
+    }
+  };
+
   /**
    * Asserts that the provided duration is greater than the default minimum of
    * 336h
@@ -114,7 +123,8 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
         return `Invalid value: "${ duration }": must be at least 336h0m0s`;
       }
     } catch (error: any) {
-      return error.message;
+      // eslint-disable-next-line no-console
+      console.warn(error.message, 'Will fail validation if `validationDuration()` validator in in use.');
     }
   };
 
@@ -133,12 +143,14 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
         return `Invalid value: "${ duration }": must be at least ${ SETTING.AUTH_USER_SESSION_TTL_MINUTES } (${ authUserSessionTtlMinutes.value?.value }m)`;
       }
     } catch (error: any) {
-      return error.message;
+      // eslint-disable-next-line no-console
+      console.warn(error.message, 'Will fail validation if `validationDuration()` validator in in use.');
     }
   };
 
   return {
     validateUserRetentionCron,
+    validateDuration,
     validateDeleteInactiveUserAfter,
     validateDurationAgainstAuthUserSession,
     setValidation,

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -3,65 +3,12 @@ import { Ref, ComputedRef, ref, computed } from 'vue';
 import { SETTING } from '@shell/config/settings';
 import { useStore } from '@shell/composables/useStore';
 import { useI18n } from '@shell/composables/useI18n';
+import type { Setting } from '@shell/types/resources/settings';
 
 import { isValidCron } from 'cron-validator';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 dayjs.extend(duration);
-
-type Links = {
-  remove: string;
-  self: string;
-  update: string;
-  view: string;
-};
-
-type FieldsV1 = {
-  'f:customized': {};
-  'f:default': {};
-  'f:source': {};
-  'f:value': {};
-};
-
-type ManagedFields = {
-  apiVersion: string;
-  fieldsType: string;
-  fieldsV1: FieldsV1;
-  manager: string;
-  operation: string;
-  time: string;
-};
-
-type Metadata = {
-  creationTimestamp: string;
-  fields: string[];
-  generation: number;
-  managedFields: ManagedFields[];
-  name: string;
-  relationships: null;
-  resourceVersion: string;
-  state: {
-    error: boolean;
-    message: string;
-    name: string;
-    transitioning: boolean;
-  };
-  uid: string;
-};
-
-export type Setting = {
-  id: string;
-  type: string;
-  links: Links;
-  apiVersion: string;
-  customized: boolean;
-  default: string;
-  kind: string;
-  metadata: Metadata;
-  source: string;
-  value: string | null;
-  save: () => void;
-};
 
 interface UseUserRetentionValidation {
   validateUserRetentionCron: (cronSetting: string | null) => string | undefined;

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -1,0 +1,157 @@
+import { Ref, ref, computed } from 'vue';
+
+import { SETTING } from '@shell/config/settings';
+import { useStore } from '@shell/composables/useStore';
+import { useI18n } from '@shell/composables/useI18n';
+
+import { isValidCron } from 'cron-validator';
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+dayjs.extend(duration);
+
+type Links = {
+  remove: string;
+  self: string;
+  update: string;
+  view: string;
+};
+
+type FieldsV1 = {
+  'f:customized': {};
+  'f:default': {};
+  'f:source': {};
+  'f:value': {};
+};
+
+type ManagedFields = {
+  apiVersion: string;
+  fieldsType: string;
+  fieldsV1: FieldsV1;
+  manager: string;
+  operation: string;
+  time: string;
+};
+
+type Metadata = {
+  creationTimestamp: string;
+  fields: string[];
+  generation: number;
+  managedFields: ManagedFields[];
+  name: string;
+  relationships: null;
+  resourceVersion: string;
+  state: {
+    error: boolean;
+    message: string;
+    name: string;
+    transitioning: boolean;
+  };
+  uid: string;
+};
+
+export type Setting = {
+  id: string;
+  type: string;
+  links: Links;
+  apiVersion: string;
+  customized: boolean;
+  default: string;
+  kind: string;
+  metadata: Metadata;
+  source: string;
+  value: string | null;
+  save: () => void;
+};
+
+export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, deleteAfterPeriod: Ref<boolean>, authUserSessionTtlMinutes: Ref<Setting | null>) => {
+  const store = useStore();
+  const { t } = useI18n(store);
+
+  const validation = ref({
+    [SETTING.DISABLE_INACTIVE_USER_AFTER]: true,
+    [SETTING.DELETE_INACTIVE_USER_AFTER]: true,
+    [SETTING.USER_RETENTION_CRON]: true,
+  })
+
+  const isFormValid = computed(() => {
+    const validations = validation.value
+    return !Object.values(validations).includes(false);
+  })
+
+  const setValidation = (formField: string, isValid: boolean) => {
+    validation.value[formField] = isValid;
+  }
+
+  const validateUserRetentionCron = (cronSetting: string | null) => {
+    // Only require user retention cron when disable or delete after are active
+    if (!disableAfterPeriod.value && !deleteAfterPeriod.value) {
+      return;
+    }
+
+    if (!cronSetting) {
+      return;
+    }
+
+    if (typeof cronSetting === 'string' && !isValidCron(cronSetting)) {
+      return t('user.retention.edit.form.cron.errorMessage');
+    }
+  };
+
+  const validateDurationFormat = (duration: string) => {
+    const durationPattern = /^(\d+)h|(\d+)m|(\d+)s$/;
+    const match = duration?.match(durationPattern);
+
+    if (!match) {
+      return 'Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})';
+    }
+  }
+
+  const validateDeleteInactiveUserAfter = (duration: string) => {
+    const durationPattern = /^(\d+)h|(\d+)m|(\d+)s$/;
+    const match = duration?.match(durationPattern);
+
+    if (!match) {
+      return 'Invalid duration format';
+    }
+
+    const hours = match[1] ? parseInt(match[1]) : 0;
+    const minutes = match[2] ? parseInt(match[2]) : 0;
+    const seconds = match[3] ? parseInt(match[3]) : 0;
+
+    const inputDuration = dayjs.duration({ hours, minutes, seconds });
+    const minDuration = dayjs.duration({ hours: 336 });
+
+    if (inputDuration.asMilliseconds() < minDuration.asMilliseconds()) {
+      return `Invalid value: "${duration}": must be at least 336h0m0s`;
+    };
+  }
+
+  const validateDurationAgainstAuthUserSession = (duration: string) => {
+    const durationPattern = /^(\d+)h|(\d+)m|(\d+)s$/;
+    const match = duration?.match(durationPattern);
+
+    if (!match) {
+      return 'Invalid duration format';
+    }
+
+    const hours = match[1] ? parseInt(match[1]) : 0;
+    const minutes = match[2] ? parseInt(match[2]) : 0;
+    const seconds = match[3] ? parseInt(match[3]) : 0;
+
+    const inputDuration = dayjs.duration({ hours, minutes, seconds });
+    const minDuration = dayjs.duration({ minutes: authUserSessionTtlMinutes.value?.value });
+
+    if (inputDuration.asMilliseconds() < minDuration.asMilliseconds()) {
+      return `Invalid value: "${duration}": must be at least ${SETTING.AUTH_USER_SESSION_TTL_MINUTES} (${authUserSessionTtlMinutes.value?.value}m)`;
+    };
+  }
+
+  return {
+    validateUserRetentionCron,
+    validateDurationFormat,
+    validateDeleteInactiveUserAfter,
+    validateDurationAgainstAuthUserSession,
+    setValidation,
+    isFormValid,
+  }
+};

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -12,7 +12,8 @@ dayjs.extend(duration);
 
 interface UseUserRetentionValidation {
   validateUserRetentionCron: (cronSetting: string | null) => string | undefined;
-  validateDuration: (duration: string) => string | undefined;
+  validateDisableInactiveUserAfterDuration: (duration: string) => string | undefined;
+  validateDeleteInactiveUserAfterDuration: (duration: string) => string | undefined;
   validateDeleteInactiveUserAfter: (duration: string) => string | undefined;
   validateDurationAgainstAuthUserSession: (duration: string) => string | undefined;
   setValidation: (formField: string, isValid: boolean) => void;
@@ -99,7 +100,23 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     }
   };
 
-  const validateDuration = (duration: string): string | undefined => {
+  const validateDisableInactiveUserAfterDuration = (duration: string): string | undefined => {
+    if (!disableAfterPeriod.value) {
+      return;
+    }
+
+    try {
+      parseDuration(duration);
+    } catch (error: any) {
+      return error.message;
+    }
+  };
+
+  const validateDeleteInactiveUserAfterDuration = (duration: string): string | undefined => {
+    if (!deleteAfterPeriod.value) {
+      return;
+    }
+
     try {
       parseDuration(duration);
     } catch (error: any) {
@@ -150,7 +167,8 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
 
   return {
     validateUserRetentionCron,
-    validateDuration,
+    validateDisableInactiveUserAfterDuration,
+    validateDeleteInactiveUserAfterDuration,
     validateDeleteInactiveUserAfter,
     validateDurationAgainstAuthUserSession,
     setValidation,

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -10,15 +10,23 @@ import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 dayjs.extend(duration);
 
+type SettingValidation = 'user-retention-cron' | 'disable-inactive-user-after' | 'delete-inactive-user-after';
+
+type Validation = {
+  [SETTING.DISABLE_INACTIVE_USER_AFTER]?: boolean;
+  [SETTING.DELETE_INACTIVE_USER_AFTER]?: boolean;
+  [SETTING.USER_RETENTION_CRON]?: boolean;
+}
+
 interface UseUserRetentionValidation {
   validateUserRetentionCron: (cronSetting: string | null) => string | undefined;
   validateDisableInactiveUserAfterDuration: (duration: string) => string | undefined;
   validateDeleteInactiveUserAfterDuration: (duration: string) => string | undefined;
   validateDeleteInactiveUserAfter: (duration: string) => string | undefined;
   validateDurationAgainstAuthUserSession: (duration: string) => string | undefined;
-  setValidation: (formField: string, isValid: boolean) => void;
-  removeCronValidation: () => void;
-  addCronValidation: () => void;
+  setValidation: (formField: SettingValidation, isValid: boolean) => void;
+  removeValidation : (setting: SettingValidation) => void;
+  addValidation: (setting: SettingValidation) => void;
   isFormValid: ComputedRef<boolean>;
 }
 
@@ -37,7 +45,7 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
   /**
    * Tracks the validation state for user retention fields
    */
-  const validation = ref({
+  const validation = ref<Validation>({
     [SETTING.DISABLE_INACTIVE_USER_AFTER]: true,
     [SETTING.DELETE_INACTIVE_USER_AFTER]:  true,
     [SETTING.USER_RETENTION_CRON]:         true,
@@ -49,20 +57,20 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     return !Object.values(validations).includes(false);
   });
 
-  const setValidation = (formField: string, isValid: boolean) => {
+  const setValidation = (formField: SettingValidation, isValid: boolean) => {
     validation.value[formField] = isValid;
   };
 
-  const removeCronValidation = () => {
-    const { [SETTING.USER_RETENTION_CRON]: _, ...rest } = validation.value;
+  const removeValidation = (setting: SettingValidation) => {
+    const { [setting]: _, ...rest } = validation.value;
 
     validation.value = rest;
   };
 
-  const addCronValidation = () => {
+  const addValidation = (setting: SettingValidation) => {
     validation.value = {
       ...validation.value,
-      [SETTING.USER_RETENTION_CRON]: true,
+      [setting]: true,
     };
   };
 
@@ -186,8 +194,8 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     validateDeleteInactiveUserAfter,
     validateDurationAgainstAuthUserSession,
     setValidation,
-    removeCronValidation,
-    addCronValidation,
+    removeValidation,
+    addValidation,
     isFormValid,
   };
 };

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -82,6 +82,18 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     validation.value[formField] = isValid;
   }
 
+  const removeCronValidation = () => {
+    const { [SETTING.USER_RETENTION_CRON]: _, ...rest } = validation.value;
+    validation.value = rest;
+  }
+
+  const addCronValidation = () => {
+    validation.value = {
+      ...validation.value,
+      [SETTING.USER_RETENTION_CRON]: true,
+    }
+  }
+
   const parseDuration = (duration: string) => {
     const durationPattern = /^(\d+)h|(\d+)m|(\d+)s$/;
     const match = duration?.match(durationPattern);
@@ -103,11 +115,10 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
       return;
     }
 
-    if (!cronSetting) {
-      return;
-    }
-
-    if (typeof cronSetting === 'string' && !isValidCron(cronSetting)) {
+    if (
+      !cronSetting ||
+      (typeof cronSetting === 'string' && !isValidCron(cronSetting))
+    ) {
       return t('user.retention.edit.form.cron.errorMessage');
     }
   };
@@ -143,6 +154,8 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     validateDeleteInactiveUserAfter,
     validateDurationAgainstAuthUserSession,
     setValidation,
+    removeCronValidation,
+    addCronValidation,
     isFormValid,
   }
 };

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -69,30 +69,32 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
 
   const validation = ref({
     [SETTING.DISABLE_INACTIVE_USER_AFTER]: true,
-    [SETTING.DELETE_INACTIVE_USER_AFTER]: true,
-    [SETTING.USER_RETENTION_CRON]: true,
-  })
+    [SETTING.DELETE_INACTIVE_USER_AFTER]:  true,
+    [SETTING.USER_RETENTION_CRON]:         true,
+  });
 
   const isFormValid = computed(() => {
-    const validations = validation.value
+    const validations = validation.value;
+
     return !Object.values(validations).includes(false);
-  })
+  });
 
   const setValidation = (formField: string, isValid: boolean) => {
     validation.value[formField] = isValid;
-  }
+  };
 
   const removeCronValidation = () => {
     const { [SETTING.USER_RETENTION_CRON]: _, ...rest } = validation.value;
+
     validation.value = rest;
-  }
+  };
 
   const addCronValidation = () => {
     validation.value = {
       ...validation.value,
       [SETTING.USER_RETENTION_CRON]: true,
-    }
-  }
+    };
+  };
 
   const parseDuration = (duration: string) => {
     const durationPattern = /^(\d+)h|(\d+)m|(\d+)s$/;
@@ -106,7 +108,9 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     const minutes = match[2] ? parseInt(match[2]) : 0;
     const seconds = match[3] ? parseInt(match[3]) : 0;
 
-    return dayjs.duration({ hours, minutes, seconds });
+    return dayjs.duration({
+      hours, minutes, seconds
+    });
   };
 
   const validateUserRetentionCron = (cronSetting: string | null) => {
@@ -129,12 +133,12 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
       const minDuration = dayjs.duration({ hours: 336 });
 
       if (inputDuration.asMilliseconds() < minDuration.asMilliseconds()) {
-        return `Invalid value: "${duration}": must be at least 336h0m0s`;
+        return `Invalid value: "${ duration }": must be at least 336h0m0s`;
       }
     } catch (error: any) {
       return error.message;
     }
-  }
+  };
 
   const validateDurationAgainstAuthUserSession = (duration: string) => {
     try {
@@ -142,12 +146,12 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
       const minDuration = dayjs.duration({ minutes: authUserSessionTtlMinutes.value?.value });
 
       if (inputDuration.asMilliseconds() < minDuration.asMilliseconds()) {
-        return `Invalid value: "${duration}": must be at least ${SETTING.AUTH_USER_SESSION_TTL_MINUTES} (${authUserSessionTtlMinutes.value?.value}m)`;
+        return `Invalid value: "${ duration }": must be at least ${ SETTING.AUTH_USER_SESSION_TTL_MINUTES } (${ authUserSessionTtlMinutes.value?.value }m)`;
       }
     } catch (error: any) {
       return error.message;
     }
-  }
+  };
 
   return {
     validateUserRetentionCron,
@@ -157,5 +161,5 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     removeCronValidation,
     addCronValidation,
     isFormValid,
-  }
+  };
 };

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -22,6 +22,14 @@ interface UseUserRetentionValidation {
   isFormValid: ComputedRef<boolean>;
 }
 
+class ExpectedValidationError extends Error {
+  isExpected = true;
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExpectedError';
+  }
+}
+
 export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, deleteAfterPeriod: Ref<boolean>, authUserSessionTtlMinutes: Ref<Setting | null>): UseUserRetentionValidation => {
   const store = useStore();
   const { t } = useI18n(store);
@@ -68,7 +76,7 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     const match = duration?.match(durationPattern);
 
     if (!match) {
-      throw new Error('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
+      throw new ExpectedValidationError('Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})');
     }
 
     const hours = match[1] ? parseInt(match[1]) : 0;
@@ -140,8 +148,11 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
         return `Invalid value: "${ duration }": must be at least 336h0m0s`;
       }
     } catch (error: any) {
-      // eslint-disable-next-line no-console
-      console.warn(error.message, 'Will fail validation if `validationDuration()` validator in in use.');
+      if (error instanceof ExpectedValidationError) {
+
+      } else {
+        return error.message;
+      }
     }
   };
 
@@ -160,8 +171,11 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
         return `Invalid value: "${ duration }": must be at least ${ SETTING.AUTH_USER_SESSION_TTL_MINUTES } (${ authUserSessionTtlMinutes.value?.value }m)`;
       }
     } catch (error: any) {
-      // eslint-disable-next-line no-console
-      console.warn(error.message, 'Will fail validation if `validationDuration()` validator in in use.');
+      if (error instanceof ExpectedValidationError) {
+
+      } else {
+        return error.message;
+      }
     }
   };
 

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -1,4 +1,4 @@
-import { Ref, ref, computed } from 'vue';
+import { Ref, ComputedRef, ref, computed } from 'vue';
 
 import { SETTING } from '@shell/config/settings';
 import { useStore } from '@shell/composables/useStore';
@@ -63,7 +63,17 @@ export type Setting = {
   save: () => void;
 };
 
-export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, deleteAfterPeriod: Ref<boolean>, authUserSessionTtlMinutes: Ref<Setting | null>) => {
+interface UseUserRetentionValidation {
+  validateUserRetentionCron: (cronSetting: string | null) => string | undefined;
+  validateDeleteInactiveUserAfter: (duration: string) => string | undefined;
+  validateDurationAgainstAuthUserSession: (duration: string) => string | undefined;
+  setValidation: (formField: string, isValid: boolean) => void;
+  removeCronValidation: () => void;
+  addCronValidation: () => void;
+  isFormValid: ComputedRef<boolean>;
+}
+
+export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, deleteAfterPeriod: Ref<boolean>, authUserSessionTtlMinutes: Ref<Setting | null>): UseUserRetentionValidation => {
   const store = useStore();
   const { t } = useI18n(store);
 
@@ -113,7 +123,7 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     });
   };
 
-  const validateUserRetentionCron = (cronSetting: string | null) => {
+  const validateUserRetentionCron = (cronSetting: string | null): string | undefined => {
     // Only require user retention cron when disable or delete after are active
     if (!disableAfterPeriod.value && !deleteAfterPeriod.value) {
       return;
@@ -127,7 +137,7 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     }
   };
 
-  const validateDeleteInactiveUserAfter = (duration: string) => {
+  const validateDeleteInactiveUserAfter = (duration: string): string | undefined => {
     try {
       const inputDuration = parseDuration(duration);
       const minDuration = dayjs.duration({ hours: 336 });
@@ -140,7 +150,7 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     }
   };
 
-  const validateDurationAgainstAuthUserSession = (duration: string) => {
+  const validateDurationAgainstAuthUserSession = (duration: string): string | undefined => {
     try {
       const inputDuration = parseDuration(duration);
       const minDuration = dayjs.duration({ minutes: authUserSessionTtlMinutes.value?.value });

--- a/shell/composables/useUserRetentionValidation.ts
+++ b/shell/composables/useUserRetentionValidation.ts
@@ -77,6 +77,9 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
   const store = useStore();
   const { t } = useI18n(store);
 
+  /**
+   * Tracks the validation state for user retention fields
+   */
   const validation = ref({
     [SETTING.DISABLE_INACTIVE_USER_AFTER]: true,
     [SETTING.DELETE_INACTIVE_USER_AFTER]:  true,
@@ -106,6 +109,11 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     };
   };
 
+  /**
+   * Takes a duration string and produces a dayjs duration object.
+   * @param duration Duration string in {h|m|s} (e.g. 6h3m2s)
+   * @returns Day.js duration object
+   */
   const parseDuration = (duration: string) => {
     const durationPattern = /^(\d+)h|(\d+)m|(\d+)s$/;
     const match = duration?.match(durationPattern);
@@ -123,6 +131,12 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     });
   };
 
+  /**
+   * Asserts that a given string is a valid cron expression
+   * @param cronSetting Cron expression to test
+   * @returns Undefined if cron expression is valid; Error string for an invalid
+   * cron expression.
+   */
   const validateUserRetentionCron = (cronSetting: string | null): string | undefined => {
     // Only require user retention cron when disable or delete after are active
     if (!disableAfterPeriod.value && !deleteAfterPeriod.value) {
@@ -137,6 +151,13 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     }
   };
 
+  /**
+   * Asserts that the provided duration is greater than the default minimum of
+   * 336h
+   * @param duration Duration string in {h|m|s} (e.g. 6h3m2s)
+   * @returns Undefined if duration is valid; Error string for an invalid
+   * duration
+   */
   const validateDeleteInactiveUserAfter = (duration: string): string | undefined => {
     try {
       const inputDuration = parseDuration(duration);
@@ -150,6 +171,12 @@ export const useUserRetentionValidation = (disableAfterPeriod: Ref<boolean>, del
     }
   };
 
+  /**
+   * Asserts that the provided duration is not less than the user session TTL
+   * @param duration Duration string in {h|m|s} (e.g. 6h3m2s)
+   * @returns Undefined if duration is valid; Error string for an invalid
+   * duration
+   */
   const validateDurationAgainstAuthUserSession = (duration: string): string | undefined => {
     try {
       const inputDuration = parseDuration(duration);

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -108,7 +108,7 @@ export const SETTING = {
   USER_LAST_LOGIN_DEFAULT:              'user-last-login-default',
   DISABLE_INACTIVE_USER_AFTER:          'disable-inactive-user-after',
   DELETE_INACTIVE_USER_AFTER:           'delete-inactive-user-after',
-};
+} as const;
 
 // These are the settings that are allowed to be edited via the UI
 export const ALLOWED_SETTINGS: GlobalSetting = {

--- a/shell/mixins/labeled-form-element.ts
+++ b/shell/mixins/labeled-form-element.ts
@@ -155,6 +155,8 @@ export default Vue.extend({
         const message = requiredRule(value);
 
         if (!!message) {
+          this.$emit('update:validation', false);
+
           return message;
         }
       }
@@ -167,8 +169,12 @@ export default Vue.extend({
         }
       }
       if (ruleMessages.length > 0 && (this.blurred || this.focused || !this.requireDirty)) {
+        this.$emit('update:validation', false);
+
         return ruleMessages.join(', ');
       } else {
+        this.$emit('update:validation', true);
+
         return undefined;
       }
     }

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -32,7 +32,6 @@ const deleteAfterPeriod = ref(false);
 const loading = ref(true);
 const {
   validateUserRetentionCron,
-  validateDurationFormat,
   validateDeleteInactiveUserAfter,
   validateDurationAgainstAuthUserSession,
   setValidation,
@@ -199,7 +198,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           class="input-field"
           :label="t('user.retention.edit.form.disableAfter.input.label')"
           :disabled="!disableAfterPeriod"
-          :rules="[validateDurationFormat, validateDurationAgainstAuthUserSession]"
+          :rules="[validateDurationAgainstAuthUserSession]"
           @update:validation="e => setValidation(SETTING.DISABLE_INACTIVE_USER_AFTER, e)"
         />
       </div>
@@ -217,7 +216,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           :label="t('user.retention.edit.form.deleteAfter.input.label')"
           :sub-label="t('user.retention.edit.form.deleteAfter.input.subLabel')"
           :disabled="!deleteAfterPeriod"
-          :rules="[validateDurationFormat, validateDurationAgainstAuthUserSession, validateDeleteInactiveUserAfter]"
+          :rules="[validateDurationAgainstAuthUserSession, validateDeleteInactiveUserAfter]"
           @update:validation="e => setValidation(SETTING.DELETE_INACTIVE_USER_AFTER, e)"
         />
       </div>

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -173,31 +173,33 @@ onMounted(async() => {
   validateUserRetentionCron();
 });
 
-const isFormValid = ref(false);
+const validation = ref({
+  [SETTING.DELETE_INACTIVE_USER_AFTER]: true,
+  [SETTING.USER_RETENTION_CRON]: true,
+})
+const isFormValid = computed(() => {
+  const validations = validation.value
+  return !Object.values(validations).includes(false);
+})
+const setValidation = (formField: string, isValid: boolean) => {
+  validation.value[formField] = isValid;
+}
 const { t } = useI18n(store);
 const validateUserRetentionCron = () => {
   const { [SETTING.USER_RETENTION_CRON]: cronSetting } = userRetentionSettings;
 
   // Only require user retention cron when disable or delete after are active
   if (!disableAfterPeriod.value && !deleteAfterPeriod.value) {
-    isFormValid.value = true;
-
     return;
   }
 
   if (!cronSetting) {
-    isFormValid.value = false;
-
     return;
   }
 
   if (typeof cronSetting === 'string' && !isValidCron(cronSetting)) {
-    isFormValid.value = false;
-
     return t('user.retention.edit.form.cron.errorMessage');
   }
-
-  isFormValid.value = true;
 };
 
 const error = ref<string | null>(null);
@@ -299,7 +301,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
             :tooltip="t('user.retention.edit.form.cron.subLabel')"
             :rules="[validateUserRetentionCron]"
             :label="t('user.retention.edit.form.cron.label')"
-            @input="validateUserRetentionCron"
+            @update:validation="e => setValidation(SETTING.USER_RETENTION_CRON, e)"
           />
         </div>
         <div class="input-fieldset condensed pt-12">

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -35,6 +35,8 @@ const {
   validateDeleteInactiveUserAfter,
   validateDurationAgainstAuthUserSession,
   setValidation,
+  removeCronValidation,
+  addCronValidation,
   isFormValid,
 } = useUserRetentionValidation(disableAfterPeriod, deleteAfterPeriod, authUserSessionTtlMinutes);
 let settings: { [id: string]: Setting } = {};
@@ -78,7 +80,7 @@ watch([disableAfterPeriod, deleteAfterPeriod], ([newDisableAfterPeriod, newDelet
       userRetentionSettings[key] = null;
     });
 
-    validateUserRetentionCron(userRetentionSettings[SETTING.USER_RETENTION_CRON]);
+    removeCronValidation();
 
     return;
   }
@@ -86,7 +88,7 @@ watch([disableAfterPeriod, deleteAfterPeriod], ([newDisableAfterPeriod, newDelet
   ids.filter((id) => ![SETTING.DISABLE_INACTIVE_USER_AFTER, SETTING.DELETE_INACTIVE_USER_AFTER].includes(id))
     .forEach(assignSettings);
 
-  validateUserRetentionCron(userRetentionSettings[SETTING.USER_RETENTION_CRON]);
+  addCronValidation();
 });
 
 const assignSettings = (key: string) => {
@@ -125,8 +127,6 @@ onMounted(async() => {
   disableAfterPeriod.value = !!userRetentionSettings[SETTING.DISABLE_INACTIVE_USER_AFTER];
   deleteAfterPeriod.value = !!userRetentionSettings[SETTING.DELETE_INACTIVE_USER_AFTER];
   loading.value = false;
-
-  validateUserRetentionCron(userRetentionSettings[SETTING.USER_RETENTION_CRON]);
 });
 
 const { t } = useI18n(store);

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -176,6 +176,7 @@ onMounted(async() => {
 });
 
 const validation = ref({
+  [SETTING.DISABLE_INACTIVE_USER_AFTER]: true,
   [SETTING.DELETE_INACTIVE_USER_AFTER]: true,
   [SETTING.USER_RETENTION_CRON]: true,
 })
@@ -203,6 +204,15 @@ const validateUserRetentionCron = () => {
     return t('user.retention.edit.form.cron.errorMessage');
   }
 };
+
+const validateDurationFormat = (duration: string) => {
+  const durationPattern = /^(\d+)h|(\d+)m|(\d+)s$/;
+  const match = duration?.match(durationPattern);
+
+  if (!match) {
+    return 'Invalid duration format. Accepted duration units are Hours, Minutes, and Seconds ({h|m|s})';
+  }
+}
 
 const validateDeleteInactiveUserAfter = () => {
   const { [SETTING.DELETE_INACTIVE_USER_AFTER]: cronSetting } = userRetentionSettings;
@@ -294,6 +304,8 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           class="input-field"
           :label="t('user.retention.edit.form.disableAfter.input.label')"
           :disabled="!disableAfterPeriod"
+          :rules="[validateDurationFormat]"
+          @update:validation="e => setValidation(SETTING.DISABLE_INACTIVE_USER_AFTER, e)"
         />
       </div>
       <div class="input-fieldset">
@@ -310,7 +322,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           :label="t('user.retention.edit.form.deleteAfter.input.label')"
           :sub-label="t('user.retention.edit.form.deleteAfter.input.subLabel')"
           :disabled="!deleteAfterPeriod"
-          :rules="[validateDeleteInactiveUserAfter]"
+          :rules="[validateDurationFormat, validateDeleteInactiveUserAfter]"
           @update:validation="e => setValidation(SETTING.DELETE_INACTIVE_USER_AFTER, e)"
         />
       </div>

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -39,8 +39,8 @@ const {
   validateDeleteInactiveUserAfter,
   validateDurationAgainstAuthUserSession,
   setValidation,
-  removeCronValidation,
-  addCronValidation,
+  removeValidation,
+  addValidation,
   isFormValid,
 } = useUserRetentionValidation(disableAfterPeriod, deleteAfterPeriod, authUserSessionTtlMinutes);
 let settings: { [id: string]: Setting } = {};
@@ -84,7 +84,7 @@ watch([disableAfterPeriod, deleteAfterPeriod], ([newDisableAfterPeriod, newDelet
       userRetentionSettings[key] = null;
     });
 
-    removeCronValidation();
+    removeValidation(SETTING.USER_RETENTION_CRON);
 
     return;
   }
@@ -92,7 +92,7 @@ watch([disableAfterPeriod, deleteAfterPeriod], ([newDisableAfterPeriod, newDelet
   ids.filter((id) => ![SETTING.DISABLE_INACTIVE_USER_AFTER, SETTING.DELETE_INACTIVE_USER_AFTER].includes(id))
     .forEach(assignSettings);
 
-  addCronValidation();
+  addValidation(SETTING.USER_RETENTION_CRON);
 });
 
 const assignSettings = (key: string) => {

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -34,7 +34,8 @@ const deleteAfterPeriod = ref(false);
 const loading = ref(true);
 const {
   validateUserRetentionCron,
-  validateDuration,
+  validateDisableInactiveUserAfterDuration,
+  validateDeleteInactiveUserAfterDuration,
   validateDeleteInactiveUserAfter,
   validateDurationAgainstAuthUserSession,
   setValidation,
@@ -201,7 +202,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           class="input-field"
           :label="t('user.retention.edit.form.disableAfter.input.label')"
           :disabled="!disableAfterPeriod"
-          :rules="[validateDuration, validateDurationAgainstAuthUserSession]"
+          :rules="[validateDisableInactiveUserAfterDuration, validateDurationAgainstAuthUserSession]"
           @update:validation="e => setValidation(SETTING.DISABLE_INACTIVE_USER_AFTER, e)"
         />
       </div>
@@ -219,7 +220,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           :label="t('user.retention.edit.form.deleteAfter.input.label')"
           :sub-label="t('user.retention.edit.form.deleteAfter.input.subLabel')"
           :disabled="!deleteAfterPeriod"
-          :rules="[validateDuration, validateDurationAgainstAuthUserSession, validateDeleteInactiveUserAfter]"
+          :rules="[validateDeleteInactiveUserAfterDuration, validateDurationAgainstAuthUserSession, validateDeleteInactiveUserAfter]"
           @update:validation="e => setValidation(SETTING.DELETE_INACTIVE_USER_AFTER, e)"
         />
       </div>

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -6,10 +6,12 @@ import UserRetentionHeader from '@shell/components/user.retention/user-retention
 import Footer from '@shell/components/form/Footer.vue';
 import { useStore } from '@shell/composables/useStore';
 import { useI18n } from '@shell/composables/useI18n';
-import { useUserRetentionValidation, Setting } from '@shell/composables/useUserRetentionValidation';
+import { useUserRetentionValidation } from '@shell/composables/useUserRetentionValidation';
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import { isAdminUser } from '@shell/store/type-map';
+
+import type { Setting } from '@shell/types/resources/settings';
 
 import Banner from '@components/Banner/Banner.vue';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -233,6 +233,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
             :tooltip="t('user.retention.edit.form.cron.subLabel')"
             :rules="[validateUserRetentionCron]"
             :label="t('user.retention.edit.form.cron.label')"
+            :require-dirty="false"
             @update:validation="e => setValidation(SETTING.USER_RETENTION_CRON, e)"
           />
         </div>

--- a/shell/pages/c/_cluster/auth/user.retention/index.vue
+++ b/shell/pages/c/_cluster/auth/user.retention/index.vue
@@ -34,6 +34,7 @@ const deleteAfterPeriod = ref(false);
 const loading = ref(true);
 const {
   validateUserRetentionCron,
+  validateDuration,
   validateDeleteInactiveUserAfter,
   validateDurationAgainstAuthUserSession,
   setValidation,
@@ -200,7 +201,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           class="input-field"
           :label="t('user.retention.edit.form.disableAfter.input.label')"
           :disabled="!disableAfterPeriod"
-          :rules="[validateDurationAgainstAuthUserSession]"
+          :rules="[validateDuration, validateDurationAgainstAuthUserSession]"
           @update:validation="e => setValidation(SETTING.DISABLE_INACTIVE_USER_AFTER, e)"
         />
       </div>
@@ -218,7 +219,7 @@ onBeforeRouteUpdate((_to: unknown, _from: unknown) => {
           :label="t('user.retention.edit.form.deleteAfter.input.label')"
           :sub-label="t('user.retention.edit.form.deleteAfter.input.subLabel')"
           :disabled="!deleteAfterPeriod"
-          :rules="[validateDurationAgainstAuthUserSession, validateDeleteInactiveUserAfter]"
+          :rules="[validateDuration, validateDurationAgainstAuthUserSession, validateDeleteInactiveUserAfter]"
           @update:validation="e => setValidation(SETTING.DELETE_INACTIVE_USER_AFTER, e)"
         />
       </div>

--- a/shell/types/resources/settings.d.ts
+++ b/shell/types/resources/settings.d.ts
@@ -30,3 +30,57 @@ export interface PaginationSettings {
     }
   }
 }
+
+type Links = {
+  remove: string;
+  self: string;
+  update: string;
+  view: string;
+};
+
+type FieldsV1 = {
+  'f:customized': {};
+  'f:default': {};
+  'f:source': {};
+  'f:value': {};
+};
+
+type ManagedFields = {
+  apiVersion: string;
+  fieldsType: string;
+  fieldsV1: FieldsV1;
+  manager: string;
+  operation: string;
+  time: string;
+};
+
+type Metadata = {
+  creationTimestamp: string;
+  fields: string[];
+  generation: number;
+  managedFields: ManagedFields[];
+  name: string;
+  relationships: null;
+  resourceVersion: string;
+  state: {
+    error: boolean;
+    message: string;
+    name: string;
+    transitioning: boolean;
+  };
+  uid: string;
+};
+
+export type Setting = {
+  id: string;
+  type: string;
+  links: Links;
+  apiVersion: string;
+  customized: boolean;
+  default: string;
+  kind: string;
+  metadata: Metadata;
+  source: string;
+  value: string | null;
+  save: () => void;
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds additional validation rules to the user retention form. The following validations have been added:

- Disable/Delete after
   - validate the duration format `{h|m|s}`
      - disallow fractional seconds
   - validate that the value is greater than `auth-user-session-ttl-minutes`
- Delete after
   - validate that the value is greater than 336h0m0s

Additional changes have been made to support the validation changes:

- Add `requireDirty` prop to the `useLabeledFormElement` composable under `shell/composables/useLabeledFormElement.ts`
- Emit `update:validation` events when validation fails for a given input

Fixes #11333 
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- User Retention form
  - Disable user after inactivity period validation
  - Delete user after inactivity period validation
  - User retention process schedule validation

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Validations surrounding the user retention form
- Submitting the user retention form

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
