### PR TITLE
EKS - fix secrets encryption with KMS key checkbox

### DIFF
--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -349,7 +349,7 @@ export default defineComponent({
           :disabled="mode!=='create'"
           :mode="mode"
           label-key="eks.encryptSecrets.label"
-          data-testid="eks-encrypt-secrets-checkbox"
+          data-testid="eks-secrets-encryption-checkbox"
           @input="$emit('update:secretsEncryption', $event)"
         />
       </div>

--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -59,6 +59,11 @@ export default defineComponent({
       default: ''
     },
 
+    secretsEncryption: {
+      type:    Boolean,
+      default: false
+    },
+
     serviceRole: {
       type:    String,
       default: ''
@@ -101,7 +106,6 @@ export default defineComponent({
       canReadKms:            false,
       supportedVersionRange,
       customServiceRole:     !!this.serviceRole && !!this.serviceRole.length,
-      encryptSecrets:        false,
       loadingVersions:       false,
       loadingKms:            false,
       allKubernetesVersions: eksVersions as string[],
@@ -131,7 +135,7 @@ export default defineComponent({
       immediate: true
     },
 
-    'encryptSecrets'(neu) {
+    'secretsEncryption'(neu) {
       if (!neu) {
         this.$emit('update:kmsKey', '');
       }
@@ -341,16 +345,17 @@ export default defineComponent({
     <div class="row mb-10">
       <div class="col span-6">
         <Checkbox
-          v-model="encryptSecrets"
+          :value="secretsEncryption"
           :disabled="mode!=='create'"
           :mode="mode"
           label-key="eks.encryptSecrets.label"
           data-testid="eks-encrypt-secrets-checkbox"
+          @input="$emit('update:secretsEncryption', $event)"
         />
       </div>
     </div>
     <div
-      v-if="encryptSecrets"
+      v-if="secretsEncryption"
       class="row mb-10"
     >
       <div

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -688,6 +688,7 @@ export default defineComponent({
           :ebs-c-s-i-driver.sync="config.ebsCSIDriver"
           :service-role.sync="config.serviceRole"
           :kms-key.sync="config.kmsKey"
+          :secrets-encryption.sync="config.secretsEncryption"
           :tags.sync="config.tags"
           :mode="mode"
           :config="config"

--- a/pkg/eks/components/__mocks__/listKeys.js
+++ b/pkg/eks/components/__mocks__/listKeys.js
@@ -8,7 +8,17 @@ export default {
   Keys: [
     {
       KeyArn: 'arn:aws:kms:us-west-2:testdata2134',
-      KeyId:  '1234-4321'
+      KeyId:  '1234-2134'
+    },
+    {
+      KeyArn: 'arn:aws:kms:us-west-2:testdata6543',
+      KeyId:  '1234-6543'
+    }, {
+      KeyArn: 'arn:aws:kms:us-west-2:testdata3454',
+      KeyId:  '1234-3454'
+    }, {
+      KeyArn: 'arn:aws:kms:us-west-2:testdata8762',
+      KeyId:  '1234-8762'
     }
   ],
   Truncated: false


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11558 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the EKS provisioning form to set `eksConfig.secretsEncryption` when the 'Encrypt Secrets with a KMS key' checkbox is checked.



### Areas or cases that should be tested
1. Create an EKS cluster, check the 'Encrypt secrets' checkbox and select a key. Verify that the save request includes `eksConfig.secrets.Encryption: true`
2. Wait for the cluster to provision; edit the cluster and verify that the kms key arn is shown in the form ,but is not editable



### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
