### PR TITLE
Fix navigation from Global Settings --> Performance to any Cluster Explorer custom list

### DIFF
--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -61,7 +61,7 @@ export default {
 
   data() {
     return {
-      uiPerfSetting:              DEFAULT_PERF_SETTING,
+      uiPerfSetting:              null,
       authUserTTL:                null,
       bannerVal:                  {},
       value:                      {},

--- a/shell/utils/settings.ts
+++ b/shell/utils/settings.ts
@@ -102,5 +102,7 @@ export const getPerformanceSetting = (rootGetters: Record<string, (arg0: string,
   }
 
   // Start with the default and overwrite the values from the setting - ensures we have defaults for newly added options
-  return Object.assign(DEFAULT_PERF_SETTING, perfSetting || {});
+  const safeDefaults = Object.assign({}, DEFAULT_PERF_SETTING);
+
+  return Object.assign(safeDefaults, perfSetting || {});
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11496
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- 2.8 based bug
- Only reproducible when
  - performance settings have been changed
  - navigating from performance page to list page
  - prod build
- Root effect
  - Constant trigger of two computed properties
    - namespaceFilterRequired 
      - shell/mixins/resource-fetch-namespaced.js 
    - namespaceFilter --> __namespaceRequired --> value (all same colour, suggesting our code)
      - tracing shows this also to start from shell/mixins/resource-fetch-namespaced.js
- Issue
  - It looks like additional reactivity was happening around the `DEFAULT_PERF_SETTING` object
  - This meant computed properties were continually being called making the browser hang
- Fix
  - shell/pages/c/_cluster/settings/performance.vue removed assignment to component `data
    - this alone would fix the issue
    - vue will add reactivity to component `data` objects, however it's unclear why this specifically causes the error
  - shell/utils/settings.ts correct use of Object.assign
    - this alone would also fix the issue, however is a bug in itself
    - getPerformanceSetting was ensuring the object always at least had the defaults
    - however it was assigning custom settings directly to the `DEFAULT_PERF_SETTING` object and returning it
    - this could have resulted in an issue reactivity side given it's called from a computed property

### Areas or cases that should be tested
- Navigating from Global Settings --> Performance to any Cluster Explorer custom list does not cause a hang (as per issue)
- Performance settings can be correctly applied and persist over refresh, and also removed over refresh

### Areas which could experience regressions
- Global Settings --> Performance Page

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
