### PR TITLE
Fixing a warning where we didn't have a template tag

### DIFF
--- a/shell/pages/index.vue
+++ b/shell/pages/index.vue
@@ -41,3 +41,6 @@ export default {
   }
 };
 </script>
+<template>
+  <div />
+</template>


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Previously the page would just redirect using middleware so the template was never looked at. This puts in an empty template since we don't intend to render anything on this page.

fixes https://github.com/rancher/dashboard/issues/11585
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
