### PR TITLE
Remove unused dependency `@innologica/vue-dropdown-menu`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@aws-sdk/client-eks": "3.1.0",
     "@aws-sdk/client-iam": "3.18.0",
     "@aws-sdk/client-kms": "3.8.1",
-    "@innologica/vue-dropdown-menu": "0.1.3",
     "@novnc/novnc": "1.2.0",
     "@nuxtjs/axios": "5.13.6",
     "@nuxtjs/webpack-profile": "0.1.0",

--- a/shell/package.json
+++ b/shell/package.json
@@ -34,7 +34,6 @@
     "@babel/plugin-proposal-optional-chaining": "7.14.5",
     "@babel/plugin-proposal-private-property-in-object": "7.14.5",
     "@babel/preset-typescript": "7.16.7",
-    "@innologica/vue-dropdown-menu": "0.1.3",
     "@novnc/novnc": "1.2.0",
     "@nuxt/types": "2.14.6",
     "@nuxt/typescript-build": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,14 +2737,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@innologica/vue-dropdown-menu@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@innologica/vue-dropdown-menu/-/vue-dropdown-menu-0.1.3.tgz#f2b3741296ed6c1dca4a1d04f824d08b1ce3ae14"
-  integrity sha512-kWeu/M+2E+b1z0qRovlP7T3Zctapcg7UBfZ4kC+BepgjvlSprNREKC7JN9bAWObPWB5WO8mHk3FRFCl/YBGIyQ==
-  dependencies:
-    core-js "^2.6.5"
-    vue "^2.6.10"
-
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz#be7c7846128b88f6a9b1d1261a0ad06eb5c0fdf8"
@@ -6131,11 +6123,6 @@ core-js@3.25.3:
   version "3.25.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.25.3.tgz#cbc2be50b5ddfa7981837bd8c41639f27b166593"
   integrity sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ==
-
-core-js@^2.6.5:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.6.5:
   version "3.30.1"
@@ -16032,7 +16019,7 @@ vue@2.7.16:
     "@vue/compiler-sfc" "2.7.16"
     csstype "^3.1.0"
 
-vue@^2.0.0, vue@^2.6.10:
+vue@^2.0.0:
   version "2.7.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.14.tgz#3743dcd248fd3a34d421ae456b864a0246bafb17"
   integrity sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Discovered that `@innologica/vue-dropdown-menu` is unused in our project while working on Vue3 migration. I think that we should get rid of it if we don't use it.

Fixes #11562
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove unused dependency `@innologica/vue-dropdown-menu`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- No usages of `@innologica/vue-dropdown-menu` throughout Dashboard, this looks safe to remove

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Any code that might have used `@innologica/vue-dropdown-menu`; I don't see any references in Dashboard 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Any code that might have used `@innologica/vue-dropdown-menu`; I don't see any references in Dashboard

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
