### PR TITLE
Ensure that route paths are non-empty

### DIFF
--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -18,7 +18,7 @@ export default [
     meta:      { requiresAuthentication: true },
     children:  [
       {
-        path:      '',
+        path:      '/',
         component: () => interopDefault(import('@shell/pages/index.vue')),
         name:      'index'
       },
@@ -30,7 +30,7 @@ export default [
     name:      'fail-whale'
   },
   {
-    path:      '',
+    path:      '/',
     component: () => interopDefault(import('@shell/components/templates/blank.vue')),
     name:      'blank',
     meta:      { requiresAuthentication: true },
@@ -38,7 +38,7 @@ export default [
     ]
   },
   {
-    path:      '',
+    path:      '/',
     component: () => interopDefault(import('@shell/components/templates/home.vue')),
     meta:      { requiresAuthentication: true },
     children:  [
@@ -55,7 +55,7 @@ export default [
     ]
   },
   {
-    path:      '',
+    path:      '/',
     component: () => interopDefault(import('@shell/components/templates/plain.vue')),
     name:      'plain',
     meta:      { requiresAuthentication: true },
@@ -118,14 +118,14 @@ export default [
     ]
   },
   {
-    path:      '',
+    path:      '/',
     component: () => interopDefault(import('@shell/components/templates/standalone.vue')),
     name:      'standalone',
     children:  [
     ]
   },
   {
-    path:      '',
+    path:      '/',
     component: () => interopDefault(import('@shell/components/templates/unauthenticated.vue')),
     name:      'unauthenticated',
     children:  [
@@ -151,7 +151,7 @@ export default [
     ]
   },
   {
-    path:      '',
+    path:      '/',
     component: () => interopDefault(import('@shell/components/templates/default.vue')),
     name:      'default',
     meta:      { requiresAuthentication: true },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensures that paths are non-empty strings. Empty strings in paths aren't an issue now, but will have an effect on properly matching routes when migrating to Vue3. 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Vue router provides a path matching tool that can be used to debug potential issues[^1]. Using this tool with our current route definition will produce the following error:

```
Error parsing routes:
Invalid route at position 2: Property "path" must be a non-epmty string
```

This doesn't appear to be an issue in Vue2, but it's safe to fix this now so that there's less to track and troubleshoot for Vue3.

[^1]: https://paths.esm.dev/?p=AAMsIPQgYAEL9lNgQAECUgPgDIFiDgCg#

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Anything that touches routing

- login
- logout
- navigating clusters
- navigating extensions

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Anything that touches routing

- login
- logout
- navigating clusters
- navigating extensions

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
