### PR TITLE
Hide Certificates table if vai is enabled

### DIFF
--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -48,6 +48,7 @@ import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import TabTitle from '@shell/components/TabTitle';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import capitalize from 'lodash/capitalize';
+import paginationUtils from '@shell/utils/pagination-utils';
 
 export const RESOURCES = [NAMESPACE, INGRESS, PV, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.STATEFUL_SET, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.DAEMON_SET, SERVICE];
 
@@ -122,6 +123,8 @@ export default {
         this.loadAgents();
       }
     }
+
+    this.showCertificates = !paginationUtils.isSteveCacheEnabled({ rootGetters: this.$store.getters });
   },
 
   data() {
@@ -156,6 +159,7 @@ export default {
       clusterCounts,
       selectedTab:        'cluster-events',
       extensionCards:     getApplicableExtensionEnhancements(this, ExtensionPoint.CARD, CardLocation.CLUSTER_DASHBOARD_CARD, this.$route),
+      showCertificates:   false,
     };
   },
 
@@ -739,6 +743,7 @@ export default {
           <AlertTable v-if="selectedTab === 'cluster-alerts'" />
         </Tab>
         <Tab
+          v-if="showCertificates"
           name="cluster-certs"
           :label="t('clusterIndexPage.sections.certs.label')"
           :weight="1"


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11524
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- The Cluster Dashboard --> Certificates Tab --> Certificates list uses a filter that is not compatible with the Vai backed api
- So hide the tab when vai is enabled

 
### Technical notes summary
- This is a 2.9 issue only, in 2.10 the table should be updated to handle the different way of filtering

### Areas or cases that should be tested
As per issue

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
