### PR TITLE
Fixing harvester cluster page reload routing + Harvester console button

### DIFF
--- a/shell/config/router/navigation-guards/runtime-extension-route.js
+++ b/shell/config/router/navigation-guards/runtime-extension-route.js
@@ -17,11 +17,11 @@ export async function runtimeExtensionRoute(to, from, next, { store }) {
     const newLocation = await dynamicPluginLoader.check({ route: { path: window.location.pathname }, store });
 
     // If we have a new location, double check that it's actually valid
-    const resolvedRoute = newLocation ? store.app.router.resolve(newLocation) : null;
+    const resolvedRoute = newLocation?.path ? store.app.router.resolve({ path: newLocation.path.replace(/^\/{0,1}dashboard/, '') }) : null;
 
     if (resolvedRoute?.route.matched.length) {
       // Note - don't use `redirect` or `store.app.route` (breaks feature by failing to run middleware in default layout)
-      return next(newLocation);
+      return next(resolvedRoute.resolved.path);
     }
   } catch (e) {
     console.error('Failed to load harvester', e); // eslint-disable-line no-console


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
contains ported partial fixes for https://github.com/rancher/dashboard/issues/9814
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
