### PR TITLE
Fix two e2e tests given chart changes

### DIFF
--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -52,7 +52,6 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
   });
 
   it('Charts have expected icons', () => {
-    chartsPage.checkChartGenericIcon('External IP Webhook', true);
     chartsPage.checkChartGenericIcon('Alerting Driver', false);
     chartsPage.checkChartGenericIcon('CIS Benchmark', false);
     chartsPage.checkChartGenericIcon('Logging', false);

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -5,9 +5,8 @@ import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
 
 describe('Apps', () => {
   describe('Repositories', { tags: ['@explorer', '@adminUser'] }, () => {
-    const reposToDelete = [];
-
     describe('Add', () => {
+      const reposToDelete = [];
       const appRepoList = new ReposListPagePo('local', 'apps');
 
       beforeEach(() => {
@@ -131,6 +130,10 @@ describe('Apps', () => {
         appRepoCreate.authSelectOrCreate().authSelect().getOptions().contains('Create a SSH Key Secret')
           .should('not.exist');
       });
+
+      after(() => {
+        reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', r));
+      });
     });
 
     describe('Refresh', () => {
@@ -192,10 +195,6 @@ describe('Apps', () => {
         // The specific version of the chart should be fetched (as the cache was cleared)
         cy.wait('@rancherCharts3').its('request.url').should('include', 'version=');
       });
-    });
-
-    after(() => {
-      reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', r));
     });
   });
 });

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -176,7 +176,8 @@ describe('Apps', () => {
         appRepoList.waitForPage();
 
         // Nav back to the summary page for a specific chart
-        cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?*', cy.spy().as('rancherCharts2'));
+        // Note we're intercepting a more precise url here to avoid any icon requests made from the charts list
+        cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?link=info&chartName=rancher-backup&version=*', cy.spy().as('rancherCharts2'));
         ChartPage.navTo(clusterId, 'Rancher Backups');
         chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
         // The specific version of the chart (and any other) should NOT be fetched


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Occurred changes and/or fixed issues
- Fix `Charts have expected icons` - `External IP Webhook` app was removed, we were checking it for a generic icon
- Fix `Repo Refresh results in correct api requests` - errent requests for chart icons were being treated as requests for a chart... which the test was ensuring were not happening. made this more resilient 
- Make Apps Repositories tests more resilient to cypress retries

### Technical notes summary
- needs a forward port

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
