### PR TITLE
BP: [FIX] Changed JWT Authentication page to disable ClusterProxyConfigs

### DIFF
--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -85,11 +85,12 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     JWTAuthenticationPagePo.navTo();
     jwtAuthenticationPage.waitForPage();
 
-    cy.intercept('DELETE', `/v1/management.cattle.io.clusterproxyconfigs/**`).as('disableJWT');
+    cy.intercept('PUT', `/v1/management.cattle.io.clusterproxyconfigs/**`).as('disableJWT');
     jwtAuthenticationPage.list().clickRowActionMenuItem(instance0, 'Disable');
 
     cy.wait('@disableJWT', { requestTimeout: 10000 }).then(({ request, response }) => {
-      expect(response?.statusCode).to.eq(204);
+      expect(response?.statusCode).to.eq(200);
+      expect(request.body.enabled).to.equal(false);
     });
 
     jwtAuthenticationPage.list().state(instance0).should('contain', 'Disabled');
@@ -98,7 +99,7 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
   it('should be able to enable JWT Authentication in bulk', () => {
     JWTAuthenticationPagePo.navTo();
     jwtAuthenticationPage.waitForPage();
-    cy.intercept('POST', `/v1/management.cattle.io.clusterproxyconfigs`).as('enableJWT');
+    cy.intercept('PUT', `/v1/management.cattle.io.clusterproxyconfigs/**`).as('enableJWT');
 
     jwtAuthenticationPage.list().resourceTable().sortableTable().rowSelectCtlWithName(instance0)
       .set();
@@ -107,7 +108,7 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     jwtAuthenticationPage.list().activate();
 
     cy.wait('@enableJWT', { requestTimeout: 10000 }).then(({ request, response }) => {
-      expect(response?.statusCode).to.eq(201);
+      expect(response?.statusCode).to.eq(200);
       expect(request.body.enabled).to.equal(true);
     });
     jwtAuthenticationPage.list().state(instance0).should('contain', 'Enabled');
@@ -117,7 +118,7 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
   it('should be able to disable JWT Authentication in bulk', () => {
     JWTAuthenticationPagePo.navTo();
     jwtAuthenticationPage.waitForPage();
-    cy.intercept('DELETE', `/v1/management.cattle.io.clusterproxyconfigs/**`).as('disableJWT');
+    cy.intercept('PUT', `/v1/management.cattle.io.clusterproxyconfigs/**`).as('disableJWT');
 
     jwtAuthenticationPage.list().resourceTable().sortableTable().rowSelectCtlWithName(instance0)
       .set();
@@ -126,7 +127,8 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     jwtAuthenticationPage.list().deactivate();
 
     cy.wait('@disableJWT', { requestTimeout: 10000 }).then(({ request, response }) => {
-      expect(response?.statusCode).to.eq(204);
+      expect(response?.statusCode).to.eq(200);
+      expect(request.body.enabled).to.equal(false);
     });
 
     jwtAuthenticationPage.list().state(instance0).should('contain', 'Disabled');

--- a/shell/pages/c/_cluster/manager/jwt.authentication/index.vue
+++ b/shell/pages/c/_cluster/manager/jwt.authentication/index.vue
@@ -22,7 +22,7 @@ export default {
   async fetch() {
     const hash = {
       mgmtClusters: this.$fetchType(MANAGEMENT.CLUSTER),
-      proxyConfig:  this.$fetchType(MANAGEMENT.CLUSTER_PROXY_CONFIG)
+      proxyConfig:  this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER_PROXY_CONFIG, opt: { omitExcludeFields: ['metadata.managedFields'] } })
     };
 
     const res = await allHash(hash);
@@ -150,7 +150,11 @@ export default {
 
           const value = config?.enabled || '';
           const configName = config?.metadata?.name || '';
-          const updatedOn = value ? config?.metadata?.creationTimestamp : '';
+          let updatedOn = '';
+
+          if (value) {
+            updatedOn = config?.metadata?.managedFields?.find((field) => field.operation === 'Update')?.time || '';
+          }
           const stateBackground = value ? colorForState(STATES_ENUM.ACTIVE).replace('text', 'bg') : colorForState(STATES_ENUM.INFO).replace('text', 'bg');
           const stateLabel = value ? this.t('jwt.state.enabled') : this.t('jwt.state.disabled');
           const creationTimestamp = cluster.metadata.creationTimestamp;
@@ -159,7 +163,7 @@ export default {
             if (!configName) {
               const clusterProxyConfig = await this.$store.dispatch('management/create', {
                 enabled:  true,
-                metadata: { namespace: id, generateName: 'cluster-proxy-config-' },
+                metadata: { namespace: id, name: 'clusterproxyconfig' },
               });
 
               return clusterProxyConfig.save({ url: 'v1/management.cattle.io.clusterproxyconfigs', method: 'POST' });
@@ -170,7 +174,9 @@ export default {
             }
           };
           const disable = async() => {
-            return config.remove();
+            config.enabled = false;
+
+            return config.save();
           };
 
           rows.push({

--- a/shell/plugins/steve/__tests__/getters.test.ts
+++ b/shell/plugins/steve/__tests__/getters.test.ts
@@ -109,13 +109,13 @@ describe('steve: getters:', () => {
     it('returns a string with a labelSelector and filter, and formatted for steve if the url starts with "/v1"', () => {
       expect(urlOptionsGetter('/v1/foo', { labelSelector: 'a=b', filter: { bar: 'baz', far: 'faz' } })).toBe('/v1/foo?labelSelector=a=b&filter=bar=baz&far=faz&exclude=metadata.managedFields');
     });
-    it('returns a string with an exclude statement for "bar" and "metadata.managedFields" if excludeFields is a single element array with the string "bar" and the url starts with "/v1/"', () => {
-      expect(urlOptionsGetter('/v1/foo', { excludeFields: ['bar'] })).toBe('/v1/foo?exclude=bar&exclude=metadata.managedFields');
+    it('returns a string with an exclude statement for "bar" if excludeFields is a single element array with the string "bar" and the url starts with "/v1/"', () => {
+      expect(urlOptionsGetter('/v1/foo', { excludeFields: ['bar'] })).toBe('/v1/foo?exclude=bar');
     });
-    it('returns a string without an exclude statement if excludeFields is but the url does not start with "/v1/"', () => {
-      expect(urlOptionsGetter('foo', { excludeFields: ['bar'] })).toBe('foo');
+    it('returns a string without an exclude statement for "managedFields" if omitExcludeFields includes it and the url starts with "/v1/"', () => {
+      expect(urlOptionsGetter('/v1/foo', { omitExcludeFields: ['metadata.managedFields'] })).toBe('/v1/foo?');
     });
-    it('returns a string without an exclude statement if excludeFields is an array but the URL doesn\'t include the "/v1/ string"', () => {
+    it('returns a string without an exclude statement if excludeFields is set but the url does not start with "/v1/"', () => {
       expect(urlOptionsGetter('foo', { excludeFields: ['bar'] })).toBe('foo');
     });
     it('returns a string with a limit applied if a limit is provided', () => {

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -119,11 +119,13 @@ export default {
     // excludeFields should be an array of strings representing the paths of the fields to exclude
     // only works on Steve but is ignored without error by Norman
     if (isSteve) {
-      if (Array.isArray(opt?.excludeFields)) {
-        opt.excludeFields = [...opt.excludeFields, 'metadata.managedFields'];
-      } else {
-        opt.excludeFields = ['metadata.managedFields'];
+      if (!Array.isArray(opt?.excludeFields)) {
+        const excludeFields = ['metadata.managedFields'];
+
+        // for some resources, we might want to include fields, excluded by default.
+        opt.excludeFields = Array.isArray(opt?.omitExcludeFields) ? excludeFields.filter((f) => !f.includes(opt.omitExcludeFields)) : excludeFields;
       }
+
       const excludeParamsString = opt.excludeFields.map((field) => `exclude=${ field }`).join('&');
 
       url += `${ url.includes('?') ? '&' : '?' }${ excludeParamsString }`;


### PR DESCRIPTION
Changed JWT Authentication page to disable ClusterProxyConfigs instead of removing

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Backport - Fixes #11462 
<!-- Define findings related to the feature or bug issue. -->
The original behavior was to remove ClusterProxyConfig in the corresponding namespace if JWTA for that cluster is disabled. This change sets it to disabled instead.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This required changes to excludeFields behavior:
Current behavior: 'metadata.managedFields' is always excluded. If a list of fields to exclude is provided, 'metadata.managedFields' is appended to that list
New behavior: if a list of fields to exclude is provided, we just use it. A new option 'omitExcludeFields' is provided to make it possible to overwrite default exclude fields behavior.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
JWT Authentication page:
- Check that JWTA can be enabled, disabled, and re-enabled for clusters. (covered by existing tests)
- Check that ClusterProxyConfig still exists after JWTA has been disabled for a cluster

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
excludeFields change can affect all requests

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/3f0eab94-634a-4961-ad1f-6c11803d0f65


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
