### PR TITLE
Update rancher-2.9-support.md

### DIFF
--- a/docusaurus/docs/extensions/rancher-2.9-support.md
+++ b/docusaurus/docs/extensions/rancher-2.9-support.md
@@ -27,7 +27,7 @@ These changes bring Shell versions in line with standard versioning patterns. On
 
 ## How to update your extension for Rancher 2.9.0
 
-- In the root of your extension repository, update `package.json` `@rancher/shell` to the new `2.1.0` version and `yarn install` to fetch it. Then do a local build of your extensions and `Developer Load` them on the desired Rancher version to confirm everything works as expected. Check documentation about a Developer Load [here](./extensions-getting-started#test-built-extension-by-doing-a-developer-load).
+- In the root of your extension repository, update `package.json` `@rancher/shell` to the new `2.0.1` version and `yarn install` to fetch it. Then do a local build of your extensions and `Developer Load` them on the desired Rancher version to confirm everything works as expected. Check documentation about a Developer Load [here](./extensions-getting-started#test-built-extension-by-doing-a-developer-load).
 
 - Before publishing it, add annotation(s) to your extension `pkg/<-YOUR EXTENSION->/package.json` like:
 

--- a/docusaurus/docs/extensions/rancher-2.9-support.md
+++ b/docusaurus/docs/extensions/rancher-2.9-support.md
@@ -23,15 +23,15 @@ For future releases of your extension to **work on Rancher 2.9.0** you will need
 
 > If your extension is using Shell `0.5.3` and you **don't need** to be compliant with Rancher 2.9.0, there's no update to do.
 
-These changes bring Shell versions in line with standard versioning patterns. Only major version updates are expected to container breaking changes, minor and patch versions should not.
+These changes bring Shell versions in line with standard versioning patterns. Only major version updates are expected to contain breaking changes, minor and patch versions should not.
 
 ## How to update your extension for Rancher 2.9.0
 
-- In the root of your extension repository update `package.json` `@rancher/shell` to the new `2.9.0` version and `yarn install` to fetch it. Then do a local build of your extensions and `Developer Load` them on the desired Rancher version to confirm everything works as expected. Check documentation about a Developer Load [here](./extensions-getting-started#test-built-extension-by-doing-a-developer-load).
+- In the root of your extension repository, update `package.json` `@rancher/shell` to the new `2.1.0` version and `yarn install` to fetch it. Then do a local build of your extensions and `Developer Load` them on the desired Rancher version to confirm everything works as expected. Check documentation about a Developer Load [here](./extensions-getting-started#test-built-extension-by-doing-a-developer-load).
 
 - Before publishing it, add annotation(s) to your extension `pkg/<-YOUR EXTENSION->/package.json` like:
 
-```
+```json
 {
   "name": "your-extension",
   "description": "your-extension description",


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes typo in the desired `@rancher/shell` version from 2.9.0 to 2.0.1
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
