### PR TITLE
Backport fix for elemental-ui issue 202

### DIFF
--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -178,7 +178,7 @@ export function isChartVersionAvailableForInstall(versionsData, returnObj = fals
 
   const parsedRancherVersion = rancherVersion.split('-')?.[0];
   const regexHashString = new RegExp('^[A-Za-z0-9]{9}$');
-  const isRancherVersionHashString = regexHashString.test(rancherVersion);
+  const isRancherVersionHashStringOrHead = regexHashString.test(rancherVersion) || rancherVersion.includes('head');
   const requiredUiVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.UI_VERSION];
   const requiredKubeVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION];
   const versionObj = { ...version };
@@ -187,7 +187,7 @@ export function isChartVersionAvailableForInstall(versionsData, returnObj = fals
   versionObj.isCompatibleWithKubeVersion = true;
 
   // if it's a head version of Rancher, then we skip the validation and enable them all
-  if (!isRancherVersionHashString && requiredUiVersion && !semver.satisfies(parsedRancherVersion, requiredUiVersion)) {
+  if (!isRancherVersionHashStringOrHead && requiredUiVersion && !semver.satisfies(parsedRancherVersion, requiredUiVersion)) {
     if (!returnObj) {
       return false;
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Backport - Fixes #https://github.com/rancher/elemental-ui/issues/202
Based on: https://github.com/rancher/dashboard/pull/11448
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add check for `head` string on Rancher version in dev builds so that QA can test Elemental releases properly
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
**Only occurs for head/dev builds of Rancher**

The `rancherVersion` in this particular case is `v2.9-a402bfa1ff0cc051cfabe3d9380b7eca678443f9-head` string which won't meet the condition in https://github.com/rancher/dashboard/blob/master/shell/config/uiplugins.js#L195 `isRancherVersionHashString` which was the only condition that defined versions that were "head" builds of some sort. With the inclusion of the above, these strings for `rancherVersion` would fall on the category to have this check ignored
 
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to `Extensions` -> try to install Elemental on a head build (I can provide access to a system with this problem)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Afaik, it's only Elemental that uses the `catalog.cattle.io/ui-version` which is the one responsible for the disabling of the buttons on the UI side, so other extensions will experience this same problem

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**With problem (buttons disabled)**
<img width="2132" alt="Screenshot 2024-07-16 at 11 46 50" src="https://github.com/user-attachments/assets/5e79b8f0-e807-4eaa-8fc7-eeb76da9c1ab">

**Fixed**
<img width="2132" alt="Screenshot 2024-07-16 at 11 45 38" src="https://github.com/user-attachments/assets/0c1f669a-8b62-4f8d-b9b4-fe51168adb3c">

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
